### PR TITLE
Add retries when running git fetch

### DIFF
--- a/build/scripts/GuardingV2ExtensionsHelper.psm1
+++ b/build/scripts/GuardingV2ExtensionsHelper.psm1
@@ -259,7 +259,7 @@ function Test-IsStrictModeEnabled
 
 function Get-MaxAllowedObsoleteVersion() {
     git fetch origin main
-    $alGoSettings = $(git show main:.github/AL-Go-Settings.json) | ConvertFrom-Json
+    $alGoSettings = $(git show origin/main:.github/AL-Go-Settings.json) | ConvertFrom-Json
     if (-not $alGoSettings.repoVersion) {
         throw "Unable to find repoVersion in AL-Go-Settings.json"
     }

--- a/build/scripts/GuardingV2ExtensionsHelper.psm1
+++ b/build/scripts/GuardingV2ExtensionsHelper.psm1
@@ -259,7 +259,7 @@ function Test-IsStrictModeEnabled
 
 function Get-MaxAllowedObsoleteVersion() {
     Import-Module -Name $PSScriptRoot\EnlistmentHelperFunctions.psm1
-    
+
     Invoke-CommandWithRetry -ScriptBlock { RunAndCheck git fetch origin main }
     $alGoSettings = $(RunAndCheck git show origin/main:.github/AL-Go-Settings.json) | ConvertFrom-Json
     if (-not $alGoSettings.repoVersion) {

--- a/build/scripts/GuardingV2ExtensionsHelper.psm1
+++ b/build/scripts/GuardingV2ExtensionsHelper.psm1
@@ -258,8 +258,10 @@ function Test-IsStrictModeEnabled
 }
 
 function Get-MaxAllowedObsoleteVersion() {
-    git fetch origin main
-    $alGoSettings = $(git show origin/main:.github/AL-Go-Settings.json) | ConvertFrom-Json
+    Import-Module -Name $PSScriptRoot\EnlistmentHelperFunctions.psm1
+    
+    Invoke-CommandWithRetry -ScriptBlock { RunAndCheck git fetch origin main }
+    $alGoSettings = $(RunAndCheck git show origin/main:.github/AL-Go-Settings.json) | ConvertFrom-Json
     if (-not $alGoSettings.repoVersion) {
         throw "Unable to find repoVersion in AL-Go-Settings.json"
     }

--- a/build/scripts/GuardingV2ExtensionsHelper.psm1
+++ b/build/scripts/GuardingV2ExtensionsHelper.psm1
@@ -259,7 +259,7 @@ function Test-IsStrictModeEnabled
 
 function Get-MaxAllowedObsoleteVersion() {
     git fetch origin main
-    $alGoSettings = $(git show origin/main:.github/AL-Go-Settings.json) | ConvertFrom-Json
+    $alGoSettings = $(git show main:.github/AL-Go-Settings.json) | ConvertFrom-Json
     if (-not $alGoSettings.repoVersion) {
         throw "Unable to find repoVersion in AL-Go-Settings.json"
     }


### PR DESCRIPTION
_**Issue**_:
Builds sometimes fail with:
```
Error: Unexpected error when running action. Error Message: Unable to find repoVersion in AL-Go-Settings.json, StackTrace: at Get-MaxAllowedObsoleteVersion, D:\a\BCApps\BCApps\build\scripts\GuardingV2ExtensionsHelper.psm1: line 264 <- at Update-AppSourceCopVersion, D:\a\BCApps\BCApps\build\scripts\GuardingV2ExtensionsHelper.psm1: line 208 <- at Enable-BreakingChangesCheck, D:\a\BCApps\BCApps\build\scripts\GuardingV2ExtensionsHelper.psm1: line 67 <- at <ScriptBlock>, D:\a\BCApps\BCApps\build\scripts\PreCompileApp.ps1: line 63 <- at <ScriptBlock>, D:\a\BCApps\BCApps\build\projects\System Application\.AL-Go\PreCompileApp.ps1: line 7 <- at <ScriptBlock>, C:\ProgramData\BcContainerHelper\6.0.29-preview1267\BcContainerHelper\AppHandling\Run-AlPipeline.ps1: line 2070 <- at <ScriptBlock>
```

The underlying error is
```
  fatal: unable to access 'https://github.com/microsoft/BCApps/': Recv failure: Connection was aborted
  fatal: invalid object name 'origin/main'.
```

or sometimes

```
  fatal: unable to access 'https://github.com/microsoft/BCApps/': OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 0
  fatal: invalid object name 'origin/main'.
```

_**Solution**_:
Add retries when running `git fetch` to catch the instability.

Fixes [AB#557642](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/557642)







