### PR TITLE
Use "Billing Period" instead of "Subscription Period" in Invoice

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/CreateBillingDocuments.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/CreateBillingDocuments.Codeunit.al
@@ -930,7 +930,7 @@ codeunit 8060 "Create Billing Documents"
 
     procedure GetBillingPeriodDescriptionTxt() DescriptionText: Text
     begin
-        DescriptionText := ServicePeriodDescriptionTxt;
+        DescriptionText := BillingPeriodDescriptionTxt;
     end;
 
     procedure GetBillingPeriodDescriptionTxt(LanguageCode: Code[10]) DescriptionText: Text
@@ -1220,7 +1220,7 @@ codeunit 8060 "Create Billing Documents"
         ProgressTxt: Label 'Creating documents...\Partner No. #1#################################\Contract No. #2#################################', Comment = '%1=Partner No., %2=Contract No.';
         OnlyOneServicePartnerErr: Label 'You can create documents only for one type of partner at a time (Customer or Vendor). Please check your filters.';
         UpdateRequiredErr: Label 'At least one Subscription Line was changed after billing proposal was created. Please check the lines marked with "Update Required" field and update the billing proposal before the billing documents can be created.';
-        ServicePeriodDescriptionTxt: Label 'Subscription period: %1 to %2', Comment = '%1=Recurring Billing from, %2=Recurring Billing to';
+        BillingPeriodDescriptionTxt: Label 'Billing period: %1 to %2', Comment = '%1=Recurring Billing from, %2=Recurring Billing to';
         NoDocumentsCreatedMsg: Label 'No documents have been created.';
         DocumentsCreatedMsg: Label 'Creation of documents completed.\\%1 document(s) for %2 contract(s) were created.', Comment = '%1=Number of documents, %2=Number of contracts';
         DocumentsCreatedAndPostedMsg: Label 'Creation of documents completed.\\%1 document(s) for %2 contract(s) were created and posted.', Comment = '%1=Number of documents, %2=Number of contracts';

--- a/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingDocsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingDocsTest.Codeunit.al
@@ -236,8 +236,8 @@ codeunit 139687 "Recurring Billing Docs Test"
         SalesLine2.SetRange("Attached to Line No.", SalesLine."Line No.");
         Assert.AreEqual(5, SalesLine2.Count, 'Setup-failure: expected five attached Lines.');
         SalesLine2.FindSet();
-        // 1st line: Service Period
-        Assert.IsSubstring(SalesLine2.Description, 'Subscription period');
+        // 1st line: Billing Period
+        Assert.IsSubstring(SalesLine2.Description, 'Billing period');
         ParentSalesLine.Get(SalesLine2."Document Type", SalesLine2."Document No.", SalesLine2."Attached to Line No.");
         SalesLine2.Next();
         // 2nd line: Subscription Description


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Use text "Billing Period" instead of "Subscription Period" in Invoice Line. Consistent with how the Option in the Contract Setup is called.
<img width="1576" height="572" alt="image" src="https://github.com/user-attachments/assets/9e537b4e-d9cb-44a6-93cc-1dd787275813" />


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #5517

Fixes [AB#612783](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612783)

