### PR TITLE
Bug 609291: Invoice discount fails to finalize

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
@@ -140,6 +140,8 @@ codeunit 6117 "E-Doc. Create Purchase Invoice" implements IEDocumentFinishDraft,
                 PurchaseLine."Variant Code" := EDocumentPurchaseLine."[BC] Variant Code";
                 PurchaseLine.Type := EDocumentPurchaseLine."[BC] Purchase Line Type";
                 PurchaseLine.Validate("No.", EDocumentPurchaseLine."[BC] Purchase Type No.");
+                if (PurchaseLine.Type = PurchaseLine.Type::"G/L Account") and (EDocumentPurchaseHeader."Total Discount" > 0) then
+                    PurchaseLine.Validate("Allow Invoice Disc.", true);
                 PurchaseLine.Description := EDocumentPurchaseLine.Description;
 
                 if EDocumentPurchaseLine."[BC] Item Reference No." <> '' then


### PR DESCRIPTION
Setting the "Allow Inv. Disc" to true for G/L accounts if total discount is set in the header. For other types like items and fixed assets i suppose that users need to set the proper value in the master data, while for g/l accounts it is always false.

[AB#609291](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/609291)

