### PR TITLE
Bump action versions. Fix for "Node.js actions are deprecated" warnings

### DIFF
--- a/.github/workflows/CreateBuildTag.yaml
+++ b/.github/workflows/CreateBuildTag.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get Build Version
         id: GetBuildVersion
@@ -31,7 +31,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "BuildVersion=$buildVersion"
 
       - name: Create version tag
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           BuildVersion: ${{ steps.GetBuildVersion.outputs.BuildVersion}}
         with:

--- a/.github/workflows/MSDO.yml
+++ b/.github/workflows/MSDO.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-        
+        uses: actions/checkout@v4
+
       - name: Run Credential Scanning
         uses: microsoft/security-devops-action@v1.10.0
         id: credscan
         with:
           policy: Microsoft
           tools: credscan
-          
+
       - name: Upload results to Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/PullRequestLabeler.yaml
+++ b/.github/workflows/PullRequestLabeler.yaml
@@ -17,11 +17,11 @@ jobs:
     if: github.repository_owner == 'microsoft'
     steps:
       - name: Label pull request
-        uses: actions/labeler@v4
+        uses: actions/labeler@v5
         with:
             repo-token: '${{ secrets.GITHUB_TOKEN }}'
             sync-labels: true
-      
+
       - name: Label community contribution
         if: github.event.pull_request.head.repo.full_name != github.repository
         env:

--- a/.github/workflows/UpdateBCArtifactVersion.yaml
+++ b/.github/workflows/UpdateBCArtifactVersion.yaml
@@ -17,7 +17,7 @@ jobs:
       UpdateBranches: ${{ steps.GetBranches.outputs.UpdateBranches }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get Branches
         id: GetBranches
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
 

--- a/.github/workflows/UpdatePackageVersions.yaml
+++ b/.github/workflows/UpdatePackageVersions.yaml
@@ -17,7 +17,7 @@ jobs:
       UpdateBranches: ${{ steps.GetBranches.outputs.UpdateBranches }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get Branches
         id: GetBranches
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
 

--- a/.github/workflows/WorkitemValidation.yaml
+++ b/.github/workflows/WorkitemValidation.yaml
@@ -20,22 +20,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Validate work items for pull request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           build/scripts/PullRequestValidation/ValidateIssuesForPullRequest.ps1 -PullRequestNumber ${{ github.event.pull_request.number }} -Repository ${{ github.repository }}
-  
+
   WorkItemValidationForMicrosoft:
     if: github.repository_owner == 'microsoft' && github.event.pull_request.state == 'open'
-    name: 'For Microsoft: Validate link to internal work items' 
+    name: 'For Microsoft: Validate link to internal work items'
     runs-on: ubuntu-latest
     needs: GitHubIssueValidation
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Link work items to pull request if possible
         env:

--- a/.github/workflows/powershell.yaml
+++ b/.github/workflows/powershell.yaml
@@ -19,7 +19,7 @@ jobs:
     name: PSScriptAnalyzer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run PSScriptAnalyzer
         uses: microsoft/psscriptanalyzer-action@v1.1
@@ -31,6 +31,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Fix for warnings:
> Node.js 16 actions are deprecated... For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

and 
> CodeQL Action v2 will be deprecated on December 5th, 2024. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#500607](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/500607)



