### PR TITLE
[Languages] Show all Windows Languages if no Allowed Languages are configured

### DIFF
--- a/src/System Application/App/Language/src/AllowedLanguage.Table.al
+++ b/src/System Application/App/Language/src/AllowedLanguage.Table.al
@@ -23,7 +23,7 @@ table 3563 "Allowed Language"
             Caption = 'Language Id';
             NotBlank = true;
             BlankZero = true;
-            TableRelation = "Windows Language" where("Localization Exist" = const(true), "Globally Enabled" = const(true));
+            TableRelation = "Windows Language";
             ToolTip = 'Specifies the language id(s) that should be available for this environment.';
         }
         field(2; Language; Text[80])

--- a/src/System Application/App/Language/src/LanguageImpl.Codeunit.al
+++ b/src/System Application/App/Language/src/LanguageImpl.Codeunit.al
@@ -188,8 +188,6 @@ codeunit 54 "Language Impl."
         if LanguageFilter <> '' then
             WindowsLanguage.SetFilter("Language ID", LanguageFilter);
 
-        WindowsLanguage.SetRange("Localization Exist", true);
-        WindowsLanguage.SetRange("Globally Enabled", true);
         if WindowsLanguage.FindSet() then
             repeat
                 TempWindowsLanguage := WindowsLanguage;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
The filters on "Localization Exist" and "Globally Enabled" limited the list of languages that were previously allowed to be selected from. This removed numerous languages resulting in incidents.

Removal of the filter resets this back to how it worked before 26.0 and only if you set up Allowed Languages, then the list of languages will be filtered.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#591234](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/591234)


