### PR TITLE
[26.x][Copilot] Allow capabilities to run in background (#3225)

### DIFF
--- a/src/System Application/App/AI/app.json
+++ b/src/System Application/App/AI/app.json
@@ -94,6 +94,12 @@
       "name": "Guided Experience",
       "publisher": "Microsoft",
       "version": "26.1.0.0"
+    },
+    {
+      "id": "7f3d7c69-3ffc-4201-b2b9-9f7cd56f7c50",
+      "name": "Client Type Management",
+      "publisher": "Microsoft",
+      "version": "26.1.0.0"
     }
   ],
   "screenshots": [],


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
__BACKPORT:__

When the AL developer toolkit was introduced, our AI systems were still in an early stage, and we did not have an infrastructure capable of supporting high volumes of calls, or throttling capabilities, or use cases that required running AI capabilities in the background.
Now we have a strong Copilot backend that can throttle high usage, measure consumption, as well as Agents that run in the background and can use AI to provide huge business values for customers and users of the system.
Removing the gating that doesn't allow using capabilities in background sessions.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#569021](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/569021)









