### PR TITLE
Consider permission sets from security groups in the User Permissions module 

### DIFF
--- a/src/System Application/App/Azure AD Plan/src/AzureADPlanImpl.Codeunit.al
+++ b/src/System Application/App/Azure AD Plan/src/AzureADPlanImpl.Codeunit.al
@@ -257,8 +257,8 @@ codeunit 9018 "Azure AD Plan Impl."
     procedure CheckMixedPlans(PlanNamesPerUserFromGraph: Dictionary of [Text, List of [Text]]; ErrorOutForAdmin: Boolean)
     var
         Company: Record Company;
-        AccessControl: Record "Access Control";
         EnvironmentInformation: Codeunit "Environment Information";
+        UserPermissions: Codeunit "User Permissions";
         CanManageUsers: Boolean;
         UserAuthenticationEmailFirst: Text;
         UserAuthenticationEmailSecond: Text;
@@ -285,7 +285,7 @@ codeunit 9018 "Azure AD Plan Impl."
         if not MixedPlansExist(PlanNamesPerUserFromGraph, UserAuthenticationEmailFirst, UserAuthenticationEmailSecond, FirstConflictingPlanName, SecondConflictingPlanName) then
             exit;
 
-        CanManageUsers := AccessControl.WritePermission();
+        CanManageUsers := UserPermissions.CanManageUsersOnTenant(UserSecurityId());
         if not CanManageUsers then
             Error(MixedPlansNonAdminErr, UserAuthenticationEmailFirst, UserAuthenticationEmailSecond);
 

--- a/src/System Application/App/User Permissions/src/UserPermissionsImpl.Codeunit.al
+++ b/src/System Application/App/User Permissions/src/UserPermissionsImpl.Codeunit.al
@@ -27,23 +27,21 @@ codeunit 153 "User Permissions Impl."
 
     procedure IsSuper(UserSecurityId: Guid): Boolean
     var
-        AccessControl: Record "Access Control";
+        DummyAccessControl: Record "Access Control";
         User: Record User;
+        NullGuid: Guid;
     begin
         if User.IsEmpty() then
             exit(true);
 
-        AccessControl.SetRange("User Security ID", UserSecurityId);
-        SetSuperFilters(AccessControl);
-
-        exit(not AccessControl.IsEmpty());
+        exit(HasUserPermissionSetAssigned(UserSecurityId, '', SUPERTok, DummyAccessControl.Scope::System, NullGuid));
     end;
 
     procedure RemoveSuperPermissions(UserSecurityId: Guid): Boolean
     var
         AccessControl: Record "Access Control";
     begin
-        if not IsAnyoneElseSuper(UserSecurityId) then
+        if not IsAnyoneElseDirectSuper(UserSecurityId) then
             exit(false);
 
         SetSuperFilters(AccessControl);
@@ -67,7 +65,7 @@ codeunit 153 "User Permissions Impl."
         if not IsSuper(xRec) then
             exit;
 
-        if IsAnyoneElseSuper(Rec."User Security ID") then
+        if IsAnyoneElseDirectSuper(Rec."User Security ID") then
             exit;
 
         Error(SUPERPermissionErr);
@@ -90,7 +88,7 @@ codeunit 153 "User Permissions Impl."
         if not IsSuper(Rec) then
             exit;
 
-        if IsAnyoneElseSuper(Rec."User Security ID") then
+        if IsAnyoneElseDirectSuper(Rec."User Security ID") then
             exit;
 
         Error(SUPERPermissionErr);
@@ -107,10 +105,10 @@ codeunit 153 "User Permissions Impl."
         if (Rec.State <> Rec.State::Disabled) then
             exit;
 
-        if not IsSuper(Rec."User Security ID") then
+        if not IsDirectSuper(Rec."User Security ID") then
             exit;
 
-        if IsAnyoneElseSuper(Rec."User Security ID") then
+        if IsAnyoneElseDirectSuper(Rec."User Security ID") then
             exit;
 
         // Workaround since the xRec parameter is equal to Rec, when called from code.
@@ -134,10 +132,10 @@ codeunit 153 "User Permissions Impl."
         if Rec.IsTemporary() then
             exit;
 
-        if not IsSuper(Rec."User Security ID") then
+        if not IsDirectSuper(Rec."User Security ID") then
             exit;
 
-        if IsAnyoneElseSuper(Rec."User Security ID") then
+        if IsAnyoneElseDirectSuper(Rec."User Security ID") then
             exit;
 
         Error(SUPERPermissionErr);
@@ -154,7 +152,21 @@ codeunit 153 "User Permissions Impl."
         exit((AccessControlRec."Role ID" = SUPERTok) and (AccessControlRec."Company Name" = ''));
     end;
 
-    local procedure IsAnyoneElseSuper(UserSecurityId: Guid): Boolean
+    local procedure IsDirectSuper(UserSecurityId: Guid): Boolean
+    var
+        AccessControl: Record "Access Control";
+        User: Record User;
+    begin
+        if User.IsEmpty() then
+            exit(true);
+
+        AccessControl.SetRange("User Security ID", UserSecurityId);
+        SetSuperFilters(AccessControl);
+
+        exit(not AccessControl.IsEmpty());
+    end;
+
+    local procedure IsAnyoneElseDirectSuper(UserSecurityId: Guid): Boolean
     var
         AccessControl: Record "Access Control";
         User: Record User;
@@ -174,7 +186,7 @@ codeunit 153 "User Permissions Impl."
             repeat
                 if User.Get(AccessControl."User Security ID") then begin
                     isUserEnabled := (User.State = User.State::Enabled);
-                    if isUserEnabled and (not IsSyncDeamon(User)) then
+                    if isUserEnabled and (not IsSyncDaemon(User)) then
                         exit(true);
                 end;
             until AccessControl.Next() = 0;
@@ -182,16 +194,17 @@ codeunit 153 "User Permissions Impl."
         exit(false);
     end;
 
-    local procedure IsSyncDeamon(User: Record User): Boolean
+    local procedure IsSyncDaemon(User: Record User): Boolean
     begin
-        // Sync Deamon is the only user with license "External User"
+        // Sync Daemon is the only user with license "External User"
         exit(User."License Type" = User."License Type"::"External User");
     end;
 
     procedure CanManageUsersOnTenant(UserSID: Guid) Result: Boolean
     var
-        AccessControl: Record "Access Control";
+        DummyAccessControl: Record "Access Control";
         User: Record User;
+        NullGuid: Guid;
     begin
         if User.IsEmpty() then
             exit(true);
@@ -203,10 +216,7 @@ codeunit 153 "User Permissions Impl."
         if IsSuper(UserSID) then
             exit(true);
 
-        AccessControl.SetRange("Role ID", SECURITYPermissionSetTxt);
-        AccessControl.SetFilter("Company Name", '%1|%2', '', CompanyName);
-        AccessControl.SetRange("User Security ID", UserSID);
-        exit(not AccessControl.IsEmpty());
+        exit(HasUserPermissionSetAssigned(UserSID, CompanyName(), SECURITYPermissionSetTxt, DummyAccessControl.Scope::System, NullGuid));
     end;
 
 #if not CLEAN22
@@ -226,15 +236,15 @@ codeunit 153 "User Permissions Impl."
 
     procedure HasUserPermissionSetAssigned(UserSecurityId: Guid; Company: Text; RoleId: Code[20]; ItemScope: Option; AppId: Guid): Boolean
     var
-        AccessControl: Record "Access Control";
+        NavUserAccountHelper: DotNet NavUserAccountHelper;
     begin
-        AccessControl.SetRange("User Security ID", UserSecurityId);
-        AccessControl.SetRange("Role ID", RoleId);
-        AccessControl.SetFilter("Company Name", '%1|%2', '', Company);
-        AccessControl.SetRange(Scope, ItemScope);
-        AccessControl.SetRange("App ID", AppId);
+        if NavUserAccountHelper.IsPermissionSetAssigned(UserSecurityId, '', RoleId, AppId, ItemScope) then
+            exit(true);
 
-        exit(not AccessControl.IsEmpty());
+        if Company <> '' then
+            exit(NavUserAccountHelper.IsPermissionSetAssigned(UserSecurityId, Company, RoleId, AppId, ItemScope));
+
+        exit(false);
     end;
 
     internal procedure GetEffectivePermission(UserSecurityIdToCheck: Guid; CompanyNameToCheck: Text; PermissionObjectType: Option "Table Data","Table",,"Report",,"Codeunit","XMLport",MenuSuite,"Page","Query","System",,,,,,,,,; ObjectId: Integer): Text

--- a/src/System Application/Test/Azure AD Plan/src/AzureADPlanTests.Codeunit.al
+++ b/src/System Application/Test/Azure AD Plan/src/AzureADPlanTests.Codeunit.al
@@ -367,7 +367,6 @@ codeunit 132912 "Azure AD Plan Tests"
         LibraryAssert.AreEqual(PlanIds.GetDelegatedAdminPlanId(), UserPlan."Plan ID", 'Wrong plan was assigned');
 
         // [Then] SUPER was not removed from the user
-        asserterror Commit(); // NavUserAccountHelper.IsPermissionSetAssigned needs a Commit to be called first
         LibraryAssert.IsTrue(UserPermissions.IsSuper(UserSID), 'User should be SUPER');
     end;
 
@@ -419,7 +418,6 @@ codeunit 132912 "Azure AD Plan Tests"
         LibraryAssert.AreEqual(0, UserPlan.Count(), 'There should not be any plan assignments');
 
         // [Then] SUPER was not removed from the user
-        asserterror Commit(); // NavUserAccountHelper.IsPermissionSetAssigned needs a Commit to be called first
         LibraryAssert.IsTrue(UserPermissions.IsSuper(UserSID), 'User should be SUPER');
     end;
 
@@ -475,7 +473,6 @@ codeunit 132912 "Azure AD Plan Tests"
         LibraryAssert.AreEqual(PlanIds.GetDelegatedAdminPlanId(), UserPlan."Plan ID", 'Wrong plan was assigned');
 
         // [Then] SUPER was not removed from the user
-        asserterror Commit(); // NavUserAccountHelper.IsPermissionSetAssigned needs a Commit to be called first
         LibraryAssert.IsTrue(UserPermissions.IsSuper(UserSID), 'User should be SUPER');
     end;
 
@@ -530,7 +527,6 @@ codeunit 132912 "Azure AD Plan Tests"
         LibraryAssert.AreEqual(PlanIds.GetHelpDeskPlanId(), UserPlan."Plan ID", 'Wrong plan was assigned');
 
         // [Then] SUPER was not removed from the user
-        asserterror Commit(); // NavUserAccountHelper.IsPermissionSetAssigned needs a Commit to be called first
         LibraryAssert.IsTrue(UserPermissions.IsSuper(UserSID), 'User should be SUPER');
     end;
 
@@ -582,7 +578,6 @@ codeunit 132912 "Azure AD Plan Tests"
         LibraryAssert.AreEqual(0, UserPlan.Count(), 'There should not be any plan assignments');
 
         // [Then] SUPER was not removed from the user
-        asserterror Commit(); // NavUserAccountHelper.IsPermissionSetAssigned needs a Commit to be called first
         LibraryAssert.IsTrue(UserPermissions.IsSuper(UserSID), 'User should be SUPER');
     end;
 
@@ -638,7 +633,6 @@ codeunit 132912 "Azure AD Plan Tests"
         LibraryAssert.AreEqual(PlanIds.GetHelpDeskPlanId(), UserPlan."Plan ID", 'Wrong plan was assigned');
 
         // [Then] SUPER was not removed from the user
-        asserterror Commit(); // NavUserAccountHelper.IsPermissionSetAssigned needs a Commit to be called first
         LibraryAssert.IsTrue(UserPermissions.IsSuper(UserSID), 'User should be SUPER');
     end;
 

--- a/src/System Application/Test/Azure AD Plan/src/AzureADPlanTests.Codeunit.al
+++ b/src/System Application/Test/Azure AD Plan/src/AzureADPlanTests.Codeunit.al
@@ -367,6 +367,7 @@ codeunit 132912 "Azure AD Plan Tests"
         LibraryAssert.AreEqual(PlanIds.GetDelegatedAdminPlanId(), UserPlan."Plan ID", 'Wrong plan was assigned');
 
         // [Then] SUPER was not removed from the user
+        asserterror Commit(); // NavUserAccountHelper.IsPermissionSetAssigned needs a Commit to be called first
         LibraryAssert.IsTrue(UserPermissions.IsSuper(UserSID), 'User should be SUPER');
     end;
 
@@ -418,6 +419,7 @@ codeunit 132912 "Azure AD Plan Tests"
         LibraryAssert.AreEqual(0, UserPlan.Count(), 'There should not be any plan assignments');
 
         // [Then] SUPER was not removed from the user
+        asserterror Commit(); // NavUserAccountHelper.IsPermissionSetAssigned needs a Commit to be called first
         LibraryAssert.IsTrue(UserPermissions.IsSuper(UserSID), 'User should be SUPER');
     end;
 
@@ -473,6 +475,7 @@ codeunit 132912 "Azure AD Plan Tests"
         LibraryAssert.AreEqual(PlanIds.GetDelegatedAdminPlanId(), UserPlan."Plan ID", 'Wrong plan was assigned');
 
         // [Then] SUPER was not removed from the user
+        asserterror Commit(); // NavUserAccountHelper.IsPermissionSetAssigned needs a Commit to be called first
         LibraryAssert.IsTrue(UserPermissions.IsSuper(UserSID), 'User should be SUPER');
     end;
 
@@ -527,6 +530,7 @@ codeunit 132912 "Azure AD Plan Tests"
         LibraryAssert.AreEqual(PlanIds.GetHelpDeskPlanId(), UserPlan."Plan ID", 'Wrong plan was assigned');
 
         // [Then] SUPER was not removed from the user
+        asserterror Commit(); // NavUserAccountHelper.IsPermissionSetAssigned needs a Commit to be called first
         LibraryAssert.IsTrue(UserPermissions.IsSuper(UserSID), 'User should be SUPER');
     end;
 
@@ -578,6 +582,7 @@ codeunit 132912 "Azure AD Plan Tests"
         LibraryAssert.AreEqual(0, UserPlan.Count(), 'There should not be any plan assignments');
 
         // [Then] SUPER was not removed from the user
+        asserterror Commit(); // NavUserAccountHelper.IsPermissionSetAssigned needs a Commit to be called first
         LibraryAssert.IsTrue(UserPermissions.IsSuper(UserSID), 'User should be SUPER');
     end;
 
@@ -633,6 +638,7 @@ codeunit 132912 "Azure AD Plan Tests"
         LibraryAssert.AreEqual(PlanIds.GetHelpDeskPlanId(), UserPlan."Plan ID", 'Wrong plan was assigned');
 
         // [Then] SUPER was not removed from the user
+        asserterror Commit(); // NavUserAccountHelper.IsPermissionSetAssigned needs a Commit to be called first
         LibraryAssert.IsTrue(UserPermissions.IsSuper(UserSID), 'User should be SUPER');
     end;
 

--- a/src/System Application/Test/DisabledTests/AzureADPlanTests.DisabledTest.json
+++ b/src/System Application/Test/DisabledTests/AzureADPlanTests.DisabledTest.json
@@ -1,0 +1,38 @@
+[
+    {
+        "bug":  "497548",
+        "codeunitId":  132912,
+        "codeunitName":  "Azure AD Plan Tests",
+        "method":  "AssignPlansToUserDelegatedAdmin"
+    },
+    {
+        "bug":  "497548",
+        "codeunitId":  132912,
+        "codeunitName":  "Azure AD Plan Tests",
+        "method":  "AssignPlansToUserDelegatedAdminKeepSuper"
+    },
+    {
+        "bug":  "497548",
+        "codeunitId":  132912,
+        "codeunitName":  "Azure AD Plan Tests",
+        "method":  "AssignPlansToUserDelegatedHelpdesk"
+    },
+    {
+        "bug":  "497548",
+        "codeunitId":  132912,
+        "codeunitName":  "Azure AD Plan Tests",
+        "method":  "AssignPlansToUserDelegatedHelpdeskKeepSuper"
+    },
+    {
+        "bug":  "497548",
+        "codeunitId":  132912,
+        "codeunitName":  "Azure AD Plan Tests",
+        "method":  "AssignPlansToUserNoDelegatedAdmin"
+    },
+    {
+        "bug":  "497548",
+        "codeunitId":  132912,
+        "codeunitName":  "Azure AD Plan Tests",
+        "method":  "AssignPlansToUserNoDelegatedHelpdesk"
+    }
+]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
**Problem:**
`User Permissions` module implementation only considers permission sets directly assigned to the user. This means that a lot of scenarios don't work when certain permission sets are assigned to users via security groups.

**Solution:**
Uptake a new platform function `NavUserAccountHelper.IsPermissionSetAssigned` that checks both direct and inherited permission sets.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#481017](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/481017)






