### PR TITLE
Add Business Foundation as an alternate app to Base App

### DIFF
--- a/src/Business Foundation/App/app.json
+++ b/src/Business Foundation/App/app.json
@@ -49,5 +49,6 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "contextSensitiveHelpUrl": "https://learn.microsoft.com/dynamics365/business-central/"
+  "contextSensitiveHelpUrl": "https://learn.microsoft.com/dynamics365/business-central/",
+  "alternateIds": ["437dbf0e-84ff-417a-965d-ed2bb9650972"]
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
**Problem**

In 24.x some objects were defined on the Base App, and they were then moved to Business Foundation in 25.x.
A customer has published an app A which extends these objects, and it has been compiled against 24.x symbols. Hence the references to these objects are to Base App objects.
Now the customer creates another app B which uses the object extensions created in app A and is compiled against 25.x symbols. And when it tries to resolve the references it cannot find them anymore, because it's looking in Base App instead of Business Foundation.

**Solution**
Use alternateId property in the app.json of app A to indicate that an app B contains symbols that were once contained in app A.

Hence, when looking for a symbol, look both in the app A defined in the SymbolReference.json file but also in all apps B that are alternate to A. This is made possible through thte corresponding compiler changes.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#551120](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/551120)


