### PR TITLE
Bug 561192: Don't replicate data of Ext. File Storage tables

### DIFF
--- a/src/System Application/App/External File Storage/src/Connector/FileStorageConnectorLogo.Table.al
+++ b/src/System Application/App/External File Storage/src/Connector/FileStorageConnectorLogo.Table.al
@@ -9,6 +9,7 @@ table 9452 "File Storage Connector Logo"
 {
     DataClassification = SystemMetadata;
     Access = Internal;
+    ReplicateData = false;
     InherentPermissions = X;
     InherentEntitlements = X;
 

--- a/src/System Application/App/External File Storage/src/Scenario/FileScenario.Table.al
+++ b/src/System Application/App/External File Storage/src/Scenario/FileScenario.Table.al
@@ -14,6 +14,7 @@ table 9454 "File Scenario"
 {
     DataClassification = SystemMetadata;
     Access = Internal;
+    ReplicateData = false;
     InherentPermissions = X;
     InherentEntitlements = X;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Data should not be replicated, as data is created by the module itself.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#561192](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/561192)


