### PR TITLE
[Shopify] Add Shopify related fields to sales order archives

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyCopySalesDocument.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyCopySalesDocument.Codeunit.al
@@ -1,0 +1,36 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify;
+
+using Microsoft.Sales.Document;
+using Microsoft.Utilities;
+
+codeunit 30402 "Shpfy Copy Sales Document"
+{
+    Access = Internal;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Copy Document Mgt.", 'OnAfterCopySalesHeaderArchive', '', false, false)]
+    local procedure OnAfterCopySalesHeaderArchive(var ToSalesHeader: Record "Sales Header")
+    begin
+        if (ToSalesHeader."Shpfy Order Id" = 0) and (ToSalesHeader."Shpfy Order No." = '') then
+            exit;
+
+        Clear(ToSalesHeader."Shpfy Order Id");
+        Clear(ToSalesHeader."Shpfy Order No.");
+        ToSalesHeader.Modify();
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Copy Document Mgt.", 'OnAfterCopySalesDocSalesLineArchive', '', false, false)]
+    local procedure OnAfterCopySalesDocSalesLineArchive(ToSalesLine: Record "Sales Line")
+    begin
+        if (ToSalesLine."Shpfy Order Line Id" = 0) and (ToSalesLine."Shpfy Order No." = '') then
+            exit;
+
+        Clear(ToSalesLine."Shpfy Order Line Id");
+        Clear(ToSalesLine."Shpfy Order No.");
+        ToSalesLine.Modify();
+    end;
+}

--- a/src/Apps/W1/Shopify/App/src/Order handling/Table Extensions/ShpfySalesHeaderArchive.TableExt.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Table Extensions/ShpfySalesHeaderArchive.TableExt.al
@@ -1,0 +1,31 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify;
+
+using Microsoft.Sales.Archive;
+
+/// <summary>
+/// TableExtension Shpfy Sales Header Archive (ID 30203) extends Record Sales Header Archive.
+/// </summary>
+tableextension 30203 "Shpfy Sales Header Archive" extends "Sales Header Archive"
+{
+    fields
+    {
+        field(30100; "Shpfy Order Id"; BigInteger)
+        {
+            Caption = 'Shopify Order Id';
+            DataClassification = CustomerContent;
+            Editable = false;
+        }
+
+        field(30101; "Shpfy Order No."; Code[50])
+        {
+            Caption = 'Shopify Order No.';
+            DataClassification = CustomerContent;
+            Editable = false;
+        }
+    }
+}

--- a/src/Apps/W1/Shopify/App/src/Order handling/Table Extensions/ShpfySalesLineArchive.TableExt.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Table Extensions/ShpfySalesLineArchive.TableExt.al
@@ -1,0 +1,31 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify;
+
+using Microsoft.Sales.Archive;
+
+/// <summary>
+/// TableExtension Shpfy Sales Line Archive (ID 30204) extends Record Sales Line Archive.
+/// </summary>
+tableextension 30204 "Shpfy Sales Line Archive" extends "Sales Line Archive"
+{
+    fields
+    {
+        field(30100; "Shpfy Order Line Id"; BigInteger)
+        {
+            Caption = 'Shopify Order Line Id';
+            DataClassification = CustomerContent;
+            Editable = false;
+        }
+
+        field(30101; "Shpfy Order No."; Code[50])
+        {
+            Caption = 'Shopify Order No.';
+            DataClassification = CustomerContent;
+            Editable = false;
+        }
+    }
+}

--- a/src/Apps/W1/Shopify/App/src/PermissionSets/ShpfyObjects.PermissionSet.al
+++ b/src/Apps/W1/Shopify/App/src/PermissionSets/ShpfyObjects.PermissionSet.al
@@ -119,6 +119,7 @@ permissionset 30104 "Shpfy - Objects"
         codeunit "Shpfy Company Export" = X,
         codeunit "Shpfy Company Import" = X,
         codeunit "Shpfy Company Mapping" = X,
+        codeunit "Shpfy Copy Sales Document" = X,
         codeunit "Shpfy County Code" = X,
         codeunit "Shpfy County From Json Code" = X,
         codeunit "Shpfy County From Json Name" = X,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Add Shopify related fields to sales order achives

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#596501](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/596501)
