### PR TITLE
Prevent record lock on No. Series Line if the record is not changed in No. Series Impl.

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
@@ -141,7 +141,7 @@ codeunit 304 "No. Series - Impl."
         if not LineFound then
             LineFound := NoSeriesLine.FindLast();
 
-        if LineFound and NoSeries.MayProduceGaps(NoSeriesLine) then begin
+        if LineFound and NoSeriesLine.Open and NoSeries.MayProduceGaps(NoSeriesLine) then begin
             NoSeriesLine.Validate(Open);
             if not NoSeriesLine.Open then
                 NoSeriesLine.Modify(true);


### PR DESCRIPTION
#### Summary 

When the DrillDown action is invoked on any field in the No. Series page, `Page.Runmodal` fails because of an open write transaction. There is an active update lock on the No. Series Line table acquired by the `Modify` statement invoked from the `OnAfterGetRecord` trigger.

The sequence of events in this scenario:
1. User opens the No. Series page and scrolls to the record they want to open. `OnAfterGetRecord` trigger fires on each `No. Series` record and invokes `NoSeriesSetupImpl.UpdateLine`.
2. UpdateLine called from the trigger updates the `Open` flag on `No. Series Line` if necessary.
3. Each invocation of the `OnAfterGetRecord` trigger is executed in a separate DB transaction, therefore any changes that take place in the trigger are committed.
4. User clicks on a field triggering the DrillDown action.
5. Before executing the DrillDown, the runtime invokes the `OnAfterGetRecord` on the selected record and goes through `NoSeriesSetupImpl.UpdateLine` once again.
6. When the `Modify` statement in `GetNoSeriesLine` is hit, the line is already updated by the previous call of the `OnAfterGetRecord`, therefore, even if the Open flag had not been not set by the time when the page was open, it is updated now. Nonetheless, `Modify` is still invoked without any changes in the record.
7. If the record is not changed, the runtime does not issue an UPDATE SQL statement, but runs a SELECT WITH (UPDLOCK) query, still locking the No. Series Line record, even though no changes were made.
8. `OnDrillDown` trigger is called within the same DB transaction which still holds the update lock.
9. `Page.RunModal` fails due to the active update lock.

To solve this, we can skip modification of the record if no fields are changed. When `GetNoSeriesLine` is invoked from the `No. Series` page, the record is already updated by the first call of the `OnAfterGetRecord` trigger and the `Modify` in the procedure is always redundant.
I did not find a way to reproduce this behaviour in a test. The same Modify does not issue SELECT WITH (UPDLOCK) query when executed from a test page, therefore tested manually.

#### Work Item(s) 
Fixes #4433 
