### PR TITLE
Fix TestPreprocessorSymbols action ref

### DIFF
--- a/.github/workflows/VerifyAppChanges.yaml
+++ b/.github/workflows/VerifyAppChanges.yaml
@@ -18,4 +18,4 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
-      - uses: microsoft/BCApps/.github/actions/TestPreprocessorSymbols@cedb78a7972da09fcdaf9ccaa86aef0ded2b5da7
+      - uses: microsoft/BCApps/.github/actions/TestPreprocessorSymbols@main


### PR DESCRIPTION
The current SHA is from another branch.

[AB#549296](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/549296)
