### PR TITLE
[26.x] Fix email concurrency limit issue with read Isolation 

### DIFF
--- a/src/System Application/App/Email/src/RateLimit/EmailRateLimitImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/RateLimit/EmailRateLimitImpl.Codeunit.al
@@ -54,6 +54,8 @@ codeunit 8999 "Email Rate Limit Impl."
         EmailImpl: Codeunit "Email Impl";
         RateLimit: Integer;
     begin
+        SentEmail.ReadIsolation := ReadIsolation::Uncommitted;
+        EmailOutboxCurrent.ReadIsolation := ReadIsolation::Uncommitted;
         RateLimit := GetRateLimit(AccountId, Connector, EmailAddress);
         if RateLimit = 0 then
             exit(false);
@@ -75,6 +77,7 @@ codeunit 8999 "Email Rate Limit Impl."
     var
         EmailOutbox: Record "Email Outbox";
     begin
+        EmailOutbox.ReadIsolation := ReadIsolation::Uncommitted;
         EmailOutbox.SetRange(Status, EmailOutbox.Status::Processing);
         EmailOutbox.SetRange("Account Id", AccountId);
         if EmailOutbox.IsEmpty() then

--- a/src/System Application/App/Email/src/RateLimit/EmailRateLimitImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/RateLimit/EmailRateLimitImpl.Codeunit.al
@@ -54,8 +54,8 @@ codeunit 8999 "Email Rate Limit Impl."
         EmailImpl: Codeunit "Email Impl";
         RateLimit: Integer;
     begin
-        SentEmail.ReadIsolation := ReadIsolation::Uncommitted;
-        EmailOutboxCurrent.ReadIsolation := ReadIsolation::Uncommitted;
+        SentEmail.ReadIsolation := IsolationLevel::ReadUncommitted;
+        EmailOutboxCurrent.ReadIsolation := IsolationLevel::ReadUncommitted;
         RateLimit := GetRateLimit(AccountId, Connector, EmailAddress);
         if RateLimit = 0 then
             exit(false);
@@ -77,12 +77,12 @@ codeunit 8999 "Email Rate Limit Impl."
     var
         EmailOutbox: Record "Email Outbox";
     begin
-        EmailOutbox.ReadIsolation := ReadIsolation::Uncommitted;
+        EmailOutbox.ReadIsolation := IsolationLevel::ReadUncommitted;
         EmailOutbox.SetRange(Status, EmailOutbox.Status::Processing);
         EmailOutbox.SetRange("Account Id", AccountId);
         if EmailOutbox.IsEmpty() then
             exit(0);
-
+        tes
         exit(EmailOutbox.Count());
     end;
 

--- a/src/System Application/App/Email/src/RateLimit/EmailRateLimitImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/RateLimit/EmailRateLimitImpl.Codeunit.al
@@ -82,7 +82,7 @@ codeunit 8999 "Email Rate Limit Impl."
         EmailOutbox.SetRange("Account Id", AccountId);
         if EmailOutbox.IsEmpty() then
             exit(0);
-        tes
+
         exit(EmailOutbox.Count());
     end;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
The root cause is if our customer scheduled too many emails at the same time, for every email sending we shall check if it exceeds the max concurrency limit in background -> too many reading to the same table emailOutbox at the same time. And this table is also used in the following sending steps -> this causes the deadlock.

I shall create a hotfix for this issue -
Use readIsolate:Uncommitted because we don't care a lot if the table is changed or not.
Change the order to processing email sending to ensure the lock time is shortest.


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#592726](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/592726)




