### PR TITLE
Private/nhsejth/memory telemetry

### DIFF
--- a/src/System Application/App/Base64 Convert/src/Base64ConvertImpl.Codeunit.al
+++ b/src/System Application/App/Base64 Convert/src/Base64ConvertImpl.Codeunit.al
@@ -15,23 +15,14 @@ codeunit 4111 "Base64 Convert Impl."
     InherentPermissions = X;
 
     var
-        IsInitialized: Boolean;
         SourceWarningLength: Integer;
         TextLengtWarningTxt: Label 'The input string length (%1) exceeds the maximum suggested length (%2) for Base64 conversion.', Locked = true;
         StreamLengtWarningTxt: Label 'The input stream length (%1) exceeds the maximum suggested length (%2) for Base64 conversion.', Locked = true;
 
-    internal procedure Initialize()
-    begin
-        if not IsInitialized then begin
-            SourceWarningLength := 10 * 1024 * 1024; // 10 MB
-            IsInitialized := true;
-        end;
-    end;
-
     internal procedure EmitLengthWarning(SourceLength: Integer; tag: Text; FormatString: Text)
     begin
-        if not IsInitialized then
-            this.Initialize();
+        if SourceWarningLength <= 0 then
+            SourceWarningLength := 10485760; // 10 * 1024 * 1024 = 10 MB
 
         if SourceLength > SourceWarningLength then
             Session.LogMessage(tag, StrSubstNo(FormatString, SourceLength, SourceWarningLength), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'resources', 'memory');

--- a/src/System Application/App/Json/src/JsonImpl.Codeunit.al
+++ b/src/System Application/App/Json/src/JsonImpl.Codeunit.al
@@ -16,25 +16,15 @@ codeunit 5461 "Json Impl."
     InherentPermissions = X;
 
     var
-        IsInitialized: Boolean;
         SourceWarningLength: Integer;
         JsonArrayDotNet: DotNet JArray;
         JsonObjectDotNet: DotNet JObject;
         LogLimitWarningTxt: Label 'The JSON input length (%1) exceeds the maximum suggested length (%2) for JSON processing.', Locked = true;
 
-
-    internal procedure Initialize()
-    begin
-        if not IsInitialized then begin
-            SourceWarningLength := 10 * 1024 * 1024; // 10 MB
-            IsInitialized := true;
-        end;
-    end;
-
     internal procedure EmitLengthWarning(SourceLength: Integer; tag: Text; FormatString: Text)
     begin
-        if not IsInitialized then
-            this.Initialize();
+        if SourceWarningLength <= 0 then
+            SourceWarningLength := 10485760; // 10 * 1024 * 1024 = 10 MB
 
         if SourceLength > SourceWarningLength then
             Session.LogMessage(tag, StrSubstNo(FormatString, SourceLength, SourceWarningLength), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'resources', 'memory');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Add telemetry to the Base64 converter and Json functions that that emits the source length when then input exceeds a given limit. These functions are often seen in call stacks when the NST gets OutOfMemory exceptions and we need to see how large elements are causing this.
There are no functional changes in this PR.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#612984](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612984)







