### PR TITLE
[Copilot] Revert error in CheckTextCompletionMetaprompt

### DIFF
--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -684,9 +684,16 @@ codeunit 7772 "Azure OpenAI Impl"
 
     [NonDebuggable]
     local procedure CheckTextCompletionMetaprompt(Metaprompt: SecretText; CustomDimensions: Dictionary of [Text, Text])
+    var
+        ModuleInfo: ModuleInfo;
     begin
-        if Metaprompt.Unwrap().Trim() = '' then
+        if Metaprompt.Unwrap().Trim() = '' then begin
             FeatureTelemetry.LogError('0000LO8', CopilotCapabilityImpl.GetAzureOpenAICategory(), TelemetryGenerateTextCompletionLbl, EmptyMetapromptErr, '', Enum::"AL Telemetry Scope"::All, CustomDimensions);
+
+            NavApp.GetCurrentModuleInfo(ModuleInfo);
+            if ModuleInfo.Publisher = 'Microsoft' then
+                Error(EmptyMetapromptErr);
+        end;
     end;
 #if not CLEAN24
     [NonDebuggable]

--- a/src/System Application/Test/DisabledTests/AzureOpenAITest.json
+++ b/src/System Application/Test/DisabledTests/AzureOpenAITest.json
@@ -27,12 +27,6 @@
         "bug":  "488815",
         "codeunitId":  132684,
         "CodeunitName": "Azure OpenAI Test",
-        "Method": "GenerateTextCompletionsMetapromptNotSetFails"
-    },
-    {
-        "bug":  "488815",
-        "codeunitId":  132684,
-        "CodeunitName": "Azure OpenAI Test",
         "Method": "GenerateTextCompletionsFails"
     },
     {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
The error was removed in #2723, this makes a test fail during uptake to NAV.

Reverting the error and adding the Microsoft check.
Also reenabling that test. Will reenable the rest of the tests in another PR.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#561929](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/561929)


