### PR TITLE
Named return variables must not have the same name as global var

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
@@ -398,14 +398,14 @@ codeunit 7774 "Copilot Capability Impl"
         GlobalLanguage(SavedGlobalLanguageId);
     end;
 
-    procedure IsAdmin() IsAdmin: Boolean
+    procedure IsAdmin(): Boolean
     var
         AzureADGraphUser: Codeunit "Azure AD Graph User";
         AzureADPlan: Codeunit "Azure AD Plan";
         PlanIds: Codeunit "Plan Ids";
         UserPermissions: Codeunit "User Permissions";
     begin
-        IsAdmin := AzureADGraphUser.IsUserDelegatedAdmin() or AzureADPlan.IsPlanAssignedToUser(PlanIds.GetGlobalAdminPlanId()) or AzureADPlan.IsPlanAssignedToUser(PlanIds.GetBCAdminPlanId()) or AzureADPlan.IsPlanAssignedToUser(PlanIds.GetD365AdminPlanId()) or AzureADGraphUser.IsUserDelegatedHelpdesk() or UserPermissions.IsSuper(UserSecurityId());
+        exit(AzureADGraphUser.IsUserDelegatedAdmin() or AzureADPlan.IsPlanAssignedToUser(PlanIds.GetGlobalAdminPlanId()) or AzureADPlan.IsPlanAssignedToUser(PlanIds.GetBCAdminPlanId()) or AzureADPlan.IsPlanAssignedToUser(PlanIds.GetD365AdminPlanId()) or AzureADGraphUser.IsUserDelegatedHelpdesk() or UserPermissions.IsSuper(UserSecurityId()));
     end;
 
     [TryFunction]

--- a/src/System Application/App/Password/src/PasswordDialog.Page.al
+++ b/src/System Application/App/Password/src/PasswordDialog.Page.al
@@ -109,10 +109,10 @@ page 9810 "Password Dialog"
     /// </summary>
     /// <returns>The password value typed on the page.</returns>
     [Scope('OnPrem')]
-    procedure GetPasswordSecretValue() Password: SecretText
+    procedure GetPasswordSecretValue(): SecretText
     begin
         if ValidPassword then
-            Password := PasswordValue;
+            exit(PasswordValue);
     end;
 
     /// <summary>
@@ -120,10 +120,10 @@ page 9810 "Password Dialog"
     /// </summary>
     /// <returns>The old password typed on the page.</returns>
     [Scope('OnPrem')]
-    procedure GetOldPasswordSecretValue() Password: SecretText
+    procedure GetOldPasswordSecretValue(): SecretText
     begin
         if ValidPassword then
-            Password := OldPasswordValue;
+            exit(OldPasswordValue);
     end;
 
     /// <summary>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

Named return variables must not have the same name as global var, fixing in System App to unblock the uptake.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes AB#571222

#7741