### PR TITLE
Add the ability to check if there is an email account set for a scanrio

### DIFF
--- a/src/System Application/App/Email/src/Scenario/EmailScenario.Codeunit.al
+++ b/src/System Application/App/Email/src/Scenario/EmailScenario.Codeunit.al
@@ -33,6 +33,16 @@ codeunit 8893 "Email Scenario"
     end;
 
     /// <summary>
+    /// Check if there is an email account set for the given email scenario.
+    /// </summary>
+    /// <param name="Scenario">The scenario to look for.</param>
+    /// <returns>True if there is an account set for the specified scenario; otherwise - false.</returns>
+    procedure IsThereEmailAccountSetForScenario(Scenario: Enum "Email Scenario"): Boolean
+    begin
+        exit(EmailScenarioImpl.IsThereEmailAccountSetForScenario(Scenario));
+    end;
+
+    /// <summary>
     /// Sets a default email account.
     /// </summary>
     /// <param name="EmailAccount">The email account to use.</param>

--- a/src/System Application/App/Email/src/Scenario/EmailScenarioImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Scenario/EmailScenarioImpl.Codeunit.al
@@ -39,6 +39,13 @@ codeunit 8892 "Email Scenario Impl."
         exit(false);
     end;
 
+    procedure IsThereEmailAccountSetForScenario(Scenario: Enum "Email Scenario"): Boolean
+    var
+        EmailScenario: Record "Email Scenario";
+    begin
+        exit(EmailScenario.Get(Scenario));
+    end;
+
     procedure SetEmailAccount(Scenario: Enum "Email Scenario"; EmailAccount: Record "Email Account")
     var
         EmailScenario: Record "Email Scenario";

--- a/src/System Application/Test/Email/src/EmailScenarioTest.Codeunit.al
+++ b/src/System Application/Test/Email/src/EmailScenarioTest.Codeunit.al
@@ -103,6 +103,29 @@ codeunit 134693 "Email Scenario Test"
     end;
 
     [Test]
+    procedure IsThereEmailAccountSetForScenarioTest()
+    var
+        AccountId: Guid;
+    begin
+        // [Scenario] IsThereEmailAccountSetForScenario will check whether an email account is set for a given scenario
+        PermissionsMock.Set('Email Admin');
+
+        // [Given] An email scenario is assigned an account
+        Initialize();
+        ConnectorMock.AddAccount(AccountId);
+
+        // [When] An email account is set for the default scenario
+        EmailScenarioMock.AddMapping(Enum::"Email Scenario"::Default, AccountId, Enum::"Email Connector"::"Test Email Connector");
+        // [Then] false is returned for the test scenario
+        Assert.IsFalse(EmailScenario.IsThereEmailAccountSetForScenario(Enum::"Email Scenario"::"Test Email Scenario"), 'No email account is set for the default scenario');
+
+        // [When] An email account is set for the test scenario
+        EmailScenarioMock.AddMapping(Enum::"Email Scenario"::"Test Email Scenario", AccountId, Enum::"Email Connector"::"Test Email Connector");
+        // [Then] true is returned for the test scenario
+        Assert.IsTrue(EmailScenario.IsThereEmailAccountSetForScenario(Enum::"Email Scenario"::"Test Email Scenario"), 'An email account is set for the test scenario');
+    end;
+
+    [Test]
     [Scope('OnPrem')]
     procedure GetEmailAccountExistsTest()
     var


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->

Add the ability to check if there is an email account set for a scanrio

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#524050](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/524050)


