### PR TITLE
[Copilot] Adding telemetry tag for retrying generation completion

### DIFF
--- a/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
@@ -286,6 +286,7 @@ codeunit 2012 "Entity Text Impl."
                 exit(Completion);
 
             Sleep(500);
+            Session.LogMessage('0000LVP', StrSubstNo(TelemetryGenerationRetryTxt, Attempt + 1), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', TelemetryCategoryLbl);
         end;
 
         // this completion is of low quality
@@ -472,4 +473,5 @@ codeunit 2012 "Entity Text Impl."
         TelemetryCompletionExtraTextTxt: Label 'The completion contains a Translation or Note section.', Locked = true;
         TelemetryPromptManyFactsTxt: Label 'There are %1 facts defined, they will be limited to %2.', Locked = true;
         TelemetryNoAuthorizationHandlerTxt: Label 'Entity Text authorization was not set.', Locked = true;
+        TelemetryGenerationRetryTxt: Label 'Retrying text generation, attempt: %1', Locked = true;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
In marketing text generation added tag `0000LVP` emitted when a generation is retried. It is emitted when the generation was not of good quality or failed, and contains the generation attempt number.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes AB#491911


