### PR TITLE
Remove ability to expose a Microsoft page as a SOAP endpoint

### DIFF
--- a/src/System Application/App/Feature Key/permissions/FeatureKeyView.PermissionSet.al
+++ b/src/System Application/App/Feature Key/permissions/FeatureKeyView.PermissionSet.al
@@ -10,7 +10,7 @@ namespace System.Environment.Configuration;
 /// </summary>
 permissionset 2612 "Feature Key - View"
 {
-    Access = Internal;
+    Access = Public;
     Assignable = false;
 
     IncludedPermissionSets = "Feature Key - Read",

--- a/src/System Application/App/Web Service Management/app.json
+++ b/src/System Application/App/Web Service Management/app.json
@@ -16,6 +16,12 @@
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
       "version": "26.0.0.0"
+    },
+    {
+      "id": "ae59aed1-040c-453c-9585-fe9da2f8211e",
+      "name": "Feature Key",
+      "publisher": "Microsoft",
+      "version": "26.0.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Web Service Management/permissions/WebServiceManagementAdmin.Permissionset.al
+++ b/src/System Application/App/Web Service Management/permissions/WebServiceManagementAdmin.Permissionset.al
@@ -4,13 +4,15 @@
 // ------------------------------------------------------------------------------------------------
 
 namespace System.Integration;
+using System.Environment.Configuration;
 
 permissionset 6712 "Web Service Management - Admin"
 {
     Access = Public;
     Assignable = false;
 
-    IncludedPermissionSets = "Web Service Management - View";
+    IncludedPermissionSets = "Web Service Management - View",
+                             "Feature Key - View";
 
     Permissions = tabledata "Tenant Web Service" = IMD,
                   tabledata "Tenant Web Service Columns" = IMD,

--- a/src/System Application/App/Web Service Management/permissions/WebServiceManagementRead.Permissionset.al
+++ b/src/System Application/App/Web Service Management/permissions/WebServiceManagementRead.Permissionset.al
@@ -6,6 +6,7 @@
 namespace System.Integration;
 
 using System.Reflection;
+using System.Apps;
 using System.Environment.Configuration;
 
 permissionset 6710 "Web Service Management - Read"
@@ -18,6 +19,7 @@ permissionset 6710 "Web Service Management - Read"
     Permissions = tabledata AllObj = r,
                   tabledata AllObjWithCaption = r,
                   tabledata Field = r,
+                  tabledata "Published Application" = r,
                   tabledata "Record Link" = R,
                   tabledata "Tenant Web Service" = R,
                   tabledata "Tenant Web Service Columns" = R,

--- a/src/System Application/App/Web Service Management/src/WebServiceManagementImpl.Codeunit.al
+++ b/src/System Application/App/Web Service Management/src/WebServiceManagementImpl.Codeunit.al
@@ -6,7 +6,7 @@
 namespace System.Integration;
 
 using System;
-#if not CLEAN29
+#if not CLEAN26
 using System.Environment.Configuration;
 #endif
 using System.Apps;
@@ -42,7 +42,7 @@ codeunit 9751 "Web Service Management Impl."
         TenantWebServiceDeletedTxt: Label 'Tenant Web Service Deleted', Locked = true;
         ODataUnboundActionHelpUrlLbl: Label 'https://go.microsoft.com/fwlink/?linkid=2138827', Locked = true;
         MicrosoftPublisherLbl: Label 'Microsoft', Locked = true;
-#if not CLEAN29
+#if not CLEAN26
         DisableSoapWebServicesOnMicrosoftUIPagesTok: Label 'DisableSOAPwebservicesonMicrosoftUIpages', Locked = true;
 #endif
 
@@ -181,11 +181,11 @@ codeunit 9751 "Web Service Management Impl."
     var
         AllObj: Record AllObj;
         PublishedApplication: Record "Published Application";
-#if not CLEAN29
+#if not CLEAN26
         FeatureManagementFacade: Codeunit "Feature Management Facade";
 #endif
     begin
-#if not CLEAN29
+#if not CLEAN26
         if not FeatureManagementFacade.IsEnabled(DisableSoapWebServicesOnMicrosoftUIPagesTok) then
             exit(false);
 #endif

--- a/src/System Application/App/Web Service Management/src/WebServiceManagementImpl.Codeunit.al
+++ b/src/System Application/App/Web Service Management/src/WebServiceManagementImpl.Codeunit.al
@@ -20,6 +20,7 @@ codeunit 9751 "Web Service Management Impl."
     Permissions = tabledata AllObj = r,
                   tabledata AllObjWithCaption = r,
                   tabledata Field = r,
+                  tabledata "Published Application" = r,
                   tabledata "Tenant Web Service" = rimd,
                   tabledata "Web Service" = rimd,
                   tabledata "Tenant Web Service Columns" = imd,

--- a/src/System Application/Test/Web Service Management/src/WebServiceManagementTest.Codeunit.al
+++ b/src/System Application/Test/Web Service Management/src/WebServiceManagementTest.Codeunit.al
@@ -50,7 +50,11 @@ codeunit 139043 "Web Service Management Test"
         if WebServiceAggregate.Get(WebService."Object Type"::Page, PageServiceTxt) then begin
             VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::ODataV3), PageServiceTxt);
             VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::ODataV4), PageServiceTxt);
+#if not CLEAN26            
+            VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::SOAP), PageServiceTxt);
+#else
             VerifyUrlMissingServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::SOAP), PageServiceTxt);
+#endif
         end;
 
         if WebServiceAggregate.Get(WebService."Object Type"::Query, QueryServiceTxt) then begin
@@ -68,7 +72,9 @@ codeunit 139043 "Web Service Management Test"
         if WebServiceAggregate.Get(WebService."Object Type"::Page, UnpublishedPageTxt) then begin
             Assert.AreEqual('', WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::ODataV3), 'ODataV3 Url should be empty when not published: ' + CodeunitServiceTxt);
             Assert.AreEqual('', WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::ODataV4), 'ODataV4 Url should be empty when not published: ' + CodeunitServiceTxt);
+#if not CLEAN26
             Assert.AreEqual('', WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::SOAP), 'SOAP Url should be empty when not published: ' + CodeunitServiceTxt);
+#endif
         end;
     end;
 
@@ -126,14 +132,22 @@ codeunit 139043 "Web Service Management Test"
         if WebServiceAggregate.Get(WebService."Object Type"::Page, PageATxt) then begin
             VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::ODataV3), PageATxt);
             VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::ODataV4), PageATxt);
+#if not CLEAN26
+            VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::SOAP), PageATxt);
+#else
             VerifyUrlMissingServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::SOAP), PageATxt);
+#endif
             Assert.IsTrue(WebServiceAggregate.Published, PageATxt + ' web service record "Published" field should be checked.');
         end;
 
         if WebServiceAggregate.Get(WebService."Object Type"::Page, PageBTxt) then begin
             VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::ODataV3), PageBTxt);
             VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::ODataV4), PageBTxt);
+#if not CLEAN26
             VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::SOAP), PageBTxt);
+#else
+            VerifyUrlMissingServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::SOAP), PageBTxt);
+#endif
             Assert.IsTrue(WebServiceAggregate.Published, PageBTxt + ' web service record "Published" field should be checked.');
         end;
     end;
@@ -234,40 +248,6 @@ codeunit 139043 "Web Service Management Test"
         Assert.AreEqual(PAGE::"Dummy Page", TenantWebService."Object ID", AutoServiceName + ' incorrect object ID');
         Assert.AreEqual(AutoServiceName, TenantWebService."Service Name", AutoServiceName + ' incorrect service name');
         Assert.IsTrue(TenantWebService.Published, AutoServiceName + ' should be published');
-    end;
-
-    [Test]
-    [Scope('OnPrem')]
-    procedure TestInsertDuplicateServiceName()
-    var
-        TempWebServiceAggregate: Record "Web Service Aggregate" temporary;
-        Any: Codeunit Any;
-        AutoServiceName: Text[240];
-    begin
-        PermissionsMock.Set('Web Service Admin');
-
-        Initialize();
-        // Test that adding a new web service with the same Object Type and Service Name as an existing record
-        // (system or tenant record) will result in a duplicate service error.
-        AutoServiceName := Any.GuidValue();
-
-        TempWebServiceAggregate.Init();
-        TempWebServiceAggregate."Object Type" := TempWebServiceAggregate."Object Type"::Codeunit;
-        TempWebServiceAggregate."Object ID" := Codeunit::"Dummy Codeunit";
-        TempWebServiceAggregate."Service Name" := AutoServiceName;
-        TempWebServiceAggregate."All Tenants" := true;
-        TempWebServiceAggregate.Published := true;
-        TempWebServiceAggregate.Insert(true);
-
-        TempWebServiceAggregate.Init();
-        TempWebServiceAggregate."Object Type" := TempWebServiceAggregate."Object Type"::Codeunit;
-        TempWebServiceAggregate."Object ID" := Codeunit::"Dummy Codeunit";
-        TempWebServiceAggregate."Service Name" := AutoServiceName;
-        TempWebServiceAggregate."All Tenants" := false;
-        TempWebServiceAggregate.Published := true;
-
-        asserterror TempWebServiceAggregate.Insert(true);
-        Assert.ExpectedError('The web service cannot be added because it conflicts with an unpublished system web service for the object.');
     end;
 
     [Test]

--- a/src/System Application/Test/Web Service Management/src/WebServiceManagementTest.Codeunit.al
+++ b/src/System Application/Test/Web Service Management/src/WebServiceManagementTest.Codeunit.al
@@ -50,7 +50,7 @@ codeunit 139043 "Web Service Management Test"
         if WebServiceAggregate.Get(WebService."Object Type"::Page, PageServiceTxt) then begin
             VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::ODataV3), PageServiceTxt);
             VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::ODataV4), PageServiceTxt);
-            VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::SOAP), PageServiceTxt);
+            VerifyUrlMissingServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::SOAP), PageServiceTxt);
         end;
 
         if WebServiceAggregate.Get(WebService."Object Type"::Query, QueryServiceTxt) then begin
@@ -126,7 +126,7 @@ codeunit 139043 "Web Service Management Test"
         if WebServiceAggregate.Get(WebService."Object Type"::Page, PageATxt) then begin
             VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::ODataV3), PageATxt);
             VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::ODataV4), PageATxt);
-            VerifyUrlHasServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::SOAP), PageATxt);
+            VerifyUrlMissingServiceName(WebServiceManagement.GetWebServiceUrl(WebServiceAggregate, ClientType::SOAP), PageATxt);
             Assert.IsTrue(WebServiceAggregate.Published, PageATxt + ' web service record "Published" field should be checked.');
         end;
 
@@ -252,16 +252,16 @@ codeunit 139043 "Web Service Management Test"
         AutoServiceName := Any.GuidValue();
 
         TempWebServiceAggregate.Init();
-        TempWebServiceAggregate."Object Type" := TempWebServiceAggregate."Object Type"::Page;
-        TempWebServiceAggregate."Object ID" := Page::"Dummy Page";
+        TempWebServiceAggregate."Object Type" := TempWebServiceAggregate."Object Type"::Codeunit;
+        TempWebServiceAggregate."Object ID" := Codeunit::"Dummy Codeunit";
         TempWebServiceAggregate."Service Name" := AutoServiceName;
         TempWebServiceAggregate."All Tenants" := true;
         TempWebServiceAggregate.Published := true;
         TempWebServiceAggregate.Insert(true);
 
         TempWebServiceAggregate.Init();
-        TempWebServiceAggregate."Object Type" := TempWebServiceAggregate."Object Type"::Page;
-        TempWebServiceAggregate."Object ID" := Page::"Dummy Page2";
+        TempWebServiceAggregate."Object Type" := TempWebServiceAggregate."Object Type"::Codeunit;
+        TempWebServiceAggregate."Object ID" := Codeunit::"Dummy Codeunit";
         TempWebServiceAggregate."Service Name" := AutoServiceName;
         TempWebServiceAggregate."All Tenants" := false;
         TempWebServiceAggregate.Published := true;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
When the feature key `DisableSOAPwebservicesonMicrosoftUIpages` is on, it's no longer possible to expose a Microsoft page as a SOAP endpoint. Starting version 29.0 it will be on by default. 

This PR shows the endpoints as "Not applicable" for these pages when the feature key is on.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#566342](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/566342)







