### PR TITLE
[releases/24.x] Disable Translated mode due to instabilities with error "End of Central Directory record could not be found"

### DIFF
--- a/build/projects/Business Foundation/.AL-Go/settings.json
+++ b/build/projects/Business Foundation/.AL-Go/settings.json
@@ -8,9 +8,6 @@
     "..\\..\\..\\src\\Business Foundation\\Test",
     "..\\..\\..\\src\\Business Foundation\\Test Library"
   ],
-  "buildModes": [
-    "Translated"
-  ],
   "installOnlyReferencedApps": false,
   "ConditionalSettings": [
     {

--- a/build/projects/System Application/.AL-Go/settings.json
+++ b/build/projects/System Application/.AL-Go/settings.json
@@ -4,9 +4,6 @@
   "appFolders": [
     "..\\..\\..\\src\\System Application\\App"
   ],
-  "buildModes": [
-    "Translated"
-  ],
   "doNotRunTests": true,
   "useCompilerFolder": true,
   "doNotPublishApps": true,
@@ -17,7 +14,6 @@
       ],
       "settings": {
         "buildModes": [
-          "Translated",
           "Strict"
         ]
       }

--- a/build/projects/Test Framework/.AL-Go/settings.json
+++ b/build/projects/Test Framework/.AL-Go/settings.json
@@ -5,9 +5,6 @@
     "..\\..\\..\\src\\Tools\\Test Framework\\Test Libraries\\*",
     "..\\..\\..\\src\\Tools\\Test Framework\\Test Runner"
   ],
-  "buildModes": [
-    "Translated"
-  ],
   "doNotRunTests": true,
   "useCompilerFolder": true,
   "doNotPublishApps": true,
@@ -18,7 +15,6 @@
       ],
       "settings": {
         "buildModes": [
-          "Translated",
           "Strict"
         ]
       }


### PR DESCRIPTION
This pull request backports #4095 to releases/24.x

Fixes [AB#591759](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/591759)



