### PR TITLE
[releases/24.x] Return rather than exit strictmode when tag isn't present

### DIFF
--- a/build/scripts/PreCompileApp.ps1
+++ b/build/scripts/PreCompileApp.ps1
@@ -57,7 +57,7 @@ if($appType -eq 'app')
 
             if(($appBuildMode -eq 'Strict') -and !(Test-IsStrictModeEnabled)) {
                 Write-Host "::Warning:: Strict mode is not enabled for this branch. Exiting without enabling the strict mode breaking changes check."
-                exit
+                return
             }
 
             Enable-BreakingChangesCheck -AppSymbolsFolder $parameters.Value["appSymbolsFolder"] -AppProjectFolder $parameters.Value["appProjectFolder"] -BuildMode $appBuildMode | Out-Null


### PR DESCRIPTION
This pull request backports #641 to releases/24.x

Fixes [AB#502108](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/502108)
