### PR TITLE
Clean AllowExtensionAndTargetInSameModule from manifests

### DIFF
--- a/src/System Application/App/app.json
+++ b/src/System Application/App/app.json
@@ -38,8 +38,7 @@
                  ],
     "features":  [
                      "TranslationFile",
-                     "GenerateCaptions",
-                     "AllowExtensionAndTargetInSameModule"
+                     "GenerateCaptions"
                  ],
     "resourceExposurePolicy":  {
                                    "allowDebugging":  false,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Clean AllowExtensionAndTargetInSameModule from manifests because the flag isn't needed and has been removed from the compiler

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#496866](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/496866)

