### PR TITLE
[DRAFT] Add Procedure ReinstallExtension to trigger Install Code from AL

### DIFF
--- a/src/System Application/App/Extension Management/src/ExtensionInstallationImpl.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionInstallationImpl.Codeunit.al
@@ -405,5 +405,52 @@ codeunit 2500 "Extension Installation Impl"
 
         exit(Result = PolicyToTestFor);
     end;
+
+    procedure ReinstallExtension(PackageId: Guid; lcid: Integer; IsUIEnabled: Boolean): Boolean
+    var
+        DependentModules: List of [ModuleInfo];
+        DependentModule: ModuleInfo;
+        Success: Boolean;
+    begin
+        Success := true;
+        DependentModules := GetDependentModulesForExtensionToReinstall(PackageId);
+
+        if not UninstallExtension(PackageId, IsUIEnabled) then
+            Success := false;
+
+        if not InstallExtension(PackageId, lcid, IsUIEnabled) then
+            Success := false;
+
+        foreach DependentModule in DependentModules do
+            if not InstallExtension(DependentModule.PackageId, lcid, IsUIEnabled) then
+                Success := false;
+
+        exit(Success);
+    end;
+
+    local procedure GetDependentModulesForExtensionToReinstall(PackageId: Guid): List of [ModuleInfo]
+    var
+        DependencyApp: Record "NAV App Installed App";
+        NAVAppInstalledApp: Record "NAV App Installed App";
+        InstalledModuleDependencies: List of [ModuleDependencyInfo];
+        DependentModules: List of [ModuleInfo];
+        InstalledModuleDependency: ModuleDependencyInfo;
+        InstalledModule: ModuleInfo;
+    begin
+        if NAVAppInstalledApp.FindSet() then
+            repeat
+                NavApp.GetModuleInfo(NAVAppInstalledApp."App ID", InstalledModule);
+                InstalledModuleDependencies := InstalledModule.Dependencies();
+                foreach InstalledModuleDependency in InstalledModuleDependencies do begin
+                    DependencyApp.Get(InstalledModuleDependency.Id);
+                    if DependencyApp."Package ID" = PackageId then begin
+                        if not DependentModules.Contains(InstalledModule) then
+                            DependentModules.Add(InstalledModule);
+                    end;
+                end;
+            until NAVAppInstalledApp.Next() = 0;
+        exit(DependentModules);
+    end;
+
 }
 

--- a/src/System Application/App/Extension Management/src/ExtensionManagement.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionManagement.Codeunit.al
@@ -283,5 +283,18 @@ codeunit 2504 "Extension Management"
     begin
         ExtensionOperationImpl.GetDeploymentDetailedStatusMessageAsStream(OperationId, OutStream);
     end;
+
+    /// <summary>
+    /// ReInstalls an extension.
+    /// Uninstalls the extension and all dependent extensions and then installs it again.
+    /// </summary>
+    /// <param name="PackageId">The ID of the extension package.</param>
+    /// <param name="lcid">The Locale Identifier.</param>
+    /// <param name="IsUIEnabled">Indicates if the reinstall operation is invoked through the UI.</param>
+    /// <returns></returns>
+    procedure ReinstallExtension(PackageId: Guid; lcid: Integer; IsUIEnabled: Boolean): Boolean
+    begin
+        exit(ExtensionOperationImpl.ReinstallExtension(PackageId, lcid, IsUIEnabled));
+    end;
 }
 


### PR DESCRIPTION
This is a Draft because i think this is a hack and could be better solved by adding a possibility to trigger upgrade code (with DataTransfer) from AL Code. 
But currently this seems to be the only way to trigger code that uses DataTransfer from AL. 

#### Summary
Adds a new Procedure "ReinstallExtension" to Extension Management. The Procedure uninstalls and then installs the extension again. It also reinstalls the extensions that are dependent on the reinstalled extension.

By Installing the Extension the Install Codeunints of the extension are triggered.
Inside Install Codeunits we can use DataTransfer to move Data between Tables/Fields.
This is usefull if you have features that can be enabled by the user, but these features require some data beeing moved to new tables/fields. If we copy the Data using repeat until this can be very slow and time consuming. Accordin to the docs using DataTransfer instead, can result in a "~200x performance improvement".

#### Work Item(s) 
Fixes #1659
