### PR TITLE
[Email] Use Sent From email in EmailViewer

### DIFF
--- a/src/System Application/App/Email/src/Email/Sent/EmailViewer.Page.al
+++ b/src/System Application/App/Email/src/Email/Sent/EmailViewer.Page.al
@@ -218,10 +218,10 @@ page 12 "Email Viewer"
 
     local procedure UpdateFromField(EmailAccountRec: Record "Email Account" temporary)
     begin
-        if EmailAccountRec."Email Address" = '' then
+        if Rec."Sent From" = '' then
             FromDisplayName := ''
         else
-            FromDisplayName := StrSubstNo(FromDisplayNameLbl, EmailAccountRec.Name, EmailAccountRec."Email Address");
+            FromDisplayName := StrSubstNo(FromDisplayNameLbl, EmailAccountRec.Name, Rec."Sent From");
     end;
 
     var


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
The EmailViewer is using the Email Account's "Email Address" field. This is always the current user's email and not the email address of the user who sent the email.

This PR uses the stored Sent Email's "Sent From" to show the correct email address of the sender.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes AB#491830

