### PR TITLE
Data Driven Tests: Show better error message when parsing of JSONL fails

### DIFF
--- a/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInputJson.Codeunit.al
+++ b/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInputJson.Codeunit.al
@@ -29,7 +29,7 @@ codeunit 130464 "Test Input Json"
     begin
         TestInputJson := ElementExists(ElementName, ElementSearchedExist);
         if not ElementSearchedExist then
-            Error(ElementDoesNotExistErr);
+            Error(ElementDoesNotExistErr, ElementName);
 
         exit(TestInputJson);
     end;
@@ -119,7 +119,7 @@ codeunit 130464 "Test Input Json"
     end;
 
     var
-        ElementDoesNotExistErr: Label 'DataInput - The element does not exist.';
+        ElementDoesNotExistErr: Label 'DataInput - The element %1 does not exist.', Comment = '%1 = Element name';
         TheElementIsNotAnArrayErr: Label 'DataInput - The element is not an array, use a different method.';
         TestJson: JsonToken;
 }

--- a/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInputsManagement.Codeunit.al
+++ b/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInputsManagement.Codeunit.al
@@ -169,7 +169,7 @@ codeunit 130458 "Test Inputs Management"
             exit;
         end;
 
-        Error(CouldNotParseJsonlInputErr);
+        Error(CouldNotParseInputErr);
     end;
 
     local procedure ParseDataInputsJsonl(var TestInputInStream: InStream; var TestInputGroup: Record "Test Input Group")
@@ -181,7 +181,7 @@ codeunit 130458 "Test Inputs Management"
             if TestInputJsonToken.ReadFrom(JsonLine) then
                 InsertDataInputLine(TestInputJsonToken, TestInputGroup)
             else
-                Error(CouldNotParseJsonlInputErr);
+                Error(CouldNotParseJsonlInputErr, JsonLine);
     end;
 
     local procedure InsertDataInputsFromJsonArray(var TestInputGroup: Record "Test Input Group"; var DataOnlyTestInputsArray: JsonArray)
@@ -277,7 +277,8 @@ codeunit 130458 "Test Inputs Management"
         TestInputTok: Label 'testInput', Locked = true;
         ChooseFileLbl: Label 'Choose a file to import';
         TestInputNameTok: Label 'INPUT-', Locked = true;
-        CouldNotParseJsonlInputErr: Label 'Could not parse JSONL input';
+        CouldNotParseInputErr: Label 'Could not parse input dataset';
+        CouldNotParseJsonlInputErr: Label 'Could not parse JSONL input line: %1', Comment = '%1 = JSON Line Content';
         LineTypeMustBeCodeunitErr: Label 'Line type must be Codeunit.';
         JsonFileExtensionTxt: Label '.json', Locked = true;
         JsonlFileExtensionTxt: Label '.jsonl', Locked = true;


### PR DESCRIPTION
#### Summary
Improve error message when
1. Uploading a faulty jsonl dataset
2. Accessing Test Input Element which does not exist

#### Work Item(s)
Fixes [AB#541849](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/541849)

