### PR TITLE
fix empty record is shown when no data is fetched

### DIFF
--- a/src/System Application/App/Guided Experience/src/Guided Experience/GuidedExperienceItemCleanup.Page.al
+++ b/src/System Application/App/Guided Experience/src/Guided Experience/GuidedExperienceItemCleanup.Page.al
@@ -112,7 +112,7 @@ page 1998 "Guided Experience Item Cleanup"
         Rec.DeleteAll();
         GuidedExperienceImpl.GetDuplicatedGuidedExperienceItems(TempGuidedExperienceItem, 100);
 
-        if TempGuidedExperienceItem.Count() = 0 then
+        if TempGuidedExperienceItem.IsEmpty() then
             exit;
 
         Rec.Copy(TempGuidedExperienceItem, true);

--- a/src/System Application/App/Guided Experience/src/Guided Experience/GuidedExperienceItemCleanup.Page.al
+++ b/src/System Application/App/Guided Experience/src/Guided Experience/GuidedExperienceItemCleanup.Page.al
@@ -111,6 +111,10 @@ page 1998 "Guided Experience Item Cleanup"
     begin
         Rec.DeleteAll();
         GuidedExperienceImpl.GetDuplicatedGuidedExperienceItems(TempGuidedExperienceItem, 100);
+
+        if TempGuidedExperienceItem.Count() = 0 then
+            exit;
+
         Rec.Copy(TempGuidedExperienceItem, true);
         if Rec.FindFirst() then; // set focus on the first row
         CurrPage.Update();


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->
When no duplicated guided experience item is presented, the current logic will show an empty line.

Adding check to see if there is any record retrieved.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#485933](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/485933)



