### PR TITLE
[Payables Agent] Fix HITL dialog for historical matching to show AI-generated message.

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/History/EDocPurchaseHistMapping.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/History/EDocPurchaseHistMapping.Codeunit.al
@@ -120,47 +120,19 @@ codeunit 6120 "E-Doc. Purchase Hist. Mapping"
     end;
 
     /// <summary>
-    /// Takes a draft line EDocumentPurchaseLine and the corresponding historic record found for it EDocPurchaseLineHistory.
-    /// If the values on the draft line have already been set by other mechanisms we don't assign it to avoid overwriting it.
-    /// </summary>
-    /// <param name="EDocPurchaseLineHistory"></param>
-    /// <param name="EDocumentPurchaseLine"></param>
-    procedure UpdateMissingLineValuesFromHistory(EDocPurchaseLineHistory: Record "E-Doc. Purchase Line History"; var EDocumentPurchaseLine: Record "E-Document Purchase Line"; CustomExplanationTxt: Text[250])
-    var
-        PurchInvLine: Record "Purch. Inv. Line";
-    begin
-        // If there is no such Purchase Invoice Line we can't apply any values to the draft
-        if not PurchInvLine.GetBySystemId(EDocPurchaseLineHistory."Purch. Inv. Line SystemId") then
-            exit;
-
-        UpdateMissingLineValuesFromHistory(PurchInvLine, EDocumentPurchaseLine, CustomExplanationTxt);
-
-        // We mark this draft with the historic match for future application of the additional fields
-        EDocumentPurchaseLine."E-Doc. Purch. Line History Id" := EDocPurchaseLineHistory."Entry No.";
-        EDocImpSessionTelemetry.SetLineBool(EDocumentPurchaseLine.SystemId, 'Line History', true);
-    end;
-
-    /// <summary>
     /// Takes a draft line EDocumentPurchaseLine and the corresponding historic record found for it PurchInvLine.
     /// If the values on the draft line have already been set by other mechanisms we don't assign it to avoid overwriting it.
     /// </summary>
     /// <param name="PurchInvLine"></param>
     /// <param name="EDocumentPurchaseLine"></param>
-    procedure UpdateMissingLineValuesFromHistory(PurchInvLine: Record "Purch. Inv. Line"; var EDocumentPurchaseLine: Record "E-Document Purchase Line"; CustomExplanationTxt: Text[250])
+    procedure UpdateMissingLineValuesFromHistory(PurchInvLine: Record "Purch. Inv. Line"; var EDocumentPurchaseLine: Record "E-Document Purchase Line"; ExplanationTxt: Text[250])
     var
         PurchInvHeader: Record "Purch. Inv. Header";
         DeferralTemplate: Record "Deferral Template";
         UnitOfMeasure: Record "Unit of Measure";
         EDocActivityLogSession: Codeunit "E-Doc. Activity Log Session";
         DeferralActivityLog, AccountNumberActivityLog : Codeunit "Activity Log Builder";
-        ExplanationTxt: Label 'Line value was retrieved from posted purchase invoice history. See source for details.';
-        CurrentExplanationTxt: Text[250];
     begin
-        if CustomExplanationTxt <> '' then
-            CurrentExplanationTxt := CopyStr(CustomExplanationTxt, 1, MaxStrLen(CurrentExplanationTxt))
-        else
-            CurrentExplanationTxt := ExplanationTxt;
-
         PurchInvHeader.SetRange("No.", PurchInvLine."Document No.");
         if not PurchInvHeader.FindFirst() then
             exit;
@@ -171,7 +143,7 @@ codeunit 6120 "E-Doc. Purchase Hist. Mapping"
         if EDocumentPurchaseLine."[BC] Deferral Code" = '' then
             if DeferralTemplate.Get(PurchInvLine."Deferral Code") then begin // we only assign if it's a valid deferral template
                 EDocumentPurchaseLine."[BC] Deferral Code" := PurchInvLine."Deferral Code";
-                SetActivityLog(EDocumentPurchaseLine.SystemId, EDocumentPurchaseLine.FieldNo("[BC] Deferral Code"), PurchInvHeader, CurrentExplanationTxt, DeferralActivityLog, EDocActivityLogSession.DeferralTok());
+                SetActivityLog(EDocumentPurchaseLine.SystemId, EDocumentPurchaseLine.FieldNo("[BC] Deferral Code"), PurchInvHeader, ExplanationTxt, DeferralActivityLog, EDocActivityLogSession.DeferralTok());
             end;
         if EDocumentPurchaseLine."[BC] Shortcut Dimension 1 Code" = '' then
             EDocumentPurchaseLine."[BC] Shortcut Dimension 1 Code" := PurchInvLine."Shortcut Dimension 1 Code";
@@ -193,7 +165,7 @@ codeunit 6120 "E-Doc. Purchase Hist. Mapping"
             end;
             // If we assigned something in this if-branch, we set the activity log
             if (EDocumentPurchaseLine."[BC] Purchase Line Type" <> "Purchase Line Type"::" ") or (EDocumentPurchaseLine."[BC] Purchase Type No." <> '') then
-                SetActivityLog(EDocumentPurchaseLine.SystemId, EDocumentPurchaseLine.FieldNo("[BC] Purchase Type No."), PurchInvHeader, CurrentExplanationTxt, AccountNumberActivityLog, EDocActivityLogSession.AccountNumberTok());
+                SetActivityLog(EDocumentPurchaseLine.SystemId, EDocumentPurchaseLine.FieldNo("[BC] Purchase Type No."), PurchInvHeader, ExplanationTxt, AccountNumberActivityLog, EDocActivityLogSession.AccountNumberTok());
         end;
     end;
 
@@ -218,6 +190,7 @@ codeunit 6120 "E-Doc. Purchase Hist. Mapping"
         ActivityLog
             .Init(Database::"E-Document Purchase Line", FieldNo, SystemId)
             .SetExplanation(Reasoning)
+            .SetType(Enum::"Activity Log Type"::"AI")
             .SetReferenceSource(Page::"Posted Purchase Invoice", RecordRef)
             .SetReferenceTitle(StrSubstNo(HistoricalExplanationTxt, PurchInvHeader.GetFilter("No.")));
         EDocActivityLogSession.Set(ActivityLogSessionToken, ActivityLog);

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/History/EDocPurchaseHistMapping.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/History/EDocPurchaseHistMapping.Codeunit.al
@@ -120,6 +120,27 @@ codeunit 6120 "E-Doc. Purchase Hist. Mapping"
     end;
 
     /// <summary>
+    /// Takes a draft line EDocumentPurchaseLine and the corresponding historic record found for it EDocPurchaseLineHistory.
+    /// If the values on the draft line have already been set by other mechanisms we don't assign it to avoid overwriting it.
+    /// </summary>
+    /// <param name="EDocPurchaseLineHistory"></param>
+    /// <param name="EDocumentPurchaseLine"></param>
+    procedure UpdateMissingLineValuesFromHistory(EDocPurchaseLineHistory: Record "E-Doc. Purchase Line History"; var EDocumentPurchaseLine: Record "E-Document Purchase Line"; CustomExplanationTxt: Text[250])
+    var
+        PurchInvLine: Record "Purch. Inv. Line";
+    begin
+        // If there is no such Purchase Invoice Line we can't apply any values to the draft
+        if not PurchInvLine.GetBySystemId(EDocPurchaseLineHistory."Purch. Inv. Line SystemId") then
+            exit;
+
+        UpdateMissingLineValuesFromHistory(PurchInvLine, EDocumentPurchaseLine, CustomExplanationTxt);
+
+        // We mark this draft with the historic match for future application of the additional fields
+        EDocumentPurchaseLine."E-Doc. Purch. Line History Id" := EDocPurchaseLineHistory."Entry No.";
+        EDocImpSessionTelemetry.SetLineBool(EDocumentPurchaseLine.SystemId, 'Line History', true);
+    end;
+
+    /// <summary>
     /// Takes a draft line EDocumentPurchaseLine and the corresponding historic record found for it PurchInvLine.
     /// If the values on the draft line have already been set by other mechanisms we don't assign it to avoid overwriting it.
     /// </summary>


### PR DESCRIPTION
This pull request refactors the handling of explanation text and activity log entries in the `UpdateMissingLineValuesFromHistory` procedures within the `codeunit 6120 "E-Doc. Purchase Hist. Mapping"`. The main focus is on simplifying the explanation text management and ensuring that activity logs are consistently marked as AI-generated. Below are the most important changes grouped by theme:

**Refactoring of Explanation Text Handling:**

* Removed the overloaded `UpdateMissingLineValuesFromHistory` procedure that accepted a history record, consolidating logic to use the version that works directly with `PurchInvLine`. This reduces redundancy and simplifies the update process.
* Changed the `CustomExplanationTxt` parameter to `ExplanationTxt` and removed the logic for selecting between a default and custom explanation, making the explanation text usage more straightforward.

**Activity Log Improvements:**

* Updated calls to `SetActivityLog` to use the unified `ExplanationTxt` parameter, ensuring consistent logging of explanations for field updates. [[1]](diffhunk://#diff-2f5a9ee3b8c857722f5e7bc4ea416bd0fa19943192edb46d949a4dfc36efd8e1L174-R146) [[2]](diffhunk://#diff-2f5a9ee3b8c857722f5e7bc4ea416bd0fa19943192edb46d949a4dfc36efd8e1L196-R168)
* Added `.SetType(Enum::"Activity Log Type"::"AI")` to activity log creation, explicitly marking these logs as AI-generated for better traceability.

Fixes [AB#611426](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611426)



