### PR TITLE
When controlling field visibility, use variable instead of field to avoid client error

### DIFF
--- a/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetupCard.Page.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetupCard.Page.al
@@ -86,7 +86,7 @@ page 3901 "Retention Policy Setup Card"
                     ToolTip = 'Specifies the number of expired records.';
                     Editable = false;
                     StyleExpr = ExpiredRecordCountStyleTxt;
-                    Visible = Rec."Apply to all records";
+                    Visible = not ShowExpiredRecordExpirationDate;
                 }
                 field("Records To Delete"; ExpiredRecordCount)
                 {
@@ -95,7 +95,7 @@ page 3901 "Retention Policy Setup Card"
                     ToolTip = 'Specifies the number of expired records the retention policy will delete the next time it runs.';
                     Editable = false;
                     StyleExpr = ExpiredRecordCountStyleTxt;
-                    Visible = not Rec."Apply to all records";
+                    Visible = ShowExpiredRecordExpirationDate;
                 }
                 field("Expired Record Expiration Date"; ExpiredRecordExpirationDate)
                 {
@@ -132,7 +132,7 @@ page 3901 "Retention Policy Setup Card"
                 ApplicationArea = All;
                 Caption = 'Record Retention Policy', Comment = 'Record as in ''a record in a table''.';
                 SubPageLink = "Table ID" = field("Table Id");
-                Visible = not Rec."Apply to all records";
+                Visible = ShowExpiredRecordExpirationDate;
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
1) Go to Retention Policies
2) Create new one or edit

Expected: works
Actual:
Copy the error details to share with support.:

The identifier 'Apply to all records' could not be found.

Internal session ID: 
1fcd0b6e-05f9-457a-8bf2-31f72d10bb64

Application Insights session ID: 
fac2fc19-9b4b-447b-86a7-770b14696b3a

Client activity id: 
7079d263-1e87-fcb5-e9f2-d38e66b0eaff

Time stamp on error: 
2024-01-24T13:37:55.5870243Z

User telemetry id: 
00000000-0000-0000-0000-000000000000

Client workload elaborates: The issue is the addition of the two fields and the visible property referencing  Rec."Apply to all records".

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #497821
