### PR TITLE
[main] Update BCArtifact version. New value: 26.0.30142.0

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -5,7 +5,7 @@
   "runs-on": "windows-latest",
   "cacheImageName": "",
   "UsePsSession": false,
-  "artifact": "https://bcinsider-fvh2ekdjecfjd6gk.b02.azurefd.net/sandbox/26.0.30098.0/base",
+  "artifact": "https://bcinsider-fvh2ekdjecfjd6gk.b02.azurefd.net/sandbox/26.0.30142.0/base",
   "country": "base",
   "useProjectDependencies": true,
   "repoVersion": "26.0",


### PR DESCRIPTION
This PR contains the following changes:
- Update BCArtifact version. New value: 26.0.30142.0

[AB#539394](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/539394)


