### PR TITLE
[releases/26.x] [Permissions] Functionality to restore license configuration default to defaults without tenant permission sets

### DIFF
--- a/src/System Application/App/Azure AD Plan/src/Plan Configuration/Default Permssions/DefaultPermissionSetInPlan.Page.al
+++ b/src/System Application/App/Azure AD Plan/src/Plan Configuration/Default Permssions/DefaultPermissionSetInPlan.Page.al
@@ -12,7 +12,7 @@ page 9827 "Default Permission Set In Plan"
 {
     PageType = ListPart;
     SourceTable = "Default Permission Set In Plan";
-    Permissions = tabledata "Custom Permission Set In Plan" = rimd;
+    Permissions = tabledata "Default Permission Set In Plan" = rimd;
     Editable = false;
     Extensible = false;
     InsertAllowed = false;

--- a/src/System Application/App/Azure AD Plan/src/Plan Configuration/PlanConfigurationCard.Page.al
+++ b/src/System Application/App/Azure AD Plan/src/Plan Configuration/PlanConfigurationCard.Page.al
@@ -124,6 +124,22 @@ page 9069 "Plan Configuration Card"
                     PlanConfigurationImpl.OpenM365AdminCenter();
                 end;
             }
+
+            action(RestoreDefaultConfiguration)
+            {
+                ApplicationArea = All;
+                Caption = 'Restore Default Configuration';
+                Image = Default;
+                ToolTip = 'Restore license configurations to system defaults and remove any custom tenant permission sets.';
+                Visible = not Rec.Customized;
+
+                trigger OnAction()
+                var
+                    PlanConfigurationImpl: Codeunit "Plan Configuration Impl.";
+                begin
+                    PlanConfigurationImpl.RestoreDefaultConfiguration(Rec);
+                end;
+            }
         }
     }
 


### PR DESCRIPTION
This pull request backports #3970 to releases/26.x

Fixes AB#[**Insert Work Item Number Here**]