### PR TITLE
Delay obsoletion of ExtractEntry

### DIFF
--- a/src/System Application/App/Data Compression/src/DataCompression.Codeunit.al
+++ b/src/System Application/App/Data Compression/src/DataCompression.Codeunit.al
@@ -94,6 +94,20 @@ codeunit 425 "Data Compression"
         DataCompressionImpl.GetEntryList(EntryList);
     end;
 
+#if not CLEAN26
+    /// <summary>
+    /// Extracts an entry from the ZipArchive.
+    /// </summary>
+    /// <param name="EntryName">The name of the ZipArchive entry to be extracted.</param>
+    /// <param name="OutputOutStream">The OutStream to which binary content of the extracted entry is saved.</param>
+    /// <param name="EntryLength">The length of the extracted entry.</param>
+    [Obsolete('This function has been replaced by the function ExtractEntry(EntryName: Text; OutputOutStream: OutStream) which instead returns the entry length.', '23.0')]
+    procedure ExtractEntry(EntryName: Text; OutputOutStream: OutStream; var EntryLength: Integer)
+    begin
+        DataCompressionImpl.ExtractEntry(EntryName, OutputOutStream, EntryLength);
+    end;
+
+#endif
     /// <summary>
     /// Extracts an entry from the ZipArchive.
     /// </summary>


### PR DESCRIPTION
Multiple apps are still depending on this function and will stop working. Hence delaying the obsoletion of the function further and more announcements should also be provided about it now. This is not to start a trend but one time since many tenants will be affected by the removal at this time (see bug).
Fixes [AB#561369](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/561369)


