### PR TITLE
[Language] Revert LookupWindowsLanguageId change from #2463

### DIFF
--- a/src/System Application/App/Language/src/LanguageImpl.Codeunit.al
+++ b/src/System Application/App/Language/src/LanguageImpl.Codeunit.al
@@ -290,16 +290,14 @@ codeunit 54 "Language Impl."
 
     procedure LookupWindowsLanguageId(var LanguageId: Integer)
     var
-        TempWindowsLanguage: Record "Windows Language" temporary;
+        WindowsLanguage: Record "Windows Language";
     begin
-        GetApplicationLanguages(TempWindowsLanguage);
+        WindowsLanguage.SetCurrentKey(Name);
 
-        TempWindowsLanguage.SetCurrentKey(Name);
+        if WindowsLanguage.Get(LanguageId) then;
 
-        if TempWindowsLanguage.Get(LanguageId) then;
-
-        if Page.RunModal(Page::"Windows Languages", TempWindowsLanguage) = Action::LookupOK then
-            LanguageId := TempWindowsLanguage."Language ID";
+        if Page.RunModal(Page::"Windows Languages", WindowsLanguage) = Action::LookupOK then
+            LanguageId := WindowsLanguage."Language ID";
     end;
 
     procedure GetParentLanguageId(LanguageId: Integer) ParentLanguageId: Integer


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

Change from #2463 limited the Region selection to application languages. This change reverts the LookupWindowsLanguageId change to allow users to select any language available from the Windows Languages.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#575955](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/575955)


