### PR TITLE
[24.x][CopilotToolkit] Allow allowlisted tenants to get the first party deployment names

### DIFF
--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIAuthorization.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIAuthorization.Codeunit.al
@@ -5,9 +5,6 @@
 namespace System.AI;
 
 using System;
-using System.Azure.Identity;
-using System.Azure.KeyVault;
-using System.Environment;
 
 /// <summary>
 /// Store the authorization information for the AOAI service.
@@ -25,13 +22,11 @@ codeunit 7767 "AOAI Authorization"
         Deployment: Text;
         [NonDebuggable]
         ApiKey: SecretText;
-        EmptyTenantIdTelemetryMsg: Label 'Empty or malformed tenant ID.', Locked = true;
-        TenantIsAllowListedTelemetryMsg: Label 'The current tenant is allowlisted for first party auth.', Locked = true;
-        AllowlistedTenantsAkvKeyTok: Label 'AOAI-Allow-1P-Auth', Locked = true;
 
     [NonDebuggable]
     procedure IsConfigured(CallerModule: ModuleInfo): Boolean
     var
+        AzureOpenAiImpl: Codeunit "Azure OpenAI Impl";
         CurrentModule: ModuleInfo;
         ALCopilotFunctions: DotNet ALCopilotFunctions;
     begin
@@ -41,7 +36,7 @@ codeunit 7767 "AOAI Authorization"
             exit(false);
 
         if (Endpoint = '') and ApiKey.IsEmpty() then
-            exit(IsTenantAllowlistedForPlatformAuthorization()
+            exit(AzureOpenAiImpl.IsTenantAllowlistedForFirstPartyCopilotCalls()
                 or ALCopilotFunctions.IsPlatformAuthorizationConfigured(CallerModule.Publisher(), CurrentModule.Publisher()));
 
         if (Endpoint = '') or ApiKey.IsEmpty() then
@@ -74,36 +69,5 @@ codeunit 7767 "AOAI Authorization"
     procedure GetApiKey(): SecretText
     begin
         exit(ApiKey);
-    end;
-
-    [NonDebuggable]
-    local procedure IsTenantAllowlistedForPlatformAuthorization(): Boolean
-    var
-        EnvironmentInformation: Codeunit "Environment Information";
-        CopilotCapabilityImpl: Codeunit "Copilot Capability Impl";
-        AzureKeyVault: Codeunit "Azure Key Vault";
-        AzureAdTenant: Codeunit "Azure AD Tenant";
-        AllowlistedTenants: Text;
-        EntraTenantIdAsText: Text;
-        EntraTenantIdAsGuid: Guid;
-    begin
-        if not EnvironmentInformation.IsSaaSInfrastructure() then
-            exit(false);
-
-        if (not AzureKeyVault.GetAzureKeyVaultSecret(AllowlistedTenantsAkvKeyTok, AllowlistedTenants)) or (AllowlistedTenants.Trim() = '') then
-            exit(false);
-
-        EntraTenantIdAsText := AzureAdTenant.GetAadTenantId();
-
-        if (EntraTenantIdAsText = '') or not Evaluate(EntraTenantIdAsGuid, EntraTenantIdAsText) or IsNullGuid(EntraTenantIdAsGuid) then begin
-            Session.LogMessage('0000MLN', EmptyTenantIdTelemetryMsg, Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CopilotCapabilityImpl.GetAzureOpenAICategory());
-            exit(false);
-        end;
-
-        if not AllowlistedTenants.Contains(EntraTenantIdAsText) then
-            exit(false);
-
-        Session.LogMessage('0000MLE', TenantIsAllowListedTelemetryMsg, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CopilotCapabilityImpl.GetAzureOpenAICategory());
-        exit(true);
     end;
 }

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIDeploymentsImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIDeploymentsImpl.Codeunit.al
@@ -72,10 +72,11 @@ codeunit 7769 "AOAI Deployments Impl"
 
     local procedure GetDeploymentName(DeploymentName: Text; CallerModuleInfo: ModuleInfo): Text
     var
+        AzureOpenAiImpl: Codeunit "Azure OpenAI Impl";
         CurrentModuleInfo: ModuleInfo;
     begin
         NavApp.GetCurrentModuleInfo(CurrentModuleInfo);
-        if (CallerModuleInfo.Publisher <> CurrentModuleInfo.Publisher) then
+        if (CallerModuleInfo.Publisher <> CurrentModuleInfo.Publisher) and not AzureOpenAiImpl.IsTenantAllowlistedForFirstPartyCopilotCalls() then
             Error(UnableToGetDeploymentNameErr);
 
         exit(DeploymentName);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Backporting: In previous workshops and in general for future usage, we want the AOAI deployment names to be accessible to tenants that are allowlisted.


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#527326](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/527326)



