### PR TITLE
[Data Driven Test Tool] Add YAML support

### DIFF
--- a/src/Tools/AI Test Toolkit/src/AITCommandLineCard.Page.al
+++ b/src/Tools/AI Test Toolkit/src/AITCommandLineCard.Page.al
@@ -80,7 +80,7 @@ page 149042 "AIT CommandLine Card"
                         InputDatasetOutStream := TempBlob.CreateOutStream();
                         InputDatasetOutStream.WriteText(InputDataset);
                         TempBlob.CreateInStream(InputDatasetInStream);
-                        TestInputsManagement.UploadAndImportDataInputsFromJson(InputDatasetFilename, InputDatasetInStream);
+                        TestInputsManagement.UploadAndImportDataInputs(InputDatasetFilename, InputDatasetInStream);
                     end;
                 }
             }

--- a/src/Tools/AI Test Toolkit/src/TestSuite/AITALTestSuiteMgt.Codeunit.al
+++ b/src/Tools/AI Test Toolkit/src/TestSuite/AITALTestSuiteMgt.Codeunit.al
@@ -226,7 +226,7 @@ codeunit 149037 "AIT AL Test Suite Mgt"
                         Error(SameDatasetNameErr, DatasetFileName, StrSubstNo(SourceOfTheDatasetIsAppIdLbl, TestInputGroup."Imported by AppId"));
                 end;
 
-        TestInputsManagement.UploadAndImportDataInputsFromJson(DatasetFileName, DatasetInStream, CallerModuleInfo.Id);
+        TestInputsManagement.UploadAndImportDataInputs(DatasetFileName, DatasetInStream, CallerModuleInfo.Id);
     end;
 
     /// <summary>

--- a/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataDrivenTestTool.PageExt.al
+++ b/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataDrivenTestTool.PageExt.al
@@ -42,7 +42,7 @@ pageextension 130451 "Data Driven Test Tool" extends "AL Test Tool"
                     var
                         TestInputsManagement: Codeunit "Test Inputs Management";
                     begin
-                        TestInputsManagement.UploadAndImportDataInputsFromJson();
+                        TestInputsManagement.UploadAndImportDataInputs();
                     end;
                 }
                 action(DataInputs)

--- a/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInputGroups.Page.al
+++ b/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInputGroups.Page.al
@@ -45,8 +45,8 @@ page 130462 "Test Input Groups"
             {
                 Caption = 'Import data-driven test inputs';
                 AllowMultipleFiles = true;
-                ToolTip = 'Import data-driven test inputs from a JSON or JSONL file';
-                AllowedFileExtensions = '.jsonl', '.json';
+                ToolTip = 'Import data-driven test inputs from a JSON, JSONL or YAML file';
+                AllowedFileExtensions = '.jsonl', '.json', '.yaml';
                 Image = Attach;
 
                 trigger OnAction(Files: List of [FileUpload])
@@ -55,9 +55,9 @@ page 130462 "Test Input Groups"
                     CurrentFile: FileUpload;
                     FileDataInStream: InStream;
                 begin
-                    foreach CurrentFile in files do begin
+                    foreach CurrentFile in Files do begin
                         CurrentFile.CreateInStream(FileDataInStream, TextEncoding::UTF8);
-                        TestInputsManagement.UploadAndImportDataInputsFromJson(CurrentFile.FileName, FileDataInStream);
+                        TestInputsManagement.UploadAndImportDataInputs(CurrentFile.FileName, FileDataInStream);
                     end;
                 end;
             }

--- a/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInputPart.Page.al
+++ b/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInputPart.Page.al
@@ -52,7 +52,7 @@ page 130459 "Test Input Part"
             {
                 Caption = 'Import';
                 Image = ImportCodes;
-                ToolTip = 'Import data-driven test inputs from a JSON file';
+                ToolTip = 'Import data-driven test inputs from a JSON, JSONL or YAML file';
 
                 trigger OnAction()
                 var
@@ -60,7 +60,7 @@ page 130459 "Test Input Part"
                     TestInputsManagement: Codeunit "Test Inputs Management";
                 begin
                     TestInputGroup.Get(Rec."Test Input Group Code");
-                    TestInputsManagement.UploadAndImportDataInputsFromJson(TestInputGroup);
+                    TestInputsManagement.UploadAndImportDataInputs(TestInputGroup);
                 end;
             }
         }

--- a/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInputPart.Page.al
+++ b/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInputPart.Page.al
@@ -56,11 +56,9 @@ page 130459 "Test Input Part"
 
                 trigger OnAction()
                 var
-                    TestInputGroup: Record "Test Input Group";
                     TestInputsManagement: Codeunit "Test Inputs Management";
                 begin
-                    TestInputGroup.Get(Rec."Test Input Group Code");
-                    TestInputsManagement.UploadAndImportDataInputs(TestInputGroup);
+                    TestInputsManagement.UploadAndImportDataInputs();
                 end;
             }
         }

--- a/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInputsManagement.Codeunit.al
+++ b/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInputsManagement.Codeunit.al
@@ -100,13 +100,6 @@ codeunit 130458 "Test Inputs Management"
 
     procedure UploadAndImportDataInputs()
     var
-        TestInputGroup: Record "Test Input Group";
-    begin
-        UploadAndImportDataInputs(TestInputGroup);
-    end;
-
-    procedure UploadAndImportDataInputs(var TestInputGroup: Record "Test Input Group")
-    var
         TempDummyTestInput: Record "Test Input" temporary;
         TestInputInStream: InStream;
         FileName: Text;
@@ -170,7 +163,7 @@ codeunit 130458 "Test Inputs Management"
     [Obsolete('Replaced by UploadAndImportDataInputs.', '26.0')]
     procedure UploadAndImportDataInputsFromJson(var TestInputGroup: Record "Test Input Group")
     begin
-        UploadAndImportDataInputs(TestInputGroup)
+        UploadAndImportDataInputs()
     end;
 
     [Obsolete('Replaced by UploadAndImportDataInputs.', '26.0')]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Add support in the Data-driven Test Tool for uploading datasets in `YAML` file format. 

`YAML` files are converted to `JSON `format and are as such a destructive action. Once uploaded and converted they are treated as `JSON`.

Multiple test cases are supported by defining a dictionary `tests`, e.g.:

```
tests:
- name: TEST01
  description: (...)
- name: TEST02
  description: (...)

(...)
```
A single test case can be uploaded with or without the `tests` key.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#555676](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/548276)







