### PR TITLE
ExtensionDeploymentStatus new Actions

### DIFF
--- a/src/System Application/App/Extension Management/src/ExtensionDeploymentStatus.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionDeploymentStatus.Page.al
@@ -111,7 +111,8 @@ page 2508 "Extension Deployment Status"
                     NavAppTenantOperationTable: Record "NAV App Tenant Operation";
                     ExtensionOperationImpl: Codeunit "Extension Operation Impl";
                 begin
-                    NavAppTenantOperationTable.CopyFilters(Rec);
+                    NavAppTenantOperationTable.Copy(Rec);
+                    NavAppTenantOperationTable.SetFilter(Status, '%1|%2|%3', NavAppTenantOperationTable.Status::Unknown, NavAppTenantOperationTable.Status::NotFound, NavAppTenantOperationTable.Status::InProgress);
                     if NavAppTenantOperationTable.FindSet() then
                         repeat
                             ExtensionOperationImpl.RefreshStatus(NavAppTenantOperationTable."Operation ID");
@@ -120,6 +121,7 @@ page 2508 "Extension Deployment Status"
             }
             action("Upload Extension")
             {
+                ApplicationArea = All;
                 Caption = 'Upload Extension';
                 Image = Import;
                 RunObject = page "Upload And Deploy Extension";

--- a/src/System Application/App/Extension Management/src/ExtensionDeploymentStatus.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionDeploymentStatus.Page.al
@@ -115,7 +115,7 @@ page 2508 "Extension Deployment Status"
                     if NavAppTenantOperationTable.FindSet() then
                         repeat
                             ExtensionOperationImpl.RefreshStatus(NavAppTenantOperationTable."Operation ID");
-                        until NavAppTenantOperationTable.Next = 0;
+                        until NavAppTenantOperationTable.Next() = 0;
                 end;
             }
             action("Upload Extension")
@@ -172,8 +172,6 @@ page 2508 "Extension Deployment Status"
     local procedure DetermineEnvironmentConfigurations()
     var
         EnvironmentInformation: Codeunit "Environment Information";
-        ExtensionMarketplace: Codeunit "Extension Marketplace";
-        IsSaaSInstallAllowed: Boolean;
     begin
         IsSaaS := EnvironmentInformation.IsSaaS();
     end;

--- a/src/System Application/App/Extension Management/src/ExtensionDeploymentStatus.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionDeploymentStatus.Page.al
@@ -5,6 +5,8 @@
 
 namespace System.Apps;
 
+using System.Environment;
+
 /// <summary>
 /// Displays the deployment status for extensions that are deployed or are scheduled for deployment.
 /// </summary>
@@ -87,7 +89,6 @@ page 2508 "Extension Deployment Status"
                 Image = View;
                 Scope = Repeater;
                 ShortcutKey = 'Return';
-                Visible = false;
 
                 trigger OnAction()
                 var
@@ -99,6 +100,49 @@ page 2508 "Extension Deployment Status"
                     ExtnDeploymentStatusDetail.Run();
                 end;
             }
+            action(Refresh)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Refresh the deployment details.';
+                Image = Refresh;
+
+                trigger OnAction()
+                var
+                    NavAppTenantOperationTable: Record "NAV App Tenant Operation";
+                    ExtensionOperationImpl: Codeunit "Extension Operation Impl";
+                begin
+                    NavAppTenantOperationTable.CopyFilters(Rec);
+                    if NavAppTenantOperationTable.FindSet() then
+                        repeat
+                            ExtensionOperationImpl.RefreshStatus(NavAppTenantOperationTable."Operation ID");
+                        until NavAppTenantOperationTable.Next = 0;
+                end;
+            }
+            action("Upload Extension")
+            {
+                Caption = 'Upload Extension';
+                Image = Import;
+                RunObject = page "Upload And Deploy Extension";
+                ToolTip = 'Upload an extension to your application.';
+                Ellipsis = true;
+                Visible = IsSaaS;
+            }
+        }
+        area(Navigation)
+        {
+            action(ExtensionManagement)
+            {
+                Caption = 'Extension Management';
+                ApplicationArea = All;
+                ToolTip = 'Open the Extension Management page.';
+                Image = Setup;
+                RunObject = Page "Extension Management";
+            }
+        }
+        area(Promoted)
+        {
+            actionref(Refresh_Promoted; Refresh) { }
+            actionref(View_Promoted; View) { }
         }
     }
 
@@ -121,6 +165,17 @@ page 2508 "Extension Deployment Status"
     begin
         Rec.SetCurrentKey("Started On");
         Rec.Ascending(false);
+
+        DetermineEnvironmentConfigurations();
+    end;
+
+    local procedure DetermineEnvironmentConfigurations()
+    var
+        EnvironmentInformation: Codeunit "Environment Information";
+        ExtensionMarketplace: Codeunit "Extension Marketplace";
+        IsSaaSInstallAllowed: Boolean;
+    begin
+        IsSaaS := EnvironmentInformation.IsSaaS();
     end;
 
     var
@@ -129,6 +184,7 @@ page 2508 "Extension Deployment Status"
         AppPublisher: Text;
         AppName: Text;
         OperationType: Option Upload,Install;
+        IsSaaS: Boolean;
 }
 
 


### PR DESCRIPTION
#### Summary
Added new actions to page "Extensions Deployment Status"

- Refresh: for refreshing the status of the deployment
- Upload Extension: to re-upload an extension if the first try failed for some reason
- Extension Management: to go back to the extension management page

Unfortunately it's not possible to test this Onprem and there does not seem to be a whole lot of test automation for this which I could re-use. Hopefully you can qualitity check this manually.

#### Work Item(s)
Fixes #977

Fixes [AB#527490](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/527490)



