### PR TITLE
[releases/26.1] [releases/26.x] Disable image tests 

### DIFF
--- a/src/System Application/Test/DisabledTests/ImageTests.DisabledTest.json
+++ b/src/System Application/Test/DisabledTests/ImageTests.DisabledTest.json
@@ -1,0 +1,20 @@
+[
+  {
+    "bug": "584006",
+    "codeunitId": 135135,
+    "codeunitName": "Image Tests",
+    "method": "ClearTest"
+  },
+  {
+    "bug": "584006",
+    "codeunitId": 135135,
+    "codeunitName": "Image Tests",
+    "method": "RotateFlip360Test"
+  },
+  {
+    "bug": "584006",
+    "codeunitId": 135135,
+    "codeunitName": "Image Tests",
+    "method": "RotateFlipTest"
+  }
+]


### PR DESCRIPTION
This pull request backports #4874 to releases/26.1

Fixes AB#[**Insert Work Item Number Here**]