### PR TITLE
[Subscription Billing] - Account Payable Administrator extension with Vendor Contract action

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/RoleCenters/APAdminActivities.PageExt.al
+++ b/src/Apps/W1/Subscription Billing/App/RoleCenters/APAdminActivities.PageExt.al
@@ -1,0 +1,35 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.SubscriptionBilling;
+
+using Microsoft.Finance.RoleCenters;
+
+pageextension 8013 "A/P Admin Activities" extends "A/P Admin Activities"
+{
+    layout
+    {
+        addafter("Purch. Invoices Due Next Week")
+        {
+            field("Vendor Contracts"; this.VendorContracts)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Vendor Contracts';
+                DrillDownPageID = "Vendor Contracts";
+                Editable = false;
+                Tooltip = 'Specifies the number of vendor contracts.';
+            }
+        }
+    }
+
+    var
+        VendorContracts: Integer;
+
+    trigger OnOpenPage()
+    var
+        VendorContract: Record "Vendor Subscription Contract";
+    begin
+        this.VendorContracts := VendorContract.Count();
+    end;
+}

--- a/src/Apps/W1/Subscription Billing/App/RoleCenters/AccPayableAdministratorRC.PageExt.al
+++ b/src/Apps/W1/Subscription Billing/App/RoleCenters/AccPayableAdministratorRC.PageExt.al
@@ -1,0 +1,26 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.SubscriptionBilling;
+
+using Microsoft.Finance.RoleCenters;
+
+pageextension 8011 "Acc. Payable Administrator RC" extends "Acc. Payable Administrator RC"
+{
+    actions
+    {
+        addlast(CreatePurchaseDocuments)
+        {
+            action(VendorContract)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Vendor Contract';
+                Image = FileContract;
+                ToolTip = 'Create a vendor contract.';
+                RunObject = Page "Vendor Contract";
+                RunPageMode = Create;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request does not have a related issue as it's part of the delivery for development agreed directly with @altotovi @Groenbech96

Implementation

These changes extend new Account Payable Administrator Role Center page with action 'Vendor Contract' which enables user to create new Vendor Contract directly from role center page.

Related with changes in Base App: https://github.com/microsoft/BusinessCentralApps/pull/1379

Fixes [AB#581591]