### PR TITLE
Remove legacy add-in Microsoft.Dynamics.Nav.Integration.Office

### DIFF
--- a/src/System Application/App/DotNet Aliases/src/dotnet.al
+++ b/src/System Application/App/DotNet Aliases/src/dotnet.al
@@ -531,42 +531,6 @@ dotnet
         }
     }
 
-    assembly("Microsoft.Dynamics.Nav.Integration.Office")
-    {
-
-        type("Microsoft.Dynamics.Nav.Integration.Office.Outlook.IOutlookMessage"; "IOutlookMessage")
-        {
-        }
-
-        type("Microsoft.Dynamics.Nav.Integration.Office.Outlook.IOutlookMessageFactory"; "IOutlookMessageFactory")
-        {
-        }
-
-        type("Microsoft.Dynamics.Nav.Integration.Office.Outlook.OutlookHelper"; "OutlookHelper")
-        {
-        }
-
-        type("Microsoft.Dynamics.Nav.Integration.Office.Outlook.OutlookMessageFactory"; "OutlookMessageFactory")
-        {
-        }
-
-        type("Microsoft.Dynamics.Nav.Integration.Office.Outlook.OutlookStatusCode"; "OutlookStatusCode")
-        {
-        }
-
-        type("Microsoft.Dynamics.Nav.Integration.Office.Word.MergeHandler"; "MergeHandler")
-        {
-        }
-
-        type("Microsoft.Dynamics.Nav.Integration.Office.Word.WordHandler"; "WordHandler")
-        {
-        }
-
-        type("Microsoft.Dynamics.Nav.Integration.Office.Word.WordHelper"; "WordHelper")
-        {
-        }
-    }
-
     assembly("Microsoft.Dynamics.Nav.LicensingService.Model")
     {
         Culture = 'neutral';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Remove unused legacy Office Add-in that was based on COM Office interop. Not being used in production since version 14 as it had dependencies to the windows client.
#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#523970](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/523970)



