### PR TITLE
ResetAssistedSetup doesn't take filter into consideration

### DIFF
--- a/src/System Application/Test Library/Guided Experience/src/Assisted Setup/MyAssistedSetupTestPage2.Page.al
+++ b/src/System Application/Test Library/Guided Experience/src/Assisted Setup/MyAssistedSetupTestPage2.Page.al
@@ -1,0 +1,11 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.TestLibraries.Environment.Configuration;
+
+page 132588 "My Assisted Setup Test Page 2"
+{
+
+}

--- a/src/System Application/Test/Guided Experience/src/AssistedSetupTest.Codeunit.al
+++ b/src/System Application/Test/Guided Experience/src/AssistedSetupTest.Codeunit.al
@@ -163,12 +163,16 @@ codeunit 132586 "Assisted Setup Test"
 
         // [WHEN] Setup is set to be Completed 
         AssistedSetupTestLibrary.SetStatusToCompleted(Page::"Other Assisted Setup Test Page");
+        AssistedSetupTestLibrary.SetStatusToCompleted(Page::"My Assisted Setup Test Page 2");
 
         // [WHEN] Reset is called
         GuidedExperience.ResetAssistedSetup(ObjectType::Page, Page::"Other Assisted Setup Test Page");
 
         // [THEN] Status is incomplete
         LibraryAssert.IsFalse(GuidedExperience.IsAssistedSetupComplete(ObjectType::Page, Page::"Other Assisted Setup Test Page"), 'Complete!');
+
+        // [THEN] Status is still set to be Completed
+        LibraryAssert.IsTrue(GuidedExperience.IsAssistedSetupComplete(ObjectType::Page, Page::"My Assisted Setup Test Page 2"), 'InComplete!');
 
         UnbindSubscription(AssistedSetupTest);
     end;
@@ -225,6 +229,9 @@ codeunit 132586 "Assisted Setup Test"
 
         GuidedExperience.InsertAssistedSetup('Other Assisted Setup Test Page', 'Other Assisted Setup Test Page', '', 0, ObjectType::Page,
             Page::"Other Assisted Setup Test Page", AssistedSetupGroup::WithoutLinks, '', "Video Category"::Uncategorized, '');
+
+        GuidedExperience.InsertAssistedSetup('My Assisted Setup Test Page 2', 'My Assisted Setup Test Page 2', '', 0, ObjectType::Page,
+            Page::"My Assisted Setup Test Page 2", AssistedSetupGroup::WithoutLinks, '', "Video Category"::Uncategorized, '');
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Guided Experience", 'OnAfterRunAssistedSetup', '', true, true)]


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->

The `ResetAssistedSetup` function does not take filter into consideration in the final modification.

#### Work Item(s)
Fixes [AB#524168](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/524168)


