### PR TITLE
Fail if secret is empty as it could be missing

### DIFF
--- a/src/System Application/App/Azure Key Vault/src/AzureKeyVaultImpl.Codeunit.al
+++ b/src/System Application/App/Azure Key Vault/src/AzureKeyVaultImpl.Codeunit.al
@@ -30,18 +30,25 @@ codeunit 2202 "Azure Key Vault Impl."
         IsKeyVaultClientInitialized: Boolean;
         AzureKeyVaultTxt: Label 'Azure Key Vault', Locked = true;
         CertificateInfoTxt: Label 'Successfully constructed certificate from secret %1. Certificate thumbprint %2', Locked = true;
+        MissingSecretErr: Label '%1 is either missing or empty', Comment = '%1 = Secret Name.';
 
     [NonDebuggable]
     procedure GetAzureKeyVaultSecret(SecretName: Text; var Secret: Text)
     begin
         // Gets the secret as a Text from the key vault, given a SecretName.
         Secret := GetSecretFromClient(SecretName);
+
+        if Secret = '' then
+            Error(MissingSecretErr);
     end;
 
     [NonDebuggable]
     procedure GetAzureKeyVaultSecret(SecretName: Text; var Secret: SecretText)
     begin
         Secret := GetSecretFromClient(SecretName);
+
+        if Secret.IsEmpty() then
+            Error(MissingSecretErr);
     end;
 
     [NonDebuggable]


### PR DESCRIPTION
Summary
Throwing an error if keyvault secret does not exist or is stored empty in the KV, as in both situation it is a broken secret. Doing it from app as Platform does not fail if the secret does not exist. 

Fixes #
[AB#544481](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/544481)