### PR TITLE
Move system application test library to another AL-Go project

### DIFF
--- a/build/projects/System Application Tests/.AL-Go/settings.json
+++ b/build/projects/System Application Tests/.AL-Go/settings.json
@@ -3,7 +3,6 @@
   "projectName": "System Application Tests",
   "testFolders": [
     "../../../src/System Application/Test",
-    "../../../src/System Application/Test Library",
     "../../../src/System Application/Partner Test"
   ]
 }

--- a/build/projects/System Application/.AL-Go/settings.json
+++ b/build/projects/System Application/.AL-Go/settings.json
@@ -7,6 +7,9 @@
     "../../../src/Tools/Test Framework/Test Libraries/*",
     "../../../src/Tools/Test Framework/Test Runner"
   ],
+  "testFolders": [
+    "../../../src/System Application/Test Library"
+  ],
   "doNotRunTests": true,
   "useCompilerFolder": true,
   "doNotPublishApps": true,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Move system application test library to another AL-Go project

This fixes the linked bug because right now testapp dependencies can only be properly picked up if the appFolders setting isn't empty. 

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#593430](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/593430)


