### PR TITLE
Scheduled Profiler - Add event subscriber to link help page with schedules + profiling status on the schedules page

### DIFF
--- a/src/System Application/App/Performance Profiler/src/PerfProfilerSchedulesList.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerSchedulesList.Page.al
@@ -28,35 +28,35 @@ page 1933 "Perf. Profiler Schedules List"
         {
             group("Profiling Status")
             {
-                Caption = 'Profiling Status';
                 AboutTitle = 'Profiling Status';
-                AboutText = 'See if profiling is enabled for the current user session.';
+                AboutText = 'Specifies if profiling is enabled for the current user session.';
+                Caption = 'Profiling Status';
 
                 field("Profiling Enabled"; IsProfilingEnabled)
                 {
+                    AboutText = 'Specifies if profiling is enabled for the current user session.';
                     Caption = 'Profiling Enabled';
-                    ToolTip = 'Shows if profiling is enabled for the current user session.';
-                    AboutText = 'Shows if profiling is enabled for the current user session.';
                     Editable = false;
+                    ToolTip = 'Specifies if profiling is enabled for the current user session.';
                 }
 
                 field("Active Schedule ID"; ActiveScheduleId)
                 {
-                    Caption = 'Active Schedule ID';
-                    ToolTip = 'Shows the ID of the active schedule.';
                     AboutText = 'The ID of the active schedule.';
+                    Caption = 'Active Schedule ID';
                     Editable = false;
                     DrillDown = true;
+                    ToolTip = 'Specifies the ID of the active schedule.';
 
                     trigger OnDrillDown()
                     var
                         PerformanceProfileScheduler: Record "Performance Profile Scheduler";
                         ScheduleCardPage: Page "Perf. Profiler Schedule Card";
                     begin
-                        if (IsNullGuid(ActiveScheduleId)) then
+                        if IsNullGuid(ActiveScheduleId) then
                             exit;
 
-                        if (not PerformanceProfileScheduler.Get(ActiveScheduleId)) then
+                        if not PerformanceProfileScheduler.Get(ActiveScheduleId) then
                             exit;
 
                         ScheduleCardPage.SetRecord(PerformanceProfileScheduler);

--- a/src/System Application/App/Performance Profiler/src/PerfProfilerSchedulesList.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerSchedulesList.Page.al
@@ -26,8 +26,50 @@ page 1933 "Perf. Profiler Schedules List"
     {
         area(Content)
         {
-            repeater(Profiles)
+            group("Profiling Status")
             {
+                Caption = 'Profiling Status';
+                AboutTitle = 'Profiling Status';
+                AboutText = 'See if profiling is enabled for the current user session.';
+
+                field("Profiling Enabled"; IsProfilingEnabled)
+                {
+                    Caption = 'Profiling Enabled';
+                    ToolTip = 'Shows if profiling is enabled for the current user session.';
+                    AboutText = 'Shows if profiling is enabled for the current user session.';
+                    Editable = false;
+                }
+
+                field("Active Schedule ID"; ActiveScheduleId)
+                {
+                    Caption = 'Active Schedule ID';
+                    ToolTip = 'Shows the ID of the active schedule.';
+                    AboutText = 'The ID of the active schedule.';
+                    Editable = false;
+                    DrillDown = true;
+
+                    trigger OnDrillDown()
+                    var
+                        ScheduleCardPage: Page "Perf. Profiler Schedule Card";
+                        PerformanceProfileScheduler: Record "Performance Profile Scheduler";
+                    begin
+                        if (IsNullGuid(ActiveScheduleId)) then
+                            exit;
+
+                        if (not PerformanceProfileScheduler.Get(ActiveScheduleId)) then
+                            exit;
+
+                        ScheduleCardPage.SetRecord(PerformanceProfileScheduler);
+                        ScheduleCardPage.Run();
+                    end;
+                }
+            }
+
+            repeater(ProfilerSchedules)
+            {
+                AboutTitle = 'The list of profiler schedules';
+                AboutText = 'See the existing profiler schedules.';
+
                 field("Schedule ID"; Rec."Schedule ID")
                 {
                     Caption = 'Schedule ID';
@@ -38,8 +80,8 @@ page 1933 "Perf. Profiler Schedules List"
                 field(Enabled; Rec.Enabled)
                 {
                     Caption = 'Enabled';
-                    ToolTip = 'Specifies whether the schedule is enabled.';
-                    AboutText = 'Specifies whether the schedule is enabled.';
+                    ToolTip = 'Specifies if the schedule is enabled.';
+                    AboutText = 'Specifies if the schedule is enabled.';
                 }
                 field("Start Time"; Rec."Starting Date-Time")
                 {
@@ -112,6 +154,7 @@ page 1933 "Perf. Profiler Schedules List"
     trigger OnOpenPage()
     begin
         ScheduledPerfProfiler.FilterUsers(Rec, UserSecurityId());
+        IsProfilingEnabled := ScheduledPerfProfiler.IsProfilingEnabled(ActiveScheduleId);
     end;
 
     trigger OnAfterGetRecord()
@@ -136,4 +179,6 @@ page 1933 "Perf. Profiler Schedules List"
         ScheduledPerfProfiler: Codeunit "Scheduled Perf. Profiler";
         UserName: Text;
         Activity: Enum "Perf. Profile Activity Type";
+        ActiveScheduleId: Guid;
+        IsProfilingEnabled: Boolean;
 }

--- a/src/System Application/App/Performance Profiler/src/PerfProfilerSchedulesList.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerSchedulesList.Page.al
@@ -67,9 +67,6 @@ page 1933 "Perf. Profiler Schedules List"
 
             repeater(ProfilerSchedules)
             {
-                AboutTitle = 'The list of profiler schedules';
-                AboutText = 'See the existing profiler schedules.';
-
                 field("Schedule ID"; Rec."Schedule ID")
                 {
                     Caption = 'Schedule ID';

--- a/src/System Application/App/Performance Profiler/src/PerfProfilerSchedulesList.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerSchedulesList.Page.al
@@ -50,8 +50,8 @@ page 1933 "Perf. Profiler Schedules List"
 
                     trigger OnDrillDown()
                     var
-                        ScheduleCardPage: Page "Perf. Profiler Schedule Card";
                         PerformanceProfileScheduler: Record "Performance Profile Scheduler";
+                        ScheduleCardPage: Page "Perf. Profiler Schedule Card";
                     begin
                         if (IsNullGuid(ActiveScheduleId)) then
                             exit;

--- a/src/System Application/App/Performance Profiler/src/PerformanceProfileList.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerformanceProfileList.Page.al
@@ -31,11 +31,13 @@ page 1931 "Performance Profile List"
                 {
                     Caption = 'Start Time';
                     ToolTip = 'Specifies the time the profile was started.';
+                    AboutText = 'The time the profile was started.';
                 }
                 field("User Name"; Rec."User Name")
                 {
                     Caption = 'User Name';
                     ToolTip = 'Specifies the name of the user that was profiled.';
+                    AboutText = 'The username of the user that was profiled.';
                 }
                 field(Activity; ActivityType)
                 {
@@ -47,36 +49,43 @@ page 1931 "Performance Profile List"
                 {
                     Caption = 'Activity Description';
                     ToolTip = 'Specifies a short description of the activity that was profiled.';
+                    AboutText = 'A description of the activity that was profiled.';
                 }
                 field("Object Display Name"; Rec."Object Display Name")
                 {
                     Caption = 'Object';
                     ToolTip = 'Specifies the object that contains the entry point for this profile.';
+                    AboutText = 'The object that contains the entry point for this profile.';
                 }
                 field(Duration; Rec.Duration)
                 {
                     Caption = 'Activity Duration';
                     ToolTip = 'Specifies the duration of the activity that was profiled in milliseconds.';
+                    AboutText = 'The duration of the activity that was profiled.';
                 }
                 field("Http Call Duration"; Rec."Http Call Duration")
                 {
                     Caption = 'Duration of Http Calls';
                     ToolTip = 'Specifies the duration of the http calls during the activity that was profiled in milliseconds.';
+                    AboutText = 'The duration of external http calls during the activity that was profiled.';
                 }
                 field("Http Call Number"; Rec."Http Call Number")
                 {
                     Caption = 'Number of Http Calls';
                     ToolTip = 'Specifies the number of http calls during the activity that was profiled.';
+                    AboutText = 'The number of external http calls during the activity that was profiled.';
                 }
                 field("Client Session ID"; Rec."Client Session ID")
                 {
                     Caption = 'Client Session ID';
                     ToolTip = 'Specifies the ID of the client session that was profiled.';
+                    AboutText = 'The ID of the client session that was profiled.';
                 }
                 field("Schedule ID"; Rec."Schedule ID")
                 {
                     Caption = 'Schedule ID';
                     ToolTip = 'Specifies the ID of the schedule that was used to profile the activity.';
+                    AboutText = 'The ID of the schedule that was used to profile the activity.';
                     TableRelation = "Performance Profile Scheduler"."Schedule ID";
                     DrillDown = true;
 

--- a/src/System Application/App/Performance Profiler/src/ScheduledPerfProfiler.Codeunit.al
+++ b/src/System Application/App/Performance Profiler/src/ScheduledPerfProfiler.Codeunit.al
@@ -123,4 +123,14 @@ codeunit 1931 "Scheduled Perf. Profiler"
     begin
         ScheduledPerfProfilerImpl.ValidateThreshold(PerformanceProfileScheduler);
     end;
+
+    /// <summary>
+    /// Returns true if profiling is enabled for the session.
+    /// </summary>
+    /// <param name="ScheduleID">The schedule ID that triggers the profiling.</param>
+    /// <returns>True if profiling is enabled, false otherwise.</returns>
+    procedure IsProfilingEnabled(var ScheduleID: Guid): Boolean
+    begin
+        exit(ScheduledPerfProfilerImpl.IsProfilingEnabled(ScheduleID));
+    end;
 }

--- a/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
+++ b/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
@@ -10,7 +10,6 @@ using System.DataAdministration;
 using System.Security.AccessControl;
 using System.Security.User;
 using System.Environment;
-using System.Environment.Configuration;
 
 codeunit 1932 "Scheduled Perf. Profiler Impl."
 {

--- a/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
+++ b/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
@@ -216,9 +216,5 @@ codeunit 1932 "Scheduled Perf. Profiler Impl."
         ProfileCannotBeInThePastErr: Label 'A schedule cannot be set to run in the past.';
         ScheduleDurationCannotExceedRetentionPeriodErr: Label 'The performance profile schedule duration cannot exceed the retention period.';
         ScheduleEndTimeCannotBeEmptyErr: Label 'The performance profile schedule must have an end time.';
-        ScheduleCouldNotBeFoundErr: Label 'The performance profile schedule could not be found.';
-        SessionIsBeingProfiledTxt: Label 'Performance analysis is enabled for this session. You may experience some performance degradation.';
-        ScheduleIdKeyTxt: Label 'Schedule ID';
-        ViewScheduleTxt: Label 'View performance profile schedule';
 
 }

--- a/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
+++ b/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
@@ -216,5 +216,4 @@ codeunit 1932 "Scheduled Perf. Profiler Impl."
         ProfileCannotBeInThePastErr: Label 'A schedule cannot be set to run in the past.';
         ScheduleDurationCannotExceedRetentionPeriodErr: Label 'The performance profile schedule duration cannot exceed the retention period.';
         ScheduleEndTimeCannotBeEmptyErr: Label 'The performance profile schedule must have an end time.';
-
 }

--- a/src/System Application/App/Performance Profiler/src/dotnet.al
+++ b/src/System Application/App/Performance Profiler/src/dotnet.al
@@ -21,5 +21,11 @@ dotnet
         type("Microsoft.Dynamics.Nav.Runtime.Debugger.ProfilerSamplingInterval"; "ProfilerSamplingInterval")
         {
         }
+        type("Microsoft.Dynamics.Nav.Runtime.Debugger.ALProfilerHelper"; ProfilerHelper)
+        {
+        }
+        type("Microsoft.Dynamics.Nav.Runtime.Debugger.ALPerformanceProfileSchedulerRecord"; PerformanceProfileSchedulerRecord)
+        {
+        }
     }
 }


### PR DESCRIPTION
#### Summary
This PR adds two features:
1) It adds an event subscriber to link the new help page link with the profiler schedules page
2) It adds a new group to show the scheduled profiling status on the schedules page. This new group contains information about if profiling is active for the current session and shows the active schedule.

#### Work Item(s)
Fixes [AB#501774](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/501774)













