### PR TITLE
[25.x]  Profiler Schedules - Incorrect caption 

### DIFF
--- a/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
@@ -97,8 +97,8 @@ page 1932 "Perf. Profiler Schedule Card"
                 {
                     ApplicationArea = All;
                     Caption = 'User ID';
-                    ToolTip = 'Specifies the ID of the user who created the schedule.';
-                    AboutText = 'The ID of the user who created the schedule.';
+                    ToolTip = 'Specifies the ID of the user associated with the schedule.';
+                    AboutText = 'The ID of the user associated with the schedule.';
                     TableRelation = User."User Security ID";
                     Lookup = true;
 


### PR DESCRIPTION
Fixes a caption on the profiler schedule card as it was incorrect, due to an overeager copilot and a less than careful eye of the author of this PR.

Work Item(s)
Fixes [AB#547281](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/547281)

