### PR TITLE
Unnecessary variable ShowLogo in Email Accounts Page

### DIFF
--- a/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
+++ b/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
@@ -34,7 +34,6 @@ page 8887 "Email Accounts"
         {
             repeater(Accounts)
             {
-                Visible = ShowLogo;
                 FreezeColumn = NameField;
 #pragma warning disable AW0009
                 field(LogoField; Rec.LogoBlob)
@@ -43,7 +42,6 @@ page 8887 "Email Accounts"
                     ApplicationArea = All;
                     ShowCaption = false;
                     Caption = ' ';
-                    Visible = ShowLogo;
                     ToolTip = 'Specifies the logo for the type of email account.';
                     Width = 1;
                 }
@@ -355,7 +353,6 @@ page 8887 "Email Accounts"
         CanUserManageEmailSetup := EmailAccountImpl.IsUserEmailAdmin();
         Rec.SetCurrentKey("Account Id", Connector);
         UpdateEmailAccounts();
-        ShowLogo := true;
     end;
 
     trigger OnAfterGetRecord()
@@ -474,7 +471,6 @@ page 8887 "Email Accounts"
         CanUserManageEmailSetup: Boolean;
         DefaultTxt: Text;
         UpdateAccounts: Boolean;
-        ShowLogo: Boolean;
         IsLookupMode: Boolean;
         HasEmailAccount: Boolean;
         V2Filter: Boolean;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Variable Show Logo on Email Accounts page have no function:
![image](https://github.com/user-attachments/assets/4adbcaeb-f8b2-4d94-8698-c9377c667adf)

![image](https://github.com/user-attachments/assets/117236a4-97ec-439c-9c18-0152437f6af6)

It's always set to true.
We could do cleanup and remove it, behavior would stay same.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #2365


Fixes [AB#559267](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/559267)

