### PR TITLE
[26.0]Include security filter when import permissionset from xml

### DIFF
--- a/src/System Application/App/Permission Sets/src/xmlports/ImportPermissionSets.xmlport.al
+++ b/src/System Application/App/Permission Sets/src/xmlports/ImportPermissionSets.xmlport.al
@@ -326,6 +326,7 @@ xmlport 9864 "Import Permission Sets"
                 TenantPermission."Delete Permission" := SourceMetadataPermission."Delete Permission";
             if IsFirstPermissionHigherThanSecond(SourceMetadataPermission."Execute Permission", TenantPermission."Execute Permission") then
                 TenantPermission."Execute Permission" := SourceMetadataPermission."Execute Permission";
+            TenantPermission."Security Filter" := SourceMetadataPermission."Security Filter";
             TenantPermission.Modify();
         end;
     end;
@@ -391,6 +392,7 @@ xmlport 9864 "Import Permission Sets"
                 TenantPermission."Delete Permission" := SourceTenantPermission."Delete Permission";
             if IsFirstPermissionHigherThanSecond(SourceTenantPermission."Execute Permission", TenantPermission."Execute Permission") then
                 TenantPermission."Execute Permission" := SourceTenantPermission."Execute Permission";
+            TenantPermission."Security Filter" := SourceTenantPermission."Security Filter";
             TenantPermission.Modify();
         end;
     end;

--- a/src/System Application/Test/Permission Sets/src/PermissionImportExportTests.Codeunit.al
+++ b/src/System Application/Test/Permission Sets/src/PermissionImportExportTests.Codeunit.al
@@ -303,6 +303,167 @@ codeunit 132437 "Permission Import Export Tests"
         LibraryAssert.AreEqual(TenantPermission."Delete Permission", TenantPermission."Delete Permission"::" ", 'Delete permission is not set correctly.');
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportTenantPermissionSetUsingOverwriteOption()
+    var
+        TenantPermission: Record "Tenant Permission";
+        TenantPermissionSet: Record "Tenant Permission Set";
+        TenantPermissionSetRel: Record "Tenant Permission Set Rel.";
+        PermissionSetRelation: Codeunit "Permission Set Relation";
+        TempBlobOriginal: Codeunit "Temp Blob";
+        TempBlobModified: Codeunit "Temp Blob";
+        ImportPermissionSets: XmlPort "Import Permission Sets";
+        OutStr: OutStream;
+        InStr: InStream;
+        ZeroGuid: Guid;
+        AppId: Guid;
+        NewRoleId: Code[20];
+        NewName: Text;
+    begin
+        // [FEATURE] [Import] [XMLPORT] [Permission Set] [Tenant Permission Set]
+        // [SCENARIO] Tenant permission set is exported and imported. Then the same permission set is imported again with changed permissions and should be imported as is without merging.
+
+        Initialize();
+
+        NewRoleId := 'Test Permission Set';
+        NewName := 'Test Permission Set';
+
+        // [WHEN] Permission Set C is cloned to get a tenant permission set
+        PermissionSetRelation.CopyPermissionSet(NewRoleId, NewName, 'Permission Set C', AppId, Scope::System, Enum::"Permission Set Copy Type"::Clone);
+
+        TenantPermissionSet.SetFilter("Role ID", NewRoleId);
+        TempBlobOriginal.CreateOutStream(OutStr);
+
+        // [WHEN] Export Tenant permission set
+        Xmlport.Export(Xmlport::"Export Permission Sets Tenant", OutStr, TenantPermissionSet);
+
+        LibraryAssert.IsTrue(TenantPermissionSet.Get(ZeroGuid, NewRoleId), 'Test permission set is missing');
+        LibraryAssert.IsTrue(TenantPermission.Get(ZeroGuid, TenantPermissionSet."Role ID", TenantPermission."Object Type"::"Table Data", Database::"Tenant Permission"), 'Included permission to Test permission set is missing');
+
+        // [WHEN] Existing permission for the permission set is changed
+        TenantPermission."Read Permission" := TenantPermission."Read Permission"::" "; // read permission is removed
+        TenantPermission."Delete Permission" := TenantPermission."Delete Permission"::Yes; // delete permission is added
+        TenantPermission.Modify();
+
+        // [WHEN] A new permission is added to the permission set
+        TenantPermission.Init();
+        TenantPermission."Role ID" := NewRoleId;
+        TenantPermission."Object Type" := TenantPermission."Object Type"::"Table Data";
+        TenantPermission."Object ID" := Database::"Metadata Permission";
+        TenantPermission."Read Permission" := TenantPermission."Read Permission"::Indirect;
+        TenantPermission."Insert Permission" := TenantPermission."Insert Permission"::" ";
+        TenantPermission."Modify Permission" := TenantPermission."Modify Permission"::" ";
+        TenantPermission."Delete Permission" := TenantPermission."Delete Permission"::" ";
+        TenantPermission.Insert();
+
+        // [WHEN] Tenant permission set is exported again
+        TempBlobModified.CreateOutStream(OutStr);
+        Xmlport.Export(Xmlport::"Export Permission Sets Tenant", OutStr, TenantPermissionSet);
+
+        // [WHEN] No tenant permission sets exists
+        TenantPermissionSet.DeleteAll();
+        TenantPermissionSet.SetFilter("Role ID", NewRoleId);
+        LibraryAssert.RecordIsEmpty(TenantPermissionSet);
+        TenantPermissionSetRel.SetFilter("Role ID", NewRoleId);
+        LibraryAssert.RecordIsEmpty(TenantPermissionSetRel);
+
+        // [WHEN] Import the original tenant permission set that was exported
+        TempBlobOriginal.CreateInStream(InStr);
+        ImportPermissionSets.SetSource(InStr);
+        ImportPermissionSets.SetUpdatePermissions(false);
+        ImportPermissionSets.Import();
+
+        // [THEN] Tenant permission set is found with the correct permissions
+        LibraryAssert.IsTrue(TenantPermissionSet.Get(ZeroGuid, NewRoleId), 'Test permission set is missing');
+        LibraryAssert.IsTrue(TenantPermission.Get(ZeroGuid, TenantPermissionSet."Role ID", TenantPermission."Object Type"::"Table Data", Database::"Tenant Permission"), 'Included permission to Test permission set is missing');
+        LibraryAssert.AreEqual(TenantPermission."Read Permission", TenantPermission."Read Permission"::Yes, 'Read permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Insert Permission", TenantPermission."Insert Permission"::Indirect, 'Insert permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Modify Permission", TenantPermission."Modify Permission"::Indirect, 'Modify permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Delete Permission", TenantPermission."Delete Permission"::" ", 'Delete permission is not set correctly.');
+        LibraryAssert.IsFalse(TenantPermission.Get(ZeroGuid, TenantPermissionSet."Role ID", TenantPermission."Object Type"::"Table Data", Database::"Metadata Permission"), 'Metadata permission should not be included');
+
+        // [WHEN] Import the modified tenant permission set
+        TempBlobModified.CreateInStream(InStr);
+        Clear(ImportPermissionSets);
+        ImportPermissionSets.SetSource(InStr);
+        ImportPermissionSets.SetUpdatePermissions(false);
+        ImportPermissionSets.Import();
+
+        // [THEN] Tenant permission set is found with the modified permissions
+        LibraryAssert.IsTrue(TenantPermissionSet.Get(ZeroGuid, NewRoleId), 'Test permission set is missing');
+        LibraryAssert.IsTrue(TenantPermission.Get(ZeroGuid, TenantPermissionSet."Role ID", TenantPermission."Object Type"::"Table Data", Database::"Tenant Permission"), 'Included permission to Test permission set is missing');
+        LibraryAssert.AreEqual(TenantPermission."Read Permission", TenantPermission."Read Permission"::" ", 'Read permission is not set correctly.'); // Import is not additive, the permission should be imported as is
+        LibraryAssert.AreEqual(TenantPermission."Insert Permission", TenantPermission."Insert Permission"::Indirect, 'Insert permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Modify Permission", TenantPermission."Modify Permission"::Indirect, 'Modify permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Delete Permission", TenantPermission."Delete Permission"::Yes, 'Delete permission is not set correctly.');
+        LibraryAssert.IsTrue(TenantPermission.Get(ZeroGuid, TenantPermissionSet."Role ID", TenantPermission."Object Type"::"Table Data", Database::"Metadata Permission"), 'Included permission to Test permission set is missing');
+        LibraryAssert.AreEqual(TenantPermission."Read Permission", TenantPermission."Read Permission"::Indirect, 'Read permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Insert Permission", TenantPermission."Insert Permission"::" ", 'Insert permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Modify Permission", TenantPermission."Modify Permission"::" ", 'Modify permission is not set correctly.');
+        LibraryAssert.AreEqual(TenantPermission."Delete Permission", TenantPermission."Delete Permission"::" ", 'Delete permission is not set correctly.');
+    end;
+
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportTenantPermissionSetUsingOverwriteOptionWithSecurityFilter()
+    var
+        TenantPermission: Record "Tenant Permission";
+        TenantPermissionSet: Record "Tenant Permission Set";
+        PermissionSetRelation: Codeunit "Permission Set Relation";
+        TempBlobOriginal: Codeunit "Temp Blob";
+        ImportPermissionSets: XmlPort "Import Permission Sets";
+        OutStr: OutStream;
+        InStr: InStream;
+        ZeroGuid: Guid;
+        AppId: Guid;
+        NewRoleId: Code[20];
+        NewName: Text;
+    begin
+        // [FEATURE] [Import] [XMLPORT] [Permission Set] [Tenant Permission Set]
+        // [SCENARIO] Tenant permission set is exported, then change the security filter, and then import the original permission set. The origin security filter should be imported.
+
+        Initialize();
+
+        NewRoleId := 'Test Permission Set';
+        NewName := 'Test Permission Set';
+
+        // [WHEN] Permission Set C is cloned to get a tenant permission set
+        PermissionSetRelation.CopyPermissionSet(NewRoleId, NewName, 'Permission Set C', AppId, Scope::System, Enum::"Permission Set Copy Type"::Clone);
+
+        LibraryAssert.IsTrue(TenantPermissionSet.Get(ZeroGuid, NewRoleId), 'Test permission set is missing');
+        LibraryAssert.IsTrue(TenantPermission.Get(ZeroGuid, TenantPermissionSet."Role ID", TenantPermission."Object Type"::"Table Data", Database::"Tenant Permission"), 'Included permission to Test permission set is missing');
+
+        // [WHEN] Change the security filter before exporting
+        Evaluate(TenantPermission."Security Filter", 'Tenant Permission: Type=<>Include');
+        TenantPermission.Modify();
+
+        TenantPermissionSet.SetFilter("Role ID", NewRoleId);
+        TempBlobOriginal.CreateOutStream(OutStr);
+
+        // [WHEN] Export Tenant permission set
+        Xmlport.Export(Xmlport::"Export Permission Sets Tenant", OutStr, TenantPermissionSet);
+
+        LibraryAssert.IsTrue(TenantPermissionSet.Get(ZeroGuid, NewRoleId), 'Test permission set is missing');
+        LibraryAssert.IsTrue(TenantPermission.Get(ZeroGuid, TenantPermissionSet."Role ID", TenantPermission."Object Type"::"Table Data", Database::"Tenant Permission"), 'Included permission to Test permission set is missing');
+
+        // [WHEN] Change the security filter from '<>Include' to '<>Exclude'
+        Evaluate(TenantPermission."Security Filter", 'Tenant Permission: Type=<>Exclude');
+        TenantPermission.Modify();
+
+        // [WHEN] Import the original tenant permission set that was exported, and user choose to overwrite the permission set
+        TempBlobOriginal.CreateInStream(InStr);
+        ImportPermissionSets.SetSource(InStr);
+        ImportPermissionSets.SetUpdatePermissions(false);
+        ImportPermissionSets.Import();
+
+        // [THEN] The original security filter is imported, and the permission set is found with the correct permissions
+        LibraryAssert.IsTrue(TenantPermissionSet.Get(ZeroGuid, NewRoleId), 'Test permission set is missing');
+        LibraryAssert.IsTrue(TenantPermission.Get(ZeroGuid, TenantPermissionSet."Role ID", TenantPermission."Object Type"::"Table Data", Database::"Tenant Permission"), 'Included permission to Test permission set is missing');
+        LibraryAssert.AreEqual('Tenant Permission: Type=<>Include', Format(TenantPermission."Security Filter"), 'Security Filter is not set correctly.');
+    end;
+
     local procedure Initialize()
     var
         TenantPermission: Record "Tenant Permission";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Include security filter when import permissionset from xml
#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#575215](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/575215)



