### PR TITLE
[releases/26.x] #3114 Format AppId without brackets and lowercase for VsCode Integration

### DIFF
--- a/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
+++ b/src/System Application/App/VS Code Integration/src/VsCodeIntegrationImpl.Codeunit.al
@@ -133,6 +133,7 @@ codeunit 8333 "VS Code Integration Impl."
     [Scope('OnPrem')]
     local procedure FormatDependencyAsParameter(var NavAppInstalledApp: Record "NAV App Installed App"): Text
     var
+        AppId: Text;
         AppVersion: Text;
         DependencyFormatLbl: Label '%1,%2,%3,%4;', Comment = '%1 = Id, %2 = Name, %3 = Publisher, %4 = Version', Locked = true;
     begin
@@ -141,8 +142,9 @@ codeunit 8333 "VS Code Integration Impl."
             SystemApplicationIdTxt, BaseApplicationIdTxt, ApplicationIdTxt, SystemIdTxt:
                 exit('')
             else
+                AppId := FormatDependencyId(NavAppInstalledApp."App ID");
                 AppVersion := FormatDependencyVersion(NavAppInstalledApp."Version Major", NavAppInstalledApp."Version Minor", NavAppInstalledApp."Version Build", NavAppInstalledApp."Version Revision");
-                exit(StrSubstNo(DependencyFormatLbl, Format(NavAppInstalledApp."App ID", 0, 4), NavAppInstalledApp.Name, NavAppInstalledApp.Publisher, AppVersion));
+                exit(StrSubstNo(DependencyFormatLbl, AppId, NavAppInstalledApp.Name, NavAppInstalledApp.Publisher, AppVersion));
         end;
     end;
 
@@ -163,10 +165,12 @@ codeunit 8333 "VS Code Integration Impl."
     [Scope('OnPrem')]
     local procedure FormatDependencyAsSerializedJsonObject(var PublishedApplication: Record "Published Application") Value: Text
     var
+        AppId: Text;
         AppVersion: Text;
         Dependency: JsonObject;
     begin
-        Dependency.Add('id', PublishedApplication.ID);
+        AppId := FormatDependencyId(PublishedApplication.ID);
+        Dependency.Add('id', AppId);
         Dependency.Add('name', PublishedApplication.Name);
         Dependency.Add('publisher', PublishedApplication.Publisher);
         AppVersion := FormatDependencyVersion(PublishedApplication."Version Major", PublishedApplication."Version Minor", PublishedApplication."Version Build", PublishedApplication."Version Revision");
@@ -181,6 +185,12 @@ codeunit 8333 "VS Code Integration Impl."
         AppVersionLbl: Label '%1.%2.%3.%4', Comment = '%1 = major, %2 = minor, %3 = build, %4 = revision', Locked = true;
     begin
         exit(StrSubstNo(AppVersionLbl, Major, Minor, Build, Revision));
+    end;
+
+    [Scope('OnPrem')]
+    local procedure FormatDependencyId(AppId: Guid): Text
+    begin
+        exit(LowerCase(Format(AppId, 0, 4)));
     end;
 
     [Scope('OnPrem')]

--- a/src/System Application/Test/Vs Code Integration/src/VSCodeIntegrationTest.Codeunit.al
+++ b/src/System Application/Test/Vs Code Integration/src/VSCodeIntegrationTest.Codeunit.al
@@ -77,7 +77,7 @@ codeunit 138133 "VS Code Integration Test"
         // [SCENARIO] Constructing URL to send a request to VS Code to navigate to the page with dependencies
 
         Initialize();
-        HyperlinkStorage.Enqueue('&dependencies=A15FD72B-6430-4BB6-DFBC-1A948B7B15B4%2CMyApp2%2CPublisher2%2C23.0.0.0%3BF15FD82B-8050-4BB6-BFBC-1A948B7B17C3%2CMyApp1%2CPublisher1%2C1.2.3.4%3B');
+        HyperlinkStorage.Enqueue('&dependencies=a15fd72b-6430-4bb6-dfbc-1a948b7b15b4%2CMyApp2%2CPublisher2%2C23.0.0.0%3Bf15fd82b-8050-4bb6-bfbc-1a948b7b17c3%2CMyApp1%2CPublisher1%2C1.2.3.4%3B');
 
         // [GIVEN] a page's dependencies
         TempNavInstalledApp.Init();


### PR DESCRIPTION
This pull request backports #3137 to releases/26.x

Fixes [AB#579978](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/579978)


