### PR TITLE
Fix getting app ID for system objects

### DIFF
--- a/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
+++ b/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
@@ -11,7 +11,6 @@ codeunit 8333 "VS Code Integration Impl."
     InherentPermissions = X;
 
     var
-        AllObjWithCaption: Record AllObjWithCaption;
         UriBuilder: Codeunit "Uri Builder";
         VSCodeRequestHelper: DotNet VSCodeRequestHelper;
         AlExtensionUriTxt: Label 'vscode://ms-dynamics-smb.al', Locked = true;
@@ -105,6 +104,8 @@ codeunit 8333 "VS Code Integration Impl."
 
     [Scope('OnPrem')]
     local procedure FormatObjectType(ObjectType: Option): Text
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
     begin
         case ObjectType of
             AllObjWithCaption."Object Type"::Page:
@@ -119,6 +120,7 @@ codeunit 8333 "VS Code Integration Impl."
     [Scope('OnPrem')]
     local procedure GetAppIdForObject(ObjectType: Option; ObjectId: Integer): Text
     var
+        AllObjWithCaption: Record AllObjWithCaption;
         NavAppInstalledApp: Record "NAV App Installed App";
         EmptyGuid: Guid;
     begin
@@ -127,7 +129,6 @@ codeunit 8333 "VS Code Integration Impl."
             exit(EmptyGuid);
 
         if AllObjWithCaption.ReadPermission() then begin
-            AllObjWithCaption.Reset();
             AllObjWithCaption.SetRange("Object Type", ObjectType);
             AllObjWithCaption.SetRange("Object ID", ObjectId);
 

--- a/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
+++ b/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
@@ -119,7 +119,7 @@ codeunit 8333 "VS Code Integration Impl."
     [Scope('OnPrem')]
     local procedure GetAppIdForObject(ObjectType: Option; ObjectId: Integer): Text
     var
-        NavAppInstalledApp: Record;
+        NavAppInstalledApp: Record "NAV App Installed App";
         EmptyGuid: Guid;
     begin
         // Objects in the system app range

--- a/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
+++ b/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
@@ -119,8 +119,13 @@ codeunit 8333 "VS Code Integration Impl."
     [Scope('OnPrem')]
     local procedure GetAppIdForObject(ObjectType: Option; ObjectId: Integer): Text
     var
-        NavAppInstalledApp: Record "NAV App Installed App";
+        NavAppInstalledApp: Record;
+        EmptyGuid: Guid;
     begin
+        // Objects in the system app range
+        if ObjectId >= '2000000000' then
+            exit(EmptyGuid);
+
         if AllObjWithCaption.ReadPermission() then begin
             AllObjWithCaption.Reset();
             AllObjWithCaption.SetRange("Object Type", ObjectType);

--- a/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
+++ b/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
@@ -123,7 +123,7 @@ codeunit 8333 "VS Code Integration Impl."
         EmptyGuid: Guid;
     begin
         // Objects in the system app range
-        if ObjectId >= '2000000000' then
+        if ObjectId >= 2000000000 then
             exit(EmptyGuid);
 
         if AllObjWithCaption.ReadPermission() then begin


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
GetAppIdForObject wouldn't work on System objects, since it's not on the "NAV App Installed App" record.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#548696](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/548696)




