### PR TITLE
Updating the max runtime for a BCPT suite from 4 hrs to 8 hrs

### DIFF
--- a/src/Tools/Performance Toolkit/App/src/BCPTHeader.Table.al
+++ b/src/Tools/Performance Toolkit/App/src/BCPTHeader.Table.al
@@ -30,7 +30,7 @@ table 149000 "BCPT Header"
             Caption = 'Duration (minutes)';
             InitValue = 1;
             MinValue = 1;
-            MaxValue = 240; // 4 hrs
+            MaxValue = 480; // 8 hrs
         }
         field(4; Status; Enum "BCPT Header Status")
         {


### PR DESCRIPTION
Updated the max runtime from 4 hrs to 8 hrs

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#492402](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/492402)



