### PR TITLE
AL0792 - Decrease severity temporarily so that violations can be fixed

### DIFF
--- a/src/rulesets/Compiler.ruleset.json
+++ b/src/rulesets/Compiler.ruleset.json
@@ -3167,7 +3167,7 @@
         },
         {
             "id": "AL0792",
-            "action": "Warning"
+            "action": "Error"
         },
         {
             "id": "AL0793",

--- a/src/rulesets/ruleset.json
+++ b/src/rulesets/ruleset.json
@@ -123,6 +123,11 @@
       "id": "AL0678",
       "action": "None",
       "justification": "Information diagnostic reported on obsolete symbols contributing to metadata name conflicts, ex: 'My Page' and 'My_Page'."
+    },
+    {
+      "id": "AL0792",
+      "action": "None",
+      "justification": "The rule was not being promoted to error, so BaseApp has multiple violations. They will have to be fixed and then the rule should be enabled."
     }
   ]
 }


### PR DESCRIPTION
**Issue**
Due to a bug in how this rule was promoted from a ruleset, there are some places where the base app has violated it. 

**Solution**
Temporarily demote it to a warning in order to allow BaseApp to build.