### PR TITLE
[24.x] Feature Management. Add an overload to IsEnabled procedure. (#1720)

### DIFF
--- a/src/System Application/App/Feature Key/src/FeatureManagementFacade.Codeunit.al
+++ b/src/System Application/App/Feature Key/src/FeatureManagementFacade.Codeunit.al
@@ -26,6 +26,17 @@ codeunit 2611 "Feature Management Facade"
     end;
 
     /// <summary>
+    /// Returns true if the feature is enabled and data update, if required, is complete.
+    /// </summary>
+    /// <param name="FeatureId">the feature id in the system table "Feature Key"</param>
+    /// <param name="AllowInsert">specifies if inserts are allowed while checking for feature being enabled</param>
+    /// <returns>if the feature is fully enabled</returns>
+    procedure IsEnabled(FeatureId: Text[50]; AllowInsert: Boolean): Boolean;
+    begin
+        exit(FeatureManagementImpl.IsEnabled(FeatureId, AllowInsert));
+    end;
+
+    /// <summary>
     /// Updates the status in "Feature Data Update Status" records related to all companies.
     /// Also sends the notification reminding user to sign in again after feature is enabled/disabled.
     /// </summary>


### PR DESCRIPTION
Backport of [this merged PR](https://github.com/microsoft/BCApps/pull/1720) to 24.x

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Add an overload to IsEnabled procedure to be able to avoid inserts when checking the feature enabled state, since in some circumstances (init of a report) we cannot afford a transaction without error.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#543746](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/543746)
