### PR TITLE
Bug 579193: [26.x][BCApps #3540]Refactors cookie handling and add support for UseServerCertificateValidation

### DIFF
--- a/src/System Application/App/Rest Client/src/HttpResponseMessageImpl.Codeunit.al
+++ b/src/System Application/App/Rest Client/src/HttpResponseMessageImpl.Codeunit.al
@@ -99,10 +99,6 @@ codeunit 2357 "Http Response Message Impl."
         CurrHttpResponseMessageInstance: HttpResponseMessage;
 
     procedure SetResponseMessage(var ResponseMessage: HttpResponseMessage)
-    var
-        Cookie: Cookie;
-        Cookies: Dictionary of [Text, Cookie];
-        CookieName: Text;
     begin
         ClearAll();
         CurrHttpResponseMessageInstance := ResponseMessage;
@@ -112,11 +108,6 @@ codeunit 2357 "Http Response Message Impl."
         SetIsSuccessStatusCode(ResponseMessage.IsSuccessStatusCode);
         SetHeaders(ResponseMessage.Headers);
         SetContent(HttpContent.Create(ResponseMessage.Content));
-        foreach CookieName in ResponseMessage.GetCookieNames() do begin
-            ResponseMessage.GetCookie(CookieName, Cookie);
-            Cookies.Add(CookieName, Cookie);
-        end;
-        SetCookies(Cookies);
     end;
 
     procedure GetResponseMessage() ReturnValue: HttpResponseMessage
@@ -142,31 +133,53 @@ codeunit 2357 "Http Response Message Impl."
 
     #region Cookies
     var
+        GlobalCookiesInitialized: Boolean;
         GlobalCookies: Dictionary of [Text, Cookie];
 
     procedure SetCookies(Cookies: Dictionary of [Text, Cookie])
     begin
         GlobalCookies := Cookies;
+        GlobalCookiesInitialized := true;
     end;
 
     procedure GetCookies() Cookies: Dictionary of [Text, Cookie]
     begin
+        InitializeCookies();
         Cookies := GlobalCookies;
     end;
 
     procedure GetCookieNames() CookieNames: List of [Text]
     begin
-        CookieNames := GlobalCookies.Keys;
+        InitializeCookies();
+        CookieNames := GlobalCookies.Keys();
     end;
 
     procedure GetCookie(Name: Text) TheCookie: Cookie
     begin
+        InitializeCookies();
         if GlobalCookies.Get(Name, TheCookie) then;
     end;
 
     procedure GetCookie(Name: Text; var TheCookie: Cookie) Success: Boolean
     begin
+        InitializeCookies();
         Success := GlobalCookies.Get(Name, TheCookie);
+    end;
+
+    local procedure InitializeCookies()
+    var
+        CookieName: Text;
+        Cookie: Cookie;
+    begin
+        if GlobalCookiesInitialized then
+            exit;
+
+        foreach CookieName in CurrHttpResponseMessageInstance.GetCookieNames() do begin
+            CurrHttpResponseMessageInstance.GetCookie(CookieName, Cookie);
+            GlobalCookies.Add(CookieName, Cookie);
+        end;
+
+        GlobalCookiesInitialized := true;
     end;
     #endregion
 

--- a/src/System Application/App/Rest Client/src/RestClient.Codeunit.al
+++ b/src/System Application/App/Rest Client/src/RestClient.Codeunit.al
@@ -159,6 +159,15 @@ codeunit 2350 "Rest Client"
         RestClientImpl.AddCertificate(Certificate, Password);
     end;
 
+    /// <summary>Sets the use of server certificate validation.</summary>
+    /// <param name="Value">If true, the server certificate validation is enabled. False to disable</param>
+    /// <remarks>Use this function to enable or disable the server certificate validation.
+    /// The Rest Client will be initialized if it was not initialized before.</remarks>
+    procedure SetUseServerCertificateValidation(Value: Boolean)
+    begin
+        RestClientImpl.SetUseServerCertificateValidation(Value);
+    end;
+
     /// <summary>Sets the user agent header of the Rest Client.</summary>
     /// <remarks>Use this function to overwrite the default User-Agent header.
     /// The default user agent header is "Dynamics 365 Business Central - |[Publisher]| [App Name]/[App Version]".

--- a/src/System Application/App/Rest Client/src/RestClientImpl.Codeunit.al
+++ b/src/System Application/App/Rest Client/src/RestClientImpl.Codeunit.al
@@ -128,6 +128,12 @@ codeunit 2351 "Rest Client Impl."
         CurrHttpClientInstance.AddCertificate(Certificate, Password);
     end;
 
+    procedure SetUseServerCertificateValidation(Value: Boolean)
+    begin
+        CheckInitialized();
+        CurrHttpClientInstance.UseServerCertificateValidation(Value);
+    end;
+
     procedure SetAuthorizationHeader(Value: SecretText)
     begin
         SetDefaultRequestHeader('Authorization', Value);


### PR DESCRIPTION
Backport

This change removes code for cookie handling in the `SetResponseMessage` procedure in codeunit `"Http Response Message Impl."`. Instead, cookie handling is done using a separate InitializeCookies procedure upon first access of the response cookies. This change improves code resiliency in case of incorrectly formatted cookie headers.

Support for UseServerCertificateValidation was added to the Rest Client.

Added StrMenuHandler to the automated tests to handle the popup for allowing outgoing HTTP requests.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes AB#579193
