### PR TITLE
Make Engineering Systems owner of app.json files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,7 +27,7 @@ dotnet.al @microsoft/d365-bc-app-security
 *.Permissionsetext.al @microsoft/d365-bc-app-permissions
 *.Entitlement.al @microsoft/d365-bc-app-permissions
 
-# app.json files are owned by Engineering Systems to control the versions
+# app.json files are owned by Engineering Systems to control the versions and BC app team to control the other metadata
 app.json @microsoft/d365-bc-engineering-systems @microsoft/d365-bc-app-required
 
 # AL-Go files and build scripts are owned by Engineering Systems

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,7 +28,7 @@ dotnet.al @microsoft/d365-bc-app-security
 *.Entitlement.al @microsoft/d365-bc-app-permissions
 
 # app.json files are owned by Engineering Systems to control the versions
-app.json @microsoft/d365-bc-engineering-systems
+app.json @microsoft/d365-bc-engineering-systems @microsoft/d365-bc-app-required
 
 # AL-Go files and build scripts are owned by Engineering Systems
 .AL-Go/ @microsoft/d365-bc-engineering-systems

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,6 +27,9 @@ dotnet.al @microsoft/d365-bc-app-security
 *.Permissionsetext.al @microsoft/d365-bc-app-permissions
 *.Entitlement.al @microsoft/d365-bc-app-permissions
 
+# app.json files are owned by Engineering Systems to control the versions
+app.json @microsoft/d365-bc-engineering-systems
+
 # AL-Go files and build scripts are owned by Engineering Systems
 .AL-Go/ @microsoft/d365-bc-engineering-systems
 *.ps1 @microsoft/d365-bc-engineering-systems


### PR DESCRIPTION
Make Engineering Systems owner of app.json files.

This is mainly needed around branching, when versions need to be changed.

[AB#572904](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/572904)






