### PR TITLE
TestRunner will be powered by CodeunitMetadata instead

### DIFF
--- a/src/Tools/Test Framework/Test Runner/src/SelectTestRunner.Page.al
+++ b/src/Tools/Test Framework/Test Runner/src/SelectTestRunner.Page.al
@@ -11,9 +11,8 @@ page 130454 "Select TestRunner"
 {
     Editable = false;
     PageType = List;
-    SourceTable = AllObjWithCaption;
-    SourceTableView = where("Object Type" = const(Codeunit),
-                            "Object Subtype" = const('TestRunner'));
+    SourceTable = "CodeUnit Metadata";
+    SourceTableView = where(Subtype = const(TestRunner));
 
     layout
     {
@@ -22,12 +21,12 @@ page 130454 "Select TestRunner"
             repeater(Control1)
             {
                 ShowCaption = false;
-                field("Object ID"; Rec."Object ID")
+                field("Object ID"; Rec.ID)
                 {
                     ApplicationArea = All;
                     ToolTip = 'Specifies the Object ID';
                 }
-                field("Object Name"; Rec."Object Name")
+                field("Object Name"; Rec.Name)
                 {
                     ApplicationArea = All;
                     ToolTip = 'Specifies the Object Name';

--- a/src/Tools/Test Framework/Test Runner/src/SelectTestRunner.Page.al
+++ b/src/Tools/Test Framework/Test Runner/src/SelectTestRunner.Page.al
@@ -11,7 +11,9 @@ page 130454 "Select TestRunner"
 {
     Editable = false;
     PageType = List;
+#pragma warning disable AS0035
     SourceTable = "CodeUnit Metadata";
+#pragma warning restore
     SourceTableView = where(Subtype = const(TestRunner));
 
     layout

--- a/src/Tools/Test Framework/Test Runner/src/SelectTests.Page.al
+++ b/src/Tools/Test Framework/Test Runner/src/SelectTests.Page.al
@@ -11,7 +11,9 @@ page 130453 "Select Tests"
 {
     Editable = false;
     PageType = List;
+#pragma warning disable AS0035
     SourceTable = "CodeUnit Metadata";
+#pragma warning restore
     SourceTableView = where(Subtype = const(Test));
 
     layout

--- a/src/Tools/Test Framework/Test Runner/src/SelectTests.Page.al
+++ b/src/Tools/Test Framework/Test Runner/src/SelectTests.Page.al
@@ -11,9 +11,8 @@ page 130453 "Select Tests"
 {
     Editable = false;
     PageType = List;
-    SourceTable = AllObjWithCaption;
-    SourceTableView = where("Object Type" = const(Codeunit),
-                            "Object Subtype" = const('Test'));
+    SourceTable = "CodeUnit Metadata";
+    SourceTableView = where(Subtype = const(Test));
 
     layout
     {
@@ -22,12 +21,12 @@ page 130453 "Select Tests"
             repeater(Control1)
             {
                 ShowCaption = false;
-                field("Object ID"; Rec."Object ID")
+                field("Object ID"; Rec.ID)
                 {
                     ApplicationArea = All;
                     ToolTip = 'Specifies the Object ID';
                 }
-                field("Object Name"; Rec."Object Name")
+                field("Object Name"; Rec.Name)
                 {
                     ApplicationArea = All;
                     ToolTip = 'Specifies the Object Name';

--- a/src/Tools/Test Framework/Test Runner/src/TestMethodLine.Table.al
+++ b/src/Tools/Test Framework/Test Runner/src/TestMethodLine.Table.al
@@ -40,8 +40,7 @@ table 130450 "Test Method Line"
         field(4; "Test Codeunit"; Integer)
         {
             Editable = false;
-            TableRelation = if ("Line Type" = const(Codeunit)) AllObjWithCaption."Object ID" where("Object Type" = const(Codeunit),
-                                                                                                  "Object Subtype" = const('Test'));
+            TableRelation = if ("Line Type" = const(Codeunit)) "CodeUnit Metadata".ID where(Subtype = const(Test));
 
             trigger OnValidate()
             var


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

`AllObjWithCaption` was used to power TestRunner probably because we don't have `Codeunit Metadata` until recently.

Switching to `Codeunit Metadata` will:
1. Speed things up (naturally, with less data in the table)
2. Laying down the foundation to uptake `TestType` property on codeunits

#### Breaking Changes

Checking Telemetry for Symbol Usage:
1. The 2 pages have no usage, using pragma to suppress warnings
2. There is usage for `procedure GetTestMethods`. Properly obsolete it instead. 


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#579962](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/579962)



