### PR TITLE
Update UploadAndDeployExtension.Page.al to make it clear that we are referring to 3rd party extensions

### DIFF
--- a/src/System Application/App/Extension Management/src/UploadAndDeployExtension.Page.al
+++ b/src/System Application/App/Extension Management/src/UploadAndDeployExtension.Page.al
@@ -85,13 +85,13 @@ page 2507 "Upload And Deploy Extension"
             field(Accepted; IsAccepted)
             {
                 ApplicationArea = All;
-                Caption = 'Accept the privacy policy and the disclaimer';
+                Caption = 'By deploying this extension you acknowledge that your data may be sent outside the compliance boundary of Business Central. Each per tenant extension is subject to its own third party terms and conditions and privacy policies.';
                 ToolTip = 'Specifies that you accept the privacy policy and the disclaimer.';
             }
             field(Disclaimer; DisclaimerLbl)
             {
                 ApplicationArea = All;
-                Caption = 'Microsft Business Central Disclaimer';
+                Caption = 'Per Tenant Extension (PTE) Disclaimer';
                 ToolTip = 'View the disclaimer.';
                 Editable = false;
                 ShowCaption = false;
@@ -100,20 +100,6 @@ page 2507 "Upload And Deploy Extension"
                 trigger OnDrillDown()
                 begin
                     Hyperlink(ExtensionInstallationImpl.GetDisclaimerURL());
-                end;
-            }
-            field(PrivacyAndCookies; PrivacyAndCookiesLbl)
-            {
-                ApplicationArea = All;
-                Caption = 'Privacy and Cookies';
-                ToolTip = 'View the privacy and cookies.';
-                Editable = false;
-                ShowCaption = false;
-                Style = None;
-
-                trigger OnDrillDown()
-                begin
-                    Hyperlink(ExtensionInstallationImpl.GetPrivacyAndCookeisURL());
                 end;
             }
             field(BestPractices; 'Read more about the best practices for installing and publishing extensions')
@@ -194,8 +180,7 @@ page 2507 "Upload And Deploy Extension"
         DialogTitleTxt: Label 'Select .APP';
         AppFileFilterTxt: Label 'Extension Files|*.app', Locked = true;
         ExtensionNotUploadedMsg: Label 'Please upload an extension file before clicking "Deploy" button.';
-        DisclaimerLbl: Label 'Microsoft Business Central PTE Disclaimer';
-        PrivacyAndCookiesLbl: Label 'Privacy and Cookies';
+        DisclaimerLbl: Label 'Per Tenant Extension (PTE) Disclaimer';
         IsAccepted: Boolean;
 }
 

--- a/src/System Application/App/Extension Management/src/UploadAndDeployExtension.Page.al
+++ b/src/System Application/App/Extension Management/src/UploadAndDeployExtension.Page.al
@@ -85,13 +85,13 @@ page 2507 "Upload And Deploy Extension"
             field(Accepted; IsAccepted)
             {
                 ApplicationArea = All;
-                Caption = 'By deploying this extension you acknowledge that your data may be sent outside the compliance boundary of Business Central. Each per tenant extension is subject to its own third party terms and conditions and privacy policies.';
+                Caption = 'By deploying this extension you acknowledge that your data may be sent outside the compliance boundary of Business Central. Each per-tenant extension is subject to its own third party terms and conditions and privacy policies.';
                 ToolTip = 'Specifies that you accept the privacy policy and the disclaimer.';
             }
             field(Disclaimer; DisclaimerLbl)
             {
                 ApplicationArea = All;
-                Caption = 'Per Tenant Extension (PTE) Disclaimer';
+                Caption = 'Per-Tenant Extension (PTE) Disclaimer';
                 ToolTip = 'View the disclaimer.';
                 Editable = false;
                 ShowCaption = false;
@@ -180,7 +180,7 @@ page 2507 "Upload And Deploy Extension"
         DialogTitleTxt: Label 'Select .APP';
         AppFileFilterTxt: Label 'Extension Files|*.app', Locked = true;
         ExtensionNotUploadedMsg: Label 'Please upload an extension file before clicking "Deploy" button.';
-        DisclaimerLbl: Label 'Per Tenant Extension (PTE) Disclaimer';
+        DisclaimerLbl: Label 'Per-Tenant Extension (PTE) Disclaimer';
         IsAccepted: Boolean;
 }
 


### PR DESCRIPTION
Make it clear in the UI that we are referring to 3rd party extensions, not Microsoft extensions.

* Remove the “Microsoft Business Central “ – have “Per Tenant Extension (PTE) Disclaimer”
* Remove completely the link to our Privacy and  cookies
* Add to the following UI (after clicking Deploy) the following sentences “By deploying this extension you acknowledge that your data may be sent outside the compliance boundary of Business Central. Each per tenant extension is subject to its own third party terms and conditions and privacy policies.”