### PR TITLE
[Shopify] Add error to item creation when setting is not enabled

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyCreateItem.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyCreateItem.Codeunit.al
@@ -466,6 +466,7 @@ codeunit 30171 "Shpfy Create Item"
     begin
         ProductImport.SetShop(Product."Shop Code");
         ProductImport.SetProduct(Product);
+        ProductImport.SetCreateNewItem(true);
         Commit();  // Ensure product/variant creation is committed before running the item create/update
         ProductImport.Run();
     end;

--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductImport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductImport.Codeunit.al
@@ -43,7 +43,9 @@ codeunit 30180 "Shpfy Product Import"
                                 ItemCreated := CreateItem.Run(ShopifyVariant);
                                 SetProductConflict(ShopifyProduct.Id, ItemCreated);
                             until ShopifyVariant.Next() = 0;
-                    end;
+                    end else
+                        if CreateNewItem then
+                            SetProductConflict(ShopifyProduct.Id, false, AutoCreateUnknownItemsDisabledErr);
             until ShopifyVariant.Next() = 0;
     end;
 
@@ -54,6 +56,8 @@ codeunit 30180 "Shpfy Product Import"
         ShopifyVariant: Record "Shpfy Variant";
         ProductApi: Codeunit "Shpfy Product API";
         VariantApi: Codeunit "Shpfy Variant API";
+        CreateNewItem: Boolean;
+        AutoCreateUnknownItemsDisabledErr: Label 'Auto Create Unknown Item must be enabled and an Item Template must be selected for the shop.';
 
     /// <summary> 
     /// Get Product.
@@ -134,12 +138,12 @@ codeunit 30180 "Shpfy Product Import"
         VariantApi.SetShop(Shop);
     end;
 
-    /// <summary>
-    /// Set Product Conflict.
-    /// </summary>
-    /// <param name="ProductId">Parameter of type BigInteger.</param>
-    /// <param name="ItemCreated">Parameter of type Boolean.</param>
     local procedure SetProductConflict(ProductId: BigInteger; ItemCreated: Boolean)
+    begin
+        SetProductConflict(ProductId, ItemCreated, '');
+    end;
+
+    local procedure SetProductConflict(ProductId: BigInteger; ItemCreated: Boolean; ErrorMessage: Text)
     var
         Product: Record "Shpfy Product";
     begin
@@ -149,11 +153,19 @@ codeunit 30180 "Shpfy Product Import"
 
         if not ItemCreated then begin
             Product.Validate("Has Error", true);
-            Product.Validate("Error Message", CopyStr(Format(Time) + ' ' + GetLastErrorText(), 1, MaxStrLen(Product."Error Message")));
+
+            if ErrorMessage = '' then
+                ErrorMessage := GetLastErrorText();
+            Product.Validate("Error Message", CopyStr(Format(Time) + ' ' + ErrorMessage, 1, MaxStrLen(Product."Error Message")));
         end else begin
             Product.Validate("Has Error", false);
             Product.Validate("Error Message", '');
         end;
         Product.Modify(true);
+    end;
+
+    internal procedure SetCreateNewItem(Value: Boolean)
+    begin
+        CreateNewItem := Value;
     end;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Add error to item creation when setting is not enabled

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#599007](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/599007)
