### PR TITLE
Install AL Extension included in container

### DIFF
--- a/build/scripts/DevEnv/NewDevEnv.ps1
+++ b/build/scripts/DevEnv/NewDevEnv.ps1
@@ -91,6 +91,7 @@ try {
     {
         Write-Host "Configuring vscode for development against the container..."
         Configure-ALProjectsInPath -ContainerName $ContainerName -Authentication $Authentication
+        Install-ALExtension -ContainerName $ContainerName
     }
 }
 finally {

--- a/build/scripts/DevEnv/NewDevEnv.psm1
+++ b/build/scripts/DevEnv/NewDevEnv.psm1
@@ -410,7 +410,7 @@ function Install-ALExtension([string] $ContainerName, [switch] $Force) {
 
     $vsixPath = Get-ChildItem "$($bcContainerHelperConfig.containerHelperFolder)\Extensions\$ContainerName\*.vsix" | Select-Object -ExpandProperty FullName
     if ($Force) {
-        code --install-extension $vsixPath --force 
+        code --install-extension $vsixPath --force
     } else {
         code --install-extension $vsixPath
     }

--- a/build/scripts/DevEnv/NewDevEnv.psm1
+++ b/build/scripts/DevEnv/NewDevEnv.psm1
@@ -394,8 +394,11 @@ function Get-CredentialForContainer($AuthenticationType) {
 
     .Parameter ContainerName
     The name of the container for which to install the extension.
+
+    .Parameter Force
+    If specified, the extension will be installed even there is a newer version already installed.
 #>
-function Install-ALExtension($ContainerName) {
+function Install-ALExtension([string] $ContainerName, [switch] $Force) {
     if (-not (Get-Command code -ErrorAction SilentlyContinue)) {
         Write-Host "VSCode is not installed or 'code' is not in the PATH. See https://code.visualstudio.com/docs/setup/windows for installation instructions." -ForegroundColor Red
         return
@@ -406,8 +409,11 @@ function Install-ALExtension($ContainerName) {
     Stop-Process -Name code -Force -ErrorAction SilentlyContinue
 
     $vsixPath = Get-ChildItem "$($bcContainerHelperConfig.containerHelperFolder)\Extensions\$ContainerName\*.vsix" | Select-Object -ExpandProperty FullName
-    Write-Host "code --install-extension $vsixPath --force"
-    code --install-extension $vsixPath --force
+    if ($Force) {
+        code --install-extension $vsixPath --force 
+    } else {
+        code --install-extension $vsixPath
+    }
     Write-Host "VSCode extension installed." -ForegroundColor Magenta
 }
 

--- a/build/scripts/DevEnv/NewDevEnv.psm1
+++ b/build/scripts/DevEnv/NewDevEnv.psm1
@@ -388,6 +388,13 @@ function Get-CredentialForContainer($AuthenticationType) {
     }
 }
 
+<#
+    .Synopsis
+    Installs the AL extension in VSCode.
+
+    .Parameter ContainerName
+    The name of the container for which to install the extension.
+#>
 function Install-ALExtension($ContainerName) {
     if (-not (Get-Command code -ErrorAction SilentlyContinue)) {
         Write-Host "VSCode is not installed or 'code' is not in the PATH. See https://code.visualstudio.com/docs/setup/windows for installation instructions." -ForegroundColor Red
@@ -401,7 +408,7 @@ function Install-ALExtension($ContainerName) {
     $vsixPath = Get-ChildItem "$($bcContainerHelperConfig.containerHelperFolder)\Extensions\$ContainerName\*.vsix" | Select-Object -ExpandProperty FullName
     Write-Host "code --install-extension $vsixPath --force"
     code --install-extension $vsixPath --force
-    Write-Host "VSCode extension installed." -ForegroundColor Magenta  
+    Write-Host "VSCode extension installed." -ForegroundColor Magenta
 }
 
 Export-ModuleMember -Function Create-BCContainer

--- a/build/scripts/DevEnv/NewDevEnv.psm1
+++ b/build/scripts/DevEnv/NewDevEnv.psm1
@@ -388,9 +388,26 @@ function Get-CredentialForContainer($AuthenticationType) {
     }
 }
 
+function Install-ALExtension($ContainerName) {
+    if (-not (Get-Command code -ErrorAction SilentlyContinue)) {
+        Write-Host "VSCode is not installed or 'code' is not in the PATH. See https://code.visualstudio.com/docs/setup/windows for installation instructions." -ForegroundColor Red
+        return
+    }
+
+    Write-Host "Installing VSCode extension..." -ForegroundColor Magenta
+    # Kill VSCode to avoid issues with the extension installation
+    Stop-Process -Name code -Force -ErrorAction SilentlyContinue
+
+    $vsixPath = Get-ChildItem "$($bcContainerHelperConfig.containerHelperFolder)\Extensions\$ContainerName\*.vsix" | Select-Object -ExpandProperty FullName
+    Write-Host "code --install-extension $vsixPath --force"
+    code --install-extension $vsixPath --force
+    Write-Host "VSCode extension installed." -ForegroundColor Magenta  
+}
+
 Export-ModuleMember -Function Create-BCContainer
 Export-ModuleMember -Function Resolve-ProjectPaths
 Export-ModuleMember -Function Build-Apps
 Export-ModuleMember -Function Publish-Apps
 Export-ModuleMember -Function Test-ContainerExists
 Export-ModuleMember -Function Get-CredentialForContainer
+Export-ModuleMember -Function Install-ALExtension


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
**Problem** 
Sometimes we roll out new compiler features and start using them in BCApps before they're released through VS Code Marketplace. Therefore, right now you will get the following error with the latest VS Code extension and latest BCApps source code:
`error AL0132: 'NavApp' does not contain a definition for 'GetCallerCallstackModuleInfos'`

**Solution**
Install AL Extension included in container. 

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#521408](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/521408)






