### PR TITLE
Add reference "FindBlobsByTags" from the "ABS Client Impl." codeunit to the "ABS Blob Client"

### DIFF
--- a/src/System Application/App/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
@@ -570,6 +570,18 @@ codeunit 9053 "ABS Blob Client"
     end;
 
     /// <summary>
+    /// The Find Blobs By Tags operation retrieves blobs based on user-defined tags for the specified blob, represented as one or more key-value pairs.
+    /// see: https://go.microsoft.com/fwlink/?linkid=2211407
+    /// </summary> 
+    /// <param name="SearchTags">A Dictionary of [Text, Text] with tags to search on.</param>   
+    /// <param name="FoundBlobs">An XmlDocument containing the results of the identified blobs.</param>    
+    /// <returns>An operation response object</returns>
+    procedure FindBlobsByTags(SearchTags: Dictionary of [Text, Text]; var FoundBlobs: XmlDocument): Codeunit "ABS Operation Response"
+    begin
+        exit(ABSClientImpl.FindBlobsByTags(SearchTags, FoundBlobs));
+    end;
+
+    /// <summary>
     /// The Get Blob Tags operation gets user-defined tags for the specified blob as XmlDocument.
     /// see: https://go.microsoft.com/fwlink/?linkid=2211502
     /// </summary>


### PR DESCRIPTION
#### Summary 
BC Idea Link
https://experience.dynamics.com/ideas/idea/?ideaid=6c231259-217e-ee11-a81c-000d3ae53364

Description
I want to filter the blobs by their tags.

The function is allready created in the implementation codeunit but is not added to the client.

In this pull request, I included the function in the client codeunit.

#### Work Item(s) 
Add reference "FindBlobsByTags" from the "ABS Client Impl." codeunit to the "ABS Blob Client" codeunit #314 
https://github.com/microsoft/BCApps/issues/314
