### PR TITLE
Set PTE0021 action to None in PTECop.ruleset.json

### DIFF
--- a/src/rulesets/PTECop.ruleset.json
+++ b/src/rulesets/PTECop.ruleset.json
@@ -83,7 +83,8 @@
                   },
                   {
                       "id":  "PTE0021",
-                      "action":  "None"
+                      "action":  "None",
+                      "justification": "Defining reserved Microsoft and System namespaces is not allowed"
                   },
                   {
                       "id":  "PTE0022",


### PR DESCRIPTION
This rule should be disabled here. It checks that we the no Microsoft or System namespaces are defined.