### PR TITLE
Fix setting marketing text authorization

### DIFF
--- a/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
@@ -135,7 +135,7 @@ codeunit 2012 "Entity Text Impl."
     procedure SetEntityTextAuthorization(NewEndpoint: Text; NewDeployment: Text; NewApiKey: SecretText)
     begin
         Endpoint := NewEndpoint;
-        Deployment := NewEndpoint;
+        Deployment := NewDeployment;
         ApiKey := NewApiKey;
     end;
 
@@ -413,15 +413,16 @@ codeunit 2012 "Entity Text Impl."
         NewLineChar := 10;
 
         NavApp.GetCurrentModuleInfo(EntityTextModuleInfo);
-        if (not IsNullGuid(CallerModuleInfo.Id())) and (CallerModuleInfo.Publisher() = EntityTextModuleInfo.Publisher()) then
-            AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetTurbo0301())
-        else begin
-            if (Endpoint = '') or (Deployment = '') then begin
+        if (not (Endpoint = '')) and (not (Deployment = ''))
+        then
+            AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", Endpoint, Deployment, ApiKey)
+        else
+            if (not IsNullGuid(CallerModuleInfo.Id())) and (CallerModuleInfo.Publisher() = EntityTextModuleInfo.Publisher()) then
+                AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetTurbo0301())
+            else begin
                 Session.LogMessage('0000LJB', TelemetryNoAuthorizationHandlerTxt, Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', TelemetryCategoryLbl);
                 Error(NoAuthorizationHandlerErr);
             end;
-            AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", Endpoint, Deployment, ApiKey);
-        end;
 
         AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"Entity Text");
 


### PR DESCRIPTION
#### Summary
When setting Marketing Text authorization parameters, passed endpoint was set as both endpoint and deployment.
When calling from 1st party module, custom auth was overwritten with default one.
Both issues are addressed in this PR

#### Work Item(s)
Fixes [AB#498109](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/498109)


