### PR TITLE
Remove update lock from batch

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
@@ -77,7 +77,6 @@ codeunit 309 "No. Series - Batch Impl."
         NextNo: Code[20];
     begin
         SyncGlobalLineWithProvidedLine(TempNoSeriesLine, UsageDate);
-        LockedNoSeriesLine.ReadIsolation(IsolationLevel::UpdLock);
         NextNo := NoSeries.GetNextNo(TempGlobalNoSeriesLine, UsageDate, HideErrorsAndWarnings);
         TempNoSeriesLine := TempGlobalNoSeriesLine;
         exit(NextNo);

--- a/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
@@ -14,7 +14,6 @@ codeunit 309 "No. Series - Batch Impl."
 
     var
         TempGlobalNoSeriesLine: Record "No. Series Line" temporary;
-        LockedNoSeriesLine: Record "No. Series Line";
         SimulationMode: Boolean;
         CannotSaveNonExistingNoSeriesErr: Label 'Cannot save No. Series Line that does not exist: %1, %2', Comment = '%1 = No. Series Code, %2 = Line No.';
         CannotSaveWhileSimulatingNumbersErr: Label 'No. Series state cannot be saved while simulating numbers.';
@@ -150,11 +149,13 @@ codeunit 309 "No. Series - Batch Impl."
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series Line", 'm')]
     local procedure UpdateNoSeriesLine(var TempNoSeriesLine: Record "No. Series Line" temporary)
+    var
+        NoSeriesLine: Record "No. Series Line";
     begin
-        LockedNoSeriesLine.Get(TempNoSeriesLine."Series Code", TempNoSeriesLine."Line No.");
-        LockedNoSeriesLine.TransferFields(TempNoSeriesLine);
-        LockedNoSeriesLine.Modify(true);
-        TempNoSeriesLine := LockedNoSeriesLine;
+        NoSeriesLine.Get(TempNoSeriesLine."Series Code", TempNoSeriesLine."Line No.");
+        NoSeriesLine.TransferFields(TempNoSeriesLine);
+        NoSeriesLine.Modify(true);
+        TempNoSeriesLine := NoSeriesLine;
         TempNoSeriesLine.Modify();
     end;
 


### PR DESCRIPTION
With the update lock, we start a transaction, which means you cannot run pages and similar when using the No. Series - Batch, which NoSeriesManagement. Instead we now fail when calling SaveNoSeries simlar to how NoSeriesManagement behaves (aligning behaviour).

Fixes AB#471519
