### PR TITLE
[releases/25.2] Fixes an issue when comparing a blank no. series code to a filter for blank

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesSetupImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesSetupImpl.Codeunit.al
@@ -140,13 +140,16 @@ codeunit 305 "No. Series - Setup Impl."
     var
         NoSeriesLine2: Record "No. Series Line";
         NoSeries: Codeunit "No. Series";
+        NoSeriesCodeFilter: Text;
     begin
         NoSeriesLine2.SetCurrentKey("Series Code", "Starting Date");
         NoSeriesLine2.SetRange("Starting Date", 0D, StartingDate);
         NoSeriesLine2.SetRange("Series Code", NoSeriesCode);
         NoSeries.OnSetNoSeriesLineFilters(NoSeriesLine2);
-        if NoSeriesLine2.GetFilter("Series Code") <> NoSeriesCode then
-            Error(CodeFieldChangedErr, NoSeriesLine2.FieldCaption("Series Code"), NoSeriesCode, NoSeriesLine2.GetFilter("Series Code"));
+        if NoSeriesCode <> '' then
+            NoSeriesCodeFilter := NoSeriesLine2.GetFilter("Series Code");
+        if NoSeriesCodeFilter <> NoSeriesCode then
+            Error(CodeFieldChangedErr, NoSeriesLine2.FieldCaption("Series Code"), NoSeriesCode, NoSeriesCodeFilter);
 
         NoSeriesLine.SetCurrentKey("Series Code", "Starting Date");
         NoSeriesLine.CopyFilters(NoSeriesLine2);


### PR DESCRIPTION
This pull request backports #2543 to releases/25.2

Fixes [AB#560711](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/560711)


