### PR TITLE
[24.x] Setup No. Series on upgrade

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Upgrade/NoSeriesInstaller.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Upgrade/NoSeriesInstaller.Codeunit.al
@@ -19,7 +19,7 @@ codeunit 329 "No. Series Installer"
         SetupNoSeriesImplementation();
     end;
 
-    local procedure SetupNoSeriesImplementation()
+    internal procedure SetupNoSeriesImplementation()
     var
         NoSeriesLine: Record "No. Series Line";
         UpgradeTag: Codeunit "Upgrade Tag";
@@ -28,6 +28,7 @@ codeunit 329 "No. Series Installer"
         if UpgradeTag.HasUpgradeTag(NoSeriesUpgradeTags.GetImplementationUpgradeTag()) then
             exit;
 
+        NoSeriesLine.SetRange(Implementation, 0); // Only update the No. Series Lines that are still referencing the default implementation (0)
         NoSeriesLine.SetRange("Allow Gaps in Nos.", true);
         NoSeriesLine.ModifyAll(Implementation, "No. Series Implementation"::Sequence, false);
         NoSeriesLine.SetRange("Allow Gaps in Nos.", false);

--- a/src/Business Foundation/App/NoSeries/src/Upgrade/NoSeriesUpgrade.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Upgrade/NoSeriesUpgrade.Codeunit.al
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------------------------------------------
 
 namespace Microsoft.Foundation.NoSeries;
+
 codeunit 328 "No. Series Upgrade"
 {
     Access = Internal;
@@ -16,5 +17,6 @@ codeunit 328 "No. Series Upgrade"
         NoSeriesInstaller: Codeunit "No. Series Installer";
     begin
         NoSeriesInstaller.TriggerMovedTableSchemaSanityCheck();
+        NoSeriesInstaller.SetupNoSeriesImplementation();
     end;
 }

--- a/src/Business Foundation/App/NoSeries/src/Upgrade/NoSeriesUpgradeTags.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Upgrade/NoSeriesUpgradeTags.Codeunit.al
@@ -5,11 +5,19 @@
 
 namespace Microsoft.Foundation.NoSeries;
 
+using System.Upgrade;
+
 codeunit 332 "No. Series Upgrade Tags"
 {
     Access = Internal;
     InherentEntitlements = X;
     InherentPermissions = X;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Upgrade Tag", OnGetPerCompanyUpgradeTags, '', false, false)]
+    local procedure RegisterPerCompanyTags(var PerCompanyUpgradeTags: List of [Code[250]])
+    begin
+        PerCompanyUpgradeTags.Add(GetImplementationUpgradeTag());
+    end;
 
     procedure GetImplementationUpgradeTag(): Code[250]
     begin


### PR DESCRIPTION
Make sure No. Series are setup whenever you upgrade to a v24 or newer tenant.

Fixes [AB#537077](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/537077)

