### PR TITLE
Clean up app from symbols folder if it already exists before compilation

### DIFF
--- a/build/projects/Apps (W1)/.AL-Go/PreCompileApp.ps1
+++ b/build/projects/Apps (W1)/.AL-Go/PreCompileApp.ps1
@@ -13,7 +13,7 @@ if ($ENV:BuildMode -eq 'Clean') {
         # This is to ensure that we don't end up using any of those apps as dependencies in the clean build
         $appFiles = Get-ChildItem -Path $symbolsPath -Filter *.app -Recurse | Where-Object { $_.Name -ne 'System.app' }
         foreach ($appFile in $appFiles) {
-            Remove-Item -Path $appFile.FullName -Force -Verbose
+            Remove-Item -Path $appFile.FullName -Force
         }
     }
 

--- a/build/scripts/PreCompileApp.ps1
+++ b/build/scripts/PreCompileApp.ps1
@@ -71,6 +71,8 @@ if($appType -eq 'app')
                 $tempParameters["appSymbolsFolder"] = $defaultSymbolsPath # Use the default symbols folder as appSymbolsFolder
 
                 $appName = (Get-Content -Path (Join-Path $tempParameters["appProjectFolder"] "app.json" -Resolve) | ConvertFrom-Json).Name
+                
+                # If the app has already been restored to the default symbols folder, remove it before recompiling
                 Get-ChildItem -Path $defaultSymbolsPath -Filter "Microsoft_$($appName)*.app" | ForEach-Object {
                     Write-Host "Removing existing app file in symbols folder: $($_.FullName)"
                     Remove-Item -Path $_.FullName -Force

--- a/build/scripts/PreCompileApp.ps1
+++ b/build/scripts/PreCompileApp.ps1
@@ -70,6 +70,12 @@ if($appType -eq 'app')
                 $tempParameters["appOutputFolder"] = $defaultSymbolsPath # Output the default app into the default symbols folder
                 $tempParameters["appSymbolsFolder"] = $defaultSymbolsPath # Use the default symbols folder as appSymbolsFolder
 
+                $appName = (Get-Content -Path (Join-Path $tempParameters["appProjectFolder"] "app.json" -Resolve) | ConvertFrom-Json).Name
+                Get-ChildItem -Path $defaultSymbolsPath -Filter "Microsoft_$($appName)*.app" | ForEach-Object {
+                    Write-Host "Removing existing app file in symbols folder: $($_.FullName)"
+                    Remove-Item -Path $_.FullName -Force
+                }
+
                 if($useCompilerFolder) {
                     Compile-AppWithBcCompilerFolder @tempParameters | Out-Null
                 }
@@ -78,7 +84,6 @@ if($appType -eq 'app')
                 }
 
                 # Copy the the generated app to the symbols folder for the CLEAN mode build
-                $appName = (Get-Content -Path (Join-Path $tempParameters["appProjectFolder"] "app.json" -Resolve) | ConvertFrom-Json).Name
                 $appFile = Get-ChildItem -Path $tempParameters["appOutputFolder"] -Filter "Microsoft_$($appName)*.app" | Select-Object -First 1
                 $location = Join-Path $parameters.Value["appSymbolsFolder"] "$($appName)_clean.app"
                 Write-Host "Copying $($appFile.FullName) to $location"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
When we compile apps in clean mode we start by compiling the app in "default" mode i.e. without preprocessor symbols. However, in some cases the folder that holds the apps built in "default" mode may already contain the app we're about to build. To avoid issues, we can remove the app file before we recompile in default mode to ensure that the .app file was built without preprocessor symbols etc. 

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Related to AB#603840
