### PR TITLE
Bug 564483: W1 2025 - Bug Bash I: Terminology of Ext. File Storage module is inconsistent and feature uptake telemetry is reused from email

### DIFF
--- a/src/System Application/App/External File Storage/permissions/FileStorageEdit.PermissionSet.al
+++ b/src/System Application/App/External File Storage/permissions/FileStorageEdit.PermissionSet.al
@@ -11,7 +11,7 @@ permissionset 9453 "File Storage - Edit"
 {
     Access = Public;
     Assignable = false;
-    Caption = 'File Storage - Edit';
+    Caption = 'External File Storage - Edit';
 
     IncludedPermissionSets = "File Storage - Read";
 

--- a/src/System Application/App/External File Storage/permissions/FileStorageObjects.PermissionSet.al
+++ b/src/System Application/App/External File Storage/permissions/FileStorageObjects.PermissionSet.al
@@ -4,6 +4,7 @@ permissionset 9452 "File Storage - Objects"
 {
     Access = Internal;
     Assignable = false;
+    Caption = 'External File Storage - Objects';
 
     Permissions =
         codeunit "File Account" = X,

--- a/src/System Application/App/External File Storage/permissions/FileStorageRead.PermissionSet.al
+++ b/src/System Application/App/External File Storage/permissions/FileStorageRead.PermissionSet.al
@@ -11,6 +11,7 @@ permissionset 9451 "File Storage - Read"
 {
     Access = Internal;
     Assignable = false;
+    Caption = 'External File Storage - Read';
     IncludedPermissionSets = "File Storage - Objects";
 
     Permissions =

--- a/src/System Application/App/External File Storage/src/Account/FileAccount.Table.al
+++ b/src/System Application/App/External File Storage/src/Account/FileAccount.Table.al
@@ -12,6 +12,7 @@ table 9450 "File Account"
 {
     Extensible = false;
     TableType = Temporary;
+    Caption = 'External File Account';
 
     fields
     {

--- a/src/System Application/App/External File Storage/src/Account/FileAccountWizard.Page.al
+++ b/src/System Application/App/External File Storage/src/Account/FileAccountWizard.Page.al
@@ -314,10 +314,10 @@ page 9451 "File Account Wizard"
     begin
         DurationAsInt := CurrentDateTime() - StartTime;
         if Step = Step::Done then begin
-            Session.LogMessage('', StrSubstNo(AccountCreationSuccessfullyCompletedDurationLbl, DurationAsInt), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', FileCategoryLbl);
-            FeatureTelemetry.LogUptake('', 'External File Storage', Enum::"Feature Uptake Status"::"Set up");
+            Session.LogMessage('0000OPM', StrSubstNo(AccountCreationSuccessfullyCompletedDurationLbl, DurationAsInt), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', FileCategoryLbl);
+            FeatureTelemetry.LogUptake('0000OPI', 'External File Storage', Enum::"Feature Uptake Status"::"Set up");
         end else
-            Session.LogMessage('', StrSubstNo(AccountCreationFailureDurationLbl, DurationAsInt), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', FileCategoryLbl);
+            Session.LogMessage('0000OPN', StrSubstNo(AccountCreationFailureDurationLbl, DurationAsInt), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', FileCategoryLbl);
     end;
 
     trigger OnInit()
@@ -393,11 +393,11 @@ page 9451 "File Account Wizard"
         CustomDimensions.Add('Category', FileCategoryLbl);
 
         if AccountWasRegistered then begin
-            FeatureTelemetry.LogUptake('', 'File Access', Enum::"Feature Uptake Status"::"Set up");
-            Telemetry.LogMessage('', StrSubstNo(TelemetryAccountRegisteredLbl, Rec.Connector), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, CustomDimensions);
+            FeatureTelemetry.LogUptake('0000OPJ', 'File Access', Enum::"Feature Uptake Status"::"Set up");
+            Telemetry.LogMessage('0000OPK', StrSubstNo(TelemetryAccountRegisteredLbl, Rec.Connector), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, CustomDimensions);
             NextStep(false);
         end else begin
-            Telemetry.LogMessage('', StrSubstNo(TelemetryAccountFailedtoRegisterLbl, Rec.Connector, GetLastErrorCallStack()), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, CustomDimensions);
+            Telemetry.LogMessage('0000OPL', StrSubstNo(TelemetryAccountFailedtoRegisterLbl, Rec.Connector, GetLastErrorCallStack()), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, CustomDimensions);
             NextStep(true);
         end;
 

--- a/src/System Application/App/External File Storage/src/Account/FileAccountWizard.Page.al
+++ b/src/System Application/App/External File Storage/src/Account/FileAccountWizard.Page.al
@@ -17,7 +17,7 @@ page 9451 "File Account Wizard"
     PageType = NavigatePage;
     ApplicationArea = All;
     UsageCategory = Administration;
-    Caption = 'Set Up File Accounts';
+    Caption = 'Set Up External File Accounts';
     SourceTable = "Ext. File Storage Connector";
     SourceTableTemporary = true;
     InsertAllowed = false;
@@ -309,13 +309,15 @@ page 9451 "File Account Wizard"
 
     trigger OnQueryClosePage(CloseAction: Action): Boolean
     var
+        FeatureTelemetry: Codeunit "Feature Telemetry";
         DurationAsInt: Integer;
     begin
         DurationAsInt := CurrentDateTime() - StartTime;
-        if Step = Step::Done then
-            Session.LogMessage('0000CTK', StrSubstNo(AccountCreationSuccessfullyCompletedDurationLbl, DurationAsInt), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', FileCategoryLbl)
-        else
-            Session.LogMessage('0000CTL', StrSubstNo(AccountCreationFailureDurationLbl, DurationAsInt), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', FileCategoryLbl);
+        if Step = Step::Done then begin
+            Session.LogMessage('', StrSubstNo(AccountCreationSuccessfullyCompletedDurationLbl, DurationAsInt), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', FileCategoryLbl);
+            FeatureTelemetry.LogUptake('', 'External File Storage', Enum::"Feature Uptake Status"::"Set up");
+        end else
+            Session.LogMessage('', StrSubstNo(AccountCreationFailureDurationLbl, DurationAsInt), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', FileCategoryLbl);
     end;
 
     trigger OnInit()
@@ -391,11 +393,11 @@ page 9451 "File Account Wizard"
         CustomDimensions.Add('Category', FileCategoryLbl);
 
         if AccountWasRegistered then begin
-            FeatureTelemetry.LogUptake('0000CTF', 'File Access', Enum::"Feature Uptake Status"::"Set up");
-            Telemetry.LogMessage('0000CTH', StrSubstNo(TelemetryAccountRegisteredLbl, Rec.Connector), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, CustomDimensions);
+            FeatureTelemetry.LogUptake('', 'File Access', Enum::"Feature Uptake Status"::"Set up");
+            Telemetry.LogMessage('', StrSubstNo(TelemetryAccountRegisteredLbl, Rec.Connector), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, CustomDimensions);
             NextStep(false);
         end else begin
-            Telemetry.LogMessage('0000CTI', StrSubstNo(TelemetryAccountFailedtoRegisterLbl, Rec.Connector, GetLastErrorCallStack()), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, CustomDimensions);
+            Telemetry.LogMessage('', StrSubstNo(TelemetryAccountFailedtoRegisterLbl, Rec.Connector, GetLastErrorCallStack()), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, CustomDimensions);
             NextStep(true);
         end;
 

--- a/src/System Application/App/External File Storage/src/Account/FileAccounts.Page.al
+++ b/src/System Application/App/External File Storage/src/Account/FileAccounts.Page.al
@@ -13,7 +13,7 @@ using System.Telemetry;
 page 9450 "File Accounts"
 {
     PageType = List;
-    Caption = 'File Accounts';
+    Caption = 'External File Accounts';
     ApplicationArea = All;
     UsageCategory = Administration;
     SourceTable = "File Account";
@@ -216,7 +216,7 @@ page 9450 "File Accounts"
     var
         FeatureTelemetry: Codeunit "Feature Telemetry";
     begin
-        FeatureTelemetry.LogUptake('0000CTA', 'External File Storage', Enum::"Feature Uptake Status"::Discovered);
+        FeatureTelemetry.LogUptake('', 'External File Storage', Enum::"Feature Uptake Status"::Discovered);
         CanUserManageFileSetup := FileAccountImpl.IsUserFileAdmin();
         Rec.SetCurrentKey("Account Id", Connector);
         UpdateFileAccounts();

--- a/src/System Application/App/External File Storage/src/Account/FileAccounts.Page.al
+++ b/src/System Application/App/External File Storage/src/Account/FileAccounts.Page.al
@@ -216,7 +216,7 @@ page 9450 "File Accounts"
     var
         FeatureTelemetry: Codeunit "Feature Telemetry";
     begin
-        FeatureTelemetry.LogUptake('', 'External File Storage', Enum::"Feature Uptake Status"::Discovered);
+        FeatureTelemetry.LogUptake('0000OPH', 'External File Storage', Enum::"Feature Uptake Status"::Discovered);
         CanUserManageFileSetup := FileAccountImpl.IsUserFileAdmin();
         Rec.SetCurrentKey("Account Id", Connector);
         UpdateFileAccounts();

--- a/src/System Application/App/External File Storage/src/FileStorage/ExternalFileStorage.Codeunit.al
+++ b/src/System Application/App/External File Storage/src/FileStorage/ExternalFileStorage.Codeunit.al
@@ -11,7 +11,7 @@ codeunit 9454 "External File Storage"
         ExternalFileStorageImpl: Codeunit "External File Storage Impl.";
 
     /// <summary>
-    /// Initialized the File Storage for the given scenario.
+    /// Initializes the File Storage for the given scenario.
     /// </summary>
     /// <param name="Scenario">File Scenario to use.</param>
     procedure Initialize(Scenario: Enum "File Scenario")
@@ -20,7 +20,7 @@ codeunit 9454 "External File Storage"
     end;
 
     /// <summary>
-    /// Initialized the File Storage for the give file account.
+    /// Initializes the File Storage for the give file account.
     /// </summary>
     /// <param name="TempFileAccount"> File Account to use.</param>
     procedure Initialize(TempFileAccount: Record "File Account" temporary)

--- a/src/System Application/App/External File Storage/src/FileStorage/ExternalFileStorageImpl.Codeunit.al
+++ b/src/System Application/App/External File Storage/src/FileStorage/ExternalFileStorageImpl.Codeunit.al
@@ -5,6 +5,8 @@
 
 namespace System.ExternalFileStorage;
 
+using System.Telemetry;
+
 codeunit 9455 "External File Storage Impl."
 {
     Access = Internal;
@@ -19,6 +21,7 @@ codeunit 9455 "External File Storage Impl."
     procedure Initialize(Scenario: Enum "File Scenario")
     var
         TempFileAccount: Record "File Account" temporary;
+        FeatureTelemetry: Codeunit "Feature Telemetry";
         FileScenarioMgt: Codeunit "File Scenario";
         NoFileAccountFoundErr: Label 'No default file account defined.';
     begin
@@ -26,6 +29,8 @@ codeunit 9455 "External File Storage Impl."
             Error(NoFileAccountFoundErr);
 
         Initialize(TempFileAccount);
+
+        FeatureTelemetry.LogUptake('', 'External File Storage', Enum::"Feature Uptake Status"::Used);
     end;
 
     procedure Initialize(TempFileAccount: Record "File Account" temporary)

--- a/src/System Application/App/External File Storage/src/FileStorage/ExternalFileStorageImpl.Codeunit.al
+++ b/src/System Application/App/External File Storage/src/FileStorage/ExternalFileStorageImpl.Codeunit.al
@@ -30,7 +30,7 @@ codeunit 9455 "External File Storage Impl."
 
         Initialize(TempFileAccount);
 
-        FeatureTelemetry.LogUptake('', 'External File Storage', Enum::"Feature Uptake Status"::Used);
+        FeatureTelemetry.LogUptake('0000OPO', 'External File Storage', Enum::"Feature Uptake Status"::Used);
     end;
 
     procedure Initialize(TempFileAccount: Record "File Account" temporary)

--- a/src/System Application/App/External File Storage/src/Lookup/StorageBrowser.Page.al
+++ b/src/System Application/App/External File Storage/src/Lookup/StorageBrowser.Page.al
@@ -7,7 +7,7 @@ namespace System.ExternalFileStorage;
 
 page 9455 "Storage Browser"
 {
-    Caption = 'Storage Browser';
+    Caption = 'External Storage Browser';
     PageType = List;
     ApplicationArea = All;
     SourceTable = "File Account Content";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
- We should update the terminology to clearly indicate, that this module is for setting up external storage accounts.
- Feature uptake telemetry was incomplete and the tags from the email module were reused.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes AB#564483
