### PR TITLE
[releases/25.x] Only send errors to background session for logging

### DIFF
--- a/src/System Application/App/Retention Policy/src/Retention Policy Log/RetentionPolicyLogImpl.Codeunit.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Log/RetentionPolicyLogImpl.Codeunit.al
@@ -58,7 +58,7 @@ codeunit 3909 "Retention Policy Log Impl."
         TempRetentionPolicyLogEntry.Insert();
 
         RetenPolicyTelemetryImpl.SendLogEntryToTelemetry(TempRetentionPolicyLogEntry);
-        if (not SystemInitialization.IsInProgress()) and (Session.GetExecutionContext() = ExecutionContext::Normal) then begin // no background logging during OnCompanyOpen() or during install/upgrade
+        if (EntryMessageType = Enum::"Retention Policy Log Message Type"::Error) and (not SystemInitialization.IsInProgress()) and (Session.GetExecutionContext() = ExecutionContext::Normal) then begin // no background logging during OnCompanyOpen() or during install/upgrade
             // add log entry in background session to avoid rollback
             if not InsertLogEntryInBackgroundSession(TempRetentionPolicyLogEntry) then
                 RetenPolicyTelemetryImpl.SendTelemetryOnInsertLogEntryInBackgroundSessionFailed(SystemInitialization.IsInProgress(), Session.GetExecutionContext());

--- a/src/System Application/Test Library/Retention Policy/src/RetentionPolicyTestLibrary.Codeunit.al
+++ b/src/System Application/Test Library/Retention Policy/src/RetentionPolicyTestLibrary.Codeunit.al
@@ -76,7 +76,7 @@ codeunit 138709 "Retention Policy Test Library"
     /// Gets the entry number of the last record in the Retention Policy Log Entry table.
     /// </summary>
     /// <returns>The entry number of the last record.</returns>
-    procedure RetenionPolicyLogLastEntryNo(): Integer
+    procedure RetentionPolicyLogLastEntryNo(): Integer
     var
         RetentionPolicyLogEntry: Record "Retention Policy Log Entry";
     begin
@@ -95,6 +95,23 @@ codeunit 138709 "Retention Policy Test Library"
     begin
         SelectLatestVersion(Database::"Retention Policy Log Entry");
         RetentionPolicyLogEntry.Get(EntryNo);
+        FieldValues.Add('MessageType', Format(RetentionPolicyLogEntry."Message Type"));
+        FieldValues.Add('Category', Format(RetentionPolicyLogEntry.Category));
+        FieldValues.Add('Message', RetentionPolicyLogEntry.Message);
+    end;
+
+    /// <summary>
+    /// Gets the field values of the Retention Policy Log Entry with EntryNo or the closest higher EntryNo.
+    /// </summary>
+    /// <param name="EntryNo">The entry number of the log entry.</param>
+    /// <returns>A dictionary containing the field values of the log entry.</returns>
+    procedure GetNextRetentionPolicyLogEntry(EntryNo: Integer) FieldValues: Dictionary of [Text, Text]
+    var
+        RetentionPolicyLogEntry: Record "Retention Policy Log Entry";
+    begin
+        SelectLatestVersion(Database::"Retention Policy Log Entry");
+        RetentionPolicyLogEntry.SetFilter("Entry No.", '%1..', EntryNo);
+        RetentionPolicyLogEntry.FindFirst();
         FieldValues.Add('MessageType', Format(RetentionPolicyLogEntry."Message Type"));
         FieldValues.Add('Category', Format(RetentionPolicyLogEntry.Category));
         FieldValues.Add('Message', RetentionPolicyLogEntry.Message);

--- a/src/System Application/Test/Retention Policy/src/RetentionPolicyLogTest.Codeunit.al
+++ b/src/System Application/Test/Retention Policy/src/RetentionPolicyLogTest.Codeunit.al
@@ -10,7 +10,7 @@ using System.TestLibraries.DataAdministration;
 using System.TestLibraries.Utilities;
 using System.TestLibraries.Security.AccessControl;
 
-// This codeunit must be executed by a test-runnner which has test-isolation disabled. 
+// This codeunit must be executed by a test-runnner which has test-isolation disabled.
 
 codeunit 138705 "Retention Policy Log Test"
 {
@@ -34,18 +34,19 @@ codeunit 138705 "Retention Policy Log Test"
     begin
         PermissionsMock.Set('Retention Pol. Admin');
         //Setup
-        LastRetentionPolicyLogEntryNo := RetentionPolicyTestLibrary.RetenionPolicyLogLastEntryNo();
+        LastRetentionPolicyLogEntryNo := RetentionPolicyTestLibrary.RetentionPolicyLogLastEntryNo();
 
         //Exercise
         RetentionPolicyLog.LogInfo(RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Info, LastRetentionPolicyLogEntryNo + 1)); // runs a background task
-        sleep(50); // need some time for background session
         VerifyLogEntry(LastRetentionPolicyLogEntryNo + 1, enum::"Retention Policy Log Message Type"::Info, RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Info, LastRetentionPolicyLogEntryNo + 1));
 
         // verify
         asserterror
             error('An error to ensure rollback');
 
-        VerifyLogEntry(LastRetentionPolicyLogEntryNo + 1, enum::"Retention Policy Log Message Type"::Info, RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Info, LastRetentionPolicyLogEntryNo + 1));
+        // info is rolled back
+        asserterror
+            VerifyLogEntry(LastRetentionPolicyLogEntryNo + 1, enum::"Retention Policy Log Message Type"::Info, RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Info, LastRetentionPolicyLogEntryNo + 1));
     end;
 
     [Test]
@@ -56,18 +57,19 @@ codeunit 138705 "Retention Policy Log Test"
     begin
         PermissionsMock.Set('Retention Pol. Admin');
         //Setup
-        LastRetentionPolicyLogEntryNo := RetentionPolicyTestLibrary.RetenionPolicyLogLastEntryNo();
+        LastRetentionPolicyLogEntryNo := RetentionPolicyTestLibrary.RetentionPolicyLogLastEntryNo();
 
         //Exercise
         RetentionPolicyLog.LogWarning(RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Warning, LastRetentionPolicyLogEntryNo + 1)); // runs a background task
-        sleep(50); // need some time for background session
         VerifyLogEntry(LastRetentionPolicyLogEntryNo + 1, enum::"Retention Policy Log Message Type"::Warning, RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Warning, LastRetentionPolicyLogEntryNo + 1));
 
         // verify
         asserterror
             error('An error to ensure rollback');
 
-        VerifyLogEntry(LastRetentionPolicyLogEntryNo + 1, enum::"Retention Policy Log Message Type"::Warning, RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Warning, LastRetentionPolicyLogEntryNo + 1));
+        // warning is rolled back
+        asserterror
+            VerifyLogEntry(LastRetentionPolicyLogEntryNo + 1, enum::"Retention Policy Log Message Type"::Warning, RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Warning, LastRetentionPolicyLogEntryNo + 1));
     end;
 
     [Test]
@@ -78,13 +80,14 @@ codeunit 138705 "Retention Policy Log Test"
     begin
         PermissionsMock.Set('Retention Pol. Admin');
         //Setup
-        LastRetentionPolicyLogEntryNo := RetentionPolicyTestLibrary.RetenionPolicyLogLastEntryNo();
+        LastRetentionPolicyLogEntryNo := RetentionPolicyTestLibrary.RetentionPolicyLogLastEntryNo();
 
         //Exercise
         asserterror
-    RetentionPolicyLog.LogError(RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Error, LastRetentionPolicyLogEntryNo + 1)); // runs a background task
+            RetentionPolicyLog.LogError(RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Error, LastRetentionPolicyLogEntryNo + 1)); // runs a background task
 
         // Verify
+        // error is NOT rolled back
         sleep(50); // need some time for background session
         VerifyLogEntry(LastRetentionPolicyLogEntryNo + 1, enum::"Retention Policy Log Message Type"::Error, RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Error, LastRetentionPolicyLogEntryNo + 1));
     end;
@@ -97,13 +100,14 @@ codeunit 138705 "Retention Policy Log Test"
     begin
         PermissionsMock.Set('Retention Pol. Admin');
         //Setup
-        LastRetentionPolicyLogEntryNo := RetentionPolicyTestLibrary.RetenionPolicyLogLastEntryNo();
+        LastRetentionPolicyLogEntryNo := RetentionPolicyTestLibrary.RetentionPolicyLogLastEntryNo();
 
         //Exercise
         asserterror
-    RetentionPolicyLog.LogError(RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Error, LastRetentionPolicyLogEntryNo + 1), true); // runs a background task
+            RetentionPolicyLog.LogError(RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Error, LastRetentionPolicyLogEntryNo + 1), true); // runs a background task
 
         // Verify
+        // error is NOT rolled back
         sleep(50); // need some time for background session
         VerifyLogEntry(LastRetentionPolicyLogEntryNo + 1, enum::"Retention Policy Log Message Type"::Error, RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Error, LastRetentionPolicyLogEntryNo + 1));
     end;
@@ -116,12 +120,13 @@ codeunit 138705 "Retention Policy Log Test"
     begin
         PermissionsMock.Set('Retention Pol. Admin');
         //Setup
-        LastRetentionPolicyLogEntryNo := RetentionPolicyTestLibrary.RetenionPolicyLogLastEntryNo();
+        LastRetentionPolicyLogEntryNo := RetentionPolicyTestLibrary.RetentionPolicyLogLastEntryNo();
 
         //Exercise
         RetentionPolicyLog.LogError(RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Error, LastRetentionPolicyLogEntryNo + 1), false); // runs a background task
 
         // Verify
+        // error is NOT rolled back
         sleep(50); // need some time for background session
         VerifyLogEntry(LastRetentionPolicyLogEntryNo + 1, enum::"Retention Policy Log Message Type"::Error, RetentionPolicyLogCategory::"Retention Policy - Period", StrSubstNo(TestLogMessageLbl, enum::"Retention Policy Log Message Type"::Error, LastRetentionPolicyLogEntryNo + 1));
     end;
@@ -132,20 +137,23 @@ codeunit 138705 "Retention Policy Log Test"
         RetentionPolicySetup: Record "Retention Policy Setup";
         RetentionPolicyLog: Codeunit "Retention Policy Log";
         LastRetentionPolicyLogEntryNo: BigInteger;
+        RunSuccessful: Boolean;
     begin
         PermissionsMock.Set('Retention Pol. Admin');
         // Setup
-        LastRetentionPolicyLogEntryNo := RetentionPolicyTestLibrary.RetenionPolicyLogLastEntryNo();
+        LastRetentionPolicyLogEntryNo := RetentionPolicyTestLibrary.RetentionPolicyLogLastEntryNo();
         RetentionPolicySetup.SystemId := CreateGuid();
         RetentionPolicySetup."Table Id" := Database::"Retention Policy Test Data";
         RetentionPolicySetup.CalcFields("Table Name");
         ClearLastError();
 
         // Exercise
-        if not RetentionPolicyTestLibrary.RunApplyRetentionPolicyImpl(RetentionPolicySetup) then
-            RetentionPolicyLog.LogError(RetentionPolicyLogCategory::"Retention Policy - Apply", StrSubstNo(ErrorOccuredDuringApplyErrLbl, RetentionPolicySetup."Table Id", RetentionPolicySetup."Table Name", GetLastErrorText()), false);
+        RunSuccessful := RetentionPolicyTestLibrary.RunApplyRetentionPolicyImpl(RetentionPolicySetup);
+        assert.IsFalse(RunSuccessful, 'ApplyRetentionPolicyImpl should return false when record is not temporary');
+        RetentionPolicyLog.LogError(RetentionPolicyLogCategory::"Retention Policy - Apply", StrSubstNo(ErrorOccuredDuringApplyErrLbl, RetentionPolicySetup."Table Id", RetentionPolicySetup."Table Name", GetLastErrorText()), false);
 
         // Verify
+        // error is NOT rolled back
         sleep(50);
         Assert.ExpectedError(RetentionPolicySetupRecordNotTempErr);
         VerifyLogEntry(LastRetentionPolicyLogEntryNo + 1, enum::"Retention Policy Log Message Type"::Error, RetentionPolicyLogCategory::"Retention Policy - Apply",
@@ -158,20 +166,23 @@ codeunit 138705 "Retention Policy Log Test"
         TempRetentionPolicySetup: Record "Retention Policy Setup" temporary;
         RetentionPolicyLog: Codeunit "Retention Policy Log";
         LastRetentionPolicyLogEntryNo: BigInteger;
+        RunSuccessful: Boolean;
     begin
         PermissionsMock.Set('Retention Pol. Admin');
         // Setup
-        LastRetentionPolicyLogEntryNo := RetentionPolicyTestLibrary.RetenionPolicyLogLastEntryNo();
+        LastRetentionPolicyLogEntryNo := RetentionPolicyTestLibrary.RetentionPolicyLogLastEntryNo();
         TempRetentionPolicySetup.SystemId := CreateGuid();
         TempRetentionPolicySetup."Table Id" := Database::"Retention Policy Test Data";
         TempRetentionPolicySetup.CalcFields("Table Name");
         ClearLastError();
 
         // Exercise
-        if not RetentionPolicyTestLibrary.RunApplyRetentionPolicyImpl(TempRetentionPolicySetup) then
-            RetentionPolicyLog.LogError(RetentionPolicyLogCategory::"Retention Policy - Apply", StrSubstNo(ErrorOccuredDuringApplyErrLbl, TempRetentionPolicySetup."Table Id", TempRetentionPolicySetup."Table Name", GetLastErrorText()), false);
+        RunSuccessful := RetentionPolicyTestLibrary.RunApplyRetentionPolicyImpl(TempRetentionPolicySetup);
+        assert.IsFalse(RunSuccessful, 'ApplyRetentionPolicyImpl should return false when record does not exist');
+        RetentionPolicyLog.LogError(RetentionPolicyLogCategory::"Retention Policy - Apply", StrSubstNo(ErrorOccuredDuringApplyErrLbl, TempRetentionPolicySetup."Table Id", TempRetentionPolicySetup."Table Name", GetLastErrorText()), false);
 
         // Verify
+        // error is NOT rolled back
         sleep(50);
         Assert.ExpectedError(StrSubstNo(RecordDoesNotExistErr, TempRetentionPolicySetup.SystemId));
         VerifyLogEntry(LastRetentionPolicyLogEntryNo + 1, enum::"Retention Policy Log Message Type"::Error, RetentionPolicyLogCategory::"Retention Policy - Apply",
@@ -182,7 +193,7 @@ codeunit 138705 "Retention Policy Log Test"
     var
         FieldValues: Dictionary of [Text, Text];
     begin
-        FieldValues := RetentionPolicyTestLibrary.GetRetentionPolicyLogEntry(EntryNo);
+        FieldValues := RetentionPolicyTestLibrary.GetNextRetentionPolicyLogEntry(EntryNo);
         Assert.AreEqual(Format(MessageType), FieldValues.Get('MessageType'), 'wrong message type');
         Assert.AreEqual(Format(Category), FieldValues.Get('Category'), 'wrong category');
         Assert.AreEqual(Message, FieldValues.Get('Message'), 'wrong message');


### PR DESCRIPTION
This pull request backports #3140 to releases/25.x

Fixes [AB#568056](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/568056)


