### PR TITLE
[releases/26.x] M365 Sync may fail as multiple identical permissions are added to the same temporary table

### DIFF
--- a/src/System Application/App/Azure AD User Management/src/AzureADUserMgmtImpl.Codeunit.al
+++ b/src/System Application/App/Azure AD User Management/src/AzureADUserMgmtImpl.Codeunit.al
@@ -299,7 +299,7 @@ codeunit 9017 "Azure AD User Mgmt. Impl."
 
                     repeat
                         TempAccessControlWithDefaultPermissions.Copy(AccessControl);
-                        TempAccessControlWithDefaultPermissions.Insert();
+                        if not TempAccessControlWithDefaultPermissions.Insert() then; // Ignore multiple plans referencing the same permission
                     until AccessControl.Next() = 0;
                 until PermissionSetInPlanBuffer.Next() = 0;
         end;


### PR DESCRIPTION
In certain situations when we sync users from M365 they have multiple identical permissions. This means we will attempt to add the same access control to TempAccessControlWithDefaultPermissions multiple times.
Solution, if it's already added once, don't re-add it.

Fixes [AB#575639](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/575639)


