### PR TITLE
Fix sub contract subscriber

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Base/Codeunits/SubContractsGeneralMgt.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Base/Codeunits/SubContractsGeneralMgt.Codeunit.al
@@ -501,6 +501,10 @@ codeunit 8059 "Sub. Contracts General Mgt."
     begin
         if Rec.IsTemporary() then
             exit;
+
+        if not RunTrigger then
+            exit;
+
         CustomerContract.SetRange("Sell-to Customer No.", Rec."No.");
         if not CustomerContract.IsEmpty() then
             Error(CustomerContractExistErr, Rec.TableCaption, Rec."No.");
@@ -518,6 +522,10 @@ codeunit 8059 "Sub. Contracts General Mgt."
     begin
         if Rec.IsTemporary() then
             exit;
+
+        if not RunTrigger then
+            exit;
+
         VendorContract.SetRange("Buy-from Vendor No.", Rec."No.");
         if not VendorContract.IsEmpty() then
             Error(VendorContractExistErr, Rec.TableCaption, Rec."No.");


### PR DESCRIPTION
These event subscribers cause AI tests to fail. To fix it we could take dependency on Sub Billing, but i really dont want to do that.. Instead, if someone calls delete with false trigger, dont run code as caller was intending it so.  

Fixes [AB#612608](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612608)
[AB#611827](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611827)



