### PR TITLE
[Copilot] Europe geo check addition

### DIFF
--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -109,10 +109,11 @@ codeunit 7772 "Azure OpenAI Impl"
 
     local procedure CheckPrivacyNoticeState(Silent: Boolean; Capability: Enum "Copilot Capability"): Boolean
     var
+        CopilotCapabilityImpl: Codeunit "Copilot Capability Impl";
         PrivacyNotice: Codeunit "Privacy Notice";
         CopilotNotAvailable: Page "Copilot Not Available";
-        ALCopilotFunctions: DotNet ALCopilotFunctions;
         WithinGeo: Boolean;
+        WithinEuropeGeo: Boolean;
     begin
         case PrivacyNotice.GetPrivacyNoticeApprovalState(CopilotCapabilityImpl.GetAzureOpenAICategory(), false) of
             Enum::"Privacy Notice Approval State"::Agreed:
@@ -129,7 +130,8 @@ codeunit 7772 "Azure OpenAI Impl"
             else begin
                 // Privacy notice not set, we will not cross geo-boundries
                 if not Silent then begin
-                    WithinGeo := ALCopilotFunctions.IsWithinGeo() or ALCopilotFunctions.IsEuropeGeo();
+                    CopilotCapabilityImpl.CheckGeo(WithinGeo, WithinEuropeGeo);
+                    WithinGeo := WithinGeo or WithinEuropeGeo;
                     if not WithinGeo then begin
                         CopilotNotAvailable.SetCopilotCapability(Capability);
                         CopilotNotAvailable.Run();

--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -109,7 +109,6 @@ codeunit 7772 "Azure OpenAI Impl"
 
     local procedure CheckPrivacyNoticeState(Silent: Boolean; Capability: Enum "Copilot Capability"): Boolean
     var
-        CopilotCapabilityImpl: Codeunit "Copilot Capability Impl";
         PrivacyNotice: Codeunit "Privacy Notice";
         CopilotNotAvailable: Page "Copilot Not Available";
         WithinGeo: Boolean;

--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -127,13 +127,14 @@ codeunit 7772 "Azure OpenAI Impl"
                     exit(false);
                 end;
             else begin
-                WithinGeo := ALCopilotFunctions.IsWithinGeo();
                 // Privacy notice not set, we will not cross geo-boundries
-                if not Silent then
+                if not Silent then begin
+                    WithinGeo := ALCopilotFunctions.IsWithinGeo() or ALCopilotFunctions.IsEuropeGeo();
                     if not WithinGeo then begin
                         CopilotNotAvailable.SetCopilotCapability(Capability);
                         CopilotNotAvailable.Run();
                     end;
+                end;
 
                 exit(WithinGeo);
             end;

--- a/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
@@ -151,6 +151,7 @@ page 7775 "Copilot AI Capabilities"
         OnRegisterCopilotCapability();
 
         InGeo := ALCopilotFunctions.IsWithinGeo();
+        InEuropeGeo := ALCopilotFunctions.IsEuropeGeo();
 
         case PrivacyNotice.GetPrivacyNoticeApprovalState(CopilotCapabilityImpl.GetAzureOpenAICategory(), false) of
             Enum::"Privacy Notice Approval State"::Agreed:
@@ -158,7 +159,7 @@ page 7775 "Copilot AI Capabilities"
             Enum::"Privacy Notice Approval State"::Disagreed:
                 AllowDataMovement := false;
             else
-                AllowDataMovement := InGeo;
+                AllowDataMovement := InGeo or InEuropeGeo;
         end;
 
         AllowDataMovementEditable := CopilotCapabilityImpl.IsAdmin();
@@ -183,6 +184,7 @@ page 7775 "Copilot AI Capabilities"
         CopilotCapabilityImpl: Codeunit "Copilot Capability Impl";
         PrivacyNotice: Codeunit "Privacy Notice";
         InGeo: Boolean;
+        InEuropeGeo: Boolean;
         AllowDataMovement: Boolean;
         AllowDataMovementEditable: Boolean;
         CopilotGovernDataLbl: Label 'How do I govern my Copilot data?';

--- a/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
@@ -36,7 +36,7 @@ page 7775 "Copilot AI Capabilities"
             {
                 ShowCaption = false;
                 InstructionalText = 'Copilot and other generative AI capabilities use Azure OpenAI Service. Your environment connects to Azure OpenAI Service in your region.';
-                Visible = InGeo;
+                Visible = WithinGeo;
 
                 field(GovernData; CopilotGovernDataLbl)
                 {
@@ -54,7 +54,7 @@ page 7775 "Copilot AI Capabilities"
             {
                 ShowCaption = false;
                 InstructionalText = 'Generative AI capabilities are deactivated because Azure OpenAI Service is not available in your region. By allowing data movement, you agree to data being stored and processed by the Azure OpenAI Service outside of your environment''s geographic region or compliance boundary.';
-                Visible = not InGeo;
+                Visible = not WithinGeo;
 
                 field(DataMovement; AllowDataMovement)
                 {
@@ -150,8 +150,7 @@ page 7775 "Copilot AI Capabilities"
     begin
         OnRegisterCopilotCapability();
 
-        InGeo := ALCopilotFunctions.IsWithinGeo();
-        InEuropeGeo := ALCopilotFunctions.IsEuropeGeo();
+        CopilotCapabilityImpl.CheckGeo(WithinGeo, WithinEuropeGeo);
 
         case PrivacyNotice.GetPrivacyNoticeApprovalState(CopilotCapabilityImpl.GetAzureOpenAICategory(), false) of
             Enum::"Privacy Notice Approval State"::Agreed:
@@ -159,7 +158,7 @@ page 7775 "Copilot AI Capabilities"
             Enum::"Privacy Notice Approval State"::Disagreed:
                 AllowDataMovement := false;
             else
-                AllowDataMovement := InGeo or InEuropeGeo;
+                AllowDataMovement := WithinGeo or WithinEuropeGeo;
         end;
 
         AllowDataMovementEditable := CopilotCapabilityImpl.IsAdmin();
@@ -170,7 +169,7 @@ page 7775 "Copilot AI Capabilities"
         if not EnvironmentInformation.IsSaaSInfrastructure() then
             CopilotCapabilityImpl.ShowCapabilitiesNotAvailableOnPremNotification();
 
-        if InGeo and (not AllowDataMovement) then
+        if WithinGeo and (not AllowDataMovement) then
             CopilotCapabilityImpl.ShowPrivacyNoticeDisagreedNotification();
     end;
 
@@ -183,8 +182,8 @@ page 7775 "Copilot AI Capabilities"
     var
         CopilotCapabilityImpl: Codeunit "Copilot Capability Impl";
         PrivacyNotice: Codeunit "Privacy Notice";
-        InGeo: Boolean;
-        InEuropeGeo: Boolean;
+        WithinGeo: Boolean;
+        WithinEuropeGeo: Boolean;
         AllowDataMovement: Boolean;
         AllowDataMovementEditable: Boolean;
         CopilotGovernDataLbl: Label 'How do I govern my Copilot data?';

--- a/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
@@ -35,7 +35,7 @@ page 7775 "Copilot AI Capabilities"
             {
                 ShowCaption = false;
                 InstructionalText = 'Copilot and other generative AI capabilities use Azure OpenAI Service. Your environment connects to Azure OpenAI Service in your region.';
-                Visible = WithinGeo;
+                Visible = WithinGeo and (not WithinEuropeGeo);
 
                 field(GovernData; CopilotGovernDataLbl)
                 {
@@ -52,8 +52,8 @@ page 7775 "Copilot AI Capabilities"
             group(NotAlwaysConnected)
             {
                 ShowCaption = false;
-                InstructionalText = 'Generative AI capabilities are deactivated because Azure OpenAI Service is not available in your region. By allowing data movement, you agree to data being stored and processed by the Azure OpenAI Service outside of your environment''s geographic region or compliance boundary.';
-                Visible = not WithinGeo;
+                InstructionalText = 'Generative AI capabilities are deactivated because Azure OpenAI Service is not available in your region. By allowing data movement, you agree to data being stored and processed by the Azure OpenAI Service outside of your environment''s geographic region or compliance boundary. For environments located in West Europe and North Europe Azure regions, Business Central automatically opts in to data movement, but administrators can choose to opt out at any time.';
+                Visible = (not WithinGeo) or WithinEuropeGeo;
 
                 field(DataMovement; AllowDataMovement)
                 {

--- a/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
@@ -146,7 +146,6 @@ page 7775 "Copilot AI Capabilities"
     trigger OnOpenPage()
     var
         EnvironmentInformation: Codeunit "Environment Information";
-        ALCopilotFunctions: DotNet ALCopilotFunctions;
     begin
         OnRegisterCopilotCapability();
 

--- a/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
@@ -6,7 +6,6 @@ namespace System.AI;
 
 using System.Environment;
 using System.Privacy;
-using System;
 
 /// <summary>
 /// This page is used to set the Copilot settings in the Environment.

--- a/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
@@ -52,7 +52,7 @@ page 7775 "Copilot AI Capabilities"
             group(NotAlwaysConnected)
             {
                 ShowCaption = false;
-                InstructionalText = 'Generative AI capabilities are deactivated because Azure OpenAI Service is not available in your region. By allowing data movement, you agree to data being stored and processed by the Azure OpenAI Service outside of your environment''s geographic region or compliance boundary. For environments located in West Europe and North Europe Azure regions, Business Central automatically opts in to data movement, but administrators can choose to opt out at any time.';
+                InstructionalText = 'Generative AI capabilities are deactivated because Azure OpenAI Service is not available in your region. By allowing data movement, you agree to data being stored and processed by the Azure OpenAI Service outside of your environment''s geographic region or compliance boundary.';
                 Visible = (not WithinGeo) or WithinEuropeGeo;
 
                 field(DataMovement; AllowDataMovement)

--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
@@ -237,6 +237,15 @@ codeunit 7774 "Copilot Capability Impl"
         IsAdmin := AzureADGraphUser.IsUserDelegatedAdmin() or AzureADPlan.IsPlanAssignedToUser(PlanIds.GetGlobalAdminPlanId()) or AzureADPlan.IsPlanAssignedToUser(PlanIds.GetD365AdminPlanId()) or AzureADGraphUser.IsUserDelegatedHelpdesk() or UserPermissions.IsSuper(UserSecurityId());
     end;
 
+    [Tryfunction]
+    procedure CheckGeo(var WithinGeo: Boolean; var WithinEuropeGeo: Boolean)
+    var
+        ALCopilotFunctions: DotNet ALCopilotFunctions;
+    begin
+        WithinGeo := ALCopilotFunctions.IsWithinGeo();
+        WithinEuropeGeo := ALCopilotFunctions.IsEuropeGeo();
+    end;
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Privacy Notice", 'OnRegisterPrivacyNotices', '', false, false)]
     local procedure CreatePrivacyNoticeRegistrations(var TempPrivacyNotice: Record "Privacy Notice" temporary)
     begin

--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------------------------------------------
 namespace System.AI;
 
+using System;
 using System.Globalization;
 using System.Telemetry;
 using System.Security.User;

--- a/src/System Application/App/Privacy Notice/src/PrivacyNoticeImpl.Codeunit.al
+++ b/src/System Application/App/Privacy Notice/src/PrivacyNoticeImpl.Codeunit.al
@@ -128,10 +128,9 @@ codeunit 1565 "Privacy Notice Impl."
         PrivacyNotice.SetAutoCalcFields(Enabled, Disabled);
         PrivacyNotice.SetRange("User SID Filter", EmptyGuid);
 
-        // If the Privacy Notice does not exist then re-initialize all Privacy Notices
         if not PrivacyNotice.Get(PrivacyNoticeId) then begin
             Session.LogMessage('0000GN7', StrSubstNo(PrivacyNoticeDoesNotExistTelemetryTxt, PrivacyNoticeId), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', TelemetryCategoryTxt);
-            if Company.Get(CompanyName()) and Company."Evaluation Company" then
+            if SkipCheckInEval and Company.Get(CompanyName()) and Company."Evaluation Company" then
                 exit("Privacy Notice Approval State"::Agreed); // Auto-agree for evaluation companies if admin has not explicitly disagreed
             exit("Privacy Notice Approval State"::"Not set"); // If there are no Privacy Notice then it is by default "Not set".
         end;

--- a/src/System Application/Test/Web Service Management/src/WebServiceManagementTest.Codeunit.al
+++ b/src/System Application/Test/Web Service Management/src/WebServiceManagementTest.Codeunit.al
@@ -689,7 +689,9 @@ codeunit 139043 "Web Service Management Test"
 
         WebService.DeleteAll();
         TenantWebService.DeleteAll();
+#pragma warning disable AS0059
         WebServiceAggregate.DeleteAll();
+#pragma warning restore AS0059
         Initialized := true;
     end;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
1.  Move geo calls into a TryFunction. If the dotnet call fails, the geo check falls back to False as default.
2. Add Europe geo check which sets the toggle for allowing data movement if the region does not have resources. 
      - Europe region will always show the toggle and this is opt out.
      - In geo (With resources), no toggle
      - Out of geo (Without resources), toggle will show and it is opt in.

EU
![image](https://github.com/microsoft/BCApps/assets/18476646/c687ab64-9930-41b0-891a-ded9f19437f8)
Out of EU
![image](https://github.com/microsoft/BCApps/assets/18476646/a06736d5-8abc-4f37-a8e6-e6f0ccc72de4)

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#491306](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/491306) [AB#495385](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/495385)










