### PR TITLE
Check for necessary information when reading ADI data.

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentADIHandler.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentADIHandler.Codeunit.al
@@ -44,7 +44,7 @@ codeunit 6174 "E-Document ADI Handler" implements IStructureReceivedEDocument, I
         Data := Base64Convert.ToBase64(InStream);
         StructuredData := AzureDocumentIntelligence.AnalyzeInvoice(Data);
         // If the call to ADI fails the system module will return an empty string, in such case we want to carry on with a blank draft
-        if StructuredData = '' then begin
+        if (StructuredData = '') or (not ContainsNecessaryInformation(StructuredData)) then begin
             FileFormat := "E-Doc. File Format"::Unspecified;
             ReadIntoDraftImpl := "E-Doc. Read into Draft"::"Blank Draft";
         end else begin
@@ -130,6 +130,25 @@ codeunit 6174 "E-Document ADI Handler" implements IStructureReceivedEDocument, I
         ReadIntoBuffer(EDocument, TempBlob, TempEDocPurchaseHeader, TempEDocPurchaseLine);
         EDocReadablePurchaseDoc.SetBuffer(TempEDocPurchaseHeader, TempEDocPurchaseLine);
         EDocReadablePurchaseDoc.Run();
+    end;
+
+    local procedure ContainsNecessaryInformation(Data: Text): Boolean
+    var
+        TempEDocPurchaseHeader: Record "E-Document Purchase Header" temporary;
+        TempEDocPurchaseLine: Record "E-Document Purchase Line" temporary;
+        TempEDocument: Record "E-Document" temporary;
+        TempBlob: Codeunit "Temp Blob";
+        OutStream: OutStream;
+    begin
+        TempBlob.CreateOutStream(OutStream);
+        OutStream.WriteText(Data);
+        TempEDocument."Entry No" := 1;
+        ReadIntoBuffer(TempEDocument, TempBlob, TempEDocPurchaseHeader, TempEDocPurchaseLine);
+
+        exit(
+            (TempEDocPurchaseHeader."Vendor Company Name" <> '') or
+            (TempEDocPurchaseHeader."Vendor Address" <> '') or
+            (TempEDocPurchaseHeader."Vendor VAT Id" <> ''));
     end;
 
     local procedure PopulateEDocumentPurchaseLines(ItemsArray: JsonArray; EDocumentEntryNo: Integer; var TempEDocPurchaseLine: Record "E-Document Purchase Line" temporary)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary 

When we read data from ADI, in cases where the pdf is not properly read, or it is a protected pdf, and vendor information is not read, we want to mark the draft as blank. 

That means the user must do the data entry manually.

We reuse the read into buffer impl. we have to quickly parse the output and check the returned values. 

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#602142](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/602142)




