### PR TITLE
[Language] Add function to get current user language tag (e.g. 'en-US')

### DIFF
--- a/src/System Application/App/Language/src/Language.Codeunit.al
+++ b/src/System Application/App/Language/src/Language.Codeunit.al
@@ -21,12 +21,23 @@ codeunit 43 Language
     /// To change the language code returned from this function, subscribe for this event and change the passed language code.
     /// </summary>
     /// <seealso cref="OnGetUserLanguageCode"/>
-    /// <returns>The language code of the user's language</returns>
+    /// <returns>The language code of the user's language, for example 'ENU' for 'English (United States)'</returns>
     procedure GetUserLanguageCode(): Code[10]
     var
         LanguageImpl: Codeunit "Language Impl.";
     begin
         exit(LanguageImpl.GetUserLanguageCode());
+    end;
+
+    /// <summary>
+    /// Gets the current user's language tag.
+    /// </summary>
+    /// <returns>The language tag of the user's language, for example 'en-US' for 'English (United States)'</returns>
+    procedure GetUserLanguageTag(): Text[80]
+    var
+        LanguageImpl: Codeunit "Language Impl.";
+    begin
+        exit(LanguageImpl.GetUserLanguageTag());
     end;
 
     /// <summary>

--- a/src/System Application/App/Language/src/LanguageImpl.Codeunit.al
+++ b/src/System Application/App/Language/src/LanguageImpl.Codeunit.al
@@ -44,6 +44,11 @@ codeunit 54 "Language Impl."
             UserLanguageCode := GetLanguageCode(GlobalLanguage());
     end;
 
+    procedure GetUserLanguageTag() UserLanguageTag: Text[80]
+    begin
+        UserLanguageTag := GetLanguageTag(GlobalLanguage());
+    end;
+
     procedure GetLanguageIdOrDefault(LanguageCode: Code[10]): Integer;
     var
         LanguageId: Integer;
@@ -124,6 +129,19 @@ codeunit 54 "Language Impl."
         if Language.FindFirst() then;
 
         exit(Language.Code);
+    end;
+
+    procedure GetLanguageTag(LanguageId: Integer): Text[80]
+    var
+        WindowsLanguage: Record "Windows Language";
+    begin
+        if LanguageId = 0 then
+            exit('');
+
+        WindowsLanguage.SetRange("Language ID", LanguageId);
+        if WindowsLanguage.FindFirst() then;
+
+        exit(WindowsLanguage."Language Tag");
     end;
 
     procedure GetWindowsLanguageName(LanguageCode: Code[10]): Text


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Power BI add-in and other functionalities require the user language in the form of the user language tag. Currently we are using GetCurrentCultureName which references the Dotnet object CultureInfo, but recommendations from the server team advise to resolve GlobalLanguage using the system tables instead.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Related [AB#568067](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/568067)



