### PR TITLE
[Hotfix] Added dotnet wrappers for Purview telemetry 24.5

### DIFF
--- a/src/System Application/App/DotNet Aliases/src/dotnet.al
+++ b/src/System Application/App/DotNet Aliases/src/dotnet.al
@@ -729,6 +729,18 @@ dotnet
         type("Microsoft.Dynamics.Nav.Runtime.Designer.NavDesignerALCopyResponse"; "NavDesignerALCopyResponse")
         {
         }
+
+        type("Microsoft.Dynamics.Nav.Runtime.CustomerAudit.CustomerAuditLoggerALHelper"; "CustomerAuditLoggerALHelper")
+        {
+        }
+
+        type("Microsoft.Dynamics.Nav.Runtime.ALSecurityOperationResult"; "ALSecurityOperationResult")
+        {
+        }
+
+        type("Microsoft.Dynamics.Nav.Runtime.ALAuditCategory"; "ALAuditCategory")
+        {
+        }
     }
 
     assembly("Microsoft.Dynamics.Nav.OAuth")


### PR DESCRIPTION
#### Summary
Added dotnet wrappers for Purview telemetry 24.5 for use in BaseApp 24.5

[Original PR for 24.x](https://github.com/microsoft/BCApps/pull/2064)

#### Work Item(s)
Fixes [AB#550961](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/550961)



