### PR TITLE
[Copilot reminder texts] New enum values and events to support feature-specific prompt, capability and saving the accepted suggestion

### DIFF
--- a/src/System Application/App/Entity Text/src/EntityText.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityText.Codeunit.al
@@ -81,6 +81,23 @@ codeunit 2010 "Entity Text"
         exit(EntityTextImpl.GenerateSuggestion(Facts, Tone, TextFormat, TextEmphasis, CurrentModuleInfo));
     end;
 
+    /// <summary>
+    /// Generate Entity Text using AI capabilities.
+    /// </summary>
+    /// <param name="SourceTableId">The number of the table for which you are generating text.</param>
+    /// <param name="Facts">The Facts of the Entity used for generation.</param>
+    /// <param name="Tone">The tone of the generated text.</param>
+    /// <param name="TextFormat">The length and format of the generated text.</param>
+    /// <param name="TextEmphasis">Feature to emphasize.</param>
+    /// <returns>Generated entity text.</returns>
+    procedure GenerateText(SourceTableId: Integer; Facts: Dictionary of [Text, Text]; Tone: Enum "Entity Text Tone"; TextFormat: Enum "Entity Text Format"; TextEmphasis: Enum "Entity Text Emphasis"): Text
+    var
+        CurrentModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CurrentModuleInfo);
+        exit(EntityTextImpl.GenerateSuggestion(SourceTableId, Facts, Tone, TextFormat, TextEmphasis, CurrentModuleInfo));
+    end;
+
 
     /// <summary>
     /// Updates the Entity Text record with the current text.

--- a/src/System Application/App/Entity Text/src/EntityText.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityText.Codeunit.al
@@ -84,18 +84,18 @@ codeunit 2010 "Entity Text"
     /// <summary>
     /// Generate Entity Text using AI capabilities.
     /// </summary>
-    /// <param name="SourceTableId">The number of the table for which you are generating text.</param>
     /// <param name="Facts">The Facts of the Entity used for generation.</param>
     /// <param name="Tone">The tone of the generated text.</param>
     /// <param name="TextFormat">The length and format of the generated text.</param>
     /// <param name="TextEmphasis">Feature to emphasize.</param>
+    /// <param name="Scenario">The entity text scenario.</param>
     /// <returns>Generated entity text.</returns>
-    procedure GenerateText(SourceTableId: Integer; Facts: Dictionary of [Text, Text]; Tone: Enum "Entity Text Tone"; TextFormat: Enum "Entity Text Format"; TextEmphasis: Enum "Entity Text Emphasis"): Text
+    procedure GenerateText(Facts: Dictionary of [Text, Text]; Tone: Enum "Entity Text Tone"; TextFormat: Enum "Entity Text Format"; TextEmphasis: Enum "Entity Text Emphasis"; Scenario: Enum "Entity Text Scenario"): Text
     var
         CurrentModuleInfo: ModuleInfo;
     begin
         NavApp.GetCallerModuleInfo(CurrentModuleInfo);
-        exit(EntityTextImpl.GenerateSuggestion(SourceTableId, Facts, Tone, TextFormat, TextEmphasis, CurrentModuleInfo));
+        exit(EntityTextImpl.GenerateSuggestion(Facts, Tone, TextFormat, TextEmphasis, CurrentModuleInfo, Scenario));
     end;
 
 

--- a/src/System Application/App/Entity Text/src/EntityText.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityText.Codeunit.al
@@ -95,7 +95,7 @@ codeunit 2010 "Entity Text"
         CurrentModuleInfo: ModuleInfo;
     begin
         NavApp.GetCallerModuleInfo(CurrentModuleInfo);
-        exit(EntityTextImpl.GenerateSuggestion(Facts, Tone, TextFormat, TextEmphasis, CurrentModuleInfo, Scenario));
+        exit(EntityTextImpl.GenerateSuggestion(Facts, Tone, TextFormat, TextEmphasis, CurrentModuleInfo, Format(Scenario)));
     end;
 
 

--- a/src/System Application/App/Entity Text/src/EntityTextCapability.EnumExt.al
+++ b/src/System Application/App/Entity Text/src/EntityTextCapability.EnumExt.al
@@ -7,5 +7,9 @@ enumextension 2015 "Entity Text Capability" extends "Copilot Capability"
     {
         Caption = 'Marketing text suggestions';
     }
+    value(2016; "Reminder Text")
+    {
+        Caption = 'Reminder text suggestions';
+    }
 
 }

--- a/src/System Application/App/Entity Text/src/EntityTextCapability.EnumExt.al
+++ b/src/System Application/App/Entity Text/src/EntityTextCapability.EnumExt.al
@@ -3,13 +3,13 @@ using System.AI;
 
 enumextension 2015 "Entity Text Capability" extends "Copilot Capability"
 {
+    value(2014; "Reminder Text")
+    {
+        Caption = 'Reminder text suggestions';
+    }
     value(2015; "Entity Text")
     {
         Caption = 'Marketing text suggestions';
-    }
-    value(2016; "Reminder Text")
-    {
-        Caption = 'Reminder text suggestions';
     }
 
 }

--- a/src/System Application/App/Entity Text/src/EntityTextEmphasis.Enum.al
+++ b/src/System Application/App/Entity Text/src/EntityTextEmphasis.Enum.al
@@ -67,4 +67,13 @@ enum 2012 "Entity Text Emphasis"
     {
         Caption = 'Speed';
     }
+
+    /// <summary>
+    /// Emphasizes consequences.
+    /// </summary>
+    value(7; Consequences)
+    {
+        Caption = 'Consequences';
+    }
+
 }

--- a/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
@@ -226,7 +226,7 @@ codeunit 2012 "Entity Text Impl."
     begin
         PromptSecretName := PromptObjectKeyTxt;
 
-        exit(GetPromptObject(PromptObjectKeyTxt))
+        exit(GetPromptObject(PromptSecretName))
     end;
 
     [NonDebuggable]

--- a/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
@@ -221,7 +221,11 @@ codeunit 2012 "Entity Text Impl."
 
     [NonDebuggable]
     local procedure GetPromptInfo(): JsonObject
+    var
+        PromptSecretName: Text;
     begin
+        PromptSecretName := PromptObjectKeyTxt;
+
         exit(GetPromptObject(PromptObjectKeyTxt))
     end;
 

--- a/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
@@ -243,7 +243,7 @@ codeunit 2012 "Entity Text Impl."
     end;
 
     [NonDebuggable]
-    local procedure GetPromptObject(var PromptSecretName: Text): JsonObject
+    local procedure GetPromptObject(PromptSecretName: Text): JsonObject
     var
         AzureKeyVault: Codeunit "Azure Key Vault";
         PromptObject: JsonObject;

--- a/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
@@ -47,7 +47,7 @@ codeunit 2012 "Entity Text Impl."
     [NonDebuggable]
     procedure GenerateSuggestion(Facts: Dictionary of [Text, Text]; Tone: Enum "Entity Text Tone"; TextFormat: Enum "Entity Text Format"; TextEmphasis: Enum "Entity Text Emphasis"; CallerModuleInfo: ModuleInfo): Text
     begin
-        exit(GenerateSuggestion(Facts, Tone, TextFormat, TextEmphasis, CallerModuleInfo, Enum::"Entity Text Scenario"::0));
+        exit(GenerateSuggestion(Facts, Tone, TextFormat, TextEmphasis, CallerModuleInfo, 0));
     end;
 
     [NonDebuggable]

--- a/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
@@ -47,7 +47,7 @@ codeunit 2012 "Entity Text Impl."
     [NonDebuggable]
     procedure GenerateSuggestion(Facts: Dictionary of [Text, Text]; Tone: Enum "Entity Text Tone"; TextFormat: Enum "Entity Text Format"; TextEmphasis: Enum "Entity Text Emphasis"; CallerModuleInfo: ModuleInfo): Text
     begin
-        exit(GenerateSuggestion(Facts, Tone, TextFormat, TextEmphasis, CallerModuleInfo, 0));
+        exit(GenerateSuggestion(Facts, Tone, TextFormat, TextEmphasis, CallerModuleInfo, Enum::"Entity Text Scenario"::0));
     end;
 
     [NonDebuggable]

--- a/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
@@ -159,7 +159,7 @@ codeunit 2012 "Entity Text Impl."
     end;
 
     [NonDebuggable]
-    local procedure BuildPrompts(var Facts: Dictionary of [Text, Text]; Tone: Enum "Entity Text Tone"; TextFormat: Enum "Entity Text Format"; TextEmphasis: Enum "Entity Text Emphasis"; var SystemPrompt: Text; var UserPrompt: Text; var SourceScenarioName: Text)
+    local procedure BuildPrompts(var Facts: Dictionary of [Text, Text]; Tone: Enum "Entity Text Tone"; TextFormat: Enum "Entity Text Format"; TextEmphasis: Enum "Entity Text Emphasis"; var SystemPrompt: Text; var UserPrompt: Text; SourceScenarioName: Text)
     var
         EntityTextAOAISettings: Codeunit "Entity Text AOAI Settings";
         PromptInfo: JsonObject;
@@ -230,7 +230,7 @@ codeunit 2012 "Entity Text Impl."
     end;
 
     [NonDebuggable]
-    local procedure GetPromptInfo(var SourceScenarioName: Text): JsonObject
+    local procedure GetPromptInfo(SourceScenarioName: Text): JsonObject
     var
         PromptSecretName: Text;
     begin
@@ -270,7 +270,7 @@ codeunit 2012 "Entity Text Impl."
 
     [TryFunction]
     [NonDebuggable]
-    procedure HasPromptInfo(var SourceScenarioName: Text)
+    procedure HasPromptInfo(SourceScenarioName: Text)
     begin
         GetPromptInfo(SourceScenarioName);
     end;
@@ -321,7 +321,7 @@ codeunit 2012 "Entity Text Impl."
     end;
 
     [NonDebuggable]
-    local procedure GenerateAndReviewCompletion(SystemPrompt: Text; UserPrompt: Text; TextFormat: Enum "Entity Text Format"; Facts: Dictionary of [Text, Text]; CallerModuleInfo: ModuleInfo; var SourceScenarioName: Text): Text
+    local procedure GenerateAndReviewCompletion(SystemPrompt: Text; UserPrompt: Text; TextFormat: Enum "Entity Text Format"; Facts: Dictionary of [Text, Text]; CallerModuleInfo: ModuleInfo; SourceScenarioName: Text): Text
     var
         Completion: Text;
         MaxAttempts: Integer;
@@ -446,7 +446,7 @@ codeunit 2012 "Entity Text Impl."
     end;
 
     [NonDebuggable]
-    local procedure GenerateCompletion(SystemPrompt: Text; UserPrompt: Text; CallerModuleInfo: ModuleInfo; var SourceScenarioName: Text): Text
+    local procedure GenerateCompletion(SystemPrompt: Text; UserPrompt: Text; CallerModuleInfo: ModuleInfo; SourceScenarioName: Text): Text
     var
         AzureOpenAI: Codeunit "Azure OpenAI";
         EntityTextAOAISettings: Codeunit "Entity Text AOAI Settings";
@@ -458,7 +458,6 @@ codeunit 2012 "Entity Text Impl."
         Result: Text;
         NewLineChar: Char;
         EntityTextModuleInfo: ModuleInfo;
-        Handled: Boolean;
         CopilotCapability: Enum "Copilot Capability";
     begin
         NewLineChar := 10;

--- a/src/System Application/App/Entity Text/src/EntityTextScenarioExt.EnumExt.al
+++ b/src/System Application/App/Entity Text/src/EntityTextScenarioExt.EnumExt.al
@@ -1,6 +1,6 @@
 namespace System.Text;
 
-enumextension 2016 "Entity Text Scenario Ext." extends "Entity Text Scenario"
+enumextension 2014 "Entity Text Scenario Ext." extends "Entity Text Scenario"
 {
     value(1; "Reminder Text")
     {

--- a/src/System Application/App/Entity Text/src/EntityTextScenarioExt.EnumExt.al
+++ b/src/System Application/App/Entity Text/src/EntityTextScenarioExt.EnumExt.al
@@ -1,6 +1,6 @@
 namespace System.Text;
 
-enumextension 2016 "Extity Text Scenario Ext." extends "Entity Text Scenario"
+enumextension 2016 "Entity Text Scenario Ext." extends "Entity Text Scenario"
 {
     value(1; "Reminder Text")
     {

--- a/src/System Application/App/Entity Text/src/EntityTextScenarioExt.EnumExt.al
+++ b/src/System Application/App/Entity Text/src/EntityTextScenarioExt.EnumExt.al
@@ -1,0 +1,9 @@
+namespace System.Text;
+
+enumextension 2016 "Extity Text Scenario Ext." extends "Entity Text Scenario"
+{
+    value(1; "Reminder Text")
+    {
+        Caption = 'Reminder Text';
+    }
+}

--- a/src/System Application/App/Entity Text/src/EntityTextScenarioExt.EnumExt.al
+++ b/src/System Application/App/Entity Text/src/EntityTextScenarioExt.EnumExt.al
@@ -2,7 +2,7 @@ namespace System.Text;
 
 enumextension 2014 "Entity Text Scenario Ext." extends "Entity Text Scenario"
 {
-    value(1; "Reminder Text")
+    value(2014; "Reminder Text")
     {
         Caption = 'Reminder Text';
     }

--- a/src/System Application/App/Entity Text/src/EntityTextTone.Enum.al
+++ b/src/System Application/App/Entity Text/src/EntityTextTone.Enum.al
@@ -51,4 +51,13 @@ enum 2011 "Entity Text Tone"
     {
         Caption = 'Creative';
     }
+
+    /// <summary>
+    /// The tone of voice should be empathetic.
+    /// </summary>
+    value(5; Empathetic)
+    {
+        Caption = 'Empathetic';
+    }
+
 }

--- a/src/System Application/App/Entity Text/src/EntityTextTone.Enum.al
+++ b/src/System Application/App/Entity Text/src/EntityTextTone.Enum.al
@@ -60,4 +60,12 @@ enum 2011 "Entity Text Tone"
         Caption = 'Empathetic';
     }
 
+    /// <summary>
+    /// The tone of voice should be severe.
+    /// </summary>
+    value(6; Severe)
+    {
+        Caption = 'Severe';
+    }
+
 }


### PR DESCRIPTION
Entity Text has a hardcoded completion prompt and Copilot Capability for 'Generate Marketing Text'. It also does the saving of accepted proposal in a very specific way (directly to Entity Text system table).
With this change I am:
- introducing overrides based on Entity Text Scenario, that enables Entity Text logic to be run for Reminder Text as well as for Marketing Text
- new tone and emphasis values.


<br /><br />Internal work item: AB#493390












