### PR TITLE
[Plans] Add plan for delegated dynamics 365 administrator

### DIFF
--- a/src/System Application/App/Azure AD Plan/src/PlanInstaller.Codeunit.al
+++ b/src/System Application/App/Azure AD Plan/src/PlanInstaller.Codeunit.al
@@ -38,6 +38,7 @@ codeunit 9056 "Plan Installer"
         CreatePlan(PlanIds.GetHelpDeskPlanId(), 'Delegated Helpdesk agent - Partner', 9022, '8884DDCA-27B8-E911-BB26-000D3A2B005C');
         CreatePlan(PlanIds.GetGlobalAdminPlanId(), 'Internal Administrator', 9022, '9B84DDCA-27B8-E911-BB26-000D3A2B005C'); // Global admin
         CreatePlan(PlanIds.GetD365AdminPlanId(), 'Dynamics 365 Administrator', 9022, 'F67B9B96-C667-4DD2-B370-FA065A895C9D');
+        CreatePlan(PlanIds.GetD365AdminPartnerPlanId(), 'Delegated Dynamics 365 Admin agent - Partner', 9022, '5C28E514-8AFD-4158-B8C0-93A5915938F9');
         CreatePlan(PlanIds.GetEssentialISVPlanId(), 'Dynamics 365 Business Central Essential - Embedded', 9022, '2E84DDCA-27B8-E911-BB26-000D3A2B005C');
         CreatePlan(PlanIds.GetTeamMemberPlanId(), 'Dynamics 365 Business Central Team Member', 9028, '5784DDCA-27B8-E911-BB26-000D3A2B005C');
         CreatePlan(PlanIds.GetMicrosoft365PlanId(), 'Microsoft 365', 8999, '57ff2da0-773e-42df-b2af-ffb7a2317929');

--- a/src/System Application/App/Azure AD Plan/src/PlanUpgrade.Codeunit.al
+++ b/src/System Application/App/Azure AD Plan/src/PlanUpgrade.Codeunit.al
@@ -31,6 +31,7 @@ codeunit 9057 "Plan Upgrade"
         AddEssentialAttach();
         AddD365Admin();
         AddBCAdmin();
+        AddDelegatedD365Admin();
 
         AddDefaultPlanConfigurations();
     end;
@@ -265,6 +266,32 @@ codeunit 9057 "Plan Upgrade"
         CreatePlan(PlanId, PlanName, RoleCenterId);
 
         UpgradeTag.SetUpgradeTag(PlanUpgradeTag.GetMD365AdminUpgradeTag());
+    end;
+
+    [NonDebuggable]
+    local procedure AddDelegatedD365Admin()
+    var
+        Plan: Record Plan;
+        UpgradeTag: Codeunit "Upgrade Tag";
+        PlanUpgradeTag: Codeunit "Plan Upgrade Tag";
+        PlanIds: Codeunit "Plan Ids";
+        PlanId: Guid;
+        PlanName: Text[50];
+        RoleCenterId: Integer;
+    begin
+        if UpgradeTag.HasUpgradeTag(PlanUpgradeTag.GetDelegatedD365AdminUpgradeTag()) then
+            exit;
+
+        PlanId := PlanIds.GetD365AdminPartnerPlanId();
+        PlanName := 'Delegated Dynamics 365 Admin agent - Partner';
+        RoleCenterId := 9022;
+
+        if Plan.Get(PlanId) then
+            exit;
+
+        CreatePlan(PlanId, PlanName, RoleCenterId);
+
+        UpgradeTag.SetUpgradeTag(PlanUpgradeTag.GetDelegatedD365AdminUpgradeTag());
     end;
 
     local procedure AddDefaultPlanConfigurations()

--- a/src/System Application/App/Azure AD Plan/src/PlanUpgradeTag.Codeunit.al
+++ b/src/System Application/App/Azure AD Plan/src/PlanUpgradeTag.Codeunit.al
@@ -28,6 +28,7 @@ codeunit 9058 "Plan Upgrade Tag"
         PerDatabaseUpgradeTags.Add(GetEssentialAttachUpgradeTag());
         PerDatabaseUpgradeTags.Add(GetMD365AdminUpgradeTag());
         PerDatabaseUpgradeTags.Add(GetBCAdminUpgradeTag());
+        PerDatabaseUpgradeTags.Add(GetDelegatedD365AdminUpgradeTag());
     end;
 
     /// <summary>
@@ -100,6 +101,15 @@ codeunit 9058 "Plan Upgrade Tag"
     internal procedure GetMD365AdminUpgradeTag(): Code[250]
     begin
         exit('MS-465490-AddD365Admin-20230103');
+    end;
+
+    /// <summary>
+    /// Returns the Delegated Dynamics 365 Administrator upgrade tag.
+    /// </summary>
+    /// <returns>The Dynamics 365 Administrator upgrade tag.</returns>
+    internal procedure GetDelegatedD365AdminUpgradeTag(): Code[250]
+    begin
+        exit('MS-548582-AddDelegatedD365Admin-20240912');
     end;
 
     /// <summary>

--- a/src/System Application/Test/Azure AD Plan/src/AzureADPlanTests.Codeunit.al
+++ b/src/System Application/Test/Azure AD Plan/src/AzureADPlanTests.Codeunit.al
@@ -31,12 +31,12 @@ codeunit 132912 "Azure AD Plan Tests"
     var
         AzureADPlan: Codeunit "Azure AD Plan";
     begin
-        // [SCENARIO] There should be 22 Plans
+        // [SCENARIO] There should be 23 Plans
 
         // Verify the module highest permission level is sufficient ignore non Tables
         PermissionsMock.Set('AAD Plan View');
 
-        LibraryAssert.AreEqual(22, AzureADPlan.GetAvailablePlansCount(),
+        LibraryAssert.AreEqual(23, AzureADPlan.GetAvailablePlansCount(),
             'The number of available plans has changed. Make sure that you have added or removed tests on these changes in Plan-Based tests and then update the number of plans in this test.');
     end;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
**Problem**
The delegated dynamics 365 administrator is not added to the plan table. As a consequence, license configuration can not be set up for the role.

**Solution**
Add `Delegated Dynamics 365 Admin agent - Partner` plan.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#548582](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/548582)


