### PR TITLE
[Feature Management] Fix test to be able to remove the Feature Key SAFTAuditFileExport

### DIFF
--- a/src/System Application/Test/Feature Key/src/FeatureKeyTest.Codeunit.al
+++ b/src/System Application/Test/Feature Key/src/FeatureKeyTest.Codeunit.al
@@ -364,7 +364,8 @@ codeunit 135003 "Feature Key Test"
             FeatureManagement.EnabledFor.Value(Format(FeatureKey.Enabled::"All Users"));
             // [THEN] "Feature Status" is 'Enabled'
             FeatureManagement.DataUpdateStatus.AssertEquals("Feature Status"::Enabled);
-        end;
+        end else
+            if Confirm('dummy confirm') then;
     end;
 
     [Test]


### PR DESCRIPTION
The feature key SAFTAuditFileExport must be removed, but the test T009_EnableOneWayFeatureThatDoesNotRequireDataUpdate fails in platform repository when the key is removed.
Test must be fixed before the key is removed.

Test fails when there are no FeatureKey records with specific field values were not found. The error is: "The following UI handlers were not executed: ConfirmYesHandler"
I added dummy confirm to prevent such failure.
Fixes [AB#564916](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/564916)

