### PR TITLE
Add build metadata to Extension Settings page

### DIFF
--- a/src/System Application/App/Extension Management/src/ExtensionSettings.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionSettings.Page.al
@@ -117,6 +117,26 @@ page 2511 "Extension Settings"
                     ToolTip = 'Specifies the commit ID of the source code for the current version of the project.';
                 }
             }
+
+            group("Build app metadata")
+            {
+                Caption = 'Build app metadata';
+                Visible = IsBuildInformationAvailable;
+
+                field(BuildBy; BuildBy)
+                {
+                    Caption = 'Build by';
+                    Editable = false;
+                    ToolTip = 'Specifies the name of the system that assisted in the compilation of this extension.';
+                }
+                field(BuildUrl; BuildUrl)
+                {
+                    Caption = 'Build URL';
+                    Editable = false;
+                    ToolTip = 'Specifies the URL of where the package can be found.';
+                    ExtendedDatatype = URL;
+                }
+            }
         }
     }
 
@@ -140,7 +160,10 @@ page 2511 "Extension Settings"
             AppAllowsDownloadSourceInSymbols := IsTenantExtension and ExtensionInstallationImpl.AllowsDownloadSourceInSymbols(PublishedApplication."Resource Exposure Policy");
             RepositoryUrl := PublishedApplication."Source Repository Url";
             CommitId := PublishedApplication."Source Commit ID";
-            IsSourceInformationAvailable := PublishedApplication."Source Repository Url" <> '';
+            IsSourceInformationAvailable := RepositoryUrl <> '';
+            BuildBy := PublishedApplication."Build By";
+            BuildUrl := PublishedApplication."Build Url";
+            IsBuildInformationAvailable := BuildBy + BuildUrl <> '';
         end;
     end;
 
@@ -167,6 +190,8 @@ page 2511 "Extension Settings"
         PublishedAs: Text;
         RepositoryUrl: Text;
         CommitId: Text;
+        BuildBy: Text;
+        BuildUrl: Text;
         AppIsInstalled: Boolean;
         IsTenantExtension: Boolean;
         AppAllowsDebuggging: Boolean;
@@ -174,4 +199,5 @@ page 2511 "Extension Settings"
         AppAllowsDownloadSourceInSymbols: Boolean;
         CanManageExtensions: Boolean;
         IsSourceInformationAvailable: Boolean;
+        IsBuildInformationAvailable: Boolean;
 }

--- a/src/System Application/App/Extension Management/src/ExtensionSettings.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionSettings.Page.al
@@ -127,13 +127,13 @@ page 2511 "Extension Settings"
                 {
                     Caption = 'Build by';
                     Editable = false;
-                    ToolTip = 'Specifies the name of the system that assisted in the compilation of this extension.';
+                    ToolTip = 'Specifies the name of the system that orchestrated the build.';
                 }
                 field(BuildUrl; BuildUrl)
                 {
                     Caption = 'Build URL';
                     Editable = false;
-                    ToolTip = 'Specifies the URL of where the package can be found.';
+                    ToolTip = 'Specifies the URL to the build system invocation where the build can be found.';
                     ExtendedDatatype = URL;
                 }
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Surface an extension's build metadata Extension Settings page. More specifically, the system that compiled it and the URL where the package is located. These properties are defined in the app.json and/or stamped by some CI/CD pipelines, like AL-Go for Github:

![image](https://github.com/user-attachments/assets/f52c9d8e-0108-48c0-85b8-2baabb9be0d8)


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#547675](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/547675)






