### PR TITLE
Bug 560051: New "Allowed Languages" page is missing permissions and some fit and finish

### DIFF
--- a/src/System Application/App/Language/src/AllowedLanguage.Table.al
+++ b/src/System Application/App/Language/src/AllowedLanguage.Table.al
@@ -13,8 +13,8 @@ table 3563 "Allowed Language"
     Caption = 'Allowed Language';
     DataClassification = SystemMetadata;
     DataPerCompany = false;
-    InherentEntitlements = X;
-    InherentPermissions = X;
+    InherentEntitlements = RX;
+    InherentPermissions = RX;
 
     fields
     {

--- a/src/System Application/App/Language/src/AllowedLanguages.Page.al
+++ b/src/System Application/App/Language/src/AllowedLanguages.Page.al
@@ -18,7 +18,7 @@ page 3563 "Allowed Languages"
     HelpLink = 'https://go.microsoft.com/fwlink/?linkid=2149387';
     AdditionalSearchTerms = 'company,role center,role,language';
     AboutTitle = 'About allowed languages.';
-    AboutText = 'Define a list of allowed languages which is enabled for this environment. If nothing is specified, then the user will be able to use all available languages.';
+    AboutText = 'Define a list of allowed languages which is enabled for this environment. If nothing is specified, the user will be able to select from all languages.';
     Permissions = tabledata "Allowed Language" = r;
 
     layout
@@ -28,9 +28,11 @@ page 3563 "Allowed Languages"
             repeater(AllowedLanguages)
             {
                 field("Language Id"; Rec."Language Id")
-                { }
+                {
+                }
                 field(Language; Rec.Language)
-                { }
+                {
+                }
             }
         }
     }

--- a/src/System Application/App/Language/src/LanguageImpl.Codeunit.al
+++ b/src/System Application/App/Language/src/LanguageImpl.Codeunit.al
@@ -29,6 +29,9 @@ codeunit 54 "Language Impl."
         LanguageIdOverrideMsg: Label 'LanguageIdOverride has been applied in GetLanguageIdOrDefault. The new Language Id is %1.', Comment = '%1 - Language ID';
         FormatRegionOverrideMsg: Label 'FormatRegionOverride has been applied in GetFormatRegionOrDefault. The new FormatRegion is %1.', Comment = '%1 - Format Region';
         LanguageCategoryTxt: Label 'Language';
+        NotificationAllowedLanguagesLbl: Label '2c2bd28b-926c-47a7-bbc4-cf76f8173549', Locked = true;
+        NotificationAllowedLanguagesMessageLbl: Label 'This list of languages has been filtered by your adminitrator.';
+        ReadMoreLbl: Label 'Read more';
 
     procedure GetUserLanguageCode() UserLanguageCode: Code[10]
     var
@@ -340,6 +343,27 @@ codeunit 54 "Language Impl."
     begin
         CultureInfo := CultureInfo.CultureInfo(LanguageID);
         exit(CultureInfo.Name);
+    end;
+
+    procedure ShowAllowedLanguagesNotification()
+    var
+        AllowedLanguage: Record "Allowed Language";
+        Notification: Notification;
+        NotificationGuid: Guid;
+    begin
+        if AllowedLanguage.IsEmpty() then
+            exit;
+
+        NotificationGuid := NotificationAllowedLanguagesLbl;
+        Notification.Id(NotificationGuid);
+        Notification.Message(NotificationAllowedLanguagesMessageLbl);
+        Notification.AddAction(ReadMoreLbl, Codeunit::"Language Impl.", 'OpenReadMore');
+        Notification.Send();
+    end;
+
+    procedure OpenReadMore(Notification: Notification)
+    begin
+        Hyperlink('https://go.microsoft.com/fwlink/?linkid=2299275');
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"UI Helper Triggers", GetApplicationLanguage, '', false, false)]

--- a/src/System Application/App/Language/src/Languages.Page.al
+++ b/src/System Application/App/Language/src/Languages.Page.al
@@ -50,7 +50,18 @@ page 9 Languages
             }
         }
     }
-
+    actions
+    {
+        area(Navigation)
+        {
+            action(ShowAllowedLanguagesNotification)
+            {
+                ApplicationArea = All;
+                Caption = 'Allowed Languages';
+                ToolTip = 'Shows the list of allowed languages for this environment.';
+                RunObject = Page "Allowed Languages";
+                Image = Language;
+            }
+        }
+    }
 }
-
-

--- a/src/System Application/App/Language/src/WindowsLanguages.Page.al
+++ b/src/System Application/App/Language/src/WindowsLanguages.Page.al
@@ -45,6 +45,10 @@ page 535 "Windows Languages"
         }
     }
 
+    trigger OnOpenPage()
+    var
+        LanguageImpl: Codeunit "Language Impl.";
+    begin
+        LanguageImpl.ShowAllowedLanguagesNotification();
+    end;
 }
-
-


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
- Adds missing permission. Everyone should be able to read "Allowed Languages"
- Add a notification to the Languages page, if the view is filtered
- Updates a few strings
- Adds action to reach the Allowed Languages from the UI (Languages page)

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes AB#560051
