### PR TITLE
[27.2] Agent Task Message - Allow downloading multiple attachments

### DIFF
--- a/src/System Application/App/Agent/Interaction/Internal/AgentMessageImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentMessageImpl.Codeunit.al
@@ -5,6 +5,9 @@
 
 namespace System.Agents;
 
+using System.IO;
+using System.Utilities;
+
 codeunit 4308 "Agent Message Impl."
 {
     Access = Internal;
@@ -13,6 +16,7 @@ codeunit 4308 "Agent Message Impl."
 
     var
         GlobalIgnoreAttachment: Boolean;
+        AttachmentsFilenameLbl: Label 'attachments_task%1_msg%2.zip', Comment = 'Filename format for downloading multiple attachments as a zip file. %1 = Task ID, %2 = Message ID';
 
     procedure GetText(var AgentTaskMessage: Record "Agent Task Message"): Text
     var
@@ -94,15 +98,47 @@ codeunit 4308 "Agent Message Impl."
     procedure DownloadAttachments(var AgentTaskMessage: Record "Agent Task Message")
     var
         AgentTaskMessageAttachment: Record "Agent Task Message Attachment";
+        AgentTaskFile: Record "Agent Task File";
+        DataCompression: Codeunit "Data Compression";
+        TempBlob: Codeunit "Temp Blob";
+        AgentTaskImpl: Codeunit "Agent Task Impl.";
+        FileInStream: InStream;
+        ZipOutStream: OutStream;
+        ZipInStream: InStream;
+        FileName: Text;
+        AttachmentCount: Integer;
+        DownloadDialogTitleLbl: Label 'Download Email Attachment';
     begin
         AgentTaskMessageAttachment.SetRange("Task ID", AgentTaskMessage."Task ID");
         AgentTaskMessageAttachment.SetRange("Message ID", AgentTaskMessage.ID);
         if not AgentTaskMessageAttachment.FindSet() then
             exit;
 
-        repeat
+        // Count attachments
+        AttachmentCount := AgentTaskMessageAttachment.Count();
+
+        // If single file, download directly
+        if AttachmentCount = 1 then begin
             ShowOrDownloadAttachment(AgentTaskMessageAttachment."Task ID", AgentTaskMessageAttachment."File ID", true);
+            exit;
+        end;
+
+        // If multiple files, create a zip
+        DataCompression.CreateZipArchive();
+        repeat
+            if AgentTaskFile.Get(AgentTaskMessageAttachment."Task ID", AgentTaskMessageAttachment."File ID") then begin
+                AgentTaskFile.CalcFields(Content);
+                AgentTaskFile.Content.CreateInStream(FileInStream, AgentTaskImpl.GetDefaultEncoding());
+                DataCompression.AddEntry(FileInStream, AgentTaskFile."File Name");
+            end;
         until AgentTaskMessageAttachment.Next() = 0;
+
+        TempBlob.CreateOutStream(ZipOutStream);
+        DataCompression.SaveZipArchive(ZipOutStream);
+        DataCompression.CloseZipArchive();
+        TempBlob.CreateInStream(ZipInStream);
+        FileName := StrSubstNo(AttachmentsFilenameLbl, Format(AgentTaskMessage."Task ID"), Format(AgentTaskMessage.ID));
+        File.DownloadFromStream(ZipInStream, DownloadDialogTitleLbl, '', '', FileName);
     end;
 
     procedure ShowOrDownloadAttachment(TaskID: BigInteger; FileID: BigInteger; ForceDownloadAttachment: Boolean)

--- a/src/System Application/App/Agent/app.json
+++ b/src/System Application/App/Agent/app.json
@@ -56,6 +56,18 @@
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
       "version": "27.2.0.0"
+    },
+    {
+      "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
+      "name": "BLOB Storage",
+      "publisher": "Microsoft",
+      "version": "27.2.0.0"
+    },
+    {
+      "id": "008c9419-0c3b-4d08-b03e-84e3adca689f",
+      "name": "Data Compression",
+      "publisher": "Microsoft",
+      "version": "27.2.0.0"
     }
   ],
   "propagateDependencies": true,


### PR DESCRIPTION
#### Summary
When trying to download multiple attachments, only the last one was downloaded. This is a limitation in BC.

Solution:
Make a zip out of them if there's more than one, like the Email module does.

#### Work Item(s)
Fixes [AB#615056](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/615056)




