### PR TITLE
Run extension setup after installing app from AppSource

### DIFF
--- a/src/System Application/App/Extension Management/src/ExtensionOperationImpl.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionOperationImpl.Codeunit.al
@@ -46,7 +46,7 @@ codeunit 2503 "Extension Operation Impl"
         end;
     end;
 
-    procedure DeployExtension(AppId: Guid; lcid: Integer; IsUIEnabled: Boolean; PreviewKey: Text): Boolean
+    procedure DeployExtension(AppId: Guid; lcid: Integer; IsUIEnabled: Boolean; PreviewKey: Text)
     var
         NAVAppTenantOperation: Record "NAV App Tenant Operation";
         ExtensionOperationImpl: Codeunit "Extension Operation Impl";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
When installing app after being redirected from the AppSource Marketplace page, the extension setup is not run. Hence user doesn't know whether the app was successfully installed, and other setup steps are omitted. This PR fixes this.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#524024](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/524024)






