### PR TITLE
[Bug fix] The function logapply does not take the record as var. As such the telemetry is never sent

### DIFF
--- a/src/Business Foundation/App/NoSeriesCopilot/src/Copilot/Telemetry/NoSeriesCopilotTelemetry.Codeunit.al
+++ b/src/Business Foundation/App/NoSeriesCopilot/src/Copilot/Telemetry/NoSeriesCopilotTelemetry.Codeunit.al
@@ -28,7 +28,7 @@ codeunit 389 "No. Series Copilot Telemetry"
         FeatureTelemetry.LogUptake('0000O9D', NoSeriesCopilotImpl.FeatureName(), Enum::"Feature Uptake Status"::"Set up");
     end;
 
-    procedure LogApply(GeneratedNoSeries: Record "No. Series Generation Detail")
+    procedure LogApply(var GeneratedNoSeries: Record "No. Series Generation Detail")
     var
         FeatureTelemetry: Codeunit "Feature Telemetry";
         NoSeriesCopilotImpl: Codeunit "No. Series Copilot Impl.";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

The function `LogApply` does not take the record as var. As such when it does a count, the result is always 0 and the telemetry is never sent.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#575872](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/575872)