### PR TITLE
[releases/27.1] Disable UT_UpdateServiceDatesDoesNotCalculateCancellationPossibleUntilAndTermUntilWhenNoticePeriodIsEmpty

### DIFF
--- a/src/Apps/W1/Subscription Billing/Test/DisabledTests/ServiceObjectTest.json
+++ b/src/Apps/W1/Subscription Billing/Test/DisabledTests/ServiceObjectTest.json
@@ -1,0 +1,8 @@
+[
+    {
+        "bug": "615089",
+        "codeunitId": 148157,
+        "CodeunitName": "Service Object Test",
+        "Method": "UT_UpdateServiceDatesDoesNotCalculateCancellationPossibleUntilAndTermUntilWhenNoticePeriodIsEmpty"
+    }
+]


### PR DESCRIPTION
This pull request backports #5673 to releases/27.1

Fixes [AB#615120](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/615120)


