### PR TITLE
[releases/24.x] Update AL-Go System Files from microsoft/AL-Go-PTE@preview -  50903624159826257124c0f799a1b4add9b0260b

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -72,5 +72,5 @@
     ]
   },
   "UpdateALGoSystemFilesEnvironment": "Official-Build",
-  "templateSha": "c62bf167f8c516d997bed1ed600a9d03d5093ad5"
+  "templateSha": "50903624159826257124c0f799a1b4add9b0260b"
 }

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -1,11 +1,9 @@
-## preview
-
-Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.
+## v6.1
 
 ### Issues
 
 - Issue 1241 Increment Version Number might produce wrong app.json
-- `deployTo<environment>` now has an additional property called DependencyInstallMode, which determines how dependencies are deployed if GenerateDependencyArtifact is true. Default value is `install` to install dependencies if not already installed. Other values are `ignore` for ignoring dependencies, `upgrade` for upgrading dependencies if possible and `forceUpgrade` for force upgrading dependencies.
+- When auto discovering appFolders, testFolders and bcptTestFolders - if a BCPT Test app has a dependency to a test framework app, it is added to testFolders as well as bcptTestFolders and will cause a failure.
 
 ### New Project Settings
 
@@ -16,6 +14,7 @@ Note that when using the preview version of AL-Go for GitHub, we recommend you U
 ### New Repository Settings
 
 - `trustedSigning` is a structure defining `Account`, `EndPoint` and `CertificateProfile` if you want to use trusted signing. Note that your Azure_Credentials secret (Microsoft Entra ID App or Managed identity) still needs to provide access to your azure subscription and be assigned the `Trusted Signing Certificate Profile Signer` role in the Trusted Signing Account.
+- `deployTo<environment>` now has an additional property called DependencyInstallMode, which determines how dependencies are deployed if GenerateDependencyArtifact is true. Default value is `install` to install dependencies if not already installed. Other values are `ignore` for ignoring dependencies, `upgrade` for upgrading dependencies if possible and `forceUpgrade` for force upgrading dependencies.
 
 ### Support for Azure Trusted Signing
 
@@ -27,6 +26,10 @@ Page Scripting tests are now supported as part of CI/CD. By specifying pageScrip
 
 - `PageScriptingTestResults` is a JUnit test results file with all results combined.
 - `PageScriptingTestResultDetails` are the detailed test results (including videos) when any of the page scripting tests have failures. If the page scripting tests succeed - the details are not published.
+
+### Experimental support for Git submodule
+
+[Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) is now supported as part of CI/CD on your project.
 
 ## v6.0
 

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -45,7 +45,7 @@ jobs:
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.1
         with:
           shell: powershell
 
@@ -53,16 +53,17 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
+          submodules: recursive
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.1
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSettings@v6.1
         with:
           shell: powershell
           get: type, powerPlatformSolutionFolder
@@ -74,7 +75,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v6.1
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -87,7 +88,7 @@ jobs:
 
       - name: Determine Delivery Target Secrets
         id: DetermineDeliveryTargetSecrets
-        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v6.1
         with:
           shell: powershell
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
@@ -95,7 +96,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -103,7 +104,7 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v6.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -113,7 +114,7 @@ jobs:
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v6.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -129,13 +130,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSettings@v6.1
         with:
           shell: powershell
           get: templateUrl
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@v6.1
         with:
           shell: powershell
           templateUrl: ${{ env.templateUrl }}
@@ -210,7 +211,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSettings@v6.1
         with:
           shell: powershell
 
@@ -219,7 +220,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v6.1
         with:
           shell: powershell
           artifacts: '.artifacts'
@@ -256,7 +257,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSettings@v6.1
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
@@ -270,7 +271,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.1
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -278,7 +279,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: microsoft/AL-Go/Actions/Deploy@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/Deploy@v6.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -290,7 +291,7 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@v6.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -318,20 +319,20 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSettings@v6.1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: Deliver
-        uses: microsoft/AL-Go/Actions/Deliver@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/Deliver@v6.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -351,7 +352,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/.github/workflows/DeployReferenceDocumentation.yaml
@@ -30,18 +30,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.1
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSettings@v6.1
         with:
           shell: powershell
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v6.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -54,7 +54,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v6.1
         with:
           shell: powershell
           artifacts: 'latest'
@@ -71,7 +71,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.1
         with:
           shell: powershell
 
@@ -50,18 +50,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.1
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSettings@v6.1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -69,7 +69,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
-        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v6.1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -28,7 +28,7 @@ jobs:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
     runs-on: windows-latest
     steps:
-      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+      - uses: microsoft/AL-Go-Actions/VerifyPRChanges@v6.1
 
   Initialization:
     needs: [ PregateCheck ]
@@ -43,7 +43,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.1
         with:
           shell: powershell
 
@@ -55,13 +55,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.1
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSettings@v6.1
         with:
           shell: powershell
 
@@ -72,7 +72,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v6.1
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -131,7 +131,7 @@ jobs:
     steps:
       - name: Pull Request Status Check
         id: PullRequestStatusCheck
-        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/PullRequestStatusCheck@v6.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -139,7 +139,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.1
         if: success() || failure()
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/Troubleshooting.yaml
+++ b/.github/workflows/Troubleshooting.yaml
@@ -30,7 +30,7 @@ jobs:
           lfs: true
 
       - name: Troubleshooting
-        uses: microsoft/AL-Go/Actions/Troubleshooting@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/Troubleshooting@v6.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v6.1
         with:
           shell: powershell
 
@@ -46,19 +46,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v6.1
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSettings@v6.1
         with:
           shell: powershell
           get: templateUrl
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -94,7 +94,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@v6.1
         with:
           shell: powershell
           token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v6.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -91,9 +91,10 @@ jobs:
         with:
           ref: ${{ inputs.checkoutRef }}
           lfs: true
+          submodules: recursive
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSettings@v6.1
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -102,14 +103,14 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         if: github.event_name != 'pull_request'
-        uses: microsoft/AL-Go/Actions/ReadSecrets@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v6.1
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ inputs.secrets }},appDependencySecrets,AZURE_CREDENTIALS'
 
       - name: Determine ArtifactUrl
-        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v6.1
         id: determineArtifactUrl
         with:
           shell: ${{ inputs.shell }}
@@ -124,7 +125,7 @@ jobs:
 
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
-        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/DownloadProjectDependencies@v6.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -135,7 +136,7 @@ jobs:
           baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
 
       - name: Build
-        uses: microsoft/AL-Go/Actions/RunPipeline@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/RunPipeline@v6.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
           BuildMode: ${{ inputs.buildMode }}
@@ -150,7 +151,7 @@ jobs:
       - name: Sign
         if: inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != ''))
         id: sign
-        uses: microsoft/AL-Go/Actions/Sign@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/Sign@v6.1
         with:
           shell: ${{ inputs.shell }}
           azureCredentialsJson: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).AZURE_CREDENTIALS }}'
@@ -158,7 +159,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v6.1
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -268,14 +269,14 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: (success() || failure()) && env.doNotRunTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/AnalyzeTests@v6.1
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
 
       - name: Cleanup
         if: always()
-        uses: microsoft/AL-Go/Actions/PipelineCleanup@a46044fa1ffca4b1ff05d2d1844fd7d5922c6984
+        uses: microsoft/AL-Go-Actions/PipelineCleanup@v6.1
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}

--- a/build/projects/Business Foundation/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Business Foundation/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Business Foundation/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Business Foundation/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Performance Toolkit/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Performance Toolkit/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Performance Toolkit/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Performance Toolkit/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Modules/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Modules/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Modules/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Modules/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests (No Isolation)/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Tests (No Isolation)/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests (No Isolation)/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Tests (No Isolation)/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Tests/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Tests/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Framework/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Test Framework/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Framework/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Test Framework/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Stability Tools/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Test Stability Tools/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Stability Tools/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Test Stability Tools/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/a46044fa1ffca4b1ff05d2d1844fd7d5922c6984/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v6.1/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local


### PR DESCRIPTION
## v6.1

### Issues

- Issue 1241 Increment Version Number might produce wrong app.json
- When auto discovering appFolders, testFolders and bcptTestFolders - if a BCPT Test app has a dependency to a test framework app, it is added to testFolders as well as bcptTestFolders and will cause a failure.

### New Project Settings

- `pageScriptingTests` should be an array of page scripting test file specifications, relative to the AL-Go project. Examples of file specifications: `recordings/my*.yml` (for all yaml files in the recordings subfolder matching my\*.yml), `recordings` (for all \*.yml files in the recordings subfolder) or `recordings/test.yml` (for a single yml file)
- `doNotRunPageScriptingTests` can force the pipeline to NOT run the page scripting tests specified in pageScriptingTests. Note this setting can be set in a [workflow specific settings file](#where-are-the-settings-located) to only apply to that workflow
- `restoreDatabases` should be an array of events, indicating when you want to start with clean databases in the container. Possible events are: `BeforeBcpTests`, `BeforePageScriptingTests`, `BeforeEachTestApp`, `BeforeEachBcptTestApp`, `BeforeEachPageScriptingTest`

### New Repository Settings

- `trustedSigning` is a structure defining `Account`, `EndPoint` and `CertificateProfile` if you want to use trusted signing. Note that your Azure_Credentials secret (Microsoft Entra ID App or Managed identity) still needs to provide access to your azure subscription and be assigned the `Trusted Signing Certificate Profile Signer` role in the Trusted Signing Account.
- `deployTo<environment>` now has an additional property called DependencyInstallMode, which determines how dependencies are deployed if GenerateDependencyArtifact is true. Default value is `install` to install dependencies if not already installed. Other values are `ignore` for ignoring dependencies, `upgrade` for upgrading dependencies if possible and `forceUpgrade` for force upgrading dependencies.

### Support for Azure Trusted Signing

Read https://learn.microsoft.com/en-us/azure/trusted-signing/ for more information about Trusted Signing and how to set it up. After setting up your trusted signing account and certificate profile, you need to create a setting called [trustedSigning](https://aka.ms/algosettings#trustedSigning) for AL-Go to sign your apps using Azure Trusted Signing.

### Support for Page Scripting Tests

Page Scripting tests are now supported as part of CI/CD. By specifying pageScriptingTests in your project settings file, AL-Go for GitHub will automatically run these page scripting tests as part of your CI/CD workflow, generating the following build artifacts:

- `PageScriptingTestResults` is a JUnit test results file with all results combined.
- `PageScriptingTestResultDetails` are the detailed test results (including videos) when any of the page scripting tests have failures. If the page scripting tests succeed - the details are not published.

### Experimental support for Git submodule

[Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) is now supported as part of CI/CD on your project.

[AB#539394](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/539394)

