### PR TITLE
Fix automation PRs title and branch name

### DIFF
--- a/.github/actions/RunAutomation/UpdateBCArtifact/run.ps1
+++ b/.github/actions/RunAutomation/UpdateBCArtifact/run.ps1
@@ -11,16 +11,21 @@ Import-Module BcContainerHelper -DisableNameChecking
 
 Import-Module $PSScriptRoot\..\..\..\..\build\scripts\EnlistmentHelperFunctions.psm1
 
-$newVersion = Update-BCArtifactVersion
+$newArtifactUrl = Update-BCArtifactVersion
 
 $result = @{
     'Files' = @()
     'Message' = "No update available"
 }
 
-if ($newVersion) {
+if ($newArtifactUrl) {
     $result.Files = @(Get-ALGoSettingsPath -Relative)
-    $result.Message = "Update BCArtifact version. New value: $newVersion"
+
+    if ($newArtifactUrl -match "\d+\.\d+\.\d+\.\d+") {
+        $result.Message = "Update BCArtifact version. New value: $Matches[0]"
+    } else {
+        $result.Message = "Update BCArtifact version. New value: $newArtifactUrl"
+    }
 }
 
 return $result

--- a/.github/actions/RunAutomation/run.ps1
+++ b/.github/actions/RunAutomation/run.ps1
@@ -107,10 +107,18 @@ function OpenPR {
         git commit -m $commitMessage | Out-Null
     }
 
+    # The PR title is the first update message. Include the target branch in the title for visibility.
+    $prTitle = "[$($TargetBranch -replace 'releases/','')] $($AvailableUpdates[0].Result.Message)"
+
+    # If there are more than one update, add a count to the PR title
+    if($AvailableUpdates.Count -gt 1) {
+        $prTitle += " (+ $($AvailableUpdates.Count - 1) more update(s))"
+    }
+
     git push -u origin $branch | Out-Null
 
     $prDescription += "`n`nFixes AB#420000." # Add link to a work item
-    return New-GitHubPullRequest -Repository $Repository -BranchName $branch -TargetBranch $TargetBranch -PullRequestDescription $prDescription
+    return New-GitHubPullRequest -Repository $Repository -BranchName $branch -TargetBranch $TargetBranch -Title $prTitle -Description $prDescription
 }
 
 $automationsFolder = $PSScriptRoot

--- a/.github/actions/RunAutomation/run.ps1
+++ b/.github/actions/RunAutomation/run.ps1
@@ -78,6 +78,8 @@ function OpenPR {
         [Parameter(Mandatory=$true)]
         [array] $AvailableUpdates,
         [Parameter(Mandatory=$true)]
+        [string] $Category,
+        [Parameter(Mandatory=$true)]
         [string] $Repository,
         [Parameter(Mandatory=$true)]
         [string] $TargetBranch,
@@ -91,7 +93,10 @@ function OpenPR {
     }
 
     Set-GitConfig -Actor $Actor
-    $branch = New-TopicBranch -Category "updates/$TargetBranch"
+
+    $shortTargetBranch = $TargetBranch -replace 'releases/',''
+    $Category = "$shortTargetBranch/$Category".ToLower().Replace(' ', '_')
+    $branch = New-TopicBranchIfNeeded -Category "$shortTargetBranch/$Category"
 
     # Open PR with a commit for each update
     $prDescription = "This PR contains the following changes:"
@@ -108,7 +113,7 @@ function OpenPR {
     }
 
     # The PR title is the first update message. Include the target branch in the title for visibility.
-    $prTitle = "[$($TargetBranch -replace 'releases/','')] $($AvailableUpdates[0].Result.Message)"
+    $prTitle = "[$shortTargetBranch] $($AvailableUpdates[0].Result.Message)"
 
     # If there are more than one update, add a count to the PR title
     if($AvailableUpdates.Count -gt 1) {
@@ -124,11 +129,11 @@ function OpenPR {
 $automationsFolder = $PSScriptRoot
 
 # An automation is a folder with a run.ps1 file
-$automationNames = Get-ChildItem -Path $automationsFolder -Directory | Where-Object { Test-Path (Join-Path $_.FullName 'run.ps1') } | ForEach-Object { $_.Name }
+$automationNames = @(Get-ChildItem -Path $automationsFolder -Directory | Where-Object { Test-Path (Join-Path $_.FullName 'run.ps1') } | ForEach-Object { $_.Name })
 
 # Filter out the automations that are not included
 if($Include) {
-    $automationNames = $automationNames | Where-Object { $Include -contains $_ }
+    $automationNames = @($automationNames | Where-Object { $Include -contains $_ })
 }
 
 if(-not $automationNames) {
@@ -152,7 +157,7 @@ if($availableUpdates) { # Only open PR if there are updates
     Write-Host "::group::Create PR for available updates"
     Import-Module $PSScriptRoot\..\..\..\build\scripts\AutomatedSubmission.psm1 -DisableNameChecking
 
-    $prLink = OpenPR -AvailableUpdates $availableUpdates -Repository $Repository -TargetBranch $TargetBranch -Actor $Actor
+    $prLink = OpenPR -AvailableUpdates $availableUpdates -Category $automationNames[0] -Repository $Repository -TargetBranch $TargetBranch -Actor $Actor
 
     Write-Host "::Notice::PR created: $prLink"
     Write-Host "::endgroup::"

--- a/build/scripts/AutomatedSubmission.psm1
+++ b/build/scripts/AutomatedSubmission.psm1
@@ -62,7 +62,7 @@ function New-TopicBranch
     )
 
     if($PsCmdlet.ParameterSetName -eq "Category") {
-        $currentDate = (Get-Date).ToUniversalTime().ToString("yyMMddHHmmss")
+        $currentDate = (Get-Date).ToUniversalTime().ToString("yyMMddHHmm")
         $BranchName = "automation/$Category/$currentDate"
     }
 

--- a/build/scripts/AutomatedSubmission.psm1
+++ b/build/scripts/AutomatedSubmission.psm1
@@ -115,9 +115,11 @@ function New-GitHubPullRequest
         [Parameter(Mandatory=$true)]
         [string] $TargetBranch,
         [Parameter(Mandatory=$false)]
-        [string] $label = "Automation",
+        [string] $Title,
         [Parameter(Mandatory=$false)]
-        [string] $PullRequestDescription
+        [string] $Description,
+        [Parameter(Mandatory=$false)]
+        [string] $Label = "Automation"
     )
 
     if ([GitHubPullRequest]::GetFromBranch($BranchName, $Repository)) {
@@ -131,15 +133,19 @@ function New-GitHubPullRequest
         "--fill"
     )
 
-    if ($label) {
+    if ($Label) {
         $availableLabels = gh label list --json name | ConvertFrom-Json
-        if ($label -cin $availableLabels.name) {
-            $params += "--label '$($label)'"
+        if ($Label -cin $availableLabels.name) {
+            $params += "--label '$($Label)'"
         }
     }
 
-    if ($PullRequestDescription) {
-        $params += "--body '$($PullRequestDescription)'"
+    if ($Title) {
+        $params += "--title '$($Title)'"
+    }
+
+    if ($Description) {
+        $params += "--body '$($Description)'"
     }
 
     $parameters = ($params -join " ")


### PR DESCRIPTION
- Fix automation branch name to include the automation name as category
- Improve automation PR title to include the branch name. E.g. "[24.x] Update BC Artifact"
[AB#486716](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/486716)


