### PR TITLE
[Shopify] Sync only mapped customers if import setting is "with order import"

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Companies/Codeunits/ShpfySyncCompanies.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Companies/Codeunits/ShpfySyncCompanies.Codeunit.al
@@ -23,7 +23,9 @@ codeunit 30285 "Shpfy Sync Companies"
         SetShop(Rec);
         SyncStartTime := CurrentDateTime;
         if Shop."Company Import From Shopify" = Shop."Company Import From Shopify"::AllCompanies then
-            ImportCompaniesFromShopify();
+            ImportCompaniesFromShopify(true);
+        if (Shop."Company Import From Shopify" = Shop."Company Import From Shopify"::WithOrderImport) and Shop."Shopify Can Update Companies" then
+            ImportCompaniesFromShopify(false);
         if Shop."Can Update Shopify Companies" then
             ExportCompaniesToShopify();
 
@@ -39,7 +41,7 @@ codeunit 30285 "Shpfy Sync Companies"
         CompanyImport: Codeunit "Shpfy Company Import";
         CompanyApi: Codeunit "Shpfy Company API";
 
-    local procedure ImportCompaniesFromShopify()
+    local procedure ImportCompaniesFromShopify(CreateCompanies: Boolean)
     var
         Company: Record "Shpfy Company";
         TempCompany: Record "Shpfy Company" temporary;
@@ -57,6 +59,8 @@ codeunit 30285 "Shpfy Sync Companies"
                     TempCompany.Insert(false);
                 end;
             end else begin
+                if not CreateCompanies then
+                    continue;
                 Clear(TempCompany);
                 TempCompany.Id := Id;
                 TempCompany.Insert(false);

--- a/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfySyncCustomers.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfySyncCustomers.Codeunit.al
@@ -23,7 +23,9 @@ codeunit 30123 "Shpfy Sync Customers"
         SetShop(Rec);
         SyncStartTime := CurrentDateTime;
         if Shop."Customer Import From Shopify" = Shop."Customer Import From Shopify"::AllCustomers then
-            ImportCustomersFromShopify();
+            ImportCustomersFromShopify(true);
+        if (Shop."Customer Import From Shopify" = Shop."Customer Import From Shopify"::WithOrderImport) and Shop."Shopify Can Update Customer" then
+            ImportCustomersFromShopify(false);
         if Shop."Can Update Shopify Customer" then
             SyncCustomersToShopify();
 
@@ -54,7 +56,7 @@ codeunit 30123 "Shpfy Sync Customers"
     /// <summary> 
     /// Import Customers From Shopify.
     /// </summary>
-    local procedure ImportCustomersFromShopify()
+    local procedure ImportCustomersFromShopify(CreateCustomers: Boolean)
     var
         Customer: Record "Shpfy Customer";
         TempCustomer: Record "Shpfy Customer" temporary;
@@ -72,6 +74,8 @@ codeunit 30123 "Shpfy Sync Customers"
                     TempCustomer.Insert(false);
                 end;
             end else begin
+                if not CreateCustomers then
+                    continue;
                 Clear(TempCustomer);
                 TempCustomer.Id := Id;
                 TempCustomer."Shop Id" := Shop."Shop Id";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Sync only mapped customers if import setting is "with order import"

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#602510](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/602510)

