### PR TITLE
[24.x] Implement different fallback mechanism when determining baselines

### DIFF
--- a/build/scripts/EnlistmentHelperFunctions.psm1
+++ b/build/scripts/EnlistmentHelperFunctions.psm1
@@ -174,8 +174,15 @@ function Get-PackageLatestVersion() {
                 $storageAccountOrder = @("bcinsider")
             }
 
+            $latestArtifactUrl = Get-LatestBCArtifactUrl -minimumVersion $minimumVersion -storageAccountOrder $storageAccountOrder
 
-            return Get-LatestBCArtifactVersion -minimumVersion $minimumVersion -storageAccountOrder $storageAccountOrder
+            if ($latestArtifactUrl -and ($latestArtifactUrl -match "\d+\.\d+\.\d+\.\d+")) {
+                $latestVersion = $Matches[0]
+            } else {
+                throw "Could not find BCArtifact version (for min version: $minimumVersion)"
+            }
+
+            return $latestVersion
         }
         default {
             throw "Unknown package source: $($package.Source)"
@@ -188,8 +195,10 @@ function Get-PackageLatestVersion() {
     Gets the latest version of a BC artifact
 .Parameter MinimumVersion
     The minimum version of the artifact to look for
+.Parameter StorageAccountOrder
+    The order of storage accounts to look for the artifact in
 #>
-function Get-LatestBCArtifactVersion
+function Get-LatestBCArtifactUrl
 (
     [Parameter(Mandatory=$true)]
     $minimumVersion,
@@ -204,13 +213,11 @@ function Get-LatestBCArtifactVersion
         $artifactUrl = Get-BCArtifactUrl -type Sandbox -country base -version $minimumVersion -select Latest -storageAccount $storageAccountOrder[1] -accept_insiderEula
     }
 
-    if ($artifactUrl -and ($artifactUrl -match "\d+\.\d+\.\d+\.\d+")) {
-        $latestVersion = $Matches[0]
-    } else {
-        throw "Could not find BCArtifact version (for min version: $minimumVersion)"
+    if(-not $artifactUrl) {
+        throw "No artifact found for version $minimumVersion"
     }
 
-    return $latestVersion
+    return $artifactUrl
 }
 
 <#

--- a/build/scripts/EnlistmentHelperFunctions.psm1
+++ b/build/scripts/EnlistmentHelperFunctions.psm1
@@ -167,7 +167,15 @@ function Get-PackageLatestVersion() {
                 }
             }
 
-            return Get-LatestBCArtifactVersion -minimumVersion $minimumVersion
+            $currentBranch = Get-CurrentBranch
+            $storageAccountOrder = @("bcartifacts", "bcinsider")
+            if($currentBranch -eq "main") {
+                # Always use bcinsider for baselines for the main branch
+                $storageAccountOrder = @("bcinsider")
+            }
+
+
+            return Get-LatestBCArtifactVersion -minimumVersion $minimumVersion -storageAccountOrder $storageAccountOrder
         }
         default {
             throw "Unknown package source: $($package.Source)"
@@ -184,14 +192,16 @@ function Get-PackageLatestVersion() {
 function Get-LatestBCArtifactVersion
 (
     [Parameter(Mandatory=$true)]
-    $minimumVersion
+    $minimumVersion,
+    [Parameter(Mandatory=$false)]
+    $storageAccountOrder = @("bcartifacts", "bcinsider")
 )
 {
-    $artifactUrl = Get-BCArtifactUrl -type Sandbox -country base -version $minimumVersion -select Latest
+    $artifactUrl = Get-BCArtifactUrl -type Sandbox -country base -version $minimumVersion -select Latest -storageAccount $storageAccountOrder[0] -accept_insiderEula
 
-    if(-not $artifactUrl) {
-        #Fallback to bcinsider
-        $artifactUrl = Get-BCArtifactUrl -type Sandbox -country base -version $minimumVersion -select Latest -storageAccount bcinsider -accept_insiderEula
+    if(-not $artifactUrl -and $storageAccountOrder.Count -gt 1) {
+        #Fallback to the other storage account
+        $artifactUrl = Get-BCArtifactUrl -type Sandbox -country base -version $minimumVersion -select Latest -storageAccount $storageAccountOrder[1] -accept_insiderEula
     }
 
     if ($artifactUrl -and ($artifactUrl -match "\d+\.\d+\.\d+\.\d+")) {

--- a/build/scripts/UpdateBCArtifactVersion.ps1
+++ b/build/scripts/UpdateBCArtifactVersion.ps1
@@ -26,25 +26,18 @@ Import-Module $PSScriptRoot\EnlistmentHelperFunctions.psm1
 Import-Module $PSScriptRoot\AutomatedSubmission.psm1
 
 function UpdateBCArtifactVersion() {
-    $artifactValue = Get-ConfigValue -Key "artifact" -ConfigType AL-Go
-    if ($artifactValue -and ($artifactValue -match "\d+\.\d+\.\d+\.\d+")) {
-        $currentArtifactVersion = $Matches[0]
-    } else {
-        throw "Could not find BCArtifact version: $artifactValue"
-    }
+    $currentArtifactUrl = Get-ConfigValue -Key "artifact" -ConfigType AL-Go
 
-    Write-Host "Current BCArtifact version: $currentArtifactVersion"
+    Write-Host "Current BCArtifact URL: $currentArtifactUrl"
 
     $currentVersion = Get-ConfigValue -Key "repoVersion" -ConfigType AL-Go
-    $latestArtifactVersion = Get-LatestBCArtifactVersion -minimumVersion $currentVersion
+    $latestArtifactUrl = Get-LatestBCArtifactUrl -minimumVersion $currentVersion
 
-    Write-Host "Latest BCArtifact version: $latestArtifactVersion"
+    Write-Host "Latest BCArtifact URL: $latestArtifactUrl"
 
-    if($latestArtifactVersion -gt $currentArtifactVersion) {
-        Write-Host "Updating BCArtifact version from $currentArtifactVersion to $latestArtifactVersion"
-
-        $artifactValue = $artifactValue -replace $currentArtifactVersion, $latestArtifactVersion
-        Set-ConfigValue -Key "artifact" -Value $artifactValue -ConfigType AL-Go
+    if($latestArtifactUrl -ne $currentArtifactUrl) {
+        Write-Host "Updating BCArtifact version from $currentArtifactUrl to $latestArtifactUrl"
+        Set-ConfigValue -Key "artifact" -Value $latestArtifactUrl -ConfigType AL-Go
 
         return $true
     }


### PR DESCRIPTION
Cherry-pick:
- Implement different fallback mechanism when determining baselines for main branch: https://github.com/microsoft/BCApps/commit/e41c068cfa2ff5a6877f452e5f3399498f2b79e8
- Calculate full BC artifact URL when updating it: https://github.com/microsoft/BCApps/commit/db97751818611fb1e537cf6a5f4482e3eea6e250

[AB#524129](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/524129)



