### PR TITLE
[releases/26.x] [VS Code Integration] Fix filtering of extensions and enabling of "Get selected as dependencies" actions

### DIFF
--- a/src/System Application/App/Extension Management/src/ExtensionManagement.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionManagement.Page.al
@@ -301,14 +301,15 @@ page 2500 "Extension Management"
                     {
                         AccessByPermission = System "Tools, Zoom" = X;
                         Caption = 'Download in VS Code';
-                        Enabled = IsInstalled;
                         Image = Download;
                         ToolTip = 'Adds the selected extensions to your local project''s dependencies in Visual Studio Code, and downloads the symbols for them.';
 
                         trigger OnAction()
+                        var
+                            PublishedApplication: Record "Published Application";
                         begin
-                            CurrPage.SetSelectionFilter(Rec);
-                            VSCodeIntegration.UpdateDependenciesInVSCode(Rec);
+                            CurrPage.SetSelectionFilter(PublishedApplication);
+                            VSCodeIntegration.UpdateDependenciesInVSCode(PublishedApplication);
                         end;
                     }
 
@@ -317,14 +318,15 @@ page 2500 "Extension Management"
                         AccessByPermission = System "Tools, Zoom" = X;
                         ApplicationArea = All;
                         Caption = 'Show and copy';
-                        Enabled = IsInstalled;
                         Image = Copy;
                         ToolTip = 'Formats the selected dependencies as a json array and displays them in a dialog window.';
 
                         trigger OnAction()
+                        var
+                            PublishedApplication: Record "Published Application";
                         begin
-                            CurrPage.SetSelectionFilter(Rec);
-                            Message(VSCodeIntegration.GetDependenciesAsJson(Rec));
+                            CurrPage.SetSelectionFilter(PublishedApplication);
+                            Message(VSCodeIntegration.GetDependenciesAsJson(PublishedApplication));
                         end;
                     }
                 }

--- a/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
+++ b/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
@@ -18,6 +18,7 @@ codeunit 8333 "VS Code Integration Impl."
         BaseApplicationIdTxt: Label '437dbf0e-84ff-417a-965d-ed2bb9650972', Locked = true;
         SystemApplicationIdTxt: Label '63ca2fa4-4f03-4f2b-a480-172fef340d3f', Locked = true;
         ApplicationIdTxt: Label 'c1335042-3002-4257-bf8a-75c898ccb1b8', Locked = true;
+        SystemIdTxt: Label '8874ed3a-0643-4247-9ced-7a7002f7135d', Locked = true;
         NotSufficientPermissionErr: Label 'You do not have sufficient permissions to interact with the source code of extensions. Please contact your administrator.';
 
     [Scope('OnPrem')]
@@ -137,7 +138,7 @@ codeunit 8333 "VS Code Integration Impl."
     begin
         // Skip System and Base app
         case NavAppInstalledApp."App ID" of
-            SystemApplicationIdTxt, BaseApplicationIdTxt, ApplicationIdTxt:
+            SystemApplicationIdTxt, BaseApplicationIdTxt, ApplicationIdTxt, SystemIdTxt:
                 exit('')
             else
                 AppVersion := FormatDependencyVersion(NavAppInstalledApp."Version Major", NavAppInstalledApp."Version Minor", NavAppInstalledApp."Version Build", NavAppInstalledApp."Version Revision");
@@ -202,11 +203,10 @@ codeunit 8333 "VS Code Integration Impl."
     var
         AllObjWithCaption: Record AllObjWithCaption;
         NavAppInstalledApp: Record "NAV App Installed App";
-        EmptyGuid: Guid;
     begin
         // Objects in the system app range
         if ObjectId >= 2000000000 then
-            exit(EmptyGuid);
+            exit(SystemIdTxt);
 
         if AllObjWithCaption.ReadPermission() then begin
             AllObjWithCaption.SetRange("Object Type", ObjectType);


### PR DESCRIPTION
This pull request backports #3118 to releases/26.x

Fixes [AB#565834](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/565834)
Fixes [AB#565829](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/565829)

