### PR TITLE
Require SUPER permission to run AAD user sync

### DIFF
--- a/src/System Application/App/Azure AD User Management/src/User sync/AzureADUserUpdateWizard.Page.al
+++ b/src/System Application/App/Azure AD User Management/src/User sync/AzureADUserUpdateWizard.Page.al
@@ -363,7 +363,7 @@ page 9515 "Azure AD User Update Wizard"
     var
         UserPermissions: Codeunit "User Permissions";
     begin
-        if not UserPermissions.CanManageUsersOnTenant(UserSecurityId()) then
+        if not (UserPermissions.CanManageUsersOnTenant(UserSecurityId()) and UserPermissions.IsSuper(UserSecurityId())) then
             Error(CannotUpdateUsersFromOfficeErr);
 
         MakeAllGroupsInvisible();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Currently it's possible to open the user sync with only e.g. Security. However, SUPER permissions are required to create new users and thus sync will fail if user does not have SUPER.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#497926](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/497926/)

