### PR TITLE
Calculate full BC artifact URL when updating it

### DIFF
--- a/build/scripts/EnlistmentHelperFunctions.psm1
+++ b/build/scripts/EnlistmentHelperFunctions.psm1
@@ -213,8 +213,15 @@ function Get-PackageLatestVersion() {
                 $storageAccountOrder = @("bcinsider")
             }
 
+            $latestArtifactUrl = Get-LatestBCArtifactUrl -minimumVersion $minimumVersion -storageAccountOrder $storageAccountOrder
 
-            return Get-LatestBCArtifactVersion -minimumVersion $minimumVersion -storageAccountOrder $storageAccountOrder
+            if ($latestArtifactUrl -and ($latestArtifactUrl -match "\d+\.\d+\.\d+\.\d+")) {
+                $latestVersion = $Matches[0]
+            } else {
+                throw "Could not find BCArtifact version (for min version: $minimumVersion)"
+            }
+
+            return $latestVersion
         }
         default {
             throw "Unknown package source: $($package.Source)"
@@ -227,8 +234,10 @@ function Get-PackageLatestVersion() {
     Gets the latest version of a BC artifact
 .Parameter MinimumVersion
     The minimum version of the artifact to look for
+.Parameter StorageAccountOrder
+    The order of storage accounts to look for the artifact in
 #>
-function Get-LatestBCArtifactVersion
+function Get-LatestBCArtifactUrl
 (
     [Parameter(Mandatory=$true)]
     $minimumVersion,
@@ -243,13 +252,11 @@ function Get-LatestBCArtifactVersion
         $artifactUrl = Get-BCArtifactUrl -type Sandbox -country base -version $minimumVersion -select Latest -storageAccount $storageAccountOrder[1] -accept_insiderEula
     }
 
-    if ($artifactUrl -and ($artifactUrl -match "\d+\.\d+\.\d+\.\d+")) {
-        $latestVersion = $Matches[0]
-    } else {
-        throw "Could not find BCArtifact version (for min version: $minimumVersion)"
+    if(-not $artifactUrl) {
+        throw "No artifact found for version $minimumVersion"
     }
 
-    return $latestVersion
+    return $artifactUrl
 }
 
 <#

--- a/build/scripts/UpdateBCArtifactVersion.ps1
+++ b/build/scripts/UpdateBCArtifactVersion.ps1
@@ -35,7 +35,7 @@ function UpdateBCArtifactVersion() {
 
     Write-Host "Latest BCArtifact URL: $latestArtifactUrl"
 
-    if($latestArtifactUrl -ne $currentArtifactVersion) {
+    if($latestArtifactUrl -ne $currentArtifactUrl) {
         Write-Host "Updating BCArtifact version from $currentArtifactUrl to $latestArtifactUrl"
         Set-ConfigValue -Key "artifact" -Value $latestArtifactUrl -ConfigType AL-Go
 

--- a/build/scripts/UpdateBCArtifactVersion.ps1
+++ b/build/scripts/UpdateBCArtifactVersion.ps1
@@ -26,25 +26,18 @@ Import-Module $PSScriptRoot\EnlistmentHelperFunctions.psm1
 Import-Module $PSScriptRoot\AutomatedSubmission.psm1
 
 function UpdateBCArtifactVersion() {
-    $artifactValue = Get-ConfigValue -Key "artifact" -ConfigType AL-Go
-    if ($artifactValue -and ($artifactValue -match "\d+\.\d+\.\d+\.\d+")) {
-        $currentArtifactVersion = $Matches[0]
-    } else {
-        throw "Could not find BCArtifact version: $artifactValue"
-    }
+    $currentArtifactUrl = Get-ConfigValue -Key "artifact" -ConfigType AL-Go
 
-    Write-Host "Current BCArtifact version: $currentArtifactVersion"
+    Write-Host "Current BCArtifact URL: $currentArtifactUrl"
 
     $currentVersion = Get-ConfigValue -Key "repoVersion" -ConfigType AL-Go
-    $latestArtifactVersion = Get-LatestBCArtifactVersion -minimumVersion $currentVersion
+    $latestArtifactUrl = Get-LatestBCArtifactUrl -minimumVersion $currentVersion
 
-    Write-Host "Latest BCArtifact version: $latestArtifactVersion"
+    Write-Host "Latest BCArtifact URL: $latestArtifactUrl"
 
-    if($latestArtifactVersion -gt $currentArtifactVersion) {
-        Write-Host "Updating BCArtifact version from $currentArtifactVersion to $latestArtifactVersion"
-
-        $artifactValue = $artifactValue -replace $currentArtifactVersion, $latestArtifactVersion
-        Set-ConfigValue -Key "artifact" -Value $artifactValue -ConfigType AL-Go
+    if($latestArtifactUrl -ne $currentArtifactVersion) {
+        Write-Host "Updating BCArtifact version from $currentArtifactUrl to $latestArtifactUrl"
+        Set-ConfigValue -Key "artifact" -Value $latestArtifactUrl -ConfigType AL-Go
 
         return $true
     }


### PR DESCRIPTION
Calculating BC artifact might switch between _bcinsider_ and _bcartifacts_ (typically around branching when a new version is available but not yet released). This PR addresses the issue when the storage account needs to be changed as well.

[AB#524129](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/524129)
