### PR TITLE
[releases/27.0] [Shopify] Add HttpClientHandler request path check from a single place

### DIFF
--- a/src/Apps/W1/Shopify/Test/Base/ShpfyInitializeTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Base/ShpfyInitializeTest.Codeunit.al
@@ -422,4 +422,11 @@ codeunit 139561 "Shpfy Initialize Test"
         CreateVATPostingSetup(PostingGroupCode, ShippingChargesGLAccount."VAT Prod. Posting Group");
         exit(ShippingChargesGLAccount."No.");
     end;
+
+    internal procedure VerifyRequestUrl(RequestPath: Text; ShopUrl: Text): Boolean
+    var
+        ShopifyShopUrlTok: Label '%1/admin/api/%2/graphql.json', Locked = true;
+    begin
+        exit(RequestPath = StrSubstNo(ShopifyShopUrlTok, ShopUrl, CommunicationMgt.GetApiVersion()));
+    end;
 }


### PR DESCRIPTION
This pull request backports #4501 to releases/27.0

Fixes [AB#598714](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/598714)

