### PR TITLE
Obsolete Extension Marketplace page

### DIFF
--- a/src/System Application/App/Extension Management/permissions/ExtensionManagementObjects.PermissionSet.al
+++ b/src/System Application/App/Extension Management/permissions/ExtensionManagementObjects.PermissionSet.al
@@ -25,7 +25,9 @@ permissionset 2504 "Extension Management - Objects"
                   page "Extension Installation" = X,
                   page "Extension Logo Part" = X,
                   page "Extension Management" = X,
+#if not CLEAN24
                   page "Extension Marketplace" = X,
+#endif                  
                   page "Extension Settings" = X,
                   page "Extension Setup Launcher" = X,
                   page "Extn. Installation Progress" = X,

--- a/src/System Application/App/Extension Management/permissions/ExtensionManagementObjects.PermissionSet.al
+++ b/src/System Application/App/Extension Management/permissions/ExtensionManagementObjects.PermissionSet.al
@@ -26,7 +26,9 @@ permissionset 2504 "Extension Management - Objects"
                   page "Extension Logo Part" = X,
                   page "Extension Management" = X,
 #if not CLEAN24
+#pragma warning disable AL0432
                   page "Extension Marketplace" = X,
+#pragma warning restore AL0432                  
 #endif                  
                   page "Extension Settings" = X,
                   page "Extension Setup Launcher" = X,

--- a/src/System Application/App/Extension Management/src/ExtensionManagement.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionManagement.Page.al
@@ -266,7 +266,7 @@ page 2500 "Extension Management"
 #else                    
                     trigger OnAction()
                     begin
-                        Hyperlink('https://appsource.microsoft.com/en-us/marketplace/apps?product=dynamics-365%3Bdynamics-365-business-central&page=1');
+                        Hyperlink('https://aka.ms/bcappsource');
                     end;
 #endif
                 }

--- a/src/System Application/App/Extension Management/src/ExtensionManagement.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionManagement.Page.al
@@ -260,7 +260,9 @@ page 2500 "Extension Management"
                     ToolTip = 'Browse the extension marketplace for new extensions to install.';
                     Visible = not IsOnPremDisplay;
 #if not CLEAN24                    
+#pragma warning disable AL0432
                     RunObject = page "Extension Marketplace";
+#pragma warning restore AL0432
 #else                    
                     trigger OnAction()
                     begin

--- a/src/System Application/App/Extension Management/src/ExtensionManagement.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionManagement.Page.al
@@ -259,7 +259,14 @@ page 2500 "Extension Management"
                     PromotedIsBig = true;
                     ToolTip = 'Browse the extension marketplace for new extensions to install.';
                     Visible = not IsOnPremDisplay;
+#if not CLEAN24                    
                     RunObject = page "Extension Marketplace";
+#else                    
+                    trigger OnAction()
+                    begin
+                        Hyperlink('https://appsource.microsoft.com/en-us/marketplace/apps?product=dynamics-365%3Bdynamics-365-business-central&page=1');
+                    end;
+#endif
                 }
                 action("Upload Extension")
                 {
@@ -390,5 +397,3 @@ page 2500 "Extension Management"
         InfoStyle := IsInstalled and IsInstallAllowed;
     end;
 }
-
-

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
@@ -530,7 +530,7 @@ codeunit 2501 "Extension Marketplace"
         Page.Run(Page::"Extension Marketplace");
 #pragma warning restore AL0432
 #else        
-        Hyperlink('https://appsource.microsoft.com/en-us/marketplace/apps?product=dynamics-365%3Bdynamics-365-business-central&page=1');
+        Hyperlink('https://aka.ms/BCAppSource');
 #endif        
     end;
 }

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
@@ -525,6 +525,10 @@ codeunit 2501 "Extension Marketplace"
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"System Action Triggers", OpenAppSourceMarket, '', false, false)]
     local procedure OpenAppSourceMarket()
     begin
+#if not CLEAN24        
         Page.Run(Page::"Extension Marketplace");
+#else        
+        Hyperlink('https://appsource.microsoft.com/en-us/marketplace/apps?product=dynamics-365%3Bdynamics-365-business-central&page=1');
+#endif        
     end;
 }

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
@@ -526,7 +526,9 @@ codeunit 2501 "Extension Marketplace"
     local procedure OpenAppSourceMarket()
     begin
 #if not CLEAN24        
+#pragma warning disable AL0432
         Page.Run(Page::"Extension Marketplace");
+#pragma warning restore AL0432
 #else        
         Hyperlink('https://appsource.microsoft.com/en-us/marketplace/apps?product=dynamics-365%3Bdynamics-365-business-central&page=1');
 #endif        

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Page.al
@@ -19,6 +19,9 @@ page 2502 "Extension Marketplace"
     ApplicationArea = All;
     UsageCategory = Administration;
     Editable = false;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'This page will be obsoleted. Microsoft AppSource apps feature will replace the Extension Marketplace.';
+    ObsoleteTag = '24.0';
 
     layout
     {

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Page.al
@@ -1,3 +1,4 @@
+#if not CLEAN24
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -111,4 +112,4 @@ page 2502 "Extension Marketplace"
         TelemetryUrl: Text;
         AppsourceUrl: Text;
 }
-
+#endif


### PR DESCRIPTION
The Extension Marketplace page is using an embeded view of Microsoft AppSource and the endpoint will be discontinued in 2024.
Marking the page as obsolete and that it will be replaced with a new Microsoft AppSource apps feature providing similar functionality.

Fixes [AB#493421](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/493421)





