### PR TITLE
[releases/26.x] Add indirect permissions to ScheduledPerfProfilerImpl codeunit

### DIFF
--- a/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
+++ b/src/System Application/App/Performance Profiler/src/ScheduledPerfProfilerImpl.Codeunit.al
@@ -17,6 +17,7 @@ codeunit 1932 "Scheduled Perf. Profiler Impl."
     InherentEntitlements = X;
     InherentPermissions = X;
     SingleInstance = true;
+    Permissions = tabledata "Retention Policy Setup" = ri;
 
     procedure MapActivityTypeToRecord(var PerformanceProfileScheduler: Record "Performance Profile Scheduler"; ActivityType: Enum "Perf. Profile Activity Type")
     var


### PR DESCRIPTION
This pull request backports #4342 to releases/26.x

Fixes [AB#595909](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/595909)


