### PR TITLE
Turn time token to uppercase before compare

### DIFF
--- a/src/System Application/App/Filter Tokens/src/FilterTokensImpl.Codeunit.al
+++ b/src/System Application/App/Filter Tokens/src/FilterTokensImpl.Codeunit.al
@@ -387,6 +387,7 @@ codeunit 58 "Filter Tokens Impl."
     local procedure ResolveTimeToken(var TimeFilter: Time; TimeToken: Text) Handled: Boolean
     begin
         TimeToken := DelChr(TimeToken); // Deletes all spaces in TimeToke
+        TimeToken := UpperCase(TimeToken); // Turn TimeToken into uppercase
         case TimeToken of
             NowTxt, 'NOW':
                 begin


### PR DESCRIPTION
The case expects uppercase tokens. We must turn the input filter token into uppercase before we do the compare.

Fixes [AB#483241](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/483241)


