### PR TITLE
Agent Access Control - Don't show agents in access control list

### DIFF
--- a/src/System Application/App/Agent/Setup/AgentAccessControl.Page.al
+++ b/src/System Application/App/Agent/Setup/AgentAccessControl.Page.al
@@ -28,7 +28,7 @@ page 4320 "Agent Access Control"
                 {
                     Caption = 'User Name';
                     ToolTip = 'Specifies the name of the User that can access the agent.';
-                    TableRelation = User;
+                    TableRelation = User where("License Type" = filter(<> Agent));
 
                     trigger OnValidate()
                     begin


### PR DESCRIPTION
#### Summary
Adding agents to the users who can configure an agent is not permitted, thus the lookup should not show them.
This changes the UI so that we filter on that.

#### Work Item(s)
Fixes AB#597109
