### PR TITLE
Added DataSources Array to AI Chat Completion

### DIFF
--- a/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIChatComplParamsImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIChatComplParamsImpl.Codeunit.al
@@ -11,6 +11,7 @@ codeunit 7762 "AOAI Chat Compl Params Impl"
     InherentPermissions = X;
 
     var
+        DataSourcesArray: JsonArray;
         Initialized: Boolean;
         Temperature: Decimal;
         MaxTokens: Integer;
@@ -139,8 +140,23 @@ codeunit 7762 "AOAI Chat Compl Params Impl"
         Payload.Add('presence_penalty', GetPresencePenalty());
         Payload.Add('frequency_penalty', GetFrequencyPenalty());
 
+        AddDataSourcesArrayToPayload(Payload);
+
         if IsJsonMode() then
             Payload.Add('response_format', GetJsonResponseFormat());
+    end;
+
+    [NonDebuggable]
+    procedure SetDataSourcesArrayToPayload(var _DataSourcesArray: JsonArray)
+    begin
+        DataSourcesArray := _DataSourcesArray;
+    end;
+
+    [NonDebuggable]
+    local procedure AddDataSourcesArrayToPayload(var Payload: JsonObject)
+    begin
+        if DataSourcesArray.Count() > 0 then
+            Payload.Add('data_sources', DataSourcesArray);
     end;
 
     local procedure GetJsonResponseFormat() ResponseFormat: JsonObject

--- a/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIChatCompletionParams.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIChatCompletionParams.Codeunit.al
@@ -136,4 +136,13 @@ codeunit 7761 "AOAI Chat Completion Params"
     begin
         AOAIChatComplParamsImpl.AddChatCompletionsParametersToPayload(Payload);
     end;
+
+    /// <summary>
+    /// Sets the data_sources array in the payload. The data sources can be used to provide additional search data to the model.
+    /// </summary>
+    /// <param name="DataSourceArray">JsonArray to add parameters relevant for the data sources to be included.</param>
+    procedure SetDataSourcesArrayToPayload(var DataSourcesArray: JsonArray)
+    begin
+        AOAIChatComplParamsImpl.SetDataSourcesArrayToPayload(DataSourcesArray);
+    end;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Enhanced the AI Chat Completion functionality to be able to add data sources to the Azure OpenAI model. Data sources can be added via a JsonArray, which can have many parameters and filter again. The most flexible way is therefore to pass the JsonArray.
Here an example of how the new procedure _AOAIChatCompletionParams.SetDataSourcesArrayToPayload_ can be used by a developer:

`
local procedure AddAzureSearchParameters(var AOAIChatCompletionParams: Codeunit "AOAI Chat Completion Params")
    var
        DataSourceArray: JsonArray;
        DataSourceObject: JsonObject;
        DataSourceParametersObject: JsonObject;
        DataSourceAuthenticationObject: JsonObject;
        BlankJsonObject: JsonObject;
    begin
        DataSourceObject.Add('type', 'azure_search');

        DataSourceParametersObject.Add('endpoint', GetAzureSearchEndpoint());
        DataSourceParametersObject.Add('index_name', GetAzureSearchIndexName());
        DataSourceParametersObject.Add('semantic_configuration', 'default');
        DataSourceParametersObject.Add('query_type', 'simple');
        DataSourceParametersObject.Add('fields_mapping', BlankJsonObject);
        DataSourceParametersObject.Add('in_scope', 'true');
        DataSourceParametersObject.Add('role_information', '');
        //DataSourceParametersObject.Add('filter', ));
        DataSourceParametersObject.Add('strictness', 3);
        DataSourceParametersObject.Add('top_n_documents', 5);
        DataSourceAuthenticationObject.Add('type', 'api_key');
        DataSourceAuthenticationObject.Add('key', GetAzureSearchKey());
        DataSourceParametersObject.Add('authentication', DataSourceAuthenticationObject);
        DataSourceParametersObject.Add('key', GetAzureSearchKey());
        
        DataSourceObject.Add('parameters', DataSourceParametersObject);

        DataSourceArray.Add(DataSourceObject);
        
        AOAIChatCompletionParams.SetDataSourcesArrayToPayload(DataSourceArray);
    end;`


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #1178 
