### PR TITLE
[SubscriptionBilling] Use page "Service Objects" instead of "Service Object"

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Customer Contracts/Page Extensions/CustomerCard.PageExt.al
+++ b/src/Apps/W1/Subscription Billing/App/Customer Contracts/Page Extensions/CustomerCard.PageExt.al
@@ -44,7 +44,7 @@ pageextension 8051 "Customer Card" extends "Customer Card"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Subscriptions';
                 Image = ServiceItem;
-                RunObject = page "Service Object";
+                RunObject = page "Service Objects";
                 RunPageLink = "End-User Customer No." = field("No.");
                 ToolTip = 'View a list of Subscriptions for the customer.';
             }

--- a/src/Apps/W1/Subscription Billing/App/Customer Contracts/Page Extensions/CustomerList.PageExt.al
+++ b/src/Apps/W1/Subscription Billing/App/Customer Contracts/Page Extensions/CustomerList.PageExt.al
@@ -44,7 +44,7 @@ pageextension 8052 "Customer List" extends "Customer List"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Subscriptions';
                 Image = ServiceItem;
-                RunObject = page "Service Object";
+                RunObject = page "Service Objects";
                 RunPageLink = "End-User Customer No." = field("No.");
                 ToolTip = 'View a list of Subscriptions for the customer.';
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Using page "Service Objects" instead of "Service Object" on Customer Card and Customer List

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #5297


Fixes [AB#611442](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611442)


