### PR TITLE
[OAuth] Reintroduce OAuthControlAddin for OnPrem support

### DIFF
--- a/src/System Application/App/ControlAddIns/src/OAuthControlAddIn.ControlAddIn.al
+++ b/src/System Application/App/ControlAddIns/src/OAuthControlAddIn.ControlAddIn.al
@@ -1,4 +1,3 @@
-#if not CLEAN24
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,16 +7,13 @@ namespace System.Security.Authentication;
 
 controladdin OAuthControlAddIn
 {
-    Scripts = 'Resources\OAuthIntegration\js\OAuthIntegration.js';
-    StartupScript = 'Resources\OAuthIntegration\js\Startup.js';
     RequestedWidth = 0;
     RequestedHeight = 0;
     HorizontalStretch = false;
     VerticalStretch = false;
-    ObsoleteState = Pending;
-    ObsoleteReason = 'This control add-in is replaced by OAuthIntegration.';
-    ObsoleteTag = '24.0';
 
+    Scripts = 'Resources\OAuthIntegration\js\OAuthIntegration.js';
+    StartupScript = 'Resources\OAuthIntegration\js\Startup.js';
 
     /// <summary>
     /// Starts the authorization process.
@@ -43,4 +39,3 @@ controladdin OAuthControlAddIn
     /// </summary>
     event ControlAddInReady();
 }
-#endif

--- a/src/System Application/App/ControlAddIns/src/OAuthIntegration.Controladdin.al
+++ b/src/System Application/App/ControlAddIns/src/OAuthIntegration.Controladdin.al
@@ -7,12 +7,14 @@ namespace System.Security.Authentication;
 
 controladdin OAuthIntegration
 {
-    RequestedWidth = 0;
-    RequestedHeight = 0;
-    HorizontalStretch = false;
-    VerticalStretch = false;
-    HorizontalShrink = true;
+    RequestedHeight = 30;
+    RequestedWidth = 200;
+    MinimumHeight = 20;
+    MinimumWidth = 200;
+    VerticalStretch = true;
     VerticalShrink = true;
+    HorizontalStretch = true;
+    HorizontalShrink = true;
 
     Scripts = 'Resources\OAuthIntegration\js\OAuthIntegration.js';
     StyleSheets = 'Resources\OAuthIntegration\stylesheets\OAuthIntegration.css';

--- a/src/System Application/App/OAuth2/OAuth2ControlAddIn.Page.al
+++ b/src/System Application/App/OAuth2/OAuth2ControlAddIn.Page.al
@@ -28,7 +28,7 @@ page 502 OAuth2ControlAddIn
                 InstructionalText = 'A sign in window is open. To continue, pick the account you want to use and accept the conditions. This message will close when you are done.';
                 ShowCaption = false;
             }
-            usercontrol(OAuthIntegration; OAuthIntegration)
+            usercontrol(OAuthIntegration; OAuthControlAddIn)
             {
                 ApplicationArea = All;
                 trigger AuthorizationCodeRetrieved(code: Text)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
OAuthControlAddin was obsoleted in previous PR in favor of OAuthIntegration.

Both should exist, as OAuthIntegration is used to create an authorization link and needs a min height and width to do that. The OAuthControlAddin has no height and width.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#502131](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/502131/)


