### PR TITLE
[Copilot] Ignore capability/appid for telemetry when provided by platform

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotTelemetry.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotTelemetry.Codeunit.al
@@ -16,7 +16,6 @@ codeunit 7775 "Copilot Telemetry"
     var
         CopilotCapability: Enum "Copilot Capability";
         AppId: Guid;
-        Initialized: Boolean;
         TelemetryFeedbackOnCopilotCapabilityLbl: Label 'Feedback on Copilot Capability.', Locked = true;
         TelemetryActionInvokedOnCopilotCapabilityLbl: Label 'Action invoked on Copilot Capability.', Locked = true;
 
@@ -24,7 +23,6 @@ codeunit 7775 "Copilot Telemetry"
     begin
         CopilotCapability := NewCopilotCapability;
         AppId := NewAppId;
-        Initialized := true;
     end;
 
     procedure SendCopilotFeedbackTelemetry(CustomDimensions: Dictionary of [Text, Text])
@@ -32,7 +30,7 @@ codeunit 7775 "Copilot Telemetry"
         CopilotCapabilitiesImpl: Codeunit "Copilot Capability Impl";
         FeatureTelemetry: Codeunit "Feature Telemetry";
     begin
-        if Initialized then
+        if not CustomDimensions.ContainsKey('Capability') then
             CopilotCapabilitiesImpl.AddTelemetryDimensions(CopilotCapability, AppId, CustomDimensions);
         FeatureTelemetry.LogUsage('0000LFO', CopilotCapabilitiesImpl.GetCopilotCategory(), TelemetryFeedbackOnCopilotCapabilityLbl, CustomDimensions);
     end;
@@ -42,7 +40,7 @@ codeunit 7775 "Copilot Telemetry"
         CopilotCapabilitiesImpl: Codeunit "Copilot Capability Impl";
         FeatureTelemetry: Codeunit "Feature Telemetry";
     begin
-        if Initialized then
+        if not CustomDimensions.ContainsKey('Capability') then
             CopilotCapabilitiesImpl.AddTelemetryDimensions(CopilotCapability, AppId, CustomDimensions);
         FeatureTelemetry.LogUsage('0000LLW', CopilotCapabilitiesImpl.GetCopilotCategory(), TelemetryActionInvokedOnCopilotCapabilityLbl, CustomDimensions);
     end;

--- a/src/System Application/App/AI/src/Copilot/CopilotTelemetry.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotTelemetry.Codeunit.al
@@ -16,6 +16,7 @@ codeunit 7775 "Copilot Telemetry"
     var
         CopilotCapability: Enum "Copilot Capability";
         AppId: Guid;
+        Initialized: Boolean;
         TelemetryFeedbackOnCopilotCapabilityLbl: Label 'Feedback on Copilot Capability.', Locked = true;
         TelemetryActionInvokedOnCopilotCapabilityLbl: Label 'Action invoked on Copilot Capability.', Locked = true;
 
@@ -23,6 +24,7 @@ codeunit 7775 "Copilot Telemetry"
     begin
         CopilotCapability := NewCopilotCapability;
         AppId := NewAppId;
+        Initialized := true;
     end;
 
     procedure SendCopilotFeedbackTelemetry(CustomDimensions: Dictionary of [Text, Text])
@@ -30,7 +32,8 @@ codeunit 7775 "Copilot Telemetry"
         CopilotCapabilitiesImpl: Codeunit "Copilot Capability Impl";
         FeatureTelemetry: Codeunit "Feature Telemetry";
     begin
-        CopilotCapabilitiesImpl.AddTelemetryDimensions(CopilotCapability, AppId, CustomDimensions);
+        if Initialized then
+            CopilotCapabilitiesImpl.AddTelemetryDimensions(CopilotCapability, AppId, CustomDimensions);
         FeatureTelemetry.LogUsage('0000LFO', CopilotCapabilitiesImpl.GetCopilotCategory(), TelemetryFeedbackOnCopilotCapabilityLbl, CustomDimensions);
     end;
 
@@ -39,7 +42,8 @@ codeunit 7775 "Copilot Telemetry"
         CopilotCapabilitiesImpl: Codeunit "Copilot Capability Impl";
         FeatureTelemetry: Codeunit "Feature Telemetry";
     begin
-        CopilotCapabilitiesImpl.AddTelemetryDimensions(CopilotCapability, AppId, CustomDimensions);
+        if Initialized then
+            CopilotCapabilitiesImpl.AddTelemetryDimensions(CopilotCapability, AppId, CustomDimensions);
         FeatureTelemetry.LogUsage('0000LLW', CopilotCapabilitiesImpl.GetCopilotCategory(), TelemetryActionInvokedOnCopilotCapabilityLbl, CustomDimensions);
     end;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
If the CustomDimensions contains capability, it means platform has provided the information and is a platform copilot.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#497679](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/497679)





