### PR TITLE
Importing Permissions with Overwrite Option

### DIFF
--- a/src/System Application/App/Permission Sets/src/xmlports/ImportPermissionSets.xmlport.al
+++ b/src/System Application/App/Permission Sets/src/xmlports/ImportPermissionSets.xmlport.al
@@ -120,9 +120,20 @@ xmlport 9864 "Import Permission Sets"
                 }
 
                 trigger OnBeforeInsertRecord()
+                var
+                    TenantPermission: Record "Tenant Permission";
+                    TenantPermissionSetRel: Record "Tenant Permission Set Rel.";
                 begin
                     if TempTenantPermissionSet.Get(TempTenantPermissionSet."App ID", TempTenantPermissionSet."Role ID") then
                         currXMLport.Skip();
+                    if not UpdatePermissions then begin
+                        TenantPermissionSetRel.SetFilter("App ID", TempTenantPermissionSet."App ID");
+                        TenantPermissionSetRel.SetFilter("Role ID", TempTenantPermissionSet."Role ID");
+                        TenantPermissionSetRel.DeleteAll;
+                        TenantPermission.SetFilter("App ID", TempTenantPermissionSet."App ID");
+                        TenantPermission.SetFilter("Role ID", TempTenantPermissionSet."Role ID");
+                        TenantPermission.DeleteAll;
+                    end;
                 end;
             }
             tableelement(TempMetadataPermissionSet; "Metadata Permission Set")
@@ -211,9 +222,20 @@ xmlport 9864 "Import Permission Sets"
                 }
 
                 trigger OnBeforeInsertRecord()
+                var
+                    MetadataPermission: Record "Metadata Permission";
+                    MetadataPermissionSetRel: Record "Metadata Permission Set Rel.";
                 begin
                     if TempMetadataPermissionSet.Get(TempMetadataPermissionSet."App ID", TempMetadataPermissionSet."Role ID") then
                         currXMLport.Skip();
+                    if not UpdatePermissions then begin
+                        MetadataPermissionSetRel.SetFilter("App ID", TempMetadataPermissionSet."App ID");
+                        MetadataPermissionSetRel.SetFilter("Role ID", TempMetadataPermissionSet."Role ID");
+                        MetadataPermissionSetRel.DeleteAll;
+                        MetadataPermission.SetFilter("App ID", TempMetadataPermissionSet."App ID");
+                        MetadataPermission.SetFilter("Role ID", TempTenantPermissionSet."Role ID");
+                        MetadataPermission.DeleteAll;
+                    end;
                 end;
             }
         }
@@ -326,6 +348,7 @@ xmlport 9864 "Import Permission Sets"
                 TenantPermission."Delete Permission" := SourceMetadataPermission."Delete Permission";
             if IsFirstPermissionHigherThanSecond(SourceMetadataPermission."Execute Permission", TenantPermission."Execute Permission") then
                 TenantPermission."Execute Permission" := SourceMetadataPermission."Execute Permission";
+            TenantPermission."Security Filter" := SourceMetadataPermission."Security Filter";
             TenantPermission.Modify();
         end;
     end;
@@ -391,6 +414,7 @@ xmlport 9864 "Import Permission Sets"
                 TenantPermission."Delete Permission" := SourceTenantPermission."Delete Permission";
             if IsFirstPermissionHigherThanSecond(SourceTenantPermission."Execute Permission", TenantPermission."Execute Permission") then
                 TenantPermission."Execute Permission" := SourceTenantPermission."Execute Permission";
+            TenantPermission."Security Filter" := SourceTenantPermission."Security Filter";
             TenantPermission.Modify();
         end;
     end;

--- a/src/System Application/App/Permission Sets/src/xmlports/ImportPermissionSets.xmlport.al
+++ b/src/System Application/App/Permission Sets/src/xmlports/ImportPermissionSets.xmlport.al
@@ -129,10 +129,10 @@ xmlport 9864 "Import Permission Sets"
                     if not UpdatePermissions then begin
                         TenantPermissionSetRel.SetFilter("App ID", TempTenantPermissionSet."App ID");
                         TenantPermissionSetRel.SetFilter("Role ID", TempTenantPermissionSet."Role ID");
-                        TenantPermissionSetRel.DeleteAll;
+                        TenantPermissionSetRel.DeleteAll();
                         TenantPermission.SetFilter("App ID", TempTenantPermissionSet."App ID");
                         TenantPermission.SetFilter("Role ID", TempTenantPermissionSet."Role ID");
-                        TenantPermission.DeleteAll;
+                        TenantPermission.DeleteAll();
                     end;
                 end;
             }
@@ -231,10 +231,10 @@ xmlport 9864 "Import Permission Sets"
                     if not UpdatePermissions then begin
                         MetadataPermissionSetRel.SetFilter("App ID", TempMetadataPermissionSet."App ID");
                         MetadataPermissionSetRel.SetFilter("Role ID", TempMetadataPermissionSet."Role ID");
-                        MetadataPermissionSetRel.DeleteAll;
+                        MetadataPermissionSetRel.DeleteAll();
                         MetadataPermission.SetFilter("App ID", TempMetadataPermissionSet."App ID");
                         MetadataPermission.SetFilter("Role ID", TempTenantPermissionSet."Role ID");
-                        MetadataPermission.DeleteAll;
+                        MetadataPermission.DeleteAll();
                     end;
                 end;
             }
@@ -348,7 +348,6 @@ xmlport 9864 "Import Permission Sets"
                 TenantPermission."Delete Permission" := SourceMetadataPermission."Delete Permission";
             if IsFirstPermissionHigherThanSecond(SourceMetadataPermission."Execute Permission", TenantPermission."Execute Permission") then
                 TenantPermission."Execute Permission" := SourceMetadataPermission."Execute Permission";
-            TenantPermission."Security Filter" := SourceMetadataPermission."Security Filter";
             TenantPermission.Modify();
         end;
     end;
@@ -414,7 +413,6 @@ xmlport 9864 "Import Permission Sets"
                 TenantPermission."Delete Permission" := SourceTenantPermission."Delete Permission";
             if IsFirstPermissionHigherThanSecond(SourceTenantPermission."Execute Permission", TenantPermission."Execute Permission") then
                 TenantPermission."Execute Permission" := SourceTenantPermission."Execute Permission";
-            TenantPermission."Security Filter" := SourceTenantPermission."Security Filter";
             TenantPermission.Modify();
         end;
     end;

--- a/src/System Application/Test/Permission Sets/src/PermissionImportExportTests.Codeunit.al
+++ b/src/System Application/Test/Permission Sets/src/PermissionImportExportTests.Codeunit.al
@@ -28,6 +28,7 @@ codeunit 132437 "Permission Import Export Tests"
         MetadataPermissionSet: Record "Metadata Permission Set";
         TenantPermissionSetRel: Record "Tenant Permission Set Rel.";
         TempBlob: Codeunit "Temp Blob";
+        ImportPermissionSets: XmlPort "Import Permission Sets";
         OutStr: OutStream;
         InStr: InStream;
         ZeroGuid: Guid;
@@ -52,7 +53,9 @@ codeunit 132437 "Permission Import Export Tests"
 
         // [WHEN] Import exported permission set
         TempBlob.CreateInStream(InStr);
-        Xmlport.Import(Xmlport::"Import Permission Sets", InStr);
+        ImportPermissionSets.SetSource(InStr);
+        ImportPermissionSets.SetUpdatePermissions(true);
+        ImportPermissionSets.Import();
 
         MetadataPermissionSet.SetFilter("Role ID", 'Permission Set A');
         MetadataPermissionSet.FindFirst();
@@ -72,6 +75,7 @@ codeunit 132437 "Permission Import Export Tests"
         MetadataPermissionSet: Record "Metadata Permission Set";
         TenantPermissionSetRel: Record "Tenant Permission Set Rel.";
         TempBlob: Codeunit "Temp Blob";
+        ImportPermissionSets: XmlPort "Import Permission Sets";
         OutStr: OutStream;
         InStr: InStream;
         ZeroGuid: Guid;
@@ -96,7 +100,9 @@ codeunit 132437 "Permission Import Export Tests"
 
         // [WHEN] Import exported permission set
         TempBlob.CreateInStream(InStr);
-        Xmlport.Import(Xmlport::"Import Permission Sets", InStr);
+        ImportPermissionSets.SetSource(InStr);
+        ImportPermissionSets.SetUpdatePermissions(true);
+        ImportPermissionSets.Import();
 
         // [THEN] System PS "Permission Set C" is now found as a tenant permission set with relation
         LibraryAssert.IsTrue(TenantPermissionSet.Get(ZeroGuid, 'Permission Set C'), 'Permission Set C is missing');
@@ -116,6 +122,7 @@ codeunit 132437 "Permission Import Export Tests"
         MetadataPermissionSet: Record "Metadata Permission Set";
         TenantPermissionSetRel: Record "Tenant Permission Set Rel.";
         TempBlob: Codeunit "Temp Blob";
+        ImportPermissionSets: XmlPort "Import Permission Sets";
         OutStr: OutStream;
         InStr: InStream;
         ZeroGuid: Guid;
@@ -140,7 +147,9 @@ codeunit 132437 "Permission Import Export Tests"
 
         // [WHEN] Import exported permission set
         TempBlob.CreateInStream(InStr);
-        Xmlport.Import(Xmlport::"Import Permission Sets", InStr);
+        ImportPermissionSets.SetSource(InStr);
+        ImportPermissionSets.SetUpdatePermissions(true);
+        ImportPermissionSets.Import();
 
         MetadataPermissionSet.SetFilter("Role ID", 'Permission Set A');
         MetadataPermissionSet.FindFirst();
@@ -164,6 +173,7 @@ codeunit 132437 "Permission Import Export Tests"
         TenantPermissionSetRel: Record "Tenant Permission Set Rel.";
         PermissionSetRelation: Codeunit "Permission Set Relation";
         TempBlob: Codeunit "Temp Blob";
+        ImportPermissionSets: XmlPort "Import Permission Sets";
         OutStr: OutStream;
         InStr: InStream;
         ZeroGuid: Guid;
@@ -197,7 +207,9 @@ codeunit 132437 "Permission Import Export Tests"
 
         // [WHEN] Import exported tenant permission set
         TempBlob.CreateInStream(InStr);
-        Xmlport.Import(Xmlport::"Import Permission Sets", InStr);
+        ImportPermissionSets.SetSource(InStr);
+        ImportPermissionSets.SetUpdatePermissions(true);
+        ImportPermissionSets.Import();
 
         // [THEN] Tenant permission set is found with the correct permissions
         LibraryAssert.IsTrue(TenantPermissionSet.Get(ZeroGuid, NewRoleId), 'Test permission set is missing');
@@ -218,6 +230,7 @@ codeunit 132437 "Permission Import Export Tests"
         PermissionSetRelation: Codeunit "Permission Set Relation";
         TempBlobOriginal: Codeunit "Temp Blob";
         TempBlobModified: Codeunit "Temp Blob";
+        ImportPermissionSets: XmlPort "Import Permission Sets";
         OutStr: OutStream;
         InStr: InStream;
         ZeroGuid: Guid;
@@ -274,7 +287,9 @@ codeunit 132437 "Permission Import Export Tests"
 
         // [WHEN] Import the original tenant permission set that was exported
         TempBlobOriginal.CreateInStream(InStr);
-        Xmlport.Import(Xmlport::"Import Permission Sets", InStr);
+        ImportPermissionSets.SetSource(InStr);
+        ImportPermissionSets.SetUpdatePermissions(true);
+        ImportPermissionSets.Import();
 
         // [THEN] Tenant permission set is found with the correct permissions
         LibraryAssert.IsTrue(TenantPermissionSet.Get(ZeroGuid, NewRoleId), 'Test permission set is missing');
@@ -287,12 +302,116 @@ codeunit 132437 "Permission Import Export Tests"
 
         // [WHEN] Import the modified tenant permission set
         TempBlobModified.CreateInStream(InStr);
-        Xmlport.Import(Xmlport::"Import Permission Sets", InStr);
+        Clear(ImportPermissionSets);
+        ImportPermissionSets.SetSource(InStr);
+        ImportPermissionSets.SetUpdatePermissions(true);
+        ImportPermissionSets.Import();
 
         // [THEN] Tenant permission set is found with the modified permissions
         LibraryAssert.IsTrue(TenantPermissionSet.Get(ZeroGuid, NewRoleId), 'Test permission set is missing');
         LibraryAssert.IsTrue(TenantPermission.Get(ZeroGuid, TenantPermissionSet."Role ID", TenantPermission."Object Type"::"Table Data", Database::"Tenant Permission"), 'Included permission to Test permission set is missing');
         LibraryAssert.AreEqual(TenantPermission."Read Permission", TenantPermission."Read Permission"::Yes, 'Read permission is not set correctly.'); // Import is additive, the permission should still be there
+        LibraryAssert.AreEqual(TenantPermission."Insert Permission", TenantPermission."Insert Permission"::Indirect, 'Insert permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Modify Permission", TenantPermission."Modify Permission"::Indirect, 'Modify permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Delete Permission", TenantPermission."Delete Permission"::Yes, 'Delete permission is not set correctly.');
+        LibraryAssert.IsTrue(TenantPermission.Get(ZeroGuid, TenantPermissionSet."Role ID", TenantPermission."Object Type"::"Table Data", Database::"Metadata Permission"), 'Included permission to Test permission set is missing');
+        LibraryAssert.AreEqual(TenantPermission."Read Permission", TenantPermission."Read Permission"::Indirect, 'Read permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Insert Permission", TenantPermission."Insert Permission"::" ", 'Insert permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Modify Permission", TenantPermission."Modify Permission"::" ", 'Modify permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Delete Permission", TenantPermission."Delete Permission"::" ", 'Delete permission is not set correctly.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportTenantPermissionSetUsingOverwriteOption()
+    var
+        TenantPermission: Record "Tenant Permission";
+        TenantPermissionSet: Record "Tenant Permission Set";
+        TenantPermissionSetRel: Record "Tenant Permission Set Rel.";
+        PermissionSetRelation: Codeunit "Permission Set Relation";
+        TempBlobOriginal: Codeunit "Temp Blob";
+        TempBlobModified: Codeunit "Temp Blob";
+        ImportPermissionSets: XmlPort "Import Permission Sets";
+        OutStr: OutStream;
+        InStr: InStream;
+        ZeroGuid: Guid;
+        AppId: Guid;
+        NewRoleId: Code[20];
+        NewName: Text;
+    begin
+        // [FEATURE] [Import] [XMLPORT] [Permission Set] [Tenant Permission Set]
+        // [SCENARIO] Tenant permission set is exported and imported. Then the same permission set is imported again with changed permissions and should be imported as is without merging.
+
+        Initialize();
+
+        NewRoleId := 'Test Permission Set';
+        NewName := 'Test Permission Set';
+
+        // [WHEN] Permission Set C is cloned to get a tenant permission set
+        PermissionSetRelation.CopyPermissionSet(NewRoleId, NewName, 'Permission Set C', AppId, Scope::System, Enum::"Permission Set Copy Type"::Clone);
+
+        TenantPermissionSet.SetFilter("Role ID", NewRoleId);
+        TempBlobOriginal.CreateOutStream(OutStr);
+
+        // [WHEN] Export Tenant permission set
+        Xmlport.Export(Xmlport::"Export Permission Sets Tenant", OutStr, TenantPermissionSet);
+
+        LibraryAssert.IsTrue(TenantPermissionSet.Get(ZeroGuid, NewRoleId), 'Test permission set is missing');
+        LibraryAssert.IsTrue(TenantPermission.Get(ZeroGuid, TenantPermissionSet."Role ID", TenantPermission."Object Type"::"Table Data", Database::"Tenant Permission"), 'Included permission to Test permission set is missing');
+
+        // [WHEN] Existing permission for the permission set is changed
+        TenantPermission."Read Permission" := TenantPermission."Read Permission"::" "; // read permission is removed
+        TenantPermission."Delete Permission" := TenantPermission."Delete Permission"::Yes; // delete permission is added
+        TenantPermission.Modify();
+
+        // [WHEN] A new permission is added to the permission set
+        TenantPermission.Init();
+        TenantPermission."Role ID" := NewRoleId;
+        TenantPermission."Object Type" := TenantPermission."Object Type"::"Table Data";
+        TenantPermission."Object ID" := Database::"Metadata Permission";
+        TenantPermission."Read Permission" := TenantPermission."Read Permission"::Indirect;
+        TenantPermission."Insert Permission" := TenantPermission."Insert Permission"::" ";
+        TenantPermission."Modify Permission" := TenantPermission."Modify Permission"::" ";
+        TenantPermission."Delete Permission" := TenantPermission."Delete Permission"::" ";
+        TenantPermission.Insert();
+
+        // [WHEN] Tenant permission set is exported again
+        TempBlobModified.CreateOutStream(OutStr);
+        Xmlport.Export(Xmlport::"Export Permission Sets Tenant", OutStr, TenantPermissionSet);
+
+        // [WHEN] No tenant permission sets exists
+        TenantPermissionSet.DeleteAll();
+        TenantPermissionSet.SetFilter("Role ID", NewRoleId);
+        LibraryAssert.RecordIsEmpty(TenantPermissionSet);
+        TenantPermissionSetRel.SetFilter("Role ID", NewRoleId);
+        LibraryAssert.RecordIsEmpty(TenantPermissionSetRel);
+
+        // [WHEN] Import the original tenant permission set that was exported
+        TempBlobOriginal.CreateInStream(InStr);
+        ImportPermissionSets.SetSource(InStr);
+        ImportPermissionSets.SetUpdatePermissions(false);
+        ImportPermissionSets.Import();
+
+        // [THEN] Tenant permission set is found with the correct permissions
+        LibraryAssert.IsTrue(TenantPermissionSet.Get(ZeroGuid, NewRoleId), 'Test permission set is missing');
+        LibraryAssert.IsTrue(TenantPermission.Get(ZeroGuid, TenantPermissionSet."Role ID", TenantPermission."Object Type"::"Table Data", Database::"Tenant Permission"), 'Included permission to Test permission set is missing');
+        LibraryAssert.AreEqual(TenantPermission."Read Permission", TenantPermission."Read Permission"::Yes, 'Read permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Insert Permission", TenantPermission."Insert Permission"::Indirect, 'Insert permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Modify Permission", TenantPermission."Modify Permission"::Indirect, 'Modify permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Delete Permission", TenantPermission."Delete Permission"::" ", 'Delete permission is not set correctly.');
+        LibraryAssert.IsFalse(TenantPermission.Get(ZeroGuid, TenantPermissionSet."Role ID", TenantPermission."Object Type"::"Table Data", Database::"Metadata Permission"), 'Metadata permission should not be included');
+
+        // [WHEN] Import the modified tenant permission set
+        TempBlobModified.CreateInStream(InStr);
+        Clear(ImportPermissionSets);
+        ImportPermissionSets.SetSource(InStr);
+        ImportPermissionSets.SetUpdatePermissions(false);
+        ImportPermissionSets.Import();
+
+        // [THEN] Tenant permission set is found with the modified permissions
+        LibraryAssert.IsTrue(TenantPermissionSet.Get(ZeroGuid, NewRoleId), 'Test permission set is missing');
+        LibraryAssert.IsTrue(TenantPermission.Get(ZeroGuid, TenantPermissionSet."Role ID", TenantPermission."Object Type"::"Table Data", Database::"Tenant Permission"), 'Included permission to Test permission set is missing');
+        LibraryAssert.AreEqual(TenantPermission."Read Permission", TenantPermission."Read Permission"::" ", 'Read permission is not set correctly.'); // Import is not additive, the permission should be imported as is
         LibraryAssert.AreEqual(TenantPermission."Insert Permission", TenantPermission."Insert Permission"::Indirect, 'Insert permission is not set correctly.');
         LibraryAssert.AreEqual(TenantPermission."Modify Permission", TenantPermission."Modify Permission"::Indirect, 'Modify permission is not set correctly.');
         LibraryAssert.AreEqual(TenantPermission."Delete Permission", TenantPermission."Delete Permission"::Yes, 'Delete permission is not set correctly.');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
With this change, I have enabled the user to be able to overwrite permission sets contained in the import file. Up until now, the permissions from the import file were merged with the permissions already present in the permission sets.

The majority of changes were done in this repo but the text for a confirmation dialog has been changed in the repo containing the Base App
https://github.com/microsoft/BusinessCentralApps/pull/1287

#### Description of the problem

Importing user defined permissions sets leaves permissions in inconsistent state.

Users tend to test the permissions sets in multiple rounds in a test system. After they are satisfied with the result they decide to import it in a production. However the outcome of the import is not reliable. Users would like to overwrite current user defined permission set with preserving assignment to the users/security groups. Currently if a permission set is imported there are two problems:

1. If in a test systems some permissions were reduced to indirect or removed those changes do not get imported into permissions.
1. If a permission for a certain object is removed in a test system and then exported and imported to production the permission cannot be removed.

That means that importing permission sets is basically "additive" and can only give more "power". There is no easy way to import XX permission sets that are already assigned to users or security groups and that those are imported "as is" in the import file.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #3162
Fixes [AB#559224](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/559224)


