### PR TITLE
Set enableCodeAnalyzersOnTestApps to true

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -53,6 +53,7 @@
     "enableAppSourceCop":  true,
     "enablePerTenantExtensionCop":  true,
     "enableUICop":  true,
+    "enableCodeAnalyzersOnTestApps":  true,
     "rulesetFile":  "..\\..\\..\\src\\rulesets\\ruleset.json",
     "skipUpgrade":  true,
     "PartnerTelemetryConnectionString":  "InstrumentationKey=403ba4d3-ad2b-4ca1-8602-b7746de4c048;IngestionEndpoint=https://swedencentral-0.in.applicationinsights.azure.com/",


### PR DESCRIPTION
Setting `enableCodeAnalyzersOnTestApps` to true means code analyzers will be applied to test apps the same way they are applied to normal (non-test) apps.

Pending AL-Go preview release and uptake ✅

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#495937](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/495937)





