### PR TITLE
[Copilot] Add authorization interface for managed resources

### DIFF
--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIAuthorization.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIAuthorization.Codeunit.al
@@ -22,35 +22,61 @@ codeunit 7767 "AOAI Authorization"
         Deployment: Text;
         [NonDebuggable]
         ApiKey: SecretText;
+        [NonDebuggable]
+        ManagedResourceDeployment: Text;
+        ResourceUtilization: Enum "AOAI Resource Utilization";
 
     [NonDebuggable]
     procedure IsConfigured(CallerModule: ModuleInfo): Boolean
     var
-        AzureOpenAiImpl: Codeunit "Azure OpenAI Impl";
+        AzureOpenAIImpl: Codeunit "Azure OpenAI Impl";
         CurrentModule: ModuleInfo;
         ALCopilotFunctions: DotNet ALCopilotFunctions;
     begin
         NavApp.GetCurrentModuleInfo(CurrentModule);
 
-        if Deployment = '' then
-            exit(false);
+        case ResourceUtilization of
+            Enum::"AOAI Resource Utilization"::FirstParty:
+                exit((Deployment <> '') and ALCopilotFunctions.IsPlatformAuthorizationConfigured(CallerModule.Publisher(), CurrentModule.Publisher()));
+            Enum::"AOAI Resource Utilization"::SelfManaged:
+                exit((Deployment <> '') and (Endpoint <> '') and (not ApiKey.IsEmpty()));
+            Enum::"AOAI Resource Utilization"::MicrosoftManaged:
+                exit((Deployment <> '') and (Endpoint <> '') and (not ApiKey.IsEmpty()) and (ManagedResourceDeployment <> '') and AzureOpenAIImpl.IsTenantAllowlistedForFirstPartyCopilotCalls());
+        end;
 
-        if (Endpoint = '') and ApiKey.IsEmpty() then
-            exit(AzureOpenAiImpl.IsTenantAllowlistedForFirstPartyCopilotCalls()
-                or ALCopilotFunctions.IsPlatformAuthorizationConfigured(CallerModule.Publisher(), CurrentModule.Publisher()));
-
-        if (Endpoint = '') or ApiKey.IsEmpty() then
-            exit(false);
-
-        exit(true);
+        exit(false);
     end;
 
     [NonDebuggable]
-    procedure SetAuthorization(NewEndpoint: Text; NewDeployment: Text; NewApiKey: SecretText)
+    procedure SetMicrosoftManagedAuthorization(NewEndpoint: Text; NewDeployment: Text; NewApiKey: SecretText; NewManagedResourceDeployment: Text)
     begin
+        ClearVariables();
+
+        ResourceUtilization := Enum::"AOAI Resource Utilization"::MicrosoftManaged;
         Endpoint := NewEndpoint;
         Deployment := NewDeployment;
         ApiKey := NewApiKey;
+        ManagedResourceDeployment := NewManagedResourceDeployment;
+    end;
+
+    [NonDebuggable]
+    procedure SetSelfManagedAuthorization(NewEndpoint: Text; NewDeployment: Text; NewApiKey: SecretText)
+    begin
+        ClearVariables();
+
+        ResourceUtilization := Enum::"AOAI Resource Utilization"::SelfManaged;
+        Endpoint := NewEndpoint;
+        Deployment := NewDeployment;
+        ApiKey := NewApiKey;
+    end;
+
+    [NonDebuggable]
+    procedure SetFirstPartyAuthorization(NewDeployment: Text)
+    begin
+        ClearVariables();
+
+        ResourceUtilization := Enum::"AOAI Resource Utilization"::FirstParty;
+        Deployment := NewDeployment;
     end;
 
     [NonDebuggable]
@@ -69,5 +95,25 @@ codeunit 7767 "AOAI Authorization"
     procedure GetApiKey(): SecretText
     begin
         exit(ApiKey);
+    end;
+
+    [NonDebuggable]
+    procedure GetManagedResourceDeployment(): SecretText
+    begin
+        exit(ManagedResourceDeployment);
+    end;
+
+    procedure GetResourceUtilization(): Enum "AOAI Resource Utilization"
+    begin
+        exit(ResourceUtilization);
+    end;
+
+    local procedure ClearVariables()
+    begin
+        Clear(Endpoint);
+        Clear(ApiKey);
+        Clear(Deployment);
+        Clear(ManagedResourceDeployment);
+        Clear(ResourceUtilization);
     end;
 }

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIAuthorization.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIAuthorization.Codeunit.al
@@ -36,11 +36,11 @@ codeunit 7767 "AOAI Authorization"
         NavApp.GetCurrentModuleInfo(CurrentModule);
 
         case ResourceUtilization of
-            Enum::"AOAI Resource Utilization"::FirstParty:
+            Enum::"AOAI Resource Utilization"::"First Party":
                 exit((Deployment <> '') and ALCopilotFunctions.IsPlatformAuthorizationConfigured(CallerModule.Publisher(), CurrentModule.Publisher()));
-            Enum::"AOAI Resource Utilization"::SelfManaged:
+            Enum::"AOAI Resource Utilization"::"Self-Managed":
                 exit((Deployment <> '') and (Endpoint <> '') and (not ApiKey.IsEmpty()));
-            Enum::"AOAI Resource Utilization"::MicrosoftManaged:
+            Enum::"AOAI Resource Utilization"::"Microsoft Managed":
                 exit((Deployment <> '') and (Endpoint <> '') and (not ApiKey.IsEmpty()) and (ManagedResourceDeployment <> '') and AzureOpenAiImpl.IsTenantAllowlistedForFirstPartyCopilotCalls());
         end;
 
@@ -52,7 +52,7 @@ codeunit 7767 "AOAI Authorization"
     begin
         ClearVariables();
 
-        ResourceUtilization := Enum::"AOAI Resource Utilization"::MicrosoftManaged;
+        ResourceUtilization := Enum::"AOAI Resource Utilization"::"Microsoft Managed";
         Endpoint := NewEndpoint;
         Deployment := NewDeployment;
         ApiKey := NewApiKey;
@@ -64,7 +64,7 @@ codeunit 7767 "AOAI Authorization"
     begin
         ClearVariables();
 
-        ResourceUtilization := Enum::"AOAI Resource Utilization"::SelfManaged;
+        ResourceUtilization := Enum::"AOAI Resource Utilization"::"Self-Managed";
         Endpoint := NewEndpoint;
         Deployment := NewDeployment;
         ApiKey := NewApiKey;
@@ -75,7 +75,7 @@ codeunit 7767 "AOAI Authorization"
     begin
         ClearVariables();
 
-        ResourceUtilization := Enum::"AOAI Resource Utilization"::FirstParty;
+        ResourceUtilization := Enum::"AOAI Resource Utilization"::"First Party";
         Deployment := NewDeployment;
     end;
 

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIAuthorization.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIAuthorization.Codeunit.al
@@ -29,7 +29,7 @@ codeunit 7767 "AOAI Authorization"
     [NonDebuggable]
     procedure IsConfigured(CallerModule: ModuleInfo): Boolean
     var
-        AzureOpenAIImpl: Codeunit "Azure OpenAI Impl";
+        AzureOpenAiImpl: Codeunit "Azure OpenAI Impl";
         CurrentModule: ModuleInfo;
         ALCopilotFunctions: DotNet ALCopilotFunctions;
     begin
@@ -41,7 +41,7 @@ codeunit 7767 "AOAI Authorization"
             Enum::"AOAI Resource Utilization"::SelfManaged:
                 exit((Deployment <> '') and (Endpoint <> '') and (not ApiKey.IsEmpty()));
             Enum::"AOAI Resource Utilization"::MicrosoftManaged:
-                exit((Deployment <> '') and (Endpoint <> '') and (not ApiKey.IsEmpty()) and (ManagedResourceDeployment <> '') and AzureOpenAIImpl.IsTenantAllowlistedForFirstPartyCopilotCalls());
+                exit((Deployment <> '') and (Endpoint <> '') and (not ApiKey.IsEmpty()) and (ManagedResourceDeployment <> '') and AzureOpenAiImpl.IsTenantAllowlistedForFirstPartyCopilotCalls());
         end;
 
         exit(false);

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIResourceUtilization.Enum.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIResourceUtilization.Enum.al
@@ -13,7 +13,7 @@ enum 7771 "AOAI Resource Utilization"
     Extensible = false;
 
     /// <summary>
-    /// The Self-managed utilization (the resource used for the LLM call is the one provided by the developer).
+    /// The first party utilization (only available for Microsoft first party apps).
     /// </summary>
     value(0; FirstParty)
     {

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIResourceUtilization.Enum.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIResourceUtilization.Enum.al
@@ -15,22 +15,22 @@ enum 7771 "AOAI Resource Utilization"
     /// <summary>
     /// The first party utilization (only available for Microsoft first party apps).
     /// </summary>
-    value(0; FirstParty)
+    value(0; "First Party")
     {
     }
 
     /// <summary>
-    /// The MicrosoftManaged utilization (the resource used for the LLM call is provided and managed by Microsoft).
+    /// The Microsoft managed utilization (the resource used for the LLM call is provided and managed by Microsoft).
     /// </summary>
     /// <remarks>A valid resource is still required to validate that the developer has access to Azure OpenAI.</remarks>
-    value(1; MicrosoftManaged)
+    value(1; "Microsoft Managed")
     {
     }
 
     /// <summary>
     /// The Self-managed utilization (the resource used for the LLM call is the one provided by the developer).
     /// </summary>
-    value(2; SelfManaged)
+    value(2; "Self-Managed")
     {
     }
 }

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIResourceUtilization.Enum.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIResourceUtilization.Enum.al
@@ -1,0 +1,36 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace System.AI;
+
+/// <summary>
+/// The supported utilization models for Azure OpenAI resources.
+/// </summary>
+enum 7771 "AOAI Resource Utilization"
+{
+    Access = Internal;
+    Extensible = false;
+
+    /// <summary>
+    /// The Self-managed utilization (the resource used for the LLM call is the one provided by the developer).
+    /// </summary>
+    value(0; FirstParty)
+    {
+    }
+
+    /// <summary>
+    /// The MicrosoftManaged utilization (the resource used for the LLM call is provided and managed by Microsoft).
+    /// </summary>
+    /// <remarks>A valid resource is still required to validate that the developer has access to Azure OpenAI.</remarks>
+    value(1; MicrosoftManaged)
+    {
+    }
+
+    /// <summary>
+    /// The Self-managed utilization (the resource used for the LLM call is the one provided by the developer).
+    /// </summary>
+    value(2; SelfManaged)
+    {
+    }
+}

--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAI.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAI.Codeunit.al
@@ -71,7 +71,6 @@ codeunit 7771 "Azure OpenAI"
     end;
 
     /// <summary>
-    /// NOTE: This function is currently only available to selected partners.
     /// Sets the managed Azure OpenAI API authorization to use for a specific model type.
     /// This will send the Azure OpenAI call to the deployment specified in <paramref name="ManagedResourceDeployment"/>, and will use the other parameters to verify that you have access to Azure OpenAI.
     /// </summary>
@@ -80,7 +79,8 @@ codeunit 7771 "Azure OpenAI"
     /// <param name="Deployment">The deployment to use to verify access to Azure OpenAI. This is used only for verification, not for actual Azure OpenAI calls.</param>
     /// <param name="ApiKey">The API key to use  to verify access to Azure OpenAI. This is used only for verification, not for actual Azure OpenAI calls.</param>
     /// <param name="ManagedResourceDeployment">The managed deployment to use for the model type.</param>
-    /// <remarks>Endpoint would look like: https://resource-name.openai.azure.com/
+    /// <remarks> NOTE: This function is currently only available to selected partners.
+    /// Endpoint would look like: https://resource-name.openai.azure.com/
     /// Deployment would look like: gpt-35-turbo-16k
     /// </remarks>
     [NonDebuggable]

--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAI.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAI.Codeunit.al
@@ -81,6 +81,22 @@ codeunit 7771 "Azure OpenAI"
     /// Deployment would look like: gpt-35-turbo-16k
     /// </remarks>
     [NonDebuggable]
+    procedure SetManagedResourceAuthorization(ModelType: Enum "AOAI Model Type"; Endpoint: Text; Deployment: Text; ApiKey: SecretText; ManagedResourceDeployment: Text)
+    begin
+        AzureOpenAIImpl.SetManagedResourceAuthorization(ModelType, Endpoint, Deployment, ApiKey, ManagedResourceDeployment);
+    end;
+
+    /// <summary>
+    /// Sets the Azure OpenAI API authorization to use for a specific model type and endpoint.
+    /// </summary>
+    /// <param name="ModelType">The model type to set authorization for.</param>
+    /// <param name="Endpoint">The endpoint to use for the model type.</param>
+    /// <param name="Deployment">The deployment to use for the endpoint.</param>
+    /// <param name="ApiKey">The API key to use for the endpoint.</param>
+    /// <remarks>Endpoint would look like: https://resource-name.openai.azure.com/
+    /// Deployment would look like: gpt-35-turbo-16k
+    /// </remarks>
+    [NonDebuggable]
     procedure SetAuthorization(ModelType: Enum "AOAI Model Type"; Endpoint: Text; Deployment: Text; ApiKey: SecretText)
     begin
         AzureOpenAIImpl.SetAuthorization(ModelType, Endpoint, Deployment, ApiKey);

--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAI.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAI.Codeunit.al
@@ -71,12 +71,15 @@ codeunit 7771 "Azure OpenAI"
     end;
 
     /// <summary>
-    /// Sets the Azure OpenAI API authorization to use for a specific model type and endpoint.
+    /// NOTE: This function is currently only available to selected partners.
+    /// Sets the managed Azure OpenAI API authorization to use for a specific model type.
+    /// This will send the Azure OpenAI call to the deployment specified in <paramref name="ManagedResourceDeployment"/>, and will use the other parameters to verify that you have access to Azure OpenAI.
     /// </summary>
     /// <param name="ModelType">The model type to set authorization for.</param>
-    /// <param name="Endpoint">The endpoint to use for the model type.</param>
-    /// <param name="Deployment">The deployment to use for the endpoint.</param>
-    /// <param name="ApiKey">The API key to use for the endpoint.</param>
+    /// <param name="Endpoint">The endpoint to use to verify access to Azure OpenAI. This is used only for verification, not for actual Azure OpenAI calls.</param>
+    /// <param name="Deployment">The deployment to use to verify access to Azure OpenAI. This is used only for verification, not for actual Azure OpenAI calls.</param>
+    /// <param name="ApiKey">The API key to use  to verify access to Azure OpenAI. This is used only for verification, not for actual Azure OpenAI calls.</param>
+    /// <param name="ManagedResourceDeployment">The managed deployment to use for the model type.</param>
     /// <remarks>Endpoint would look like: https://resource-name.openai.azure.com/
     /// Deployment would look like: gpt-35-turbo-16k
     /// </remarks>

--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -506,9 +506,9 @@ codeunit 7772 "Azure OpenAI Impl"
         ClearLastError();
         case AOAIAuthorization.GetResourceUtilization() of
             Enum::"AOAI Resource Utilization"::MicrosoftManaged:
-                ALCopilotAuthorization := ALCopilotAuthorization.Create(EmptySecretText, AOAIAuthorization.GetDeployment(), EmptySecretText);
+                ALCopilotAuthorization := ALCopilotAuthorization.Create(EmptySecretText, AOAIAuthorization.GetManagedResourceDeployment(), EmptySecretText);
             Enum::"AOAI Resource Utilization"::FirstParty:
-                ALCopilotAuthorization := ALCopilotAuthorization.Create(EmptySecretText, AOAIAuthorization.GetDeployment(), EmptySecretText);
+                ALCopilotAuthorization := ALCopilotAuthorization.Create(EmptySecretText, AOAIAuthorization.GetManagedResourceDeployment(), EmptySecretText);
             else
                 ALCopilotAuthorization := ALCopilotAuthorization.Create(AOAIAuthorization.GetEndpoint(), AOAIAuthorization.GetDeployment(), AOAIAuthorization.GetApiKey());
         end;

--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -559,8 +559,13 @@ codeunit 7772 "Azure OpenAI Impl"
 
     local procedure GuiCheck(AOAIAuthorization: Codeunit "AOAI Authorization")
     begin
-        if (not GuiAllowed()) and (AOAIAuthorization.GetResourceUtilization() <> Enum::"AOAI Resource Utilization"::SelfManaged) then
-            Error(CapabilityBackgroundErr);
+        if GuiAllowed() then
+            exit;
+
+        if AOAIAuthorization.GetResourceUtilization() = Enum::"AOAI Resource Utilization"::SelfManaged then
+            exit;
+
+        Error(CapabilityBackgroundErr);
     end;
 
     local procedure AddTelemetryCustomDimensions(var CustomDimensions: Dictionary of [Text, Text]; CallerModuleInfo: ModuleInfo)

--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -505,9 +505,9 @@ codeunit 7772 "Azure OpenAI Impl"
     begin
         ClearLastError();
         case AOAIAuthorization.GetResourceUtilization() of
-            Enum::"AOAI Resource Utilization"::MicrosoftManaged:
+            Enum::"AOAI Resource Utilization"::"Microsoft Managed":
                 ALCopilotAuthorization := ALCopilotAuthorization.Create(EmptySecretText, AOAIAuthorization.GetManagedResourceDeployment(), EmptySecretText);
-            Enum::"AOAI Resource Utilization"::FirstParty:
+            Enum::"AOAI Resource Utilization"::"First Party":
                 ALCopilotAuthorization := ALCopilotAuthorization.Create(EmptySecretText, AOAIAuthorization.GetManagedResourceDeployment(), EmptySecretText);
             else
                 ALCopilotAuthorization := ALCopilotAuthorization.Create(AOAIAuthorization.GetEndpoint(), AOAIAuthorization.GetDeployment(), AOAIAuthorization.GetApiKey());
@@ -562,7 +562,7 @@ codeunit 7772 "Azure OpenAI Impl"
         if GuiAllowed() then
             exit;
 
-        if AOAIAuthorization.GetResourceUtilization() = Enum::"AOAI Resource Utilization"::SelfManaged then
+        if AOAIAuthorization.GetResourceUtilization() = Enum::"AOAI Resource Utilization"::"Self-Managed" then
             exit;
 
         Error(CapabilityBackgroundErr);

--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -246,7 +246,7 @@ codeunit 7772 "Azure OpenAI Impl"
         PayloadText: Text;
         UnwrappedPrompt: Text;
     begin
-        GuiCheck(CallerModuleInfo);
+        GuiCheck(TextCompletionsAOAIAuthorization);
 
         CheckCapabilitySet();
         CheckEnabled(CallerModuleInfo);
@@ -280,7 +280,7 @@ codeunit 7772 "Azure OpenAI Impl"
         Payload: JsonObject;
         PayloadText: Text;
     begin
-        GuiCheck(CallerModuleInfo);
+        GuiCheck(EmbeddingsAOAIAuthorization);
 
         CheckCapabilitySet();
         CheckEnabled(CallerModuleInfo);
@@ -334,7 +334,7 @@ codeunit 7772 "Azure OpenAI Impl"
         MetapromptTokenCount: Integer;
         PromptTokenCount: Integer;
     begin
-        GuiCheck(CallerModuleInfo);
+        GuiCheck(ChatCompletionsAOAIAuthorization);
 
         CheckCapabilitySet();
         CheckEnabled(CallerModuleInfo);
@@ -501,15 +501,16 @@ codeunit 7772 "Azure OpenAI Impl"
         ALCopilotFunctions: DotNet ALCopilotFunctions;
         ALCopilotOperationResponse: DotNet ALCopilotOperationResponse;
         Error: Text;
+        EmptySecretText: SecretText;
     begin
         ClearLastError();
         case AOAIAuthorization.GetResourceUtilization() of
             Enum::"AOAI Resource Utilization"::MicrosoftManaged:
-                ALCopilotAuthorization := ALCopilotAuthorization.CreateMicrosoftManaged(AOAIAuthorization.GetEndpoint(), AOAIAuthorization.GetDeployment(), AOAIAuthorization.GetApiKey());
+                ALCopilotAuthorization := ALCopilotAuthorization.Create(EmptySecretText, AOAIAuthorization.GetDeployment(), EmptySecretText);
             Enum::"AOAI Resource Utilization"::FirstParty:
-                ALCopilotAuthorization := ALCopilotAuthorization.CreateFirstParty(AOAIAuthorization.GetEndpoint(), AOAIAuthorization.GetDeployment(), AOAIAuthorization.GetApiKey());
+                ALCopilotAuthorization := ALCopilotAuthorization.Create(EmptySecretText, AOAIAuthorization.GetDeployment(), EmptySecretText);
             else
-                ALCopilotAuthorization := ALCopilotAuthorization.CreateSelfManaged(AOAIAuthorization.GetEndpoint(), AOAIAuthorization.GetDeployment(), AOAIAuthorization.GetApiKey());
+                ALCopilotAuthorization := ALCopilotAuthorization.Create(AOAIAuthorization.GetEndpoint(), AOAIAuthorization.GetDeployment(), AOAIAuthorization.GetApiKey());
         end;
 
         ALCopilotCapability := ALCopilotCapability.ALCopilotCapability(CallerModuleInfo.Publisher(), CallerModuleInfo.Id(), Format(CallerModuleInfo.AppVersion()), GetCapabilityName());
@@ -556,13 +557,9 @@ codeunit 7772 "Azure OpenAI Impl"
         Telemetry.LogMessage('0000LT4', StrSubstNo(TelemetryTokenCountLbl, Metaprompt, Prompt, Metaprompt + Prompt), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, CustomDimensions);
     end;
 
-    local procedure GuiCheck(CallerModuleInfo: ModuleInfo)
-    var
-        CurrentModuleInfo: ModuleInfo;
+    local procedure GuiCheck(AOAIAuthorization: Codeunit "AOAI Authorization")
     begin
-        NavApp.GetCallerModuleInfo(CurrentModuleInfo);
-
-        if (not GuiAllowed()) and (CallerModuleInfo.Publisher = CurrentModuleInfo.Publisher) then
+        if (not GuiAllowed()) and (AOAIAuthorization.GetResourceUtilization() <> Enum::"AOAI Resource Utilization"::SelfManaged) then
             Error(CapabilityBackgroundErr);
     end;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Adds a new function to `AzureOpenAI.Codeunit.al` that allows partners approved for the private preview program to use the Microsoft managed AI resources.

Reworked some of the logic in `AOAIAuthorization.Codeunit.al` to more clearly distinguish between the three authorization cases that we have today (first party, managed, self-managed), and created an enum to store that information.

Polish logic to disallow background calls to Azure OpenAI. The previous logic wanted to express that calls in the background are allowed if it's the partner's own AOAI resource (the partner decides in that case), but not if it's using Microsoft managed resources.

_Note: the logic at the moment does not verify that the partner AOAI deployment exists and is valid in the case of Managed resources. This is because we are currently in private preview, so the selected partners are already allowlisted. We will add the verification logic when we move to public preview._

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#537361](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/537361)
Fixes [AB#527684](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/527684)




