### PR TITLE
Bug 573459: [26.x][BCApps #3443]Update SignData procedure to include RSASignaturePadding parameter

### DIFF
--- a/src/System Application/App/Cryptography Management/src/CryptographyManagementImpl.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/CryptographyManagementImpl.Codeunit.al
@@ -417,7 +417,7 @@ codeunit 1279 "Cryptography Management Impl."
         TempBlob.CreateOutStream(DataOutStream, TextEncoding::UTF8);
         TempBlob.CreateInStream(DataInStream, TextEncoding::UTF8);
         DataOutStream.WriteText(InputString);
-        SignData(DataInStream, XmlString, HashAlgorithm, SignatureOutStream);
+        SignData(DataInStream, XmlString, HashAlgorithm, RSASignaturePadding, SignatureOutStream);
     end;
 
     procedure SignData(DataInStream: InStream; XmlString: SecretText; HashAlgorithm: Enum "Hash Algorithm"; RSASignaturePadding: Enum "RSA Signature Padding"; SignatureOutStream: OutStream)


### PR DESCRIPTION
Backport of https://github.com/microsoft/BCApps/pull/3443

Fixes #3438
Fixes [AB#573459](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/573459)