### PR TITLE
Add access to countryLetterCode and preferredLanguage from tenant info.

### DIFF
--- a/src/System Application/App/Azure AD Tenant/src/AzureADTenant.Codeunit.al
+++ b/src/System Application/App/Azure AD Tenant/src/AzureADTenant.Codeunit.al
@@ -46,15 +46,8 @@ codeunit 433 "Azure AD Tenant"
     /// <see cref="Microsoft Admin Cententer to view or edit Organizational Information"/>
     /// <error>Cannot retrieve the Microsoft Entra tenant country letter code.</error>
     procedure GetCountryLetterCode(): Text;
-    var
-        AzureADGraph: Codeunit "Azure AD Graph";
-        TenantInfo: DotNet TenantInfo;
     begin
-        AzureADGraph.GetTenantDetail(TenantInfo);
-        if not IsNull(TenantInfo) then
-            exit(TenantInfo.CountryLetterCode());
-
-        Error(TenantDomainNameErr);
+        exit(AzureADTenantImpl.GetCountryLetterCode());
     end;
 
     /// <summary>
@@ -65,15 +58,8 @@ codeunit 433 "Azure AD Tenant"
     /// <returns>Preferred Language</returns>
     /// <error>Cannot retrieve the Microsoft Entra tenant preferred language.</error>
     procedure GetPreferredLanguage(): Text;
-    var
-        AzureADGraph: Codeunit "Azure AD Graph";
-        TenantInfo: DotNet TenantInfo;
     begin
-        AzureADGraph.GetTenantDetail(TenantInfo);
-        if not IsNull(TenantInfo) then
-            exit(TenantInfo.PreferredLanguage());
-
-        Error(TenantDomainNameErr);
+        exit(AzureADTenantImpl.GetPreferredLanguage());
     end;
 }
 

--- a/src/System Application/App/Azure AD Tenant/src/AzureADTenant.Codeunit.al
+++ b/src/System Application/App/Azure AD Tenant/src/AzureADTenant.Codeunit.al
@@ -42,7 +42,7 @@ codeunit 433 "Azure AD Tenant"
     /// Gets the current Microsoft Entra tenant registered country letter code.
     /// Visit Microsoft Admin Cententer to view or edit Organizational Information.
     /// If the Microsoft Graph API cannot be reached, the error is displayed.
-    /// <summary>
+    /// </summary>
     /// <returns>Country letter code</returns>
     /// <error>Cannot retrieve the Microsoft Entra tenant country letter code.</error>
     procedure GetCountryLetterCode(): Text;
@@ -54,7 +54,7 @@ codeunit 433 "Azure AD Tenant"
     /// Gets the current Microsoft Entra tenant registered preferred language.
     /// Visit Microsoft Admin Cententer to view or edit Organizational Information.
     /// If the Microsoft Graph API cannot be reached, the error is displayed.
-    /// <summary>
+    /// </summary>
     /// <returns>Preferred Language</returns>
     /// <error>Cannot retrieve the Microsoft Entra tenant preferred language.</error>
     procedure GetPreferredLanguage(): Text;

--- a/src/System Application/App/Azure AD Tenant/src/AzureADTenant.Codeunit.al
+++ b/src/System Application/App/Azure AD Tenant/src/AzureADTenant.Codeunit.al
@@ -43,7 +43,7 @@ codeunit 433 "Azure AD Tenant"
     /// Visit Microsoft Admin Cententer to view or edit Organizational Information.
     /// If the Microsoft Graph API cannot be reached, the error is displayed.
     /// </summary>
-    /// <returns>Country letter code</returns>
+    /// <returns>Country or region abbreviation for the organization in ISO 3166-2 format.</returns>
     /// <error>Cannot retrieve the Microsoft Entra tenant country letter code.</error>
     procedure GetCountryLetterCode(): Text;
     begin
@@ -55,7 +55,7 @@ codeunit 433 "Azure AD Tenant"
     /// Visit Microsoft Admin Cententer to view or edit Organizational Information.
     /// If the Microsoft Graph API cannot be reached, the error is displayed.
     /// </summary>
-    /// <returns>Preferred Language</returns>
+    /// <returns>The preferred language for the organization. Should follow ISO 639-1 Code; for example, en.</returns>
     /// <error>Cannot retrieve the Microsoft Entra tenant preferred language.</error>
     procedure GetPreferredLanguage(): Text;
     begin

--- a/src/System Application/App/Azure AD Tenant/src/AzureADTenant.Codeunit.al
+++ b/src/System Application/App/Azure AD Tenant/src/AzureADTenant.Codeunit.al
@@ -39,11 +39,11 @@ codeunit 433 "Azure AD Tenant"
     end;
 
     /// <summary>
-    /// Gets the current Microsoft Entra tenant registered country letter code
+    /// Gets the current Microsoft Entra tenant registered country letter code.
+    /// Visit Microsoft Admin Cententer to view or edit Organizational Information.
     /// If the Microsoft Graph API cannot be reached, the error is displayed.
     /// <summary>
     /// <returns>Country letter code</returns>
-    /// <see cref="Microsoft Admin Cententer to view or edit Organizational Information"/>
     /// <error>Cannot retrieve the Microsoft Entra tenant country letter code.</error>
     procedure GetCountryLetterCode(): Text;
     begin
@@ -51,10 +51,10 @@ codeunit 433 "Azure AD Tenant"
     end;
 
     /// <summary>
-    /// Gets the current Microsoft Entra tenant registered preferred language
+    /// Gets the current Microsoft Entra tenant registered preferred language.
+    /// Visit Microsoft Admin Cententer to view or edit Organizational Information.
     /// If the Microsoft Graph API cannot be reached, the error is displayed.
     /// <summary>
-    /// <see cref="Microsoft Admin Cententer to view or edit Organizational Information"/>
     /// <returns>Preferred Language</returns>
     /// <error>Cannot retrieve the Microsoft Entra tenant preferred language.</error>
     procedure GetPreferredLanguage(): Text;

--- a/src/System Application/App/Azure AD Tenant/src/AzureADTenant.Codeunit.al
+++ b/src/System Application/App/Azure AD Tenant/src/AzureADTenant.Codeunit.al
@@ -45,7 +45,7 @@ codeunit 433 "Azure AD Tenant"
     /// </summary>
     /// <returns>Country or region abbreviation for the organization in ISO 3166-2 format.</returns>
     /// <error>Cannot retrieve the Microsoft Entra tenant country letter code.</error>
-    procedure GetCountryLetterCode(): Text;
+    procedure GetCountryLetterCode(): Code[2];
     begin
         exit(AzureADTenantImpl.GetCountryLetterCode());
     end;
@@ -57,7 +57,7 @@ codeunit 433 "Azure AD Tenant"
     /// </summary>
     /// <returns>The preferred language for the organization. Should follow ISO 639-1 Code; for example, en.</returns>
     /// <error>Cannot retrieve the Microsoft Entra tenant preferred language.</error>
-    procedure GetPreferredLanguage(): Text;
+    procedure GetPreferredLanguage(): Code[2];
     begin
         exit(AzureADTenantImpl.GetPreferredLanguage());
     end;

--- a/src/System Application/App/Azure AD Tenant/src/AzureADTenant.Codeunit.al
+++ b/src/System Application/App/Azure AD Tenant/src/AzureADTenant.Codeunit.al
@@ -37,5 +37,43 @@ codeunit 433 "Azure AD Tenant"
     begin
         exit(AzureADTenantImpl.GetAadTenantDomainName());
     end;
+
+    /// <summary>
+    /// Gets the current Microsoft Entra tenant registered country letter code
+    /// If the Microsoft Graph API cannot be reached, the error is displayed.
+    /// <summary>
+    /// <returns>Country letter code</returns>
+    /// <see cref="Microsoft Admin Cententer to view or edit Organizational Information"/>
+    /// <error>Cannot retrieve the Microsoft Entra tenant country letter code.</error>
+    procedure GetCountryLetterCode(): Text;
+    var
+        AzureADGraph: Codeunit "Azure AD Graph";
+        TenantInfo: DotNet TenantInfo;
+    begin
+        AzureADGraph.GetTenantDetail(TenantInfo);
+        if not IsNull(TenantInfo) then
+            exit(TenantInfo.CountryLetterCode());
+
+        Error(TenantDomainNameErr);
+    end;
+
+    /// <summary>
+    /// Gets the current Microsoft Entra tenant registered preferred language
+    /// If the Microsoft Graph API cannot be reached, the error is displayed.
+    /// <summary>
+    /// <see cref="Microsoft Admin Cententer to view or edit Organizational Information"/>
+    /// <returns>Preferred Language</returns>
+    /// <error>Cannot retrieve the Microsoft Entra tenant preferred language.</error>
+    procedure GetPreferredLanguage(): Text;
+    var
+        AzureADGraph: Codeunit "Azure AD Graph";
+        TenantInfo: DotNet TenantInfo;
+    begin
+        AzureADGraph.GetTenantDetail(TenantInfo);
+        if not IsNull(TenantInfo) then
+            exit(TenantInfo.PreferredLanguage());
+
+        Error(TenantDomainNameErr);
+    end;
 }
 

--- a/src/System Application/App/Azure AD Tenant/src/AzureADTenantImpl.Codeunit.al
+++ b/src/System Application/App/Azure AD Tenant/src/AzureADTenantImpl.Codeunit.al
@@ -15,6 +15,8 @@ codeunit 3705 "Azure AD Tenant Impl."
     InherentPermissions = X;
 
     var
+        AzureADGraph: Codeunit "Azure AD Graph";
+        TenantInfo: DotNet TenantInfo;
         NavTenantSettingsHelper: DotNet NavTenantSettingsHelper;
         TenantDomainNameErr: Label 'Failed to retrieve the Microsoft Entra tenant domain name.';
         CountryLetterCodeErr: Label 'Failed to retrieve the Microsoft Entra tenant domain name.';
@@ -26,11 +28,8 @@ codeunit 3705 "Azure AD Tenant Impl."
     end;
 
     procedure GetAadTenantDomainName(): Text;
-    var
-        AzureADGraph: Codeunit "Azure AD Graph";
-        TenantInfo: DotNet TenantInfo;
     begin
-        AzureADGraph.GetTenantDetail(TenantInfo);
+        Initialize();
         if not IsNull(TenantInfo) then
             exit(TenantInfo.InitialDomain());
 
@@ -38,11 +37,8 @@ codeunit 3705 "Azure AD Tenant Impl."
     end;
 
     procedure GetCountryLetterCode(): Text;
-    var
-        AzureADGraph: Codeunit "Azure AD Graph";
-        TenantInfo: DotNet TenantInfo;
     begin
-        AzureADGraph.GetTenantDetail(TenantInfo);
+        Initialize();
         if not IsNull(TenantInfo) then
             exit(TenantInfo.CountryLetterCode());
 
@@ -50,15 +46,18 @@ codeunit 3705 "Azure AD Tenant Impl."
     end;
 
     procedure GetPreferredLanguage(): Text;
-    var
-        AzureADGraph: Codeunit "Azure AD Graph";
-        TenantInfo: DotNet TenantInfo;
     begin
-        AzureADGraph.GetTenantDetail(TenantInfo);
+        Initialize();
         if not IsNull(TenantInfo) then
             exit(TenantInfo.PreferredLanguage());
 
         Error(PreferedLanguageErr);
+    end;
+
+    local procedure Initialize()
+    begin
+        if IsNull(TenantInfo) then
+            AzureADGraph.GetTenantDetail(TenantInfo);
     end;
 }
 

--- a/src/System Application/App/Azure AD Tenant/src/AzureADTenantImpl.Codeunit.al
+++ b/src/System Application/App/Azure AD Tenant/src/AzureADTenantImpl.Codeunit.al
@@ -34,5 +34,29 @@ codeunit 3705 "Azure AD Tenant Impl."
 
         Error(TenantDomainNameErr);
     end;
+
+    procedure GetCountryLetterCode(): Text;
+    var
+        AzureADGraph: Codeunit "Azure AD Graph";
+        TenantInfo: DotNet TenantInfo;
+    begin
+        AzureADGraph.GetTenantDetail(TenantInfo);
+        if not IsNull(TenantInfo) then
+            exit(TenantInfo.CountryLetterCode());
+
+        Error(TenantDomainNameErr);
+    end;
+
+    procedure GetPreferredLanguage(): Text;
+    var
+        AzureADGraph: Codeunit "Azure AD Graph";
+        TenantInfo: DotNet TenantInfo;
+    begin
+        AzureADGraph.GetTenantDetail(TenantInfo);
+        if not IsNull(TenantInfo) then
+            exit(TenantInfo.PreferredLanguage());
+
+        Error(TenantDomainNameErr);
+    end;
 }
 

--- a/src/System Application/App/Azure AD Tenant/src/AzureADTenantImpl.Codeunit.al
+++ b/src/System Application/App/Azure AD Tenant/src/AzureADTenantImpl.Codeunit.al
@@ -17,6 +17,8 @@ codeunit 3705 "Azure AD Tenant Impl."
     var
         NavTenantSettingsHelper: DotNet NavTenantSettingsHelper;
         TenantDomainNameErr: Label 'Failed to retrieve the Microsoft Entra tenant domain name.';
+        CountryLetterCodeErr: Label 'Failed to retrieve the Microsoft Entra tenant domain name.';
+        PreferedLanguageErr: Label 'Failed to retrieve the Microsoft Entra tenant domain name.';
 
     procedure GetAadTenantId() TenantIdValue: Text
     begin
@@ -44,7 +46,7 @@ codeunit 3705 "Azure AD Tenant Impl."
         if not IsNull(TenantInfo) then
             exit(TenantInfo.CountryLetterCode());
 
-        Error(TenantDomainNameErr);
+        Error(CountryLetterCodeErr);
     end;
 
     procedure GetPreferredLanguage(): Text;
@@ -56,7 +58,7 @@ codeunit 3705 "Azure AD Tenant Impl."
         if not IsNull(TenantInfo) then
             exit(TenantInfo.PreferredLanguage());
 
-        Error(TenantDomainNameErr);
+        Error(PreferedLanguageErr);
     end;
 }
 

--- a/src/System Application/App/Azure AD Tenant/src/AzureADTenantImpl.Codeunit.al
+++ b/src/System Application/App/Azure AD Tenant/src/AzureADTenantImpl.Codeunit.al
@@ -19,8 +19,8 @@ codeunit 3705 "Azure AD Tenant Impl."
         TenantInfo: DotNet TenantInfo;
         NavTenantSettingsHelper: DotNet NavTenantSettingsHelper;
         TenantDomainNameErr: Label 'Failed to retrieve the Microsoft Entra tenant domain name.';
-        CountryLetterCodeErr: Label 'Failed to retrieve the Microsoft Entra tenant domain name.';
-        PreferedLanguageErr: Label 'Failed to retrieve the Microsoft Entra tenant domain name.';
+        CountryLetterCodeErr: Label 'Failed to retrieve the Microsoft Entra tenant country letter code.';
+        PreferredLanguageErr: Label 'Failed to retrieve the Microsoft Entra tenant preferred language code.';
 
     procedure GetAadTenantId() TenantIdValue: Text
     begin
@@ -51,7 +51,7 @@ codeunit 3705 "Azure AD Tenant Impl."
         if not IsNull(TenantInfo) then
             exit(TenantInfo.PreferredLanguage());
 
-        Error(PreferedLanguageErr);
+        Error(PreferredLanguageErr);
     end;
 
     local procedure Initialize()

--- a/src/System Application/App/Azure AD Tenant/src/AzureADTenantImpl.Codeunit.al
+++ b/src/System Application/App/Azure AD Tenant/src/AzureADTenantImpl.Codeunit.al
@@ -36,20 +36,20 @@ codeunit 3705 "Azure AD Tenant Impl."
         Error(TenantDomainNameErr);
     end;
 
-    procedure GetCountryLetterCode(): Text;
+    procedure GetCountryLetterCode(): Code[2];
     begin
         Initialize();
         if not IsNull(TenantInfo) then
-            exit(TenantInfo.CountryLetterCode());
+            exit(CopyStr(TenantInfo.CountryLetterCode(), 1, 2));
 
         Error(CountryLetterCodeErr);
     end;
 
-    procedure GetPreferredLanguage(): Text;
+    procedure GetPreferredLanguage(): Code[2];
     begin
         Initialize();
         if not IsNull(TenantInfo) then
-            exit(TenantInfo.PreferredLanguage());
+            exit(CopyStr(TenantInfo.PreferredLanguage(), 1, 2));
 
         Error(PreferredLanguageErr);
     end;


### PR DESCRIPTION
## Challenge
When working with W1 base applications it is challenging to figure out the country or prefered language.

## Change
Exposing countryLetterCode and preferredLanguage form the Organizational Information page in Microsoft Administration Center enables better defaulting.

![image](https://github.com/microsoft/BCApps/assets/9417259/0e2ffa1c-0d49-47b4-901f-3dfbe0a21aae)

Fixes #408

Internal work item: AB#493149


