### PR TITLE
[PowerBI] Avoid race condition when setting filters for a loaded report before it's rendered

### DIFF
--- a/src/System Application/App/ControlAddIns/Resources/PowerBIManagement/js/PowerBIManagement.js
+++ b/src/System Application/App/ControlAddIns/Resources/PowerBIManagement/js/PowerBIManagement.js
@@ -175,8 +175,8 @@ function EmbedPowerBIReport(reportLink, reportId, pageName) {
 
     RegisterCommonEmbedEvents();
 
-    embed.off("loaded");
-    embed.on('loaded', function (event) {
+    embed.off("rendered");
+    embed.on('rendered', function (event) {
         var reportPages = null;
         var reportFilters = null;
         var pageFilters = null;
@@ -207,6 +207,7 @@ function EmbedPowerBIReport(reportLink, reportId, pageName) {
 
         Promise.all(promises).then(
             function (values) {
+                embed.off("rendered");
                 RaiseReportLoaded(reportFilters, reportPages, pageFilters, embedCorrelationId);
             },
             function (error) {

--- a/src/System Application/App/Resources/PowerBIManagement/js/PowerBIManagement.js
+++ b/src/System Application/App/Resources/PowerBIManagement/js/PowerBIManagement.js
@@ -175,8 +175,8 @@ function EmbedPowerBIReport(reportLink, reportId, pageName) {
 
     RegisterCommonEmbedEvents();
 
-    embed.off("loaded");
-    embed.on('loaded', function (event) {
+    embed.off("rendered");
+    embed.on('rendered', function (event) {
         var reportPages = null;
         var reportFilters = null;
         var pageFilters = null;
@@ -207,6 +207,7 @@ function EmbedPowerBIReport(reportLink, reportId, pageName) {
 
         Promise.all(promises).then(
             function (values) {
+                embed.off("rendered");
                 RaiseReportLoaded(reportFilters, reportPages, pageFilters, embedCorrelationId);
             },
             function (error) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
In the Power BI embed addin, we allow AL code to set report filters through the add-in.
How that works in our current implementation is:
1. We open the AL page hosting the addin
1. Once the addin is ready, we Embed the Power BI report
1. Once the report is `loaded`, we set the initial filters
1. The filters can then be changed by AL code

The issue here happens in step 3, because we set the initial filters after the report is `loaded` and before it's `rendered`. In some cases and depending on the machine performances/internet connection/browser/Power BI service load, there can occur a race condition between the report being `rendered` and the filters being applied.

This is more visible when using the action "Expand Report", because the initial filter will always be in place there, and in my tests in SaaS, around 1 time every 3 times the filter fails to apply (but it's still listed under the Power BI filters within the addin). When testing on my local development environment, I could repro this only by introducing a delay before applying the filters, small enough to collide with the rendering.

To fix this race condition, with this PR we wait for the report to be `rendered` for the first time before raising the Report Loaded event (which causes AL to send the filters ahead). Notice that `loaded` happens only once per report, whereas `rendered` happens after any change in the UI happens, including setting filters, so we need to turn the event off after the first occurrence to avoid infinite loops.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#556391](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/556391)


