### PR TITLE
[releases/24.3] Run CLEAN mode only on main and major release branches

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -9,15 +9,30 @@
   "country": "base",
   "useProjectDependencies": true,
   "repoVersion": "24.3",
-  "cleanModePreprocessorSymbols": [
-    "CLEAN17",
-    "CLEAN18",
-    "CLEAN19",
-    "CLEAN20",
-    "CLEAN21",
-    "CLEAN22",
-    "CLEAN23",
-    "CLEAN24"
+  "conditionalSettings": [
+    {
+        "buildModes": [ "Clean" ],
+        "settings": {
+            "preprocessorSymbols": [
+              "CLEAN17",
+              "CLEAN18",
+              "CLEAN19",
+              "CLEAN20",
+              "CLEAN21",
+              "CLEAN22",
+              "CLEAN23",
+              "CLEAN24",
+              "CLEAN25",
+              "CLEAN26"
+             ]
+        }
+    },
+    {
+        "branches": [ "main", "releases/*.x" ],
+        "settings": {
+            "buildModes": [ "Clean" ]
+        }
+    }
   ],
   "unusedALGoSystemFiles": [
     "AddExistingAppOrTestApp.yaml",
@@ -36,8 +51,7 @@
     "Official-Build"
   ],
   "buildModes": [
-    "Default",
-    "Clean"
+    "Default"
   ],
   "CICDPushBranches": [
     "main",


### PR DESCRIPTION
This pull request backports #2732 to releases/24.3

Fixes [AB#561502](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/561502)
