### PR TITLE
[AI] Fix indirect permissions on Copilot AI page

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
@@ -25,6 +25,7 @@ page 7775 "Copilot AI Capabilities"
     Extensible = false;
     InherentEntitlements = X;
     InherentPermissions = X;
+    Permissions = tabledata "Copilot Settings" = r;
 
     layout
     {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
The table `Copilot Settings` has inherent indirect permissions but it isn't provided on the `Copilot AI Capabilities` page which uses that table. This PR fixes the issue by adding the indirect permissions to the `Copilot AI Capabilities` page

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#562707](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/562707)
