### PR TITLE
Fix error in AFS shared key authorization (#961)

### DIFF
--- a/src/System Application/App/Azure File Services API/src/AFSOperationPayloadImpl.Codeunit.al
+++ b/src/System Application/App/Azure File Services API/src/AFSOperationPayloadImpl.Codeunit.al
@@ -6,6 +6,7 @@
 namespace System.Azure.Storage.Files;
 
 using System.Azure.Storage;
+using System;
 
 codeunit 8952 "AFS Operation Payload Impl."
 {
@@ -115,12 +116,16 @@ codeunit 8952 "AFS Operation Payload Impl."
     [NonDebuggable]
     procedure GetRequestHeaders(): Dictionary of [Text, Text]
     begin
+        SortHeaders(RequestHeaders);
+
         exit(RequestHeaders);
     end;
 
     [NonDebuggable]
     procedure GetContentHeaders(): Dictionary of [Text, Text]
     begin
+        SortHeaders(ContentHeaders);
+
         exit(ContentHeaders);
     end;
 
@@ -189,5 +194,23 @@ codeunit 8952 "AFS Operation Payload Impl."
         Optionals := AFSOptionalParameters.GetParameters();
         foreach OptionalParameterKey in Optionals.Keys() do
             AddUriParameter(OptionalParameterKey, Optionals.Get(OptionalParameterKey));
+    end;
+
+    [NonDebuggable]
+    local procedure SortHeaders(var Headers: Dictionary of [Text, Text])
+    var
+        SortedDictionary: DotNet GenericSortedDictionary2;
+        SortedDictionaryEntry: DotNet GenericKeyValuePair2;
+        HeaderKey: Text;
+    begin
+        SortedDictionary := SortedDictionary.SortedDictionary();
+
+        foreach HeaderKey in Headers.Keys() do
+            SortedDictionary.Add(HeaderKey, Headers.Get(HeaderKey));
+
+        Clear(Headers);
+
+        foreach SortedDictionaryEntry in SortedDictionary do
+            Headers.Add(SortedDictionaryEntry."Key"(), SortedDictionaryEntry.Value());
     end;
 }

--- a/src/System Application/App/Azure File Services API/src/Helper/AFSHttpContentHelper.Codeunit.al
+++ b/src/System Application/App/Azure File Services API/src/Helper/AFSHttpContentHelper.Codeunit.al
@@ -94,7 +94,7 @@ codeunit 8953 "AFS HttpContent Helper"
 
         AFSOperationPayload.AddContentHeader('Content-Type', ContentType);
         if AFSOperationPayload.GetOperation() in [FileServiceAPIOperation::CreateFile] then
-            AFSOperationPayload.AddContentHeader('x-ms-content-length', StrSubstNo(ContentLengthLbl, ContentLength))
+            AFSOperationPayload.AddRequestHeader('x-ms-content-length', StrSubstNo(ContentLengthLbl, ContentLength))
         else
             AFSOperationPayload.AddContentHeader('Content-Length', StrSubstNo(ContentLengthLbl, ContentLength));
 

--- a/src/System Application/Test/Azure File Services API/src/AFSFileClientTest.Codeunit.al
+++ b/src/System Application/Test/Azure File Services API/src/AFSFileClientTest.Codeunit.al
@@ -44,6 +44,35 @@ codeunit 132520 "AFS File Client Test"
     end;
 
     [Test]
+    procedure CreateTextFileStorageAccountKeyTest()
+    var
+        AFSFileClient: Codeunit "AFS File Client";
+        AFSOperationResponse: Codeunit "AFS Operation Response";
+        FileContentLbl: Label 'Hello World!', Locked = true;
+        FilePathLbl: Label 'test.txt', Locked = true;
+        FileContentReturn: Text;
+    begin
+        // [SCENARIO] User wants to send a text file to azure file share using shared key authorization.
+
+        // [GIVEN] A storage account with shared key authorization
+        AFSInitTestStorage.ClearFileShare();
+        SharedKeyAuthorization := AFSGetTestStorageAuth.GetSharedKeyAuthorization(AFSInitTestStorage.GetAccessKey());
+
+        // [WHEN] The programmer creates a text file in the file share and puts the content in it
+        AFSFileClient.Initialize(AFSInitTestStorage.GetStorageAccountName(), AFSInitTestStorage.GetFileShareName(), SharedKeyAuthorization);
+
+        AFSOperationResponse := AFSFileClient.CreateFile(FilePathLbl, StrLen(FileContentLbl));
+        LibraryAssert.AreEqual(true, AFSOperationResponse.IsSuccessful(), AFSOperationResponse.GetError());
+        AFSOperationResponse := AFSFileClient.PutFileText(FilePathLbl, FileContentLbl);
+        LibraryAssert.AreEqual(true, AFSOperationResponse.IsSuccessful(), AFSOperationResponse.GetError());
+
+        // [THEN] The file is created and the content is correct
+        AFSOperationResponse := AFSFileClient.GetFileAsText(FilePathLbl, FileContentReturn);
+        LibraryAssert.AreEqual(true, AFSOperationResponse.IsSuccessful(), AFSOperationResponse.GetError());
+        LibraryAssert.AreEqual(FileContentLbl, FileContentReturn, 'File content mismatch.');
+    end;
+
+    [Test]
     procedure CreateTextFileNoParentDirectoryTest()
     var
         AFSFileClient: Codeunit "AFS File Client";

--- a/src/System Application/Test/Azure File Services API/src/AFSGetTestStorageAuth.Codeunit.al
+++ b/src/System Application/Test/Azure File Services API/src/AFSGetTestStorageAuth.Codeunit.al
@@ -29,6 +29,15 @@ codeunit 132518 "AFS Get Test Storage Auth."
         exit(GetDefaultAccountSAS(AccountKey, StorageServiceAuthorization.GetDefaultAPIVersion()));
     end;
 
+    procedure GetSharedKeyAuthorization(AccountKey: Text): Interface "Storage Service Authorization"
+    var
+        StorageServiceAuthorization: Codeunit "Storage Service Authorization";
+        SecretAccountKey: SecretText;
+    begin
+        SecretAccountKey := AccountKey;
+        exit(StorageServiceAuthorization.CreateSharedKey(SecretAccountKey));
+    end;
+
     procedure GetDefaultAccountSAS(AccountKey: Text; APIVersion: Enum "Storage Service API Version"): Interface "Storage Service Authorization"
     var
         StorageServiceAuthorization: Codeunit "Storage Service Authorization";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

This is a PR, that should fix the error that occured when creating or sending file to Azure File Share with AFS Library.
I also created a simple test to ensure it doesn't happen again.

The issue was with two things:
1. Sorting of the headers - In BC the order of the headers in the string to sign was different than in the documentation, which led azure to calculate a different hash for the authorization. I added sorting of the headers in the same way as implemented in ABS module, which should ensure correct order.
2. The header x-ms-content-length required when using CreateFile call, was added to the content headers, which led to it not being correctly added to the string to sign. I changed it to be added to request headers.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #961 #685 


Fixes [AB#532987](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/532987)

