### PR TITLE
Skip workitem validation when PR is closed

### DIFF
--- a/.github/workflows/WorkitemValidation.yaml
+++ b/.github/workflows/WorkitemValidation.yaml
@@ -15,6 +15,7 @@ defaults:
 
 jobs:
   GitHubIssueValidation:
+    if: github.repository_owner == 'microsoft' && github.event.pull_request.state == 'open'
     name: 'Validate link to issues'
     runs-on: ubuntu-latest
     steps:
@@ -28,6 +29,7 @@ jobs:
           build/scripts/PullRequestValidation/ValidateIssuesForPullRequest.ps1 -PullRequestNumber ${{ github.event.pull_request.number }} -Repository ${{ github.repository }}
   
   WorkItemValidationForMicrosoft:
+    if: github.repository_owner == 'microsoft' && github.event.pull_request.state == 'open'
     name: 'For Microsoft: Validate link to internal work items' 
     runs-on: ubuntu-latest
     needs: GitHubIssueValidation


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Right now work item validation also runs when the PR is closed. Let's not do that 😄 

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#495038](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/495038)


