### PR TITLE
Improve Shopify Shop Card access token tooltip

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -77,10 +77,10 @@ page 30101 "Shpfy Shop Card"
                 field(HasAccessKey; Rec.HasAccessToken())
                 {
                     ApplicationArea = All;
-                    Caption = 'Has AccessKey';
+                    Caption = 'Has access token';
                     Importance = Additional;
                     ShowMandatory = true;
-                    ToolTip = 'Specifies if an access key is available for this store.';
+                    ToolTip = 'Specifies if an API access token is available for this store. The token allows the connector to access your shop''s data as long as the app is installed. To acquire a token, turn on the Enabled toggle or use the Request Access action.';
                 }
                 field(CurrencyCode; Rec."Currency Code")
                 {
@@ -881,7 +881,8 @@ page 30101 "Shpfy Shop Card"
                     ApplicationArea = All;
                     Image = EncryptionKeys;
                     Caption = 'Request Access';
-                    ToolTip = 'Request Access to your Shopify store.';
+                    ToolTip = 'Request access to your Shopify store. Use this to fix connection issues, after connector updates that require new permissions, or when rotating security tokens for this shop.';
+                    Enabled = Rec.Enabled;
 
                     trigger OnAction()
                     begin


### PR DESCRIPTION
## Summary
This PR improves the tooltip for the 'Has access token' field on the Shopify Shop Card page to provide better guidance to users.

## Changes
- Updated tooltip text from 'is received' to 'is available' for more natural language
- Added clear explanation of what the API access token does (allows connector to access shop data)
- Included instructions on how to acquire a token (turn on Enabled toggle or use Request Access action)
- Conditional access to the Request Access action and improved tooltip


## Benefit
Users will have better understanding of:
- What the field indicates
- Why the access token is important
- How to obtain an access token if they don't have one

fixes: [AB#609816](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/609816)


