### PR TITLE
Invalid Date Formula Ratio for Subscription Package Line prevented

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Contract Renewal/Tables/PlannedSubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Contract Renewal/Tables/PlannedSubscriptionLine.Table.al
@@ -197,6 +197,8 @@ table 8002 "Planned Subscription Line"
                 if Format("Extension Term") = '' then
                     TestField("Notice Period", "Extension Term");
                 DateFormulaManagement.ErrorIfDateFormulaNegative("Extension Term");
+                if (Format("Billing Base Period") <> '') and (Format("Billing Rhythm") <> '') then
+                    DateFormulaManagement.CheckIntegerRatioForDateFormulas("Billing Base Period", FieldCaption("Billing Base Period"), "Billing Rhythm", FieldCaption("Billing Rhythm"));
             end;
         }
         field(23; "Billing Rhythm"; DateFormula)
@@ -206,6 +208,8 @@ table 8002 "Planned Subscription Line"
             begin
                 DateFormulaManagement.ErrorIfDateFormulaEmpty("Billing Rhythm", FieldCaption("Billing Rhythm"));
                 DateFormulaManagement.ErrorIfDateFormulaNegative("Billing Rhythm");
+                if (Format("Billing Base Period") <> '') and (Format("Billing Rhythm") <> '') then
+                    DateFormulaManagement.CheckIntegerRatioForDateFormulas("Billing Base Period", FieldCaption("Billing Base Period"), "Billing Rhythm", FieldCaption("Billing Rhythm"));
             end;
         }
         field(24; "Cancellation Possible Until"; Date)
@@ -397,12 +401,6 @@ table 8002 "Planned Subscription Line"
         key(Contract; "Subscription Contract No.", "Subscription Contract Line No.") { }
         key(Quote; "Sales Quote No.", "Sales Quote Line No.") { }
     }
-    trigger OnModify()
-    begin
-        xRec.Get(xRec."Entry No.");
-        if ((xRec."Billing Base Period" <> Rec."Billing Base Period") or (xRec."Billing Rhythm" <> Rec."Billing Rhythm")) then
-            DateFormulaManagement.CheckIntegerRatioForDateFormulas("Billing Base Period", FieldCaption("Billing Base Period"), "Billing Rhythm", FieldCaption("Billing Rhythm"));
-    end;
 
     local procedure CheckServiceDates()
     begin

--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
@@ -181,7 +181,7 @@ table 8068 "Sales Subscription Line"
             trigger OnValidate()
             begin
                 TestIfSalesOrderIsReleased();
-                DateFormulaManagementGlobal.ErrorIfDateFormulaNegative("Initial Term");
+                DateFormulaManagement.ErrorIfDateFormulaNegative("Initial Term");
             end;
         }
         field(24; "Notice Period"; DateFormula)
@@ -190,7 +190,7 @@ table 8068 "Sales Subscription Line"
             trigger OnValidate()
             begin
                 TestIfSalesOrderIsReleased();
-                DateFormulaManagementGlobal.ErrorIfDateFormulaNegative("Notice Period");
+                DateFormulaManagement.ErrorIfDateFormulaNegative("Notice Period");
             end;
         }
         field(25; "Extension Term"; DateFormula)
@@ -201,7 +201,7 @@ table 8068 "Sales Subscription Line"
                 TestIfSalesOrderIsReleased();
                 if Format("Extension Term") = '' then
                     TestField("Notice Period", "Extension Term");
-                DateFormulaManagementGlobal.ErrorIfDateFormulaNegative("Extension Term");
+                DateFormulaManagement.ErrorIfDateFormulaNegative("Extension Term");
             end;
         }
         field(26; "Billing Base Period"; DateFormula)
@@ -212,8 +212,10 @@ table 8068 "Sales Subscription Line"
             trigger OnValidate()
             begin
                 TestIfSalesOrderIsReleased();
-                DateFormulaManagementGlobal.ErrorIfDateFormulaEmpty("Billing Base Period", FieldCaption("Billing Base Period"));
-                DateFormulaManagementGlobal.ErrorIfDateFormulaNegative("Billing Base Period");
+                DateFormulaManagement.ErrorIfDateFormulaEmpty("Billing Base Period", FieldCaption("Billing Base Period"));
+                DateFormulaManagement.ErrorIfDateFormulaNegative("Billing Base Period");
+                if (Format("Billing Base Period") <> '') and (Format("Billing Rhythm") <> '') then
+                    DateFormulaManagement.CheckIntegerRatioForDateFormulas("Billing Base Period", FieldCaption("Billing Base Period"), "Billing Rhythm", FieldCaption("Billing Rhythm"));
             end;
         }
         field(27; "Billing Rhythm"; DateFormula)
@@ -224,8 +226,10 @@ table 8068 "Sales Subscription Line"
             trigger OnValidate()
             begin
                 TestIfSalesOrderIsReleased();
-                DateFormulaManagementGlobal.ErrorIfDateFormulaEmpty("Billing Rhythm", FieldCaption("Billing Rhythm"));
-                DateFormulaManagementGlobal.ErrorIfDateFormulaNegative("Billing Rhythm");
+                DateFormulaManagement.ErrorIfDateFormulaEmpty("Billing Rhythm", FieldCaption("Billing Rhythm"));
+                DateFormulaManagement.ErrorIfDateFormulaNegative("Billing Rhythm");
+                if (Format("Billing Base Period") <> '') and (Format("Billing Rhythm") <> '') then
+                    DateFormulaManagement.CheckIntegerRatioForDateFormulas("Billing Base Period", FieldCaption("Billing Base Period"), "Billing Rhythm", FieldCaption("Billing Rhythm"));
             end;
         }
         field(28; "Invoicing via"; Enum "Invoicing Via")
@@ -393,9 +397,6 @@ table 8068 "Sales Subscription Line"
     trigger OnModify()
     begin
         TestIfSalesOrderIsReleased();
-        xRec.Get(xRec."Line No.");
-        if ((xRec."Billing Base Period" <> Rec."Billing Base Period") or (xRec."Billing Rhythm" <> Rec."Billing Rhythm")) then
-            DateFormulaManagementGlobal.CheckIntegerRatioForDateFormulas("Billing Base Period", FieldCaption("Billing Base Period"), "Billing Rhythm", FieldCaption("Billing Rhythm"));
     end;
 
     trigger OnDelete()
@@ -688,7 +689,6 @@ table 8068 "Sales Subscription Line"
     var
         SalesLineVAT: Record "Sales Line";
         ContractRenewalMgt: Codeunit "Sub. Contract Renewal Mgt.";
-        DateFormulaManagement: Codeunit "Date Formula Management";
         IsHandled: Boolean;
         RhythmIdentifier: Code[20];
         ContractRenewalPriceCalculationRatio: Decimal;
@@ -876,7 +876,7 @@ table 8068 "Sales Subscription Line"
         Currency: Record Currency;
         CurrExchRate: Record "Currency Exchange Rate";
         SalesLine: Record "Sales Line";
-        DateFormulaManagementGlobal: Codeunit "Date Formula Management";
+        DateFormulaManagement: Codeunit "Date Formula Management";
         ServiceAmountIncreaseErr: Label '%1 cannot be greater than %2.', Comment = '%1 and %2 are numbers';
         ReleasedSalesOrderExistsErr: Label 'Subscription Lines cannot be edited on orders with status = Released.';
         CalculateBaseTypeOptionNotImplementedErr: Label 'Unknown option %1 for %2.\\ Object Name: %3, Procedure: %4', Comment = '%1=Format("Calculation Base Type"), %2 = Fieldcaption for "Calculation Base Type", %3 = Current object name, %4 = Current procedure name';

--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
@@ -182,6 +182,8 @@ table 8059 "Subscription Line"
             begin
                 DateFormulaManagement.ErrorIfDateFormulaEmpty("Billing Base Period", FieldCaption("Billing Base Period"));
                 DateFormulaManagement.ErrorIfDateFormulaNegative("Billing Base Period");
+                if (Format("Billing Base Period") <> '') and (Format("Billing Rhythm") <> '') then
+                    DateFormulaManagement.CheckIntegerRatioForDateFormulas("Billing Base Period", FieldCaption("Billing Base Period"), "Billing Rhythm", FieldCaption("Billing Rhythm"));
             end;
         }
         field(16; "Invoicing via"; Enum "Invoicing Via")
@@ -254,6 +256,8 @@ table 8059 "Subscription Line"
             begin
                 DateFormulaManagement.ErrorIfDateFormulaEmpty("Billing Rhythm", FieldCaption("Billing Rhythm"));
                 DateFormulaManagement.ErrorIfDateFormulaNegative("Billing Rhythm");
+                if (Format("Billing Base Period") <> '') and (Format("Billing Rhythm") <> '') then
+                    DateFormulaManagement.CheckIntegerRatioForDateFormulas("Billing Base Period", FieldCaption("Billing Base Period"), "Billing Rhythm", FieldCaption("Billing Rhythm"));
             end;
         }
         field(24; "Cancellation Possible Until"; Date)
@@ -595,9 +599,6 @@ table 8059 "Subscription Line"
 
     trigger OnModify()
     begin
-        xRec.Get(xRec."Entry No.");
-        if ((xRec."Billing Base Period" <> Rec."Billing Base Period") or (xRec."Billing Rhythm" <> Rec."Billing Rhythm")) then
-            DateFormulaManagement.CheckIntegerRatioForDateFormulas("Billing Base Period", FieldCaption("Billing Base Period"), "Billing Rhythm", FieldCaption("Billing Rhythm"));
         DisplayErrorIfContractLinesExist(ClosedContractLineExistErr, true);
         SetUpdateRequiredOnBillingLines();
         UpdateCustomerContractLineServiceCommitmentDescription();

--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionPackageLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionPackageLine.Table.al
@@ -108,6 +108,8 @@ table 8056 "Subscription Package Line"
             trigger OnValidate()
             begin
                 DateFormulaManagement.ErrorIfDateFormulaNegative("Billing Base Period");
+                if (Format("Billing Base Period") <> '') and (Format("Billing Rhythm") <> '') then
+                    DateFormulaManagement.CheckIntegerRatioForDateFormulas("Billing Base Period", FieldCaption("Billing Base Period"), "Billing Rhythm", FieldCaption("Billing Rhythm"));
             end;
         }
         field(11; "Billing Rhythm"; DateFormula)
@@ -117,6 +119,8 @@ table 8056 "Subscription Package Line"
             begin
                 DateFormulaManagement.ErrorIfDateFormulaEmpty("Billing Rhythm", FieldCaption("Billing Rhythm"));
                 DateFormulaManagement.ErrorIfDateFormulaNegative("Billing Rhythm");
+                if (Format("Billing Base Period") <> '') and (Format("Billing Rhythm") <> '') then
+                    DateFormulaManagement.CheckIntegerRatioForDateFormulas("Billing Base Period", FieldCaption("Billing Base Period"), "Billing Rhythm", FieldCaption("Billing Rhythm"));
             end;
         }
         field(12; "Sub. Line Start Formula"; DateFormula)
@@ -221,12 +225,6 @@ table 8056 "Subscription Package Line"
             Clustered = true;
         }
     }
-    trigger OnModify()
-    begin
-        xRec.Get(xRec."Subscription Package Code", xRec."Line No.");
-        if ((xRec."Billing Base Period" <> Rec."Billing Base Period") or (xRec."Billing Rhythm" <> Rec."Billing Rhythm")) then
-            DateFormulaManagement.CheckIntegerRatioForDateFormulas("Billing Base Period", FieldCaption("Billing Base Period"), "Billing Rhythm", FieldCaption("Billing Rhythm"));
-    end;
 
     var
         DateFormulaManagement: Codeunit "Date Formula Management";

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
@@ -63,6 +63,7 @@ codeunit 139915 "Sales Service Commitment Test"
         NoOfServiceObjects: Integer;
         NotCreatedProperlyErr: Label 'Subscription Lines are not created properly.';
         SalesServiceCommitmentCannotBeDeletedErr: Label 'The Sales Subscription Line cannot be deleted, because it is the last line with Process Contract Renewal. Please delete the Sales line in order to delete the Sales Subscription Line.', Locked = true;
+        NaturalNumberRatioErr: Label 'The ratio of ''%1'' and ''%2'' or vice versa must give a natural number.', Comment = '%1=Field Caption, %2=Field Caption', Locked = true;
 
     #region Tests
 
@@ -1264,6 +1265,38 @@ codeunit 139915 "Sales Service Commitment Test"
 
         LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Quote, '');
         LibrarySales.CreateSalesLine(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", LibraryRandom.RandIntInRange(1, 100));
+    end;
+
+    [Test]
+    procedure PreventInvalidDateFormulaRatioForSalesSubscriptionLine()
+    var
+        TwelveMonthsDateFormula: DateFormula;
+        FifteenMonthsDateFormula: DateFormula;
+    begin
+        // [SCENARIO] When Sales Subscription Line has been created with a Billing Base Period and Billing Rhythm that do not have a valid ratio, the error is thrown as soon as invalid date formula is entered
+
+        // [GIVEN] A single SalesSubscription Line with Billing Base Period and Billing Rhythm equal to 12M has been created
+        Initialize();
+        Evaluate(TwelveMonthsDateFormula, '<12M>');
+        ServiceCommPackageLine.Validate("Billing Base Period", TwelveMonthsDateFormula);
+        ServiceCommPackageLine.Validate("Billing Rhythm", TwelveMonthsDateFormula);
+        ServiceCommPackageLine.Modify(false);
+        ContractTestLibrary.SetupSalesServiceCommitmentItemAndAssignToServiceCommitmentPackage(Item, Enum::"Item Service Commitment Type"::"Service Commitment Item", ServiceCommitmentPackage.Code);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Quote, '');
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", LibraryRandom.RandIntInRange(1, 100));
+
+        Commit(); // retain data after asserterror
+
+        // [WHEN] A invalid date formula is created for the purpose of validating Billing Base Period and Billing Rhythm
+        Evaluate(FifteenMonthsDateFormula, '<15M>');
+
+        // [THEN] Error expected when invalid date formula is entered for Billing Base Period or Billing Rhythm
+        SalesServiceCommitment.FilterOnSalesLine(SalesLine);
+        SalesServiceCommitment.FindFirst();
+        asserterror SalesServiceCommitment.Validate("Billing Base Period", FifteenMonthsDateFormula);
+        Assert.ExpectedError(StrSubstNo(NaturalNumberRatioErr, SalesServiceCommitment.FieldCaption("Billing Base Period"), SalesServiceCommitment.FieldCaption("Billing Rhythm")));
+        asserterror SalesServiceCommitment.Validate("Billing Rhythm", FifteenMonthsDateFormula);
+        Assert.ExpectedError(StrSubstNo(NaturalNumberRatioErr, SalesServiceCommitment.FieldCaption("Billing Base Period"), SalesServiceCommitment.FieldCaption("Billing Rhythm")));
     end;
 
     [Test]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
A check whether Billing Base Period have a valid ratio should happen during field validation and not in OnModify trigger for following tables:

- table 8002 "Planned Subscription Line"
- table 8068 "Sales Subscription Line"
- table 8059 "Subscription Line"
- table 8056 "Subscription Package Line"

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #4166 
