### PR TITLE
[Copilot] Hide status field when data movement is not enabled

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesGA.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesGA.Page.al
@@ -165,7 +165,6 @@ page 7774 "Copilot Capabilities GA"
 
     internal procedure SetDataMovement(Value: Boolean)
     begin
-        LogMessage('12345', 'SetDataMovement', Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::All, 'Data', Format(Value));
         DataMovementEnabled := Value;
         SetActionsEnabled();
         CurrPage.Update(false);

--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesGA.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesGA.Page.al
@@ -41,6 +41,7 @@ page 7774 "Copilot Capabilities GA"
                     Caption = 'Status';
                     ToolTip = 'Specifies if the Copilot is active and can be used in this environment.';
                     StyleExpr = StatusStyleExpr;
+                    Visible = DataMovementEnabled;
 
                     trigger OnValidate()
                     begin
@@ -164,6 +165,7 @@ page 7774 "Copilot Capabilities GA"
 
     internal procedure SetDataMovement(Value: Boolean)
     begin
+        LogMessage('12345', 'SetDataMovement', Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::All, 'Data', Format(Value));
         DataMovementEnabled := Value;
         SetActionsEnabled();
         CurrPage.Update(false);

--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesPreview.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesPreview.Page.al
@@ -41,6 +41,7 @@ page 7773 "Copilot Capabilities Preview"
                     Caption = 'Status';
                     ToolTip = 'Specifies if the Copilot is active and can be used in this environment.';
                     StyleExpr = StatusStyleExpr;
+                    Visible = DataMovementEnabled;
 
                     trigger OnValidate()
                     begin
@@ -158,6 +159,7 @@ page 7773 "Copilot Capabilities Preview"
 
     internal procedure SetDataMovement(Value: Boolean)
     begin
+        LogMessage('12346', 'SetDataMovement', Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::All, 'Data', Format(Value));
         DataMovementEnabled := Value;
         SetActionsEnabled();
         CurrPage.Update(false);

--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesPreview.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesPreview.Page.al
@@ -159,7 +159,6 @@ page 7773 "Copilot Capabilities Preview"
 
     internal procedure SetDataMovement(Value: Boolean)
     begin
-        LogMessage('12346', 'SetDataMovement', Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::All, 'Data', Format(Value));
         DataMovementEnabled := Value;
         SetActionsEnabled();
         CurrPage.Update(false);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
**Problem** 
It is currently misleading that copilots are active/enabled when the data movement toggle is off.
If the toggle is off and copilots show active, the copilots are actually deactivated due to data movement not being allowed.

**Solution**
Hide the Status column whenever data movement toggle is off.

![image](https://github.com/microsoft/BCApps/assets/18476646/580e305c-f12f-4e3f-b13a-ad78c9f50254)

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes AB#491279



