### PR TITLE
Uptake version 27.0.25098.1 of Microsoft.Dynamics.BusinessCentral.Translations

### DIFF
--- a/build/Packages.json
+++ b/build/Packages.json
@@ -1,6 +1,6 @@
 {
   "Microsoft.Dynamics.BusinessCentral.Translations": {
-    "Version": "27.0.20250403.2",
+    "Version": "27.0.25098.1",
     "Source": "NuGet.org"
   },
   "AppBaselines-BCArtifacts": {

--- a/build/scripts/EnlistmentHelperFunctions.psm1
+++ b/build/scripts/EnlistmentHelperFunctions.psm1
@@ -367,7 +367,7 @@ function Update-PackageVersion
     Write-Host "Latest $PackageName version found: $latestVersion"
 
     $result = $null
-    if ([System.Version] $latestVersion -gt [System.Version] $currentVersion) {
+    if ([System.Version] $latestVersion -ne [System.Version] $currentVersion) {
         Write-Host "Updating $PackageName version from $currentVersion to $latestVersion"
 
         $currentPackage.Version = $latestVersion


### PR DESCRIPTION
Version 27.0.25098.1 is the latest version of the package, but due to a change in the versioning, it's lower than the current version.

Fixes [AB#573748](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/573748)





