### PR TITLE
Add Base64UrlEncode() function to "Base64 Convert" codeunit

### DIFF
--- a/src/System Application/App/Base64 Convert/src/Base64Convert.Codeunit.al
+++ b/src/System Application/App/Base64 Convert/src/Base64Convert.Codeunit.al
@@ -109,6 +109,59 @@ codeunit 4110 "Base64 Convert"
     end;
 
     /// <summary>
+    /// Converts the value of the input string to its equivalent string representation that is encoded with base64 URL-safe characters.
+    /// </summary>
+    /// <param name="String">The string to convert.</param>
+    /// <returns>The string representation, in base64url, of the input string.</returns>
+    procedure ToBase64Url(String: Text): Text
+    begin
+        exit(Base64ConvertImpl.ToBase64Url(String));
+    end;
+
+    /// <summary>
+    /// Converts the value of the input secret string to its equivalent secret string representation that is encoded with base64 URL-safe characters.
+    /// </summary>
+    /// <param name="SecretString">The secret string to convert.</param>
+    /// <returns>The secret string representation, in base64url, of the input secret string.</returns>
+    procedure ToBase64Url(SecretString: SecretText): SecretText
+    begin
+        exit(Base64ConvertImpl.ToBase64Url(SecretString));
+    end;
+
+    /// <summary>
+    /// Converts the value of the input string to its equivalent string representation that is encoded with base64 URL-safe characters.
+    /// </summary>
+    /// <param name="String">The string to convert.</param>
+    /// <param name="TextEncoding">The TextEncoding for the input string.</param>
+    /// <returns>The string representation, in base64url, of the input string.</returns>
+    procedure ToBase64Url(String: Text; TextEncoding: TextEncoding): Text
+    begin
+        exit(Base64ConvertImpl.ToBase64Url(String, TextEncoding));
+    end;
+
+    /// <summary>
+    /// Converts the value of the input string to its equivalent string representation that is encoded with base64 URL-safe characters.
+    /// </summary>
+    /// <param name="String">The string to convert.</param>
+    /// <param name="TextEncoding">The TextEncoding for the input string.</param>
+    /// <param name="Codepage">The Codepage if TextEncoding is MsDos or Windows.</param>
+    /// <returns>The string representation, in base64url, of the input string.</returns>
+    procedure ToBase64Url(String: Text; TextEncoding: TextEncoding; Codepage: Integer): Text
+    begin
+        exit(Base64ConvertImpl.ToBase64Url(String, TextEncoding, Codepage));
+    end;
+
+    /// <summary>
+    /// Converts the value of the input stream to its equivalent string representation that is encoded with base64 URL-safe characters.
+    /// </summary>
+    /// <param name="InStream">The stream to read the input from.</param>
+    /// <returns>The string representation, in base64url, of the input string.</returns>
+    procedure ToBase64Url(InStream: InStream): Text
+    begin
+        exit(Base64ConvertImpl.ToBase64Url(InStream));
+    end;
+
+    /// <summary>
     /// Converts the specified string, which encodes binary data as base-64 digits, to an equivalent regular string.
     /// </summary>
     /// <param name="Base64String">The string to convert.</param>

--- a/src/System Application/App/Base64 Convert/src/Base64ConvertImpl.Codeunit.al
+++ b/src/System Application/App/Base64 Convert/src/Base64ConvertImpl.Codeunit.al
@@ -105,6 +105,66 @@ codeunit 4111 "Base64 Convert Impl."
         exit(Convert.ToBase64String(Encoding.UTF8().GetBytes(SecretString.Unwrap()), Base64FormattingOptions));
     end;
 
+    procedure ToBase64Url(String: Text; TextEncoding: TextEncoding; Codepage: Integer): Text
+    var
+        Base64String: Text;
+    begin
+        Base64String := ToBase64(String, false, TextEncoding, Codepage);
+        exit(RemoveUrlUnsafeChars(Base64String));
+    end;
+
+    procedure ToBase64Url(String: Text): Text
+    begin
+        exit(ToBase64Url(String, TextEncoding::UTF8, 0));
+    end;
+
+    procedure ToBase64Url(String: Text; TextEncoding: TextEncoding): Text
+    begin
+        exit(ToBase64Url(String, TextEncoding, 0));
+    end;
+
+    procedure ToBase64Url(InStream: InStream): Text
+    var
+        Base64String: Text;
+    begin
+        Base64String := ToBase64(InStream, false);
+        exit(RemoveUrlUnsafeChars(Base64String));
+    end;
+
+    [NonDebuggable]
+    procedure ToBase64Url(SecretString: SecretText): SecretText
+    var
+        Base64SecretString: SecretText;
+        Base64String: Text;
+    begin
+        Base64SecretString := ToBase64(SecretString);
+        if Base64SecretString.IsEmpty() then
+            exit;
+        Base64String := Base64SecretString.Unwrap();
+        exit(RemoveUrlUnsafeChars(Base64String));
+    end;
+
+    [NonDebuggable]
+    local procedure RemoveUrlUnsafeChars(Base64String: Text): Text
+    var
+        TB: TextBuilder;
+        Ch: Char;
+    begin
+        foreach Ch in Base64String do
+            case Ch of
+                '+':
+                    TB.Append('-');
+                '/':
+                    TB.Append('_');
+                '=':
+                    continue;
+                else
+                    TB.Append(Ch);
+            end;
+
+        exit(TB.ToText());
+    end;
+
     procedure FromBase64(Base64String: Text; TextEncoding: TextEncoding): Text
     begin
         exit(FromBase64(Base64String, TextEncoding, 1252));


### PR DESCRIPTION
When base64 string is sent as a part of URL, it must be URL-safe, i.e. must not contain characters +, / and =:
"+" must be replaced with "-"
"/" must be replaced with "_"
"=" must be removed
I want to add a new function that will do base64url encoding to the "Base64 Convert" codeunit.

Fixes #AB578358