### PR TITLE
Exposing part business foundation test libraries to SaaS

### DIFF
--- a/src/Business Foundation/Test Library/app.json
+++ b/src/Business Foundation/Test Library/app.json
@@ -27,7 +27,7 @@
   "internalsVisibleTo": [],
   "screenshots": [],
   "platform": "28.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
   "idRanges": [
     {
       "from": 134510,


### PR DESCRIPTION
The goal of this pull request is to expose business foundation test library to SaaS for two reasons:
1. The base Application's test library "Library - Utility" has a dependency on LibraryNoSeries which is part of the business foundation
2. We have a request from partner to use this library

It is achieved by moving the NoSeries app inside of SaaS folder that has a "Cloud" scope. The plan is to make this test app available for partners and also change the dependency in "Library - Utility"

[AB#559125](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/559125)








