### PR TITLE
[26.x][Performance Scheduler] Allow scheduling profilers for all user types except external

### DIFF
--- a/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
@@ -183,7 +183,7 @@ page 1932 "Perf. Profiler Schedule Card"
                         SelectedUser: Record User;
                         UserSelection: Codeunit "User Selection";
                     begin
-                        UserSelection.Open(SelectedUser);
+                        UserSelection.OpenWithSystemUsers(SelectedUser);
                         UserName := SelectedUser."User Name";
                         Rec.Validate("User ID", SelectedUser."User Security ID");
                     end;

--- a/src/System Application/App/User Selection/src/UserLookup.Page.al
+++ b/src/System Application/App/User Selection/src/UserLookup.Page.al
@@ -66,13 +66,17 @@ page 9843 "User Lookup"
     var
         EnvironmentInformation: Codeunit "Environment Information";
     begin
-        UserSelectionImpl.HideExternalUsers(Rec);
+        if HideOnlyExternalUsers then
+            UserSelectionImpl.HideOnlyExternalUsers(Rec)
+        else
+            UserSelectionImpl.HideExternalAndSystemUsers(Rec);
         IsSaaS := EnvironmentInformation.IsSaaS();
     end;
 
     var
         UserSelectionImpl: Codeunit "User Selection Impl.";
         IsSaaS: Boolean;
+        HideOnlyExternalUsers: Boolean;
 
     /// <summary>
     /// Gets the currently selected users.
@@ -96,6 +100,11 @@ page 9843 "User Lookup"
             CurrPage.SetSelectionFilter(SelectedUser);
             SelectedUser.FindSet();
         end;
+    end;
+
+    internal procedure SetHideOnlyExternalUsers(HideOnlyExternal: Boolean)
+    begin
+        HideOnlyExternalUsers := HideOnlyExternal;
     end;
 }
 

--- a/src/System Application/App/User Selection/src/UserSelection.Codeunit.al
+++ b/src/System Application/App/User Selection/src/UserSelection.Codeunit.al
@@ -15,7 +15,7 @@ codeunit 9843 "User Selection"
     Access = Public;
 
     /// <summary>
-    /// Opens the user lookup page and assigns the selected users on the <paramref name="SelectedUser"/> parameter.
+    /// Opens the user lookup page with external and system users (application, agent, etc.) filtered out and assigns the selected users on the <paramref name="SelectedUser"/> parameter.
     /// </summary>
     /// <param name="SelectedUser">The variable to return the selected users. Any filters on this record will influence the page view.</param>
     /// <returns>Returns true if a user was selected.</returns>
@@ -23,7 +23,19 @@ codeunit 9843 "User Selection"
     var
         UserSelectionImpl: Codeunit "User Selection Impl.";
     begin
-        exit(UserSelectionImpl.Open(SelectedUser));
+        exit(UserSelectionImpl.Open(SelectedUser, false));
+    end;
+
+    /// <summary>
+    /// Opens the user lookup page with only external users filtered out and assigns the selected users on the <paramref name="SelectedUser"/> parameter.
+    /// </summary>
+    /// <param name="SelectedUser">The variable to return the selected users. Any filters on this record will influence the page view.</param>
+    /// <returns>Returns true if a user was selected.</returns>
+    procedure OpenWithSystemUsers(var SelectedUser: Record User): Boolean
+    var
+        UserSelectionImpl: Codeunit "User Selection Impl.";
+    begin
+        exit(UserSelectionImpl.Open(SelectedUser, true));
     end;
 
     /// <summary>
@@ -38,14 +50,14 @@ codeunit 9843 "User Selection"
     end;
 
     /// <summary>
-    /// Sets Filter on the given User Record to exclude external users.
+    /// Sets Filter on the given User Record to exclude external and system (application, agent, etc.) users.
     /// </summary>
     /// <param name="User">The User Record to return.</param>
     procedure HideExternalUsers(var User: Record User)
     var
         UserSelectionImpl: Codeunit "User Selection Impl.";
     begin
-        UserSelectionImpl.HideExternalUsers(User);
+        UserSelectionImpl.HideExternalAndSystemUsers(User);
     end;
 
     /// <summary>

--- a/src/System Application/App/User Selection/src/UserSelectionImpl.Codeunit.al
+++ b/src/System Application/App/User Selection/src/UserSelectionImpl.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 9844 "User Selection Impl."
     var
         UserNameDoesNotExistErr: Label 'The user name %1 does not exist.', Comment = '%1 username';
 
-    procedure HideExternalUsers(var User: Record User)
+    procedure HideExternalAndSystemUsers(var User: Record User)
     var
         EnvironmentInformation: Codeunit "Environment Information";
     begin
@@ -30,10 +30,21 @@ codeunit 9844 "User Selection Impl."
         User.FilterGroup(0);
     end;
 
-    procedure Open(var SelectedUser: Record User): Boolean
+    procedure HideOnlyExternalUsers(var User: Record User)
+    var
+        EnvironmentInformation: Codeunit "Environment Information";
+    begin
+        User.FilterGroup(2);
+        if EnvironmentInformation.IsSaaS() then
+            User.SetFilter("License Type", '<>%1', User."License Type"::"External User");
+        User.FilterGroup(0);
+    end;
+
+    procedure Open(var SelectedUser: Record User; HideOnlyExternal: Boolean): Boolean
     var
         UserLookup: Page "User Lookup";
     begin
+        UserLookup.SetHideOnlyExternalUsers(HideOnlyExternal);
         UserLookup.SetTableView(SelectedUser);
         UserLookup.LookupMode := true;
         if UserLookup.RunModal() = Action::LookupOK then begin


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Recent change to show user name instead of ID in the scheduler card regressed ability to schedule for external users. That is because the user lookup page filters out external users. Added an API to the facade to not filter out external users.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#591952](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/591952)


