### PR TITLE
Fix unguarded record lookup which fails choosing email scenario with no email account

### DIFF
--- a/src/System Application/App/Email/src/Scenario/EmailScenarioSetup.Page.al
+++ b/src/System Application/App/Email/src/Scenario/EmailScenarioSetup.Page.al
@@ -205,7 +205,7 @@ page 8893 "Email Scenario Setup"
     local procedure SetSelectedRecord()
     begin
         if not Rec.Get(SelectedEmailAccountScenario.Scenario, SelectedEmailAccountScenario."Account Id", SelectedEmailAccountScenario.Connector) then
-            Rec.FindFirst();
+            if Rec.FindFirst() then;
     end;
 
     var


### PR DESCRIPTION
If you open email scenarios and click assign scenarios, it fails if there is no email account due to an unguarded findfirst check.

Fixes [AB#551605](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/551605)




