### PR TITLE
SetSigningKey in SignedXml accepts the key as SecretText

### DIFF
--- a/src/System Application/App/Cryptography Management/src/Xml/SignedXml.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/Xml/SignedXml.Codeunit.al
@@ -57,6 +57,25 @@ codeunit 1460 SignedXml
     /// <summary>
     /// Sets the key used for signing a SignedXml object.
     /// </summary>
+    /// <param name="XmlString">The XML string containing key information.</param>
+    procedure SetSigningKey(XmlString: SecretText)
+    begin
+        SignedXmlImpl.SetSigningKey(XmlString);
+    end;
+
+    /// <summary>
+    /// Sets the key used for signing a SignedXml object.
+    /// </summary>
+    /// <param name="XmlString">The XML string containing key information.</param>
+    /// <param name="SignatureAlgorithm">The type of asymmetric algorithms.</param>
+    procedure SetSigningKey(XmlString: SecretText; SignatureAlgorithm: Enum SignatureAlgorithm)
+    begin
+        SignedXmlImpl.SetSigningKey(XmlString, SignatureAlgorithm);
+    end;
+    
+    /// <summary>
+    /// Sets the key used for signing a SignedXml object.
+    /// </summary>
     /// <param name="SignatureKey">The key used for signing the SignedXml object.</param>
     procedure SetSigningKey(SignatureKey: Codeunit "Signature Key")
     begin

--- a/src/System Application/Test/Cryptography Management/src/Xml/SignedXmlModuleTest.Codeunit.al
+++ b/src/System Application/Test/Cryptography Management/src/Xml/SignedXmlModuleTest.Codeunit.al
@@ -81,6 +81,46 @@ codeunit 132612 "Signed Xml Module Test"
         LibraryAssert.IsTrue(SignedXml.CheckSignature(CertBase64Data, Password, true), 'Failed to verify the xml signature.');
     end;
 
+    [Test]
+    procedure SignXmlDocumentWithSigningKeyAsSecretText()
+    var
+        XmlToSign: XmlDocument;
+        SignedXmlElement: XmlElement;
+        SigningKey: SecretText;
+    begin
+        XmlDocument.ReadFrom('<TestXml Id="ID01">XML to sign</TestXml>', XmlToSign);
+        SignedXml.InitializeSignedXml(XmlToSign);
+
+        GetSignatureKeyXmlString(SigningKey);
+        SignedXml.SetSigningKey(SigningKey);
+        SignedXml.InitializeReference('#ID01');
+
+        SignedXml.ComputeSignature();
+
+        SignedXmlElement := SignedXml.GetXml();
+        LibraryAssert.AreEqual('Signature', SignedXmlElement.LocalName, 'Signature was not computed.');
+    end;
+
+    [Test]
+    procedure SignXmlDocumentWithSigningKeyAsSecretTextAndRsaAlgorithm()
+    var
+        XmlToSign: XmlDocument;
+        SignedXmlElement: XmlElement;
+        SigningKey: SecretText;
+    begin
+        XmlDocument.ReadFrom('<TestXml Id="ID01">XML to sign</TestXml>', XmlToSign);
+        SignedXml.InitializeSignedXml(XmlToSign);
+
+        GetSignatureKeyXmlString(SigningKey);
+        SignedXml.SetSigningKey(SigningKey, Enum::SignatureAlgorithm::RSA);
+        SignedXml.InitializeReference('#ID01');
+
+        SignedXml.ComputeSignature();
+
+        SignedXmlElement := SignedXml.GetXml();
+        LibraryAssert.AreEqual('Signature', SignedXmlElement.LocalName, 'Signature was not computed.');
+    end;
+
     local procedure GetSignatureElement(SignedXmlDocument: XmlDocument; var SignatureElement: XmlElement)
     var
         NSMgr: XmlNamespaceManager;


### PR DESCRIPTION
#### Summary
Added methods in SignedXml accepting the signing key as a SecretText:
```
SetSigningKey(XmlString: SecretText)
SetSigningKey(XmlString: SecretText; SignatureAlgorithm: Enum SignatureAlgorithm)
```

#### Work Item(s)
Fixes #4176 



Fixes [AB#596370](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/596370)
