### PR TITLE
Remove NonDebuggable from Azure Blob Storage

### DIFF
--- a/src/System Application/App/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
@@ -20,7 +20,6 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="StorageAccount">The name of Storage Account to use.</param>
     /// <param name="Container">The name of the container to use.</param>
     /// <param name="Authorization">The authorization to use.</param>
-    [NonDebuggable]
     procedure Initialize(StorageAccount: Text; Container: Text; Authorization: Interface "Storage Service Authorization")
     var
         StorageServiceAuthorization: Codeunit "Storage Service Authorization";
@@ -35,7 +34,6 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="Container">The name of the container to use.</param>
     /// <param name="Authorization">The authorization to use.</param>
     /// <param name="APIVersion">The used API version to use.</param>
-    [NonDebuggable]
     procedure Initialize(StorageAccount: Text; Container: Text; Authorization: Interface "Storage Service Authorization"; APIVersion: Enum "Storage Service API Version")
     begin
         ABSClientImpl.Initialize(StorageAccount, Container, '', Authorization, APIVersion);

--- a/src/System Application/App/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
@@ -49,7 +49,6 @@ codeunit 9051 "ABS Client Impl."
 
     #endregion
 
-    [NonDebuggable]
     procedure Initialize(StorageAccountName: Text; ContainerName: Text; BlobName: Text; Authorization: Interface "Storage Service Authorization"; ApiVersion: Enum "Storage Service API Version")
     begin
         ABSOperationPayload.Initialize(StorageAccountName, ContainerName, BlobName, Authorization, ApiVersion);
@@ -60,7 +59,6 @@ codeunit 9051 "ABS Client Impl."
         ABSOperationPayload.SetBaseUrl(BaseUrl);
     end;
 
-    [NonDebuggable]
     procedure ListContainers(var ABSContainer: Record "ABS Container"; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     var
         ABSOperationResponse: Codeunit "ABS Operation Response";
@@ -108,7 +106,6 @@ codeunit 9051 "ABS Client Impl."
         exit(ABSOperationResponse);
     end;
 
-    [NonDebuggable]
     procedure ListBlobs(var ABSContainerContent: Record "ABS Container Content"; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     var
         ABSHelperLibrary: Codeunit "ABS Helper Library";
@@ -130,7 +127,6 @@ codeunit 9051 "ABS Client Impl."
         exit(ABSOperationResponse);
     end;
 
-    [NonDebuggable]
     procedure ListBlobs(var BlobList: Dictionary of [Text, XmlNode]; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     var
         ABSHelperLibrary: Codeunit "ABS Helper Library";

--- a/src/System Application/App/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
@@ -20,7 +20,6 @@ codeunit 9052 "ABS Container Client"
     /// </summary>
     /// <param name="StorageAccount">The name of Storage Account to use.</param>
     /// <param name="Authorization">The authorization to use.</param>
-    [NonDebuggable]
     procedure Initialize(StorageAccount: Text; Authorization: Interface "Storage Service Authorization")
     var
         StorageServiceAuthorization: Codeunit "Storage Service Authorization";
@@ -33,7 +32,6 @@ codeunit 9052 "ABS Container Client"
     /// </summary>
     /// <param name="StorageAccount">The Storage Account to use.</param>
     /// <param name="ApiVersion">The API version to use.</param>
-    [NonDebuggable]
     procedure Initialize(StorageAccount: Text; Authorization: Interface "Storage Service Authorization"; ApiVersion: Enum "Storage Service API Version")
     begin
         ABSClientImpl.Initialize(StorageAccount, '', '', Authorization, ApiVersion);

--- a/src/System Application/App/Azure Blob Services API/src/ABSOperationPayload.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/ABSOperationPayload.Codeunit.al
@@ -14,22 +14,15 @@ codeunit 9042 "ABS Operation Payload"
     InherentPermissions = X;
 
     var
-        [NonDebuggable]
         ContentHeaders: Dictionary of [Text, Text];
-        [NonDebuggable]
         RequestHeaders: Dictionary of [Text, Text];
-        [NonDebuggable]
         UriParameters: Dictionary of [Text, Text];
 
         Authorization: Interface "Storage Service Authorization";
         ApiVersion: Enum "Storage Service API Version";
-        [NonDebuggable]
         StorageBaseUrl: Text;
-        [NonDebuggable]
         StorageAccountName: Text;
-        [NonDebuggable]
         ContainerName: Text;
-        [NonDebuggable]
         BlobName: Text;
 
 
@@ -45,7 +38,6 @@ codeunit 9042 "ABS Operation Payload"
         Authorization := StorageServiceAuthorization;
     end;
 
-    [NonDebuggable]
     procedure SetOperation(NewOperation: Enum "ABS Operation")
     begin
         Operation := NewOperation;
@@ -66,43 +58,36 @@ codeunit 9042 "ABS Operation Payload"
         ApiVersion := StorageServiceApiVersion;
     end;
 
-    [NonDebuggable]
     procedure GetStorageAccountName(): Text
     begin
         exit(StorageAccountName);
     end;
 
-    [NonDebuggable]
     procedure SetStorageAccountName(StorageAccount: Text);
     begin
         StorageAccountName := StorageAccount;
     end;
 
-    [NonDebuggable]
     procedure GetContainerName(): Text
     begin
         exit(ContainerName);
     end;
 
-    [NonDebuggable]
     procedure SetContainerName(Container: Text);
     begin
         ContainerName := Container;
     end;
 
-    [NonDebuggable]
     procedure GetBlobName(): Text
     begin
         exit(BlobName);
     end;
 
-    [NonDebuggable]
     procedure SetBlobName("Blob": Text);
     begin
         BlobName := "Blob";
     end;
 
-    [NonDebuggable]
     procedure SetBaseUrl(BaseUrl: Text)
     begin
         StorageBaseUrl := BaseUrl;
@@ -113,7 +98,6 @@ codeunit 9042 "ABS Operation Payload"
         exit(Operation);
     end;
 
-    [NonDebuggable]
     procedure GetRequestHeaders(): Dictionary of [Text, Text]
     begin
         SortHeaders(RequestHeaders);
@@ -121,7 +105,6 @@ codeunit 9042 "ABS Operation Payload"
         exit(RequestHeaders);
     end;
 
-    [NonDebuggable]
     procedure GetContentHeaders(): Dictionary of [Text, Text]
     begin
         SortHeaders(ContentHeaders);
@@ -129,7 +112,6 @@ codeunit 9042 "ABS Operation Payload"
         exit(ContentHeaders);
     end;
 
-    [NonDebuggable]
     procedure Initialize(StorageAccount: Text; Container: Text; BlobNameText: Text; StorageServiceAuthorization: Interface "Storage Service Authorization"; StorageServiceAPIVersion: Enum "Storage Service API Version")
     begin
         StorageAccountName := StorageAccount;
@@ -148,7 +130,6 @@ codeunit 9042 "ABS Operation Payload"
     /// Creates the Uri for this object, based on given values
     /// </summary>
     /// <returns>An Uri (as Text) for this API Operation</returns>
-    [NonDebuggable]
     internal procedure ConstructUri(): Text
     var
         ABSURIHelper: Codeunit "ABS URI Helper";
@@ -157,7 +138,6 @@ codeunit 9042 "ABS Operation Payload"
         exit(ABSURIHelper.ConstructUri(StorageBaseUrl, StorageAccountName, ContainerName, BlobName, Operation));
     end;
 
-    [NonDebuggable]
     local procedure SortHeaders(var Headers: Dictionary of [Text, Text])
     var
         SortedDictionary: DotNet GenericSortedDictionary2;
@@ -175,28 +155,24 @@ codeunit 9042 "ABS Operation Payload"
             Headers.Add(SortedDictionaryEntry."Key"(), SortedDictionaryEntry.Value());
     end;
 
-    [NonDebuggable]
     procedure AddRequestHeader(HeaderKey: Text; HeaderValue: Text)
     begin
         if RequestHeaders.Remove(HeaderKey) then;
         RequestHeaders.Add(HeaderKey, HeaderValue);
     end;
 
-    [NonDebuggable]
     procedure AddContentHeader(HeaderKey: Text; HeaderValue: Text)
     begin
         if ContentHeaders.Remove(HeaderKey) then;
         ContentHeaders.Add(HeaderKey, HeaderValue);
     end;
 
-    [NonDebuggable]
     procedure AddUriParameter(ParameterKey: Text; ParameterValue: Text)
     begin
         UriParameters.Remove(ParameterKey);
         UriParameters.Add(ParameterKey, ParameterValue);
     end;
 
-    [NonDebuggable]
     procedure SetOptionalParameters(ABSOptionalParameters: Codeunit "ABS Optional Parameters")
     var
         Optionals: Dictionary of [Text, Text];

--- a/src/System Application/App/Azure Blob Services API/src/ABSOperationPayload.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/ABSOperationPayload.Codeunit.al
@@ -17,7 +17,6 @@ codeunit 9042 "ABS Operation Payload"
         ContentHeaders: Dictionary of [Text, Text];
         RequestHeaders: Dictionary of [Text, Text];
         UriParameters: Dictionary of [Text, Text];
-
         Authorization: Interface "Storage Service Authorization";
         ApiVersion: Enum "Storage Service API Version";
         StorageBaseUrl: Text;

--- a/src/System Application/App/Azure Blob Services API/src/Helper/ABSContainerContentHelper.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/Helper/ABSContainerContentHelper.Codeunit.al
@@ -11,7 +11,6 @@ codeunit 9054 "ABS Container Content Helper"
     InherentEntitlements = X;
     InherentPermissions = X;
 
-    [NonDebuggable]
     procedure AddNewEntryFromNode(var ABSContainerContent: Record "ABS Container Content"; var Node: XmlNode; XPathName: Text; var EntryNo: Integer)
     var
         ABSHelperLibrary: Codeunit "ABS Helper Library";
@@ -28,7 +27,6 @@ codeunit 9054 "ABS Container Content Helper"
         AddNewEntry(ABSContainerContent, NameFromXml, OuterXml, ChildNodes, EntryNo, GetBlobResourceType(Node));
     end;
 
-    [NonDebuggable]
     procedure AddNewEntry(var ABSContainerContent: Record "ABS Container Content"; NameFromXml: Text; OuterXml: Text; ChildNodes: XmlNodeList; var EntryNo: Integer; ResourceType: Enum "ABS Blob Resource Type")
     var
         OutStream: OutStream;
@@ -54,7 +52,6 @@ codeunit 9054 "ABS Container Content Helper"
         EntryNo += 1;
     end;
 
-    [NonDebuggable]
     local procedure AddParentEntries(NameFromXml: Text; var ABSContainerContent: Record "ABS Container Content"; var EntryNo: Integer)
     var
         DirectoryContentTypeTxt: Label 'Directory', Locked = true;
@@ -98,7 +95,6 @@ codeunit 9054 "ABS Container Content Helper"
         end;
     end;
 
-    [NonDebuggable]
     local procedure SetPropertyFields(var ABSContainerContent: Record "ABS Container Content"; ChildNodes: XmlNodeList)
     var
         ABSFormatHelper: Codeunit "ABS Format Helper";
@@ -136,7 +132,6 @@ codeunit 9054 "ABS Container Content Helper"
         end;
     end;
 
-    [NonDebuggable]
     local procedure GetLevel(Name: Text): Integer
     var
         StringSplit: List of [Text];
@@ -147,7 +142,6 @@ codeunit 9054 "ABS Container Content Helper"
         exit(StringSplit.Count() - 1);
     end;
 
-    [NonDebuggable]
     local procedure GetName(Name: Text): Text
     var
         StringSplit: List of [Text];
@@ -158,7 +152,6 @@ codeunit 9054 "ABS Container Content Helper"
         exit(StringSplit.Get(StringSplit.Count()));
     end;
 
-    [NonDebuggable]
     local procedure GetParentDirectory(Name: Text): Text
     var
         Parent: Text;
@@ -176,7 +169,6 @@ codeunit 9054 "ABS Container Content Helper"
     /// Use this function to retrieve the original name of the blob (read from saved XmlNode)
     /// </summary>
     /// <returns>The Full name of the Blob, recovered from saved XmlNode</returns>
-    [NonDebuggable]
     internal procedure GetFullNameFromXML(var ABSContainerContent: Record "ABS Container Content"): Text
     var
         ABSHelperLibrary: Codeunit "ABS Helper Library";
@@ -188,7 +180,6 @@ codeunit 9054 "ABS Container Content Helper"
         exit(NameFromXml);
     end;
 
-    [NonDebuggable]
     local procedure GetXmlNodeForEntry(var ABSContainerContent: Record "ABS Container Content"; var Node: XmlNode)
     var
         InStream: InStream;

--- a/src/System Application/App/Azure Blob Services API/src/Helper/ABSContainerHelper.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/Helper/ABSContainerHelper.Codeunit.al
@@ -11,7 +11,6 @@ codeunit 9055 "ABS Container Helper"
     InherentEntitlements = X;
     InherentPermissions = X;
 
-    [NonDebuggable]
     procedure AddNewEntryFromNode(var ABSContainer: Record "ABS Container"; var Node: XmlNode; XPathName: Text)
     var
         ABSHelperLibrary: Codeunit "ABS Helper Library";
@@ -30,7 +29,6 @@ codeunit 9055 "ABS Container Helper"
             AddNewEntry(ABSContainer, NameFromXml, OuterXml, ChildNodes);
     end;
 
-    [NonDebuggable]
     procedure AddNewEntry(var ABSContainer: Record "ABS Container"; NameFromXml: Text; OuterXml: Text)
     var
         ChildNodes: XmlNodeList;
@@ -38,7 +36,6 @@ codeunit 9055 "ABS Container Helper"
         AddNewEntry(ABSContainer, NameFromXml, OuterXml, ChildNodes);
     end;
 
-    [NonDebuggable]
     procedure AddNewEntry(var ABSContainer: Record "ABS Container"; NameFromXml: Text; OuterXml: Text; ChildNodes: XmlNodeList)
     var
         Output: OutStream;
@@ -51,7 +48,6 @@ codeunit 9055 "ABS Container Helper"
         ABSContainer.Insert(true);
     end;
 
-    [NonDebuggable]
     local procedure SetPropertyFields(var ABSContainer: Record "ABS Container"; ChildNodes: XmlNodeList)
     var
         ABSFormatHelper: Codeunit "ABS Format Helper";

--- a/src/System Application/App/Azure Blob Services API/src/Helper/ABSFormatHelper.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/Helper/ABSFormatHelper.Codeunit.al
@@ -15,7 +15,6 @@ codeunit 9044 "ABS Format Helper"
     InherentEntitlements = X;
     InherentPermissions = X;
 
-    [NonDebuggable]
     procedure AppendToUri(var UriText: Text; ParameterIdentifier: Text; ParameterValue: Text)
     var
         Uri: Codeunit Uri;
@@ -34,19 +33,16 @@ codeunit 9044 "ABS Format Helper"
             UriText += StrSubstNo(AppendType2Lbl, ConcatChar, EscapedParameterValue)
     end;
 
-    [NonDebuggable]
     procedure RemoveCurlyBracketsFromString("Value": Text): Text
     begin
         exit(DelChr("Value", '=', '{}'));
     end;
 
-    [NonDebuggable]
     procedure GetBase64BlockId(): Text
     begin
         exit(GetBase64BlockId(RemoveCurlyBracketsFromString(Format(CreateGuid()))));
     end;
 
-    [NonDebuggable]
     procedure GetBase64BlockId(BlockId: Text): Text
     var
         Base64Convert: Codeunit "Base64 Convert";
@@ -55,7 +51,6 @@ codeunit 9044 "ABS Format Helper"
         exit(Uri.EscapeDataString(Base64Convert.ToBase64(BlockId)));
     end;
 
-    [NonDebuggable]
     procedure BlockDictionariesToBlockListDictionary(CommitedBlocks: Dictionary of [Text, Integer]; UncommitedBlocks: Dictionary of [Text, Integer]; var BlockList: Dictionary of [Text, Text]; OverwriteValueToLatest: Boolean)
     var
         Keys: List of [Text];
@@ -77,7 +72,6 @@ codeunit 9044 "ABS Format Helper"
             BlockList.Add("Key", "Value");
     end;
 
-    [NonDebuggable]
     procedure BlockListDictionaryToXmlDocument(BlockList: Dictionary of [Text, Text]): XmlDocument
     var
         Document: XmlDocument;
@@ -96,7 +90,6 @@ codeunit 9044 "ABS Format Helper"
         exit(Document);
     end;
 
-    [NonDebuggable]
     procedure TagsDictionaryToXmlDocument(Tags: Dictionary of [Text, Text]): XmlDocument
     var
         Document: XmlDocument;
@@ -122,7 +115,6 @@ codeunit 9044 "ABS Format Helper"
         exit(Document);
     end;
 
-    [NonDebuggable]
     procedure XmlDocumentToTagsDictionary(Document: XmlDocument): Dictionary of [Text, Text]
     var
         Tags: Dictionary of [Text, Text];
@@ -146,7 +138,6 @@ codeunit 9044 "ABS Format Helper"
         exit(Tags);
     end;
 
-    [NonDebuggable]
     local procedure GetSingleNodeInnerText(Node: XmlNode; XPath: Text): Text
     var
         ChildNode: XmlNode;
@@ -158,7 +149,6 @@ codeunit 9044 "ABS Format Helper"
         exit(XmlElement.InnerText());
     end;
 
-    [NonDebuggable]
     procedure TagsDictionaryToSearchExpression(Tags: Dictionary of [Text, Text]): Text
     var
         Keys: List of [Text];
@@ -177,7 +167,6 @@ codeunit 9044 "ABS Format Helper"
         exit(Expression);
     end;
 
-    [NonDebuggable]
     procedure QueryExpressionToQueryBlobContent(QueryExpression: Text): XmlDocument
     var
         Document: XmlDocument;
@@ -194,7 +183,6 @@ codeunit 9044 "ABS Format Helper"
         exit(Document);
     end;
 
-    [NonDebuggable]
     local procedure GetOperatorFromValue("Value": Text): Text
     var
         NewValue: Text;
@@ -203,7 +191,6 @@ codeunit 9044 "ABS Format Helper"
         exit(NewValue.Trim());
     end;
 
-    [NonDebuggable]
     local procedure GetValueWithoutOperator("Value": Text): Text
     var
         NewValue: Text;
@@ -212,7 +199,6 @@ codeunit 9044 "ABS Format Helper"
         exit(NewValue.Trim());
     end;
 
-    [NonDebuggable]
     procedure TextToXmlDocument(SourceText: Text): XmlDocument
     var
         Document: XmlDocument;

--- a/src/System Application/App/Azure Blob Services API/src/Helper/ABSHelperLibrary.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/Helper/ABSHelperLibrary.Codeunit.al
@@ -15,20 +15,17 @@ codeunit 9043 "ABS Helper Library"
     Permissions = tabledata Field = r;
 
     // #region Container-specific Helper
-    [NonDebuggable]
     procedure ContainerNodeListTotempRecord(NodeList: XmlNodeList; var ABSContainer: Record "ABS Container")
     begin
         NodeListToTempRecord(NodeList, './/Name', ABSContainer);
     end;
 
-    [NonDebuggable]
     procedure CreateContainerNodeListFromResponse(ResponseAsText: Text): XmlNodeList
     begin
         exit(CreateXPathNodeListFromResponse(ResponseAsText, '/*/Containers/Container'));
     end;
     // #endregion
 
-    [NonDebuggable]
     procedure PageRangesResultToDictionairy(Document: XmlDocument; var PageRanges: Dictionary of [Integer, Integer])
     var
         NodeList: XmlNodeList;
@@ -47,13 +44,11 @@ codeunit 9043 "ABS Helper Library"
         end;
     end;
 
-    [NonDebuggable]
     procedure CreatePageRangesNodeListFromResponse(Document: XmlDocument): XmlNodeList
     begin
         exit(CreateXPathNodeListFromResponse(Document, '/*/PageRange'));
     end;
 
-    [NonDebuggable]
     procedure BlockListResultToDictionary(Document: XmlDocument; var CommitedBlocks: Dictionary of [Text, Integer]; var UncommitedBlocks: Dictionary of [Text, Integer])
     var
         NodeList: XmlNodeList;
@@ -80,20 +75,17 @@ codeunit 9043 "ABS Helper Library"
             end;
     end;
 
-    [NonDebuggable]
     procedure CreateBlockListCommitedNodeListFromResponse(Document: XmlDocument): XmlNodeList
     begin
         exit(CreateXPathNodeListFromResponse(Document, '/*/CommittedBlocks/Block'));
     end;
 
-    [NonDebuggable]
     procedure CreateBlockListUncommitedNodeListFromResponse(Document: XmlDocument): XmlNodeList
     begin
         exit(CreateXPathNodeListFromResponse(Document, '/*/UncommittedBlocks/Block'));
     end;
 
     // #region Blob-specific Helper
-    [NonDebuggable]
     procedure CreateBlobNodeListFromResponse(ResponseAsText: Text; var NextMarker: Text): XmlNodeList
     var
         XmlDoc: XmlDocument;
@@ -108,7 +100,6 @@ codeunit 9043 "ABS Helper Library"
         exit(NodeList);
     end;
 
-    [NonDebuggable]
     procedure BlobNodeListToTempRecord(NodeList: XmlNodeList)
     var
         ABSContainerContent: Record "ABS Container Content";
@@ -116,7 +107,6 @@ codeunit 9043 "ABS Helper Library"
         BlobNodeListToTempRecord(NodeList, ABSContainerContent);
     end;
 
-    [NonDebuggable]
     procedure BlobNodeListToTempRecord(NodeList: XmlNodeList; var ABSContainerContent: Record "ABS Container Content")
     begin
         NodeListToTempRecord(NodeList, './/Name', ABSContainerContent);
@@ -134,7 +124,6 @@ codeunit 9043 "ABS Helper Library"
     // #endregion
 
     // #region XML Helper
-    [NonDebuggable]
     local procedure GetXmlDocumentFromResponse(var Document: XmlDocument; ResponseAsText: Text)
     var
         ReadingAsXmlErr: Label 'Error reading Response as XML.';
@@ -143,7 +132,6 @@ codeunit 9043 "ABS Helper Library"
             Error(ReadingAsXmlErr);
     end;
 
-    [NonDebuggable]
     local procedure CreateXPathNodeListFromResponse(ResponseAsText: Text; XPath: Text): XmlNodeList
     var
         Document: XmlDocument;
@@ -156,7 +144,6 @@ codeunit 9043 "ABS Helper Library"
         exit(NodeList);
     end;
 
-    [NonDebuggable]
     local procedure CreateXPathNodeListFromResponse(Document: XmlDocument; XPath: Text): XmlNodeList
     var
         RootNode: XmlElement;
@@ -167,7 +154,6 @@ codeunit 9043 "ABS Helper Library"
         exit(NodeList);
     end;
 
-    [NonDebuggable]
     procedure GetValueFromNode(Node: XmlNode; XPath: Text): Text
     var
         Node2: XmlNode;
@@ -178,7 +164,6 @@ codeunit 9043 "ABS Helper Library"
         exit(Value);
     end;
 
-    [NonDebuggable]
     local procedure NodeListToTempRecord(NodeList: XmlNodeList; XPathName: Text; var ABSContainerContent: Record "ABS Container Content")
     var
         ABSContainerContentHelper: Codeunit "ABS Container Content Helper";
@@ -195,7 +180,6 @@ codeunit 9043 "ABS Helper Library"
             ABSContainerContentHelper.AddNewEntryFromNode(ABSContainerContent, Node, XPathName, EntryNo);
     end;
 
-    [NonDebuggable]
     local procedure NodeListToTempRecord(NodeList: XmlNodeList; XPathName: Text; var ABSContainer: Record "ABS Container")
     var
         ContainerHelper: Codeunit "ABS Container Helper";
@@ -211,7 +195,6 @@ codeunit 9043 "ABS Helper Library"
     // #endregion
 
     // #region Format Helper
-    [NonDebuggable]
     procedure GetFieldByName(TableNo: Integer; FieldCaption: Text; var FieldNo: Integer): Boolean
     var
         Field: Record Field;

--- a/src/System Application/App/Azure Blob Services API/src/Helper/ABSHttpContentHelper.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/Helper/ABSHttpContentHelper.Codeunit.al
@@ -14,7 +14,6 @@ codeunit 9049 "ABS HttpContent Helper"
     var
         ContentLengthLbl: Label '%1', Comment = '%1 = Length', Locked = true;
 
-    [NonDebuggable]
     procedure AddBlobPutBlockBlobContentHeaders(var HttpContent: HttpContent; ABSOperationPayload: Codeunit "ABS Operation Payload"; var SourceInStream: InStream; ContentType: Text)
     var
         BlobType: Enum "ABS Blob Type";
@@ -22,7 +21,6 @@ codeunit 9049 "ABS HttpContent Helper"
         AddBlobPutContentHeaders(HttpContent, ABSOperationPayload, SourceInStream, BlobType::BlockBlob, ContentType)
     end;
 
-    [NonDebuggable]
     procedure AddBlobPutBlockBlobContentHeaders(var HttpContent: HttpContent; ABSOperationPayload: Codeunit "ABS Operation Payload"; SourceText: Text; ContentType: Text)
     var
         BlobType: Enum "ABS Blob Type";
@@ -30,7 +28,6 @@ codeunit 9049 "ABS HttpContent Helper"
         AddBlobPutContentHeaders(HttpContent, ABSOperationPayload, SourceText, BlobType::BlockBlob, ContentType)
     end;
 
-    [NonDebuggable]
     procedure AddBlobPutPageBlobContentHeaders(ABSOperationPayload: Codeunit "ABS Operation Payload"; ContentLength: Integer; ContentType: Text)
     var
         BlobType: Enum "ABS Blob Type";
@@ -41,7 +38,6 @@ codeunit 9049 "ABS HttpContent Helper"
         AddBlobPutContentHeaders(HttpContent, ABSOperationPayload, BlobType::PageBlob, ContentLength, ContentType)
     end;
 
-    [NonDebuggable]
     procedure AddBlobPutAppendBlobContentHeaders(ABSOperationPayload: Codeunit "ABS Operation Payload"; ContentType: Text)
     var
         BlobType: Enum "ABS Blob Type";
@@ -50,7 +46,6 @@ codeunit 9049 "ABS HttpContent Helper"
         AddBlobPutContentHeaders(HttpContent, ABSOperationPayload, BlobType::AppendBlob, 0, ContentType)
     end;
 
-    [NonDebuggable]
     local procedure AddBlobPutContentHeaders(var HttpContent: HttpContent; ABSOperationPayload: Codeunit "ABS Operation Payload"; var SourceInStream: InStream; BlobType: Enum "ABS Blob Type"; ContentType: Text)
     var
         Length: BigInteger;
@@ -66,7 +61,6 @@ codeunit 9049 "ABS HttpContent Helper"
         AddBlobPutContentHeaders(HttpContent, ABSOperationPayload, BlobType, Length, ContentType);
     end;
 
-    [NonDebuggable]
     local procedure AddBlobPutContentHeaders(var HttpContent: HttpContent; ABSOperationPayload: Codeunit "ABS Operation Payload"; SourceText: Text; BlobType: Enum "ABS Blob Type"; ContentType: Text)
     var
         Length: Integer;
@@ -81,7 +75,6 @@ codeunit 9049 "ABS HttpContent Helper"
         AddBlobPutContentHeaders(HttpContent, ABSOperationPayload, BlobType, Length, ContentType);
     end;
 
-    [NonDebuggable]
     local procedure AddBlobPutContentHeaders(var HttpContent: HttpContent; ABSOperationPayload: Codeunit "ABS Operation Payload"; BlobType: Enum "ABS Blob Type"; ContentLength: BigInteger; ContentType: Text)
     var
         Headers: HttpHeaders;
@@ -109,19 +102,16 @@ codeunit 9049 "ABS HttpContent Helper"
             ABSOperationPayload.AddRequestHeader('x-ms-blob-type', Format(BlobType));
     end;
 
-    [NonDebuggable]
     procedure AddTagsContent(var HttpContent: HttpContent; var ABSOperationPayload: Codeunit "ABS Operation Payload"; Document: XmlDocument)
     begin
         AddXmlDocumentAsContent(HttpContent, ABSOperationPayload, Document);
     end;
 
-    [NonDebuggable]
     procedure AddBlockListContent(var HttpContent: HttpContent; var ABSOperationPayload: Codeunit "ABS Operation Payload"; Document: XmlDocument)
     begin
         AddXmlDocumentAsContent(HttpContent, ABSOperationPayload, Document);
     end;
 
-    [NonDebuggable]
     local procedure AddXmlDocumentAsContent(var HttpContent: HttpContent; var ABSOperationPayload: Codeunit "ABS Operation Payload"; Document: XmlDocument)
     var
         Headers: HttpHeaders;
@@ -138,7 +128,6 @@ codeunit 9049 "ABS HttpContent Helper"
         ABSOperationPayload.AddContentHeader('Content-Length', Format(Length));
     end;
 
-    [NonDebuggable]
     procedure ContentSet(HttpContent: HttpContent): Boolean
     var
         VarContent: Text;
@@ -155,7 +144,6 @@ codeunit 9049 "ABS HttpContent Helper"
     /// </summary>
     /// <param name="SourceInStream">The InStream for Request Body.</param>
     /// <returns>The length of the current stream</returns>
-    [NonDebuggable]
     local procedure GetContentLength(var SourceInStream: InStream): BigInteger
     begin
         exit(SourceInStream.Length());
@@ -166,7 +154,6 @@ codeunit 9049 "ABS HttpContent Helper"
     /// </summary>
     /// <param name="SourceText">The Text for Request Body.</param>
     /// <returns>The length of the current stream</returns>
-    [NonDebuggable]
     local procedure GetContentLength(SourceText: Text): Integer
     var
         Length: Integer;

--- a/src/System Application/App/Azure Blob Services API/src/Helper/ABSHttpHeaderHelper.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/Helper/ABSHttpHeaderHelper.Codeunit.al
@@ -13,7 +13,6 @@ codeunit 9048 "ABS HttpHeader Helper"
     InherentEntitlements = X;
     InherentPermissions = X;
 
-    [NonDebuggable]
     procedure HandleRequestHeaders(HttpRequestType: Enum "Http Request Type"; var HttpRequestMessage: HttpRequestMessage; var ABSOperationPayload: Codeunit "ABS Operation Payload")
     var
         ABSFormatHelper: Codeunit "ABS Format Helper";
@@ -36,7 +35,6 @@ codeunit 9048 "ABS HttpHeader Helper"
         end;
     end;
 
-    [NonDebuggable]
     procedure HandleContentHeaders(var HttpContent: HttpContent; var ABSOperationPayload: Codeunit "ABS Operation Payload"): Boolean
     var
         Headers: HttpHeaders;

--- a/src/System Application/App/Azure Blob Services API/src/Helper/ABSURIHelper.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/Helper/ABSURIHelper.Codeunit.al
@@ -12,17 +12,14 @@ codeunit 9046 "ABS URI Helper"
     InherentPermissions = X;
 
     var
-        [NonDebuggable]
         OptionalUriParameters: Dictionary of [Text, Text];
         BlobStorageBaseUrlLbl: Label 'https://%1.blob.core.windows.net', Comment = '%1 = Storage Account Name', Locked = true;
 
-    [NonDebuggable]
     procedure SetOptionalUriParameter(NewOptionalUriParameters: Dictionary of [Text, Text])
     begin
         OptionalUriParameters := NewOptionalUriParameters;
     end;
 
-    [NonDebuggable]
     procedure ConstructUri(StorageBaseUrl: Text; StorageAccountName: Text; ContainerName: Text; BlobName: Text; Operation: Enum "ABS Operation"): Text
     var
         ABSFormatHelper: Codeunit "ABS Format Helper";
@@ -56,7 +53,6 @@ codeunit 9046 "ABS URI Helper"
         exit(ConstructedUrl);
     end;
 
-    [NonDebuggable]
     local procedure AppendContainerIfNecessary(var ConstructedUrl: Text; ContainerName: Text; Operation: Enum "ABS Operation")
     begin
         // e.g. https://<StorageAccountName>.blob.core.windows.net/<ContainerName>?restype=container
@@ -74,7 +70,6 @@ codeunit 9046 "ABS URI Helper"
         ConstructedUrl += ContainerName;
     end;
 
-    [NonDebuggable]
     local procedure AppendBlobIfNecessary(var ConstructedUrl: Text; BlobName: Text; Operation: Enum "ABS Operation")
     begin
         // e.g. https://<StorageAccountName>.blob.core.windows.net/<Container>/<BlobName>
@@ -91,7 +86,6 @@ codeunit 9046 "ABS URI Helper"
         ConstructedUrl += BlobName;
     end;
 
-    [NonDebuggable]
     local procedure AppendRestTypeIfNecessary(var ConstructedUrl: Text; Operation: Enum "ABS Operation")
     var
         ABSFormatHelper: Codeunit "ABS Format Helper";
@@ -119,7 +113,6 @@ codeunit 9046 "ABS URI Helper"
         ABSFormatHelper.AppendToUri(ConstructedUrl, RestTypeLbl, RestType);
     end;
 
-    [NonDebuggable]
     local procedure AppendCompValueIfNecessary(var ConstructedUrl: Text; Operation: Enum "ABS Operation")
     var
         ABSFormatHelper: Codeunit "ABS Format Helper";
@@ -199,7 +192,6 @@ codeunit 9046 "ABS URI Helper"
         ABSFormatHelper.AppendToUri(ConstructedUrl, CompIdentifierLbl, CompValue);
     end;
 
-    [NonDebuggable]
     local procedure RetrieveFromOptionalUriParameters(Identifier: Text): Text
     var
         ReturnValue: Text;
@@ -211,7 +203,6 @@ codeunit 9046 "ABS URI Helper"
         exit(ReturnValue);
     end;
 
-    [NonDebuggable]
     local procedure AddOptionalUriParameters(var Uri: Text)
     var
         ABSFormatHelper: Codeunit "ABS Format Helper";
@@ -228,7 +219,6 @@ codeunit 9046 "ABS URI Helper"
             end;
     end;
 
-    [NonDebuggable]
     local procedure TestConstructUrlParameter(StorageAccountName: Text; ContainerName: Text; BlobName: Text; Operation: Enum "ABS Operation")
     var
         ValueCanNotBeEmptyErr: Label '%1 can not be empty', Comment = '%1 = Variable Name';

--- a/src/System Application/App/Azure Blob Services API/src/Helper/ABSWebRequestHelper.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/Helper/ABSWebRequestHelper.Codeunit.al
@@ -18,7 +18,6 @@ codeunit 9045 "ABS Web Request Helper"
         HttpResponseInfoErr: Label '%1.\\Response Code: %2 %3', Comment = '%1 = Default Error Message ; %2 = Status Code; %3 = Reason Phrase';
 
     #region GET Request
-    [NonDebuggable]
     procedure GetOperationAsText(var ABSOperationPayload: Codeunit "ABS Operation Payload"; var ResponseText: Text; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
     var
         ABSOperationResponse: Codeunit "ABS Operation Response";
@@ -32,7 +31,6 @@ codeunit 9045 "ABS Web Request Helper"
         exit(ABSOperationResponse);
     end;
 
-    [NonDebuggable]
     procedure GetOperationAsStream(var ABSOperationPayload: Codeunit "ABS Operation Payload"; var InStream: InStream; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
     var
         ABSOperationResponse: Codeunit "ABS Operation Response";

--- a/src/System Application/App/Azure Storage Services Authorization/src/AuthFormatHelper.Codeunit.al
+++ b/src/System Application/App/Azure Storage Services Authorization/src/AuthFormatHelper.Codeunit.al
@@ -41,7 +41,6 @@ codeunit 9060 "Auth. Format Helper"
         exit(DotNetDateTime.Parse(DateTimeAsXmlString).ToUniversalTime().ToString(FormatSpecifier));
     end;
 
-    [NonDebuggable]
     procedure GetAccessKeyHashCode(StringToSign: Text; AccessKey: SecretText): Text;
     var
         CryptographyManagement: Codeunit "Cryptography Management";

--- a/src/System Application/App/Azure Storage Services Authorization/src/SAS/StorServAuthSAS.Codeunit.al
+++ b/src/System Application/App/Azure Storage Services Authorization/src/SAS/StorServAuthSAS.Codeunit.al
@@ -39,13 +39,11 @@ codeunit 9061 "Stor. Serv. Auth. SAS" implements "Storage Service Authorization"
         HttpRequestMessage.SetRequestUri(Uri.GetAbsoluteUri());
     end;
 
-    [NonDebuggable]
     procedure SetStorageAccountName(NewStorageAccountName: Text)
     begin
         StorageAccountName := NewStorageAccountName;
     end;
 
-    [NonDebuggable]
     procedure SetSigningKey(NewSigningKey: SecretText)
     begin
         SigningKey := NewSigningKey;

--- a/src/System Application/App/Azure Storage Services Authorization/src/SharedKey/StorServAuthSharedKey.Codeunit.al
+++ b/src/System Application/App/Azure Storage Services Authorization/src/SharedKey/StorServAuthSharedKey.Codeunit.al
@@ -28,7 +28,6 @@ codeunit 9064 "Stor. Serv. Auth. Shared Key" implements "Storage Service Authori
         Headers.Add('Authorization', GetSharedKeySignature(HttpRequest, StorageAccount));
     end;
 
-    [NonDebuggable]
     procedure SetSharedKey(SharedKey: SecretText)
     begin
         Secret := SharedKey;
@@ -39,7 +38,6 @@ codeunit 9064 "Stor. Serv. Auth. Shared Key" implements "Storage Service Authori
         ApiVersion := NewApiVersion;
     end;
 
-    [NonDebuggable]
     local procedure GetSharedKeySignature(HttpRequestMessage: HttpRequestMessage; StorageAccount: Text): Text
     var
         StringToSign: Text;
@@ -86,7 +84,6 @@ codeunit 9064 "Stor. Serv. Auth. Shared Key" implements "Storage Service Authori
     end;
 
     [TryFunction]
-    [NonDebuggable]
     local procedure TryGetContentHeaders(var HttpRequestMessage: HttpRequestMessage; var RequestHttpHeaders: HttpHeaders)
     begin
         HttpRequestMessage.Content.GetHeaders(RequestHttpHeaders);

--- a/src/System Application/App/Azure Storage Services Authorization/src/StorServAuthImpl.Codeunit.al
+++ b/src/System Application/App/Azure Storage Services Authorization/src/StorServAuthImpl.Codeunit.al
@@ -11,7 +11,6 @@ codeunit 9063 "Stor. Serv. Auth. Impl."
     InherentEntitlements = X;
     InherentPermissions = X;
 
-    [NonDebuggable]
     procedure CreateSAS(SigningKey: SecretText; SignedVersion: Enum "Storage Service API Version"; SignedServices: List of [Enum "SAS Service Type"]; SignedResources: List of [Enum "SAS Resource Type"]; SignedPermissions: List of [Enum "SAS Permission"]; SignedExpiry: DateTime): Interface "Storage Service Authorization"
     var
         OptionalParams: Record "SAS Parameters";
@@ -20,7 +19,6 @@ codeunit 9063 "Stor. Serv. Auth. Impl."
         exit(CreateSAS(SigningKey, SignedVersion, SignedServices, SignedResources, SignedPermissions, SignedExpiry, OptionalParams));
     end;
 
-    [NonDebuggable]
     procedure CreateSAS(SigningKey: SecretText; SignedVersion: Enum "Storage Service API Version"; SignedServices: List of [Enum "SAS Service Type"]; SignedResources: List of [Enum "SAS Resource Type"]; SignedPermissions: List of [Enum "SAS Permission"]; SignedExpiry: DateTime; OptionalParams: Record "SAS Parameters"): Interface "Storage Service Authorization"
     var
         StorServAuthSAS: Codeunit "Stor. Serv. Auth. SAS";
@@ -41,7 +39,6 @@ codeunit 9063 "Stor. Serv. Auth. Impl."
         exit(StorServAuthSAS);
     end;
 
-    [NonDebuggable]
     procedure SharedKey(SharedKeyToUse: SecretText; ApiVersion: Enum "Storage Service API Version"): Interface "Storage Service Authorization"
     var
         StorServAuthSharedKey: Codeunit "Stor. Serv. Auth. Shared Key";

--- a/src/System Application/App/Azure Storage Services Authorization/src/StorageServiceAuthorization.Codeunit.al
+++ b/src/System Application/App/Azure Storage Services Authorization/src/StorageServiceAuthorization.Codeunit.al
@@ -87,11 +87,7 @@ codeunit 9062 "Storage Service Authorization"
     /// <param name="SignedExpiry">The time at which the shared access signature becomes invalid.</param>
     /// <param name="OptionalSASParameters">See table "Stor. Serv. SAS Parameters".</param>
     /// <returns>An account SAS authorization.</returns>
-    procedure CreateAccountSAS(SigningKey: SecretText; SignedVersion: Enum "Storage Service API Version"; SignedServices: List of [Enum "SAS Service Type"];
-                                                                    SignedResources: List of [Enum "SAS Resource Type"];
-                                                                    SignedPermissions: List of [Enum "SAS Permission"];
-                                                                    SignedExpiry: DateTime;
-                                                                    OptionalSASParameters: Record "SAS Parameters"): Interface "Storage Service Authorization"
+    procedure CreateAccountSAS(SigningKey: SecretText; SignedVersion: Enum "Storage Service API Version"; SignedServices: List of [Enum "SAS Service Type"]; SignedResources: List of [Enum "SAS Resource Type"]; SignedPermissions: List of [Enum "SAS Permission"]; SignedExpiry: DateTime; OptionalSASParameters: Record "SAS Parameters"): Interface "Storage Service Authorization"
     var
         StorServAuthImpl: Codeunit "Stor. Serv. Auth. Impl.";
     begin

--- a/src/System Application/App/Azure Storage Services Authorization/src/StorageServiceAuthorization.Codeunit.al
+++ b/src/System Application/App/Azure Storage Services Authorization/src/StorageServiceAuthorization.Codeunit.al
@@ -14,6 +14,7 @@ codeunit 9062 "Storage Service Authorization"
     InherentEntitlements = X;
     InherentPermissions = X;
 
+#if not CLEAN25
     /// <summary>
     /// Creates an account SAS (Shared Access Signature) for authorizing HTTP request to Azure Storage Services.
     /// see: https://go.microsoft.com/fwlink/?linkid=2210398
@@ -25,6 +26,7 @@ codeunit 9062 "Storage Service Authorization"
     /// <param name="SignedExpiry">The time at which the shared access signature becomes invalid.</param>
     /// <returns>An account SAS authorization.</returns>
     [NonDebuggable]
+    [Obsolete('Use CreateAccountSAS with SecretText data type for SigningKey.', '25.0')]
     procedure CreateAccountSAS(SigningKey: Text; SignedVersion: Enum "Storage Service API Version"; SignedServices: List of [Enum "SAS Service Type"]; SignedResources: List of [Enum "SAS Resource Type"]; SignedPermissions: List of [Enum "SAS Permission"]; SignedExpiry: DateTime): Interface "Storage Service Authorization"
     var
         StorServAuthImpl: Codeunit "Stor. Serv. Auth. Impl.";
@@ -41,10 +43,51 @@ codeunit 9062 "Storage Service Authorization"
     /// <param name="SignedServices">Specifies the signed services accessible with the account SAS.</param>
     /// <param name="SignedPermissions">Specifies the signed permissions for the account SAS. Permissions are only valid if they match the specified signed resource type; otherwise they are ignored.</param>
     /// <param name="SignedExpiry">The time at which the shared access signature becomes invalid.</param>
-    /// <param name="OptionalParams">See table "Stor. Serv. SAS Parameters".</param>
+    /// <param name="OptionalSASParameters">See table "Stor. Serv. SAS Parameters".</param>
     /// <returns>An account SAS authorization.</returns>
     [NonDebuggable]
+    [Obsolete('Use CreateAccountSAS with SecretText data type for SigningKey.', '25.0')]
     procedure CreateAccountSAS(SigningKey: Text; SignedVersion: Enum "Storage Service API Version"; SignedServices: List of [Enum "SAS Service Type"];
+                                                                    SignedResources: List of [Enum "SAS Resource Type"];
+                                                                    SignedPermissions: List of [Enum "SAS Permission"];
+                                                                    SignedExpiry: DateTime;
+                                                                    OptionalSASParameters: Record "SAS Parameters"): Interface "Storage Service Authorization"
+    var
+        StorServAuthImpl: Codeunit "Stor. Serv. Auth. Impl.";
+    begin
+        exit(StorServAuthImpl.CreateSAS(SigningKey, SignedVersion, SignedServices, SignedResources, SignedPermissions, SignedExpiry, OptionalSASParameters));
+    end;
+#endif
+
+    /// <summary>
+    /// Creates an account SAS (Shared Access Signature) for authorizing HTTP request to Azure Storage Services.
+    /// see: https://go.microsoft.com/fwlink/?linkid=2210398
+    /// </summary>
+    /// <param name="SigningKey">The signing key to use.</param>
+    /// <param name="SignedVersion">Specifies the signed storage service version to use to authorize requests made with this account SAS. Must be set to version 2015-04-05 or later.</param>
+    /// <param name="SignedServices">Specifies the signed services accessible with the account SAS.</param>
+    /// <param name="SignedPermissions">Specifies the signed permissions for the account SAS. Permissions are only valid if they match the specified signed resource type; otherwise they are ignored.</param>
+    /// <param name="SignedExpiry">The time at which the shared access signature becomes invalid.</param>
+    /// <returns>An account SAS authorization.</returns>
+    procedure CreateAccountSAS(SigningKey: SecretText; SignedVersion: Enum "Storage Service API Version"; SignedServices: List of [Enum "SAS Service Type"]; SignedResources: List of [Enum "SAS Resource Type"]; SignedPermissions: List of [Enum "SAS Permission"]; SignedExpiry: DateTime): Interface "Storage Service Authorization"
+    var
+        StorServAuthImpl: Codeunit "Stor. Serv. Auth. Impl.";
+    begin
+        exit(StorServAuthImpl.CreateSAS(SigningKey, SignedVersion, SignedServices, SignedResources, SignedPermissions, SignedExpiry));
+    end;
+
+    /// <summary>
+    /// Creates an account SAS (Shared Access Signature) for authorizing HTTP request to Azure Storage Services.
+    /// see: https://go.microsoft.com/fwlink/?linkid=2210398
+    /// </summary>
+    /// <param name="SigningKey">The signing key to use.</param>
+    /// <param name="SignedVersion">Specifies the signed storage service version to use to authorize requests made with this account SAS. Must be set to version 2015-04-05 or later.</param>
+    /// <param name="SignedServices">Specifies the signed services accessible with the account SAS.</param>
+    /// <param name="SignedPermissions">Specifies the signed permissions for the account SAS. Permissions are only valid if they match the specified signed resource type; otherwise they are ignored.</param>
+    /// <param name="SignedExpiry">The time at which the shared access signature becomes invalid.</param>
+    /// <param name="OptionalSASParameters">See table "Stor. Serv. SAS Parameters".</param>
+    /// <returns>An account SAS authorization.</returns>
+    procedure CreateAccountSAS(SigningKey: SecretText; SignedVersion: Enum "Storage Service API Version"; SignedServices: List of [Enum "SAS Service Type"];
                                                                     SignedResources: List of [Enum "SAS Resource Type"];
                                                                     SignedPermissions: List of [Enum "SAS Permission"];
                                                                     SignedExpiry: DateTime;
@@ -94,7 +137,6 @@ codeunit 9062 "Storage Service Authorization"
     /// </summary>
     /// <param name="SharedKey">The shared key to use.</param>
     /// <returns>A Shared Key authorization.</returns>
-    [NonDebuggable]
     procedure CreateSharedKey(SharedKey: SecretText): Interface "Storage Service Authorization"
     var
         StorServAuthImpl: Codeunit "Stor. Serv. Auth. Impl.";
@@ -109,7 +151,6 @@ codeunit 9062 "Storage Service Authorization"
     /// <param name="SharedKey">The shared key to use.</param>
     /// <param name="ApiVersion">The API version to use.</param>
     /// <returns>A Shared Key authorization.</returns>
-    [NonDebuggable]
     procedure CreateSharedKey(SharedKey: SecretText; ApiVersion: Enum "Storage Service API Version"): Interface "Storage Service Authorization"
     var
         StorServAuthImpl: Codeunit "Stor. Serv. Auth. Impl.";

--- a/src/System Application/Test/Azure File Services API/src/AFSGetTestStorageAuth.Codeunit.al
+++ b/src/System Application/Test/Azure File Services API/src/AFSGetTestStorageAuth.Codeunit.al
@@ -46,7 +46,9 @@ codeunit 132518 "AFS Get Test Storage Auth."
         SignedResources: List of [Enum "SAS Resource Type"];
         SignedExpiry: DateTime;
         Second: Integer;
+        SecretAccountKey: SecretText;
     begin
+        SecretAccountKey := AccountKey;
         Second := 1000;
         SignedExpiry := CurrentDateTime() + (60 * Second);
 
@@ -57,7 +59,7 @@ codeunit 132518 "AFS Get Test Storage Auth."
         SignedResources.AddRange(Enum::"SAS Resource Type"::Object, Enum::"SAS Resource Type"::Container);
 
         exit(StorageServiceAuthorization.CreateAccountSAS(
-            AccountKey,
+            SecretAccountKey,
             APIVersion,
             SignedServices,
             SignedResources,

--- a/src/System Application/Test/Azure Storage Services Authorization/src/StorServAccountSASTest.Codeunit.al
+++ b/src/System Application/Test/Azure Storage Services Authorization/src/StorServAccountSASTest.Codeunit.al
@@ -26,6 +26,7 @@ codeunit 132918 "Stor. Serv. Account SAS Test"
         Services: List of [Enum "SAS Service Type"];
         Resources: List of [Enum "SAS Resource Type"];
         ExpiryDate: DateTime;
+        SecretAccountKey: SecretText;
     begin
         // [Given] A storage account and an HTTP request with random URI
         AccountKey := '8jOLRYYU9UOaxhW1yeVUbA==';
@@ -41,8 +42,8 @@ codeunit 132918 "Stor. Serv. Account SAS Test"
         Permissions.Add(Enum::"SAS Permission"::Read);
         Permissions.Add(Enum::"SAS Permission"::Write);
         Permissions.Add(Enum::"SAS Permission"::Tag);
-
-        SASAuthorization := StorageServiceAuthorization.CreateAccountSAS(AccountKey, Enum::"Storage Service API Version"::"2020-10-02", Services, Resources, Permissions, ExpiryDate);
+        SecretAccountKey := AccountKey;
+        SASAuthorization := StorageServiceAuthorization.CreateAccountSAS(SecretAccountKey, Enum::"Storage Service API Version"::"2020-10-02", Services, Resources, Permissions, ExpiryDate);
         SASAuthorization.Authorize(HttpRequest, StorageAccount);
 
         // [Then] The Authorization header is present on the HTTP request and nothing else has changed


### PR DESCRIPTION
#### Summary
Remove NonDebuggable from Azure Blob Storage and Storage Authorization

This PR removes the NonDebuggable from Helper procedure and other procedures where the data of the procedures is already known, since it's provided from upper codeunits.

I skipped the RequestHelper Codeunit for the moment, since I'm not sure if we can remove the NonDebuggable property there.
e.g. if we use the ReadSAS Authorization where the Secret is part of the request uri.

I added new Overloads to the `codeunit 9062 "Storage Service Authorization"` for `CreateAccountSAS` with SecretText.

#### Work Item(s)
Partially Fixes #875

Fixes [AB#524277](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/524277)






