### PR TITLE
Add Register Copilot Capability for specific app id  procedure to "Copilot Test Library"

### DIFF
--- a/src/System Application/Test Library/AI/src/CopilotTestLibrary.Codeunit.al
+++ b/src/System Application/Test Library/AI/src/CopilotTestLibrary.Codeunit.al
@@ -32,6 +32,7 @@ codeunit 132932 "Copilot Test Library"
     procedure RegisterCopilotCapabilityWithAppId(Capability: Enum "Copilot Capability"; AppId: Guid)
     var
         CopilotSettings: Record "Copilot Settings";
+        ModuleInfo: ModuleInfo;
     begin
         if CopilotSettings.Get(Capability, AppId) then
             if CopilotSettings.Status = CopilotSettings.Status::Active then

--- a/src/System Application/Test Library/AI/src/CopilotTestLibrary.Codeunit.al
+++ b/src/System Application/Test Library/AI/src/CopilotTestLibrary.Codeunit.al
@@ -33,12 +33,22 @@ codeunit 132932 "Copilot Test Library"
     var
         CopilotSettings: Record "Copilot Settings";
     begin
+        if CopilotSettings.Get(Capability, AppId) then
+            if CopilotSettings.Status = CopilotSettings.Status::Active then
+                exit
+            else begin
+                CopilotSettings.Status := CopilotSettings.Status::Active;
+                CopilotSettings.Modify();
+                exit;
+            end;
+
         RegisterCopilotCapability(Capability);
 
-        CopilotSettings.SetRange(Capability, Capability);
-        CopilotSettings.FindFirst();
-        CopilotSettings."App Id" := AppId;
-        CopilotSettings.Modify();
+        NavApp.GetCurrentModuleInfo(ModuleInfo);
+        if CopilotSettings.Get(Capability, ModuleInfo.Id) then begin
+            CopilotSettings."App Id" := AppId;
+            CopilotSettings.Modify();
+        end;
     end;
 
     procedure UnregisterCopilotCapability(Capability: Enum "Copilot Capability")


### PR DESCRIPTION
#### Summary
To be able to run SLS tests in pipeline, we need overwritten procedure
"Register Copilot Capability", that will allow us to register copilot
capability for specifi app id.

#### Work Item(s) 

[AB#543582](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/543582)
Add Register Copilot Capability for specific app id procedure to "Copilot Test Library"
