### PR TITLE
[26.0] Azure OpenAI app - Expose GPT 4.1

### DIFF
--- a/src/Business Foundation/App/NoSeriesCopilot/src/Copilot/NoSeriesCopilotImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeriesCopilot/src/Copilot/NoSeriesCopilotImpl.Codeunit.al
@@ -173,7 +173,15 @@ codeunit 324 "No. Series Copilot Impl."
         if not AzureOpenAI.IsEnabled(Enum::"Copilot Capability"::"No. Series Copilot") then
             exit;
 
+#if not CLEAN27
+#pragma warning disable AS0105    
+#pragma warning disable AL0432
         AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT4oLatest());
+#pragma warning restore AL0432
+#pragma warning restore AS0105            
+#else
+        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT41Latest());
+#endif   
         AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"No. Series Copilot");
         AOAIChatCompletionParams.SetMaxTokens(MaxOutputTokens());
         AOAIChatCompletionParams.SetTemperature(0);

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIDeployments.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIDeployments.Codeunit.al
@@ -109,10 +109,12 @@ codeunit 7768 "AOAI Deployments"
     end;
 #endif
 
+#if not CLEAN27
     /// <summary>
     /// Returns the name of the latest AOAI deployment model of GPT4o.
     /// </summary>
     /// <returns>The deployment name.</returns>
+    [Obsolete('GPT4o deployment name is no longer supported from 15 July 2025. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
     procedure GetGPT4oLatest(): Text
     var
         CallerModuleInfo: ModuleInfo;
@@ -125,6 +127,7 @@ codeunit 7768 "AOAI Deployments"
     /// Returns the name of preview AOAI deployment model of GPT4o.
     /// </summary>
     /// <returns>The deployment name.</returns>
+    [Obsolete('GPT4o deployment name is no longer supported from 15 July 2025. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
     procedure GetGPT4oPreview(): Text
     var
         CallerModuleInfo: ModuleInfo;
@@ -137,6 +140,7 @@ codeunit 7768 "AOAI Deployments"
     /// Returns the name of the latest AOAI deployment model of GPT4o-Mini.
     /// </summary>
     /// <returns>The deployment name.</returns>
+    [Obsolete('GPT4o deployment name is no longer supported from 15 July 2025. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
     procedure GetGPT4oMiniLatest(): Text
     var
         CallerModuleInfo: ModuleInfo;
@@ -149,6 +153,7 @@ codeunit 7768 "AOAI Deployments"
     /// Returns the name of preview AOAI deployment model of GPT4o-Mini.
     /// </summary>
     /// <returns>The deployment name.</returns>
+    [Obsolete('GPT4o deployment name is no longer supported from 15 July 2025. Use GetGPT41Latest instead (or GetGPT41Preview for testing upcoming versions).', '27.0')]
     procedure GetGPT4oMiniPreview(): Text
     var
         CallerModuleInfo: ModuleInfo;
@@ -156,6 +161,7 @@ codeunit 7768 "AOAI Deployments"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         exit(AOAIDeploymentsImpl.GetGPT4oMiniPreview(CallerModuleInfo));
     end;
+#endif    
 
     /// <summary>
     /// Returns the name of the latest AOAI deployment model of GPT-4.1.

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIDeployments.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIDeployments.Codeunit.al
@@ -156,4 +156,52 @@ codeunit 7768 "AOAI Deployments"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         exit(AOAIDeploymentsImpl.GetGPT4oMiniPreview(CallerModuleInfo));
     end;
+
+    /// <summary>
+    /// Returns the name of the latest AOAI deployment model of GPT-4.1.
+    /// </summary>
+    /// <returns>The deployment name.</returns>
+    procedure GetGPT41Latest(): Text
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        exit(AOAIDeploymentsImpl.GetGPT41Latest(CallerModuleInfo));
+    end;
+
+    /// <summary>
+    /// Returns the name of the preview AOAI deployment model of GPT-4.1.
+    /// </summary>
+    /// <returns>The deployment name.</returns>
+    procedure GetGPT41Preview(): Text
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        exit(AOAIDeploymentsImpl.GetGPT41Preview(CallerModuleInfo));
+    end;
+
+    /// <summary>
+    /// Returns the name of the latest AOAI deployment model of GPT-4.1 mini.
+    /// </summary>
+    /// <returns>The deployment name.</returns>
+    procedure GetGPT41MiniLatest(): Text
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        exit(AOAIDeploymentsImpl.GetGPT41MiniLatest(CallerModuleInfo));
+    end;
+
+    /// <summary>
+    /// Returns the name of the preview AOAI deployment model of GPT-4.1 mini.
+    /// </summary>
+    /// <returns>The deployment name.</returns>
+    procedure GetGPT41MiniPreview(): Text
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        exit(AOAIDeploymentsImpl.GetGPT41MiniPreview(CallerModuleInfo));
+    end;
 }

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIDeploymentsImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIDeploymentsImpl.Codeunit.al
@@ -22,6 +22,10 @@ codeunit 7769 "AOAI Deployments Impl"
         GPT4oPreviewLbl: Label 'gpt-4o-preview', Locked = true;
         GPT4oMiniLatestLbl: Label 'gpt-4o-mini-latest', Locked = true;
         GPT4oMiniPreviewLbl: Label 'gpt-4o-mini-preview', Locked = true;
+        GPT41LatestLbl: Label 'gpt-41-latest', Locked = true;
+        GPT41PreviewLbl: Label 'gpt-41-preview', Locked = true;
+        GPT41MiniLatestLbl: Label 'gpt-41-mini-latest', Locked = true;
+        GPT41MiniPreviewLbl: Label 'gpt-41-mini-preview', Locked = true;
         DeprecatedDeployments: Dictionary of [Text, Date];
         DeprecationDatesInitialized: Boolean;
         DeprecationMessageLbl: Label 'We detected usage of the Azure OpenAI deployment "%1". This model is obsoleted starting %2 and the quality of your results might vary after that date. Check out codeunit 7768 AOAI Deployments to find the supported deployments.', Comment = 'Telemetry message where %1 is the name of the deployment and %2 is the date of deprecation';
@@ -108,6 +112,26 @@ codeunit 7769 "AOAI Deployments Impl"
         exit(GetDeploymentName(GPT4oMiniLatestLbl, CallerModuleInfo));
     end;
 
+    procedure GetGPT41Preview(CallerModuleInfo: ModuleInfo): Text
+    begin
+        exit(GetDeploymentName(GPT41PreviewLbl));
+    end;
+
+    procedure GetGPT41Latest(CallerModuleInfo: ModuleInfo): Text
+    begin
+        exit(GetDeploymentName(GPT41LatestLbl));
+    end;
+
+    procedure GetGPT41MiniPreview(CallerModuleInfo: ModuleInfo): Text
+    begin
+        exit(GetDeploymentName(GPT41MiniPreviewLbl));
+    end;
+
+    procedure GetGPT41MiniLatest(CallerModuleInfo: ModuleInfo): Text
+    begin
+        exit(GetDeploymentName(GPT41MiniLatestLbl));
+    end;
+
     // Initializes dictionary of deprecated models
     local procedure InitializeDeploymentDeprecationDates()
     begin
@@ -123,6 +147,13 @@ codeunit 7769 "AOAI Deployments Impl"
         DeprecatedDeployments.Add(Turbo0301SaasLbl, DMY2Date(1, 11, 2024));
         DeprecatedDeployments.Add(GPT40613SaasLbl, DMY2Date(1, 11, 2024));
         DeprecatedDeployments.Add(Turbo0613SaasLbl, DMY2Date(1, 11, 2024));
+#endif
+
+#if not CLEAN27
+        DeprecatedDeployments.Add(GPT4oLatestLbl, DMY2Date(15, 7, 2025));
+        DeprecatedDeployments.Add(GPT4oPreviewLbl, DMY2Date(15, 7, 2025));
+        DeprecatedDeployments.Add(GPT4oMiniLatestLbl, DMY2Date(15, 7, 2025));
+        DeprecatedDeployments.Add(GPT4oMiniPreviewLbl, DMY2Date(15, 7, 2025));
 #endif
         DeprecationDatesInitialized := true;
     end;

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIDeploymentsImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIDeploymentsImpl.Codeunit.al
@@ -118,22 +118,22 @@ codeunit 7769 "AOAI Deployments Impl"
 
     procedure GetGPT41Preview(CallerModuleInfo: ModuleInfo): Text
     begin
-        exit(GetDeploymentName(GPT41PreviewLbl));
+        exit(GetDeploymentName(GPT41PreviewLbl, CallerModuleInfo));
     end;
 
     procedure GetGPT41Latest(CallerModuleInfo: ModuleInfo): Text
     begin
-        exit(GetDeploymentName(GPT41LatestLbl));
+        exit(GetDeploymentName(GPT41LatestLbl, CallerModuleInfo));
     end;
 
     procedure GetGPT41MiniPreview(CallerModuleInfo: ModuleInfo): Text
     begin
-        exit(GetDeploymentName(GPT41MiniPreviewLbl));
+        exit(GetDeploymentName(GPT41MiniPreviewLbl, CallerModuleInfo));
     end;
 
     procedure GetGPT41MiniLatest(CallerModuleInfo: ModuleInfo): Text
     begin
-        exit(GetDeploymentName(GPT41MiniLatestLbl));
+        exit(GetDeploymentName(GPT41MiniLatestLbl, CallerModuleInfo));
     end;
 
     // Initializes dictionary of deprecated models

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIDeploymentsImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIDeploymentsImpl.Codeunit.al
@@ -18,10 +18,12 @@ codeunit 7769 "AOAI Deployments Impl"
     var
         Telemetry: Codeunit Telemetry;
         UnableToGetDeploymentNameErr: Label 'Unable to get deployment name, if this is a third party capability you must specify your own deployment name. You may need to contact your partner.';
+#if not CLEAN27        
         GPT4oLatestLbl: Label 'gpt-4o-latest', Locked = true;
         GPT4oPreviewLbl: Label 'gpt-4o-preview', Locked = true;
         GPT4oMiniLatestLbl: Label 'gpt-4o-mini-latest', Locked = true;
         GPT4oMiniPreviewLbl: Label 'gpt-4o-mini-preview', Locked = true;
+#endif        
         GPT41LatestLbl: Label 'gpt-41-latest', Locked = true;
         GPT41PreviewLbl: Label 'gpt-41-preview', Locked = true;
         GPT41MiniLatestLbl: Label 'gpt-41-mini-latest', Locked = true;
@@ -92,6 +94,7 @@ codeunit 7769 "AOAI Deployments Impl"
     end;
 #endif
 
+#if not CLEAN27
     procedure GetGPT4oPreview(CallerModuleInfo: ModuleInfo): Text
     begin
         exit(GetDeploymentName(GPT4oPreviewLbl, CallerModuleInfo));
@@ -111,6 +114,7 @@ codeunit 7769 "AOAI Deployments Impl"
     begin
         exit(GetDeploymentName(GPT4oMiniLatestLbl, CallerModuleInfo));
     end;
+#endif
 
     procedure GetGPT41Preview(CallerModuleInfo: ModuleInfo): Text
     begin

--- a/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
+++ b/src/System Application/App/Entity Text/src/EntityTextImpl.Codeunit.al
@@ -343,7 +343,15 @@ codeunit 2012 "Entity Text Impl."
             AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", Endpoint, Deployment, ApiKey)
         else
             if (not IsNullGuid(CallerModuleInfo.Id())) and (CallerModuleInfo.Publisher() = EntityTextModuleInfo.Publisher()) then
+#if not CLEAN27
+#pragma warning disable AS0105
+#pragma warning disable AL0432
                 AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT4oLatest())
+#pragma warning restore AL0432
+#pragma warning restore AS0105
+#else
+                AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT41Latest())
+#endif
             else begin
                 TelemetryCD.Add('CallerModuleInfo', Format(CallerModuleInfo.Publisher()));
                 TelemetryCD.Add('EntityTextModuleInfo', Format(EntityTextModuleInfo.Publisher()));


### PR DESCRIPTION

#### Summary
 On July 15th, BIC will switch to the model GPT 4.1, so this is a step into that direction.

Work Item(s)
Fixes [AB#591908](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/591908)





