### PR TITLE
Added dotnet wrappers for Purview telemetry

### DIFF
--- a/src/System Application/App/DotNet Aliases/src/dotnet.al
+++ b/src/System Application/App/DotNet Aliases/src/dotnet.al
@@ -729,6 +729,18 @@ dotnet
         type("Microsoft.Dynamics.Nav.Runtime.Designer.NavDesignerALCopyResponse"; "NavDesignerALCopyResponse")
         {
         }
+
+        type("Microsoft.Dynamics.Nav.Runtime.CustomerAudit.CustomerAuditLoggerALHelper"; "CustomerAuditLoggerALHelper")
+        {
+        }
+
+        type("Microsoft.Dynamics.Nav.Runtime.ALSecurityOperationResult"; "ALSecurityOperationResult")
+        {
+        }
+
+        type("Microsoft.Dynamics.Nav.Runtime.ALAuditCategory"; "ALAuditCategory")
+        {
+        }
     }
 
     assembly("Microsoft.Dynamics.Nav.OAuth")


### PR DESCRIPTION
#### Summary

Added three DotNet types to enable the use of Purview telemetry (audit logging) in BaseApp (24.x).

Required for deliverables [AB#549389](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/549389) and [AB#548176](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/548176)


