### PR TITLE
Sort available profiles by caption (= display name)

### DIFF
--- a/src/System Application/App/User Settings/src/UserSettingsImpl.Codeunit.al
+++ b/src/System Application/App/User Settings/src/UserSettingsImpl.Codeunit.al
@@ -81,8 +81,10 @@ codeunit 9175 "User Settings Impl."
     begin
         TempAllProfile.Reset();
         TempAllProfile.DeleteAll();
+
         AllProfile.SetRange(Enabled, true);
         AllProfile.SetFilter(Description, '<> %1', DescriptionFilterTxt);
+
         if AllProfile.FindSet() then
             repeat
                 TempAllProfile := AllProfile;
@@ -90,6 +92,8 @@ codeunit 9175 "User Settings Impl."
                     TempAllProfile."App Name" := UserCreatedAppNameTxt;
                 TempAllProfile.Insert();
             until AllProfile.Next() = 0;
+
+        TempAllProfile.SetCurrentKey(Caption, "Profile ID");
     end;
 
     procedure GetUserSettings(UserSecurityID: Guid; var UserSettingsRec: Record "User Settings")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
When picking a profile in My Settings, the sorting behind the scenes happens by profile ID and not by profile display name, causing a weird sorting.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#544052](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/544052)


