### PR TITLE
[releases/24.0] Language Id and Format Region override methods

### DIFF
--- a/src/System Application/App/Language/app.json
+++ b/src/System Application/App/Language/app.json
@@ -17,8 +17,8 @@
                                    "publisher":  "Microsoft"
                                }
                            ],
-    "dependencies":  [
-                         {
+    "dependencies": [
+                        {
                              "id":  "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
                              "name":  "DotNet Aliases",
                              "publisher":  "Microsoft",

--- a/src/System Application/App/Language/src/Language.Codeunit.al
+++ b/src/System Application/App/Language/src/Language.Codeunit.al
@@ -67,6 +67,55 @@ codeunit 43 Language
         exit(LanguageImpl.GetLanguageId(LanguageCode));
     end;
 
+    /// <summary>  
+    /// Overrides the language ID returned by the GetLanguageIdOrDefault function. 
+    /// </summary>  
+    /// <param name="LanguageId">The ID of the language to use. This must be a valid language ID.</param>  
+    /// <remarks>  
+    /// This override will be reset after it's used once in the GetLanguageIdOrDefault function. To keep the override throughout the application, use SetOverrideLanguageId(LanguageId: Integer; ResetOverride: Boolean) method.  
+    /// </remarks>  
+    procedure SetOverrideLanguageId(LanguageId: Integer)
+    begin
+        SetOverrideLanguageId(LanguageId, true);
+    end;
+
+    /// <summary>  
+    /// Overrides the language ID returned by the GetLanguageIdOrDefault function.  
+    /// </summary>  
+    /// <param name="LanguageId">The ID of the language to use. This must be a valid language ID.</param>  
+    /// <param name="ResetOverride">A boolean value indicating whether the override should be reset after use in the GetLanguageIdOrDefault function. If set to true, the override is reset after it's used once. If set to false, the override remains until it's manually reset or the session is restarted.</param>  
+
+    procedure SetOverrideLanguageId(LanguageId: Integer; ResetOverride: Boolean)
+    var
+        LanguageImpl: Codeunit "Language Impl.";
+    begin
+        LanguageImpl.SetOverrideLanguageId(LanguageId, ResetOverride);
+    end;
+
+    /// <summary>  
+    /// Overrides the format region returned by the GetFormatRegionOrDefault function.  
+    /// </summary>  
+    /// <param name="FormatRegion">The region to use for formatting purposes. This must be a valid region code.</param>  
+    /// <remarks>  
+    /// This override will be reset after it's used once in the GetFormatRegionOrDefault function. To keep the override throughout the session, use SetOverrideFormatRegion(FormatRegion: Text[80]; ResetOverride: Boolean) method.  
+    /// </remarks>  
+    procedure SetOverrideFormatRegion(FormatRegion: Text[80])
+    begin
+        SetOverrideFormatRegion(FormatRegion, true);
+    end;
+
+    /// <summary>  
+    /// Overrides the format region returned by the GetFormatRegionOrDefault function.
+    /// </summary>  
+    /// <param name="FormatRegion">The region to use for formatting purposes. This must be a valid region code.</param>  
+    /// <param name="ResetOverride">A boolean value indicating whether the override should be reset after use in the GetFormatRegionOrDefault function. If set to true, the override is reset after it's used once. If set to false, the override remains until it's manually reset or the session is restarted.</param>  
+    procedure SetOverrideFormatRegion(FormatRegion: Text[80]; ResetOverride: Boolean)
+    var
+        LanguageImpl: Codeunit "Language Impl.";
+    begin
+        LanguageImpl.SetOverrideFormatRegion(FormatRegion, ResetOverride);
+    end;
+
     /// <summary>
     /// Gets the code for a language based on its ID.
     /// </summary>

--- a/src/System Application/App/Language/src/LanguageImpl.Codeunit.al
+++ b/src/System Application/App/Language/src/LanguageImpl.Codeunit.al
@@ -21,7 +21,13 @@ codeunit 54 "Language Impl."
                   tabledata "Windows Language" = r;
 
     var
+        ResetLanguageIdOverrideAfterUse, ResetFormatRegionOverrideAfterUse : Boolean;
+        LanguageIdOverride: Integer;
+        FormatRegionOverride: Text[80];
         LanguageNotFoundErr: Label 'The language %1 could not be found.', Comment = '%1 = Language ID';
+        LanguageIdOverrideMsg: Label 'LanguageIdOverride has been applied in GetLanguageIdOrDefault. The new Language Id is %1.', Comment = '%1 - Language ID';
+        FormatRegionOverrideMsg: Label 'FormatRegionOverride has been applied in GetFormatRegionOrDefault. The new FormatRegion is %1.', Comment = '%1 - Format Region';
+        LanguageCategoryTxt: Label 'Language';
 
     procedure GetUserLanguageCode() UserLanguageCode: Code[10]
     var
@@ -38,8 +44,15 @@ codeunit 54 "Language Impl."
     var
         LanguageId: Integer;
     begin
-        LanguageId := GetLanguageId(LanguageCode);
+        if LanguageIdOverride <> 0 then begin
+            LanguageId := LanguageIdOverride;
+            Session.LogMessage('0000MJQ', StrSubstNo(LanguageIdOverrideMsg, LanguageId), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', LanguageCategoryTxt);
+            if ResetLanguageIdOverrideAfterUse then
+                LanguageIdOverride := 0;
+            exit(LanguageId);
+        end;
 
+        LanguageId := GetLanguageId(LanguageCode);
         if LanguageId = 0 then
             LanguageId := GlobalLanguage();
 
@@ -52,6 +65,14 @@ codeunit 54 "Language Impl."
         UserSessionSettings: SessionSettings;
         LocalId: Integer;
     begin
+        if FormatRegionOverride <> '' then begin
+            FormatRegion := FormatRegionOverride;
+            Session.LogMessage('0000MJR', StrSubstNo(FormatRegionOverrideMsg, FormatRegion), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', LanguageCategoryTxt);
+            if ResetFormatRegionOverrideAfterUse then
+                FormatRegionOverride := '';
+            exit(FormatRegion);
+        end;
+
         if FormatRegion <> '' then
             exit(FormatRegion);
 
@@ -63,6 +84,18 @@ codeunit 54 "Language Impl."
             exit(LanguageSelection."Language Tag");
 
         exit('en-US');
+    end;
+
+    procedure SetOverrideLanguageId(LanguageId: Integer; ResetOverride: Boolean)
+    begin
+        LanguageIdOverride := LanguageId;
+        ResetLanguageIdOverrideAfterUse := ResetOverride;
+    end;
+
+    procedure SetOverrideFormatRegion(FormatRegion: Text[80]; ResetOverride: Boolean)
+    begin
+        FormatRegionOverride := FormatRegion;
+        ResetFormatRegionOverrideAfterUse := ResetOverride;
     end;
 
     procedure GetLanguageId(LanguageCode: Code[10]): Integer


### PR DESCRIPTION
This pull request backports #549 to releases/24.0

Fixes [[AB#507000](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/507000)]




