### PR TITLE
Add ability to delete orphaned email messages

### DIFF
--- a/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
@@ -75,7 +75,7 @@ codeunit 8904 "Email Message"
     /// Deletes messages that does not have a reference from either the email outbox nor sent email.
     /// This functionality is only needed if email messages have been created without any email outbox or sent email referencing it, otherwise they will be cleaned up automatically.
     /// </summary>
-    /// <param name="StartMessageId">The email message id to start from.</param>
+    /// <param name="StartMessageId">The email message id to start from. Using empty guid will start from the beginning.</param>
     /// <param name="MessagesToIterate">Number of email messages to loop over.</param>
     /// <returns>The next email message id to be checked. Returns empty guid if there are no more messages.</returns>
     procedure DeleteOrphanedMessages(StartMessageId: Guid; MessagesToIterate: Integer) NextMessageId: Guid

--- a/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
@@ -72,6 +72,18 @@ codeunit 8904 "Email Message"
     end;
 
     /// <summary>
+    /// Deletes messages that does not have a reference from either the email outbox nor sent email.
+    /// This functionality is only needed if email messages have been created without any email outbox or sent email referencing it, otherwise they will be cleaned up automatically.
+    /// </summary>
+    /// <param name="StartMessageId">The email message id to start from.</param>
+    /// <param name="MessagesToIterate">Number of email messages to loop over.</param>
+    /// <returns>The next email message id to be checked. Returns empty guid if there are no more messages.</returns>
+    procedure DeleteOrphanedMessages(StartMessageId: Guid; MessagesToIterate: Integer) NextMessageId: Guid
+    begin
+        exit(EmailMessageImpl.DeleteOrphanedMessages(StartMessageId, MessagesToIterate));
+    end;
+
+    /// <summary>
     /// Gets the body of the email message.
     /// </summary>
     /// <returns>The body of the email.</returns>

--- a/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -621,20 +621,20 @@ codeunit 8905 "Email Message Impl."
         exit(EmailMessage.Id);
     end;
 
-    local procedure DeleteIfOrphaned(var EmailMessage: Record "Email Message"): Boolean
+    local procedure DeleteIfOrphaned(var EmailMessage: Record "Email Message")
     var
         EmailOutbox: Record "Email Outbox";
         SentEmail: Record "Sent Email";
     begin
         EmailOutbox.SetRange("Message Id", EmailMessage.Id);
         if not EmailOutbox.IsEmpty() then
-            exit(false);
+            exit;
 
         SentEmail.SetRange("Message Id", EmailMessage.Id);
         if not SentEmail.IsEmpty() then
-            exit(false);
+            exit;
 
-        exit(EmailMessage.Delete());
+        EmailMessage.Delete();
     end;
 
     procedure ValidateRecipients()

--- a/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -599,6 +599,43 @@ codeunit 8905 "Email Message Impl."
         exit(GlobalEmailMessage.Get(MessageId));
     end;
 
+    procedure DeleteOrphanedMessages(StartMessageId: Guid; MessagesToIterate: Integer) NextMessageId: Guid
+    var
+        EmailMessage: Record "Email Message";
+        EmptyGuid: Guid;
+        MessageNo: Integer;
+    begin
+        EmailMessage.SetLoadFields(Id);
+        EmailMessage.SetFilter(Id, '>=%1', StartMessageId);
+        if not EmailMessage.FindSet() then
+            exit(EmptyGuid);
+
+        for MessageNo := 1 to MessagesToIterate do begin
+            DeleteIfOrphaned(EmailMessage);
+
+            if EmailMessage.Next() = 0 then
+                exit(EmptyGuid);
+        end;
+
+        exit(EmailMessage.Id);
+    end;
+
+    local procedure DeleteIfOrphaned(var EmailMessage: Record "Email Message"): Boolean
+    var
+        EmailOutbox: Record "Email Outbox";
+        SentEmail: Record "Sent Email";
+    begin
+        EmailOutbox.SetRange("Message Id", EmailMessage.Id);
+        if not EmailOutbox.IsEmpty() then
+            exit(false);
+
+        SentEmail.SetRange("Message Id", EmailMessage.Id);
+        if not SentEmail.IsEmpty() then
+            exit(false);
+
+        exit(EmailMessage.Delete());
+    end;
+
     procedure ValidateRecipients()
     var
         EmailAccount: Codeunit "Email Account";

--- a/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -606,6 +606,7 @@ codeunit 8905 "Email Message Impl."
         MessageNo: Integer;
     begin
         EmailMessage.SetLoadFields(Id);
+        EmailMessage.ReadIsolation(IsolationLevel::ReadCommitted);
         EmailMessage.SetFilter(Id, '>=%1', StartMessageId);
         if not EmailMessage.FindSet() then
             exit(EmptyGuid);


### PR DESCRIPTION
This PR provides the ability to clean up orphaned email messages you may have created without an email outbox or sent email referencing them.
This is not a normal situation to end up in and only occurs if you simply create the message without linking.
It's not the most optimized solution, it's simply there to allow cleaning up incorrectly created messages.

Fixes [AB#524544](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/524544)






