### PR TITLE
Add GetLinkedPowerPlatformEnvironmentId() method to Environment Information codeunit

### DIFF
--- a/src/System Application/App/Environment Information/src/EnvironmentInformation.Codeunit.al
+++ b/src/System Application/App/Environment Information/src/EnvironmentInformation.Codeunit.al
@@ -118,4 +118,13 @@ codeunit 457 "Environment Information"
         EnvironmentInformationImpl.EnableM365Collaboration();
     end;
 
+    /// <summary>
+    /// Gets the linked Power Platform environment id.
+    /// </summary>
+    /// <returns>The linked Power Platform environment id, if set.</returns>
+    procedure GetLinkedPowerPlatformEnvironmentId(): Text
+    begin
+        exit(EnvironmentInformationImpl.GetLinkedPowerPlatformEnvironmentId());
+    end;
+
 }

--- a/src/System Application/App/Environment Information/src/EnvironmentInformationImpl.Codeunit.al
+++ b/src/System Application/App/Environment Information/src/EnvironmentInformationImpl.Codeunit.al
@@ -187,6 +187,11 @@ codeunit 3702 "Environment Information Impl."
             AppId := ApplicationIdentifier();
     end;
 
+    procedure GetLinkedPowerPlatformEnvironmentId(): Text
+    begin
+        exit(NavTenantSettingsHelper.GetLinkedPowerPlatformEnvironmentId());
+    end;
+
     [InternalEvent(false)]
     procedure OnBeforeGetApplicationIdentifier(var AppId: Text)
     begin


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This commit adds GetLinkedPowerPlatformEnvironmentId() method to Environment Information codeunit which helps get the linked Power Platform environment id for the current session's environment, if it is set. The internal implementation is added to the Environment Information Impl. codeunit.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#499267](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/499267)



