### PR TITLE
[releases/26.x] [Email] Add filter on time when counting email concurrency to avoid fake "Processing" email block email sending

### DIFF
--- a/src/System Application/Test/Email/src/EmailRetryTest.Codeunit.al
+++ b/src/System Application/Test/Email/src/EmailRetryTest.Codeunit.al
@@ -54,12 +54,12 @@ codeunit 134703 "Email Retry Test"
         EmailRetry.DeleteAll();
         EmailOutbox.DeleteAll();
 
-        // [Given] The Email Rate Limit is set to 10 for the account
+        // [Given] The Email Retry Limit is set to 10 for the account
         UpdateEmailMaxAttemptNo(TempAccount."Account Id", 10);
 
         // [Given] Create the first email message without retry records
         EmailMessage.Create(Any.Email(), Any.UnicodeText(50), Any.UnicodeText(250), true);
-        EmailOutbox := SetupEmailOutbox(EmailMessage.GetId(), Enum::"Email Connector"::"Test Email Connector", TempAccount."Account Id", 'Test Subject1', TempAccount."Email Address", UserSecurityId(), Enum::"Email Status"::Processing, 10, true);
+        EmailOutbox := SetupEmailOutbox(EmailMessage.GetId(), Enum::"Email Connector"::"Test Email Connector", TempAccount."Account Id", 'Test Subject1', TempAccount."Email Address", UserSecurityId(), Enum::"Email Status"::Processing, 0, true);
 
         // [When] Open the Email Outbox page and check the first email outbox record
         EmailOutboxTestPage.Trap();
@@ -97,10 +97,10 @@ codeunit 134703 "Email Retry Test"
         EmailRetry.DeleteAll();
         EmailOutbox.DeleteAll();
 
-        // [Given] The Email Rate Limit is set to 10 for the account
+        // [Given] The Email Retry Limit is set to 10 for the account
         UpdateEmailMaxAttemptNo(TempAccount."Account Id", 10);
 
-        // [Given] Create the second email message and retry record
+        // [Given] Create the first email message and retry record
         EmailMessage.Create(Any.Email(), Any.UnicodeText(50), Any.UnicodeText(250), true);
         EmailOutbox := SetupEmailOutbox(EmailMessage.GetId(), Enum::"Email Connector"::"Test Email Connector", TempAccount."Account Id", 'Test Subject2', TempAccount."Email Address", UserSecurityId(), Enum::"Email Status"::Failed, 3, true);
         CreateMultipleEmailRetryRecords(3, EmailOutbox);
@@ -138,7 +138,7 @@ codeunit 134703 "Email Retry Test"
         EmailRetry.DeleteAll();
         EmailOutbox.DeleteAll();
 
-        // [Given] The Email Rate Limit is set to 10 for the account
+        // [Given] The Email Retry Limit is set to 10 for the account
         UpdateEmailMaxAttemptNo(TempAccount."Account Id", 10);
 
         // [Given] Create the third email message and retry record
@@ -180,7 +180,7 @@ codeunit 134703 "Email Retry Test"
         EmailRetry.DeleteAll();
         EmailOutbox.DeleteAll();
 
-        // [Given] The Email Rate Limit is set to 10 for the account
+        // [Given] The Email Retry Limit is set to 10 for the account
         UpdateEmailMaxAttemptNo(TempAccount."Account Id", 10);
 
         // [Given] Create the forth email message and retry record
@@ -233,7 +233,7 @@ codeunit 134703 "Email Retry Test"
         EmailRetry.DeleteAll();
         EmailOutbox.DeleteAll();
 
-        // [Given] The Email Rate Limit is set to 10 for the account
+        // [Given] The Email Retry Limit is set to 10 for the account
         UpdateEmailMaxAttemptNo(TempAccount."Account Id", 10);
 
         // [Given] Create the email message and retry record
@@ -278,7 +278,7 @@ codeunit 134703 "Email Retry Test"
         ConnectorMock.Initialize();
         ConnectorMock.AddAccount(TempAccount);
 
-        // [Given] The Email Rate Limit is set to 10 for the account
+        // [Given] The Email Retry Limit is set to 10 for the account
         UpdateEmailMaxAttemptNo(TempAccount."Account Id", 10);
 
         EmailMessage.Create(Any.Email(), Any.UnicodeText(50), Any.UnicodeText(250), true);
@@ -401,7 +401,7 @@ codeunit 134703 "Email Retry Test"
         ConnectorMock.Initialize();
         ConnectorMock.AddAccount(AccountId);
 
-        // [Given] The Email Rate Limit is set to 10 for the account
+        // [Given] The Email Retry Limit is set to 10 for the account
         UpdateEmailMaxAttemptNo(AccountId, 10);
 
         // [When] Sending the email fails
@@ -435,7 +435,6 @@ codeunit 134703 "Email Retry Test"
 
     [Test]
     [Scope('OnPrem')]
-    [TransactionModel(TransactionModel::AutoRollback)]
     procedure SendEmailMessageForegroundExceedingMaxConcurrencyTest()
     var
         TempAccount: Record "Email Account" temporary;
@@ -467,7 +466,116 @@ codeunit 134703 "Email Retry Test"
         Codeunit.Run(Codeunit::"Email Dispatcher", EmailOutbox);
 
         // [Then] The sending task is rescheduled, and the email outbox entry is updated with the error message and status
-        Assert.AreNotEqual(OriginalScheduledDateTime, EmailOutbox."Date Sending", 'The Date Sending should be updated');
+        Assert.AreNotEqual(Format(OriginalScheduledDateTime, 0, 9), Format(EmailOutbox."Date Sending", 0, 9), 'The Date Sending should be updated');
+        Assert.AreNotEqual(OriginalTaskId, EmailOutbox."Task Scheduler Id", 'The Task Scheduler Id should be updated');
+        Assert.AreEqual(EmailOutbox.Status, EmailOutbox.Status::Queued, 'The status should not be Processing');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure SendEmailMessageForegroundWithTimeOneHourEarlierTest1()
+    var
+        TempAccount: Record "Email Account" temporary;
+        EmailOutbox: Record "Email Outbox";
+        EmailRateLimit: Record "Email Rate Limit";
+        Any: Codeunit Any;
+        EmailMessage: Codeunit "Email Message";
+        ConnectorMock: Codeunit "Connector Mock";
+        OriginalScheduledDateTime: DateTime;
+        OriginalTaskId: Guid;
+    begin
+        // [Bug] 603459 [IcM] Job queue task failed but email stuck with status "Processing"
+        // [Scenario] The account has a concurrency limit of 10. There are 11 outbox entries:
+        //  - 10 pre-existing entries, where the first one was sent 2 hours ago and the other 9 are "just now".
+        //  - The 11th is created from the foreground.
+        // Expectation: Because one of the 10 existing entries is older (2 hours ago), sending the 11th from the foreground
+        // should proceed without rescheduling: the scheduling fields remain unchanged and status becomes Processing.
+        PermissionsMock.Set('Email Edit');
+        ConnectorMock.Initialize();
+        ConnectorMock.AddAccount(TempAccount);
+        EmailOutbox.DeleteAll();
+
+        // [Given] Concurrency limit for this account is set to 10
+        EmailRateLimit.SetRange("Account Id", TempAccount."Account Id");
+        Assert.IsTrue(EmailRateLimit.FindFirst(), 'The Email Rate Limit entry should exist');
+        EmailRateLimit.Validate("Concurrency Limit", 10);
+        EmailRateLimit.Modify();
+
+        // [Given] Create 11 outbox entries for the account
+        CreateEmailMessageAndEmailOutboxRecord(11, TempAccount, false);
+
+        // [Given] Make the first existing entry appear sent 2 hours earlier (freeing one concurrency slot)
+        EmailOutbox.FindFirst();
+        EmailOutbox."Date Sending" := EmailOutbox."Date Sending" - 7200000; // 2 hours in milliseconds
+        EmailOutbox.Modify();
+
+        // [Given] Create the 11th email from the foreground
+        EmailMessage.Create(Any.Email(), Any.UnicodeText(50), Any.UnicodeText(250), true);
+        SetupEmailOutbox(EmailMessage.GetId(), Enum::"Email Connector"::"Test Email Connector", TempAccount."Account Id", 'Test Subject', TempAccount."Email Address", UserSecurityId(), Enum::"Email Status"::Queued, 0, false);
+
+        // [When] Attempt to send the 11th email from the foreground
+        EmailOutbox.SetRange("Message Id", EmailMessage.GetId());
+        EmailOutbox.FindFirst();
+        OriginalScheduledDateTime := EmailOutbox."Date Sending";
+        OriginalTaskId := EmailOutbox."Task Scheduler Id";
+        Codeunit.Run(Codeunit::"Email Dispatcher", EmailOutbox);
+
+        // [Then] No rescheduling occurs and the message transitions to Processing
+        Assert.AreEqual(Format(OriginalScheduledDateTime, 0, 9), Format(EmailOutbox."Date Sending", 0, 9), 'The Date Sending should not be updated');
+        Assert.AreEqual(OriginalTaskId, EmailOutbox."Task Scheduler Id", 'The Task Scheduler Id should not be updated');
+        Assert.AreEqual(EmailOutbox.Status, EmailOutbox.Status::Processing, 'The status should be Processing');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure SendEmailMessageForegroundWithTimeOneHourEarlierTest2()
+    var
+        TempAccount: Record "Email Account" temporary;
+        EmailOutbox: Record "Email Outbox";
+        EmailRateLimit: Record "Email Rate Limit";
+        Any: Codeunit Any;
+        EmailMessage: Codeunit "Email Message";
+        ConnectorMock: Codeunit "Connector Mock";
+        OriginalScheduledDateTime: DateTime;
+        OriginalTaskId: Guid;
+    begin
+        // [Bug] 603459 [IcM] Job queue task failed but email stuck with status "Processing"
+        // [Scenario] The account has a concurrency limit of 10. There are 12 outbox entries:
+        //  - 12 pre-existing entries will be present after setup (we then adjust the first to be 2 hours ago).
+        //  - The 11th email (created from the foreground) is attempted while 10 "recent" sends still occupy slots.
+        // Expectation: Even with one older (2 hours ago) entry, concurrency is still exceeded when the foreground send happens,
+        // so the 11th email should be rescheduled: scheduling fields change and status remains/returns to Queued.
+        PermissionsMock.Set('Email Edit');
+        ConnectorMock.Initialize();
+        ConnectorMock.AddAccount(TempAccount);
+
+        // [Given] Concurrency limit for this account is set to 10
+        EmailRateLimit.SetRange("Account Id", TempAccount."Account Id");
+        Assert.IsTrue(EmailRateLimit.FindFirst(), 'The Email Rate Limit entry should exist');
+        EmailRateLimit.Validate("Concurrency Limit", 10);
+        EmailRateLimit.Modify();
+
+        // [Given] Create 12 outbox entries for the account
+        CreateEmailMessageAndEmailOutboxRecord(12, TempAccount, false);
+
+        // [Given] Make the first existing entry appear sent 2 hours earlier (still leaving 10 "recent" concurrent sends)
+        EmailOutbox.FindFirst();
+        EmailOutbox."Date Sending" := EmailOutbox."Date Sending" - 7200000; // 2 hours in milliseconds
+        EmailOutbox.Modify();
+
+        // [Given] Create the 11th email from the foreground
+        EmailMessage.Create(Any.Email(), Any.UnicodeText(50), Any.UnicodeText(250), true);
+        SetupEmailOutbox(EmailMessage.GetId(), Enum::"Email Connector"::"Test Email Connector", TempAccount."Account Id", 'Test Subject', TempAccount."Email Address", UserSecurityId(), Enum::"Email Status"::Queued, 0, false);
+
+        // [When] Attempt to send the 11th email from the foreground
+        EmailOutbox.SetRange("Message Id", EmailMessage.GetId());
+        EmailOutbox.FindFirst();
+        OriginalScheduledDateTime := EmailOutbox."Date Sending";
+        OriginalTaskId := EmailOutbox."Task Scheduler Id";
+        Codeunit.Run(Codeunit::"Email Dispatcher", EmailOutbox);
+
+        // [Then] The send is throttled and rescheduled: scheduling fields change and status is Queued
+        Assert.AreNotEqual(Format(OriginalScheduledDateTime, 0, 9), Format(EmailOutbox."Date Sending", 0, 9), 'The Date Sending should be updated');
         Assert.AreNotEqual(OriginalTaskId, EmailOutbox."Task Scheduler Id", 'The Task Scheduler Id should be updated');
         Assert.AreEqual(EmailOutbox.Status, EmailOutbox.Status::Queued, 'The status should not be Processing');
     end;
@@ -555,11 +663,11 @@ codeunit 134703 "Email Retry Test"
         Codeunit.Run(Codeunit::"Email Dispatcher", EmailOutbox);
 
         // [Then] The sending task is rescheduled, and the email outbox entry is updated with the error message and status
-        Assert.AreNotEqual(OriginalScheduledDateTime, EmailOutbox."Date Sending", 'The Date Sending should be updated');
+        Assert.AreNotEqual(Format(OriginalScheduledDateTime, 0, 9), Format(EmailOutbox."Date Sending", 0, 9), 'The Date Sending should be updated');
         Assert.AreNotEqual(OriginalTaskId, EmailOutbox."Task Scheduler Id", 'The Task Scheduler Id should be updated');
         Assert.AreEqual(EmailOutbox.Status, EmailOutbox.Status::Queued, 'The status should not be Processing');
 
-        // [Given] The Email Rate Limit is set to 10 for the account
+        // [Given] The Email Retry Limit is set to 10 for the account
         EmailRateLimit.SetRange("Account Id", TempAccount."Account Id");
         Assert.IsTrue(EmailRateLimit.FindFirst(), 'The Email Rate Limit entry should exist');
         EmailRateLimit.Validate("Concurrency Limit", 10);
@@ -578,7 +686,7 @@ codeunit 134703 "Email Retry Test"
 
         // [Then] The sending task is rescheduled, and the email outbox entry is updated with the error message and status
         Assert.AreEqual(EmailOutbox.Status::Processing, EmailOutbox.Status, 'The status should be Processing');
-        Assert.AreEqual(OriginalScheduledDateTime, EmailOutbox."Date Sending", 'The Date Sending should not be updated');
+        Assert.AreEqual(Format(OriginalScheduledDateTime, 0, 9), Format(EmailOutbox."Date Sending", 0, 9), 'The Date Sending should not be updated');
         Assert.AreEqual(OriginalTaskId, EmailOutbox."Task Scheduler Id", 'The Task Scheduler Id should not be updated');
     end;
 
@@ -607,14 +715,14 @@ codeunit 134703 "Email Retry Test"
         UpdateEmailMaxAttemptNo(TempAccount1."Account Id", 5);
         UpdateEmailMaxAttemptNo(TempAccount2."Account Id", 5);
 
-        // [Given] The Email Rate Limit is set to 10 for the account1
+        // [Given] The Email Retry Limit is set to 10 for the account1
         EmailRateLimit.SetRange("Account Id", TempAccount1."Account Id");
         Assert.IsTrue(EmailRateLimit.FindFirst(), 'The Email Rate Limit entry should exist');
         EmailRateLimit.Validate("Concurrency Limit", 10);
         EmailRateLimit.Modify();
 
         // [Given] 10 email messages and an email account are created
-        CreateEmailMessageAndEmailOutboxRecord(10, TempAccount1, true);
+        CreateEmailMessageAndEmailOutboxRecord(11, TempAccount1, true);
 
         // [Given] The 11th email is created
         EmailMessage.Create(Any.Email(), Any.UnicodeText(50), Any.UnicodeText(250), true);
@@ -628,7 +736,7 @@ codeunit 134703 "Email Retry Test"
         Codeunit.Run(Codeunit::"Email Dispatcher", EmailOutbox);
 
         // [Then] The sending task is rescheduled because of exceeding max concurrency limit, and the email outbox entry is updated with the error message and status
-        Assert.AreNotEqual(OriginalScheduledDateTime, EmailOutbox."Date Sending", 'The Date Sending should be updated');
+        Assert.AreNotEqual(Format(OriginalScheduledDateTime, 0, 9), Format(EmailOutbox."Date Sending", 0, 9), 'The Date Sending should be updated');
         Assert.AreNotEqual(OriginalTaskId, EmailOutbox."Task Scheduler Id", 'The Task Scheduler Id should be updated');
         Assert.AreEqual(EmailOutbox.Status::Queued, EmailOutbox.Status, 'The status should not be Processing');
 
@@ -645,7 +753,7 @@ codeunit 134703 "Email Retry Test"
 
         // [Then] The sending task is processing correctly, and the email outbox entry is updated with the error message and status
         Assert.AreEqual(EmailOutbox.Status::Processing, EmailOutbox.Status, 'The status should be Processing');
-        Assert.AreEqual(OriginalScheduledDateTime, EmailOutbox."Date Sending", 'The Date Sending should not be updated');
+        Assert.AreEqual(Format(OriginalScheduledDateTime, 0, 9), Format(EmailOutbox."Date Sending", 0, 9), 'The Date Sending should not be updated');
         Assert.AreEqual(OriginalTaskId, EmailOutbox."Task Scheduler Id", 'The Task Scheduler Id should not be updated');
     end;
 
@@ -689,7 +797,7 @@ codeunit 134703 "Email Retry Test"
         Assert.AreEqual(1, EmailRetry."Retry No.", 'The retry number should be 1');
         Assert.AreEqual(1, EmailRetry.Count(), 'There are two entries in the Email Retry table');
 
-        // [Given] The Email Rate Limit is set to 2 for the account
+        // [Given] The Email Retry Limit is set to 2 for the account
         UpdateEmailMaxAttemptNo(TempAccount."Account Id", 2);
 
         // [Given] The second email message is created
@@ -737,10 +845,10 @@ codeunit 134703 "Email Retry Test"
         Any: Codeunit Any;
         i: Integer;
     begin
-        for i := 0 to NumberOfRecords do begin
+        for i := 1 to NumberOfRecords do begin
             EmailMessage.Create(Any.Email(), Any.UnicodeText(50), Any.UnicodeText(250), true);
             // [Given] The email is enqueued in the outbox
-            SetupEmailOutbox(EmailMessage.GetId(), Enum::"Email Connector"::"Test Email Connector", TempAccount."Account Id", 'Test Subject', TempAccount."Email Address", UserSecurityId(), Enum::"Email Status"::Processing, i, IsBackground);
+            SetupEmailOutbox(EmailMessage.GetId(), Enum::"Email Connector"::"Test Email Connector", TempAccount."Account Id", 'Test Subject', TempAccount."Email Address", UserSecurityId(), Enum::"Email Status"::Processing, 0, IsBackground);
         end;
     end;
 
@@ -755,6 +863,7 @@ codeunit 134703 "Email Retry Test"
         EmailOutbox.Validate(Description, EmailDescription);
         EmailOutbox.Validate("User Security Id", UserSecurityId);
         EmailOutbox.Validate("Send From", EmailAddress);
+        EmailOutbox.Validate("Date Sending", CurrentDateTime());
         EmailOutbox.Validate(Status, Status);
         EmailOutbox.Validate("Retry No.", RetryCount);
         EmailOutbox.Validate("Is Background Task", IsBackground);
@@ -767,10 +876,10 @@ codeunit 134703 "Email Retry Test"
         i: Integer;
     begin
         for i := 1 to NumberOfRecords do
-            CreateEmailRetryRecord(EmailOutbox."Message Id", EmailOutbox.Connector, EmailOutbox."Account Id", EmailOutbox.Description, EmailOutbox."Send From", EmailOutbox."User Security Id");
+            CreateEmailRetryRecord(EmailOutbox."Message Id", EmailOutbox.Connector, EmailOutbox."Account Id", EmailOutbox.Description, EmailOutbox."Send From", EmailOutbox."User Security Id", i);
     end;
 
-    local procedure CreateEmailRetryRecord(EmailMessageId: Guid; Connector: Enum "Email Connector"; EmailAccountId: Guid; EmailDescription: Text; EmailAddress: Text[250]; UserSecurityId: Code[50])
+    local procedure CreateEmailRetryRecord(EmailMessageId: Guid; Connector: Enum "Email Connector"; EmailAccountId: Guid; EmailDescription: Text; EmailAddress: Text[250]; UserSecurityId: Code[50]; RetryNo: Integer)
     var
         EmailRetry: Record "Email Retry";
     begin
@@ -781,16 +890,17 @@ codeunit 134703 "Email Retry Test"
         EmailRetry.Validate(Description, EmailDescription);
         EmailRetry.Validate("User Security Id", UserSecurityId);
         EmailRetry.Validate("Send From", EmailAddress);
+        EmailRetry.Validate("Retry No.", RetryNo);
         EmailRetry.Modify();
     end;
 
-    local procedure UpdateEmailMaxAttemptNo(AccountId: Guid; ConcurrencyLimit: Integer)
+    local procedure UpdateEmailMaxAttemptNo(AccountId: Guid; MaximumRetryNo: Integer)
     var
         EmailRateLimit: Record "Email Rate Limit";
     begin
         EmailRateLimit.SetRange("Account Id", AccountId);
         Assert.IsTrue(EmailRateLimit.FindFirst(), 'The Email Rate Limit entry should exist');
-        EmailRateLimit.Validate("Max. Retry Limit", ConcurrencyLimit);
+        EmailRateLimit.Validate("Max. Retry Limit", MaximumRetryNo);
         EmailRateLimit.Modify();
     end;
 


### PR DESCRIPTION
This pull request backports #4820 to releases/26.x

Fixes [AB#606060](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/606060)

