### PR TITLE
Fetching user settings should return the company specified in the user personalization if specified

### DIFF
--- a/src/System Application/App/User Settings/src/UserSettingsImpl.Codeunit.al
+++ b/src/System Application/App/User Settings/src/UserSettingsImpl.Codeunit.al
@@ -131,7 +131,7 @@ codeunit 9175 "User Settings Impl."
         UserSettingsRec."Locale ID" := UserPersonalization."Locale ID";
         UserSettingsRec."Time Zone" := UserPersonalization."Time Zone";
 
-        if CompanyName() <> '' then
+        if (UserPersonalization.Company = '') and (CompanyName() <> '') then
             UserSettingsRec.Company := CopyStr(CompanyName(), 1, 30)
         else
             UserSettingsRec.Company := UserPersonalization.Company;


### PR DESCRIPTION
Currently we are specifying that all users are in the current company, however we should only fall back to this if the user personalization does not specify otherwise.
This fixes an issue on users list where all users are shown to be in the current company.

Fixes [AB#537109](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/537109)



