### PR TITLE
Improve error message when failing to parse yaml

### DIFF
--- a/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInputsManagement.Codeunit.al
+++ b/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInputsManagement.Codeunit.al
@@ -243,7 +243,7 @@ codeunit 130458 "Test Inputs Management"
         DataInputJsonArray: JsonArray;
     begin
         if not DataInputJsonObject.ReadFromYaml(TestData) then
-            Error(CouldNotParseInputErr);
+            Error(CouldNotParseYamlInputErr);
 
         if not DataInputJsonObject.Get(TestsTok, DataInputJsonToken) then begin
             InsertDataInputLine(DataInputJsonObject, TestInputGroup);
@@ -356,7 +356,8 @@ codeunit 130458 "Test Inputs Management"
         TestInputTok: Label 'testInput', Locked = true;
         ChooseFileLbl: Label 'Choose a file to import';
         TestInputNameTok: Label 'INPUT-', Locked = true;
-        CouldNotParseInputErr: Label 'Could not parse input dataset';
+        CouldNotParseYamlInputErr: Label 'The data does not represent valid YAML.';
+        CouldNotParseInputErr: Label 'Could not parse input dataset.';
         CouldNotParseJsonlInputErr: Label 'Could not parse JSONL input line: %1', Comment = '%1 = JSON Line Content';
         LineTypeMustBeCodeunitErr: Label 'Line type must be Codeunit.';
         JsonFileExtensionTxt: Label '.json', Locked = true;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
**Problem:**
When failing to parse YAML file, a generic error is thrown.

**Solution:**
Improve error message when failing to parse YAML due to the data not representing valid YAML.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#592948](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/592948/)

