### PR TITLE
Scheduled Profiler - Bugfixes from testing

### DIFF
--- a/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
@@ -80,7 +80,12 @@ page 1932 "Perf. Profiler Schedule Card"
                     Caption = 'Description';
                     ToolTip = 'Specifies the description of the schedule.';
                     AboutText = 'The description of the schedule.';
-                    NotBlank = true;
+
+                    trigger OnValidate()
+                    begin
+                        if Rec.Description = '' then
+                            Error(NotEmptyDescriptionErr);
+                    end;
                 }
             }
 
@@ -228,6 +233,7 @@ page 1932 "Perf. Profiler Schedule Card"
         MaxRetentionPeriod: Duration;
         NoRetentionPolicySetupErr: Label 'No retention policy setup found for the performance profiles table.';
         CreateRetentionPolicySetupTxt: Label 'Create a retention policy setup';
+        NotEmptyDescriptionErr: Label 'Description must be filled in.';
 
     local procedure ValidateRecord()
     begin

--- a/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
@@ -97,6 +97,11 @@ page 1932 "Perf. Profiler Schedule Card"
                     AboutText = 'The ID of the user who created the schedule.';
                     TableRelation = User."User Security ID";
                     Lookup = true;
+
+                    trigger OnValidate()
+                    begin
+                        ScheduledPerfProfiler.ValidateScheduleCreationPermissions(UserSecurityId(), Rec."User ID");
+                    end;
                 }
                 field(Activity; Activity)
                 {

--- a/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
@@ -83,8 +83,7 @@ page 1932 "Perf. Profiler Schedule Card"
 
                     trigger OnValidate()
                     begin
-                        if Rec.Description = '' then
-                            Error(NotEmptyDescriptionErr);
+                        this.ValidateDescription();
                     end;
                 }
             }
@@ -223,6 +222,7 @@ page 1932 "Perf. Profiler Schedule Card"
     trigger OnInsertRecord(BelowxRec: Boolean): Boolean
     begin
         this.ValidateRecord();
+        this.ValidateDescription();
     end;
 
     var
@@ -233,11 +233,17 @@ page 1932 "Perf. Profiler Schedule Card"
         MaxRetentionPeriod: Duration;
         NoRetentionPolicySetupErr: Label 'No retention policy setup found for the performance profiles table.';
         CreateRetentionPolicySetupTxt: Label 'Create a retention policy setup';
-        NotEmptyDescriptionErr: Label 'Description must be filled in.';
+        NotEmptyDescriptionErr: Label 'The description must be filled in.';
 
     local procedure ValidateRecord()
     begin
         ScheduledPerfProfiler.ValidatePerformanceProfileSchedulerDates(Rec, MaxRetentionPeriod);
         ScheduledPerfProfiler.ValidatePerformanceProfileSchedulerRecord(Rec, Activity);
+    end;
+
+    local procedure ValidateDescription()
+    begin
+        if Rec.Description = '' then
+            Error(NotEmptyDescriptionErr);
     end;
 }

--- a/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
@@ -233,7 +233,7 @@ page 1932 "Perf. Profiler Schedule Card"
         MaxRetentionPeriod: Duration;
         NoRetentionPolicySetupErr: Label 'No retention policy setup found for the performance profiles table.';
         CreateRetentionPolicySetupTxt: Label 'Create a retention policy setup';
-        NotEmptyDescriptionErr: Label 'The description must be filled in.';
+        EmptyDescriptionErr: Label 'The description must be filled in.';
 
     local procedure ValidateRecord()
     begin
@@ -244,6 +244,6 @@ page 1932 "Perf. Profiler Schedule Card"
     local procedure ValidateDescription()
     begin
         if Rec.Description = '' then
-            Error(NotEmptyDescriptionErr);
+            Error(EmptyDescriptionErr);
     end;
 }

--- a/src/System Application/App/Performance Profiler/src/PerformanceProfileList.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerformanceProfileList.Page.al
@@ -53,13 +53,13 @@ page 1931 "Performance Profile List"
                 }
                 field(ActivityDuration; Rec."Activity Duration")
                 {
-                    Caption = 'Activity Duration (ms)';
+                    Caption = 'Activity Duration';
                     ToolTip = 'Specifies the duration of the recorded activity including system operations and waiting for input.';
                     AboutText = 'The duration of the recorded activity including system operations and waiting for input.';
                 }
                 field(ALExecutionTime; Rec.Duration)
                 {
-                    Caption = 'AL Execution Duration (ms)';
+                    Caption = 'AL Execution Duration';
                     ToolTip = 'Specifies the total duration of the sampled AL code in the recorded activity. This measurement is approximate as it depends on the selected sampling frequency.';
                     AboutText = 'The duration of the sampled AL code in this activity.';
                 }

--- a/src/System Application/App/Performance Profiler/src/ScheduledPerfProfiler.Codeunit.al
+++ b/src/System Application/App/Performance Profiler/src/ScheduledPerfProfiler.Codeunit.al
@@ -88,6 +88,16 @@ codeunit 1931 "Scheduled Perf. Profiler"
     end;
 
     /// <summary>
+    /// Returns true if the user can make schedules for other users.
+    /// </summary>
+    /// <param name="UserID">The current user ID.</param>
+    /// <param name="ScheduleUserId">The schedule user ID.</param>
+    procedure ValidateScheduleCreationPermissions(UserID: Guid; ScheduleUserId: Guid)
+    begin
+        ScheduledPerfProfilerImpl.ValidateScheduleCreationPermissions(UserID, ScheduleUserId);
+    end;
+
+    /// <summary>
     /// Maps a session type to an activity type.
     /// </summary>
     /// <param name="PerformanceProfileScheduler">The "Performance Profile Scheduler" record </param>

--- a/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
+++ b/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
@@ -231,5 +231,5 @@ codeunit 1932 "Scheduled Perf. Profiler Impl."
         ProfileCannotBeInThePastErr: Label 'A schedule cannot be set to run in the past.';
         ScheduleDurationCannotExceedRetentionPeriodErr: Label 'The performance profile schedule duration cannot exceed the retention period.';
         ScheduleEndTimeCannotBeEmptyErr: Label 'The performance profile schedule must have an end time.';
-        CannotCreateSchedulesForOtherUsersErr: Label 'Only user admins can create schedules for other users.';
+        CannotCreateSchedulesForOtherUsersErr: Label 'You do not have sufficient permissions to create profiler schedules for other users. Please contact your administrator.';
 }

--- a/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
+++ b/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
@@ -65,6 +65,17 @@ codeunit 1932 "Scheduled Perf. Profiler Impl."
         RecordRef.FilterGroup(0);
     end;
 
+    procedure ValidateScheduleCreationPermissions(UserID: Guid; ScheduleUserID: Guid)
+    var
+        UserPermissions: Codeunit "User Permissions";
+    begin
+        if (UserID = ScheduleUserID) then
+            exit;
+
+        if (not UserPermissions.CanManageUsersOnTenant(UserID)) then
+            Error(CannotCreateSchedulesForOtherUsersErr);
+    end;
+
     procedure InitializeFields(var PerformanceProfileScheduler: Record "Performance Profile Scheduler"; var ActivityType: Enum "Perf. Profile Activity Type")
     var
         OneHour: Duration;
@@ -220,4 +231,5 @@ codeunit 1932 "Scheduled Perf. Profiler Impl."
         ProfileCannotBeInThePastErr: Label 'A schedule cannot be set to run in the past.';
         ScheduleDurationCannotExceedRetentionPeriodErr: Label 'The performance profile schedule duration cannot exceed the retention period.';
         ScheduleEndTimeCannotBeEmptyErr: Label 'The performance profile schedule must have an end time.';
+        CannotCreateSchedulesForOtherUsersErr: Label 'Only user admins can create schedules for other users.';
 }


### PR DESCRIPTION

#### Summary
Some bugs were identified on further testing of the feature. These are:
1) While non-admin users cannot see other users' profiles and schedules, they can create them as insert wasn't guarded on the page.
2) The description is not correctly validated to be non-empty
3) On the performance profiles page, we incorrectly include "(ms)" in the caption although the duration type is formatted with a textual form of the duration.

#### Work Item(s)
Fixes [AB#544034](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/544034)



