### PR TITLE
Fix error "The date is not valid." in SetDefaultSeed

### DIFF
--- a/src/Tools/Test Framework/Test Libraries/Any/src/Any.Codeunit.al
+++ b/src/Tools/Test Framework/Test Libraries/Any/src/Any.Codeunit.al
@@ -254,7 +254,7 @@ codeunit 130500 "Any"
     procedure SetDefaultSeed()
     begin
         SeedSet := true;
-        SetSeed(Time() - 0T);
+        SetSeed(Time() - 000000T);
     end;
 
     /// <summary>.


### PR DESCRIPTION
#### Summary
Time-0T will throw an error.

#### Work Item(s)

Fixes [AB#495083](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/495083)

