### PR TITLE
[Email] Add functionality to delete orphaned email recipients.

### DIFF
--- a/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
@@ -165,9 +165,9 @@ codeunit 8904 "Email Message"
     /// <param name="MessagesToIterate">Number of email messages to loop over.</param>
     /// <returns>The next email message id to be checked. Returns empty guid if there are no more messages.</returns>
     /// <remarks>Only the recipients that are not referenced by any email message will be deleted.</remarks>
-    procedure DeleteOrphanedEmailRecipients(StartMessageId: Guid; MessagesToIterate: Integer) NextMessageId: Guid
+    procedure DeleteEmailRecipientsIfOrphaned(StartMessageId: Guid; MessagesToIterate: Integer) NextMessageId: Guid
     begin
-        exit(EmailMessageImpl.DeleteOrphanedEmailRecipients(StartMessageId, MessagesToIterate));
+        exit(EmailMessageImpl.DeleteEmailRecipientsIfOrphaned(StartMessageId, MessagesToIterate));
     end;
 
     /// <summary>

--- a/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
@@ -158,6 +158,19 @@ codeunit 8904 "Email Message"
     end;
 
     /// <summary>
+    /// Deletes email recipients that do not have a reference from email message.
+    /// This functionality is only needed if email recipients have been created without any email message referencing it, otherwise they will be cleaned up automatically.
+    /// </summary>
+    /// <param name="StartMessageId">The email message id to start from. Using empty guid will start from the beginning.</param>
+    /// <param name="MessagesToIterate">Number of email messages to loop over.</param>
+    /// <returns>The next email message id to be checked. Returns empty guid if there are no more messages.</returns>
+    /// <remarks>Only the recipients that are not referenced by any email message will be deleted.</remarks>
+    procedure DeleteOrphanedEmailRecipients(StartMessageId: Guid; MessagesToIterate: Integer) NextMessageId: Guid
+    begin
+        exit(EmailMessageImpl.DeleteOrphanedEmailRecipients(StartMessageId, MessagesToIterate));
+    end;
+
+    /// <summary>
     /// Gets the body of the email message.
     /// </summary>
     /// <returns>The body of the email.</returns>

--- a/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -690,12 +690,12 @@ codeunit 8905 "Email Message Impl."
         EmailMessage.Delete();
     end;
 
-    procedure DeleteOrphanedEmailRecipients(StartMessageId: Guid; MessagesToIterate: Integer) NextMessageId: Guid
+    procedure DeleteEmailRecipientsIfOrphaned(StartMessageId: Guid; RecipientsToIterate: Integer) NextMessageId: Guid
     var
         EmailRecipients: Record "Email Recipient";
         OrphanedDict: Dictionary of [Guid, Boolean];
         EmptyGuid: Guid;
-        MessageNo: Integer;
+        RecipientIdx: Integer;
     begin
         EmailRecipients.SetLoadFields("Email Message Id");
         EmailRecipients.ReadIsolation(IsolationLevel::ReadCommitted);
@@ -704,7 +704,7 @@ codeunit 8905 "Email Message Impl."
         if not EmailRecipients.FindSet() then
             exit;
 
-        for MessageNo := 1 to MessagesToIterate do begin
+        for RecipientIdx := 1 to RecipientsToIterate do begin
             if IsEmailRecipientOrphaned(OrphanedDict, EmailRecipients) then
                 EmailRecipients.Delete();
 

--- a/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -727,9 +727,12 @@ codeunit 8905 "Email Message Impl."
             exit(false);
 
         EmailMessage.SetRange(Id, EmailRecipient."Email Message Id");
-        if EmailMessage.IsEmpty() then
+        if EmailMessage.IsEmpty() then begin
+            OrphanedList.Add(EmailRecipient."Email Message Id");
             exit(true);
+        end;
 
+        NotOrphanedList.Add(EmailRecipient."Email Message Id");
         exit(false);
     end;
 

--- a/src/System Application/Test/Email/src/EmailMessageUnitTest.Codeunit.al
+++ b/src/System Application/Test/Email/src/EmailMessageUnitTest.Codeunit.al
@@ -1361,6 +1361,7 @@ codeunit 134689 "Email Message Unit Test"
     begin
         // [SCENARIO] There are orphaned email recipients in the database
         // [GIVEN] Orphaned email recipients
+        EmailRecipient.DeleteAll();
         AddEmailRecipients(1, MessageId1Txt);
         AddEmailRecipients(4, MessageId2Txt);
         AddEmailRecipients(5, MessageId3Txt);

--- a/src/System Application/Test/Email/src/EmailMessageUnitTest.Codeunit.al
+++ b/src/System Application/Test/Email/src/EmailMessageUnitTest.Codeunit.al
@@ -1355,13 +1355,16 @@ codeunit 134689 "Email Message Unit Test"
     var
         EmailRecipient: Record "Email Recipient";
         EmailMessage: Codeunit "Email Message";
+        OriginalCount: Integer;
+        EmptyGuid: Guid;
         MessageId1Txt: Label '{00000000-0000-0000-0000-000000000001}';
         MessageId2Txt: Label '{00000000-0000-0000-0000-000000000011}';
         MessageId3Txt: Label '{00000000-0000-0000-0000-000000000111}';
     begin
         // [SCENARIO] There are orphaned email recipients in the database
         // [GIVEN] Orphaned email recipients
-        EmailRecipient.DeleteAll();
+        EmailMessage.DeleteEmailRecipientsIfOrphaned(EmptyGuid, 999999);
+        OriginalCount := EmailRecipient.Count();
         AddEmailRecipients(1, MessageId1Txt);
         AddEmailRecipients(4, MessageId2Txt);
         AddEmailRecipients(5, MessageId3Txt);
@@ -1370,20 +1373,20 @@ codeunit 134689 "Email Message Unit Test"
         EmailMessage.DeleteEmailRecipientsIfOrphaned(MessageId1Txt, 1);
 
         // [THEN] 1 orphaned email recipient is deleted, for message id 1
-        Assert.AreEqual(9, EmailRecipient.Count(), 'Orphaned email recipient for message id 1 was not deleted');
+        Assert.AreEqual(9 + OriginalCount, EmailRecipient.Count(), 'Orphaned email recipient for message id 1 was not deleted');
 
         // [WHEN] DeleteOrphanedEmailRecipients is called with 10 messages to iterate
         EmailMessage.DeleteEmailRecipientsIfOrphaned(MessageId3Txt, 10);
 
         // [THEN] 5 orphaned email recipient is deleted, for message id 3
         // Message id 2 is not deleted because the GUID id is earlier than message id 3.
-        Assert.AreEqual(4, EmailRecipient.Count(), 'Orphaned email recipient for message id 3 was not deleted');
+        Assert.AreEqual(4 + OriginalCount, EmailRecipient.Count(), 'Orphaned email recipient for message id 3 was not deleted');
 
         // [WHEN] DeleteOrphanedEmailRecipients is called with 5 messages to iterate
         EmailMessage.DeleteEmailRecipientsIfOrphaned(MessageId2Txt, 4);
 
         // [THEN] 4 orphaned email recipient is deleted, for message id 2
-        Assert.AreEqual(0, EmailRecipient.Count(), 'Orphaned email recipient for message id 2 was not deleted');
+        Assert.AreEqual(0 + OriginalCount, EmailRecipient.Count(), 'Orphaned email recipient for message id 2 was not deleted');
     end;
 
     [StrMenuHandler]

--- a/src/System Application/Test/Email/src/EmailMessageUnitTest.Codeunit.al
+++ b/src/System Application/Test/Email/src/EmailMessageUnitTest.Codeunit.al
@@ -1350,6 +1350,41 @@ codeunit 134689 "Email Message Unit Test"
         Assert.AreEqual(0, EmailMessage.Attachments_GetLength(), 'Attachment content was not deleted');
     end;
 
+    [Test]
+    procedure TestDeleteOrphanEmailRecipients()
+    var
+        EmailRecipient: Record "Email Recipient";
+        EmailMessage: Codeunit "Email Message";
+        MessageId1Txt: Label '{00000000-0000-0000-0000-000000000001}';
+        MessageId2Txt: Label '{00000000-0000-0000-0000-000000000011}';
+        MessageId3Txt: Label '{00000000-0000-0000-0000-000000000111}';
+    begin
+        // [SCENARIO] There are orphaned email recipients in the database
+        // [GIVEN] Orphaned email recipients
+        AddEmailRecipients(1, MessageId1Txt);
+        AddEmailRecipients(4, MessageId2Txt);
+        AddEmailRecipients(5, MessageId3Txt);
+
+        // [WHEN] DeleteOrphanedEmailRecipients is called with 1 message to iterate
+        EmailMessage.DeleteEmailRecipientsIfOrphaned(MessageId1Txt, 1);
+
+        // [THEN] 1 orphaned email recipient is deleted, for message id 1
+        Assert.AreEqual(9, EmailRecipient.Count(), 'Orphaned email recipient for message id 1 was not deleted');
+
+        // [WHEN] DeleteOrphanedEmailRecipients is called with 10 messages to iterate
+        EmailMessage.DeleteEmailRecipientsIfOrphaned(MessageId3Txt, 10);
+
+        // [THEN] 5 orphaned email recipient is deleted, for message id 3
+        // Message id 2 is not deleted because the GUID id is earlier than message id 3.
+        Assert.AreEqual(4, EmailRecipient.Count(), 'Orphaned email recipient for message id 3 was not deleted');
+
+        // [WHEN] DeleteOrphanedEmailRecipients is called with 5 messages to iterate
+        EmailMessage.DeleteEmailRecipientsIfOrphaned(MessageId2Txt, 4);
+
+        // [THEN] 4 orphaned email recipient is deleted, for message id 2
+        Assert.AreEqual(0, EmailRecipient.Count(), 'Orphaned email recipient for message id 2 was not deleted');
+    end;
+
     [StrMenuHandler]
     [Scope('OnPrem')]
     procedure CloseEmailEditorHandler(Options: Text[1024]; var Choice: Integer; Instruction: Text[1024])
@@ -1365,5 +1400,19 @@ codeunit 134689 "Email Message Unit Test"
 
         foreach Recipient in ExpectedRecipients do
             Assert.IsTrue(ActualRecipient.Contains(Recipient), 'Recipient missing: ' + Recipient);
+    end;
+
+    local procedure AddEmailRecipients(Count: Integer; MessageId: Guid)
+    var
+        EmailRecipient: Record "Email Recipient";
+        Index: Integer;
+    begin
+        for Index := 1 to Count do begin
+            EmailRecipient.Init();
+            EmailRecipient."Email Message Id" := MessageId;
+            EmailRecipient."Email Recipient Type" := Enum::"Email Recipient Type"::"To";
+            EmailRecipient."Email Address" := 'test' + Format(Index) + '@test.com';
+            EmailRecipient.Insert();
+        end;
     end;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Adding a requested functionality for deleting orphaned Email Recipients.
As the primary key is related to the Email Message, it validates if the Email Message still exists before deleting.

The dict of orphans are used for caching to reduce checking on the DB.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#572212](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/572212)










