### PR TITLE
[24.x] Add ability to delete orphaned email messages (#1029)

### DIFF
--- a/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
@@ -72,6 +72,18 @@ codeunit 8904 "Email Message"
     end;
 
     /// <summary>
+    /// Deletes messages that does not have a reference from either the email outbox nor sent email.
+    /// This functionality is only needed if email messages have been created without any email outbox or sent email referencing it, otherwise they will be cleaned up automatically.
+    /// </summary>
+    /// <param name="StartMessageId">The email message id to start from. Using empty guid will start from the beginning.</param>
+    /// <param name="MessagesToIterate">Number of email messages to loop over.</param>
+    /// <returns>The next email message id to be checked. Returns empty guid if there are no more messages.</returns>
+    procedure DeleteOrphanedMessages(StartMessageId: Guid; MessagesToIterate: Integer) NextMessageId: Guid
+    begin
+        exit(EmailMessageImpl.DeleteOrphanedMessages(StartMessageId, MessagesToIterate));
+    end;
+
+    /// <summary>
     /// Gets the body of the email message.
     /// </summary>
     /// <returns>The body of the email.</returns>


### PR DESCRIPTION
This PR provides the ability to clean up orphaned email messages you may have created without an email outbox or sent email referencing them. This is not a normal situation to end up in and only occurs if you simply create the message without linking.
It's not the most optimized solution, it's simply there to allow cleaning up incorrectly created messages.

Fixes [AB#533515](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/533515)



