### PR TITLE
[26.x] Allow filter to only V3 Email accounts

### DIFF
--- a/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
+++ b/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
@@ -386,6 +386,9 @@ page 8887 "Email Accounts"
         EmailAccount.GetAllAccounts(true, Rec); // Refresh the email accounts
         if V2V3Filter then
             FilterToConnectorv2v3Accounts(Rec);
+        if V3Filter then
+            FilterToConnectorv3Accounts(Rec);
+
         EmailScenario.GetDefaultEmailAccount(DefaultEmailAccount); // Refresh the default email account
 
         if IsSelected then begin
@@ -399,6 +402,21 @@ page 8887 "Email Accounts"
         CurrPage.Update(false);
     end;
 
+    local procedure FilterToConnectorv3Accounts(var EmailAccounts: Record "Email Account")
+    var
+        IConnector: Interface "Email Connector";
+    begin
+        if EmailAccounts.IsEmpty() then
+            exit;
+
+        if EmailAccounts.FindSet() then
+            repeat
+                IConnector := EmailAccounts.Connector;
+                if not (IConnector is "Email Connector v3") then
+                    EmailAccounts.Delete();
+            until EmailAccounts.Next() = 0;
+    end;
+
     local procedure FilterToConnectorv2v3Accounts(var EmailAccounts: Record "Email Account")
     var
         IConnector: Interface "Email Connector";
@@ -408,6 +426,7 @@ page 8887 "Email Accounts"
 
         repeat
             IConnector := EmailAccounts.Connector;
+
 #if not CLEAN26
 #pragma warning disable AL0432
             if not (IConnector is "Email Connector v2") and not (IConnector is "Email Connector v3") then
@@ -416,6 +435,7 @@ page 8887 "Email Accounts"
             if not (IConnector is "Email Connector v3") then
 #endif
                 EmailAccounts.Delete();
+
         until EmailAccounts.Next() = 0;
     end;
 
@@ -480,6 +500,15 @@ page 8887 "Email Accounts"
         V2V3Filter := UseFilter;
     end;
 
+    /// <summary>
+    /// Filters the email accounts to only show accounts using the Email Connector v3.
+    /// </summary>
+    /// <param name="Version3">Show accounts using the Email Connector v3</param>
+    procedure FilterConnectorV3AccountsOnly(Version3: Boolean)
+    begin
+        V3Filter := Version3;
+    end;
+
     var
         DefaultEmailAccount: Record "Email Account";
         EmailAccountImpl: Codeunit "Email Account Impl.";
@@ -491,6 +520,6 @@ page 8887 "Email Accounts"
         UpdateAccounts: Boolean;
         IsLookupMode: Boolean;
         HasEmailAccount: Boolean;
-        V2V3Filter: Boolean;
+        V2V3Filter, V3Filter : Boolean;
         EmailConnectorHasBeenUninstalledMsg: Label 'The selected email extension has been uninstalled. To view information about the email account, you must reinstall the extension.';
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md -->
#### Summary

Adds that you can filter down on V3 accounts only.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes
[AB#578780](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/578780)

