### PR TITLE
Bug 602448: [27.0] There is no method to compare old and current password since SecretTexts cannot be compared in Cloud - missing capability in 27 compared to 26! - Copy

### DIFF
--- a/src/System Application/App/Password/src/PasswordDialogImpl.Codeunit.al
+++ b/src/System Application/App/Password/src/PasswordDialogImpl.Codeunit.al
@@ -91,4 +91,11 @@ codeunit 9811 "Password Dialog Impl."
         if CurrentPasswordToCompare.Unwrap() = NewPassword.Unwrap() then
             Error(PasswordSameAsNewErr);
     end;
+
+    [NonDebuggable]
+    procedure ValidatedPasswordMatch(CurrentPasswordToCompare: SecretText; PasswordToCompare: SecretText)
+    begin
+        if CurrentPasswordToCompare.Unwrap() <> PasswordToCompare.Unwrap() then
+            Error(CurrentPasswordMismatchErr);
+    end;
 }

--- a/src/System Application/App/Password/src/PasswordDialogManagement.Codeunit.al
+++ b/src/System Application/App/Password/src/PasswordDialogManagement.Codeunit.al
@@ -63,6 +63,16 @@ codeunit 9810 "Password Dialog Management"
     end;
 
     /// <summary>
+    /// Compare the passwords and return the error if the passwords do not match
+    /// </summary>
+    /// <param name="CurrentPasswordToCompare">In parameter, the current password to compare with the password user provided.</param>
+    /// <param name="PasswordToCompare">Thepassword user typed.</param>
+    procedure ValidatedPasswordMatch(CurrentPasswordToCompare: SecretText; PasswordToCompare: SecretText)
+    begin
+        PasswordDialogImpl.ValidatedPasswordMatch(CurrentPasswordToCompare, PasswordToCompare);
+    end;
+
+    /// <summary>
     /// Event to override the Minimum number of characters in the password.
     /// The Minimum length can only be increased not decreased. Default value is 8 characters long.
     /// </summary>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Backport of #4654

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#602448](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/602448)


