### PR TITLE
[24.x] Fix path to loading image resource

### DIFF
--- a/src/System Application/App/ControlAddIns/Resources/WaitSpinner/js/WaitSpinner.js
+++ b/src/System Application/App/ControlAddIns/Resources/WaitSpinner/js/WaitSpinner.js
@@ -1,6 +1,6 @@
 var spinner = document.createElement("img");
 spinner.className = "spinner-image";
-spinner.src = Microsoft.Dynamics.NAV.GetImageResource("ControlAddIns/images/spinner.gif");
+spinner.src = Microsoft.Dynamics.NAV.GetImageResource("Resources/WaitSpinner/images/spinner.gif");
 
 var container = document.createElement("div");
 container.className = "spinner-container";

--- a/src/System Application/App/Resources/WaitSpinner/js/WaitSpinner.js
+++ b/src/System Application/App/Resources/WaitSpinner/js/WaitSpinner.js
@@ -1,6 +1,6 @@
 var spinner = document.createElement("img");
 spinner.className = "spinner-image";
-spinner.src = Microsoft.Dynamics.NAV.GetImageResource("ControlAddIns/images/spinner.gif");
+spinner.src = Microsoft.Dynamics.NAV.GetImageResource("Resources/WaitSpinner/images/spinner.gif");
 
 var container = document.createElement("div");
 container.className = "spinner-container";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary 
When control add-in resources where moved, these paths where not updated, hence they currently don't render in the web client.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#524865](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/524865)





