### PR TITLE
[releases/25.2] [Email] Add Last Message Only into the email filters table

### DIFF
--- a/src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al
+++ b/src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al
@@ -48,10 +48,13 @@ table 8885 "Email Retrieval Filters"
             InitValue = "HTML";
             Caption = 'Body Type';
         }
-
         field(7; "Earliest Email"; DateTime)
         {
             Caption = 'Earliest Email';
+        }
+        field(8; "Last Message Only"; Boolean)
+        {
+            Caption = 'Last Message Only';
         }
     }
 


### PR DESCRIPTION
This pull request backports #2547 to releases/25.2

Fixes [AB#560756](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/560756)


