### PR TITLE
[25.x] [Copilot] Expand chat availability

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilityInstall.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilityInstall.Codeunit.al
@@ -22,14 +22,8 @@ codeunit 7760 "Copilot Capability Install"
         AnalyzeListLearnMoreLbl: Label 'https://go.microsoft.com/fwlink/?linkid=2252783', Locked = true;
 
     internal procedure RegisterCapabilities()
-    var
-        EnvironmentInformation: Codeunit "Environment Information";
-        ApplicationFamily: Text;
     begin
-        ApplicationFamily := EnvironmentInformation.GetApplicationFamily();
-        if ApplicationFamily in ['AT', 'BE', 'BG', 'CH', 'CZ', 'DK', 'EE', 'ES', 'FI', 'GR', 'HR', 'HU', 'IE', 'IS', 'IT', 'LT', 'LV', 'MX', 'NL', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK', 'UA', 'US', 'W1'] then
-            RegisterSaaSCapability(Enum::"Copilot Capability"::Chat, Enum::"Copilot Availability"::Preview, ChatLearnMoreLbl);
-
+        RegisterSaaSCapability(Enum::"Copilot Capability"::Chat, Enum::"Copilot Availability"::Preview, ChatLearnMoreLbl);
         RegisterSaaSCapability(Enum::"Copilot Capability"::"Analyze List", Enum::"Copilot Availability"::Preview, AnalyzeListLearnMoreLbl);
     end;
 


### PR DESCRIPTION
#### Summary
Remove the application family check when registering the Chat Copilot capability.
This will allow the capability to be enabled in all deployments 🎉 

#### Work Item(s)
Fixes [AB#502565](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/502565)


