### PR TITLE
[releases/25.1] Run CLEAN mode only on main and major release branches

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -9,16 +9,30 @@
   "country": "base",
   "useProjectDependencies": true,
   "repoVersion": "25.1",
-  "cleanModePreprocessorSymbols": [
-    "CLEAN17",
-    "CLEAN18",
-    "CLEAN19",
-    "CLEAN20",
-    "CLEAN21",
-    "CLEAN22",
-    "CLEAN23",
-    "CLEAN24",
-    "CLEAN25"
+  "conditionalSettings": [
+    {
+        "buildModes": [ "Clean" ],
+        "settings": {
+            "preprocessorSymbols": [
+              "CLEAN17",
+              "CLEAN18",
+              "CLEAN19",
+              "CLEAN20",
+              "CLEAN21",
+              "CLEAN22",
+              "CLEAN23",
+              "CLEAN24",
+              "CLEAN25",
+              "CLEAN26"
+             ]
+        }
+    },
+    {
+        "branches": [ "main", "releases/*.x" ],
+        "settings": {
+            "buildModes": [ "Clean" ]
+        }
+    }
   ],
   "unusedALGoSystemFiles": [
     "AddExistingAppOrTestApp.yaml",
@@ -37,8 +51,7 @@
     "Official-Build"
   ],
   "buildModes": [
-    "Default",
-    "Clean"
+    "Default"
   ],
   "CICDPushBranches": [
     "main",


### PR DESCRIPTION
This pull request backports #2732 to releases/25.1

Fixes [AB#561502](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/561502)
