### PR TITLE
Add SecretText overload

### DIFF
--- a/src/System Application/App/Azure Key Vault/src/AzureKeyVault.Codeunit.al
+++ b/src/System Application/App/Azure Key Vault/src/AzureKeyVault.Codeunit.al
@@ -35,6 +35,21 @@ codeunit 2200 "Azure Key Vault"
     end;
 
     /// <summary>
+    /// Retrieves a secret from the key vault.
+    /// </summary>
+    /// <remarks>This is a try function.</remarks>
+    /// <param name="SecretName">The name of the secret to retrieve.</param>
+    /// <param name="Secret">Out parameter that holds the secret that was retrieved from the key vault.</param>
+    /// <remarks>As a best practice, you should only store secrets in a key vault. For example, avoid storing information that can be available elsewhere, such as configuration details or URLs.</remarks>
+    [TryFunction]
+    [Scope('OnPrem')]
+    [NonDebuggable]
+    procedure GetAzureKeyVaultSecret(SecretName: Text; var Secret: SecretText)
+    begin
+        AzureKeyVaultImpl.GetAzureKeyVaultSecret(SecretName, Secret);
+    end;
+
+    /// <summary>
     /// Retrieves a certificate from the key vault.
     /// </summary>
     /// <remarks>This is a try function.</remarks>

--- a/src/System Application/App/Azure Key Vault/src/AzureKeyVaultImpl.Codeunit.al
+++ b/src/System Application/App/Azure Key Vault/src/AzureKeyVaultImpl.Codeunit.al
@@ -53,6 +53,18 @@ codeunit 2202 "Azure Key Vault Impl."
     end;
 
     [NonDebuggable]
+    procedure GetAzureKeyVaultSecret(SecretName: Text; var Secret: SecretText)
+    begin
+        if not InitializeAllowedSecretNames() then
+            Error(InitializeAllowedSecretNamesErr);
+
+        if not IsSecretNameAllowed(SecretName) then
+            Error(SecretNotFoundErr, SecretName);
+
+        Secret := GetSecretFromClient(SecretName);
+    end;
+
+    [NonDebuggable]
     procedure GetAzureKeyVaultCertificate(CertificateName: Text; var Certificate: Text)
     begin
         // Gets the certificate as a base 64 encoded string from the key vault, given a CertificateName.

--- a/src/System Application/App/Secrets/src/AppKeyVaultSecretPrImpl.Codeunit.al
+++ b/src/System Application/App/Secrets/src/AppKeyVaultSecretPrImpl.Codeunit.al
@@ -66,4 +66,15 @@ codeunit 3801 "App Key Vault Secret Pr. Impl."
         // It will return false in these cases, and set SecretValue=''.
         exit(NavAzureKeyVaultAppSecretProvider.TryGetAzureKeyVaultSecret(SecretName, SecretValue));
     end;
+
+    [NonDebuggable]
+    procedure GetSecret(SecretName: Text; var SecretValue: SecretText): Boolean
+    var
+        SecretValueText: Text;
+    begin
+        if not GetSecret(SecretName, secretValueText) then
+            exit(false);
+        SecretValue := SecretValueText;
+        exit(true);
+    end;
 }

--- a/src/System Application/App/Secrets/src/AppKeyVaultSecretPrImpl.Codeunit.al
+++ b/src/System Application/App/Secrets/src/AppKeyVaultSecretPrImpl.Codeunit.al
@@ -72,7 +72,7 @@ codeunit 3801 "App Key Vault Secret Pr. Impl."
     var
         SecretValueText: Text;
     begin
-        if not GetSecret(SecretName, secretValueText) then
+        if not GetSecret(SecretName, SecretValueText) then
             exit(false);
         SecretValue := SecretValueText;
         exit(true);

--- a/src/System Application/App/Secrets/src/AppKeyVaultSecretProvider.Codeunit.al
+++ b/src/System Application/App/Secrets/src/AppKeyVaultSecretProvider.Codeunit.al
@@ -39,4 +39,16 @@ codeunit 3800 "App Key Vault Secret Provider" implements "Secret Provider"
     begin
         exit(AppKeyVaultSecretPrImpl.GetSecret(SecretName, SecretValue));
     end;
+
+    /// <summary>
+    /// Retrieves a secret value from one of the app's key vaults.
+    /// </summary>
+    /// <param name="SecretName">The name of the secret to retrieve.</param>
+    /// <param name="SecretValue">SecretText containing the value of the secret, or the empty string if the value could not be retrieved.</param>
+    /// <returns>True if the secret value could be retrieved; false otherwise.</returns>
+    [NonDebuggable]
+    procedure GetSecret(SecretName: Text; var SecretValue: SecretText): Boolean
+    begin
+        exit(AppKeyVaultSecretPrImpl.GetSecret(SecretName, SecretValue));
+    end;
 }

--- a/src/System Application/App/Secrets/src/AppKeyVaultSecretProvider.Codeunit.al
+++ b/src/System Application/App/Secrets/src/AppKeyVaultSecretProvider.Codeunit.al
@@ -8,7 +8,13 @@ namespace System.Security;
 /// <summary>
 /// Exposes functionality to retrieve app secrets from the key vault that is specified in the app's manifest file.
 /// </summary>
-codeunit 3800 "App Key Vault Secret Provider" implements "Secret Provider"
+#if not CLEAN24
+#pragma warning disable AL0432
+codeunit 3800 "App Key Vault Secret Provider" implements "Secret Provider", "Secret Provider v2"
+#pragma warning restore AL0432
+#else
+codeunit 3800 "App Key Vault Secret Provider" implements "Secret Provider v2"
+#endif
 {
     Access = Public;
     InherentEntitlements = X;

--- a/src/System Application/App/Secrets/src/InMemorySecretProvImpl.Codeunit.al
+++ b/src/System Application/App/Secrets/src/InMemorySecretProvImpl.Codeunit.al
@@ -37,4 +37,16 @@ codeunit 3803 "In Memory Secret Prov Impl."
 
         exit(false);
     end;
+
+    [NonDebuggable]
+    procedure GetSecret(SecretName: Text; var SecretValue: SecretText): Boolean
+    var
+        SecretValueText: Text;
+    begin
+        if not GetSecret(SecretName, secretValueText) then
+            exit(false);
+        SecretValue := SecretValueText;
+        exit(true);
+    end;
+
 }

--- a/src/System Application/App/Secrets/src/InMemorySecretProvImpl.Codeunit.al
+++ b/src/System Application/App/Secrets/src/InMemorySecretProvImpl.Codeunit.al
@@ -43,7 +43,7 @@ codeunit 3803 "In Memory Secret Prov Impl."
     var
         SecretValueText: Text;
     begin
-        if not GetSecret(SecretName, secretValueText) then
+        if not GetSecret(SecretName, SecretValueText) then
             exit(false);
         SecretValue := SecretValueText;
         exit(true);

--- a/src/System Application/App/Secrets/src/InMemorySecretProvider.Codeunit.al
+++ b/src/System Application/App/Secrets/src/InMemorySecretProvider.Codeunit.al
@@ -40,4 +40,17 @@ codeunit 3802 "In Memory Secret Provider" implements "Secret Provider"
     begin
         exit(InMemorySecretProviderImpl.GetSecret(SecretName, SecretValue));
     end;
+
+    /// <summary>
+    /// Retrieves a secret value from the secret provider.
+    /// </summary>
+    /// <param name="SecretName">The name of the secret to retrieve.</param>
+    /// <param name="SecretValue">SecretText containing the value of the secret, or the empty string if the value could not be retrieved.</param>
+    /// <returns>True if the secret value could be retrieved; false otherwise.</returns>
+    [NonDebuggable]
+    procedure GetSecret(SecretName: Text; var SecretValue: SecretText): Boolean
+    begin
+        exit(InMemorySecretProviderImpl.GetSecret(SecretName, SecretValue));
+    end;
+
 }

--- a/src/System Application/App/Secrets/src/InMemorySecretProvider.Codeunit.al
+++ b/src/System Application/App/Secrets/src/InMemorySecretProvider.Codeunit.al
@@ -8,7 +8,13 @@ namespace System.Security;
 /// <summary>
 /// An in-memory secret provider that can be populated with secrets from any source.
 /// </summary>
-codeunit 3802 "In Memory Secret Provider" implements "Secret Provider"
+#if not CLEAN24
+#pragma warning disable AL0432
+codeunit 3802 "In Memory Secret Provider" implements "Secret Provider", "Secret Provider v2"
+#pragma warning restore AL0432
+#else
+codeunit 3802 "In Memory Secret Provider" implements "Secret Provider v2"
+#endif
 {
     Access = Public;
     InherentEntitlements = X;

--- a/src/System Application/App/Secrets/src/SecretProvider.Interface.al
+++ b/src/System Application/App/Secrets/src/SecretProvider.Interface.al
@@ -17,4 +17,12 @@ interface "Secret Provider"
     /// <param name="SecretValue">The value of the secret, or the empty string if the value could not be retrieved.</param>
     /// <returns>True if the secret value could be retrieved; false otherwise.</returns>
     procedure GetSecret(SecretName: Text; var SecretValue: Text): Boolean
+
+    /// <summary>
+    /// Retrieves a secret value.
+    /// </summary>
+    /// <param name="SecretName">The name of the secret to retrieve.</param>
+    /// <param name="SecretValue">SecretText containing the value of the secret, or the empty string if the value could not be retrieved.</param>
+    /// <returns>True if the secret value could be retrieved; false otherwise.</returns>
+    procedure GetSecret(SecretName: Text; var SecretValue: SecretText): Boolean
 }

--- a/src/System Application/App/Secrets/src/SecretProviderv2.Interface.al
+++ b/src/System Application/App/Secrets/src/SecretProviderv2.Interface.al
@@ -1,4 +1,3 @@
-#if not CLEAN24
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -9,13 +8,8 @@ namespace System.Security;
 /// <summary>
 /// Abstraction for secret providers.
 /// </summary>
-interface "Secret Provider"
+interface "Secret Provider v2"
 {
-
-    ObsoleteReason = 'Replaced by Secret Provider v2 with support for SecretValue as SecretText data type.';
-    ObsoleteState = Pending;
-    ObsoleteTag = '24.0';
-
     /// <summary>
     /// Retrieves a secret value.
     /// </summary>
@@ -23,5 +17,12 @@ interface "Secret Provider"
     /// <param name="SecretValue">The value of the secret, or the empty string if the value could not be retrieved.</param>
     /// <returns>True if the secret value could be retrieved; false otherwise.</returns>
     procedure GetSecret(SecretName: Text; var SecretValue: Text): Boolean
+
+    /// <summary>
+    /// Retrieves a secret value.
+    /// </summary>
+    /// <param name="SecretName">The name of the secret to retrieve.</param>
+    /// <param name="SecretValue">SecretText containing the value of the secret, or the empty string if the value could not be retrieved.</param>
+    /// <returns>True if the secret value could be retrieved; false otherwise.</returns>
+    procedure GetSecret(SecretName: Text; var SecretValue: SecretText): Boolean
 }
-#endif

--- a/src/System Application/Test/Secrets/app.json
+++ b/src/System Application/Test/Secrets/app.json
@@ -28,6 +28,7 @@
 
                     ],
     "platform":  "24.0.0.0",
+    "target": "OnPrem",
     "idRanges":  [
                      {
                          "from":  135213,

--- a/src/System Application/Test/Secrets/src/AppKeyVaultSecretProTest.Codeunit.al
+++ b/src/System Application/Test/Secrets/src/AppKeyVaultSecretProTest.Codeunit.al
@@ -45,4 +45,16 @@ codeunit 135213 "App Key Vault Secret Pro. Test"
         asserterror AppKeyVaultSecretProvider.GetSecret('foo', SecretValue);
         Assert.ExpectedError('Cannot get secrets because the App Key Vault Secret Provider has not been initialized.');
     end;
+
+    [Test]
+    procedure GetSecretasSecretTextbeforeInitializedGivesError()
+    var
+        AppKeyVaultSecretProvider: Codeunit "App Key Vault Secret Provider";
+        SecretValue: SecretText;
+    begin
+        // [SCENARIO] Calling GetSecret before calling TryInitializeFromCurrentApp should give error.
+
+        asserterror AppKeyVaultSecretProvider.GetSecret('foo', SecretValue);
+        Assert.ExpectedError('Cannot get secrets because the App Key Vault Secret Provider has not been initialized.');
+    end;
 }

--- a/src/System Application/Test/Secrets/src/InMemorySecretProviderTest.Codeunit.al
+++ b/src/System Application/Test/Secrets/src/InMemorySecretProviderTest.Codeunit.al
@@ -27,6 +27,7 @@ codeunit 135214 "In Memory Secret Provider Test"
     var
         InMemorySecretProvider: Codeunit "In Memory Secret Provider";
         Secret: Text;
+        SecretSecretText: SecretText;
         Result: Boolean;
     begin
         // [SCENARIO] Populate the secret provider with some values and read them back
@@ -37,10 +38,13 @@ codeunit 135214 "In Memory Secret Provider Test"
 
         // [WHEN] The a secret is retrieved
         Result := InMemorySecretProvider.GetSecret('secret1', Secret);
+        Assert.IsTrue(Result, 'GetSecret should return true if it could read the secret');
+        Result := InMemorySecretProvider.GetSecret('secret1', SecretSecretText);
+        Assert.IsTrue(Result, 'GetSecret as SecretText should return true if it could read the secret');
 
         // [THEN] The value is retrieved
         Assert.AreEqual('value1', Secret, 'The returned secret does not match.');
-        Assert.IsTrue(Result, 'GetSecret should return true if it could read the secret');
+        Assert.AreEqual('value1', GetSecretOut(SecretSecretText), 'The returned secret does not match.');
     end;
 
     [Test]
@@ -49,6 +53,7 @@ codeunit 135214 "In Memory Secret Provider Test"
     var
         InMemorySecretProvider: Codeunit "In Memory Secret Provider";
         Secret: Text;
+        SecretSecretText: SecretText;
         Result: Boolean;
     begin
         // [SCENARIO] Populate the secret provider with the same value twice -> show overwrite the value
@@ -59,10 +64,13 @@ codeunit 135214 "In Memory Secret Provider Test"
         // [WHEN] Overwriting a secret and reading it back
         InMemorySecretProvider.AddSecret('secret1', 'value2');
         Result := InMemorySecretProvider.GetSecret('secret1', Secret);
+        Assert.IsTrue(Result, 'GetSecret should return true if it could read the secret');
+        Result := InMemorySecretProvider.GetSecret('secret1', SecretSecretText);
+        Assert.IsTrue(Result, 'GetSecret as SecretText should return true if it could read the secret');
 
         // [THEN] The new value is retrieved
         Assert.AreEqual('value2', Secret, 'The returned secret does not match.');
-        Assert.IsTrue(Result, 'GetSecret should return true if it could read the secret');
+        Assert.AreEqual('value2', GetSecretOut(SecretSecretText), 'The returned secret does not match.');
     end;
 
     [Test]
@@ -71,6 +79,7 @@ codeunit 135214 "In Memory Secret Provider Test"
     var
         InMemorySecretProvider: Codeunit "In Memory Secret Provider";
         Secret: Text;
+        SecretSecretText: SecretText;
         Result: Boolean;
     begin
         // [SCENARIO] Try to read a secret that doesn't exist
@@ -78,9 +87,19 @@ codeunit 135214 "In Memory Secret Provider Test"
         // [GIVEN] A secret provider
         // [WHEN] Reading a non-existing secret
         Result := InMemorySecretProvider.GetSecret('secret1', Secret);
+        Assert.IsFalse(Result, 'GetSecret should return false if it couldn''t read the secret');
+        Result := InMemorySecretProvider.GetSecret('secret1', SecretSecretText);
+        Assert.IsFalse(Result, 'GetSecret as SecretText should return false if it couldn''t read the secret');
+
 
         // [THEN] The value should be empty, and the result should be false
         Assert.AreEqual('', Secret, 'The returned secret should be empty.');
-        Assert.IsFalse(Result, 'GetSecret should return false if it couldn''t read the secret');
+        Assert.IsTrue(SecretSecretText.IsEmpty(), 'The returned secret should be empty.');
+    end;
+
+    [NonDebuggable]
+    local procedure GetSecretOut(Secret: SecretText): Text
+    begin
+        exit(Secret.Unwrap());
     end;
 }


### PR DESCRIPTION
When working with Azure KeyVault it should be possible to get secrets as SecretText.

Fixes [AB#493425](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/493425)








