### PR TITLE
[AI Test Tool] Fix GetNextTurn

### DIFF
--- a/src/Tools/AI Test Toolkit/src/AITTestContextImpl.Codeunit.al
+++ b/src/Tools/AI Test Toolkit/src/AITTestContextImpl.Codeunit.al
@@ -186,7 +186,7 @@ codeunit 149043 "AIT Test Context Impl."
         if not IsMultiTurn then
             exit(false);
 
-        if CurrentTurn > NumberOfTurns then
+        if CurrentTurn + 1 > NumberOfTurns then
             exit(false);
 
         CurrentTurn := CurrentTurn + 1;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Causes indexing error in multi-turn testing. 

Current turn should never be larger than number of turns. Otherwise GetTestInput will fail:
`TestInputJson := TestInput.GetTestInput(TurnsTok).ElementAt(CurrentTurn - 1).Element(ElementName)`

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#571847](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/571847)

