### PR TITLE
Test codeunits with RequiredTestIsolation set to None and Codeunit will run together

### DIFF
--- a/src/Tools/Test Framework/Test Runner/src/TestSuiteMgt.Codeunit.al
+++ b/src/Tools/Test Framework/Test Runner/src/TestSuiteMgt.Codeunit.al
@@ -344,7 +344,12 @@ codeunit 130456 "Test Suite Mgt."
 
         // inexplicit conversion from Integer to Option
         CodeunitMetadata.SetRange(TestType, TestType);
-        CodeunitMetadata.SetRange(RequiredTestIsolation, RequiredTestIsolation);
+
+        if RequiredTestIsolation = 0 then
+            // test codeunits with RequiredTestIsolation set to None will be run together with Codeunit ones
+            CodeunitMetadata.SetFilter(RequiredTestIsolation, '%1|%2', CodeunitMetadata.RequiredTestIsolation::None, CodeunitMetadata.RequiredTestIsolation::Codeunit)
+        else
+            CodeunitMetadata.SetRange(RequiredTestIsolation, RequiredTestIsolation);
 
         GetTestMethods(ALTestSuite, CodeunitMetadata);
     end;


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->

This is more of future proof.

By default, all test codeunits are run with [Test Runner with Isolation Codeunit](https://github.com/microsoft/BCApps/blob/main/src/Tools/Test%20Framework/Test%20Runner/src/TestRunnerIsolCodeunit.Codeunit.al). so no test codeunit has `RequiredTestIsolation = Codeunit` at the moment.

But in case that happens, it won't be automatically picked up in the gate at the moment. Fixing this by filtering on both `None` and `Codeunit` by default

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#593048](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/593048)


