### PR TITLE
[releases/24.1] Update AL-Go System Files from microsoft/AL-Go-PTE@preview -  0aab342a0ddd80612fafbc5149c8e95b3476b12a

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -73,5 +73,5 @@
     ]
   },
   "UpdateALGoSystemFilesEnvironment": "Official-Build",
-  "templateSha": "4acdc62744cd82c1e8a15695b54a91e59e3d3d7c"
+  "templateSha": "0aab342a0ddd80612fafbc5149c8e95b3476b12a"
 }

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -1,19 +1,170 @@
-## Preview
+## preview
 
 Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.
 
+### Issues
+
+- Issue 1105 Increment Version Number - repoVersion in .github/AL-Go-Settings.json is not updated
+- Issue 1073 Publish to AppSource - Automated validation: failure
+- Issue 980 Allow Scope to be PTE in continuousDeployment for PTE extensions in Sandbox (enhancement request)
+- Issue 1079 AppSource App deployment failes with PerTenantExtensionCop Error PTE0001 and PTE0002
+- Issue 866 Accessing GitHub Environment Variables in DeployToCustom Scenarios for PowerShell Scripts
+- Issue 1083 SyncMode for custom deployments?
+- Issue 1109 Why filter deployment settings?
+- Fix issue with github ref when running reusable workflows
+- Issue 1098 Support for specifying the name of the AZURE_CREDENTIALS secret by adding a AZURE_CREDENTIALSSecretName setting
+
+### Dependencies to PowerShell modules
+
+AL-Go for GitHub relies on specific PowerShell modules, and the minimum versions required for these modules are tracked in [Packages.json](https://raw.githubusercontent.com/microsoft/AL-Go/main/Actions/Packages.json) file. Should the installed modules on the GitHub runner not meet these minimum requirements, the necessary modules will be installed as needed.
+
+### Support managed identities and federated credentials
+
+All authentication context secrets now supports managed identities and federated credentials. See more [here](Scenarios/secrets.md). Furthermore, you can now use https://aka.ms/algosecrets#authcontext to learn more about the formatting of that secret.
+
+### Business Central Performance Toolkit Test Result Viewer
+
+In the summary after a Test Run, you now also have the result of performance tests.
+
 ### New Settings
+
+- `deployTo<environmentName>`: is not really new, but has a new property:
+
+  - **Scope** = specifies the scope of the deployment: Dev, PTE. If not specified, AL-Go for GitHub will always use the Dev Scope for AppSource Apps, but also for PTEs when deploying to sandbox environments when impersonation (refreshtoken) is used for authentication.
+  - **\<custom>** = custom properties are now supported and will be transferred to a custom deployment script in the hashtable.
+
+- `bcptThresholds` is a JSON object with properties for the default thresholds for the Business Central Performance Toolkit
+
+  - **DurationWarning** - a warning is issued if the duration of a bcpt test degrades more than this percentage (default 10)
+  - **DurationError** - an error is issued if the duration of a bcpt test degrades more than this percentage (default 25)
+  - **NumberOfSqlStmtsWarning** - a warning is issued if the number of SQL statements from a bcpt test increases more than this percentage (default 5)
+  - **NumberOfSqlStmtsError** - an error is issued if the number of SQL statements from a bcpt test increases more than this percentage (default 10)
+
+> \[!NOTE\]
+> Duration thresholds are subject to varying results depending on the performance of the agent running the tests. Number of SQL statements executed by a test is often the most reliable indicator of performance degredation.
+
+## v5.2
+
+### Issues
+
+- Issue 1084 Automatic updates for AL-Go are failing when main branch requires Pull Request
+
+### New Settings
+
+- `PowerPlatformSolutionFolder`: Contains the name of the folder containing a PowerPlatform Solution (only one)
+- `DeployTo<environment>` now has two additional properties `companyId` is the Company Id from Business Central (for PowerPlatform connection) and `ppEnvironmentUrl` is the Url of the PowerPlatform environment to deploy to.
+
+### New Actions
+
+- `BuildPowerPlatform`: to build a PowerPlatform Solution
+- `DeployPowerPlatform`: to deploy a PowerPlatform Solution
+- `PullPowerPlatformChanges`: to pull changes made in PowerPlatform studio into the repository
+- `ReadPowerPlatformSettings`: to read settings and secrets for PowerPlatform deployment
+- `GetArtifactsForDeployment`: originally code from deploy.ps1 to retrieve artifacts for releases or builds - now as an action to read apps into a folder.
+
+### New Workflows
+
+- **Pull PowerPlatform Changes** for pulling changes from your PowerPlatform development environment into your AL-Go for GitHub repository
+- **Push PowerPlatform Changes** for pushing changes from your AL-Go for GitHub repository to your PowerPlatform development environment
+
+> \[!NOTE\]
+> PowerPlatform workflows are only available in the PTE template and will be removed if no PowerPlatformSolutionFolder is defined in settings.
+
+### New Scenarios (Documentation)
+
+- [Connect your GitHub repository to Power Platform](https://github.com/microsoft/AL-Go/blob/main/Scenarios/SetupPowerPlatform.md)
+- [How to set up Service Principal for Power Platform](https://github.com/microsoft/AL-Go/blob/main/Scenarios/SetupServicePrincipalForPowerPlatform.md)
+- [Try one of the Business Central and Power Platform samples](https://github.com/microsoft/AL-Go/blob/main/Scenarios/TryPowerPlatformSamples.md)
+- [Publish To AppSource](https://github.com/microsoft/AL-Go/blob/main/Scenarios/PublishToAppSource.md)
+
+> \[!NOTE\]
+> PowerPlatform functionality are only available in the PTE template.
+
+## v5.1
+
+### Issues
+
+- Issue 1019 CI/CD Workflow still being scheduled after it was disabled
+- Issue 1021 Error during Create Online Development Environment action
+- Issue 1022 Error querying artifacts: No such host is known. (bcartifacts-exdbf9fwegejdqak.blob.core.windows.net:443)
+- Issue 922 Deploy Reference Documentation (ALDoc) failed with custom
+- ContainerName used during build was invalid if project names contained special characters
+- Issue 1009 by adding a includeDependencies property in DeliverToAppSource
+- Issue 997 'Deliver to AppSource' action fails for projects containing a space
+- Issue 987 Resource not accessible by integration when creating release from specific version
+- Issue 979 Publish to AppSource Documentation
+- Issue 1018 Artifact setting - possibility to read version from app.json
+- Issue 1008 Allow PullRequestHandler to use ubuntu or self hosted runners for all jobs except for pregateCheck
+- Issue 962 Finer control of "shell"-property
+- Issue 1041 Harden the version comparison when incrementing version number
+- Issue 1042 Downloading artifacts from GitHub doesn't work with branch names which include forward slashes
+
+### Better artifact selection
+
+The artifact setting in your project settings file can now contain a `*` instead of the version number. This means that AL-Go for GitHub will determine the application dependency for your projects together with the `applicationDependency` setting and determine which Business Central version is needed for the project.
+
+- `"artifact": "//*//latest"` will give you the latest Business Central version, higher than your application dependency and with the same major.minor as your application dependency.
+- `"artifact": "//*//first"` will give you the first Business Central version, higher than your application dependency and with the same major.minor as your application dependency.
+
+### New Settings
+
+- `deliverToAppSource`: a JSON object containing the following properties
+  - **productId** must be the product Id from partner Center.
+  - **mainAppFolder** specifies the appFolder of the main app if you have multiple apps in the same project.
+  - **continuousDelivery** can be set to true to enable continuous delivery of every successful build to AppSource Validation. Note that the app will only be in preview in AppSource and you will need to manually press GO LIVE in order for the app to be promoted to production.
+  - **includeDependencies** can be set to an array of file names (incl. wildcards) which are the names of the dependencies to include in the AppSource submission. Note that you need to set `generateDependencyArtifact` in the project settings file to true in order to include dependencies.
+- Add `shell` as a property under `DeployTo` structure
+
+### Deprecated Settings
+
+- `appSourceContinuousDelivery` is moved to the `deliverToAppSource` structure
+- `appSourceMainAppFolder` is moved to the `deliverToAppSource` structure
+- `appSourceProductId` is moved to the `deliverToAppSource` structure
+
+### New parameter -clean on localdevenv and clouddevenv
+
+Adding -clean when running localdevenv or clouddevenv will create a clean development environment without compiling and publishing your apps.
+
+## v5.0
+
+### Issues
+
+- Issue 940 Publish to Environment is broken when specifying projects to publish
+- Issue 994 CI/CD ignores Deploy to GitHub Pages in private repositories
+
+### New Settings
+
+- `UpdateALGoSystemFilesEnvironment`: The name of the environment that is referenced in job `UpdateALGoSystemFiles` in the _Update AL-Go System Files_ workflow. See [jobs.\<job_id>.environment](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idenvironment) for more information. Currently, only setting the environment name is supported.
+
+### Issues
+
+- Support release branches that start with releases/
+- Issue 870 Improve Error Handling when CLI is missing
+- Issue 889 CreateRelease and IncrementVersionNumber workflow did not handle wild characters in `appFolders`, `testFolders` or `bcptTestFolders` settings.
+- Issue 973 Prerelease is not used for deployment
+
+### Build modes
+
+AL-Go ships with Default, Translated and Clean mode out of the box. Now you can also define custom build modes in addition to the ones shipped with AL-Go. This allows you to define your own build modes, which can be used to build your apps in different ways. By default, a custom build mode will build the apps similarly to the Default mode but this behavior can be overridden in e.g. script overrides in your repository.
+
+## v4.1
+
+### New Settings
+
 - `templateSha`: The SHA of the version of AL-Go currently used
 
 ### New Actions
+
 - `DumpWorkflowInfo`: Dump information about running workflow
 - `Troubleshooting` : Run troubleshooting for repository
 
 ### Update AL-Go System Files
+
 Add another parameter when running Update AL-Go System Files, called downloadLatest, used to indicate whether to download latest version from template repository. Default value is true.
 If false, the templateSha repository setting is used to download specific AL-Go System Files when calculating new files.
 
 ### Issues
+
 - Issue 782 Exclude '.altestrunner/' from template .gitignore
 - Issue 823 Dependencies from prior build jobs are not included when using useProjectDependencies
 - App artifacts for version 'latest' are now fetched from the latest CICD run that completed and successfully built all the projects for the corresponding branch.
@@ -33,13 +184,15 @@ If false, the templateSha repository setting is used to download specific AL-Go 
   - **footer** = Footer for the documentation site. (Default: Made with...)
   - **defaultIndexMD** = Markdown for the landing page of the documentation site. (Default: Reference documentation...)
   - **defaultReleaseMD** = Markdown for the landing page of the release sites. (Default: Release reference documentation...)
-  - *Note that in header, footer, defaultIndexMD and defaultReleaseMD you can use the following placeholders: {REPOSITORY}, {VERSION}, {INDEXTEMPLATERELATIVEPATH}, {RELEASENOTES}* 
+  - *Note that in header, footer, defaultIndexMD and defaultReleaseMD you can use the following placeholders: {REPOSITORY}, {VERSION}, {INDEXTEMPLATERELATIVEPATH}, {RELEASENOTES}*
 
 ### New Workflows
+
 - **Deploy Reference Documentation** is a workflow, which you can invoke manually or on a schedule to generate and deploy reference documentation using the aldoc tool, using the ALDoc setting properties described above.
 - **Troubleshooting** is a workflow, which you can invoke manually to run troubleshooting on the repository and check for settings or secrets, containing illegal values. When creating issues on https://github.com/microsoft/AL-Go/issues, we might ask you to run the troubleshooter to help identify common problems.
 
 ### Support for ALDoc reference documentation tool
+
 ALDoc reference documentation tool is now supported for generating and deploying reference documentation for your projects either continuously or manually/scheduled.
 
 ## v4.0
@@ -51,19 +204,22 @@ As of October 1st 2023, Business Central insider builds are now publicly availab
 AL-Go for GitHub allows you to build and test using insider builds without any explicit approval, but please note that the insider artifacts contains the insider Eula and you automatically accept this when using the builds.
 
 ### Issues
+
 - Issue 730 Support for external rulesets.
 - Issue 739 Workflow specific KeyVault settings doesn't work for localDevEnv
-- Using self-hosted runners while using Azure KeyVault for secrets or signing might fail with C:\Modules doesn't exist
+- Using self-hosted runners while using Azure KeyVault for secrets or signing might fail with C:\\Modules doesn't exist
 - PullRequestHandler wasn't triggered if only .md files where changes. This lead to PRs which couldn't be merged if a PR status check was mandatory.
 - Artifacts names for PR Builds were using the merge branch instead of the head branch.
 
 ### New Settings
+
 - `enableExternalRulesets`: set this setting to true if you want to allow AL-Go to automatically download external references in rulesets.
 - `deliverTo<deliveryTarget>`: is not really new, but has new properties and wasn't documented. The complete list of properties is here (note that some properties are deliveryTarget specific):
-  - **Branches** = an array of branch patterns, which are allowed to deliver to this deliveryTarget. (Default [ "main" ])
-  - **CreateContainerIfNotExist** = *[Only for DeliverToStorage]* Create Blob Storage Container if it doesn't already exist. (Default false)
+  - **Branches** = an array of branch patterns, which are allowed to deliver to this deliveryTarget. (Default \[ "main" \])
+  - **CreateContainerIfNotExist** = *\[Only for DeliverToStorage\]* Create Blob Storage Container if it doesn't already exist. (Default false)
 
 ### Deployment
+
 Environment URL is now displayed underneath the environment being deployed to in the build summary. For Custom Deployment, the script can set the GitHub Output variable `environmentUrl` in order to show a custom URL.
 
 ## v3.3
@@ -89,18 +245,20 @@ This mechanism is no longer supported and you will get an error if your reposito
 Earlier, you could also specify the projects you want to deploy to an environment in a setting called `<environmentName>_Projects` or `<environmentName>-Projects`. This is also no longer supported. Instead use the `DeployTo<environmentName>` and remove the old settings.
 
 ### New Actions
+
 - `DetermineDeliveryTargets`: Determine which delivery targets should be used for delivering artifacts from the build job.
 - `DetermineDeploymentEnvironments`: Determine which deployment environments should be used for the workflow.
 
 ### New Settings
+
 - `projectName`: project setting used as friendly name for an AL-Go project, to be used in the UI for various workflows, e.g. CICD, Pull Request Build.
 - `fullBuildPatterns`: used by `DetermineProjectsToBuild` action to specify changes in which files and folders would trigger a full build (building all AL-Go projects).
 - `excludeEnvironments`: used by `DetermineDeploymentEnvironments` action to exclude environments from the list of environments considered for deployment.
 - `deployTo<environmentName>`: is not really new, but has new properties. The complete list of properties is here:
   - **EnvironmentType** = specifies the type of environment. The environment type can be used to invoke a custom deployment. (Default SaaS)
   - **EnvironmentName** = specifies the "real" name of the environment if it differs from the GitHub environment
-  - **Branches** = an array of branch patterns, which are allowed to deploy to this environment. (Default [ "main" ])
-  - **Projects** = In multi-project repositories, this property can be a comma separated list of project patterns to deploy to this environment. (Default *)
+  - **Branches** = an array of branch patterns, which are allowed to deploy to this environment. (Default \[ "main" \])
+  - **Projects** = In multi-project repositories, this property can be a comma separated list of project patterns to deploy to this environment. (Default \*)
   - **SyncMode** = ForceSync if deployment to this environment should happen with ForceSync, else Add. If deploying to the development endpoint you can also specify Development or Clean. (Default Add)
   - **ContinuousDeployment** = true if this environment should be used for continuous deployment, else false. (Default: AL-Go will continuously deploy to sandbox environments or environments, which doesn't end in (PROD) or (FAT)
   - **runs-on** = specifies which GitHub runner to use when deploying to this environment. (Default is settings.runs-on)
@@ -127,6 +285,7 @@ By specifying a custom EnvironmentType in the DeployTo structure for an environm
 AL-Go for GitHub now adds status checks to Pull Requests Builds. In your GitHub branch protection rules, you can set up "Pull Request Status Check" to be a required status check to ensure Pull Request Builds succeed before merging.
 
 ### Secrets in AL-Go for GitHub
+
 In v3.2 of AL-Go for GitHub, all secrets requested by AL-Go for GitHub were available to all steps in a job one compressed JSON structure in env:Secrets.
 With this update, only the steps that actually requires secrets will have the secrets available.
 
@@ -147,6 +306,7 @@ Create Online Development environment workflow didn't work if runs-on was set to
 Special characters are not supported in RepoName, Project names or other settings - Use UTF8 encoding to handle special characters in GITHUB_OUTPUT and GITHUB_ENV
 
 ### Issue 555
+
 AL-Go contains several workflows, which create a Pull Request or pushes code directly.
 All (except Update AL-Go System Files) earlier used the GITHUB_TOKEN to create the PR or commit.
 The problem using GITHUB_TOKEN is that is doesn't trigger a pull request build or a commit build.
@@ -154,20 +314,23 @@ This is by design: https://docs.github.com/en/actions/using-workflows/triggering
 Now, you can set the checkbox called Use GhTokenWorkflow to allowing you to use the GhTokenWorkflow instead of the GITHUB_TOKEN - making sure that workflows are triggered
 
 ### New Settings
+
 - `keyVaultCodesignCertificateName`:  With this setting you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module
 - `PullRequestTrigger`:  With this setting you can set which trigger to use for Pull Request Builds. By default AL-Go will use pull_request_target.
 
 ### New Actions
+
 - `DownloadProjectDependencies`: Downloads the dependency apps for a given project and build mode.
 
 ### Settings and Secrets in AL-Go for GitHub
+
 In earlier versions of AL-Go for GitHub, all settings were available as individual environment variables to scripts and overrides, this is no longer the case.
 Settings were also available as one compressed JSON structure in env:Settings, this is still the case.
 Settings can no longer contain line breaks. It might have been possible to use line breaks earlier, but it would likely have unwanted consequences.
 Use `$settings = $ENV:Settings | ConvertFrom-Json` to get all settings in PowerShell.
 
 In earlier versions of AL-Go for GitHub, all secrets requested by AL-Go for GitHub were available as individual environment variables to scripts and overrides, this is no longer the case.
-As described in bug 647, all secrets available to the workflow were also available in env:_Secrets, this is no longer the case.
+As described in bug 647, all secrets available to the workflow were also available in env:\_Secrets, this is no longer the case.
 All requested secrets were also available (base64 encoded) as one compressed JSON structure in env:Secrets, this is still the case.
 Use `$secrets = $ENV:Secrets | ConvertFrom-Json` to get all requested secrets in PowerShell.
 You cannot get to any secrets that weren't requested by AL-Go for GitHub.
@@ -180,7 +343,6 @@ Issue #446 Wrong NewLine character in Release Notes
 Issue #453 DeliverToStorage - override fails reading secrets
 Issue #434 Use gh auth token to get authentication token instead of gh auth status
 Issue #501 The Create New App action will now use 22.0.0.0 as default application reference and include NoImplicitwith feature.
-
 
 ### New behavior
 
@@ -202,8 +364,8 @@ All these actions now uses the selected branch in the **Run workflow** dialog as
 
 ### New Workflows
 
-- **_BuildALGoProject** is a reusable workflow that unites the steps for building an AL-Go projects. It has been reused in the following workflows: _CI/CD_, _Pull Request Build_, _NextMinor_, _NextMajor_ and _Current_.
-The workflow appears under the _Actions_ tab in GitHub, but it is not actionable in any way.
+- **\_BuildALGoProject** is a reusable workflow that unites the steps for building an AL-Go projects. It has been reused in the following workflows: _CI/CD_, _Pull Request Build_, _NextMinor_, _NextMajor_ and _Current_.
+  The workflow appears under the _Actions_ tab in GitHub, but it is not actionable in any way.
 
 ### New Actions
 
@@ -217,29 +379,36 @@ Obviously, if you build and test your app for Business Central versions prior to
 ## v3.0
 
 ### **NOTE:** When upgrading to this version
+
 When upgrading to this version form earlier versions of AL-Go for GitHub, you will need to run the _Update AL-Go System Files_ workflow twice if you have the `useProjectDependencies` setting set to _true_.
 
 ### Publish to unknown environment
+
 You can now run the **Publish To Environment** workflow without creating the environment in GitHub or settings up-front, just by specifying the name of a single environment in the Environment Name when running the workflow.
 Subsequently, if an AuthContext secret hasn't been created for this environment, the Device Code flow authentication will be initiated from the Publish To Environment workflow and you can publish to the new environment without ever creating a secret.
 Open Workflow details to get the device Code for authentication in the job summary for the initialize job.
 
 ### Create Online Dev. Environment
+
 When running the **Create Online Dev. Environment** workflow without having the _adminCenterApiCredentials_ secret created, the workflow will intiate the deviceCode flow and allow you to authenticate to the Business Central Admin Center.
 Open Workflow details to get the device Code for authentication in the job summary for the initialize job.
 
 ### Issues
+
 - Issue #391 Create release action - CreateReleaseBranch error
 - Issue 434 Building local DevEnv, downloading dependencies: Authentication fails when using "gh auth status"
 
 ### Changes to Pull Request Process
+
 In v2.4 and earlier, the PullRequestHandler would trigger the CI/CD workflow to run the PR build.
 Now, the PullRequestHandler will perform the build and the CI/CD workflow is only run on push (or manual dispatch) and will perform a complete build.
 
 ### Build modes per project
+
 Build modes can now be specified per project
 
 ### New Actions
+
 - **DetermineProjectsToBuild** is used to determine which projects to build in PullRequestHandler, CI/CD, Current, NextMinor and NextMajor workflows.
 - **CalculateArtifactNames** is used to calculate artifact names in PullRequestHandler, CI/CD, Current, NextMinor and NextMajor workflows.
 - **VerifyPRChanges** is used to verify whether a PR contains changes, which are not allowed from a fork.
@@ -247,6 +416,7 @@ Build modes can now be specified per project
 ## v2.4
 
 ### Issues
+
 - Issue #171 create a workspace file when creating a project
 - Issue #356 Publish to AppSource fails in multi project repo
 - Issue #358 Publish To Environment Action stopped working in v2.3
@@ -256,9 +426,11 @@ Build modes can now be specified per project
 - Issue #376 CICD jobs that are triggered by the pull request trigger run directly to an error if title contains quotes
 
 ### Release Branches
+
 **NOTE:** Release Branches are now only named after major.minor if the patch value is 0 in the release tag (which must be semver compatible)
 
 This version contains a number of bug fixes to release branches, to ensure that the recommended branching strategy is fully supported. Bugs fixed includes:
+
 - Release branches was named after the full tag (1.0.0), even though subsequent hotfixes released from this branch would be 1.0.x
 - Release branches named 1.0 wasn't picked up as a release branch
 - Release notes contained the wrong changelog
@@ -271,9 +443,11 @@ Recommended branching strategy:
 ![Branching Strategy](https://raw.githubusercontent.com/microsoft/AL-Go/main/Scenarios/images/branchingstrategy.png)
 
 ### New Settings
+
 New Project setting: EnableTaskScheduler in container executing tests and when setting up local development environment
 
 ### Support for GitHub variables: ALGoOrgSettings and ALGoRepoSettings
+
 Recently, GitHub added support for variables, which you can define on your organization or your repository.
 AL-Go now supports that you can define a GitHub variable called ALGoOrgSettings, which will work for all repositories (with access to the variable)
 Org Settings will be applied before Repo settings and local repository settings files will override values in the org settings
@@ -282,11 +456,13 @@ Example for usage could be setup of branching strategies, versioning or an appDe
 appDependencyProbingPaths from settings variables are merged together with appDependencyProbingPaths defined in repositories
 
 ### Refactoring and tests
+
 ReadSettings has been refactored to allow organization wide settings to be added as well. CI Tests have been added to cover ReadSettings.
 
 ## v2.3
 
 ### Issues
+
 - Issue #312 Branching enhancements
 - Issue #229 Create Release action tags wrong commit
 - Issue #283 Create Release workflow uses deprecated actions
@@ -296,45 +472,56 @@ ReadSettings has been refactored to allow organization wide settings to be added
 - Issue #345 LocalDevEnv.ps1 can't Dowload the file license file
 
 ### New Settings
+
 New Project setting: AssignPremiumPlan on user in container executing tests and when setting up local development environment
 New Repo setting: unusedALGoSystemFiles is an array of AL-Go System Files, which won't be updated during Update AL-Go System Files. They will instead be removed. Use with care, as this can break the AL-Go for GitHub functionality and potentially leave your repo no longer functional.
 
 ### Build modes support
+
 AL-Go projects can now be built in different modes, by specifying the _buildModes_ setting in AL-Go-Settings.json. Read more about build modes in the [Basic Repository settings](https://github.com/microsoft/AL-Go/blob/main/Scenarios/settings.md#basic-repository-settings).
 
 ### LocalDevEnv / CloudDevEnv
+
 With the support for PowerShell 7 in BcContainerHelper, the scripts LocalDevEnv and CloudDevEnv (placed in the .AL-Go folder) for creating development environments have been modified to run inside VS Code instead of spawning a new powershell 5.1 session.
 
 ### Continuous Delivery
-Continuous Delivery can now run from other branches than main. By specifying a property called branches, containing an array of branches in the deliveryContext json construct, the artifacts generated from this branch are also delivered. The branch specification can include wildcards (like release/*). Default is main, i.e. no changes to functionality.
+
+Continuous Delivery can now run from other branches than main. By specifying a property called branches, containing an array of branches in the deliveryContext json construct, the artifacts generated from this branch are also delivered. The branch specification can include wildcards (like release/\*). Default is main, i.e. no changes to functionality.
 
 ### Continuous Deployment
-Continuous Deployment can now run from other branches than main. By creating a repo setting (.github/AL-Go-Settings.json) called **`<environmentname>-Branches`**, which is an array of branches, which will deploy the generated artifacts to this environment. The branch specification can include wildcards (like release/*), although this probably won't be used a lot in continuous deployment. Default is main, i.e. no changes to functionality.
+
+Continuous Deployment can now run from other branches than main. By creating a repo setting (.github/AL-Go-Settings.json) called **`<environmentname>-Branches`**, which is an array of branches, which will deploy the generated artifacts to this environment. The branch specification can include wildcards (like release/\*), although this probably won't be used a lot in continuous deployment. Default is main, i.e. no changes to functionality.
 
 ### Create Release
+
 When locating artifacts for the various projects, the SHA used to build the artifact is used for the release tag
 If all projects are not available with the same SHA, this error is thrown: **The build selected for release doesn't contain all projects. Please rebuild all projects by manually running the CI/CD workflow and recreate the release.**
 There is no longer a hard dependency on the main branch name from Create Release.
 
 ### AL-Go Tests
+
 Some unit tests have been added and AL-Go unit tests can now be run directly from VS Code.
 Another set of end to end tests have also been added and in the documentation on contributing to AL-Go, you can see how to run these in a local fork or from VS Code.
 
 ### LF, UTF8 and JSON
+
 GitHub natively uses LF as line seperator in source files.
 In earlier versions of AL-Go for GitHub, many scripts and actions would use CRLF and convert back and forth. Some files were written with UTF8 BOM (Byte Order Mark), other files without and JSON formatting was done using PowerShell 5.1 (which is different from PowerShell 7).
 In the latest version, we always use LF as line seperator, UTF8 without BOM and JSON files are written using PowerShell 7. If you have self-hosted runners, you need to ensure that PS7 is installed to make this work.
 
 ### Experimental Support
+
 Setting the repo setting "shell" to "pwsh", followed by running Update AL-Go System Files, will cause all PowerShell code to be run using PowerShell 7 instead of PowerShell 5. This functionality is experimental. Please report any issues at https://github.com/microsoft/AL-Go/issues
 Setting the repo setting "runs-on" to "Ubuntu-Latest", followed by running Update AL-Go System Files, will cause all non-build jobs to run using Linux. This functionality is experimental. Please report any issues at https://github.com/microsoft/AL-Go/issues
 
 ## v2.2
 
 ### Enhancements
+
 - Container Event log is added as a build artifact if builds or tests are failing
 
 ### Issues
+
 - Issue #280 Overflow error when test result summary was too big
 - Issue #282, 292 AL-Go for GitHub causes GitHub to issue warnings
 - Issue #273 Potential security issue in Pull Request Handler in Open Source repositories
@@ -344,25 +531,30 @@ Setting the repo setting "runs-on" to "Ubuntu-Latest", followed by running Updat
 - Issue #287 AL-Go pipeline fails in ReadSettings step
 
 ### Changes
+
 - VersioningStrategy 1 is no longer supported. GITHUB_ID has changed behavior (Issue #277)
 
 ## v2.1
 
 ### Issues
+
 - Issue #233 AL-Go for GitHub causes GitHub to issue warnings
 - Issue #244 Give error if AZURE_CREDENTIALS contains line breaks
 
 ### Changes
+
 - New workflow: PullRequestHandler to handle all Pull Requests and pass control safely to CI/CD
 - Changes to yaml files, PowerShell scripts and codeowners files are not permitted from fork Pull Requests
 - Test Results summary (and failed tests) are now displayed directly in the CI/CD workflow and in the Pull Request Check
 
 ### Continuous Delivery
+
 - Proof Of Concept Delivery to GitHub Packages and Nuget
 
 ## v2.0
 
 ### Issues
+
 - Issue #143 Commit Message for **Increment Version Number** workflow
 - Issue #160 Create local DevEnv aith appDependencyProbingPaths
 - Issue #156 Versioningstrategy 2 doesn't use 24h format
@@ -376,15 +568,18 @@ Setting the repo setting "runs-on" to "Ubuntu-Latest", followed by running Updat
 - Special characters wasn't supported in parameters to GitHub actions (Create New App etc.)
 
 ### Continuous Delivery
+
 - Added new GitHub Action "Deliver" to deliver build output to Storage or AppSource
 - Refactor CI/CD and Release workflows to use new deliver action
-- Custom delivery supported by creating scripts with the naming convention DeliverTo*.ps1 in the .github folder
+- Custom delivery supported by creating scripts with the naming convention DeliverTo\*.ps1 in the .github folder
 
 ### AppSource Apps
+
 - New workflow: Publish to AppSource
 - Continuous Delivery to AppSource validation supported
 
 ### Settings
+
 - New Repo setting: CICDPushBranches can be specified as an array of branches, which triggers a CI/CD workflow on commit. Default is main', release/\*, feature/\*
 - New Repo setting: CICDPullRequestBranches can be specified as an array of branches, which triggers a CI/CD workflow on pull request. Default is main
 - New Repo setting: CICDSchedule can specify a CRONTab on when you want to run CI/CD on a schedule. Note that this will disable Push and Pull Request triggers unless specified specifically using CICDPushBranches or CICDPullRequestBranches
@@ -395,16 +590,19 @@ Setting the repo setting "runs-on" to "Ubuntu-Latest", followed by running Updat
 - New project Setting: AppSourceMainAppFolder. If you have multiple appFolders, this is the folder name of the main app to submit to AppSource.
 
 ### All workflows
-- Support 2 folder levels projects (apps\w1, apps\dk etc.)
+
+- Support 2 folder levels projects (apps\\w1, apps\\dk etc.)
 - Better error messages for if an error occurs within an action
 - Special characters are now supported in secrets
 - Initial support for agents running inside containers on a host
 - Optimized workflows to have fewer jobs
 
 ### Update AL-Go System Files Workflow
+
 - workflow now displays the currently used template URL when selecting the Run Workflow action
 
 ### CI/CD workflow
+
 - Better detection of changed projects
 - appDependencyProbingPaths did not support multiple projects in the same repository for latestBuild dependencies
 - appDependencyProbingPaths with release=latestBuild only considered the last 30 artifacts
@@ -413,45 +611,56 @@ Setting the repo setting "runs-on" to "Ubuntu-Latest", followed by running Updat
 - Continue on error with Deploy and Deliver
 
 ### CI/CD and Publish To New Environment
+
 - Base functionality for selecting a specific GitHub runner for an environment
 - Include dependencies artifacts when deploying (if generateDependencyArtifacts is true)
 
 ### localDevEnv.ps1 and cloudDevEnv.ps1
+
 - Display clear error message if something goes wrong
 
 ## v1.5
 
 ### Issues
+
 - Issue #100 - Add more resilience to localDevEnv.ps1 and cloudDevEnv.ps1
 - Issue #131 - Special characters are not allowed in secrets
 
 ### All workflows
+
 - During initialize, all AL-Go settings files are now checked for validity and reported correctly
 - During initialize, the version number of AL-Go for GitHub is printed in large letters (incl. preview or dev.)
 
 ### New workflow: Create new Performance Test App
+
 - Create BCPT Test app and add to bcptTestFolders to run bcpt Tests in workflows (set doNotRunBcptTests in workflow settings for workflows where you do NOT want this)
 
 ### Update AL-Go System Files Workflow
+
 - Include release notes of new version in the description of the PR (and in the workflow output)
 
 ### CI/CD workflow
+
 - Apps are not signed when the workflow is running as a Pull Request validation
 - if a secret called applicationInsightsConnectionString exists, then the value of that will be used as ApplicationInsightsConnectionString for the app
 
 ### Increment Version Number Workflow
+
 - Bugfix: increment all apps using f.ex. +0.1 would fail.
 
 ### Environments
-- Add suport for EnvironmentName redirection by adding an Environment Secret under the environment or a repo secret called \<environmentName\>_EnvironmentName with the actual environment name.
+
+- Add suport for EnvironmentName redirection by adding an Environment Secret under the environment or a repo secret called \<environmentName>\_EnvironmentName with the actual environment name.
 - No default environment name on Publish To Environment
-- For multi-project repositories, you can specify an environment secret called Projects or a repo setting called \<environment\>_Projects, containing the projects you want to deploy to this environment.
+- For multi-project repositories, you can specify an environment secret called Projects or a repo setting called \<environment>\_Projects, containing the projects you want to deploy to this environment.
 
 ### Settings
+
 - New setting: **runs-on** to allow modifying runs-on for all jobs (requires Update AL-Go System files after changing the setting)
 - New setting: **DoNotSignApps** - setting this to true causes signing of the app to be skipped
 - New setting: **DoNotPublishApps** - setting this to true causes the workflow to skip publishing, upgrading and testing the app to improve performance.
 - New setting: **ConditionalSettings** to allow to use different settings for specific branches. Example:
+
 ```
     "ConditionalSettings": [
         {
@@ -465,6 +674,7 @@ Setting the repo setting "runs-on" to "Ubuntu-Latest", followed by running Updat
         }
     ]
 ```
+
 - Default **BcContainerHelperVersion** is now based on AL-Go version. Preview AL-Go selects preview bcContainerHelper, normal selects latest.
 - New Setting: **bcptTestFolders** contains folders with BCPT tests, which will run in all build workflows
 - New Setting: set **doNotRunBcptTest** to true (in workflow specific settings file?) to avoid running BCPT tests
@@ -473,54 +683,64 @@ Setting the repo setting "runs-on" to "Ubuntu-Latest", followed by running Updat
 ## v1.4
 
 ### All workflows
+
 - Add requested permissions to avoid dependency on user/org defaults being too permissive
 
 ### Update AL-Go System Files Workflow
+
 - Default host to https://github.com/ (you can enter **myaccount/AL-Go-PTE@main** to change template)
-- Support for "just" changing branch (ex. **\@Preview**) to shift to the preview version
+- Support for "just" changing branch (ex. **@Preview**) to shift to the preview version
 
 ### CI/CD Workflow
+
 - Support for feature branches (naming **feature/\***) - CI/CD workflow will run, but not generate artifacts nor deploy to QA
 
 ### Create Release Workflow
+
 - Support for release branches
 - Force Semver format on release tags
 - Add support for creating release branches on release (naming release/\*)
 - Add support for incrementing main branch after release
 
 ### Increment version number workflow
+
 - Add support for incremental (and absolute) version number change
 
 ### Environments
+
 - Support environmentName redirection in CI/CD and Publish To Environments workflows
 - If the name in Environments or environments settings doesn't match the actual environment name,
-- You can add a secret called EnvironmentName under the environment (or \<environmentname\>_ENVIRONMENTNAME globally)
-
+- You can add a secret called EnvironmentName under the environment (or \<environmentname>\_ENVIRONMENTNAME globally)
 
 ## v1.3
 
 ### Issues
-- Issue #90 - Environments did not work. Secrets for environments specified in settings can now be **\<environmentname\>_AUTHCONTEXT**
+
+- Issue #90 - Environments did not work. Secrets for environments specified in settings can now be **\<environmentname>\_AUTHCONTEXT**
 
 ### CI/CD Workflow
+
 - Give warning instead of error If no artifacts are found in **appDependencyProbingPaths**
 
 ## v1.2
 
 ### Issues
+
 - Issue #90 - Environments did not work. Environments (even if only defined in the settings file) did not work for private repositories if you didn't have a premium subscription.
 
 ### Local scripts
-- **LocalDevEnv.ps1** and ***CloudDevEnv.ps1** will now spawn a new PowerShell window as admin instead of running inside VS Code. Normally people doesn't run VS Code as administrator, and they shouldn't have to. Furthermore, I have seen a some people having problems when running these scripts inside VS Code.
 
+- **LocalDevEnv.ps1** and \***CloudDevEnv.ps1** will now spawn a new PowerShell window as admin instead of running inside VS Code. Normally people doesn't run VS Code as administrator, and they shouldn't have to. Furthermore, I have seen a some people having problems when running these scripts inside VS Code.
 
 ## v1.1
 
 ### Settings
+
 - New Repo Setting: **GenerateDependencyArtifact** (default **false**). When true, CI/CD pipeline generates an artifact with the external dependencies used for building the apps in this repo.
 - New Repo Setting: **UpdateDependencies** (default **false**). When true, the default artifact for building the apps in this repo is not the latest available artifacts for this country, but instead the first compatible version (after calculating application dependencies). It is recommended to run Test Current, Test NextMinor and Test NextMajor in order to test your app against current and future builds.
 
 ### CI/CD Workflow
+
 - New Artifact: BuildOutput.txt. All compiler warnings and errors are emitted to this file to make it easier to investigate compiler errors and build a better UI for build errors and test results going forward.
 - TestResults artifact name to include repo version number and workflow name (for Current, NextMinor and NextMajor)
 - Default dependency version in appDependencyProbingPaths setting used is now latest Release instead of LatestBuild

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -45,7 +45,7 @@ jobs:
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
 
@@ -56,14 +56,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           eventId: "DO0091"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/ReadSettings@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           get: type, powerPlatformSolutionFolder
@@ -75,7 +75,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Determine Delivery Target Secrets
         id: DetermineDeliveryTargetSecrets
-        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
@@ -96,7 +96,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/ReadSecrets@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -104,7 +104,7 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -114,7 +114,7 @@ jobs:
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -130,13 +130,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/ReadSettings@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           get: templateUrl
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           templateUrl: ${{ env.templateUrl }}
@@ -213,7 +213,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/ReadSettings@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
 
@@ -222,7 +222,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           artifacts: '.artifacts'
@@ -259,7 +259,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/ReadSettings@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
@@ -273,7 +273,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/ReadSecrets@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -281,7 +281,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: microsoft/AL-Go/Actions/Deploy@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/Deploy@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -293,7 +293,7 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -321,20 +321,20 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/ReadSettings@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/ReadSecrets@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: Deliver
-        uses: microsoft/AL-Go/Actions/Deliver@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/Deliver@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -354,7 +354,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           eventId: "DO0091"

--- a/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/.github/workflows/DeployReferenceDocumentation.yaml
@@ -30,19 +30,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           eventId: "DO0097"
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/ReadSettings@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -55,7 +55,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           artifacts: 'latest'

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -28,7 +28,7 @@ jobs:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
     runs-on: windows-latest
     steps:
-      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@5eeeec54ab7e6a9d97701effe420ef74bda08c67
 
   Initialization:
     needs: [ PregateCheck ]
@@ -45,7 +45,7 @@ jobs:
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
 
@@ -53,18 +53,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.sha || format('refs/pull/${0}/merge', github.event.pull_request.number) }}
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           eventId: "DO0104"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/ReadSettings@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
 
@@ -75,7 +75,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -93,7 +93,7 @@ jobs:
     with:
       shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
       runsOn: ${{ needs.Initialization.outputs.githubRunner }}
-      checkoutRef: ${{ github.event.pull_request.merge_commit_sha }}
+      checkoutRef: ${{ github.event_name == 'pull_request' && github.sha || format('refs/pull/${0}/merge', github.event.pull_request.number) }}
       parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
       project: ${{ matrix.project }}
       projectName: ${{ matrix.projectName }}
@@ -117,7 +117,7 @@ jobs:
     with:
       shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
       runsOn: ${{ needs.Initialization.outputs.githubRunner }}
-      checkoutRef: ${{ github.event.pull_request.merge_commit_sha }}
+      checkoutRef: ${{ github.event_name == 'pull_request' && github.sha || format('refs/pull/${0}/merge', github.event.pull_request.number) }}
       parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
       project: ${{ matrix.project }}
       projectName: ${{ matrix.projectName }}
@@ -136,7 +136,7 @@ jobs:
     steps:
       - name: Pull Request Status Check
         id: PullRequestStatusCheck
-        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/Troubleshooting.yaml
+++ b/.github/workflows/Troubleshooting.yaml
@@ -30,7 +30,7 @@ jobs:
           lfs: true
 
       - name: Troubleshooting
-        uses: microsoft/AL-Go/Actions/Troubleshooting@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/Troubleshooting@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
 
@@ -45,20 +45,20 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           eventId: "DO0098"
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/ReadSettings@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           get: templateUrl
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/ReadSecrets@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -94,7 +94,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: powershell
           eventId: "DO0098"

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -97,7 +97,7 @@ jobs:
           lfs: true
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/ReadSettings@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -106,14 +106,14 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         if: github.event_name != 'pull_request'
-        uses: microsoft/AL-Go/Actions/ReadSecrets@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/ReadSecrets@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ inputs.secrets }},appDependencyProbingPathsSecrets,AZURE_CREDENTIALS'
 
       - name: Determine ArtifactUrl
-        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         id: determineArtifactUrl
         with:
           shell: ${{ inputs.shell }}
@@ -129,7 +129,7 @@ jobs:
 
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
-        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -140,7 +140,7 @@ jobs:
           baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
 
       - name: Build
-        uses: microsoft/AL-Go/Actions/RunPipeline@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/RunPipeline@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
           BuildMode: ${{ inputs.buildMode }}
@@ -156,7 +156,7 @@ jobs:
       - name: Sign
         if: inputs.signArtifacts && env.doNotSignApps == 'False' && env.keyVaultCodesignCertificateName != ''
         id: sign
-        uses: microsoft/AL-Go/Actions/Sign@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/Sign@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           azureCredentialsJson: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).AZURE_CREDENTIALS }}'
@@ -165,7 +165,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -259,7 +259,7 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: (success() || failure()) && env.doNotRunTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: ${{ inputs.shell }}
           parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
@@ -267,7 +267,7 @@ jobs:
 
       - name: Cleanup
         if: always()
-        uses: microsoft/AL-Go/Actions/PipelineCleanup@3ecb65a53dfa9187e7b329bebdc443e42c6dde51
+        uses: microsoft/AL-Go/Actions/PipelineCleanup@5eeeec54ab7e6a9d97701effe420ef74bda08c67
         with:
           shell: ${{ inputs.shell }}
           parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}

--- a/build/projects/Business Foundation/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Business Foundation/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Business Foundation/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Business Foundation/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Performance Toolkit/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Performance Toolkit/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Performance Toolkit/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Performance Toolkit/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Modules/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Modules/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Modules/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Modules/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Tests/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Tests/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Framework/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Test Framework/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Framework/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Test Framework/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Stability Tools/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Test Stability Tools/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Stability Tools/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Test Stability Tools/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/3ecb65a53dfa9187e7b329bebdc443e42c6dde51/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5eeeec54ab7e6a9d97701effe420ef74bda08c67/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local


### PR DESCRIPTION
Fixes [AB#420000](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/420000)

## preview

Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.

### Issues

- Issue 1105 Increment Version Number - repoVersion in .github/AL-Go-Settings.json is not updated
- Issue 1073 Publish to AppSource - Automated validation: failure
- Issue 980 Allow Scope to be PTE in continuousDeployment for PTE extensions in Sandbox (enhancement request)
- Issue 1079 AppSource App deployment failes with PerTenantExtensionCop Error PTE0001 and PTE0002
- Issue 866 Accessing GitHub Environment Variables in DeployToCustom Scenarios for PowerShell Scripts
- Issue 1083 SyncMode for custom deployments?
- Issue 1109 Why filter deployment settings?
- Fix issue with github ref when running reusable workflows
- Issue 1098 Support for specifying the name of the AZURE_CREDENTIALS secret by adding a AZURE_CREDENTIALSSecretName setting

### Dependencies to PowerShell modules

AL-Go for GitHub relies on specific PowerShell modules, and the minimum versions required for these modules are tracked in [Packages.json](https://raw.githubusercontent.com/microsoft/AL-Go/main/Actions/Packages.json) file. Should the installed modules on the GitHub runner not meet these minimum requirements, the necessary modules will be installed as needed.

### Support managed identities and federated credentials

All authentication context secrets now supports managed identities and federated credentials. See more [here](Scenarios/secrets.md). Furthermore, you can now use https://aka.ms/algosecrets#authcontext to learn more about the formatting of that secret.

### Business Central Performance Toolkit Test Result Viewer

In the summary after a Test Run, you now also have the result of performance tests.

### New Settings

- `deployTo<environmentName>`: is not really new, but has a new property:

  - **Scope** = specifies the scope of the deployment: Dev, PTE. If not specified, AL-Go for GitHub will always use the Dev Scope for AppSource Apps, but also for PTEs when deploying to sandbox environments when impersonation (refreshtoken) is used for authentication.
  - **\<custom>** = custom properties are now supported and will be transferred to a custom deployment script in the hashtable.

- `bcptThresholds` is a JSON object with properties for the default thresholds for the Business Central Performance Toolkit

  - **DurationWarning** - a warning is issued if the duration of a bcpt test degrades more than this percentage (default 10)
  - **DurationError** - an error is issued if the duration of a bcpt test degrades more than this percentage (default 25)
  - **NumberOfSqlStmtsWarning** - a warning is issued if the number of SQL statements from a bcpt test increases more than this percentage (default 5)
  - **NumberOfSqlStmtsError** - an error is issued if the number of SQL statements from a bcpt test increases more than this percentage (default 10)

> \[!NOTE\]
> Duration thresholds are subject to varying results depending on the performance of the agent running the tests. Number of SQL statements executed by a test is often the most reliable indicator of performance degredation.

## v5.2

### Issues

- Issue 1084 Automatic updates for AL-Go are failing when main branch requires Pull Request

### New Settings

- `PowerPlatformSolutionFolder`: Contains the name of the folder containing a PowerPlatform Solution (only one)
- `DeployTo<environment>` now has two additional properties `companyId` is the Company Id from Business Central (for PowerPlatform connection) and `ppEnvironmentUrl` is the Url of the PowerPlatform environment to deploy to.

### New Actions

- `BuildPowerPlatform`: to build a PowerPlatform Solution
- `DeployPowerPlatform`: to deploy a PowerPlatform Solution
- `PullPowerPlatformChanges`: to pull changes made in PowerPlatform studio into the repository
- `ReadPowerPlatformSettings`: to read settings and secrets for PowerPlatform deployment
- `GetArtifactsForDeployment`: originally code from deploy.ps1 to retrieve artifacts for releases or builds - now as an action to read apps into a folder.

### New Workflows

- **Pull PowerPlatform Changes** for pulling changes from your PowerPlatform development environment into your AL-Go for GitHub repository
- **Push PowerPlatform Changes** for pushing changes from your AL-Go for GitHub repository to your PowerPlatform development environment

> \[!NOTE\]
> PowerPlatform workflows are only available in the PTE template and will be removed if no PowerPlatformSolutionFolder is defined in settings.

### New Scenarios (Documentation)

- [Connect your GitHub repository to Power Platform](https://github.com/microsoft/AL-Go/blob/main/Scenarios/SetupPowerPlatform.md)
- [How to set up Service Principal for Power Platform](https://github.com/microsoft/AL-Go/blob/main/Scenarios/SetupServicePrincipalForPowerPlatform.md)
- [Try one of the Business Central and Power Platform samples](https://github.com/microsoft/AL-Go/blob/main/Scenarios/TryPowerPlatformSamples.md)
- [Publish To AppSource](https://github.com/microsoft/AL-Go/blob/main/Scenarios/PublishToAppSource.md)

> \[!NOTE\]
> PowerPlatform functionality are only available in the PTE template.

## v5.1

### Issues

- Issue 1019 CI/CD Workflow still being scheduled after it was disabled
- Issue 1021 Error during Create Online Development Environment action
- Issue 1022 Error querying artifacts: No such host is known. (bcartifacts-exdbf9fwegejdqak.blob.core.windows.net:443)
- Issue 922 Deploy Reference Documentation (ALDoc) failed with custom
- ContainerName used during build was invalid if project names contained special characters
- Issue 1009 by adding a includeDependencies property in DeliverToAppSource
- Issue 997 'Deliver to AppSource' action fails for projects containing a space
- Issue 987 Resource not accessible by integration when creating release from specific version
- Issue 979 Publish to AppSource Documentation
- Issue 1018 Artifact setting - possibility to read version from app.json
- Issue 1008 Allow PullRequestHandler to use ubuntu or self hosted runners for all jobs except for pregateCheck
- Issue 962 Finer control of "shell"-property
- Issue 1041 Harden the version comparison when incrementing version number
- Issue 1042 Downloading artifacts from GitHub doesn't work with branch names which include forward slashes

### Better artifact selection

The artifact setting in your project settings file can now contain a `*` instead of the version number. This means that AL-Go for GitHub will determine the application dependency for your projects together with the `applicationDependency` setting and determine which Business Central version is needed for the project.

- `"artifact": "//*//latest"` will give you the latest Business Central version, higher than your application dependency and with the same major.minor as your application dependency.
- `"artifact": "//*//first"` will give you the first Business Central version, higher than your application dependency and with the same major.minor as your application dependency.

### New Settings

- `deliverToAppSource`: a JSON object containing the following properties
  - **productId** must be the product Id from partner Center.
  - **mainAppFolder** specifies the appFolder of the main app if you have multiple apps in the same project.
  - **continuousDelivery** can be set to true to enable continuous delivery of every successful build to AppSource Validation. Note that the app will only be in preview in AppSource and you will need to manually press GO LIVE in order for the app to be promoted to production.
  - **includeDependencies** can be set to an array of file names (incl. wildcards) which are the names of the dependencies to include in the AppSource submission. Note that you need to set `generateDependencyArtifact` in the project settings file to true in order to include dependencies.
- Add `shell` as a property under `DeployTo` structure

### Deprecated Settings

- `appSourceContinuousDelivery` is moved to the `deliverToAppSource` structure
- `appSourceMainAppFolder` is moved to the `deliverToAppSource` structure
- `appSourceProductId` is moved to the `deliverToAppSource` structure

### New parameter -clean on localdevenv and clouddevenv

Adding -clean when running localdevenv or clouddevenv will create a clean development environment without compiling and publishing your apps.

## v5.0

### Issues

- Issue 940 Publish to Environment is broken when specifying projects to publish
- Issue 994 CI/CD ignores Deploy to GitHub Pages in private repositories

### New Settings

- `UpdateALGoSystemFilesEnvironment`: The name of the environment that is referenced in job `UpdateALGoSystemFiles` in the _Update AL-Go System Files_ workflow. See [jobs.\<job_id>.environment](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idenvironment) for more information. Currently, only setting the environment name is supported.

### Issues

- Support release branches that start with releases/
- Issue 870 Improve Error Handling when CLI is missing
- Issue 889 CreateRelease and IncrementVersionNumber workflow did not handle wild characters in `appFolders`, `testFolders` or `bcptTestFolders` settings.
- Issue 973 Prerelease is not used for deployment

### Build modes

AL-Go ships with Default, Translated and Clean mode out of the box. Now you can also define custom build modes in addition to the ones shipped with AL-Go. This allows you to define your own build modes, which can be used to build your apps in different ways. By default, a custom build mode will build the apps similarly to the Default mode but this behavior can be overridden in e.g. script overrides in your repository.

## v4.1

### New Settings

- `templateSha`: The SHA of the version of AL-Go currently used

### New Actions

- `DumpWorkflowInfo`: Dump information about running workflow
- `Troubleshooting` : Run troubleshooting for repository

### Update AL-Go System Files

Add another parameter when running Update AL-Go System Files, called downloadLatest, used to indicate whether to download latest version from template repository. Default value is true.
If false, the templateSha repository setting is used to download specific AL-Go System Files when calculating new files.

### Issues

- Issue 782 Exclude '.altestrunner/' from template .gitignore
- Issue 823 Dependencies from prior build jobs are not included when using useProjectDependencies
- App artifacts for version 'latest' are now fetched from the latest CICD run that completed and successfully built all the projects for the corresponding branch.
- Issue 824 Utilize `useCompilerFolder` setting when creating an development environment for an AL-Go project.
- Issue 828 and 825 display warnings for secrets, which might cause AL-Go for GitHub to malfunction

### New Settings

- `alDoc` : JSON object with properties for the ALDoc reference document generation
  - **continuousDeployment** = Determines if reference documentation will be deployed continuously as part of CI/CD. You can run the **Deploy Reference Documentation** workflow to deploy manually or on a schedule. (Default false)
  - **deployToGitHubPages** = Determines whether or not the reference documentation site should be deployed to GitHub Pages for the repository. In order to deploy to GitHub Pages, GitHub Pages must be enabled and set to GitHub Actions. (Default true)
  - **maxReleases** = Maximum number of releases to include in the reference documentation. (Default 3)
  - **groupByProject** = Determines whether projects in multi-project repositories are used as folders in reference documentation
  - **includeProjects** = An array of projects to include in the reference documentation. (Default all)
  - **excludeProjects** = An array of projects to exclude in the reference documentation. (Default none)-
  - **header** = Header for the documentation site. (Default: Documentation for...)
  - **footer** = Footer for the documentation site. (Default: Made with...)
  - **defaultIndexMD** = Markdown for the landing page of the documentation site. (Default: Reference documentation...)
  - **defaultReleaseMD** = Markdown for the landing page of the release sites. (Default: Release reference documentation...)
  - *Note that in header, footer, defaultIndexMD and defaultReleaseMD you can use the following placeholders: {REPOSITORY}, {VERSION}, {INDEXTEMPLATERELATIVEPATH}, {RELEASENOTES}*

### New Workflows

- **Deploy Reference Documentation** is a workflow, which you can invoke manually or on a schedule to generate and deploy reference documentation using the aldoc tool, using the ALDoc setting properties described above.
- **Troubleshooting** is a workflow, which you can invoke manually to run troubleshooting on the repository and check for settings or secrets, containing illegal values. When creating issues on https://github.com/microsoft/AL-Go/issues, we might ask you to run the troubleshooter to help identify common problems.

### Support for ALDoc reference documentation tool

ALDoc reference documentation tool is now supported for generating and deploying reference documentation for your projects either continuously or manually/scheduled.

[AB#420000](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/420000)



