### PR TITLE
No. Series seems to miss a check on "Sequence Name" being blank when getting a new sequence number

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesSequenceImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesSequenceImpl.Codeunit.al
@@ -116,6 +116,7 @@ codeunit 307 "No. Series - Sequence Impl." implements "No. Series - Single"
     [TryFunction]
     local procedure TryGetNextSequenceNo(var NoSeriesLine: Record "No. Series Line"; ModifySeries: Boolean; var NewNo: BigInteger)
     begin
+        NoSeriesLine.TestField("Sequence Name");
         if ModifySeries then begin
             NewNo := NumberSequence.Next(NoSeriesLine."Sequence Name");
             if NewNo < NoSeriesLine."Starting Sequence No." then


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
When Sequence Name is blank, the TryFunction doesn't catch the error on NumberSequence.Next killing the process. The TestField should prevent this.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#610953](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/610953)



