### PR TITLE
Add back and add obsoletion to secrettext uptake functions

### DIFF
--- a/src/System Application/App/Azure Storage Services Authorization/src/AuthFormatHelper.Codeunit.al
+++ b/src/System Application/App/Azure Storage Services Authorization/src/AuthFormatHelper.Codeunit.al
@@ -41,6 +41,19 @@ codeunit 9060 "Auth. Format Helper"
         exit(DotNetDateTime.Parse(DateTimeAsXmlString).ToUniversalTime().ToString(FormatSpecifier));
     end;
 
+#if not CLEAN24
+    [NonDebuggable]
+    [Obsolete('Replaced by GetAccessKeyHashCode with SecretText data type for AccessKey parameter.', '24.0')]
+    procedure GetAccessKeyHashCode(StringToSign: Text; AccessKey: Text): Text;
+    var
+        CryptographyManagement: Codeunit "Cryptography Management";
+        HashAlgorithmType: Option HMACMD5,HMACSHA1,HMACSHA256,HMACSHA384,HMACSHA512;
+    begin
+#pragma warning disable AL0432
+        exit(CryptographyManagement.GenerateBase64KeyedHashAsBase64String(StringToSign, AccessKey, HashAlgorithmType::HMACSHA256));
+#pragma warning restore AL0432
+    end;
+#endif
     [NonDebuggable]
     procedure GetAccessKeyHashCode(StringToSign: Text; AccessKey: SecretText): Text;
     var

--- a/src/System Application/App/Azure Storage Services Authorization/src/SAS/StorServAuthSAS.Codeunit.al
+++ b/src/System Application/App/Azure Storage Services Authorization/src/SAS/StorServAuthSAS.Codeunit.al
@@ -45,6 +45,15 @@ codeunit 9061 "Stor. Serv. Auth. SAS" implements "Storage Service Authorization"
         StorageAccountName := NewStorageAccountName;
     end;
 
+#if not CLEAN24
+    [NonDebuggable]
+    [Obsolete('Replaced by SetSigningKey with SecretText data type for NewSigningKey parameter.', '24.0')]
+    procedure SetSigningKey(NewSigningKey: Text)
+    begin
+        SigningKey := NewSigningKey;
+    end;
+#endif
+
     [NonDebuggable]
     procedure SetSigningKey(NewSigningKey: SecretText)
     begin

--- a/src/System Application/App/Azure Storage Services Authorization/src/SharedKey/StorServAuthSharedKey.Codeunit.al
+++ b/src/System Application/App/Azure Storage Services Authorization/src/SharedKey/StorServAuthSharedKey.Codeunit.al
@@ -28,6 +28,15 @@ codeunit 9064 "Stor. Serv. Auth. Shared Key" implements "Storage Service Authori
         Headers.Add('Authorization', GetSharedKeySignature(HttpRequest, StorageAccount));
     end;
 
+#if not CLEAN24
+    [NonDebuggable]
+    [Obsolete('Replaced by SetSharedKey with SecretText data type for SharedKey parameter.', '24.0')]
+    procedure SetSharedKey(SharedKey: Text)
+    begin
+        Secret := SharedKey;
+    end;
+#endif
+
     [NonDebuggable]
     procedure SetSharedKey(SharedKey: SecretText)
     begin


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Some functions were changed directly to `SecretText` without having obsoletion on the original function first.
This puts back those functions and adds obsoletion to them.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#463599](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/463599)



