### PR TITLE
Exception for PTE0024 - Unblock uptake

### DIFF
--- a/src/rulesets/ruleset.json
+++ b/src/rulesets/ruleset.json
@@ -115,6 +115,11 @@
       "justification": "Entitlements cannot be defined in an extension."
     },
     {
+      "id": "PTE0024",
+      "action": "None",
+      "justification": "We allow moved symbols for Microsoft apps because we run PTECop on the entire codebase which includes global apps."
+    },
+    {
       "id": "AW0006",
       "action": "None",
       "justification": "Pages and reports should use the UsageCategory and ApplicationArea properties to be searchable."


### PR DESCRIPTION
#### Summary 

The new PTECop is meant to block moves in PTEs as it is not supported yet. However, we run PTECop on apps like the business foundation which is not a PTE

#### Work Item
Fixes [AB#561076](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/561076)



