### PR TITLE
[27.0] Incorrect Billing To Date for Billing Lines (#4621)

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Billing/Pages/ArchivedBillingLines.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Pages/ArchivedBillingLines.Page.al
@@ -65,6 +65,10 @@ page 8073 "Archived Billing Lines"
                 {
                     ToolTip = 'Specifies the date to which the Subscription Line is billed.';
                 }
+                field("Billing Reference Date Changed"; Rec."Billing Reference Date Changed")
+                {
+                    Visible = false;
+                }
                 field("Service Amount"; Rec.Amount)
                 {
                     ToolTip = 'Specifies the amount for the Subscription Line including discount.';

--- a/src/Apps/W1/Subscription Billing/App/Billing/Pages/ArchivedBillingLinesList.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Pages/ArchivedBillingLinesList.Page.al
@@ -43,6 +43,10 @@ page 8017 "Archived Billing Lines List"
                 {
                     ToolTip = 'Specifies the date to which the Subscription Line is billed.';
                 }
+                field("Billing Reference Date Changed"; Rec."Billing Reference Date Changed")
+                {
+                    Visible = false;
+                }
                 field("Service Object Description"; Rec."Subscription Description")
                 {
                     ToolTip = 'Specifies a description of the Subscription.';

--- a/src/Apps/W1/Subscription Billing/App/Billing/Pages/BillingLines.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Pages/BillingLines.Page.al
@@ -114,6 +114,12 @@ page 8074 "Billing Lines"
                     Style = StrongAccent;
                     StyleExpr = UpdateRequiredStyleExpr;
                 }
+                field("Billing Reference Date Changed"; Rec."Billing Reference Date Changed")
+                {
+                    Style = StrongAccent;
+                    StyleExpr = UpdateRequiredStyleExpr;
+                    Visible = false;
+                }
                 field("Service Object Quantity"; Rec."Service Object Quantity")
                 {
                     ToolTip = 'Specifies the quantity from the Subscription.';

--- a/src/Apps/W1/Subscription Billing/App/Billing/Pages/BillingLinesList.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Pages/BillingLinesList.Page.al
@@ -46,6 +46,10 @@ page 8016 "Billing Lines List"
                 {
                     ToolTip = 'Specifies the date to which the Subscription Line is billed.';
                 }
+                field("Billing Reference Date Changed"; Rec."Billing Reference Date Changed")
+                {
+                    Visible = false;
+                }
                 field("Service Object Description"; Rec."Subscription Description")
                 {
                     ToolTip = 'Specifies a description of the Subscription.';

--- a/src/Apps/W1/Subscription Billing/App/Billing/Pages/RecurringBilling.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Pages/RecurringBilling.Page.al
@@ -115,6 +115,11 @@ page 8067 "Recurring Billing"
                     ToolTip = 'Specifies the date to which the Subscription Line is billed.';
                     StyleExpr = LineStyleExpr;
                 }
+                field("Billing Reference Date Changed"; Rec."Billing Reference Date Changed")
+                {
+                    StyleExpr = LineStyleExpr;
+                    Visible = false;
+                }
                 field("Service Amount"; Rec.Amount)
                 {
                     ToolTip = 'Specifies the amount for the Subscription Line including discount.';

--- a/src/Apps/W1/Subscription Billing/App/Billing/Tables/BillingLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Tables/BillingLine.Table.al
@@ -171,6 +171,11 @@ table 8061 "Billing Line"
             else
             if (Partner = const(Vendor), "Document Type" = const("Credit Memo")) "Purchase Line"."Line No." where("Document Type" = const("Credit Memo"), "Document No." = field("Document No."));
         }
+        field(63; "Billing Reference Date Changed"; Boolean)
+        {
+            Caption = 'Billing Reference Date Changed';
+            ToolTip = 'Specifies whether the billing period has been adjusted manually. This is taken into account by the period calculation and may have an effect on the creation of future billing proposals.';
+        }
         field(100; "Billing Template Code"; Code[20])
         {
             Caption = 'Code';

--- a/src/Apps/W1/Subscription Billing/App/Billing/Tables/BillingLineArchive.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Tables/BillingLineArchive.Table.al
@@ -159,6 +159,11 @@ table 8064 "Billing Line Archive"
             else
             if (Partner = const(Vendor), "Document Type" = const("Credit Memo")) "Purchase Line"."Line No." where("Document Type" = const("Credit Memo"), "Document No." = field("Document No."));
         }
+        field(63; "Billing Reference Date Changed"; Boolean)
+        {
+            Caption = 'Billing Reference Date Changed';
+            ToolTip = 'Specifies whether the billing period has been adjusted manually. This is taken into account by the period calculation and may have an effect on the creation of future billing proposals.';
+        }
         field(100; "Billing Template Code"; Code[20])
         {
             Caption = 'Code';

--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
@@ -1795,11 +1795,12 @@ table 8059 "Subscription Line"
     var
         UnitCost: Decimal;
         UnitCostLCY: Decimal;
+        BillingReferenceDateChanged: Boolean;
     begin
-        Rec.UnitPriceAndCostForPeriod(Rec."Billing Rhythm", ChargePeriodStart, ChargePeriodEnd, UnitPrice, UnitCost, UnitCostLCY);
+        Rec.UnitPriceAndCostForPeriod(Rec."Billing Rhythm", ChargePeriodStart, ChargePeriodEnd, UnitPrice, UnitCost, UnitCostLCY, BillingReferenceDateChanged);
     end;
 
-    internal procedure UnitPriceAndCostForPeriod(BillingRhythm: DateFormula; ChargePeriodStart: Date; ChargePeriodEnd: Date; var UnitPrice: Decimal; var UnitCost: Decimal; var UnitCostLCY: Decimal)
+    internal procedure UnitPriceAndCostForPeriod(BillingRhythm: DateFormula; ChargePeriodStart: Date; ChargePeriodEnd: Date; var UnitPrice: Decimal; var UnitCost: Decimal; var UnitCostLCY: Decimal; var BillingReferenceDateChanged: Boolean)
     var
         PeriodFormula: DateFormula;
         BillingPeriodRatio: Decimal;
@@ -1826,6 +1827,7 @@ table 8059 "Subscription Line"
             DayPrice := PeriodPrice / FollowUpPeriodDays;
             DayUnitCost := PeriodUnitCost / FollowUpPeriodDays;
             DayUnitCostLCY := PeriodUnitCostLCY / FollowUpPeriodDays;
+            BillingReferenceDateChanged := true;
         end;
         UnitPrice := PeriodPrice * Periods + DayPrice * FollowUpDays;
         UnitCost := PeriodUnitCost * Periods + DayUnitCost * FollowUpDays;
@@ -1883,7 +1885,7 @@ table 8059 "Subscription Line"
                 NextToDate := CalcDate(PeriodFormula, FromDate) - 1;
             Rec."Period Calculation"::"Align to End of Month":
                 begin
-                    DistanceToEndOfMonth := CalcDate('<CM>', Rec."Subscription Line Start Date") - Rec."Subscription Line Start Date";
+                    DistanceToEndOfMonth := CalcDate('<CM>', GetBillingReferenceDate()) - GetBillingReferenceDate();
                     if DistanceToEndOfMonth > 2 then
                         NextToDate := CalcDate(PeriodFormula, FromDate) - 1
                     else begin
@@ -1892,6 +1894,27 @@ table 8059 "Subscription Line"
                         NextToDate := LastDateInLastMonth - DistanceToEndOfMonth - 1;
                     end;
                 end;
+        end;
+    end;
+
+    local procedure GetBillingReferenceDate() BillingReferenceDate: Date
+    var
+        BillingLine: Record "Billing Line";
+        BillingLineArchive: Record "Billing Line Archive";
+    begin
+        BillingReferenceDate := Rec."Subscription Line Start Date";
+
+        BillingLine.SetRange("Subscription Header No.", "Subscription Header No.");
+        BillingLine.SetRange("Subscription Line Entry No.", "Entry No.");
+        BillingLine.SetRange("Billing Reference Date Changed", true);
+        if BillingLine.FindLast() then
+            exit(BillingLine."Billing to" + 1)
+        else begin
+            BillingLineArchive.SetRange("Subscription Header No.", "Subscription Header No.");
+            BillingLineArchive.SetRange("Subscription Line Entry No.", "Entry No.");
+            BillingLineArchive.SetRange("Billing Reference Date Changed", true);
+            if BillingLineArchive.FindLast() then
+                exit(BillingLineArchive."Billing to" + 1);
         end;
     end;
 

--- a/src/Apps/W1/Subscription Billing/App/Usage Based Billing/Codeunits/ProcessUsageDataBilling.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Usage Based Billing/Codeunits/ProcessUsageDataBilling.Codeunit.al
@@ -235,12 +235,13 @@ codeunit 8026 "Process Usage Data Billing"
         ServiceCommitmentUnitCostLCY: Decimal;
         RoundingPrecision: Decimal;
         ServiceCommitmentUpdated: Boolean;
+        BillingReferenceDateChanged: Boolean;
     begin
         if UnitPrice = 0 then
             exit;
         SetCurrency(Currency, ServiceCommitment."Currency Code");
 
-        ServiceCommitment.UnitPriceAndCostForPeriod(ServiceCommitment."Billing Rhythm", LastUsageDataBilling."Charge Start Date", LastUsageDataBilling."Charge End Date", ServiceCommitmentUnitPrice, ServiceCommitmentUnitCost, ServiceCommitmentUnitCostLCY);
+        ServiceCommitment.UnitPriceAndCostForPeriod(ServiceCommitment."Billing Rhythm", LastUsageDataBilling."Charge Start Date", LastUsageDataBilling."Charge End Date", ServiceCommitmentUnitPrice, ServiceCommitmentUnitCost, ServiceCommitmentUnitCostLCY, BillingReferenceDateChanged);
 
         SetRoundingPrecision(RoundingPrecision, UnitPrice, Currency);
         if Round(ServiceCommitmentUnitPrice, RoundingPrecision) <> UnitPrice then begin

--- a/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingTest.Codeunit.al
@@ -127,6 +127,39 @@ codeunit 139688 "Recurring Billing Test"
     end;
 
     [Test]
+    procedure BillFullQuarterWhenServiceStartDateIsThreeDaysBeforeFebruaryEndsOnLeapYearWithPartialBillingAlignedToEndOfMonth()
+    var
+        StartDate: Date;
+    begin
+        // [SCENARIO] When Customer Subscription Contract has Subscription Line Start Date at the three days before the end of February in a leap year, the proposed billing lines should cover the whole period when services are billed partially
+        Initialize();
+
+        // [GIVEN] Customer Subscription Contract with specific period calculation with Billing Period for month and Billing Period Set to quarter
+        StartDate := 20200227D; // 27th February 2020
+        CreateCustomerContract("Period Calculation"::"Align to Start of Month", '<1Q>', '<1M>', StartDate, LibraryRandom.RandIntInRange(100, 200), LibraryRandom.RandIntInRange(1, 99));
+        CustomerContract.SetRecFilter();
+
+        // [GIVEN] Billing Template for Customer Subscription Contract
+        ContractTestLibrary.CreateRecurringBillingTemplate(BillingTemplate, '', '', CustomerContract.GetView(), Enum::"Service Partner"::Customer);
+
+        // [WHEN] Create Billing Proposal for Customer Subscription Contract for first partial period - until the end of February
+        ContractTestLibrary.CreateBillingProposal(BillingTemplate, Enum::"Service Partner"::Customer, StartDate, CalcDate('<CM>', StartDate));
+
+        // [THEN] Billing Lines are created for Customer Subscription Contract for the first partial period
+        BillingLine.SetRange("Subscription Contract No.", CustomerContract."No.");
+        BillingLine.FindLast();
+        Assert.AreEqual(CalcDate('<CM>', StartDate), BillingLine."Billing to", 'Expected End Date for Billing Line is incorrect.');
+
+        // [WHEN] Create Billing Proposal for Customer Subscription Contract for second partial period - for the whole quarter
+        ContractTestLibrary.CreateBillingProposal(BillingTemplate, Enum::"Service Partner"::Customer, CalcDate('<CM>', StartDate) + 1, 0D);
+
+        // [THEN] Billing Lines are created for Customer Subscription Contract for the second partial period
+        BillingLine.SetRange("Subscription Contract No.", CustomerContract."No.");
+        BillingLine.FindLast();
+        Assert.AreEqual(CalcDate('<1Q>', CalcDate('<CM>', StartDate) + 1) - 1, BillingLine."Billing to", 'Expected End Date for Billing Line is incorrect.');
+    end;
+
+    [Test]
     [HandlerFunctions('BillingTemplateModalPageHandler')]
     procedure CheckBillingDateCalculationFromCustomerBillingTemplate()
     var


### PR DESCRIPTION
#### Summary

For a contract starting on **27.02.2020**, billed quarterly with **"Align to End of Month"** enabled:

This fix corrects the **Billing-To Date** calculation for quarterly contracts that use the **"Align to End of Month"** option.

- For example, a contract starting on **27.02.2020** with the first billing period split manually (**27.02.2020–29.02.2020**) and the next period beginning **01.03.2020** should end on **31.05.2020**.
- Previously, the system incorrectly calculated the end date as **27.06.2020**.
- The fix ensures that when the start of the billing period is adjusted to the **first of the month**, the system correctly determines the end of the full billing quarter, preserving alignment with the “End of Month” rule.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #5089 
Fixes
[AB#609479](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/609479)


