### PR TITLE
[24.x] Only table with type Normal is supported in Data Classification Worksheet and Data Privacy Utilities

### DIFF
--- a/src/System Application/App/Data Classification/src/DataClassificationMgt.Codeunit.al
+++ b/src/System Application/App/Data Classification/src/DataClassificationMgt.Codeunit.al
@@ -186,6 +186,16 @@ codeunit 1750 "Data Classification Mgt."
     end;
 
     /// <summary>
+    /// Check if the table is supported in the Data Privacy Utilities and Data Classification Worksheet.
+    /// </summary>
+    /// <param name="TableNo"></param>
+    /// <returns>True if the table has type Normal and not obsoleted</returns>
+    procedure IsSupportedTable(TableNo: Integer): Boolean
+    begin
+        exit(DataClassificationMgtImpl.IsSupportedTable(TableNo));
+    end;
+
+    /// <summary>
     /// Raises an event that allows subscribers to insert Data Privacy Entities in the DataPrivacyEntities record.
     /// Throws an error when it is not called with a temporary record.
     /// </summary>

--- a/src/System Application/App/Data Classification/src/DataClassificationMgtImpl.Codeunit.al
+++ b/src/System Application/App/Data Classification/src/DataClassificationMgtImpl.Codeunit.al
@@ -40,12 +40,14 @@ codeunit 1753 "Data Classification Mgt. Impl."
     var
         DataSensitivity: Record "Data Sensitivity";
     begin
-        DataSensitivity.Init();
-        DataSensitivity."Company Name" := CopyStr(CompanyName(), 1, MaxStrLen(DataSensitivity."Company Name"));
-        DataSensitivity."Table No" := TableNo;
-        DataSensitivity."Field No" := FieldNo;
-        DataSensitivity."Data Sensitivity" := DataSensitivityOption;
-        DataSensitivity.Insert();
+        if IsSupportedTable(TableNo) then begin
+            DataSensitivity.Init();
+            DataSensitivity."Company Name" := CopyStr(CompanyName(), 1, MaxStrLen(DataSensitivity."Company Name"));
+            DataSensitivity."Table No" := TableNo;
+            DataSensitivity."Field No" := FieldNo;
+            DataSensitivity."Data Sensitivity" := DataSensitivityOption;
+            DataSensitivity.Insert();
+        end;
     end;
 
     procedure SetSensitivities(var DataSensitivity: Record "Data Sensitivity"; Sensitivity: Option)
@@ -396,6 +398,19 @@ codeunit 1753 "Data Classification Mgt. Impl."
         DataSensitivity.FilterGroup(2);
         DataSensitivity.SetRange("Table No", TableNo);
         Page.RunModal(Page::"Data Classification Worksheet", DataSensitivity);
+    end;
+
+    procedure IsSupportedTable(TableNo: Integer): Boolean
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        if TableMetadata.Get(TableNo) then
+            if (TableMetadata.ObsoleteState = TableMetadata.ObsoleteState::Removed) or (TableMetadata.TableType <> TableMetadata.TableType::Normal) then
+                exit(false)
+            else
+                exit(true);
+
+        exit(false);
     end;
 }
 

--- a/src/System Application/Test Library/Data Classification/src/LibraryDataClassification.Codeunit.al
+++ b/src/System Application/Test Library/Data Classification/src/LibraryDataClassification.Codeunit.al
@@ -6,6 +6,7 @@
 namespace System.TestLibraries.Privacy;
 
 using System.Privacy;
+using System.Reflection;
 
 codeunit 135157 "Library - Data Classification"
 {
@@ -25,5 +26,26 @@ codeunit 135157 "Library - Data Classification"
         FieldsSyncStatus.Init();
         FieldsSyncStatus."Last Sync Date Time" := LastFieldsSyncStatusDate;
         FieldsSyncStatus.Insert();
+    end;
+
+    /// <summary>
+    /// Get the number of enabled sensitive fields for all supported tables.
+    /// </summary>
+    procedure GetNumberOfEnabledSensitiveFieldsForAllSupportedTables() FieldCount: Integer
+    var
+        TableMetaData: Record "Table Metadata";
+        Field: Record Field;
+        DataClassificationMgt: Codeunit "Data Classification Mgt.";
+        DataClassificationMgtImpl: Codeunit "Data Classification Mgt. Impl.";
+    begin
+        FieldCount := 0;
+        if TableMetaData.FindSet() then
+            repeat
+                if DataClassificationMgt.IsSupportedTable(TableMetaData.ID) then begin
+                    Field.SetRange(TableNo, TableMetaData.ID);
+                    DataClassificationMgtImpl.GetEnabledSensitiveFields(Field);
+                    FieldCount := FieldCount + Field.Count();
+                end;
+            until TableMetaData.Next() = 0;
     end;
 }

--- a/src/System Application/Test/Data Classification/src/DataClassWorksheetTests.Codeunit.al
+++ b/src/System Application/Test/Data Classification/src/DataClassWorksheetTests.Codeunit.al
@@ -6,7 +6,7 @@
 namespace System.Test.Privacy;
 
 using System.Privacy;
-using System.Reflection;
+using System.TestLibraries.Privacy;
 using System.TestLibraries.Utilities;
 using System.TestLibraries.Security.AccessControl;
 
@@ -18,6 +18,7 @@ codeunit 135159 "Data Class. Worksheet Tests"
 
     var
         LibraryAssert: Codeunit "Library Assert";
+        LibraryDataClassification: Codeunit "Library - Data Classification";
         PermissionsMock: Codeunit "Permissions Mock";
         NotificationCount: Integer;
         FieldSyncStatusGetErr: Label 'The ID %1 cannot be found in the Field Sync Status table', Locked = true;
@@ -86,9 +87,7 @@ codeunit 135159 "Data Class. Worksheet Tests"
     procedure TestFindNewFieldsForEmptyDataSensitivityTable()
     var
         DataSensitivity: Record "Data Sensitivity";
-        Field: Record Field;
         FieldsSyncStatus: Record "Fields Sync Status";
-        DataClassificationMgtImpl: Codeunit "Data Classification Mgt. Impl.";
         DataClassificationWorksheet: TestPage "Data Classification Worksheet";
         FieldCount: Integer;
     begin
@@ -96,9 +95,7 @@ codeunit 135159 "Data Class. Worksheet Tests"
         PermissionsMock.Set('Data Class Edit');
 
         // [GIVEN] The number of enabled, sensitive, normal fields
-        Field.SetRange(Class, Field.Class::Normal);
-        DataClassificationMgtImpl.GetEnabledSensitiveFields(Field);
-        FieldCount := Field.Count();
+        FieldCount := LibraryDataClassification.GetNumberOfEnabledSensitiveFieldsForAllSupportedTables();
 
         // [GIVEN] The Data Classification Worksheet page is open for editing
         DataClassificationWorksheet.OpenEdit();
@@ -128,7 +125,6 @@ codeunit 135159 "Data Class. Worksheet Tests"
     var
         DataSensitivity: Record "Data Sensitivity";
         FieldsSyncStatus: Record "Fields Sync Status";
-        Field: Record Field;
         DataClassificationMgtImpl: Codeunit "Data Classification Mgt. Impl.";
         DataClassificationWorksheet: TestPage "Data Classification Worksheet";
         TableNo: Integer;
@@ -141,16 +137,14 @@ codeunit 135159 "Data Class. Worksheet Tests"
 
         // [GIVEN] The Data Sensitivity table contains two entries - one that is classified and one that isn't
         DataSensitivity.DeleteAll();
-        TableNo := 50000;
+        TableNo := Database::"Data Sensitivity";
         SensitiveFieldNo := 1;
         UnclassifiedFieldNo := 2;
         DataClassificationMgtImpl.InsertDataSensitivityForField(TableNo, SensitiveFieldNo, DataSensitivity."Data Sensitivity"::Personal);
         DataClassificationMgtImpl.InsertDataSensitivityForField(TableNo, UnclassifiedFieldNo, DataSensitivity."Data Sensitivity"::Unclassified);
 
         // [GIVEN] The number of enabled, sensitive, normal fields
-        Field.SetRange(Class, Field.Class::Normal);
-        DataClassificationMgtImpl.GetEnabledSensitiveFields(Field);
-        FieldCount := Field.Count();
+        FieldCount := LibraryDataClassification.GetNumberOfEnabledSensitiveFieldsForAllSupportedTables();
 
         // [GIVEN] The Data Classification Worksheet page is open for editing
         DataClassificationWorksheet.OpenEdit();

--- a/src/System Application/Test/Data Classification/src/DataClassificationMgtTests.Codeunit.al
+++ b/src/System Application/Test/Data Classification/src/DataClassificationMgtTests.Codeunit.al
@@ -8,6 +8,7 @@ namespace System.Test.Privacy;
 using System.Privacy;
 using System.Reflection;
 using System.Integration;
+using System.TestLibraries.Privacy;
 using System.TestLibraries.Utilities;
 using System.TestLibraries.Security.AccessControl;
 
@@ -26,6 +27,7 @@ codeunit 135150 "Data Classification Mgt. Tests"
     var
         DataClassificationMgt: Codeunit "Data Classification Mgt.";
         LibraryAssert: Codeunit "Library Assert";
+        LibraryDataClassification: Codeunit "Library - Data Classification";
         PermissionsMock: Codeunit "Permissions Mock";
 
     [Test]
@@ -35,7 +37,6 @@ codeunit 135150 "Data Classification Mgt. Tests"
         DataSensitivity: Record "Data Sensitivity";
         "Field": Record "Field";
         FieldsSyncStatus: Record "Fields Sync Status";
-        DataClassificationMgtImpl: Codeunit "Data Classification Mgt. Impl.";
         DataSensitivityCount: Integer;
         FieldCount: Integer;
     begin
@@ -50,11 +51,9 @@ codeunit 135150 "Data Classification Mgt. Tests"
         // [WHEN] The data sensitivity table is populated
         DataClassificationMgt.PopulateDataSensitivityTable();
 
-        // [WHEN] The Field table is filtered to the potentially data sensitive entries
-        DataClassificationMgtImpl.GetEnabledSensitiveFields(Field);
-
         DataSensitivityCount := DataSensitivity.Count();
-        FieldCount := Field.Count();
+
+        FieldCount := LibraryDataClassification.GetNumberOfEnabledSensitiveFieldsForAllSupportedTables();
 
         // [WHEN] There exist entries in the Field table
         if not Field.IsEmpty() then
@@ -75,6 +74,18 @@ codeunit 135150 "Data Classification Mgt. Tests"
     end;
 
     [Test]
+    procedure TestIsSupportedTable()
+    begin
+        // [SCENARIO] Test if IsSupportedTable works as expected
+
+        // Verify a Normal and non-obsoleted table is supported
+        LibraryAssert.IsTrue(DataClassificationMgt.IsSupportedTable(Database::"Data Sensitivity"), 'Data Sensitivity is a supported table');
+
+        // Verify a temporary table is not supported
+        LibraryAssert.IsFalse(DataClassificationMgt.IsSupportedTable(Database::"Field Content Buffer"), 'Field Content Buffer is not a supported table because it is temporary');
+    end;
+
+    [Test]
     [Scope('OnPrem')]
     procedure TestInsertDataSensitivityForField()
     var
@@ -92,7 +103,7 @@ codeunit 135150 "Data Classification Mgt. Tests"
         DataSensitivity.DeleteAll();
 
         // [GIVEN] A table number, a field number and a data sensitivity
-        TableNo := 18;
+        TableNo := Database::"Data Sensitivity";
         FieldNo := 3;
         DataSensitivityOption := DataSensitivity."Data Sensitivity"::Sensitive;
 
@@ -133,8 +144,8 @@ codeunit 135150 "Data Classification Mgt. Tests"
         DataPrivacyEntities.DeleteAll();
         DataSensitivity.DeleteAll();
 
-        // [GIVEN] A fictive table number and an entry in the Data Privacy Entities corresponding to this table number
-        TableNo := 50001;
+        // [GIVEN] A random table number and an entry in the Data Privacy Entities corresponding to this table number
+        TableNo := Database::"Data Sensitivity";
         DataClassificationMgt.InsertDataPrivacyEntity(DataPrivacyEntities, TableNo, 0, 0, '', 0);
 
         // [GIVEN] A company confidential entry in the data sensitivity corresponding to the aforementioned table number
@@ -171,10 +182,8 @@ codeunit 135150 "Data Classification Mgt. Tests"
 
         // [GIVEN] The Data Sensitivity table contains two entries with different data sensitivities
         DataSensitivity.DeleteAll();
-        DataClassificationMgt.InsertDataSensitivityForField(
-          18, 4, DataSensitivity."Data Sensitivity"::"Company Confidential");
-        DataClassificationMgt.InsertDataSensitivityForField(
-          18, 5, DataSensitivity."Data Sensitivity"::Personal);
+        DataClassificationMgt.InsertDataSensitivityForField(Database::"Data Sensitivity", 4, DataSensitivity."Data Sensitivity"::"Company Confidential");
+        DataClassificationMgt.InsertDataSensitivityForField(Database::"Data Sensitivity", 5, DataSensitivity."Data Sensitivity"::Personal);
 
         // [WHEN] Setting the sensitivity for the filtered Data Sensitivity table to Normal
         DataClassificationMgt.SetSensitivities(DataSensitivity, DataSensitivity."Data Sensitivity"::Normal);
@@ -229,7 +238,7 @@ codeunit 135150 "Data Classification Mgt. Tests"
 
         // [GIVEN] A single entry in the Data Sensitivity table that is unclassified
         DataSensitivity.DeleteAll();
-        DataClassificationMgt.InsertDataSensitivityForField(18, 3, DataSensitivity."Data Sensitivity"::Unclassified);
+        DataClassificationMgt.InsertDataSensitivityForField(Database::"Data Sensitivity", 3, DataSensitivity."Data Sensitivity"::Unclassified);
 
         // [WHEN] Querying whether all the fields are classified
         AreAllFieldsClassified := DataClassificationMgt.AreAllFieldsClassified();
@@ -250,7 +259,7 @@ codeunit 135150 "Data Classification Mgt. Tests"
         LibraryAssert.IsTrue(AreAllFieldsClassified, 'All the fields are classified');
 
         // [GIVEN] There are two entries in the Data Sensitivity table - a classified and an unclassified one
-        DataClassificationMgt.InsertDataSensitivityForField(27, 3, DataSensitivity."Data Sensitivity"::Unclassified);
+        DataClassificationMgt.InsertDataSensitivityForField(Database::"Fields Sync Status", 3, DataSensitivity."Data Sensitivity"::Unclassified);
 
         // [WHEN] Querying whether all the fields are classified
         AreAllFieldsClassified := DataClassificationMgt.AreAllFieldsClassified();
@@ -277,7 +286,7 @@ codeunit 135150 "Data Classification Mgt. Tests"
         // [GIVEN] The Data Sensitivity table contains two entries - one of them Normal, the other one Company Confidential
         DataSensitivity.DeleteAll();
 
-        TableNo := 18;
+        TableNo := Database::"Data Sensitivity";
         NormalFieldNo := 3;
         CompanyConfidentialFieldNo := 4;
 
@@ -342,7 +351,7 @@ codeunit 135150 "Data Classification Mgt. Tests"
         // [GIVEN] The Data Sensitivity table contains two entries - one of them Normal, the other one Company Confidential
         DataSensitivity.DeleteAll();
 
-        TableNo := 18;
+        TableNo := Database::"Data Sensitivity";
         NormalFieldNo := 3;
         CompanyConfidentialFieldNo := 4;
 
@@ -407,7 +416,7 @@ codeunit 135150 "Data Classification Mgt. Tests"
         // [GIVEN] The Data Sensitivity table contains two entries - one of them Normal, the other one Sensitive
         DataSensitivity.DeleteAll();
 
-        TableNo := 18;
+        TableNo := Database::"Data Sensitivity";
         NormalFieldNo := 3;
         SensitiveFieldNo := 4;
 
@@ -472,7 +481,7 @@ codeunit 135150 "Data Classification Mgt. Tests"
         // [GIVEN] The Data Sensitivity table contains two entries - one of them Personal, the other one Sensitive
         DataSensitivity.DeleteAll();
 
-        TableNo := 18;
+        TableNo := Database::"Data Sensitivity";
         PersonalFieldNo := 3;
         SensitiveFieldNo := 4;
 
@@ -537,7 +546,7 @@ codeunit 135150 "Data Classification Mgt. Tests"
         DataSensitivity.DeleteAll();
 
         // [GIVEN] A table number
-        TableNo := 1180;
+        TableNo := Database::"Data Sensitivity";
 
         // [GIVEN] The Field table is filtered to include only the enabled, sensitive fields in this table
         Field.SetRange(TableNo, TableNo);
@@ -589,7 +598,7 @@ codeunit 135150 "Data Classification Mgt. Tests"
           'The data sensitivity table is empty');
 
         // [GIVEN] The Data Sensitivity table contains one entry
-        DataClassificationMgt.InsertDataSensitivityForField(18, 3, DataSensitivity."Data Sensitivity"::Personal);
+        DataClassificationMgt.InsertDataSensitivityForField(Database::"Data Sensitivity", 3, DataSensitivity."Data Sensitivity"::Personal);
 
         // [WHEN] Querying whether it is empty
         // [THEN] The result should be false
@@ -603,8 +612,6 @@ codeunit 135150 "Data Classification Mgt. Tests"
     var
         DataSensitivity: Record "Data Sensitivity";
         FieldsSyncStatus: Record "Fields Sync Status";
-        Field: Record Field;
-        DataClassificationMgtImpl: Codeunit "Data Classification Mgt. Impl.";
         FieldCount: Integer;
     begin
         // [SCENARIO] Synchronizing the Field and Data Sensitivity table when the Data Sensitivity table is empty
@@ -616,8 +623,7 @@ codeunit 135150 "Data Classification Mgt. Tests"
         DataSensitivity.DeleteAll();
 
         // [GIVEN] The number of enabled, sensitive fields
-        DataClassificationMgtImpl.GetEnabledSensitiveFields(Field);
-        FieldCount := Field.Count();
+        FieldCount := LibraryDataClassification.GetNumberOfEnabledSensitiveFieldsForAllSupportedTables();
 
         // [WHEN] Synchronizing the Field and Data Sensitivity table
         DataClassificationMgt.SyncAllFields();
@@ -639,8 +645,6 @@ codeunit 135150 "Data Classification Mgt. Tests"
     var
         DataSensitivity: Record "Data Sensitivity";
         FieldsSyncStatus: Record "Fields Sync Status";
-        Field: Record Field;
-        DataClassificationMgtImpl: Codeunit "Data Classification Mgt. Impl.";
         FieldCount: Integer;
         TableNo: Integer;
         SensitiveFieldNo: Integer;
@@ -654,16 +658,14 @@ codeunit 135150 "Data Classification Mgt. Tests"
         // [GIVEN] The Data Sensitivity table is not empty - it contains a classified and an unclassifed entry
         DataSensitivity.DeleteAll();
 
-        TableNo := 50000;
+        TableNo := Database::"Data Sensitivity";
         SensitiveFieldNo := 1;
         UnclassifiedFieldNo := 2;
         DataClassificationMgt.InsertDataSensitivityForField(TableNo, SensitiveFieldNo, DataSensitivity."Data Sensitivity"::Personal);
         DataClassificationMgt.InsertDataSensitivityForField(TableNo, UnclassifiedFieldNo, DataSensitivity."Data Sensitivity"::Unclassified);
 
         // [GIVEN] The number of enabled, sensitive, normal fields
-        Field.SetRange(Class, Field.Class::Normal);
-        DataClassificationMgtImpl.GetEnabledSensitiveFields(Field);
-        FieldCount := Field.Count();
+        FieldCount := LibraryDataClassification.GetNumberOfEnabledSensitiveFieldsForAllSupportedTables();
 
         // [WHEN] Synchronizing the Field and Data Sensitivity table
         DataClassificationMgt.SyncAllFields();
@@ -755,7 +757,7 @@ codeunit 135150 "Data Classification Mgt. Tests"
         DataPrivacyEntities.DeleteAll();
 
         // [WHEN] Inserting a Data Privacy Entities entry
-        TableNo := 50000;
+        TableNo := Database::"Data Sensitivity";
         PageNo := 7;
         KeyFieldNo := 13;
         EntityFilter := 'filter filter filter';
@@ -860,8 +862,6 @@ codeunit 135150 "Data Classification Mgt. Tests"
         if FieldsSyncStatus.IsEmpty() then
             FieldsSyncStatus.Insert();
 
-        DataClassificationMgt.InsertDataPrivacyEntity(DataPrivacyEntities, Database::"Fields Sync Status",
-          Page::"Field Content Buffer", 1, '', 1);
+        DataClassificationMgt.InsertDataPrivacyEntity(DataPrivacyEntities, Database::"Fields Sync Status", Page::"Field Content Buffer", 1, '', 1);
     end;
 }
-


### PR DESCRIPTION

#### Summary <!-- Provide a general summary of your changes -->

Porting down from #903

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#523733](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/523733)


