### PR TITLE
[26.x] Update app baselines package version. New value: 26.0.30643.30657 (+ 1 more update(s))

### DIFF
--- a/build/Packages.json
+++ b/build/Packages.json
@@ -1,10 +1,10 @@
 {
   "Microsoft.Dynamics.BusinessCentral.Translations": {
-    "Version": "26.0.20250217.3",
+    "Version": "26.0.20250224.2",
     "Source": "NuGet.org"
   },
   "AppBaselines-BCArtifacts": {
-    "Version": "25.5.30256.0",
+    "Version": "26.0.30643.30657",
     "Source": "BCArtifacts",
     "_comment": "Used to fetch app baselines from BC artifacts"
   }


### PR DESCRIPTION
This PR contains the following changes:
- Update app baselines package version. New value: 26.0.30643.30657
- Update translation package version. New value: 26.0.20250224.2

AB#539394