### PR TITLE
[24.0] Fix Get-CurrentBranch to always rely on git (and not GITHUB_REF env variable)

### DIFF
--- a/build/scripts/EnlistmentHelperFunctions.psm1
+++ b/build/scripts/EnlistmentHelperFunctions.psm1
@@ -13,9 +13,6 @@ function Get-BuildMode() {
 }
 
 function Get-CurrentBranch() {
-    if ($ENV:GITHUB_REF) {
-        return $ENV:GITHUB_REF.Replace("refs/heads/", "")
-    }
     return git rev-parse --abbrev-ref HEAD
 }
 


### PR DESCRIPTION
Fix `Get-CurrentBranch` to always rely on git (and not GITHUB_REF env variable)

`$env:GITHUB_REF` is not the same as the checked out branch. `$env:GITHUB_REF` is the branch the workflow is running on.

Fixes AB#525684
