### PR TITLE
[main] [net8] UriBuilderTest.Codeunit.al - update port validation error text

### DIFF
--- a/src/System Application/Test/URI/src/UriBuilderTest.Codeunit.al
+++ b/src/System Application/Test/URI/src/UriBuilderTest.Codeunit.al
@@ -108,6 +108,8 @@ codeunit 135071 "Uri Builder Test"
     procedure SetIncorrectPortTest()
     var
         ExpectedErr: Label 'A call to System.UriBuilder.Port failed with this message: Specified argument was out of the range of valid values. (Parameter ''value'')', Locked = true;
+        Expected1Err: Label 'A call to System.UriBuilder.Port failed with this message: value (''-2'') must be greater than or equal to ''-1''. (Parameter ''value'')\Actual value was -2.', Locked = true;
+        Expected2Err: Label 'A call to System.UriBuilder.Port failed with this message: value (''65536'') must be less than or equal to ''65535''. (Parameter ''value'')\Actual value was 65536.', Locked = true;
     begin
         // [Given] A Url
         UriBuilder.Init('http://microsoft.com');
@@ -116,13 +118,13 @@ codeunit 135071 "Uri Builder Test"
         asserterror UriBuilder.SetPort(-2);
 
         // [Then] An error occurs
-        Assert.ExpectedError(ExpectedErr);
+        Assert.IsFalse((StrPos(GetLastErrorText(), ExpectedErr) = 0) and (StrPos(GetLastErrorText(), Expected1Err) = 0), 'The error message does not match');
 
         // [When] Setting the port number too high
         asserterror UriBuilder.SetPort(65536);
 
         // [Then] An error occurs
-        Assert.ExpectedError(ExpectedErr);
+        Assert.IsFalse((StrPos(GetLastErrorText(), ExpectedErr) = 0) and (StrPos(GetLastErrorText(), Expected2Err) = 0), 'The error message does not match');
     end;
 
     [Test]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

This updates port validation error text assertions in UriBuilderTest.Codeunit.al to align with updated underlying exception message changed in .NET 8. The old validation texts remain to keep compatibility with platform versions based on .NET 6.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#477674](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/477674)




