### PR TITLE
Remove MI5 and MI4 logs

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
@@ -20,8 +20,6 @@ codeunit 309 "No. Series - Batch Impl."
         NoSeriesBatchTxt: Label 'No. Series - Batch', Locked = true;
         SimulationModeStartedTxt: Label 'No. Series simulation mode started.', Locked = true;
         SavingSingleNoSeriesStateTxt: Label 'Saving single No. Series state.', Locked = true;
-        SavingAllNoSeriesStatesTxt: Label 'Saving all No. Series states.', Locked = true;
-        UpdatingNoSeriesLinesFromDbTxt: Label 'Updating No. Series lines from database.', Locked = true;
 
     procedure SetInitialState(TempNoSeriesLine: Record "No. Series Line" temporary)
     begin

--- a/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Batch/NoSeriesBatchImpl.Codeunit.al
@@ -150,7 +150,6 @@ codeunit 309 "No. Series - Batch Impl."
     begin
         if SimulationMode then
             Error(CannotSaveWhileSimulatingNumbersErr);
-        Session.LogMessage('0000MI4', SavingAllNoSeriesStatesTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', NoSeriesBatchTxt);
         TempGlobalNoSeriesLine.Reset();
         if TempGlobalNoSeriesLine.FindSet() then
             repeat
@@ -163,7 +162,6 @@ codeunit 309 "No. Series - Batch Impl."
     var
         NoSeriesLine: Record "No. Series Line";
     begin
-        Session.LogMessage('0000MI5', UpdatingNoSeriesLinesFromDbTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', NoSeriesBatchTxt);
         NoSeriesLine.Get(TempNoSeriesLine."Series Code", TempNoSeriesLine."Line No.");
         NoSeriesLine.TransferFields(TempNoSeriesLine);
         NoSeriesLine.Modify(true);


### PR DESCRIPTION
The MI5 and MI4 logs uses a lot of space and aren't really useful. Hence removing these to telemetry tags.

Fixes [AB#567206](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/567206)


