### PR TITLE
Address upcoming PTECop rule in test enum extension - part 2

### DIFF
--- a/src/System Application/Test/Auto Format/src/AutoFormatTest.EnumExt.al
+++ b/src/System Application/Test/Auto Format/src/AutoFormatTest.EnumExt.al
@@ -13,9 +13,11 @@ enumextension 132584 AutoFormatTest extends "Auto Format"
     {
         caption = 'Whatever';
     }
+#pragma warning disable PTE0023 // The ID is in the right range but unfortunately there's only one ID in that range
     value(132585; "1 decimal")
     {
         Caption = '1 decimal';
     }
+#pragma warning restore PTE0023 // The ID is in the right range but unfortunately there's only one ID in that range
 }
-#pragma warning restore AS0099
+#pragma warning restore AS0099,

--- a/src/System Application/Test/Auto Format/src/AutoFormatTest.EnumExt.al
+++ b/src/System Application/Test/Auto Format/src/AutoFormatTest.EnumExt.al
@@ -20,4 +20,4 @@ enumextension 132584 AutoFormatTest extends "Auto Format"
     }
 #pragma warning restore PTE0023 // The ID is in the right range but unfortunately there's only one ID in that range
 }
-#pragma warning restore AS0099,
+#pragma warning restore AS0099


### PR DESCRIPTION
#### Summary
Ignores rule PTE0023 inline because ID space is too small to accommodate enum value.


#### Work Item(s)
Fixes
[AB#487991](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/487991)

