### PR TITLE
[Copilot] Check if Marketing text generated successfully before returning last message

### DIFF
--- a/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
@@ -431,6 +431,11 @@ codeunit 2012 "Entity Text Impl."
         AOAIChatMessages.AddUserMessage(UserPrompt);
 
         AzureOpenAI.GenerateChatCompletion(AOAIChatMessages, AOAICompletionParams, AOAIOperationResponse);
+        if not AOAIOperationResponse.IsSuccess() then begin
+            Clear(Result);
+            Error(CompletionDeniedPhraseErr);
+        end;
+
         Result := HttpUtility.HtmlEncode(AOAIChatMessages.GetLastMessage());
         Result := Result.Replace(NewLineChar, EncodedNewlineTok);
 


### PR DESCRIPTION
#### Summary 
After requesting a chat completion, check with AI SDK if it was successful, instead of returning the last message straight away. This prevents retrieving assistant/user message that was part of the original request.

#### Work Item
Fixes AB#487536
