### PR TITLE
[24.5] Adding Purview telemetry to the System apps

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesGA.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesGA.Page.al
@@ -93,6 +93,7 @@ page 7774 "Copilot Capabilities GA"
                     Rec.Modify(true);
 
                     CopilotCapabilityImpl.SendActivateTelemetry(Rec.Capability, Rec."App Id");
+                    Session.LogAuditMessage(StrSubstNo(CopilotFeatureActivatedLbl, Rec.Capability, Rec."App Id", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 4, 0);
                 end;
             }
             action(Deactivate)
@@ -114,6 +115,7 @@ page 7774 "Copilot Capabilities GA"
                         Rec.Modify(true);
 
                         CopilotCapabilityImpl.SendDeactivateTelemetry(Rec.Capability, Rec."App Id", CopilotDeactivate.GetReason());
+                        Session.LogAuditMessage(StrSubstNo(CopilotFeatureDeactivatedLbl, Rec.Capability, Rec."App Id", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 4, 0);
                     end;
                 end;
             }
@@ -162,6 +164,8 @@ page 7774 "Copilot Capabilities GA"
         CapabilityEnabled: Boolean;
         DataMovementEnabled: Boolean;
         SupplementalTermsLinkTxt: Label 'https://go.microsoft.com/fwlink/?linkid=2236010', Locked = true;
+        CopilotFeatureDeactivatedLbl: Label 'The copilot/AI capability %1, App Id %2 has been deactivated by the UserSecurityId %3.', Locked = true;
+        CopilotFeatureActivatedLbl: Label 'The copilot/AI capability %1, App Id %2 has been activated by the UserSecurityId %3.', Locked = true;
 
     internal procedure SetDataMovement(Value: Boolean)
     begin

--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesGA.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesGA.Page.al
@@ -4,6 +4,8 @@
 // ------------------------------------------------------------------------------------------------
 namespace System.AI;
 
+using System;
+
 /// <summary>
 /// Page for listing the Copilot Capabilities which are Generally Available.
 /// </summary>
@@ -88,12 +90,16 @@ page 7774 "Copilot Capabilities GA"
                 Scope = Repeater;
 
                 trigger OnAction()
+                var
+                    MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+                    MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+                    MyALAuditCategory: DotNet ALAuditCategory;
                 begin
                     Rec.Status := Rec.Status::Active;
                     Rec.Modify(true);
 
                     CopilotCapabilityImpl.SendActivateTelemetry(Rec.Capability, Rec."App Id");
-                    Session.LogAuditMessage(StrSubstNo(CopilotFeatureActivatedLbl, Rec.Capability, Rec."App Id", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 4, 0);
+                    MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(CopilotFeatureActivatedLbl, Rec.Capability, Rec."App Id", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 4, 0);
                 end;
             }
             action(Deactivate)
@@ -108,6 +114,9 @@ page 7774 "Copilot Capabilities GA"
                 trigger OnAction()
                 var
                     CopilotDeactivate: Page "Copilot Deactivate Capability";
+                    MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+                    MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+                    MyALAuditCategory: DotNet ALAuditCategory;
                 begin
                     CopilotDeactivate.SetCaption(Format(Rec.Capability));
                     if CopilotDeactivate.RunModal() = Action::OK then begin
@@ -115,7 +124,7 @@ page 7774 "Copilot Capabilities GA"
                         Rec.Modify(true);
 
                         CopilotCapabilityImpl.SendDeactivateTelemetry(Rec.Capability, Rec."App Id", CopilotDeactivate.GetReason());
-                        Session.LogAuditMessage(StrSubstNo(CopilotFeatureDeactivatedLbl, Rec.Capability, Rec."App Id", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 4, 0);
+                        MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(CopilotFeatureDeactivatedLbl, Rec.Capability, Rec."App Id", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 4, 0);
                     end;
                 end;
             }

--- a/src/System Application/App/Azure AD Plan/src/Plan Configuration/PlanConfiguration.Table.al
+++ b/src/System Application/App/Azure AD Plan/src/Plan Configuration/PlanConfiguration.Table.al
@@ -54,4 +54,24 @@ table 9017 "Plan Configuration"
             Unique = true;
         }
     }
+    trigger OnDelete()
+    begin
+        Session.LogAuditMessage(StrSubstNo(PlanConfigurationDeletedLbl, Rec.Id, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::EntitlementManagement, 2, 0);
+    end;
+
+    trigger OnInsert()
+    begin
+        Session.LogAuditMessage(StrSubstNo(PlanConfigurationCreatedLbl, Rec.Id, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::EntitlementManagement, 2, 0);
+    end;
+
+    trigger OnModify()
+    begin
+        Session.LogAuditMessage(StrSubstNo(PlanConfigurationModifiedLbl, Rec.Id, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::EntitlementManagement, 2, 0);
+    end;
+
+    var
+        PlanConfigurationDeletedLbl: Label 'The license configuration ID %1, has been deleted by the UserSecurityId %2.', Locked = true;
+        PlanConfigurationModifiedLbl: Label 'The license configuration ID %1, has been modified by the UserSecurityId %2.', Locked = true;
+        PlanConfigurationCreatedLbl: Label 'The license configuration ID %1, has been created by the UserSecurityId %2.', Locked = true;
+
 }

--- a/src/System Application/App/Azure AD Plan/src/Plan Configuration/PlanConfiguration.Table.al
+++ b/src/System Application/App/Azure AD Plan/src/Plan Configuration/PlanConfiguration.Table.al
@@ -5,6 +5,8 @@
 
 namespace System.Azure.Identity;
 
+using System;
+
 table 9017 "Plan Configuration"
 {
     Access = Internal;
@@ -55,18 +57,30 @@ table 9017 "Plan Configuration"
         }
     }
     trigger OnDelete()
+    var
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
     begin
-        Session.LogAuditMessage(StrSubstNo(PlanConfigurationDeletedLbl, Rec.Id, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::EntitlementManagement, 2, 0);
+        MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PlanConfigurationDeletedLbl, Rec.Id, UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::EntitlementManagement, 2, 0);
     end;
 
     trigger OnInsert()
+    var
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
     begin
-        Session.LogAuditMessage(StrSubstNo(PlanConfigurationCreatedLbl, Rec.Id, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::EntitlementManagement, 2, 0);
+        MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PlanConfigurationCreatedLbl, Rec.Id, UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::EntitlementManagement, 2, 0);
     end;
 
     trigger OnModify()
+    var
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
     begin
-        Session.LogAuditMessage(StrSubstNo(PlanConfigurationModifiedLbl, Rec.Id, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::EntitlementManagement, 2, 0);
+        MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PlanConfigurationModifiedLbl, Rec.Id, UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::EntitlementManagement, 2, 0);
     end;
 
     var

--- a/src/System Application/App/Azure AD Plan/src/Plan Configuration/PlanConfigurationCard.Page.al
+++ b/src/System Application/App/Azure AD Plan/src/Plan Configuration/PlanConfigurationCard.Page.al
@@ -47,6 +47,13 @@ page 9069 "Plan Configuration Card"
                         Importance = Promoted;
                         Caption = 'Customize permissions';
                         ToolTip = 'Specifies whether the default permissions are customized.';
+
+                        trigger OnValidate()
+                        begin
+                            if Rec.Customized then
+                                Session.LogAuditMessage(StrSubstNo(PlanConfigurationCustomizedLbl, Rec.Id, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
+
+                        end;
                     }
                 }
             }
@@ -122,6 +129,7 @@ page 9069 "Plan Configuration Card"
 
     var
         IsSaaS: Boolean;
+        PlanConfigurationCustomizedLbl: Label 'The Plan configuration %1, has been customized by the UserSecurityId %2.', Locked = true;
 
     trigger OnAfterGetCurrRecord()
     var

--- a/src/System Application/App/Azure AD Plan/src/Plan Configuration/PlanConfigurationCard.Page.al
+++ b/src/System Application/App/Azure AD Plan/src/Plan Configuration/PlanConfigurationCard.Page.al
@@ -5,6 +5,7 @@
 
 namespace System.Azure.Identity;
 
+using System;
 using System.Environment;
 
 /// <summary>
@@ -49,9 +50,13 @@ page 9069 "Plan Configuration Card"
                         ToolTip = 'Specifies whether the default permissions are customized.';
 
                         trigger OnValidate()
+                        var
+                            MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+                            MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+                            MyALAuditCategory: DotNet ALAuditCategory;
                         begin
                             if Rec.Customized then
-                                Session.LogAuditMessage(StrSubstNo(PlanConfigurationCustomizedLbl, Rec.Id, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
+                                MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PlanConfigurationCustomizedLbl, Rec.Id, UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 2, 0);
 
                         end;
                     }

--- a/src/System Application/App/Azure AD User Management/src/User sync/AzureADUserUpdateWizard.Page.al
+++ b/src/System Application/App/Azure AD User Management/src/User sync/AzureADUserUpdateWizard.Page.al
@@ -289,6 +289,7 @@ page 9515 "Azure AD User Update Wizard"
                     AzureADUserSyncImpl: Codeunit "Azure AD User Sync Impl.";
                     GuidedExperience: Codeunit "Guided Experience";
                     SuccessCount: Integer;
+                    UpdateUsersfromMicrosoft365RunLbl: Label 'Update users from Microsoft 365 wizard has been run by the UserSecurityId %1.', Locked = true;
                 begin
                     Rec.Reset();
                     SuccessCount := AzureADUserSyncImpl.ApplyUpdatesFromAzureGraph(Rec);
@@ -296,6 +297,7 @@ page 9515 "Azure AD User Update Wizard"
                     Rec.DeleteAll();
 
                     GuidedExperience.CompleteAssistedSetup(ObjectType::Page, Page::"Azure AD User Update Wizard");
+                    Session.LogAuditMessage(StrSubstNo(UpdateUsersfromMicrosoft365RunLbl, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
 
                     MakeAllGroupsInvisible();
                     FinishedVisible := true;

--- a/src/System Application/App/Azure AD User Management/src/User sync/AzureADUserUpdateWizard.Page.al
+++ b/src/System Application/App/Azure AD User Management/src/User sync/AzureADUserUpdateWizard.Page.al
@@ -5,6 +5,7 @@
 
 namespace System.Azure.Identity;
 
+using System;
 using System.Utilities;
 using System.Environment.Configuration;
 using System.Security.User;
@@ -288,6 +289,9 @@ page 9515 "Azure AD User Update Wizard"
                 var
                     AzureADUserSyncImpl: Codeunit "Azure AD User Sync Impl.";
                     GuidedExperience: Codeunit "Guided Experience";
+                    MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+                    MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+                    MyALAuditCategory: DotNet ALAuditCategory;
                     SuccessCount: Integer;
                     UpdateUsersfromMicrosoft365RunLbl: Label 'Update users from Microsoft 365 wizard has been run by the UserSecurityId %1.', Locked = true;
                 begin
@@ -297,7 +301,7 @@ page 9515 "Azure AD User Update Wizard"
                     Rec.DeleteAll();
 
                     GuidedExperience.CompleteAssistedSetup(ObjectType::Page, Page::"Azure AD User Update Wizard");
-                    Session.LogAuditMessage(StrSubstNo(UpdateUsersfromMicrosoft365RunLbl, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
+                    MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(UpdateUsersfromMicrosoft365RunLbl, UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 2, 0);
 
                     MakeAllGroupsInvisible();
                     FinishedVisible := true;

--- a/src/System Application/App/Data Classification/app.json
+++ b/src/System Application/App/Data Classification/app.json
@@ -10,7 +10,14 @@
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
   "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
-  "dependencies": [],
+  "dependencies": [
+    {
+      "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
+      "name": "DotNet Aliases",
+      "publisher": "Microsoft",
+      "version": "24.6.0.0"
+    }
+  ],
   "screenshots": [],
   "platform": "24.0.0.0",
   "idRanges": [

--- a/src/System Application/App/Data Classification/app.json
+++ b/src/System Application/App/Data Classification/app.json
@@ -15,7 +15,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "24.6.0.0"
+      "version": "24.5.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Data Classification/src/DataClassificationMgtImpl.Codeunit.al
+++ b/src/System Application/App/Data Classification/src/DataClassificationMgtImpl.Codeunit.al
@@ -19,6 +19,7 @@ codeunit 1753 "Data Classification Mgt. Impl."
     var
         DataSensitivityOptionStringTxt: Label 'Unclassified,Sensitive,Personal,Company Confidential,Normal', Comment = 'It needs to be translated as the field Data Sensitivity on Page 1751 Data Classification WorkSheet and field Data Sensitivity of Table 1180 Data Privacy Entities';
         LegalDisclaimerTxt: Label 'Microsoft is providing this Data Classification feature as a matter of convenience only. It''s your responsibility to classify the data appropriately and comply with any laws and regulations that are applicable to you. Microsoft disclaims all responsibility towards any claims related to your classification of the data.';
+        DataSensitivitySetLbl: Label 'The Data sensitivity value %1 has been set for Company Name %2, Table No %3, Field No %4 by UserSecurityId %5.', Locked = true;
 
     procedure PopulateDataSensitivityTable()
     var
@@ -47,6 +48,8 @@ codeunit 1753 "Data Classification Mgt. Impl."
             DataSensitivity."Field No" := FieldNo;
             DataSensitivity."Data Sensitivity" := DataSensitivityOption;
             DataSensitivity.Insert();
+            Session.LogAuditMessage(StrSubstNo(DataSensitivitySetLbl, DataSensitivity."Data Sensitivity", DataSensitivity."Company Name",
+                DataSensitivity."Table No", DataSensitivity."Field No", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 3, 0);
         end;
     end;
 
@@ -63,6 +66,8 @@ codeunit 1753 "Data Classification Mgt. Impl."
                 DataSensitivity."Last Modified By" := UserSecurityId();
                 DataSensitivity."Last Modified" := Now;
                 DataSensitivity.Modify();
+                Session.LogAuditMessage(StrSubstNo(DataSensitivitySetLbl, DataSensitivity."Data Sensitivity", DataSensitivity."Company Name",
+                    DataSensitivity."Table No", DataSensitivity."Field No", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 3, 0);
             until DataSensitivity.Next() = 0;
     end;
 

--- a/src/System Application/App/Data Classification/src/DataClassificationMgtImpl.Codeunit.al
+++ b/src/System Application/App/Data Classification/src/DataClassificationMgtImpl.Codeunit.al
@@ -5,6 +5,7 @@
 
 namespace System.Privacy;
 
+using System;
 using System.Reflection;
 
 codeunit 1753 "Data Classification Mgt. Impl."
@@ -40,6 +41,9 @@ codeunit 1753 "Data Classification Mgt. Impl."
     procedure InsertDataSensitivityForField(TableNo: Integer; FieldNo: Integer; DataSensitivityOption: Option)
     var
         DataSensitivity: Record "Data Sensitivity";
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
     begin
         if IsSupportedTable(TableNo) then begin
             DataSensitivity.Init();
@@ -48,13 +52,16 @@ codeunit 1753 "Data Classification Mgt. Impl."
             DataSensitivity."Field No" := FieldNo;
             DataSensitivity."Data Sensitivity" := DataSensitivityOption;
             DataSensitivity.Insert();
-            Session.LogAuditMessage(StrSubstNo(DataSensitivitySetLbl, DataSensitivity."Data Sensitivity", DataSensitivity."Company Name",
-                DataSensitivity."Table No", DataSensitivity."Field No", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 3, 0);
+            MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(DataSensitivitySetLbl, DataSensitivity."Data Sensitivity", DataSensitivity."Company Name",
+                DataSensitivity."Table No", DataSensitivity."Field No", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 3, 0);
         end;
     end;
 
     procedure SetSensitivities(var DataSensitivity: Record "Data Sensitivity"; Sensitivity: Option)
     var
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
         Now: DateTime;
     begin
         // MODIFYALL does not result in a bulk query for this table,looping through the records performs faster
@@ -66,8 +73,8 @@ codeunit 1753 "Data Classification Mgt. Impl."
                 DataSensitivity."Last Modified By" := UserSecurityId();
                 DataSensitivity."Last Modified" := Now;
                 DataSensitivity.Modify();
-                Session.LogAuditMessage(StrSubstNo(DataSensitivitySetLbl, DataSensitivity."Data Sensitivity", DataSensitivity."Company Name",
-                    DataSensitivity."Table No", DataSensitivity."Field No", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 3, 0);
+                MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(DataSensitivitySetLbl, DataSensitivity."Data Sensitivity", DataSensitivity."Company Name",
+                    DataSensitivity."Table No", DataSensitivity."Field No", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 3, 0);
             until DataSensitivity.Next() = 0;
     end;
 

--- a/src/System Application/App/Feature Key/app.json
+++ b/src/System Application/App/Feature Key/app.json
@@ -28,6 +28,12 @@
       "name": "System Initialization",
       "publisher": "Microsoft",
       "version": "24.5.0.0"
+    },
+    {
+      "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
+      "name": "DotNet Aliases",
+      "publisher": "Microsoft",
+      "version": "24.6.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Feature Key/app.json
+++ b/src/System Application/App/Feature Key/app.json
@@ -33,7 +33,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "24.6.0.0"
+      "version": "24.5.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Feature Key/src/FeatureManagementImpl.Codeunit.al
+++ b/src/System Application/App/Feature Key/src/FeatureManagementImpl.Codeunit.al
@@ -85,6 +85,7 @@ codeunit 2610 "Feature Management Impl."
     var
         FeatureManagementFacade: Codeunit "Feature Management Facade";
         InitializeHandled: Boolean;
+        FeatureKeyStatusChangedLbl: Label 'The status of the feature key %1 has been set to %2 by UserSecurityId %3.', Locked = true;
     begin
         if FeatureDataUpdateStatus.Get(FeatureKey.ID, CompanyName()) then
             exit;
@@ -107,7 +108,8 @@ codeunit 2610 "Feature Management Impl."
         // If the table extension is not in sync during upgrade then Get() always returns False,
         // so the following insert will fail if the record does exist.
         if AllowInsert then
-            if FeatureDataUpdateStatus.Insert() then;
+            if FeatureDataUpdateStatus.Insert() then
+                Session.LogAuditMessage(StrSubstNo(FeatureKeyStatusChangedLbl, FeatureDataUpdateStatus."Feature Key", FeatureDataUpdateStatus."Feature Status", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 4, 0);
     end;
 
     /// <summary>

--- a/src/System Application/App/Feature Key/src/FeatureManagementImpl.Codeunit.al
+++ b/src/System Application/App/Feature Key/src/FeatureManagementImpl.Codeunit.al
@@ -5,6 +5,7 @@
 
 namespace System.Environment.Configuration;
 
+using System;
 using System.DateTime;
 using System.Utilities;
 using System.Environment;
@@ -84,6 +85,9 @@ codeunit 2610 "Feature Management Impl."
     local procedure InitializeFeatureDataUpdateStatus(FeatureKey: Record "Feature Key"; var FeatureDataUpdateStatus: Record "Feature Data Update Status"; AllowInsert: Boolean)
     var
         FeatureManagementFacade: Codeunit "Feature Management Facade";
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
         InitializeHandled: Boolean;
         FeatureKeyStatusChangedLbl: Label 'The status of the feature key %1 has been set to %2 by UserSecurityId %3.', Locked = true;
     begin
@@ -109,7 +113,7 @@ codeunit 2610 "Feature Management Impl."
         // so the following insert will fail if the record does exist.
         if AllowInsert then
             if FeatureDataUpdateStatus.Insert() then
-                Session.LogAuditMessage(StrSubstNo(FeatureKeyStatusChangedLbl, FeatureDataUpdateStatus."Feature Key", FeatureDataUpdateStatus."Feature Status", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 4, 0);
+                MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(FeatureKeyStatusChangedLbl, FeatureDataUpdateStatus."Feature Key", FeatureDataUpdateStatus."Feature Status", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 4, 0);
     end;
 
     /// <summary>

--- a/src/System Application/App/Permission Sets/src/PermissionImpl.Codeunit.al
+++ b/src/System Application/App/Permission Sets/src/PermissionImpl.Codeunit.al
@@ -23,6 +23,8 @@ codeunit 9864 "Permission Impl."
         IncludeDescriptionOption: Option "Specifies no permission","Specifies direct permission","Specifies indirect permission";
         ExcludeOption: Option " ",Exclude,"Reduce to indirect";
         ExcludeDescriptionOption: Option "No change to permission","Excludes any permission","Excludes any direct permission";
+        PermissionUpdatedLbl: Label 'The tenant %1 permission for the App Id %2, Role %3, ObjectType %4, ObjectId %5  has been updated with the value: "%6", by the UserSecurityId %7.', Locked = true;
+        MultiplePermissionsUpdatedLbl: Label 'The tenant permissions for the App Id %1, Role %2, ObjectType %3, ObjectId %4  have been updated with the following values - Read "%5", Insert "%6", Modify "%7" and Delete "%8" by the UserSecurityId %9.', Locked = true;
 
     procedure SelectPermissions(CurrAppId: Guid; CurrRoleID: Code[20]): Boolean
     var
@@ -97,30 +99,40 @@ codeunit 9864 "Permission Impl."
                             if TenantPermission."Read Permission" <> PermissionOption then begin
                                 TenantPermission."Read Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
+                                Session.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
+                                    TenantPermission."Read Permission", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
                             end;
                     'I':
                         if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then
                             if TenantPermission."Insert Permission" <> PermissionOption then begin
                                 TenantPermission."Insert Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
+                                Session.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
+                                    TenantPermission."Insert Permission", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
                             end;
                     'M':
                         if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then
                             if TenantPermission."Modify Permission" <> PermissionOption then begin
                                 TenantPermission."Modify Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
+                                Session.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
+                                    TenantPermission."Modify Permission", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
                             end;
                     'D':
                         if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then
                             if TenantPermission."Delete Permission" <> PermissionOption then begin
                                 TenantPermission."Delete Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
+                                Session.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
+                                    TenantPermission."Delete Permission", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
                             end;
                     'X':
                         if TenantPermission."Object Type" <> TenantPermission."Object Type"::"Table Data" then
                             if TenantPermission."Execute Permission" <> PermissionOption then begin
                                 TenantPermission."Execute Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
+                                Session.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
+                                    TenantPermission."Execute Permission", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
                             end;
                     '*':
                         if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then begin
@@ -134,11 +146,15 @@ codeunit 9864 "Permission Impl."
                                 TenantPermission."Modify Permission" := PermissionOption;
                                 TenantPermission."Delete Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
+                                Session.LogAuditMessage(StrSubstNo(MultiplePermissionsUpdatedLbl, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
+                                    TenantPermission."Read Permission", TenantPermission."Insert Permission", TenantPermission."Modify Permission", TenantPermission."Delete Permission", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
                             end;
                         end else
                             if TenantPermission."Execute Permission" <> PermissionOption then begin
                                 TenantPermission."Execute Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
+                                Session.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
+                                    TenantPermission."Execute Permission", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
                             end;
                 end;
                 if ModifyPermissionLine then

--- a/src/System Application/App/Permission Sets/src/PermissionImpl.Codeunit.al
+++ b/src/System Application/App/Permission Sets/src/PermissionImpl.Codeunit.al
@@ -5,6 +5,7 @@
 
 namespace System.Security.AccessControl;
 
+using System;
 using System.Reflection;
 
 codeunit 9864 "Permission Impl."
@@ -88,6 +89,9 @@ codeunit 9864 "Permission Impl."
 
     procedure UpdateSelectedPermissionLines(var TenantPermission: Record "Tenant Permission"; RIMDX: Text[1]; PermissionOption: Option)
     var
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
         ModifyPermissionLine: Boolean;
     begin
         if TenantPermission.FindSet() then
@@ -99,40 +103,40 @@ codeunit 9864 "Permission Impl."
                             if TenantPermission."Read Permission" <> PermissionOption then begin
                                 TenantPermission."Read Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
-                                Session.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
-                                    TenantPermission."Read Permission", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
+                                MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
+                                    TenantPermission."Read Permission", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::RoleManagement, 2, 0);
                             end;
                     'I':
                         if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then
                             if TenantPermission."Insert Permission" <> PermissionOption then begin
                                 TenantPermission."Insert Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
-                                Session.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
-                                    TenantPermission."Insert Permission", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
+                                MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
+                                    TenantPermission."Insert Permission", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::RoleManagement, 2, 0);
                             end;
                     'M':
                         if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then
                             if TenantPermission."Modify Permission" <> PermissionOption then begin
                                 TenantPermission."Modify Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
-                                Session.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
-                                    TenantPermission."Modify Permission", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
+                                MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
+                                    TenantPermission."Modify Permission", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::RoleManagement, 2, 0);
                             end;
                     'D':
                         if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then
                             if TenantPermission."Delete Permission" <> PermissionOption then begin
                                 TenantPermission."Delete Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
-                                Session.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
-                                    TenantPermission."Delete Permission", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
+                                MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
+                                    TenantPermission."Delete Permission", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::RoleManagement, 2, 0);
                             end;
                     'X':
                         if TenantPermission."Object Type" <> TenantPermission."Object Type"::"Table Data" then
                             if TenantPermission."Execute Permission" <> PermissionOption then begin
                                 TenantPermission."Execute Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
-                                Session.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
-                                    TenantPermission."Execute Permission", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
+                                MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
+                                    TenantPermission."Execute Permission", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::RoleManagement, 2, 0);
                             end;
                     '*':
                         if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then begin
@@ -146,15 +150,15 @@ codeunit 9864 "Permission Impl."
                                 TenantPermission."Modify Permission" := PermissionOption;
                                 TenantPermission."Delete Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
-                                Session.LogAuditMessage(StrSubstNo(MultiplePermissionsUpdatedLbl, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
-                                    TenantPermission."Read Permission", TenantPermission."Insert Permission", TenantPermission."Modify Permission", TenantPermission."Delete Permission", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
+                                MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(MultiplePermissionsUpdatedLbl, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
+                                    TenantPermission."Read Permission", TenantPermission."Insert Permission", TenantPermission."Modify Permission", TenantPermission."Delete Permission", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::RoleManagement, 2, 0);
                             end;
                         end else
                             if TenantPermission."Execute Permission" <> PermissionOption then begin
                                 TenantPermission."Execute Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
-                                Session.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
-                                    TenantPermission."Execute Permission", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
+                                MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PermissionUpdatedLbl, RIMDX, TenantPermission."App ID", TenantPermission."Role ID", TenantPermission."Object Type", TenantPermission."Object ID",
+                                    TenantPermission."Execute Permission", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::RoleManagement, 2, 0);
                             end;
                 end;
                 if ModifyPermissionLine then

--- a/src/System Application/App/Permission Sets/src/PermissionSet.Page.al
+++ b/src/System Application/App/Permission Sets/src/PermissionSet.Page.al
@@ -177,6 +177,7 @@ page 9855 "Permission Set"
                             exit;
 
                         AddLoggedPermissions(TempTablePermissionBuffer);
+                        Session.LogAuditMessage(StrSubstNo(PermissionSetModifiedLbl, Rec."Role ID", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
                         CurrPage.MetadataPermissions.Page.Update(false);
                     end;
                 }
@@ -277,5 +278,6 @@ page 9855 "Permission Set"
         CannotManagePermissionsErr: Label 'Only users with the SUPER or the SECURITY permission set can delete permission sets.';
         CannotDeletePermissionSetErr: Label 'You can only delete user-created or copied permission sets.';
         PermissionSetCaptionTok: Label '%1 (%2)', Locked = true;
+        PermissionSetModifiedLbl: Label 'The permission set %1 has been modified by the UserSecurityId %2.', Locked = true;
         PermissionLoggingRunning: Boolean;
 }

--- a/src/System Application/App/Permission Sets/src/PermissionSet.Page.al
+++ b/src/System Application/App/Permission Sets/src/PermissionSet.Page.al
@@ -5,6 +5,7 @@
 
 namespace System.Security.AccessControl;
 
+using System;
 using System.Telemetry;
 using System.Security.User;
 
@@ -170,6 +171,9 @@ page 9855 "Permission Set"
                     trigger OnAction()
                     var
                         TempTablePermissionBuffer: Record "Tenant Permission" temporary;
+                        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+                        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+                        MyALAuditCategory: DotNet ALAuditCategory;
                     begin
                         LogTablePermissions.Stop(TempTablePermissionBuffer);
                         PermissionLoggingRunning := false;
@@ -177,7 +181,7 @@ page 9855 "Permission Set"
                             exit;
 
                         AddLoggedPermissions(TempTablePermissionBuffer);
-                        Session.LogAuditMessage(StrSubstNo(PermissionSetModifiedLbl, Rec."Role ID", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::RoleManagement, 2, 0);
+                        MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PermissionSetModifiedLbl, Rec."Role ID", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::RoleManagement, 2, 0);
                         CurrPage.MetadataPermissions.Page.Update(false);
                     end;
                 }

--- a/src/System Application/App/Permission Sets/src/PermissionSetCopyImpl.Codeunit.al
+++ b/src/System Application/App/Permission Sets/src/PermissionSetCopyImpl.Codeunit.al
@@ -18,6 +18,9 @@ codeunit 9863 "Permission Set Copy Impl."
         FeatureTelemetry: Codeunit "Feature Telemetry";
         PermissionSetExistsErr: Label 'Permission set already exists.';
         ComposablePermissionSetsTok: Label 'Composable Permission Sets', Locked = true;
+        PermissionsUpdatedLbl: Label 'The tenant permissions for the App Id %1, Role %2, ObjectType %3, ObjectId %4  have been updated with the following values - Read "%5", Insert "%6", Modify "%7", Delete "%8" and Execute "%9"  by the UserSecurityId %10.', Locked = true;
+        PermissionsInsertedLbl: Label 'The tenant permissions for the App Id %1, Role %2, ObjectType %3, ObjectId %4  have been inserted with the following values - Read "%5", Insert "%6", Modify "%7", Delete "%8" and Execute "%9"  by the UserSecurityId %10.', Locked = true;
+        ReadAccessAddedToRelatedTablesLbl: Label 'The Read Permission for the App Id %1, Role %2, ObjectType %3, ObjectId %4  have been granted by the UserSecurityId %5.', Locked = true;
 
     procedure CopyPermissionSet(NewRoleId: Code[30]; NewName: Text; SourceRoleId: Code[30]; SourceAppId: Guid; SourceScope: Option System,Tenant; CopyType: Enum "Permission Set Copy Type")
     begin
@@ -257,6 +260,8 @@ codeunit 9863 "Permission Set Copy Impl."
             TenantPermission."Delete Permission" := AddDelete;
             TenantPermission."Execute Permission" := AddExecute;
             TenantPermission.Insert();
+            Session.LogAuditMessage(StrSubstNo(PermissionsInsertedLbl, AppID, CopyStr(RoleID, 1, MaxStrLen(TenantPermission."Role ID")), ObjectType, ObjectID,
+                AddRead, AddInsert, AddModify, AddDelete, AddExecute, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
         end else begin
             TenantPermission."Read Permission" := LogActivityPermissions.GetMaxPermission(TenantPermission."Read Permission", AddRead);
             TenantPermission."Insert Permission" := LogActivityPermissions.GetMaxPermission(TenantPermission."Insert Permission", AddInsert);
@@ -264,6 +269,8 @@ codeunit 9863 "Permission Set Copy Impl."
             TenantPermission."Delete Permission" := LogActivityPermissions.GetMaxPermission(TenantPermission."Delete Permission", AddDelete);
             TenantPermission."Execute Permission" := LogActivityPermissions.GetMaxPermission(TenantPermission."Execute Permission", AddExecute);
             TenantPermission.Modify();
+            Session.LogAuditMessage(StrSubstNo(PermissionsUpdatedLbl, AppID, CopyStr(RoleID, 1, MaxStrLen(TenantPermission."Role ID")), ObjectType, ObjectID,
+                AddRead, AddInsert, AddModify, AddDelete, AddExecute, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
         end;
     end;
 
@@ -283,6 +290,8 @@ codeunit 9863 "Permission Set Copy Impl."
                 AddToTenantPermission(
                   AppID, RoleID, TempTenantPermission."Object Type"::"Table Data", TableRelationsMetadata."Related Table ID", TempTenantPermission."Read Permission"::Yes,
                   TempTenantPermission."Insert Permission"::" ", TempTenantPermission."Modify Permission"::" ", TempTenantPermission."Delete Permission"::" ", TempTenantPermission."Execute Permission"::" ");
+                Session.LogAuditMessage(StrSubstNo(ReadAccessAddedToRelatedTablesLbl, AppID, RoleID, TempTenantPermission."Object Type"::"Table Data", TempTenantPermission."Object ID", UserSecurityId()),
+                    SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
             until TableRelationsMetadata.Next() = 0;
     end;
 

--- a/src/System Application/App/Permission Sets/src/PermissionSetCopyImpl.Codeunit.al
+++ b/src/System Application/App/Permission Sets/src/PermissionSetCopyImpl.Codeunit.al
@@ -5,6 +5,7 @@
 
 namespace System.Security.AccessControl;
 
+using System;
 using System.Telemetry;
 using System.Reflection;
 
@@ -247,6 +248,9 @@ codeunit 9863 "Permission Set Copy Impl."
     var
         TenantPermission: Record "Tenant Permission";
         LogActivityPermissions: Codeunit "Log Activity Permissions";
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
     begin
         TenantPermission.LockTable();
         if not TenantPermission.Get(AppID, RoleID, ObjectType, ObjectID) then begin
@@ -260,8 +264,8 @@ codeunit 9863 "Permission Set Copy Impl."
             TenantPermission."Delete Permission" := AddDelete;
             TenantPermission."Execute Permission" := AddExecute;
             TenantPermission.Insert();
-            Session.LogAuditMessage(StrSubstNo(PermissionsInsertedLbl, AppID, CopyStr(RoleID, 1, MaxStrLen(TenantPermission."Role ID")), ObjectType, ObjectID,
-                AddRead, AddInsert, AddModify, AddDelete, AddExecute, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
+            MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PermissionsInsertedLbl, AppID, CopyStr(RoleID, 1, MaxStrLen(TenantPermission."Role ID")), ObjectType, ObjectID,
+                AddRead, AddInsert, AddModify, AddDelete, AddExecute, UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 2, 0);
         end else begin
             TenantPermission."Read Permission" := LogActivityPermissions.GetMaxPermission(TenantPermission."Read Permission", AddRead);
             TenantPermission."Insert Permission" := LogActivityPermissions.GetMaxPermission(TenantPermission."Insert Permission", AddInsert);
@@ -269,14 +273,17 @@ codeunit 9863 "Permission Set Copy Impl."
             TenantPermission."Delete Permission" := LogActivityPermissions.GetMaxPermission(TenantPermission."Delete Permission", AddDelete);
             TenantPermission."Execute Permission" := LogActivityPermissions.GetMaxPermission(TenantPermission."Execute Permission", AddExecute);
             TenantPermission.Modify();
-            Session.LogAuditMessage(StrSubstNo(PermissionsUpdatedLbl, AppID, CopyStr(RoleID, 1, MaxStrLen(TenantPermission."Role ID")), ObjectType, ObjectID,
-                AddRead, AddInsert, AddModify, AddDelete, AddExecute, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
+            MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PermissionsUpdatedLbl, AppID, CopyStr(RoleID, 1, MaxStrLen(TenantPermission."Role ID")), ObjectType, ObjectID,
+                AddRead, AddInsert, AddModify, AddDelete, AddExecute, UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 2, 0);
         end;
     end;
 
     internal procedure AddReadAccessToRelatedTables(var TempTenantPermission: Record "Tenant Permission" temporary; AppID: Guid; RoleID: Code[30])
     var
         TableRelationsMetadata: Record "Table Relations Metadata";
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
     begin
         if TempTenantPermission."Object Type" <> TempTenantPermission."Object Type"::"Table Data" then
             exit;
@@ -290,8 +297,8 @@ codeunit 9863 "Permission Set Copy Impl."
                 AddToTenantPermission(
                   AppID, RoleID, TempTenantPermission."Object Type"::"Table Data", TableRelationsMetadata."Related Table ID", TempTenantPermission."Read Permission"::Yes,
                   TempTenantPermission."Insert Permission"::" ", TempTenantPermission."Modify Permission"::" ", TempTenantPermission."Delete Permission"::" ", TempTenantPermission."Execute Permission"::" ");
-                Session.LogAuditMessage(StrSubstNo(ReadAccessAddedToRelatedTablesLbl, AppID, RoleID, TempTenantPermission."Object Type"::"Table Data", TempTenantPermission."Object ID", UserSecurityId()),
-                    SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
+                MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(ReadAccessAddedToRelatedTablesLbl, AppID, RoleID, TempTenantPermission."Object Type"::"Table Data", TempTenantPermission."Object ID", UserSecurityId()),
+                    MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 2, 0);
             until TableRelationsMetadata.Next() = 0;
     end;
 

--- a/src/System Application/App/Privacy Notice/app.json
+++ b/src/System Application/App/Privacy Notice/app.json
@@ -16,6 +16,12 @@
       "name": "Upgrade Tags",
       "publisher": "Microsoft",
       "version": "24.5.0.0"
+    },
+    {
+      "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
+      "name": "DotNet Aliases",
+      "publisher": "Microsoft",
+      "version": "24.6.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Privacy Notice/app.json
+++ b/src/System Application/App/Privacy Notice/app.json
@@ -21,7 +21,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "24.6.0.0"
+      "version": "24.5.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Privacy Notice/src/PrivacyNoticeApproval.Codeunit.al
+++ b/src/System Application/App/Privacy Notice/src/PrivacyNoticeApproval.Codeunit.al
@@ -15,6 +15,7 @@ codeunit 1564 "Privacy Notice Approval"
     procedure SetApprovalState(PrivacyNoticeId: Code[50]; UserSID: Guid; PrivacyNoticeApprovalState: Enum "Privacy Notice Approval State")
     var
         PrivacyNoticeApproval: Record "Privacy Notice Approval";
+        PrivacyNoticeApprovedLbl: Label 'Privacy Notice Approval ID %1 provided by User SID %2.', Locked = true;
     begin
         if PrivacyNoticeApprovalState = "Privacy Notice Approval State"::"Not set" then begin
             ResetApproval(PrivacyNoticeId, UserSID);
@@ -28,14 +29,17 @@ codeunit 1564 "Privacy Notice Approval"
         PrivacyNoticeApproval."Approver User SID" := UserSecurityId();
         PrivacyNoticeApproval.Approved := PrivacyNoticeApprovalState = "Privacy Notice Approval State"::Agreed;
         PrivacyNoticeApproval.Modify();
+        Session.LogAuditMessage(StrSubstNo(PrivacyNoticeApprovedLbl, PrivacyNoticeId, UserSID), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 4, 0);
     end;
 
     procedure ResetApproval(PrivacyNoticeId: Code[50]; UserSID: Guid)
     var
         PrivacyNoticeApproval: Record "Privacy Notice Approval";
+        PrivacyNoticeResetLbl: Label 'Privacy Notice Approval ID %1 has been reset by User SID %2.', Locked = true;
     begin
         PrivacyNoticeApproval.SetRange(ID, PrivacyNoticeId);
         PrivacyNoticeApproval.SetRange("User SID", UserSID);
         PrivacyNoticeApproval.DeleteAll();
+        Session.LogAuditMessage(StrSubstNo(PrivacyNoticeResetLbl, PrivacyNoticeId, UserSID), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 4, 0);
     end;
 }

--- a/src/System Application/App/Privacy Notice/src/PrivacyNoticeApproval.Codeunit.al
+++ b/src/System Application/App/Privacy Notice/src/PrivacyNoticeApproval.Codeunit.al
@@ -5,6 +5,8 @@
 
 namespace System.Privacy;
 
+using System;
+
 codeunit 1564 "Privacy Notice Approval"
 {
     Access = Internal;
@@ -15,6 +17,9 @@ codeunit 1564 "Privacy Notice Approval"
     procedure SetApprovalState(PrivacyNoticeId: Code[50]; UserSID: Guid; PrivacyNoticeApprovalState: Enum "Privacy Notice Approval State")
     var
         PrivacyNoticeApproval: Record "Privacy Notice Approval";
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
         PrivacyNoticeApprovedLbl: Label 'Privacy Notice Approval ID %1 provided by User SID %2.', Locked = true;
     begin
         if PrivacyNoticeApprovalState = "Privacy Notice Approval State"::"Not set" then begin
@@ -29,17 +34,20 @@ codeunit 1564 "Privacy Notice Approval"
         PrivacyNoticeApproval."Approver User SID" := UserSecurityId();
         PrivacyNoticeApproval.Approved := PrivacyNoticeApprovalState = "Privacy Notice Approval State"::Agreed;
         PrivacyNoticeApproval.Modify();
-        Session.LogAuditMessage(StrSubstNo(PrivacyNoticeApprovedLbl, PrivacyNoticeId, UserSID), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 4, 0);
+        MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PrivacyNoticeApprovedLbl, PrivacyNoticeId, UserSID), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 4, 0);
     end;
 
     procedure ResetApproval(PrivacyNoticeId: Code[50]; UserSID: Guid)
     var
         PrivacyNoticeApproval: Record "Privacy Notice Approval";
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
         PrivacyNoticeResetLbl: Label 'Privacy Notice Approval ID %1 has been reset by User SID %2.', Locked = true;
     begin
         PrivacyNoticeApproval.SetRange(ID, PrivacyNoticeId);
         PrivacyNoticeApproval.SetRange("User SID", UserSID);
         PrivacyNoticeApproval.DeleteAll();
-        Session.LogAuditMessage(StrSubstNo(PrivacyNoticeResetLbl, PrivacyNoticeId, UserSID), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 4, 0);
+        MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PrivacyNoticeResetLbl, PrivacyNoticeId, UserSID), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 4, 0);
     end;
 }

--- a/src/System Application/App/Retention Policy/src/Apply Retention Policy/ApplyRetentionPolicyImpl.Codeunit.al
+++ b/src/System Application/App/Retention Policy/src/Apply Retention Policy/ApplyRetentionPolicyImpl.Codeunit.al
@@ -30,6 +30,7 @@ codeunit 3904 "Apply Retention Policy Impl."
         StartApplyRetentionPoliciesInfoLbl: Label 'Started applying all retention policies.';
         EndApplyRetentionPoliciesInfoLbl: Label 'Finished applying all retention policies.';
         StartApplyRetentionPolicyInfoLbl: Label 'Started applying the retention policy defined for table %1, %2. ', Comment = '%1 = a id of a table (integer), %2 = the caption of the table.';
+        RetentionPolicyAppliedLbl: Label 'The retention policy defined for table %1, %2 applied by the UserSecurityId %3. ', Locked = true;
         EndApplyRetentionPolicyInfoLbl: Label 'Finished applying the retention policy defined for table: %1, %2.', Comment = '%1 = a id of a table (integer), %2 = the caption of the table.';
         DisabledRetentionPolicyOnMissingTableLbl: Label 'Table %1 was not found. The retention policy has been disabled.', Comment = '%1 = a id of a table (integer)';
         StartRetentionPolicyRecordCountLbl: Label 'Started counting the number of expired records in table %1, %2. ', Comment = '%1 = a id of a table (integer), %2 = table caption';
@@ -132,6 +133,7 @@ codeunit 3904 "Apply Retention Policy Impl."
 
         RetentionPolicySetup.CalcFields("Table Name", "Table Caption");
         RetentionPolicyLog.LogInfo(LogCategory(), AppendStartedByUserMessage(StrSubstNo(StartApplyRetentionPolicyInfoLbl, RetentionPolicySetup."Table Id", RetentionPolicySetup."Table Caption"), UserInvokedRun));
+        Session.LogAuditMessage(StrSubstNo(RetentionPolicyAppliedLbl, RetentionPolicySetup."Table Id", RetentionPolicySetup."Table Caption", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 3, 0);
 
         if GetExpiredRecords(RetentionPolicySetup, RecordRef, ExpiredRecordExpirationDate) then
             DeleteExpiredRecords(RecordRef)

--- a/src/System Application/App/Retention Policy/src/Apply Retention Policy/ApplyRetentionPolicyImpl.Codeunit.al
+++ b/src/System Application/App/Retention Policy/src/Apply Retention Policy/ApplyRetentionPolicyImpl.Codeunit.al
@@ -5,6 +5,7 @@
 
 namespace System.DataAdministration;
 
+using System;
 using System.Telemetry;
 using System.Reflection;
 using System.Security.User;
@@ -116,6 +117,9 @@ codeunit 3904 "Apply Retention Policy Impl."
         RetenPolicyTelemetryImpl: Codeunit "Reten. Policy Telemetry Impl.";
         FeatureTelemetry: Codeunit "Feature Telemetry";
         RecordRef: RecordRef;
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
         Dialog: Dialog;
         ExpiredRecordExpirationDate: Date;
     begin
@@ -133,7 +137,7 @@ codeunit 3904 "Apply Retention Policy Impl."
 
         RetentionPolicySetup.CalcFields("Table Name", "Table Caption");
         RetentionPolicyLog.LogInfo(LogCategory(), AppendStartedByUserMessage(StrSubstNo(StartApplyRetentionPolicyInfoLbl, RetentionPolicySetup."Table Id", RetentionPolicySetup."Table Caption"), UserInvokedRun));
-        Session.LogAuditMessage(StrSubstNo(RetentionPolicyAppliedLbl, RetentionPolicySetup."Table Id", RetentionPolicySetup."Table Caption", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 3, 0);
+        MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(RetentionPolicyAppliedLbl, RetentionPolicySetup."Table Id", RetentionPolicySetup."Table Caption", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 3, 0);
 
         if GetExpiredRecords(RetentionPolicySetup, RecordRef, ExpiredRecordExpirationDate) then
             DeleteExpiredRecords(RecordRef)

--- a/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Table.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Table.al
@@ -176,6 +176,13 @@ table 3901 "Retention Policy Setup"
         RetentionPolicySetupImpl.DeleteRetentionPolicySetup(Rec);
     end;
 
+    trigger OnInsert()
+    var
+        NewRetentionPolicyCreatedLbl: Label 'The new Retention Policy record with Table ID %1 is created by the UserSecurityId %2.', Locked = true;
+    begin
+        Session.LogAuditMessage(StrSubstNo(NewRetentionPolicyCreatedLbl, Rec."Table ID", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 3, 0);
+    end;
+
     local procedure LogCategory() RetentionPolicyLogCategory: Enum "Retention Policy Log Category"
     begin
         exit(RetentionPolicyLogCategory::"Retention Policy - Setup")

--- a/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Table.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Table.al
@@ -5,6 +5,7 @@
 
 namespace System.DataAdministration;
 
+using System;
 using System.Reflection;
 
 /// <summary>
@@ -178,9 +179,12 @@ table 3901 "Retention Policy Setup"
 
     trigger OnInsert()
     var
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
         NewRetentionPolicyCreatedLbl: Label 'The new Retention Policy record with Table ID %1 is created by the UserSecurityId %2.', Locked = true;
     begin
-        Session.LogAuditMessage(StrSubstNo(NewRetentionPolicyCreatedLbl, Rec."Table ID", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 3, 0);
+        MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(NewRetentionPolicyCreatedLbl, Rec."Table ID", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 3, 0);
     end;
 
     local procedure LogCategory() RetentionPolicyLogCategory: Enum "Retention Policy Log Category"

--- a/src/System Application/App/Security Groups/src/SecurityGroupPermissionSets.Page.al
+++ b/src/System Application/App/Security Groups/src/SecurityGroupPermissionSets.Page.al
@@ -116,6 +116,8 @@ page 9868 "Security Group Permission Sets"
 
     trigger OnInsertRecord(BelowxRec: Boolean): Boolean
     begin
+        if Rec."Role ID" <> '' then
+            Session.LogAuditMessage(StrSubstNo(PermissionSetAddedToSecurityGroupLbl, Rec."Role ID", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
         exit(Rec."Role ID" <> '');
     end;
 
@@ -138,5 +140,6 @@ page 9868 "Security Group Permission Sets"
 
     var
         PageCaptionExpression: Text;
+        PermissionSetAddedToSecurityGroupLbl: Label 'The permission set %1 has been added to the security group by UserSecurityId %2.', Locked = true;
 }
 

--- a/src/System Application/App/Security Groups/src/SecurityGroupPermissionSets.Page.al
+++ b/src/System Application/App/Security Groups/src/SecurityGroupPermissionSets.Page.al
@@ -5,6 +5,8 @@
 
 namespace System.Security.AccessControl;
 
+using System;
+
 /// <summary>
 /// View and edit the permission sets associated with a security group.
 /// </summary>
@@ -115,9 +117,13 @@ page 9868 "Security Group Permission Sets"
     }
 
     trigger OnInsertRecord(BelowxRec: Boolean): Boolean
+    var
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
     begin
         if Rec."Role ID" <> '' then
-            Session.LogAuditMessage(StrSubstNo(PermissionSetAddedToSecurityGroupLbl, Rec."Role ID", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
+            MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(PermissionSetAddedToSecurityGroupLbl, Rec."Role ID", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 2, 0);
         exit(Rec."Role ID" <> '');
     end;
 

--- a/src/System Application/App/User Settings/src/UserSettingsImpl.Codeunit.al
+++ b/src/System Application/App/User Settings/src/UserSettingsImpl.Codeunit.al
@@ -164,6 +164,9 @@ codeunit 9175 "User Settings Impl."
     var
         UserPersonalization: Record "User Personalization";
         ApplicationUserSettings: Record "Application User Settings";
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
     begin
         UserPersonalization.Get(NewUserSettings."User Security ID");
 
@@ -180,8 +183,8 @@ codeunit 9175 "User Settings Impl."
         ApplicationUserSettings."Teaching Tips" := NewUserSettings."Teaching Tips";
         ApplicationUserSettings."Legacy Action Bar" := NewUserSettings."Legacy Action Bar";
         ApplicationUserSettings.Modify();
-        Session.LogAuditMessage(StrSubstNo(UserSettingsUpdatedLbl, UserPersonalization."User SID", UserPersonalization."Language ID", UserPersonalization."Locale ID",
-            UserPersonalization.Company, UserPersonalization."Time Zone", UserPersonalization."Profile ID", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
+        MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(UserSettingsUpdatedLbl, UserPersonalization."User SID", UserPersonalization."Language ID", UserPersonalization."Locale ID",
+            UserPersonalization.Company, UserPersonalization."Time Zone", UserPersonalization."Profile ID", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 2, 0);
     end;
 
     local procedure UpdateCurrentUsersSettings(OldUserSettings: Record "User Settings"; NewUserSettings: Record "User Settings")

--- a/src/System Application/App/User Settings/src/UserSettingsImpl.Codeunit.al
+++ b/src/System Application/App/User Settings/src/UserSettingsImpl.Codeunit.al
@@ -31,6 +31,7 @@ codeunit 9175 "User Settings Impl."
         UserCreatedAppNameTxt: Label '(User-created)';
         DescriptionFilterTxt: Label 'Navigation menu only.';
         NotEnoughPermissionsErr: Label 'You cannot open this page. Only administrators can access settings for other users.';
+        UserSettingsUpdatedLbl: Label 'The user settings (UserSecurityId %1) has been updated with the values: Language ID %2, Locale ID %3, Company %4, Time Zone %5, Profile ID %6 by UserSecurityId %7 ', Locked = true;
 
     procedure GetPageId(): Integer
     var
@@ -179,6 +180,8 @@ codeunit 9175 "User Settings Impl."
         ApplicationUserSettings."Teaching Tips" := NewUserSettings."Teaching Tips";
         ApplicationUserSettings."Legacy Action Bar" := NewUserSettings."Legacy Action Bar";
         ApplicationUserSettings.Modify();
+        Session.LogAuditMessage(StrSubstNo(UserSettingsUpdatedLbl, UserPersonalization."User SID", UserPersonalization."Language ID", UserPersonalization."Locale ID",
+            UserPersonalization.Company, UserPersonalization."Time Zone", UserPersonalization."Profile ID", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
     end;
 
     local procedure UpdateCurrentUsersSettings(OldUserSettings: Record "User Settings"; NewUserSettings: Record "User Settings")

--- a/src/System Application/App/Web Service Management/src/WebServiceManagementImpl.Codeunit.al
+++ b/src/System Application/App/Web Service Management/src/WebServiceManagementImpl.Codeunit.al
@@ -700,6 +700,7 @@ codeunit 9751 "Web Service Management Impl."
     var
         WebService: Record "Web Service";
         TenantWebService: Record "Tenant Web Service";
+        WebServiceCreatedLbl: Label 'The Web Service record with Object Type %1, Service Name %2 has been created by UserSecurityId %3.', Locked = true;
     begin
         if WebServiceAggregate."All Tenants" then begin
             Clear(WebService);
@@ -709,7 +710,8 @@ codeunit 9751 "Web Service Management Impl."
             Clear(TenantWebService);
             TenantWebService.TransferFields(WebServiceAggregate);
             TenantWebService.Insert();
-        end
+        end;
+        Session.LogAuditMessage(StrSubstNo(WebServiceCreatedLbl, WebServiceAggregate."Object Type", WebServiceAggregate."Service Name", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 4, 0);
     end;
 
     procedure RemoveUnselectedColumnsFromFilter(var TenantWebService: Record "Tenant Web Service"; DataItemNumber: Integer; DataItemView: Text): Text

--- a/src/System Application/App/Web Service Management/src/WebServiceManagementImpl.Codeunit.al
+++ b/src/System Application/App/Web Service Management/src/WebServiceManagementImpl.Codeunit.al
@@ -700,6 +700,9 @@ codeunit 9751 "Web Service Management Impl."
     var
         WebService: Record "Web Service";
         TenantWebService: Record "Tenant Web Service";
+        MyCustomerAuditLoggerALHelper: DotNet CustomerAuditLoggerALHelper;
+        MyALSecurityOperationResult: DotNet ALSecurityOperationResult;
+        MyALAuditCategory: DotNet ALAuditCategory;
         WebServiceCreatedLbl: Label 'The Web Service record with Object Type %1, Service Name %2 has been created by UserSecurityId %3.', Locked = true;
     begin
         if WebServiceAggregate."All Tenants" then begin
@@ -711,7 +714,7 @@ codeunit 9751 "Web Service Management Impl."
             TenantWebService.TransferFields(WebServiceAggregate);
             TenantWebService.Insert();
         end;
-        Session.LogAuditMessage(StrSubstNo(WebServiceCreatedLbl, WebServiceAggregate."Object Type", WebServiceAggregate."Service Name", UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 4, 0);
+        MyCustomerAuditLoggerALHelper.LogAuditMessage(StrSubstNo(WebServiceCreatedLbl, WebServiceAggregate."Object Type", WebServiceAggregate."Service Name", UserSecurityId()), MyALSecurityOperationResult::Success, MyALAuditCategory::ApplicationManagement, 4, 0);
     end;
 
     procedure RemoveUnselectedColumnsFromFilter(var TenantWebService: Record "Tenant Web Service"; DataItemNumber: Integer; DataItemView: Text): Text


### PR DESCRIPTION
#### Summary

Backporting [those changes](https://github.com/microsoft/BCApps/pull/2067) to 24.5.

It requires the use of DotNet wrappers for audit logging, made available with [this PR](https://github.com/microsoft/BCApps/pull/2114)

#### Work Item(s)

Fixes [AB#550437](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/550437)





