### PR TITLE
Move OpenXml type to framework

### DIFF
--- a/src/System Application/App/DotNet Aliases/src/dotnet.al
+++ b/src/System Application/App/DotNet Aliases/src/dotnet.al
@@ -7,6 +7,13 @@ namespace System;
 
 dotnet
 {
+    assembly("DocumentFormat.OpenXml.Framework")
+    {
+        type("DocumentFormat.OpenXml.OpenXmlUnknownElement"; "OpenXmlUnknownElement")
+        {
+        }
+    }
+
     assembly("DocumentFormat.OpenXml")
     {
 
@@ -35,10 +42,6 @@ dotnet
         }
 
         type("DocumentFormat.OpenXml.OpenXmlElement"; "OpenXmlElement")
-        {
-        }
-
-        type("DocumentFormat.OpenXml.OpenXmlUnknownElement"; "OpenXmlUnknownElement")
         {
         }
 

--- a/src/System Application/App/DotNet Aliases/src/dotnet.al
+++ b/src/System Application/App/DotNet Aliases/src/dotnet.al
@@ -7,16 +7,8 @@ namespace System;
 
 dotnet
 {
-    assembly("DocumentFormat.OpenXml.Framework")
-    {
-        type("DocumentFormat.OpenXml.OpenXmlUnknownElement"; "OpenXmlUnknownElement")
-        {
-        }
-    }
-
     assembly("DocumentFormat.OpenXml")
     {
-
         type("DocumentFormat.OpenXml.BooleanValue"; "BooleanValue")
         {
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Breaking change in OpenXml3, where type OpenXmlUnknownElement is moved to the assembly DocumentFormat.OpenXml.Framework. The OpenXmlUnknownElement type reference has been removed in Base application and the functionality is replaced with a function in the BC OpenXml add-in which prevents compile issues with the new assembly.
#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#524860](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/524860)







