### PR TITLE
NoSeriesManagement - add var to handle obsolete No Series

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
@@ -869,7 +869,7 @@ codeunit 396 NoSeriesManagement
     end;
 
     [Obsolete('This is a temporary method for compatibility only. Please use the "No. Series" codeunit instead', '24.0')]
-    internal procedure RaiseObsoleteOnAfterGetNextNo3(NoSeriesLine: Record "No. Series Line"; ModifySeries: Boolean)
+    internal procedure RaiseObsoleteOnAfterGetNextNo3(var NoSeriesLine: Record "No. Series Line"; ModifySeries: Boolean)
     begin
         OnAfterGetNextNo3(NoSeriesLine, ModifySeries);
     end;


### PR DESCRIPTION
On the previous versions of BC there was an event:
![image](https://github.com/microsoft/BCApps/assets/24941235/94820f02-80e0-4a88-9ee2-dd4647478b8b)

But now there is new event:
![image](https://github.com/microsoft/BCApps/assets/24941235/4fe444a2-4862-4a17-b0d6-11a9c7d6cfdb)
And var is missing despite of that the function in body has a var.
