### PR TITLE
[26.x] Update app baselines package version. New value: 26.0.30643.31360 (+ 1 more update(s))

### DIFF
--- a/build/Packages.json
+++ b/build/Packages.json
@@ -1,10 +1,10 @@
 {
   "Microsoft.Dynamics.BusinessCentral.Translations": {
-    "Version": "26.0.20250224.2",
+    "Version": "26.1.20250310.7",
     "Source": "NuGet.org"
   },
   "AppBaselines-BCArtifacts": {
-    "Version": "26.0.30643.30994",
+    "Version": "26.0.30643.31360",
     "Source": "BCArtifacts",
     "_comment": "Used to fetch app baselines from BC artifacts"
   }


### PR DESCRIPTION
This PR contains the following changes:
- Update app baselines package version. New value: 26.0.30643.31360
- Update translation package version. New value: 26.1.20250310.7

AB#539394