### PR TITLE
Updated Warning No Field of No Series Line table

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesLine.Table.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesLine.Table.al
@@ -64,7 +64,8 @@ table 309 "No. Series Line"
             var
                 NoSeriesSetup: Codeunit "No. Series - Setup";
             begin
-                TestField("Ending No.");
+                if "Warning No." <> '' then
+                    TestField("Ending No.");
                 NoSeriesSetup.UpdateNoSeriesLine(Rec, "Warning No.", CopyStr(FieldCaption("Warning No."), 1, 100));
             end;
         }


### PR DESCRIPTION
When the No. Series "Warning No." field is set to empty, we don't need to validate that "Ending No." is set. It should always be possible to remove the "Warning No.".

Fixes [AB#563048](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/563048)




