### PR TITLE
[Email] Add Last Message Only into the email filters table

### DIFF
--- a/src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al
+++ b/src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al
@@ -52,9 +52,9 @@ table 8885 "Email Retrieval Filters"
         {
             Caption = 'Earliest Email';
         }
-        field(8; "Remove Past Sections"; Boolean)
+        field(8; "Remove History"; Boolean)
         {
-            Caption = 'Remove Past Sections';
+            Caption = 'Remove History';
         }
     }
 

--- a/src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al
+++ b/src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al
@@ -52,9 +52,9 @@ table 8885 "Email Retrieval Filters"
         {
             Caption = 'Earliest Email';
         }
-        field(8; "Remove History"; Boolean)
+        field(8; "Last Message Only"; Boolean)
         {
-            Caption = 'Remove History';
+            Caption = 'Last Message Only';
         }
     }
 

--- a/src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al
+++ b/src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al
@@ -48,10 +48,13 @@ table 8885 "Email Retrieval Filters"
             InitValue = "HTML";
             Caption = 'Body Type';
         }
-
         field(7; "Earliest Email"; DateTime)
         {
             Caption = 'Earliest Email';
+        }
+        field(8; "Remove Past Sections"; Boolean)
+        {
+            Caption = 'Remove Past Sections';
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This filter allows each connector to parse and keep only the last message of the email contents of emails retrieved. Email clients automatically append the history messages when replying to an email.
Each connector still needs to implement this functionality.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#560747](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/560747)





