### PR TITLE
Bug 501006: [Bug] Page "Word Template Creation Wizard" (9995) - missing variable update leads to an error #23867

### DIFF
--- a/src/System Application/App/Word Templates/src/WordTemplatesRelatedPart.Page.al
+++ b/src/System Application/App/Word Templates/src/WordTemplatesRelatedPart.Page.al
@@ -73,7 +73,6 @@ page 9987 "Word Templates Related Part"
                         WordTemplateFieldSelection.ShowFieldSelection(Rec."Related Table ID", TempWordTemplateField);
                         NumberOfSelectedFields := WordTemplateFieldSelection.CalculateNoSelectedFields(Rec."Related Table ID", TempWordTemplateField);
                         SelectedFieldsCount.Set(Rec."Related Table ID", NumberOfSelectedFields);
-                        CalculateSelectedFields();
                     end;
                 }
                 field("Entity Relation"; RecordTypeTxt)
@@ -200,6 +199,8 @@ page 9987 "Word Templates Related Part"
         TempWordTemplateField.Reset();
         TempWordTemplateField.SetRange("Table ID", Rec."Related Table ID");
         TempWordTemplateField.DeleteAll();
+
+        SelectedFieldsCount.Remove(Rec."Related Table ID");
     end;
 
     internal procedure AddRelatedTable(TableId: Integer)

--- a/src/System Application/App/Word Templates/src/WordTemplatesRelatedPart.Page.al
+++ b/src/System Application/App/Word Templates/src/WordTemplatesRelatedPart.Page.al
@@ -73,6 +73,7 @@ page 9987 "Word Templates Related Part"
                         WordTemplateFieldSelection.ShowFieldSelection(Rec."Related Table ID", TempWordTemplateField);
                         NumberOfSelectedFields := WordTemplateFieldSelection.CalculateNoSelectedFields(Rec."Related Table ID", TempWordTemplateField);
                         SelectedFieldsCount.Set(Rec."Related Table ID", NumberOfSelectedFields);
+                        CalculateSelectedFields();
                     end;
                 }
                 field("Entity Relation"; RecordTypeTxt)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
The issue was reported here: https://github.com/microsoft/ALAppExtensions/issues/23867
In essence, if you ever got the error message that more than 250 fields were selected and you tried to delete a row, the count wouldn't get updated and you couldn't get past it. Now you can.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#501006](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/501006)



