### PR TITLE
Missing ReplicateData on new table

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/PurchaseOrderMatching/EDocPurchaseLinePOMatch.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/PurchaseOrderMatching/EDocPurchaseLinePOMatch.Table.al
@@ -9,6 +9,7 @@ table 6114 "E-Doc. Purchase Line PO Match"
     Access = Internal;
     InherentEntitlements = RIMDX;
     InherentPermissions = RIMDX;
+    ReplicateData = false;
 
     fields
     {


### PR DESCRIPTION
#### Summary 
In the PR https://github.com/microsoft/BCApps/pull/5148 the ReplicateData property was not added to the new table, causing the NewObjects test to fail at BCApps' uptake in NAV.

#### Work Item(s) 
Fixes [AB#610103](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/610103)


