### PR TITLE
[MCP] Disabling modify setting does not apply for already added tools

### DIFF
--- a/src/System Application/App/MCP/src/Configuration/Codeunits/MCPConfigImplementation.Codeunit.al
+++ b/src/System Application/App/MCP/src/Configuration/Codeunits/MCPConfigImplementation.Codeunit.al
@@ -78,9 +78,26 @@ codeunit 8351 "MCP Config Implementation"
         if not MCPConfiguration.GetBySystemId(ConfigId) then
             exit;
 
+        if not Allow then
+            DisableCreateUpdateDeleteToolsInConfig(ConfigId);
+
         MCPConfiguration.AllowProdChanges := Allow;
         MCPConfiguration.Modify();
         Session.LogMessage('0000QEA', StrSubstNo(SettingConfigurationAllowProdChangesLbl, ConfigId, Allow), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', GetTelemetryCategory());
+    end;
+
+    internal procedure DisableCreateUpdateDeleteToolsInConfig(ConfigId: Guid)
+    var
+        MCPConfigurationTool: Record "MCP Configuration Tool";
+    begin
+        MCPConfigurationTool.SetRange(ID, ConfigId);
+        if MCPConfigurationTool.IsEmpty() then
+            exit;
+
+        MCPConfigurationTool.ModifyAll("Allow Create", false);
+        MCPConfigurationTool.ModifyAll("Allow Modify", false);
+        MCPConfigurationTool.ModifyAll("Allow Delete", false);
+        MCPConfigurationTool.ModifyAll("Allow Bound Actions", false);
     end;
 
     internal procedure DeleteConfiguration(ConfigId: Guid)

--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
@@ -76,6 +76,8 @@ page 8351 "MCP Config Card"
 
                     trigger OnValidate()
                     begin
+                        if not Rec.AllowProdChanges then
+                            MCPConfigImplementation.DisableCreateUpdateDeleteToolsInConfig(Rec.SystemId);
                         CurrPage.Update();
                         Session.LogMessage('0000QE8', StrSubstNo(SettingConfigurationAllowProdChangesLbl, Rec.SystemId, Rec.AllowProdChanges), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', MCPConfigImplementation.GetTelemetryCategory());
                     end;

--- a/src/System Application/Test/MCP/src/MCPConfigTest.Codeunit.al
+++ b/src/System Application/Test/MCP/src/MCPConfigTest.Codeunit.al
@@ -549,6 +549,35 @@ codeunit 130130 "MCP Config Test"
         Assert.AreEqual('mcp', APIGroup, 'APIGroup mismatch');
     end;
 
+    [Test]
+    procedure TestDisableCreateUpdateDeleteToolsDisablesAllowCreate()
+    var
+        MCPConfigurationTool: Record "MCP Configuration Tool";
+        ConfigId: Guid;
+        ToolId: Guid;
+    begin
+        // [GIVEN] Configuration and tool is created
+        ConfigId := CreateMCPConfig(false, false, true, false);
+        ToolId := CreateMCPConfigTool(ConfigId);
+        Commit();
+
+        // [GIVEN] Create, update and delete tools are enabled
+        MCPConfig.AllowCreate(ToolId, true);
+        MCPConfig.AllowModify(ToolId, true);
+        MCPConfig.AllowDelete(ToolId, true);
+        MCPConfig.AllowBoundActions(ToolId, true);
+
+        // [WHEN] Disable create, update and delete tools is called
+        MCPConfig.AllowCreateUpdateDeleteTools(ConfigId, false);
+
+        // [THEN] Allow create, modify, delete and bound actions are set to false
+        MCPConfigurationTool.GetBySystemId(ToolId);
+        Assert.IsFalse(MCPConfigurationTool."Allow Create", 'Allow Create is not false');
+        Assert.IsFalse(MCPConfigurationTool."Allow Modify", 'Allow Modify is not false');
+        Assert.IsFalse(MCPConfigurationTool."Allow Delete", 'Allow Delete is not false');
+        Assert.IsFalse(MCPConfigurationTool."Allow Bound Actions", 'Allow Bound Actions is not false');
+    end;
+
     local procedure CreateMCPConfig(Active: Boolean; DynamicToolMode: Boolean; AllowCreateUpdateDeleteTools: Boolean; DiscoverReadOnlyObjects: Boolean): Guid
     var
         MCPConfiguration: Record "MCP Configuration";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Disabling modify setting does not apply for already added tools

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#612544](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612544)
