### PR TITLE
[releases/25.0] Fix get app id for object

### DIFF
--- a/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
+++ b/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
@@ -128,7 +128,7 @@ codeunit 8333 "VS Code Integration Impl."
 
             if AllObjWithCaption.FindFirst() then begin
                 NavAppInstalledApp.Reset();
-                NavAppInstalledApp.SetRange("Package ID", AllObjWithCaption."App Runtime Package ID");
+                NavAppInstalledApp.SetRange("Package ID", AllObjWithCaption."App Package ID");
                 if NavAppInstalledApp.FindFirst() then
                     exit(NavAppInstalledApp."App ID");
             end;


### PR DESCRIPTION
This pull request backports #1900 to releases/25.0

Fixes [AB#547341](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/547341)


