### PR TITLE
[Edit-In Excel] Improve the invalid filter error message

### DIFF
--- a/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
+++ b/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
@@ -43,7 +43,7 @@ codeunit 1482 "Edit in Excel Impl."
         CreateEndpointForObjectTxt: Label 'Creating endpoint for %1 %2.', Locked = true;
         EditInExcelHandledTxt: Label 'Edit in excel has been handled.', Locked = true;
         EditInExcelOnlySupportPageWebServicesTxt: Label 'Edit in Excel only support web services created from pages.', Locked = true;
-        EditInExcelInvalidFilterErr: Label 'We had to remove the filters applied to the following fields, because they are not available in the Office Add-In. Please notice that as a result of this the number of rows you exported to Excel could vary.\ %1', Comment = '%1 = The field filters we had to remove because they are not exposed through OData';
+        EditInExcelInvalidFilterErr: Label 'We had to remove the filters applied to the following fields because they are not available in the Office Add-In. As a result, the number of rows you see in Excel may differ from what you see in Dynamics 365 Business Central.\ \ Removed filters: %1', Comment = '%1 = The field filters we had to remove because they are not exposed through OData';
         DialogTitleTxt: Label 'Export';
         ExcelFileNameTxt: Text;
         XmlByteEncodingTok: Label '_x00%1_%2', Locked = true;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

We merged in this [PR](https://github.com/microsoft/BCApps/pull/1249) earlier for Edit-In Excel. Which shows a dialog when users try to filter on fields that are not keys and is not exposed on the page(therefore not available in OData either, so Edit-In Excel cannot use those filters).

This PR is just to make the dialog a little nicer, so now it will look like this:
![image](https://github.com/user-attachments/assets/f9c225aa-c93e-4d70-a077-0cbcbf82817c)


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes 
[AB#542876](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/542876/)
