### PR TITLE
[25.x] Delete TenantMediaSet in Batch and safeguard loading detached media

### DIFF
--- a/src/System Application/App/Data Administration/src/MediaCleanup.Codeunit.al
+++ b/src/System Application/App/Data Administration/src/MediaCleanup.Codeunit.al
@@ -83,6 +83,8 @@ codeunit 1927 "Media Cleanup"
 
     /// <summary>
     /// Deletes all detached tenant media sets.
+    /// Note: This function will delete detached media set in batches of 10 and commit in between each batch.
+    /// This is to ensure we don't get stuck always trying to delete the same media and time out.
     /// </summary>
     procedure DeleteDetachedTenantMediaSet()
     begin

--- a/src/System Application/App/Data Administration/src/MediaCleanupImpl.Codeunit.al
+++ b/src/System Application/App/Data Administration/src/MediaCleanupImpl.Codeunit.al
@@ -74,8 +74,8 @@ codeunit 1928 "Media Cleanup Impl."
                 repeat
                     if TenantMedia.Get(TenantMediaSet."Media ID".MediaId()) then begin
                         TempTenantMediaVar := TenantMedia;
-                        TempTenantMediaVar.Insert();
-                        MediaLoaded += 1;
+                        if TempTenantMediaVar.Insert() then
+                            MediaLoaded += 1;
                         if MediaLoaded >= RecordLimit then
                             exit(false);
                     end;
@@ -162,16 +162,19 @@ codeunit 1928 "Media Cleanup Impl."
     var
         [SecurityFiltering(SecurityFilter::Ignored)]
         TenantMediaSet: Record "Tenant Media Set";
+        SplitList: List of [List of [Guid]];
         MediaSetOrphans: List of [Guid];
-        Orphan: Guid;
+        MediaOrphanSubList: List of [Guid];
     begin
         if not TenantMediaSet.WritePermission() then
             exit;
 
         MediaSetOrphans := MediaSet.FindOrphans();
-        foreach Orphan in MediaSetOrphans do begin
-            TenantMediaSet.SetRange(ID, Orphan);
+        SplitListIntoSubLists(MediaSetOrphans, 10, SplitList);
+        foreach MediaOrphanSubList in SplitList do begin
+            TenantMediaSet.SetFilter(ID, CreateOrFilter(MediaOrphanSubList));
             TenantMediaSet.DeleteAll();
+            Commit(); // Ensure we keep the progress even on timeout (in case of large amounts of detached media).
         end;
     end;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

port from #1990

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#548339](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/548339)


