### PR TITLE
Set internal descriptions for row definitions in Demo Data Tool

### DIFF
--- a/src/Apps/W1/ContosoCoffeeDemoDataset/App/DemoData/Finance/1.Setup data/CreateAccScheduleName.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/App/DemoData/Finance/1.Setup data/CreateAccScheduleName.Codeunit.al
@@ -32,10 +32,29 @@ codeunit 5223 "Create Acc. Schedule Name"
     var
         ContosoAccountSchedule: Codeunit "Contoso Account Schedule";
     begin
-        ContosoAccountSchedule.InsertAccScheduleName(CashCycle(), CashCycleDataLbl, '');
-        ContosoAccountSchedule.InsertAccScheduleName(CashFlow(), CashFlowDataLbl, '');
-        ContosoAccountSchedule.InsertAccScheduleName(IncomeExpense(), IncomeExpenseDataLbl, '');
-        ContosoAccountSchedule.InsertAccScheduleName(ReducedTrialBalance(), ReducedTrialBalanceDataLbl, '');
+        ContosoAccountSchedule.InsertAccScheduleName(CashCycle(), CashCycleDataLbl, '', CashCycleInternalDescLbl);
+        ContosoAccountSchedule.InsertAccScheduleName(CashFlow(), CashFlowDataLbl, '', CashFlowInternalDescLbl);
+        ContosoAccountSchedule.InsertAccScheduleName(IncomeExpense(), IncomeExpenseDataLbl, '', IncomeExpenseInternalDescLbl);
+        ContosoAccountSchedule.InsertAccScheduleName(ReducedTrialBalance(), ReducedTrialBalanceDataLbl, '', ReducedTrialBalanceInternalDescLbl);
+    end;
+
+    procedure UpdateInternalDescriptions()
+    var
+        ContosoAccountSchedule: Codeunit "Contoso Account Schedule";
+        BalanceSheetCodeTok: Label 'M-BALANCE', MaxLength = 10;
+        IncomeStmdCodeTok: Label 'M-INCOME', MaxLength = 10;
+        CashFlowCodeTok: Label 'M-CASHFLOW', MaxLength = 10;
+        RetainedEarnCodeTok: Label 'M-RETAIND', MaxLength = 10;
+        InternalDescriptionLbl: Label 'Generated from the G/L Account Categories page.', MaxLength = 250;
+    begin
+        ContosoAccountSchedule.UpdateAccScheduleName(CashCycle(), CashCycleInternalDescLbl);
+        ContosoAccountSchedule.UpdateAccScheduleName(CashFlow(), CashFlowInternalDescLbl);
+        ContosoAccountSchedule.UpdateAccScheduleName(IncomeExpense(), IncomeExpenseInternalDescLbl);
+        ContosoAccountSchedule.UpdateAccScheduleName(ReducedTrialBalance(), ReducedTrialBalanceInternalDescLbl);
+        ContosoAccountSchedule.UpdateAccScheduleName(BalanceSheetCodeTok, InternalDescriptionLbl);
+        ContosoAccountSchedule.UpdateAccScheduleName(IncomeStmdCodeTok, InternalDescriptionLbl);
+        ContosoAccountSchedule.UpdateAccScheduleName(CashFlowCodeTok, InternalDescriptionLbl);
+        ContosoAccountSchedule.UpdateAccScheduleName(RetainedEarnCodeTok, InternalDescriptionLbl);
     end;
 
     procedure AccountCategoriesOverview(): Code[10]
@@ -129,5 +148,9 @@ codeunit 5223 "Create Acc. Schedule Name"
         CashFlowDataLbl: Label 'Data for Cash Flow Chart', MaxLength = 80;
         IncomeExpenseDataLbl: Label 'Data for Income & Expense Chart', MaxLength = 80;
         ReducedTrialBalanceDataLbl: Label 'Data for Reduced Trial Balance Info Part', MaxLength = 80;
+        CashCycleInternalDescLbl: Label 'Used for generating data for the Cash Cycle Chart.', MaxLength = 250;
+        CashFlowInternalDescLbl: Label 'Used for generating data for the Cash Flow Chart.', MaxLength = 250;
+        IncomeExpenseInternalDescLbl: Label 'Used for generating data for the Income & Expense Chart.', MaxLength = 250;
+        ReducedTrialBalanceInternalDescLbl: Label 'Used for generating data for the Reduced Trial Balance Info Part.', MaxLength = 250;
         RevenuesLbl: Label 'Revenues', MaxLength = 80;
 }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/App/DemoTool/Contoso Helpers/ContosoAccountSchedule.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/App/DemoTool/Contoso Helpers/ContosoAccountSchedule.Codeunit.al
@@ -102,6 +102,11 @@ codeunit 5239 "Contoso Account Schedule"
     end;
 
     procedure InsertAccScheduleName(Name: Code[10]; Description: Text[80]; AnalysisViewName: Code[10])
+    begin
+        InsertAccScheduleName(Name, Description, AnalysisViewName, '');
+    end;
+
+    procedure InsertAccScheduleName(Name: Code[10]; Description: Text[80]; AnalysisViewName: Code[10]; InternalDescription: Text[250])
     var
         AccScheduleName: Record "Acc. Schedule Name";
         Exists: Boolean;
@@ -116,6 +121,9 @@ codeunit 5239 "Contoso Account Schedule"
         AccScheduleName.Validate(Name, Name);
         AccScheduleName.Validate(Description, Description);
         AccScheduleName.Validate("Analysis View Name", AnalysisViewName);
+        if InternalDescription <> '' then begin
+            AccScheduleName.Validate("Internal Description", InternalDescription);
+        end;
 
         if Exists then
             AccScheduleName.Modify(true)
@@ -278,5 +286,17 @@ codeunit 5239 "Contoso Account Schedule"
         ChartDefinition.Validate(Enabled, Enabled);
 
         ChartDefinition.Insert(true);
+    end;
+
+    procedure UpdateAccScheduleName(Name: Code[10]; InternalDescription: Text[250])
+    var
+        AccScheduleName: Record "Acc. Schedule Name";
+    begin
+        if AccScheduleName.Get(Name) then begin
+            if AccScheduleName."Internal Description" = '' then begin
+                AccScheduleName.Validate("Internal Description", InternalDescription);
+                AccScheduleName.Modify(true);
+            end;
+        end;
     end;
 }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/App/DemoTool/ContosoDemoTool.Page.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/App/DemoTool/ContosoDemoTool.Page.al
@@ -5,6 +5,7 @@
 
 namespace Microsoft.DemoTool;
 
+using Microsoft.DemoData.Finance;
 using System.Telemetry;
 
 page 5194 "Contoso Demo Tool"
@@ -86,6 +87,27 @@ page 5194 "Contoso Demo Tool"
                         FeatureTelemetry.LogUsage('0000L01', ContosoCoffeeDemoDatasetFeatureNameTok, 'Contoso demo Data generated for Setup');
                     end;
                 }
+                action(UpdateInternalDescriptions)
+                {
+                    Caption = 'Update Internal Descriptions';
+                    ToolTip = 'Update internal definitions for financial report defintions in the existing demo company.';
+                    Image = Create;
+
+                    trigger OnAction()
+                    var
+                        CreateColumnLayoutName: Codeunit "Create Column Layout Name";
+                        CreateAccScheduleName: Codeunit "Create Acc. Schedule Name";
+                        UpdateNewColumnDefinitionsMsg: Label 'Would you like to update internal descriptions for financial report definitions in the existing demo company?';
+                    begin
+                        Rec.TestField(Module, Rec.Module::Finance);
+                        Rec.TestField("Data Level", Rec."Data Level"::All);
+
+                        if not Confirm(UpdateNewColumnDefinitionsMsg) then
+                            exit;
+
+                        CreateAccScheduleName.UpdateInternalDescriptions();
+                    end;
+                }
             }
             action(Configuration)
             {
@@ -115,6 +137,7 @@ page 5194 "Contoso Demo Tool"
             }
 
             actionref(Configuration_Promoted; Configuration) { }
+            actionref(UpdateInternalDescriptions_Promoted; UpdateInternalDescriptions) { }
         }
     }
 


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->

- Overload the InsertAccScheduleName function to accept a new parameter for Internal Description input.
- Set the internal description for row definitions that are created using the Demo Data tool.
- Ability to update internal description for existing row definitions.

<img width="1405" height="877" alt="image" src="https://github.com/user-attachments/assets/f14ef376-0d91-4d8e-a795-51f287f1e549" />


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes: #4311
Fixes: [AB #580996](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/580996)
Fixes: [AB #575837](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/575837)
