### PR TITLE
[AI] Update telemetry verbosity for CanConsume from warning to normal.

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotQuotaImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotQuotaImpl.Codeunit.al
@@ -50,7 +50,7 @@ codeunit 7786 "Copilot Quota Impl."
             exit(false);
         end;
 
-        Session.LogMessage('0000P7O', StrSubstNo(IsTenantAllowedToConsumeQuotaLbl, Format(ALCopilotQuotaDetails.CanConsume())), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'category', CopilotCapabilityImpl.GetCopilotCategory());
+        Session.LogMessage('0000P7O', StrSubstNo(IsTenantAllowedToConsumeQuotaLbl, Format(ALCopilotQuotaDetails.CanConsume())), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'category', CopilotCapabilityImpl.GetCopilotCategory());
 
         exit(ALCopilotQuotaDetails.CanConsume());
     end;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
The telemetry is not a warning but is being published as a warning.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#575607](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/575607)



