### PR TITLE
Get applications from all market in the AppSource Apps list page.

### DIFF
--- a/src/System Application/App/AppSource Gallery/src/AppSourceProductManager.Codeunit.al
+++ b/src/System Application/App/AppSource Gallery/src/AppSourceProductManager.Codeunit.al
@@ -103,6 +103,8 @@ codeunit 2515 "AppSource Product Manager"
         PlanObject: JsonObject;
         CallToActionToken: JsonToken;
     begin
+        Init();
+
         // Query legacy api toget all the plan and test if there is a contact me call to action.
         LegacyProductObject := GetProductDetails(UniqieProductIDValue, ConstructProductUri(UniqieProductIDValue, CatalogApiVersionOldQueryParamValueLbl));
         LegacyProductObject.Get('plans', LegacyPlansToken);


### PR DESCRIPTION
Changes the market on the list page to all and only uses the Entra Id market when querying for the details (market is mandatory and all cannot be used).

Fixes [AB#555868](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/555868)




