### PR TITLE
Marking all Subscription Billing's tests as Uncategroized

### DIFF
--- a/build/projects/Apps (W1)/.AL-Go/RunTestsInBcContainer.ps1
+++ b/build/projects/Apps (W1)/.AL-Go/RunTestsInBcContainer.ps1
@@ -2,16 +2,5 @@ Param(
     [Hashtable]$parameters
 )
 
-$parameters["returnTrueIfAllPassed"] = $true
 $script = Join-Path $PSScriptRoot "../../../scripts/RunTestsInBcContainer.ps1" -Resolve
-
-$parameters["testType"] = "UnitTest"
-[bool] $AllUnitTestsPassed = (. $script -parameters $parameters)
-
-$parameters["testType"] = "IntegrationTest"
-[bool] $AllIntegrationTestsPassed = (. $script -parameters $parameters)
-
-$parameters["testType"] = "Uncategorized"
-[bool] $AllUncategorizedTestsPassed = (. $script -parameters $parameters)
-
-return $AllUnitTestsPassed -and $AllIntegrationTestsPassed -and $AllUncategorizedTestsPassed
+. $script -parameters $parameters

--- a/build/projects/Apps (W1)/.AL-Go/RunTestsInBcContainer.ps1
+++ b/build/projects/Apps (W1)/.AL-Go/RunTestsInBcContainer.ps1
@@ -2,5 +2,16 @@ Param(
     [Hashtable]$parameters
 )
 
+$parameters["returnTrueIfAllPassed"] = $true
 $script = Join-Path $PSScriptRoot "../../../scripts/RunTestsInBcContainer.ps1" -Resolve
-. $script -parameters $parameters
+
+$parameters["testType"] = "UnitTest"
+[bool] $AllUnitTestsPassed = (. $script -parameters $parameters)
+
+$parameters["testType"] = "IntegrationTest"
+[bool] $AllIntegrationTestsPassed = (. $script -parameters $parameters)
+
+$parameters["testType"] = "Uncategorized"
+[bool] $AllUncategorizedTestsPassed = (. $script -parameters $parameters)
+
+return $AllUnitTestsPassed -and $AllIntegrationTestsPassed -and $AllUncategorizedTestsPassed

--- a/src/Apps/W1/Subscription Billing/Test/Billing/BillingCorrectionTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Billing/BillingCorrectionTest.Codeunit.al
@@ -9,6 +9,7 @@ using Microsoft.Purchases.History;
 codeunit 139686 "Billing Correction Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingDocsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingDocsTest.Codeunit.al
@@ -23,6 +23,7 @@ using System.TestLibraries.Utilities;
 codeunit 139687 "Recurring Billing Docs Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingTest.Codeunit.al
@@ -14,6 +14,7 @@ using Microsoft.Sales.History;
 codeunit 139688 "Recurring Billing Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/Billing/RecurringDiscountTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Billing/RecurringDiscountTest.Codeunit.al
@@ -12,6 +12,7 @@ using Microsoft.Purchases.History;
 codeunit 139689 "Recurring Discount Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/Contract Price Update/ContractPriceProposalTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Contract Price Update/ContractPriceProposalTest.Codeunit.al
@@ -14,6 +14,7 @@ using System.TestLibraries.Utilities;
 codeunit 139690 "Contract Price Proposal Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/Contract Price Update/ContractPriceUpdateTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Contract Price Update/ContractPriceUpdateTest.Codeunit.al
@@ -7,6 +7,7 @@ using Microsoft.Purchases.Vendor;
 codeunit 139691 "Contract Price Update Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/Contract Renewal/ContractRenewalTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Contract Renewal/ContractRenewalTest.Codeunit.al
@@ -11,6 +11,7 @@ using Microsoft.Purchases.Vendor;
 codeunit 139692 "Contract Renewal Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractDimensionsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractDimensionsTest.Codeunit.al
@@ -5,6 +5,7 @@ using Microsoft.Finance.Dimension;
 codeunit 139693 "Contract Dimensions Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     Access = Internal;
 
     var

--- a/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractsTest.Codeunit.al
@@ -16,6 +16,7 @@ using System.TestLibraries.Utilities;
 codeunit 148155 "Contracts Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ExtendContractTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ExtendContractTest.Codeunit.al
@@ -10,6 +10,7 @@ using Microsoft.Purchases.Vendor;
 codeunit 148152 "Extend Contract Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     Access = Internal;
 
     var

--- a/src/Apps/W1/Subscription Billing/Test/Deferrals/CustomerDeferralsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Deferrals/CustomerDeferralsTest.Codeunit.al
@@ -14,6 +14,7 @@ using Microsoft.Finance.GeneralLedger.Ledger;
 codeunit 139912 "Customer Deferrals Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/Deferrals/VendorDeferralsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Deferrals/VendorDeferralsTest.Codeunit.al
@@ -16,6 +16,7 @@ using Microsoft.Finance.GeneralLedger.Ledger;
 codeunit 139913 "Vendor Deferrals Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/Import/ImpServiceAndContractTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Import/ImpServiceAndContractTest.Codeunit.al
@@ -9,6 +9,7 @@ using Microsoft.Purchases.Vendor;
 codeunit 139914 "Imp. Service And Contract Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     Access = Internal;
 
     var

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
@@ -29,6 +29,7 @@ using System.TestLibraries.Utilities;
 codeunit 139915 "Sales Service Commitment Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     Access = Internal;
 
     var

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/ServiceCommArchiveTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/ServiceCommArchiveTest.Codeunit.al
@@ -6,6 +6,7 @@ using Microsoft.Sales.Customer;
 codeunit 139916 "Service Comm. Archive Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     Access = Internal;
 
     var

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/ServiceCommDimensions.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/ServiceCommDimensions.Codeunit.al
@@ -13,6 +13,7 @@ using Microsoft.Finance.Dimension;
 codeunit 148160 "Service Comm. Dimensions"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/ServiceCommitmentTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/ServiceCommitmentTest.Codeunit.al
@@ -6,6 +6,7 @@ using Microsoft.Sales.Document;
 codeunit 148156 "Service Commitment Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     Access = Internal;
 
     var

--- a/src/Apps/W1/Subscription Billing/Test/Service Objects/ItemServCommTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Objects/ItemServCommTest.Codeunit.al
@@ -5,6 +5,7 @@ using Microsoft.Inventory.Item;
 codeunit 139884 "Item Serv. Comm. Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     Access = Internal;
 
     var

--- a/src/Apps/W1/Subscription Billing/Test/Service Objects/ItemServiceCommTypeTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Objects/ItemServiceCommTypeTest.Codeunit.al
@@ -11,6 +11,7 @@ using Microsoft.Pricing.Asset;
 codeunit 139885 "Item Service Comm. Type Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/Service Objects/ServiceObjectTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Objects/ServiceObjectTest.Codeunit.al
@@ -20,6 +20,7 @@ using Microsoft.Pricing.PriceList;
 codeunit 148157 "Service Object Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     Access = Internal;
 
     var

--- a/src/Apps/W1/Subscription Billing/Test/Service Objects/TemplatesTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Objects/TemplatesTest.Codeunit.al
@@ -6,6 +6,7 @@ using Microsoft.Inventory.Item.Catalog;
 codeunit 139887 "Templates Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     Access = Internal;
 
     var

--- a/src/Apps/W1/Subscription Billing/Test/UBB/GenericImportTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/UBB/GenericImportTest.Codeunit.al
@@ -5,6 +5,7 @@ using System.IO;
 codeunit 139888 "Generic Import Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/UBB/ItemReferenceTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/UBB/ItemReferenceTest.Codeunit.al
@@ -7,6 +7,7 @@ using Microsoft.Purchases.Vendor;
 codeunit 139889 "Item Reference Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/UBB/LinkSubscriptionToSOTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/UBB/LinkSubscriptionToSOTest.Codeunit.al
@@ -8,6 +8,7 @@ using Microsoft.Sales.Customer;
 codeunit 148158 "Link Subscription To SO Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/UBB/UsageBasedBillingTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/UBB/UsageBasedBillingTest.Codeunit.al
@@ -19,6 +19,7 @@ using System.TestLibraries.Utilities;
 codeunit 148153 "Usage Based Billing Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/UBB/UsageBasedExtendContrTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/UBB/UsageBasedExtendContrTest.Codeunit.al
@@ -10,6 +10,7 @@ using Microsoft.Purchases.Vendor;
 codeunit 148159 "Usage Based Extend Contr. Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 

--- a/src/Apps/W1/Subscription Billing/Test/UBB/UsageBasedRebillingTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/UBB/UsageBasedRebillingTest.Codeunit.al
@@ -10,6 +10,7 @@ codeunit 139694 "Usage Based Rebilling Test"
 {
     Access = Internal;
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
 
     [Test]

--- a/src/Apps/W1/Subscription Billing/Test/UBB/UsageBasedServiceCommTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/UBB/UsageBasedServiceCommTest.Codeunit.al
@@ -6,6 +6,7 @@ using Microsoft.Sales.Document;
 codeunit 139895 "Usage Based Service Comm. Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     Access = Internal;
 
     var

--- a/src/Apps/W1/Subscription Billing/Test/Vendor Contracts/VendorContractsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Vendor Contracts/VendorContractsTest.Codeunit.al
@@ -11,6 +11,7 @@ using Microsoft.Purchases.Document;
 codeunit 148154 "Vendor Contracts Test"
 {
     Subtype = Test;
+    TestType = Uncategorized;
     TestPermissions = Disabled;
     Access = Internal;
 


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->

Marking all Subscription Billing's tests as `Uncategroized`.

This is needed because we haven't gotten to this project yet, marking tests as `Uncategroized` will ensure tests run exactly as before.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#593048](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/593048)



