### PR TITLE
Retention Policy: Convert total number of deleted records to BigInteger

### DIFF
--- a/src/System Application/App/Retention Policy/src/Apply Retention Policy/ApplyRetentionPolicyImpl.Codeunit.al
+++ b/src/System Application/App/Retention Policy/src/Apply Retention Policy/ApplyRetentionPolicyImpl.Codeunit.al
@@ -19,7 +19,7 @@ codeunit 3904 "Apply Retention Policy Impl."
     Permissions = tabledata AllObjWithCaption = r;
 
     var
-        TotalNumberOfRecordsDeleted: Integer;
+        TotalNumberOfRecordsDeleted: BigInteger;
         EndCurrentRun: Boolean;
         ApplyAllRetentionPolicies: Boolean;
         IsUserInvokedRun: Boolean;
@@ -222,7 +222,7 @@ codeunit 3904 "Apply Retention Policy Impl."
         RecordRefDuplicate: RecordRef;
         RetenPolDeleting: Interface "Reten. Pol. Deleting";
         Handled: Boolean;
-        NumberOfRecordsDeleted: Integer;
+        NumberOfRecordsDeleted: BigInteger;
         RecordCountBefore: Integer;
         RecordCountAfter: Integer;
     begin
@@ -427,12 +427,12 @@ codeunit 3904 "Apply Retention Policy Impl."
         exit(RetentionPolicyLogCategory::"Retention Policy - Apply");
     end;
 
-    internal procedure MaxNumberOfRecordsToDelete(): Integer
+    internal procedure MaxNumberOfRecordsToDelete(): BigInteger
     begin
         exit(10000)
     end;
 
-    internal procedure NumberOfRecordsToDeleteBuffer(): Integer
+    internal procedure NumberOfRecordsToDeleteBuffer(): BigInteger
     begin
         exit(0)
     end;

--- a/src/System Application/App/Retention Policy/src/Apply Retention Policy/RetenPolDeletingParam.Table.al
+++ b/src/System Application/App/Retention Policy/src/Apply Retention Policy/RetenPolDeletingParam.Table.al
@@ -56,11 +56,13 @@ table 3907 "Reten. Pol. Deleting Param"
         /// <summary>
         /// Indicates the maximum number of records to be deleted.
         /// </summary>
+#pragma warning disable AS0004
         field(4; "Max. Number of Rec. to Delete"; BigInteger)
         {
             DataClassification = SystemMetadata;
             MinValue = 0;
         }
+#pragma warning restore AS0004
         /// <summary>
         /// if set to true the event OnApplyRetentionPolicyRecordLimitExceeded will not be raised.
         /// </summary>
@@ -71,11 +73,13 @@ table 3907 "Reten. Pol. Deleting Param"
         /// <summary>
         /// Indicates the maximum number of records that can be deleted at the same time across all retention policies
         /// </summary>
+#pragma warning disable AS0004
         field(6; "Total Max. Nr. of Rec. to Del."; BigInteger)
         {
             DataClassification = SystemMetadata;
             MinValue = 0;
         }
+#pragma warning restore AS0004
         /// <summary>
         /// If true, indicates that user is applying the retention policies manually.
         /// If false, the retention policies are applied by a scheduled task.
@@ -88,10 +92,12 @@ table 3907 "Reten. Pol. Deleting Param"
         /// The number of records in the table before the deletion.
         /// The count is calculated once before passing this table to the deletion implementation and is used to limit the number of records to be deleted as well as record the number of records actually deleted.
         /// </summary>
+#pragma warning disable AS0004
         field(8; "Record Count Before Delete"; BigInteger)
         {
             DataClassification = SystemMetadata;
         }
+#pragma warning restore AS0004
     }
 
     keys

--- a/src/System Application/App/Retention Policy/src/Apply Retention Policy/RetenPolDeletingParam.Table.al
+++ b/src/System Application/App/Retention Policy/src/Apply Retention Policy/RetenPolDeletingParam.Table.al
@@ -56,7 +56,7 @@ table 3907 "Reten. Pol. Deleting Param"
         /// <summary>
         /// Indicates the maximum number of records to be deleted.
         /// </summary>
-        field(4; "Max. Number of Rec. to Delete"; Integer)
+        field(4; "Max. Number of Rec. to Delete"; BigInteger)
         {
             DataClassification = SystemMetadata;
             MinValue = 0;
@@ -69,9 +69,9 @@ table 3907 "Reten. Pol. Deleting Param"
             DataClassification = SystemMetadata;
         }
         /// <summary>
-        /// Indicates the maximum number of records that can be deleted at the same time accross all retention policies
+        /// Indicates the maximum number of records that can be deleted at the same time across all retention policies
         /// </summary>
-        field(6; "Total Max. Nr. of Rec. to Del."; Integer)
+        field(6; "Total Max. Nr. of Rec. to Del."; BigInteger)
         {
             DataClassification = SystemMetadata;
             MinValue = 0;
@@ -88,7 +88,7 @@ table 3907 "Reten. Pol. Deleting Param"
         /// The number of records in the table before the deletion.
         /// The count is calculated once before passing this table to the deletion implementation and is used to limit the number of records to be deleted as well as record the number of records actually deleted.
         /// </summary>
-        field(8; "Record Count Before Delete"; Integer)
+        field(8; "Record Count Before Delete"; BigInteger)
         {
             DataClassification = SystemMetadata;
         }

--- a/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Table.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Table.al
@@ -148,7 +148,7 @@ table 3901 "Retention Policy Setup"
         {
             DataClassification = SystemMetadata;
         }
-        field(100; "Number Of Records Deleted"; Integer)
+        field(100; "Number Of Records Deleted"; BigInteger)
         {
             DataClassification = SystemMetadata;
             Access = Internal;

--- a/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Table.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Table.al
@@ -148,12 +148,14 @@ table 3901 "Retention Policy Setup"
         {
             DataClassification = SystemMetadata;
         }
+#pragma warning disable AS0004
         field(100; "Number Of Records Deleted"; BigInteger)
         {
             DataClassification = SystemMetadata;
             Access = Internal;
             Editable = false;
         }
+#pragma warning restore AS0004
     }
 
     keys


### PR DESCRIPTION
In some very rare cases, we delete more entries than can be stored in an Integer, hence I'm upgrading all the deletion fields to BigInteger to make us future proof.

Fixes [AB#562945](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/562945)



