### PR TITLE
Test Runner - Hardening the UI around Code Coverage

### DIFF
--- a/src/Tools/Test Framework/Test Runner/src/CodeCoverage/ALCodeCoverage.Page.al
+++ b/src/Tools/Test Framework/Test Runner/src/CodeCoverage/ALCodeCoverage.Page.al
@@ -270,6 +270,11 @@ page 130460 "AL Code Coverage"
         SetStyles();
     end;
 
+    trigger OnAfterGetCurrRecord()
+    begin
+        CodeCoverageRunning := System.CodeCoverageLog();
+    end;
+
     trigger OnInit()
     begin
         RequiredCoveragePercent := 90;

--- a/src/Tools/Test Framework/Test Runner/src/CodeCoverage/ALCodeCoverageMgt.Codeunit.al
+++ b/src/Tools/Test Framework/Test Runner/src/CodeCoverage/ALCodeCoverageMgt.Codeunit.al
@@ -23,7 +23,14 @@ codeunit 130470 "AL Code Coverage Mgt."
     procedure Start(MultiSession: Boolean)
     begin
         if IsRunning then
-            Error('Already recording CC');
+            if GuiAllowed() then
+                if Confirm(RestartCodeCoverageQst) then begin
+                    ForceStopCodeCoverage();
+                    IsRunning := false;
+                end;
+
+        if IsRunning then
+            Error(CodeCoverageIsAlreadyRunningErr);
 
         System.CodeCoverageLog(true, MultiSession);
         IsRunning := true;
@@ -37,9 +44,16 @@ codeunit 130470 "AL Code Coverage Mgt."
 
     procedure Stop()
     begin
-        if not IsRunning then
-            Error('Not recording CC');
+        IsRunning := System.CodeCoverageLog();
 
+        if not IsRunning then
+            Error(CodeCoverageIsNotRunningErr);
+
+        ForceStopCodeCoverage();
+    end;
+
+    local procedure ForceStopCodeCoverage()
+    begin
         System.CodeCoverageLog(false, IsMultiSession);
         IsRunning := false;
     end;
@@ -258,4 +272,9 @@ codeunit 130470 "AL Code Coverage Mgt."
 
         exit(1.0)
     end;
+
+    var
+        RestartCodeCoverageQst: Label 'Code Coverage tracking is already started. Would you like to restart the Code Coverage?';
+        CodeCoverageIsAlreadyRunningErr: Label 'Code Coverage tracking is already started. You must stop it before starting a new one.';
+        CodeCoverageIsNotRunningErr: Label 'Code Coverage tracking is not started.';
 }


### PR DESCRIPTION
#### Summary 
Hardening the UI around Code Coverage
We will update the status when the page is opened. If there is a misalignment in any way, now it is easy to restart the code coverage.

#### Work Item(s) 
Fixes [AB#564436](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/564436)



