### PR TITLE
[Page Summary Provider] Add 'Data for External Use' parameter

### DIFF
--- a/src/System Application/App/Page Summary Provider/src/PageSummaryParameters.Table.al
+++ b/src/System Application/App/Page Summary Provider/src/PageSummaryParameters.Table.al
@@ -35,6 +35,12 @@ table 2719 "Page Summary Parameters"
             ToolTip = 'Specifies if the media should be included in the summary.';
             InitValue = true;
         }
+        field(5; "Data for External Use"; Boolean)
+        {
+            Caption = 'Data for External Use';
+            ToolTip = 'Specifies if the summary data needs to satisfy the data visibility preference as it will be used in an external system.';
+            InitValue = true;
+        }
     }
 
     keys

--- a/src/System Application/App/Page Summary Provider/src/PageSummaryProvider.Codeunit.al
+++ b/src/System Application/App/Page Summary Provider/src/PageSummaryProvider.Codeunit.al
@@ -64,7 +64,7 @@ codeunit 2718 "Page Summary Provider"
     var
         SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
     begin
-        exit(SummaryProviderImpl.GetPageSummary(PageId, Bookmark, true));
+        exit(SummaryProviderImpl.GetPageSummary(PageId, Bookmark, true, true));
     end;
 
     /// <summary>
@@ -121,7 +121,7 @@ codeunit 2718 "Page Summary Provider"
     var
         SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
     begin
-        exit(SummaryProviderImpl.GetPageSummary(PageId, SystemId, true));
+        exit(SummaryProviderImpl.GetPageSummary(PageId, SystemId, true, true));
     end;
 
     /// <summary>
@@ -153,7 +153,7 @@ codeunit 2718 "Page Summary Provider"
     var
         SummaryProviderImpl: Codeunit "Page Summary Provider Impl.";
     begin
-        exit(SummaryProviderImpl.GetPageSummary(PageId, '', true));
+        exit(SummaryProviderImpl.GetPageSummary(PageId, '', true, true));
     end;
 
     /// <summary>


### PR DESCRIPTION
#### Summary
Various integrations can leverage the page summary provider to retrieve page summaries.
For Teams, users can specify that they do not want the cards to show summary information containing the page data.
However, other integrations, such as chat, should still be able to request this data.

This change adds a new parameter to indicate if the data will be used in an external system, and if true (default) will respect the data visibility option.

#### Work Item(s)
Fixes [AB#544205](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/544205)



