### PR TITLE
Fix obsoletion in v27.0 for No Series

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Upgrade/NoSeriesInstaller.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Upgrade/NoSeriesInstaller.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN28
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -5,32 +6,13 @@
 
 namespace Microsoft.Foundation.NoSeries;
 
-using System.Upgrade;
-
 codeunit 329 "No. Series Installer"
 {
     Subtype = Install;
     InherentEntitlements = X;
     InherentPermissions = X;
-
-    trigger OnInstallAppPerCompany()
-    begin
-        SetupNoSeriesImplementation();
-    end;
-
-    internal procedure SetupNoSeriesImplementation()
-    var
-        NoSeriesLine: Record "No. Series Line";
-        UpgradeTag: Codeunit "Upgrade Tag";
-        NoSeriesUpgradeTags: Codeunit "No. Series Upgrade Tags";
-    begin
-        if UpgradeTag.HasUpgradeTag(NoSeriesUpgradeTags.GetImplementationUpgradeTag()) then
-            exit;
-
-        NoSeriesLine.SetRange(Implementation, 0); // Only update the No. Series Lines that are still referencing the default implementation (0)
-        NoSeriesLine.SetRange("Allow Gaps in Nos.", true);
-        NoSeriesLine.ModifyAll(Implementation, "No. Series Implementation"::Sequence, false);
-
-        UpgradeTag.SetUpgradeTag(NoSeriesUpgradeTags.GetImplementationUpgradeTag());
-    end;
+    ObsoleteReason = 'Upgrade logic is moved to No. Series Upgrade codeunit 328.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '28.0';
 }
+#endif

--- a/src/Business Foundation/App/NoSeries/src/Upgrade/NoSeriesUpgrade.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Upgrade/NoSeriesUpgrade.Codeunit.al
@@ -1,9 +1,12 @@
+#if not CLEANSCHEMA27
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 
 namespace Microsoft.Foundation.NoSeries;
+
+using System.Upgrade;
 
 codeunit 328 "No. Series Upgrade"
 {
@@ -13,9 +16,24 @@ codeunit 328 "No. Series Upgrade"
     InherentPermissions = X;
 
     trigger OnUpgradePerCompany()
-    var
-        NoSeriesInstaller: Codeunit "No. Series Installer";
     begin
-        NoSeriesInstaller.SetupNoSeriesImplementation();
+        SetupNoSeriesImplementation();
+    end;
+
+    internal procedure SetupNoSeriesImplementation()
+    var
+        NoSeriesLine: Record "No. Series Line";
+        UpgradeTag: Codeunit "Upgrade Tag";
+        NoSeriesUpgradeTags: Codeunit "No. Series Upgrade Tags";
+    begin
+        if UpgradeTag.HasUpgradeTag(NoSeriesUpgradeTags.GetImplementationUpgradeTag()) then
+            exit;
+
+        NoSeriesLine.SetRange(Implementation, 0); // Only update the No. Series Lines that are still referencing the default implementation (0)
+        NoSeriesLine.SetRange("Allow Gaps in Nos.", true);
+        NoSeriesLine.ModifyAll(Implementation, "No. Series Implementation"::Sequence, false);
+
+        UpgradeTag.SetUpgradeTag(NoSeriesUpgradeTags.GetImplementationUpgradeTag());
     end;
 }
+#endif

--- a/src/Business Foundation/App/NoSeries/src/Upgrade/NoSeriesUpgradeTags.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Upgrade/NoSeriesUpgradeTags.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEANSCHEMA27
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -24,3 +25,4 @@ codeunit 332 "No. Series Upgrade Tags"
         exit('MS-471519-AddImplementationExtensibility-20231206 ');
     end;
 }
+#endif


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

`"Allow Gaps in Nos."` field is obsoleted, but we are still referencing it in `Install` codeunit.

Moving the upgrade logic completely into `Upgrade` codeunit.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#599301](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/599301)


