### PR TITLE
Manually calculate Field Type in OnAfterGetCurrRecord

### DIFF
--- a/src/System Application/App/Data Classification/src/DataClassificationWorksheet.Page.al
+++ b/src/System Application/App/Data Classification/src/DataClassificationWorksheet.Page.al
@@ -389,7 +389,7 @@ page 1751 "Data Classification Worksheet"
         Field: Record Field;
     begin
         CurrPage.SetSelectionFilter(DataSensitivity);
-        CalcFields("Field Type");
+        Rec.CalcFields("Field Type");
         FieldContentEnabled := ((Rec."Field Type" = Field.Type::Code) or (Rec."Field Type" = Field.Type::Text))
             and (DataSensitivity.Count() = 1);
     end;

--- a/src/System Application/App/Data Classification/src/DataClassificationWorksheet.Page.al
+++ b/src/System Application/App/Data Classification/src/DataClassificationWorksheet.Page.al
@@ -389,6 +389,7 @@ page 1751 "Data Classification Worksheet"
         Field: Record Field;
     begin
         CurrPage.SetSelectionFilter(DataSensitivity);
+        CalcFields("Field Type");
         FieldContentEnabled := ((Rec."Field Type" = Field.Type::Code) or (Rec."Field Type" = Field.Type::Text))
             and (DataSensitivity.Count() = 1);
     end;


### PR DESCRIPTION
Manually calculate Field Type in OnAfterGetCurrRecord, as it might not be calculated if the field is invisible.

Needed for [AB#537292](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/537292)


