### PR TITLE
Allow setting SASToken as SecretText in Storage Service Authorization

### DIFF
--- a/src/System Application/App/Azure Storage Services Authorization/src/ReadySAS/StorServAuthReadySAS.Codeunit.al
+++ b/src/System Application/App/Azure Storage Services Authorization/src/ReadySAS/StorServAuthReadySAS.Codeunit.al
@@ -51,6 +51,12 @@ codeunit 9088 "Stor. Serv. Auth. Ready SAS" implements "Storage Service Authoriz
             SharedAccessSignature := DelChr(SharedAccessSignature, '<', '?');
     end;
 
+    [NonDebuggable]
+    procedure SetSharedAccessSignature(NewSharedAccessSignature: SecretText)
+    begin
+        SetSharedAccessSignature(NewSharedAccessSignature.Unwrap())
+    end;
+
     var
         SharedAccessSignature: Text;
 }

--- a/src/System Application/App/Azure Storage Services Authorization/src/StorServAuthImpl.Codeunit.al
+++ b/src/System Application/App/Azure Storage Services Authorization/src/StorServAuthImpl.Codeunit.al
@@ -62,6 +62,16 @@ codeunit 9063 "Stor. Serv. Auth. Impl."
         exit(StorServAuthReadySAS);
     end;
 
+    [NonDebuggable]
+    procedure ReadySAS(SASToken: SecretText): Interface "Storage Service Authorization"
+    var
+        StorServAuthReadySAS: Codeunit "Stor. Serv. Auth. Ready SAS";
+    begin
+        StorServAuthReadySAS.SetSharedAccessSignature(SASToken);
+
+        exit(StorServAuthReadySAS);
+    end;
+
     procedure GetDefaultAPIVersion(): Enum "Storage Service API Version"
     begin
         exit(Enum::"Storage Service API Version"::"2020-10-02");

--- a/src/System Application/App/Azure Storage Services Authorization/src/StorageServiceAuthorization.Codeunit.al
+++ b/src/System Application/App/Azure Storage Services Authorization/src/StorageServiceAuthorization.Codeunit.al
@@ -132,6 +132,20 @@ codeunit 9062 "Storage Service Authorization"
     end;
 
     /// <summary>
+    /// Uses a pre-generated account SAS (Shared Access Signature) for authorizing HTTP request to Azure Storage Services.
+    /// see: https://go.microsoft.com/fwlink/?linkid=2210398
+    /// </summary>
+    /// <param name="SASToken">A pre-generated SAS token.</param>
+    /// <returns>An account SAS authorization.</returns>
+    [NonDebuggable]
+    procedure UseReadySAS(SASToken: SecretText): Interface "Storage Service Authorization"
+    var
+        StorServAuthImpl: Codeunit "Stor. Serv. Auth. Impl.";
+    begin
+        exit(StorServAuthImpl.ReadySAS(SASToken));
+    end;
+
+    /// <summary>
     /// Get the default Storage Service API Version.
     /// </summary>
     /// <returns>The default Storage Service API Version</returns>


### PR DESCRIPTION

#### Summary <!-- Provide a general summary of your changes -->
Currently you can set SASToken only as Text. Adding an overload with a SecretText parameter allowes to secure the value from isolated storage to Auth Codeunit.
#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #895 
