### PR TITLE
Remove unused preprocessor symbols from settings

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -17,8 +17,6 @@
       ],
       "settings": {
         "preprocessorSymbols": [
-          "CLEAN23",
-          "CLEAN24",
           "CLEAN25",
           "CLEAN26",
           "CLEAN27",


### PR DESCRIPTION
Removed unused preprocessor symbols CLEAN23 and CLEAN24.

[AB#608795](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/608795)


