### PR TITLE
[25.x] Rename agent task objects

### DIFF
--- a/src/System Application/App/Agent/TaskPane/AgentTaskDetails.Page.al
+++ b/src/System Application/App/Agent/TaskPane/AgentTaskDetails.Page.al
@@ -5,7 +5,7 @@
 
 namespace System.Agents;
 
-page 4313 "Task Details"
+page 4313 "Agent Task Details"
 {
     PageType = ListPart;
     ApplicationArea = All;

--- a/src/System Application/App/Agent/TaskPane/AgentTaskTimeline.Page.al
+++ b/src/System Application/App/Agent/TaskPane/AgentTaskTimeline.Page.al
@@ -7,7 +7,7 @@ namespace System.Agents;
 
 using System.Security.AccessControl;
 
-page 4307 "Task Timeline"
+page 4307 "Agent Task Timeline"
 {
     PageType = ListPart;
     ApplicationArea = All;

--- a/src/System Application/App/Agent/TaskPane/AgentTasks.Page.al
+++ b/src/System Application/App/Agent/TaskPane/AgentTasks.Page.al
@@ -5,7 +5,7 @@
 
 namespace System.Agents;
 
-page 4306 Tasks
+page 4306 "Agent Tasks"
 {
     PageType = ListPlus;
     ApplicationArea = All;
@@ -67,14 +67,14 @@ page 4306 Tasks
 
         area(FactBoxes)
         {
-            part(Timeline; "Task Timeline")
+            part(Timeline; "Agent Task Timeline")
             {
                 SubPageLink = "Task ID" = field("Task ID");
                 UpdatePropagation = Both;
                 Editable = true;
             }
 
-            part(Details; "Task Details")
+            part(Details; "Agent Task Details")
             {
                 Provider = Timeline;
                 SubPageLink = "Task ID" = field("Task ID"), "Timeline Entry ID" = field(ID);


### PR DESCRIPTION
#### Summary
Renaming the agent objects to avoid clashes with similarly named objects

#### Work Item(s)
Fixes [AB#536497](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/536497)

