### PR TITLE
Make ToXmlString() function of codeunit "Signature Key" external

### DIFF
--- a/src/System Application/App/Cryptography Management/src/SignatureKey.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/SignatureKey.Codeunit.al
@@ -42,7 +42,7 @@ codeunit 1474 "Signature Key"
     /// Gets an XML string containing the key of the saved key value.
     /// </summary>
     /// <returns>An XML string containing the key of the saved key value.</returns>
-    internal procedure ToXmlString(): SecretText
+    procedure ToXmlString(): SecretText
     begin
         exit(SignatureKeyImpl.ToXmlString());
     end;


### PR DESCRIPTION
I need to sign some data with the private key of the certificate that is stored in Azure Key Vault.

- The private key is obtained in base64 format by running AzureKeyVault.GetAzureKeyVaultCertificate('Key', Certificate).
- Then dotnet object X509Certificate2 is initialized from that base64 string by running SignatureKey.FromBase64String(Certificate.Unwrap(), EmptySecretText, true).
- And finally the function CryptographyManagement.SignData() is used, but it accepts private key only in XML format.

To convert X509Certificate2 to XML format, SignatureKey.ToXmlString() function can be used, but it is now internal, so I want to make it external to use for that purpose.

Full code:
```
    [NonDebuggable]
    procedure SignDataWithAKVCertificate(DataToSign: Text)
    var
        AzureKeyVault: Codeunit "Azure Key Vault";
        CryptographyManagement: Codeunit "Cryptography Management";
        SignatureKey: Codeunit "Signature Key";
        Certificate: SecretText;
        EmptySecretText: SecretText;
        SignatureOutStream: OutStream;
    begin
        AzureKeyVault.GetAzureKeyVaultCertificate('Key', Certificate);
        SignatureKey.FromBase64String(Certificate.Unwrap(), EmptySecretText, true);
        CryptographyManagement.SignData(DataToSign, SignatureKey.ToXmlString(), Enum::"Hash Algorithm"::SHA256, SignatureOutStream);
        // Do something with SignatureOutStream
    end;
```

Fixes [AB#578074](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/578074)

