### PR TITLE
Make the 'Extension Marketplace' page discoverable with 'AppSource' search term

### DIFF
--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Page.al
@@ -14,6 +14,7 @@ using System.Utilities;
 page 2502 "Extension Marketplace"
 {
     Caption = 'Extension Marketplace';
+    AdditionalSearchTerms = 'app,add-in,customize,plug-in,appsource';
     PageType = Card;
     ApplicationArea = All;
     UsageCategory = Administration;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

I often find myself searching for 'AppSource' via 'Tell me' to install apps from AppSource, but don't get the expected 'Extension Marketplace' page in the search results. 

It would be nice if the 'Extension Marketplace' page was discoverable using the same keywords (at least 'appsource'), similar to the 'Extension Management' page. 

`AdditionalSearchTerms = 'app,add-in,customize,plug-in,appsource';`

_AppSource_ seems to be a valid search term as well in the BC community, compared to just 'marketplace'...

---

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #370
<br /><br />Internal work item: AB#492551
