### PR TITLE
Marketing Text: JA/Japanese: Remove lower boundary check as this blocks languages where spaces are…

### DIFF
--- a/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
@@ -359,8 +359,6 @@ codeunit 2012 "Entity Text Impl."
                 begin
                     SplitCompletion := Completion.Split(EncodedNewlineTok + EncodedNewlineTok);
                     FormatValid := SplitCompletion.Count() = 2; // a tagline + paragraph must contain an empty line
-                    if FormatValid then
-                        FormatValid := SplitCompletion.Get(2).Split(' ').Count() >= MinParagraphWords; // the paragraph must be more than MinParagraphWords words
                 end;
             TextFormat::Paragraph:
                 FormatValid := (not Completion.Contains(EncodedNewlineTok + EncodedNewlineTok)) and (Completion.Split(' ').Count() >= MinParagraphWords); // multiple paragraphs should be avoided, and must have more than MinParagraphWords words


### PR DESCRIPTION
#### Summary 
Remove lower boundary check as this blocks languages where spaces are not used.

#### Work Item(s)
Fixes # [AB#506451](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/506451)


