### PR TITLE
Add procedures with defaultButton true

### DIFF
--- a/src/System Application/App/Confirm Management/src/ConfirmManagement.Codeunit.al
+++ b/src/System Application/App/Confirm Management/src/ConfirmManagement.Codeunit.al
@@ -23,11 +23,33 @@ codeunit 27 "Confirm Management"
     /// If UI is not allowed, the default response is returned.
     /// </summary>
     /// <param name="ConfirmQuestion">The question to be asked to the user.</param>
+    /// <returns>The response of the user or the default response passed if no UI is allowed.</returns>
+    procedure GetResponseOrDefault(ConfirmQuestion: Text): Boolean
+    begin
+        exit(ConfirmManagementImpl.GetResponseOrDefault(ConfirmQuestion, false));
+    end;
+
+    /// <summary>
+    /// Raises a confirm dialog with a question and the default response on which the cursor is shown.
+    /// If UI is not allowed, the default response is returned.
+    /// </summary>
+    /// <param name="ConfirmQuestion">The question to be asked to the user.</param>
     /// <param name="DefaultButton">The default response expected.</param>
     /// <returns>The response of the user or the default response passed if no UI is allowed.</returns>
     procedure GetResponseOrDefault(ConfirmQuestion: Text; DefaultButton: Boolean): Boolean
     begin
         exit(ConfirmManagementImpl.GetResponseOrDefault(ConfirmQuestion, DefaultButton));
+    end;
+
+    /// <summary>
+    /// Raises a confirm dialog with a question and the default response on which the cursor is shown.
+    /// If UI is not allowed, the function returns FALSE.
+    /// </summary>
+    /// <param name="ConfirmQuestion">The question to be asked to the user.</param>
+    /// <returns>The response of the user or FALSE if no UI is allowed.</returns>
+    procedure GetResponse(ConfirmQuestion: Text): Boolean
+    begin
+        exit(ConfirmManagementImpl.GetResponse(ConfirmQuestion, false));
     end;
 
     /// <summary>

--- a/src/System Application/App/Confirm Management/src/ConfirmManagement.Codeunit.al
+++ b/src/System Application/App/Confirm Management/src/ConfirmManagement.Codeunit.al
@@ -26,7 +26,7 @@ codeunit 27 "Confirm Management"
     /// <returns>The response of the user or the default response passed if no UI is allowed.</returns>
     procedure GetResponseOrDefault(ConfirmQuestion: Text): Boolean
     begin
-        exit(ConfirmManagementImpl.GetResponseOrDefault(ConfirmQuestion, false));
+        exit(ConfirmManagementImpl.GetResponseOrDefault(ConfirmQuestion, true));
     end;
 
     /// <summary>
@@ -49,7 +49,7 @@ codeunit 27 "Confirm Management"
     /// <returns>The response of the user or FALSE if no UI is allowed.</returns>
     procedure GetResponse(ConfirmQuestion: Text): Boolean
     begin
-        exit(ConfirmManagementImpl.GetResponse(ConfirmQuestion, false));
+        exit(ConfirmManagementImpl.GetResponse(ConfirmQuestion, true));
     end;
 
     /// <summary>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

In most cases where we want the user to confirm an action, we set the default button to true. This will set the focus to the specific button so that the user can simply press enter and continue.

DefaultButton should be set to false on critical actions manually.

- [ ] Additional tests should be added

*Note*: When I first read the DefaultButton parameter, I thought that this parameter would also be applied if the confirmation page was canceled by pressing <kbd>Esc</kbd>, for example. However, this is not the case. The DefaultButton parameter only sets the focus on the button.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #436





<br /><br />Internal work item: AB#495008
