### PR TITLE
Scheduled Profiler - Fix value update deadlock with different validation strategy + misc fixes

### DIFF
--- a/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
@@ -55,6 +55,11 @@ page 1932 "Perf. Profiler Schedule Card"
                     Caption = 'Start Time';
                     ToolTip = 'Specifies the start time of the schedule.';
                     AboutText = 'The start time of the schedule.';
+
+                    trigger OnValidate()
+                    begin
+                        ScheduledPerfProfiler.ValidatePerformanceProfileSchedulerDatesRelation(Rec);
+                    end;
                 }
                 field("End Time"; Rec."Ending Date-Time")
                 {
@@ -65,7 +70,7 @@ page 1932 "Perf. Profiler Schedule Card"
 
                     trigger OnValidate()
                     begin
-                        ScheduledPerfProfiler.ValidatePerformanceProfileSchedulerDates(Rec, MaxRetentionPeriod);
+                        ScheduledPerfProfiler.ValidatePerformanceProfileSchedulerDatesRelation(Rec);
                         ScheduledPerfProfiler.ValidatePerformanceProfileEndTime(Rec);
                     end;
                 }

--- a/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
@@ -203,12 +203,12 @@ page 1932 "Perf. Profiler Schedule Card"
     trigger OnModifyRecord(): Boolean
     begin
         ScheduledPerfProfiler.MapActivityTypeToRecord(Rec, Activity);
-        ValidateRecord();
+        this.ValidateRecord();
     end;
 
     trigger OnInsertRecord(BelowxRec: Boolean): Boolean
     begin
-        ValidateRecord();
+        this.ValidateRecord();
     end;
 
     var

--- a/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
@@ -93,6 +93,7 @@ page 1932 "Perf. Profiler Schedule Card"
                     TableRelation = User."User Security ID";
                     Lookup = true;
                 }
+
                 field(Activity; Activity)
                 {
                     ApplicationArea = All;
@@ -131,7 +132,7 @@ page 1932 "Perf. Profiler Schedule Card"
                         RetentionPolicySetup: Record "Retention Policy Setup";
                         NoRetentionPolicyErrorInfo: ErrorInfo;
                     begin
-                        if RetentionPolicySetup.Get(Database::"Performance Profiles") then
+                        if RetentionPolicySetup.Get(Database::"Performance Profile Scheduler") then
                             Page.Run(Page::"Retention Policy Setup Card", RetentionPolicySetup)
                         else begin
                             NoRetentionPolicyErrorInfo.Message := NoRetentionPolicySetupErr;
@@ -140,16 +141,18 @@ page 1932 "Perf. Profiler Schedule Card"
                         end;
                     end;
                 }
-                field("Profile Creation Threshold"; Rec."Profile Creation Threshold")
+                field("Activity Duration Threshold"; ProfileCreationThreshold)
                 {
                     ApplicationArea = All;
-                    Caption = 'Profile Creation Threshold (ms)';
-                    ToolTip = 'Specifies Create only profiles that are greater then the profile creation threshold';
-                    AboutText = 'Limit the amount of sampling profiles that are created by setting a millisecond threshold. Only profiles larger then the threshold will be created.';
+                    Caption = 'Activity Duration Threshold (ms)';
+                    ToolTip = 'Specifies the minimum amount of time an activity must last in order to be recorded in a profile.';
+                    AboutText = 'Limit the amount of sampling profiles that are created by setting a millisecond threshold. Only activities that last longer then the threshold will be created.';
 
                     trigger OnValidate()
                     begin
+                        Rec."Profile Creation Threshold" := ProfileCreationThreshold;
                         ScheduledPerfProfiler.ValidateThreshold(Rec);
+                        ProfileCreationThreshold := Rec."Profile Creation Threshold";
                     end;
                 }
             }
@@ -194,30 +197,32 @@ page 1932 "Perf. Profiler Schedule Card"
     begin
         ScheduledPerfProfiler.MapActivityTypeToRecord(Rec, Activity);
         RetentionPeriod := ScheduledPerfProfiler.GetRetentionPeriod();
+        ProfileCreationThreshold := Rec."Profile Creation Threshold";
     end;
 
     trigger OnModifyRecord(): Boolean
     begin
         ScheduledPerfProfiler.MapActivityTypeToRecord(Rec, Activity);
-        this.ValidateRecord();
+        ValidateRecord();
     end;
 
     trigger OnInsertRecord(BelowxRec: Boolean): Boolean
     begin
-        this.ValidateRecord();
+        ValidateRecord();
     end;
+
+    var
+        ScheduledPerfProfiler: Codeunit "Scheduled Perf. Profiler";
+        Activity: Enum "Perf. Profile Activity Type";
+        ProfileCreationThreshold: BigInteger;
+        RetentionPeriod: Code[20];
+        MaxRetentionPeriod: Duration;
+        NoRetentionPolicySetupErr: Label 'No retention policy setup found for the performance profiles table.';
+        CreateRetentionPolicySetupTxt: Label 'Create a retention policy setup';
 
     local procedure ValidateRecord()
     begin
         ScheduledPerfProfiler.ValidatePerformanceProfileSchedulerDates(Rec, MaxRetentionPeriod);
         ScheduledPerfProfiler.ValidatePerformanceProfileSchedulerRecord(Rec, Activity);
     end;
-
-    var
-        ScheduledPerfProfiler: Codeunit "Scheduled Perf. Profiler";
-        Activity: Enum "Perf. Profile Activity Type";
-        RetentionPeriod: Code[20];
-        MaxRetentionPeriod: Duration;
-        NoRetentionPolicySetupErr: Label 'No retention policy setup found for the performance profiles table.';
-        CreateRetentionPolicySetupTxt: Label 'Create a retention policy setup';
 }

--- a/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
@@ -55,11 +55,6 @@ page 1932 "Perf. Profiler Schedule Card"
                     Caption = 'Start Time';
                     ToolTip = 'Specifies the start time of the schedule.';
                     AboutText = 'The start time of the schedule.';
-
-                    trigger OnValidate()
-                    begin
-                        ScheduledPerfProfiler.ValidatePerformanceProfileSchedulerDates(Rec, MaxRetentionPeriod);
-                    end;
                 }
                 field("End Time"; Rec."Ending Date-Time")
                 {
@@ -80,6 +75,7 @@ page 1932 "Perf. Profiler Schedule Card"
                     Caption = 'Description';
                     ToolTip = 'Specifies the description of the schedule.';
                     AboutText = 'The description of the schedule.';
+                    NotBlank = true;
                 }
             }
 
@@ -203,11 +199,17 @@ page 1932 "Perf. Profiler Schedule Card"
     trigger OnModifyRecord(): Boolean
     begin
         ScheduledPerfProfiler.MapActivityTypeToRecord(Rec, Activity);
-        ScheduledPerfProfiler.ValidatePerformanceProfileSchedulerRecord(Rec, Activity);
+        this.ValidateRecord();
     end;
 
     trigger OnInsertRecord(BelowxRec: Boolean): Boolean
     begin
+        this.ValidateRecord();
+    end;
+
+    local procedure ValidateRecord()
+    begin
+        ScheduledPerfProfiler.ValidatePerformanceProfileSchedulerDates(Rec, MaxRetentionPeriod);
         ScheduledPerfProfiler.ValidatePerformanceProfileSchedulerRecord(Rec, Activity);
     end;
 

--- a/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
@@ -93,7 +93,6 @@ page 1932 "Perf. Profiler Schedule Card"
                     TableRelation = User."User Security ID";
                     Lookup = true;
                 }
-
                 field(Activity; Activity)
                 {
                     ApplicationArea = All;

--- a/src/System Application/App/Performance Profiler/src/PerfProfilerSchedulesList.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerSchedulesList.Page.al
@@ -33,21 +33,13 @@ page 1933 "Perf. Profiler Schedules List"
                 AboutText = 'Specifies if profiling is enabled for the current user session.';
                 Caption = 'Profiling Status';
 
-                field("Profiling Enabled"; IsProfilingEnabled)
+                field("Active Schedule ID"; ActiveScheduleDisplayName())
                 {
-                    AboutText = 'Specifies if profiling is enabled for the current user session.';
-                    Caption = 'Profiling Enabled';
-                    Editable = false;
-                    ToolTip = 'Specifies if profiling is enabled for the current user session.';
-                }
-
-                field("Active Schedule ID"; ActiveScheduleId)
-                {
-                    AboutText = 'The ID of the active schedule.';
+                    AboutText = 'The ID of the active schedule for the current session.';
                     Caption = 'Active Schedule ID';
                     Editable = false;
                     DrillDown = true;
-                    ToolTip = 'Specifies the ID of the active schedule.';
+                    ToolTip = 'Specifies the ID of the active schedule for the current session.';
 
                     trigger OnDrillDown()
                     var
@@ -68,6 +60,12 @@ page 1933 "Perf. Profiler Schedules List"
 
             repeater(ProfilerSchedules)
             {
+                field(Description; Rec.Description)
+                {
+                    Caption = 'Description';
+                    ToolTip = 'Specifies the description of the schedule.';
+                    AboutText = 'The description of the schedule.';
+                }
                 field("Schedule ID"; Rec."Schedule ID")
                 {
                     Caption = 'Schedule ID';
@@ -104,12 +102,6 @@ page 1933 "Perf. Profiler Schedules List"
                     Caption = 'Activity Type';
                     ToolTip = 'Specifies the type of activity for which the schedule is created.';
                     AboutText = 'The type of activity for which the schedule is created.';
-                }
-                field(Description; Rec.Description)
-                {
-                    Caption = 'Description';
-                    ToolTip = 'Specifies the description of the schedule.';
-                    AboutText = 'The description of the schedule.';
                 }
                 field(Frequency; Rec.Frequency)
                 {
@@ -152,7 +144,7 @@ page 1933 "Perf. Profiler Schedules List"
     trigger OnOpenPage()
     begin
         ScheduledPerfProfiler.FilterUsers(Rec, UserSecurityId());
-        IsProfilingEnabled := ScheduledPerfProfiler.IsProfilingEnabled(ActiveScheduleId);
+        ScheduledPerfProfiler.IsProfilingEnabled(ActiveScheduleId);
     end;
 
     trigger OnAfterGetRecord()
@@ -178,5 +170,12 @@ page 1933 "Perf. Profiler Schedules List"
         UserName: Text;
         Activity: Enum "Perf. Profile Activity Type";
         ActiveScheduleId: Guid;
-        IsProfilingEnabled: Boolean;
+
+    local procedure ActiveScheduleDisplayName(): Text
+    begin
+        if IsNullGuid(ActiveScheduleId) then
+            exit('');
+
+        exit(Format(ActiveScheduleId));
+    end;
 }

--- a/src/System Application/App/Performance Profiler/src/PerfProfilerSchedulesList.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerSchedulesList.Page.al
@@ -33,7 +33,7 @@ page 1933 "Perf. Profiler Schedules List"
                 AboutText = 'Specifies if profiling is enabled for the current user session.';
                 Caption = 'Profiling Status';
 
-                field("Active Schedule ID"; ActiveScheduleDisplayName())
+                field("Active Schedule ID"; this.ActiveScheduleDisplayName())
                 {
                     AboutText = 'The ID of the active schedule for the current session.';
                     Caption = 'Active Schedule ID';

--- a/src/System Application/App/Performance Profiler/src/PerfProfilerSchedulesList.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerSchedulesList.Page.al
@@ -33,7 +33,7 @@ page 1933 "Perf. Profiler Schedules List"
                 AboutText = 'Specifies if profiling is enabled for the current user session.';
                 Caption = 'Profiling Status';
 
-                field("Active Schedule ID"; this.ActiveScheduleDisplayName())
+                field("Active Schedule ID"; ActiveScheduleIdDisplayText)
                 {
                     AboutText = 'The ID of the active schedule for the current session.';
                     Caption = 'Active Schedule ID';
@@ -145,6 +145,7 @@ page 1933 "Perf. Profiler Schedules List"
     begin
         ScheduledPerfProfiler.FilterUsers(Rec, UserSecurityId());
         ScheduledPerfProfiler.IsProfilingEnabled(ActiveScheduleId);
+        ActiveScheduleIdDisplayText := ActiveScheduleDisplayName();
     end;
 
     trigger OnAfterGetRecord()
@@ -169,6 +170,7 @@ page 1933 "Perf. Profiler Schedules List"
         ScheduledPerfProfiler: Codeunit "Scheduled Perf. Profiler";
         UserName: Text;
         Activity: Enum "Perf. Profile Activity Type";
+        ActiveScheduleIdDisplayText: Text;
         ActiveScheduleId: Guid;
 
     local procedure ActiveScheduleDisplayName(): Text

--- a/src/System Application/App/Performance Profiler/src/PerformanceProfileList.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerformanceProfileList.Page.al
@@ -51,29 +51,31 @@ page 1931 "Performance Profile List"
                     ToolTip = 'Specifies a short description of the activity that was profiled.';
                     AboutText = 'A description of the activity that was profiled.';
                 }
-                field("Object Display Name"; Rec."Object Display Name")
+                field(ActivityDuration; Rec."Activity Duration")
                 {
-                    Caption = 'Object';
-                    ToolTip = 'Specifies the object that contains the entry point for this profile.';
-                    AboutText = 'The object that contains the entry point for this profile.';
+                    Caption = 'Activity Duration (ms)';
+                    ToolTip = 'Specifies the duration of the recorded activity including system operations and waiting for input.';
+                    AboutText = 'The duration of the recorded activity including system operations and waiting for input.';
                 }
-                field(Duration; Rec.Duration)
+                field(ALExecutionTime; Rec.Duration)
                 {
-                    Caption = 'Activity Duration';
-                    ToolTip = 'Specifies the duration of the activity that was profiled in milliseconds.';
-                    AboutText = 'The duration of the activity that was profiled.';
+                    Caption = 'AL Execution Duration (ms)';
+                    ToolTip = 'Specifies the total duration of the sampled AL code in the recorded activity. This measurement is approximate as it depends on the selected sampling frequency.';
+                    AboutText = 'The duration of the sampled AL code in this activity.';
                 }
                 field("Http Call Duration"; Rec."Http Call Duration")
                 {
                     Caption = 'Duration of Http Calls';
                     ToolTip = 'Specifies the duration of the http calls during the activity that was profiled in milliseconds.';
                     AboutText = 'The duration of external http calls during the activity that was profiled.';
+                    Visible = false;
                 }
                 field("Http Call Number"; Rec."Http Call Number")
                 {
                     Caption = 'Number of Http Calls';
                     ToolTip = 'Specifies the number of http calls during the activity that was profiled.';
                     AboutText = 'The number of external http calls during the activity that was profiled.';
+                    Visible = false;
                 }
                 field("Correlation ID"; Rec."Activity ID")
                 {

--- a/src/System Application/App/Performance Profiler/src/PerformanceProfileList.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerformanceProfileList.Page.al
@@ -75,6 +75,12 @@ page 1931 "Performance Profile List"
                     ToolTip = 'Specifies the number of http calls during the activity that was profiled.';
                     AboutText = 'The number of external http calls during the activity that was profiled.';
                 }
+                field("Correlation ID"; Rec."Activity ID")
+                {
+                    Caption = 'Correlation ID';
+                    ToolTip = 'Specifies the ID of the activity that was profiled.';
+                    AboutText = 'The ID of the activity that was profiled.';
+                }
                 field("Client Session ID"; Rec."Client Session ID")
                 {
                     Caption = 'Client Session ID';

--- a/src/System Application/App/Performance Profiler/src/ScheduledPerfProfiler.Codeunit.al
+++ b/src/System Application/App/Performance Profiler/src/ScheduledPerfProfiler.Codeunit.al
@@ -47,7 +47,7 @@ codeunit 1931 "Scheduled Perf. Profiler"
     end;
 
     /// <summary>
-    /// Maps an activity type to a session type
+    /// Maps an activity type to a session type.
     /// </summary>
     /// <param name="PerformanceProfileScheduler">The "Performance Profile Scheduler" record </param>
     /// <param name="ActivityType">The activity enum type</param>

--- a/src/System Application/App/Performance Profiler/src/ScheduledPerfProfiler.Codeunit.al
+++ b/src/System Application/App/Performance Profiler/src/ScheduledPerfProfiler.Codeunit.al
@@ -18,13 +18,23 @@ codeunit 1931 "Scheduled Perf. Profiler"
         ScheduledPerfProfilerImpl: Codeunit "Scheduled Perf. Profiler Impl.";
 
     /// <summary>
-    /// Validate dates for the "Performance Profile Scheduler" record
+    /// Validate dates for the "Performance Profile Scheduler" record with all validations.
     /// </summary>
     /// <param name="PerformanceProfileScheduler">The "Performance Profile Scheduler" record</param>
     /// <param name="MaxRetentionPeriod">The maximum retention period</param>
     procedure ValidatePerformanceProfileSchedulerDates(PerformanceProfileScheduler: Record "Performance Profile Scheduler"; MaxRetentionPeriod: Duration)
     begin
         ScheduledPerfProfilerImpl.ValidatePerformanceProfileSchedulerDates(PerformanceProfileScheduler, MaxRetentionPeriod);
+    end;
+
+    /// <summary>
+    /// Validate the relation between the dates for the "Performance Profile Scheduler" record.
+    /// </summary>
+    /// <param name="PerformanceProfileScheduler">The "Performance Profile Scheduler" record</param>
+    /// <param name="MaxRetentionPeriod">The maximum retention period</param>
+    procedure ValidatePerformanceProfileSchedulerDatesRelation(PerformanceProfileScheduler: Record "Performance Profile Scheduler")
+    begin
+        ScheduledPerfProfilerImpl.ValidatePerformanceProfileSchedulerDatesRelation(PerformanceProfileScheduler);
     end;
 
     /// <summary>

--- a/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
+++ b/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
@@ -149,8 +149,8 @@ codeunit 1932 "Scheduled Perf. Profiler Impl."
         RetentionPolicySetupRec: Record "Retention Policy Setup";
         RetentionPolicySetup: Codeunit "Retention Policy Setup";
     begin
-        this.CreateRetentionPolicySetup(Database::"Performance Profiles", RetentionPolicySetup.FindOrCreateRetentionPeriod("Retention Period Enum"::"1 Week"));
-        if RetentionPolicySetupRec.Get(Database::"Performance Profiles") then
+        this.CreateRetentionPolicySetup(Database::"Performance Profile Scheduler", RetentionPolicySetup.FindOrCreateRetentionPeriod("Retention Period Enum"::"1 Week"));
+        if RetentionPolicySetupRec.Get(Database::"Performance Profile Scheduler") then
             Page.Run(Page::"Retention Policy Setup Card", RetentionPolicySetupRec);
     end;
 

--- a/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
+++ b/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
@@ -86,11 +86,7 @@ codeunit 1932 "Scheduled Perf. Profiler Impl."
     var
         ScheduleDuration: Duration;
     begin
-        if ((PerformanceProfileScheduler."Ending Date-Time" <> 0DT) and (PerformanceProfileScheduler."Ending Date-Time" < CurrentDateTime())) then
-            Error(ProfileCannotBeInThePastErr);
-
-        if ((PerformanceProfileScheduler."Ending Date-Time" <> 0DT) and (PerformanceProfileScheduler."Starting Date-Time" > PerformanceProfileScheduler."Ending Date-Time")) then
-            Error(ProfileStartingDateLessThenEndingDateErr);
+        this.ValidatePerformanceProfileSchedulerDatesRelation(PerformanceProfileScheduler);
 
         if (MaxRetentionPeriod = 0) then
             exit;
@@ -98,6 +94,15 @@ codeunit 1932 "Scheduled Perf. Profiler Impl."
         ScheduleDuration := PerformanceProfileScheduler."Ending Date-Time" - PerformanceProfileScheduler."Starting Date-Time";
         if (ScheduleDuration > MaxRetentionPeriod) then
             Error(ScheduleDurationCannotExceedRetentionPeriodErr);
+    end;
+
+    procedure ValidatePerformanceProfileSchedulerDatesRelation(PerformanceProfileScheduler: Record "Performance Profile Scheduler")
+    begin
+        if ((PerformanceProfileScheduler."Ending Date-Time" <> 0DT) and (PerformanceProfileScheduler."Ending Date-Time" < CurrentDateTime())) then
+            Error(ProfileCannotBeInThePastErr);
+
+        if ((PerformanceProfileScheduler."Ending Date-Time" <> 0DT) and (PerformanceProfileScheduler."Starting Date-Time" > PerformanceProfileScheduler."Ending Date-Time")) then
+            Error(ProfileStartingDateLessThenEndingDateErr);
     end;
 
     procedure ValidatePerformanceProfileEndTime(PerformanceProfileScheduler: Record "Performance Profile Scheduler")


### PR DESCRIPTION
#### Summary
Right now, it's only possible to create or set start/end dates of a schedule for the next week. The reason why is because due to how we made the validation triggers, the start time and end time triggers block each other from ever completing when one gets an incorrect value.

The solution is to keep one validate trigger on the "End Time" and also validate that the dates are correct before saving the values to the database. This way, there's no way the triggers can block each other.

Furthermore, this fixes a few minor issues from internal testing, like field order, descriptions and an incorrect reference for the retention policy.

#### Work Item
Fixes [AB#501774](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/501774)











