### PR TITLE
Allow plus sign in field names when using Edit-In Excel

### DIFF
--- a/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
+++ b/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
@@ -733,7 +733,7 @@ codeunit 1482 "Edit in Excel Impl."
         CurrentPosition := 1;
 
         while CurrentPosition <= StrLen(ConvertedName) do begin
-            if ConvertedName[CurrentPosition] = '''' then begin
+            if ConvertedName[CurrentPosition] in ['''', '+'] then begin
                 ByteValue := Convert.ToByte(ConvertedName[CurrentPosition]);
                 StartStr := CopyStr(ConvertedName, 1, CurrentPosition - 1);
                 EndStr := CopyStr(ConvertedName, CurrentPosition + 1);

--- a/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
+++ b/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
@@ -191,6 +191,7 @@ codeunit 132525 "Edit in Excel Test"
     var
         EditinExcelTestLibrary: Codeunit "Edit in Excel Test Library";
         ApostropheFieldName: Text;
+        PlusFieldName: Text;
         RegularFieldName: Text;
         FieldNameStartingWDigit: Text;
     begin
@@ -198,9 +199,11 @@ codeunit 132525 "Edit in Excel Test"
         FieldNameStartingWDigit := EditinExcelTestLibrary.ExternalizeODataObjectName('3field');
         RegularFieldName := EditinExcelTestLibrary.ExternalizeODataObjectName('field');
         ApostropheFieldName := EditinExcelTestLibrary.ExternalizeODataObjectName('new vendor''s name');
+        PlusFieldName := EditinExcelTestLibrary.ExternalizeODataObjectName('c+c field');
         LibraryAssert.AreEqual('field', RegularFieldName, 'Conversion alters name that does not begin with a string');
         LibraryAssert.AreEqual('_x0033_field', FieldNameStartingWDigit, 'Did not convert the name with number correctly');
         LibraryAssert.AreEqual('new_vendor_x0027_s_name', ApostropheFieldName, 'Did not convert the name with an apostrophe correctly');
+        LibraryAssert.AreEqual('c_x002b_c_field', PlusFieldName, 'Did not convert the name with a plus correctly');
     end;
 
     [Test]


### PR DESCRIPTION
The issue

Edit-In Excel module does not externalize page field names the same way the platform does, when the field name contains an plus sign.
For a page field defined as:
```
field("new vendor+s name"; rec."New Vendor+s Name")
{
	ApplicationArea = All;
}
```

The platform will externalize this name as `new_vendor_x002b_name` while the Edit-In Excel module will externalize it as `new_vendor_name`.

Expected behavior

Within reason the platform and the Edit-In Excel module should externalize fields the same way to avoid discrepancies between the API metadata and the Edit-In Excel field bindings.

Steps to reproduce

Create a page field with an plus sign in its name on a card page, then try to export its corresponding list page using Edit-In Excel and observe the error dialog in the Excel side pane where add-ins are loaded.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#498449](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/498449/)

