### PR TITLE
[releases/25.1] Unix Timestamp test should use offset for the specified date

### DIFF
--- a/src/System Application/Test/Date and Time/src/UnixTimestampTest.Codeunit.al
+++ b/src/System Application/Test/Date and Time/src/UnixTimestampTest.Codeunit.al
@@ -29,7 +29,7 @@ codeunit 132980 "Unix Timestamp Test"
         // [GIVEN] A DateTime with value 2024-07-01 06:30:30 in the user time zone
         GivenDateTime := CreateDateTime(20240701D, 063030T);
         // [GIVEN] The offset of the session's timezone
-        Offset := TimeZone.GetTimezoneOffset(CurrentDateTime);
+        Offset := TimeZone.GetTimezoneOffset(GivenDateTime);
 
         // [WHEN] Given DateTime is converted to a Unix timestamp after a correction for timezone offset
         ResultTimestamp := UnixTimestamp.CreateTimestampSeconds(GivenDateTime + Offset);
@@ -52,7 +52,7 @@ codeunit 132980 "Unix Timestamp Test"
         // [GIVEN] A DateTime with value 2024-07-01 06:30:30 in the user time zone
         GivenDateTime := CreateDateTime(20240701D, 063030T);
         // [GIVEN] The offset of the session's timezone
-        Offset := TimeZone.GetTimezoneOffset(CurrentDateTime);
+        Offset := TimeZone.GetTimezoneOffset(GivenDateTime);
 
         // [WHEN] Given DateTime is converted to a Unix timestamp after a correction for timezone offset
         ResultTimestamp := UnixTimestamp.CreateTimestampMilliseconds(GivenDateTime + Offset);


### PR DESCRIPTION
This pull request backports #2287 to releases/25.1
The current date may have daylights savings or not. This will cause the test to fail if daylight savings is in effect. Hence getting the offset based on the given date instead.

Fixes [AB#555972](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/555972)


