### PR TITLE
[Shopify] Sync gross weight instead of net weight on invoice lines

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Invoicing/Codeunits/ShpfyPostedInvoiceExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Invoicing/Codeunits/ShpfyPostedInvoiceExport.Codeunit.al
@@ -319,7 +319,7 @@ codeunit 30362 "Shpfy Posted Invoice Export"
         TempOrderLine."Gift Card" := false;
         TempOrderLine.Taxable := false;
         TempOrderLine."Unit Price" := SalesInvoiceLine."Unit Price";
-        TempOrderLine.Weight := SalesInvoiceLine."Net Weight";
+        TempOrderLine.Weight := SalesInvoiceLine."Gross Weight";
         TempOrderHeader."Discount Amount" += SalesInvoiceLine."Line Discount Amount";
         TempOrderHeader.Modify(false);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Sync gross weight instead of net weight on invoice lines
#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#614154](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/614154)


