### PR TITLE
No. Series: Update running out of numbers warning

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesStatelessImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesStatelessImpl.Codeunit.al
@@ -16,6 +16,7 @@ codeunit 306 "No. Series - Stateless Impl." implements "No. Series - Single"
 
     var
         CannotAssignNumbersGreaterThanErr: Label 'You cannot assign numbers greater than %1 from the number series %2. No. assigned: %3', Comment = '%1=Last No.,%2=No. Series Code, %3=the new no.';
+        WarnNoSeriesRunningOutMsg: Label 'The No. Series %1 is soon running out. The current number is %2 and the last allowed number of the sequence is %3.', Comment = '%1=No. Series code,%2=Current No.,%3=Last No. of the sequence';
 
     procedure PeekNextNo(NoSeriesLine: Record "No. Series Line"; UsageDate: Date): Code[20]
     begin
@@ -92,7 +93,8 @@ codeunit 306 "No. Series - Stateless Impl." implements "No. Series - Single"
         if (NoSeriesLine."Ending No." <> '') and (NoSeriesLine."Warning No." <> '') and (NoSeriesLine."Last No. Used" >= NoSeriesLine."Warning No.") then begin
             if NoErrorsOrWarnings then
                 exit(false);
-            Message(CannotAssignNumbersGreaterThanErr, NoSeriesLine."Ending No.", NoSeriesLine."Series Code", NoSeriesLine."Last No. Used");
+            if GuiAllowed() then
+                Message(WarnNoSeriesRunningOutMsg, NoSeriesLine."Series Code", NoSeriesLine."Last No. Used", NoSeriesLine."Ending No.");
         end;
         exit(true);
     end;


### PR DESCRIPTION
In number series, when the last no. is at the warning threshold we want to provide a nice message explaining what is happening. Currently this looks like an error.

Fixes [AB#500462](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/500462)



