### PR TITLE
Refactors cookie handling in HttpResponseMessageImpl.Codeunit.al

### DIFF
--- a/src/System Application/App/Rest Client/src/HttpResponseMessageImpl.Codeunit.al
+++ b/src/System Application/App/Rest Client/src/HttpResponseMessageImpl.Codeunit.al
@@ -99,10 +99,6 @@ codeunit 2357 "Http Response Message Impl."
         CurrHttpResponseMessageInstance: HttpResponseMessage;
 
     procedure SetResponseMessage(var ResponseMessage: HttpResponseMessage)
-    var
-        Cookie: Cookie;
-        Cookies: Dictionary of [Text, Cookie];
-        CookieName: Text;
     begin
         ClearAll();
         CurrHttpResponseMessageInstance := ResponseMessage;
@@ -112,11 +108,6 @@ codeunit 2357 "Http Response Message Impl."
         SetIsSuccessStatusCode(ResponseMessage.IsSuccessStatusCode);
         SetHeaders(ResponseMessage.Headers);
         SetContent(HttpContent.Create(ResponseMessage.Content));
-        foreach CookieName in ResponseMessage.GetCookieNames() do begin
-            ResponseMessage.GetCookie(CookieName, Cookie);
-            Cookies.Add(CookieName, Cookie);
-        end;
-        SetCookies(Cookies);
     end;
 
     procedure GetResponseMessage() ReturnValue: HttpResponseMessage
@@ -142,31 +133,53 @@ codeunit 2357 "Http Response Message Impl."
 
     #region Cookies
     var
+        GlobalCookiesInitialized: Boolean;
         GlobalCookies: Dictionary of [Text, Cookie];
 
     procedure SetCookies(Cookies: Dictionary of [Text, Cookie])
     begin
         GlobalCookies := Cookies;
+        GlobalCookiesInitialized := true;
     end;
 
     procedure GetCookies() Cookies: Dictionary of [Text, Cookie]
     begin
+        InitializeCookies();
         Cookies := GlobalCookies;
     end;
 
     procedure GetCookieNames() CookieNames: List of [Text]
     begin
-        CookieNames := GlobalCookies.Keys;
+        InitializeCookies();
+        CookieNames := GlobalCookies.Keys();
     end;
 
     procedure GetCookie(Name: Text) TheCookie: Cookie
     begin
+        InitializeCookies();
         if GlobalCookies.Get(Name, TheCookie) then;
     end;
 
     procedure GetCookie(Name: Text; var TheCookie: Cookie) Success: Boolean
     begin
+        InitializeCookies();
         Success := GlobalCookies.Get(Name, TheCookie);
+    end;
+
+    local procedure InitializeCookies()
+    var
+        CookieName: Text;
+        Cookie: Cookie;
+    begin
+        if GlobalCookiesInitialized then
+            exit;
+
+        foreach CookieName in CurrHttpResponseMessageInstance.GetCookieNames() do begin
+            CurrHttpResponseMessageInstance.GetCookie(CookieName, Cookie);
+            GlobalCookies.Add(CookieName, Cookie);
+        end;
+
+        GlobalCookiesInitialized := true;
     end;
     #endregion
 

--- a/src/System Application/Test/Rest Client/src/RestClientTests.Codeunit.al
+++ b/src/System Application/Test/Rest Client/src/RestClientTests.Codeunit.al
@@ -17,6 +17,7 @@ codeunit 134971 "Rest Client Tests"
         HttpClientHandler: Codeunit "Test Http Client Handler";
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestGet()
     var
         RestClient: Codeunit "Rest Client";
@@ -40,6 +41,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestGetWithQueryParameters()
     var
         RestClient: Codeunit "Rest Client";
@@ -64,6 +66,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestPost()
     var
         RestClient: Codeunit "Rest Client";
@@ -89,6 +92,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestPatch()
     var
         RestClient: Codeunit "Rest Client";
@@ -114,6 +118,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestPut()
     var
         RestClient: Codeunit "Rest Client";
@@ -139,6 +144,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestDelete()
     var
         RestClient: Codeunit "Rest Client";
@@ -162,6 +168,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestGetWithDefaultHeaders()
     var
         RestClient: Codeunit "Rest Client";
@@ -187,6 +194,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestBaseAddress()
     var
         RestClient: Codeunit "Rest Client";
@@ -211,6 +219,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestDefaultUserAgentHeader()
     var
         RestClient: Codeunit "Rest Client";
@@ -234,6 +243,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestCustomUserAgentHeader()
     var
         RestClient: Codeunit "Rest Client";
@@ -258,6 +268,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestGetAsJson()
     var
         RestClient: Codeunit "Rest Client";
@@ -277,6 +288,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     [ErrorBehavior(ErrorBehavior::Collect)]
     procedure TestGetAsJsonWithCollectingErrors()
     var
@@ -302,6 +314,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestPostAsJson()
     var
         RestClient: Codeunit "Rest Client";
@@ -331,6 +344,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestPatchAsJson()
     var
         RestClient: Codeunit "Rest Client";
@@ -360,6 +374,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestPutAsJson()
     var
         RestClient: Codeunit "Rest Client";
@@ -389,6 +404,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestSendWithoutGetContent()
     var
         RestClient: Codeunit "Rest Client";
@@ -412,6 +428,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestSendWithGetContent()
     var
         RestClient: Codeunit "Rest Client";
@@ -437,6 +454,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestSendRequestMessage()
     var
         RestClient: Codeunit "Rest Client";
@@ -463,6 +481,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestBasicAuthentication()
     var
         RestClient: Codeunit "Rest Client";
@@ -488,6 +507,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestResponseWithCookies()
     var
         RestClient: Codeunit "Rest Client";
@@ -509,6 +529,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestRequestWithCookies()
     var
         RestClient: Codeunit "Rest Client";
@@ -539,6 +560,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestWithoutUseResponseCookies()
     var
         RestClient: Codeunit "Rest Client";
@@ -569,6 +591,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestWithUseResponseCookies()
     var
         RestClient: Codeunit "Rest Client";
@@ -598,6 +621,7 @@ codeunit 134971 "Rest Client Tests"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
     procedure TestUseResponseCookiesWithAdditionalCookies()
     var
         RestClient: Codeunit "Rest Client";
@@ -638,5 +662,11 @@ codeunit 134971 "Rest Client Tests"
     local procedure SelectJsonToken(JsonObject: JsonObject; Path: Text) JsonToken: JsonToken
     begin
         JsonObject.SelectToken(Path, JsonToken);
+    end;
+
+    [StrMenuHandler]
+    procedure StrMenuHandler(Options: Text[1024]; var Choice: Integer; Instruction: Text[1024])
+    begin
+        Choice := 2;
     end;
 }


### PR DESCRIPTION
#### Summary
This change removes code for cookie handling in the `SetResponseMessage` procedure in codeunit `"Http Response Message Impl."`. Instead, cookie handling is done using a separate InitializeCookies procedure upon first access of the response cookies. This change improves code resiliency in case of incorrectly formatted cookie headers.

Added StrMenuHandler to the automated tests to handle the popup for allowing outgoing HTTP requests.

#### Work Item(s)
Fixes #3329 
