### PR TITLE
Bugfix nextmarker in AFSFileClientImpl.Codeunit

### DIFF
--- a/src/System Application/App/Azure File Services API/src/AFSFileClientImpl.Codeunit.al
+++ b/src/System Application/App/Azure File Services API/src/AFSFileClientImpl.Codeunit.al
@@ -187,7 +187,7 @@ codeunit 8951 "AFS File Client Impl."
 
         AFSHelperLibrary.DirectoryContentNodeListToTempRecord(DirectoryURI, DirectoryPath, NodeList, PreserveDirectoryContent, AFSDirectoryContent);
 
-        if AFSOperationResponse.IsSuccessful() then begin
+        if AFSOperationResponse.IsSuccessful() and (AFSDirectoryContent."Entry No." <> 0) then begin
             AFSDirectoryContent."Next Marker" := CopyStr(AFSHelperLibrary.GetNextMarkerFromResponse(ResponseText), 1, MaxStrLen(AFSDirectoryContent."Next Marker"));
             AFSDirectoryContent.Modify();
         end;
@@ -217,7 +217,7 @@ codeunit 8951 "AFS File Client Impl."
         NodeList := AFSHelperLibrary.CreateHandleNodeListFromResponse(ResponseText);
         AFSHelperLibrary.HandleNodeListToTempRecord(NodeList, AFSHandle);
 
-        if AFSOperationResponse.IsSuccessful() then begin
+        if AFSOperationResponse.IsSuccessful() and (AFSHandle."Entry No." <> 0) then begin
             AFSHandle."Next Marker" := CopyStr(AFSHelperLibrary.GetNextMarkerFromResponse(ResponseText), 1, MaxStrLen(AFSHandle."Next Marker"));
             AFSHandle.Modify();
         end;


### PR DESCRIPTION
if NodeList is empty no temprecords are beiing inserted and an error will occur because of the modify on an not inserted temprecord

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #1409

Fixes [AB#540616](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/540616)

