### PR TITLE
[Tenant Media Cleanup] Only delete if filter is not empty

### DIFF
--- a/src/System Application/App/Data Administration/src/MediaCleanupImpl.Codeunit.al
+++ b/src/System Application/App/Data Administration/src/MediaCleanupImpl.Codeunit.al
@@ -165,6 +165,7 @@ codeunit 1928 "Media Cleanup Impl."
         SplitList: List of [List of [Guid]];
         MediaSetOrphans: List of [Guid];
         MediaOrphanSubList: List of [Guid];
+        TenantMediaFilter: Text;
     begin
         if not TenantMediaSet.WritePermission() then
             exit;
@@ -172,9 +173,12 @@ codeunit 1928 "Media Cleanup Impl."
         MediaSetOrphans := MediaSet.FindOrphans();
         SplitListIntoSubLists(MediaSetOrphans, 10, SplitList);
         foreach MediaOrphanSubList in SplitList do begin
-            TenantMediaSet.SetFilter(ID, CreateOrFilter(MediaOrphanSubList));
-            TenantMediaSet.DeleteAll();
-            Commit(); // Ensure we keep the progress even on timeout (in case of large amounts of detached media).
+            TenantMediaFilter := CreateOrFilter(MediaOrphanSubList);
+            if TenantMediaFilter <> '' then begin
+                TenantMediaSet.SetFilter(ID, TenantMediaFilter);
+                TenantMediaSet.DeleteAll();
+                Commit(); // Ensure we keep the progress even on timeout (in case of large amounts of detached media).
+            end;
         end;
     end;
 
@@ -185,6 +189,7 @@ codeunit 1928 "Media Cleanup Impl."
         SplitList: List of [List of [Guid]];
         MediaOrphans: List of [Guid];
         MediaOrphanSubList: List of [Guid];
+        TenantMediaFilter: Text;
     begin
         if not TenantMedia.WritePermission() then
             exit;
@@ -192,9 +197,12 @@ codeunit 1928 "Media Cleanup Impl."
         MediaOrphans := Media.FindOrphans();
         SplitListIntoSubLists(MediaOrphans, 100, SplitList);
         foreach MediaOrphanSubList in SplitList do begin
-            TenantMedia.SetFilter(ID, CreateOrFilter(MediaOrphanSubList));
-            TenantMedia.DeleteAll();
-            Commit(); // Ensure we keep the progress even on timeout (in case of large amounts of detached media).
+            TenantMediaFilter := CreateOrFilter(MediaOrphanSubList);
+            if TenantMediaFilter <> '' then begin
+                TenantMedia.SetFilter(ID, TenantMediaFilter);
+                TenantMedia.DeleteAll();
+                Commit(); // Ensure we keep the progress even on timeout (in case of large amounts of detached media).
+            end;
         end;
     end;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
**Problem**
When any of the sublists returned by `SplitListIntoSubLists` are empty, then the filter set on `Tenant Media` and `Tenant Media Set` is empty, causing all media to be deleted.

**Solution**
Only delete `Tenant Media` and `Tenant Media Set` when a filter is set on the record.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#550939](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/550939/)


