### PR TITLE
[Copilot] Include arguments on the function result

### DIFF
--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -410,6 +410,7 @@ codeunit 7772 "Azure OpenAI Impl"
         AOAIFunctionResponse: Codeunit "AOAI Function Response";
         CustomDimensions: Dictionary of [Text, Text];
         Response: JsonObject;
+        EmptyArguments: JsonObject;
         CompletionToken: JsonToken;
         XPathLbl: Label '$.content', Comment = 'For more details on response, see https://aka.ms/AAlrz36', Locked = true;
         XPathToolCallsLbl: Label '$.tool_calls', Comment = 'For more details on response, see https://aka.ms/AAlrz36', Locked = true;
@@ -422,7 +423,7 @@ codeunit 7772 "Azure OpenAI Impl"
             ChatMessages.AddToolCalls(CompletionToken.AsArray());
 
             if not ProcessToolCalls(CompletionToken.AsArray(), ChatMessages, AOAIOperationResponse) then begin
-                AOAIFunctionResponse.SetFunctionCallingResponse(true, Enum::"AOAI Function Response Status"::"Function Invalid", '', '', '', '', '');
+                AOAIFunctionResponse.SetFunctionCallingResponse(true, Enum::"AOAI Function Response Status"::"Function Invalid", '', '', EmptyArguments, '', '', '');
                 AOAIOperationResponse.AddFunctionResponse(AOAIFunctionResponse);
             end;
 
@@ -491,21 +492,21 @@ codeunit 7772 "Azure OpenAI Impl"
         if ChatMessages.GetFunctionTool(FunctionName, AOAIFunction) then
             if ChatMessages.GetToolInvokePreference() in [Enum::"AOAI Tool Invoke Preference"::"Invoke Tools Only", Enum::"AOAI Tool Invoke Preference"::Automatic] then
                 if TryExecuteFunction(AOAIFunction, Arguments, FunctionResult) then begin
-                    AOAIFunctionResponse.SetFunctionCallingResponse(true, Enum::"AOAI Function Response Status"::"Invoke Success", AOAIFunction.GetName(), FunctionId, FunctionResult, '', '');
+                    AOAIFunctionResponse.SetFunctionCallingResponse(true, Enum::"AOAI Function Response Status"::"Invoke Success", AOAIFunction.GetName(), FunctionId, Arguments, FunctionResult, '', '');
                     AOAIOperationResponse.AddFunctionResponse(AOAIFunctionResponse);
                     exit(true);
                 end else begin
-                    AOAIFunctionResponse.SetFunctionCallingResponse(true, Enum::"AOAI Function Response Status"::"Invoke Error", AOAIFunction.GetName(), FunctionId, FunctionResult, GetLastErrorText(), GetLastErrorCallStack());
+                    AOAIFunctionResponse.SetFunctionCallingResponse(true, Enum::"AOAI Function Response Status"::"Invoke Error", AOAIFunction.GetName(), FunctionId, Arguments, FunctionResult, GetLastErrorText(), GetLastErrorCallStack());
                     AOAIOperationResponse.AddFunctionResponse(AOAIFunctionResponse);
                     exit(true);
                 end
             else begin
-                AOAIFunctionResponse.SetFunctionCallingResponse(true, Enum::"AOAI Function Response Status"::"Not Invoked", AOAIFunction.GetName(), FunctionId, FunctionResult, '', '');
+                AOAIFunctionResponse.SetFunctionCallingResponse(true, Enum::"AOAI Function Response Status"::"Not Invoked", AOAIFunction.GetName(), FunctionId, Arguments, FunctionResult, '', '');
                 AOAIOperationResponse.AddFunctionResponse(AOAIFunctionResponse);
                 exit(true);
             end
         else begin
-            AOAIFunctionResponse.SetFunctionCallingResponse(true, Enum::"AOAI Function Response Status"::"Function Not Found", FunctionName, FunctionId, FunctionResult, StrSubstNo(FunctionCallingFunctionNotFoundErr, FunctionName), '');
+            AOAIFunctionResponse.SetFunctionCallingResponse(true, Enum::"AOAI Function Response Status"::"Function Not Found", FunctionName, FunctionId, Arguments, FunctionResult, StrSubstNo(FunctionCallingFunctionNotFoundErr, FunctionName), '');
             AOAIOperationResponse.AddFunctionResponse(AOAIFunctionResponse);
             exit(true);
         end;

--- a/src/System Application/App/AI/src/Azure OpenAI/Operation Response/AOAIFunctionResponse.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/Operation Response/AOAIFunctionResponse.Codeunit.al
@@ -18,9 +18,10 @@ codeunit 7758 "AOAI Function Response"
         FunctionCall: Boolean;
         FunctionName: Text;
         FunctionId: Text;
-        Result: Variant;
         Error: Text;
         ErrorCallStack: Text;
+        Arguments: JsonObject;
+        Result: Variant;
 
     /// <summary>
     /// Get whether the function call was successful.
@@ -47,6 +48,15 @@ codeunit 7758 "AOAI Function Response"
     procedure GetResult(): Variant
     begin
         exit(Result);
+    end;
+
+    /// <summary>
+    /// Get the arguments for the function call.
+    /// </summary>
+    /// <returns>The arguments for the function</returns>
+    procedure GetArguments(): JsonObject
+    begin
+        exit(Arguments);
     end;
 
     /// <summary>
@@ -98,12 +108,13 @@ codeunit 7758 "AOAI Function Response"
         exit(FunctionCall);
     end;
 
-    internal procedure SetFunctionCallingResponse(NewIsFunctionCall: Boolean; NewAOAIFunctionResponseStatus: Enum "AOAI Function Response Status"; NewFunctionCalled: Text; NewFunctionId: Text; NewFunctionResult: Variant; NewFunctionError: Text; NewFunctionErrorCallStack: Text)
+    internal procedure SetFunctionCallingResponse(NewIsFunctionCall: Boolean; NewAOAIFunctionResponseStatus: Enum "AOAI Function Response Status"; NewFunctionCalled: Text; NewFunctionId: Text; NewArguments: JsonObject; NewFunctionResult: Variant; NewFunctionError: Text; NewFunctionErrorCallStack: Text)
     begin
         FunctionCall := NewIsFunctionCall;
         AOAIFunctionResponseStatus := NewAOAIFunctionResponseStatus;
         FunctionName := NewFunctionCalled;
         FunctionId := NewFunctionId;
+        Arguments := NewArguments;
         Result := NewFunctionResult;
         Error := NewFunctionError;
         ErrorCallStack := NewFunctionErrorCallStack;

--- a/src/System Application/Test Library/AI/src/AzureOpenAITestLibrary.Codeunit.al
+++ b/src/System Application/Test Library/AI/src/AzureOpenAITestLibrary.Codeunit.al
@@ -28,23 +28,34 @@ codeunit 132933 "Azure OpenAI Test Library"
         AOAIChatCompletionParams.AddChatCompletionsParametersToPayload(Payload);
     end;
 
-    procedure SetAOAIFunctionResponse(var AOAIFunctionResponse: Codeunit "AOAI Function Response"; NewIsFunctionCall: Boolean; NewAOAIFunctionResponseStatus: Enum "AOAI Function Response Status"; NewFunctionCalled: Text; NewFunctionId: Text; NewFunctionResult: Variant; NewFunctionError: Text; NewFunctionErrorCallStack: Text)
+    procedure SetAOAIFunctionResponse(var AOAIFunctionResponse: Codeunit "AOAI Function Response"; NewIsFunctionCall: Boolean; NewAOAIFunctionResponseStatus: Enum "AOAI Function Response Status"; NewFunctionCalled: Text; NewFunctionId: Text; NewArguments: Text; NewFunctionResult: Variant; NewFunctionError: Text; NewFunctionErrorCallStack: Text)
+    var
+        ParsedArguments: JsonObject;
     begin
-        AOAIFunctionResponse.SetFunctionCallingResponse(NewIsFunctionCall, NewAOAIFunctionResponseStatus, NewFunctionCalled, NewFunctionId, NewFunctionResult, NewFunctionError, NewFunctionErrorCallStack);
+        if NewArguments <> '' then
+            ParsedArguments.ReadFrom(NewArguments);
+
+        AOAIFunctionResponse.SetFunctionCallingResponse(NewIsFunctionCall, NewAOAIFunctionResponseStatus, NewFunctionCalled, NewFunctionId, ParsedArguments, NewFunctionResult, NewFunctionError, NewFunctionErrorCallStack);
     end;
 
-    procedure AddAOAIFunctionResponse(var AOAIOperationResponse: Codeunit "AOAI Operation Response"; var AOAIFunctionResponse: Codeunit "AOAI Function Response"; NewIsFunctionCall: Boolean; NewAOAIFunctionResponseStatus: Enum "AOAI Function Response Status"; NewFunctionCalled: Text; NewFunctionId: Text; NewFunctionResult: Variant; NewFunctionError: Text; NewFunctionErrorCallStack: Text)
+    procedure AddAOAIFunctionResponse(var AOAIOperationResponse: Codeunit "AOAI Operation Response"; var AOAIFunctionResponse: Codeunit "AOAI Function Response"; NewIsFunctionCall: Boolean; NewAOAIFunctionResponseStatus: Enum "AOAI Function Response Status"; NewFunctionCalled: Text; NewFunctionId: Text; NewArguments: Text; NewFunctionResult: Variant; NewFunctionError: Text; NewFunctionErrorCallStack: Text)
     begin
-        SetAOAIFunctionResponse(AOAIFunctionResponse, NewIsFunctionCall, NewAOAIFunctionResponseStatus, NewFunctionCalled, NewFunctionId, NewFunctionResult, NewFunctionError, NewFunctionErrorCallStack);
+        AOAIOperationResponse.SetOperationResponse(true, 200, '', '');
+        SetAOAIFunctionResponse(AOAIFunctionResponse, NewIsFunctionCall, NewAOAIFunctionResponseStatus, NewFunctionCalled, NewFunctionId, NewArguments, NewFunctionResult, NewFunctionError, NewFunctionErrorCallStack);
         AOAIOperationResponse.AddFunctionResponse(AOAIFunctionResponse);
     end;
 
     procedure SetToolCalls(AOAIChatMessages: Codeunit "AOAI Chat Messages"; ToolCallId: Text; FunctionName: Text)
+    begin
+        SetToolCalls(AOAIChatMessages, ToolCallId, FunctionName, '{}');
+    end;
+
+    procedure SetToolCalls(AOAIChatMessages: Codeunit "AOAI Chat Messages"; ToolCallId: Text; FunctionName: Text; Arguments: Text)
     var
         ToolCalls: JsonArray;
-        ToolSelectionResponseLbl: Label '[{"id":"%1","type":"function","function":{"name":"%2","arguments":"{}"}}]', Locked = true;
+        ToolSelectionResponseLbl: Label '[{"id":"%1","type":"function","function":{"name":"%2","arguments":"%3"}}]', Locked = true;
     begin
-        ToolCalls.ReadFrom(StrSubstNo(ToolSelectionResponseLbl, ToolCallId, FunctionName));
+        ToolCalls.ReadFrom(StrSubstNo(ToolSelectionResponseLbl, ToolCallId, FunctionName, Arguments));
 
         AOAIChatMessages.AddToolCalls(ToolCalls);
     end;

--- a/src/System Application/Test/AI/src/AzureOpenAIToolsTest.Codeunit.al
+++ b/src/System Application/Test/AI/src/AzureOpenAIToolsTest.Codeunit.al
@@ -408,7 +408,7 @@ codeunit 132686 "Azure OpenAI Tools Test"
 
         // Selected function was executed by system
         FunctionExecutionResult := 'test function execution result';
-        AzureOpenAITestLibrary.AddAOAIFunctionResponse(AOAIOperationResponse, AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction1.GetName(), ToolCallId, FunctionExecutionResult, '', '');
+        AzureOpenAITestLibrary.AddAOAIFunctionResponse(AOAIOperationResponse, AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction1.GetName(), ToolCallId, '', FunctionExecutionResult, '', '');
 
         LibraryAssert.IsTrue(AOAIOperationResponse.IsFunctionCall(), 'Function call should be true.');
         LibraryAssert.AreEqual(AOAIFunctionResponse.GetFunctionName(), TestFunction1.GetName(), 'Function name should be the same as the value set.');
@@ -439,7 +439,7 @@ codeunit 132686 "Azure OpenAI Tools Test"
 
         // Selected function was executed by system
         FunctionExecutionResult := 'test function execution result';
-        AzureOpenAITestLibrary.SetAOAIFunctionResponse(AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction1.GetName(), ToolCallId, FunctionExecutionResult, '', '');
+        AzureOpenAITestLibrary.SetAOAIFunctionResponse(AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction1.GetName(), ToolCallId, '', FunctionExecutionResult, '', '');
 
         // Save the function execution result to the chat messages
         AOAIChatMessages.AddToolMessage(AOAIFunctionResponse.GetFunctionId(), AOAIFunctionResponse.GetFunctionName(), AOAIFunctionResponse.GetResult());
@@ -471,7 +471,7 @@ codeunit 132686 "Azure OpenAI Tools Test"
 
         // Selected function was executed by system
         FunctionExecutionResult := 'test function execution result';
-        AzureOpenAITestLibrary.SetAOAIFunctionResponse(AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction1.GetName(), ToolCallId, FunctionExecutionResult, '', '');
+        AzureOpenAITestLibrary.SetAOAIFunctionResponse(AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction1.GetName(), ToolCallId, '', FunctionExecutionResult, '', '');
 
         // Save the function execution result to the chat messages
         AOAIChatMessages.AddToolMessage(AOAIFunctionResponse.GetFunctionId(), AOAIFunctionResponse.GetFunctionName(), AOAIFunctionResponse.GetResult());
@@ -510,7 +510,7 @@ codeunit 132686 "Azure OpenAI Tools Test"
 
         // Selected function was executed by system
         FunctionExecutionResult := 'test function execution result';
-        AzureOpenAITestLibrary.SetAOAIFunctionResponse(AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction1.GetName(), ToolCallId, FunctionExecutionResult, '', '');
+        AzureOpenAITestLibrary.SetAOAIFunctionResponse(AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction1.GetName(), ToolCallId, '', FunctionExecutionResult, '', '');
 
         // Save the function execution result to the chat messages
         AOAIChatMessages.AddToolMessage(AOAIFunctionResponse.GetFunctionId(), AOAIFunctionResponse.GetFunctionName(), AOAIFunctionResponse.GetResult());
@@ -585,7 +585,7 @@ codeunit 132686 "Azure OpenAI Tools Test"
         // Create some operation and function response for a tool call that did not happen
         ToolCallId := 'call_of7GnOMuBT4H95XkuN14qfai';
         FunctionExecutionResult := 'test function execution result';
-        AzureOpenAITestLibrary.AddAOAIFunctionResponse(AOAIOperationResponse, AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction1.GetName(), ToolCallId, FunctionExecutionResult, '', '');
+        AzureOpenAITestLibrary.AddAOAIFunctionResponse(AOAIOperationResponse, AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction1.GetName(), ToolCallId, '', FunctionExecutionResult, '', '');
 
         // Append the incorrect function response
         asserterror AOAIOperationResponse.AppendFunctionResponsesToChatMessages(AOAIChatMessages);
@@ -619,7 +619,7 @@ codeunit 132686 "Azure OpenAI Tools Test"
 
         // Create some operation and function response for a tool call that did not happen
         FunctionExecutionResult := 'test function execution result';
-        AzureOpenAITestLibrary.AddAOAIFunctionResponse(AOAIOperationResponse, AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction1.GetName(), ToolCallId, FunctionExecutionResult, '', '');
+        AzureOpenAITestLibrary.AddAOAIFunctionResponse(AOAIOperationResponse, AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction1.GetName(), ToolCallId, '', FunctionExecutionResult, '', '');
 
         // Append the incorrect function response
         asserterror AOAIOperationResponse.AppendFunctionResponsesToChatMessages(AOAIChatMessages);
@@ -652,7 +652,7 @@ codeunit 132686 "Azure OpenAI Tools Test"
         // Create some operation and function response for a tool call that did not happen
         ToolCallId := 'call_anothertoolcallid';
         FunctionExecutionResult := 'test function execution result';
-        AzureOpenAITestLibrary.AddAOAIFunctionResponse(AOAIOperationResponse, AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction2.GetName(), ToolCallId, FunctionExecutionResult, '', '');
+        AzureOpenAITestLibrary.AddAOAIFunctionResponse(AOAIOperationResponse, AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction2.GetName(), ToolCallId, '', FunctionExecutionResult, '', '');
 
         // Append the incorrect function response
         asserterror AOAIOperationResponse.AppendFunctionResponsesToChatMessages(AOAIChatMessages);
@@ -689,7 +689,7 @@ codeunit 132686 "Azure OpenAI Tools Test"
 
         // Create an operation and function response for the tool call
         FunctionExecutionResult := 'test function execution result';
-        AzureOpenAITestLibrary.AddAOAIFunctionResponse(AOAIOperationResponse, AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction1.GetName(), ToolCallId, FunctionExecutionResult, '', '');
+        AzureOpenAITestLibrary.AddAOAIFunctionResponse(AOAIOperationResponse, AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Invoke Success", TestFunction1.GetName(), ToolCallId, '', FunctionExecutionResult, '', '');
 
         // Append the function response
         AOAIOperationResponse.AppendFunctionResponsesToChatMessages(AOAIChatMessages);
@@ -745,10 +745,61 @@ codeunit 132686 "Azure OpenAI Tools Test"
         // Enumerate the function response statuses
         foreach AOAIFunctionRepsonseStatusCode in Enum::"AOAI Function Response Status".Ordinals() do begin
             AOAIFunctionResponseStatus := Enum::"AOAI Function Response Status".FromInteger(AOAIFunctionRepsonseStatusCode);
-            AzureOpenAITestLibrary.SetAOAIFunctionResponse(AOAIFunctionResponse, true, AOAIFunctionResponseStatus, TestFunction1.GetName(), ToolCallId, FunctionExecutionResult, '', '');
+            AzureOpenAITestLibrary.SetAOAIFunctionResponse(AOAIFunctionResponse, true, AOAIFunctionResponseStatus, TestFunction1.GetName(), ToolCallId, '', FunctionExecutionResult, '', '');
 
             LibraryAssert.AreEqual(AOAIFunctionResponseStatus in [Enum::"AOAI Function Response Status"::"Invoke Success"], AOAIFunctionResponse.IsSuccess(), 'IsSuccess did not return the expected result for the given response status');
         end;
+    end;
+
+    [Test]
+    procedure TestFunctionCallInvokedManually()
+    var
+        AzureOpenAITestLibrary: Codeunit "Azure OpenAI Test Library";
+        AOAIChatMessages: Codeunit "AOAI Chat Messages";
+        TestFunction1: Codeunit "Test Function 1";
+        AOAIFunctionResponse: Codeunit "AOAI Function Response";
+        AOAIOperationResponse: Codeunit "AOAI Operation Response";
+        ToolCallId: Text;
+        FunctionExecutionResult: Text;
+        ToolCall: JsonToken;
+        ArgumentToken: JsonToken;
+        ParsedArguments: JsonObject;
+    begin
+        AOAIChatMessages.AddTool(TestFunction1);
+
+        AOAIChatMessages.AddSystemMessage('test system message');
+        AOAIChatMessages.AddUserMessage('test user message');
+
+        AOAIChatMessages.SetToolInvokePreference(Enum::"AOAI Tool Invoke Preference"::Manual);
+
+        // Function is been selected by LLM
+        ToolCallId := 'call_of7GnOMuBT4H95XkuN14qfai';
+        AzureOpenAITestLibrary.SetToolCalls(AOAIChatMessages, ToolCallId, TestFunction1.GetName(), '{\"TestParameter\": \"TestValue\"}');
+
+        // Create an operation and function response for the tool call
+        AOAIChatMessages.GetLastToolCalls().Get(0, ToolCall);
+        ToolCall.SelectToken('$.function.arguments', ArgumentToken);
+        FunctionExecutionResult := ''; // the function is not invoked
+
+        AzureOpenAITestLibrary.AddAOAIFunctionResponse(AOAIOperationResponse, AOAIFunctionResponse, true, Enum::"AOAI Function Response Status"::"Not Invoked", TestFunction1.GetName(), ToolCallId, ArgumentToken.AsValue().AsText(), FunctionExecutionResult, '', '');
+
+        // Assert the operation and result
+        LibraryAssert.AreEqual(true, AOAIOperationResponse.IsFunctionCall(), 'Expected function call');
+        LibraryAssert.AreEqual(true, AOAIOperationResponse.IsSuccess(), 'The operation did not succeed');
+        LibraryAssert.AreEqual(1, AOAIOperationResponse.GetFunctionResponses().Count(), 'There was not exactly one function response');
+
+        AOAIFunctionResponse := AOAIOperationResponse.GetFunctionResponses().Get(1);
+
+        LibraryAssert.AreEqual(false, AOAIFunctionResponse.IsSuccess(), 'The function was invoked successfully when the invoke preference was manual');
+        LibraryAssert.AreEqual(Enum::"AOAI Function Response Status"::"Not Invoked", AOAIFunctionResponse.GetStatus(), 'The function is not in the expected status');
+        LibraryAssert.AreEqual(TestFunction1.GetName(), AOAIFunctionResponse.GetFunctionName(), 'The function returned was not the expected name');
+
+        ParsedArguments := AOAIFunctionResponse.GetArguments();
+        LibraryAssert.IsTrue(ParsedArguments.Get('TestParameter', ArgumentToken), 'Could not find argument parameter');
+        LibraryAssert.AreEqual('TestValue', ArgumentToken.AsValue().AsText(), 'Could not read argument parameter');
+
+        FunctionExecutionResult := TestFunction1.Execute(ParsedArguments);
+        LibraryAssert.AreNotEqual('', FunctionExecutionResult, 'The function was not invoked successfully');
     end;
 
     local procedure GetTestFunction1Tool(): JsonObject


### PR DESCRIPTION
#### Summary
When setting the tool invoke preference to `Manual`, the caller may want to invoke the function results manually. To do this, the caller needs to be able to read the function arguments in order to pass them into their function.

This PR adds the function arguments to the function response object.

#### Work Item(s) 
Fixes [AB#542604](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/542604)



