### PR TITLE
#4653 There is no method to compare old and current password since SecretTexts cannot be compared in Cloud

### DIFF
--- a/src/System Application/App/Password/src/PasswordDialogImpl.Codeunit.al
+++ b/src/System Application/App/Password/src/PasswordDialogImpl.Codeunit.al
@@ -91,4 +91,11 @@ codeunit 9811 "Password Dialog Impl."
         if CurrentPasswordToCompare.Unwrap() = NewPassword.Unwrap() then
             Error(PasswordSameAsNewErr);
     end;
+
+    [NonDebuggable]
+    procedure ValidatedPasswordMatch(CurrentPasswordToCompare: SecretText; PasswordToCompare: SecretText)
+    begin
+        if CurrentPasswordToCompare.Unwrap() <> PasswordToCompare.Unwrap() then
+            Error(CurrentPasswordMismatchErr);
+    end;
 }

--- a/src/System Application/App/Password/src/PasswordDialogManagement.Codeunit.al
+++ b/src/System Application/App/Password/src/PasswordDialogManagement.Codeunit.al
@@ -63,7 +63,7 @@ codeunit 9810 "Password Dialog Management"
     end;
 
     /// <summary>
-    /// Compare the passwords and return the error if the passwords does not match
+    /// Compare the passwords and return the error if the passwords do not match
     /// </summary>
     /// <param name="CurrentPasswordToCompare">In parameter, the current password to compare with the password user provided.</param>
     /// <param name="PasswordToCompare">Thepassword user typed.</param>

--- a/src/System Application/App/Password/src/PasswordDialogManagement.Codeunit.al
+++ b/src/System Application/App/Password/src/PasswordDialogManagement.Codeunit.al
@@ -63,6 +63,16 @@ codeunit 9810 "Password Dialog Management"
     end;
 
     /// <summary>
+    /// Compare the passwords and return the error if the passwords does not match
+    /// </summary>
+    /// <param name="CurrentPasswordToCompare">In parameter, the current password to compare with the password user provided.</param>
+    /// <param name="PasswordToCompare">Thepassword user typed.</param>
+    procedure ValidatedPasswordMatch(CurrentPasswordToCompare: SecretText; PasswordToCompare: SecretText)
+    begin
+        PasswordDialogImpl.ValidatedPasswordMatch(CurrentPasswordToCompare, PasswordToCompare);
+    end;
+
+    /// <summary>
     /// Event to override the Minimum number of characters in the password.
     /// The Minimum length can only be increased not decreased. Default value is 8 characters long.
     /// </summary>


### PR DESCRIPTION
#### Summary 
Adding the function to compare secret texts for Password module. The new function is needed to make sure that the two passwords match. There is already function ValidateOldPasswordMatch in Implementation however it cannot be used since:
1. Name is not correct
2. It is not used in any facade codeunit
3. it exists if the input is empty

Therefore for clarity the similar function has been added with the proper name. Also to facade codeunit the function has been added to be able to run it by developers.

#### Work Item(s) #4653

