### PR TITLE
Allow public key to be retrieved as plaintext

### DIFF
--- a/src/System Application/App/Cryptography Management/src/RSACryptoServiceProvider.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/RSACryptoServiceProvider.Codeunit.al
@@ -32,7 +32,7 @@ codeunit 1445 RSACryptoServiceProvider
     /// </summary>
     /// <param name="IncludePrivateParameters">true to include a public and private RSA key; false to include only the public key.</param>
     /// <returns>An XML string containing the key of the current RSA object.</returns>
-    [Obsolete('Use ToSecretXmlString with SecretText data type for XmlString.', '24.0')]
+    [Obsolete('Use ToSecretXmlString with SecretText data type for XmlString or use PublicKeyToXmlString to retrieve the public key as Text.', '24.0')]
     procedure ToXmlString(IncludePrivateParameters: Boolean): Text
     begin
 #pragma warning disable AL0432
@@ -96,6 +96,15 @@ codeunit 1445 RSACryptoServiceProvider
         RSACryptoServiceProviderImpl.Decrypt(XmlString, EncryptedTextInStream, OaepPadding, DecryptedTextOutStream);
     end;
 #endif
+
+    /// <summary>
+    /// Creates and returns an XML string containing the public key of the current RSA object.
+    /// </summary>
+    /// <returns>An XML string containing the public key of the current RSA object.</returns>
+    procedure PublicKeyToXmlString(): Text
+    begin
+        exit(RSACryptoServiceProviderImpl.PublicKeyToXmlString());
+    end;
 
     /// <summary>
     /// Creates and returns an XML string containing the key of the current RSA object.

--- a/src/System Application/App/Cryptography Management/src/RSACryptoServiceProviderImpl.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/RSACryptoServiceProviderImpl.Codeunit.al
@@ -158,6 +158,10 @@ codeunit 1446 "RSACryptoServiceProvider Impl." implements "Signature Algorithm v
         DotNetRSACryptoServiceProvider.FromXmlString(XmlString);
     end;
 #endif
+    procedure PublicKeyToXmlString(): Text
+    begin
+        exit(DotNetRSACryptoServiceProvider.ToXmlString(false));
+    end;
 
     procedure ToSecretXmlString(IncludePrivateParameters: Boolean): SecretText
     begin

--- a/src/System Application/Test/Cryptography Management/src/RSACryptoServiceProviderTests.Codeunit.al
+++ b/src/System Application/Test/Cryptography Management/src/RSACryptoServiceProviderTests.Codeunit.al
@@ -37,12 +37,15 @@ codeunit 132613 RSACryptoServiceProviderTests
         KeyXml: XmlDocument;
         Root: XmlElement;
         Node: XmlNode;
-        KeyXmlText: SecretText;
+        KeyXmlSecretText: SecretText;
+        KeyXmlText: Text;
     begin
         RSACryptoServiceProvider.InitializeRSA(2048);
-        KeyXmlText := RSACryptoServiceProvider.ToSecretXmlString(true);
+        KeyXmlSecretText := RSACryptoServiceProvider.ToSecretXmlString(true);
+        KeyXmlText := RSACryptoServiceProvider.PublicKeyToXmlString();
 
-        LibraryAssert.IsTrue(XmlDocument.ReadFrom(GetXmlString(KeyXmlText), KeyXml), 'RSA key is not valid xml data.');
+        LibraryAssert.IsTrue(XmlDocument.ReadFrom(KeyXmlText, KeyXml), 'RSA pubilc key is not valid xml data.');
+        LibraryAssert.IsTrue(XmlDocument.ReadFrom(GetXmlString(KeyXmlSecretText), KeyXml), 'RSA key is not valid xml data.');
         LibraryAssert.IsTrue(KeyXml.GetRoot(Root), 'Could not get Root element of key.');
 
         LibraryAssert.IsTrue(Root.SelectSingleNode('Modulus', Node), 'Could not find <Modulus> in key.');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
- Added a procedure in the facade and implementation codeunits that allows the public key of the RSA key pair to be retrieved as Text instead of SecretText.
- Also amended the obsolete message of the original procedure to reflect this change.
- Amended the automated test to include the new procedure.
#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #987



Fixes [AB#533942](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/533942)

