### PR TITLE
[Shopify] Allow creation of credit memos for refunds with restock type return

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order Refunds/Codeunits/ShpfyRefundsAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/Codeunits/ShpfyRefundsAPI.Codeunit.al
@@ -166,7 +166,7 @@ codeunit 30228 "Shpfy Refunds API"
         JsonHelper.GetValueIntoField(JLine, 'totalTaxSet.presentmentMoney.amount', RefundLineRecordRef, RefundLine.FieldNo("Presentment Total Tax Amount"));
         RefundLineRecordRef.SetTable(RefundLine);
 
-        RefundLine."Can Create Credit Memo" := NonZeroOrReturnRefund;
+        RefundLine."Can Create Credit Memo" := NonZeroOrReturnRefund or (RefundLine."Restock Type" = RefundLine."Restock Type"::Return);
         RefundLine."Location Id" := JsonHelper.GetValueAsBigInteger(JLine, 'location.legacyResourceId');
 
         // If refund was created from a return, the location needs to come from the return

--- a/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
@@ -145,6 +145,7 @@ codeunit 139611 "Shpfy Order Refund Test"
         RefundId1: BigInteger;
         RefundId2: BigInteger;
         RefundId3: BigInteger;
+        RefundId4: BigInteger;
     begin
         // [SCENARIO] Can create credit memo check returns
         // Non-zero refund = true
@@ -158,11 +159,14 @@ codeunit 139611 "Shpfy Order Refund Test"
         RefundId2 := ShopifyIds.Get('Refund').Get(4);
         // [GIVEN] Zero and not linked refund
         RefundId3 := ShopifyIds.Get('Refund').Get(6);
+        // [GIVEN] Zero refund with restock type return
+        RefundId4 := ShopifyIds.Get('Refund').Get(7);
 
         // [WHEN] Execute VerifyRefundCanCreateCreditMemo
         RefundsAPI.VerifyRefundCanCreateCreditMemo(RefundId1);
         RefundsAPI.VerifyRefundCanCreateCreditMemo(RefundId2);
-        asserterror RefundsAPI.VerifyRefundCanCreateCreditMemo(RefundId3);
+        RefundsAPI.VerifyRefundCanCreateCreditMemo(RefundId3);
+        asserterror RefundsAPI.VerifyRefundCanCreateCreditMemo(RefundId4);
 
         // [THEN] Only RefundId3 throws an error
         LibraryAssert.ExpectedError('The refund imported from Shopify can''t be used to create a credit memo. Only refunds for paid items can be used to create credit memos.');
@@ -262,7 +266,7 @@ codeunit 139611 "Shpfy Order Refund Test"
         // [GIVEN] Refund Header
         RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, ReturnId, 156.38, Shop.Code);
         // [GIVEN] Refund line without location
-        OrderRefundsHelper.CreateRefundLine(RefundId, OrderLineId, 0);
+        OrderRefundsHelper.CreateRefundLine(RefundId, OrderLineId, 0, "Shpfy Restock Type"::Return);
 
         // [WHEN] Execute create credit memo
         IReturnRefundProcess := Enum::"Shpfy ReturnRefund ProcessType"::"Auto Create Credit Memo";
@@ -308,7 +312,7 @@ codeunit 139611 "Shpfy Order Refund Test"
         // [GIVEN] Refund Header
         RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, ReturnId, 156.38, Shop.Code);
         // [GIVEN] Refund line without location
-        OrderRefundsHelper.CreateRefundLine(RefundId, OrderLineId, LocationId);
+        OrderRefundsHelper.CreateRefundLine(RefundId, OrderLineId, LocationId, "Shpfy Restock Type"::Return);
 
         // [WHEN] Execute create credit memo
         IReturnRefundProcess := Enum::"Shpfy ReturnRefund ProcessType"::"Auto Create Credit Memo";

--- a/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundsHelper.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundsHelper.Codeunit.al
@@ -52,27 +52,31 @@ codeunit 139564 "Shpfy Order Refunds Helper"
         ShopifyIds.Get('Return').Add(ReturnId);
 
         RefundId := CreateRefundHeader(OrderId, ShopifyIds.Get('Return').Get(1), 156.38);
-        CreateRefundLine(RefundId, ShopifyIds.Get('OrderLine').Get(1));
+        CreateRefundLine(RefundId, ShopifyIds.Get('OrderLine').Get(1), "Shpfy Restock Type"::Return);
         ShopifyIds.Get('Refund').Add(RefundId);
 
         RefundId := CreateRefundHeader(OrderId, 0, 5);
         ShopifyIds.Get('Refund').Add(RefundId);
 
         RefundId := CreateRefundHeader(OrderId, ShopifyIds.Get('Return').Get(2), 0);
-        CreateRefundLine(RefundId, ShopifyIds.Get('OrderLine').Get(2));
+        CreateRefundLine(RefundId, ShopifyIds.Get('OrderLine').Get(2), "Shpfy Restock Type"::Return);
         ShopifyIds.Get('Refund').Add(RefundId);
 
         RefundId := CreateRefundHeader(OrderId, Any.IntegerInRange(100000, 999999), 0);
-        CreateRefundLine(RefundId, Any.IntegerInRange(100000, 999999));
+        CreateRefundLine(RefundId, Any.IntegerInRange(100000, 999999), "Shpfy Restock Type"::Return);
         ShopifyIds.Get('Refund').Add(RefundId); // 4th refund - linked zero
 
         RefundId := CreateRefundHeader(OrderId, 0, 150);
-        CreateRefundLine(RefundId, Any.IntegerInRange(100000, 999999));
+        CreateRefundLine(RefundId, Any.IntegerInRange(100000, 999999), "Shpfy Restock Type"::Return);
         ShopifyIds.Get('Refund').Add(RefundId); // 5th refund - non linked non zero
 
         RefundId := CreateRefundHeader(OrderId, 0, 0);
-        CreateRefundLine(RefundId, Any.IntegerInRange(100000, 999999));
-        ShopifyIds.Get('Refund').Add(RefundId); // 6th refund - not linked zero
+        CreateRefundLine(RefundId, Any.IntegerInRange(100000, 999999), "Shpfy Restock Type"::Return);
+        ShopifyIds.Get('Refund').Add(RefundId); // 6th refund - not linked zero and restock type return
+
+        RefundId := CreateRefundHeader(OrderId, 0, 0);
+        CreateRefundLine(RefundId, Any.IntegerInRange(100000, 999999), "Shpfy Restock Type"::"No Restock");
+        ShopifyIds.Get('Refund').Add(RefundId); // 6th refund - not linked zero and no restock type no restock
 
         Commit();
     end;
@@ -249,43 +253,41 @@ codeunit 139564 "Shpfy Order Refunds Helper"
         exit(RefundHeader."Refund Id");
     end;
 
-    internal procedure CreateRefundLine(RefundId: BigInteger; OrderLineId: BigInteger)
+    internal procedure CreateRefundLine(RefundId: BigInteger; OrderLineId: BigInteger; RestockType: Enum "Shpfy Restock Type")
     var
         RefundLine: Record "Shpfy Refund Line";
         RefundHeader: Record "Shpfy Refund Header";
         RefundsAPI: Codeunit "Shpfy Refunds API";
-        RefundEnumConvertor: Codeunit "Shpfy Refund Enum Convertor";
     begin
         RefundHeader.Get(RefundId);
         RefundLine."Refund Line Id" := Any.IntegerInRange(100000, 999999);
         RefundLine."Refund Id" := RefundId;
         RefundLine."Order Line Id" := OrderLineId;
-        RefundLine."Restock Type" := RefundEnumConvertor.ConvertToReStockType('RETURN');
+        RefundLine."Restock Type" := RestockType;
         RefundLine.Quantity := 1;
         RefundLine.Restocked := true;
         RefundLine.Amount := 156.38;
         RefundLine."Subtotal Amount" := 156.38;
-        RefundLine."Can Create Credit Memo" := RefundsAPI.IsNonZeroOrReturnRefund(RefundHeader);
+        RefundLine."Can Create Credit Memo" := RefundsAPI.IsNonZeroOrReturnRefund(RefundHeader) or (RefundLine."Restock Type" = RefundLine."Restock Type"::Return);
         RefundLine.Insert();
     end;
 
-    internal procedure CreateRefundLine(RefundId: BigInteger; OrderLineId: BigInteger; LocationId: BigInteger)
+    internal procedure CreateRefundLine(RefundId: BigInteger; OrderLineId: BigInteger; LocationId: BigInteger; RestockType: Enum "Shpfy Restock Type")
     var
         RefundLine: Record "Shpfy Refund Line";
         RefundHeader: Record "Shpfy Refund Header";
         RefundsAPI: Codeunit "Shpfy Refunds API";
-        RefundEnumConvertor: Codeunit "Shpfy Refund Enum Convertor";
     begin
         RefundHeader.Get(RefundId);
         RefundLine."Refund Line Id" := Any.IntegerInRange(100000, 999999);
         RefundLine."Refund Id" := RefundId;
         RefundLine."Order Line Id" := OrderLineId;
-        RefundLine."Restock Type" := RefundEnumConvertor.ConvertToReStockType('RETURN');
+        RefundLine."Restock Type" := RestockType;
         RefundLine.Quantity := 1;
         RefundLine.Restocked := true;
         RefundLine.Amount := 156.38;
         RefundLine."Subtotal Amount" := 156.38;
-        RefundLine."Can Create Credit Memo" := RefundsAPI.IsNonZeroOrReturnRefund(RefundHeader);
+        RefundLine."Can Create Credit Memo" := RefundsAPI.IsNonZeroOrReturnRefund(RefundHeader) or (RefundLine."Restock Type" = RefundLine."Restock Type"::Return);
         RefundLine."Location Id" := LocationId;
         RefundLine.Insert();
     end;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Allow creation of credit memos for refunds with restock type return

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#609317](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/609317)

