### PR TITLE
[24.x] [Email] Make Email Related Record table public

### DIFF
--- a/src/System Application/App/Email/src/Email/EmailRelatedRecord.Table.al
+++ b/src/System Application/App/Email/src/Email/EmailRelatedRecord.Table.al
@@ -11,7 +11,6 @@ namespace System.Email;
 table 8909 "Email Related Record"
 {
     DataClassification = SystemMetadata;
-    Access = Internal;
     InherentPermissions = X;
     InherentEntitlements = X;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
The `Email Related Record` is an extensibility point of the email module, providing lookup of relations between emails and entities in BC, but currently it's marked as Internal. Like the `Email Outbox` and `Sent Email` tables, this table should be public.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#546670](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/546670/)

