### PR TITLE
[AI] Add missing govern data url to copilot admin page

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
@@ -43,7 +43,7 @@ page 7775 "Copilot AI Capabilities"
 
                     trigger OnDrillDown()
                     begin
-                        Hyperlink('');
+                        Hyperlink('https://go.microsoft.com/fwlink/?linkid=2249575');
                     end;
                 }
 


### PR DESCRIPTION
**Problem**
The copilot admin page's govern data action has a hyperlink with no url.

**Solution**
Update that hyperlink with the proper forwardlink.