### PR TITLE
[27.x] Add DOTNET module for Power Platform API Wrapper

### DIFF
--- a/src/System Application/App/DotNet Aliases/src/dotnet.al
+++ b/src/System Application/App/DotNet Aliases/src/dotnet.al
@@ -2213,4 +2213,13 @@ dotnet
         {
         }
     }
+    assembly("Microsoft.Dynamics.Nav.PowerPlatform.Api")
+    {
+        Culture = 'neutral';
+        PublicKeyToken = '31bf3856ad364e35';
+
+        type("Microsoft.Dynamics.Nav.PowerPlatform.Api.PowerPlatformApiWrapper"; "PowerPlatformApiWrapper")
+        {
+        }
+    }
 }


### PR DESCRIPTION
#### Summary
We add a new Power Platform API Wrapper DOTNET module to be able to use it in Power Automate Environment Picker.

#### Work Item(s)
Fixes AB#593052
