### PR TITLE
RSACryptoServiceProvider missing function to initialize an instance of the provider

### DIFF
--- a/src/System Application/App/Cryptography Management/src/RSACryptoServiceProvider.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/RSACryptoServiceProvider.Codeunit.al
@@ -19,6 +19,15 @@ codeunit 1445 "RSACryptoServiceProvider"
         RSACryptoServiceProviderImpl: Codeunit "RSACryptoServiceProvider Impl.";
 
     /// <summary>
+    /// Initializes a new instance of RSACryptoServiceProvider with the specified key size and returns the key as an XML string. 
+    /// </summary>
+    /// <param name="KeySize">The size of the key in bits.</param>
+    procedure InitializeRSA(KeySize: Integer)
+    begin
+        RSACryptoServiceProviderImpl.InitializeRSA(KeySize);
+    end;
+
+    /// <summary>
     /// Creates and returns an XML string containing the key of the current RSA object.
     /// </summary>
     /// <param name="IncludePrivateParameters">true to include a public and private RSA key; false to include only the public key.</param>

--- a/src/System Application/App/Cryptography Management/src/RSACryptoServiceProviderImpl.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/RSACryptoServiceProviderImpl.Codeunit.al
@@ -16,6 +16,11 @@ codeunit 1446 "RSACryptoServiceProvider Impl." implements SignatureAlgorithm
     var
         DotNetRSACryptoServiceProvider: DotNet RSACryptoServiceProvider;
 
+    procedure InitializeRSA(KeySize: Integer)
+    begin
+        DotNetRSACryptoServiceProvider := DotNetRSACryptoServiceProvider.RSACryptoServiceProvider(KeySize);
+    end;
+
     procedure GetInstance(var DotNetAsymmetricAlgorithm: DotNet AsymmetricAlgorithm)
     begin
         DotNetAsymmetricAlgorithm := DotNetRSACryptoServiceProvider;

--- a/src/System Application/Test/Cryptography Management/src/RSACryptoServiceProviderTests.Codeunit.al
+++ b/src/System Application/Test/Cryptography Management/src/RSACryptoServiceProviderTests.Codeunit.al
@@ -33,6 +33,24 @@ codeunit 132613 RSACryptoServiceProviderTests
     end;
 
     [Test]
+    procedure InitializeKeys()
+    var
+        KeyXml: XmlDocument;
+        Root: XmlElement;
+        Node: XmlNode;
+        KeyXmlText: Text;
+    begin
+        RSACryptoServiceProvider.InitializeRSA(2048);
+        KeyXmlText := RSACryptoServiceProvider.ToXmlString(true);
+
+        Assert.IsTrue(XmlDocument.ReadFrom(KeyXmlText, KeyXml), 'RSA key is not valid xml data.');
+        Assert.IsTrue(KeyXml.GetRoot(Root), 'Could not get Root element of key.');
+
+        Assert.IsTrue(Root.SelectSingleNode('Modulus', Node), 'Could not find <Modulus> in key.');
+        Assert.IsTrue(Root.SelectSingleNode('DQ', Node), 'Could not find <DQ> in key.');
+    end;
+
+    [Test]
     procedure TestSignDataWithCert()
     var
         TempBlob: Codeunit "Temp Blob";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
A funciton is added to RSACryptoServiceProvider to initialize an instance of the provider.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #305 
