### PR TITLE
Set proper experience item code upon upgrade

### DIFF
--- a/src/System Application/App/Guided Experience/src/Guided Experience/GuidedExperienceImpl.Codeunit.al
+++ b/src/System Application/App/Guided Experience/src/Guided Experience/GuidedExperienceImpl.Codeunit.al
@@ -580,7 +580,7 @@ codeunit 1991 "Guided Experience Impl."
         end;
     end;
 
-    local procedure GetCode(Type: Enum "Guided Experience Type"; ObjectType: Enum "Guided Experience Object Type"; ObjectID: Integer; Link: Text[250]; VideoUrl: Text[250]; SpotlightTourType: Enum "Spotlight Tour Type"): Code[300]
+    procedure GetCode(Type: Enum "Guided Experience Type"; ObjectType: Enum "Guided Experience Object Type"; ObjectID: Integer; Link: Text[250]; VideoUrl: Text[250]; SpotlightTourType: Enum "Spotlight Tour Type"): Code[300]
     var
         Url: Text[250];
     begin


### PR DESCRIPTION
When upgrading, make sure the guided experience item name is always set according to the standard.

Fixes #

