### PR TITLE
missing ReplicateData on new E-Documents table

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/PurchaseOrderMatching/EDocPOMatchingSetup.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/PurchaseOrderMatching/EDocPOMatchingSetup.Table.al
@@ -11,6 +11,7 @@ table 6116 "E-Doc. PO Matching Setup"
     Access = Internal;
     InherentEntitlements = RID;
     InherentPermissions = RID;
+    ReplicateData = false;
 
     fields
     {


### PR DESCRIPTION
#### Summary 
Fixes the break of New-ObjectsTests which are run for this extension in NAV. PA is SaaS only, and this table is currently only for config of PA (although we may move it to BaseApp), but for now it doesn't make sense to consider it for CM.

#### Work Item(s) 
Fixes [AB#611333](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611333)


