### PR TITLE
Skip API and ODATAV4 client types in Azure AD User Mgt

### DIFF
--- a/src/System Application/App/Azure AD User Management/src/AzureADUserMgmtImpl.Codeunit.al
+++ b/src/System Application/App/Azure AD User Management/src/AzureADUserMgmtImpl.Codeunit.al
@@ -23,7 +23,7 @@ codeunit 9017 "Azure AD User Mgmt. Impl."
 
     trigger OnRun()
     begin
-        if ClientTypeManagement.GetCurrentClientType() = ClientType::Background then
+        if ClientTypeManagement.GetCurrentClientType() in [ClientType::Background, ClientType::Api, ClientType::ODataV4] then
             exit;
 
         Run(UserSecurityId());


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
When application users are used for API calls, they're not users that can be logged into BC directly through a webclient session.
This bypasses the checks to graph in app which is only done the first time a user logs in. The check is always done by platform when any user logs into BC.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#569521](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/569521)


