### PR TITLE
[Copilot] Geocheck failure when silent

### DIFF
--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -129,9 +129,10 @@ codeunit 7772 "Azure OpenAI Impl"
                 end;
             else begin
                 // Privacy notice not set, we will not cross geo-boundries
+                CopilotCapabilityImpl.CheckGeo(WithinGeo, WithinEuropeGeo);
+                WithinGeo := WithinGeo or WithinEuropeGeo;
+
                 if not Silent then begin
-                    CopilotCapabilityImpl.CheckGeo(WithinGeo, WithinEuropeGeo);
-                    WithinGeo := WithinGeo or WithinEuropeGeo;
                     if not WithinGeo then begin
                         CopilotNotAvailable.SetCopilotCapability(Capability);
                         CopilotNotAvailable.Run();

--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -132,12 +132,11 @@ codeunit 7772 "Azure OpenAI Impl"
                 CopilotCapabilityImpl.CheckGeo(WithinGeo, WithinEuropeGeo);
                 WithinGeo := WithinGeo or WithinEuropeGeo;
 
-                if not Silent then begin
+                if not Silent then
                     if not WithinGeo then begin
                         CopilotNotAvailable.SetCopilotCapability(Capability);
                         CopilotNotAvailable.Run();
                     end;
-                end;
 
                 exit(WithinGeo);
             end;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
When IsEnabled is called silently, it will return `false` if the privacy notice has not been accepted due to `CheckGeo` call being placed in the `if not Silent then` condition.

Solution is to move it before the check, as such, the return will have the proper value.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#496840](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/496840)


