### PR TITLE
Properly handle paging (max. results and marker) for ListDirectory()

### DIFF
--- a/src/System Application/App/Azure File Services API/src/AFSDirectoryContent.Table.al
+++ b/src/System Application/App/Azure File Services API/src/AFSDirectoryContent.Table.al
@@ -113,6 +113,11 @@ table 8950 "AFS Directory Content"
             DataClassification = SystemMetadata;
             Caption = 'URI', Locked = true;
         }
+        field(120; "Next Marker"; Text[2048])
+        {
+            DataClassification = SystemMetadata;
+            Caption = 'NextMarker';
+        }
     }
 
     keys

--- a/src/System Application/App/Azure File Services API/src/AFSDirectoryContent.Table.al
+++ b/src/System Application/App/Azure File Services API/src/AFSDirectoryContent.Table.al
@@ -115,7 +115,7 @@ table 8950 "AFS Directory Content"
         }
         field(120; "Next Marker"; Text[2048])
         {
-            DataClassification = SystemMetadata;
+            DataClassification = CustomerContent;
             Caption = 'NextMarker';
         }
     }

--- a/src/System Application/App/Azure File Services API/src/AFSFileClientImpl.Codeunit.al
+++ b/src/System Application/App/Azure File Services API/src/AFSFileClientImpl.Codeunit.al
@@ -186,8 +186,11 @@ codeunit 8951 "AFS File Client Impl."
         DirectoryURI := AFSHelperLibrary.GetDirectoryPathFromResponse(ResponseText);
 
         AFSHelperLibrary.DirectoryContentNodeListToTempRecord(DirectoryURI, DirectoryPath, NodeList, PreserveDirectoryContent, AFSDirectoryContent);
-        AFSDirectoryContent."Next Marker" := CopyStr(AFSHelperLibrary.GetNextMarkerFromResponse(ResponseText), 1, MaxStrLen(AFSDirectoryContent."Next Marker"));
-        AFSDirectoryContent.Modify();
+
+        if AFSOperationResponse.IsSuccessful() then begin
+            AFSDirectoryContent."Next Marker" := CopyStr(AFSHelperLibrary.GetNextMarkerFromResponse(ResponseText), 1, MaxStrLen(AFSDirectoryContent."Next Marker"));
+            AFSDirectoryContent.Modify();
+        end;
 
         exit(AFSOperationResponse);
     end;
@@ -213,8 +216,11 @@ codeunit 8951 "AFS File Client Impl."
 
         NodeList := AFSHelperLibrary.CreateHandleNodeListFromResponse(ResponseText);
         AFSHelperLibrary.HandleNodeListToTempRecord(NodeList, AFSHandle);
-        AFSHandle."Next Marker" := CopyStr(AFSHelperLibrary.GetNextMarkerFromResponse(ResponseText), 1, MaxStrLen(AFSHandle."Next Marker"));
-        AFSHandle.Modify();
+
+        if AFSOperationResponse.IsSuccessful() then begin
+            AFSHandle."Next Marker" := CopyStr(AFSHelperLibrary.GetNextMarkerFromResponse(ResponseText), 1, MaxStrLen(AFSHandle."Next Marker"));
+            AFSHandle.Modify();
+        end;
 
         exit(AFSOperationResponse);
     end;

--- a/src/System Application/App/Azure File Services API/src/AFSFileClientImpl.Codeunit.al
+++ b/src/System Application/App/Azure File Services API/src/AFSFileClientImpl.Codeunit.al
@@ -186,6 +186,8 @@ codeunit 8951 "AFS File Client Impl."
         DirectoryURI := AFSHelperLibrary.GetDirectoryPathFromResponse(ResponseText);
 
         AFSHelperLibrary.DirectoryContentNodeListToTempRecord(DirectoryURI, DirectoryPath, NodeList, PreserveDirectoryContent, AFSDirectoryContent);
+        AFSDirectoryContent."Next Marker" := CopyStr(AFSHelperLibrary.GetNextMarkerFromResponse(ResponseText), 1, MaxStrLen(AFSDirectoryContent."Next Marker"));
+        AFSDirectoryContent.Modify();
 
         exit(AFSOperationResponse);
     end;

--- a/src/System Application/Test/Azure File Services API/src/AFSFileClientTest.Codeunit.al
+++ b/src/System Application/Test/Azure File Services API/src/AFSFileClientTest.Codeunit.al
@@ -99,7 +99,7 @@ codeunit 132520 "AFS File Client Test"
         // [WHEN] The programmer runs a list operation on the root directory
         AFSFileClient.Initialize(AFSInitTestStorage.GetStorageAccountName(), AFSInitTestStorage.GetFileShareName(), SharedKeyAuthorization);
         AFSOperationResponse := AFSFileClient.ListDirectory('', AFSDirectoryContent, AFSOptionalParameters);
-        LibraryAssert.AreEqual(true, AFSOperationResponse.IsSuccessful(), AFSOperationResponse.GetError());
+        LibraryAssert.IsTrue(AFSOperationResponse.IsSuccessful(), AFSOperationResponse.GetError());
 
         // [THEN] Only the first entry parentdir must be returned and a marker must be set
         LibraryAssert.AreEqual(1, AFSDirectoryContent.Count(), 'Wrong number of files and/or directories returned with MaxResults set.');
@@ -111,7 +111,7 @@ codeunit 132520 "AFS File Client Test"
         // [WHEN] The programmer runs a further list operation on the root directory with the returned marker set
         AFSOptionalParameters.Marker(AFSDirectoryContent."Next Marker");
         AFSOperationResponse := AFSFileClient.ListDirectory('', AFSDirectoryContent, AFSOptionalParameters);
-        LibraryAssert.AreEqual(true, AFSOperationResponse.IsSuccessful(), AFSOperationResponse.GetError());
+        LibraryAssert.IsTrue(AFSOperationResponse.IsSuccessful(), AFSOperationResponse.GetError());
 
         // [THEN] The second entry anotherdir must be returned and the marker must be cleared
         LibraryAssert.AreEqual(1, AFSDirectoryContent.Count(), 'Wrong number of files and/or directories returned with MaxResults set.');

--- a/src/System Application/Test/Azure File Services API/src/AFSFileClientTest.Codeunit.al
+++ b/src/System Application/Test/Azure File Services API/src/AFSFileClientTest.Codeunit.al
@@ -68,6 +68,60 @@ codeunit 132520 "AFS File Client Test"
     end;
 
     [Test]
+    procedure MaxResultsAndMarkerTest()
+    var
+        AFSDirectoryContent: Record "AFS Directory Content";
+        AFSFileClient: Codeunit "AFS File Client";
+        AFSOperationResponse: Codeunit "AFS Operation Response";
+        AFSOptionalParameters: Codeunit "AFS Optional Parameters";
+    begin
+        // [SCENARIO] User wants to read directory entries with paging
+
+        // [GIVEN] A storage account with a file share and a preset file structure
+        // -- parentdir
+        //    -- test.txt
+        //    -- test2.txt
+        //    -- deeperdir
+        //       -- test3.txt
+        //       -- test4.txt
+        // -- anotherdir
+        //    -- image.jpg
+        //    -- document.pdf
+        //    -- spreadsheet.xlsx
+        //    -- emptydir
+        AFSInitTestStorage.ClearFileShare();
+        SharedKeyAuthorization := AFSGetTestStorageAuth.GetDefaultAccountSAS(AFSInitTestStorage.GetAccessKey());
+        InitializeFileShareStructure();
+
+        // [GIVEN] Parameter to limit the number of results to 1 (paging)
+        AFSOptionalParameters.MaxResults(1);
+
+        // [WHEN] The programmer runs a list operation on the root directory
+        AFSFileClient.Initialize(AFSInitTestStorage.GetStorageAccountName(), AFSInitTestStorage.GetFileShareName(), SharedKeyAuthorization);
+        AFSOperationResponse := AFSFileClient.ListDirectory('', AFSDirectoryContent, AFSOptionalParameters);
+        LibraryAssert.AreEqual(true, AFSOperationResponse.IsSuccessful(), AFSOperationResponse.GetError());
+
+        // [THEN] Only the first entry parentdir must be returned and a marker must be set
+        LibraryAssert.AreEqual(1, AFSDirectoryContent.Count(), 'Wrong number of files and/or directories returned with MaxResults set.');
+        LibraryAssert.AreNotEqual('', AFSDirectoryContent."Next Marker", 'Next Marker must not be empty.');
+
+        AFSDirectoryContent.SetRange("Full Name", 'parentdir');
+        LibraryAssert.RecordIsNotEmpty(AFSDirectoryContent);
+
+        // [WHEN] The programmer runs a further list operation on the root directory with the returned marker set
+        AFSOptionalParameters.Marker(AFSDirectoryContent."Next Marker");
+        AFSOperationResponse := AFSFileClient.ListDirectory('', AFSDirectoryContent, AFSOptionalParameters);
+        LibraryAssert.AreEqual(true, AFSOperationResponse.IsSuccessful(), AFSOperationResponse.GetError());
+
+        // [THEN] The second entry anotherdir must be returned and the marker must be cleared
+        LibraryAssert.AreEqual(1, AFSDirectoryContent.Count(), 'Wrong number of files and/or directories returned with MaxResults set.');
+        LibraryAssert.AreEqual('', AFSDirectoryContent."Next Marker", 'Next Marker must be empty.');
+
+        AFSDirectoryContent.SetRange("Full Name", 'anotherdir');
+        LibraryAssert.RecordIsNotEmpty(AFSDirectoryContent);
+    end;
+
+    [Test]
     procedure ListDirectoryTest()
     var
         AFSDirectoryContent: Record "AFS Directory Content";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary
Properly handle paging (max. results and marker) for ListDirectory(). This has been aligned with the existing implementation of ListFileHandles(). Furthermore, error returns are handled properly.

#### Work Item(s)
Fixes #509 



Fixes [AB#503159](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/503159)



