### PR TITLE
[Email] Allow filtering of EmailAccounts page to only v2 accounts

### DIFF
--- a/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
+++ b/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
@@ -414,7 +414,6 @@ page 8887 "Email Accounts"
             if not (IConnector is "Email Connector v2") then
                 EmailAccounts.Delete();
         until EmailAccounts.Next() = 0;
-        if EmailAccounts.FindSet() then;
     end;
 
     local procedure ShowAccountInformation()

--- a/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
+++ b/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
@@ -414,7 +414,7 @@ page 8887 "Email Accounts"
             if not (IConnector is "Email Connector v2") then
                 EmailAccounts.Delete();
         until EmailAccounts.Next() = 0;
-        EmailAccounts.FindSet();
+        if EmailAccounts.FindSet() then;
     end;
 
     local procedure ShowAccountInformation()

--- a/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
+++ b/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
@@ -387,6 +387,8 @@ page 8887 "Email Accounts"
         IsSelected := not IsNullGuid(SelectedAccountId);
 
         EmailAccount.GetAllAccounts(true, Rec); // Refresh the email accounts
+        if V2Filter then
+            FilterToConnectorv2Accounts(Rec);
         EmailScenario.GetDefaultEmailAccount(DefaultEmailAccount); // Refresh the default email account
 
         if IsSelected then begin
@@ -398,6 +400,21 @@ page 8887 "Email Accounts"
         HasEmailAccount := not Rec.IsEmpty();
 
         CurrPage.Update(false);
+    end;
+
+    local procedure FilterToConnectorv2Accounts(var EmailAccounts: Record "Email Account")
+    var
+        IConnector: Interface "Email Connector";
+    begin
+        if EmailAccounts.IsEmpty() then
+            exit;
+
+        repeat
+            IConnector := EmailAccounts.Connector;
+            if not (IConnector is "Email Connector v2") then
+                EmailAccounts.Delete();
+        until EmailAccounts.Next() = 0;
+        EmailAccounts.FindSet();
     end;
 
     local procedure ShowAccountInformation()
@@ -440,6 +457,15 @@ page 8887 "Email Accounts"
         CurrPage.LookupMode(true);
     end;
 
+    /// <summary>
+    /// Filters the email accounts to only show accounts that are using the Email Connector v2.
+    /// </summary>
+    /// <param name="Filter">True to filter the email accounts, false to show all email accounts</param>
+    procedure FilterToConnectorv2Accounts(Filter: Boolean)
+    begin
+        V2Filter := Filter;
+    end;
+
     var
         DefaultEmailAccount: Record "Email Account";
         EmailAccountImpl: Codeunit "Email Account Impl.";
@@ -452,5 +478,6 @@ page 8887 "Email Accounts"
         ShowLogo: Boolean;
         IsLookupMode: Boolean;
         HasEmailAccount: Boolean;
+        V2Filter: Boolean;
         EmailConnectorHasBeenUninstalledMsg: Label 'The selected email extension has been uninstalled. To view information about the email account, you must reinstall the extension.';
 }

--- a/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
+++ b/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
@@ -461,7 +461,7 @@ page 8887 "Email Accounts"
     /// Filters the email accounts to only show accounts that are using the Email Connector v2.
     /// </summary>
     /// <param name="Filter">True to filter the email accounts, false to show all email accounts</param>
-    procedure FilterToConnectorv2Accounts(Filter: Boolean)
+    procedure FilterConnectorV2Accounts(Filter: Boolean)
     begin
         V2Filter := Filter;
     end;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Add functionality to filter Email Accounts page to only those that are using Connector v2 interface

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#539754](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/539754)




