### PR TITLE
Only Append Asterisk for Quote and Order

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Codeunits/SalesReportPrintoutMgmt.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Codeunits/SalesReportPrintoutMgmt.Codeunit.al
@@ -1,8 +1,6 @@
 namespace Microsoft.SubscriptionBilling;
 
 using System.Text;
-using System.Reflection;
-using System.Text;
 using Microsoft.Utilities;
 using Microsoft.Sales.Document;
 using Microsoft.Inventory.Item;


### PR DESCRIPTION
#### Summary
Only append an asterisk to the Line Amount for Document Type Quote and Order.

#### Work Item(s) 
Fixes #5285


Fixes [AB#611135](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611135)


