### PR TITLE
[releases/24.x] Limit the minor version for baselines to 5

### DIFF
--- a/build/scripts/EnlistmentHelperFunctions.psm1
+++ b/build/scripts/EnlistmentHelperFunctions.psm1
@@ -158,7 +158,7 @@ function Get-PackageLatestVersion() {
             if ($PackageName -eq "AppBaselines-BCArtifacts") {
                 # For app baselines, use the previous minor version as minimum version
                 if ($majorMinorVersion.Minor -gt 0) {
-                    $minimumVersion = "$($majorMinorVersion.Major).$($majorMinorVersion.Minor - 1)"
+                    $minimumVersion = "$($majorMinorVersion.Major).$([Math]::Min($majorMinorVersion.Minor - 1, 5))" # limit the minor version to 5, as it is the maximum minor version for SaaS
                 } else {
                     $minimumVersion = "$($majorMinorVersion.Major - 1)"
                 }


### PR DESCRIPTION
This pull request backports #2438 to releases/24.x

Fixes [AB#555469](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/555469)


