### PR TITLE
Unpublish apps in BCApps repo during Apps (W1) build

### DIFF
--- a/build/projects/Apps (W1)/.AL-Go/NewBcContainer.ps1
+++ b/build/projects/Apps (W1)/.AL-Go/NewBcContainer.ps1
@@ -1,6 +1,7 @@
 Param(
     [Hashtable]$parameters
 )
+Import-Module "../../../scripts/EnlistmentHelperFunctions.psm1"
 
 $script = Join-Path $PSScriptRoot "../../../scripts/NewBcContainer.ps1" -Resolve
-. $script -parameters $parameters -AppsToUnpublish @("E-Document Connector - Avalara","E-Document Connector - Avalara Tests","Shopify Connector","Shopify Connector Test","Subscription Billing","Subscription Billing Demo Data","Subscription Billing Test")
+. $script -parameters $parameters -AppsToUnpublish (Get-AppsInFolder "src/Apps/W1")

--- a/build/projects/Apps (W1)/.AL-Go/NewBcContainer.ps1
+++ b/build/projects/Apps (W1)/.AL-Go/NewBcContainer.ps1
@@ -3,4 +3,4 @@ Param(
 )
 
 $script = Join-Path $PSScriptRoot "../../../scripts/NewBcContainer.ps1" -Resolve
-. $script -parameters $parameters -KeepAppsPublished
+. $script -parameters $parameters -AppsToUnpublish @("E-Document Connector - Avalara","E-Document Connector - Avalara Tests","Shopify Connector","Shopify Connector Test","Subscription Billing","Subscription Billing Demo Data","Subscription Billing Test")

--- a/build/scripts/EnlistmentHelperFunctions.psm1
+++ b/build/scripts/EnlistmentHelperFunctions.psm1
@@ -552,5 +552,29 @@ function Test-IsBranchInSupport() {
     return $isSupported
 }
 
+<#
+.SYNOPSIS
+    Gets the list of apps in a folder.
+.DESCRIPTION
+    This function gets the list of apps in a folder by reading the app.json files in the folder and returning the names of the apps.
+.PARAMETER RelativePath
+    The relative path to the folder containing the apps.
+#>
+function Get-AppsInFolder() {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string] $RelativePath
+    )
+    $Path = Join-Path (Get-BaseFolder) $RelativePath -Resolve
+
+    $apps = @()
+    $appJsons = Get-ChildItem -Path $Path -Recurse -Filter "app.json"
+    foreach ($appJson in $appJsons) {
+        $app = Get-Content -Path $appJson.FullName | ConvertFrom-Json
+        $apps += $app.name
+    }
+    return $apps
+}
+
 Export-ModuleMember -Function *-*
 Export-ModuleMember -Function RunAndCheck

--- a/build/scripts/NewBcContainer.ps1
+++ b/build/scripts/NewBcContainer.ps1
@@ -1,6 +1,6 @@
 Param(
     [Hashtable]$parameters,
-    [switch]$KeepAppsPublished
+    [string[]]$AppsToUnpublish = @("All")
 )
 
 $parameters.multitenant = $false
@@ -20,13 +20,8 @@ foreach($app in $installedApps) {
     Write-Host "Removing $($app.Name)"
     UnInstall-BcContainerApp -containerName $parameters.ContainerName -name $app.Name -doNotSaveData -doNotSaveSchema -force
 
-    if ((-not $KeepAppsPublished)) {
+    if (($AppsToUnpublish -contains "All") -or ($AppsToUnpublish -contains $app.Name)) {
         Write-Host "Unpublishing $($app.Name)"
-        Unpublish-BcContainerApp -containerName $parameters.ContainerName -name $app.Name -unInstall -doNotSaveData -doNotSaveSchema -force
-    }
-
-    # Temp fix
-    if ($app.Name -like "*Shopify*") {
         Unpublish-BcContainerApp -containerName $parameters.ContainerName -name $app.Name -unInstall -doNotSaveData -doNotSaveSchema -force
     }
 }

--- a/build/scripts/NewBcContainer.ps1
+++ b/build/scripts/NewBcContainer.ps1
@@ -24,6 +24,11 @@ foreach($app in $installedApps) {
         Write-Host "Unpublishing $($app.Name)"
         Unpublish-BcContainerApp -containerName $parameters.ContainerName -name $app.Name -unInstall -doNotSaveData -doNotSaveSchema -force
     }
+
+    # Temp fix
+    if ($app.Name -like "*Shopify*") {
+        Unpublish-BcContainerApp -containerName $parameters.ContainerName -name $app.Name -unInstall -doNotSaveData -doNotSaveSchema -force
+    }
 }
 
 Write-Host "Current installed apps in container $($parameters.ContainerName)"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
During the Apps (W1) job in the PR Build and CICD we keep all apps published but uninstalled. Unfortunately, that causes an issue when publishing the newly built apps to the container

See https://github.com/microsoft/BCApps/actions/runs/16896859350

```
  Extension compilation failed
  Order%20Handling/ShpfyOrderTest.Codeunit.al(62,60): error AL0132: 'Record "Sales Header Archive"' does not contain a definition for 'Shpfy Order No.'
  Order%20Handling/ShpfyOrderTest.Codeunit.al(66,58): error AL0132: 'Record "Sales Line Archive"' does not contain a definition for 'Shpfy Order No.'
```

A mitigation to this would be to unpublish the 1st Party apps we build in BCApps 

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes AB#596980
