### PR TITLE
Add ability to reuse the work item when backporting PRs

### DIFF
--- a/build/scripts/CrossBranchPorting.psm1
+++ b/build/scripts/CrossBranchPorting.psm1
@@ -82,7 +82,8 @@ function New-BCAppsBackport() {
                 # Create a new branch for the cherry-pick
                 $cherryPickBranch = "backport/$TargetBranch/$branchNameSuffix"
 
-                if(!$PSCmdlet.ShouldProcess("WhatIf: Porting PR $PullRequestNumber to $TargetBranch. Branch: $cherryPickBranch")) {
+                if(!$PSCmdlet.ShouldProcess) {
+                    Write-Host "WhatIf: Porting PR $PullRequestNumber to $TargetBranch. Branch: $cherryPickBranch" -ForegroundColor Magenta
                     continue
                 }
 

--- a/build/scripts/CrossBranchPorting.psm1
+++ b/build/scripts/CrossBranchPorting.psm1
@@ -108,7 +108,7 @@ function New-BCAppsBackport() {
             }
         }
 
-        if(!$PSCmdlet.ShouldProcess()) {
+        if(!$PSCmdlet.ShouldProcess("PR $PullRequestNumber backported")) {
             return # Nothing else to do
         }
 

--- a/build/scripts/CrossBranchPorting.psm1
+++ b/build/scripts/CrossBranchPorting.psm1
@@ -83,7 +83,6 @@ function New-BCAppsBackport() {
                 $cherryPickBranch = "backport/$TargetBranch/$branchNameSuffix"
 
                 if(!$PSCmdlet.ShouldProcess("Porting PR $PullRequestNumber to $TargetBranch (fromb branch: $cherryPickBranch)", "$TargetBranch", "PortPullRequest $PullRequestNumber")) {
-                    Write-Host "WhatIf: Porting PR $PullRequestNumber to $TargetBranch. Branch: $cherryPickBranch" -ForegroundColor Magenta
                     continue
                 }
 

--- a/build/scripts/CrossBranchPorting.psm1
+++ b/build/scripts/CrossBranchPorting.psm1
@@ -35,7 +35,7 @@ function New-BCAppsBackport() {
 
         # Get the pull request details
         $pullRequestDetails = (gh pr view $PullRequestNumber --json title,number,body,headRefName,baseRefName,mergeCommit,potentialMergeCommit | ConvertFrom-Json)
-        Write-Host "Backport to: $($TargetBranches -join ",")" -ForegroundColor Cyan
+        Write-Host "Backport to branches: $($TargetBranches -join ", ")" -ForegroundColor Cyan
         Write-Host "Pull Request Source Branch: $($pullRequestDetails.headRefName)" -ForegroundColor Cyan
         Write-Host "Pull Request Target Branch: $($pullRequestDetails.baseRefName)" -ForegroundColor Cyan
         Write-Host "Pull Request Title: $($pullRequestDetails.title)" -ForegroundColor Cyan
@@ -82,7 +82,7 @@ function New-BCAppsBackport() {
                 # Create a new branch for the cherry-pick
                 $cherryPickBranch = "backport/$TargetBranch/$branchNameSuffix"
 
-                if(!$PSCmdlet.ShouldProcess("Porting PR $PullRequestNumber to $TargetBranch (fromb branch: $cherryPickBranch)", "$TargetBranch", "PortPullRequest $PullRequestNumber")) {
+                if(!$PSCmdlet.ShouldProcess("Porting PR $PullRequestNumber to $TargetBranch (from branch: $cherryPickBranch)", "$TargetBranch", "PortPullRequest $PullRequestNumber")) {
                     continue
                 }
 

--- a/build/scripts/CrossBranchPorting.psm1
+++ b/build/scripts/CrossBranchPorting.psm1
@@ -102,8 +102,14 @@ function New-BCAppsBackport() {
             Write-Host $_.Exception.Message -ForegroundColor Red
             throw $_.Exception.Message
         } finally {
-            # Go back to the original branch
-            RunAndCheck git checkout $startingBranch
+            $currentBranch = RunAndCheck git rev-parse --abbrev-ref HEAD
+            if ($currentBranch -ne $startingBranch) {
+                RunAndCheck git checkout $startingBranch
+            }
+        }
+
+        if(!$PSCmdlet.ShouldProcess()) {
+            return # Nothing else to do
         }
 
         if ($pullRequests.Count -eq 0) {

--- a/build/scripts/CrossBranchPorting.psm1
+++ b/build/scripts/CrossBranchPorting.psm1
@@ -108,7 +108,7 @@ function New-BCAppsBackport() {
             }
         }
 
-        if(!$PSCmdlet.ShouldProcess("PR $PullRequestNumber backported")) {
+        if(!$PSCmdlet.ShouldProcess("PR $PullRequestNumber backported", "", "")) {
             return # Nothing else to do
         }
 

--- a/build/scripts/CrossBranchPorting.psm1
+++ b/build/scripts/CrossBranchPorting.psm1
@@ -13,6 +13,8 @@
     Reuse the work item number from the original pull request.
 #>
 function New-BCAppsBackport() {
+    [CmdletBinding(SupportsShouldProcess=$true)]
+
     param(
         [Parameter(Mandatory=$true)]
         [string] $PullRequestNumber,
@@ -20,7 +22,7 @@ function New-BCAppsBackport() {
         [string[]] $TargetBranches,
         [Parameter(Mandatory=$false)]
         [switch] $SkipConfirmation,
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory=$false, DontShow=$true)]
         [switch] $ReuseWorkItem
     )
     Import-Module $PSScriptRoot/EnlistmentHelperFunctions.psm1
@@ -44,6 +46,7 @@ function New-BCAppsBackport() {
             if ($pullRequestDetails.body -match "AB#(\d+)") {
                 $workItemNumber = $matches[1]
                 Write-Host "Reusing work item number: $workItemNumber" -ForegroundColor Cyan
+                Write-Warning "You are reusing the work item number from the original pull request."
             } else {
                 Write-Host "No work item number found in the pull request description." -ForegroundColor Yellow
             }
@@ -78,6 +81,10 @@ function New-BCAppsBackport() {
 
                 # Create a new branch for the cherry-pick
                 $cherryPickBranch = "backport/$TargetBranch/$branchNameSuffix"
+
+                if(!$PSCmdlet.ShouldProcess("WhatIf: Porting PR $PullRequestNumber to $TargetBranch. Branch: $cherryPickBranch")) {
+                    continue
+                }
 
                 # Port the pull request to the target branch
                 PortPullRequest -PullRequestDetails $pullRequestDetails -TargetBranch $TargetBranch -CherryPickBranch $cherryPickBranch

--- a/build/scripts/CrossBranchPorting.psm1
+++ b/build/scripts/CrossBranchPorting.psm1
@@ -82,7 +82,7 @@ function New-BCAppsBackport() {
                 # Create a new branch for the cherry-pick
                 $cherryPickBranch = "backport/$TargetBranch/$branchNameSuffix"
 
-                if(!$PSCmdlet.ShouldProcess) {
+                if(!$PSCmdlet.ShouldProcess("Porting PR $PullRequestNumber to $TargetBranch (fromb branch: $cherryPickBranch)", "$TargetBranch", "PortPullRequest $PullRequestNumber")) {
                     Write-Host "WhatIf: Porting PR $PullRequestNumber to $TargetBranch. Branch: $cherryPickBranch" -ForegroundColor Magenta
                     continue
                 }


### PR DESCRIPTION
Sometimes backporting doesn't require new work items and it's useful to reuse the work item number from the original pull request.

Plus, a support for `SupportsShouldProcess`.

[AB#572904](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/572904)


