### PR TITLE
[releases/27.x] [Shopify] Remove confusing filter and add views instead to orders page

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Page Extensions/ShpfyBusinessManagerRC.PageExt.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Page Extensions/ShpfyBusinessManagerRC.PageExt.al
@@ -61,7 +61,6 @@ pageextension 30101 "Shpfy Business Manager RC" extends "Business Manager Role C
                     Caption = 'Orders';
                     Image = OrderList;
                     RunObject = page "Shpfy Orders";
-                    RunPageView = where(Closed = const(false));
                     ToolTip = 'View your Shopify agreements with customers to sell certain products on certain delivery and payment terms.';
                 }
                 action(Refunds)

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrders.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrders.Page.al
@@ -420,6 +420,30 @@ page 30115 "Shpfy Orders"
         }
     }
 
+    views
+    {
+        view(UnprocessedOrders)
+        {
+            Caption = 'Unprocessed Orders';
+            Filters = where(Processed = const(false));
+        }
+        view(OrderWithConflicts)
+        {
+            Caption = 'Orders with Conflicts';
+            Filters = where("Has Order State Error" = const(true));
+        }
+        view(OrderWithProcessingErrors)
+        {
+            Caption = 'Orders with Processing Errors';
+            Filters = where("Has Error" = const(true));
+        }
+        view(OpenOrders)
+        {
+            Caption = 'Open Orders';
+            Filters = where(Closed = const(false));
+        }
+    }
+
     var
         ConfirmLbl: Label 'Create sales document(s) from the selected Shopify order(s)?';
 }


### PR DESCRIPTION
This pull request backports #4627 to releases/27.x

Fixes [AB#608785](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/608785)
