### PR TITLE
Determine maxAllowedObsoleteVersion from config in main

### DIFF
--- a/build/BuildConfig.json
+++ b/build/BuildConfig.json
@@ -1,3 +1,0 @@
-{
-    "MaxAllowedObsoleteVersion":  "25"
-}

--- a/build/scripts/GuardingV2ExtensionsHelper.psm1
+++ b/build/scripts/GuardingV2ExtensionsHelper.psm1
@@ -199,7 +199,7 @@ function Update-AppSourceCopVersion
 
     # All major versions greater than current but less or equal to main should be allowed
     $currentBuildVersion = [int] $buildVersion.Split('.')[0]
-    $maxAllowedObsoleteVersion = [int] (GetCurrentBuildVersionFromMain)
+    $maxAllowedObsoleteVersion = [int] (GetMaxAllowedObsoleteVersion)
     $obsoleteTagAllowedVersions = @()
 
     # Add 3 versions for tasks built with CLEANpreProcessorSymbols
@@ -251,7 +251,7 @@ function Test-IsStrictModeEnabled
     return $false
 }
 
-function GetCurrentBuildVersionFromMain() {
+function GetMaxAllowedObsoleteVersion() {
     git fetch origin main
     $alGoSettings = $(git show origin/main:.github/AL-Go-Settings.json) | ConvertFrom-Json
     if (-not $alGoSettings.repoVersion) {

--- a/build/scripts/GuardingV2ExtensionsHelper.psm1
+++ b/build/scripts/GuardingV2ExtensionsHelper.psm1
@@ -199,7 +199,7 @@ function Update-AppSourceCopVersion
 
     # All major versions greater than current but less or equal to main should be allowed
     $currentBuildVersion = [int] $buildVersion.Split('.')[0]
-    $maxAllowedObsoleteVersion = [int] (Get-ConfigValue -ConfigType BuildConfig -Key "MaxAllowedObsoleteVersion")
+    $maxAllowedObsoleteVersion = [int] (GetCurrentBuildVersionFromMain)
     $obsoleteTagAllowedVersions = @()
 
     # Add 3 versions for tasks built with CLEANpreProcessorSymbols
@@ -249,6 +249,14 @@ function Test-IsStrictModeEnabled
     }
 
     return $false
+}
+
+function GetCurrentBuildVersionFromMain() {
+    $alGoSettings = $(git show main:.github/AL-Go-Settings.json) | ConvertFrom-Json
+    if (-not $alGoSettings.repoVersion) {
+        throw "Unable to find repoVersion in AL-Go-Settings.json"
+    }
+    return [System.Version]::Parse($alGoSettings.repoVersion).Major
 }
 
 Export-ModuleMember -Function *-*

--- a/build/scripts/GuardingV2ExtensionsHelper.psm1
+++ b/build/scripts/GuardingV2ExtensionsHelper.psm1
@@ -252,6 +252,7 @@ function Test-IsStrictModeEnabled
 }
 
 function GetCurrentBuildVersionFromMain() {
+    git fetch origin main
     $alGoSettings = $(git show main:.github/AL-Go-Settings.json) | ConvertFrom-Json
     if (-not $alGoSettings.repoVersion) {
         throw "Unable to find repoVersion in AL-Go-Settings.json"

--- a/build/scripts/GuardingV2ExtensionsHelper.psm1
+++ b/build/scripts/GuardingV2ExtensionsHelper.psm1
@@ -253,7 +253,7 @@ function Test-IsStrictModeEnabled
 
 function GetCurrentBuildVersionFromMain() {
     git fetch origin main
-    $alGoSettings = $(git show main:.github/AL-Go-Settings.json) | ConvertFrom-Json
+    $alGoSettings = $(git show origin/main:.github/AL-Go-Settings.json) | ConvertFrom-Json
     if (-not $alGoSettings.repoVersion) {
         throw "Unable to find repoVersion in AL-Go-Settings.json"
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Determine maxAllowedObsoleteVersion from config in main

Right now it's not possible to backport PRs with 25.0 as an obsolete tag because we didn't update the config value when we branched: https://github.com/microsoft/BCApps/actions/runs/8449290970?pr=841

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#523764](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/523764)




