### PR TITLE
Fix paths in the System Application workspace

### DIFF
--- a/src/SystemApplication.code-workspace
+++ b/src/SystemApplication.code-workspace
@@ -2,27 +2,31 @@
 	"folders": [
 		{
 			"name": "Any",
-			"path": "Tools\\TestFramework\\TestLibraries\\Any"
+			"path": "Tools\\Test Framework\\Test Libraries\\Any"
 		},
 		{
 			"name": "Assert",
-			"path": "Tools\\TestFramework\\TestLibraries\\Assert"
+			"path": "Tools\\Test Framework\\Test Libraries\\Assert"
+		},
+		{
+			"name": "Permissions Mock",
+			"path": "Tools\\Test Framework\\Test Libraries\\Permissions Mock"
 		},
 		{
 			"name": "Variable Storage",
-			"path": "Tools\\TestFramework\\TestLibraries\\Variable Storage"
+			"path": "Tools\\Test Framework\\Test Libraries\\Variable Storage"
 		},
 		{
 			"name": "TestRunner",
-			"path": "Tools\\TestFramework\\TestRunner"
+			"path": "Tools\\Test Framework\\Test Runner"
 		},
 		{
-			"name": "System Applcation",
+			"name": "System Application",
 			"path": "System Application\\App"
 		},
 		{
 			"name": "System Application Test Libraries",
-			"path": "System Application\\Library"
+			"path": "System Application\\Test Library"
 		},
 		{
 			"name": "System Application Tests",


### PR DESCRIPTION
**Problem:**
The paths listed in the workspace are currently not correct, so it's impossible to use the workspace.

**Solution:**
Fix the workspace paths and include the `Permissions Mock` app (needed for tests).