### PR TITLE
[releases/24.1] fixes an issue where a subscriber can no longer change the result from GetNextNo or PeekNextNo. The fix is for obsolete code only.

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
@@ -869,7 +869,7 @@ codeunit 396 NoSeriesManagement
     end;
 
     [Obsolete('This is a temporary method for compatibility only. Please use the "No. Series" codeunit instead', '24.0')]
-    internal procedure RaiseObsoleteOnAfterGetNextNo3(NoSeriesLine: Record "No. Series Line"; ModifySeries: Boolean)
+    internal procedure RaiseObsoleteOnAfterGetNextNo3(var NoSeriesLine: Record "No. Series Line"; ModifySeries: Boolean)
     begin
         OnAfterGetNextNo3(NoSeriesLine, ModifySeries);
     end;

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
@@ -133,8 +133,10 @@ codeunit 304 "No. Series - Impl."
 #if not CLEAN24
 #pragma warning disable AL0432, AA0205
         Result := NoSeriesSingle.GetNextNo(NoSeriesLine, UsageDate, HideErrorsAndWarnings);
+        if Result <> NoSeriesLine."Last No. Used" then
+            NoSeriesLine."Last No. Used" := Result;
         NoSeriesManagement.RaiseObsoleteOnAfterGetNextNo3(NoSeriesLine, true);
-        exit(Result);
+        exit(NoSeriesLine."Last No. Used");
 #pragma warning restore AL0432, AA0205
 #else
         exit(NoSeriesSingle.GetNextNo(NoSeriesLine, UsageDate, HideErrorsAndWarnings))
@@ -281,8 +283,10 @@ codeunit 304 "No. Series - Impl."
 #if not CLEAN24
 #pragma warning disable AL0432, AA0205
         Result := NoSeriesSingle.PeekNextNo(NoSeriesLine, UsageDate);
+        if Result <> NoSeriesLine."Last No. Used" then
+            NoSeriesLine."Last No. Used" := Result;
         NoSeriesManagement.RaiseObsoleteOnAfterGetNextNo3(NoSeriesLine, false);
-        exit(Result);
+        exit(NoSeriesLine."Last No. Used");
 #pragma warning restore AL0432, AA0205
 #else
         exit(NoSeriesSingle.PeekNextNo(NoSeriesLine, UsageDate));


### PR DESCRIPTION
This pull request backports #1446 to releases/24.1

Fixes [AB#540014](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/540014)

