### PR TITLE
[26.1] Add support for agent suggestions and free text instructions in the agent task pane

### DIFF
--- a/src/System Application/App/Agent/Interaction/AgentTaskImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/AgentTaskImpl.Codeunit.al
@@ -113,6 +113,21 @@ codeunit 4300 "Agent Task Impl."
         CreateUserIntervention(UserInterventionRequestEntry, '', SelectedSuggestionId);
     end;
 
+    procedure CreateUserIntervention(UserInterventionRequestEntry: Record "Agent Task Log Entry"; UserInput: Text; SelectedSuggestionId: Text)
+    var
+        SelectedSuggestionIdInt: Integer;
+    begin
+        if SelectedSuggestionId <> '' then
+            if Evaluate(SelectedSuggestionIdInt, SelectedSuggestionId) then begin
+                CreateUserIntervention(UserInterventionRequestEntry, UserInput, SelectedSuggestionIdInt);
+                exit;
+            end
+            else
+                Session.LogMessage('0000PKA', StrSubstNo(InvalidSelectedSuggestionIdErr, SelectedSuggestionId), Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CategoryTok);
+
+        CreateUserIntervention(UserInterventionRequestEntry, UserInput);
+    end;
+
     procedure CreateUserIntervention(UserInterventionRequestEntry: Record "Agent Task Log Entry"; UserInput: Text; SelectedSuggestionId: Integer)
     var
         AgentTask: Record "Agent Task";
@@ -217,4 +232,6 @@ codeunit 4300 "Agent Task Impl."
         MessageTextMustBeProvidedErr: Label 'You must provide a message text.';
         AreYouSureThatYouWantToRestartTheTaskQst: Label 'Are you sure that you want to restart the task?';
         AreYouSureThatYouWantToStopTheTaskQst: Label 'Are you sure that you want to stop the task?';
+        InvalidSelectedSuggestionIdErr: Label 'Invalid SelectedSuggestionId: %1', Comment = '%1 - SelectedSuggestionId', Locked = true;
+        CategoryTok: Label 'Agents', Locked = true;
 }

--- a/src/System Application/App/Agent/TaskPane/AgentTaskDetails.Page.al
+++ b/src/System Application/App/Agent/TaskPane/AgentTaskDetails.Page.al
@@ -11,9 +11,7 @@ page 4313 "Agent Task Details"
     ApplicationArea = All;
     SourceTable = "Agent Task Timeline Step Det.";
     Caption = 'Agent Task Timeline Step Details';
-    Editable = false;
     InsertAllowed = false;
-    ModifyAllowed = false;
     DeleteAllowed = false;
     Extensible = false;
     InherentEntitlements = X;
@@ -23,8 +21,21 @@ page 4313 "Agent Task Details"
     {
         area(content)
         {
+            field(SelectedSuggestionId; SelectedSuggestionId)
+            {
+                Editable = true;
+                Caption = 'Selected Suggestion ID';
+                ToolTip = 'Specifies the selected suggestion ID for the user intervention request.';
+            }
+            field(UserMessage; UserMessage)
+            {
+                Editable = true;
+                Caption = 'Additional Instructions';
+                ToolTip = 'Specifies additional instructions for the user intervention request.';
+            }
             repeater(Details)
             {
+                Editable = false;
                 field(ClientContext; ClientContext)
                 {
                     Caption = 'Client Context';
@@ -65,6 +76,12 @@ page 4313 "Agent Task Details"
         }
     }
 
+    trigger OnOpenPage()
+    begin
+        Clear(SelectedSuggestionId);
+        Clear(UserMessage);
+    end;
+
     trigger OnAfterGetRecord()
     begin
         SetClientContext();
@@ -88,21 +105,13 @@ page 4313 "Agent Task Details"
     var
         UserInterventionRequestEntry: Record "Agent Task Log Entry";
         TaskTimelineStep: Record "Agent Task Timeline Step";
-        UserInput: Text;
     begin
         TaskTimelineStep.SetRange("Task ID", Rec."Task ID");
         TaskTimelineStep.SetRange(ID, Rec."Timeline Step ID");
         TaskTimelineStep.SetRange("Last Log Entry Type", "Agent Task Log Entry Type"::"User Intervention Request");
-        if TaskTimelineStep.FindLast() then begin
-            case TaskTimelineStep."User Intervention Request Type" of
-                TaskTimelineStep."User Intervention Request Type"::ReviewMessage:
-                    UserInput := '';
-                else
-                    UserInput := UserMessage; //ToDo: Will be implemented when we have a message field.
-            end;
+        if TaskTimelineStep.FindLast() then
             if UserInterventionRequestEntry.Get(TaskTimelineStep."Task ID", TaskTimelineStep."Last Log Entry ID") then
-                AgentTaskImpl.CreateUserIntervention(UserInterventionRequestEntry, UserInput);
-        end;
+                AgentTaskImpl.CreateUserIntervention(UserInterventionRequestEntry, UserMessage, SelectedSuggestionId);
     end;
 
     local procedure SkipStep()
@@ -126,7 +135,8 @@ page 4313 "Agent Task Details"
     var
         AgentTaskImpl: Codeunit "Agent Task Impl.";
         ClientContext: BigText;
-        UserMessage: Text;
+        UserMessage: Text[250];
+        SelectedSuggestionId: Text[3];
 }
 
 

--- a/src/System Application/App/Agent/TaskPane/AgentTaskTimeline.Page.al
+++ b/src/System Application/App/Agent/TaskPane/AgentTaskTimeline.Page.al
@@ -29,8 +29,15 @@ page 4307 "Agent Task Timeline"
                 Caption = 'Selected Suggestion ID';
                 ToolTip = 'Specifies the selected suggestion ID for the user intervention request.';
             }
+            field(UserMessage; UserMessage)
+            {
+                Editable = true;
+                Caption = 'Additional Instructions';
+                ToolTip = 'Specifies additional instructions for the user intervention request.';
+            }
             repeater(TaskTimeline)
             {
+                Editable = false;
                 field(Header; Rec.Title)
                 {
                     Caption = 'Header';
@@ -101,6 +108,11 @@ page 4307 "Agent Task Timeline"
                     Caption = 'First Step Created At';
                     ToolTip = 'Specifies the date and time when the timeline step was created.';
                 }
+                field(LastUserInterventionDetails; GlobalUserInterventionDetails)
+                {
+                    Caption = 'Last User Intervention Details';
+                    ToolTip = 'Specifies the details of the last user intervention in the timeline step.';
+                }
             }
         }
     }
@@ -119,12 +131,10 @@ page 4307 "Agent Task Timeline"
                 var
                     UserInterventionRequestEntry: Record "Agent Task Log Entry";
                     AgentTaskImpl: Codeunit "Agent Task Impl.";
-                    SelectedSuggestionIdInt: Integer;
                 begin
                     if UserInterventionRequestEntry.Get(Rec."Task ID", Rec."Last Log Entry ID") then
                         if UserInterventionRequestEntry.Type = "Agent Task Log Entry Type"::"User Intervention Request" then
-                            if Evaluate(SelectedSuggestionIdInt, SelectedSuggestionId) then
-                                AgentTaskImpl.CreateUserIntervention(UserInterventionRequestEntry, SelectedSuggestionIdInt);
+                            AgentTaskImpl.CreateUserIntervention(UserInterventionRequestEntry, UserMessage, SelectedSuggestionId);
                 end;
             }
 
@@ -151,7 +161,8 @@ page 4307 "Agent Task Timeline"
 
     trigger OnOpenPage()
     begin
-        SelectedSuggestionId := '';
+        Clear(SelectedSuggestionId);
+        Clear(UserMessage);
         Rec.SetRange(Importance, Rec.Importance::Primary);
     end;
 
@@ -178,23 +189,29 @@ page 4307 "Agent Task Timeline"
         Clear(GlobalPageQuery);
         Clear(GlobalAnnotations);
         Clear(GlobalSuggestions);
+        Clear(GlobalUserInterventionDetails);
 
         GlobalDescription := Rec.Description;
 
-        if Rec.CalcFields("Primary Page Summary", "Primary Page Query", "Annotations") then begin
-            if Rec."Primary Page Summary".HasValue then begin
+        if Rec.CalcFields("Primary Page Summary", "Primary Page Query", "Annotations", "Last User Intervention Details") then begin
+            if Rec."Primary Page Summary".HasValue() then begin
                 Rec."Primary Page Summary".CreateInStream(InStream, TextEncoding::UTF8);
                 GlobalPageSummary.Read(InStream);
                 Clear(InStream);
             end;
-            if Rec."Primary Page Query".HasValue then begin
+            if Rec."Primary Page Query".HasValue() then begin
                 Rec."Primary Page Query".CreateInStream(InStream, TextEncoding::UTF8);
                 GlobalPageQuery.Read(InStream);
                 Clear(InStream);
             end;
-            if Rec."Annotations".HasValue then begin
+            if Rec."Annotations".HasValue() then begin
                 Rec."Annotations".CreateInStream(InStream, TextEncoding::UTF8);
                 GlobalAnnotations.Read(InStream);
+                Clear(InStream);
+            end;
+            if Rec."Last User Intervention Details".HasValue() then begin
+                Rec."Last User Intervention Details".CreateInStream(InStream, TextEncoding::UTF8);
+                GlobalUserInterventionDetails.Read(InStream);
                 Clear(InStream);
             end;
         end;
@@ -332,12 +349,13 @@ page 4307 "Agent Task Timeline"
         GlobalPageQuery: BigText;
         GlobalAnnotations: BigText;
         GlobalSuggestions: BigText;
+        GlobalUserInterventionDetails: BigText;
         GlobalDescription: Text[2048];
         GlobalConfirmedBy: Text[250];
         GlobalNowAuthorizedBy: Text[250];
         GlobalConfirmedAt: DateTime;
         ConfirmationStatusOption: Option " ",ConfirmationNotRequired,ReviewConfirmationRequired,ReviewConfirmed,StopConfirmationRequired,StopConfirmed,Discarded;
+        UserMessage: Text[250];
         SelectedSuggestionId: Text[3];
 }
-
 

--- a/src/System Application/App/Agent/TaskPane/AgentTasks.Page.al
+++ b/src/System Application/App/Agent/TaskPane/AgentTasks.Page.al
@@ -63,6 +63,7 @@ page 4306 "Agent Tasks"
                 field(TaskLastStepCompletedOn; Rec."Last Step Timestamp")
                 {
                     Caption = 'Last Step Completed On';
+                    ToolTip = 'Specifies the date and time when the last step for the task was completed.';
                 }
                 field(TaskStepType; Rec."Current Step Type")
                 {


### PR DESCRIPTION
Add support for agent suggestions and free text instructions in the agent task pane (#3784)

Fixes

[AB#579777](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/579777)

[AB#579778](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/579778)

[AB#596026](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/596026)

