### PR TITLE
Add indirect permissions to ScheduledPerfProfilerImpl codeunit

### DIFF
--- a/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
+++ b/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
@@ -17,6 +17,7 @@ codeunit 1932 "Scheduled Perf. Profiler Impl."
     InherentEntitlements = X;
     InherentPermissions = X;
     SingleInstance = true;
+    Permissions = tabledata "Retention Policy Setup" = ri;
 
     procedure MapActivityTypeToRecord(var PerformanceProfileScheduler: Record "Performance Profile Scheduler"; ActivityType: Enum "Perf. Profile Activity Type")
     var


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
GDAP users are affected when this code is run from various places and prevents them from performing their action.
They have the license permission for indirect insert but not direct insert. 

This adds indirect read and indirect insert to the permissions on the codeunit.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#595852](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/595852)



