### PR TITLE
Trigger full build on workflow and rulesets changes

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -54,7 +54,10 @@
     "skipUpgrade":  true,
     "PartnerTelemetryConnectionString":  "InstrumentationKey=403ba4d3-ad2b-4ca1-8602-b7746de4c048;IngestionEndpoint=https://swedencentral-0.in.applicationinsights.azure.com/",
     "fullBuildPatterns":  [
-                              "build/*"
+                              "build/*",
+                              "src/rulesets/*",
+                              ".github/workflows/PullRequestHandler.yaml",
+                              ".github/workflows/_BuildALGoProject.yaml"
                           ],
     "PullRequestTrigger":  "pull_request"
 }


### PR DESCRIPTION
Full Build should be triggered if the rulesets are changed, as well as the workflows responsible for the build.