### PR TITLE
Remove NonDebuggable SharePoint Module

### DIFF
--- a/src/System Application/App/SharePoint/src/model/file/SharePointFile.Codeunit.al
+++ b/src/System Application/App/SharePoint/src/model/file/SharePointFile.Codeunit.al
@@ -11,7 +11,6 @@ codeunit 9106 "SharePoint File"
     InherentEntitlements = X;
     InherentPermissions = X;
 
-    [NonDebuggable]
     procedure Parse(Payload: Text; var SharePointFile: Record "SharePoint File" temporary)
     var
         JObject: JsonObject;
@@ -20,7 +19,6 @@ codeunit 9106 "SharePoint File"
             Parse(JObject, SharePointFile);
     end;
 
-    [NonDebuggable]
     procedure ParseSingleReturnValue(Payload: Text; var SharePointFile: Record "SharePoint File" temporary)
     var
         JObject: JsonObject;
@@ -34,7 +32,6 @@ codeunit 9106 "SharePoint File"
             end;
     end;
 
-    [NonDebuggable]
     procedure ParseSingle(Payload: Text; var SharePointFile: Record "SharePoint File" temporary)
     var
         JObject: JsonObject;
@@ -43,7 +40,6 @@ codeunit 9106 "SharePoint File"
             SharePointFile := ParseSingle(JObject);
     end;
 
-    [NonDebuggable]
     procedure Parse(Payload: JsonObject; var SharePointFile: Record "SharePoint File" temporary)
     var
         JToken: JsonToken;
@@ -55,7 +51,6 @@ codeunit 9106 "SharePoint File"
             end;
     end;
 
-    [NonDebuggable]
     local procedure ParseSingle(Payload: JsonObject) SharePointFile: Record "SharePoint File" temporary
     var
         SharePointClient: Codeunit "SharePoint Client";

--- a/src/System Application/App/SharePoint/src/model/folder/SharePointFolder.Codeunit.al
+++ b/src/System Application/App/SharePoint/src/model/folder/SharePointFolder.Codeunit.al
@@ -11,7 +11,6 @@ codeunit 9105 "SharePoint Folder"
     InherentEntitlements = X;
     InherentPermissions = X;
 
-    [NonDebuggable]
     procedure Parse(Payload: Text; var SharePointFolder: Record "SharePoint Folder" temporary)
     var
         JObject: JsonObject;
@@ -20,7 +19,6 @@ codeunit 9105 "SharePoint Folder"
             Parse(JObject, SharePointFolder);
     end;
 
-    [NonDebuggable]
     procedure Parse(Payload: JsonObject; var SharePointFolder: Record "SharePoint Folder" temporary)
     var
         JToken: JsonToken;
@@ -32,7 +30,6 @@ codeunit 9105 "SharePoint Folder"
             end;
     end;
 
-    [NonDebuggable]
     procedure ParseSingleReturnValue(Payload: Text; var SharePointFolder: Record "SharePoint Folder" temporary)
     var
         JObject: JsonObject;
@@ -46,7 +43,6 @@ codeunit 9105 "SharePoint Folder"
             end;
     end;
 
-    [NonDebuggable]
     procedure ParseSingle(Payload: Text; var SharePointFolder: Record "SharePoint Folder" temporary)
     var
         JObject: JsonObject;
@@ -57,7 +53,6 @@ codeunit 9105 "SharePoint Folder"
         end;
     end;
 
-    [NonDebuggable]
     local procedure ParseSingle(Payload: JsonObject) SharePointFolder: Record "SharePoint Folder" temporary
     var
         JToken: JsonToken;

--- a/src/System Application/App/SharePoint/src/model/list/SharePointList.Codeunit.al
+++ b/src/System Application/App/SharePoint/src/model/list/SharePointList.Codeunit.al
@@ -11,7 +11,6 @@ codeunit 9104 "SharePoint List"
     InherentEntitlements = X;
     InherentPermissions = X;
 
-    [NonDebuggable]
     procedure Parse(Payload: Text; var SharePointList: Record "SharePoint List" temporary)
     var
         JObject: JsonObject;
@@ -20,7 +19,6 @@ codeunit 9104 "SharePoint List"
             Parse(JObject, SharePointList);
     end;
 
-    [NonDebuggable]
     procedure Parse(Payload: JsonObject; var SharePointList: Record "SharePoint List" temporary)
     var
         JToken: JsonToken;
@@ -32,7 +30,6 @@ codeunit 9104 "SharePoint List"
             end;
     end;
 
-    [NonDebuggable]
     procedure ParseSingleReturnValue(Payload: Text; var SharePointList: Record "SharePoint List" temporary)
     var
         JObject: JsonObject;
@@ -46,7 +43,6 @@ codeunit 9104 "SharePoint List"
             end;
     end;
 
-    [NonDebuggable]
     local procedure ParseSingle(Payload: JsonObject) SharePointList: Record "SharePoint List" temporary
     var
         JToken: JsonToken;

--- a/src/System Application/App/SharePoint/src/model/listitem/SharePointListItem.Codeunit.al
+++ b/src/System Application/App/SharePoint/src/model/listitem/SharePointListItem.Codeunit.al
@@ -11,7 +11,6 @@ codeunit 9103 "SharePoint List Item"
     InherentEntitlements = X;
     InherentPermissions = X;
 
-    [NonDebuggable]
     procedure Parse(Payload: Text; var SharePointListItem: Record "SharePoint List Item" temporary)
     var
         JObject: JsonObject;
@@ -20,7 +19,6 @@ codeunit 9103 "SharePoint List Item"
             Parse(JObject, SharePointListItem);
     end;
 
-    [NonDebuggable]
     procedure Parse(Payload: JsonObject; var SharePointListItem: Record "SharePoint List Item" temporary)
     var
         JToken: JsonToken;
@@ -32,7 +30,6 @@ codeunit 9103 "SharePoint List Item"
             end;
     end;
 
-    [NonDebuggable]
     procedure ParseSingleReturnValue(Payload: Text; var SharePointListItem: Record "SharePoint List Item" temporary)
     var
         JObject: JsonObject;
@@ -46,7 +43,6 @@ codeunit 9103 "SharePoint List Item"
             end;
     end;
 
-    [NonDebuggable]
     local procedure ParseSingle(Payload: JsonObject) SharePointListItem: Record "SharePoint List Item" temporary
     var
         SharePointUriBuilder: Codeunit "SharePoint Uri Builder";

--- a/src/System Application/App/SharePoint/src/model/listitemattachment/SharePointListItemAtch.Codeunit.al
+++ b/src/System Application/App/SharePoint/src/model/listitemattachment/SharePointListItemAtch.Codeunit.al
@@ -11,7 +11,6 @@ codeunit 9102 "SharePoint List Item Atch."
     InherentEntitlements = X;
     InherentPermissions = X;
 
-    [NonDebuggable]
     procedure Parse(Payload: Text; var SharePointListItemAtch: Record "SharePoint List Item Atch" temporary)
     var
         JObject: JsonObject;
@@ -20,7 +19,6 @@ codeunit 9102 "SharePoint List Item Atch."
             Parse(JObject, SharePointListItemAtch);
     end;
 
-    [NonDebuggable]
     procedure Parse(Payload: JsonObject; var SharePointListItemAtch: Record "SharePoint List Item Atch" temporary)
     var
         JToken: JsonToken;
@@ -32,7 +30,6 @@ codeunit 9102 "SharePoint List Item Atch."
             end;
     end;
 
-    [NonDebuggable]
     procedure ParseSingleReturnValue(Payload: Text; var SharePointListItemAtch: Record "SharePoint List Item Atch" temporary)
     var
         JObject: JsonObject;
@@ -46,7 +43,6 @@ codeunit 9102 "SharePoint List Item Atch."
             end;
     end;
 
-    [NonDebuggable]
     procedure ParseSingle(Payload: Text; var SharePointListItemAtch: Record "SharePoint List Item Atch" temporary)
     var
         JObject: JsonObject;
@@ -55,7 +51,6 @@ codeunit 9102 "SharePoint List Item Atch."
             SharePointListItemAtch := ParseSingle(JObject);
     end;
 
-    [NonDebuggable]
     local procedure ParseSingle(Payload: JsonObject) SharePointListItemAttachment: Record "SharePoint List Item Atch" temporary
     var
         SharePointUriBuilder: Codeunit "SharePoint Uri Builder";


### PR DESCRIPTION
#### Summary
This PR remove NonDebuggable property from parts of the SharePoint module because the values are already debuggable in an upper level and there are are no secrets.

#### Work Item(s)
Fixes #854 
