### PR TITLE
[releases/24.x] Determine maxAllowedObsoleteVersion from config in main

### DIFF
--- a/build/BuildConfig.json
+++ b/build/BuildConfig.json
@@ -1,3 +1,0 @@
-{
-    "MaxAllowedObsoleteVersion":  "24"
-}

--- a/build/scripts/GuardingV2ExtensionsHelper.psm1
+++ b/build/scripts/GuardingV2ExtensionsHelper.psm1
@@ -199,7 +199,7 @@ function Update-AppSourceCopVersion
 
     # All major versions greater than current but less or equal to main should be allowed
     $currentBuildVersion = [int] $buildVersion.Split('.')[0]
-    $maxAllowedObsoleteVersion = [int] (Get-ConfigValue -ConfigType BuildConfig -Key "MaxAllowedObsoleteVersion")
+    $maxAllowedObsoleteVersion = [int] (GetMaxAllowedObsoleteVersion)
     $obsoleteTagAllowedVersions = @()
 
     # Add 3 versions for tasks built with CLEANpreProcessorSymbols
@@ -249,6 +249,15 @@ function Test-IsStrictModeEnabled
     }
 
     return $false
+}
+
+function GetMaxAllowedObsoleteVersion() {
+    git fetch origin main
+    $alGoSettings = $(git show origin/main:.github/AL-Go-Settings.json) | ConvertFrom-Json
+    if (-not $alGoSettings.repoVersion) {
+        throw "Unable to find repoVersion in AL-Go-Settings.json"
+    }
+    return [System.Version]::Parse($alGoSettings.repoVersion).Major
 }
 
 Export-ModuleMember -Function *-*


### PR DESCRIPTION
This pull request backports #856 to releases/24.x

Fixes [AB#523764](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/523764)


