### PR TITLE
Turn AW0009 and AS0059 warnings into errors

### DIFF
--- a/src/System Application/App/Data Administration/src/MediaCleanupFactbox.Page.al
+++ b/src/System Application/App/Data Administration/src/MediaCleanupFactbox.Page.al
@@ -20,7 +20,9 @@ page 1928 "Media Cleanup FactBox"
     {
         area(Content)
         {
+#pragma warning disable AW0009
             field(MediaContent; Rec.Content)
+#pragma warning restore AW0009
             {
                 ApplicationArea = All;
                 ShowCaption = false;

--- a/src/System Application/App/Email/src/Account/EmailAccountWizard.Page.al
+++ b/src/System Application/App/Email/src/Account/EmailAccountWizard.Page.al
@@ -129,7 +129,9 @@ page 8886 "Email Account Wizard"
                     FreezeColumn = Name;
                     Editable = false;
 
+#pragma warning disable AW0009
                     field(Logo; Rec.Logo)
+#pragma warning restore AW0009
                     {
                         ApplicationArea = All;
                         Caption = ' ';

--- a/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
+++ b/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
@@ -36,7 +36,9 @@ page 8887 "Email Accounts"
             {
                 Visible = ShowLogo;
                 FreezeColumn = NameField;
+#pragma warning disable AW0009
                 field(LogoField; Rec.LogoBlob)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = All;
                     ShowCaption = false;

--- a/src/System Application/App/Web Service Management/src/WebServiceManagementImpl.Codeunit.al
+++ b/src/System Application/App/Web Service Management/src/WebServiceManagementImpl.Codeunit.al
@@ -309,14 +309,19 @@ codeunit 9751 "Web Service Management Impl."
         TenantWebService: Record "Tenant Web Service";
     begin
         WebServiceAggregate.Reset();
+#pragma warning disable AS0059
         WebServiceAggregate.DeleteAll();
+#pragma warning restore AS0059
 
         if WebService.FindSet() then
             repeat
                 WebServiceAggregate.Init();
                 WebServiceAggregate.TransferFields(WebService);
                 WebServiceAggregate."All Tenants" := true;
+
+#pragma warning disable AS0059
                 WebServiceAggregate.Insert();
+#pragma warning restore AS0059
             until WebService.Next() = 0;
 
         WebServiceAggregate."All Tenants" := false;
@@ -333,7 +338,9 @@ codeunit 9751 "Web Service Management Impl."
                     if WebService.IsEmpty() then begin
                         WebServiceAggregate.Init();
                         WebServiceAggregate.TransferFields(TenantWebService);
+#pragma warning disable AS0059
                         WebServiceAggregate.Insert();
+#pragma warning restore AS0059
                     end
                 end
             until TenantWebService.Next() = 0;

--- a/src/rulesets/ruleset.json
+++ b/src/rulesets/ruleset.json
@@ -31,12 +31,12 @@
   "rules": [
     {
       "id": "AS0059",
-      "action": "Warning",
+      "action": "Error",
       "justification": "Will be fixed. Reserved database tables are read-only in a multi-tenant environment"
     },
     {
       "id": "AW0009",
-      "action": "Warning",
+      "action": "Error",
       "justification": "Using a Blob with subtype Bitmap on a page field is deprecated. Instead use the Media/MediaSet data types."
     },
     {

--- a/src/rulesets/ruleset.json
+++ b/src/rulesets/ruleset.json
@@ -30,16 +30,6 @@
   ],
   "rules": [
     {
-      "id": "AS0059",
-      "action": "Error",
-      "justification": "Will be fixed. Reserved database tables are read-only in a multi-tenant environment"
-    },
-    {
-      "id": "AW0009",
-      "action": "Error",
-      "justification": "Using a Blob with subtype Bitmap on a page field is deprecated. Instead use the Media/MediaSet data types."
-    },
-    {
       "id": "AS0053",
       "action": "None",
       "justification": "The compilation target of an application must be a value that is allowed in a multi-tenant SaaS environment"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Turn codecop AW0009 and AS0059 into errors.

Using pragmas instead of fixing due to following reasons:
AS0059: Table needs to be changed to temporary. Codecop was added due to their specific apparently.

AW0009: The places where the bitmaps are used, aren't one of the supported places for media/mediaset fields.
Fx, list of records. The only time it works, is if it is showing in a tile view, which for Emails, we are not.
The MediaCleanup uses Tenant Media record directly, which is a blob.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#487172](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/487172)





