### PR TITLE
New Compare Methods for Time and DateTime Comparison

### DIFF
--- a/src/System Application/App/Date and Time/src/DateAndTimeHelper.Codeunit.al
+++ b/src/System Application/App/Date and Time/src/DateAndTimeHelper.Codeunit.al
@@ -9,6 +9,51 @@ codeunit 8722 "Date and Time Helper"
     InherentPermissions = X;
 
     /// <summary>
+    /// Compares two DateTime values and returns true if the FirstDateTime is greater than the SecondDateTime.
+    /// The DateTimes are rounded to SQL Server accuracy before comparison,
+    /// to account for the fact that SQL Server rounds DateTime values to the nearest 0, 3, or 7 milliseconds.
+    /// </summary>
+    /// <param name="FirstDateTime">The first DateTime value to compare.</param>
+    /// <param name="SecondDateTime">The second DateTime value to compare</param>
+    /// <returns>true if the FirstDateTime is greater than the SecondDateTime; otherwise, false.</returns>
+    procedure IsGreater(FirstDateTime: DateTime; SecondDateTime: DateTime): Boolean
+    var
+        DateandTimeHelperImpl: Codeunit "Date and Time Helper Impl.";
+    begin
+        exit(DateandTimeHelperImpl.Compare(FirstDateTime, SecondDateTime) = 1);
+    end;
+
+    /// <summary>
+    /// Compares two DateTime values and returns true if the FirstDateTime is less than the SecondDateTime.
+    /// The DateTimes are rounded to SQL Server accuracy before comparison,
+    /// to account for the fact that SQL Server rounds DateTime values to the nearest 0, 3, or 7 milliseconds.
+    /// </summary>
+    /// <param name="FirstDateTime">The first DateTime value to compare.</param>
+    /// <param name="SecondDateTime">The second DateTime value to compare</param>
+    /// <returns>true if the FirstDateTime is less than the SecondDateTime; otherwise, false.</returns>
+    procedure IsLess(FirstDateTime: DateTime; SecondDateTime: DateTime): Boolean
+    var
+        DateandTimeHelperImpl: Codeunit "Date and Time Helper Impl.";
+    begin
+        exit(DateandTimeHelperImpl.Compare(FirstDateTime, SecondDateTime) = -1);
+    end;
+
+    /// <summary>
+    /// Compares two DateTime values and returns true if the FirstDateTime is equal to the SecondDateTime.
+    /// The DateTimes are rounded to SQL Server accuracy before comparison,
+    /// to account for the fact that SQL Server rounds DateTime values to the nearest 0, 3, or 7 milliseconds.
+    /// </summary>
+    /// <param name="FirstDateTime">The first DateTime value to compare.</param>
+    /// <param name="SecondDateTime">The second DateTime value to compare</param>
+    /// <returns>true if the FirstDateTime is equal to the SecondDateTime; otherwise, false.</returns>
+    procedure IsEqual(FirstDateTime: DateTime; SecondDateTime: DateTime): Boolean
+    var
+        DateandTimeHelperImpl: Codeunit "Date and Time Helper Impl.";
+    begin
+        exit(DateandTimeHelperImpl.Compare(FirstDateTime, SecondDateTime) = 0);
+    end;
+
+    /// <summary>
     /// Compares two DateTime values and returns an integer indicating their relative order.
     ///         - 0 if the two values are equal.
     ///         - 1 if the firstDateTime is greater than the secondDateTime.
@@ -16,14 +61,14 @@ codeunit 8722 "Date and Time Helper"
     /// The DateTimes are rounded to SQL Server accuracy before comparison,
     /// to account for the fact that SQL Server rounds DateTime values to the nearest 0, 3, or 7 milliseconds.
     /// </summary>
-    /// <param name="firstDateTime">The first DateTime value to compare.</param>
-    /// <param name="secondDateTime">The second DateTime value to compare</param>
+    /// <param name="FirstDateTime">The first DateTime value to compare.</param>
+    /// <param name="SecondDateTime">The second DateTime value to compare</param>
     /// <returns>An integer indicating the relative order of the two DateTime values</returns>
-    procedure CompareDateTimes(firstTime: DateTime; secondTime: DateTime): Integer
+    procedure Compare(FirstDateTime: DateTime; SecondDateTime: DateTime): Integer
     var
         DateandTimeHelperImpl: Codeunit "Date and Time Helper Impl.";
     begin
-        exit(DateandTimeHelperImpl.CompareDateTimes(firstTime, secondTime));
+        exit(DateandTimeHelperImpl.Compare(FirstDateTime, SecondDateTime));
     end;
 
     /// <summary>
@@ -39,6 +84,51 @@ codeunit 8722 "Date and Time Helper"
     end;
 
     /// <summary>
+    /// Compares two Time values and returns true if the FirstTime is greater than the SecondTime.
+    /// The Times are rounded to SQL Server accuracy before comparison,
+    /// to account for the fact that SQL Server rounds DateTime values to the nearest 0, 3, or 7 milliseconds.
+    /// </summary>
+    /// <param name="FirstTime">The first Time value to compare.</param>
+    /// <param name="SecondTime">The second Time value to compare</param>
+    /// <returns>true if the FirstTime is greater than the SecondTime; otherwise, false.</returns>
+    procedure IsGreater(FirstTime: Time; SecondTime: Time): Boolean
+    var
+        DateandTimeHelperImpl: Codeunit "Date and Time Helper Impl.";
+    begin
+        exit(DateandTimeHelperImpl.Compare(FirstTime, SecondTime) = 1);
+    end;
+
+    /// <summary>
+    /// Compares two Time values and returns true if the FirstTime is less than the SecondTime.
+    /// The Times are rounded to SQL Server accuracy before comparison,
+    /// to account for the fact that SQL Server rounds DateTime values to the nearest 0, 3, or 7 milliseconds.
+    /// </summary>
+    /// <param name="FirstTime">The first Time value to compare.</param>
+    /// <param name="SecondTime">The second Time value to compare</param>
+    /// <returns>true if the FirstTime is less than the SecondTime; otherwise, false.</returns>
+    procedure IsLess(FirstTime: Time; SecondTime: Time): Boolean
+    var
+        DateandTimeHelperImpl: Codeunit "Date and Time Helper Impl.";
+    begin
+        exit(DateandTimeHelperImpl.Compare(FirstTime, SecondTime) = -1);
+    end;
+
+    /// <summary>
+    /// Compares two Time values and returns true if the FirstTime is equal to the SecondTime.
+    /// The Times are rounded to SQL Server accuracy before comparison,
+    /// to account for the fact that SQL Server rounds DateTime values to the nearest 0, 3, or 7 milliseconds.
+    /// </summary>
+    /// <param name="FirstTime">The first Time value to compare.</param>
+    /// <param name="SecondTime">The second Time value to compare</param>
+    /// <returns>true if the FirstTime is equal to the SecondTime; otherwise, false.</returns>
+    procedure IsEqual(FirstTime: Time; SecondTime: Time): Boolean
+    var
+        DateandTimeHelperImpl: Codeunit "Date and Time Helper Impl.";
+    begin
+        exit(DateandTimeHelperImpl.Compare(FirstTime, SecondTime) = 0);
+    end;
+
+    /// <summary>
     /// Compares two Time values and returns an integer indicating their relative order.
     ///         - 0 if the two values are equal.
     ///         - 1 if the firstTime is greater than the secondTime.
@@ -46,14 +136,14 @@ codeunit 8722 "Date and Time Helper"
     /// The Times are rounded to SQL Server accuracy before comparison,
     /// to account for the fact that SQL Server rounds DateTime values to the nearest 0, 3, or 7 milliseconds.
     /// </summary>
-    /// <param name="firstTime">The first Time value to compare.</param>
-    /// <param name="secondTime">The second Time value to compare</param>
+    /// <param name="FirstTime">The first Time value to compare.</param>
+    /// <param name="SecondTime">The second Time value to compare</param>
     /// <returns>An integer indicating the relative order of the two Time values</returns>
-    procedure CompareTimes(firstTime: Time; secondTime: Time): Integer
+    procedure Compare(FirstTime: Time; SecondTime: Time): Integer
     var
         DateandTimeHelperImpl: Codeunit "Date and Time Helper Impl.";
     begin
-        exit(DateandTimeHelperImpl.CompareTimes(firstTime, secondTime));
+        exit(DateandTimeHelperImpl.Compare(FirstTime, SecondTime));
     end;
 
     /// <summary>

--- a/src/System Application/App/Date and Time/src/DateAndTimeHelper.Codeunit.al
+++ b/src/System Application/App/Date and Time/src/DateAndTimeHelper.Codeunit.al
@@ -1,0 +1,71 @@
+namespace System.DateTime;
+
+/// <summary>
+/// Codeunit that provides helper methods for DateTime and Time types.
+/// </summary>
+codeunit 8722 "Date and Time Helper"
+{
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    /// <summary>
+    /// Compares two DateTime values and returns an integer indicating their relative order.
+    ///         - 0 if the two values are equal.
+    ///         - 1 if the firstDateTime is greater than the secondDateTime.
+    ///         - -1 if the firstDateTime is less than the secondDateTime.
+    /// The DateTimes are rounded to SQL Server accuracy before comparison,
+    /// to account for the fact that SQL Server rounds DateTime values to the nearest 0, 3, or 7 milliseconds.
+    /// </summary>
+    /// <param name="firstDateTime">The first DateTime value to compare.</param>
+    /// <param name="secondDateTime">The second DateTime value to compare</param>
+    /// <returns>An integer indicating the relative order of the two DateTime values</returns>
+    procedure CompareDateTimes(firstTime: DateTime; secondTime: DateTime): Integer
+    var
+        DateandTimeHelperImpl: Codeunit "Date and Time Helper Impl.";
+    begin
+        exit(DateandTimeHelperImpl.CompareDateTimes(firstTime, secondTime));
+    end;
+
+    /// <summary>
+    /// Rounds the given DateTime value to the nearest value that can be accurately represented in SQL Server.
+    /// </summary>
+    /// <param name="DateTimeToRound">The DateTime value to round.</param>
+    /// <returns>The rounded DateTime value.</returns>
+    procedure RoundToSQLAccuracy(DateTimeToRound: DateTime): DateTime
+    var
+        DateandTimeHelperImpl: Codeunit "Date and Time Helper Impl.";
+    begin
+        exit(DateandTimeHelperImpl.RoundToSQLAccuracy(DateTimeToRound));
+    end;
+
+    /// <summary>
+    /// Compares two Time values and returns an integer indicating their relative order.
+    ///         - 0 if the two values are equal.
+    ///         - 1 if the firstTime is greater than the secondTime.
+    ///         - -1 if the firstTime is less than the secondTime.
+    /// The Times are rounded to SQL Server accuracy before comparison,
+    /// to account for the fact that SQL Server rounds DateTime values to the nearest 0, 3, or 7 milliseconds.
+    /// </summary>
+    /// <param name="firstTime">The first Time value to compare.</param>
+    /// <param name="secondTime">The second Time value to compare</param>
+    /// <returns>An integer indicating the relative order of the two Time values</returns>
+    procedure CompareTimes(firstTime: Time; secondTime: Time): Integer
+    var
+        DateandTimeHelperImpl: Codeunit "Date and Time Helper Impl.";
+    begin
+        exit(DateandTimeHelperImpl.CompareTimes(firstTime, secondTime));
+    end;
+
+    /// <summary>
+    /// Rounds the given Time value to the nearest value that can be accurately represented in SQL Server.
+    /// </summary>
+    /// <param name="TimeToRound">The Time value to round.</param>
+    /// <returns>The rounded Time value.</returns>
+    procedure RoundToSQLAccuracy(TimeToRound: Time): Time
+    var
+        DateandTimeHelperImpl: Codeunit "Date and Time Helper Impl.";
+    begin
+        exit(DateandTimeHelperImpl.RoundToSQLAccuracy(TimeToRound));
+    end;
+
+}

--- a/src/System Application/App/Date and Time/src/DateAndTimeHelperImpl.Codeunit.al
+++ b/src/System Application/App/Date and Time/src/DateAndTimeHelperImpl.Codeunit.al
@@ -9,72 +9,62 @@ codeunit 8723 "Date and Time Helper Impl."
     InherentPermissions = X;
     Access = Internal;
 
-    procedure CompareDateTimes(firstDateTime: DateTime; secondDateTime: DateTime): Integer
+    procedure Compare(FirstDateTime: DateTime; SecondDateTime: DateTime): Integer
     begin
-        if firstDateTime = secondDateTime then
+        if FirstDateTime = SecondDateTime then
             exit(0);
 
-        if firstDateTime = 0DT then
+        if FirstDateTime = 0DT then
             exit(-1);
 
-        if secondDateTime = 0DT then
+        if SecondDateTime = 0DT then
             exit(1);
 
         // Round the Time values to the nearest 0, 3, or 7 milliseconds.
-        firstDateTime := RoundToSQLAccuracy(firstDateTime);
-        secondDateTime := RoundToSQLAccuracy(secondDateTime);
+        FirstDateTime := RoundToSQLAccuracy(FirstDateTime);
+        SecondDateTime := RoundToSQLAccuracy(SecondDateTime);
 
-        if firstDateTime = secondDateTime then
+        if FirstDateTime = SecondDateTime then
             exit(0);
 
-        if firstDateTime > secondDateTime then
+        if FirstDateTime > SecondDateTime then
             exit(1);
 
         exit(-1);
     end;
 
     procedure RoundToSQLAccuracy(DateTimeToRound: DateTime): DateTime
+    var
+        TimeToRound: Time;
+        RoundedTime: Time;
     begin
-        // Rounds the specified DateTime value to the nearest 0, 3, or 7 milliseconds.
-        case (DateTimeToRound - 0DT) mod 10 of
-            1:
-                exit(DateTimeToRound - 1); // round to 0
-            2:
-                exit(DateTimeToRound + 1); // round to 3
-            4:
-                exit(DateTimeToRound - 1); // round to 3
-            5:
-                exit(DateTimeToRound + 2); // round to 7
-            6:
-                exit(DateTimeToRound + 1); // round to 7
-            8:
-                exit(DateTimeToRound - 1); // round to 7
-            9:
-                exit(DateTimeToRound + 1); // round to 0
-            else
-                exit(DateTimeToRound);
-        end;
+        TimeToRound := DT2Time(DateTimeToRound);
+        RoundedTime := RoundToSQLAccuracy(TimeToRound);
+        if RoundedTime <> TimeToRound then
+            exit(CreateDateTime(DT2Date(DateTimeToRound), RoundedTime))
+        else
+            exit(DateTimeToRound);
     end;
 
-    procedure CompareTimes(firstTime: Time; secondTime: Time): Integer
+    procedure Compare(FirstTime: Time; SecondTime: Time): Integer
     begin
-        if firstTime = secondTime then
+        if FirstTime = SecondTime then
             exit(0);
 
-        if firstTime = 0T then
+        if FirstTime = 0T then
             exit(-1);
 
-        if secondTime = 0T then
+        if SecondTime = 0T then
             exit(1);
 
         // Round the Time values to the nearest 0, 3, or 7 milliseconds.
-        firstTime := RoundToSQLAccuracy(firstTime);
-        secondTime := RoundToSQLAccuracy(secondTime);
+        FirstTime := RoundToSQLAccuracy(FirstTime);
+        SecondTime := RoundToSQLAccuracy(SecondTime);
 
-        if firstTime = secondTime then
+        if FirstTime = SecondTime then
             exit(0);
 
-        if firstTime > secondTime then
+        if FirstTime > SecondTime then
             exit(1);
 
         exit(-1);

--- a/src/System Application/App/Date and Time/src/DateAndTimeHelperImpl.Codeunit.al
+++ b/src/System Application/App/Date and Time/src/DateAndTimeHelperImpl.Codeunit.al
@@ -1,0 +1,105 @@
+namespace System.DateTime;
+
+/// <summary>
+/// Codeunit that provides helper methods for DateTime and Time types.
+/// </summary>
+codeunit 8723 "Date and Time Helper Impl."
+{
+    InherentEntitlements = X;
+    InherentPermissions = X;
+    Access = Internal;
+
+    procedure CompareDateTimes(firstDateTime: DateTime; secondDateTime: DateTime): Integer
+    begin
+        if firstDateTime = secondDateTime then
+            exit(0);
+
+        if firstDateTime = 0DT then
+            exit(-1);
+
+        if secondDateTime = 0DT then
+            exit(1);
+
+        // Round the Time values to the nearest 0, 3, or 7 milliseconds.
+        firstDateTime := RoundToSQLAccuracy(firstDateTime);
+        secondDateTime := RoundToSQLAccuracy(secondDateTime);
+
+        if firstDateTime = secondDateTime then
+            exit(0);
+
+        if firstDateTime > secondDateTime then
+            exit(1);
+
+        exit(-1);
+    end;
+
+    procedure RoundToSQLAccuracy(DateTimeToRound: DateTime): DateTime
+    begin
+        // Rounds the specified DateTime value to the nearest 0, 3, or 7 milliseconds.
+        case (DateTimeToRound - 0DT) mod 10 of
+            1:
+                exit(DateTimeToRound - 1); // round to 0
+            2:
+                exit(DateTimeToRound + 1); // round to 3
+            4:
+                exit(DateTimeToRound - 1); // round to 3
+            5:
+                exit(DateTimeToRound + 2); // round to 7
+            6:
+                exit(DateTimeToRound + 1); // round to 7
+            8:
+                exit(DateTimeToRound - 1); // round to 7
+            9:
+                exit(DateTimeToRound + 1); // round to 0
+            else
+                exit(DateTimeToRound);
+        end;
+    end;
+
+    procedure CompareTimes(firstTime: Time; secondTime: Time): Integer
+    begin
+        if firstTime = secondTime then
+            exit(0);
+
+        if firstTime = 0T then
+            exit(-1);
+
+        if secondTime = 0T then
+            exit(1);
+
+        // Round the Time values to the nearest 0, 3, or 7 milliseconds.
+        firstTime := RoundToSQLAccuracy(firstTime);
+        secondTime := RoundToSQLAccuracy(secondTime);
+
+        if firstTime = secondTime then
+            exit(0);
+
+        if firstTime > secondTime then
+            exit(1);
+
+        exit(-1);
+    end;
+
+    procedure RoundToSQLAccuracy(TimeToRound: Time): Time
+    begin
+        // Rounds the specified Time value to the nearest 0, 3, or 7 milliseconds.
+        case (TimeToRound - 000000T) mod 10 of
+            1:
+                exit(TimeToRound - 1); // round to 0
+            2:
+                exit(TimeToRound + 1); // round to 3
+            4:
+                exit(TimeToRound - 1); // round to 3
+            5:
+                exit(TimeToRound + 2); // round to 7
+            6:
+                exit(TimeToRound + 1); // round to 7
+            8:
+                exit(TimeToRound - 1); // round to 7
+            9:
+                exit(TimeToRound + 1); // round to 0
+            else
+                exit(TimeToRound);
+        end;
+    end;
+}

--- a/src/System Application/Test/Date and Time/src/DateAndTimeHelperTest.Codeunit.al
+++ b/src/System Application/Test/Date and Time/src/DateAndTimeHelperTest.Codeunit.al
@@ -1,0 +1,89 @@
+namespace System.Test.DateTime;
+
+using System.DateTime;
+using System.TestLibraries.Utilities;
+
+codeunit 132980 "Date and Time Helper Test"
+{
+    Subtype = Test;
+
+    var
+        LibraryAssert: Codeunit "Library Assert";
+        Any: Codeunit Any;
+        IsInitialized: Boolean;
+        DSTTimeZoneData: Dictionary of [Text, Decimal];
+        NonDSTTimeZoneData: Dictionary of [Text, Decimal];
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TestDateTimeComparison()
+    var
+        DateAndTimeHelper: Codeunit "Date and Time Helper";
+        DateTimeA: DateTime;
+        DateTimeB: DateTime;
+        Threshold: Integer;
+    begin
+        // Threshold for equality when comparing DateTime values. If the difference
+        // is less than this value, then we treat them as equal values.
+        Threshold := 10;
+
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareDateTimes(DateTimeA, DateTimeB) = 0, 'Return value should be 0 for two null values.');
+
+        DateTimeA := CurrentDateTime();
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareDateTimes(DateTimeA, DateTimeB) > 0, 'Return value should be > 0 if second value is null.');
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareDateTimes(DateTimeB, DateTimeA) < 0, 'Return value should be < 0 if first value is null.');
+
+        DateTimeB := DateTimeA;
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareDateTimes(DateTimeA, DateTimeB) = 0, 'Return value should be 0 for equal values.');
+
+        DateTimeB := DateTimeA + Any.IntegerInRange(0, Threshold - 1);
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareDateTimes(DateTimeA, DateTimeB) = 0, 'Return value should be 0 for values within threshold.');
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareDateTimes(DateTimeB, DateTimeA) = 0, 'Return value should be 0 for values within threshold.');
+
+        DateTimeB := DateTimeA + Threshold;
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareDateTimes(DateTimeA, DateTimeB) < 0, 'Return value should be < 0.');
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareDateTimes(DateTimeB, DateTimeA) > 0, 'Return value should be > 0.');
+
+        DateTimeB := DateTimeA + Any.IntegerInRange(Threshold + 1, 500);
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareDateTimes(DateTimeA, DateTimeB) < 0, 'Return value should be < 0.');
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareDateTimes(DateTimeB, DateTimeA) > 0, 'Return value should be > 0.');
+    end;
+
+    [Test]
+    procedure TestTimeComparison()
+    var
+        DateAndTimeHelper: Codeunit "Date and Time Helper";
+        TimeA: Time;
+        TimeB: Time;
+        Threshold: Integer;
+    begin
+        // Threshold for equality when comparing Time values. If the difference
+        // is less than this value, then we treat them as equal values.
+        Threshold := 10;
+
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareTimes(TimeA, TimeB) = 0, 'Return value should be 0 for two null values.');
+
+        TimeA := DT2Time(CurrentDateTime());
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareTimes(TimeA, TimeB) > 0, 'Return value should be > 0 if second value is null.');
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareTimes(TimeB, TimeA) < 0, 'Return value should be < 0 if first value is null.');
+
+        TimeB := TimeA;
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareTimes(TimeA, TimeB) = 0, 'Return value should be 0 for equal values.');
+
+        TimeB := TimeA + Any.IntegerInRange(0, Threshold - 1);
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareTimes(TimeA, TimeB) = 0, 'Return value should be 0 for values within threshold.');
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareTimes(TimeB, TimeA) = 0, 'Return value should be 0 for values within threshold.');
+
+        TimeB := TimeA + Threshold;
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareTimes(TimeA, TimeB) < 0, 'Return value should be < 0.');
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareTimes(TimeB, TimeA) > 0, 'Return value should be > 0.');
+
+        TimeB := TimeA + Any.IntegerInRange(Threshold + 1, 500);
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareTimes(TimeA, TimeB) < 0, 'Return value should be < 0.');
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareTimes(TimeB, TimeA) > 0, 'Return value should be > 0.');
+
+        TimeA := 235959.999T;
+        TimeB := 000000.000T;
+        LibraryAssert.IsTrue(DateAndTimeHelper.CompareTimes(TimeA, TimeB) = 0, 'Return value should be 0 for values that would be equal after sql server rounding.');
+    end;
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
# Summary <!-- Provide a general summary of your changes -->
Add Methods to for DateTimes and Times:
- Compare
- IsGreater
- IsLess
- IsEqual
- RoundToSQLAccuracy

# Please give feedback for the following points

- [ ] Do we really need and want a procedure that only tells us whether two (date)times are very close? Would we use the procedure also if the SQL rounding issue never existed? (See https://github.com/microsoft/BusinessCentralApps/issues/483#issuecomment-1805345350)
- [ ] CompareTimes is now missing the case, when both times are guaranteed unrounded (See https://github.com/microsoft/BusinessCentralApps/issues/483#issuecomment-1804541820)
- [ ] I don't like the Codeunit Naming "Date and Time Helper", any better ideas?


# Work Item(s) <!-- Add the issue number here after the # -->
Fixes #335