### PR TITLE
[releases/24.0] Return rather than exit strictmode when tag isn't present

### DIFF
--- a/build/projects/Business Foundation/.AL-Go/settings.json
+++ b/build/projects/Business Foundation/.AL-Go/settings.json
@@ -17,7 +17,7 @@
                 "releases/*.[0-5]"
             ],
             "settings": {
-                "buildModes": [ ]
+                "buildModes": [ "Strict" ]
             }
         }
     ]

--- a/build/projects/Performance Toolkit/.AL-Go/settings.json
+++ b/build/projects/Performance Toolkit/.AL-Go/settings.json
@@ -13,7 +13,7 @@
                 "releases/*.[0-5]"
             ],
             "settings": {
-                "buildModes": [ ]
+                "buildModes": [ "Strict" ]
             }
         }
     ]

--- a/build/projects/System Application/.AL-Go/settings.json
+++ b/build/projects/System Application/.AL-Go/settings.json
@@ -13,7 +13,7 @@
                 "releases/*.[0-5]"
             ],
             "settings": {
-                "buildModes": [ "Translated" ]
+                "buildModes": [ "Translated", "Strict"]
             }
         }
     ]

--- a/build/projects/Test Framework/.AL-Go/settings.json
+++ b/build/projects/Test Framework/.AL-Go/settings.json
@@ -14,7 +14,7 @@
                 "releases/*.[0-5]"
             ],
             "settings": {
-                "buildModes": [ "Translated" ]
+                "buildModes": [ "Translated", "Strict"]
             }
         }
     ]

--- a/build/scripts/PreCompileApp.ps1
+++ b/build/scripts/PreCompileApp.ps1
@@ -57,7 +57,7 @@ if($appType -eq 'app')
 
             if(($appBuildMode -eq 'Strict') -and !(Test-IsStrictModeEnabled)) {
                 Write-Host "::Warning:: Strict mode is not enabled for this branch. Exiting without enabling the strict mode breaking changes check."
-                exit
+                return
             }
 
             Enable-BreakingChangesCheck -AppSymbolsFolder $parameters.Value["appSymbolsFolder"] -AppProjectFolder $parameters.Value["appProjectFolder"] -BuildMode $appBuildMode | Out-Null


### PR DESCRIPTION
This pull request backports #641 to releases/24.0

+ Reenable strict mode 

Fixes [AB#502108](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/502108)



