### PR TITLE
No. Series: Ability to show only expiring lines

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeries.Page.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeries.Page.al
@@ -264,7 +264,7 @@ page 456 "No. Series"
                     ApplicationArea = Basic, Suite;
                     Caption = 'Show Expiring';
                     Image = ShowList;
-                    ToolTip = 'Show only No. Series that have open lines which have reached the warning threshold.';
+                    ToolTip = 'Show No. Series that have no lines or an open line which have reached the warning threshold.';
 
                     trigger OnAction()
                     begin
@@ -351,7 +351,9 @@ page 456 "No. Series"
                                 break;
                             end;
                         end;
-                    until NoSeriesLine.Next() = 0;
+                    until NoSeriesLine.Next() = 0
+                else
+                    Rec.Mark(true);
             until Rec.Next() = 0;
         Rec.MarkedOnly(true);
         CurrPage.Update(false);

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeries.Page.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeries.Page.al
@@ -274,8 +274,11 @@ page 456 "No. Series"
                     ToolTip = 'Show all number series.';
 
                     trigger OnAction()
+                    var
+                        NoSeriesSetupImpl: Codeunit "No. Series - Setup Impl.";
                     begin
-                        ShowNoSeriesWithWarningsOnly(false);
+                        NoSeriesSetupImpl.ShowNoSeriesWithWarningsOnly(Rec, false);
+                        CurrPage.Update(false);
                     end;
                 }
 
@@ -287,8 +290,11 @@ page 456 "No. Series"
                     ToolTip = 'Show number series that require your attention, such as, number series that have no lines or an have open lines which have reached the warning threshold.';
 
                     trigger OnAction()
+                    var
+                        NoSeriesSetupImpl: Codeunit "No. Series - Setup Impl.";
                     begin
-                        ShowNoSeriesWithWarningsOnly(true);
+                        NoSeriesSetupImpl.ShowNoSeriesWithWarningsOnly(Rec, true);
+                        CurrPage.Update(false);
                     end;
                 }
             }
@@ -364,38 +370,5 @@ page 456 "No. Series"
         NoSeriesSetupImpl.UpdateLine(Rec, StartDate, StartNo, EndNo, LastNoUsed, WarningNo, IncrementByNo, LastDateUsed, Implementation);
         NoSeriesSingle := Implementation;
         AllowGaps := NoSeriesSingle.MayProduceGaps();
-    end;
-
-    local procedure ShowNoSeriesWithWarningsOnly(ShowWarningsOnly: Boolean)
-    var
-        NoSeriesLine: Record "No. Series Line";
-        NoSeries: Codeunit "No. Series";
-        LastNoUsedForLine: Code[20];
-    begin
-        Rec.ClearMarks();
-        if not ShowWarningsOnly then begin
-            Rec.MarkedOnly(false);
-            CurrPage.Update(false);
-            exit;
-        end;
-
-        if Rec.FindSet() then
-            repeat
-                NoSeriesLine.SetRange("Series Code", Rec.Code);
-                if NoSeriesLine.FindSet() then
-                    repeat
-                        if (NoSeriesLine."Warning No." <> '') and NoSeriesLine.Open then begin
-                            LastNoUsedForLine := NoSeries.GetLastNoUsed(NoSeriesLine);
-                            if (LastNoUsedForLine <> '') and (LastNoUsedForLine >= NoSeriesLine."Warning No.") then begin
-                                Rec.Mark(true);
-                                break;
-                            end;
-                        end;
-                    until NoSeriesLine.Next() = 0
-                else
-                    Rec.Mark(true);
-            until Rec.Next() = 0;
-        Rec.MarkedOnly(true);
-        CurrPage.Update(false);
     end;
 }

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeries.Page.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeries.Page.al
@@ -269,7 +269,7 @@ page 456 "No. Series"
                     ApplicationArea = Basic, Suite;
                     Caption = 'Show All';
                     Image = List;
-                    ToolTip = 'Show all No. Series.';
+                    ToolTip = 'Show all number series.';
 
                     trigger OnAction()
                     begin
@@ -282,7 +282,7 @@ page 456 "No. Series"
                     ApplicationArea = Basic, Suite;
                     Caption = 'Show Expiring';
                     Image = ShowList;
-                    ToolTip = 'Show No. Series that have no lines or an open line which have reached the warning threshold.';
+                    ToolTip = 'Show number series that have no lines or an open line which have reached the warning threshold.';
 
                     trigger OnAction()
                     begin
@@ -338,7 +338,6 @@ page 456 "No. Series"
         LastDateUsed: Date;
         AllowGaps: Boolean;
         Implementation: Enum "No. Series Implementation";
-        ShowNoSeriesWithWarnings: Boolean;
         CheckNoSucceededTxt: Label 'The test was successful. Number %1 for date %2 was returned.', Comment = '%1 = A No. Series number, %2 = a date';
         CheckNoFailedTxt: Label 'The test failed. No number was returned for date %1.', Comment = '%1 = a date';
 
@@ -358,9 +357,8 @@ page 456 "No. Series"
         NoSeries: Codeunit "No. Series";
         LastNoUsedForLine: Code[20];
     begin
-        ShowNoSeriesWithWarnings := ShowWarningsOnly;
         Rec.ClearMarks();
-        if not ShowNoSeriesWithWarnings then begin
+        if not ShowWarningsOnly then begin
             Rec.MarkedOnly(false);
             CurrPage.Update(false);
             exit;

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeries.Page.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeries.Page.al
@@ -227,6 +227,7 @@ page 456 "No. Series"
                     ToolTip = 'View or edit additional information about the number series lines.';
                     RunObject = Page "No. Series Lines";
                     RunPageLink = "Series Code" = field(Code);
+                    Scope = Repeater;
                 }
                 action(Relationships)
                 {
@@ -235,6 +236,7 @@ page 456 "No. Series"
                     RunObject = page "No. Series Relationships";
                     RunPageLink = Code = field(Code);
                     ToolTip = 'View or edit relationships between number series.';
+                    Scope = Repeater;
                 }
             }
         }
@@ -282,7 +284,7 @@ page 456 "No. Series"
                     ApplicationArea = Basic, Suite;
                     Caption = 'Show Expiring';
                     Image = ShowList;
-                    ToolTip = 'Show number series that have no lines or an open line which have reached the warning threshold.';
+                    ToolTip = 'Show number series that require your attention, such as, number series that have no lines or an have open lines which have reached the warning threshold.';
 
                     trigger OnAction()
                     begin
@@ -313,6 +315,19 @@ page 456 "No. Series"
             {
             }
             actionref(Relationships_Promoted; Relationships)
+            {
+            }
+            group(View_Promoted)
+            {
+                ShowAs = SplitButton;
+                actionref(ShowAll_Promoted; ShowAll)
+                {
+                }
+                actionref(ShowExpiring_Promoted; ShowExpiring)
+                {
+                }
+            }
+            actionref(TestNoSeriesSingle_Promoted; TestNoSeriesSingle)
             {
             }
         }

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeries.Page.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeries.Page.al
@@ -274,10 +274,9 @@ page 456 "No. Series"
                     ToolTip = 'Show all number series.';
 
                     trigger OnAction()
-                    var
-                        NoSeriesSetupImpl: Codeunit "No. Series - Setup Impl.";
                     begin
-                        NoSeriesSetupImpl.ShowNoSeriesWithWarningsOnly(Rec, false);
+                        Rec.ClearMarks();
+                        Rec.MarkedOnly(false);
                         CurrPage.Update(false);
                     end;
                 }
@@ -293,7 +292,7 @@ page 456 "No. Series"
                     var
                         NoSeriesSetupImpl: Codeunit "No. Series - Setup Impl.";
                     begin
-                        NoSeriesSetupImpl.ShowNoSeriesWithWarningsOnly(Rec, true);
+                        NoSeriesSetupImpl.ShowNoSeriesWithWarningsOnly(Rec);
                         CurrPage.Update(false);
                     end;
                 }

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesSetupImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesSetupImpl.Codeunit.al
@@ -63,6 +63,36 @@ codeunit 305 "No. Series - Setup Impl."
         Implementation := NoSeriesLine.Implementation;
     end;
 
+    procedure ShowNoSeriesWithWarningsOnly(var NoSeries: Record "No. Series"; ShowWarningsOnly: Boolean)
+    var
+        NoSeriesLine: Record "No. Series Line";
+        NoSeriesCodeunit: Codeunit "No. Series";
+        LastNoUsedForLine: Code[20];
+    begin
+        NoSeries.ClearMarks();
+        NoSeries.MarkedOnly(false);
+        if not ShowWarningsOnly then
+            exit;
+
+        if NoSeries.FindSet() then
+            repeat
+                NoSeriesLine.SetRange("Series Code", NoSeries.Code);
+                if NoSeriesLine.FindSet() then
+                    repeat
+                        if (NoSeriesLine."Warning No." <> '') and NoSeriesLine.Open then begin
+                            LastNoUsedForLine := NoSeriesCodeunit.GetLastNoUsed(NoSeriesLine);
+                            if (LastNoUsedForLine <> '') and (LastNoUsedForLine >= NoSeriesLine."Warning No.") then begin
+                                NoSeries.Mark(true);
+                                break;
+                            end;
+                        end;
+                    until NoSeriesLine.Next() = 0
+                else
+                    NoSeries.Mark(true);
+            until NoSeries.Next() = 0;
+        NoSeries.MarkedOnly(true);
+    end;
+
     local procedure SetNoSeriesCurrentLineFilters(var NoSeriesRec: Record "No. Series"; var NoSeriesLine: Record "No. Series Line"; ResetForDrillDown: Boolean)
     var
         NoSeries: Codeunit "No. Series";

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesSetupImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesSetupImpl.Codeunit.al
@@ -63,17 +63,12 @@ codeunit 305 "No. Series - Setup Impl."
         Implementation := NoSeriesLine.Implementation;
     end;
 
-    procedure ShowNoSeriesWithWarningsOnly(var NoSeries: Record "No. Series"; ShowWarningsOnly: Boolean)
+    procedure ShowNoSeriesWithWarningsOnly(var NoSeries: Record "No. Series")
     var
         NoSeriesLine: Record "No. Series Line";
         NoSeriesCodeunit: Codeunit "No. Series";
         LastNoUsedForLine: Code[20];
     begin
-        NoSeries.ClearMarks();
-        NoSeries.MarkedOnly(false);
-        if not ShowWarningsOnly then
-            exit;
-
         if NoSeries.FindSet() then
             repeat
                 NoSeriesLine.SetRange("Series Code", NoSeries.Code);


### PR DESCRIPTION
This PR introduces the ability to see No. Series that are expiring. Whether that means there are no open lines or at least one line is in warning state.

Fixes [AB#476364](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/476364)







