### PR TITLE
[Word Template] Fix unexpected behavior of AddUnrelatedTable

### DIFF
--- a/src/System Application/App/Word Templates/src/WordTemplate.Codeunit.al
+++ b/src/System Application/App/Word Templates/src/WordTemplate.Codeunit.al
@@ -297,16 +297,16 @@ codeunit 9987 "Word Template"
     end;
 
     /// <summary>
-    /// Add unrelated table.
+    /// Adds an unrelated table entry for the specified <paramref name="WordTemplateCode"/>.
     /// </summary>
     /// <param name="WordTemplateCode">The code of an existing parent Word template.</param>
     /// <param name="PrefixCode">The code of the unrelated table to add.</param>
     /// <param name="UnrelatedTableId">The ID of the unrelated table to add.</param>
     /// <param name="RecordSystemId">The system id of the record to add.</param>
-    /// <returns>True if the unrelated table was added, false otherwise.</returns>
+    /// <returns>True if the unrelated table was added; otherwise, false.</returns>
     procedure AddUnrelatedTable(WordTemplateCode: Code[30]; PrefixCode: Code[5]; UnrelatedTableId: Integer; RecordSystemId: Guid): Boolean
     begin
-        WordTemplateImpl.AddUnrelatedTable(WordTemplateCode, PrefixCode, UnrelatedTableId, RecordSystemId);
+        exit(WordTemplateImpl.AddUnrelatedTable(WordTemplateCode, PrefixCode, UnrelatedTableId, RecordSystemId));
     end;
 
     /// <summary>

--- a/src/System Application/App/Word Templates/src/WordTemplateImpl.Codeunit.al
+++ b/src/System Application/App/Word Templates/src/WordTemplateImpl.Codeunit.al
@@ -912,7 +912,9 @@ codeunit 9988 "Word Template Impl."
         WordTemplatesRelatedTable.SetRange("Related Table Code", TableCode);
 
         if not WordTemplatesRelatedTable.IsEmpty() then begin
-            Message(RelatedTableCodeAlreadyUsedMsg);
+            if GuiAllowed() then
+                Message(RelatedTableCodeAlreadyUsedMsg);
+
             exit(false);
         end;
 
@@ -921,9 +923,12 @@ codeunit 9988 "Word Template Impl."
         WordTemplatesRelatedTable.SetRange("Related Table ID", TableId);
 
         if not WordTemplatesRelatedTable.IsEmpty() then begin
-            Message(RelatedTableIdAlreadyUsedMsg);
+            if GuiAllowed() then
+                Message(RelatedTableIdAlreadyUsedMsg);
+
             exit(false);
         end;
+
         exit(true);
     end;
 

--- a/src/System Application/App/Word Templates/src/WordTemplateImpl.Codeunit.al
+++ b/src/System Application/App/Word Templates/src/WordTemplateImpl.Codeunit.al
@@ -942,6 +942,7 @@ codeunit 9988 "Word Template Impl."
             exit(false);
 
         WordTemplatesRelatedTable.Init();
+        WordTemplatesRelatedTable.Code := WordTemplateCode;
         WordTemplatesRelatedTable."Source Record ID" := RecordSystemId;
         WordTemplatesRelatedTable."Related Table ID" := UnrelatedTableId;
         WordTemplatesRelatedTable."Related Table Code" := PrefixCode;

--- a/src/System Application/Test/Word Templates/src/WordTemplatesTest.Codeunit.al
+++ b/src/System Application/Test/Word Templates/src/WordTemplatesTest.Codeunit.al
@@ -91,8 +91,8 @@ codeunit 130443 "Word Templates Test"
         RelatedTableSystemId: Guid;
         Result: Boolean;
     begin
-        // [SCENARIO 3105] Calling AddUnrelatedTable returns false if related table already e
-        i
+        // [SCENARIO 3105] Calling AddUnrelatedTable returns false if related table already exists
+
         // [GIVEN] A Word Template Code
         TemplateCode := Any.AlphabeticText(10);
 

--- a/src/System Application/Test/Word Templates/src/WordTemplatesTest.Codeunit.al
+++ b/src/System Application/Test/Word Templates/src/WordTemplatesTest.Codeunit.al
@@ -24,6 +24,98 @@ codeunit 130443 "Word Templates Test"
         Assert: Codeunit "Library Assert";
 
     [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure AddUnrelatedTable_CreatesRecord()
+    var
+        WordTemplatesRelatedTable: Record "Word Templates Related Table";
+        Any: Codeunit Any;
+        WordTemplate: Codeunit "Word Template";
+        TemplateCode: Code[30];
+        PrefixCode: Code[5];
+        RelatedTableSystemId: Guid;
+    begin
+        // [SCENARIO 3105] Calling AddUnrelatedTable creates a related table record correctly
+
+        // [GIVEN] A Word Template Code
+        TemplateCode := Any.AlphabeticText(10);
+
+        // [GIVEN] A prefix code for the unrelated table
+        PrefixCode := Any.AlphabeticText(5);
+
+        // [GIVEN] A SystemId for the unrelated table record
+        RelatedTableSystemId := CreateGuid();
+
+        // [WHEN] AddUnrelatedTable is called for a specific table and record
+        WordTemplate.AddUnrelatedTable(TemplateCode, PrefixCode, Database::"Word Templates Table", RelatedTableSystemId);
+
+        // [THEN] The related table record is created
+        WordTemplatesRelatedTable.Get(TemplateCode, Database::"Word Templates Table");
+
+        // [THEN] The values match the provided parameters
+        Assert.AreEqual(PrefixCode, WordTemplatesRelatedTable."Related Table Code", WordTemplatesRelatedTable.FieldName("Related Table Code"));
+        Assert.AreEqual(RelatedTableSystemId, WordTemplatesRelatedTable."Source Record ID", WordTemplatesRelatedTable.FieldName("Source Record ID"));
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure AddUnrelatedTable_ReturnsTrue_IfCreated()
+    var
+        WordTemplatesRelatedTable: Record "Word Templates Related Table";
+        Any: Codeunit Any;
+        WordTemplate: Codeunit "Word Template";
+        Result: Boolean;
+    begin
+        // [SCENARIO 3105] Calling AddUnrelatedTable returns true if the record is created
+
+        // [GIVEN] No related table records exist
+        if not WordTemplatesRelatedTable.IsEmpty() then
+            WordTemplatesRelatedTable.DeleteAll(false);
+
+        // [WHEN] AddUnrelatedTable is called with arbitrary table and record id
+        Result := WordTemplate.AddUnrelatedTable(Any.AlphabeticText(10), Any.AlphabeticText(5), Any.IntegerInRange(1, 100), CreateGuid());
+
+        // [THEN] The method result is true
+        Assert.IsTrue(Result, 'Unexpected method return value.');
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure AddUnrelatedTable_ReturnsFalse_IfNotCreated()
+    var
+        WordTemplatesRelatedTable: Record "Word Templates Related Table";
+        Any: Codeunit Any;
+        WordTemplate: Codeunit "Word Template";
+        TemplateCode: Code[30];
+        PrefixCode: Code[5];
+        RelatedTableSystemId: Guid;
+        Result: Boolean;
+    begin
+        // [SCENARIO 3105] Calling AddUnrelatedTable returns false if related table already e
+        i
+        // [GIVEN] A Word Template Code
+        TemplateCode := Any.AlphabeticText(10);
+
+        // [GIVEN] A prefix code for the unrelated table
+        PrefixCode := Any.AlphabeticText(5);
+
+        // [GIVEN] A SystemId for the unrelated table record
+        RelatedTableSystemId := CreateGuid();
+
+        // [GIVEN] The related table already exists
+        WordTemplate.AddUnrelatedTable(TemplateCode, PrefixCode, Database::"Word Templates Table", RelatedTableSystemId);
+
+        // [WHEN] AddUnrelatedTable is called for the same table and record
+        Result := WordTemplate.AddUnrelatedTable(TemplateCode, PrefixCode, Database::"Word Templates Table", RelatedTableSystemId);
+
+        // [THEN] The user is informed that the (un)related table already exists
+        // Verified by MessageHandler
+
+        // [THEN] The method result is false
+        Assert.IsFalse(Result, 'Unexpected method return value.');
+    end;
+
+    [Test]
     procedure TestCreateDocument()
     var
         WordTemplates: Codeunit "Word Template";
@@ -252,5 +344,10 @@ codeunit 130443 "Word Templates Test"
     procedure ConfirmHandlerFalse(Question: Text[1024]; var Reply: Boolean)
     begin
         Reply := false;
+    end;
+
+    [MessageHandler]
+    procedure MessageHandler(Message: Text[1024])
+    begin
     end;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary
This change addresses two issues that were present in the AddUnrelatedTable method.
  1. The result of the implementation method call is returned so that callers know if the record was successfully added.
  2. The "Word Templates Related Table" record that is created has the word template code assigned to it that was provided by the caller.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #3105 
