### PR TITLE
Add Visual Indication to the user for paid copilot features

### DIFF
--- a/src/System Application/App/AI/src/Azure AI Document Intelligence/AzureDIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure AI Document Intelligence/AzureDIImpl.Codeunit.al
@@ -36,7 +36,7 @@ codeunit 7779 "Azure DI Impl." implements "AI Service Name"
 
     procedure RegisterCopilotCapability(CopilotCapability: Enum "Copilot Capability"; CopilotAvailability: Enum "Copilot Availability"; LearnMoreUrl: Text[2048]; CallerModuleInfo: ModuleInfo)
     begin
-        CopilotCapabilityImpl.RegisterCapability(CopilotCapability, CopilotAvailability, Enum::"Azure AI Service Type"::"Azure Document Intelligence", LearnMoreUrl, CallerModuleInfo);
+        CopilotCapabilityImpl.RegisterCapability(CopilotCapability, CopilotAvailability, Enum::"Copilot Billing Type"::"Undefined", Enum::"Azure AI Service Type"::"Azure Document Intelligence", LearnMoreUrl, CallerModuleInfo);
     end;
 
     /// <summary>

--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -47,7 +47,7 @@ codeunit 7772 "Azure OpenAI Impl" implements "AI Service Name"
         TelemetryMetapromptRetrievalErr: Label 'Unable to retrieve metaprompt from Azure Key Vault.', Locked = true;
         TelemetryFunctionCallingFailedErr: Label 'Function calling failed for function: %1', Comment = '%1 is the name of the function', Locked = true;
         AzureOpenAiTxt: Label 'Azure OpenAI', Locked = true;
-        BillingTypeAuthorizationErr: Label 'Usage of resources not authorized with current billing type.', Locked = true;
+        BillingTypeAuthorizationErr: Label 'Usage of AI resources not authorized with chosen billing type. Please reach out to your administrator to resolve this issue.';
 
     procedure IsEnabled(Capability: Enum "Copilot Capability"; CallerModuleInfo: ModuleInfo): Boolean
     begin

--- a/src/System Application/App/AI/src/Copilot/CopilotBillingType.Enum.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotBillingType.Enum.al
@@ -1,0 +1,46 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace System.AI;
+
+/// <summary>
+/// The billable type of the Copilot Capability.
+/// </summary>
+enum 8000 "Copilot Billing Type"
+{
+    Access = Public;
+    Extensible = false;
+
+    /// <summary>
+    /// The Copilot Capability is in free.
+    /// </summary>
+    value(0; "Not Billed")
+    {
+        Caption = 'Not Billed';
+    }
+
+    /// <summary>
+    /// The Copilot Capability is billed by Microsoft.
+    /// </summary>
+    value(1; "Microsoft Billed")
+    {
+        Caption = 'Microsoft billed';
+    }
+
+    /// <summary>
+    /// The Copilot Capability is billed by partner/publisher.
+    /// </summary>
+    value(2; "Custom Billed")
+    {
+        Caption = 'Custom billed';
+    }
+
+    /// <summary>
+    /// UnDefined, only for internal use.
+    /// </summary>
+    value(3; "Undefined")
+    {
+        Caption = 'Undefined';
+    }
+}

--- a/src/System Application/App/AI/src/Copilot/CopilotCapEarlyPreview.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapEarlyPreview.Page.al
@@ -55,6 +55,13 @@ page 7770 "Copilot Cap. Early Preview"
                     ToolTip = 'Specifies the publisher of this Copilot.';
                     Editable = false;
                 }
+                field("Billing Type"; Rec."Billing Type")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Billing Type';
+                    ToolTip = 'Specifies the billing type of this Copilot.';
+                    Editable = false;
+                }
                 field("Learn More"; LearnMore)
                 {
                     ApplicationArea = All;

--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesGA.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesGA.Page.al
@@ -55,6 +55,13 @@ page 7774 "Copilot Capabilities GA"
                     ToolTip = 'Specifies the publisher of this Copilot.';
                     Editable = false;
                 }
+                field("Billing Type"; Rec."Billing Type")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Billing Type';
+                    ToolTip = 'Specifies the billing type of this Copilot.';
+                    Editable = false;
+                }
                 field("Learn More"; LearnMore)
                 {
                     ApplicationArea = All;

--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesPreview.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilitiesPreview.Page.al
@@ -55,6 +55,13 @@ page 7773 "Copilot Capabilities Preview"
                     ToolTip = 'Specifies the publisher of this Copilot.';
                     Editable = false;
                 }
+                field("Billing Type"; Rec."Billing Type")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Billing Type';
+                    ToolTip = 'Specifies the billing type of this Copilot.';
+                    Editable = false;
+                }
                 field("Learn More"; LearnMore)
                 {
                     ApplicationArea = All;

--- a/src/System Application/App/AI/src/Copilot/CopilotCapability.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapability.Codeunit.al
@@ -44,6 +44,21 @@ codeunit 7773 "Copilot Capability"
     end;
 
     /// <summary>
+    /// Register a capability.
+    /// </summary>
+    /// <param name="CopilotCapability">The capability.</param>
+    /// <param name="CopilotAvailability">The availability.</param>
+    /// <param name="CopilotBillingType">BillingType.</param>
+    /// <param name="LearnMoreUrl">The learn more url.</param>
+    procedure RegisterCapability(CopilotCapability: Enum "Copilot Capability"; CopilotAvailability: Enum "Copilot Availability"; CopilotBillingType: Enum "Copilot Billing Type"; LearnMoreUrl: Text[2048])
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        CopilotCapabilityImpl.RegisterCapability(CopilotCapability, CopilotAvailability, CopilotBillingType, LearnMoreUrl, CallerModuleInfo);
+    end;
+
+    /// <summary>
     /// Modify an existing capability.
     /// </summary>
     /// <param name="CopilotCapability">The capability.</param>
@@ -55,6 +70,21 @@ codeunit 7773 "Copilot Capability"
     begin
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         CopilotCapabilityImpl.ModifyCapability(CopilotCapability, CopilotAvailability, LearnMoreUrl, CallerModuleInfo);
+    end;
+
+    /// <summary>
+    /// Modify an existing capability.
+    /// </summary>
+    /// <param name="CopilotCapability">The capability.</param>
+    /// <param name="CopilotAvailability">The availability.</param>
+    /// <param name="CopilotBillingType">BillingType.</param>
+    /// <param name="LearnMoreUrl">The learn more url.</param>
+    procedure ModifyCapability(CopilotCapability: Enum "Copilot Capability"; CopilotAvailability: Enum "Copilot Availability"; CopilotBillingType: Enum "Copilot Billing Type"; LearnMoreUrl: Text[2048])
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        CopilotCapabilityImpl.ModifyCapability(CopilotCapability, CopilotAvailability, CopilotBillingType, LearnMoreUrl, CallerModuleInfo);
     end;
 
     /// <summary>

--- a/src/System Application/App/AI/src/Copilot/CopilotSettings.Table.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotSettings.Table.al
@@ -48,6 +48,11 @@ table 7775 "Copilot Settings"
         {
             DataClassification = SystemMetadata;
         }
+        field(8; "Billing Type"; Enum "Copilot Billing Type")
+        {
+            DataClassification = SystemMetadata;
+            ValuesAllowed = 0, 1, 2;
+        }
     }
 
     keys

--- a/src/System Application/Test Library/AI/src/CopilotSettingsTestLibrary.Codeunit.al
+++ b/src/System Application/Test Library/AI/src/CopilotSettingsTestLibrary.Codeunit.al
@@ -43,6 +43,16 @@ codeunit 132934 "Copilot Settings Test Library"
         exit(CopilotSettings."Learn More URL");
     end;
 
+    procedure GetPublisher(): Text
+    begin
+        exit(CopilotSettings."Publisher");
+    end;
+
+    procedure GetBillingType(): Enum "Copilot Billing Type"
+    begin
+        exit(CopilotSettings."Billing Type");
+    end;
+
     procedure IsEmpty(): Boolean
     begin
         exit(CopilotSettings.IsEmpty());

--- a/src/System Application/Test/AI Partner/app.json
+++ b/src/System Application/Test/AI Partner/app.json
@@ -1,0 +1,54 @@
+{
+  "id": "37bcbda0-e1e2-4172-8dc1-423980ac503b",
+  "name": "AI Partner Test",
+  "publisher": "Partner",
+  "brief": "",
+  "description": "Tests for the AI module for partners",
+  "version": "27.0.0.0",
+  "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
+  "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
+  "help": "",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
+  "logo": "",
+  "dependencies": [
+       {
+      "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
+      "name": "System Application",
+      "publisher": "Microsoft",
+      "version": "27.0.0.0"
+    },
+        {
+      "id": "9856ae4f-d1a7-46ef-89bb-6ef056398228",
+      "name": "System Application Test Library",
+      "publisher": "Microsoft",
+      "version": "27.0.0.0"
+    },
+    {
+    "id": "0d60b215-6ee1-4789-8e53-866cfa50c23c",
+  "name": "System Application Test",
+  "publisher": "Microsoft",
+  "version": "27.0.0.0"
+    },
+        {
+      "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
+      "name": "Library Assert",
+      "publisher": "Microsoft",
+      "version": "27.0.0.0"
+    },
+    {
+      "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
+      "name": "Any",
+      "publisher": "Microsoft",
+      "version": "27.0.0.0"
+    }
+   ],
+  "screenshots": [],
+  "platform": "27.0.0.0",
+  "idRanges": [
+    {
+      "from": 139019,
+      "to": 139020
+    }
+  ],
+  "target": "OnPrem"
+}

--- a/src/System Application/Test/AI Partner/app.json
+++ b/src/System Application/Test/AI Partner/app.json
@@ -46,8 +46,8 @@
   "platform": "27.0.0.0",
   "idRanges": [
     {
-      "from": 139019,
-      "to": 139020
+      "from": 139024,
+      "to": 139025
     }
   ],
   "target": "OnPrem"

--- a/src/System Application/Test/AI Partner/src/AzureOpenAITestPartner.Codeunit.al
+++ b/src/System Application/Test/AI Partner/src/AzureOpenAITestPartner.Codeunit.al
@@ -11,7 +11,7 @@ using System.TestLibraries.AI;
 using System.TestLibraries.Environment;
 using System.TestLibraries.Utilities;
 
-codeunit 139020 "Azure OpenAI Test Partner"
+codeunit 139025 "Azure OpenAI Test Partner"
 {
     Subtype = Test;
 
@@ -71,7 +71,7 @@ codeunit 139020 "Azure OpenAI Test Partner"
         AzureOpenAI.GenerateTextCompletion(Metaprompt, Any.AlphanumericText(10), AOAIOperationResponse);
 
         // [THEN] GenerateTextCompletion returns an error [CAPI with Partner Billed - Not allowed for Partner published capabilities]
-        LibraryAssert.ExpectedError('Usage of resources not authorized with current billing type.');
+        LibraryAssert.ExpectedError('Usage of AI resources not authorized with chosen billing type. Please reach out to your administrator to resolve this issue.');
     end;
 
     [Test]
@@ -96,7 +96,7 @@ codeunit 139020 "Azure OpenAI Test Partner"
         AzureOpenAI.GenerateEmbeddings(Any.AlphanumericText(10), AOAIOperationResponse);
 
         // [THEN] GenerateEmbeddings returns an error [BYO with Microsoft Billed - Not allowed for Partner published capabilities]
-        LibraryAssert.ExpectedError('Usage of resources not authorized with current billing type.');
+        LibraryAssert.ExpectedError('Usage of AI resources not authorized with chosen billing type. Please reach out to your administrator to resolve this issue.');
     end;
 
     [Test]
@@ -123,7 +123,7 @@ codeunit 139020 "Azure OpenAI Test Partner"
         AzureOpenAI.GenerateChatCompletion(AOAIChatMessages, AOAIOperationResponse);
 
         // [THEN] GenerateChatCompletion fails [CAPI with Free billing type - Not allowed for Partner published capabilities]
-        LibraryAssert.ExpectedError('Usage of resources not authorized with current billing type.');
+        LibraryAssert.ExpectedError('Usage of AI resources not authorized with chosen billing type. Please reach out to your administrator to resolve this issue.');
     end;
 
     local procedure RegisterCapabilityWithBillingType(Capability: Enum "Copilot Capability"; Availability: Enum "Copilot Availability"; BillingType: Enum "Copilot Billing Type")

--- a/src/System Application/Test/AI Partner/src/AzureOpenAITestPartner.Codeunit.al
+++ b/src/System Application/Test/AI Partner/src/AzureOpenAITestPartner.Codeunit.al
@@ -1,0 +1,161 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Test.AI;
+
+using System.AI;
+using System.Privacy;
+using System.TestLibraries.AI;
+using System.TestLibraries.Environment;
+using System.TestLibraries.Utilities;
+
+codeunit 139020 "Azure OpenAI Test Partner"
+{
+    Subtype = Test;
+
+    var
+        CopilotTestLibrary: Codeunit "Copilot Test Library";
+        EnvironmentInfoTestLibrary: Codeunit "Environment Info Test Library";
+        LibraryAssert: Codeunit "Library Assert";
+        Any: Codeunit Any;
+        AzureOpenAiTxt: Label 'Azure OpenAI', Locked = true;
+        EndpointTxt: Label 'https://resourcename.openai.azure.com/', Locked = true;
+        DeploymentTxt: Label 'deploymentid', Locked = true;
+        AccountNameTxt: Label 'account', Locked = true;
+        ManagedResourceDeploymentTxt: Label 'Managed AI Resource', Locked = true;
+        LearMoreUrlLbl: Label 'http://LearnMore.com', Locked = true;
+
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('MockHandlerForAccountVerification')]
+    procedure GenerateTextCompletionsBillingTypeAuthorizationErr()
+    var
+        AzureOpenAI: Codeunit "Azure OpenAI";
+        AOAIOperationResponse: Codeunit "AOAI Operation Response";
+        PrivacyNotice: Codeunit "Privacy Notice";
+        Metaprompt: Text;
+        CurrentModuleInfo: ModuleInfo;
+        CopilotSettingsTestLibrary: Codeunit "Copilot Settings Test Library";
+    begin
+        // Initialize the Copilot Settings Test Library
+        CopilotSettingsTestLibrary.DeleteAll();
+
+        // [SCENARIO] GenerateTextCompletion returns an error when generate complete is called
+
+        // [GIVEN] The privacy notice is agreed to
+        // [GIVEN] The authorization key is set
+        PrivacyNotice.SetApprovalState(AzureOpenAITxt, "Privacy Notice Approval State"::Agreed);
+        //AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Text Completions", EndpointTxt, DeploymentTxt, Any.AlphanumericText(10));
+        AzureOpenAI.SetManagedResourceAuthorization(Enum::"AOAI Model Type"::"Text Completions", AccountNameTxt, Any.AlphanumericText(10), ManagedResourceDeploymentTxt);
+
+        // [GIVEN] Capability is set
+        RegisterCapabilityWithBillingType(Enum::"Copilot Capability"::"Text Capability", Enum::"Copilot Availability"::"Preview", Enum::"Copilot Billing Type"::"Custom Billed");
+        AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"Text Capability");
+
+        // [THEN] Copilot capability is registered
+        LibraryAssert.IsTrue(CopilotSettingsTestLibrary.FindFirst(), 'Copilot capability should be registered');
+        LibraryAssert.AreEqual(Enum::"Copilot Capability"::"Text Capability", CopilotSettingsTestLibrary.GetCapability(), 'Copilot capability is not "Text Capability"');
+        LibraryAssert.AreEqual(Enum::"Copilot Billing Type"::"Custom Billed", CopilotSettingsTestLibrary.GetBillingType(), 'Billing type is not "Custom Billed"');
+
+        // [THEN] Registered capability is associated with the current module
+        NavApp.GetCurrentModuleInfo(CurrentModuleInfo);
+        LibraryAssert.AreEqual(CurrentModuleInfo.Id(), CopilotSettingsTestLibrary.GetAppId(), 'App Id is different from the current module');
+        LibraryAssert.AreEqual(CurrentModuleInfo.Publisher(), CopilotSettingsTestLibrary.GetPublisher(), 'Publisher is different from the current module');
+        LibraryAssert.AreEqual(CurrentModuleInfo.Publisher(), 'Partner', 'CurrentModule Publisher is Microsoft');
+
+        Metaprompt := 'metaprompt';
+
+        // [WHEN] GenerateTextCompletion is called
+        AzureOpenAI.GenerateTextCompletion(Metaprompt, Any.AlphanumericText(10), AOAIOperationResponse);
+
+        // [THEN] GenerateTextCompletion returns an error [CAPI with Partner Billed - Not allowed for Partner published capabilities]
+        LibraryAssert.ExpectedError('Usage of resources not authorized with current billing type.');
+    end;
+
+    [Test]
+    procedure GenerateEmbeddingsBillingTypeAuthorizationErr()
+    var
+        AzureOpenAI: Codeunit "Azure OpenAI";
+        AOAIOperationResponse: Codeunit "AOAI Operation Response";
+        PrivacyNotice: Codeunit "Privacy Notice";
+    begin
+        // [SCENARIO] GenerateEmbeddings returns an error when generate complete is called
+
+        // [GIVEN] The privacy notice is agreed to
+        // [GIVEN] The authorization key is set
+        PrivacyNotice.SetApprovalState(AzureOpenAITxt, "Privacy Notice Approval State"::Agreed);
+        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::Embeddings, EndpointTxt, DeploymentTxt, Any.AlphanumericText(10));
+
+        // [GIVEN] Capability is set
+        RegisterCapabilityWithBillingType(Enum::"Copilot Capability"::"Embedding Capability", Enum::"Copilot Availability"::"Preview", Enum::"Copilot Billing Type"::"Microsoft Billed");
+        AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"Embedding Capability");
+
+        // [WHEN] GenerateEmbeddings is called
+        AzureOpenAI.GenerateEmbeddings(Any.AlphanumericText(10), AOAIOperationResponse);
+
+        // [THEN] GenerateEmbeddings returns an error [BYO with Microsoft Billed - Not allowed for Partner published capabilities]
+        LibraryAssert.ExpectedError('Usage of resources not authorized with current billing type.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('MockHandlerForAccountVerification')]
+    procedure GenerateChatCompletionBillingTypeAuthorizationErr()
+    var
+        AzureOpenAI: Codeunit "Azure OpenAI";
+        AOAIChatMessages: Codeunit "AOAI Chat Messages";
+        AOAIOperationResponse: Codeunit "AOAI Operation Response";
+        PrivacyNotice: Codeunit "Privacy Notice";
+    begin
+        // [SCENARIO] GenerateEmbeddings returns an error when generate chat complete is called
+
+        // [GIVEN] The authorization key is set
+        PrivacyNotice.SetApprovalState(AzureOpenAITxt, "Privacy Notice Approval State"::Agreed);
+        AzureOpenAI.SetManagedResourceAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AccountNameTxt, Any.AlphanumericText(10), ManagedResourceDeploymentTxt);
+
+        // [GIVEN] Capability is set
+        RegisterCapabilityWithBillingType(Enum::"Copilot Capability"::"Chat Capability", Enum::"Copilot Availability"::"Generally Available", Enum::"Copilot Billing Type"::"Not Billed");
+        AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"Chat Capability");
+
+        // [WHEN] GenerateChatCompletion is called
+        AzureOpenAI.GenerateChatCompletion(AOAIChatMessages, AOAIOperationResponse);
+
+        // [THEN] GenerateChatCompletion fails [CAPI with Free billing type - Not allowed for Partner published capabilities]
+        LibraryAssert.ExpectedError('Usage of resources not authorized with current billing type.');
+    end;
+
+    local procedure RegisterCapabilityWithBillingType(Capability: Enum "Copilot Capability"; Availability: Enum "Copilot Availability"; BillingType: Enum "Copilot Billing Type")
+    var
+        CopilotCapability: Codeunit "Copilot Capability";
+    begin
+        if CopilotCapability.IsCapabilityRegistered(Capability) then
+            exit;
+
+        CopilotCapability.RegisterCapability(Capability, Availability, BillingType, LearMoreUrlLbl);
+    end;
+
+    local procedure GetModuleAppId(): Guid
+    var
+        CurrentModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCurrentModuleInfo(CurrentModuleInfo);
+        exit(CurrentModuleInfo.Id());
+    end;
+
+    // HttpClient Mock Handler
+    [HttpClientHandler]
+    procedure MockHandlerForAccountVerification(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        if (Request.RequestType = HttpRequestType::Get) and (Request.Path = 'https://account.openai.azure.com/openai/models') then begin
+            // Populate the mocked response with 200 Success
+            response.HttpStatusCode := 200;
+            response.ReasonPhrase := 'Success';
+
+            exit(false); // Use the mocked response
+        end;
+
+        exit(true); // fall through and issue the original request in case of other requests
+    end;
+}

--- a/src/System Application/Test/AI Partner/src/CopilotTestPartner.Codeunit.al
+++ b/src/System Application/Test/AI Partner/src/CopilotTestPartner.Codeunit.al
@@ -1,0 +1,87 @@
+namespace System.Test.AI;
+
+using System.AI;
+using System.TestLibraries.Utilities;
+using System.TestLibraries.AI;
+
+codeunit 139019 "Copilot Test Partner"
+{
+    Subtype = Test;
+
+    var
+        CopilotCapability: Codeunit "Copilot Capability";
+        //CopilotTestLibrary: Codeunit "Copilot Test Library";
+        LibraryAssert: Codeunit "Library Assert";
+        LearnMoreUrlLbl: Label 'http://LearnMore.com', Locked = true;
+        LearnMoreUrl2Lbl: Label 'http://LearnMore2.com', Locked = true;
+
+    [Test]
+    procedure TestRegisterCapabilityWithBillingType()
+    var
+        CopilotSettingsTestLibrary: Codeunit "Copilot Settings Test Library";
+        CurrentModuleInfo: ModuleInfo;
+    begin
+        // [SCENARIO] Register a copilot capability with billing type set to Microsoft-billed
+
+        // [GIVEN] Copilot capability is not registered
+        Initialize();
+
+        // [WHEN] RegisterCapability is called
+        CopilotCapability.RegisterCapability(Enum::"Copilot Capability"::"Text Capability", Enum::"Copilot Availability"::"Preview", Enum::"Copilot Billing Type"::"Microsoft Billed", LearnMoreUrlLbl);
+
+        // [THEN] Copilot capability is registered
+        LibraryAssert.IsTrue(CopilotSettingsTestLibrary.FindFirst(), 'Copilot capability should be registered');
+        LibraryAssert.AreEqual(Enum::"Copilot Capability"::"Text Capability", CopilotSettingsTestLibrary.GetCapability(), 'Copilot capability is not "Text Capability"');
+        LibraryAssert.AreEqual(Enum::"Copilot Billing Type"::"Microsoft Billed", CopilotSettingsTestLibrary.GetBillingType(), 'Billing type is not "Microsoft Billed"');
+
+        // [THEN] Registered capability is associated with the current module
+        NavApp.GetCurrentModuleInfo(CurrentModuleInfo);
+        LibraryAssert.AreEqual(CurrentModuleInfo.Id(), CopilotSettingsTestLibrary.GetAppId(), 'App Id is different from the current module');
+        LibraryAssert.AreEqual(CurrentModuleInfo.Publisher(), CopilotSettingsTestLibrary.GetPublisher(), 'Publisher is different from the current module');
+        LibraryAssert.AreEqual(CurrentModuleInfo.Publisher(), 'Partner', 'CurrentModule Publisher is Microsoft');
+
+        // [THEN] Registered capability is in preview
+        LibraryAssert.AreEqual(Enum::"Copilot Availability"::"Preview", CopilotSettingsTestLibrary.GetAvailability(), 'Availability is not Preview');
+    end;
+
+    [Test]
+    procedure TestModifyCapabilityForBillingType()
+    var
+        CopilotSettingsTestLibrary: Codeunit "Copilot Settings Test Library";
+        CurrentModuleInfo: ModuleInfo;
+    begin
+        // [SCENARIO] Modify copilot capabilities - Availability, Billing Type, and Learn More Url
+
+        // [GIVEN] Copilot capability is registered
+        Initialize();
+        CopilotCapability.RegisterCapability(Enum::"Copilot Capability"::"Text Capability", Enum::"Copilot Availability"::"Early Preview", Enum::"Copilot Billing Type"::"Custom Billed", LearnMoreUrlLbl);
+
+        // [THEN] Copilot capability is registered
+        LibraryAssert.IsTrue(CopilotSettingsTestLibrary.FindFirst(), 'Copilot capability should be registered');
+        LibraryAssert.AreEqual(Enum::"Copilot Capability"::"Text Capability", CopilotSettingsTestLibrary.GetCapability(), 'Copilot capability is not "Text Capability"');
+        LibraryAssert.AreEqual(Enum::"Copilot Billing Type"::"Custom Billed", CopilotSettingsTestLibrary.GetBillingType(), 'Billing type is not "Custom Billed"');
+
+        // [THEN] Registered capability is associated with the current module
+        NavApp.GetCurrentModuleInfo(CurrentModuleInfo);
+        LibraryAssert.AreEqual(CurrentModuleInfo.Id(), CopilotSettingsTestLibrary.GetAppId(), 'App Id is different from the current module');
+        LibraryAssert.AreEqual(CurrentModuleInfo.Publisher(), CopilotSettingsTestLibrary.GetPublisher(), 'Publisher is different from the current module');
+        LibraryAssert.AreEqual(CurrentModuleInfo.Publisher(), 'Partner', 'CurrentModule Publisher is Microsoft');
+
+        // [WHEN] ModifyCapability is called
+        CopilotCapability.ModifyCapability(Enum::"Copilot Capability"::"Text Capability", Enum::"Copilot Availability"::"Preview", Enum::"Copilot Billing Type"::"Microsoft Billed", LearnMoreUrl2Lbl);
+
+        // [THEN] Copilot capability is modified
+        CopilotSettingsTestLibrary.FindFirst();
+        LibraryAssert.AreEqual(Enum::"Copilot Availability"::"Preview", CopilotSettingsTestLibrary.GetAvailability(), 'Availability is not updated');
+        LibraryAssert.AreEqual(LearnMoreUrl2Lbl, CopilotSettingsTestLibrary.GetLearnMoreUrl(), 'Learn More Url is not updated');
+        LibraryAssert.AreEqual(Enum::"Copilot Status"::Active, CopilotSettingsTestLibrary.GetStatus(), 'Status is not Active');
+        LibraryAssert.AreEqual(Enum::"Copilot Billing Type"::"Microsoft Billed", CopilotSettingsTestLibrary.GetBillingType(), 'Billing type is not updated');
+    end;
+
+    local procedure Initialize()
+    var
+        CopilotSettingsTestLibrary: Codeunit "Copilot Settings Test Library";
+    begin
+        CopilotSettingsTestLibrary.DeleteAll();
+    end;
+}

--- a/src/System Application/Test/AI Partner/src/CopilotTestPartner.Codeunit.al
+++ b/src/System Application/Test/AI Partner/src/CopilotTestPartner.Codeunit.al
@@ -4,7 +4,7 @@ using System.AI;
 using System.TestLibraries.Utilities;
 using System.TestLibraries.AI;
 
-codeunit 139019 "Copilot Test Partner"
+codeunit 139024 "Copilot Test Partner"
 {
     Subtype = Test;
 

--- a/src/System Application/Test/AI/src/AzureOpenAITest.Codeunit.al
+++ b/src/System Application/Test/AI/src/AzureOpenAITest.Codeunit.al
@@ -316,7 +316,7 @@ codeunit 132684 "Azure OpenAI Test"
         AzureOpenAI.GenerateTextCompletion(Metaprompt, Any.AlphanumericText(10), AOAIOperationResponse);
 
         // [THEN] GenerateTextCompletion shall fail [CAPI with Custom Billed - Not allowed for Microsoft published capabilities]
-        LibraryAssert.ExpectedError('Usage of resources not authorized with current billing type.');
+        LibraryAssert.ExpectedError('Usage of AI resources not authorized with chosen billing type. Please reach out to your administrator to resolve this issue');
     end;
 
     [Test]

--- a/src/System Application/Test/AI/src/AzureOpenAITest.Codeunit.al
+++ b/src/System Application/Test/AI/src/AzureOpenAITest.Codeunit.al
@@ -292,6 +292,34 @@ codeunit 132684 "Azure OpenAI Test"
     end;
 
     [Test]
+    procedure GenerateTextCompletionsBillingTypeAuthorizationErr()
+    var
+        AzureOpenAI: Codeunit "Azure OpenAI";
+        AOAIOperationResponse: Codeunit "AOAI Operation Response";
+        PrivacyNotice: Codeunit "Privacy Notice";
+        Metaprompt: Text;
+        CopilotCapability: Codeunit "Copilot Capability";
+    begin
+        // [SCENARIO] GenerateTextCompletion returns an error when generate complete is called
+
+        // [GIVEN] The privacy notice is agreed to
+        // [GIVEN] The authorization key is set
+        PrivacyNotice.SetApprovalState(AzureOpenAITxt, "Privacy Notice Approval State"::Agreed);
+        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Text Completions", EndpointTxt, DeploymentTxt, Any.AlphanumericText(10));
+
+        // [GIVEN] Capability is set
+        CopilotCapability.RegisterCapability(Enum::"Copilot Capability"::"Text Capability", Enum::"Copilot Availability"::"Preview", Enum::"Copilot Billing Type"::"Custom Billed", '');
+        AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"Text Capability");
+        Metaprompt := 'metaprompt';
+
+        // [WHEN] GenerateTextCompletion is called
+        AzureOpenAI.GenerateTextCompletion(Metaprompt, Any.AlphanumericText(10), AOAIOperationResponse);
+
+        // [THEN] GenerateTextCompletion shall fail [CAPI with Custom Billed - Not allowed for Microsoft published capabilities]
+        LibraryAssert.ExpectedError('Usage of resources not authorized with current billing type.');
+    end;
+
+    [Test]
     procedure GenerateEmbeddingCopilotCapabilityNotSet()
     var
         AzureOpenAI: Codeunit "Azure OpenAI";


### PR DESCRIPTION
#### Summary <Add visual indication to the user for paid copilot features>

#### Work Item(s) <https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/568080>

Fixes #
1. Add a new column in 'copilot and agent capabilities' page. 
Column Name - Billing Type
Possible Values - Not Billed, Microsoft Billed, Custom Billed, Undefined (internal use only for existing capabilities)
NOTE: Naming conventions are yet to be finalized, feedback welcomed.
2. Authorize the usage of AI resources based on selected billing type at registration of a capability

![image](https://github.com/user-attachments/assets/41da9bbc-6ba3-4a4e-9716-c64652e42953)

