### PR TITLE
Discussion: Introduce company initialize in System Application

### DIFF
--- a/src/System Application/App/Company Initialize/CompanyInitialize.Codeunit.al
+++ b/src/System Application/App/Company Initialize/CompanyInitialize.Codeunit.al
@@ -1,0 +1,19 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Environment.Configuration;
+
+codeunit 900 "Company Initialize"
+{
+    [IntegrationEvent(false, false)]
+    internal procedure InitializeCompanySetup()
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    internal procedure InitializeCompany()
+    begin
+    end;
+}

--- a/src/System Application/App/Company Initialize/CompanyInitialize.Table.al
+++ b/src/System Application/App/Company Initialize/CompanyInitialize.Table.al
@@ -1,0 +1,33 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Environment.Configuration;
+
+table 900 "Company Initialize"
+{
+    DataClassification = SystemMetadata;
+
+    fields
+    {
+        field(1; "Primary Key"; Integer)
+        {
+        }
+        field(2; "Initialized Time"; DateTime)
+        {
+        }
+        field(3; "Initialized Version"; Code[20])
+        {
+        }
+    }
+
+    keys
+    {
+        key(Key1; "Primary Key")
+        {
+            Clustered = true;
+        }
+    }
+
+}

--- a/src/System Application/App/Company Initialize/CompanyInitializeImpl.Codeunit.al
+++ b/src/System Application/App/Company Initialize/CompanyInitializeImpl.Codeunit.al
@@ -1,0 +1,51 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Environment.Configuration;
+
+using System.Environment;
+
+codeunit 901 "Company Initialize Impl."
+{
+    Access = Internal;
+
+    procedure InitializeCompany()
+    var
+        CompanyInitialize: Record "Company Initialize";
+        CompanyInitializeCodeunit: Codeunit "Company Initialize";
+        ModuleInfo: ModuleInfo;
+    begin
+        CompanyInitialize."Initialized Time" := CurrentDateTime();
+
+        if NavApp.GetCurrentModuleInfo(ModuleInfo) then
+            CompanyInitialize."Initialized Version" := format(ModuleInfo.AppVersion());
+        CompanyInitialize.Insert();
+
+        CompanyInitializeCodeunit.InitializeCompanySetup();
+
+        CompanyInitializeCodeunit.InitializeCompany();
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"System Initialization", 'OnAfterLogin', '', false, false)]
+    local procedure OnLoginInitializeCompany()
+    var
+        CompanyInitialize: Record "Company Initialize";
+        ClientTypeManagement: Codeunit "Client Type Management";
+    begin
+        if not GuiAllowed() then
+            exit;
+
+        if ClientTypeManagement.GetCurrentClientType() = ClientType::Background then
+            exit;
+
+        if GetExecutionContext() <> ExecutionContext::Normal then
+            exit;
+
+        if CompanyInitialize.Get() then
+            exit;
+
+        InitializeCompany();
+    end;
+}


### PR DESCRIPTION
I have created this PR to start a discussion of whether we should have company initialize in System Application and see how it might look like. We currently have apps with tables that require setup data per company. So far we insert data on the fly, but should we always do this check or should it be done as part of initializing each company?
Either way, let's see.

System Application examples are: "AAD Application Setup", "Setup Azure AD Mgt. Provider", "Register Company Signal".


