### PR TITLE
Temporarily disable AA0139

### DIFF
--- a/src/rulesets/CodeCop.ruleset.json
+++ b/src/rulesets/CodeCop.ruleset.json
@@ -556,7 +556,8 @@
                   },
                   {
                       "id":  "AA0139",
-                      "action":  "Warning"
+                      "action":  "None",
+                      "justification": "This rule reports potential text overflows."
                   },
                   {
                       "id":  "AA0140",

--- a/src/rulesets/CodeCop.ruleset.json
+++ b/src/rulesets/CodeCop.ruleset.json
@@ -556,7 +556,7 @@
                   },
                   {
                       "id":  "AA0139",
-                      "action":  "Error"
+                      "action":  "Warning"
                   },
                   {
                       "id":  "AA0140",


### PR DESCRIPTION
#### Summary Set AA0139 as warning in the CodeCop ruleset, following the changes for reporting potential overflow in conversions in method invocation.

Related to [AB#481371](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/481371/).



