### PR TITLE
[Permissions] Functionality to restore license configuration default to defaults without tenant permission sets

### DIFF
--- a/src/System Application/App/Azure AD Plan/src/Plan Configuration/Default Permssions/DefaultPermissionSetInPlan.Page.al
+++ b/src/System Application/App/Azure AD Plan/src/Plan Configuration/Default Permssions/DefaultPermissionSetInPlan.Page.al
@@ -12,7 +12,7 @@ page 9827 "Default Permission Set In Plan"
 {
     PageType = ListPart;
     SourceTable = "Default Permission Set In Plan";
-    Permissions = tabledata "Custom Permission Set In Plan" = rimd;
+    Permissions = tabledata "Default Permission Set In Plan" = rimd;
     Editable = false;
     Extensible = false;
     InsertAllowed = false;

--- a/src/System Application/App/Azure AD Plan/src/Plan Configuration/PlanConfigurationCard.Page.al
+++ b/src/System Application/App/Azure AD Plan/src/Plan Configuration/PlanConfigurationCard.Page.al
@@ -124,6 +124,22 @@ page 9069 "Plan Configuration Card"
                     PlanConfigurationImpl.OpenM365AdminCenter();
                 end;
             }
+
+            action(RestoreDefaultConfiguration)
+            {
+                ApplicationArea = All;
+                Caption = 'Restore Default Configuration';
+                Image = Default;
+                ToolTip = 'Restore license configurations to system defaults and remove any custom tenant permission sets.';
+                Visible = not Rec.Customized;
+
+                trigger OnAction()
+                var
+                    PlanConfigurationImpl: Codeunit "Plan Configuration Impl.";
+                begin
+                    PlanConfigurationImpl.RestoreDefaultConfiguration(Rec);
+                end;
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
**Problem**
Few customers have default license configurations that have tenant permission sets mixed in with their default license configuration. This is likely due to the conversion of User Groups to permission sets.

**Solution**
Add an action to remove the tenant permission sets from the selected license configuration.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#581156](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/581156)




