### PR TITLE
[27.x][Agent] Allow 'AGENT - ADMIN' to access Agent Cards 

### DIFF
--- a/src/System Application/App/Agent/Permissions/AgentSystemPermissions.Codeunit.al
+++ b/src/System Application/App/Agent/Permissions/AgentSystemPermissions.Codeunit.al
@@ -1,0 +1,45 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Agents;
+
+codeunit 4317 "Agent System Permissions"
+{
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    /// <summary>
+    /// Gets whether the current user has permissions to manage all agents.
+    /// </summary>
+    /// <returns>True if the user has permissions to manage all agents, false otherwise.</returns>
+    [Scope('OnPrem')]
+    procedure CurrentUserHasCanManageAllAgentsPermission(): Boolean
+    begin
+        exit("Agent System Permissions Impl.".CurrentUserHasCanManageAllAgentsPermission());
+    end;
+
+    /// <summary>
+    /// Gets whether the current user has permissions to troubleshoot the execution of agent tasks.
+    /// </summary>
+    /// <returns>True if the user has troubleshoot permissions, false otherwise.</returns>
+    [Scope('OnPrem')]
+    procedure CurrentUserHasTroubleshootAllAgents(): Boolean
+    begin
+        exit("Agent System Permissions Impl.".CurrentUserHasTroubleshootAllAgents());
+    end;
+
+    /// <summary>
+    /// Gets whether the current user has permissions to create custom agents.
+    /// </summary>
+    /// <returns>True if the user has create permissions, false otherwise.</returns>
+    [Scope('OnPrem')]
+    procedure CurrentUserHasCanCreateCustomAgent(): Boolean
+    begin
+        exit("Agent System Permissions Impl.".CurrentUserHasCanCreateCustomAgent());
+    end;
+
+    var
+        "Agent System Permissions Impl.": Codeunit "Agent System Permissions Impl.";
+}

--- a/src/System Application/App/Agent/Permissions/Internal/AgentSystemPermissionsImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Permissions/Internal/AgentSystemPermissionsImpl.Codeunit.al
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Agents;
+
+using System.Security.AccessControl;
+using System.Security.User;
+
+codeunit 4318 "Agent System Permissions Impl."
+{
+    Access = Internal;
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    procedure CurrentUserHasCanManageAllAgentsPermission(): Boolean
+    begin
+        exit(CurrentUserHasExecuteSystemPermission(9665)); // "Configure All Agents"
+    end;
+
+    procedure CurrentUserHasTroubleshootAllAgents(): Boolean
+    begin
+        exit(CurrentUserHasExecuteSystemPermission(9666)); // "Troubleshoot All Agents"
+    end;
+
+    procedure CurrentUserHasCanCreateCustomAgent(): Boolean
+    begin
+        // exit(CurrentUserHasExecuteSystemPermission(9667)); // "Create Custom Agent", not supported yet.
+        exit(false);
+    end;
+
+    local procedure CurrentUserHasExecuteSystemPermission(PermissionId: Integer): Boolean
+    var
+        TempPermission: Record "Expanded Permission" temporary;
+        UserPermissions: Codeunit "User Permissions";
+    begin
+        TempPermission := UserPermissions.GetEffectivePermission(TempPermission."Object Type"::System, PermissionId);
+        exit(TempPermission."Execute Permission" = TempPermission."Execute Permission"::Yes);
+    end;
+}

--- a/src/System Application/App/Agent/Setup/AgentCard.Page.al
+++ b/src/System Application/App/Agent/Setup/AgentCard.Page.al
@@ -193,9 +193,11 @@ page 4315 "Agent Card"
     trigger OnOpenPage()
     var
         AgentUtilities: Codeunit "Agent Utilities";
+        AgentSystemPermissions: Codeunit "Agent System Permissions";
     begin
         AgentUtilities.BlockPageFromBeingOpenedByAgent();
-        if not Rec.WritePermission() then
+
+        if not AgentSystemPermissions.CurrentUserHasCanManageAllAgentsPermission() then
             Error(YouDoNotHavePermissionToModifyThisAgentErr);
     end;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Allow agent admins to access the agent cards without requiring SUPER.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#604144](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/604144)


