### PR TITLE
[Copilot] Assisted setup cannot be marked as completed

### DIFF
--- a/src/System Application/App/AI/app.json
+++ b/src/System Application/App/AI/app.json
@@ -70,6 +70,12 @@
             "name":  "User Permissions",
             "publisher":  "Microsoft",
             "version": "24.0.0.0"
+          },
+          {
+            "id":  "c64d75f0-e9f1-4d0f-9949-cd453b9b1466",
+            "name":  "Guided Experience",
+            "publisher":  "Microsoft",
+            "version": "24.0.0.0"
           }
                      ],
     "screenshots":  [

--- a/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
@@ -74,6 +74,7 @@ page 7775 "Copilot AI Capabilities"
 
                         CurrPage.GenerallyAvailableCapabilities.Page.SetDataMovement(AllowDataMovement);
                         CurrPage.PreviewCapabilities.Page.SetDataMovement(AllowDataMovement);
+                        CopilotCapabilityImpl.UpdateGuidedExperience(AllowDataMovement);
                     end;
                 }
 
@@ -171,6 +172,8 @@ page 7775 "Copilot AI Capabilities"
 
         if InGeo and (not AllowDataMovement) then
             CopilotCapabilityImpl.ShowPrivacyNoticeDisagreedNotification();
+
+        CopilotCapabilityImpl.UpdateGuidedExperience(AllowDataMovement);
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
@@ -4,12 +4,13 @@
 // ------------------------------------------------------------------------------------------------
 namespace System.AI;
 
-using System.Globalization;
-using System.Telemetry;
-using System.Security.User;
 using System.Azure.Identity;
 using System.Environment;
+using System.Environment.Configuration;
+using System.Globalization;
 using System.Privacy;
+using System.Security.User;
+using System.Telemetry;
 
 codeunit 7774 "Copilot Capability Impl"
 {
@@ -235,6 +236,16 @@ codeunit 7774 "Copilot Capability Impl"
         UserPermissions: Codeunit "User Permissions";
     begin
         IsAdmin := AzureADGraphUser.IsUserDelegatedAdmin() or AzureADPlan.IsPlanAssignedToUser(PlanIds.GetGlobalAdminPlanId()) or AzureADPlan.IsPlanAssignedToUser(PlanIds.GetD365AdminPlanId()) or AzureADGraphUser.IsUserDelegatedHelpdesk() or UserPermissions.IsSuper(UserSecurityId());
+    end;
+
+    procedure UpdateGuidedExperience(AllowDataMovement: Boolean)
+    var
+        GuidedExperience: Codeunit "Guided Experience";
+    begin
+        if AllowDataMovement then
+            GuidedExperience.CompleteAssistedSetup(ObjectType::Page, Page::"Copilot AI Capabilities")
+        else
+            GuidedExperience.ResetAssistedSetup(ObjectType::Page, Page::"Copilot AI Capabilities");
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Privacy Notice", 'OnRegisterPrivacyNotices', '', false, false)]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
**Problem**
When going through assisted setup, Copilot can be setup however the `Completed` flag will never be checked off even if `Data Movement` is set to True or in Geo.

**Solution**
1. Upon opening of the `Copilot & AI Capabilities` page, set the assisted setup to completed if in geo.
2. Toggle `complete` on/off depending on `Allow Data Movement` for other geos.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#492206](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/492206)




