### PR TITLE
Update TestDefaultSettings

### DIFF
--- a/src/System Application/Test/User Settings/src/UserSettingsTests.Codeunit.al
+++ b/src/System Application/Test/User Settings/src/UserSettingsTests.Codeunit.al
@@ -182,10 +182,7 @@ codeunit 132905 "User Settings Tests"
         // [THEN] The default user Settings are populated
         Assert.AreEqual(UserSecurityId(), UserSettingsRec."User Security ID", 'The current user''s id was expected.');
         Assert.IsTrue(UserSettingsRec.Initialized, 'The settings should have been initialized.');
-        Assert.AreEqual(0, UserSettingsRec."Language ID", 'No language was expected.');
         Assert.AreEqual(CompanyName(), UserSettingsRec.Company, 'Company should match CompanyName (<Blank Company>).');
-        Assert.AreEqual(0, UserSettingsRec."Locale ID", 'No region was expected.');
-        Assert.AreEqual('', UserSettingsRec."Time Zone", 'A different time zone was expected.');
         Assert.AreEqual(WorkDate(), UserSettingsRec."Work Date", 'A different work date was expected.');
         Assert.IsTrue(UserSettingsRec."Teaching Tips", 'Teaching tips should be enabled.');
     end;


### PR DESCRIPTION
#### Summary 
Update TestDefaultSettings test as the platform will now return the default values if no user personalization exists to avoid blank values in the UI.

#### Work Item(s) 
Fixes [AB#548303](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/548303)


