### PR TITLE
[Email] Email accounts page allow showing of Create Account in lookupmode

### DIFF
--- a/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
+++ b/src/System Application/App/Email/src/Account/EmailAccounts.Page.al
@@ -178,7 +178,7 @@ page 8887 "Email Accounts"
                 Image = Add;
                 Caption = 'Add an email account';
                 ToolTip = 'Add an email account.';
-                Visible = (not IsLookupMode) and CanUserManageEmailSetup;
+                Visible = ((not IsLookupMode) or ShowCreateAccount) and CanUserManageEmailSetup;
 
                 trigger OnAction()
                 begin
@@ -531,6 +531,15 @@ page 8887 "Email Accounts"
     end;
 
     /// <summary>
+    /// Sets whether the action to create a new email account is shown.
+    /// </summary>
+    /// <param name="Show">True to show the create account action, false to hide it</param>
+    procedure SetShowCreateAccount(Show: Boolean)
+    begin
+        ShowCreateAccount := Show;
+    end;
+
+    /// <summary>
     /// Filters the email accounts to only show accounts that are using the Email Connector v2 or v3.
     /// </summary>
     /// <param name="Filter">True to filter the email accounts, false to show all email accounts</param>
@@ -581,6 +590,7 @@ page 8887 "Email Accounts"
         DefaultTxt: Text;
         UpdateAccounts: Boolean;
         IsLookupMode: Boolean;
+        ShowCreateAccount: Boolean;
         HasEmailAccount: Boolean;
         V2V3Filter, V3Filter : Boolean;
         V4Filter: Boolean;


### PR DESCRIPTION
…n loopupmode

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Currently when we enable lookupmode for the Email Accounts page, the page will hide all actions.
We want to show & enable the Create Account action from specific callers like the Sales Order Agent setup.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#599333](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/599333)


