### PR TITLE
Add system permissions to control the access to Page Scripting

### DIFF
--- a/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
+++ b/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
@@ -31,6 +31,7 @@ permissionset 154 "System Application - Admin"
                              "Permissions & Licenses - Edit",
                              "Priv. Notice - Admin",
                              "Retention Policy - Admin",
+                             "PageScripting - Play",
                              "Page Summary - Admin",
                              "TROUBLESHOOT TOOLS";
 }

--- a/src/System Application/App/Permissions/SystemApplicationEdit.PermissionSet.al
+++ b/src/System Application/App/Permissions/SystemApplicationEdit.PermissionSet.al
@@ -25,6 +25,7 @@ permissionset 22 "System Application - Edit"
                              "Entity Text - Edit",
                              "Guided Experience - Edit",
                              "Language - Edit",
+                             "PageScripting - Rec",
                              "Translation - Edit",
                              "Word Templates - Edit";
 }

--- a/src/System Application/App/System Permissions/permissions/PageScriptingPlay.Permissionset.al
+++ b/src/System Application/App/System Permissions/permissions/PageScriptingPlay.Permissionset.al
@@ -1,0 +1,15 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Security.AccessControl;
+
+permissionset 9656 "PageScripting - Play"
+{
+    Access = Public;
+    Assignable = true;
+    Caption = 'Allow Page Scripting Playback';
+
+    Permissions = system "Allow Page Scripting Playback" = X;
+}

--- a/src/System Application/App/System Permissions/permissions/PageScriptingRec.Permissionset.al
+++ b/src/System Application/App/System Permissions/permissions/PageScriptingRec.Permissionset.al
@@ -1,0 +1,15 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Security.AccessControl;
+
+permissionset 9651 "PageScripting - Rec"
+{
+    Access = Public;
+    Assignable = true;
+    Caption = 'Allow Page Scripting Recording';
+
+    Permissions = system "Allow Page Scripting Recording" = X;
+}


### PR DESCRIPTION
Add system permissions to control the access to Page Scripting. 

Two permission added to allow to give access to record and playback a Page Script.

Feature [AB#462095](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/462095/)

