### PR TITLE
Only run automation on supported branches

### DIFF
--- a/.github/Update AL-Go System Files.settings.json
+++ b/.github/Update AL-Go System Files.settings.json
@@ -3,7 +3,10 @@
         "cron": "55 08 * * 3",
         "includeBranches": [
             "main",
-            "releases/*"
+            "releases/24.x",
+            "releases/24.5",
+            "releases/25.*",
+            "releases/26.*"
         ]
     }
 }

--- a/.github/actions/GetGitBranches/action.ps1
+++ b/.github/actions/GetGitBranches/action.ps1
@@ -24,6 +24,8 @@ else {
 }
 
 Write-Host "Git branches: $($branches -join ', ')"
+$branches = $branches | Where-Object { Test-IsBranchInSupport -BranchName $_ -Repository $ENV:GITHUB_REPOSITORY }
+Write-Host "Git branches in support: $($branches -join ', ')"
 
 $branchesJson = ConvertTo-Json $branches -Compress
 Add-Content -Path $env:GITHUB_OUTPUT -Value "branchesJson=$branchesJson"

--- a/.github/workflows/SubmitStabilityJobs.yaml
+++ b/.github/workflows/SubmitStabilityJobs.yaml
@@ -18,6 +18,8 @@ jobs:
       - name: Get Official Branches
         id: getOfficialBranches
         uses: microsoft/BCApps/.github/actions/GetGitBranches@main
+        env:
+          GH_Token: ${{ github.token }}
         with:
           include: "['releases/*']"
 

--- a/.github/workflows/UpdateBCArtifactVersion.yaml
+++ b/.github/workflows/UpdateBCArtifactVersion.yaml
@@ -27,7 +27,8 @@ jobs:
       - name: Get Official Branches
         id: getOfficialBranches
         uses: microsoft/BCApps/.github/actions/GetGitBranches@main
-
+        env:
+          GH_Token: ${{ github.token }}
         with:
           include: "['main', 'releases/*']"
 

--- a/.github/workflows/UpdatePackageVersions.yaml
+++ b/.github/workflows/UpdatePackageVersions.yaml
@@ -27,6 +27,8 @@ jobs:
       - name: Get Official Branches
         id: getOfficialBranches
         uses: microsoft/BCApps/.github/actions/GetGitBranches@main
+        env:
+          GH_Token: ${{ github.token }}
         with:
           include: "['main', 'releases/*']"
 

--- a/build/scripts/EnlistmentHelperFunctions.psm1
+++ b/build/scripts/EnlistmentHelperFunctions.psm1
@@ -517,5 +517,40 @@ function Invoke-CommandWithRetry {
     }
 }
 
+<#
+.SYNOPSIS
+    Checks if a branch is in support by checking the rulesets in the repository.
+.DESCRIPTION
+    This function checks if a branch is in support by checking the rulesets in the repository.
+    Out of support branches will have a ruleset with the name "Branch is out of support".
+.PARAMETER BranchName
+    The name of the branch to check.
+.PARAMETER Repository
+    The name of the repository to check.
+#>
+function Test-IsBranchInSupport() {
+    param(
+        [parameter(Mandatory = $true)]
+        [string] $BranchName,
+        [parameter(Mandatory = $true)]
+        [string] $Repository
+    )
+    $isSupported = $true
+    $rulesets = gh api "/repos/$Repository/rules/branches/$BranchName" | ConvertFrom-Json
+    if ($null -eq $rulesets) {
+        Write-Host "Could not find any rulesets for $BranchName"
+        return $isSupported
+    }
+
+    $rulesets = $rulesets | Where-Object type -eq required_status_checks
+    foreach ($ruleset in $rulesets) {
+        if ($ruleset.parameters.required_status_checks.context -eq "Branch is out of support") {
+            $isSupported = $false
+            break
+        }
+    }
+    return $isSupported
+}
+
 Export-ModuleMember -Function *-*
 Export-ModuleMember -Function RunAndCheck


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Currently we run some weekly automations on all branches that matches "main" or "releases/*". However, some branches like releases/24.0 is out of support. 

This PR enables us to stop running automations on out of support branches. The steps to take when a branch goes out of support is: 
* Add the branch to the "Branch is out of support" ruleset
* Update "Update AL-Go System Files.settings.json" so it doesn't include the branch

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#574801](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/574801)

