### PR TITLE
[Email] Update InsertEmailAttachments to use TransferFields instead of setting individual fields.

### DIFF
--- a/src/System Application/App/Email/src/Email/EmailAttachmens/EmailScenarioAttachImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/EmailAttachmens/EmailScenarioAttachImpl.Codeunit.al
@@ -129,7 +129,7 @@ codeunit 8902 "Email Scenario Attach Impl."
         EmailScenarioAttachments.Scenario := Enum::"Email Scenario".FromInteger(EmailScenario);
         EmailScenarioAttachments.AttachmentDefaultStatus := false;
         EmailScenarioAttachments.Insert();
-        InsertEmailAttachments(EmailScenarioAttachments, EmailAttachments, EmailScenario);
+        InsertEmailAttachments(EmailScenarioAttachments, EmailAttachments);
     end;
 
     procedure AddAttachment(var EmailScenarioAttachments: Record "Email Scenario Attachments"; var EmailAttachments: Record "Email Attachments"; EmailScenario: Integer)
@@ -146,16 +146,12 @@ codeunit 8902 "Email Scenario Attach Impl."
         EmailScenarioAttachments.Scenario := Enum::"Email Scenario".FromInteger(EmailScenario);
         EmailScenarioAttachments.AttachmentDefaultStatus := false;
         EmailScenarioAttachments.Insert();
-        InsertEmailAttachments(EmailScenarioAttachments, EmailAttachments, EmailScenario);
+        InsertEmailAttachments(EmailScenarioAttachments, EmailAttachments);
     end;
 
-    local procedure InsertEmailAttachments(EmailScenarioAttachments: Record "Email Scenario Attachments"; var EmailAttachment: Record "Email Attachments"; EmailScenario: Integer)
+    local procedure InsertEmailAttachments(EmailScenarioAttachments: Record "Email Scenario Attachments"; var EmailAttachment: Record "Email Attachments")
     begin
-        EmailAttachment.Id := EmailScenarioAttachments.Id;
-        EmailAttachment."Attachment Name" := EmailScenarioAttachments."Attachment Name";
-        EmailAttachment."Email Attachment" := EmailScenarioAttachments."Email Attachment";
-        EmailAttachment.AttachmentDefaultStatus := EmailScenarioAttachments.AttachmentDefaultStatus;
-        EmailAttachment.Scenario := Enum::"Email Scenario".FromInteger(EmailScenario);
+        EmailAttachment.TransferFields(EmailScenarioAttachments);
         EmailAttachment.Insert();
     end;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Using TransferFields opens this up for extensibility rather than limiting the fields to the fixed ones.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes AB#561285
