### PR TITLE
External File Storage: Fix File Name Filter in Storage Browser

### DIFF
--- a/src/System Application/App/External File Storage/src/Lookup/FileAccountBrowserMgt.Codeunit.al
+++ b/src/System Application/App/External File Storage/src/Lookup/FileAccountBrowserMgt.Codeunit.al
@@ -85,7 +85,7 @@ codeunit 9458 "File Account Browser Mgt."
             exit;
 
         repeat
-            ExternalFileStorage.ListFiles(Path, FilePaginationData, TempFileAccountContent);
+            ExternalFileStorage.ListFiles(Path, FilePaginationData, TempFileAccountContentToAdd);
         until FilePaginationData.IsEndOfListing();
 
         AddFiles(TempFileAccountContent, TempFileAccountContentToAdd, CurrentPath, FileNameFilter);


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->
```
ExternalFileStorage.Initialize("File Scenario"::Default);
Path := ExternalFileStorage.SelectAndGetFilePath('', '*.png');
```

Shows now only png files and folders.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #3127

Fixes [AB#567860](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/567860)


