### PR TITLE
GetNextNo should error when line is closed, not take a number from an earlier line

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
@@ -168,7 +168,6 @@ codeunit 304 "No. Series - Impl."
         NoSeriesLine2.SetCurrentKey("Series Code", "Starting Date");
         NoSeriesLine2.SetRange("Series Code", NoSeriesCode);
         NoSeriesLine2.SetRange("Starting Date", 0D, UsageDate);
-        NoSeriesLine2.SetRange(Open, true);
 #if not CLEAN24
 #pragma warning disable AL0432
         NoSeriesManagement.RaiseObsoleteOnNoSeriesLineFilterOnBeforeFindLast(NoSeriesLine2);
@@ -204,17 +203,18 @@ codeunit 304 "No. Series - Impl."
 
         if LineFound and NoSeries.MayProduceGaps(NoSeriesLine) then begin
             NoSeriesLine.Validate(Open);
-            if not NoSeriesLine.Open then begin
+            if not NoSeriesLine.Open then
                 NoSeriesLine.Modify(true);
-                exit(GetNoSeriesLine(NoSeriesLine, NoSeriesCode, UsageDate, HideErrorsAndWarnings));
-            end;
         end;
 
         if LineFound then begin
             // There may be multiple No. Series Lines for the same day, so find the first one.
+            NoSeriesLine.SetRange(Open, true);
             NoSeriesLine.SetRange("Starting Date", NoSeriesLine."Starting Date");
-            NoSeriesLine.FindFirst();
-        end else begin
+            LineFound := NoSeriesLine.FindFirst();
+        end;
+
+        if not LineFound then begin
             // Throw an error depending on the reason we couldn't find a date
             if HideErrorsAndWarnings then
                 exit(false);

--- a/src/Business Foundation/Test/NoSeries/Permissions/NoSeriesTest.PermissionSet.al
+++ b/src/Business Foundation/Test/NoSeries/Permissions/NoSeriesTest.PermissionSet.al
@@ -1,8 +1,16 @@
 namespace Microsoft.Test.Foundation.NoSeries;
 using System.TestLibraries.Utilities;
-
+#if not CLEAN24
+using Microsoft.Foundation.NoSeries;
+#endif
 permissionset 134530 "No. Series Test"
 {
     Assignable = true;
+#if not CLEAN24
+    Permissions = codeunit "Library Assert" = X,
+    tabledata "No. Series Line" = m;
+#else
     Permissions = codeunit "Library Assert" = X;
+#endif
+
 }

--- a/src/Business Foundation/Test/NoSeries/src/NoSeriesTests.Codeunit.al
+++ b/src/Business Foundation/Test/NoSeries/src/NoSeriesTests.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 134530 "No. Series Tests"
         Any: Codeunit Any;
         LibraryAssert: Codeunit "Library Assert";
         LibraryNoSeries: Codeunit "Library - No. Series";
-        CannotAssignNewErr: Label 'You cannot assign new numbers from the number series %1.', Comment = '%1=No. Series Code';
+        CannotAssignNewErr: Label 'You cannot assign new numbers from the number series %1', Comment = '%1=No. Series Code';
 
     #region sequence
     [Test]
@@ -275,6 +275,69 @@ codeunit 134530 "No. Series Tests"
         asserterror NoSeries.PeekNextNo(NoSeriesCode);
         LibraryAssert.ExpectedError(StrSubstNo(CannotAssignNewErr, NoSeriesCode));
     end;
+
+
+    [Test]
+    procedure TestGetNextNoWithMultipleLinesExhaustClosedLine_Sequence()
+    var
+        NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
+        NoSeriesCode: Code[20];
+    begin
+        // [Scenario] [Bug 538011] When we have multiple lines, the GetNextNo should return value from latest line. If there is no number left in the latest line, it should throw an error even there are numbers left in previous line.
+        // [GIVEN] Initialize the test
+        Initialize();
+        PermissionsMock.Set('No. Series - Admin');
+
+        // [GIVEN] Create a No. Series
+        NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
+        LibraryNoSeries.CreateNoSeries(NoSeriesCode);
+        // [GIVEN] Create the first line with 10 numbers and no start day, and the 'Last No. Used' set to 'TEST0005'
+        LibraryNoSeries.CreateSequenceNoSeriesLine(NoSeriesCode, 1, 'TEST0001', 'TEST0010', 'TEST0005', 0D);
+        // [GIVEN] Create the second line with 10 numbers and the start date is today, and the 'Last No. Used' set to 'TEST0039', so only one number is left
+        LibraryNoSeries.CreateSequenceNoSeriesLine(NoSeriesCode, 1, 'TEST0030', 'TEST0040', 'TEST0039', Today());
+
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
+
+        // [WHEN] Call GetNextNo and we get the last number from the second Series Line.
+        LibraryAssert.AreEqual('TEST0040', NoSeries.GetNextNo(NoSeriesCode, Today()), 'Get the last SN from the second Series Line');
+        // [Then] Call GetNextNo again, and we get an error since the second Series Line is out of SN although the first Series Line still has SN.
+        asserterror NoSeries.GetNextNo(NoSeriesCode, Today());
+        LibraryAssert.ExpectedError(StrSubstNo(CannotAssignNewErr, NoSeriesCode));
+    end;
+
+#if not CLEAN24
+#pragma warning disable AL0432
+    [Test]
+    procedure TestGetNextNoWithMultipleLinesExhaustClosedLine_Sequence_ObsoleteCode()
+    var
+        NoSeriesManagement: Codeunit NoSeriesManagement;
+        PermissionsMock: Codeunit "Permissions Mock";
+        NoSeriesCode: Code[20];
+    begin
+        // [Scenario] [Bug 538011] When we have multiple lines, the GetNextNo should return value from latest line. If there is no number left in the latest line, it should throw an error even there are numbers left in previous line.
+        // [GIVEN] Initialize the test
+        Initialize();
+        PermissionsMock.Set('No. Series - Admin');
+
+        // [GIVEN] Create a No. Series
+        NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
+        LibraryNoSeries.CreateNoSeries(NoSeriesCode);
+        // [GIVEN] Create the first line with 10 numbers and no start day, and the 'Last No. Used' set to 'TEST0005'
+        LibraryNoSeries.CreateSequenceNoSeriesLine(NoSeriesCode, 1, 'TEST0001', 'TEST0010', 'TEST0005', 0D);
+        // [GIVEN] Create the second line with 10 numbers and the start date is today, and the 'Last No. Used' set to 'TEST0039', so only one number is left
+        LibraryNoSeries.CreateSequenceNoSeriesLine(NoSeriesCode, 1, 'TEST0030', 'TEST0040', 'TEST0039', Today());
+
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
+
+        // [WHEN] Call GetNextNo and we get the last number from the second Series Line.
+        LibraryAssert.AreEqual('TEST0040', NoSeriesManagement.GetNextNo(NoSeriesCode, Today(), true), 'Get the last SN from the second Series Line');
+        // [Then] Call GetNextNo again, and we get an error since the second Series Line is out of SN although the first Series Line still has SN.
+        asserterror NoSeriesManagement.GetNextNo(NoSeriesCode, Today(), true);
+        LibraryAssert.ExpectedError(StrSubstNo(CannotAssignNewErr, NoSeriesCode));
+    end;
+#pragma warning restore AL0432
+#endif
     #endregion
 
     #region normal
@@ -566,6 +629,68 @@ codeunit 134530 "No. Series Tests"
         LibraryAssert.AreEqual(StartingNo, NoSeries.GetNextNo(NoSeriesCode), 'not the first number');
         LibraryAssert.AreEqual(IncStr(StartingNo), NoSeries.GetNextNo(NoSeriesCode), 'not the second number');
     end;
+
+    [Test]
+    procedure TestGetNextNoWithMultipleLinesExhaustClosedLine()
+    var
+        NoSeries: Codeunit "No. Series";
+        PermissionsMock: Codeunit "Permissions Mock";
+        NoSeriesCode: Code[20];
+    begin
+        // [Scenario] [Bug 538011] When we have multiple lines, the GetNextNo should return value from latest line. If there is no number left in the latest line, it should throw an error even there are numbers left in previous line.
+        // [GIVEN] Initialize the test
+        Initialize();
+        PermissionsMock.Set('No. Series - Admin');
+
+        // [GIVEN] Create a No. Series
+        NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
+        LibraryNoSeries.CreateNoSeries(NoSeriesCode);
+        // [GIVEN] Create the first line with 10 numbers and no start day, and the 'Last No. Used' set to 'TEST0005'
+        LibraryNoSeries.CreateNormalNoSeriesLine(NoSeriesCode, 1, 'TEST0001', 'TEST0010', 'TEST0005', 0D);
+        // [GIVEN] Create the second line with 10 numbers and the start date is today, and the 'Last No. Used' set to 'TEST0039', so only one number is left
+        LibraryNoSeries.CreateNormalNoSeriesLine(NoSeriesCode, 1, 'TEST0030', 'TEST0040', 'TEST0039', Today());
+
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
+
+        // [WHEN] Call GetNextNo and we get the last number from the second Series Line.
+        LibraryAssert.AreEqual('TEST0040', NoSeries.GetNextNo(NoSeriesCode, Today()), 'Get the last SN from the second Series Line');
+        // [Then] Call GetNextNo again, and we get an error since the second Series Line is out of SN although the first Series Line still has SN.
+        asserterror NoSeries.GetNextNo(NoSeriesCode, Today());
+        LibraryAssert.ExpectedError(StrSubstNo(CannotAssignNewErr, NoSeriesCode));
+    end;
+
+#if not CLEAN24
+#pragma warning disable AL0432
+    [Test]
+    procedure TestGetNextNoWithMultipleLinesExhaustClosedLine_ObsoleteCode()
+    var
+        NoSeriesManagement: Codeunit NoSeriesManagement;
+        PermissionsMock: Codeunit "Permissions Mock";
+        NoSeriesCode: Code[20];
+    begin
+        // [Scenario] [Bug 538011] When we have multiple lines, the GetNextNo should return value from latest line. If there is no number left in the latest line, it should throw an error even there are numbers left in previous line.
+        // [GIVEN] Initialize the test
+        Initialize();
+        PermissionsMock.Set('No. Series - Admin');
+
+        // [GIVEN] Create a No. Series
+        NoSeriesCode := CopyStr(UpperCase(Any.AlphabeticText(MaxStrLen(NoSeriesCode))), 1, MaxStrLen(NoSeriesCode));
+        LibraryNoSeries.CreateNoSeries(NoSeriesCode);
+        // [GIVEN] Create the first line with 10 numbers and no start day, and the 'Last No. Used' set to 'TEST0005'
+        LibraryNoSeries.CreateNormalNoSeriesLine(NoSeriesCode, 1, 'TEST0001', 'TEST0010', 'TEST0005', 0D);
+        // [GIVEN] Create the second line with 10 numbers and the start date is today, and the 'Last No. Used' set to 'TEST0039', so only one number is left
+        LibraryNoSeries.CreateNormalNoSeriesLine(NoSeriesCode, 1, 'TEST0030', 'TEST0040', 'TEST0039', Today());
+
+        PermissionsMock.SetExactPermissionSet('No. Series Test');
+
+        // [WHEN] Call GetNextNo and we get the last number from the second Series Line.
+        LibraryAssert.AreEqual('TEST0040', NoSeriesManagement.GetNextNo(NoSeriesCode, Today(), true), 'Get the last SN from the second Series Line');
+        // [Then] Call GetNextNo again, and we get an error since the second Series Line is out of SN although the first Series Line still has SN.
+        asserterror NoSeriesManagement.GetNextNo(NoSeriesCode, Today(), true);
+        LibraryAssert.ExpectedError(StrSubstNo(CannotAssignNewErr, NoSeriesCode));
+    end;
+#pragma warning restore AL0432
+#endif
     #endregion
 
     #region GetLastNoUsed


### PR DESCRIPTION
<!-- Thank you for your contribution to BCApps! For newcomers, please ensure you've read our [Pull Request Guidelines](https://github.com/microsoft/BCApps/Contributing.md). -->

### Summary
This PR addresses a bug in the `GetNoSeriesLine` function where it failed to properly handle closed lines. Previously, if a line for a specific month was closed, the system would incorrectly issue a number from a prior month instead of signaling an error. This fix ensures that an error is thrown as expected in such scenarios, aligning with the intended behavior when dealing with closed series lines.

### Work Item
- Fixes [AB#538011](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/538011)


