### PR TITLE
Fix installed extension version mismatch

### DIFF
--- a/src/System Application/App/Extension Management/src/ExtensionSettings.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionSettings.Page.al
@@ -145,6 +145,7 @@ page 2511 "Extension Settings"
         PublishedApplication: Record "Published Application";
     begin
         PublishedApplication.SetRange(ID, Rec."App ID");
+        PublishedApplication.SetRange(Installed, true);
         PublishedApplication.SetRange("Tenant Visible", true);
 
         if PublishedApplication.FindFirst() then begin


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
There is an extension version mismatch between the page Installed Extensions and Extension setting.

The problem arises because the "Extension Settings" page uses the App Id when navigated to from the "Installed Extensions" page, without distinguishing amongst the different runtime packages. 

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes AB#567978
