### PR TITLE
add locktable to no series stateless impl

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesStatelessImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesStatelessImpl.Codeunit.al
@@ -28,6 +28,11 @@ codeunit 306 "No. Series - Stateless Impl." implements "No. Series - Single"
 
     procedure GetNextNo(var NoSeriesLine: Record "No. Series Line"; UsageDate: Date; HideErrorsAndWarnings: Boolean): Code[20]
     begin
+        if not NoSeriesLine.IsTemporary() then begin
+            NoSeriesLine.LockTable();
+            NoSeriesLine.Find();
+        end;
+
         exit(GetNextNoInternal(NoSeriesLine, true, UsageDate, HideErrorsAndWarnings));
     end;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Two or more sessions cannot work simultaneously and get new numbers from number series when using the stateteless impl. because it doesn't lock the no. series line. This PR adds a locktable.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#534262](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/534262)



