### PR TITLE
Enable all analyzers for all projects

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -40,7 +40,6 @@
                        "Default",
                        "Clean"
                    ],
-    "enableCodeCop":  true,
     "CICDPushBranches":  [
                              "main",
                              "release/*"
@@ -50,6 +49,10 @@
                                     "release/*",
                                     "features/*"
                                 ],
+    "enableCodeCop":  true,
+    "enableAppSourceCop": true,
+    "enablePerTenantExtensionCop": true,
+    "enableUICop": true,
     "rulesetFile":  "..\\..\\..\\src\\rulesets\\ruleset.json",
     "skipUpgrade":  true,
     "PartnerTelemetryConnectionString":  "InstrumentationKey=403ba4d3-ad2b-4ca1-8602-b7746de4c048;IngestionEndpoint=https://swedencentral-0.in.applicationinsights.azure.com/",

--- a/build/projects/Performance Toolkit/.AL-Go/settings.json
+++ b/build/projects/Performance Toolkit/.AL-Go/settings.json
@@ -6,8 +6,5 @@
     "testFolders":  [
         "..\\..\\..\\src\\Tools\\Performance Toolkit\\Test"
     ],
-    "enableAppSourceCop": true,
-    "enablePerTenantExtensionCop": true,
-    "enableUICop": true,
     "installOnlyReferencedApps": false
 }

--- a/build/projects/System Application Modules/.AL-Go/settings.json
+++ b/build/projects/System Application Modules/.AL-Go/settings.json
@@ -7,9 +7,6 @@
         "..\\..\\..\\src\\System Application\\Test\\*",
         "..\\..\\..\\src\\System Application\\Test Library\\*"
     ],
-    "enableAppSourceCop": false,
-    "enablePerTenantExtensionCop": false,
-    "enableUICop": false,
     "useCompilerFolder": true,
     "doNotPublishApps": true,
     "rulesetFile": "..\\..\\..\\src\\rulesets\\internal.module.ruleset.json"

--- a/build/projects/System Application Tests/.AL-Go/settings.json
+++ b/build/projects/System Application Tests/.AL-Go/settings.json
@@ -3,8 +3,5 @@
     "testFolders":  [
         "..\\..\\..\\src\\System Application\\Test",
         "..\\..\\..\\src\\System Application\\Test Library"
-    ],
-    "enableAppSourceCop": true,
-    "enablePerTenantExtensionCop": true,
-    "enableUICop": true
+    ]
 }

--- a/build/projects/System Application/.AL-Go/settings.json
+++ b/build/projects/System Application/.AL-Go/settings.json
@@ -7,9 +7,6 @@
         "Translated"
     ],
     "doNotRunTests": true,
-    "enableAppSourceCop": true,
-    "enablePerTenantExtensionCop": true,
-    "enableUICop": true,
     "useCompilerFolder": true,
     "doNotPublishApps": true
 }

--- a/build/projects/Test Framework/.AL-Go/settings.json
+++ b/build/projects/Test Framework/.AL-Go/settings.json
@@ -8,9 +8,6 @@
         "Translated"
     ],
     "doNotRunTests": true,
-    "enableAppSourceCop": true,
-    "enablePerTenantExtensionCop": true,
-    "enableUICop": true,
     "useCompilerFolder": true,
     "doNotPublishApps": true
 }

--- a/build/projects/Test Stability Tools/.AL-Go/settings.json
+++ b/build/projects/Test Stability Tools/.AL-Go/settings.json
@@ -6,9 +6,6 @@
     "testFolders":  [
     ],
     "doNotRunTests": true,
-    "enableAppSourceCop": true,
-    "enablePerTenantExtensionCop": true,
-    "enableUICop": true,
     "useCompilerFolder": true,
     "doNotPublishApps": true
 }


### PR DESCRIPTION
Previously, the project 'System Application Modules' only had codecop enabled. This PR enables AppSourceCop, PTECop and UICop on that project and moves the 'enable...Cop' settings to the global configuration file. 