### PR TITLE
Make app folders relative to the AL-Go project folder

### DIFF
--- a/build/projects/System Application Modules/.AL-Go/settings.json
+++ b/build/projects/System Application Modules/.AL-Go/settings.json
@@ -1,14 +1,14 @@
 {
     "projectName": "System Application Modules",
     "appFolders":  [
-        "..\\..\\src\\System Application\\App\\*",
-        "..\\..\\src\\Business Foundation\\App\\*"
+        "..\\..\\..\\src\\System Application\\App\\*",
+        "..\\..\\..\\src\\Business Foundation\\App\\*"
     ],
     "testFolders":  [
-        "..\\..\\src\\System Application\\Test\\*",
-        "..\\..\\src\\System Application\\Test Library\\*",
-        "..\\..\\src\\Business Foundation\\Test\\*",
-        "..\\..\\src\\Business Foundation\\Test Library\\*"
+        "..\\..\\..\\src\\System Application\\Test\\*",
+        "..\\..\\..\\src\\System Application\\Test Library\\*",
+        "..\\..\\..\\src\\Business Foundation\\Test\\*",
+        "..\\..\\..\\src\\Business Foundation\\Test Library\\*"
     ],
     "useCompilerFolder": true,
     "doNotPublishApps": true,

--- a/src/Business Foundation/App/NoSeries/Permissions/NoSeriesObjects.permissionset.al
+++ b/src/Business Foundation/App/NoSeries/Permissions/NoSeriesObjects.permissionset.al
@@ -19,7 +19,11 @@ permissionset 300 "No. Series - Objects"
 #endif
         page "No. Series" = X,
         page "No. Series Lines" = X,
+#if not CLEAN24
+#pragma warning disable AL0432
         page "No. Series Lines Purchase" = X,
         page "No. Series Lines Sales" = X,
+#pragma warning restore AL0432
+#endif
         page "No. Series Relationships" = X;
 }

--- a/src/Business Foundation/App/NoSeries/Permissions/NoSeriesObjects.permissionset.al
+++ b/src/Business Foundation/App/NoSeries/Permissions/NoSeriesObjects.permissionset.al
@@ -19,5 +19,7 @@ permissionset 300 "No. Series - Objects"
 #endif
         page "No. Series" = X,
         page "No. Series Lines" = X,
+        page "No. Series Lines Purchase" = X,
+        page "No. Series Lines Sales" = X,
         page "No. Series Relationships" = X;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
[This commit](https://github.com/microsoft/BCApps/commit/c3d7199abd512b097f2ee14b64d2fca748ca662a#diff-77a9a7aace577cc7e70bf88632510803ab1784e976b4b1132f19cb1f1a97e224) changes the app folders for _System Application Modules_ project which cause no apps to be built:
> No performance test apps found in bcptTestFolders in .AL-Go\settings.json
Warning: No test apps found in testFolders in .AL-Go\settings.json
Warning: No apps found in appFolders in .AL-Go\settings.json
Checking appDependencyProbingPaths
Repository is empty, exiting

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#498753](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/498753)




