### PR TITLE
Allowing app names of 1st party apps to be larger than 50 characters.

### DIFF
--- a/src/rulesets/PTECop.ruleset.json
+++ b/src/rulesets/PTECop.ruleset.json
@@ -39,7 +39,8 @@
                   },
                   {
                       "id":  "PTE0010",
-                      "action":  "Error"
+                      "action":  "None",
+                      "justification": "Microsoft apps are not stored in EMRS, which imposes the 50 characters limit."
                   },
                   {
                       "id":  "PTE0011",


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->

Change ruleset to allow app names of 1st party apps to be larger than 50 characters, the PTE0010 diagnostic is meant for PTEs that are stored in EMRS which imposes such limit. This is not the case for 1st party apps in FAME.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
[AB#571703](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/571703)

