### PR TITLE
Set upgrade tags for new companies

### DIFF
--- a/src/System Application/App/Email/src/EmailInstaller.Codeunit.al
+++ b/src/System Application/App/Email/src/EmailInstaller.Codeunit.al
@@ -37,9 +37,10 @@ codeunit 1596 "Email Installer"
         Field: Record Field;
         RetenPolAllowedTables: Codeunit "Reten. Pol. Allowed Tables";
         UpgradeTag: Codeunit "Upgrade Tag";
+        EmailUpgrade: Codeunit "Email Upgrade";
         IsInitialSetup: Boolean;
     begin
-        IsInitialSetup := not UpgradeTag.HasUpgradeTag(GetEmailTablesAddedToAllowedListUpgradeTag());
+        IsInitialSetup := not UpgradeTag.HasUpgradeTag(EmailUpgrade.GetEmailTablesAddedToAllowedListUpgradeTag());
         if not (IsInitialSetup or ForceUpdate) then
             exit;
 
@@ -48,12 +49,7 @@ codeunit 1596 "Email Installer"
         RetenPolAllowedTables.AddAllowedTable(Database::"Email Inbox", Field.FieldNo(SystemCreatedAt), 2);
 
         if IsInitialSetup then
-            UpgradeTag.SetUpgradeTag(GetEmailTablesAddedToAllowedListUpgradeTag());
-    end;
-
-    local procedure GetEmailTablesAddedToAllowedListUpgradeTag(): Code[250]
-    begin
-        exit('MS-373161-EmailLogEntryAdded-20201005');
+            UpgradeTag.SetUpgradeTag(EmailUpgrade.GetEmailTablesAddedToAllowedListUpgradeTag());
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Reten. Pol. Allowed Tables", OnRefreshAllowedTables, '', false, false)]

--- a/src/System Application/App/Email/src/EmailUpgrade.Codeunit.al
+++ b/src/System Application/App/Email/src/EmailUpgrade.Codeunit.al
@@ -62,6 +62,11 @@ codeunit 1597 "Email Upgrade"
         exit('MS-592720-DefaultEmailMaxConcurrencyLimitChanged-20250723');
     end;
 
+    procedure GetEmailTablesAddedToAllowedListUpgradeTag(): Code[250]
+    begin
+        exit('MS-373161-EmailLogEntryAdded-20201005');
+    end;
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Upgrade Tag", OnGetPerCompanyUpgradeTags, '', false, false)]
     local procedure RegisterPerCompanyTags(var PerCompanyUpgradeTags: List of [Code[250]])
     var
@@ -71,5 +76,7 @@ codeunit 1597 "Email Upgrade"
             PerCompanyUpgradeTags.Add(GetDefaultEmailViewPolicyUpgradeTag());
         if not UpgradeTag.HasUpgradeTag(GetDefaultEmailMaxConcurrencyLimitUpgradeTag()) then
             PerCompanyUpgradeTags.Add(GetDefaultEmailMaxConcurrencyLimitUpgradeTag());
+        if not UpgradeTag.HasUpgradeTag(GetEmailTablesAddedToAllowedListUpgradeTag()) then
+            PerCompanyUpgradeTags.Add(GetEmailTablesAddedToAllowedListUpgradeTag());
     end;
 }

--- a/src/System Application/App/Performance Profiler/src/PerformanceProfilerInstaller.Codeunit.al
+++ b/src/System Application/App/Performance Profiler/src/PerformanceProfilerInstaller.Codeunit.al
@@ -55,4 +55,13 @@ codeunit 1933 "Performance Profiler Installer"
     begin
         AddRetentionPolicyAllowedTables(true);
     end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Upgrade Tag", OnGetPerCompanyUpgradeTags, '', false, false)]
+    local procedure RegisterPerCompanyTags(var PerCompanyUpgradeTags: List of [Code[250]])
+    var
+        UpgradeTag: Codeunit "Upgrade Tag";
+    begin
+        if not UpgradeTag.HasUpgradeTag(GetPerformanceProfileAddedToAllowedListUpgradeTag()) then
+            PerCompanyUpgradeTags.Add(GetPerformanceProfileAddedToAllowedListUpgradeTag());
+    end;
 }

--- a/src/System Application/App/Retention Policy/src/Install/RetentionPolicyInstaller.Codeunit.al
+++ b/src/System Application/App/Retention Policy/src/Install/RetentionPolicyInstaller.Codeunit.al
@@ -107,4 +107,13 @@ codeunit 3907 "Retention Policy Installer"
     begin
         AddAllowedTables(true);
     end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Upgrade Tag", OnGetPerCompanyUpgradeTags, '', false, false)]
+    local procedure RegisterPerCompanyTags(var PerCompanyUpgradeTags: List of [Code[250]])
+    var
+        UpgradeTag: Codeunit "Upgrade Tag";
+    begin
+        if not UpgradeTag.HasUpgradeTag(GetRetenPolLogEntryAddedUpgradeTag()) then
+            PerCompanyUpgradeTags.Add(GetRetenPolLogEntryAddedUpgradeTag());
+    end;
 }


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->

Set upgrade tags for newly created companies. Previously, this was not an issue because the records are inserted during `OnAfterLogin`, but that is no longer the case after #4178

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes AB#592991
