### PR TITLE
[User personalization] The settings' Teaching Tips field does not update when moving between records (next and previous)

### DIFF
--- a/src/System Application/App/User Settings/src/UserPersonalization.Page.al
+++ b/src/System Application/App/User Settings/src/UserPersonalization.Page.al
@@ -135,7 +135,10 @@ page 9214 "User Personalization"
         UserSettingsImpl.HideUsersDependingOnPermissions(Rec);
         UserSettingsImpl.HideExternalUsers(Rec);
         CurrPage.Caption := UserSettingsTok;
+    end;
 
+    trigger OnAfterGetCurrRecord()
+    begin
         TeachingTipsEnabled := UserSettingsImpl.TeachingTipsEnabled(Rec."User SID");
     end;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #
