### PR TITLE
[25.5] The number of records deleted are doubled every run

### DIFF
--- a/src/System Application/App/Retention Policy/src/Apply Retention Policy/ApplyRetentionPolicyImpl.Codeunit.al
+++ b/src/System Application/App/Retention Policy/src/Apply Retention Policy/ApplyRetentionPolicyImpl.Codeunit.al
@@ -183,7 +183,7 @@ codeunit 3904 "Apply Retention Policy Impl."
             RetentionPolicyLog.LogError(LogCategory(), StrSubstNo(ErrorOccuredDuringApplyErrLbl, RetentionPolicySetup."Table Id", RetentionPolicySetup."Table Caption", GetLastErrorText()), false);
             exit
         end;
-        TotalNumberOfRecordsDeleted += TempRetentionPolicySetup."Number Of Records Deleted";
+        TotalNumberOfRecordsDeleted := TempRetentionPolicySetup."Number Of Records Deleted";
     end;
 
     local procedure CanApplyRetentionPolicy(var RetentionPolicySetup: Record "Retention Policy Setup"; Manual: Boolean): Boolean


### PR DESCRIPTION
Every time SafeApplyRetentionPolicy is called, the number of records
deleted more than doubles. This is because we first set number of
deleted records to the number already deleted ex. 1000, then cleanup
records (it will increase this value further say it deletes 100, now
1100), then TotalNumberOfRecordsDeleted is incremented to 2100 instead
of just 1100.
Fixes [AB#571354](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/571354)



