### PR TITLE
fix bug related to daily no. series lines

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
@@ -150,6 +150,7 @@ codeunit 304 "No. Series - Impl."
     procedure GetNoSeriesLine(var NoSeriesLine: Record "No. Series Line"; NoSeriesCode: Code[20]; UsageDate: Date; HideErrorsAndWarnings: Boolean): Boolean
     var
         NoSeriesRec: Record "No. Series";
+        NoSeriesLine2: Record "No. Series Line";
         NoSeries: Codeunit "No. Series";
         NoSeriesErrorsImpl: Codeunit "No. Series - Errors Impl.";
 #if not CLEAN24
@@ -163,12 +164,21 @@ codeunit 304 "No. Series - Impl."
             UsageDate := WorkDate();
 
         // Find the No. Series Line closest to the usage date
-        NoSeriesLine.Reset();
-        NoSeriesLine.SetCurrentKey("Series Code", "Starting Date");
-        NoSeriesLine.SetRange("Series Code", NoSeriesCode);
-        NoSeriesLine.SetRange("Starting Date", 0D, UsageDate);
-        NoSeriesLine.SetRange(Open, true);
-        if (NoSeriesLine."Line No." <> 0) and (NoSeriesLine."Series Code" = NoSeriesCode) then begin
+        NoSeriesLine2.Reset();
+        NoSeriesLine2.SetCurrentKey("Series Code", "Starting Date");
+        NoSeriesLine2.SetRange("Series Code", NoSeriesCode);
+        NoSeriesLine2.SetRange("Starting Date", 0D, UsageDate);
+        NoSeriesLine2.SetRange(Open, true);
+#if not CLEAN24
+#pragma warning disable AL0432
+        NoSeriesManagement.RaiseObsoleteOnNoSeriesLineFilterOnBeforeFindLast(NoSeriesLine2);
+#pragma warning restore AL0432
+#endif
+        if NoSeriesLine2.FindLast() then;
+        NoSeriesLine.CopyFilters(NoSeriesLine2);
+
+        if (NoSeriesLine."Line No." <> 0) and (NoSeriesLine."Series Code" = NoSeriesCode) and (NoSeriesLine."Starting Date" = NoSeriesLine2."Starting Date") then begin
+            NoSeriesLine.CopyFilters(NoSeriesLine2);
             NoSeriesLine.SetRange("Line No.", NoSeriesLine."Line No.");
 #if not CLEAN24
 #pragma warning disable AL0432

--- a/src/Business Foundation/Test/NoSeries/src/NoSeriesBatchTests.Codeunit.al
+++ b/src/Business Foundation/Test/NoSeries/src/NoSeriesBatchTests.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 134531 "No. Series Batch Tests"
         Any: Codeunit Any;
         LibraryAssert: Codeunit "Library Assert";
         LibraryNoSeries: Codeunit "Library - No. Series";
-        CannotAssignNewErr: Label 'You cannot assign new numbers from the number series %1.', Comment = '%1=No. Series Code';
+        CannotAssignNewErr: Label 'You cannot assign new numbers from the number series %1', Comment = '%1=No. Series Code';
 
     #region sequence
     [Test]
@@ -917,6 +917,139 @@ codeunit 134531 "No. Series Batch Tests"
         // [THEN] Getting the next number, they again both return 7
         LibraryAssert.AreEqual('2', NoSeriesBatch.GetNextNo(NoSeriesLine, WorkDate()), 'GetNextNo returned wrong value');
         LibraryAssert.AreEqual('2', NoSeriesBatch2.GetNextNo(TempNoSeriesLine, WorkDate()), 'GetNextNo with temporary record returned wrong value');
+    end;
+
+    [Test]
+    procedure TestDailyNoSeriesBeforeFirstStartDateError()
+    var
+        NoSeriesBatch: Codeunit "No. Series - Batch";
+        NoSeriesCode: Code[20];
+    begin
+        // [SCENARIO] When setting up a No. Series Line with a new start date each day, ensure that the correct number is returned for each day
+        Initialize();
+
+        // [GIVEN] A No Series with 3 lines starting on 3 different days 
+        NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
+        LibraryNoSeries.CreateNoSeries(NoSeriesCode);
+        CreateDailyNoSeriesLines(NoSeriesCode);
+
+        // [WHEN] We get the next number for a day before the first starting date
+        asserterror NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate() - 1);
+        // [THEN] an error is returned
+        LibraryAssert.ExpectedError(StrSubstNo(CannotAssignNewErr, NoSeriesCode));
+    end;
+
+    [Test]
+    procedure TestDailyNoSeries()
+    var
+        NoSeriesBatch: Codeunit "No. Series - Batch";
+        NoSeriesCode: Code[20];
+        NextNo: Code[20];
+    begin
+        // [SCENARIO] When setting up a No. Series Line with a new start date each day, ensure that the correct number is returned for each day
+        Initialize();
+
+        // [GIVEN] A No Series with 3 lines starting on 3 different days 
+        NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
+        LibraryNoSeries.CreateNoSeries(NoSeriesCode);
+        CreateDailyNoSeriesLines(NoSeriesCode);
+
+        // [WHEN] We get the next number for the first starting date
+        NextNo := NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate());
+        // [THEN] the correct number is returned
+        LibraryAssert.AreEqual(StrSubstNo('%1-001', WorkDate()), NextNo, 'Number was not as expected');
+
+        // [WHEN] We get the next number for the second starting date
+        NextNo := NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate() + 1);
+        // [THEN] the correct number is returned
+        LibraryAssert.AreEqual(StrSubstNo('%1-001', WorkDate() + 1), NextNo, 'Number was not as expected');
+
+        // [WHEN] We get the next number for the first starting date
+        NextNo := NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate());
+        // [THEN] the correct number is returned
+        LibraryAssert.AreEqual(StrSubstNo('%1-002', WorkDate()), NextNo, 'Number was not as expected');
+
+        // [WHEN] We get the next number for the second starting date
+        NextNo := NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate() + 1);
+        // [THEN] the correct number is returned
+        LibraryAssert.AreEqual(StrSubstNo('%1-002', WorkDate() + 1), NextNo, 'Number was not as expected');
+
+        // [WHEN] We get the next number for the third starting date
+        NextNo := NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate() + 2);
+        // [THEN] the correct number is returned
+        LibraryAssert.AreEqual(StrSubstNo('%1-001', WorkDate() + 2), NextNo, 'Number was not as expected');
+
+        // [WHEN] We get the next number for the third starting date
+        NextNo := NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate() + 2);
+        // [THEN] the correct number is returned
+        LibraryAssert.AreEqual(StrSubstNo('%1-002', WorkDate() + 2), NextNo, 'Number was not as expected');
+
+        // [WHEN] We get the next number for the second starting date
+        NextNo := NoSeriesBatch.GetNextNo(NoSeriesCode, WorkDate() + 1);
+        // [THEN] the correct number is returned
+        LibraryAssert.AreEqual(StrSubstNo('%1-003', WorkDate() + 1), NextNo, 'Number was not as expected');
+    end;
+
+#if not CLEAN24
+#pragma warning disable AL0432
+    [Test]
+    procedure TestLegacyDailyNoSeries()
+    var
+        NoSeriesManagement: Codeunit NoSeriesManagement;
+        NoSeriesCode: Code[20];
+        NextNo: Code[20];
+    begin
+        // [SCENARIO] When setting up a No. Series Line with a new start date each day, ensure that the correct number is returned for each day
+        Initialize();
+
+        // [GIVEN] A No Series with 3 lines starting on 3 different days 
+        NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
+        LibraryNoSeries.CreateNoSeries(NoSeriesCode);
+        CreateDailyNoSeriesLines(NoSeriesCode);
+
+        // [WHEN] We get the next number for the first starting date
+        NextNo := NoSeriesManagement.GetNextNo(NoSeriesCode, WorkDate(), true);
+        // [THEN] the correct number is returned
+        LibraryAssert.AreEqual(StrSubstNo('%1-001', WorkDate()), NextNo, 'Number was not as expected');
+
+        // [WHEN] We get the next number for the second starting date
+        NextNo := NoSeriesManagement.GetNextNo(NoSeriesCode, WorkDate() + 1, true);
+        // [THEN] the correct number is returned
+        LibraryAssert.AreEqual(StrSubstNo('%1-001', WorkDate() + 1), NextNo, 'Number was not as expected');
+
+        // [WHEN] We get the next number for the first starting date
+        NextNo := NoSeriesManagement.GetNextNo(NoSeriesCode, WorkDate(), true);
+        // [THEN] the correct number is returned
+        LibraryAssert.AreEqual(StrSubstNo('%1-002', WorkDate()), NextNo, 'Number was not as expected');
+
+        // [WHEN] We get the next number for the second starting date
+        NextNo := NoSeriesManagement.GetNextNo(NoSeriesCode, WorkDate() + 1, true);
+        // [THEN] the correct number is returned
+        LibraryAssert.AreEqual(StrSubstNo('%1-002', WorkDate() + 1), NextNo, 'Number was not as expected');
+
+        // [WHEN] We get the next number for the third starting date
+        NextNo := NoSeriesManagement.GetNextNo(NoSeriesCode, WorkDate() + 2, true);
+        // [THEN] the correct number is returned
+        LibraryAssert.AreEqual(StrSubstNo('%1-001', WorkDate() + 2), NextNo, 'Number was not as expected');
+
+        // [WHEN] We get the next number for the third starting date
+        NextNo := NoSeriesManagement.GetNextNo(NoSeriesCode, WorkDate() + 2, true);
+        // [THEN] the correct number is returned
+        LibraryAssert.AreEqual(StrSubstNo('%1-002', WorkDate() + 2), NextNo, 'Number was not as expected');
+
+        // [WHEN] We get the next number for the second starting date
+        NextNo := NoSeriesManagement.GetNextNo(NoSeriesCode, WorkDate() + 1, true);
+        // [THEN] the correct number is returned
+        LibraryAssert.AreEqual(StrSubstNo('%1-003', WorkDate() + 1), NextNo, 'Number was not as expected');
+    end;
+#pragma warning restore AL0432
+#endif
+
+    local procedure CreateDailyNoSeriesLines(NoSeriesCode: Code[20])
+    begin
+        LibraryNoSeries.CreateSequenceNoSeriesLine(NoSeriesCode, 1, StrSubstNo('%1-001', WorkDate()), '', WorkDate());
+        LibraryNoSeries.CreateSequenceNoSeriesLine(NoSeriesCode, 1, StrSubstNo('%1-001', WorkDate() + 1), '', WorkDate() + 1);
+        LibraryNoSeries.CreateSequenceNoSeriesLine(NoSeriesCode, 1, StrSubstNo('%1-001', WorkDate() + 2), '', WorkDate() + 2);
     end;
 
     local procedure Initialize()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
The No.  Series module tries to use the No Series Line given before looking for a new line to use. This has the effect that as long as the usagedate is newer the given line would be used even though a closer match exists. 
This fix makes it so the given line is only used if the starting dates from the given line and the new line match. If the dates don't match, the new line is used. 

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#537258](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/537258)


