### PR TITLE
[Copilot][Marketing Text] Use SetPrimarySystemMessage instead of AddSystemMessage

### DIFF
--- a/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
@@ -427,7 +427,7 @@ codeunit 2012 "Entity Text Impl."
 
         AOAICompletionParams.SetMaxTokens(2500);
         AOAICompletionParams.SetTemperature(0.7);
-        AOAIChatMessages.AddSystemMessage(SystemPrompt);
+        AOAIChatMessages.SetPrimarySystemMessage(SystemPrompt);
         AOAIChatMessages.AddUserMessage(UserPrompt);
 
         AzureOpenAI.GenerateChatCompletion(AOAIChatMessages, AOAICompletionParams, AOAIOperationResponse);


### PR DESCRIPTION
**Problem**
As AddSystemMessage does not fulfil the criteria of a metaprompt being set, this means that Marketing Text is affected by the new default metaprompt being added.

**Solution**
Switch `AddSystemMessage` with `SetPrimarySystemMessage`.