### PR TITLE
[releases/25.5] Disable image tests 

### DIFF
--- a/src/System Application/Test/DisabledTests/ImageTests.DisabledTest.json
+++ b/src/System Application/Test/DisabledTests/ImageTests.DisabledTest.json
@@ -1,0 +1,20 @@
+[
+  {
+    "bug": "584006",
+    "codeunitId": 135135,
+    "codeunitName": "Image Tests",
+    "method": "ClearTest"
+  },
+  {
+    "bug": "584006",
+    "codeunitId": 135135,
+    "codeunitName": "Image Tests",
+    "method": "RotateFlip360Test"
+  },
+  {
+    "bug": "584006",
+    "codeunitId": 135135,
+    "codeunitName": "Image Tests",
+    "method": "RotateFlipTest"
+  }
+]


### PR DESCRIPTION
This pull request backports #4874 to releases/25.5

Fixes [AB#605665](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/605665)




