### PR TITLE
remove unnecessary upgrade code for No Series

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Upgrade/NoSeriesInstaller.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Upgrade/NoSeriesInstaller.Codeunit.al
@@ -30,8 +30,6 @@ codeunit 329 "No. Series Installer"
         NoSeriesLine.SetRange(Implementation, 0); // Only update the No. Series Lines that are still referencing the default implementation (0)
         NoSeriesLine.SetRange("Allow Gaps in Nos.", true);
         NoSeriesLine.ModifyAll(Implementation, "No. Series Implementation"::Sequence, false);
-        NoSeriesLine.SetRange("Allow Gaps in Nos.", false);
-        NoSeriesLine.ModifyAll(Implementation, "No. Series Implementation"::Normal, false);
 
         UpgradeTag.SetUpgradeTag(NoSeriesUpgradeTags.GetImplementationUpgradeTag());
     end;


### PR DESCRIPTION
#### Summary

There are some issues with No. Series upgrade (timeout), could not figure out the root cause. However, when inspecting the upgrade code, notice the second `ModifyAll` is not really needed.

The change should be low risk, because it will not be executed on already upgraded tenants.

#### Work Item(s)

Fixes [AB#537864](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/537864)


