### PR TITLE
Use AppId function to delete orphaned extension data AB#534788

### DIFF
--- a/src/System Application/App/Extension Management/src/ExtensionInstallationImpl.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionInstallationImpl.Codeunit.al
@@ -53,7 +53,8 @@ codeunit 2500 "Extension Installation Impl"
         exit(not NAVAppInstalledApp.IsEmpty());
     end;
 
-    procedure IsInstalledByAppId(AppID: Guid): Boolean
+
+    procedure IsInstalledByAppId(AppId: Guid): Boolean
     var
         [SecurityFiltering(SecurityFilter::Ignored)]
         NAVAppInstalledApp: Record "NAV App Installed App";
@@ -209,7 +210,7 @@ codeunit 2500 "Extension Installation Impl"
         exit(UninstallExtensionSilently(PackageID, ClearSchema, ClearSchema));
     end;
 
-    procedure DeleteOrphanData(PackageID: Guid; ExtensionName: Text): Boolean
+    procedure DeleteOrphanData(AppId: Guid; ExtensionName: Text): Boolean
     var
         ConfirmManagement: Codeunit "Confirm Management";
     begin
@@ -217,7 +218,7 @@ codeunit 2500 "Extension Installation Impl"
 
         if not ConfirmManagement.GetResponse(StrSubstNo(ClearExtensionSchemaOrphanMsg, ExtensionName), false) then exit(false);
 
-        exit(UninstallExtensionSilently(PackageID, false, true));
+        exit(UninstallExtensionSilentlyByAppId(AppId, false, true));
     end;
 
     procedure RunOrphanDeletion(OrphanedApplication: Record "Extension Database Snapshot"): Boolean
@@ -228,7 +229,6 @@ codeunit 2500 "Extension Installation Impl"
         exit(OrphanedExtensionDetails.RunModal() = Action::OK);
     end;
 
-
     local procedure UninstallExtensionSilently(PackageID: Guid; ClearData: Boolean; ClearSchema: Boolean): Boolean
     begin
         CheckPermissions();
@@ -236,6 +236,18 @@ codeunit 2500 "Extension Installation Impl"
         DotNetNavAppALInstaller.ALUninstallNavApp(PackageID, ClearData, ClearSchema);
 
         if IsInstalledByPackageId(PackageID) then
+            exit(false);
+
+        exit(true);
+    end;
+
+    local procedure UninstallExtensionSilentlyByAppId(AppId: Guid; ClearData: Boolean; ClearSchema: Boolean): Boolean
+    begin
+        CheckPermissions();
+        AssertIsInitialized();
+        DotNetNavAppALInstaller.ALUninstallNavAppByAppId(AppId, ClearData, ClearSchema);
+
+        if IsInstalledByAppId(AppId) then
             exit(false);
 
         exit(true);

--- a/src/System Application/App/Extension Management/src/ExtnOrphanedAppDetails.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtnOrphanedAppDetails.Page.al
@@ -73,7 +73,7 @@ page 2513 "Extn. Orphaned App Details"
 
                 trigger OnAction()
                 begin
-                    ExtensionInstallationImpl.DeleteOrphanData(Rec."Package Id", Rec."Name");
+                    ExtensionInstallationImpl.DeleteOrphanData(Rec."App Id", Rec."Name");
                     CurrPage.Close();
                 end;
             }


### PR DESCRIPTION
Problem: Before apps not installed since 14.x might be missing a package ID. So we are unable to delete them by packageID

Fix: Delete by AppId

Fixes: [AB#534788](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/534788)


