### PR TITLE
UserPersonalization.Edit permission set - Remove removed table

### DIFF
--- a/src/System Application/App/System Permissions/permissions/UserPersonalizationEdit.PermissionSet.al
+++ b/src/System Application/App/System Permissions/permissions/UserPersonalizationEdit.PermissionSet.al
@@ -17,8 +17,5 @@ permissionset 91 "User Personalization - Edit"
     Permissions = tabledata "Page Data Personalization" = IMD,
                   tabledata "User Default Style Sheet" = IMD,
                   tabledata "User Personalization" = IMD,
-#pragma warning disable AL0432
-                  tabledata "User Metadata" = IMD,
-#pragma warning restore AL0432
                   tabledata "User Page Metadata" = IMD;
 }


### PR DESCRIPTION
The "User Metadata" table was removed and thus now platform uptake is broken on master. This PR removes it from the permission set.

[AB#536536](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/536536)

