### PR TITLE
Add integration event.

### DIFF
--- a/src/System Application/App/Email/src/Account/EmailAccount.Codeunit.al
+++ b/src/System Application/App/Email/src/Account/EmailAccount.Codeunit.al
@@ -121,6 +121,11 @@ codeunit 8894 "Email Account"
     begin
     end;
 
+    [IntegrationEvent(false, false)]
+    internal procedure OnAfterDeleteEmailAccount(EmailAccountId: GUID; EmailAccountConnector: enum "Email Connector")
+    begin
+    end;
+
     var
         EmailAccountImpl: Codeunit "Email Account Impl.";
 }

--- a/src/System Application/App/Email/src/Account/EmailAccountImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Account/EmailAccountImpl.Codeunit.al
@@ -70,6 +70,7 @@ codeunit 8889 "Email Account Impl."
         EmailRateLimitToDelete: Record "Email Rate Limit";
         ConfirmManagement: Codeunit "Confirm Management";
         EmailScenario: Codeunit "Email Scenario";
+        EmailAccount: Codeunit "Email Account";
         EmailConnector: Interface "Email Connector";
     begin
         CheckPermissions();
@@ -94,6 +95,7 @@ codeunit 8889 "Email Account Impl."
                 // Delete the corresponding account in the Rate Limit table.
                 if EmailRateLimitToDelete.Get(EmailAccountsToDelete."Account Id", EmailAccountsToDelete.Connector) then
                     EmailRateLimitToDelete.Delete();
+                EmailAccount.OnAfterDeleteEmailAccount(EmailAccountsToDelete."Account Id", EmailAccountsToDelete.Connector);
             end;
         until EmailAccountsToDelete.Next() = 0;
 


### PR DESCRIPTION
Call event during account deletion.

When using an SMTP account, for example, it is possible to delete the account from the card page. The card page is not part of the system or base application, so this will add an event which captures all potential email account types.

Fixes #2957 

Fixes [AB#559950](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/559950)

