### PR TITLE
[releases/25.x] [Cryptography Management] Failing test

### DIFF
--- a/src/System Application/Test/Cryptography Management/src/RSACryptoServiceProviderTests.Codeunit.al
+++ b/src/System Application/Test/Cryptography Management/src/RSACryptoServiceProviderTests.Codeunit.al
@@ -200,8 +200,9 @@ codeunit 132613 RSACryptoServiceProviderTests
         DecryptingTempBlob.CreateOutStream(DecryptedOutStream);
         asserterror RSACryptoServiceProvider.Decrypt(PrivateKeyXmlStringSecret, EncryptedInStream, false, DecryptedOutStream);
 
-        // [THEN] Error occures
-        LibraryAssert.ExpectedError('A call to System.Security.Cryptography.RSACryptoServiceProvider.Decrypt failed with this message: The parameter is incorrect.');
+
+        // [THEN] Error occurs
+        LibraryAssert.ExpectedError('A call to System.Security.Cryptography.RSACryptoServiceProvider.Decrypt failed with this message:');
     end;
 
     local procedure SaveRandomTextToOutStream(OutStream: OutStream) PlainText: Text


### PR DESCRIPTION
This pull request backports #4116 to releases/25.x

Fixes AB#[**Insert Work Item Number Here**]