### PR TITLE
[26.x] Fix rest client tests - remove calls to outside services #3651

### DIFF
--- a/src/System Application/Test/Rest Client/app.json
+++ b/src/System Application/Test/Rest Client/app.json
@@ -23,6 +23,12 @@
       "version": "26.2.0.0"
     },
     {
+      "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
+      "name": "Library Variable Storage",
+      "publisher": "Microsoft",
+      "version": "26.2.0.0"
+    },
+    {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
@@ -33,6 +39,10 @@
   "platform": "26.0.0.0",
   "target": "OnPrem",
   "idRanges": [
+    {
+        "from": 134965,
+        "to": 134965
+    },
     {
       "from": 134970,
       "to": 134977

--- a/src/System Application/Test/Rest Client/src/MockRestClientService.Codeunit.al
+++ b/src/System Application/Test/Rest Client/src/MockRestClientService.Codeunit.al
@@ -1,0 +1,121 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Test.RestClient;
+using System.TestLibraries.Utilities;
+
+codeunit 134965 "Mock Rest Client Service"
+{
+    var
+        Assert: Codeunit "Library Assert";
+        WebRequestResponse: Codeunit "Library - Variable Storage";
+        BaseURLTxt: Label 'https://localhost';
+        GetUrlTxt: Label 'https://localhost/get';
+        PostUrlTxt: Label 'https://localhost/post';
+        PatchUrlTxt: Label 'https://localhost/patch';
+        PutUrlTxt: Label 'https://localhost/put';
+        DeleteUrlTxt: Label 'https://localhost/delete';
+        ExpectedRequestQueryParameters: Dictionary of [Text, Text];
+
+    procedure GetBaseURL(): Text
+    begin
+        exit(BaseURLTxt);
+    end;
+
+    procedure GetGetUrl(): Text
+    begin
+        exit(GetUrlTxt);
+    end;
+
+    procedure GetPostUrl(): Text
+    begin
+        exit(PostUrlTxt);
+    end;
+
+    procedure GetPatchUrl(): Text
+    begin
+        exit(PatchUrlTxt);
+    end;
+
+    procedure GetPutUrl(): Text
+    begin
+        exit(PutUrlTxt);
+    end;
+
+    procedure GetDeleteUrl(): Text
+    begin
+        exit(DeleteUrlTxt);
+    end;
+
+    procedure SetResponse(Response: Text)
+    begin
+        WebRequestResponse.Enqueue(Response);
+    end;
+
+    procedure SetQueryParameters(QueryParameters: Dictionary of [Text, Text])
+    begin
+        ExpectedRequestQueryParameters := QueryParameters;
+    end;
+
+    procedure HandleRequest(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        if not Request.Path.StartsWith(BaseURLTxt) then
+            exit;
+
+        VerifyRequestQueryParameters(Request.QueryParameters);
+
+        if Request.Path.StartsWith(GetUrlTxt) then begin
+            Response.Content.WriteFrom(WebRequestResponse.DequeueText());
+            Response.HttpStatusCode := 200;
+            exit;
+        end;
+
+        if Request.Path = PostUrlTxt then begin
+            Response.Content.WriteFrom(WebRequestResponse.DequeueText());
+            Response.HttpStatusCode := 200;
+            exit;
+        end;
+
+        if Request.Path = PatchUrlTxt then begin
+            Response.Content.WriteFrom(WebRequestResponse.DequeueText());
+            Response.HttpStatusCode := 200;
+            exit;
+        end;
+
+        if Request.Path = PutUrlTxt then begin
+            Response.Content.WriteFrom(WebRequestResponse.DequeueText());
+            Response.HttpStatusCode := 200;
+            exit;
+        end;
+
+        if Request.Path = DeleteUrlTxt then begin
+            Response.Content.WriteFrom(WebRequestResponse.DequeueText());
+            Response.HttpStatusCode := 200;
+            exit;
+        end;
+
+        Assert.Fail('Unexpected request path: ' + Request.Path);
+    end;
+
+    procedure VerifyAllExpectedRequestWereHandled()
+    begin
+        WebRequestResponse.AssertEmpty();
+    end;
+
+    local procedure VerifyRequestQueryParameters(RequestQueryParameters: Dictionary of [Text, Text])
+    var
+        QueryParameter: Text;
+    begin
+        Assert.AreEqual(ExpectedRequestQueryParameters.Count(), RequestQueryParameters.Count(), 'Wrong number of query parameters in request.');
+
+        if RequestQueryParameters.Count() = 0 then
+            exit;
+
+        foreach QueryParameter in ExpectedRequestQueryParameters.Keys() do begin
+            Assert.IsTrue(RequestQueryParameters.ContainsKey(QueryParameter), 'Missing query parameter: ' + QueryParameter);
+            Assert.AreEqual(ExpectedRequestQueryParameters.Get(QueryParameter), RequestQueryParameters.Get(QueryParameter), 'Wrong value for query parameter: ' + QueryParameter);
+        end;
+    end;
+}

--- a/src/System Application/Test/Rest Client/src/RestClientTests.Codeunit.al
+++ b/src/System Application/Test/Rest Client/src/RestClientTests.Codeunit.al
@@ -11,18 +11,29 @@ using System.TestLibraries.Utilities;
 codeunit 134971 "Rest Client Tests"
 {
     Subtype = Test;
+    TestHttpRequestPolicy = BlockOutboundRequests;
 
     var
         Assert: Codeunit "Library Assert";
         HttpClientHandler: Codeunit "Test Http Client Handler";
+        MockRestClientService: Codeunit "Mock Rest Client Service";
+        ResponseBodyUrlTxt: Label '{"url": "%1"}', Locked = true;
+
+    local procedure Initialize()
+    begin
+        Clear(MockRestClientService);
+    end;
 
     [Test]
+    [HandlerFunctions('HandleRestClientCall')]
     procedure TestGet()
     var
         RestClient: Codeunit "Rest Client";
         HttpResponseMessage: Codeunit "Http Response Message";
         JsonObject: JsonObject;
     begin
+        Initialize();
+
         // [SCENARIO] Test GET request
 
         // [GIVEN] An initialized Rest Client
@@ -30,413 +41,426 @@ codeunit 134971 "Rest Client Tests"
         RestClient.Initialize(HttpClientHandler);
 
         // [WHEN] The Get method is called
-        HttpResponseMessage := RestClient.Get('https://httpbin.org/get');
+        MockRestClientService.SetResponse(GetResponseData(MockRestClientService.GetGetUrl()));
+        HttpResponseMessage := RestClient.Get(MockRestClientService.GetGetUrl());
 
         // [THEN] The response contains the expected data
+        MockRestClientService.VerifyAllExpectedRequestWereHandled();
         Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
         Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
         JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('https://httpbin.org/get', GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
+        Assert.AreEqual(MockRestClientService.GetGetUrl(), GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
     end;
 
     [Test]
+    [HandlerFunctions('HandleRestClientCall')]
     procedure TestGetWithQueryParameters()
     var
         RestClient: Codeunit "Rest Client";
         HttpResponseMessage: Codeunit "Http Response Message";
         JsonObject: JsonObject;
+        QueryParameters: Text;
+        QueryParametersDictionary: Dictionary of [Text, Text];
+        ResponseBodyTxt: Text;
     begin
+        Initialize();
+
         // [SCENARIO] Test GET request with query parameters
 
         // [GIVEN] An initialized Rest Client
         HttpClientHandler.Initialize();
         RestClient.Initialize(HttpClientHandler);
 
-        // [WHEN] The Get method is called with query parameters
-        HttpResponseMessage := RestClient.Get('https://httpbin.org/get?param1=value1&param2=value2');
+        // [WHEN] The Get method is called with query parameters                              
+        QueryParameters := '?param1=value1&param2=value2';
+        QueryParametersDictionary.Add('param1', 'value1');
+        QueryParametersDictionary.Add('param2', 'value2');
+        MockRestClientService.SetQueryParameters(QueryParametersDictionary);
+
+        ResponseBodyTxt := GetResponseData(MockRestClientService.GetGetUrl() + QueryParameters);
+        ResponseBodyTxt := AddResponseData(ResponseBodyTxt, 'param1', 'value1');
+        ResponseBodyTxt := AddResponseData(ResponseBodyTxt, 'param2', 'value2');
+        MockRestClientService.SetResponse(ResponseBodyTxt);
+        HttpResponseMessage := RestClient.Get(MockRestClientService.GetGetUrl() + QueryParameters);
 
         // [THEN] The response contains the expected data
+        MockRestClientService.VerifyAllExpectedRequestWereHandled();
         Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
         Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
         JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('value1', SelectJsonToken(JsonObject, '$.args.param1').AsValue().AsText(), 'The response should contain the expected query parameter');
-        Assert.AreEqual('value2', SelectJsonToken(JsonObject, '$.args.param2').AsValue().AsText(), 'The response should contain the expected query parameter');
+        Assert.AreEqual('value1', SelectJsonToken(JsonObject, 'param1').AsValue().AsText(), 'The response should contain the expected query parameter');
+        Assert.AreEqual('value2', SelectJsonToken(JsonObject, 'param2').AsValue().AsText(), 'The response should contain the expected query parameter');
     end;
 
     [Test]
+    [HandlerFunctions('HandleRestClientCall')]
     procedure TestPost()
     var
         RestClient: Codeunit "Rest Client";
         HttpGetContent: Codeunit "Http Content";
         HttpResponseMessage: Codeunit "Http Response Message";
         JsonObject: JsonObject;
+        ResponseBodyTxt: Text;
+        ResponseText: Text;
     begin
+        Initialize();
+
         // [SCENARIO] Test POST request
 
         // [GIVEN] An initialized Rest Client
         HttpClientHandler.Initialize();
         RestClient.Initialize(HttpClientHandler);
+        ResponseText := 'Hello World';
+
+        ResponseBodyTxt := GetResponseData(MockRestClientService.GetPostUrl());
+        ResponseBodyTxt := AddResponseData(ResponseBodyTxt, 'data', ResponseText);
+        MockRestClientService.SetResponse(ResponseBodyTxt);
 
         // [WHEN] The Post method is called
-        HttpResponseMessage := RestClient.Post('https://httpbin.org/post', HttpGetContent.Create('Hello World'));
+        HttpResponseMessage := RestClient.Post(MockRestClientService.GetPostUrl(), HttpGetContent.Create(ResponseText));
 
         // [THEN] The response contains the expected data
+        MockRestClientService.VerifyAllExpectedRequestWereHandled();
         Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
         Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
         JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('https://httpbin.org/post', GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
-        Assert.AreEqual('Hello World', GetJsonToken(JsonObject, 'data').AsValue().AsText(), 'The response should contain the expected data');
+        Assert.AreEqual(MockRestClientService.GetPostUrl(), GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
+        Assert.AreEqual(ResponseText, GetJsonToken(JsonObject, 'data').AsValue().AsText(), 'The response should contain the expected data');
     end;
 
     [Test]
+    [HandlerFunctions('HandleRestClientCall')]
     procedure TestPatch()
     var
         RestClient: Codeunit "Rest Client";
         HttpGetContent: Codeunit "Http Content";
         HttpResponseMessage: Codeunit "Http Response Message";
         JsonObject: JsonObject;
+        ResponseText: Text;
+        ResponseBodyTxt: Text;
     begin
+        Initialize();
+
         // [SCENARIO] Test PATCH request
 
         // [GIVEN] An initialized Rest Client
         HttpClientHandler.Initialize();
         RestClient.Initialize(HttpClientHandler);
+        ResponseText := 'Hello World';
+
+        ResponseBodyTxt := GetResponseData(MockRestClientService.GetPatchUrl());
+        ResponseBodyTxt := AddResponseData(ResponseBodyTxt, 'data', ResponseText);
+        MockRestClientService.SetResponse(ResponseBodyTxt);
 
         // [WHEN] The Patch method is called
-        HttpResponseMessage := RestClient.Patch('https://httpbin.org/patch', HttpGetContent.Create('Hello World'));
+        HttpResponseMessage := RestClient.Patch(MockRestClientService.GetPatchUrl(), HttpGetContent.Create(ResponseText));
 
         // [THEN] The response contains the expected data
+        MockRestClientService.VerifyAllExpectedRequestWereHandled();
         Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
         Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
         JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('https://httpbin.org/patch', GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
-        Assert.AreEqual('Hello World', GetJsonToken(JsonObject, 'data').AsValue().AsText(), 'The response should contain the expected data');
+        Assert.AreEqual(MockRestClientService.GetPatchUrl(), GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
+        Assert.AreEqual(ResponseText, GetJsonToken(JsonObject, 'data').AsValue().AsText(), 'The response should contain the expected data');
     end;
 
     [Test]
+    [HandlerFunctions('HandleRestClientCall')]
     procedure TestPut()
     var
         RestClient: Codeunit "Rest Client";
         HttpGetContent: Codeunit "Http Content";
         HttpResponseMessage: Codeunit "Http Response Message";
         JsonObject: JsonObject;
+        ResponseBodyTxt: Text;
+        ResponseText: Text;
     begin
+        Initialize();
+
         // [SCENARIO] Test PUT request
 
         // [GIVEN] An initialized Rest Client
         HttpClientHandler.Initialize();
         RestClient.Initialize(HttpClientHandler);
+        ResponseText := 'Hello World';
+        ResponseBodyTxt := GetResponseData(MockRestClientService.GetPutUrl());
+        ResponseBodyTxt := AddResponseData(ResponseBodyTxt, 'data', ResponseText);
+        MockRestClientService.SetResponse(ResponseBodyTxt);
 
         // [WHEN] The Put method is called
-        HttpResponseMessage := RestClient.Put('https://httpbin.org/put', HttpGetContent.Create('Hello World'));
+        HttpResponseMessage := RestClient.Put(MockRestClientService.GetPutUrl(), HttpGetContent.Create(ResponseText));
 
         // [THEN] The response contains the expected data
+        MockRestClientService.VerifyAllExpectedRequestWereHandled();
         Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
         Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
         JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('https://httpbin.org/put', GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
-        Assert.AreEqual('Hello World', GetJsonToken(JsonObject, 'data').AsValue().AsText(), 'The response should contain the expected data');
+        Assert.AreEqual(MockRestClientService.GetPutUrl(), GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
+        Assert.AreEqual(ResponseText, GetJsonToken(JsonObject, 'data').AsValue().AsText(), 'The response should contain the expected data');
     end;
 
     [Test]
+    [HandlerFunctions('HandleRestClientCall')]
     procedure TestDelete()
     var
         RestClient: Codeunit "Rest Client";
         HttpResponseMessage: Codeunit "Http Response Message";
         JsonObject: JsonObject;
+        ResponseBodyTxt: Text;
     begin
+        Initialize();
+
         // [SCENARIO] Test DELETE request
 
         // [GIVEN] An initialized Rest Client
         HttpClientHandler.Initialize();
         RestClient.Initialize(HttpClientHandler);
+        ResponseBodyTxt := GetResponseData(MockRestClientService.GetDeleteUrl());
+        MockRestClientService.SetResponse(ResponseBodyTxt);
 
         // [WHEN] The Delete method is called
-        HttpResponseMessage := RestClient.Delete('https://httpbin.org/delete');
+        HttpResponseMessage := RestClient.Delete(MockRestClientService.GetDeleteUrl());
 
         // [THEN] The response contains the expected data
+        MockRestClientService.VerifyAllExpectedRequestWereHandled();
         Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
         Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
         JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('https://httpbin.org/delete', GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
+        Assert.AreEqual(MockRestClientService.GetDeleteUrl(), GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
     end;
 
-    [Test]
-    procedure TestGetWithDefaultHeaders()
-    var
-        RestClient: Codeunit "Rest Client";
-        HttpResponseMessage: Codeunit "Http Response Message";
-        JsonObject: JsonObject;
-    begin
-        // [SCENARIO] Test GET request with headers
-
-        // [GIVEN] An initialized Rest Client with default request headers
-        HttpClientHandler.Initialize();
-        RestClient.Initialize(HttpClientHandler);
-        RestClient.SetDefaultRequestHeader('X-Test-Header', 'Test');
-
-        // [WHEN] The Get method is called with headers
-        HttpResponseMessage := RestClient.Get('https://httpbin.org/get');
-
-        // [THEN] The response contains the expected data
-        Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
-        Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
-        JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('https://httpbin.org/get', GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
-        Assert.AreEqual('Test', SelectJsonToken(JsonObject, '$.headers.X-Test-Header').AsValue().AsText(), 'The response should contain the expected header');
-    end;
 
     [Test]
+    [HandlerFunctions('HandleRestClientCall')]
     procedure TestBaseAddress()
     var
         RestClient: Codeunit "Rest Client";
         HttpResponseMessage: Codeunit "Http Response Message";
         JsonObject: JsonObject;
+        ResponseBodyTxt: Text;
     begin
+        Initialize();
+
         // [SCENARIO] Test GET request with base address
 
         // [GIVEN] An initialized Rest Client with base address
         HttpClientHandler.Initialize();
         RestClient.Initialize(HttpClientHandler);
-        RestClient.SetBaseAddress('https://httpbin.org');
+        RestClient.SetBaseAddress(MockRestClientService.GetBaseURL());
+        ResponseBodyTxt := GetResponseData(MockRestClientService.GetGetUrl());
+        MockRestClientService.SetResponse(ResponseBodyTxt);
 
         // [WHEN] The Get method is called with relative url
-        HttpResponseMessage := RestClient.Get('/get');
+        HttpResponseMessage := RestClient.Get('get');
 
         // [THEN] The response contains the expected data
+        MockRestClientService.VerifyAllExpectedRequestWereHandled();
         Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
         Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
         JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('https://httpbin.org/get', GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
+        Assert.AreEqual(MockRestClientService.GetGetUrl(), GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
     end;
 
     [Test]
-    procedure TestDefaultUserAgentHeader()
-    var
-        RestClient: Codeunit "Rest Client";
-        HttpResponseMessage: Codeunit "Http Response Message";
-        JsonObject: JsonObject;
-    begin
-        // [SCENARIO] Test GET request with default User-Agent header
-
-        // [GIVEN] An initialized Rest Client 
-        HttpClientHandler.Initialize();
-        RestClient.Initialize(HttpClientHandler);
-
-        // [WHEN] The Get method is called using the default User-Agent header
-        HttpResponseMessage := RestClient.Get('https://httpbin.org/get');
-
-        // [THEN] The response contains the expected data
-        Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
-        Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
-        JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.IsTrue(SelectJsonToken(JsonObject, '$.headers.User-Agent').AsValue().AsText().StartsWith('Dynamics 365 Business Central '), 'The response should contain a User-Agent header');
-    end;
-
-    [Test]
-    procedure TestCustomUserAgentHeader()
-    var
-        RestClient: Codeunit "Rest Client";
-        HttpResponseMessage: Codeunit "Http Response Message";
-        JsonObject: JsonObject;
-    begin
-        // [SCENARIO] Test GET request with custom User-Agent header
-
-        // [GIVEN] An initialized Rest Client with a customer User-Agent header
-        HttpClientHandler.Initialize();
-        RestClient.Initialize(HttpClientHandler);
-        RestClient.SetUserAgentHeader('BC Rest Client Test');
-
-        // [WHEN] The Get method is called using a custom User-Agent header
-        HttpResponseMessage := RestClient.Get('https://httpbin.org/get');
-
-        // [THEN] The response contains the expected data
-        Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
-        Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
-        JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('BC Rest Client Test', SelectJsonToken(JsonObject, '$.headers.User-Agent').AsValue().AsText(), 'The response should contain the expected User-Agent header');
-    end;
-
-    [Test]
+    [HandlerFunctions('HandleRestClientCall')]
     procedure TestGetAsJson()
     var
         RestClient: Codeunit "Rest Client";
         JsonObject: JsonObject;
+        ResponseBodyTxt: Text;
     begin
+        Initialize();
+
         // [SCENARIO] Test GET request with JSON response
 
         // [GIVEN] An initialized Rest Client
         HttpClientHandler.Initialize();
         RestClient.Initialize(HttpClientHandler);
+        ResponseBodyTxt := GetResponseData(MockRestClientService.GetGetUrl());
+        MockRestClientService.SetResponse(ResponseBodyTxt);
 
         // [WHEN] The GetAsJson method is called
-        JsonObject := RestClient.GetAsJson('https://httpbin.org/get').AsObject();
+        JsonObject := RestClient.GetAsJson(MockRestClientService.GetGetUrl()).AsObject();
 
         // [THEN] The response contains the expected data
-        Assert.AreEqual('https://httpbin.org/get', GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
+        MockRestClientService.VerifyAllExpectedRequestWereHandled();
+        Assert.AreEqual(MockRestClientService.GetGetUrl(), GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
     end;
 
     [Test]
-    [ErrorBehavior(ErrorBehavior::Collect)]
-    procedure TestGetAsJsonWithCollectingErrors()
-    var
-        RestClient: Codeunit "Rest Client";
-        JsonToken: JsonToken;
-        ExceptionList: List of [ErrorInfo];
-        Exception: ErrorInfo;
-    begin
-        // [SCENARIO] Test GET request with JSON response
-
-        // [GIVEN] An initialized Rest Client
-        HttpClientHandler.Initialize();
-        RestClient.Initialize(HttpClientHandler);
-
-        // [WHEN] The GetAsJson method is called
-        JsonToken := RestClient.GetAsJson('https://httpbin.org/xml');
-
-        // [THEN] The response contains the expected data
-        ExceptionList := GetCollectedErrors(true);
-        Exception := ExceptionList.Get(1);
-
-        Assert.AreEqual('The content is not a valid JSON.', Exception.Message, 'The collected error message should be as expected');
-    end;
-
-    [Test]
+    [HandlerFunctions('HandleRestClientCall')]
     procedure TestPostAsJson()
     var
         RestClient: Codeunit "Rest Client";
         HttpGetContent: Codeunit "Http Content";
         JsonObject1: JsonObject;
         JsonObject2: JsonObject;
+        RequestURL: Text;
     begin
+        Initialize();
+
         // [SCENARIO] Test POST request with JSON request and response
 
         // [GIVEN] An initialized Rest Client
         HttpClientHandler.Initialize();
         RestClient.Initialize(HttpClientHandler);
+        RequestURL := MockRestClientService.GetPostUrl();
 
         // [GIVEN] A Json object
         JsonObject1.Add('name', 'John');
         JsonObject1.Add('age', 30);
+        HttpGetContent := HttpGetContent.Create(JsonObject1);
+        MockRestClientService.SetResponse(GetResponseData(RequestURL, JsonObject1));
 
         // [WHEN] The PostAsJson method is called with a Json object
-        HttpGetContent := HttpGetContent.Create(JsonObject1);
-        JsonObject2 := RestClient.PostAsJson('https://httpbin.org/post', JsonObject1).AsObject();
+        JsonObject2 := RestClient.PostAsJson(RequestURL, JsonObject1).AsObject();
 
         // [THEN] The response contains the expected data
-        Assert.AreEqual('https://httpbin.org/post', GetJsonToken(JsonObject2, 'url').AsValue().AsText(), 'The response should contain the expected url');
+        MockRestClientService.VerifyAllExpectedRequestWereHandled();
+        Assert.AreEqual(RequestURL, GetJsonToken(JsonObject2, 'url').AsValue().AsText(), 'The response should contain the expected url');
         JsonObject2.ReadFrom(GetJsonToken(JsonObject2, 'data').AsValue().AsText());
         Assert.AreEqual('John', GetJsonToken(JsonObject2, 'name').AsValue().AsText(), 'The response should contain the expected data');
         Assert.AreEqual(30, GetJsonToken(JsonObject2, 'age').AsValue().AsInteger(), 'The response should contain the expected data');
     end;
 
     [Test]
+    [HandlerFunctions('HandleRestClientCall')]
     procedure TestPatchAsJson()
     var
         RestClient: Codeunit "Rest Client";
         HttpGetContent: Codeunit "Http Content";
         JsonObject1: JsonObject;
         JsonObject2: JsonObject;
+        RequestURL: Text;
     begin
+        Initialize();
+
         // [SCENARIO] Test PATCH request with JSON request and response
 
         // [GIVEN] An initialized Rest Client
         HttpClientHandler.Initialize();
         RestClient.Initialize(HttpClientHandler);
+        RequestURL := MockRestClientService.GetPatchUrl();
 
         // [GIVEN] A Json object
         JsonObject1.Add('name', 'John');
         JsonObject1.Add('age', 30);
 
-        // [WHEN] The PatchAsJson method is called with a Json object
         HttpGetContent := HttpGetContent.Create(JsonObject1);
-        JsonObject2 := RestClient.PatchAsJson('https://httpbin.org/patch', JsonObject1).AsObject();
+        MockRestClientService.SetResponse(GetResponseData(RequestURL, JsonObject1));
+
+        // [WHEN] The PatchAsJson method is called with a Json object
+        JsonObject2 := RestClient.PatchAsJson(RequestURL, JsonObject1).AsObject();
 
         // [THEN] The response contains the expected data
-        Assert.AreEqual('https://httpbin.org/patch', GetJsonToken(JsonObject2, 'url').AsValue().AsText(), 'The response should contain the expected url');
+        MockRestClientService.VerifyAllExpectedRequestWereHandled();
+        Assert.AreEqual(RequestURL, GetJsonToken(JsonObject2, 'url').AsValue().AsText(), 'The response should contain the expected url');
         JsonObject2.ReadFrom(GetJsonToken(JsonObject2, 'data').AsValue().AsText());
         Assert.AreEqual('John', GetJsonToken(JsonObject2, 'name').AsValue().AsText(), 'The response should contain the expected data');
         Assert.AreEqual(30, GetJsonToken(JsonObject2, 'age').AsValue().AsInteger(), 'The response should contain the expected data');
     end;
 
     [Test]
+    [HandlerFunctions('HandleRestClientCall')]
     procedure TestPutAsJson()
     var
         RestClient: Codeunit "Rest Client";
         HttpGetContent: Codeunit "Http Content";
         JsonObject1: JsonObject;
         JsonObject2: JsonObject;
+        RequestURL: Text;
     begin
+        Initialize();
+
         // [SCENARIO] Test PUT request with JSON request and response
 
         // [GIVEN] An initialized Rest Client
         HttpClientHandler.Initialize();
         RestClient.Initialize(HttpClientHandler);
+        RequestURL := MockRestClientService.GetPutUrl();
 
         // [GIVEN] A Json object
         JsonObject1.Add('name', 'John');
         JsonObject1.Add('age', 30);
+        HttpGetContent := HttpGetContent.Create(JsonObject1);
+        MockRestClientService.SetResponse(GetResponseData(RequestURL, JsonObject1));
 
         // [WHEN] The PutAsJson method is called with a Json object
-        HttpGetContent := HttpGetContent.Create(JsonObject1);
-        JsonObject2 := RestClient.PutAsJson('https://httpbin.org/put', JsonObject1).AsObject();
+        JsonObject2 := RestClient.PutAsJson(RequestURL, JsonObject1).AsObject();
 
         // [THEN] The response contains the expected data
-        Assert.AreEqual('https://httpbin.org/put', GetJsonToken(JsonObject2, 'url').AsValue().AsText(), 'The response should contain the expected url');
+        MockRestClientService.VerifyAllExpectedRequestWereHandled();
+        Assert.AreEqual(RequestURL, GetJsonToken(JsonObject2, 'url').AsValue().AsText(), 'The response should contain the expected url');
         JsonObject2.ReadFrom(GetJsonToken(JsonObject2, 'data').AsValue().AsText());
         Assert.AreEqual('John', GetJsonToken(JsonObject2, 'name').AsValue().AsText(), 'The response should contain the expected data');
         Assert.AreEqual(30, GetJsonToken(JsonObject2, 'age').AsValue().AsInteger(), 'The response should contain the expected data');
     end;
 
     [Test]
+    [HandlerFunctions('HandleRestClientCall')]
     procedure TestSendWithoutGetContent()
     var
         RestClient: Codeunit "Rest Client";
         HttpResponseMessage: Codeunit "Http Response Message";
         JsonObject: JsonObject;
     begin
+        Initialize();
+
         // [SCENARIO] Test Send method without Getcontent
 
         // [GIVEN] An initialized Rest Client
         HttpClientHandler.Initialize();
         RestClient.Initialize(HttpClientHandler);
+        MockRestClientService.SetResponse(GetResponseData(MockRestClientService.GetGetUrl()));
 
         // [WHEN] The Send method is called without Getcontent
-        HttpResponseMessage := RestClient.Send(Enum::"Http Method"::GET, 'https://httpbin.org/get');
+        HttpResponseMessage := RestClient.Send(Enum::"Http Method"::GET, MockRestClientService.GetGetUrl());
 
         // [THEN] The response contains the expected data
+        MockRestClientService.VerifyAllExpectedRequestWereHandled();
         Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
         Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
         JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('https://httpbin.org/get', GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
+        Assert.AreEqual(MockRestClientService.GetGetUrl(), GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
     end;
 
     [Test]
+    [HandlerFunctions('HandleRestClientCall')]
     procedure TestSendWithGetContent()
     var
         RestClient: Codeunit "Rest Client";
         HttpContent: Codeunit "Http Content";
         HttpResponseMessage: Codeunit "Http Response Message";
         JsonObject: JsonObject;
+        ResponseBodyTxt: Text;
+        RequestText: Text;
     begin
-        // [SCENARIO] Test Send method with Getcontent
+        Initialize();
+
+        // [SCENARIO] Test Send method with Get content
 
         // [GIVEN] An initialized Rest Client
         HttpClientHandler.Initialize();
         RestClient.Initialize(HttpClientHandler);
+        RequestText := 'Hello World';
+        ResponseBodyTxt := GetResponseData(MockRestClientService.GetPostUrl());
+        ResponseBodyTxt := AddResponseData(ResponseBodyTxt, 'data', RequestText);
+        MockRestClientService.SetResponse(ResponseBodyTxt);
 
-        // [WHEN] The Send method is called with Getcontent
-        HttpResponseMessage := RestClient.Send(Enum::"Http Method"::POST, 'https://httpbin.org/post', HttpContent.Create('Hello World'));
+        // [WHEN] The Send method is called with Get content
+        HttpResponseMessage := RestClient.Send(Enum::"Http Method"::POST, MockRestClientService.GetPostUrl(), HttpContent.Create(RequestText));
 
         // [THEN] The response contains the expected data
+        MockRestClientService.VerifyAllExpectedRequestWereHandled();
         Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
         Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
         JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('https://httpbin.org/post', GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
-        Assert.AreEqual('Hello World', GetJsonToken(JsonObject, 'data').AsValue().AsText(), 'The response should contain the expected data');
+        Assert.AreEqual(MockRestClientService.GetPostUrl(), GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
+        Assert.AreEqual(RequestText, GetJsonToken(JsonObject, 'data').AsValue().AsText(), 'The response should contain the expected data');
     end;
 
     [Test]
+    [HandlerFunctions('HandleRestClientCall')]
     procedure TestSendRequestMessage()
     var
         RestClient: Codeunit "Rest Client";
@@ -444,190 +468,53 @@ codeunit 134971 "Rest Client Tests"
         HttpResponseMessage: Codeunit "Http Response Message";
         JsonObject: JsonObject;
     begin
+        Initialize();
+
         // [SCENARIO] Test Send method with request message
 
         // [GIVEN] An initialized Rest Client
         HttpClientHandler.Initialize();
         RestClient.Initialize(HttpClientHandler);
+        MockRestClientService.SetResponse(GetResponseData(MockRestClientService.GetGetUrl()));
 
         // [WHEN] The Send method is called with a request message
         ALHttpRequestMessage.SetHttpMethod(Enum::"Http Method"::GET);
-        ALHttpRequestMessage.SetRequestUri('https://httpbin.org/get');
+        ALHttpRequestMessage.SetRequestUri(MockRestClientService.GetGetUrl());
         HttpResponseMessage := RestClient.Send(ALHttpRequestMessage);
 
         // [THEN] The response contains the expected data
+        MockRestClientService.VerifyAllExpectedRequestWereHandled();
         Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
         Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
         JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('https://httpbin.org/get', GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
+        Assert.AreEqual(MockRestClientService.GetGetUrl(), GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
     end;
 
-    [Test]
-    procedure TestBasicAuthentication()
+    local procedure GetResponseData(Url: Text; BodyJsonObject: JsonObject): Text
     var
-        RestClient: Codeunit "Rest Client";
-        HttpAuthenticationBasic: Codeunit "Http Authentication Basic";
-        HttpResponseMessage: Codeunit "Http Response Message";
-        JsonObject: JsonObject;
-        PasswordText: Text;
+        ResponseBodyText: Text;
+        JsonObjectText: Text;
     begin
-        // [SCENARIO] Test Http Get with Basic Authentication
-
-        // [GIVEN] An initialized Rest Client with Basic Authentication
-        PasswordText := 'Password123';
-        HttpAuthenticationBasic.Initialize('user01', PasswordText);
-        RestClient.Initialize(HttpClientHandler, HttpAuthenticationBasic);
-
-        // [WHEN] The Get method is called
-        HttpResponseMessage := RestClient.Get('https://httpbin.org/basic-auth/user01/Password123');
-
-        // [THEN] The response contains the expected data
-        Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
-        JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual(true, GetJsonToken(JsonObject, 'authenticated').AsValue().AsBoolean(), 'The response should contain the expected data');
+        ResponseBodyText := GetResponseData(Url);
+        BodyJsonObject.WriteTo(JsonObjectText);
+        ResponseBodyText := AddResponseData(ResponseBodyText, 'data', JsonObjectText);
+        exit(ResponseBodyText);
     end;
 
-    [Test]
-    procedure TestResponseWithCookies()
-    var
-        RestClient: Codeunit "Rest Client";
-        HttpResponseMessage: Codeunit "Http Response Message";
+    local procedure GetResponseData(Url: Text): Text
     begin
-        // [SCENARIO] Test GET request with cookies
-
-        // [GIVEN] An initialized Rest Client
-        HttpClientHandler.Initialize();
-        RestClient.Initialize(HttpClientHandler);
-
-        // [WHEN] The Get method is called
-        HttpResponseMessage := RestClient.Get('https://postman-echo.com/get');
-
-        // [THEN] The response contains the expected data
-        Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
-        Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
-        Assert.IsTrue(HttpResponseMessage.GetCookieNames().Contains('sails.sid'), 'The response should contain the expected cookie');
+        exit(StrSubstNo(ResponseBodyUrlTxt, Url));
     end;
 
-    [Test]
-    procedure TestRequestWithCookies()
+    local procedure AddResponseData(ResponseBodyTxt: Text; ExpectedData1Name: Text; ExpectedData1: Text): Text
     var
-        RestClient: Codeunit "Rest Client";
-        HttpRequestMessage: Codeunit "Http Request Message";
-        HttpResponseMessage: Codeunit "Http Response Message";
-        JsonObject: JsonObject;
+        ResponseJsonObject: JsonObject;
+        ResponseText: Text;
     begin
-        // [SCENARIO] Test GET request with cookies
-
-        // [GIVEN] An initialized Rest Client
-        HttpClientHandler.Initialize();
-        RestClient.Initialize(HttpClientHandler);
-
-        // [GIVEN] A request message with cookies
-        HttpRequestMessage.SetRequestUri('https://httpbin.org/cookies');
-        HttpRequestMessage.SetCookie('cookie1', 'value1');
-        HttpRequestMessage.SetCookie('cookie2', 'value2');
-
-        // [WHEN] The Send method is called with a request message
-        HttpResponseMessage := RestClient.Send(HttpRequestMessage);
-
-        // [THEN] The response contains the expected data
-        Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
-        Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
-        JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('value1', SelectJsonToken(JsonObject, '$.cookies.cookie1').AsValue().AsText(), 'The response should contain the expected cookie1');
-        Assert.AreEqual('value2', SelectJsonToken(JsonObject, '$.cookies.cookie2').AsValue().AsText(), 'The response should contain the expected cookie2');
-    end;
-
-    [Test]
-    procedure TestWithoutUseResponseCookies()
-    var
-        RestClient: Codeunit "Rest Client";
-        HttpResponseMessage: Codeunit "Http Response Message";
-        JsonObject: JsonObject;
-        JsonToken: JsonToken;
-    begin
-        // [SCENARIO] Test GET request without using response cookies
-
-        // [GIVEN] An initialized Rest Client
-        HttpClientHandler.Initialize();
-        RestClient.Initialize(HttpClientHandler);
-
-        // [GIVEN] Use response cookies is disabled
-        RestClient.SetUseResponseCookies(false);
-
-        // [GIVEN] Specific cookies are set
-        HttpResponseMessage := RestClient.Get('https://httpbin.org/cookies/set?cookie1=value1');
-
-        // [WHEN] The cookies list is retrieved
-        HttpResponseMessage := RestClient.Get('https://httpbin.org/cookies');
-
-        // [THEN] The response contains the expected data
-        Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
-        Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
-        JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.IsFalse(JsonObject.SelectToken('$.cookies.cookie1', JsonToken), 'The response should not contain cookies');
-    end;
-
-    [Test]
-    procedure TestWithUseResponseCookies()
-    var
-        RestClient: Codeunit "Rest Client";
-        HttpResponseMessage: Codeunit "Http Response Message";
-        JsonObject: JsonObject;
-    begin
-        // [SCENARIO] Test GET request with using response cookies
-
-        // [GIVEN] An initialized Rest Client
-        HttpClientHandler.Initialize();
-        RestClient.Initialize(HttpClientHandler);
-
-        // [GIVEN] Use response cookies is enabled
-        RestClient.SetUseResponseCookies(true);
-
-        // [GIVEN] Specific cookies are set
-        HttpResponseMessage := RestClient.Get('https://httpbin.org/cookies/set?cookie1=value1');
-
-        // [WHEN] The cookies list is retrieved
-        HttpResponseMessage := RestClient.Get('https://httpbin.org/cookies');
-
-        // [THEN] The response contains the expected data
-        Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
-        Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
-        JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('value1', SelectJsonToken(JsonObject, '$.cookies.cookie1').AsValue().AsText(), 'The response should contain the expected cookie');
-    end;
-
-    [Test]
-    procedure TestUseResponseCookiesWithAdditionalCookies()
-    var
-        RestClient: Codeunit "Rest Client";
-        HttpRequestMessage: Codeunit "Http Request Message";
-        HttpResponseMessage: Codeunit "Http Response Message";
-        JsonObject: JsonObject;
-    begin
-        // [SCENARIO] Test GET request with using response cookies and additional cookies
-
-        // [GIVEN] An initialized Rest Client
-        HttpClientHandler.Initialize();
-        RestClient.Initialize(HttpClientHandler);
-
-        // [GIVEN] Use response cookies is enabled
-        RestClient.SetUseResponseCookies(true);
-
-        // [GIVEN] Specific cookies are set
-        HttpResponseMessage := RestClient.Get('https://httpbin.org/cookies/set?cookie1=value1');
-
-        // [WHEN] The cookies list is retrieved with additional cookies
-        HttpRequestMessage.SetRequestUri('https://httpbin.org/cookies');
-        HttpRequestMessage.SetCookie('cookie2', 'value2');
-        HttpResponseMessage := RestClient.Send(HttpRequestMessage);
-
-        // [THEN] The response contains the expected data
-        Assert.AreEqual(200, HttpResponseMessage.GetHttpStatusCode(), 'The response status code should be 200');
-        Assert.IsTrue(HttpResponseMessage.GetIsSuccessStatusCode(), 'GetIsSuccessStatusCode should be true');
-        JsonObject := HttpResponseMessage.GetContent().AsJson().AsObject();
-        Assert.AreEqual('value1', SelectJsonToken(JsonObject, '$.cookies.cookie1').AsValue().AsText(), 'The response should contain the expected cookie1');
-        Assert.AreEqual('value2', SelectJsonToken(JsonObject, '$.cookies.cookie2').AsValue().AsText(), 'The response should contain the expected cookie2');
+        ResponseJsonObject.ReadFrom(ResponseBodyTxt);
+        ResponseJsonObject.Add(ExpectedData1Name, ExpectedData1);
+        ResponseJsonObject.WriteTo(ResponseText);
+        exit(ResponseText);
     end;
 
     local procedure GetJsonToken(JsonObject: JsonObject; Name: Text) JsonToken: JsonToken
@@ -638,5 +525,12 @@ codeunit 134971 "Rest Client Tests"
     local procedure SelectJsonToken(JsonObject: JsonObject; Path: Text) JsonToken: JsonToken
     begin
         JsonObject.SelectToken(Path, JsonToken);
+    end;
+
+    [HttpClientHandler]
+    procedure HandleRestClientCall(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        MockRestClientService.HandleRequest(Request, Response);
+        exit(false);
     end;
 }


### PR DESCRIPTION
Summary
We must refactor the Rest Client tests not to use actual services. The tests are fragile and we must not call actual endpoints from our automation gates. It is a horrible practice that must be avoided at all costs. We are introducing the cost on the endpoint. No automated test should target actual live services. This can only be done with semiautomated or manual testing.

Work Item(s)
[AB#568108](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/568108)