### PR TITLE
Escape special characters in ABS Blob Storage blob filenames

### DIFF
--- a/src/System Application/App/Azure Blob Services API/src/ABSOperationPayload.Codeunit.al
+++ b/src/System Application/App/Azure Blob Services API/src/ABSOperationPayload.Codeunit.al
@@ -6,6 +6,7 @@
 namespace System.Azure.Storage;
 
 using System;
+using System.Utilities;
 
 codeunit 9042 "ABS Operation Payload"
 {
@@ -98,8 +99,10 @@ codeunit 9042 "ABS Operation Payload"
 
     [NonDebuggable]
     procedure SetBlobName("Blob": Text);
+    var
+        Uri: Codeunit Uri;
     begin
-        BlobName := "Blob";
+        BlobName := Uri.EscapeDataString("Blob");
     end;
 
     [NonDebuggable]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Escapes special characters in blob file names in the ABS Blob Storage module so that operations on these files work as intended.
#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #1088


Fixes [AB#539027](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/539027)

