### PR TITLE
Fix AA0202 in RetentionPolicyTest.Codeunit.al

### DIFF
--- a/src/System Application/Test/Retention Policy/src/RetentionPolicyTest.Codeunit.al
+++ b/src/System Application/Test/Retention Policy/src/RetentionPolicyTest.Codeunit.al
@@ -1782,9 +1782,9 @@ codeunit 138702 "Retention Policy Test"
         exit(true);
     end;
 
-    local procedure RetentionPolicyCode(RetentionPeriod: Variant) RetentionPolicyCode: Code[20]
+    local procedure RetentionPolicyCode(RetentionPeriod: Variant): Code[20]
     begin
-        RetentionPolicyCode := CopyStr(UpperCase(Format(RetentionPeriod)), 1, MaxStrLen(RetentionPolicyCode))
+        exit(CopyStr(UpperCase(Format(RetentionPeriod)), 1, 20))
     end;
 
     local procedure FixViewsTimeZoneIssueMaxRange(InDate: Date): Date


### PR DESCRIPTION
Error:
```
Compilation started for project 'System Application Test' containing '218' files at '20:48:05.670'.

App\BCApps\src\System Application\Test\Retention Policy\src\RetentionPolicyTest.Codeunit.al(1785,67): error AA0202: The name of the local variable 'RetentionPolicyCode' is identical to a field, method, or action in the same scope.

Compilation ended at '20:48:16.381'
```

[AB#574429](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/574429)

