### PR TITLE
[Shopify] Auto create new customer toggle prevents connector from using default customer

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyOrderMapping.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyOrderMapping.Codeunit.al
@@ -117,7 +117,7 @@ codeunit 30163 "Shpfy Order Mapping"
                 JCustomer.Add('County', OrderHeader."Bill-to County");
                 JCustomer.Add('CountryCode', OrderHeader."Bill-to Country/Region Code");
                 OrderHeader."Bill-to Customer No." := CustomerMapping.DoMapping(OrderHeader."Customer Id", JCustomer, OrderHeader."Shop Code", CustomerTemplateCode, AllowCreateCustomer);
-                if (OrderHeader."Bill-to Customer No." = '') and (not Shop."Auto Create Unknown Customers") and (Shop."Default Customer No." <> '') then
+                if (OrderHeader."Bill-to Customer No." = '') and (Shop."Default Customer No." <> '') then
                     OrderHeader."Bill-to Customer No." := Shop."Default Customer No.";
 
                 if OrderHeader."Sell-to Customer No." = '' then
@@ -161,7 +161,7 @@ codeunit 30163 "Shpfy Order Mapping"
                     OrderHeader."Bill-to Customer No." := OrderHeader."Sell-to Customer No.";
                 end;
 
-                if (OrderHeader."Bill-to Customer No." = '') and (not Shop."Auto Create Unknown Customers") and (Shop."Default Company No." <> '') then
+                if (OrderHeader."Bill-to Customer No." = '') and (Shop."Default Company No." <> '') then
                     OrderHeader."Bill-to Customer No." := Shop."Default Company No.";
                 if OrderHeader."Sell-to Customer No." = '' then
                     OrderHeader."Sell-to Customer No." := OrderHeader."Bill-to Customer No.";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Auto create new customer toggle prevents connector from using default customer

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#595971](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/592060)

