### PR TITLE
[Language] Add current culture to language module

### DIFF
--- a/src/System Application/App/Language/src/Language.Codeunit.al
+++ b/src/System Application/App/Language/src/Language.Codeunit.al
@@ -309,6 +309,17 @@ codeunit 43 Language
     end;
 
     /// <summary>
+    /// Retrieves the current culture name for the session.
+    /// </summary>
+    /// <returns>The culture name. For example, 'en-US'.</returns>
+    procedure GetCurrentCultureName(): Text
+    var
+        LanguageImpl: Codeunit "Language Impl.";
+    begin
+        exit(LanguageImpl.GetCurrentCultureName());
+    end;
+
+    /// <summary>
     /// Integration event, emitted from <see cref="GetUserLanguageCode"/>.
     /// Subscribe to this event to change the default behavior by changing the provided parameter(s).
     /// </summary>

--- a/src/System Application/App/Language/src/LanguageImpl.Codeunit.al
+++ b/src/System Application/App/Language/src/LanguageImpl.Codeunit.al
@@ -342,6 +342,13 @@ codeunit 54 "Language Impl."
         exit(CultureInfo.Name);
     end;
 
+    procedure GetCurrentCultureName(): Text
+    var
+        CultureInfo: DotNet CultureInfo;
+    begin
+        exit(CultureInfo.CurrentCulture.Name);
+    end;
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"UI Helper Triggers", GetApplicationLanguage, '', false, false)]
     local procedure SetApplicationLanguageId(var language: Integer)
     begin


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Currently our BaseApp codeunit TypeHelper has a function to get the current culture. This fits best in the language module.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes AB#559931
