### PR TITLE
[releases/26.3] Update email status when email is rescheduled

### DIFF
--- a/src/System Application/App/Email/src/Email/EmailDispatcher.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/EmailDispatcher.Codeunit.al
@@ -163,6 +163,7 @@ codeunit 8888 "Email Dispatcher"
 
         EmailOutbox."Task Scheduler Id" := TaskId;
         EmailOutbox."Date Sending" := CurrentDateTime() + Delay;
+        EmailOutbox.Status := EmailOutbox.Status::Queued;
         EmailOutbox.Modify();
 
         Dimensions.Add('TaskId', Format(TaskId));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Previously, we don't update the status of email when it's rescheduled. Then we found this cause around ten tenants generate unnecessary background tasks.
#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#609993](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/609993)




