### PR TITLE
#430 | Access to NewerThanDate in sent emails

### DIFF
--- a/src/System Application/App/Email/src/Email/Email.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/Email.Codeunit.al
@@ -350,6 +350,17 @@ codeunit 8901 Email
     end;
 
     ///<summary>
+    /// Open the sent emails page for a source record given by its table ID and system ID.
+    ///</summary>
+    ///<param name="TableId">The table ID of the source record.</param>
+    ///<param name="SystemId">The system ID of the source record.</param>
+    ///<param name="NewerThanDate">The date to which the sent emails are filtered.</param>
+    procedure OpenSentEmails(TableId: Integer; SystemId: Guid; NewerThanDate: DateTime)
+    begin
+        EmailImpl.OpenSentEmails(TableId, SystemId, NewerThanDate);
+    end;
+
+    ///<summary>
     /// Gets the outbox email status.
     ///</summary>
     ///<param name="MessageId">The MessageId of the record.</param>

--- a/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
@@ -587,6 +587,15 @@ codeunit 8900 "Email Impl"
         SentEmails.Run();
     end;
 
+    procedure OpenSentEmails(TableId: Integer; SystemId: Guid; NewerThanDate: DateTime)
+    var
+        SentEmails: Page "Sent Emails";
+    begin
+        SentEmails.SetRelatedRecord(TableId, SystemId);
+        SentEmails.SetNewerThan(NewerThanDate);
+        SentEmails.Run();
+    end;
+
     procedure GetEmailOutboxSentEmailWithinRateLimit(var SentEmail: Record "Sent Email"; var EmailOutbox: Record "Email Outbox"; AccountId: Guid): Duration
     var
         EmailCheckWindowTime: DateTime;

--- a/src/System Application/App/Email/src/Email/Sent/SentEmails.Page.al
+++ b/src/System Application/App/Email/src/Email/Sent/SentEmails.Page.al
@@ -213,6 +213,10 @@ page 8883 "Sent Emails"
         EmailConnector.ShowAccountInformation(Rec."Account Id");
     end;
 
+    /// <summary>
+    /// Set date filter for sent emails.
+    /// </summary>
+    /// <param name="NewDate">Earliest date to include sent emails from.</param>
     procedure SetNewerThan(NewDate: DateTime)
     begin
         NewerThanDate := NewDate;
@@ -223,7 +227,12 @@ page 8883 "Sent Emails"
         EmailAccountId := AccountId;
     end;
 
-    internal procedure SetRelatedRecord(TableID: Integer; SystemID: Guid)
+    /// <summary>
+    /// Set filter for related record on sent emails.
+    /// </summary>
+    /// <param name="TableID">The entity table.</param>
+    /// <param name="SystemID">A record to filter on.</param>
+    procedure SetRelatedRecord(TableID: Integer; SystemID: Guid)
     begin
         SourceTableID := TableID;
         SourceSystemID := SystemID;

--- a/src/System Application/App/Email/src/Email/Sent/SentEmails.Page.al
+++ b/src/System Application/App/Email/src/Email/Sent/SentEmails.Page.al
@@ -177,7 +177,9 @@ page 8883 "Sent Emails"
 
     trigger OnOpenPage()
     begin
-        NewerThanDate := CreateDateTime(CalcDate('<-30D>', Today()), Time());
+        if NewerThanDate = 0DT then
+            NewerThanDate := CreateDateTime(CalcDate('<-30D>', Today()), Time());
+
         EmailImpl.GetSentEmails(EmailAccountId, NewerThanDate, SourceTableID, SourceSystemID, Rec);
         Rec.SetCurrentKey("Date Time Sent");
         NoSentEmails := Rec.IsEmpty();
@@ -211,7 +213,7 @@ page 8883 "Sent Emails"
         EmailConnector.ShowAccountInformation(Rec."Account Id");
     end;
 
-    internal procedure SetNewerThan(NewDate: DateTime)
+    procedure SetNewerThan(NewDate: DateTime)
     begin
         NewerThanDate := NewDate;
     end;


### PR DESCRIPTION
Extended the access to the filter field "NewerThanDate" in the sent emails:
- new function with extended parameters for opening sent emails filtered to the source record and a specific date.
- removed the internal flag to set the date directly when opening the sent emails.
- "If" added so that the NewerThanDate is only overwritten with the "30 days filter" if it was previously empty.

Fixes #430  




Fixes [AB#497966](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/497966)


