### PR TITLE
Register Entity Text Copilot Capability per Database

### DIFF
--- a/src/System Application/App/Entity Text/src/EntityTextAIInstall.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextAIInstall.Codeunit.al
@@ -8,7 +8,7 @@ codeunit 2014 "Entity Text AI Install"
     InherentEntitlements = X;
     InherentPermissions = X;
 
-    trigger OnInstallAppPerCompany()
+    trigger OnInstallAppPerDatabase()
     begin
         RegisterCapability();
     end;


### PR DESCRIPTION
Register Entity Text capability using OnInstallAppPerDatabase() instead of OnInstallAppPerCompany(), avoiding the capability not being registered if the application is installed before there are any companies.