### PR TITLE
Bug 564482: W1 2025 - Bug Bash I: Cannot setup Ext. File Storage module - probably missing permissions

### DIFF
--- a/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
+++ b/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
@@ -28,7 +28,7 @@ permissionset 154 "System Application - Admin"
                              "Exten. Mgt. - Admin",
                              "Edit in Excel-Admin",
                              "Feature Key - Admin",
-                             "File Storage - Admin"
+                             "File Storage - Admin",
                              "Permissions & Licenses - Edit",
                              "Priv. Notice - Admin",
                              "Retention Policy - Admin",

--- a/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
+++ b/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
@@ -28,6 +28,7 @@ permissionset 154 "System Application - Admin"
                              "Exten. Mgt. - Admin",
                              "Edit in Excel-Admin",
                              "Feature Key - Admin",
+							 "File Storage - Admin"
                              "Permissions & Licenses - Edit",
                              "Priv. Notice - Admin",
                              "Retention Policy - Admin",

--- a/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
+++ b/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
@@ -28,7 +28,7 @@ permissionset 154 "System Application - Admin"
                              "Exten. Mgt. - Admin",
                              "Edit in Excel-Admin",
                              "Feature Key - Admin",
-							 "File Storage - Admin"
+                             "File Storage - Admin"
                              "Permissions & Licenses - Edit",
                              "Priv. Notice - Admin",
                              "Retention Policy - Admin",

--- a/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
+++ b/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
@@ -8,6 +8,7 @@ namespace System.Security.AccessControl;
 using System.DataAdministration;
 using System.Email;
 using System.Environment.Configuration;
+using System.ExternalFileStorage;
 using System.Integration.Excel;
 using System.Privacy;
 using System.Integration;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Adds missing admin permissions for the Ext. File Storage module to the admin set of the System Application

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#564482](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/564482)






