### PR TITLE
[User Login Times] Row gets locked and can timeout when there are many sessions

### DIFF
--- a/src/System Application/App/User Login Times/src/UserLoginTimeTrackerImpl.Codeunit.al
+++ b/src/System Application/App/User Login Times/src/UserLoginTimeTrackerImpl.Codeunit.al
@@ -55,7 +55,7 @@ codeunit 9013 "User Login Time Tracker Impl."
     begin
         // if the user exists in the User Login Times table, they have logged in in the past
         UserEnvironmentLogin.SetRange("User SID", UserSecurityID);
-        UserEnvironmentLogin.ReadIsolation := UserEnvironmentLogin.ReadIsolation::ReadCommitted;
+        UserEnvironmentLogin.ReadIsolation := UserEnvironmentLogin.ReadIsolation::ReadUncommitted;
         if not UserEnvironmentLogin.IsEmpty() then
             exit(true); // Avoid locking the table if the user has logged in before
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
When there are many sessions, fx, Web Service calls, this code which checks if it's the first time a login has happened can cause deadlocks. As many sessions hitting the DB at the same time would all need to wait for one another.

A lock is held on that specific row every time the IsEmpty check is done. ReadUncommited will ensure no lock is held and even if the data is being updated, we then know that the user has logged in previously.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes AB#598794
