### PR TITLE
[Profiler Schedules] A non-SUPER user should not be able to specify another user

### DIFF
--- a/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerfProfilerScheduleCard.Page.al
@@ -174,6 +174,7 @@ page 1932 "Perf. Profiler Schedule Card"
                 field("User Name"; UserName)
                 {
                     ApplicationArea = All;
+                    ShowMandatory = true;
                     Caption = 'User Name';
                     ToolTip = 'Specifies the name of the user associated with the schedule.';
                     AboutText = 'Only this user''s sessions will be profiled.';
@@ -185,6 +186,7 @@ page 1932 "Perf. Profiler Schedule Card"
                     begin
                         if not UserSelection.OpenWithSystemUsers(SelectedUser) then
                             exit;
+                        ScheduledPerfProfiler.ValidateScheduleCreationPermissions(UserSecurityId(), SelectedUser."User Security ID");
                         UserName := SelectedUser."User Name";
                         Rec.Validate("User ID", SelectedUser."User Security ID");
                     end;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
A non-SUPER user should not be able to specify another user

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#612567](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612567)
Fixes [AB#612543](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612543)

