### PR TITLE
Uptake requireTestIsolation to replace TestGroups.json

### DIFF
--- a/build/scripts/RunTestsInBcContainer.ps1
+++ b/build/scripts/RunTestsInBcContainer.ps1
@@ -19,44 +19,12 @@ function Get-DisabledTests
     return @($disabledTests)
 }
 
-function Get-TestsInGroup {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string] $groupName
-    )
-
-    $baseFolder = Get-BaseFolder
-
-    $groupFiles = Get-ChildItem -Path $baseFolder -Filter 'TestGroups.json' -Recurse -File
-
-    $testsInGroup = @()
-    foreach($groupFile in $groupFiles)
-    {
-        $testsInGroup += Get-Content -Raw -Path $groupFile.FullName | ConvertFrom-Json | Where-Object { $_.group -eq $groupName }
-    }
-
-    return $testsInGroup
-}
-
 $disabledTests = @(Get-DisabledTests)
-$noIsolationTests = Get-TestsInGroup -groupName "No Test Isolation"
 
 if ($DisableTestIsolation)
 {
+    $parameters["requiredTestIsolation"] = "Disabled" # filtering on tests that require Disabled Test Isolation
     $parameters["testRunnerCodeunitId"] = "130451" # Test Runner with disabled test isolation
-
-    # When test isolation is disabled, only tests from the "No Test Isolation" group should be run
-    $parameters["testCodeunitRange"] = @($noIsolationTests | ForEach-Object { $_.codeunitId }) -join "|"
-}
-else { # Test isolation is enabled
-    # Manually disable the test codeunits, as they need to be run without test isolation
-    $noIsolationTests | ForEach-Object {
-        $disabledTests += @{
-            "codeunitId" = $_.codeunitId
-            "codeunitName" = $_.codeunitName
-            "method" = "*"
-        }
-    }
 }
 
 if ($disabledTests)

--- a/src/System Application/Test/TestGroups.json
+++ b/src/System Application/Test/TestGroups.json
@@ -1,7 +1,0 @@
-[
-    {
-        "group": "No Test Isolation",
-        "codeunitId": "138705",
-        "codeunitName": "Retention Policy Log Test"
-    }
-]


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->

~Replace `System Application Tests (No Isolation)` project with the latest `RequireTestIsolation` property.~ Couldn't figure out how to run `Run-TestsInBcContainer` twice, it is failing build...

Replace `TestGroups.json` with the latest `RequireTestIsolation` property. This is a follow up for #4137 .

The change simplifies the build script, removing the need to maintain the `TestGroups.json`.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#581153](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/581153)




