### PR TITLE
Add procedures to Get/Remove for UriBuilder Query Paramaters/Flags

### DIFF
--- a/src/System Application/App/URI/src/UriBuilder.Codeunit.al
+++ b/src/System Application/App/URI/src/UriBuilder.Codeunit.al
@@ -224,9 +224,9 @@ codeunit 3061 "Uri Builder"
     end;
 
     /// <summary>
-    /// Removes a flag to the query string of this UriBuilder. In case the same query flag exists already, the action in <paramref name="DuplicateAction"/> is taken.
+    /// Removes a flag from the query string of this UriBuilder. In case the same query flag exists already, the action in <paramref name="DuplicateAction"/> is taken.
     /// </summary>
-    /// <param name="Flag">A flag to Remove to the query string of this UriBuilder. This value will be encoded before being Removed to the URI query string. Cannot be empty.</param>
+    /// <param name="Flag">A flag to Remove from the query string of this UriBuilder. This value will be encoded before being Removed to the URI query string. Cannot be empty.</param>
     /// <param name="DuplicateAction">Specifies which action to take if the flag specified already exist.</param>
     /// <error>If the provided <paramref name="Flag"/> is empty.</error>
     /// <error>If the provided <paramref name="DuplicateAction"/> is <c>"Throw Error"</c> and the flag does not exist in the URI.</error>
@@ -238,9 +238,9 @@ codeunit 3061 "Uri Builder"
     end;
 
     /// <summary>
-    /// Removes a flag to the query string of this UriBuilder. In case the same query flag exists already, only one occurrence is kept.
+    /// Removes a flag from the query string of this UriBuilder. In case the same query flag exists already, only one occurrence is kept.
     /// </summary>
-    /// <param name="Flag">A flag to Remove to the query string of this UriBuilder. This value will be encoded before being Removed to the URI query string. Cannot be empty.</param>
+    /// <param name="Flag">A flag to Remove from the query string of this UriBuilder. This value will be encoded before being Removed to the URI query string. Cannot be empty.</param>
     /// <error>If the provided <paramref name="Flag"/> is empty.</error>
     /// <remarks>This function could alter the order of the existing query string parts. For example, if the previous URL was "https://microsoft.com?foo=bar&amp;john=doe" and the new flag is "contoso", the result could be "https://microsoft.com?john=doe&amp;foo=bar&amp;contoso".</remarks>
     procedure RemoveQueryFlag(Flag: Text)
@@ -249,7 +249,7 @@ codeunit 3061 "Uri Builder"
     end;
 
     /// <summary>
-    /// Removes a parameter key-value pair to the query string of this UriBuilder (in the form <c>ParameterKey=ParameterValue</c>). In case the same query key exists already, the action in <paramref name="DuplicateAction"/> is taken.
+    /// Removes a parameter key-value pair from the query string of this UriBuilder (in the form <c>ParameterKey=ParameterValue</c>). In case the same query key exists already, the action in <paramref name="DuplicateAction"/> is taken.
     /// </summary>
     /// <param name="ParameterKey">The key for the new query parameter. This value will be encoded before being Removed to the URI query string. Cannot be empty.</param>
     /// <param name="ParameterValue">The value for the new query parameter. This value will be encoded before being Removed to the URI query string. Can be empty.</param>
@@ -260,11 +260,11 @@ codeunit 3061 "Uri Builder"
     /// <remarks>This function could alter the order of the existing query string parts. For example, if the previous URL was "https://microsoft.com?foo=bar&amp;john=doe" and the new flag is "contoso=42", the result could be "https://microsoft.com?john=doe&amp;foo=bar&amp;contoso=42".</remarks>
     procedure RemoveQueryParameter(ParameterKey: Text; ParameterValue: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour")
     begin
-        UriBuilderImpl.AddQueryParameter(ParameterKey, ParameterValue, DuplicateAction, true);
+        UriBuilderImpl.RemoveQueryParameter(ParameterKey, ParameterValue, DuplicateAction);
     end;
 
     /// <summary>
-    /// Removes a parameter key-value pair to the query string of this UriBuilder (in the form <c>ParameterKey=ParameterValue</c>). In case the same query key exists already, its value is overwritten.
+    /// Removes a parameter key-value pair from the query string of this UriBuilder (in the form <c>ParameterKey=ParameterValue</c>). In case the same query key exists already, its value is overwritten.
     /// </summary>
     /// <param name="ParameterKey">The key for the new query parameter. This value will be encoded before being Removed to the URI query string. Cannot be empty.</param>
     /// <param name="ParameterValue">The value for the new query parameter. This value will be encoded before being Removed to the URI query string. Can be empty.</param>
@@ -272,11 +272,11 @@ codeunit 3061 "Uri Builder"
     /// <remarks>This function could alter the order of the existing query string parts. For example, if the previous URL was "https://microsoft.com?foo=bar&amp;john=doe" and the new flag is "contoso=42", the result could be "https://microsoft.com?john=doe&amp;foo=bar&amp;contoso=42".</remarks>
     procedure RemoveQueryParameter(ParameterKey: Text; ParameterValue: Text)
     begin
-        UriBuilderImpl.AddQueryParameter(ParameterKey, ParameterValue, Enum::"Uri Query Duplicate Behaviour"::"Overwrite All Matching", true);
+        UriBuilderImpl.RemoveQueryParameter(ParameterKey, ParameterValue, Enum::"Uri Query Duplicate Behaviour"::"Overwrite All Matching");
     end;
 
     /// <summary>
-    /// Removes a parameter key-value pair to the query string of this UriBuilder (in the form <c>ParameterKey=ParameterValue</c>). In case the same query key exists already, the action in <paramref name="DuplicateAction"/> is taken.
+    /// Removes a parameter key-value pair from the query string of this UriBuilder (in the form <c>ParameterKey=ParameterValue</c>). In case the same query key exists already, the action in <paramref name="DuplicateAction"/> is taken.
     /// </summary>
     /// <param name="ParameterKey">The key for the new query parameter. This value will be encoded before being Removed to the URI query string. Cannot be empty.</param>
     /// <param name="DuplicateAction">Specifies which action to take if the ParameterKey specified already exist.</param>

--- a/src/System Application/App/URI/src/UriBuilder.Codeunit.al
+++ b/src/System Application/App/URI/src/UriBuilder.Codeunit.al
@@ -223,6 +223,101 @@ codeunit 3061 "Uri Builder"
         UriBuilderImpl.AddODataQueryParameter(ParameterKey, ParameterValue);
     end;
 
+    /// <summary>
+    /// Removes a flag to the query string of this UriBuilder. In case the same query flag exists already, the action in <paramref name="DuplicateAction"/> is taken.
+    /// </summary>
+    /// <param name="Flag">A flag to Remove to the query string of this UriBuilder. This value will be encoded before being Removed to the URI query string. Cannot be empty.</param>
+    /// <param name="DuplicateAction">Specifies which action to take if the flag specified already exist.</param>
+    /// <error>If the provided <paramref name="Flag"/> is empty.</error>
+    /// <error>If the provided <paramref name="DuplicateAction"/> is <c>"Throw Error"</c> and the flag does not exist in the URI.</error>
+    /// <error>If the provided <paramref name="DuplicateAction"/> is not a valid value for the enum.</error>
+    /// <remarks>This function could alter the order of the existing query string parts. For example, if the previous URL was "https://microsoft.com?foo=bar&amp;john=doe" and the new flag is "contoso", the result could be "https://microsoft.com?john=doe&amp;foo=bar&amp;contoso".</remarks>
+    procedure RemoveQueryFlag(Flag: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour")
+    begin
+        UriBuilderImpl.AddQueryFlag(Flag, DuplicateAction, true);
+    end;
+
+    /// <summary>
+    /// Removes a flag to the query string of this UriBuilder. In case the same query flag exists already, only one occurrence is kept.
+    /// </summary>
+    /// <param name="Flag">A flag to Remove to the query string of this UriBuilder. This value will be encoded before being Removed to the URI query string. Cannot be empty.</param>
+    /// <error>If the provided <paramref name="Flag"/> is empty.</error>
+    /// <remarks>This function could alter the order of the existing query string parts. For example, if the previous URL was "https://microsoft.com?foo=bar&amp;john=doe" and the new flag is "contoso", the result could be "https://microsoft.com?john=doe&amp;foo=bar&amp;contoso".</remarks>
+    procedure RemoveQueryFlag(Flag: Text)
+    begin
+        UriBuilderImpl.AddQueryFlag(Flag, Enum::"Uri Query Duplicate Behaviour"::"Overwrite All Matching", true);
+    end;
+
+    /// <summary>
+    /// Removes a parameter key-value pair to the query string of this UriBuilder (in the form <c>ParameterKey=ParameterValue</c>). In case the same query key exists already, the action in <paramref name="DuplicateAction"/> is taken.
+    /// </summary>
+    /// <param name="ParameterKey">The key for the new query parameter. This value will be encoded before being Removed to the URI query string. Cannot be empty.</param>
+    /// <param name="ParameterValue">The value for the new query parameter. This value will be encoded before being Removed to the URI query string. Can be empty.</param>
+    /// <param name="DuplicateAction">Specifies which action to take if the ParameterKey specified already exist.</param>
+    /// <error>If the provided <paramref name="ParameterKey"/> is empty.</error>
+    /// <error>If the provided <paramref name="DuplicateAction"/> is <c>"Throw Error"</c>.</error>
+    /// <error>If the provided <paramref name="DuplicateAction"/> is not a valid value for the enum.</error>
+    /// <remarks>This function could alter the order of the existing query string parts. For example, if the previous URL was "https://microsoft.com?foo=bar&amp;john=doe" and the new flag is "contoso=42", the result could be "https://microsoft.com?john=doe&amp;foo=bar&amp;contoso=42".</remarks>
+    procedure RemoveQueryParameter(ParameterKey: Text; ParameterValue: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour")
+    begin
+        UriBuilderImpl.AddQueryParameter(ParameterKey, ParameterValue, DuplicateAction, true);
+    end;
+
+    /// <summary>
+    /// Removes a parameter key-value pair to the query string of this UriBuilder (in the form <c>ParameterKey=ParameterValue</c>). In case the same query key exists already, its value is overwritten.
+    /// </summary>
+    /// <param name="ParameterKey">The key for the new query parameter. This value will be encoded before being Removed to the URI query string. Cannot be empty.</param>
+    /// <param name="ParameterValue">The value for the new query parameter. This value will be encoded before being Removed to the URI query string. Can be empty.</param>
+    /// <error>If the provided <paramref name="ParameterKey"/> is empty.</error>
+    /// <remarks>This function could alter the order of the existing query string parts. For example, if the previous URL was "https://microsoft.com?foo=bar&amp;john=doe" and the new flag is "contoso=42", the result could be "https://microsoft.com?john=doe&amp;foo=bar&amp;contoso=42".</remarks>
+    procedure RemoveQueryParameter(ParameterKey: Text; ParameterValue: Text)
+    begin
+        UriBuilderImpl.AddQueryParameter(ParameterKey, ParameterValue, Enum::"Uri Query Duplicate Behaviour"::"Overwrite All Matching", true);
+    end;
+
+    /// <summary>
+    /// Removes a parameter key-value pair to the query string of this UriBuilder (in the form <c>ParameterKey=ParameterValue</c>). In case the same query key exists already, the action in <paramref name="DuplicateAction"/> is taken.
+    /// </summary>
+    /// <param name="ParameterKey">The key for the new query parameter. This value will be encoded before being Removed to the URI query string. Cannot be empty.</param>
+    /// <param name="DuplicateAction">Specifies which action to take if the ParameterKey specified already exist.</param>
+    /// <error>If the provided <paramref name="ParameterKey"/> is empty.</error>
+    /// <error>If the provided <paramref name="DuplicateAction"/> is <c>"Throw Error"</c>.</error>
+    /// <error>If the provided <paramref name="DuplicateAction"/> is not a valid value for the enum.</error>
+    /// <remarks>This function could alter the order of the existing query string parts. For example, if the previous URL was "https://microsoft.com?foo=bar&amp;john=doe" and the new flag is "contoso=42", the result could be "https://microsoft.com?john=doe&amp;foo=bar&amp;contoso=42".</remarks>
+    procedure RemoveQueryParameters()
+    begin
+        UriBuilderImpl.RemoveQueryParameters();
+    end;
+
+    /// <summary>
+    /// Gets the flags in the query string of this UriBuilder.
+    /// </summary>
+    /// <returns>A list of flags in the query string of this UriBuilder.</returns>
+    procedure GetQueryFlags(): List of [Text]
+    begin
+        exit(UriBuilderImpl.GetQueryFlags());
+    end;
+
+    /// <summary>
+    /// Gets the parameters in the query string of this UriBuilder.
+    /// </summary>
+    /// <returns>A dictionary of parameters in the query string of this UriBuilder.</returns>
+    procedure GetQueryParameters(): Dictionary of [Text, List of [Text]]
+    begin
+        exit(UriBuilderImpl.GetQueryParameters());
+    end;
+
+    /// <summary>
+    /// Gets the value of the specified query parameter.
+    /// </summary>
+    /// <param name="ParameterKey">The key of the query parameter to get the value of.</param>
+    /// <returns>The value of the specified query parameter.</returns>
+    procedure GetQueryParameter(ParameterKey: Text): List of [Text]
+    begin
+        exit(UriBuilderImpl.GetQueryParameter(ParameterKey));
+    end;
+
+
     var
         UriBuilderImpl: Codeunit "Uri Builder Impl.";
 }

--- a/src/System Application/App/URI/src/UriBuilderImpl.Codeunit.al
+++ b/src/System Application/App/URI/src/UriBuilderImpl.Codeunit.al
@@ -173,8 +173,8 @@ codeunit 3062 "Uri Builder Impl."
     begin
         if not KeysWithValueList.ContainsKey(QueryKey) then begin
             if ShouldRemove then begin
-            if DuplicateAction = DuplicateAction::"Throw Error" then
-                Error(ParameterNotFoundErr);
+                if DuplicateAction = DuplicateAction::"Throw Error" then
+                    Error(ParameterNotFoundErr);
                 exit;
             end;
             Values.Add(QueryValue);
@@ -183,6 +183,13 @@ codeunit 3062 "Uri Builder Impl."
         end;
 
         KeysWithValueList.Get(QueryKey, Values);
+
+        if ShouldRemove then
+            if Values.Contains(QueryValue) then begin
+                Values.Remove(QueryValue); // Remove first-occurrence from List
+                KeysWithValueList.Set(QueryKey, Values);
+            end;
+
         case DuplicateAction of
             DuplicateAction::"Overwrite All Matching":
                 begin
@@ -222,6 +229,9 @@ codeunit 3062 "Uri Builder Impl."
                     Error(FlagNotFoundErr);
             exit;
         end;
+
+        if ShouldRemove then
+            Flags.Remove(Flag); // Remove first occurence from List
 
         case DuplicateAction of
             DuplicateAction::Skip:

--- a/src/System Application/App/URI/src/UriBuilderImpl.Codeunit.al
+++ b/src/System Application/App/URI/src/UriBuilderImpl.Codeunit.al
@@ -115,6 +115,11 @@ codeunit 3062 "Uri Builder Impl."
         AddQueryParameterInternal(ParameterKey, ParameterValue, Enum::"Uri Query Duplicate Behaviour"::"Overwrite All Matching", true, false);
     end;
 
+    procedure RemoveQueryParameter(ParameterKey: Text; ParameterValue: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour")
+    begin
+        AddQueryParameterInternal(ParameterKey, ParameterValue, DuplicateAction, false, true);
+    end;
+
     local procedure AddQueryParameterInternal(ParameterKey: Text; ParameterValue: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour"; UseODataEncoding: Boolean; ShouldRemove: Boolean)
     var
         KeysWithValueList: Dictionary of [Text, List of [Text]];
@@ -189,11 +194,14 @@ codeunit 3062 "Uri Builder Impl."
             DuplicateAction::Skip:
                 ; // Do nothing
             DuplicateAction::"Keep All":
-                if not ShouldRemove then
-                    Values.Add(QueryValue)
-                else if Values.Contains(QueryValue) then
-                    Values.Remove(QueryValue);
-                KeysWithValueList.Set(QueryKey, Values);
+                begin
+                    if not ShouldRemove then
+                        Values.Add(QueryValue)
+                    else
+                        if Values.Contains(QueryValue) then
+                            Values.Remove(QueryValue);
+                    KeysWithValueList.Set(QueryKey, Values);
+                end;
             DuplicateAction::"Throw Error":
                 if not ShouldRemove then
                     Error(DuplicateParameterErr);

--- a/src/System Application/App/URI/src/UriBuilderImpl.Codeunit.al
+++ b/src/System Application/App/URI/src/UriBuilderImpl.Codeunit.al
@@ -84,6 +84,11 @@ codeunit 3062 "Uri Builder Impl."
     end;
 
     procedure AddQueryFlag(Flag: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour")
+    begin
+        AddQueryFlag(Flag, DuplicateAction, false);
+    end;
+
+    procedure AddQueryFlag(Flag: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour"; ShouldRemove: Boolean)
     var
         KeysWithValueList: Dictionary of [Text, List of [Text]];
         Flags: List of [Text];
@@ -94,7 +99,7 @@ codeunit 3062 "Uri Builder Impl."
 
         QueryString := GetQuery();
         ParseParametersAndFlags(QueryString, KeysWithValueList, Flags);
-        ProcessNewFlag(Flags, Flag, DuplicateAction);
+        ProcessNewFlag(Flags, Flag, DuplicateAction, ShouldRemove);
         QueryString := CreateNewQueryString(KeysWithValueList, Flags, false);
 
         SetQuery(QueryString);
@@ -102,15 +107,15 @@ codeunit 3062 "Uri Builder Impl."
 
     procedure AddQueryParameter(ParameterKey: Text; ParameterValue: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour")
     begin
-        AddQueryParameterInternal(ParameterKey, ParameterValue, DuplicateAction, false);
+        AddQueryParameterInternal(ParameterKey, ParameterValue, DuplicateAction, false, false);
     end;
 
     procedure AddODataQueryParameter(ParameterKey: Text; ParameterValue: Text)
     begin
-        AddQueryParameterInternal(ParameterKey, ParameterValue, Enum::"Uri Query Duplicate Behaviour"::"Overwrite All Matching", true);
+        AddQueryParameterInternal(ParameterKey, ParameterValue, Enum::"Uri Query Duplicate Behaviour"::"Overwrite All Matching", true, false);
     end;
 
-    local procedure AddQueryParameterInternal(ParameterKey: Text; ParameterValue: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour"; UseODataEncoding: Boolean)
+    local procedure AddQueryParameterInternal(ParameterKey: Text; ParameterValue: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour"; UseODataEncoding: Boolean; ShouldRemove: Boolean)
     var
         KeysWithValueList: Dictionary of [Text, List of [Text]];
         Flags: List of [Text];
@@ -121,7 +126,7 @@ codeunit 3062 "Uri Builder Impl."
 
         QueryString := GetQuery();
         ParseParametersAndFlags(QueryString, KeysWithValueList, Flags);
-        ProcessNewParameter(KeysWithValueList, ParameterKey, ParameterValue, DuplicateAction);
+        ProcessNewParameter(KeysWithValueList, ParameterKey, ParameterValue, DuplicateAction, ShouldRemove);
         QueryString := CreateNewQueryString(KeysWithValueList, Flags, UseODataEncoding);
 
         SetQuery(QueryString);
@@ -157,11 +162,16 @@ codeunit 3062 "Uri Builder Impl."
             end;
     end;
 
-    local procedure ProcessNewParameter(var KeysWithValueList: Dictionary of [Text, List of [Text]]; QueryKey: Text; QueryValue: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour")
+    local procedure ProcessNewParameter(var KeysWithValueList: Dictionary of [Text, List of [Text]]; QueryKey: Text; QueryValue: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour"; ShouldRemove: Boolean)
     var
         Values: List of [Text];
     begin
         if not KeysWithValueList.ContainsKey(QueryKey) then begin
+            if ShouldRemove then begin
+            if DuplicateAction = DuplicateAction::"Throw Error" then
+                Error(ParameterNotFoundErr);
+                exit;
+            end;
             Values.Add(QueryValue);
             KeysWithValueList.Add(QueryKey, Values);
             exit;
@@ -172,33 +182,42 @@ codeunit 3062 "Uri Builder Impl."
             DuplicateAction::"Overwrite All Matching":
                 begin
                     Clear(Values);
-                    Values.Add(QueryValue);
-                    KeysWithValueList.Remove(QueryKey);
-                    KeysWithValueList.Add(QueryKey, Values);
+                    if not ShouldRemove then
+                        Values.Add(QueryValue);
+                    KeysWithValueList.Set(QueryKey, Values);
                 end;
             DuplicateAction::Skip:
                 ; // Do nothing
             DuplicateAction::"Keep All":
-                Values.Add(QueryValue);
+                if not ShouldRemove then
+                    Values.Add(QueryValue)
+                else if Values.Contains(QueryValue) then
+                    Values.Remove(QueryValue);
+                KeysWithValueList.Set(QueryKey, Values);
             DuplicateAction::"Throw Error":
-                Error(DuplicateParameterErr);
+                if not ShouldRemove then
+                    Error(DuplicateParameterErr);
             else // In case the duplicate action is invalid, it's safer to error out than to have a malformed URL
                 Error(DuplicateParameterErr);
         end;
     end;
 
-    local procedure ProcessNewFlag(var Flags: List of [Text]; Flag: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour")
+    local procedure ProcessNewFlag(var Flags: List of [Text]; Flag: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour"; ShouldRemove: Boolean)
     var
         FlagsSizeBeforeRemove: Integer;
     begin
         if not Flags.Contains(Flag) then begin
-            Flags.Add(Flag);
+            if not ShouldRemove then
+                Flags.Add(Flag)
+            else
+                if DuplicateAction = DuplicateAction::"Throw Error" then
+                    Error(FlagNotFoundErr);
             exit;
         end;
 
         case DuplicateAction of
             DuplicateAction::Skip:
-                ;
+                ; // Do nothing
             DuplicateAction::"Overwrite All Matching":
                 begin
                     // If multiple matching flags exist, we need to keep only one
@@ -208,15 +227,55 @@ codeunit 3062 "Uri Builder Impl."
                             if Flags.Remove(Flag) then;
                     until Flags.Count >= FlagsSizeBeforeRemove;
 
-                    Flags.Add(Flag);
+                    if not ShouldRemove then
+                        Flags.Add(Flag);
                 end;
             DuplicateAction::"Keep All":
-                Flags.Add(Flag);
+                if not ShouldRemove then
+                    Flags.Add(Flag);
             DuplicateAction::"Throw Error":
-                Error(DuplicateFlagErr);
+                if not ShouldRemove then
+                    Error(DuplicateFlagErr);
             else // In case the duplicate action is invalid, it's safer to error out than to have a malformed URL
                 Error(DuplicateFlagErr);
         end;
+    end;
+
+    procedure RemoveQueryParameters()
+    begin
+        SetQuery('');
+    end;
+
+    procedure GetQueryFlags(): List of [Text]
+    var
+        KeysWithValueList: Dictionary of [Text, List of [Text]];
+        Flags: List of [Text];
+        QueryString: Text;
+    begin
+        QueryString := GetQuery();
+        ParseParametersAndFlags(QueryString, KeysWithValueList, Flags);
+        exit(Flags);
+    end;
+
+    procedure GetQueryParameters(): Dictionary of [Text, List of [Text]]
+    var
+        KeysWithValueList: Dictionary of [Text, List of [Text]];
+        Flags: List of [Text];
+        QueryString: Text;
+    begin
+        QueryString := GetQuery();
+        ParseParametersAndFlags(QueryString, KeysWithValueList, Flags);
+        exit(KeysWithValueList);
+    end;
+
+    procedure GetQueryParameter(ParameterKey: Text): List of [Text]
+    var
+        KeysWithValueList: Dictionary of [Text, List of [Text]];
+    begin
+        KeysWithValueList := GetQueryParameters();
+        if not KeysWithValueList.ContainsKey(ParameterKey) then
+            exit;
+        exit(KeysWithValueList.Get(ParameterKey));
     end;
 
     local procedure CreateNewQueryString(KeysWithValueList: Dictionary of [Text, List of [Text]]; Flags: List of [Text]; UseODataEncoding: Boolean) FinalQuery: Text
@@ -261,5 +320,7 @@ codeunit 3062 "Uri Builder Impl."
         QueryParameterKeyCannotBeEmptyErr: Label 'The query parameter key cannot be empty.';
         DuplicateFlagErr: Label 'The provided query flag is already present in the URI.';
         DuplicateParameterErr: Label 'The provided query parameter is already present in the URI.';
+        FlagNotFoundErr: Label 'The provided query flag is not present in the URI.';
+        ParameterNotFoundErr: Label 'The provided query parameter is not present in the URI.';
         UriBuilder: DotNet UriBuilder;
 }

--- a/src/System Application/Test/URI/src/UriBuilderQueryTest.Codeunit.al
+++ b/src/System Application/Test/URI/src/UriBuilderQueryTest.Codeunit.al
@@ -696,15 +696,15 @@ codeunit 135072 "Uri Builder Query Test"
     procedure TestGetQueryParameterNotFound()
     var
         Uri: Codeunit Uri;
-        Params: Dictionary of [Text, List of [Text]];
+        ParamValues: List of [Text];
     begin
         // [Given] A URL with query parameters
         UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
 
         // [When] Getting query parameters that do not exist
-        Params := UriBuilder.GetQueryParameter('param3');
+        ParamValues := UriBuilder.GetQueryParameter('param3');
 
-        // [Then] The dictionary of query parameters is empty
-        Assert.AreEqual(0, Params.Count(), 'Unexpected number of parameters.');
+        // [Then] The list of query parameters is empty
+        Assert.AreEqual(0, ParamValues.Count(), 'Unexpected number of parameters.');
     end;
 }

--- a/src/System Application/Test/URI/src/UriBuilderQueryTest.Codeunit.al
+++ b/src/System Application/Test/URI/src/UriBuilderQueryTest.Codeunit.al
@@ -514,4 +514,195 @@ codeunit 135072 "Uri Builder Query Test"
         UriBuilder.GetUri(Uri);
         Assert.AreEqual('https://microsoft.com/?c=', Uri.GetAbsoluteUri(), 'Unexpected URL.');
     end;
+
+    [Test]
+    procedure TestRemoveQueryFlagWithDuplicateAction()
+    var
+        UriBuilder: Codeunit UriBuilder;
+    begin
+        // [Given] A URL with query flags
+        UriBuilder.Init('https://microsoft.com?flag1&flag2');
+
+        // [When] Removing a query flag with a specified duplicate action
+        UriBuilder.RemoveQueryFlag('flag1', Enum::"Uri Query Duplicate Behaviour"::"Throw Error");
+
+        // [Then] The query flag is removed correctly
+        Assert.AreEqual('https://microsoft.com?flag2', UriBuilder.ToString());
+    end;
+
+    [Test]
+    procedure TestRemoveQueryFlagNotFound()
+    var
+        UriBuilder: Codeunit UriBuilder;
+    begin
+        // [Given] A URL with query flags
+        UriBuilder.Init('https://microsoft.com?flag1&flag2');
+
+        // [When] Removing a query flag that does not exist
+        UriBuilder.RemoveQueryFlag('flag3');
+
+        // [Then] The URL is unchanged
+        Assert.AreEqual('https://microsoft.com?flag1&flag2', UriBuilder.ToString());
+    end;
+
+    [Test]
+    procedure TestRemoveQueryFlagNotFoundThrowError()
+    var
+        UriBuilder: Codeunit UriBuilder;
+    begin
+        // [Given] A URL with query flags
+        UriBuilder.Init('https://microsoft.com?flag1&flag2');
+
+        // [When] Removing a query flag that does not exist with throw error
+        asserterror UriBuilder.RemoveQueryFlag('flag3', Enum::"Uri Query Duplicate Behaviour"::"Throw Error");
+
+        // [Then] An error is thrown
+        Assert.ExpectedError('The provided query flag is not present in the URI.');
+    end;
+
+    [Test]
+    procedure TestRemoveQueryFlag()
+    var
+        UriBuilder: Codeunit UriBuilder;
+    begin
+        // [Given] A URL with query flags
+        UriBuilder.Init('https://microsoft.com?flag1&flag2');
+
+        // [When] Removing a query flag
+        UriBuilder.RemoveQueryFlag('flag1');
+
+        // [Then] The query flag is removed correctly
+        Assert.AreEqual('https://microsoft.com?flag2', UriBuilder.ToString());
+    end;
+
+    [Test]
+    procedure TestRemoveQueryParameterWithDuplicateAction()
+    var
+        UriBuilder: Codeunit UriBuilder;
+    begin
+        // [Given] A URL with query parameters
+        UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
+
+        // [When] Removing a query parameter with a specified duplicate action
+        UriBuilder.RemoveQueryParameter('param1', 'value1', Enum::"Uri Query Duplicate Behaviour"::"Throw Error");
+
+        // [Then] The query parameter is removed correctly
+        Assert.AreEqual('https://microsoft.com?param2=value2', UriBuilder.ToString());
+    end;
+
+    [Test]
+    procedure TestRemoveQueryParameterNotFoundThrowError()
+    var
+        UriBuilder: Codeunit UriBuilder;
+    begin
+        // [Given] A URL with query parameters
+        UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
+
+        // [When] Removing a query parameter that does not exist with throw error
+        asserterror UriBuilder.RemoveQueryParameter('param3', 'value3', Enum::"Uri Query Duplicate Behaviour"::"Throw Error");
+
+        // [Then] An error is thrown
+        Assert.ExpectedError('The provided query parameter is not present in the URI.');
+    end;
+
+    [Test]
+    procedure TestRemoveQueryParameter()
+    var
+        UriBuilder: Codeunit UriBuilder;
+    begin
+        // [Given] A URL with query parameters
+        UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
+
+        // [When] Removing a query parameter
+        UriBuilder.RemoveQueryParameter('param1', 'value1');
+
+        // [Then] The query parameter is removed correctly
+        Assert.AreEqual('https://microsoft.com?param2=value2', UriBuilder.ToString());
+    end;
+
+    [Test]
+    procedure TestRemoveQueryParameters()
+    var
+        UriBuilder: Codeunit UriBuilder;
+    begin
+        // [Given] A URL with multiple query parameters
+        UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
+
+        // [When] Removing all query parameters
+        UriBuilder.RemoveQueryParameters();
+
+        // [Then] All query parameters are removed
+        Assert.AreEqual('https://microsoft.com', UriBuilder.ToString());
+    end;
+
+    [Test]
+    procedure TestGetQueryFlags()
+    var
+        UriBuilder: Codeunit UriBuilder;
+        Flags: List of [Text];
+    begin
+        // [Given] A URL with query flags
+        UriBuilder.Init('https://microsoft.com?flag1&flag2');
+
+        // [When] Getting query flags
+        Flags := UriBuilder.GetQueryFlags();
+
+        // [Then] The list of query flags is correct
+        Assert.AreEqual(2, Flags.Count());
+        Assert.IsTrue(Flags.Contains('flag1'));
+        Assert.IsTrue(Flags.Contains('flag2'));
+    end;
+
+    [Test]
+    procedure TestGetQueryParameters()
+    var
+        UriBuilder: Codeunit UriBuilder;
+        Params: Dictionary of [Text, List of [Text]];
+    begin
+        // [Given] A URL with query parameters
+        UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
+
+        // [When] Getting query parameters
+        Params := UriBuilder.GetQueryParameters();
+
+        // [Then] The dictionary of query parameters is correct
+        Assert.AreEqual(2, Params.Count());
+        Assert.IsTrue(Params.ContainsKey('param1'));
+        Assert.IsTrue(Params.ContainsKey('param2'));
+        Assert.AreEqual('value1', Params.Get('param1').Get(1));
+        Assert.AreEqual('value2', Params.Get('param2').Get(1));
+    end;
+
+    [Test]
+    procedure TestGetQueryParameter()
+    var
+        UriBuilder: Codeunit UriBuilder;
+        ParamValues: List of [Text];
+    begin
+        // [Given] A URL with query parameters
+        UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
+
+        // [When] Getting a specific query parameter
+        ParamValues := UriBuilder.GetQueryParameter('param1');
+
+        // [Then] The value of the query parameter is correct
+        Assert.AreEqual(1, ParamValues.Count());
+        Assert.AreEqual('value1', ParamValues.Get(1));
+    end;
+
+    [Test]
+    procedure TestGetQueryParameterNotFound()
+    var
+        UriBuilder: Codeunit UriBuilder;
+        Params: Dictionary of [Text, List of [Text]];
+    begin
+        // [Given] A URL with query parameters
+        UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
+
+        // [When] Getting query parameters that do not exist
+        Params := UriBuilder.GetQueryParameter('param3');
+
+        // [Then] The dictionary of query parameters is empty
+        Assert.AreEqual(0, Params.Count());
+    end;
 }

--- a/src/System Application/Test/URI/src/UriBuilderQueryTest.Codeunit.al
+++ b/src/System Application/Test/URI/src/UriBuilderQueryTest.Codeunit.al
@@ -640,7 +640,6 @@ codeunit 135072 "Uri Builder Query Test"
     [Test]
     procedure TestGetQueryFlags()
     var
-        Uri: Codeunit Uri;
         Flags: List of [Text];
     begin
         // [Given] A URL with query flags
@@ -658,7 +657,6 @@ codeunit 135072 "Uri Builder Query Test"
     [Test]
     procedure TestGetQueryParameters()
     var
-        Uri: Codeunit Uri;
         Params: Dictionary of [Text, List of [Text]];
     begin
         // [Given] A URL with query parameters
@@ -678,7 +676,6 @@ codeunit 135072 "Uri Builder Query Test"
     [Test]
     procedure TestGetQueryParameter()
     var
-        Uri: Codeunit Uri;
         ParamValues: List of [Text];
     begin
         // [Given] A URL with query parameters
@@ -695,7 +692,6 @@ codeunit 135072 "Uri Builder Query Test"
     [Test]
     procedure TestGetQueryParameterNotFound()
     var
-        Uri: Codeunit Uri;
         ParamValues: List of [Text];
     begin
         // [Given] A URL with query parameters

--- a/src/System Application/Test/URI/src/UriBuilderQueryTest.Codeunit.al
+++ b/src/System Application/Test/URI/src/UriBuilderQueryTest.Codeunit.al
@@ -309,7 +309,7 @@ codeunit 135072 "Uri Builder Query Test"
         Uri: Codeunit Uri;
     begin
         // [Given] A Url
-        UriBuilder.Init('https://microsoft.com?è=éNotEncoded&%C3%A8=%C3%A9Encoded');
+        UriBuilder.Init('https://microsoft.com/?è=éNotEncoded&%C3%A8=%C3%A9Encoded');
 
         // [When] Adding a query parameter that needs encoding
         UriBuilder.AddQueryParameter('è', 'éAddedNotEncoded', Enum::"Uri Query Duplicate Behaviour"::"Keep All");
@@ -333,7 +333,7 @@ codeunit 135072 "Uri Builder Query Test"
         Uri: Codeunit Uri;
     begin
         // [Given] A Url
-        UriBuilder.Init('https://microsoft.com?è=éNotEncoded&%C3%A8=%C3%A9Encoded');
+        UriBuilder.Init('https://microsoft.com/?è=éNotEncoded&%C3%A8=%C3%A9Encoded');
 
         // [When] Adding OData parameters that don't include the $ sign
         UriBuilder.AddODataQueryParameter('è', 'éAddedNotEncoded');
@@ -357,7 +357,7 @@ codeunit 135072 "Uri Builder Query Test"
         Uri: Codeunit Uri;
     begin
         // [Given] A Url
-        UriBuilder.Init('https://microsoft.com?$top=33&%24skip=41&$filter=nothing&è=éNotEncoded&%C3%A8=%C3%A9Encoded');
+        UriBuilder.Init('https://microsoft.com/?$top=33&%24skip=41&$filter=nothing&è=éNotEncoded&%C3%A8=%C3%A9Encoded');
 
         // [When] Adding OData parameters that include the $ sign
         UriBuilder.AddODataQueryParameter('$filter', 'Name eq ''&Contoso''');
@@ -381,7 +381,7 @@ codeunit 135072 "Uri Builder Query Test"
         Uri: Codeunit Uri;
     begin
         // [Given] A Url
-        UriBuilder.Init('https://microsoft.com?$top=33&%24skip=41&$filter=nothing&è=éNotEncoded&%C3%A8=%C3%A9Encoded');
+        UriBuilder.Init('https://microsoft.com/?$top=33&%24skip=41&$filter=nothing&è=éNotEncoded&%C3%A8=%C3%A9Encoded');
 
         // [When] Adding OData parameters that include the $ sign
         UriBuilder.AddODataQueryParameter('$filter', 'Name eq ''&Contoso''');
@@ -409,7 +409,7 @@ codeunit 135072 "Uri Builder Query Test"
         Uri: Codeunit Uri;
     begin
         // [Given] A Url
-        UriBuilder.Init('https://microsoft.com?éNotEncoded&%C3%A9Encoded');
+        UriBuilder.Init('https://microsoft.com/?éNotEncoded&%C3%A9Encoded');
 
         // [When] Adding a flag that needs encoding
         UriBuilder.AddQueryFlag('éAddedAsNotEncoded', Enum::"Uri Query Duplicate Behaviour"::"Throw Error");
@@ -521,14 +521,14 @@ codeunit 135072 "Uri Builder Query Test"
         Uri: Codeunit Uri;
     begin
         // [Given] A URL with query flags
-        UriBuilder.Init('https://microsoft.com?flag1&flag2');
+        UriBuilder.Init('https://microsoft.com/?flag1&flag2');
 
         // [When] Removing a query flag with a specified duplicate action
         UriBuilder.RemoveQueryFlag('flag1', Enum::"Uri Query Duplicate Behaviour"::"Throw Error");
 
         // [Then] The query flag is removed correctly
         UriBuilder.GetUri(Uri);
-        Assert.AreEqual('https://microsoft.com?flag2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
+        Assert.AreEqual('https://microsoft.com/?flag2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
     end;
 
     [Test]
@@ -537,21 +537,21 @@ codeunit 135072 "Uri Builder Query Test"
         Uri: Codeunit Uri;
     begin
         // [Given] A URL with query flags
-        UriBuilder.Init('https://microsoft.com?flag1&flag2');
+        UriBuilder.Init('https://microsoft.com/?flag1&flag2');
 
         // [When] Removing a query flag that does not exist
         UriBuilder.RemoveQueryFlag('flag3');
 
         // [Then] The URL is unchanged
         UriBuilder.GetUri(Uri);
-        Assert.AreEqual('https://microsoft.com?flag1&flag2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
+        Assert.AreEqual('https://microsoft.com/?flag1&flag2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
     end;
 
     [Test]
     procedure TestRemoveQueryFlagNotFoundThrowError()
     begin
         // [Given] A URL with query flags
-        UriBuilder.Init('https://microsoft.com?flag1&flag2');
+        UriBuilder.Init('https://microsoft.com/?flag1&flag2');
 
         // [When] Removing a query flag that does not exist with throw error
         asserterror UriBuilder.RemoveQueryFlag('flag3', Enum::"Uri Query Duplicate Behaviour"::"Throw Error");
@@ -566,14 +566,14 @@ codeunit 135072 "Uri Builder Query Test"
         Uri: Codeunit Uri;
     begin
         // [Given] A URL with query flags
-        UriBuilder.Init('https://microsoft.com?flag1&flag2');
+        UriBuilder.Init('https://microsoft.com/?flag1&flag2');
 
         // [When] Removing a query flag
         UriBuilder.RemoveQueryFlag('flag1');
 
         // [Then] The query flag is removed correctly
         UriBuilder.GetUri(Uri);
-        Assert.AreEqual('https://microsoft.com?flag2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
+        Assert.AreEqual('https://microsoft.com/?flag2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
     end;
 
     [Test]
@@ -582,21 +582,21 @@ codeunit 135072 "Uri Builder Query Test"
         Uri: Codeunit Uri;
     begin
         // [Given] A URL with query parameters
-        UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
+        UriBuilder.Init('https://microsoft.com/?param1=value1&param2=value2');
 
         // [When] Removing a query parameter with a specified duplicate action
         UriBuilder.RemoveQueryParameter('param1', 'value1', Enum::"Uri Query Duplicate Behaviour"::"Throw Error");
 
         // [Then] The query parameter is removed correctly
         UriBuilder.GetUri(Uri);
-        Assert.AreEqual('https://microsoft.com?param2=value2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
+        Assert.AreEqual('https://microsoft.com/?param2=value2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
     end;
 
     [Test]
     procedure TestRemoveQueryParameterNotFoundThrowError()
     begin
         // [Given] A URL with query parameters
-        UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
+        UriBuilder.Init('https://microsoft.com/?param1=value1&param2=value2');
 
         // [When] Removing a query parameter that does not exist with throw error
         asserterror UriBuilder.RemoveQueryParameter('param3', 'value3', Enum::"Uri Query Duplicate Behaviour"::"Throw Error");
@@ -611,14 +611,14 @@ codeunit 135072 "Uri Builder Query Test"
         Uri: Codeunit Uri;
     begin
         // [Given] A URL with query parameters
-        UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
+        UriBuilder.Init('https://microsoft.com/?param1=value1&param2=value2');
 
         // [When] Removing a query parameter
         UriBuilder.RemoveQueryParameter('param1', 'value1');
 
         // [Then] The query parameter is removed correctly
         UriBuilder.GetUri(Uri);
-        Assert.AreEqual('https://microsoft.com?param2=value2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
+        Assert.AreEqual('https://microsoft.com/?param2=value2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
     end;
 
     [Test]
@@ -627,7 +627,7 @@ codeunit 135072 "Uri Builder Query Test"
         Uri: Codeunit Uri;
     begin
         // [Given] A URL with multiple query parameters
-        UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
+        UriBuilder.Init('https://microsoft.com/?param1=value1&param2=value2');
 
         // [When] Removing all query parameters
         UriBuilder.RemoveQueryParameters();
@@ -643,7 +643,7 @@ codeunit 135072 "Uri Builder Query Test"
         Flags: List of [Text];
     begin
         // [Given] A URL with query flags
-        UriBuilder.Init('https://microsoft.com?flag1&flag2');
+        UriBuilder.Init('https://microsoft.com/?flag1&flag2');
 
         // [When] Getting query flags
         Flags := UriBuilder.GetQueryFlags();
@@ -660,7 +660,7 @@ codeunit 135072 "Uri Builder Query Test"
         Params: Dictionary of [Text, List of [Text]];
     begin
         // [Given] A URL with query parameters
-        UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
+        UriBuilder.Init('https://microsoft.com/?param1=value1&param2=value2');
 
         // [When] Getting query parameters
         Params := UriBuilder.GetQueryParameters();
@@ -679,7 +679,7 @@ codeunit 135072 "Uri Builder Query Test"
         ParamValues: List of [Text];
     begin
         // [Given] A URL with query parameters
-        UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
+        UriBuilder.Init('https://microsoft.com/?param1=value1&param2=value2');
 
         // [When] Getting a specific query parameter
         ParamValues := UriBuilder.GetQueryParameter('param1');
@@ -695,7 +695,7 @@ codeunit 135072 "Uri Builder Query Test"
         ParamValues: List of [Text];
     begin
         // [Given] A URL with query parameters
-        UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
+        UriBuilder.Init('https://microsoft.com/?param1=value1&param2=value2');
 
         // [When] Getting query parameters that do not exist
         ParamValues := UriBuilder.GetQueryParameter('param3');

--- a/src/System Application/Test/URI/src/UriBuilderQueryTest.Codeunit.al
+++ b/src/System Application/Test/URI/src/UriBuilderQueryTest.Codeunit.al
@@ -518,7 +518,7 @@ codeunit 135072 "Uri Builder Query Test"
     [Test]
     procedure TestRemoveQueryFlagWithDuplicateAction()
     var
-        UriBuilder: Codeunit UriBuilder;
+        Uri: Codeunit Uri;
     begin
         // [Given] A URL with query flags
         UriBuilder.Init('https://microsoft.com?flag1&flag2');
@@ -527,13 +527,14 @@ codeunit 135072 "Uri Builder Query Test"
         UriBuilder.RemoveQueryFlag('flag1', Enum::"Uri Query Duplicate Behaviour"::"Throw Error");
 
         // [Then] The query flag is removed correctly
-        Assert.AreEqual('https://microsoft.com?flag2', UriBuilder.ToString());
+        UriBuilder.GetUri(Uri);
+        Assert.AreEqual('https://microsoft.com?flag2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
     end;
 
     [Test]
     procedure TestRemoveQueryFlagNotFound()
     var
-        UriBuilder: Codeunit UriBuilder;
+        Uri: Codeunit Uri;
     begin
         // [Given] A URL with query flags
         UriBuilder.Init('https://microsoft.com?flag1&flag2');
@@ -542,13 +543,12 @@ codeunit 135072 "Uri Builder Query Test"
         UriBuilder.RemoveQueryFlag('flag3');
 
         // [Then] The URL is unchanged
-        Assert.AreEqual('https://microsoft.com?flag1&flag2', UriBuilder.ToString());
+        UriBuilder.GetUri(Uri);
+        Assert.AreEqual('https://microsoft.com?flag1&flag2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
     end;
 
     [Test]
     procedure TestRemoveQueryFlagNotFoundThrowError()
-    var
-        UriBuilder: Codeunit UriBuilder;
     begin
         // [Given] A URL with query flags
         UriBuilder.Init('https://microsoft.com?flag1&flag2');
@@ -563,7 +563,7 @@ codeunit 135072 "Uri Builder Query Test"
     [Test]
     procedure TestRemoveQueryFlag()
     var
-        UriBuilder: Codeunit UriBuilder;
+        Uri: Codeunit Uri;
     begin
         // [Given] A URL with query flags
         UriBuilder.Init('https://microsoft.com?flag1&flag2');
@@ -572,13 +572,14 @@ codeunit 135072 "Uri Builder Query Test"
         UriBuilder.RemoveQueryFlag('flag1');
 
         // [Then] The query flag is removed correctly
-        Assert.AreEqual('https://microsoft.com?flag2', UriBuilder.ToString());
+        UriBuilder.GetUri(Uri);
+        Assert.AreEqual('https://microsoft.com?flag2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
     end;
 
     [Test]
     procedure TestRemoveQueryParameterWithDuplicateAction()
     var
-        UriBuilder: Codeunit UriBuilder;
+        Uri: Codeunit Uri;
     begin
         // [Given] A URL with query parameters
         UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
@@ -587,13 +588,12 @@ codeunit 135072 "Uri Builder Query Test"
         UriBuilder.RemoveQueryParameter('param1', 'value1', Enum::"Uri Query Duplicate Behaviour"::"Throw Error");
 
         // [Then] The query parameter is removed correctly
-        Assert.AreEqual('https://microsoft.com?param2=value2', UriBuilder.ToString());
+        UriBuilder.GetUri(Uri);
+        Assert.AreEqual('https://microsoft.com?param2=value2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
     end;
 
     [Test]
     procedure TestRemoveQueryParameterNotFoundThrowError()
-    var
-        UriBuilder: Codeunit UriBuilder;
     begin
         // [Given] A URL with query parameters
         UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
@@ -608,7 +608,7 @@ codeunit 135072 "Uri Builder Query Test"
     [Test]
     procedure TestRemoveQueryParameter()
     var
-        UriBuilder: Codeunit UriBuilder;
+        Uri: Codeunit Uri;
     begin
         // [Given] A URL with query parameters
         UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
@@ -617,13 +617,14 @@ codeunit 135072 "Uri Builder Query Test"
         UriBuilder.RemoveQueryParameter('param1', 'value1');
 
         // [Then] The query parameter is removed correctly
-        Assert.AreEqual('https://microsoft.com?param2=value2', UriBuilder.ToString());
+        UriBuilder.GetUri(Uri);
+        Assert.AreEqual('https://microsoft.com?param2=value2', Uri.GetAbsoluteUri(), 'Unexpected URL.');
     end;
 
     [Test]
     procedure TestRemoveQueryParameters()
     var
-        UriBuilder: Codeunit UriBuilder;
+        Uri: Codeunit Uri;
     begin
         // [Given] A URL with multiple query parameters
         UriBuilder.Init('https://microsoft.com?param1=value1&param2=value2');
@@ -632,13 +633,14 @@ codeunit 135072 "Uri Builder Query Test"
         UriBuilder.RemoveQueryParameters();
 
         // [Then] All query parameters are removed
-        Assert.AreEqual('https://microsoft.com', UriBuilder.ToString());
+        UriBuilder.GetUri(Uri);
+        Assert.AreEqual('https://microsoft.com', Uri.GetAbsoluteUri(), 'Unexpected URL.');
     end;
 
     [Test]
     procedure TestGetQueryFlags()
     var
-        UriBuilder: Codeunit UriBuilder;
+        Uri: Codeunit Uri;
         Flags: List of [Text];
     begin
         // [Given] A URL with query flags
@@ -648,15 +650,15 @@ codeunit 135072 "Uri Builder Query Test"
         Flags := UriBuilder.GetQueryFlags();
 
         // [Then] The list of query flags is correct
-        Assert.AreEqual(2, Flags.Count());
-        Assert.IsTrue(Flags.Contains('flag1'));
-        Assert.IsTrue(Flags.Contains('flag2'));
+        Assert.AreEqual(2, Flags.Count(), 'Unexpected number of flags.');
+        Assert.IsTrue(Flags.Contains('flag1'), 'Flag1 not found.');
+        Assert.IsTrue(Flags.Contains('flag2'), 'Flag2 not found.');
     end;
 
     [Test]
     procedure TestGetQueryParameters()
     var
-        UriBuilder: Codeunit UriBuilder;
+        Uri: Codeunit Uri;
         Params: Dictionary of [Text, List of [Text]];
     begin
         // [Given] A URL with query parameters
@@ -666,17 +668,17 @@ codeunit 135072 "Uri Builder Query Test"
         Params := UriBuilder.GetQueryParameters();
 
         // [Then] The dictionary of query parameters is correct
-        Assert.AreEqual(2, Params.Count());
-        Assert.IsTrue(Params.ContainsKey('param1'));
-        Assert.IsTrue(Params.ContainsKey('param2'));
-        Assert.AreEqual('value1', Params.Get('param1').Get(1));
-        Assert.AreEqual('value2', Params.Get('param2').Get(1));
+        Assert.AreEqual(2, Params.Count(), 'Unexpected number of parameters.');
+        Assert.IsTrue(Params.ContainsKey('param1'), 'Param1 not found.');
+        Assert.IsTrue(Params.ContainsKey('param2'), 'Param2 not found.');
+        Assert.AreEqual('value1', Params.Get('param1').Get(1), 'Unexpected value for param1.');
+        Assert.AreEqual('value2', Params.Get('param2').Get(1), 'Unexpected value for param2.');
     end;
 
     [Test]
     procedure TestGetQueryParameter()
     var
-        UriBuilder: Codeunit UriBuilder;
+        Uri: Codeunit Uri;
         ParamValues: List of [Text];
     begin
         // [Given] A URL with query parameters
@@ -686,14 +688,14 @@ codeunit 135072 "Uri Builder Query Test"
         ParamValues := UriBuilder.GetQueryParameter('param1');
 
         // [Then] The value of the query parameter is correct
-        Assert.AreEqual(1, ParamValues.Count());
-        Assert.AreEqual('value1', ParamValues.Get(1));
+        Assert.AreEqual(1, ParamValues.Count(), 'Unexpected number of values.');
+        Assert.AreEqual('value1', ParamValues.Get(1), 'Unexpected value.');
     end;
 
     [Test]
     procedure TestGetQueryParameterNotFound()
     var
-        UriBuilder: Codeunit UriBuilder;
+        Uri: Codeunit Uri;
         Params: Dictionary of [Text, List of [Text]];
     begin
         // [Given] A URL with query parameters
@@ -703,6 +705,6 @@ codeunit 135072 "Uri Builder Query Test"
         Params := UriBuilder.GetQueryParameter('param3');
 
         // [Then] The dictionary of query parameters is empty
-        Assert.AreEqual(0, Params.Count());
+        Assert.AreEqual(0, Params.Count(), 'Unexpected number of parameters.');
     end;
 }

--- a/src/System Application/Test/URI/src/UriBuilderQueryTest.Codeunit.al
+++ b/src/System Application/Test/URI/src/UriBuilderQueryTest.Codeunit.al
@@ -634,7 +634,7 @@ codeunit 135072 "Uri Builder Query Test"
 
         // [Then] All query parameters are removed
         UriBuilder.GetUri(Uri);
-        Assert.AreEqual('https://microsoft.com', Uri.GetAbsoluteUri(), 'Unexpected URL.');
+        Assert.AreEqual('https://microsoft.com/', Uri.GetAbsoluteUri(), 'Unexpected URL.');
     end;
 
     [Test]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
UriBuilder procedures can only Add/Replace Query Flags/Parameters, while the internal procedure can parse them and set them, so I want to be able to use that to only Get/Remove from the collection.

There are different ways to implement this and many ways to test this, I just wanted to propose this approach which reuses what's already there for AddQueryFlag/Parameter, figuring we might need something like this for the upcoming HttpClient mocking: https://www.yammer.com/dynamicsnavdev/#/threads/show?threadId=3029127257333760 (why expose a special QueryParameter dictionary if we already have Uri/UriBuilder codeunits that are supposed to expose these structures for us?)

The new procedures added are:

```al
procedure RemoveQueryFlag(Flag: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour")
procedure RemoveQueryFlag(Flag: Text)
procedure RemoveQueryParameter(ParameterKey: Text; ParameterValue: Text; DuplicateAction: Enum "Uri Query Duplicate Behaviour")
procedure RemoveQueryParameter(ParameterKey: Text; ParameterValue: Text)
procedure RemoveQueryParameters()
procedure GetQueryFlags(): List of [Text]
procedure GetQueryParameters(): Dictionary of [Text, List of [Text]]
procedure GetQueryParameter(ParameterKey: Text): List of [Text]
```

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #2248 
Fixes [AB#555623](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/555623)








