### PR TITLE
Fix empty No Series code in GetNoSeriesLine

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesSetupImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesSetupImpl.Codeunit.al
@@ -116,8 +116,10 @@ codeunit 305 "No. Series - Setup Impl."
             NoSeriesLine.SetRange("Series Code", NoSeriesRec.Code);
         end;
 
-        if not NoSeriesLine.FindFirst() then
+        if not NoSeriesLine.FindFirst() then begin
             NoSeriesLine.Init();
+            NoSeriesLine."Series Code" := NoSeriesRec.Code;
+        end;
 
         if ResetForDrillDown then begin
             NoSeriesLine.SetRange("Starting Date");

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeries.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeries.Codeunit.al
@@ -317,6 +317,7 @@ codeunit 310 "No. Series"
     /// <param name="NoSeriesCode">The No. Series code to lookup.</param>
     /// <param name="UsageDate">The date of retrieval, this will influence which line is used.</param>
     /// <param name="HideErrorsAndWarnings">Whether errors should be ignored.</param>
+    /// <remarks>NoSeriesCode must not be empty.</remarks>
     /// <returns>True if the No. Series line was found, false otherwise.</returns>
     procedure GetNoSeriesLine(var NoSeriesLine: Record "No. Series Line"; NoSeriesCode: Code[20]; UsageDate: Date; HideErrorsAndWarnings: Boolean): Boolean
     var

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
@@ -84,9 +84,6 @@ codeunit 304 "No. Series - Impl."
         NoSeriesLine: Record "No. Series Line";
         NoSeriesSingle: Interface "No. Series - Single";
     begin
-        if NoSeriesCode = '' then
-            exit('');
-
         if not GetNoSeriesLine(NoSeriesLine, NoSeriesCode, WorkDate(), true) then
             exit('');
 

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
@@ -22,6 +22,7 @@ codeunit 304 "No. Series - Impl."
         CannotAssignAutomaticallyErr: Label 'It is not possible to assign numbers automatically. If you want the program to assign numbers automatically, please activate %1 in %2 %3.', Comment = '%1=Default Nos. setting,%2=No. Series table caption,%3=No. Series Code';
         SeriesNotRelatedErr: Label 'The number series %1 is not related to %2.', Comment = '%1=No. Series Code,%2=No. Series Code';
         PostErr: Label 'You have one or more documents that must be posted before you post document no. %1 according to your company''s No. Series setup.', Comment = '%1=Document No.';
+        CannotGetNoSeriesLineNoWithEmtpyCodeErr: Label 'Argument NoSeriesCode in GetNoSeriesLine cannot be blank.';
 
 #if not CLEAN24
 #pragma warning disable AL0432
@@ -83,6 +84,9 @@ codeunit 304 "No. Series - Impl."
         NoSeriesLine: Record "No. Series Line";
         NoSeriesSingle: Interface "No. Series - Single";
     begin
+        if NoSeriesCode = '' then
+            exit('');
+
         if not GetNoSeriesLine(NoSeriesLine, NoSeriesCode, WorkDate(), true) then
             exit('');
 
@@ -162,6 +166,12 @@ codeunit 304 "No. Series - Impl."
 #endif
         LineFound: Boolean;
     begin
+        if NoSeriesCode = '' then begin
+            if not HideErrorsAndWarnings then
+                Error(CannotGetNoSeriesLineNoWithEmtpyCodeErr);
+            exit(false);
+        end;
+
         if UsageDate = 0D then
             UsageDate := WorkDate();
 

--- a/src/Business Foundation/Test/NoSeries/src/NoSeriesTests.Codeunit.al
+++ b/src/Business Foundation/Test/NoSeries/src/NoSeriesTests.Codeunit.al
@@ -957,28 +957,6 @@ codeunit 134530 "No. Series Tests"
         Assert.AreEqual('', NoSeries.GetLastNoUsed(''), 'GetLastNoUsed should return empty code if argument supplied is empty code');
     end;
 
-#if not CLEAN24
-    [Test]
-    [Obsolete('Obsoleted test to verify behavior in legacy code for No. Series.', '24.0')]
-    procedure TestNoSeriesEmptyCodeInLineLegacy()
-    var
-        NoSeriesLine: Record "No. Series Line";
-        Assert: Codeunit "Library Assert";
-        NoSeries: Codeunit "No. Series";
-        NoSeriesMgt: Codeunit NoSeriesManagement;
-        PermissionsMock: Codeunit "Permissions Mock";
-    begin
-        // [Scenario 540058] No series exists without any lines. No Series line exists with empty code.
-        // Test to verify legacy behavior for GetNoSeriesLine eqv. in NoSeriesManagement
-
-        Initialize();
-        PermissionsMock.Set('No. Series - Admin');
-
-        NoSeriesMgt.SetNoSeriesLineFilter(NoSeriesLine, '', WorkDate());
-        Assert.AreEqual('', NoSeriesLine."Series Code", 'SetNoSeriesLineFilter should not find anything for empty Series Code.');
-    end;
-#endif
-
     local procedure Initialize()
     begin
         Any.SetDefaultSeed();

--- a/src/Business Foundation/Test/NoSeries/src/NoSeriesTests.Codeunit.al
+++ b/src/Business Foundation/Test/NoSeries/src/NoSeriesTests.Codeunit.al
@@ -957,6 +957,28 @@ codeunit 134530 "No. Series Tests"
         Assert.AreEqual('', NoSeries.GetLastNoUsed(''), 'GetLastNoUsed should return empty code if argument supplied is empty code');
     end;
 
+#if not CLEAN24
+    [Test]
+    [Obsolete('Obsoleted test to verify behavior in legacy code for No. Series.', '24.0')]
+    procedure TestNoSeriesEmptyCodeInLineLegacy()
+    var
+        NoSeriesLine: Record "No. Series Line";
+        Assert: Codeunit "Library Assert";
+        NoSeries: Codeunit "No. Series";
+        NoSeriesMgt: Codeunit NoSeriesManagement;
+        PermissionsMock: Codeunit "Permissions Mock";
+    begin
+        // [Scenario 540058] No series exists without any lines. No Series line exists with empty code.
+        // Test to verify legacy behavior for GetNoSeriesLine eqv. in NoSeriesManagement
+
+        Initialize();
+        PermissionsMock.Set('No. Series - Admin');
+
+        NoSeriesMgt.SetNoSeriesLineFilter(NoSeriesLine, '', WorkDate());
+        Assert.AreEqual('', NoSeriesLine."Series Code", 'SetNoSeriesLineFilter should not find anything for empty Series Code.');
+    end;
+#endif
+
     local procedure Initialize()
     begin
         Any.SetDefaultSeed();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

Issue happens when we have a combination of No Series that does not have a No Series Line. 
And also have an No Series Line with empty "Series Code".

When No Series dont have a No Series Line, it is empty initialized. 
Then the code to GetNoSeries will do a findlast that will find that No Series Line with empty code. And then because logic says it found the line, it will try and do a Get later, which then fails.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#540058](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/540058)







