### PR TITLE
Do not re-run for RequiredTestIsolation = Disabled tests

### DIFF
--- a/build/scripts/RunTestsInBcContainer.ps1
+++ b/build/scripts/RunTestsInBcContainer.ps1
@@ -44,7 +44,7 @@ function Invoke-TestsWithReruns {
         } else {
             $attempt++
             $parameters["ReRun"] = $true
-            if ($attempt -gt $maxReruns) {
+            if ($attempt -ge $maxReruns) {
                 Write-Host "Tests failed after $maxReruns attempts."
                 return $false
             } else {
@@ -54,13 +54,6 @@ function Invoke-TestsWithReruns {
     }
 }
 
-if ($DisableTestIsolation)
-{
-    Write-Host "Using RequiredTestIsolation: Disabled"
-    $parameters["requiredTestIsolation"] = "Disabled" # filtering on tests that require Disabled Test Isolation
-    $parameters["testRunnerCodeunitId"] = "130451" # Test Runner with disabled test isolation
-}
-
 if ($null -ne $TestType) {
     Write-Host "Using test type $TestType"
     $parameters["testType"] = $TestType
@@ -68,5 +61,14 @@ if ($null -ne $TestType) {
 
 $parameters["disabledTests"] = @(Get-DisabledTests) # Add disabled tests to parameters
 $parameters["renewClientContextBetweenTests"] = $true
+
+if ($DisableTestIsolation)
+{
+    Write-Host "Using RequiredTestIsolation: Disabled"
+    $parameters["requiredTestIsolation"] = "Disabled" # filtering on tests that require Disabled Test Isolation
+    $parameters["testRunnerCodeunitId"] = "130451" # Test Runner with disabled test isolation
+
+    return Invoke-TestsWithReruns -parameters $parameters -maxReruns 1 # do not retry for Isolation Disabled tests, as they leave traces in the DB
+}
 
 return Invoke-TestsWithReruns -parameters $parameters


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->

Do not retry for Isolation Disabled tests, as they leave traces in the DB.

Re-run might just leave more things in DB and greater chances to fail follow up tests.
