### PR TITLE
Keep current Sequence No. for batch operations until SaveState is called and align GetNextNo events in new facade with GetNextNo events in NoSeriesManagement

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
@@ -59,7 +59,7 @@ codeunit 309 "No. Series - Batch Impl."
     var
         NoSeries: Codeunit "No. Series";
     begin
-        SetInitialState(TempNoSeriesLine);
+        SyncGlobalLineWithProvidedLine(TempNoSeriesLine, UsageDate);
         exit(NoSeries.PeekNextNo(TempGlobalNoSeriesLine, UsageDate));
     end;
 

--- a/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
@@ -966,6 +966,12 @@ codeunit 396 NoSeriesManagement
     begin
     end;
 #endif
+    [Obsolete('This is a temporary method for compatibility only. Please use the "No. Series" codeunit instead', '24.0')]
+    internal procedure RaiseObsoleteOnBeforeModifyNoSeriesLine(var NoSeriesLine: Record "No. Series Line"; var IsHandled: Boolean)
+    begin
+        OnBeforeModifyNoSeriesLine(NoSeriesLine, IsHandled);
+    end;
+
     [IntegrationEvent(false, false)]
     internal procedure OnBeforeModifyNoSeriesLine(var NoSeriesLine: Record "No. Series Line"; var IsHandled: Boolean)
     begin

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesLine.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesLine.Table.al
@@ -126,6 +126,13 @@ table 309 "No. Series Line"
             DataClassification = SystemMetadata;
 
         }
+        field(15; "Temp Current Sequence No."; Integer)
+        {
+            Caption = 'Temporary Sequence Number';
+            DataClassification = SystemMetadata;
+            Access = Internal;
+
+        }
     }
 
     keys

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesLine.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesLine.Table.al
@@ -131,7 +131,6 @@ table 309 "No. Series Line"
             Caption = 'Temporary Sequence Number';
             DataClassification = SystemMetadata;
             Access = Internal;
-
         }
     }
 

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
@@ -179,14 +179,17 @@ codeunit 304 "No. Series - Impl."
             if not LineFound then
                 NoSeriesLine.SetRange("Line No.");
         end;
-        if not LineFound then begin
 #if not CLEAN24
 #pragma warning disable AL0432
+        if not LineFound then begin
             NoSeriesManagement.RaiseObsoleteOnNoSeriesLineFilterOnBeforeFindLast(NoSeriesLine);
-#pragma warning restore AL0432
-#endif
             LineFound := NoSeriesLine.FindLast();
         end;
+#pragma warning restore AL0432
+#else
+        if not LineFound then
+            LineFound := NoSeriesLine.FindLast();
+#endif
 
         if LineFound and NoSeries.MayProduceGaps(NoSeriesLine) then begin
             NoSeriesLine.Validate(Open);

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
@@ -170,13 +170,21 @@ codeunit 304 "No. Series - Impl."
         NoSeriesLine.SetRange(Open, true);
         if (NoSeriesLine."Line No." <> 0) and (NoSeriesLine."Series Code" = NoSeriesCode) then begin
             NoSeriesLine.SetRange("Line No.", NoSeriesLine."Line No.");
+#if not CLEAN24
+#pragma warning disable AL0432
             NoSeriesManagement.RaiseObsoleteOnNoSeriesLineFilterOnBeforeFindLast(NoSeriesLine);
+#pragma warning restore AL0432
+#endif
             LineFound := NoSeriesLine.FindLast();
             if not LineFound then
                 NoSeriesLine.SetRange("Line No.");
         end;
         if not LineFound then begin
+#if not CLEAN24
+#pragma warning disable AL0432
             NoSeriesManagement.RaiseObsoleteOnNoSeriesLineFilterOnBeforeFindLast(NoSeriesLine);
+#pragma warning restore AL0432
+#endif
             LineFound := NoSeriesLine.FindLast();
         end;
 

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
@@ -152,6 +152,11 @@ codeunit 304 "No. Series - Impl."
         NoSeriesRec: Record "No. Series";
         NoSeries: Codeunit "No. Series";
         NoSeriesErrorsImpl: Codeunit "No. Series - Errors Impl.";
+#if not CLEAN24
+#pragma warning disable AL0432
+        NoSeriesManagement: Codeunit NoSeriesManagement;
+#pragma warning restore AL0432
+#endif
         LineFound: Boolean;
     begin
         if UsageDate = 0D then
@@ -165,12 +170,15 @@ codeunit 304 "No. Series - Impl."
         NoSeriesLine.SetRange(Open, true);
         if (NoSeriesLine."Line No." <> 0) and (NoSeriesLine."Series Code" = NoSeriesCode) then begin
             NoSeriesLine.SetRange("Line No.", NoSeriesLine."Line No.");
+            NoSeriesManagement.RaiseObsoleteOnNoSeriesLineFilterOnBeforeFindLast(NoSeriesLine);
             LineFound := NoSeriesLine.FindLast();
             if not LineFound then
                 NoSeriesLine.SetRange("Line No.");
         end;
-        if not LineFound then
+        if not LineFound then begin
+            NoSeriesManagement.RaiseObsoleteOnNoSeriesLineFilterOnBeforeFindLast(NoSeriesLine);
             LineFound := NoSeriesLine.FindLast();
+        end;
 
         if LineFound and NoSeries.MayProduceGaps(NoSeriesLine) then begin
             NoSeriesLine.Validate(Open);

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesSequenceImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesSequenceImpl.Codeunit.al
@@ -73,7 +73,7 @@ codeunit 307 "No. Series - Sequence Impl." implements "No. Series - Single"
 #endif
         NewNo: BigInteger;
     begin
-        if NoSeriesLine.IsTemporary() or ((NoSeriesLine."Temp Current Sequence No." <> 0) and (not ModifySeries)) then begin // Do not update the database for temporary records, if Temp Current Sequence No. is set that means we are emulating the next numbers
+        if NoSeriesLine.IsTemporary() or (NoSeriesLine."Temp Current Sequence No." <> 0) then begin // Do not update the database for temporary records, if Temp Current Sequence No. is set that means we are emulating the next numbers
             if NoSeriesLine."Temp Current Sequence No." = 0 then
                 NoSeriesLine."Temp Current Sequence No." := GetCurrentSequenceNo(NoSeriesLine);
 

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesSequenceImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesSequenceImpl.Codeunit.al
@@ -304,12 +304,26 @@ codeunit 307 "No. Series - Sequence Impl." implements "No. Series - Single"
         if Rec.IsTemporary() then
             exit;
 
-        if Rec."Temp Current Sequence No." = 0 then
+        EnsureTempCurrentSequenceNoIsReset(Rec);
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"No. Series Line", 'OnBeforeInsertEvent', '', false, false)]
+    local procedure OnInsertNoSeriesLine(var Rec: Record "No. Series Line"; RunTrigger: Boolean)
+    begin
+        if Rec.IsTemporary() then
             exit;
 
-        if Rec.Implementation = "No. Series Implementation"::Sequence then
-            RecreateNoSeriesWithLastUsedNo(Rec, Rec."Temp Current Sequence No.");
+        EnsureTempCurrentSequenceNoIsReset(Rec);
+    end;
 
-        Rec."Temp Current Sequence No." := 0; // Always reset the temporary sequence number!
+    local procedure EnsureTempCurrentSequenceNoIsReset(var NoSeriesLine: Record "No. Series Line")
+    begin
+        if NoSeriesLine."Temp Current Sequence No." = 0 then
+            exit;
+
+        if NoSeriesLine.Implementation = "No. Series Implementation"::Sequence then
+            RecreateNoSeriesWithLastUsedNo(NoSeriesLine, NoSeriesLine."Temp Current Sequence No.");
+
+        NoSeriesLine."Temp Current Sequence No." := 0; // Always reset the temporary sequence number!
     end;
 }

--- a/src/Business Foundation/Test/NoSeries/src/NoSeriesBatchTests.Codeunit.al
+++ b/src/Business Foundation/Test/NoSeries/src/NoSeriesBatchTests.Codeunit.al
@@ -570,6 +570,7 @@ codeunit 134531 "No. Series Batch Tests"
         NoSeriesBatch: Codeunit "No. Series - Batch";
         PermissionsMock: Codeunit "Permissions Mock";
         NoSeriesBatch2: Codeunit "No. Series - Batch";
+        NoSeriesBatch3: Codeunit "No. Series - Batch";
         NoSeriesCode: Code[20];
         i: Integer;
     begin
@@ -601,10 +602,17 @@ codeunit 134531 "No. Series Batch Tests"
         LibraryAssert.AreEqual('B3', NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate()), 'Getting Next No. should continue the simulation');
 
         // [WHEN] We get the next number from the No. Series using a different batch
-        // [THEN] The numbers from line 1 are exhausted so we continue from line 2
-        LibraryAssert.AreEqual('B4', NoSeriesBatch2.GetNextNo(NoSeriesCode, WorkDate()), 'No numbers from the sequence should have been used');
-        LibraryAssert.AreEqual('B5', NoSeriesBatch2.GetNextNo(NoSeriesCode, WorkDate()), 'No numbers from the sequence should have been used');
-        LibraryAssert.AreEqual('B6', NoSeriesBatch2.GetNextNo(NoSeriesCode, WorkDate()), 'No numbers from the sequence should have been used');
+        // [THEN] The numbers start again from A1
+        LibraryAssert.AreEqual('A1', NoSeriesBatch2.GetNextNo(NoSeriesCode, WorkDate()), 'No numbers from the sequence should have been used');
+        LibraryAssert.AreEqual('A2', NoSeriesBatch2.GetNextNo(NoSeriesCode, WorkDate()), 'No numbers from the sequence should have been used');
+        LibraryAssert.AreEqual('A3', NoSeriesBatch2.GetNextNo(NoSeriesCode, WorkDate()), 'No numbers from the sequence should have been used');
+
+        // [WHEN] We save the original batch
+        NoSeriesBatch.SaveState();
+        // [THEN] The numbers from another batch will continue from line 2
+        LibraryAssert.AreEqual('B4', NoSeriesBatch3.GetNextNo(NoSeriesCode, WorkDate()), 'No numbers from the sequence should have been used');
+        LibraryAssert.AreEqual('B5', NoSeriesBatch3.GetNextNo(NoSeriesCode, WorkDate()), 'No numbers from the sequence should have been used');
+        LibraryAssert.AreEqual('B6', NoSeriesBatch3.GetNextNo(NoSeriesCode, WorkDate()), 'No numbers from the sequence should have been used');
     end;
 
     [Test]
@@ -735,9 +743,9 @@ codeunit 134531 "No. Series Batch Tests"
         // [THEN] No number is returned
         LibraryAssert.AreEqual('', NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate(), true), 'A number was returned even though the sequence has run out');
 
-        // [THEN] GetLastNoUsed returns blank, however new batch references will return A9 until save since the Line is not yet closed but the sequence is updated in the database.
+        // [THEN] GetLastNoUsed returns A9, however new batch references will return blank since no number has been saved.
         LibraryAssert.AreEqual('A9', NoSeriesBatch.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed Number was not as expected after getting invalid number');
-        LibraryAssert.AreEqual('A9', NoSeriesBatch2.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed Number was not as expected');
+        LibraryAssert.AreEqual('', NoSeriesBatch2.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed Number was not as expected');
 
         // [GIVEN] The No. Series is saved
         NoSeriesBatch.SaveState();

--- a/src/Business Foundation/Test/NoSeries/src/NoSeriesTests.Codeunit.al
+++ b/src/Business Foundation/Test/NoSeries/src/NoSeriesTests.Codeunit.al
@@ -731,6 +731,60 @@ codeunit 134530 "No. Series Tests"
     end;
     #endregion
 
+    [Test]
+    procedure TestSequenceTempCurrentSequenceNoField()
+    var
+        NoSeriesLine: Record "No. Series Line";
+        TempNoSeriesLine: Record "No. Series Line" temporary;
+        NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
+        RecordRef: RecordRef;
+        TempCurrentSequenceNoField: FieldRef;
+        NoSeriesCode: Code[20];
+    begin
+        // [Scenario] Make sure the Temp Current Sequence No. field cannot be abused and is always set to 0 upon database modify
+        // Note: These scenarios are not supported, this is simply to make sure the Temp Current Sequence No. field works as expected behind the scenes.
+
+        Initialize();
+        PermissionsMock.Set('No. Series - Admin');
+
+        // [GIVEN] A No. Series with 10 numbers
+        NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
+        LibraryNoSeries.CreateNoSeries(NoSeriesCode);
+        LibraryNoSeries.CreateSequenceNoSeriesLine(NoSeriesCode, 1, '1', '9');
+        NoSeriesLine.SetRange("Series Code", NoSeriesCode);
+        NoSeriesLine.FindFirst();
+        TempNoSeriesLine := NoSeriesLine;
+        TempNoSeriesLine.Insert();
+
+        // [GIVEN] A No. Series Line and Temporary No. Series Line with Current Sequence No. set to 5
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
+        RecordRef.GetTable(NoSeriesLine);
+        TempCurrentSequenceNoField := RecordRef.Field(15); // Field "Temp Current Sequence No."
+        TempCurrentSequenceNoField.Value := 5;
+        RecordRef.SetTable(NoSeriesLine);
+        TempNoSeriesLine := NoSeriesLine;
+
+        // [WHEN] Fetching the Last No. Used, both implementations return 5
+        LibraryAssert.AreEqual('5', NoSeries.GetLastNoUsed(NoSeriesLine), 'GetLastNoUsed returned wrong value');
+        LibraryAssert.AreEqual('5', NoSeries.GetLastNoUsed(TempNoSeriesLine), 'GetLastNoUsed with temporary record returned wrong value');
+
+        // [WHEN] We peek the next number from both No. Series, they both return 6
+        LibraryAssert.AreEqual('6', NoSeries.PeekNextNo(NoSeriesLine, WorkDate()), 'PeekNextNo returned wrong value');
+        LibraryAssert.AreEqual('6', NoSeries.PeekNextNo(TempNoSeriesLine, WorkDate()), 'PeekNextNo with temporary record returned wrong value');
+
+        // [WHEN] We get the next number from both No. Series, they both return 6 since that's the number set to be next number based on Temp Current Sequence No., furthermore the Temp Current Sequence No. in the normal No. Series has been saved into the sequence due to modify on Get
+        LibraryAssert.AreEqual('6', NoSeries.GetNextNo(NoSeriesLine, WorkDate()), 'GetNextNo returned wrong value');
+        LibraryAssert.AreEqual('6', NoSeries.GetNextNo(TempNoSeriesLine, WorkDate()), 'GetNextNo with temporary record returned wrong value');
+        RecordRef.GetTable(NoSeriesLine);
+        TempCurrentSequenceNoField := RecordRef.Field(15); // Field "Temp Current Sequence No."
+        LibraryAssert.AreEqual(0, TempCurrentSequenceNoField.Value, 'Temp Current Sequence No. was not as expected');
+
+        // [THEN] Getting the next number, they again both return 7
+        LibraryAssert.AreEqual('7', NoSeries.GetNextNo(NoSeriesLine, WorkDate()), 'GetNextNo returned wrong value');
+        LibraryAssert.AreEqual('7', NoSeries.GetNextNo(TempNoSeriesLine, WorkDate()), 'GetNextNo with temporary record returned wrong value');
+    end;
+
     local procedure Initialize()
     begin
         Any.SetDefaultSeed();


### PR DESCRIPTION
Currently NoSeriesManagement does not increment the sequence numbers if it's set to not modify the record, but it will still get new numbers. Hence aligning here with batching, if it's a temporary record we should also not update the database.

Furthermore I'm also aligning the events from NoSeriesManagement.GetNextNo to the new facade GetNextNo.
Fixes [AB#471519](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/471519)






