### PR TITLE
Add Refresh Allowed Tables action to Retention Policy list page

### DIFF
--- a/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetupCard.Page.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetupCard.Page.al
@@ -190,7 +190,7 @@ page 3901 "Retention Policy Setup Card"
             }
             action(RestoreAllowedTables)
             {
-                Caption = 'Refresh allowed tables';
+                Caption = 'Refresh Allowed Tables';
                 ApplicationArea = All;
                 Image = Refresh;
                 ToolTip = 'Refreshes the list of tables that can be selected.';

--- a/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetupList.Page.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetupList.Page.al
@@ -131,6 +131,20 @@ page 3903 "Retention Policy Setup List"
                     ApplyRetentionPolicy.ApplyRetentionPolicy(true);
                 end;
             }
+            action(RestoreAllowedTables)
+            {
+                Caption = 'Refresh Allowed Tables';
+                ApplicationArea = All;
+                Image = Refresh;
+                ToolTip = 'Refreshes the list of tables that can be selected.';
+
+                trigger OnAction()
+                var
+                    RetenPolAllowedTables: Codeunit "Reten. Pol. Allowed Tables";
+                begin
+                    RetenPolAllowedTables.OnRefreshAllowedTables();
+                end;
+            }
         }
     }
 

--- a/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetupList.Page.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetupList.Page.al
@@ -135,6 +135,9 @@ page 3903 "Retention Policy Setup List"
             {
                 Caption = 'Refresh Allowed Tables';
                 ApplicationArea = All;
+                Promoted = true;
+                PromotedOnly = true;
+                PromotedCategory = Process;
                 Image = Refresh;
                 ToolTip = 'Refreshes the list of tables that can be selected.';
 


### PR DESCRIPTION
#### Summary

Currently this action is only on the card page which is not user friendly. Copy the action to list page too.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#542890](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/542890)


