### PR TITLE
Add targetbranch to topicbranch name

### DIFF
--- a/Build/Scripts/UpdatePackageVersions.ps1
+++ b/Build/Scripts/UpdatePackageVersions.ps1
@@ -40,7 +40,7 @@ foreach($packageName in $packageNames)
 if ($updatesAvailable) {
     # Create branch and push changes
     Set-GitConfig -Actor $Actor
-    $BranchName = New-TopicBranch -Category "UpdatePackageVersions"
+    $BranchName = New-TopicBranch -Category "UpdatePackageVersions/$TargetBranch"
     $title = "[$TargetBranch] Update package versions"
     Push-GitBranch -BranchName $BranchName -Files @("Build/Packages.json") -CommitMessage $title
 


### PR DESCRIPTION
We ended up pushing the release/22 and main updates to the same branch in these two PRs because they're triggered in parallel:
https://github.com/microsoft/BCApps/pull/22
https://github.com/microsoft/BCApps/pull/23