### PR TITLE
[releases/27.x] [Shopify] Add error to item creation when setting is not enabled

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyCreateItem.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyCreateItem.Codeunit.al
@@ -466,6 +466,7 @@ codeunit 30171 "Shpfy Create Item"
     begin
         ProductImport.SetShop(Product."Shop Code");
         ProductImport.SetProduct(Product);
+        ProductImport.SetCreateNewItem(true);
         Commit();  // Ensure product/variant creation is committed before running the item create/update
         ProductImport.Run();
     end;


### PR DESCRIPTION
This pull request backports #4628 to releases/27.x

Fixes [AB#599307](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/599307)
