### PR TITLE
[27.0][AnalysisMode]: Include Add Related Fields permission in Basic permis…

### DIFF
--- a/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
+++ b/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
@@ -36,6 +36,5 @@ permissionset 154 "System Application - Admin"
                              "PageScripting - Play",
                              "Page Summary - Admin",
                              "TROUBLESHOOT TOOLS",
-                             "VSC Intgr. - Admin",
-                             "Add Related Fields";
+                             "VSC Intgr. - Admin";
 }

--- a/src/System Application/App/Permissions/SystemTablesBasic.PermissionSet.al
+++ b/src/System Application/App/Permissions/SystemTablesBasic.PermissionSet.al
@@ -34,6 +34,7 @@ permissionset 66 "System Tables - Basic"
                              "User Selection - Read",
                              "Webhook - Edit",
                              "Data Analysis - Exec",
+                             "Add Related Fields",
                              "Perf. Profiler Tables - Edit";
 
     Permissions = tabledata "Add-in" = R,


### PR DESCRIPTION
"Add Related Fields" permission is not part of any user permission sets , therefore uptake is cubersome since admins need to know about this permission and assign it to the users.
The PM decision is to include "Add Related Fields" permission in Basic permision set.

Fixes [AB#604297](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/604297)










