### PR TITLE
Fix GetTableUrl for DataPerCompany=false

### DIFF
--- a/src/System Application/App/Table Information/src/TableInformationCacheImpl.Codeunit.al
+++ b/src/System Application/App/Table Information/src/TableInformationCacheImpl.Codeunit.al
@@ -145,12 +145,9 @@ codeunit 8700 "Table Information Cache Impl."
     end;
 
     procedure GetTableUrl(Company: Text; TableNo: Integer): Text
-    var
-        TableMetadata: Record "Table Metadata";
     begin
-        TableMetadata.Get(TableNo);
-        if not TableMetadata.DataPerCompany then
-            Company := CompanyName(); // use the current company for the URL for the cases when table is not per company
+        if Company = CrossCompanyDataLbl then
+            Company := ''; // Clear the Company text if it is the CrossCompanyDataLbl to avoid errors with GetUrl
 
         exit(GetUrl(ClientType::Web, Company, ObjectType::Table, TableNo));
     end;

--- a/src/System Application/App/Table Information/src/TableInformationCacheImpl.Codeunit.al
+++ b/src/System Application/App/Table Information/src/TableInformationCacheImpl.Codeunit.al
@@ -6,7 +6,6 @@
 namespace System.DataAdministration;
 
 using System.Environment;
-using System.Reflection;
 
 codeunit 8700 "Table Information Cache Impl."
 {

--- a/src/System Application/App/Table Information/src/TableInformationCacheImpl.Codeunit.al
+++ b/src/System Application/App/Table Information/src/TableInformationCacheImpl.Codeunit.al
@@ -144,8 +144,11 @@ codeunit 8700 "Table Information Cache Impl."
     end;
 
     procedure GetTableUrl(Company: Text; TableNo: Integer): Text
+    var
+        TableMetadata: Record "Table Metadata";
     begin
-        if Company = '' then
+        TableMetadata.Get(TableNo);
+        if not TableMetadata.DataPerCompany then
             Company := CompanyName(); // use the current company for the URL for the cases when table is not per company
 
         exit(GetUrl(ClientType::Web, Company, ObjectType::Table, TableNo));

--- a/src/System Application/App/Table Information/src/TableInformationCacheImpl.Codeunit.al
+++ b/src/System Application/App/Table Information/src/TableInformationCacheImpl.Codeunit.al
@@ -6,6 +6,7 @@
 namespace System.DataAdministration;
 
 using System.Environment;
+using System.Reflection;
 
 codeunit 8700 "Table Information Cache Impl."
 {


### PR DESCRIPTION
#### Summary 
Fix GetTableUrl for Tables with `DataPerCompany=false`

#### Work Item(s)
Fixes #2262


Fixes [AB#557526](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/557526)




