### PR TITLE
[releases/25.1] Update AL-Go System Files from microsoft/AL-Go-PTE@preview -  e827ae84eaf295b7b71212b99d0d1a52b996f84a / Related to AB#539394

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -92,7 +92,7 @@
     ]
   },
   "UpdateALGoSystemFilesEnvironment": "Official-Build",
-  "templateSha": "b637e79b7209c4b6e42696e1efdb066a0a25f3fb",
+  "templateSha": "e827ae84eaf295b7b71212b99d0d1a52b996f84a",
   "commitOptions": {
     "messageSuffix": "Related to AB#539394",
     "pullRequestAutoMerge": true,

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -2,6 +2,46 @@
 
 Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.
 
+### Deprecations
+
+- `alwaysBuildAllProjects` will be removed after October 1st 2025. Please set the `onPull_Request` property of the `incrementalBuilds` setting to false to force full builds in Pull Requests.
+- `<workflow>Schedule` will be removed after October 1st 2025. The old setting, where the setting key was a combination of the workflow name and `Schedule` (dynamic setting key name) is deprecated. Instead you need to use a setting called [workflowSchedule](https://aka.ms/algosettings#workflowSchedule) and either use [Conditional Settings](https://aka.ms/algosettings#conditional-settings) or place the setting in a workflow specific settings file.
+
+### Issues
+
+- Issue 1433 Publish to Environment - DependencyInstallMode not found
+- Issue 1440 Create Release fails due to recent changes to the AL-Go
+- Issue 1330 CompilerFolder doesn't transfer installed Apps to NuGet resolution
+- Issue 1268 Do not throw an un-understandable error during nuGet download
+- Performance test sample code in 25.4 contains objects with ID 149201 and 149202, which are not renumbered
+
+### New Workflow specific settings
+
+- `workflowSchedule` - can be structure with a property named `cron`, which must be a valid crontab, defining the CRON schedule for when the specified workflow should run. Default is no scheduled runs, only manual triggers. Build your crontab string here: [https://crontab.guru](https://crontab.guru). You need to run the Update AL-Go System Files workflow for the schedule to take effect.<br/>**Note:** If you configure a WorkflowSchedule for the CI/CD workflow, AL-Go will stop triggering CICDs on push unless you have also added CICDPushBranches to your settings.<br/>**Note also:** If you define a schedule for Update AL-Go System Files, it uses direct Commit instead of creating a PR.
+- `workflowConcurrency` - is used to control concurrency of workflows. Like with the `workflowSchedule` setting, this setting should be applied in workflow specific settings files or conditional settings. By default, all workflows allows for concurrency, except for the Create Release workflow. If you are using incremental builds in CI/CD it is also recommented to set WorkflowConcurrency to:<br/>`[ "group: ${{ github.workflow }}-${{ github.ref }}", "cancel-in-progress: true" ]`<br />in order to cancel prior incremental builds on the same branch.<br />Read more about workflow concurrency [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs).
+
+### New Repository Settings
+
+- `deployTo<environment>` now has two additional properties:
+  - `includeTestAppsInSandboxEnvironment`, which deploys test apps and their dependencies to the specified sandbox environment if set to `true`. Deployment will fail if used on a Prod environment or if the test app has a dependency on Tests-TestLibraries. Default value is `false`.
+  - `excludeAppIds`, which is an array of app ids which will be excluded from deployment. Default value is `[]`
+- `incrementalBuilds` - is a structure defining how you want AL-Go to handle incremental builds. When using incremental builds for a build, AL-Go will look for the latest successful build, newer than the defined `retentionDays` and only rebuild projects or apps (based on `mode`) which needs to be rebuilt. Properties in the structure includes:
+  - `onPush` - set this property to **true** in order to enable incremental builds in CI/CD triggered by a merge/push event. Default is **false**.
+  - `onPull_Request` - set this property to **false** in order to disable incremental builds in Pull Request workflows. Default is **true**.
+  - `onSchedule` - set this property to **true** in order to enable incremental builds in CI/CD when running on a schedule. Default is **false**.
+  - `retentionDays` - number of days a successful build is good (and can be used for incremental builds). Default is **30**.
+  - `mode` - defines the mode for incremental builds. Currently, two values are supported. Use **modifiedProjects** when you want to rebuild all apps in modified projects and depending projects or **modifiedApps** if you only want to rebuild modified apps and depending apps.
+
+> [!NOTE]
+> The projects mentioned here are AL-Go projects in a multi-project repository. A repository can contain multiple projects and a project can contain multiple apps.
+
+### Support for incremental builds
+
+AL-Go for GitHub now supports incremental builds, which means that unchanged projects or apps will be reused from the previous good build. Read [this](https://aka.ms/algosettings#incrementalBuilds) to learn more.
+
+> [!NOTE]
+> When using incremental builds it is recommended to also set `workflowConcurrency` as defined [here](https://aka.ms/algosettings#workflowConcurrency).
+
 ### Support for GitHub App authentication
 
 AL-Go for GitHub now supports using a GitHub App specification as the GhTokenWorkflow secret for a more secure way of allowing repositories to run Update AL-Go System Files and other workflows which are creating commits and pull requests. See [this description](https://github.com/microsoft/AL-Go/blob/main/Scenarios/GhTokenWorkflow.md) to learn how to use GitHub App authentication.
@@ -152,7 +192,7 @@ In the summary after a Test Run, you now also have the result of performance tes
 ### Support Ubuntu runners for all AL-Go workflows
 
 Previously, the workflows "Update AL-Go System Files" and "TroubleShooting" were hardcoded to always run on `windows-latest` to prevent deadlocks and security issues.
-From now on, `ubuntu-lates` will also be allowed for these mission critical workflows, when changing the `runs-on` setting. Additionally, only the value `pwsh` for `shell` setting is allowed when using `ubuntu-latest` runners.
+From now on, `ubuntu-latest` will also be allowed for these mission critical workflows, when changing the `runs-on` setting. Additionally, only the value `pwsh` for `shell` setting is allowed when using `ubuntu-latest` runners.
 
 ### Updated AL-Go telemetry
 
@@ -645,7 +685,7 @@ In the latest version, we always use LF as line seperator, UTF8 without BOM and 
 ### Experimental Support
 
 Setting the repo setting "shell" to "pwsh", followed by running Update AL-Go System Files, will cause all PowerShell code to be run using PowerShell 7 instead of PowerShell 5. This functionality is experimental. Please report any issues at https://github.com/microsoft/AL-Go/issues
-Setting the repo setting "runs-on" to "Ubuntu-Latest", followed by running Update AL-Go System Files, will cause all non-build jobs to run using Linux. This functionality is experimental. Please report any issues at https://github.com/microsoft/AL-Go/issues
+Setting the repo setting "runs-on" to "Ubuntu-latest", followed by running Update AL-Go System Files, will cause all non-build jobs to run using Linux. This functionality is experimental. Please report any issues at https://github.com/microsoft/AL-Go/issues
 
 ## v2.2
 

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -39,13 +39,16 @@ jobs:
       githubRunner: ${{ steps.ReadSettings.outputs.GitHubRunnerJson }}
       githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
       projects: ${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}
+      skippedProjects: ${{ steps.determineProjectsToBuild.outputs.SkippedProjectsJson }}
       projectDependenciesJson: ${{ steps.determineProjectsToBuild.outputs.ProjectDependenciesJson }}
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
-      powerPlatformSolutionFolder: ${{ steps.DeterminePowerPlatformSolutionFolder.outputs.powerPlatformSolutionFolder }}
+      baselineWorkflowRunId: ${{ steps.determineProjectsToBuild.outputs.BaselineWorkflowRunId }}
+      baselineWorkflowSHA: ${{ steps.determineProjectsToBuild.outputs.BaselineWorkflowSHA }}
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
+      powerPlatformSolutionFolder: ${{ steps.DeterminePowerPlatformSolutionFolder.outputs.powerPlatformSolutionFolder }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
 
@@ -56,13 +59,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           get: type,powerPlatformSolutionFolder,useGitSubmodules
@@ -70,7 +73,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go/Actions/ReadSecrets@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -91,7 +94,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -104,7 +107,7 @@ jobs:
 
       - name: Determine Delivery Target Secrets
         id: DetermineDeliveryTargetSecrets
-        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
@@ -112,7 +115,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -120,7 +123,7 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -130,7 +133,7 @@ jobs:
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -146,13 +149,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           get: templateUrl
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           templateUrl: ${{ env.templateUrl }}
@@ -174,7 +177,10 @@ jobs:
       project: ${{ matrix.project }}
       projectName: ${{ matrix.projectName }}
       buildMode: ${{ matrix.buildMode }}
+      skippedProjectsJson: ${{ needs.Initialization.outputs.skippedProjects }}
       projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+      baselineWorkflowRunId: ${{ needs.Initialization.outputs.baselineWorkflowRunId }}
+      baselineWorkflowSHA: ${{ needs.Initialization.outputs.baselineWorkflowSHA }}
       secrets: 'licenseFileUrl,codeSignCertificateUrl,*codeSignCertificatePassword,keyVaultCertificateUrl,*keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext,applicationInsightsConnectionString'
       signArtifacts: true
       useArtifactCache: true
@@ -195,7 +201,10 @@ jobs:
       project: ${{ matrix.project }}
       projectName: ${{ matrix.projectName }}
       buildMode: ${{ matrix.buildMode }}
+      skippedProjectsJson: ${{ needs.Initialization.outputs.skippedProjects }}
       projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+      baselineWorkflowRunId: ${{ needs.Initialization.outputs.baselineWorkflowRunId }}
+      baselineWorkflowSHA: ${{ needs.Initialization.outputs.baselineWorkflowSHA }}
       secrets: 'licenseFileUrl,codeSignCertificateUrl,*codeSignCertificatePassword,keyVaultCertificateUrl,*keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext,applicationInsightsConnectionString'
       signArtifacts: true
       useArtifactCache: true
@@ -223,7 +232,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
 
@@ -232,7 +241,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           artifacts: '.artifacts'
@@ -269,7 +278,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
@@ -283,7 +292,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -291,7 +300,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: microsoft/AL-Go/Actions/Deploy@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/Deploy@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -303,7 +312,7 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -331,20 +340,20 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: Deliver
-        uses: microsoft/AL-Go/Actions/Deliver@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/Deliver@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -364,7 +373,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/.github/workflows/DeployReferenceDocumentation.yaml
@@ -30,18 +30,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -54,7 +54,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           artifacts: 'latest'
@@ -71,7 +71,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -45,7 +45,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
 
@@ -54,18 +54,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -73,7 +73,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
-        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -84,7 +84,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -28,7 +28,7 @@ jobs:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
     runs-on: windows-latest
     steps:
-      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
 
   Initialization:
     needs: [ PregateCheck ]
@@ -39,12 +39,13 @@ jobs:
       projectDependenciesJson: ${{ steps.determineProjectsToBuild.outputs.ProjectDependenciesJson }}
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
       baselineWorkflowRunId: ${{ steps.determineProjectsToBuild.outputs.BaselineWorkflowRunId }}
+      baselineWorkflowSHA: ${{ steps.determineProjectsToBuild.outputs.BaselineWorkflowSHA }}
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
       artifactsRetentionDays: ${{ steps.DetermineWorkflowDepth.outputs.ArtifactsRetentionDays }}
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
 
@@ -56,13 +57,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           get: shortLivedArtifactsRetentionDays
@@ -75,7 +76,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -99,9 +100,11 @@ jobs:
       buildMode: ${{ matrix.buildMode }}
       projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
       baselineWorkflowRunId: ${{ needs.Initialization.outputs.baselineWorkflowRunId }}
+      baselineWorkflowSHA: ${{ needs.Initialization.outputs.baselineWorkflowSHA }}
       secrets: 'licenseFileUrl,keyVaultCertificateUrl,*keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext,applicationInsightsConnectionString'
       artifactsRetentionDays: ${{ fromJson(needs.Initialization.outputs.artifactsRetentionDays) }}
       artifactsNameSuffix: 'PR${{ github.event.number }}'
+      useArtifactCache: true
 
   Build:
     needs: [ Initialization, Build1 ]
@@ -122,9 +125,11 @@ jobs:
       buildMode: ${{ matrix.buildMode }}
       projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
       baselineWorkflowRunId: ${{ needs.Initialization.outputs.baselineWorkflowRunId }}
+      baselineWorkflowSHA: ${{ needs.Initialization.outputs.baselineWorkflowSHA }}
       secrets: 'licenseFileUrl,keyVaultCertificateUrl,*keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext,applicationInsightsConnectionString'
       artifactsRetentionDays: ${{ fromJson(needs.Initialization.outputs.artifactsRetentionDays) }}
       artifactsNameSuffix: 'PR${{ github.event.number }}'
+      useArtifactCache: true
 
   StatusCheck:
     needs: [ Initialization, Build ]
@@ -134,7 +139,7 @@ jobs:
     steps:
       - name: Pull Request Status Check
         id: PullRequestStatusCheck
-        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -142,7 +147,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         if: success() || failure()
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/Troubleshooting.yaml
+++ b/.github/workflows/Troubleshooting.yaml
@@ -30,7 +30,7 @@ jobs:
           lfs: true
 
       - name: Troubleshooting
-        uses: microsoft/AL-Go/Actions/Troubleshooting@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/Troubleshooting@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
 
@@ -46,19 +46,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           get: templateUrl
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -94,7 +94,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: powershell
           token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -27,6 +27,11 @@ on:
         description: Friendly name of the built project
         required: true
         type: string
+      skippedProjectsJson:
+        description: An array of AL-Go projects to skip in compressed JSON format
+        required: false
+        default: '[]'
+        type: string
       projectDependenciesJson:
         description: Dependencies of the built project in compressed Json format
         required: false
@@ -40,6 +45,11 @@ on:
         description: ID of the baseline workflow run, from where to download the current project dependencies, in case they are not built in the current workflow run
         required: false
         default: '0'
+        type: string
+      baselineWorkflowSHA:
+        description: SHA of the baseline workflow run
+        required: false
+        default: ''
         type: string
       secrets:
         description: A comma-separated string with the names of the secrets, required for the workflow.
@@ -89,17 +99,26 @@ jobs:
           lfs: true
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
           buildMode: ${{ inputs.buildMode }}
           get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,doNotRunTests,artifact,generateDependencyArtifact,trustedSigning,useGitSubmodules
 
+      - name: Determine whether to build project
+        id: DetermineBuildProject
+        uses: microsoft/AL-Go/Actions/DetermineBuildProject@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        with:
+          shell: ${{ inputs.shell }}
+          skippedProjectsJson: ${{ inputs.skippedProjectsJson }}
+          project: ${{ inputs.project }}
+          baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
+
       - name: Read secrets
         id: ReadSecrets
-        if: github.event_name != 'pull_request'
-        uses: microsoft/AL-Go/Actions/ReadSecrets@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && github.event_name != 'pull_request'
+        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -115,14 +134,15 @@ jobs:
           token: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).gitSubmodulesToken }}'
 
       - name: Determine ArtifactUrl
-        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@b8d327e7c8110b8a19a48d4e84756fd5d9222136
         id: determineArtifactUrl
+        if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
+        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
 
       - name: Cache Business Central Artifacts
-        if: env.useCompilerFolder == 'True' && inputs.useArtifactCache && env.artifactCacheKey
+        if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && env.useCompilerFolder == 'True' && inputs.useArtifactCache && env.artifactCacheKey
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: .artifactcache
@@ -130,18 +150,20 @@ jobs:
 
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
-        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
+        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
           buildMode: ${{ inputs.buildMode }}
-          projectsDependenciesJson: ${{ inputs.projectDependenciesJson }}
+          projectDependenciesJson: ${{ inputs.projectDependenciesJson }}
           baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
 
       - name: Build
-        uses: microsoft/AL-Go/Actions/RunPipeline@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/RunPipeline@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
           BuildMode: ${{ inputs.buildMode }}
@@ -152,11 +174,13 @@ jobs:
           buildMode: ${{ inputs.buildMode }}
           installAppsJson: ${{ steps.DownloadProjectDependencies.outputs.DownloadedApps }}
           installTestAppsJson: ${{ steps.DownloadProjectDependencies.outputs.DownloadedTestApps }}
+          baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
+          baselineWorkflowSHA: ${{ inputs.baselineWorkflowSHA }}
 
       - name: Sign
-        if: inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != ''))
         id: sign
-        uses: microsoft/AL-Go/Actions/Sign@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != ''))
+        uses: microsoft/AL-Go/Actions/Sign@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: ${{ inputs.shell }}
           azureCredentialsJson: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).AZURE_CREDENTIALS }}'
@@ -164,7 +188,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -174,7 +198,7 @@ jobs:
 
       - name: Publish artifacts - apps
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        if: inputs.artifactsRetentionDays >= 0
+        if: inputs.artifactsRetentionDays >= 0 && (hashFiles(format('{0}/.buildartifacts/Apps/*',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.AppsArtifactsName }}
           path: '${{ inputs.project }}/.buildartifacts/Apps/'
@@ -183,7 +207,7 @@ jobs:
 
       - name: Publish artifacts - dependencies
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        if: inputs.artifactsRetentionDays >= 0 && env.generateDependencyArtifact == 'True'
+        if: inputs.artifactsRetentionDays >= 0 && env.generateDependencyArtifact == 'True' && (hashFiles(format('{0}/.buildartifacts/Dependencies/*',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.DependenciesArtifactsName }}
           path: '${{ inputs.project }}/.buildartifacts/Dependencies/'
@@ -192,7 +216,7 @@ jobs:
 
       - name: Publish artifacts - test apps
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        if: inputs.artifactsRetentionDays >= 0
+        if: inputs.artifactsRetentionDays >= 0 && (hashFiles(format('{0}/.buildartifacts/TestApps/*',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.TestAppsArtifactsName }}
           path: '${{ inputs.project }}/.buildartifacts/TestApps/'
@@ -241,7 +265,7 @@ jobs:
 
       - name: Publish artifacts - page scripting test result details
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        if: (success() || failure())
+        if: (success() || failure()) && (hashFiles(format('{0}/.buildartifacts/PageScriptingTestResultDetails/*',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.PageScriptingTestResultDetailsArtifactsName }}
           path: '${{ inputs.project }}/.buildartifacts/PageScriptingTestResultDetails/'
@@ -249,15 +273,15 @@ jobs:
 
       - name: Analyze Test Results
         id: analyzeTestResults
-        if: (success() || failure()) && env.doNotRunTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        if: (success() || failure()) && env.doNotRunTests == 'False' && ((hashFiles(format('{0}/.buildartifacts/TestResults.xml',inputs.project)) != '') || (hashFiles(format('{0}/.buildartifacts/bcptTestResults.json',inputs.project)) != ''))
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
 
       - name: Cleanup
         if: always()
-        uses: microsoft/AL-Go/Actions/PipelineCleanup@b8d327e7c8110b8a19a48d4e84756fd5d9222136
+        uses: microsoft/AL-Go/Actions/PipelineCleanup@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}

--- a/build/projects/Business Foundation/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Business Foundation/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Business Foundation/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Business Foundation/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Performance Toolkit/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Performance Toolkit/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Performance Toolkit/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Performance Toolkit/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Modules/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Modules/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Modules/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Modules/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests (No Isolation)/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Tests (No Isolation)/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests (No Isolation)/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Tests (No Isolation)/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Tests/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Tests/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Stability Tools/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Test Stability Tools/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Stability Tools/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Test Stability Tools/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/b8d327e7c8110b8a19a48d4e84756fd5d9222136/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local


### PR DESCRIPTION
## preview

Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.

### Deprecations

- `alwaysBuildAllProjects` will be removed after October 1st 2025. Please set the `onPull_Request` property of the `incrementalBuilds` setting to false to force full builds in Pull Requests.
- `<workflow>Schedule` will be removed after October 1st 2025. The old setting, where the setting key was a combination of the workflow name and `Schedule` (dynamic setting key name) is deprecated. Instead you need to use a setting called [workflowSchedule](https://aka.ms/algosettings#workflowSchedule) and either use [Conditional Settings](https://aka.ms/algosettings#conditional-settings) or place the setting in a workflow specific settings file.

### Issues

- Issue 1433 Publish to Environment - DependencyInstallMode not found
- Issue 1440 Create Release fails due to recent changes to the AL-Go
- Issue 1330 CompilerFolder doesn't transfer installed Apps to NuGet resolution
- Issue 1268 Do not throw an un-understandable error during nuGet download
- Performance test sample code in 25.4 contains objects with ID 149201 and 149202, which are not renumbered

### New Workflow specific settings

- `workflowSchedule` - can be structure with a property named `cron`, which must be a valid crontab, defining the CRON schedule for when the specified workflow should run. Default is no scheduled runs, only manual triggers. Build your crontab string here: [https://crontab.guru](https://crontab.guru). You need to run the Update AL-Go System Files workflow for the schedule to take effect.<br/>**Note:** If you configure a WorkflowSchedule for the CI/CD workflow, AL-Go will stop triggering CICDs on push unless you have also added CICDPushBranches to your settings.<br/>**Note also:** If you define a schedule for Update AL-Go System Files, it uses direct Commit instead of creating a PR.
- `workflowConcurrency` - is used to control concurrency of workflows. Like with the `workflowSchedule` setting, this setting should be applied in workflow specific settings files or conditional settings. By default, all workflows allows for concurrency, except for the Create Release workflow. If you are using incremental builds in CI/CD it is also recommented to set WorkflowConcurrency to:<br/>`[ "group: ${{ github.workflow }}-${{ github.ref }}", "cancel-in-progress: true" ]`<br />in order to cancel prior incremental builds on the same branch.<br />Read more about workflow concurrency [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs).

### New Repository Settings

- `deployTo<environment>` now has two additional properties:
  - `includeTestAppsInSandboxEnvironment`, which deploys test apps and their dependencies to the specified sandbox environment if set to `true`. Deployment will fail if used on a Prod environment or if the test app has a dependency on Tests-TestLibraries. Default value is `false`.
  - `excludeAppIds`, which is an array of app ids which will be excluded from deployment. Default value is `[]`
- `incrementalBuilds` - is a structure defining how you want AL-Go to handle incremental builds. When using incremental builds for a build, AL-Go will look for the latest successful build, newer than the defined `retentionDays` and only rebuild projects or apps (based on `mode`) which needs to be rebuilt. Properties in the structure includes:
  - `onPush` - set this property to **true** in order to enable incremental builds in CI/CD triggered by a merge/push event. Default is **false**.
  - `onPull_Request` - set this property to **false** in order to disable incremental builds in Pull Request workflows. Default is **true**.
  - `onSchedule` - set this property to **true** in order to enable incremental builds in CI/CD when running on a schedule. Default is **false**.
  - `retentionDays` - number of days a successful build is good (and can be used for incremental builds). Default is **30**.
  - `mode` - defines the mode for incremental builds. Currently, two values are supported. Use **modifiedProjects** when you want to rebuild all apps in modified projects and depending projects or **modifiedApps** if you only want to rebuild modified apps and depending apps.

> [!NOTE]
> The projects mentioned here are AL-Go projects in a multi-project repository. A repository can contain multiple projects and a project can contain multiple apps.

### Support for incremental builds

AL-Go for GitHub now supports incremental builds, which means that unchanged projects or apps will be reused from the previous good build. Read [this](https://aka.ms/algosettings#incrementalBuilds) to learn more.

> [!NOTE]
> When using incremental builds it is recommended to also set `workflowConcurrency` as defined [here](https://aka.ms/algosettings#workflowConcurrency).

### Support for GitHub App authentication

AL-Go for GitHub now supports using a GitHub App specification as the GhTokenWorkflow secret for a more secure way of allowing repositories to run Update AL-Go System Files and other workflows which are creating commits and pull requests. See [this description](https://github.com/microsoft/AL-Go/blob/main/Scenarios/GhTokenWorkflow.md) to learn how to use GitHub App authentication.

### Support for embedded secrets in installApps and installTestApps settings

If your installApps or installTestApps are secure URL, containing a secret token, you can now use a GitHub secret specification as part of or as the full URL of apps to install. An example could be:

`"installApps": [ "https://www.dropbox.com/${{SECRETNAME}}&dl=1" ]`

Which would hide the secret part of your URL instead of exposing it in clear text.

Related to [AB#539394](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/539394)

