### PR TITLE
No error on CodeCop rule 0248

### DIFF
--- a/src/rulesets/CodeCop.ruleset.json
+++ b/src/rulesets/CodeCop.ruleset.json
@@ -994,7 +994,7 @@
                   {
                       "id":  "AA0248",
                       "action":  "None",
-                      "justification": "New rule for missing this. qualification on members. Turned off globally."
+                      "justification": "Rule for missing 'this.' qualification on members. Not an error, rule turned off globally."
                   },
                   {
                       "id":  "AA0249",

--- a/src/rulesets/CodeCop.ruleset.json
+++ b/src/rulesets/CodeCop.ruleset.json
@@ -993,7 +993,8 @@
                   },
                   {
                       "id":  "AA0248",
-                      "action":  "Error"
+                      "action":  "None",
+                      "justification": "New rule for missing this. qualification on members. Turned off globally."
                   },
                   {
                       "id":  "AA0249",


### PR DESCRIPTION
New code cop rule is coming, but is causing too many diagnostics right now. 

Related to
[AB#480821](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/480821): [AL] [Idea] Codeunit self-reference (this keyword)

