### PR TITLE
Remove duplicate part in branch name when running automations

### DIFF
--- a/.github/actions/RunAutomation/run.ps1
+++ b/.github/actions/RunAutomation/run.ps1
@@ -96,7 +96,7 @@ function OpenPR {
 
     $shortTargetBranch = $TargetBranch -replace 'releases/',''
     $Category = "$shortTargetBranch/$Category".ToLower().Replace(' ', '_')
-    $branch = New-TopicBranchIfNeeded -Category "$shortTargetBranch/$Category" -Repository $Repository
+    $branch = New-TopicBranchIfNeeded -Category $Category -Repository $Repository
 
     # Open PR with a commit for each update
     $prDescription = "This PR contains the following changes:"


### PR DESCRIPTION
_**Issue**_: 
The target branch part when creating automation PRs is duplicated:
![image](https://github.com/user-attachments/assets/449195f5-a8ff-481b-ad72-7ecc3027a832)

Fixes [AB#561456](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/561456)

