### PR TITLE
Fixing the format option used for the recordId 

### DIFF
--- a/src/System Application/Test/Translation/src/TranslationTests.Codeunit.al
+++ b/src/System Application/Test/Translation/src/TranslationTests.Codeunit.al
@@ -143,7 +143,7 @@ codeunit 137121 "Translation Tests"
         TranslationTestPage.TextField.AssistEdit();
 
         // [THEN] Page caption is set to Record ID
-        Assert.AreEqual('Translation - ' + Format(TranslationTestTable.RecordId()), TranslationPage.Caption(), 'Custom caption is to be shown');
+        Assert.AreEqual('Translation - ' + Format(TranslationTestTable.RecordId(), 0, 1), TranslationPage.Caption(), 'Custom caption is to be shown');
 
         // [THEN] Two records show up
         TranslationPage.First();


### PR DESCRIPTION
#### Summary 
The format of record Id is being changed to include the namespace. however in one of the tests the incorrect format of record id option is used to be compared with the caption. This PR will address the test defect


#### Work Item(s) 
[Slice 501761](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/501761): [AL][Namespaces] Adding namespace to the metadata system and the system tables

Fixes [AB#501761](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/501761)


Addresses the incorrect format option on a recordId 




