### PR TITLE
Only disregard cache for the user login table when updating the login time tracker

### DIFF
--- a/src/System Application/App/User Login Times/src/UserLoginTimeTrackerImpl.Codeunit.al
+++ b/src/System Application/App/User Login Times/src/UserLoginTimeTrackerImpl.Codeunit.al
@@ -102,7 +102,7 @@ codeunit 9013 "User Login Time Tracker Impl."
     begin
         Now := CurrentDateTime();
 
-        SelectLatestVersion();
+        SelectLatestVersion(Database::"User Login");
         UserLogin.ReadIsolation := UserLogin.ReadIsolation::ReadUncommitted;
         if UserLogin.Get(UserSecurityId()) and (UserLogin."Last Login Date" <> 0DT) then // 0DT is a null datetime and cannot be added with 60.000 below
             if (Now < UserLogin."Last Login Date" + 60000) and (DT2Date(Now) = DT2Date(UserLogin."Last Login Date")) then // every 1 min on same day must be enough


### PR DESCRIPTION
#### Summary
SelectLatestVersion ensures data from the cache older than the current time is disregarded. Calling this on every login effectively makes any cached values from before the login unusable. Instead, uptake the new version of SelectLatestVersion that only disregards the cache for a specific table.

#### Work Item(s)
Fixes [AB#544663](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/544663)


