### PR TITLE
Use compilerfolder for projects without tests

### DIFF
--- a/Projects/System Application/.AL-Go/settings.json
+++ b/Projects/System Application/.AL-Go/settings.json
@@ -9,6 +9,6 @@
     "doNotRunTests": true,
     "enableAppSourceCop": true,
     "enablePerTenantExtensionCop":  true,
-    "useCompilerFolder": true, // To enable containerless compiling 
-    "doNotPublishApps": true // To enable containerless compiling
+    "useCompilerFolder": true,
+    "doNotPublishApps": true
 }

--- a/Projects/Test Framework/.AL-Go/settings.json
+++ b/Projects/Test Framework/.AL-Go/settings.json
@@ -10,6 +10,6 @@
     "doNotRunTests": true,
     "enableAppSourceCop": true,
     "enablePerTenantExtensionCop":  true,
-    "useCompilerFolder": true, // To enable containerless compiling 
-    "doNotPublishApps": true // To enable containerless compiling
+    "useCompilerFolder": true,
+    "doNotPublishApps": true
 }

--- a/Projects/Test Stability Tools/.AL-Go/settings.json
+++ b/Projects/Test Stability Tools/.AL-Go/settings.json
@@ -8,6 +8,6 @@
     "doNotRunTests": true,
     "enableAppSourceCop": true,
     "enablePerTenantExtensionCop":  true,
-    "useCompilerFolder": true, // To enable containerless compiling 
-    "doNotPublishApps": true // To enable containerless compiling
+    "useCompilerFolder": true,
+    "doNotPublishApps": true
 }


### PR DESCRIPTION
Use compilerfolder for projects without tests.