### PR TITLE
Introducing TestType to TestRunner

### DIFF
--- a/src/Tools/Test Framework/Test Runner/src/CommandLineTestTool.Page.al
+++ b/src/Tools/Test Framework/Test Runner/src/CommandLineTestTool.Page.al
@@ -101,6 +101,8 @@ page 130455 "Command Line Test Tool"
                 ApplicationArea = All;
                 Caption = 'Test Type';
                 ToolTip = 'Specifies the Test Type';
+                BlankZero = true;
+                MinValue = 1;
 
                 trigger OnValidate()
                 var
@@ -484,7 +486,7 @@ page 130455 "Command Line Test Tool"
         FullErrorMessage: Text;
         StackTrace: Text;
         ExtensionId: Text;
-        TestType: Text;
+        TestType: Integer;
         RemoveTestMethod: Text;
         TestResultsJSONText: Text;
         CCResultsCSVText: Text;

--- a/src/Tools/Test Framework/Test Runner/src/TestSuiteMgt.Codeunit.al
+++ b/src/Tools/Test Framework/Test Runner/src/TestSuiteMgt.Codeunit.al
@@ -26,7 +26,6 @@ codeunit 130456 "Test Suite Mgt."
         DefaultTestSuiteNameTxt: Label 'DEFAULT', Locked = true;
         DialogUpdatingTestsMsg: Label 'Updating Tests: \#1#\#2#', Comment = '1 = Object being processed, 2 = Progress', Locked = true;
         ErrorMessageWithCallStackErr: Label 'Error Message: %1 - Error Call Stack: ', Locked = true;
-        InvalidTestTypeErr: Label 'Invalid test type: %1', Locked = true;
 
     procedure IsTestMethodLine(FunctionName: Text[128]): Boolean
     begin
@@ -310,7 +309,7 @@ codeunit 130456 "Test Suite Mgt."
         GetTestMethods(ALTestSuite, CodeunitMetadata);
     end;
 
-    internal procedure SelectTestMethodsByExtensionAndTestType(var ALTestSuite: Record "AL Test Suite"; ExtensionID: Text; TestType: Text)
+    internal procedure SelectTestMethodsByExtensionAndTestType(var ALTestSuite: Record "AL Test Suite"; ExtensionID: Text; TestType: Integer)
     var
         CodeunitMetadata: Record "CodeUnit Metadata";
         AppExtensionId: Guid;
@@ -322,17 +321,8 @@ codeunit 130456 "Test Suite Mgt."
         end;
 
         CodeunitMetadata.SetRange(SubType, CodeunitMetadata.SubType::Test);
-
-        case TestType of
-            'UnitTest':
-                CodeunitMetadata.SetRange(TestType, CodeunitMetadata.TestType::UnitTest);
-            'IntegrationTest':
-                CodeunitMetadata.SetRange(TestType, CodeunitMetadata.TestType::IntegrationTest);
-            'Uncategorized':
-                CodeunitMetadata.SetRange(TestType, CodeunitMetadata.TestType::Uncategorized);
-            else
-                Error(InvalidTestTypeErr, TestType);
-        end;
+        // inexplicit conversion from Integer to Option
+        CodeunitMetadata.SetRange(TestType, TestType);
 
         GetTestMethods(ALTestSuite, CodeunitMetadata);
     end;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

Introducing `TestType` to TestRunner. We can now select which `TestType` to run from CLI.

Related to https://github.com/microsoft/navcontainerhelper/pull/3959

There will be a follow-up PR to add this capability in both `ALTestRunner.psm1` and [navcontainerhelper  Get-Tests](https://github.com/microsoft/navcontainerhelper/blob/df270f9e3ed96260221f918f2deb0fd7af941f07/AppHandling/PsTestFunctions.ps1#L328C10-L328C13)

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#579962](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/579962)





