### PR TITLE
[26.0] [Copilot] Ensure custom dimensions for data movement telemetry are emitted in default language

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotTelemetry.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotTelemetry.Codeunit.al
@@ -5,6 +5,7 @@
 namespace System.AI;
 
 using System.Telemetry;
+using System.Globalization;
 
 /// <summary>
 /// This codeunit is called from Platform.
@@ -63,16 +64,24 @@ codeunit 7775 "Copilot Telemetry"
     var
         CopilotCapabilitiesImpl: Codeunit "Copilot Capability Impl";
         FeatureTelemetry: Codeunit "Feature Telemetry";
+        Language: Codeunit Language;
         CustomDimensions: Dictionary of [Text, Text];
         WithinGeo: Boolean;
         WithinEUDB: Boolean;
+        SavedGlobalLanguageId: Integer;
     begin
         CopilotCapabilitiesImpl.CheckGeoAndEUDB(WithinGeo, WithinEUDB);
+
+        SavedGlobalLanguageId := GlobalLanguage();
+
+        GlobalLanguage(Language.GetDefaultApplicationLanguageId());
 
         CustomDimensions.Add('Category', CopilotCapabilitiesImpl.GetCopilotCategory());
         CustomDimensions.Add('AllowDataMovement', Format(AllowDataMovement));
         CustomDimensions.Add('WithinGeo', Format(WithinGeo));
         CustomDimensions.Add('WithinEUDB', Format(WithinEUDB));
+
+        GlobalLanguage(SavedGlobalLanguageId);
 
         FeatureTelemetry.LogUsage('0000OQK', CopilotCapabilitiesImpl.GetCopilotCategory(), TelemetryAllowDataMovementUpdatedLbl, CustomDimensions);
     end;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Custom dimensions for data movement are emitted in local language. They should always be emitted in default language.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#567743](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/567743)





