### PR TITLE
[releases/24.2] Update AL-Go System Files from microsoft/AL-Go-PTE@preview -  bcf5ae3b4204b8687d8afc14a766329e684664cb

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -72,5 +72,5 @@
     ]
   },
   "UpdateALGoSystemFilesEnvironment": "Official-Build",
-  "templateSha": "f38e373bfc51cc2349114b04a159f7179de47502"
+  "templateSha": "bcf5ae3b4204b8687d8afc14a766329e684664cb"
 }

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -2,13 +2,30 @@
 
 Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.
 
+### Deprecations
+
+- `cleanModePreProcessorSymbols` will be removed after April 1st 2025. Use [Conditional Settings](https://aka.ms/algosettings#conditional-settings) instead, specifying buildModes and the `preProcessorSymbols` setting. Read [this](./DEPRECATIONS.md) for more information.
+
 ### Issues
 
 - It is now possible to skip the modification of dependency version numbers when running the Increment Version number workflow or the Create Release workflow
 
+### New Repository Settings
+
+- [`shortLivedArtifactsRetentionDays`](https://aka.ms/algosettings#shortLivedArtifactsRetentionDays) determines the number of days to keep short lived build artifacts (f.ex build artifacts from pull request builds, next minor or next major builds). 1 is default. 0 means use GitHub default.
+- [`preProcessorSymbols`](https://aka.ms/algosettings#preProcessorSymbols) is a list of preprocessor symbols to use when building the apps. This setting can be specified in [workflow specific settings files](https://aka.ms/algosettings#where-are-the-settings-located) or in [conditional settings](https://aka.ms/algosettings#conditional-settings).
+
 ### New Versioning Strategy
 
 Setting versioning strategy to 3 will allow 3 segments of the version number to be defined in app.json and repoVersion. Only the 4th segment (Revision) will be defined by the GitHub [run_number](https://go.microsoft.com/fwlink/?linkid=2217416&clcid=0x409) for the CI/CD workflow. Increment version number and Create Release now also supports the ability to set a third segment to the RepoVersion and appversion in app.json.
+
+### Change in published artifacts
+
+When using `useProjectDependencies` in a multi-project repository, AL-Go for GitHub used to generate short lived build artifacts called `thisBuild-<projectnaame>-<type>-...`. This is no longer the case. Instead, normal build artifacts will be published and used by depending projects. The retention period for the short lived artifacts generated are controlled by a settings called [`shortLivedArtifactsRetentionDays`](https://aka.ms/algosettings#shortLivedArtifactsRetentionDays).
+
+### Preprocessor symbols
+
+It is now possible to define preprocessor symbols, which will be used when building your apps using the [`preProcessorSymbols`](https://aka.ms/algosettings#preProcessorSymbols) setting. This setting can be specified in workflow specific settings file or it can be used in conditional settings.
 
 ## v6.2
 
@@ -142,7 +159,7 @@ AL-Go for GitHub now includes a new telemetry module. For detailed information o
   - **NumberOfSqlStmtsWarning** - a warning is issued if the number of SQL statements from a bcpt test increases more than this percentage (default 5)
   - **NumberOfSqlStmtsError** - an error is issued if the number of SQL statements from a bcpt test increases more than this percentage (default 10)
 
-> \[!NOTE\]
+> [!NOTE]
 > Duration thresholds are subject to varying results depending on the performance of the agent running the tests. Number of SQL statements executed by a test is often the most reliable indicator of performance degredation.
 
 ## v5.2
@@ -169,7 +186,7 @@ AL-Go for GitHub now includes a new telemetry module. For detailed information o
 - **Pull PowerPlatform Changes** for pulling changes from your PowerPlatform development environment into your AL-Go for GitHub repository
 - **Push PowerPlatform Changes** for pushing changes from your AL-Go for GitHub repository to your PowerPlatform development environment
 
-> \[!NOTE\]
+> [!NOTE]
 > PowerPlatform workflows are only available in the PTE template and will be removed if no PowerPlatformSolutionFolder is defined in settings.
 
 ### New Scenarios (Documentation)
@@ -179,7 +196,7 @@ AL-Go for GitHub now includes a new telemetry module. For detailed information o
 - [Try one of the Business Central and Power Platform samples](https://github.com/microsoft/AL-Go/blob/main/Scenarios/TryPowerPlatformSamples.md)
 - [Publish To AppSource](https://github.com/microsoft/AL-Go/blob/main/Scenarios/PublishToAppSource.md)
 
-> \[!NOTE\]
+> [!NOTE]
 > PowerPlatform functionality are only available in the PTE template.
 
 ## v5.1
@@ -317,8 +334,8 @@ AL-Go for GitHub allows you to build and test using insider builds without any e
 
 - `enableExternalRulesets`: set this setting to true if you want to allow AL-Go to automatically download external references in rulesets.
 - `deliverTo<deliveryTarget>`: is not really new, but has new properties and wasn't documented. The complete list of properties is here (note that some properties are deliveryTarget specific):
-  - **Branches** = an array of branch patterns, which are allowed to deliver to this deliveryTarget. (Default \[ "main" \])
-  - **CreateContainerIfNotExist** = *\[Only for DeliverToStorage\]* Create Blob Storage Container if it doesn't already exist. (Default false)
+  - **Branches** = an array of branch patterns, which are allowed to deliver to this deliveryTarget. (Default [ "main" ])
+  - **CreateContainerIfNotExist** = *[Only for DeliverToStorage]* Create Blob Storage Container if it doesn't already exist. (Default false)
 
 ### Deployment
 
@@ -359,7 +376,7 @@ Earlier, you could also specify the projects you want to deploy to an environmen
 - `deployTo<environmentName>`: is not really new, but has new properties. The complete list of properties is here:
   - **EnvironmentType** = specifies the type of environment. The environment type can be used to invoke a custom deployment. (Default SaaS)
   - **EnvironmentName** = specifies the "real" name of the environment if it differs from the GitHub environment
-  - **Branches** = an array of branch patterns, which are allowed to deploy to this environment. (Default \[ "main" \])
+  - **Branches** = an array of branch patterns, which are allowed to deploy to this environment. (Default [ "main" ])
   - **Projects** = In multi-project repositories, this property can be a comma separated list of project patterns to deploy to this environment. (Default \*)
   - **SyncMode** = ForceSync if deployment to this environment should happen with ForceSync, else Add. If deploying to the development endpoint you can also specify Development or Clean. (Default Add)
   - **ContinuousDeployment** = true if this environment should be used for continuous deployment, else false. (Default: AL-Go will continuously deploy to sandbox environments or environments, which doesn't end in (PROD) or (FAT)
@@ -417,8 +434,8 @@ Now, you can set the checkbox called Use GhTokenWorkflow to allowing you to use 
 
 ### New Settings
 
-- `keyVaultCodesignCertificateName`:  With this setting you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module
-- `PullRequestTrigger`:  With this setting you can set which trigger to use for Pull Request Builds. By default AL-Go will use pull_request_target.
+- `keyVaultCodesignCertificateName`: With this setting you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module
+- `PullRequestTrigger`: With this setting you can set which trigger to use for Pull Request Builds. By default AL-Go will use pull_request_target.
 
 ### New Actions
 

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -45,7 +45,7 @@ jobs:
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
 
@@ -56,13 +56,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSettings@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           get: type,powerPlatformSolutionFolder,useGitSubmodules
@@ -70,7 +70,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go/Actions/ReadSecrets@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSecrets@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -91,7 +91,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -104,7 +104,7 @@ jobs:
 
       - name: Determine Delivery Target Secrets
         id: DetermineDeliveryTargetSecrets
-        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
@@ -112,7 +112,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSecrets@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -120,7 +120,7 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@44100a28d57e2c582859205900ac519d9d76c57c
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -130,7 +130,7 @@ jobs:
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@44100a28d57e2c582859205900ac519d9d76c57c
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -146,13 +146,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSettings@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           get: templateUrl
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           templateUrl: ${{ env.templateUrl }}
@@ -176,8 +176,6 @@ jobs:
       buildMode: ${{ matrix.buildMode }}
       projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
       secrets: 'licenseFileUrl,codeSignCertificateUrl,*codeSignCertificatePassword,keyVaultCertificateUrl,*keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext,applicationInsightsConnectionString'
-      publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
-      publishArtifacts: ${{ github.ref_name == 'main' || startswith(github.ref_name, 'release/') || startswith(github.ref_name, 'releases/') || needs.Initialization.outputs.deliveryTargetsJson != '[]' || needs.Initialization.outputs.environmentCount > 0 }}
       signArtifacts: true
       useArtifactCache: true
 
@@ -199,8 +197,6 @@ jobs:
       buildMode: ${{ matrix.buildMode }}
       projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
       secrets: 'licenseFileUrl,codeSignCertificateUrl,*codeSignCertificatePassword,keyVaultCertificateUrl,*keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext,applicationInsightsConnectionString'
-      publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
-      publishArtifacts: ${{ github.ref_name == 'main' || startswith(github.ref_name, 'release/') || startswith(github.ref_name, 'releases/') || needs.Initialization.outputs.deliveryTargetsJson != '[]' || needs.Initialization.outputs.environmentCount > 0 }}
       signArtifacts: true
       useArtifactCache: true
 
@@ -227,7 +223,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSettings@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
 
@@ -236,7 +232,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           artifacts: '.artifacts'
@@ -273,7 +269,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSettings@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
@@ -287,7 +283,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSecrets@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -295,7 +291,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: microsoft/AL-Go/Actions/Deploy@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/Deploy@44100a28d57e2c582859205900ac519d9d76c57c
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -307,7 +303,7 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@44100a28d57e2c582859205900ac519d9d76c57c
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -335,20 +331,20 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSettings@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSecrets@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: Deliver
-        uses: microsoft/AL-Go/Actions/Deliver@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/Deliver@44100a28d57e2c582859205900ac519d9d76c57c
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -368,7 +364,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@44100a28d57e2c582859205900ac519d9d76c57c
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/.github/workflows/DeployReferenceDocumentation.yaml
@@ -30,18 +30,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSettings@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@44100a28d57e2c582859205900ac519d9d76c57c
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -54,7 +54,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           artifacts: 'latest'
@@ -71,7 +71,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@44100a28d57e2c582859205900ac519d9d76c57c
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -46,7 +46,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
 
@@ -55,18 +55,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSettings@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSecrets@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -74,7 +74,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
-        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -85,7 +85,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@44100a28d57e2c582859205900ac519d9d76c57c
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -28,7 +28,7 @@ jobs:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
     runs-on: windows-latest
     steps:
-      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@471b88b68863d06568efb833d74b02f0879b1c89
+      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@44100a28d57e2c582859205900ac519d9d76c57c
 
   Initialization:
     needs: [ PregateCheck ]
@@ -40,10 +40,11 @@ jobs:
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
       baselineWorkflowRunId: ${{ steps.determineProjectsToBuild.outputs.BaselineWorkflowRunId }}
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
+      artifactsRetentionDays: ${{ steps.DetermineWorkflowDepth.outputs.ArtifactsRetentionDays }}
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
 
@@ -55,24 +56,26 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSettings@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
+          get: shortLivedArtifactsRetentionDays
 
       - name: Determine Workflow Depth
         id: DetermineWorkflowDepth
         run: |
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "ArtifactsRetentionDays=$($env:shortLivedArtifactsRetentionDays)"
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -97,7 +100,7 @@ jobs:
       projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
       baselineWorkflowRunId: ${{ needs.Initialization.outputs.baselineWorkflowRunId }}
       secrets: 'licenseFileUrl,keyVaultCertificateUrl,*keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext,applicationInsightsConnectionString'
-      publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
+      artifactsRetentionDays: ${{ fromJson(needs.Initialization.outputs.artifactsRetentionDays) }}
       artifactsNameSuffix: 'PR${{ github.event.number }}'
 
   Build:
@@ -120,7 +123,7 @@ jobs:
       projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
       baselineWorkflowRunId: ${{ needs.Initialization.outputs.baselineWorkflowRunId }}
       secrets: 'licenseFileUrl,keyVaultCertificateUrl,*keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext,applicationInsightsConnectionString'
-      publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
+      artifactsRetentionDays: ${{ fromJson(needs.Initialization.outputs.artifactsRetentionDays) }}
       artifactsNameSuffix: 'PR${{ github.event.number }}'
 
   StatusCheck:
@@ -131,7 +134,7 @@ jobs:
     steps:
       - name: Pull Request Status Check
         id: PullRequestStatusCheck
-        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@44100a28d57e2c582859205900ac519d9d76c57c
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -139,7 +142,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@44100a28d57e2c582859205900ac519d9d76c57c
         if: success() || failure()
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/Troubleshooting.yaml
+++ b/.github/workflows/Troubleshooting.yaml
@@ -30,7 +30,7 @@ jobs:
           lfs: true
 
       - name: Troubleshooting
-        uses: microsoft/AL-Go/Actions/Troubleshooting@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/Troubleshooting@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
 
@@ -46,19 +46,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSettings@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           get: templateUrl
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSecrets@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -94,7 +94,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: powershell
           token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@44100a28d57e2c582859205900ac519d9d76c57c
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -46,14 +46,10 @@ on:
         required: false
         default: ''
         type: string
-      publishThisBuildArtifacts:
-        description: Flag indicating whether this build artifacts should be published
-        type: boolean
-        default: false
-      publishArtifacts:
-        description: Flag indicating whether the artifacts should be published
-        type: boolean
-        default: false
+      artifactsRetentionDays:
+        description: Number of days to keep the artifacts
+        type: number
+        default: 0
       artifactsNameSuffix:
         description: Suffix to add to the artifacts names
         required: false
@@ -93,16 +89,17 @@ jobs:
           lfs: true
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSettings@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
+          buildMode: ${{ inputs.buildMode }}
           get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,doNotRunTests,artifact,generateDependencyArtifact,trustedSigning,useGitSubmodules
 
       - name: Read secrets
         id: ReadSecrets
         if: github.event_name != 'pull_request'
-        uses: microsoft/AL-Go/Actions/ReadSecrets@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/ReadSecrets@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -118,7 +115,7 @@ jobs:
           token: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).gitSubmodulesToken }}'
 
       - name: Determine ArtifactUrl
-        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@44100a28d57e2c582859205900ac519d9d76c57c
         id: determineArtifactUrl
         with:
           shell: ${{ inputs.shell }}
@@ -133,7 +130,7 @@ jobs:
 
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
-        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@44100a28d57e2c582859205900ac519d9d76c57c
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -144,7 +141,7 @@ jobs:
           baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
 
       - name: Build
-        uses: microsoft/AL-Go/Actions/RunPipeline@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/RunPipeline@44100a28d57e2c582859205900ac519d9d76c57c
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
           BuildMode: ${{ inputs.buildMode }}
@@ -159,7 +156,7 @@ jobs:
       - name: Sign
         if: inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != ''))
         id: sign
-        uses: microsoft/AL-Go/Actions/Sign@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/Sign@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: ${{ inputs.shell }}
           azureCredentialsJson: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).AZURE_CREDENTIALS }}'
@@ -167,7 +164,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@44100a28d57e2c582859205900ac519d9d76c57c
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -175,59 +172,35 @@ jobs:
           buildMode: ${{ inputs.buildMode }}
           suffix: ${{ inputs.artifactsNameSuffix }}
 
-      - name: Upload thisbuild artifacts - apps
-        if: inputs.publishThisBuildArtifacts
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildAppsArtifactsName }}
-          path: '${{ inputs.project }}/.buildartifacts/Apps/'
-          if-no-files-found: ignore
-          retention-days: 1
-
-      - name: Upload thisbuild artifacts - dependencies
-        if: inputs.publishThisBuildArtifacts
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildDependenciesArtifactsName }}
-          path: '${{ inputs.project }}/.buildartifacts/Dependencies/'
-          if-no-files-found: ignore
-          retention-days: 1
-
-      - name: Upload thisbuild artifacts - test apps
-        if: inputs.publishThisBuildArtifacts
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildTestAppsArtifactsName }}
-          path: '${{ inputs.project }}/.buildartifacts/TestApps/'
-          if-no-files-found: ignore
-          retention-days: 1
-
       - name: Publish artifacts - apps
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: inputs.publishArtifacts
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        if: inputs.artifactsRetentionDays >= 0
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.AppsArtifactsName }}
           path: '${{ inputs.project }}/.buildartifacts/Apps/'
           if-no-files-found: ignore
+          retention-days: ${{ inputs.artifactsRetentionDays }}
 
       - name: Publish artifacts - dependencies
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: inputs.publishArtifacts && env.generateDependencyArtifact == 'True'
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        if: inputs.artifactsRetentionDays >= 0 && env.generateDependencyArtifact == 'True'
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.DependenciesArtifactsName }}
           path: '${{ inputs.project }}/.buildartifacts/Dependencies/'
           if-no-files-found: ignore
+          retention-days: ${{ inputs.artifactsRetentionDays }}
 
       - name: Publish artifacts - test apps
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if: inputs.publishArtifacts
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        if: inputs.artifactsRetentionDays >= 0
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.TestAppsArtifactsName }}
           path: '${{ inputs.project }}/.buildartifacts/TestApps/'
           if-no-files-found: ignore
+          retention-days: ${{ inputs.artifactsRetentionDays }}
 
       - name: Publish artifacts - build output
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.BuildOutputArtifactsName }}
@@ -235,7 +208,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - container event log
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         if: (failure()) && (hashFiles(format('{0}/ContainerEventLog.evtx',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.ContainerEventLogArtifactsName }}
@@ -243,7 +216,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - test results
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         if: (success() || failure()) && (hashFiles(format('{0}/.buildartifacts/TestResults.xml',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.TestResultsArtifactsName }}
@@ -251,7 +224,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - bcpt test results
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         if: (success() || failure()) && (hashFiles(format('{0}/.buildartifacts/bcptTestResults.json',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.BcptTestResultsArtifactsName }}
@@ -259,7 +232,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - page scripting test results
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         if: (success() || failure()) && (hashFiles(format('{0}/.buildartifacts/PageScriptingTestResults.xml',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.PageScriptingTestResultsArtifactsName }}
@@ -267,7 +240,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - page scripting test result details
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         if: (success() || failure())
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.PageScriptingTestResultDetailsArtifactsName }}
@@ -277,14 +250,14 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: (success() || failure()) && env.doNotRunTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
 
       - name: Cleanup
         if: always()
-        uses: microsoft/AL-Go/Actions/PipelineCleanup@471b88b68863d06568efb833d74b02f0879b1c89
+        uses: microsoft/AL-Go/Actions/PipelineCleanup@44100a28d57e2c582859205900ac519d9d76c57c
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}

--- a/build/projects/Business Foundation/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Business Foundation/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Business Foundation/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Business Foundation/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Performance Toolkit/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Performance Toolkit/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Performance Toolkit/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Performance Toolkit/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Modules/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Modules/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Modules/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Modules/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Tests/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Tests/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Framework/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Test Framework/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Framework/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Test Framework/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Stability Tools/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Test Stability Tools/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Stability Tools/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Test Stability Tools/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/471b88b68863d06568efb833d74b02f0879b1c89/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/44100a28d57e2c582859205900ac519d9d76c57c/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local


### PR DESCRIPTION
## preview

Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.

### Deprecations

- `cleanModePreProcessorSymbols` will be removed after April 1st 2025. Use [Conditional Settings](https://aka.ms/algosettings#conditional-settings) instead, specifying buildModes and the `preProcessorSymbols` setting. Read [this](./DEPRECATIONS.md) for more information.

### Issues

- It is now possible to skip the modification of dependency version numbers when running the Increment Version number workflow or the Create Release workflow

### New Repository Settings

- [`shortLivedArtifactsRetentionDays`](https://aka.ms/algosettings#shortLivedArtifactsRetentionDays) determines the number of days to keep short lived build artifacts (f.ex build artifacts from pull request builds, next minor or next major builds). 1 is default. 0 means use GitHub default.
- [`preProcessorSymbols`](https://aka.ms/algosettings#preProcessorSymbols) is a list of preprocessor symbols to use when building the apps. This setting can be specified in [workflow specific settings files](https://aka.ms/algosettings#where-are-the-settings-located) or in [conditional settings](https://aka.ms/algosettings#conditional-settings).

### New Versioning Strategy

Setting versioning strategy to 3 will allow 3 segments of the version number to be defined in app.json and repoVersion. Only the 4th segment (Revision) will be defined by the GitHub [run_number](https://go.microsoft.com/fwlink/?linkid=2217416&clcid=0x409) for the CI/CD workflow. Increment version number and Create Release now also supports the ability to set a third segment to the RepoVersion and appversion in app.json.

### Change in published artifacts

When using `useProjectDependencies` in a multi-project repository, AL-Go for GitHub used to generate short lived build artifacts called `thisBuild-<projectnaame>-<type>-...`. This is no longer the case. Instead, normal build artifacts will be published and used by depending projects. The retention period for the short lived artifacts generated are controlled by a settings called [`shortLivedArtifactsRetentionDays`](https://aka.ms/algosettings#shortLivedArtifactsRetentionDays).

### Preprocessor symbols

It is now possible to define preprocessor symbols, which will be used when building your apps using the [`preProcessorSymbols`](https://aka.ms/algosettings#preProcessorSymbols) setting. This setting can be specified in workflow specific settings file or it can be used in conditional settings.

