### PR TITLE
No. Series: Obsolete unused procedures in NoSeriesManagement

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
@@ -209,6 +209,9 @@ codeunit 396 NoSeriesManagement
 #if not CLEAN24
     [Obsolete('To check whether No. Series are related, please use the methods TestAreRelated and AreRelated in codeunit "No. Series"', '24.0')]
     procedure FilterSeries()
+#else
+    local procedure FilterSeries()
+#endif
     var
         NoSeriesRelationship: Record "No. Series Relationship";
         IsHandled: Boolean;
@@ -229,7 +232,6 @@ codeunit 396 NoSeriesManagement
             GlobalNoSeries.Mark := true;
         GlobalNoSeries.MarkedOnly := true;
     end;
-#endif
 
     procedure GetNextNo(NoSeriesCode: Code[20]; SeriesDate: Date; ModifySeries: Boolean) Result: Code[20]
     var
@@ -837,6 +839,9 @@ codeunit 396 NoSeriesManagement
 #if not CLEAN24
     [Obsolete('Please use the the No. Series Relationship table instead to lookup if there are any relations.', '24.0')]
     procedure SeriesHasRelations(DefaultNoSeriesCode: Code[20]): Boolean
+#else
+    local procedure SeriesHasRelations(DefaultNoSeriesCode: Code[20]): Boolean
+#endif
     var
         NoSeriesRelationship: Record "No. Series Relationship";
     begin
@@ -844,7 +849,6 @@ codeunit 396 NoSeriesManagement
         NoSeriesRelationship.SetRange(Code, DefaultNoSeriesCode);
         exit(not NoSeriesRelationship.IsEmpty);
     end;
-#endif
 
     [Scope('OnPrem')]
     procedure ReverseGetNextNo(NoSeriesCode: Code[20]; SeriesDate: Date; ModifySeries: Boolean): Code[20] // Backwards compatibility for apac

--- a/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
@@ -206,6 +206,8 @@ codeunit 396 NoSeriesManagement
         NewNo := GetNextNo(GlobalNoSeries.Code, 0D, true);
     end;
 
+#if not CLEAN24
+    [Obsolete('To check whether No. Series are related, please use the methods TestAreRelated and AreRelated in codeunit "No. Series"', '24.0')]
     procedure FilterSeries()
     var
         NoSeriesRelationship: Record "No. Series Relationship";
@@ -227,6 +229,7 @@ codeunit 396 NoSeriesManagement
             GlobalNoSeries.Mark := true;
         GlobalNoSeries.MarkedOnly := true;
     end;
+#endif
 
     procedure GetNextNo(NoSeriesCode: Code[20]; SeriesDate: Date; ModifySeries: Boolean) Result: Code[20]
     var
@@ -831,6 +834,8 @@ codeunit 396 NoSeriesManagement
         exit(NewNoSeriesCode);
     end;
 
+#if not CLEAN24
+    [Obsolete('Please use the the No. Series Relationship table instead to lookup if there are any relations.', '24.0')]
     procedure SeriesHasRelations(DefaultNoSeriesCode: Code[20]): Boolean
     var
         NoSeriesRelationship: Record "No. Series Relationship";
@@ -839,6 +844,7 @@ codeunit 396 NoSeriesManagement
         NoSeriesRelationship.SetRange(Code, DefaultNoSeriesCode);
         exit(not NoSeriesRelationship.IsEmpty);
     end;
+#endif
 
     [Scope('OnPrem')]
     procedure ReverseGetNextNo(NoSeriesCode: Code[20]; SeriesDate: Date; ModifySeries: Boolean): Code[20] // Backwards compatibility for apac
@@ -987,7 +993,8 @@ codeunit 396 NoSeriesManagement
     local procedure OnBeforeUpdateNoSeriesLine(var NoSeriesLine: Record "No. Series Line"; NewNo: Code[20]; NewFieldName: Text[100]; var IsHandled: Boolean)
     begin
     end;
-#endif
+
+    [Obsolete('Use PeekNextNo from codeunit "No. Series" instead.', '24.0')]
     procedure ClearStateAndGetNextNo(NoSeriesCode: Code[20]): Code[20]
     begin
         Clear(LastNoSeriesLine);
@@ -997,7 +1004,6 @@ codeunit 396 NoSeriesManagement
         exit(GetNextNo(NoSeriesCode, WorkDate(), false));
     end;
 
-#if not CLEAN24
     [Obsolete('Please use OnAfterSetNoSeriesCurrentLineFilters in the No. Series module instead.', '24.0')]
     [IntegrationEvent(false, false)]
     local procedure OnNoSeriesLineFilterOnBeforeFindLast(var NoSeriesLine: Record "No. Series Line")

--- a/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
@@ -433,8 +433,8 @@ codeunit 396 NoSeriesManagement
     begin
         SetParametersBeforeRun(NoSeriesCode, SeriesDate);
     end;
-#endif
 
+    [Obsolete('Use PeekNextNo from codeunit "No. Series" instead.', '24.0')]
     procedure SetParametersBeforeRun(NoSeriesCode: Code[20]; SeriesDate: Date)
     begin
         TryNoSeriesCode := NoSeriesCode;
@@ -442,20 +442,18 @@ codeunit 396 NoSeriesManagement
         OnAfterSetParametersBeforeRun(TryNoSeriesCode, TrySeriesDate, WarningNoSeriesCode);
     end;
 
-#if not CLEAN24
     [Obsolete('Use GetNextNoAfterRun() instead', '21.0')]
     procedure GetNextNo2(): Code[20]
     begin
         exit(GetNextNoAfterRun());
     end;
-#endif
 
+    [Obsolete('Use PeekNextNo from codeunit "No. Series" instead.', '24.0')]
     procedure GetNextNoAfterRun(): Code[20]
     begin
         exit(TryNo);
     end;
 
-#if not CLEAN24
     [Obsolete('Use the SaveState method in the No. Series - Batch codeunit instead.', '24.0')]
     procedure SaveNoSeries()
     var

--- a/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
@@ -428,7 +428,7 @@ codeunit 396 NoSeriesManagement
             exit(NoSeriesManagement.GetNextNoAfterRun());
     end;
 
-    [Obsolete('Use SetParametersBeforeRun() instead', '21.0')]
+    [Obsolete('Use PeekNextNo from codeunit "No. Series" instead.', '21.0')]
     procedure GetNextNo1(NoSeriesCode: Code[20]; SeriesDate: Date)
     begin
         SetParametersBeforeRun(NoSeriesCode, SeriesDate);
@@ -442,7 +442,7 @@ codeunit 396 NoSeriesManagement
         OnAfterSetParametersBeforeRun(TryNoSeriesCode, TrySeriesDate, WarningNoSeriesCode);
     end;
 
-    [Obsolete('Use GetNextNoAfterRun() instead', '21.0')]
+    [Obsolete('Use PeekNextNo from codeunit "No. Series" instead.', '21.0')]
     procedure GetNextNo2(): Code[20]
     begin
         exit(GetNextNoAfterRun());


### PR DESCRIPTION
The procedures SetParametersBeforeRun and GetNextNoAfterRun are not used anymore in BaseApp and can be obsoleted.

Fixes [AB#471519](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/471519)






