### PR TITLE
Subscription billing app conflicts with IRS Forms app

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/CreateBillingDocuments.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/CreateBillingDocuments.Codeunit.al
@@ -616,7 +616,9 @@ codeunit 8060 "Create Billing Documents"
         PurchaseHeader."Receiving No." := OldPurchaseHeader."Receiving No.";
         PurchaseHeader."Receiving No. Series" := OldPurchaseHeader."Receiving No. Series";
         PurchaseHeader."No. Printed" := 0;
+        DocumentChangeManagement.SetSkipContractPurchaseHeaderModifyCheck(true);
         PurchaseHeader.Validate("Posting Date", PostingDate);
+        DocumentChangeManagement.SetSkipContractPurchaseHeaderModifyCheck(false);
         PurchaseHeader.Validate("Document Date", DocumentDate);
         PurchaseHeader.Validate("Currency Code");
         PurchaseHeader."Assigned User ID" := CopyStr(UserId(), 1, MaxStrLen(SalesHeader."Assigned User ID"));


### PR DESCRIPTION
When Subscription Billing app creates a new billing document it validates the posting date. Then the IRS forms app, which is the US specific app, not related to subscription billing, run an update of certain fields related to this app. This kind of update in the IRS forms app from the other side triggers the Subscription billing app code - the PreventChangePurchaseHeader procedure. This procedure throws the following error:
_You cannot make this change because the document is linked to a contract. If you still want to change the field, first delete this document and then make the change to the contract._

This procedure have a list of fields for exclusion. It would be great to add IRS forms app fields to the exclusion list, but that is not possible unless i create a dependency between these two apps, which does not make any sense.
The other approach which i eventually chose is to skip calling the PreventChangePurchaseHeader when i change the posting date. To me it sounds much better as we keep the procedure untouched, so we continue to call it whenever some user changes this value in the document. But if we validate the posting date through the code in the CreateBillingDocuments codeunit, we can skip this check.

AB#599229

