### PR TITLE
[24.x] Add geo restrictions to the capabilities

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilityInstall.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilityInstall.Codeunit.al
@@ -22,9 +22,17 @@ codeunit 7760 "Copilot Capability Install"
         AnalyzeListLearnMoreLbl: Label 'https://go.microsoft.com/fwlink/?linkid=2252783', Locked = true;
 
     internal procedure RegisterCapabilities()
+    var
+        EnvironmentInformation: Codeunit "Environment Information";
+        ApplicationFamily: Text;
     begin
-        RegisterSaaSCapability(Enum::"Copilot Capability"::Chat, Enum::"Copilot Availability"::Preview, ChatLearnMoreLbl);
-        RegisterSaaSCapability(Enum::"Copilot Capability"::"Analyze List", Enum::"Copilot Availability"::Preview, AnalyzeListLearnMoreLbl);
+        ApplicationFamily := EnvironmentInformation.GetApplicationFamily();
+
+        if ApplicationFamily = 'US' then
+            RegisterSaaSCapability(Enum::"Copilot Capability"::Chat, Enum::"Copilot Availability"::Preview, ChatLearnMoreLbl);
+
+        if ApplicationFamily <> 'CA' then
+            RegisterSaaSCapability(Enum::"Copilot Capability"::"Analyze List", Enum::"Copilot Availability"::Preview, AnalyzeListLearnMoreLbl);
     end;
 
     local procedure RegisterSaaSCapability(Capability: Enum "Copilot Capability"; Availability: Enum "Copilot Availability"; LearnMoreUrl: Text[2048])


### PR DESCRIPTION
#### Summary
These capabilities are only available in some geos, avoid inserting them in unsupported geos to avoid confusion.

#### Work Item(s) 
Fixes [AB#502197](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/502197)

