### PR TITLE
Only table with type Normal is supported in Data Classification Worksheet and Data Privacy Utilities

### DIFF
--- a/src/System Application/App/Data Classification/src/DataClassificationMgt.Codeunit.al
+++ b/src/System Application/App/Data Classification/src/DataClassificationMgt.Codeunit.al
@@ -186,6 +186,16 @@ codeunit 1750 "Data Classification Mgt."
     end;
 
     /// <summary>
+    /// Check if the table is supported in the Data Privacy Utilities and Data Classification Worksheet.
+    /// </summary>
+    /// <param name="TableNo"></param>
+    /// <returns>True if the table has type Normal and not obsoleted</returns>
+    procedure IsSupportedTable(TableNo: Integer): Boolean
+    begin
+        exit(DataClassificationMgtImpl.IsSupportedTable(TableNo));
+    end;
+
+    /// <summary>
     /// Raises an event that allows subscribers to insert Data Privacy Entities in the DataPrivacyEntities record.
     /// Throws an error when it is not called with a temporary record.
     /// </summary>

--- a/src/System Application/App/Data Classification/src/DataClassificationMgtImpl.Codeunit.al
+++ b/src/System Application/App/Data Classification/src/DataClassificationMgtImpl.Codeunit.al
@@ -40,12 +40,14 @@ codeunit 1753 "Data Classification Mgt. Impl."
     var
         DataSensitivity: Record "Data Sensitivity";
     begin
-        DataSensitivity.Init();
-        DataSensitivity."Company Name" := CopyStr(CompanyName(), 1, MaxStrLen(DataSensitivity."Company Name"));
-        DataSensitivity."Table No" := TableNo;
-        DataSensitivity."Field No" := FieldNo;
-        DataSensitivity."Data Sensitivity" := DataSensitivityOption;
-        DataSensitivity.Insert();
+        if IsSupportedTable(TableNo) then begin
+            DataSensitivity.Init();
+            DataSensitivity."Company Name" := CopyStr(CompanyName(), 1, MaxStrLen(DataSensitivity."Company Name"));
+            DataSensitivity."Table No" := TableNo;
+            DataSensitivity."Field No" := FieldNo;
+            DataSensitivity."Data Sensitivity" := DataSensitivityOption;
+            DataSensitivity.Insert();
+        end;
     end;
 
     procedure SetSensitivities(var DataSensitivity: Record "Data Sensitivity"; Sensitivity: Option)
@@ -396,6 +398,19 @@ codeunit 1753 "Data Classification Mgt. Impl."
         DataSensitivity.FilterGroup(2);
         DataSensitivity.SetRange("Table No", TableNo);
         Page.RunModal(Page::"Data Classification Worksheet", DataSensitivity);
+    end;
+
+    procedure IsSupportedTable(TableNo: Integer): Boolean
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        if TableMetadata.Get(TableNo) then
+            if (TableMetadata.ObsoleteState = TableMetadata.ObsoleteState::Removed) or (TableMetadata.TableType <> TableMetadata.TableType::Normal) then
+                exit(false)
+            else
+                exit(true);
+
+        exit(false);
     end;
 }
 


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->

Add the public procedure `IsSupportedTable`: returns True if the table has type Normal and not obsoleted.

Will need to uptake in NAV for "Data Privacy Utilities" after this is merged.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes AB#523733