### PR TITLE
Obsolete IncrementNoText in favor of IncStr

### DIFF
--- a/src/Business Foundation/App/NoSeries/readme_refactoring.md
+++ b/src/Business Foundation/App/NoSeries/readme_refactoring.md
@@ -126,7 +126,7 @@ begin
     if GenJnlBatch."No. Series" <> '' then begin
         NoSeriesManagement.SetNoSeriesLineFilter(NoSeriesLine, GenJnlBatch."No. Series", "Posting Date");
         if NoSeriesLine."Increment-by No." > 1 then
-            NoSeriesManagement.IncrementNoText(LastDocNumber, NoSeriesLine."Increment-by No.")
+            LastDocNumber := IncStr(LastDocNumber, NoSeriesLine."Increment-by No.")
         else
             LastDocNumber := IncStr(LastDocNumber);
     end else

--- a/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Legacy/NoSeriesManagement.Codeunit.al
@@ -340,7 +340,7 @@ codeunit 396 NoSeriesManagement
                 if NoSeriesLine."Increment-by No." <= 1 then
                     NoSeriesLine."Last No. Used" := IncStr(NoSeriesLine."Last No. Used")
                 else
-                    IncrementNoText(NoSeriesLine."Last No. Used", NoSeriesLine."Increment-by No.");
+                    NoSeriesLine."Last No. Used" := IncStr(NoSeriesLine."Last No. Used", NoSeriesLine."Increment-by No.");
 
         // Ensure number is within the valid range
         if (NoSeriesLine."Ending No." <> '') and

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesSetup.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesSetup.Codeunit.al
@@ -24,18 +24,21 @@ codeunit 299 "No. Series - Setup"
         exit(NoSeriesSetupImpl.CalculateOpen(NoSeriesLine))
     end;
 
+#if not CLEAN27
     /// <summary>
     /// Increments the given No. by the specified Increment.
     /// </summary>
     /// <param name="No">The number, as a code string to increment</param>
     /// <param name="Increment">Indicates by how much to increment the No.</param>
     /// <returns>The incremented No.</returns>
+    [Obsolete('Use IncStr(No, Increment) instead.', '27.0')]
     procedure IncrementNoText(No: Code[20]; Increment: Integer): Code[20]
     var
         NoSeriesSetupImpl: Codeunit "No. Series - Setup Impl.";
     begin
         exit(NoSeriesSetupImpl.IncrementNoText(No, Increment));
     end;
+#endif
 
     /// <summary>
     /// Updates the different No. fields in the No. Series Line based on the pattern provided in the NewNo parameter.

--- a/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesSetupImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Setup/NoSeriesSetupImpl.Codeunit.al
@@ -177,7 +177,7 @@ codeunit 305 "No. Series - Setup Impl."
             exit(false);
 
         if NoSeriesLine."Increment-by No." <> 1 then begin
-            NextNo := IncrementNoText(LastNoUsed, NoSeriesLine."Increment-by No.");
+            NextNo := IncStr(LastNoUsed, NoSeriesLine."Increment-by No.");
             if NextNo > NoSeriesLine."Ending No." then
                 exit(false);
             if StrLen(NextNo) > StrLen(NoSeriesLine."Ending No.") then
@@ -220,6 +220,7 @@ codeunit 305 "No. Series - Setup Impl."
                 NoSeries.Validate("Default Nos.", true);
     end;
 
+#if not CLEAN27
     procedure IncrementNoText(No: Code[20]; Increment: Integer): Code[20]
     var
         BigIntNo: BigInteger;
@@ -235,6 +236,7 @@ codeunit 305 "No. Series - Setup Impl."
         ReplaceNoText(No, NewNo, 0, StartPos, EndPos);
         exit(No);
     end;
+#endif
 
     procedure UpdateNoSeriesLine(var NoSeriesLine: Record "No. Series Line"; NewNo: Code[20]; NewFieldCaption: Text[100])
     var

--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesStatelessImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesStatelessImpl.Codeunit.al
@@ -37,8 +37,6 @@ codeunit 306 "No. Series - Stateless Impl." implements "No. Series - Single"
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"No. Series Line", 'm')]
     local procedure GetNextNoInternal(var NoSeriesLine: Record "No. Series Line"; ModifySeries: Boolean; UsageDate: Date; HideErrorsAndWarnings: Boolean): Code[20]
-    var
-        NoSeriesSetup: Codeunit "No. Series - Setup";
     begin
         if NoSeriesLine."Last No. Used" = '' then begin
             if HideErrorsAndWarnings and (NoSeriesLine."Starting No." = '') then
@@ -49,7 +47,7 @@ codeunit 306 "No. Series - Stateless Impl." implements "No. Series - Single"
             if NoSeriesLine."Increment-by No." <= 1 then
                 NoSeriesLine."Last No. Used" := IncStr(NoSeriesLine."Last No. Used")
             else
-                NoSeriesLine."Last No. Used" := NoSeriesSetup.IncrementNoText(NoSeriesLine."Last No. Used", NoSeriesLine."Increment-by No.");
+                NoSeriesLine."Last No. Used" := IncStr(NoSeriesLine."Last No. Used", NoSeriesLine."Increment-by No.");
 
         if not EnsureLastNoUsedIsWithinValidRange(NoSeriesLine, HideErrorsAndWarnings) then
             exit('');


### PR DESCRIPTION
IncStr can now handle incrementing numbers higher or lower than 1. Hence we should be using that platform functionality instead as it's also much faster.

Fixes [AB#557645](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/557645)






