### PR TITLE
[Shopify] Using Subtotal Amount instead of Presentment Subtotal Amount

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyCreateSalesDocRefund.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyCreateSalesDocRefund.Codeunit.al
@@ -295,7 +295,7 @@ codeunit 30246 "Shpfy Create Sales Doc. Refund"
                         Shop.TestField("Refund Account");
                         SalesLine.Validate("No.", Shop."Refund Account");
                         SalesLine.Validate(Quantity, 1);
-                        SalesLine.Validate("Unit Price", RefundLine."Presentment Subtotal Amount");
+                        SalesLine.Validate("Unit Price", RefundLine."Subtotal Amount");
                         SalesLine."Shpfy Refund Id" := RefundHeader."Refund Id";
                         SalesLine."Shpfy Refund Line Id" := RefundLine."Refund Line Id";
                         SalesLine.Modify();
@@ -366,9 +366,9 @@ codeunit 30246 "Shpfy Create Sales Doc. Refund"
                 SalesLine.Validate(Description, RefundShippingLine.Title);
                 SalesLine.Validate(Quantity, 1);
                 if SalesHeader."Prices Including VAT" then
-                    SalesLine.Validate("Unit Price", RefundShippingLine."Presentment Subtotal Amount" + RefundShippingLine."Tax Amount")
+                    SalesLine.Validate("Unit Price", RefundShippingLine."Subtotal Amount" + RefundShippingLine."Tax Amount")
                 else
-                    SalesLine.Validate("Unit Price", RefundShippingLine."Presentment Subtotal Amount");
+                    SalesLine.Validate("Unit Price", RefundShippingLine."Subtotal Amount");
                 SalesLine."Shpfy Refund Id" := RefundHeader."Refund Id";
                 SalesLine."Shpfy Refund Shipping Line Id" := RefundShippingLine."Refund Shipping Line Id";
                 SalesLine.Modify();


### PR DESCRIPTION

#### Summary <shipping income for returned orders are importing from Shopify into BC using the presentment currency. The shipping income is showing as (example LCY 4.400 and 2.200. Both figures are the presentment currency (ISK and RSD)) but have imported as GBP into the GL.
 After tracing the code I have noticed in the Shopify Connector app the unit price is validated with the "Presentment Subtotal Amount" instead of the "Subtotal Amount">


#### Work Item(s) <Raised issue with Microsoft: Tracking ID is 2508050040002321 >
Fixes #
