### PR TITLE
Page Summary provider - Add ability to exclude media, media set and blobs from page summary provider

### DIFF
--- a/src/System Application/App/Page Summary Provider/permissions/PageSummaryProviderObj.PermissionSet.al
+++ b/src/System Application/App/Page Summary Provider/permissions/PageSummaryProviderObj.PermissionSet.al
@@ -11,6 +11,7 @@ permissionset 2716 "Page Summary Provider - Obj."
     Assignable = false;
 
     Permissions = table "Page Summary Settings" = X,
+                  table "Page Summary Parameters" = X,
                   codeunit "Page Summary Provider" = X,
                   codeunit "Page Summary Settings" = X,
                   page "Page Summary Settings" = X;

--- a/src/System Application/App/Page Summary Provider/src/PageSummaryParameters.Table.al
+++ b/src/System Application/App/Page Summary Provider/src/PageSummaryParameters.Table.al
@@ -1,0 +1,57 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Integration;
+
+table 2719 "Page Summary Parameters"
+{
+    DataClassification = SystemMetadata;
+    Caption = 'Page Summary Settings';
+    ReplicateData = false;
+    TableType = Temporary;
+
+    fields
+    {
+        field(1; "Page ID"; Integer)
+        {
+            Caption = 'Page ID';
+            ToolTip = 'Specifies the ID of the page for which the summary is requested. This parameter is mandatory.';
+        }
+        field(2; "Record SystemID"; Guid)
+        {
+            Caption = 'Record SystemID';
+            ToolTip = 'Specifies the SystemID of the record for which the summary is requested.';
+        }
+        field(3; Bookmark; Text[2024])
+        {
+            Caption = 'Bookmark';
+            ToolTip = 'Specifies the bookmark of the record for which the summary is requested.';
+        }
+        field(4; "Include Binary Data"; Boolean)
+        {
+            Caption = 'Include Media';
+            ToolTip = 'Specifies if the media should be included in the summary.';
+            InitValue = true;
+        }
+    }
+
+    keys
+    {
+        key(Key1; "Page ID")
+        {
+        }
+    }
+
+    /// <summary>
+    /// Initializes the page summary parameters record from JSON.
+    /// </summary>
+    /// <param name="PageSummaryParameterJson">Page summary parameters in JSON format</param>
+    procedure FromJson(PageSummaryParameterJson: Text)
+    var
+        PageSummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
+    begin
+        PageSummaryProviderImpl.InitializePageSummarySettingsFromJson(PageSummaryParameterJson, Rec);
+    end;
+}

--- a/src/System Application/App/Page Summary Provider/src/PageSummaryProvider.Codeunit.al
+++ b/src/System Application/App/Page Summary Provider/src/PageSummaryProvider.Codeunit.al
@@ -63,7 +63,61 @@ codeunit 2718 "Page Summary Provider"
     var
         SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
     begin
-        exit(SummaryProviderImpl.GetPageSummary(PageId, Bookmark));
+        exit(SummaryProviderImpl.GetPageSummary(PageId, Bookmark, false));
+    end;
+
+    /// <summary>
+    /// Gets page summary for a given Page ID and bookmark.
+    /// </summary>
+    //  <param name="PageId">The ID of the page for which to retrieve page summary.</param>
+    //  <param name="Bookmark">The Bookmark of the page for which to retrieve page summary.</param>
+    //  <param name="ExcludeMedia">If the media should be excluded from the response. If set to true then any Media or Blob objects will be excluded from the payload, making the payload smaller.</param>
+    /// <returns>Text value for the page summary in JSON format.</returns>
+    /// <example>
+    /// {
+    ///   "version":"1.1",
+    ///   "pageCaption":"Customer Card",
+    ///   "pageType":"Card",
+    ///   "summaryType":"Brick",
+    ///   "cardPageId": "0",
+    ///   "url":"https://businesscentral.dynamics.com/?company=CRONUS%20International%20Ltd.&amp;page=22&amp;bookmark=27%3bEgAAAAJ7CDAAMQA5ADAANQA4ADkAMw%3d%3",
+    ///   "fields":[
+    ///      {"caption":"No.","fieldValue":"01445544","fieldType":"Code", "tooltip":"Specifies the number of the customer."},
+    ///      {"caption":"Name","fieldValue":"Progressive Home Furnishings","fieldType":"Text","tooltip":"Specifies the customer's name. This name will appear on all sales documents for the customer."},
+    ///      {"caption":"Contact","fieldValue":"Mr. Scott Mitchell","fieldType":"Text", "tooltip":"Specifies the name of the person you regularly contact when you do business with this customer."},
+    ///      {"caption":"Balance Due (LCY)","fieldValue":"1.499,03","fieldType":"Decimal","tooltip":"Specifies the payment amount that the customer owes for completed sales."}],
+    ///   "recordFields":[
+    ///      {"caption":"No.","fieldValue":"01121212","fieldType":"Code","tooltip":"Specifies the number of the customer."},
+    ///      {"caption":"Name","fieldValue":"Spotsmeyer's Furnishings","fieldType":"Text","tooltip":"Specifies the customer's name. This name will appear on all sales documents for the customer."},
+    ///      {"caption":"Balance (LCY)","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies the payment amount that the customer owes for completed sales. This value is also known as the customer's balance."},
+    ///      {"caption":"Balance Due (LCY)","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies payments from the customer that are overdue per today's date."},
+    ///      {"caption":"Credit Limit (LCY)","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies the maximum amount you allow the customer to exceed the payment balance before warnings are issued."},
+    ///      {"caption":"Blocked","fieldValue":" ","fieldType":"Option","tooltip":"Specifies which transactions with the customer that cannot be processed, for example, because the customer is insolvent."},
+    ///      {"caption":"Privacy Blocked","fieldValue":"No","fieldType":"Boolean","tooltip":"Specifies whether to limit access to data for the data subject during daily operations. This is useful, for example, when protecting data from changes while it is under privacy review."},
+    ///      {"caption":"Salesperson Code","fieldValue":"JR","fieldType":"Code","tooltip":"Specifies a code for the salesperson who normally handles this customer's account."},
+    ///      {"caption":"Service Zone Code","fieldValue":"X","fieldType":"Code","tooltip":"Specifies the code for the service zone that is assigned to the customer."},
+    ///      {"caption":"Address","fieldValue":"612 South Sunset Drive","fieldType":"Text","tooltip":"Specifies the customer's address. This address will appear on all sales documents for the customer."}
+    ///      {"caption":"Payments This Year","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies the sum of payments received from the customer in the current fiscal year."},
+    ///      {"caption":"Last Date Modified","fieldValue":"08/02/24","fieldType":"Date","tooltip":"Specifies when the customer card was last modified."}]
+    /// }
+    ///
+    /// In case of an error:
+    /// {
+    ///   "version":"1.1",
+    ///   "pageCaption":"Customer Card",
+    ///   "pageType":"Card",
+    ///   "summaryType":"Caption",
+    ///   "error":[
+    ///     "code":"InvalidBookmark"
+    ///     "message":"The bookmark is invalid."
+    ///   ]
+    /// }
+    /// </example>
+    procedure GetPageSummary(PageId: Integer; Bookmark: Text; ExcludeMedia: Boolean): Text
+    var
+        SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
+    begin
+        exit(SummaryProviderImpl.GetPageSummary(PageId, Bookmark, ExcludeMedia));
     end;
 
     /// <summary>
@@ -72,8 +126,8 @@ codeunit 2718 "Page Summary Provider"
     //  <param name="PageId">The ID of the page for which to retrieve page summary.</param>
     //  <param name="SystemId">The system ID of the record in the page for which to retrieve page summary.
     //  Following GUID formats are supported:
-    //  1. 32 digits seperated by hyphens.
-    //  2. 32 digits seperated by hyphens and enclosed in braces.
+    //  1. 32 digits separated by hyphens.
+    //  2. 32 digits separated by hyphens and enclosed in braces.
     //  </param>
     /// <returns>Text value for the page summary in JSON format.</returns>
     /// <example>
@@ -120,7 +174,65 @@ codeunit 2718 "Page Summary Provider"
     var
         SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
     begin
-        exit(SummaryProviderImpl.GetPageSummary(PageId, SystemId));
+        exit(SummaryProviderImpl.GetPageSummary(PageId, SystemId, false));
+    end;
+
+    /// <summary>
+    /// Gets page summary for a given Page ID and System ID.
+    /// </summary>
+    //  <param name="PageId">The ID of the page for which to retrieve page summary.</param>
+    //  <param name="SystemId">The system ID of the record in the page for which to retrieve page summary.
+    //  Following GUID formats are supported:
+    //  1. 32 digits separated by hyphens.
+    //  2. 32 digits separated by hyphens and enclosed in braces.
+    //  </param>
+    //  <param name="ExcludeMedia">If the media should be excluded from the response. If set to true then any Media or Blob objects will be excluded from the payload, making the payload smaller.</param>
+    /// <returns>Text value for the page summary in JSON format.</returns>
+    /// <example>
+    /// {
+    ///   "version":"1.1",
+    ///   "pageCaption":"Customer Card",
+    ///   "pageType":"Card",
+    ///   "summaryType":"Brick",
+    ///   "cardPageId": "0",
+    ///   "url":"https://businesscentral.dynamics.com/?company=CRONUS%20International%20Ltd.&amp;page=22&amp;bookmark=27%3bEgAAAAJ7CDAAMQA5ADAANQA4ADkAMw%3d%3",
+    ///   "fields":[
+    ///      {"caption":"No.","fieldValue":"01445544","fieldType":"Code", "tooltip":"Specifies the number of the customer."},
+    ///      {"caption":"Name","fieldValue":"Progressive Home Furnishings","fieldType":"Text","tooltip":"Specifies the customer's name. This name will appear on all sales documents for the customer."},
+    ///      {"caption":"Contact","fieldValue":"Mr. Scott Mitchell","fieldType":"Text", "tooltip":"Specifies the name of the person you regularly contact when you do business with this customer."},
+    ///      {"caption":"Balance Due (LCY)","fieldValue":"1.499,03","fieldType":"Decimal","tooltip":"Specifies the payment amount that the customer owes for completed sales."}],
+    ///   "recordFields":[
+    ///      {"caption":"No.","fieldValue":"01121212","fieldType":"Code","tooltip":"Specifies the number of the customer."},
+    ///      {"caption":"Name","fieldValue":"Spotsmeyer's Furnishings","fieldType":"Text","tooltip":"Specifies the customer's name. This name will appear on all sales documents for the customer."},
+    ///      {"caption":"Balance (LCY)","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies the payment amount that the customer owes for completed sales. This value is also known as the customer's balance."},
+    ///      {"caption":"Balance Due (LCY)","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies payments from the customer that are overdue per today's date."},
+    ///      {"caption":"Credit Limit (LCY)","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies the maximum amount you allow the customer to exceed the payment balance before warnings are issued."},
+    ///      {"caption":"Blocked","fieldValue":" ","fieldType":"Option","tooltip":"Specifies which transactions with the customer that cannot be processed, for example, because the customer is insolvent."},
+    ///      {"caption":"Privacy Blocked","fieldValue":"No","fieldType":"Boolean","tooltip":"Specifies whether to limit access to data for the data subject during daily operations. This is useful, for example, when protecting data from changes while it is under privacy review."},
+    ///      {"caption":"Salesperson Code","fieldValue":"JR","fieldType":"Code","tooltip":"Specifies a code for the salesperson who normally handles this customer's account."},
+    ///      {"caption":"Service Zone Code","fieldValue":"X","fieldType":"Code","tooltip":"Specifies the code for the service zone that is assigned to the customer."},
+    ///      {"caption":"Address","fieldValue":"612 South Sunset Drive","fieldType":"Text","tooltip":"Specifies the customer's address. This address will appear on all sales documents for the customer."}
+    ///      {"caption":"Payments This Year","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies the sum of payments received from the customer in the current fiscal year."},
+    ///      {"caption":"Last Date Modified","fieldValue":"08/02/24","fieldType":"Date","tooltip":"Specifies when the customer card was last modified."}]
+    /// }
+    ///
+    /// In case of an error:
+    /// {
+    ///   "version":"1.1",
+    ///   "pageCaption":"Customer Card",
+    ///   "pageType":"Card",
+    ///   "summaryType":"Caption",
+    ///   "error":[
+    ///     "code":"InvalidSystemId"
+    ///     "message":"The system id is invalid."
+    ///   ]
+    /// }
+    /// </example>
+    procedure GetPageSummaryBySystemID(PageId: Integer; SystemId: Guid; ExcludeMedia: Boolean): Text
+    var
+        SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
+    begin
+        exit(SummaryProviderImpl.GetPageSummary(PageId, SystemId, ExcludeMedia));
     end;
 
     /// <summary>
@@ -152,7 +264,40 @@ codeunit 2718 "Page Summary Provider"
     var
         SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
     begin
-        exit(SummaryProviderImpl.GetPageSummary(PageId, ''));
+        exit(SummaryProviderImpl.GetPageSummary(PageId, '', false));
+    end;
+
+    /// <summary>
+    /// Gets page information such as page caption and and page type.
+    /// </summary>
+    //  <param name="PageId">The ID of the page for which to retrieve page summary.</param>
+    //  <param name="ExcludeMedia">If the media should be excluded from the response. If set to true then any Media or Blob objects will be excluded from the payload, making the payload smaller.</param>
+    /// <returns>Text value for the page summary in JSON format.</returns>
+    /// <example>
+    /// {
+    ///   "version":"1.1",
+    ///   "pageCaption":"Customer Card",
+    ///   "pageType":"Card",
+    ///   "summaryType":"Caption",
+    /// }
+    ///
+    /// In case of error:
+    /// {
+    ///   "version":"1.1",
+    ///   "pageCaption":"Customer Card",
+    ///   "pageType":"Card",
+    ///   "summaryType":"Caption",
+    ///   "error":[
+    ///     "code":"error code"
+    ///     "message":"error message"
+    ///   ]
+    /// }
+    /// </example>
+    procedure GetPageSummary(PageId: Integer; ExcludeMedia: Boolean): Text
+    var
+        SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
+    begin
+        exit(SummaryProviderImpl.GetPageSummary(PageId, '', false));
     end;
 
     /// <summary>
@@ -161,8 +306,8 @@ codeunit 2718 "Page Summary Provider"
     //  <param name="PageId">The ID of the page for which to retrieve the url info.</param>
     //  <param name="SystemId">The system ID of the record in the page for which to retrieve the url info.
     //  Following GUID formats are supported:
-    //  1. 32 digits seperated by hyphens.
-    //  2. 32 digits seperated by hyphens and enclosed in braces.
+    //  1. 32 digits separated by hyphens.
+    //  2. 32 digits separated by hyphens and enclosed in braces.
     //  </param>
     /// <returns>Text value for the page url info in JSON format.</returns>
     /// <example>

--- a/src/System Application/App/Page Summary Provider/src/PageSummaryProvider.Codeunit.al
+++ b/src/System Application/App/Page Summary Provider/src/PageSummaryProvider.Codeunit.al
@@ -13,6 +13,7 @@ codeunit 2718 "Page Summary Provider"
 {
     Access = Public;
 
+    #region OData API functions
     /// <summary>
     /// Gets page summary for a given Page ID and bookmark.
     /// </summary>
@@ -63,61 +64,7 @@ codeunit 2718 "Page Summary Provider"
     var
         SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
     begin
-        exit(SummaryProviderImpl.GetPageSummary(PageId, Bookmark, false));
-    end;
-
-    /// <summary>
-    /// Gets page summary for a given Page ID and bookmark.
-    /// </summary>
-    //  <param name="PageId">The ID of the page for which to retrieve page summary.</param>
-    //  <param name="Bookmark">The Bookmark of the page for which to retrieve page summary.</param>
-    //  <param name="ExcludeMedia">If the media should be excluded from the response. If set to true then any Media or Blob objects will be excluded from the payload, making the payload smaller.</param>
-    /// <returns>Text value for the page summary in JSON format.</returns>
-    /// <example>
-    /// {
-    ///   "version":"1.1",
-    ///   "pageCaption":"Customer Card",
-    ///   "pageType":"Card",
-    ///   "summaryType":"Brick",
-    ///   "cardPageId": "0",
-    ///   "url":"https://businesscentral.dynamics.com/?company=CRONUS%20International%20Ltd.&amp;page=22&amp;bookmark=27%3bEgAAAAJ7CDAAMQA5ADAANQA4ADkAMw%3d%3",
-    ///   "fields":[
-    ///      {"caption":"No.","fieldValue":"01445544","fieldType":"Code", "tooltip":"Specifies the number of the customer."},
-    ///      {"caption":"Name","fieldValue":"Progressive Home Furnishings","fieldType":"Text","tooltip":"Specifies the customer's name. This name will appear on all sales documents for the customer."},
-    ///      {"caption":"Contact","fieldValue":"Mr. Scott Mitchell","fieldType":"Text", "tooltip":"Specifies the name of the person you regularly contact when you do business with this customer."},
-    ///      {"caption":"Balance Due (LCY)","fieldValue":"1.499,03","fieldType":"Decimal","tooltip":"Specifies the payment amount that the customer owes for completed sales."}],
-    ///   "recordFields":[
-    ///      {"caption":"No.","fieldValue":"01121212","fieldType":"Code","tooltip":"Specifies the number of the customer."},
-    ///      {"caption":"Name","fieldValue":"Spotsmeyer's Furnishings","fieldType":"Text","tooltip":"Specifies the customer's name. This name will appear on all sales documents for the customer."},
-    ///      {"caption":"Balance (LCY)","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies the payment amount that the customer owes for completed sales. This value is also known as the customer's balance."},
-    ///      {"caption":"Balance Due (LCY)","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies payments from the customer that are overdue per today's date."},
-    ///      {"caption":"Credit Limit (LCY)","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies the maximum amount you allow the customer to exceed the payment balance before warnings are issued."},
-    ///      {"caption":"Blocked","fieldValue":" ","fieldType":"Option","tooltip":"Specifies which transactions with the customer that cannot be processed, for example, because the customer is insolvent."},
-    ///      {"caption":"Privacy Blocked","fieldValue":"No","fieldType":"Boolean","tooltip":"Specifies whether to limit access to data for the data subject during daily operations. This is useful, for example, when protecting data from changes while it is under privacy review."},
-    ///      {"caption":"Salesperson Code","fieldValue":"JR","fieldType":"Code","tooltip":"Specifies a code for the salesperson who normally handles this customer's account."},
-    ///      {"caption":"Service Zone Code","fieldValue":"X","fieldType":"Code","tooltip":"Specifies the code for the service zone that is assigned to the customer."},
-    ///      {"caption":"Address","fieldValue":"612 South Sunset Drive","fieldType":"Text","tooltip":"Specifies the customer's address. This address will appear on all sales documents for the customer."}
-    ///      {"caption":"Payments This Year","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies the sum of payments received from the customer in the current fiscal year."},
-    ///      {"caption":"Last Date Modified","fieldValue":"08/02/24","fieldType":"Date","tooltip":"Specifies when the customer card was last modified."}]
-    /// }
-    ///
-    /// In case of an error:
-    /// {
-    ///   "version":"1.1",
-    ///   "pageCaption":"Customer Card",
-    ///   "pageType":"Card",
-    ///   "summaryType":"Caption",
-    ///   "error":[
-    ///     "code":"InvalidBookmark"
-    ///     "message":"The bookmark is invalid."
-    ///   ]
-    /// }
-    /// </example>
-    procedure GetPageSummary(PageId: Integer; Bookmark: Text; ExcludeMedia: Boolean): Text
-    var
-        SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
-    begin
-        exit(SummaryProviderImpl.GetPageSummary(PageId, Bookmark, ExcludeMedia));
+        exit(SummaryProviderImpl.GetPageSummary(PageId, Bookmark, true));
     end;
 
     /// <summary>
@@ -174,19 +121,46 @@ codeunit 2718 "Page Summary Provider"
     var
         SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
     begin
-        exit(SummaryProviderImpl.GetPageSummary(PageId, SystemId, false));
+        exit(SummaryProviderImpl.GetPageSummary(PageId, SystemId, true));
     end;
 
     /// <summary>
-    /// Gets page summary for a given Page ID and System ID.
+    /// Gets page information such as page caption and and page type.
     /// </summary>
     //  <param name="PageId">The ID of the page for which to retrieve page summary.</param>
-    //  <param name="SystemId">The system ID of the record in the page for which to retrieve page summary.
-    //  Following GUID formats are supported:
-    //  1. 32 digits separated by hyphens.
-    //  2. 32 digits separated by hyphens and enclosed in braces.
-    //  </param>
-    //  <param name="ExcludeMedia">If the media should be excluded from the response. If set to true then any Media or Blob objects will be excluded from the payload, making the payload smaller.</param>
+    /// <returns>Text value for the page summary in JSON format.</returns>
+    /// <example>
+    /// {
+    ///   "version":"1.1",
+    ///   "pageCaption":"Customer Card",
+    ///   "pageType":"Card",
+    ///   "summaryType":"Caption",
+    /// }
+    ///
+    /// In case of error:
+    /// {
+    ///   "version":"1.1",
+    ///   "pageCaption":"Customer Card",
+    ///   "pageType":"Card",
+    ///   "summaryType":"Caption",
+    ///   "error":[
+    ///     "code":"error code"
+    ///     "message":"error message"
+    ///   ]
+    /// }
+    /// </example>
+    procedure GetPageSummary(PageId: Integer): Text
+    var
+        SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
+    begin
+        exit(SummaryProviderImpl.GetPageSummary(PageId, '', true));
+    end;
+
+    /// <summary>
+    /// Gets page summary for a given Page ID and specified parameters in JSON format.
+    /// </summary>
+    //  <param name="PageId">The ID of the page for which to retrieve page summary.</param>
+    //  <param name="Parameters">Parameters in JSON format to be used for fetching page summary.</param>
     /// <returns>Text value for the page summary in JSON format.</returns>
     /// <example>
     /// {
@@ -228,76 +202,11 @@ codeunit 2718 "Page Summary Provider"
     ///   ]
     /// }
     /// </example>
-    procedure GetPageSummaryBySystemID(PageId: Integer; SystemId: Guid; ExcludeMedia: Boolean): Text
+    procedure GetPageSummary(Parameters: Text): Text
     var
         SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
     begin
-        exit(SummaryProviderImpl.GetPageSummary(PageId, SystemId, ExcludeMedia));
-    end;
-
-    /// <summary>
-    /// Gets page information such as page caption and and page type.
-    /// </summary>
-    //  <param name="PageId">The ID of the page for which to retrieve page summary.</param>
-    /// <returns>Text value for the page summary in JSON format.</returns>
-    /// <example>
-    /// {
-    ///   "version":"1.1",
-    ///   "pageCaption":"Customer Card",
-    ///   "pageType":"Card",
-    ///   "summaryType":"Caption",
-    /// }
-    ///
-    /// In case of error:
-    /// {
-    ///   "version":"1.1",
-    ///   "pageCaption":"Customer Card",
-    ///   "pageType":"Card",
-    ///   "summaryType":"Caption",
-    ///   "error":[
-    ///     "code":"error code"
-    ///     "message":"error message"
-    ///   ]
-    /// }
-    /// </example>
-    procedure GetPageSummary(PageId: Integer): Text
-    var
-        SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
-    begin
-        exit(SummaryProviderImpl.GetPageSummary(PageId, '', false));
-    end;
-
-    /// <summary>
-    /// Gets page information such as page caption and and page type.
-    /// </summary>
-    //  <param name="PageId">The ID of the page for which to retrieve page summary.</param>
-    //  <param name="ExcludeMedia">If the media should be excluded from the response. If set to true then any Media or Blob objects will be excluded from the payload, making the payload smaller.</param>
-    /// <returns>Text value for the page summary in JSON format.</returns>
-    /// <example>
-    /// {
-    ///   "version":"1.1",
-    ///   "pageCaption":"Customer Card",
-    ///   "pageType":"Card",
-    ///   "summaryType":"Caption",
-    /// }
-    ///
-    /// In case of error:
-    /// {
-    ///   "version":"1.1",
-    ///   "pageCaption":"Customer Card",
-    ///   "pageType":"Card",
-    ///   "summaryType":"Caption",
-    ///   "error":[
-    ///     "code":"error code"
-    ///     "message":"error message"
-    ///   ]
-    /// }
-    /// </example>
-    procedure GetPageSummary(PageId: Integer; ExcludeMedia: Boolean): Text
-    var
-        SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
-    begin
-        exit(SummaryProviderImpl.GetPageSummary(PageId, '', false));
+        exit(SummaryProviderImpl.GetPageSummary(Parameters));
     end;
 
     /// <summary>
@@ -341,6 +250,60 @@ codeunit 2718 "Page Summary Provider"
         SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
     begin
         exit(SummaryProviderImpl.GetVersion());
+    end;
+    #endregion
+
+    /// <summary>
+    /// Gets page summary for a given Page ID and specified parameters record.
+    /// </summary>
+    //  <param name="PageId">The ID of the page for which to retrieve page summary.</param>
+    //  <param name="Parameters">Parameters record that is used to generate the page summary.</param>
+    /// <returns>Text value for the page summary in JSON format.</returns>
+    /// <example>
+    /// {
+    ///   "version":"1.1",
+    ///   "pageCaption":"Customer Card",
+    ///   "pageType":"Card",
+    ///   "summaryType":"Brick",
+    ///   "cardPageId": "0",
+    ///   "url":"https://businesscentral.dynamics.com/?company=CRONUS%20International%20Ltd.&amp;page=22&amp;bookmark=27%3bEgAAAAJ7CDAAMQA5ADAANQA4ADkAMw%3d%3",
+    ///   "fields":[
+    ///      {"caption":"No.","fieldValue":"01445544","fieldType":"Code", "tooltip":"Specifies the number of the customer."},
+    ///      {"caption":"Name","fieldValue":"Progressive Home Furnishings","fieldType":"Text","tooltip":"Specifies the customer's name. This name will appear on all sales documents for the customer."},
+    ///      {"caption":"Contact","fieldValue":"Mr. Scott Mitchell","fieldType":"Text", "tooltip":"Specifies the name of the person you regularly contact when you do business with this customer."},
+    ///      {"caption":"Balance Due (LCY)","fieldValue":"1.499,03","fieldType":"Decimal","tooltip":"Specifies the payment amount that the customer owes for completed sales."}],
+    ///   "recordFields":[
+    ///      {"caption":"No.","fieldValue":"01121212","fieldType":"Code","tooltip":"Specifies the number of the customer."},
+    ///      {"caption":"Name","fieldValue":"Spotsmeyer's Furnishings","fieldType":"Text","tooltip":"Specifies the customer's name. This name will appear on all sales documents for the customer."},
+    ///      {"caption":"Balance (LCY)","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies the payment amount that the customer owes for completed sales. This value is also known as the customer's balance."},
+    ///      {"caption":"Balance Due (LCY)","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies payments from the customer that are overdue per today's date."},
+    ///      {"caption":"Credit Limit (LCY)","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies the maximum amount you allow the customer to exceed the payment balance before warnings are issued."},
+    ///      {"caption":"Blocked","fieldValue":" ","fieldType":"Option","tooltip":"Specifies which transactions with the customer that cannot be processed, for example, because the customer is insolvent."},
+    ///      {"caption":"Privacy Blocked","fieldValue":"No","fieldType":"Boolean","tooltip":"Specifies whether to limit access to data for the data subject during daily operations. This is useful, for example, when protecting data from changes while it is under privacy review."},
+    ///      {"caption":"Salesperson Code","fieldValue":"JR","fieldType":"Code","tooltip":"Specifies a code for the salesperson who normally handles this customer's account."},
+    ///      {"caption":"Service Zone Code","fieldValue":"X","fieldType":"Code","tooltip":"Specifies the code for the service zone that is assigned to the customer."},
+    ///      {"caption":"Address","fieldValue":"612 South Sunset Drive","fieldType":"Text","tooltip":"Specifies the customer's address. This address will appear on all sales documents for the customer."}
+    ///      {"caption":"Payments This Year","fieldValue":"0","fieldType":"Decimal","tooltip":"Specifies the sum of payments received from the customer in the current fiscal year."},
+    ///      {"caption":"Last Date Modified","fieldValue":"08/02/24","fieldType":"Date","tooltip":"Specifies when the customer card was last modified."}]
+    /// }
+    ///
+    /// In case of an error:
+    /// {
+    ///   "version":"1.1",
+    ///   "pageCaption":"Customer Card",
+    ///   "pageType":"Card",
+    ///   "summaryType":"Caption",
+    ///   "error":[
+    ///     "code":"InvalidSystemId"
+    ///     "message":"The system id is invalid."
+    ///   ]
+    /// }
+    /// </example>
+    procedure GetPageSummary(PageSummaryParameters: Record "Page Summary Parameters"): Text
+    var
+        SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
+    begin
+        exit(SummaryProviderImpl.GetPageSummary(PageSummaryParameters));
     end;
 
     /// <summary>

--- a/src/System Application/App/Page Summary Provider/src/PageSummaryProviderImpl.Codeunit.al
+++ b/src/System Application/App/Page Summary Provider/src/PageSummaryProviderImpl.Codeunit.al
@@ -469,7 +469,7 @@ codeunit 2717 "Page Summary Provider Impl."
         GetRecordFieldsFailureTelemetryTxt: Label 'Failure to get record fields for page %1.', Locked = true;
         PageIDMustBeSpecifiedErr: Label 'Page ID must be specified.', Locked = true;
         PageIDTok: Label 'pageId', Locked = true;
-        RecordSystemIdTok: Label 'recordSystemID', Locked = true;
+        RecordSystemIdTok: Label 'recordSystemId', Locked = true;
         BookmarkTok: Label 'bookmark', Locked = true;
         IncludeBinaryDataTok: Label 'includeBinaryData', Locked = true;
 }

--- a/src/System Application/App/Page Summary Provider/src/PageSummarySettings.Table.al
+++ b/src/System Application/App/Page Summary Provider/src/PageSummarySettings.Table.al
@@ -39,5 +39,4 @@ table 2718 "Page Summary Settings"
         {
         }
     }
-
 }

--- a/src/System Application/Test Library/Page Summary Provider/Permissions/PageSumAdminTest.PermissionSet.al
+++ b/src/System Application/Test Library/Page Summary Provider/Permissions/PageSumAdminTest.PermissionSet.al
@@ -15,5 +15,6 @@ permissionset 132549 "Page Sum Admin Test"
 
     // Include Test Tables
     Permissions = tabledata "Page Provider Summary Test" = RIMD,
-                  tabledata "Page Provider Summary Test2" = RIMD;
+                  tabledata "Page Provider Summary Test2" = RIMD,
+                  tabledata "Page Provider Summary Test3" = RIMD;
 }

--- a/src/System Application/Test Library/Page Summary Provider/Permissions/PageSummaryRead.PermissionSet.al
+++ b/src/System Application/Test Library/Page Summary Provider/Permissions/PageSummaryRead.PermissionSet.al
@@ -15,5 +15,6 @@ permissionset 132548 "Page Summary Read"
 
     // Include Test Tables
     Permissions = tabledata "Page Provider Summary Test" = RIMD,
-                  tabledata "Page Provider Summary Test2" = RIMD;
+                  tabledata "Page Provider Summary Test2" = RIMD,
+                  tabledata "Page Provider Summary Test3" = RIMD;
 }

--- a/src/System Application/Test Library/Page Summary Provider/app.json
+++ b/src/System Application/Test Library/Page Summary Provider/app.json
@@ -25,7 +25,7 @@
     "idRanges":  [
                      {
                          "from":  132548,
-                         "to":  132549
+                         "to":  132550
                      }
                  ],
     "target":  "OnPrem"

--- a/src/System Application/Test Library/Page Summary Provider/src/PageProviderSummaryTest3.Table.al
+++ b/src/System Application/Test Library/Page Summary Provider/src/PageProviderSummaryTest3.Table.al
@@ -1,0 +1,87 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.TestLibraries.Integration;
+
+table 132550 "Page Provider Summary Test3"
+{
+    DataClassification = SystemMetadata;
+
+    fields
+    {
+        field(1; TestInteger; Integer)
+        {
+        }
+        field(2; TestBigInteger; BigInteger)
+        {
+        }
+        field(3; TestBlob; Blob)
+        {
+        }
+        field(4; TestBoolean; Boolean)
+        {
+        }
+        field(5; TestCode; Code[20])
+        {
+        }
+        field(6; TestDate; Date)
+        {
+        }
+        field(7; TestDateFormula; DateFormula)
+        {
+        }
+        field(8; TestDateTime; DateTime)
+        {
+        }
+        field(9; TestDecimal; Decimal)
+        {
+        }
+        field(10; TestDuration; Duration)
+        {
+        }
+        field(11; TestEnum; Enum "Page Provider Summary Test")
+        {
+        }
+        field(12; TestGuid; Guid)
+        {
+        }
+        field(13; TestMedia; Media)
+        {
+        }
+        field(14; TestMediaSet; MediaSet)
+        {
+        }
+        field(15; TestOption; Option)
+        {
+            OptionMembers = Option1,Option2,Option3;
+        }
+        field(16; TestRecordId; RecordId)
+        {
+        }
+        field(17; TestTableFilter; TableFilter)
+        {
+        }
+        field(18; TestText; Text[20])
+        {
+        }
+        field(19; TestTime; Time)
+        {
+        }
+    }
+
+    keys
+    {
+        key(PK; TestInteger)
+        {
+            Clustered = true;
+        }
+    }
+    fieldgroups
+    {
+        fieldgroup(Brick; TestInteger, TestText, TestCode, TestBlob, TestMedia, TestMediaSet, TestDateTime)
+        {
+        }
+    }
+}

--- a/src/System Application/Test Library/Page Summary Provider/src/PageSummaryMediaTestCard.Page.al
+++ b/src/System Application/Test Library/Page Summary Provider/src/PageSummaryMediaTestCard.Page.al
@@ -1,0 +1,120 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.TestLibraries.Integration;
+
+page 132550 "Page Summary Media Test Card"
+{
+    PageType = Card;
+    SourceTable = "Page Provider Summary Test3";
+    Caption = 'Page summary Media Test card';
+    CardPageId = "Page Summary Media Test Card";
+
+    layout
+    {
+        area(Content)
+        {
+            field(TestBigInteger; Rec.TestBigInteger)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field BigInteger';
+            }
+#pragma warning disable AW0004
+            field(TestBlob; Rec.TestBlob)
+#pragma warning restore AW0004
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field Blob';
+            }
+            field(TestBoolean; Rec.TestBoolean)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field Boolean';
+            }
+            field(TestCode; Rec.TestCode)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field Code';
+            }
+            field(TestDate; Rec.TestDate)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field Date';
+            }
+            field(TestDateFormula; Rec.TestDateFormula)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field DateFormula';
+            }
+            field(TestDateTime; Rec.TestDateTime)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field DateTime';
+            }
+            field(TestDecimal; Rec.TestDecimal)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field Decimal';
+            }
+            field(TestTime; Rec.TestTime)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field Time';
+            }
+            field(TestText; Rec.TestText)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field Text';
+            }
+            field(TestTableFilter; Rec.TestTableFilter)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field TableFilter';
+            }
+            field(TestRecordId; Rec.TestRecordId)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field RecordID';
+            }
+            field(TestOption; Rec.TestOption)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field Option';
+            }
+            field(TestMediaSet; Rec.TestMediaSet)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field MediaSet';
+            }
+            field(TestMedia; Rec.TestMedia)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field Media';
+            }
+            field(TestInteger; Rec.TestInteger)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field Integer';
+            }
+            field(TestGuid; Rec.TestGuid)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field GUID';
+            }
+            field(TestEnum; Rec.TestEnum)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field Option';
+            }
+            field(TestDuration; Rec.TestDuration)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies a test field Duration';
+            }
+        }
+    }
+
+}
+


### PR DESCRIPTION
#### Summary Adding the ability to exclude Media, Media Sets and Blobs from Page Summary. We need this ability for copilot and to make the data small. Pictures should not be mandatory if they are defined on the brick. 

#### Work Item(s) 
Fixes [AB#540386](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/540386)





