### PR TITLE
Replace LibraryWorkFlow.SetUpEmailAccount with LibraryEmail.SetUpEmailAccount for first-party apps

### DIFF
--- a/src/Apps/W1/UKSendRemittanceAdvice/Test/src/SendRemittanceAdvice.Codeunit.al
+++ b/src/Apps/W1/UKSendRemittanceAdvice/Test/src/SendRemittanceAdvice.Codeunit.al
@@ -46,11 +46,11 @@ codeunit 139610 SendRemittanceAdvice
         CustomReportSelection: Record "Custom Report Selection";
         GenJournalLine: Record "Gen. Journal Line";
         Vendor: Record Vendor;
-        LibraryWorkflow: Codeunit "Library - Workflow";
+        LibraryEmail: Codeunit "Library - Email";
     begin
         // [SCENARIO 339846] Send remittance advice report to vendor by email from Payment Journal using customized Document Sending Profile
         Initialize();
-        LibraryWorkflow.SetUpEmailAccount();
+        LibraryEmail.SetUpEmailAccount();
 
         // [GIVEN] Vendor with email
         // [GIVEN] Payment journal line
@@ -77,11 +77,11 @@ codeunit 139610 SendRemittanceAdvice
     var
         CustomReportSelection: Record "Custom Report Selection";
         Vendor: Record Vendor;
-        LibraryWorkflow: Codeunit "Library - Workflow";
+        LibraryEmail: Codeunit "Library - Email";
     begin
         // [SCENARIO 339846] Send remittance advice report to vendor by email from Payment Journal using customized Document Sending Profile
         Initialize();
-        LibraryWorkflow.SetUpEmailAccount();
+        LibraryEmail.SetUpEmailAccount();
 
         // [GIVEN] Vendor with email
         // [GIVEN] Vendor Ledger Entry


### PR DESCRIPTION
This is a necessary step in our project for making test libraries available in SaaS. The SetUpEmailAccount method is OnPrem will be moved out from LibraryWorkFlow to LibraryEmail which will make the first one fully available for SaaS.
The goal of this PR to make sure we can remove this function from LibraryWorkFlow in ADO repo and that will not break anything in BCApps