### PR TITLE
[Subscription billing] Unnecessary locking in Subscription Billing causing lock timeout in sales post

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Table Extensions/SalesHeader.TableExt.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Table Extensions/SalesHeader.TableExt.al
@@ -38,6 +38,7 @@ tableextension 8053 "Sales Header" extends "Sales Header"
         SalesLine: Record "Sales Line";
         HasContractRenewalLines: Boolean;
     begin
+        SalesLine.ReadIsolation(ReadIsolation::ReadUncommitted);
         SalesLine.SetRange("Document Type", Rec."Document Type");
         SalesLine.SetRange("Document No.", Rec."No.");
         SalesLine.SetFilter(Type, '<>%1', "Sales Line Type"::" ");


### PR DESCRIPTION
Added ReadIsolation for preventing unnecessary locking.

Fixes #4810
Fixes [AB#598652](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/598652)

