### PR TITLE
[Entity Text] Check if the entity text copilot capability is registered

### DIFF
--- a/src/System Application/App/Entity Text/src/EntityTextAOAISettings.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextAOAISettings.Codeunit.al
@@ -43,6 +43,7 @@ codeunit 2011 "Entity Text AOAI Settings"
 
         if not CopilotCapability.IsCapabilityRegistered(enum::"Copilot Capability"::"Entity Text") then begin
             Session.LogMessage('0000M56', TelemetryCapabilityNotRegisteredTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', TelemetryCategoryLbl);
+            exit(false);
         end;
 
         if (not Silent) and (not AzureOpenAI.IsEnabled(Enum::"Copilot Capability"::"Entity Text", Silent)) then begin


### PR DESCRIPTION
#### Summary

When running locally, navigating to the item card will render the entity text factbox part. As part of this the part determines if it has the Copilot capabilities enabled, to do this it calls into `EntityTextAOAISettings.IsEnabled(true)` (i.e. silently).

As part of the silent check it checks if the capability is enabled, but only if it should fail not silently. The idea is that we should show the capability in UI so users know to enable it.
This means the code actually passes this check and then proceeds to try to load the prompt metadata from the key vault. This fails locally and causes errors in the event logs to be spammed whenever the item card is opened.

Fix is simple, locally the copilot capability is not registered, so we can just exit false if the capability is not registered at all (and not render any UI actions - as the capability does not exist).

#### Work Item(s)
Fixes [AB#495853](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/495853)




