### PR TITLE
[releases/27.x] Hardcode platform version to 27.0.0.0 for now

### DIFF
--- a/build/scripts/AppExtensionsHelper.psm1
+++ b/build/scripts/AppExtensionsHelper.psm1
@@ -71,7 +71,8 @@ function GetSourceCodeFromArtifact() {
     # Update the version in the app.json file (temporary fix until we have versions in a Directory.App.Props.json)
     $majorMinorVersion = Get-ConfigValue -Key "repoVersion" -ConfigType AL-Go
     $fullVersion = "$($majorMinorVersion).0.0"
-    Update-VersionInAppJson -Path $sourceCodeFolder -CurrentVersion $fullVersion -MinimumVersion $fullVersion -PlatformVersion $fullVersion
+    $platformVersion = "27.0.0.0" # Temporary workaround. Needs to be updated once platform version is updated
+    Update-VersionInAppJson -Path $sourceCodeFolder -CurrentVersion $fullVersion -MinimumVersion $fullVersion -PlatformVersion $platformVersion
 
     return $sourceCodeFolder
 }


### PR DESCRIPTION
This pull request backports #4558 to releases/27.x

Related to [AB#598707](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/598707)



