### PR TITLE
Remove the faulty permission check in the RemoveOrphanedEntraGroups function

### DIFF
--- a/src/System Application/App/Security Groups/src/SecurityGroupImpl.Codeunit.al
+++ b/src/System Application/App/Security Groups/src/SecurityGroupImpl.Codeunit.al
@@ -36,6 +36,7 @@ codeunit 9871 "Security Group Impl."
         EntraTxt: Label 'Microsoft Entra', Locked = true;
         SecurityGroupAddedLbl: Label 'A security group with ID %1 has been added. Automatically created user with security ID: %2.', Locked = true;
         RemovingOrphanedGroupsTxt: Label 'Removing %1 orphaned security groups.', Locked = true;
+        CouldNotRemoveGroupErr: Label 'Could not delete an orphaned security group.', Locked = true;
         NotificationIdLbl: Label 'e78ecb57-f560-4788-b9c7-e5a477467d65', Locked = true;
 
     procedure ValidateGroupId(GroupId: Text)
@@ -587,9 +588,6 @@ codeunit 9871 "Security Group Impl."
         OrphanedGroupUserSecurityIds: List of [Guid];
         OrphanedGroupUserSecurityId: Guid;
     begin
-        if not GroupUser.WritePermission() then
-            exit;
-
         GroupUser.SetRange("License Type", GroupUser."License Type"::"AAD Group");
         if GroupUser.FindSet() then
             repeat
@@ -604,7 +602,8 @@ codeunit 9871 "Security Group Impl."
         Session.LogMessage('0000LI8', StrSubstNo(RemovingOrphanedGroupsTxt, OrphanedGroupUserSecurityIds.Count()), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', SecurityGroupsTok);
         foreach OrphanedGroupUserSecurityId in OrphanedGroupUserSecurityIds do
             if GroupUser.Get(OrphanedGroupUserSecurityId) then
-                GroupUser.Delete();
+                if not GroupUser.Delete(true) then
+                    Session.LogMessage('0000M5L', CouldNotRemoveGroupErr, Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', SecurityGroupsTok);
     end;
 
     [InternalEvent(false)]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
**Problem:**
The code for deleting orphaned security groups starts with:
```
if not User.WritePermission() then
    exit;
```
But in SaaS no entitlement has insert permission to the user table, so this check always fails. Unfortunately, there is no way to check for delete permission separately.

**Solution:**
Remove the check and protect the deletion operation with `if not ... then`.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#496007](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/496007)



