### PR TITLE
Make Edit-In Excel use mysettings.language instead of mysettings.regi…

### DIFF
--- a/src/System Application/App/Edit in Excel/src/EditInExcelWorkbookImpl.Codeunit.al
+++ b/src/System Application/App/Edit in Excel/src/EditInExcelWorkbookImpl.Codeunit.al
@@ -163,7 +163,7 @@ codeunit 1489 "Edit in Excel Workbook Impl."
         ConnectionInfo.HostName := HostName;
 
         DataEntityExportInfo.Connection := ConnectionInfo;
-        DataEntityExportInfo.Language := LanguageIDToCultureName(WindowsLanguage);
+        DataEntityExportInfo.Language := LanguageIDToCultureName(UserSettingsLanguageID());
         DataEntityExportInfo.EnableDesign := true;
         DataEntityExportInfo.RefreshOnOpen := true;
         DataEntityExportInfo.DateCreated := CurrentDateTime();
@@ -231,6 +231,35 @@ codeunit 1489 "Edit in Excel Workbook Impl."
         exit(99);
     end;
 
+    local procedure UserSettingsLanguageID(): Integer
+    var
+        DefaultLanguageID: Integer;
+        UserSessionSettings: SessionSettings;
+    begin
+        if TryUserSettingsLanguageID() then begin
+            UserSessionSettings.Init();
+            if UserSessionSettings.LanguageId() <> 0 then
+                exit(UserSessionSettings.LanguageId());
+        end;
+
+        if WindowsLanguage() <> 0 then
+            DefaultLanguageID := WindowsLanguage()
+        else
+            DefaultLanguageID := 1033; // English - United States
+
+        exit(DefaultLanguageID);
+    end;
+
+    [TryFunction]
+    local procedure TryUserSettingsLanguageID()
+    var
+        UserSessionSettings: SessionSettings;
+    begin
+        UserSessionSettings.Init();
+        if UserSessionSettings.LanguageId() = 0 then
+            error('Unable to get the SessionSettings.LanguageId()')
+    end;
+
     local procedure LanguageIDToCultureName(LanguageID: Integer): Text
     var
         CultureInfo: DotNet CultureInfo;
@@ -238,5 +267,4 @@ codeunit 1489 "Edit in Excel Workbook Impl."
         CultureInfo := CultureInfo.GetCultureInfo(LanguageID);
         exit(CultureInfo.Name);
     end;
-
 }

--- a/src/System Application/App/Edit in Excel/src/EditInExcelWorkbookImpl.Codeunit.al
+++ b/src/System Application/App/Edit in Excel/src/EditInExcelWorkbookImpl.Codeunit.al
@@ -163,7 +163,7 @@ codeunit 1489 "Edit in Excel Workbook Impl."
         ConnectionInfo.HostName := HostName;
 
         DataEntityExportInfo.Connection := ConnectionInfo;
-        DataEntityExportInfo.Language := LanguageIDToCultureName(UserSettingsLanguageID());
+        DataEntityExportInfo.Language := LanguageIDToCultureName(GlobalLanguage());
         DataEntityExportInfo.EnableDesign := true;
         DataEntityExportInfo.RefreshOnOpen := true;
         DataEntityExportInfo.DateCreated := CurrentDateTime();
@@ -229,34 +229,6 @@ codeunit 1489 "Edit in Excel Workbook Impl."
     local procedure GetExcelOnlineColumnLimit(): Integer
     begin
         exit(99);
-    end;
-
-    local procedure UserSettingsLanguageID(): Integer
-    var
-        DefaultLanguageID: Integer;
-        UserSessionSettings: SessionSettings;
-    begin
-        if TryUserSettingsLanguageID() then begin
-            UserSessionSettings.Init();
-            exit(UserSessionSettings.LanguageId());
-        end;
-
-        if WindowsLanguage() <> 0 then
-            DefaultLanguageID := WindowsLanguage()
-        else
-            DefaultLanguageID := 1033; // English - United States
-
-        exit(DefaultLanguageID);
-    end;
-
-    [TryFunction]
-    local procedure TryUserSettingsLanguageID()
-    var
-        UserSessionSettings: SessionSettings;
-    begin
-        UserSessionSettings.Init();
-        if UserSessionSettings.LanguageId() = 0 then
-            error('Unable to get the SessionSettings.LanguageId()')
     end;
 
     local procedure LanguageIDToCultureName(LanguageID: Integer): Text

--- a/src/System Application/App/Edit in Excel/src/EditInExcelWorkbookImpl.Codeunit.al
+++ b/src/System Application/App/Edit in Excel/src/EditInExcelWorkbookImpl.Codeunit.al
@@ -238,8 +238,7 @@ codeunit 1489 "Edit in Excel Workbook Impl."
     begin
         if TryUserSettingsLanguageID() then begin
             UserSessionSettings.Init();
-            if UserSessionSettings.LanguageId() <> 0 then
-                exit(UserSessionSettings.LanguageId());
+            exit(UserSessionSettings.LanguageId());
         end;
 
         if WindowsLanguage() <> 0 then


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Make Edit-In Excel use mysettings.language instead of mysettings.region as add-in language


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #[AB#538298](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/538298/)



