### PR TITLE
[VS Code Integration] Fix navigating to System app objects definition

### DIFF
--- a/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
+++ b/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
@@ -18,6 +18,7 @@ codeunit 8333 "VS Code Integration Impl."
         BaseApplicationIdTxt: Label '437dbf0e-84ff-417a-965d-ed2bb9650972', Locked = true;
         SystemApplicationIdTxt: Label '63ca2fa4-4f03-4f2b-a480-172fef340d3f', Locked = true;
         ApplicationIdTxt: Label 'c1335042-3002-4257-bf8a-75c898ccb1b8', Locked = true;
+        SystemIdTxt: Label '8874ed3a-0643-4247-9ced-7a7002f7135d', Locked = true;
         NotSufficientPermissionErr: Label 'You do not have sufficient permissions to interact with the source code of extensions. Please contact your administrator.';
 
     [Scope('OnPrem')]
@@ -137,7 +138,7 @@ codeunit 8333 "VS Code Integration Impl."
     begin
         // Skip System and Base app
         case NavAppInstalledApp."App ID" of
-            SystemApplicationIdTxt, BaseApplicationIdTxt, ApplicationIdTxt:
+            SystemApplicationIdTxt, BaseApplicationIdTxt, ApplicationIdTxt, SystemIdTxt:
                 exit('')
             else
                 AppVersion := FormatDependencyVersion(NavAppInstalledApp."Version Major", NavAppInstalledApp."Version Minor", NavAppInstalledApp."Version Build", NavAppInstalledApp."Version Revision");
@@ -202,11 +203,10 @@ codeunit 8333 "VS Code Integration Impl."
     var
         AllObjWithCaption: Record AllObjWithCaption;
         NavAppInstalledApp: Record "NAV App Installed App";
-        EmptyGuid: Guid;
     begin
         // Objects in the system app range
         if ObjectId >= 2000000000 then
-            exit(EmptyGuid);
+            exit(SystemIdTxt);
 
         if AllObjWithCaption.ReadPermission() then begin
             AllObjWithCaption.SetRange("Object Type", ObjectType);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
When trying to navigate to the source code for objects  belonging to the System app, this would not work. This is because the id was wrongly set.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#548696](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/548696)


