### PR TITLE
Allow apostrophes in page field names for edit in excel

### DIFF
--- a/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
+++ b/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
@@ -15,7 +15,7 @@ using System.Reflection;
 
 codeunit 1482 "Edit in Excel Impl."
 {
-    Access = Internal;
+    Access = Public;
     InherentEntitlements = X;
     InherentPermissions = X;
 
@@ -46,6 +46,7 @@ codeunit 1482 "Edit in Excel Impl."
         DialogTitleTxt: Label 'Export';
         ExcelFileNameTxt: Text;
         XmlByteEncodingTok: Label '_x00%1_%2', Locked = true;
+        XmlByteEncoding2Tok: Label '%1_x00%2_%3', Locked = true;
 
     procedure EditPageInExcel(PageCaption: Text[240]; PageId: Integer; EditinExcelFilters: Codeunit "Edit in Excel Filters"; FileName: Text)
     var
@@ -704,10 +705,13 @@ codeunit 1482 "Edit in Excel Impl."
     end;
 #endif
 
+
     procedure ExternalizeODataObjectName(Name: Text) ConvertedName: Text
     var
         CurrentPosition: Integer;
         Convert: DotNet Convert;
+        StartStr: Text;
+        EndStr: Text;
         ByteValue: DotNet Byte;
     begin
         ConvertedName := Name;
@@ -735,7 +739,14 @@ codeunit 1482 "Edit in Excel Impl."
                         ConvertedName := DelStr(ConvertedName, CurrentPosition, 1);
                         CurrentPosition -= 1;
                     end else
-                        ConvertedName[CurrentPosition] := '_';
+                        if ConvertedName[CurrentPosition] = '''' then begin
+                            ByteValue := Convert.ToByte(ConvertedName[CurrentPosition]);
+                            StartStr := CopyStr(ConvertedName, 1, CurrentPosition - 1);
+                            EndStr := CopyStr(ConvertedName, CurrentPosition + 1);
+                            ConvertedName := StrSubstNo(XmlByteEncoding2Tok, StartStr, Convert.ToString(ByteValue, 16), EndStr);
+                            CurrentPosition += 6;
+                        end else
+                            ConvertedName[CurrentPosition] := '_';
                 end else
                     ConvertedName[CurrentPosition] := '_';
 

--- a/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
+++ b/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
@@ -15,7 +15,7 @@ using System.Reflection;
 
 codeunit 1482 "Edit in Excel Impl."
 {
-    Access = Public;
+    Access = Internal;
     InherentEntitlements = X;
     InherentPermissions = X;
 
@@ -733,22 +733,22 @@ codeunit 1482 "Edit in Excel Impl."
         CurrentPosition := 1;
 
         while CurrentPosition <= StrLen(ConvertedName) do begin
-            if ConvertedName[CurrentPosition] in [' ', '\', '/', '''', '"', '.', '(', ')', '-', ':'] then
-                if CurrentPosition > 1 then begin
-                    if ConvertedName[CurrentPosition - 1] = '_' then begin
-                        ConvertedName := DelStr(ConvertedName, CurrentPosition, 1);
-                        CurrentPosition -= 1;
-                    end else
-                        if ConvertedName[CurrentPosition] = '''' then begin
-                            ByteValue := Convert.ToByte(ConvertedName[CurrentPosition]);
-                            StartStr := CopyStr(ConvertedName, 1, CurrentPosition - 1);
-                            EndStr := CopyStr(ConvertedName, CurrentPosition + 1);
-                            ConvertedName := StrSubstNo(XmlByteEncoding2Tok, StartStr, Convert.ToString(ByteValue, 16), EndStr);
-                            CurrentPosition += 6;
+            if ConvertedName[CurrentPosition] = '''' then begin
+                ByteValue := Convert.ToByte(ConvertedName[CurrentPosition]);
+                StartStr := CopyStr(ConvertedName, 1, CurrentPosition - 1);
+                EndStr := CopyStr(ConvertedName, CurrentPosition + 1);
+                ConvertedName := StrSubstNo(XmlByteEncoding2Tok, StartStr, Convert.ToString(ByteValue, 16), EndStr);
+                CurrentPosition += 6;
+            end else
+                if ConvertedName[CurrentPosition] in [' ', '\', '/', '"', '.', '(', ')', '-', ':'] then
+                    if CurrentPosition > 1 then begin
+                        if ConvertedName[CurrentPosition - 1] = '_' then begin
+                            ConvertedName := DelStr(ConvertedName, CurrentPosition, 1);
+                            CurrentPosition -= 1;
                         end else
                             ConvertedName[CurrentPosition] := '_';
-                end else
-                    ConvertedName[CurrentPosition] := '_';
+                    end else
+                        ConvertedName[CurrentPosition] := '_';
 
             CurrentPosition += 1;
         end;

--- a/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
+++ b/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
@@ -738,6 +738,7 @@ codeunit 1482 "Edit in Excel Impl."
                 StartStr := CopyStr(ConvertedName, 1, CurrentPosition - 1);
                 EndStr := CopyStr(ConvertedName, CurrentPosition + 1);
                 ConvertedName := StrSubstNo(XmlByteEncoding2Tok, StartStr, Convert.ToString(ByteValue, 16), EndStr);
+                // length of _x00nn_ minus one that will be added later
                 CurrentPosition += 6;
             end else
                 if ConvertedName[CurrentPosition] in [' ', '\', '/', '"', '.', '(', ')', '-', ':'] then

--- a/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
+++ b/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
@@ -190,14 +190,17 @@ codeunit 132525 "Edit in Excel Test"
     procedure TestEditInExcelNumberInFieldNameReplacement()
     var
         EditinExcelTestLibrary: Codeunit "Edit in Excel Test Library";
+        ApostropheFieldName: Text;
         RegularFieldName: Text;
         FieldNameStartingWDigit: Text;
     begin
         Init();
         FieldNameStartingWDigit := EditinExcelTestLibrary.ExternalizeODataObjectName('3field');
         RegularFieldName := EditinExcelTestLibrary.ExternalizeODataObjectName('field');
+        ApostropheFieldName := EditinExcelTestLibrary.ExternalizeODataObjectName('new vendor''s name');
         LibraryAssert.AreEqual('field', RegularFieldName, 'Conversion alters name that does not begin with a string');
         LibraryAssert.AreEqual('_x0033_field', FieldNameStartingWDigit, 'Did not convert the name with number correctly');
+        LibraryAssert.AreEqual('new_vendor_x0027_s_name', ApostropheFieldName, 'Did not convert the name with an apostrophe correctly');
     end;
 
     [Test]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

The issue

Edit-In Excel module does not externalize page field names the same way the platform does, when the field name contains an apostrophe.
For a page field defined as:
```
field("new vendor's name"; rec."New Vendor's Name")
{
	ApplicationArea = All;
}
```

The platform will externalize this name as `new_vendor_x0027_s_name` while the Edit-In Excel module will externalize it as `new_vendor_s_name`.

Expected behavior

Within reason the platform and the Edit-In Excel module should externalize fields the same way to avoid discrepancies between the API metadata and the Edit-In Excel field bindings.

Steps to reproduce

Create a page field with an apostrophe in its name on a card page, then try to export its corresponding list page using Edit-In Excel and observe the error dialog in the Excel side pane where add-ins are loaded.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#423505](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/423505/)



