### PR TITLE
[Edit In Excel] Support plus signs in field names (Currently plus is interpreted as x002b by Edit In Excel and x002B by the platform)

### DIFF
--- a/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
+++ b/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
@@ -205,6 +205,7 @@ codeunit 1482 "Edit in Excel Impl."
         StartStr: Text;
         EndStr: Text;
         ByteValue: DotNet Byte;
+        ConvertedByteValue: Text;
         IsByteValueUnderscore: Dictionary of [Integer, Boolean];
     begin
         ConvertedName := Name;
@@ -238,7 +239,9 @@ codeunit 1482 "Edit in Excel Impl."
                     ByteValue := Convert.ToByte(ConvertedName[CurrentPosition]);
                     StartStr := CopyStr(ConvertedName, 1, CurrentPosition - 1);
                     EndStr := CopyStr(ConvertedName, CurrentPosition + 1);
-                    ConvertedName := StrSubstNo(XmlByteEncoding2Tok, StartStr, Convert.ToString(ByteValue, 16), EndStr);
+                    ConvertedByteValue := Convert.ToString(ByteValue, 16);
+                    ConvertedByteValue := ConvertedByteValue.ToUpper();
+                    ConvertedName := StrSubstNo(XmlByteEncoding2Tok, StartStr, ConvertedByteValue, EndStr);
                 end;
                 // length of _x00nn_ minus one that will be added later
                 CurrentPosition += 6;

--- a/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
+++ b/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
@@ -141,7 +141,7 @@ codeunit 132525 "Edit in Excel Test"
         LibraryAssert.AreEqual('field', RegularFieldName, 'Conversion alters name that does not begin with a string');
         LibraryAssert.AreEqual('_x0033_field', FieldNameStartingWDigit, 'Did not convert the name with number correctly');
         LibraryAssert.AreEqual('new_vendor_x0027_s_name', ApostropheFieldName, 'Did not convert the name with an apostrophe correctly');
-        LibraryAssert.AreEqual('c_x002b_c_field', PlusFieldName, 'Did not convert the name with a plus correctly');
+        LibraryAssert.AreEqual('c_x002B_c_field', PlusFieldName, 'Did not convert the name with a plus correctly');
         LibraryAssert.AreEqual('lager__x2013__reklassfication_field', EnDashFieldName, 'Did not convert the name with an `en dash` with two surrounding spaces correctly');
         LibraryAssert.AreEqual('lager__x2013_reklassfication_field', EnDashFieldName2, 'Did not convert the name with a space before an `en dash` correctly');
         LibraryAssert.AreEqual('lager_x2013_reklassfication_field', EnDashFieldName3, 'Did not convert the name with an `en dash` correctly');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Support plus signs in field names when using Edit In Excel. Currently plus is interpreted as x002b by Edit In Excel and x002B by the platform.

In response to [(95) Viva Engage : Dynamics 365 Business Central Partner Community (Formerly: Development) : View Conversation](https://www.yammer.com/dynamicsnavdev/#/Threads/show?threadId=3120316127158272)


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#562349](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/562349)


