### PR TITLE
[Subscription Billing] Test StdSalesOrderConfAssemblyComponentsRDLC fails when Subscription Billing is installed

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Report Extensions/ContractSalesOrderConf.ReportExt.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Report Extensions/ContractSalesOrderConf.ReportExt.al
@@ -24,7 +24,7 @@ reportextension 8010 "Contract Sales Order Conf." extends "Standard Sales - Orde
                 SalesReportPrintoutMgmt.ExcludeItemFromTotals(Line, TotalSubTotal, TotalInvDiscAmount, TotalAmount, TotalAmountVAT, TotalAmountInclVAT);
             end;
         }
-        addbefore(AssemblyLine)
+        addlast(AssemblyLine)
         {
             dataitem(ServiceCommitmentHeaderForSalesLine; "Integer")
             {


### PR DESCRIPTION
The fix includes changes for "Standard Sales - Order Conf." report extension in Subscription billing app.
 
Fixes [AB#575361](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/575361)


