### PR TITLE
[AnalysisAssist]: Add permission to Copilot permissions page

### DIFF
--- a/src/System Application/App/System Permissions/permissions/CopilotSysFeatures.PermissionSet.al
+++ b/src/System Application/App/System Permissions/permissions/CopilotSysFeatures.PermissionSet.al
@@ -13,6 +13,6 @@ permissionset 9680 "Copilot Sys Features"
 
     Permissions = system "Allow Copilot Autofill" = X,
                   system "Allow Copilot Chat" = X,
-                  system "Allow Copilot Summary" = X;
-                  
+                  system "Allow Copilot Summary" = X,
+                  system "Allow Copilot Analysis Assist" = X;
 }


### PR DESCRIPTION
Adding Analysis Assist permission set to Copilot permission page

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#597114](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/597114/)
