### PR TITLE
Keep apps installed during Apps build and add RunNumberOffset to build numbers

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -98,5 +98,6 @@
     "pullRequestLabels": [
       "Automation"
     ]
-  }
+  },
+  "runNumberOffset": 60000
 }

--- a/build/projects/Apps (W1)/.AL-Go/NewBcContainer.ps1
+++ b/build/projects/Apps (W1)/.AL-Go/NewBcContainer.ps1
@@ -4,4 +4,4 @@ Param(
 Import-Module (Join-Path $PSScriptRoot "../../../scripts/EnlistmentHelperFunctions.psm1" -Resolve)
 
 $script = Join-Path $PSScriptRoot "../../../scripts/NewBcContainer.ps1" -Resolve
-. $script -parameters $parameters -AppsToUnpublish (Get-AppsInFolder "src/Apps/W1")
+. $script -parameters $parameters -AppsToUnpublish @("None")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
During the Apps (W1) build where we compile, publish and test the add-on apps we start out by creating the container and then we uninstall all apps and unpublish a certain set of apps. The set of apps we unpublish contains the apps under the Apps/W1 folder here in BCApps. 

Right now, the unpublish step fails in #4757 due to the fact that there are apps that take dependency on the Power BI app. To avoid having to unpublish a lot of apps, we can instead just uninstall all apps but keep the apps published. 

There is one slight challenge with this though. When we want to publish a new version of App A that takes dependency on App B. If App B is already published to the container in two different versions, it will use the version with the highest version number. Right now, the apps with the highest version numbers are the apps that come with the BC Artifact. To get around this, we can add a runNumberOffset to ensure that the apps produced in BCApps have higher version numbers than the ones on the BC Artifact. 

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#602818](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/602818)


