### PR TITLE
[releases/27.0] Fix Parameter SalesLine for Event OnAfterCreateAdditionalInvoiceLine

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/CreateBillingDocuments.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/CreateBillingDocuments.Codeunit.al
@@ -936,7 +936,7 @@ codeunit 8060 "Create Billing Documents"
         DescriptionText := GetAdditionalLineText(ServiceContractSetupFieldNo, ParentSalesLine, ServiceObject, ServiceCommitment);
         if DescriptionText = '' then
             exit;
-        SalesLine.InsertDescriptionSalesLine(SalesHeader2, DescriptionText, ParentSalesLine."Line No.");
+        SalesLine.CreateAttachedSalesLine(SalesHeader2, DescriptionText, ParentSalesLine."Line No.");
         OnAfterCreateAdditionalInvoiceLine(SalesLine, ParentSalesLine);
     end;
 

--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Table Extensions/SalesLine.TableExt.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Table Extensions/SalesLine.TableExt.al
@@ -295,10 +295,15 @@ tableextension 8054 "Sales Line" extends "Sales Line"
     var
         SalesLine: Record "Sales Line";
     begin
-        SalesLine.InitFromSalesHeader(SourceSalesHeader);
-        SalesLine."Attached to Line No." := AttachedToLineNo;
-        SalesLine.Description := CopyStr(NewDescription, 1, MaxStrLen(SalesLine.Description));
-        SalesLine.Insert(false);
+        SalesLine.CreateAttachedSalesLine(SourceSalesHeader, NewDescription, AttachedToLineNo);
+    end;
+
+    internal procedure CreateAttachedSalesLine(SourceSalesHeader: Record "Sales Header"; NewDescription: Text; AttachedToLineNo: Integer)
+    begin
+        Rec.InitFromSalesHeader(SourceSalesHeader);
+        Rec."Attached to Line No." := AttachedToLineNo;
+        Rec.Description := CopyStr(NewDescription, 1, MaxStrLen(Rec.Description));
+        Rec.Insert(false);
     end;
 
     internal procedure RetrieveFirstContractNo(ServicePartner: Enum "Service Partner"; Process: Enum Process): Code[20]


### PR DESCRIPTION
#### Summary
Make parameter `SalesLine` of event `OnAfterCreateAdditionalInvoiceLine` useful by returing the newly created attached sales line.

Backport of #5380

#### Work Item(s)
Fixes #5304 

Fixes [AB#612607](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612607)