### PR TITLE
[Bug] [Subscription Billing]: Subscription Lines Cannot Be Opened from Sales Line *1

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
@@ -83,7 +83,7 @@ table 8068 "Sales Subscription Line"
             MinValue = 0;
             BlankZero = true;
             AutoFormatType = 1;
-            AutoFormatExpression = GetCurrency();
+            AutoFormatExpression = Rec."Currency Code";
 
             trigger OnValidate()
             begin
@@ -111,7 +111,7 @@ table 8068 "Sales Subscription Line"
             Editable = false;
             BlankZero = true;
             AutoFormatType = 2;
-            AutoFormatExpression = GetCurrency();
+            AutoFormatExpression = Rec."Currency Code";
 
             trigger OnValidate()
             var
@@ -144,7 +144,7 @@ table 8068 "Sales Subscription Line"
             MinValue = 0;
             BlankZero = true;
             AutoFormatType = 1;
-            AutoFormatExpression = GetCurrency();
+            AutoFormatExpression = Rec."Currency Code";
 
             trigger OnValidate()
             begin
@@ -156,7 +156,7 @@ table 8068 "Sales Subscription Line"
             Caption = 'Amount';
             BlankZero = true;
             AutoFormatType = 1;
-            AutoFormatExpression = GetCurrency();
+            AutoFormatExpression = Rec."Currency Code";
 
             trigger OnValidate()
             begin
@@ -319,7 +319,7 @@ table 8068 "Sales Subscription Line"
             Caption = 'Unit Cost';
             Editable = false;
             AutoFormatType = 2;
-            AutoFormatExpression = GetCurrency();
+            AutoFormatExpression = Rec."Currency Code";
         }
         field(101; "Unit Cost (LCY)"; Decimal)
         {
@@ -820,12 +820,6 @@ table 8068 "Sales Subscription Line"
     local procedure GetSalesLine(var SalesLine2: Record "Sales Line")
     begin
         GetSalesLine(Rec, SalesLine2);
-    end;
-
-    local procedure GetCurrency(): Code[10]
-    begin
-        CalcFields("Currency Code");
-        exit(Rec."Currency Code");
     end;
 
     local procedure GetSalesLine(SalesSubscriptionLine: Record "Sales Subscription Line"; var SalesLine2: Record "Sales Line")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Fixes an issue where Subscription Lines could not be opened directly from the Sales Line when a Subscription Item was added.
The system previously threw an error:

_ΓÇ£Document No. must have a value in Sales Subscription Line: Line No.=0. It cannot be zero or empty.ΓÇ¥_

The issue occurred only in BC27 environments.
The fix ensures that clicking the Subscription Lines field correctly opens the related lines without an error.
#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #5286 

Fixes [AB#611134](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611134)

