### PR TITLE
[27.x] Uptake fix for CZ tests

### DIFF
--- a/src/Apps/W1/EDocumentConnectors/FORNAV/Test/src/IntegrationTests.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/FORNAV/Test/src/IntegrationTests.Codeunit.al
@@ -10,6 +10,8 @@ using Microsoft.Purchases.Document;
 using Microsoft.Foundation.Company;
 using Microsoft.Purchases.Vendor;
 using Microsoft.Sales.History;
+using Microsoft.Finance.VAT.Setup;
+using Microsoft.Finance.GeneralLedger.Setup;
 
 codeunit 148221 "Integration Tests"
 {
@@ -407,9 +409,14 @@ codeunit 148221 "Integration Tests"
     var
         Setup: Record "ForNAV Peppol Setup";
         CompanyInformation: Record "Company Information";
+        GeneralLedgerSetup: Record "General Ledger Setup";
     begin
         Test.CreateMockServiceDocumentId();
         LibraryPermission.SetOutsideO365Scope();
+
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup."VAT Reporting Date Usage" := Enum::"VAT Reporting Date Usage"::Disabled;
+        GeneralLedgerSetup.Modify();
 
         if IsInitialized then
             exit;


### PR DESCRIPTION
Disable VAT check in test, as it blocks CZ uptake of app.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#611626](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611626)




