### PR TITLE
[AI] Add GPT41 and GPT41 mini to AOAI deployments

### DIFF
--- a/src/Business Foundation/App/NoSeriesCopilot/src/Copilot/NoSeriesCopilotImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeriesCopilot/src/Copilot/NoSeriesCopilotImpl.Codeunit.al
@@ -172,7 +172,7 @@ codeunit 324 "No. Series Copilot Impl."
         if not AzureOpenAI.IsEnabled(Enum::"Copilot Capability"::"No. Series Copilot") then
             exit;
 
-        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT4oLatest());
+        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT41Latest());
         AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"No. Series Copilot");
         AOAIChatCompletionParams.SetMaxTokens(MaxOutputTokens());
         AOAIChatCompletionParams.SetTemperature(0);

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIDeployments.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIDeployments.Codeunit.al
@@ -108,11 +108,12 @@ codeunit 7768 "AOAI Deployments"
         exit(AOAIDeploymentsImpl.GetGPT4Preview(CallerModuleInfo));
     end;
 #endif
-
+#if not CLEAN27
     /// <summary>
     /// Returns the name of the latest AOAI deployment model of GPT4o.
     /// </summary>
     /// <returns>The deployment name.</returns>
+    [Obsolete('GPT4o deployment name is no longer supported. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
     procedure GetGPT4oLatest(): Text
     var
         CallerModuleInfo: ModuleInfo;
@@ -125,6 +126,7 @@ codeunit 7768 "AOAI Deployments"
     /// Returns the name of preview AOAI deployment model of GPT4o.
     /// </summary>
     /// <returns>The deployment name.</returns>
+    [Obsolete('GPT4o deployment name is no longer supported. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
     procedure GetGPT4oPreview(): Text
     var
         CallerModuleInfo: ModuleInfo;
@@ -137,6 +139,7 @@ codeunit 7768 "AOAI Deployments"
     /// Returns the name of the latest AOAI deployment model of GPT4o-Mini.
     /// </summary>
     /// <returns>The deployment name.</returns>
+    [Obsolete('GPT4o mini deployment name is no longer supported. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
     procedure GetGPT4oMiniLatest(): Text
     var
         CallerModuleInfo: ModuleInfo;
@@ -149,11 +152,61 @@ codeunit 7768 "AOAI Deployments"
     /// Returns the name of preview AOAI deployment model of GPT4o-Mini.
     /// </summary>
     /// <returns>The deployment name.</returns>
+    [Obsolete('GPT4o mini deployment name is no longer supported. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
     procedure GetGPT4oMiniPreview(): Text
     var
         CallerModuleInfo: ModuleInfo;
     begin
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         exit(AOAIDeploymentsImpl.GetGPT4oMiniPreview(CallerModuleInfo));
+    end;
+#endif
+
+    /// <summary>
+    /// Returns the name of the latest AOAI deployment model of GPT-4.1.
+    /// </summary>
+    /// <returns>The deployment name.</returns>
+    procedure GetGPT41Latest(): Text
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        exit(AOAIDeploymentsImpl.GetGPT41Latest(CallerModuleInfo));
+    end;
+
+    /// <summary>
+    /// Returns the name of the preview AOAI deployment model of GPT-4.1.
+    /// </summary>
+    /// <returns>The deployment name.</returns>
+    procedure GetGPT41Preview(): Text
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        exit(AOAIDeploymentsImpl.GetGPT41Preview(CallerModuleInfo));
+    end;
+
+    /// <summary>
+    /// Returns the name of the latest AOAI deployment model of GPT-4.1 mini.
+    /// </summary>
+    /// <returns>The deployment name.</returns>
+    procedure GetGPT41MiniLatest(): Text
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        exit(AOAIDeploymentsImpl.GetGPT41MiniLatest(CallerModuleInfo));
+    end;
+
+    /// <summary>
+    /// Returns the name of the preview AOAI deployment model of GPT-4.1 mini.
+    /// </summary>
+    /// <returns>The deployment name.</returns>
+    procedure GetGPT41MiniPreview(): Text
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        exit(AOAIDeploymentsImpl.GetGPT41MiniPreview(CallerModuleInfo));
     end;
 }

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIDeployments.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIDeployments.Codeunit.al
@@ -113,7 +113,7 @@ codeunit 7768 "AOAI Deployments"
     /// Returns the name of the latest AOAI deployment model of GPT4o.
     /// </summary>
     /// <returns>The deployment name.</returns>
-    [Obsolete('GPT4o deployment name is no longer supported. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
+    [Obsolete('GPT4o deployment name is no longer supported from 15 July 2025. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
     procedure GetGPT4oLatest(): Text
     var
         CallerModuleInfo: ModuleInfo;
@@ -126,7 +126,7 @@ codeunit 7768 "AOAI Deployments"
     /// Returns the name of preview AOAI deployment model of GPT4o.
     /// </summary>
     /// <returns>The deployment name.</returns>
-    [Obsolete('GPT4o deployment name is no longer supported. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
+    [Obsolete('GPT4o deployment name is no longer supported from 15 July 2025. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
     procedure GetGPT4oPreview(): Text
     var
         CallerModuleInfo: ModuleInfo;
@@ -139,7 +139,7 @@ codeunit 7768 "AOAI Deployments"
     /// Returns the name of the latest AOAI deployment model of GPT4o-Mini.
     /// </summary>
     /// <returns>The deployment name.</returns>
-    [Obsolete('GPT4o mini deployment name is no longer supported. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
+    [Obsolete('GPT4o mini deployment name is no longer supported from 15 July 2025. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
     procedure GetGPT4oMiniLatest(): Text
     var
         CallerModuleInfo: ModuleInfo;
@@ -152,7 +152,7 @@ codeunit 7768 "AOAI Deployments"
     /// Returns the name of preview AOAI deployment model of GPT4o-Mini.
     /// </summary>
     /// <returns>The deployment name.</returns>
-    [Obsolete('GPT4o mini deployment name is no longer supported. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
+    [Obsolete('GPT4o mini deployment name is no longer supported from 15 July 2025. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
     procedure GetGPT4oMiniPreview(): Text
     var
         CallerModuleInfo: ModuleInfo;

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIDeploymentsImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIDeploymentsImpl.Codeunit.al
@@ -17,10 +17,16 @@ codeunit 7769 "AOAI Deployments Impl"
 
     var
         Telemetry: Codeunit Telemetry;
+#if not CLEAN27
         GPT4oLatestLbl: Label 'gpt-4o-latest', Locked = true;
         GPT4oPreviewLbl: Label 'gpt-4o-preview', Locked = true;
         GPT4oMiniLatestLbl: Label 'gpt-4o-mini-latest', Locked = true;
         GPT4oMiniPreviewLbl: Label 'gpt-4o-mini-preview', Locked = true;
+#endif
+        GPT41LatestLbl: Label 'gpt-41-latest', Locked = true;
+        GPT41PreviewLbl: Label 'gpt-41-preview', Locked = true;
+        GPT41MiniLatestLbl: Label 'gpt-41-mini-latest', Locked = true;
+        GPT41MiniPreviewLbl: Label 'gpt-41-mini-preview', Locked = true;
         DeprecatedDeployments: Dictionary of [Text, Date];
         DeprecationDatesInitialized: Boolean;
         DeprecationMessageLbl: Label 'We detected usage of the Azure OpenAI deployment "%1". This model is obsoleted starting %2 and the quality of your results might vary after that date. Check out codeunit 7768 AOAI Deployments to find the supported deployments.', Comment = 'Telemetry message where %1 is the name of the deployment and %2 is the date of deprecation';
@@ -86,7 +92,7 @@ codeunit 7769 "AOAI Deployments Impl"
         exit(GetDeploymentName(GPT4LatestLbl));
     end;
 #endif
-
+#if not CLEAN27
     procedure GetGPT4oPreview(CallerModuleInfo: ModuleInfo): Text
     begin
         exit(GetDeploymentName(GPT4oPreviewLbl));
@@ -105,6 +111,27 @@ codeunit 7769 "AOAI Deployments Impl"
     procedure GetGPT4oMiniLatest(CallerModuleInfo: ModuleInfo): Text
     begin
         exit(GetDeploymentName(GPT4oMiniLatestLbl));
+    end;
+#endif
+
+    procedure GetGPT41Preview(CallerModuleInfo: ModuleInfo): Text
+    begin
+        exit(GetDeploymentName(GPT41PreviewLbl));
+    end;
+
+    procedure GetGPT41Latest(CallerModuleInfo: ModuleInfo): Text
+    begin
+        exit(GetDeploymentName(GPT41LatestLbl));
+    end;
+
+    procedure GetGPT41MiniPreview(CallerModuleInfo: ModuleInfo): Text
+    begin
+        exit(GetDeploymentName(GPT41MiniPreviewLbl));
+    end;
+
+    procedure GetGPT41MiniLatest(CallerModuleInfo: ModuleInfo): Text
+    begin
+        exit(GetDeploymentName(GPT41MiniLatestLbl));
     end;
 
     // Initializes dictionary of deprecated models

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIDeploymentsImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIDeploymentsImpl.Codeunit.al
@@ -150,6 +150,12 @@ codeunit 7769 "AOAI Deployments Impl"
         DeprecatedDeployments.Add(GPT40613SaasLbl, DMY2Date(1, 11, 2024));
         DeprecatedDeployments.Add(Turbo0613SaasLbl, DMY2Date(1, 11, 2024));
 #endif
+#if not CLEAN27
+        DeprecatedDeployments.Add(GPT4oLatestLbl, DMY2Date(15, 7, 2025));
+        DeprecatedDeployments.Add(GPT4oPreviewLbl, DMY2Date(15, 7, 2025));
+        DeprecatedDeployments.Add(GPT4oMiniLatestLbl, DMY2Date(15, 7, 2025));
+        DeprecatedDeployments.Add(GPT4oMiniPreviewLbl, DMY2Date(15, 7, 2025));
+#endif
         DeprecationDatesInitialized := true;
     end;
 

--- a/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
@@ -343,7 +343,7 @@ codeunit 2012 "Entity Text Impl."
             AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", Endpoint, Deployment, ApiKey)
         else
             if (not IsNullGuid(CallerModuleInfo.Id())) and (CallerModuleInfo.Publisher() = EntityTextModuleInfo.Publisher()) then
-                AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT4oLatest())
+                AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT41Latest())
             else begin
                 TelemetryCD.Add('CallerModuleInfo', Format(CallerModuleInfo.Publisher()));
                 TelemetryCD.Add('EntityTextModuleInfo', Format(EntityTextModuleInfo.Publisher()));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
AI Resources are adding support for GPT41 and GPT41 mini and phasing out GPT4o.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#580889](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/580889)







