### PR TITLE
Add AL support for OCV feedback API

### DIFF
--- a/src/System Application/App/DotNet Aliases/src/dotnet.al
+++ b/src/System Application/App/DotNet Aliases/src/dotnet.al
@@ -711,6 +711,10 @@ dotnet
         type("Microsoft.Dynamics.Nav.Runtime.ActivityLogAttribute"; "ActivityLogAttribute")
         {
         }
+
+        type("Microsoft.Dynamics.Nav.Runtime.ALFeedback"; ALFeedback)
+        {
+        }
     }
 
     assembly("Microsoft.Dynamics.Nav.OAuth")

--- a/src/System Application/App/Feedback/README.md
+++ b/src/System Application/App/Feedback/README.md
@@ -1,0 +1,120 @@
+# Feedback API Documentation
+
+This document describes the APIs provided by the `Feedback` codeunit (ID: 1599) in the `System.Feedback` namespace. These APIs enable user feedback collection and survey management for features in Business Central.
+
+## Overview
+The `Feedback` codeunit provides procedures to request feedback (general, like, dislike) for features, including Copilot features and feature areas, as well as triggering surveys.
+
+## API Reference
+
+---
+
+### RequestFeedback
+Requests general feedback for a feature, optionally specifying if it is a Copilot feature and its area.
+
+**Signature:**
+```al
+procedure RequestFeedback(FeatureName: Text[255]; IsCopilotFeature: Boolean; FeatureArea: Text[255])
+```
+**Parameters:**
+- `FeatureName`: The name of the feature for which feedback is requested.
+- `IsCopilotFeature`: Specifies if the feature is a Copilot feature.
+- `FeatureArea`: The area or sub-area of the feature.
+
+---
+
+### RequestLikeFeedback
+Requests a 'like' (positive) feedback for a feature, optionally specifying if it is a Copilot feature and its area.
+
+**Signature:**
+```al
+procedure RequestLikeFeedback(FeatureName: Text[255]; IsCopilotFeature: Boolean; FeatureArea: Text[255])
+```
+**Parameters:**
+- `FeatureName`: The name of the feature for which like feedback is requested.
+- `IsCopilotFeature`: Specifies if the feature is a Copilot feature.
+- `FeatureArea`: The area or sub-area of the feature.
+
+---
+
+### RequestDislikeFeedback
+Requests a 'dislike' (negative) feedback for a feature, optionally specifying if it is a Copilot feature and its area.
+
+**Signature:**
+```al
+procedure RequestDislikeFeedback(FeatureName: Text[255]; IsCopilotFeature: Boolean; FeatureArea: Text[255])
+```
+**Parameters:**
+- `FeatureName`: The name of the feature for which dislike feedback is requested.
+- `IsCopilotFeature`: Specifies if the feature is a Copilot feature.
+- `FeatureArea`: The area or sub-area of the feature.
+
+---
+
+### SurveyTimerActivity
+Starts or stops a survey timer activity. This is used to start a timer to count up user usage times, which can then trigger a survey prompt after a certain threshold is reached.
+
+For example: 5 minutes of usage time from timer start to timer end.
+
+**Signature:**
+```al
+procedure SurveyTimerActivity(ActivityName: Text[255]; Start: Boolean)
+```
+**Parameters:**
+- `ActivityName`: The name of the activity for which the timer is started or stopped.
+- `Start`: If true, starts the timer; if false, stops the timer.
+
+---
+
+### SurveyTriggerActivity
+Sends a one-time trigger event based on a specific activity name. The event could be, for example, a user clicking a button.
+
+**Signature:**
+```al
+procedure SurveyTriggerActivity(ActivityName: Text[255])
+```
+**Parameters:**
+- `ActivityName`: The name of the activity that triggers the survey.
+
+---
+
+## Usage Examples
+
+### Basic Feedback Request
+```al
+var
+    Feedback: Codeunit Feedback;
+begin
+    // Request general feedback for a feature
+    Feedback.RequestFeedback('MyFeature', false, 'MainArea');
+    
+    // Request positive feedback for a Copilot feature
+    Feedback.RequestLikeFeedback('CopilotAssist', true, 'AI');
+    
+    // Request negative feedback for troubleshooting
+    Feedback.RequestDislikeFeedback('DataSync', false, 'Integration');
+end;
+```
+
+### Survey Activity Tracking
+```al
+var
+    Feedback: Codeunit Feedback;
+begin
+    // Start timing user activity
+    Feedback.SurveyTimerActivity('DocumentProcessing', true);
+    
+    // ... user performs document processing tasks ...
+    
+    // Stop timing when task is complete
+    Feedback.SurveyTimerActivity('DocumentProcessing', false);
+    
+    // Trigger survey based on specific user action
+    Feedback.SurveyTriggerActivity('ReportGeneration');
+end;
+```
+
+---
+
+## License
+Licensed under the MIT License. See License.txt in the project root for license information.

--- a/src/System Application/App/Feedback/app.json
+++ b/src/System Application/App/Feedback/app.json
@@ -1,0 +1,33 @@
+{
+  "id": "f7964d32-7685-400f-8297-4bc17d0aab0e",
+  "name": "Feedback",
+  "publisher": "Microsoft",
+  "version": "28.0.0.0",
+  "brief": "Functionality for collecting user feedback",
+  "description": "Functionality to allow for AL developers to collect user feedback from the application.",
+  "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
+  "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
+  "help": "",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "28.0.0.0",
+  "application": "28.0.0.0",
+  "resourceExposurePolicy": {
+    "allowDebugging": true,
+    "allowDownloadingSource": true,
+    "includeSourceInSymbolFile": true
+  },
+  "runtime": "17.0",
+  "features": [
+    "NoImplicitWith"
+  ],
+  "target": "OnPrem",
+  "idRanges": [
+    {
+      "from": 1595,
+      "to": 1599
+    }
+  ]
+}

--- a/src/System Application/App/Feedback/src/Feedback.Codeunit.al
+++ b/src/System Application/App/Feedback/src/Feedback.Codeunit.al
@@ -1,0 +1,76 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Feedback;
+
+/// <summary>
+/// Codeunit for providing user feedback.
+/// </summary>
+codeunit 1599 Feedback
+{
+    /// <summary>
+    /// Requests general feedback for a feature, optionally specifying if it is a Copilot feature and its area.
+    /// </summary>
+    /// <param name="FeatureName">The name of the feature for which feedback is requested.</param>
+    /// <param name="IsCopilotFeature">Specifies if the feature is a Copilot feature.</param>
+    /// <param name="FeatureArea">The area or sub-area of the feature.</param>
+    procedure RequestFeedback(FeatureName: Text[255]; IsCopilotFeature: Boolean; FeatureArea: Text[255])
+    var
+        ALFeedback: DotNet ALFeedback;
+    begin
+        ALFeedback.RequestFeedback(FeatureName, IsCopilotFeature, FeatureArea);
+    end;
+
+    /// <summary>
+    /// Requests a 'like' (positive) feedback for a feature, optionally specifying if it is a Copilot feature and its area.
+    /// </summary>
+    /// <param name="FeatureName">The name of the feature for which like feedback is requested.</param>
+    /// <param name="IsCopilotFeature">Specifies if the feature is a Copilot feature.</param>
+    /// <param name="FeatureArea">The area or sub-area of the feature.</param>
+    procedure RequestLikeFeedback(FeatureName: Text[255]; IsCopilotFeature: Boolean; FeatureArea: Text[255])
+    var
+        ALFeedback: DotNet ALFeedback;
+    begin
+        ALFeedback.RequestLikeFeedback(FeatureName, IsCopilotFeature, FeatureArea);
+    end;
+
+    /// <summary>
+    /// Requests a 'dislike' (negative) feedback for a feature, optionally specifying if it is a Copilot feature and its area.
+    /// </summary>
+    /// <param name="FeatureName">The name of the feature for which dislike feedback is requested.</param>
+    /// <param name="IsCopilotFeature">Specifies if the feature is a Copilot feature.</param>
+    /// <param name="FeatureArea">The area or sub-area of the feature.</param>
+    procedure RequestDislikeFeedback(FeatureName: Text[255]; IsCopilotFeature: Boolean; FeatureArea: Text[255])
+    var
+        ALFeedback: DotNet ALFeedback;
+    begin
+        ALFeedback.RequestDislikeFeedback(FeatureName, IsCopilotFeature, FeatureArea);
+    end;
+
+    /// <summary>
+    /// Starts or stops a survey timer activity. This is used to start a timer to count up user usage
+    /// times, which can then trigger a survey prompt after a certain threshold is reached.
+    /// </summary>
+    /// <param name="ActivityName">The name of the activity for which the timer is started or stopped.</param>
+    /// <param name="Start">If true, starts the timer; if false, stops the timer.</param>
+    procedure SurveyTimerActivity(ActivityName: Text[255]; Start: Boolean)
+    var
+        ALFeedback: DotNet ALFeedback;
+    begin
+        ALFeedback.SurveyTimerActivity(ActivityName, Start);
+    end;
+
+    /// <summary>
+    /// Sends a one-time trigger event based on a specific activity name.
+    /// The event could be, for example, a user clicking a button
+    /// </summary>
+    /// <param name="ActivityName">The name of the activity that triggers the survey.</param>
+    procedure SurveyTriggerActivity(ActivityName: Text[255])
+    var
+        ALFeedback: DotNet ALFeedback;
+    begin
+        ALFeedback.SurveyTriggerActivity(ActivityName);
+    end;
+}

--- a/src/System Application/App/Feedback/src/dotnet.al
+++ b/src/System Application/App/Feedback/src/dotnet.al
@@ -1,0 +1,10 @@
+dotnet
+{
+    assembly("Microsoft.Dynamics.Nav.Ncl")
+    {
+        type("Microsoft.Dynamics.Nav.Runtime.ALFeedback"; ALFeedback)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->
This PR adds the following API to allow AL code request submission of feedback to OCV:
- **RequestFeedback**: Request general feedback for a feature, (or copilot feature). Also allows specifying an OCV sub-area (featureArea parameter). Allows the user to select if it is like, dislike, or a suggestion
- **RequestLikeFeedback**: Requests feedback for a feature, (or copilot feature) when the user likes the feature. Also allows specifying an OCV sub-area (featureArea parameter).
**RequestDislikeFeedback**: Requests feedback for a feature, (or copilot feature) when the user dislikes the feature. Also allows specifying an OCV sub-area (featureArea parameter).
**SurveyTimerActivity**: OCV provides a concept surrounding usage time, for example if a user has used a feature for 300 seconds. They provide a trigger name associated with the survey as the activityName parameter, and start whether to start or end the timer
**SurveyTriggerActivity**: OCV also provides a non-timer based trigger, which could be for example, a signal that a user pressed a button. This takes the activityName parameter for the trigger associated with the OCV survey.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #605545
