### PR TITLE
Generate hash and sign/verify data for secrettext values

### DIFF
--- a/src/System Application/App/Cryptography Management/src/CryptographyManagement.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/CryptographyManagement.Codeunit.al
@@ -111,11 +111,33 @@ codeunit 1266 "Cryptography Management"
     /// <param name="InputString">Input string.</param>
     /// <param name="HashAlgorithmType">The available hash algorithms include MD5, SHA1, SHA256, SHA384, and SHA512.</param>
     /// <returns>Hashed value.</returns>
+    procedure GenerateHash(InputString: SecretText; HashAlgorithmType: Option MD5,SHA1,SHA256,SHA384,SHA512): SecretText
+    begin
+        exit(CryptographyManagementImpl.GenerateHash(InputString, HashAlgorithmType));
+    end;
+
+    /// <summary>
+    /// Generates a hash from a string based on the provided hash algorithm.
+    /// </summary>
+    /// <param name="InputString">Input string.</param>
+    /// <param name="HashAlgorithmType">The available hash algorithms include MD5, SHA1, SHA256, SHA384, and SHA512.</param>
+    /// <returns>Hashed value.</returns>
     procedure GenerateHash(InputString: Text; HashAlgorithmType: Option MD5,SHA1,SHA256,SHA384,SHA512): Text
     begin
         exit(CryptographyManagementImpl.GenerateHash(InputString, HashAlgorithmType));
     end;
 
+    /// <summary>
+    /// Generates a keyed hash from a string based on provided hash algorithm and key.
+    /// </summary>
+    /// <param name="InputString">Input string.</param>
+    /// <param name="Key">Key to use in the hash algorithm.</param>
+    /// <param name="HashAlgorithmType">The available hash algorithms include HMACMD5, HMACSHA1, HMACSHA256, HMACSHA384, and HMACSHA512.</param>
+    /// <returns>Hashed value.</returns>
+    procedure GenerateHash(InputString: SecretText; "Key": SecretText; HashAlgorithmType: Option HMACMD5,HMACSHA1,HMACSHA256,HMACSHA384,HMACSHA512): SecretText
+    begin
+        exit(CryptographyManagementImpl.GenerateHash(InputString, Key, HashAlgorithmType));
+    end;
 
     /// <summary>
     /// Generates a keyed hash from a string based on provided hash algorithm and key.
@@ -146,9 +168,32 @@ codeunit 1266 "Cryptography Management"
     /// <param name="InputString">Input string.</param>
     /// <param name="HashAlgorithmType">The available hash algorithms include MD5, SHA1, SHA256, SHA384, and SHA512.</param>
     /// <returns>Base64 hashed value.</returns>
+    procedure GenerateHashAsBase64String(InputString: SecretText; HashAlgorithmType: Option MD5,SHA1,SHA256,SHA384,SHA512): SecretText
+    begin
+        exit(CryptographyManagementImpl.GenerateHashAsBase64String(InputString, HashAlgorithmType));
+    end;
+
+    /// <summary>
+    /// Generates a base64 encoded hash from a string based on provided hash algorithm.
+    /// </summary>
+    /// <param name="InputString">Input string.</param>
+    /// <param name="HashAlgorithmType">The available hash algorithms include MD5, SHA1, SHA256, SHA384, and SHA512.</param>
+    /// <returns>Base64 hashed value.</returns>
     procedure GenerateHashAsBase64String(InputString: Text; HashAlgorithmType: Option MD5,SHA1,SHA256,SHA384,SHA512): Text
     begin
         exit(CryptographyManagementImpl.GenerateHashAsBase64String(InputString, HashAlgorithmType));
+    end;
+
+    /// <summary>
+    /// Generates a keyed base64 encoded hash from a string based on provided hash algorithm and key.
+    /// </summary>
+    /// <param name="InputString">Input string.</param>
+    /// <param name="Key">Key to use in the hash algorithm.</param>
+    /// <param name="HashAlgorithmType">The available hash algorithms include HMACMD5, HMACSHA1, HMACSHA256, HMACSHA384, and HMACSHA512.</param>
+    /// <returns>Base64 hashed value.</returns>
+    procedure GenerateHashAsBase64String(InputString: SecretText; "Key": SecretText; HashAlgorithmType: Option HMACMD5,HMACSHA1,HMACSHA256,HMACSHA384,HMACSHA512): SecretText
+    begin
+        exit(CryptographyManagementImpl.GenerateHashAsBase64String(InputString, Key, HashAlgorithmType));
     end;
 
 
@@ -164,6 +209,18 @@ codeunit 1266 "Cryptography Management"
         exit(CryptographyManagementImpl.GenerateHashAsBase64String(InputString, Key, HashAlgorithmType));
     end;
 
+    /// <summary>
+    /// Generates keyed base64 encoded hash from provided string based on provided hash algorithm and base64 key.
+    /// </summary>
+    /// <param name="InputString">Input string.</param>
+    /// <param name="Key">Key to use in the hash algorithm.</param>
+    /// <param name="HashAlgorithmType">The available hash algorithms include HMACMD5, HMACSHA1, HMACSHA256, HMACSHA384, and HMACSHA512.</param>
+    /// <returns>Base64 hashed value.</returns>
+    procedure GenerateBase64KeyedHashAsBase64String(InputString: SecretText; "Key": SecretText; HashAlgorithmType: Option HMACMD5,HMACSHA1,HMACSHA256,HMACSHA384,HMACSHA512): SecretText
+    begin
+        exit(CryptographyManagementImpl.GenerateBase64KeyedHashAsBase64String(InputString, Key, HashAlgorithmType));
+    end;
+
 
     /// <summary>
     /// Generates keyed base64 encoded hash from provided string based on provided hash algorithm and base64 key.
@@ -175,6 +232,18 @@ codeunit 1266 "Cryptography Management"
     procedure GenerateBase64KeyedHashAsBase64String(InputString: Text; "Key": SecretText; HashAlgorithmType: Option HMACMD5,HMACSHA1,HMACSHA256,HMACSHA384,HMACSHA512): Text
     begin
         exit(CryptographyManagementImpl.GenerateBase64KeyedHashAsBase64String(InputString, Key, HashAlgorithmType));
+    end;
+
+    /// <summary>
+    /// Generates keyed base64 encoded hash from provided string based on provided hash algorithm and base64 key.
+    /// </summary>
+    /// <param name="InputString">Input string.</param>
+    /// <param name="Key">Key to use in the hash algorithm.</param>
+    /// <param name="HashAlgorithmType">The available hash algorithms include HMACMD5, HMACSHA1, HMACSHA256, HMACSHA384, and HMACSHA512.</param>
+    /// <returns>Hashed value.</returns>
+    procedure GenerateBase64KeyedHash(InputString: SecretText; "Key": SecretText; HashAlgorithmType: Option HMACMD5,HMACSHA1,HMACSHA256,HMACSHA384,HMACSHA512): SecretText
+    begin
+        exit(CryptographyManagementImpl.GenerateBase64KeyedHash(InputString, Key, HashAlgorithmType));
     end;
 
 
@@ -203,6 +272,18 @@ codeunit 1266 "Cryptography Management"
         CryptographyManagementImpl.SignData(InputString, XmlString, HashAlgorithm, SignatureOutStream);
     end;
 
+    /// <summary>
+    /// Computes the hash value of the specified string and signs it.
+    /// </summary>
+    /// <param name="InputString">Input string for signing.</param>
+    /// <param name="XmlString">The private key to use in the hash algorithm.</param>
+    /// <param name="HashAlgorithm">The available hash algorithms are MD5, SHA1, SHA256, SHA384, and SHA512.</param>
+    /// <param name="SignatureOutStream">The stream to write the signature for the specified string.</param>
+    procedure SignData(InputString: SecretText; XmlString: SecretText; HashAlgorithm: Enum "Hash Algorithm"; SignatureOutStream: OutStream)
+    begin
+        CryptographyManagementImpl.SignData(InputString, XmlString, HashAlgorithm, SignatureOutStream);
+    end;
+
 
     /// <summary>
     /// Computes the hash value of the specified data and signs it.
@@ -224,6 +305,18 @@ codeunit 1266 "Cryptography Management"
     /// <param name="HashAlgorithm">The available hash algorithms are MD5, SHA1, SHA256, SHA384, and SHA512.</param>
     /// <param name="SignatureOutStream">The stream to write the signature for the specified string.</param>
     procedure SignData(InputString: Text; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureOutStream: OutStream)
+    begin
+        CryptographyManagementImpl.SignData(InputString, SignatureKey, HashAlgorithm, SignatureOutStream);
+    end;
+
+    /// <summary>
+    /// Computes the hash value of the specified string and signs it.
+    /// </summary>
+    /// <param name="InputString">Input string for signing.</param>
+    /// <param name="SignatureKey">The private key to use in the hash algorithm.</param>
+    /// <param name="HashAlgorithm">The available hash algorithms are MD5, SHA1, SHA256, SHA384, and SHA512.</param>
+    /// <param name="SignatureOutStream">The stream to write the signature for the specified string.</param>
+    procedure SignData(InputString: SecretText; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureOutStream: OutStream)
     begin
         CryptographyManagementImpl.SignData(InputString, SignatureKey, HashAlgorithm, SignatureOutStream);
     end;
@@ -290,6 +383,19 @@ codeunit 1266 "Cryptography Management"
     procedure VerifyData(InputString: Text; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureInStream: InStream): Boolean
     begin
         exit(CryptographyManagementImpl.VerifyData(InputString, SignatureKey, HashAlgorithm, SignatureInStream));
+    end;
+
+    /// <summary>
+    /// Verifies that a digital signature is valid.
+    /// </summary>
+    /// <param name="InputString">Input string.</param>
+    /// <param name="XmlString">The public key to use in the hash algorithm.</param>
+    /// <param name="HashAlgorithm">The available hash algorithms are MD5, SHA1, SHA256, SHA384, and SHA512.</param>
+    /// <param name="SignatureInStream">The stream of signature.</param>
+    /// <returns>True if the signature is valid; otherwise, false.</returns>
+    procedure VerifyData(InputString: SecretText; XmlString: Text; HashAlgorithm: Enum "Hash Algorithm"; SignatureInStream: InStream): Boolean
+    begin
+        exit(CryptographyManagementImpl.VerifyData(InputString, XmlString, HashAlgorithm, SignatureInStream));
     end;
 
     /// <summary>

--- a/src/System Application/App/Cryptography Management/src/CryptographyManagementImpl.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/CryptographyManagementImpl.Codeunit.al
@@ -242,6 +242,15 @@ codeunit 1279 "Cryptography Management Impl."
         exit(ConvertByteHashToString(HashBytes));
     end;
 
+    procedure GenerateHash(InputString: SecretText; HashAlgorithmType: Option MD5,SHA1,SHA256,SHA384,SHA512): SecretText
+    var
+        HashBytes: DotNet Array;
+    begin
+        if not GenerateHashBytes(HashBytes, InputString, HashAlgorithmType) then
+            exit;
+        exit(ConvertByteHashToString(HashBytes));
+    end;
+
     procedure GenerateHashAsBase64String(InputString: Text; HashAlgorithmType: Option MD5,SHA1,SHA256,SHA384,SHA512): Text
     var
         HashBytes: DotNet Array;
@@ -251,11 +260,30 @@ codeunit 1279 "Cryptography Management Impl."
         exit(ConvertByteHashToBase64String(HashBytes));
     end;
 
+    procedure GenerateHashAsBase64String(InputString: SecretText; HashAlgorithmType: Option MD5,SHA1,SHA256,SHA384,SHA512): SecretText
+    var
+        HashBytes: DotNet Array;
+    begin
+        if not GenerateHashBytes(HashBytes, InputString, HashAlgorithmType) then
+            exit;
+        exit(ConvertByteHashToBase64String(HashBytes));
+    end;
+
     local procedure GenerateHashBytes(var HashBytes: DotNet Array; InputString: Text; HashAlgorithmType: Option MD5,SHA1,SHA256,SHA384,SHA512): Boolean
     var
         Encoding: DotNet Encoding;
     begin
         if not TryGenerateHash(HashBytes, Encoding.UTF8().GetBytes(InputString), Format(HashAlgorithmType)) then
+            Error(GetLastErrorText());
+        exit(true);
+    end;
+
+    [NonDebuggable]
+    local procedure GenerateHashBytes(var HashBytes: DotNet Array; InputString: SecretText; HashAlgorithmType: Option MD5,SHA1,SHA256,SHA384,SHA512): Boolean
+    var
+        Encoding: DotNet Encoding;
+    begin
+        if not TryGenerateHash(HashBytes, Encoding.UTF8().GetBytes(InputString.Unwrap()), Format(HashAlgorithmType)) then
             Error(GetLastErrorText());
         exit(true);
     end;
@@ -282,6 +310,17 @@ codeunit 1279 "Cryptography Management Impl."
     end;
 
     [NonDebuggable]
+    procedure GenerateHash(InputString: SecretText; "Key": SecretText; HashAlgorithmType: Option HMACMD5,HMACSHA1,HMACSHA256,HMACSHA384,HMACSHA512): SecretText
+    var
+        HashBytes: DotNet Array;
+        Encoding: DotNet Encoding;
+    begin
+        if not GenerateKeyedHashBytes(HashBytes, InputString, Encoding.UTF8().GetBytes(Key.Unwrap()), HashAlgorithmType) then
+            exit;
+        exit(ConvertByteHashToString(HashBytes));
+    end;
+
+    [NonDebuggable]
     procedure GenerateHashAsBase64String(InputString: Text; "Key": SecretText; HashAlgorithmType: Option HMACMD5,HMACSHA1,HMACSHA256,HMACSHA384,HMACSHA512): Text
     var
         HashBytes: DotNet Array;
@@ -289,6 +328,17 @@ codeunit 1279 "Cryptography Management Impl."
     begin
         if not GenerateKeyedHashBytes(HashBytes, InputString, Encoding.UTF8().GetBytes(Key.Unwrap()), HashAlgorithmType) then
             exit('');
+        exit(ConvertByteHashToBase64String(HashBytes));
+    end;
+
+    [NonDebuggable]
+    procedure GenerateHashAsBase64String(InputString: SecretText; "Key": SecretText; HashAlgorithmType: Option HMACMD5,HMACSHA1,HMACSHA256,HMACSHA384,HMACSHA512): SecretText
+    var
+        HashBytes: DotNet Array;
+        Encoding: DotNet Encoding;
+    begin
+        if not GenerateKeyedHashBytes(HashBytes, InputString, Encoding.UTF8().GetBytes(Key.Unwrap()), HashAlgorithmType) then
+            exit;
         exit(ConvertByteHashToBase64String(HashBytes));
     end;
 
@@ -303,11 +353,32 @@ codeunit 1279 "Cryptography Management Impl."
         exit(ConvertByteHashToBase64String(HashBytes));
     end;
 
+    [NonDebuggable]
+    procedure GenerateBase64KeyedHashAsBase64String(InputString: SecretText; "Key": SecretText; HashAlgorithmType: Option HMACMD5,HMACSHA1,HMACSHA256,HMACSHA384,HMACSHA512): SecretText
+    var
+        HashBytes: DotNet Array;
+        Convert: DotNet Convert;
+    begin
+        if not GenerateKeyedHashBytes(HashBytes, InputString, Convert.FromBase64String(Key.Unwrap()), HashAlgorithmType) then
+            exit;
+        exit(ConvertByteHashToBase64String(HashBytes));
+    end;
+
     local procedure GenerateKeyedHashBytes(var HashBytes: DotNet Array; InputString: Text; "Key": DotNet Array; HashAlgorithmType: Option HMACMD5,HMACSHA1,HMACSHA256,HMACSHA384,HMACSHA512): Boolean
     begin
         if (InputString = '') or (Key.Length() = 0) then
             exit(false);
         if not TryGenerateKeyedHash(HashBytes, InputString, Key, Format(HashAlgorithmType)) then
+            Error(GetLastErrorText());
+        exit(true);
+    end;
+
+    [NonDebuggable]
+    local procedure GenerateKeyedHashBytes(var HashBytes: DotNet Array; InputString: SecretText; "Key": DotNet Array; HashAlgorithmType: Option HMACMD5,HMACSHA1,HMACSHA256,HMACSHA384,HMACSHA512): Boolean
+    begin
+        if InputString.IsEmpty() or (Key.Length() = 0) then
+            exit(false);
+        if not TryGenerateKeyedHash(HashBytes, InputString.Unwrap(), Key, Format(HashAlgorithmType)) then
             Error(GetLastErrorText());
         exit(true);
     end;
@@ -370,6 +441,17 @@ codeunit 1279 "Cryptography Management Impl."
         exit(ConvertByteHashToString(HashBytes));
     end;
 
+    [NonDebuggable]
+    procedure GenerateBase64KeyedHash(InputString: SecretText; "Key": SecretText; HashAlgorithmType: Option HMACMD5,HMACSHA1,HMACSHA256,HMACSHA384,HMACSHA512): SecretText
+    var
+        HashBytes: DotNet Array;
+        Convert: DotNet Convert;
+    begin
+        if not GenerateKeyedHashBytes(HashBytes, InputString, Convert.FromBase64String(Key.Unwrap()), HashAlgorithmType) then
+            exit;
+        exit(ConvertByteHashToString(HashBytes));
+    end;
+
     procedure SignData(InputString: Text; XmlString: SecretText; HashAlgorithm: Enum "Hash Algorithm"; SignatureOutStream: OutStream)
     var
         TempBlob: Codeunit "Temp Blob";
@@ -382,6 +464,26 @@ codeunit 1279 "Cryptography Management Impl."
         TempBlob.CreateInStream(DataInStream, TextEncoding::UTF8);
         DataOutStream.WriteText(InputString);
         SignData(DataInStream, XmlString, HashAlgorithm, SignatureOutStream);
+    end;
+
+    [NonDebuggable]
+    procedure SignData(InputString: SecretText; XmlString: SecretText; HashAlgorithm: Enum "Hash Algorithm"; SignatureOutStream: OutStream)
+    var
+        TempBlob: Codeunit "Temp Blob";
+        DataOutStream: OutStream;
+        DataInStream: InStream;
+    begin
+        if InputString.IsEmpty() then
+            exit;
+        TempBlob.CreateOutStream(DataOutStream, TextEncoding::UTF8);
+        TempBlob.CreateInStream(DataInStream, TextEncoding::UTF8);
+        DataOutStream.WriteText(InputString.Unwrap());
+        SignData(DataInStream, XmlString, HashAlgorithm, SignatureOutStream);
+    end;
+
+    procedure SignData(InputString: SecretText; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureOutStream: OutStream)
+    begin
+        SignData(InputString, SignatureKey.ToXmlString(), HashAlgorithm, SignatureOutStream);
     end;
 
     procedure SignData(InputString: Text; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureOutStream: OutStream)
@@ -444,7 +546,27 @@ codeunit 1279 "Cryptography Management Impl."
         exit(VerifyData(DataInStream, XmlString, HashAlgorithm, SignatureInStream));
     end;
 
+    [NonDebuggable]
+    procedure VerifyData(InputString: SecretText; XmlString: SecretText; HashAlgorithm: Enum "Hash Algorithm"; SignatureInStream: InStream): Boolean
+    var
+        TempBlob: Codeunit "Temp Blob";
+        DataOutStream: OutStream;
+        DataInStream: InStream;
+    begin
+        if InputString.IsEmpty() then
+            exit(false);
+        TempBlob.CreateOutStream(DataOutStream, TextEncoding::UTF8);
+        TempBlob.CreateInStream(DataInStream, TextEncoding::UTF8);
+        DataOutStream.WriteText(InputString.Unwrap());
+        exit(VerifyData(DataInStream, XmlString, HashAlgorithm, SignatureInStream));
+    end;
+
     procedure VerifyData(InputString: Text; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureInStream: InStream): Boolean
+    begin
+        exit(VerifyData(InputString, SignatureKey.ToXmlString(), HashAlgorithm, SignatureInStream));
+    end;
+
+    procedure VerifyData(InputString: SecretText; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureInStream: InStream): Boolean
     begin
         exit(VerifyData(InputString, SignatureKey.ToXmlString(), HashAlgorithm, SignatureInStream));
     end;


### PR DESCRIPTION
#### Summary
New overloaded procedures for Hash and Sign/Verify that accept SecretText value as hash/sign input value.

#### Work Item(s)
Fixes #736 

Fixes [AB#507370](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/507370)


