### PR TITLE
Add permissions test for No. Series

### DIFF
--- a/src/Business Foundation/App/NoSeries/Permissions/NoSeriesObjects.permissionset.al
+++ b/src/Business Foundation/App/NoSeries/Permissions/NoSeriesObjects.permissionset.al
@@ -11,21 +11,10 @@ permissionset 300 "No. Series - Objects"
     Assignable = false;
 
     Permissions =
-        table "No. Series" = X,
-        table "No. Series Line" = X,
-#if not CLEAN24
-#pragma warning disable AL0432
-        table "No. Series Line Sales" = X,
-        table "No. Series Line Purchase" = X,
-#pragma warning restore AL0432
-#endif
-        table "No. Series Relationship" = X,
-        table "No. Series Tenant" = X,
 #if not CLEAN24
 #pragma warning disable AL0432
         report "No. Series" = X,
         report "No. Series Check" = X,
-        codeunit NoSeriesManagement = X,
 #pragma warning restore AL0432
 #endif
         page "No. Series" = X,

--- a/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatch.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatch.Codeunit.al
@@ -12,6 +12,8 @@ namespace Microsoft.Foundation.NoSeries;
 codeunit 308 "No. Series - Batch"
 {
     Access = Public;
+    InherentEntitlements = X;
+    InherentPermissions = X;
 
     var
         NoSeriesBatchImpl: Codeunit "No. Series - Batch Impl."; // Required to keep state

--- a/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
@@ -151,6 +151,7 @@ codeunit 309 "No. Series - Batch Impl."
             until TempGlobalNoSeriesLine.Next() = 0;
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series Line", 'rm')]
     local procedure UpdateNoSeriesLine(var TempNoSeriesLine: Record "No. Series Line" temporary)
     var
         NoSeriesLine: Record "No. Series Line";
@@ -183,6 +184,7 @@ codeunit 309 "No. Series - Batch Impl."
         exit(LineFound);
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series Line", 'r')]
     local procedure CopyNoSeriesLinesToTemp(NoSeriesCode: Code[20])
     var
         NoSeriesLine: Record "No. Series Line";

--- a/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
@@ -149,7 +149,6 @@ codeunit 309 "No. Series - Batch Impl."
             until TempGlobalNoSeriesLine.Next() = 0;
     end;
 
-    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series Line", 'r')]
     local procedure UpdateNoSeriesLine(var TempNoSeriesLine: Record "No. Series Line" temporary)
     begin
         LockedNoSeriesLine.Get(TempNoSeriesLine."Series Code", TempNoSeriesLine."Line No.");
@@ -182,7 +181,6 @@ codeunit 309 "No. Series - Batch Impl."
         exit(LineFound);
     end;
 
-    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series Line", 'r')]
     local procedure CopyNoSeriesLinesToTemp(NoSeriesCode: Code[20])
     var
         NoSeriesLine: Record "No. Series Line";

--- a/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
@@ -149,6 +149,7 @@ codeunit 309 "No. Series - Batch Impl."
             until TempGlobalNoSeriesLine.Next() = 0;
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series Line", 'm')]
     local procedure UpdateNoSeriesLine(var TempNoSeriesLine: Record "No. Series Line" temporary)
     begin
         LockedNoSeriesLine.Get(TempNoSeriesLine."Series Code", TempNoSeriesLine."Line No.");

--- a/src/Business Foundation/App/NoSeries/src/GlobalNoSeries/CrossCompanyNoSeries.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/GlobalNoSeries/CrossCompanyNoSeries.Codeunit.al
@@ -12,6 +12,9 @@ namespace Microsoft.Foundation.NoSeries;
 /// </summary>
 codeunit 283 "Cross-Company No. Series"
 {
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
     /// <summary>
     /// Creates a new cross-company No. Series
     /// </summary>

--- a/src/Business Foundation/App/NoSeries/src/GlobalNoSeries/NoSeriesTenant.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/GlobalNoSeries/NoSeriesTenant.Table.al
@@ -16,8 +16,8 @@ table 1263 "No. Series Tenant"
     DataPerCompany = false;
     MovedFrom = '437dbf0e-84ff-417a-965d-ed2bb9650972';
     ReplicateData = false;
-    InherentEntitlements = r;
-    InherentPermissions = r;
+    InherentEntitlements = rX;
+    InherentPermissions = rX;
 
     fields
     {

--- a/src/Business Foundation/App/NoSeries/src/GlobalNoSeries/NoSeriesTenant.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/GlobalNoSeries/NoSeriesTenant.Table.al
@@ -16,6 +16,8 @@ table 1263 "No. Series Tenant"
     DataPerCompany = false;
     MovedFrom = '437dbf0e-84ff-417a-965d-ed2bb9650972';
     ReplicateData = false;
+    InherentEntitlements = r;
+    InherentPermissions = r;
 
     fields
     {

--- a/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesLinePurchase.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesLinePurchase.Table.al
@@ -22,6 +22,8 @@ table 12146 "No. Series Line Purchase"
     ObsoleteState = Pending;
     ObsoleteTag = '24.0';
 #endif
+    InherentEntitlements = r;
+    InherentPermissions = r;
 
     fields
     {

--- a/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesLinePurchase.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesLinePurchase.Table.al
@@ -22,8 +22,8 @@ table 12146 "No. Series Line Purchase"
     ObsoleteState = Pending;
     ObsoleteTag = '24.0';
 #endif
-    InherentEntitlements = r;
-    InherentPermissions = r;
+    InherentEntitlements = rX;
+    InherentPermissions = rX;
 
     fields
     {

--- a/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesLineSales.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesLineSales.Table.al
@@ -22,6 +22,8 @@ table 12145 "No. Series Line Sales"
     ObsoleteState = Pending;
     ObsoleteTag = '24.0';
 #endif
+    InherentEntitlements = r;
+    InherentPermissions = r;
 
     fields
     {

--- a/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesLineSales.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesLineSales.Table.al
@@ -22,8 +22,8 @@ table 12145 "No. Series Line Sales"
     ObsoleteState = Pending;
     ObsoleteTag = '24.0';
 #endif
-    InherentEntitlements = r;
-    InherentPermissions = r;
+    InherentEntitlements = rX;
+    InherentPermissions = rX;
 
     fields
     {

--- a/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
@@ -8,6 +8,8 @@ namespace Microsoft.Foundation.NoSeries;
 
 codeunit 396 NoSeriesManagement
 {
+    InherentEntitlements = X;
+    InherentPermissions = X;
     ObsoleteReason = 'Please use the "No. Series" and "No. Series - Batch" codeunits instead';
     ObsoleteState = Pending;
     ObsoleteTag = '24.0';

--- a/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesMgt.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesMgt.Codeunit.al
@@ -8,6 +8,8 @@ namespace Microsoft.Foundation.NoSeries;
 codeunit 281 NoSeriesMgt
 {
     Access = Internal;
+    InherentEntitlements = X;
+    InherentPermissions = X;
     Permissions =
         tabledata "No. Series" = r,
         tabledata "No. Series Line" = rimd;

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeries.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeries.Table.al
@@ -16,6 +16,8 @@ table 308 "No. Series"
     DrillDownPageId = "No. Series";
     LookupPageId = "No. Series";
     MovedFrom = '437dbf0e-84ff-417a-965d-ed2bb9650972';
+    InherentEntitlements = r;
+    InherentPermissions = r;
 
     fields
     {

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeries.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeries.Table.al
@@ -16,8 +16,8 @@ table 308 "No. Series"
     DrillDownPageId = "No. Series";
     LookupPageId = "No. Series";
     MovedFrom = '437dbf0e-84ff-417a-965d-ed2bb9650972';
-    InherentEntitlements = r;
-    InherentPermissions = r;
+    InherentEntitlements = rX;
+    InherentPermissions = rX;
 
     fields
     {

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesLine.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesLine.Table.al
@@ -12,8 +12,8 @@ table 309 "No. Series Line"
     DrillDownPageId = "No. Series Lines";
     LookupPageId = "No. Series Lines";
     MovedFrom = '437dbf0e-84ff-417a-965d-ed2bb9650972';
-    InherentEntitlements = r;
-    InherentPermissions = r;
+    InherentEntitlements = rX;
+    InherentPermissions = rX;
 
     fields
     {

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesLine.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesLine.Table.al
@@ -12,6 +12,8 @@ table 309 "No. Series Line"
     DrillDownPageId = "No. Series Lines";
     LookupPageId = "No. Series Lines";
     MovedFrom = '437dbf0e-84ff-417a-965d-ed2bb9650972';
+    InherentEntitlements = r;
+    InherentPermissions = r;
 
     fields
     {

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesRelationship.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesRelationship.Table.al
@@ -12,8 +12,8 @@ table 310 "No. Series Relationship"
     DrillDownPageId = "No. Series Relationships";
     LookupPageId = "No. Series Relationships";
     MovedFrom = '437dbf0e-84ff-417a-965d-ed2bb9650972';
-    InherentEntitlements = r;
-    InherentPermissions = r;
+    InherentEntitlements = rX;
+    InherentPermissions = rX;
 
     fields
     {

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesRelationship.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesRelationship.Table.al
@@ -12,6 +12,8 @@ table 310 "No. Series Relationship"
     DrillDownPageId = "No. Series Relationships";
     LookupPageId = "No. Series Relationships";
     MovedFrom = '437dbf0e-84ff-417a-965d-ed2bb9650972';
+    InherentEntitlements = r;
+    InherentPermissions = r;
 
     fields
     {

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesSetupImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesSetupImpl.Codeunit.al
@@ -129,7 +129,7 @@ codeunit 305 "No. Series - Setup Impl."
             NextNo := NoSeriesStatelessImpl.IncrementNoText(LastNoUsed, NoSeriesLine."Increment-by No.");
             if NextNo > NoSeriesLine."Ending No." then
                 exit(false);
-            if StrLen(NextNo) > StrLen(NoSeriesLine."Ending No.")  then
+            if StrLen(NextNo) > StrLen(NoSeriesLine."Ending No.") then
                 exit(false);
         end;
         exit(true);

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeries.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeries.Codeunit.al
@@ -12,6 +12,8 @@ namespace Microsoft.Foundation.NoSeries;
 codeunit 310 "No. Series"
 {
     Access = Public;
+    InherentEntitlements = X;
+    InherentPermissions = X;
 
     #region GetNextNo
     /// <summary>

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
@@ -52,7 +52,6 @@ codeunit 304 "No. Series - Impl."
         TestManualInternal(NoSeriesCode, StrSubstNo(PostErr, DocumentNo));
     end;
 
-    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series", 'r')]
     local procedure TestManualInternal(NoSeriesCode: Code[20]; ErrorText: Text);
     var
         NoSeries: Record "No. Series";
@@ -62,7 +61,6 @@ codeunit 304 "No. Series - Impl."
             Error(ErrorText);
     end;
 
-    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series", 'r')]
     procedure IsManual(NoSeriesCode: Code[20]): Boolean
     var
         NoSeries: Record "No. Series";
@@ -147,8 +145,7 @@ codeunit 304 "No. Series - Impl."
         exit(NoSeriesLine.Implementation);
     end;
 
-    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series Line", 'rm')]
-    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series", 'r')]
+    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series Line", 'm')]
     procedure GetNoSeriesLine(var NoSeriesLine: Record "No. Series Line"; NoSeriesCode: Code[20]; UsageDate: Date; HideErrorsAndWarnings: Boolean): Boolean
     var
         NoSeriesRec: Record "No. Series";
@@ -265,7 +262,6 @@ codeunit 304 "No. Series - Impl."
             Error(SeriesNotRelatedErr, DefaultNoSeriesCode, RelatedNoSeriesCode);
     end;
 
-    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series", 'r')]
     procedure AreRelated(DefaultNoSeriesCode: Code[20]; RelatedNoSeriesCode: Code[20]): Boolean
     var
         NoSeries: Record "No. Series";
@@ -283,7 +279,6 @@ codeunit 304 "No. Series - Impl."
         exit(NoSeriesRelationship.Get(DefaultNoSeriesCode, RelatedNoSeriesCode));
     end;
 
-    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series", 'r')]
     procedure IsAutomaticNoSeries(NoSeriesCode: Code[20]): Boolean
     var
         NoSeries: Record "No. Series";
@@ -301,8 +296,6 @@ codeunit 304 "No. Series - Impl."
             Error(CannotAssignAutomaticallyErr, NoSeries.FieldCaption("Default Nos."), NoSeries.TableCaption(), NoSeries.Code);
     end;
 
-    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series", 'r')]
-    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series Relationship", 'r')]
     procedure SelectRelatedNoSeries(OriginalNoSeriesCode: Code[20]; DefaultHighlightedNoSeriesCode: Code[20]; var NewNoSeriesCode: Code[20]): Boolean
     var
         NoSeries: Record "No. Series";

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
@@ -52,6 +52,7 @@ codeunit 304 "No. Series - Impl."
         TestManualInternal(NoSeriesCode, StrSubstNo(PostErr, DocumentNo));
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series", 'r')]
     local procedure TestManualInternal(NoSeriesCode: Code[20]; ErrorText: Text);
     var
         NoSeries: Record "No. Series";
@@ -61,6 +62,7 @@ codeunit 304 "No. Series - Impl."
             Error(ErrorText);
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series", 'r')]
     procedure IsManual(NoSeriesCode: Code[20]): Boolean
     var
         NoSeries: Record "No. Series";
@@ -120,6 +122,8 @@ codeunit 304 "No. Series - Impl."
         exit(NoSeriesLine.Implementation);
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series Line", 'rm')]
+    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series", 'r')]
     procedure GetNoSeriesLine(var NoSeriesLine: Record "No. Series Line"; NoSeriesCode: Code[20]; UsageDate: Date; HideErrorsAndWarnings: Boolean): Boolean
     var
         NoSeriesRec: Record "No. Series";
@@ -208,6 +212,7 @@ codeunit 304 "No. Series - Impl."
             Error(SeriesNotRelatedErr, DefaultNoSeriesCode, RelatedNoSeriesCode);
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series", 'r')]
     procedure AreRelated(DefaultNoSeriesCode: Code[20]; RelatedNoSeriesCode: Code[20]): Boolean
     var
         NoSeries: Record "No. Series";
@@ -225,6 +230,7 @@ codeunit 304 "No. Series - Impl."
         exit(NoSeriesRelationship.Get(DefaultNoSeriesCode, RelatedNoSeriesCode));
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series", 'r')]
     procedure IsAutomaticNoSeries(NoSeriesCode: Code[20]): Boolean
     var
         NoSeries: Record "No. Series";
@@ -242,6 +248,8 @@ codeunit 304 "No. Series - Impl."
             Error(CannotAssignAutomaticallyErr, NoSeries.FieldCaption("Default Nos."), NoSeries.TableCaption(), NoSeries.Code);
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series", 'r')]
+    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series Relationship", 'r')]
     procedure SelectRelatedNoSeries(OriginalNoSeriesCode: Code[20]; DefaultHighlightedNoSeriesCode: Code[20]; var NewNoSeriesCode: Code[20]): Boolean
     var
         NoSeries: Record "No. Series";

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesSequenceImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesSequenceImpl.Codeunit.al
@@ -8,6 +8,8 @@ namespace Microsoft.Foundation.NoSeries;
 codeunit 307 "No. Series - Sequence Impl." implements "No. Series - Single"
 {
     Access = Internal;
+    InherentEntitlements = X;
+    InherentPermissions = X;
     Permissions =
         tabledata "No. Series" = r,
         tabledata "No. Series Line" = rimd;
@@ -50,6 +52,7 @@ codeunit 307 "No. Series - Sequence Impl." implements "No. Series - Single"
         LastSeqNoUsed := NumberSequence.Current(SequenceName);
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series Line", 'm')]
     local procedure GetNextNoInternal(var NoSeriesLine: Record "No. Series Line"; ModifySeries: Boolean; UsageDate: Date; HideErrorsAndWarnings: Boolean): Code[20]
     var
         NoSeriesLine2: Record "No. Series Line";

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesStatelessImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesStatelessImpl.Codeunit.al
@@ -8,6 +8,8 @@ namespace Microsoft.Foundation.NoSeries;
 codeunit 306 "No. Series - Stateless Impl." implements "No. Series - Single"
 {
     Access = Internal;
+    InherentEntitlements = X;
+    InherentPermissions = X;
     Permissions =
         tabledata "No. Series" = r,
         tabledata "No. Series Line" = rimd;
@@ -26,6 +28,7 @@ codeunit 306 "No. Series - Stateless Impl." implements "No. Series - Single"
         exit(GetNextNoInternal(NoSeriesLine, true, UsageDate, HideErrorsAndWarnings));
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series Line", 'm')]
     local procedure GetNextNoInternal(var NoSeriesLine: Record "No. Series Line"; ModifySeries: Boolean; UsageDate: Date; HideErrorsAndWarnings: Boolean): Code[20]
     begin
         if NoSeriesLine."Last No. Used" = '' then begin

--- a/src/Business Foundation/Test/NoSeries/src/NoSeriesBatchTests.Codeunit.al
+++ b/src/Business Foundation/Test/NoSeries/src/NoSeriesBatchTests.Codeunit.al
@@ -1,6 +1,7 @@
 namespace Microsoft.Test.Foundation.NoSeries;
 
 using System.TestLibraries.Utilities;
+using System.TestLibraries.Security.AccessControl;
 using Microsoft.TestLibraries.Foundation.NoSeries;
 using Microsoft.Foundation.NoSeries;
 
@@ -19,10 +20,12 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestGetNextNoDefaultRunOut_Sequence()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -31,6 +34,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -44,9 +48,11 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestGetNextNo_Sequence()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with a line going from 1-10, jumping 7 numbers at a time
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -55,6 +61,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first two numbers from the No. Series
         // [THEN] The numbers match with 1, 8
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('1', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('8', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -68,9 +75,11 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestGetNextNoWithLastNoUsed_Sequence()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with a line going from 1-10, jumping 2 numbers at a time, with last used number 3
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -79,6 +88,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first three new numbers from the No. Series
         // [THEN] The numbers match with 5, 7, 9
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('5', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('7', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('9', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -93,10 +103,12 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestGetNextNoDefaultOverFlow_Sequence()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines going from 1-5
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -106,6 +118,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with A1, A2, A3, A4, A5, B1, B2, B3, B4, B5 (automatically switches from the first to the second series)
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         for i := 1 to 5 do
@@ -121,9 +134,11 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestGetNextNoAdvancedOverFlow_Sequence()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines going from 1-10, jumping 7 numbers at a time
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -133,6 +148,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 4 numbers from the No. Series
         // [THEN] The numbers match with A1, A8, B1, B8
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('A01', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('A08', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('B01', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -148,11 +164,13 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestGetNextNoOverflowOutsideDate_Sequence()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         TomorrowsWorkDate: Date;
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines, one only valid from WorkDate + 1
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -163,6 +181,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the next number 5 times for WorkDate
         // [THEN] We get the numbers from the first line
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -187,10 +206,12 @@ codeunit 134531 "No. Series Batch Tests"
         NoSeriesLineA: Record "No. Series Line";
         NoSeriesLineB: Record "No. Series Line";
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines going from 1-5
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -205,6 +226,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We request numbers from each line
         // [THEN] We get the numbers for the specific line
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 5 do begin
             LibraryAssert.AreEqual('B' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesLineB, WorkDate()), 'Number was not as expected');
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesLineA, WorkDate()), 'Number was not as expected');
@@ -220,10 +242,12 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestPeekNextNoDefaultRunOut_Sequence()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -232,11 +256,13 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We peek the next number
         // [THEN] We get the first number
+        PermissionsMock.Set('No. Series - Read');
         LibraryAssert.AreEqual('A01TEST', NoSeriesBatch.PeekNextNo(NoSeriesCode), 'Initial number was not as expected');
         LibraryAssert.AreEqual('A01TEST', NoSeriesBatch.PeekNextNo(NoSeriesCode), 'Follow up call to PeekNextNo was not as expected');
 
         // [WHEN] We peek and get the next number 10 times
         // [THEN] The two match up
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(NoSeriesBatch.PeekNextNo(NoSeriesCode), NoSeriesBatch.GetNextNo(NoSeriesCode), 'GetNextNo and PeekNextNo are not aligned');
 
@@ -252,10 +278,12 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestGetNextNoDefaultRunOut()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -264,6 +292,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -277,9 +306,11 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestGetNextNo()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with a line going from 1-10, jumping 7 numbers at a time
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -288,6 +319,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first two numbers from the No. Series
         // [THEN] The numbers match with 1, 8
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('1', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('8', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -301,9 +333,11 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestGetNextNoWithLastNoUsed()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with a line going from 1-10, jumping 2 numbers at a time, with last used number 3
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -312,6 +346,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first three new numbers from the No. Series
         // [THEN] The numbers match with 5, 7, 9
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('5', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('7', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('9', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -326,10 +361,12 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestGetNextNoDefaultOverFlow()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines going from 1-5
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -339,6 +376,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with A1, A2, A3, A4, A5, B1, B2, B3, B4, B5 (automatically switches from the first to the second series)
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         for i := 1 to 5 do
@@ -354,9 +392,11 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestGetNextNoAdvancedOverFlow()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines going from 1-10, jumping 7 numbers at a time
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -366,6 +406,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 4 numbers from the No. Series
         // [THEN] The numbers match with A1, A8, B1, B8
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('A01', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('A08', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('B01', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -381,11 +422,13 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestGetNextNoOverflowOutsideDate()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         TomorrowsWorkDate: Date;
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines, one only valid from WorkDate + 1
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -396,6 +439,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the next number 5 times for WorkDate
         // [THEN] We get the numbers from the first line
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -420,10 +464,12 @@ codeunit 134531 "No. Series Batch Tests"
         NoSeriesLineA: Record "No. Series Line";
         NoSeriesLineB: Record "No. Series Line";
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines going from 1-5
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -438,6 +484,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We request numbers from each line
         // [THEN] We get the numbers for the specific line
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 5 do begin
             LibraryAssert.AreEqual('B' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesLineB, WorkDate()), 'Number was not as expected');
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesLineA, WorkDate()), 'Number was not as expected');
@@ -453,10 +500,12 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestPeekNextNoDefaultRunOut()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -465,11 +514,13 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We peek the next number
         // [THEN] We get the first number
+        PermissionsMock.Set('No. Series - Read');
         LibraryAssert.AreEqual('A01TEST', NoSeriesBatch.PeekNextNo(NoSeriesCode), 'Initial number was not as expected');
         LibraryAssert.AreEqual('A01TEST', NoSeriesBatch.PeekNextNo(NoSeriesCode), 'Follow up call to PeekNextNo was not as expected');
 
         // [WHEN] We peek and get the next number 10 times
         // [THEN] The two match up
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(NoSeriesBatch.PeekNextNo(NoSeriesCode), NoSeriesBatch.GetNextNo(NoSeriesCode), 'GetNextNo and PeekNextNo are not aligned');
 
@@ -485,12 +536,14 @@ codeunit 134531 "No. Series Batch Tests"
     var
         NoSeriesLine: Record "No. Series Line";
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         StartingNo: Code[20];
         StartingNoLbl: Label 'SCI0000001';
     begin
         // init
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // setup
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -506,6 +559,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // exercise
         // verify
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual(StartingNo, NoSeriesBatch.GetNextNo(NoSeriesCode), 'not the first number');
         LibraryAssert.AreEqual(IncStr(StartingNo), NoSeriesBatch.GetNextNo(NoSeriesCode), 'not the second number');
     end;
@@ -516,12 +570,14 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestSimulateGetNextNoSequenceDatabaseNotUpdated()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesBatch2: Codeunit "No. Series - Batch";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         // Scenario: Make sure the database sequence is not updated when calling batch simulation
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -531,11 +587,13 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5
+        PermissionsMock.Set('No. Series - Read');
         for i := 0 to 4 do
             LibraryAssert.AreEqual('A' + Format(i + 1), NoSeriesBatch.SimulateGetNextNo(NoSeriesCode, WorkDate(), 'A' + Format((i))), 'Number was not as expected');
 
         // [WHEN] We get the next number using the same batch instance, the simulation does not continue
         // [THEN] The numbers A7, A8, A9 are returned
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 9 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate()), 'Getting Next No. should continue the simulation');
 
@@ -556,12 +614,14 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestSimulateGetNextNoNormalDatabaseNotUpdated()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesBatch2: Codeunit "No. Series - Batch";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         // Scenario: Make sure the database sequence is not updated when calling batch simulation
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -571,11 +631,13 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5
+        PermissionsMock.Set('No. Series - Read');
         for i := 0 to 4 do
             LibraryAssert.AreEqual('A' + Format(i + 1), NoSeriesBatch.SimulateGetNextNo(NoSeriesCode, WorkDate(), 'A' + Format((i))), 'Number was not as expected');
 
         // [WHEN] We get the next number using the same batch, simulation does not continue
         // [THEN] The numbers A1, A2, A3 are returned
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('A1', NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate()), 'Getting Next No. should not continue the simulation');
         LibraryAssert.AreEqual('A2', NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate()), 'Getting Next No. should not continue the simulation');
         LibraryAssert.AreEqual('A3', NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate()), 'Getting Next No. should not continue the simulation');
@@ -594,11 +656,13 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestGetLastNoUsedCodeRunOut_Sequence()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesBatch2: Codeunit "No. Series - Batch";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 9 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -606,10 +670,12 @@ codeunit 134531 "No. Series Batch Tests"
         LibraryNoSeries.CreateSequenceNoSeriesLine(NoSeriesCode, 1, 'A1', 'A9');
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
+        PermissionsMock.Set('No. Series - Read');
         LibraryAssert.AreEqual('', NoSeriesBatch.GetLastNoUsed(NoSeriesCode), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 8 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8 and GetLastNoUsed reflects that
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 8 do begin
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'GetNextNo Number was not as expected');
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetLastNoUsed(NoSeriesCode), 'GetLastNoUsed Number was not as expected');
@@ -640,11 +706,13 @@ codeunit 134531 "No. Series Batch Tests"
     var
         NoSeriesLine: Record "No. Series Line";
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesBatch2: Codeunit "No. Series - Batch";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -654,10 +722,12 @@ codeunit 134531 "No. Series Batch Tests"
         NoSeriesLine.FindFirst();
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
+        PermissionsMock.Set('No. Series - Read');
         LibraryAssert.AreEqual('', NoSeriesBatch.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8 and GetLastNoUsed reflects that
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 8 do begin
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'GetNextNo Number was not as expected');
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed Number was not as expected');
@@ -692,11 +762,13 @@ codeunit 134531 "No. Series Batch Tests"
     procedure TestGetLastNoUsedCodeRunOut()
     var
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesBatch2: Codeunit "No. Series - Batch";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -704,6 +776,7 @@ codeunit 134531 "No. Series Batch Tests"
         LibraryNoSeries.CreateNormalNoSeriesLine(NoSeriesCode, 1, 'A1', 'A9');
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('', NoSeriesBatch.GetLastNoUsed(NoSeriesCode), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 10 numbers from the No. Series
@@ -738,11 +811,13 @@ codeunit 134531 "No. Series Batch Tests"
     var
         NoSeriesLine: Record "No. Series Line";
         NoSeriesBatch: Codeunit "No. Series - Batch";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesBatch2: Codeunit "No. Series - Batch";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -752,6 +827,7 @@ codeunit 134531 "No. Series Batch Tests"
         NoSeriesLine.FindFirst();
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('', NoSeriesBatch.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 10 numbers from the No. Series

--- a/src/Business Foundation/Test/NoSeries/src/NoSeriesBatchTests.Codeunit.al
+++ b/src/Business Foundation/Test/NoSeries/src/NoSeriesBatchTests.Codeunit.al
@@ -34,7 +34,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -61,7 +61,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first two numbers from the No. Series
         // [THEN] The numbers match with 1, 8
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('1', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('8', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -88,7 +88,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first three new numbers from the No. Series
         // [THEN] The numbers match with 5, 7, 9
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('5', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('7', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('9', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -118,7 +118,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with A1, A2, A3, A4, A5, B1, B2, B3, B4, B5 (automatically switches from the first to the second series)
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         for i := 1 to 5 do
@@ -148,7 +148,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 4 numbers from the No. Series
         // [THEN] The numbers match with A1, A8, B1, B8
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('A01', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('A08', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('B01', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -181,7 +181,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the next number 5 times for WorkDate
         // [THEN] We get the numbers from the first line
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -226,7 +226,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We request numbers from each line
         // [THEN] We get the numbers for the specific line
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 5 do begin
             LibraryAssert.AreEqual('B' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesLineB, WorkDate()), 'Number was not as expected');
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesLineA, WorkDate()), 'Number was not as expected');
@@ -256,13 +256,12 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We peek the next number
         // [THEN] We get the first number
-        PermissionsMock.Set('No. Series - Read');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('A01TEST', NoSeriesBatch.PeekNextNo(NoSeriesCode), 'Initial number was not as expected');
         LibraryAssert.AreEqual('A01TEST', NoSeriesBatch.PeekNextNo(NoSeriesCode), 'Follow up call to PeekNextNo was not as expected');
 
         // [WHEN] We peek and get the next number 10 times
         // [THEN] The two match up
-        PermissionsMock.Set('No. Series - View');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(NoSeriesBatch.PeekNextNo(NoSeriesCode), NoSeriesBatch.GetNextNo(NoSeriesCode), 'GetNextNo and PeekNextNo are not aligned');
 
@@ -292,7 +291,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -319,7 +318,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first two numbers from the No. Series
         // [THEN] The numbers match with 1, 8
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('1', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('8', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -346,7 +345,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first three new numbers from the No. Series
         // [THEN] The numbers match with 5, 7, 9
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('5', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('7', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('9', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -376,7 +375,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with A1, A2, A3, A4, A5, B1, B2, B3, B4, B5 (automatically switches from the first to the second series)
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         for i := 1 to 5 do
@@ -406,7 +405,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 4 numbers from the No. Series
         // [THEN] The numbers match with A1, A8, B1, B8
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('A01', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('A08', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('B01', NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -439,7 +438,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the next number 5 times for WorkDate
         // [THEN] We get the numbers from the first line
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -484,7 +483,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We request numbers from each line
         // [THEN] We get the numbers for the specific line
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 5 do begin
             LibraryAssert.AreEqual('B' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesLineB, WorkDate()), 'Number was not as expected');
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesLineA, WorkDate()), 'Number was not as expected');
@@ -514,13 +513,12 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We peek the next number
         // [THEN] We get the first number
-        PermissionsMock.Set('No. Series - Read');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('A01TEST', NoSeriesBatch.PeekNextNo(NoSeriesCode), 'Initial number was not as expected');
         LibraryAssert.AreEqual('A01TEST', NoSeriesBatch.PeekNextNo(NoSeriesCode), 'Follow up call to PeekNextNo was not as expected');
 
         // [WHEN] We peek and get the next number 10 times
         // [THEN] The two match up
-        PermissionsMock.Set('No. Series - View');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(NoSeriesBatch.PeekNextNo(NoSeriesCode), NoSeriesBatch.GetNextNo(NoSeriesCode), 'GetNextNo and PeekNextNo are not aligned');
 
@@ -559,7 +557,7 @@ codeunit 134531 "No. Series Batch Tests"
 
         // exercise
         // verify
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual(StartingNo, NoSeriesBatch.GetNextNo(NoSeriesCode), 'not the first number');
         LibraryAssert.AreEqual(IncStr(StartingNo), NoSeriesBatch.GetNextNo(NoSeriesCode), 'not the second number');
     end;
@@ -587,13 +585,12 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5
-        PermissionsMock.Set('No. Series - Read');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 0 to 4 do
             LibraryAssert.AreEqual('A' + Format(i + 1), NoSeriesBatch.SimulateGetNextNo(NoSeriesCode, WorkDate(), 'A' + Format((i))), 'Number was not as expected');
 
         // [WHEN] We get the next number using the same batch instance, the simulation does not continue
         // [THEN] The numbers A7, A8, A9 are returned
-        PermissionsMock.Set('No. Series - View');
         for i := 1 to 9 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate()), 'Getting Next No. should continue the simulation');
 
@@ -631,13 +628,12 @@ codeunit 134531 "No. Series Batch Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5
-        PermissionsMock.Set('No. Series - Read');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 0 to 4 do
             LibraryAssert.AreEqual('A' + Format(i + 1), NoSeriesBatch.SimulateGetNextNo(NoSeriesCode, WorkDate(), 'A' + Format((i))), 'Number was not as expected');
 
         // [WHEN] We get the next number using the same batch, simulation does not continue
         // [THEN] The numbers A1, A2, A3 are returned
-        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('A1', NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate()), 'Getting Next No. should not continue the simulation');
         LibraryAssert.AreEqual('A2', NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate()), 'Getting Next No. should not continue the simulation');
         LibraryAssert.AreEqual('A3', NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate()), 'Getting Next No. should not continue the simulation');
@@ -670,12 +666,11 @@ codeunit 134531 "No. Series Batch Tests"
         LibraryNoSeries.CreateSequenceNoSeriesLine(NoSeriesCode, 1, 'A1', 'A9');
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
-        PermissionsMock.Set('No. Series - Read');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('', NoSeriesBatch.GetLastNoUsed(NoSeriesCode), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 8 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8 and GetLastNoUsed reflects that
-        PermissionsMock.Set('No. Series - View');
         for i := 1 to 8 do begin
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'GetNextNo Number was not as expected');
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetLastNoUsed(NoSeriesCode), 'GetLastNoUsed Number was not as expected');
@@ -722,12 +717,11 @@ codeunit 134531 "No. Series Batch Tests"
         NoSeriesLine.FindFirst();
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
-        PermissionsMock.Set('No. Series - Read');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('', NoSeriesBatch.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8 and GetLastNoUsed reflects that
-        PermissionsMock.Set('No. Series - View');
         for i := 1 to 8 do begin
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetNextNo(NoSeriesCode), 'GetNextNo Number was not as expected');
             LibraryAssert.AreEqual('A' + Format(i), NoSeriesBatch.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed Number was not as expected');
@@ -749,6 +743,7 @@ codeunit 134531 "No. Series Batch Tests"
         NoSeriesBatch.SaveState();
 
         // [THEN] The last No. Used for a new batch is blank
+        PermissionsMock.ClearAssignments();
         Clear(NoSeriesBatch2);
         NoSeriesLine.FindFirst();
         LibraryAssert.AreEqual('A9', NoSeriesBatch2.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed Number was not as expected in batch2');
@@ -776,7 +771,7 @@ codeunit 134531 "No. Series Batch Tests"
         LibraryNoSeries.CreateNormalNoSeriesLine(NoSeriesCode, 1, 'A1', 'A9');
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('', NoSeriesBatch.GetLastNoUsed(NoSeriesCode), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 10 numbers from the No. Series
@@ -827,7 +822,7 @@ codeunit 134531 "No. Series Batch Tests"
         NoSeriesLine.FindFirst();
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('', NoSeriesBatch.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 10 numbers from the No. Series
@@ -853,6 +848,7 @@ codeunit 134531 "No. Series Batch Tests"
         NoSeriesBatch.SaveState();
 
         // [THEN] The last No. Used for a new batch is blank
+        PermissionsMock.ClearAssignments();
         Clear(NoSeriesBatch2);
         NoSeriesLine.FindFirst();
         LibraryAssert.AreEqual('A9', NoSeriesBatch2.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed Number was not as expected in batch2');

--- a/src/Business Foundation/Test/NoSeries/src/NoSeriesTest.PermissionSet.al
+++ b/src/Business Foundation/Test/NoSeries/src/NoSeriesTest.PermissionSet.al
@@ -1,0 +1,8 @@
+namespace Microsoft.Test.Foundation.NoSeries;
+using System.TestLibraries.Utilities;
+
+permissionset 134530 "No. Series Test"
+{
+    Assignable = true;
+    Permissions = codeunit "Library Assert" = X;
+}

--- a/src/Business Foundation/Test/NoSeries/src/NoSeriesTests.Codeunit.al
+++ b/src/Business Foundation/Test/NoSeries/src/NoSeriesTests.Codeunit.al
@@ -1,6 +1,7 @@
 namespace Microsoft.Test.Foundation.NoSeries;
 
 using System.TestLibraries.Utilities;
+using System.TestLibraries.Security.AccessControl;
 using Microsoft.TestLibraries.Foundation.NoSeries;
 using Microsoft.Foundation.NoSeries;
 
@@ -19,10 +20,12 @@ codeunit 134530 "No. Series Tests"
     procedure TestGetNextNoDefaultRunOut_Sequence()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -31,6 +34,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(Format(i), NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -44,9 +48,11 @@ codeunit 134530 "No. Series Tests"
     procedure TestGetNextNo_Sequence()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with a line going from 1-10, jumping 7 numbers at a time
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -55,6 +61,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first two numbers from the No. Series
         // [THEN] The numbers match with 1, 8
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('1', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('8', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -68,9 +75,11 @@ codeunit 134530 "No. Series Tests"
     procedure TestGetNextNoWithLastNoUsed_Sequence()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with a line going from 1-10, jumping 2 numbers at a time, with last used number 3
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -79,6 +88,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first three new numbers from the No. Series
         // [THEN] The numbers match with 5, 7, 9
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('5', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('7', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('9', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -93,10 +103,12 @@ codeunit 134530 "No. Series Tests"
     procedure TestGetNextNoDefaultOverFlow_Sequence()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines going from 1-5
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -106,6 +118,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with A1, A2, A3, A4, A5, B1, B2, B3, B4, B5 (automatically switches from the first to the second series)
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         for i := 1 to 5 do
@@ -121,9 +134,11 @@ codeunit 134530 "No. Series Tests"
     procedure TestGetNextNoAdvancedOverFlow_Sequence()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines going from 1-10, jumping 7 numbers at a time
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -133,6 +148,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first 4 numbers from the No. Series
         // [THEN] The numbers match with A1, A8, B1, B8
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('A01', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('A08', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('B01', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -148,11 +164,13 @@ codeunit 134530 "No. Series Tests"
     procedure TestGetNextNoOverflowOutsideDate_Sequence()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         TomorrowsWorkDate: Date;
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines, one only valid from WorkDate + 1
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -163,6 +181,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the next number 5 times for WorkDate
         // [THEN] We get the numbers from the first line
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -187,10 +206,12 @@ codeunit 134530 "No. Series Tests"
         NoSeriesLineA: Record "No. Series Line";
         NoSeriesLineB: Record "No. Series Line";
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines going from 1-5
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -205,6 +226,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We request numbers from each line
         // [THEN] We get the numbers for the specific line
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 5 do begin
             LibraryAssert.AreEqual('B' + Format(i), NoSeries.GetNextNo(NoSeriesLineB, WorkDate()), 'Number was not as expected');
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetNextNo(NoSeriesLineA, WorkDate()), 'Number was not as expected');
@@ -220,10 +242,12 @@ codeunit 134530 "No. Series Tests"
     procedure TestPeekNextNoDefaultRunOut_Sequence()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -232,11 +256,13 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We peek the next number
         // [THEN] We get the first number
+        PermissionsMock.Set('No. Series - Read');
         LibraryAssert.AreEqual('A01TEST', NoSeries.PeekNextNo(NoSeriesCode), 'Initial number was not as expected');
         LibraryAssert.AreEqual('A01TEST', NoSeries.PeekNextNo(NoSeriesCode), 'Follow up call to PeekNextNo was not as expected');
 
         // [WHEN] We peek and get the next number 10 times
         // [THEN] The two match up
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(NoSeries.PeekNextNo(NoSeriesCode), NoSeries.GetNextNo(NoSeriesCode), 'GetNextNo and PeekNextNo are not aligned');
 
@@ -252,10 +278,12 @@ codeunit 134530 "No. Series Tests"
     procedure TestGetNextNoDefaultRunOut()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -264,6 +292,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(Format(i), NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -277,9 +306,11 @@ codeunit 134530 "No. Series Tests"
     procedure TestGetNextNo()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with a line going from 1-10, jumping 7 numbers at a time
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -288,6 +319,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first two numbers from the No. Series
         // [THEN] The numbers match with 1, 8
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('1', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('8', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -301,9 +333,11 @@ codeunit 134530 "No. Series Tests"
     procedure TestGetNextNoWithLastNoUsed()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with a line going from 1-10, jumping 2 numbers at a time, with last used number 3
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -312,6 +346,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first three new numbers from the No. Series
         // [THEN] The numbers match with 5, 7, 9
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('5', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('7', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('9', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -326,10 +361,12 @@ codeunit 134530 "No. Series Tests"
     procedure TestGetNextNoDefaultOverFlow()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines going from 1-5
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -339,6 +376,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with A1, A2, A3, A4, A5, B1, B2, B3, B4, B5 (automatically switches from the first to the second series)
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         for i := 1 to 5 do
@@ -354,9 +392,11 @@ codeunit 134530 "No. Series Tests"
     procedure TestGetNextNoAdvancedOverFlow()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines going from 1-10, jumping 7 numbers at a time
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -366,6 +406,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first 4 numbers from the No. Series
         // [THEN] The numbers match with A1, A8, B1, B8
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('A01', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('A08', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('B01', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -381,11 +422,13 @@ codeunit 134530 "No. Series Tests"
     procedure TestGetNextNoOverflowOutsideDate()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         TomorrowsWorkDate: Date;
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines, one only valid from WorkDate + 1
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -396,6 +439,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the next number 5 times for WorkDate
         // [THEN] We get the numbers from the first line
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -420,10 +464,12 @@ codeunit 134530 "No. Series Tests"
         NoSeriesLineA: Record "No. Series Line";
         NoSeriesLineB: Record "No. Series Line";
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with two lines going from 1-5
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -438,6 +484,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We request numbers from each line
         // [THEN] We get the numbers for the specific line
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 5 do begin
             LibraryAssert.AreEqual('B' + Format(i), NoSeries.GetNextNo(NoSeriesLineB, WorkDate()), 'Number was not as expected');
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetNextNo(NoSeriesLineA, WorkDate()), 'Number was not as expected');
@@ -453,10 +500,12 @@ codeunit 134530 "No. Series Tests"
     procedure TestPeekNextNoDefaultRunOut()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -465,11 +514,13 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We peek the next number
         // [THEN] We get the first number
+        PermissionsMock.Set('No. Series - Read');
         LibraryAssert.AreEqual('A01TEST', NoSeries.PeekNextNo(NoSeriesCode), 'Initial number was not as expected');
         LibraryAssert.AreEqual('A01TEST', NoSeries.PeekNextNo(NoSeriesCode), 'Follow up call to PeekNextNo was not as expected');
 
         // [WHEN] We peek and get the next number 10 times
         // [THEN] The two match up
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(NoSeries.PeekNextNo(NoSeriesCode), NoSeries.GetNextNo(NoSeriesCode), 'GetNextNo and PeekNextNo are not aligned');
 
@@ -485,12 +536,14 @@ codeunit 134530 "No. Series Tests"
     var
         NoSeriesLine: Record "No. Series Line";
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         StartingNo: Code[20];
         StartingNoLbl: Label 'SCI0000001';
     begin
         // init
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // setup
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -506,6 +559,7 @@ codeunit 134530 "No. Series Tests"
 
         // exercise
         // verify
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual(StartingNo, NoSeries.GetNextNo(NoSeriesCode), 'not the first number');
         LibraryAssert.AreEqual(IncStr(StartingNo), NoSeries.GetNextNo(NoSeriesCode), 'not the second number');
     end;
@@ -516,10 +570,12 @@ codeunit 134530 "No. Series Tests"
     procedure TestGetLastNoUsedCodeRunOut_Sequence()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -527,10 +583,12 @@ codeunit 134530 "No. Series Tests"
         LibraryNoSeries.CreateSequenceNoSeriesLine(NoSeriesCode, 1, 'A1', 'A9');
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
+        PermissionsMock.Set('No. Series - Read');
         LibraryAssert.AreEqual('', NoSeries.GetLastNoUsed(NoSeriesCode), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8 and GetLastNoUsed reflects that
+        PermissionsMock.Set('No. Series - View');
         for i := 1 to 8 do begin
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetNextNo(NoSeriesCode), 'GetNextNo Number was not as expected');
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetLastNoUsed(NoSeriesCode), 'GetLastNoUsed Number was not as expected');
@@ -553,10 +611,12 @@ codeunit 134530 "No. Series Tests"
     var
         NoSeriesLine: Record "No. Series Line";
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -566,6 +626,7 @@ codeunit 134530 "No. Series Tests"
         NoSeriesLine.FindFirst();
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('', NoSeries.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 10 numbers from the No. Series
@@ -591,10 +652,12 @@ codeunit 134530 "No. Series Tests"
     procedure TestGetLastNoUsedCodeRunOut()
     var
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -602,6 +665,7 @@ codeunit 134530 "No. Series Tests"
         LibraryNoSeries.CreateNormalNoSeriesLine(NoSeriesCode, 1, 'A1', 'A9');
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('', NoSeries.GetLastNoUsed(NoSeriesCode), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 10 numbers from the No. Series
@@ -628,10 +692,12 @@ codeunit 134530 "No. Series Tests"
     var
         NoSeriesLine: Record "No. Series Line";
         NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
         Initialize();
+        PermissionsMock.Set('No. Series - Admin');
 
         // [GIVEN] A No. Series with 10 numbers
         NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
@@ -641,6 +707,7 @@ codeunit 134530 "No. Series Tests"
         NoSeriesLine.FindFirst();
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
+        PermissionsMock.Set('No. Series - View');
         LibraryAssert.AreEqual('', NoSeries.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 10 numbers from the No. Series

--- a/src/Business Foundation/Test/NoSeries/src/NoSeriesTests.Codeunit.al
+++ b/src/Business Foundation/Test/NoSeries/src/NoSeriesTests.Codeunit.al
@@ -34,7 +34,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(Format(i), NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -61,7 +61,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first two numbers from the No. Series
         // [THEN] The numbers match with 1, 8
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('1', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('8', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -88,7 +88,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first three new numbers from the No. Series
         // [THEN] The numbers match with 5, 7, 9
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('5', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('7', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('9', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -118,7 +118,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with A1, A2, A3, A4, A5, B1, B2, B3, B4, B5 (automatically switches from the first to the second series)
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         for i := 1 to 5 do
@@ -148,7 +148,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first 4 numbers from the No. Series
         // [THEN] The numbers match with A1, A8, B1, B8
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('A01', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('A08', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('B01', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -181,7 +181,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the next number 5 times for WorkDate
         // [THEN] We get the numbers from the first line
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -226,7 +226,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We request numbers from each line
         // [THEN] We get the numbers for the specific line
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 5 do begin
             LibraryAssert.AreEqual('B' + Format(i), NoSeries.GetNextNo(NoSeriesLineB, WorkDate()), 'Number was not as expected');
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetNextNo(NoSeriesLineA, WorkDate()), 'Number was not as expected');
@@ -256,13 +256,12 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We peek the next number
         // [THEN] We get the first number
-        PermissionsMock.Set('No. Series - Read');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('A01TEST', NoSeries.PeekNextNo(NoSeriesCode), 'Initial number was not as expected');
         LibraryAssert.AreEqual('A01TEST', NoSeries.PeekNextNo(NoSeriesCode), 'Follow up call to PeekNextNo was not as expected');
 
         // [WHEN] We peek and get the next number 10 times
         // [THEN] The two match up
-        PermissionsMock.Set('No. Series - View');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(NoSeries.PeekNextNo(NoSeriesCode), NoSeries.GetNextNo(NoSeriesCode), 'GetNextNo and PeekNextNo are not aligned');
 
@@ -292,7 +291,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(Format(i), NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -319,7 +318,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first two numbers from the No. Series
         // [THEN] The numbers match with 1, 8
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('1', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('8', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -346,7 +345,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first three new numbers from the No. Series
         // [THEN] The numbers match with 5, 7, 9
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('5', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('7', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('9', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -376,7 +375,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with A1, A2, A3, A4, A5, B1, B2, B3, B4, B5 (automatically switches from the first to the second series)
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         for i := 1 to 5 do
@@ -406,7 +405,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the first 4 numbers from the No. Series
         // [THEN] The numbers match with A1, A8, B1, B8
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('A01', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('A08', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
         LibraryAssert.AreEqual('B01', NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
@@ -439,7 +438,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We get the next number 5 times for WorkDate
         // [THEN] We get the numbers from the first line
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 5 do
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetNextNo(NoSeriesCode), 'Number was not as expected');
 
@@ -484,7 +483,7 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We request numbers from each line
         // [THEN] We get the numbers for the specific line
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         for i := 1 to 5 do begin
             LibraryAssert.AreEqual('B' + Format(i), NoSeries.GetNextNo(NoSeriesLineB, WorkDate()), 'Number was not as expected');
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetNextNo(NoSeriesLineA, WorkDate()), 'Number was not as expected');
@@ -514,13 +513,12 @@ codeunit 134530 "No. Series Tests"
 
         // [WHEN] We peek the next number
         // [THEN] We get the first number
-        PermissionsMock.Set('No. Series - Read');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('A01TEST', NoSeries.PeekNextNo(NoSeriesCode), 'Initial number was not as expected');
         LibraryAssert.AreEqual('A01TEST', NoSeries.PeekNextNo(NoSeriesCode), 'Follow up call to PeekNextNo was not as expected');
 
         // [WHEN] We peek and get the next number 10 times
         // [THEN] The two match up
-        PermissionsMock.Set('No. Series - View');
         for i := 1 to 10 do
             LibraryAssert.AreEqual(NoSeries.PeekNextNo(NoSeriesCode), NoSeries.GetNextNo(NoSeriesCode), 'GetNextNo and PeekNextNo are not aligned');
 
@@ -559,7 +557,7 @@ codeunit 134530 "No. Series Tests"
 
         // exercise
         // verify
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual(StartingNo, NoSeries.GetNextNo(NoSeriesCode), 'not the first number');
         LibraryAssert.AreEqual(IncStr(StartingNo), NoSeries.GetNextNo(NoSeriesCode), 'not the second number');
     end;
@@ -583,12 +581,11 @@ codeunit 134530 "No. Series Tests"
         LibraryNoSeries.CreateSequenceNoSeriesLine(NoSeriesCode, 1, 'A1', 'A9');
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
-        PermissionsMock.Set('No. Series - Read');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('', NoSeries.GetLastNoUsed(NoSeriesCode), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8 and GetLastNoUsed reflects that
-        PermissionsMock.Set('No. Series - View');
         for i := 1 to 8 do begin
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetNextNo(NoSeriesCode), 'GetNextNo Number was not as expected');
             LibraryAssert.AreEqual('A' + Format(i), NoSeries.GetLastNoUsed(NoSeriesCode), 'GetLastNoUsed Number was not as expected');
@@ -626,7 +623,7 @@ codeunit 134530 "No. Series Tests"
         NoSeriesLine.FindFirst();
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('', NoSeries.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 10 numbers from the No. Series
@@ -665,7 +662,7 @@ codeunit 134530 "No. Series Tests"
         LibraryNoSeries.CreateNormalNoSeriesLine(NoSeriesCode, 1, 'A1', 'A9');
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('', NoSeries.GetLastNoUsed(NoSeriesCode), 'GetLastNoUsed expected to return empty string for new No. Series');
 
         // [WHEN] We get the first 10 numbers from the No. Series
@@ -707,8 +704,9 @@ codeunit 134530 "No. Series Tests"
         NoSeriesLine.FindFirst();
 
         // [WHEN] GetLastNoUsed is called on a new series, an empty string is returned
-        PermissionsMock.Set('No. Series - View');
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
         LibraryAssert.AreEqual('', NoSeries.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed expected to return empty string for new No. Series');
+        PermissionsMock.ClearAssignments();
 
         // [WHEN] We get the first 10 numbers from the No. Series
         // [THEN] The numbers match with 1, 2, 3, 4, 5, 6, 7, 8 and GetLastNoUsed reflects that

--- a/src/Tools/Test Framework/Test Libraries/Permissions Mock/src/PermissionsMock.Codeunit.al
+++ b/src/Tools/Test Framework/Test Libraries/Permissions Mock/src/PermissionsMock.Codeunit.al
@@ -89,6 +89,21 @@ codeunit 131006 "Permissions Mock"
     end;
 
     /// <summary>
+    /// Clears all already assigned Permission Sets and Sets the given Permission Set
+    /// No additional permissions are provided, even test execution permissions have to be handled manually.
+    /// </summary>
+    /// <param name="RoleID">The Permission Set to set.</param>
+    procedure SetExactPermissionSet(RoleID: Code[20])
+    begin
+        if not Started then
+            exit;
+
+        PermissionTestHelper.Clear();
+
+        Assign(RoleID);
+    end;
+
+    /// <summary>
     /// Get whether permission sets mocking is started
     /// </summary>
     /// <returns>True if permission sets mocking is started.</returns>


### PR DESCRIPTION
The No. Series module should be able to use regardless of your permissions (but not the setup). Adding tests to that end.

Fixes [AB#498331](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/498331)






