### PR TITLE
Porting fix to 25.x - Client does not check Copilot Capability

### DIFF
--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAI.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAI.Codeunit.al
@@ -44,6 +44,22 @@ codeunit 7771 "Azure OpenAI"
     end;
 
     /// <summary>
+    /// Checks if the Azure OpenAI API is enabled for the environment and if the capability is active on the environment.
+    /// </summary>
+    /// <param name="CopilotCapability">The copilot capability to check.</param>
+    /// <param name="Silent">If true, no error message will be shown if API is not enabled.</param>
+    /// <param name="AppId">The id of the app, which registered the copilot capability.</param>
+    /// <returns>True if API and capability is enabled for environment.</returns>
+    procedure IsEnabled(CopilotCapability: Enum "Copilot Capability"; Silent: Boolean; AppId: Guid): Boolean
+    var
+        AppModuleInfo: ModuleInfo;
+    begin
+        if not NavApp.GetModuleInfo(AppId, AppModuleInfo) then
+            exit(false);
+        exit(AzureOpenAIImpl.IsEnabled(CopilotCapability, Silent, AppModuleInfo));
+    end;
+
+    /// <summary>
     /// Checks if the Azure OpenAI API authorization is configured for the environment.
     /// </summary>
     /// <param name="ModelType">The model type to check authorization for.</param>

--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
@@ -269,17 +269,12 @@ codeunit 7774 "Copilot Capability Impl"
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"System Action Triggers", 'GetCopilotCapabilityStatus', '', false, false)]
-    local procedure GetCopilotCapabilityStatus(Capability: Integer; var IsEnabled: Boolean)
-    var
+    local procedure GetCopilotCapabilityStatus(Capability: Integer; var IsEnabled: Boolean; AppId: Guid; Silent: Boolean)
+5a    var
         AzureOpenAI: Codeunit "Azure OpenAI";
         CopilotCapability: Enum "Copilot Capability";
-        Silent: Boolean;
     begin
         CopilotCapability := Enum::"Copilot Capability".FromInteger(Capability);
-
-        if CopilotCapability = Enum::"Copilot Capability"::Chat then
-            Silent := true;
-
-        IsEnabled := AzureOpenAI.IsEnabled(CopilotCapability, Silent);
+        IsEnabled := AzureOpenAI.IsEnabled(CopilotCapability, Silent, AppId);
     end;
 }

--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
@@ -270,7 +270,7 @@ codeunit 7774 "Copilot Capability Impl"
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"System Action Triggers", 'GetCopilotCapabilityStatus', '', false, false)]
     local procedure GetCopilotCapabilityStatus(Capability: Integer; var IsEnabled: Boolean; AppId: Guid; Silent: Boolean)
-5a    var
+    var
         AzureOpenAI: Codeunit "Azure OpenAI";
         CopilotCapability: Enum "Copilot Capability";
     begin


### PR DESCRIPTION
#### Summary
Porting the main fix
1. Add a new procedure overload that allows checking of another AppId's
capability if it is enabled.
2. Update the GetCopilotCapabilityStatus subscriber with silent
parameter.

#### Work Item(s) 
Fixes [AB#548376](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/548376)






