### PR TITLE
Scheduled Profiler - Small fixes

### DIFF
--- a/src/System Application/App/Performance Profiler/src/PerfProfileActivityType.enum.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfileActivityType.enum.al
@@ -33,6 +33,6 @@ enum 1932 "Perf. Profile Activity Type"
     /// </summary>
     value(2; "Web API Client")
     {
-        Caption = 'Calling external components through REST calls';
+        Caption = 'Web Service Calls';
     }
 }

--- a/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
@@ -20,6 +20,7 @@ page 1932 "Perf. Profiler Schedule Card"
     AboutText = 'View and modify a specific profiler schedule.';
     DataCaptionExpression = Rec.Description;
     SourceTable = "Performance Profile Scheduler";
+    DelayedInsert = true;
 
     layout
     {


### PR DESCRIPTION
#### Summary

Delayed insert is added to the profile schedules card page so that a user can fix the errors before the record is inserted. Else they are blocked from inserting since the record defaults to the current user when first opened.

Bonus:
A fix to the caption of the activity types.

#### Work Item(s)
Fixes #AB538509
