### PR TITLE
Correct auto format for Calculation Base Amount and related fields

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Contract Renewal/Pages/ContractRenewalSelection.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Contract Renewal/Pages/ContractRenewalSelection.Page.al
@@ -224,6 +224,8 @@ page 8006 "Contract Renewal Selection"
                         StyleExpr = LineFormatStyleExpression;
                         ToolTip = 'Specifies the base amount from which the price will be calculated.';
                         BlankZero = true;
+                        AutoFormatType = 2;
+                        AutoFormatExpression = TempServiceCommitment."Currency Code";
                     }
                     field("Calculation Base %"; TempServiceCommitment."Calculation Base %")
                     {

--- a/src/Apps/W1/Subscription Billing/App/Contract Renewal/Tables/PlannedSubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Contract Renewal/Tables/PlannedSubscriptionLine.Table.al
@@ -73,7 +73,7 @@ table 8002 "Planned Subscription Line"
             Caption = 'Calculation Base Amount';
             MinValue = 0;
             BlankZero = true;
-            AutoFormatType = 1;
+            AutoFormatType = 2;
             AutoFormatExpression = Rec."Currency Code";
 
             trigger OnValidate()

--- a/src/Apps/W1/Subscription Billing/App/ContractAnalysis/SubContrAnalysisEntry.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/ContractAnalysis/SubContrAnalysisEntry.Table.al
@@ -56,7 +56,7 @@ table 8019 "Sub. Contr. Analysis Entry"
             Caption = 'Calculation Base Amount';
             MinValue = 0;
             BlankZero = true;
-            AutoFormatType = 1;
+            AutoFormatType = 2;
             AutoFormatExpression = Rec."Currency Code";
         }
         field(10; "Calculation Base %"; Decimal)
@@ -198,7 +198,7 @@ table 8019 "Sub. Contr. Analysis Entry"
             Caption = 'Calculation Base Amount (LCY)';
             Editable = false;
             BlankZero = true;
-            AutoFormatType = 1;
+            AutoFormatType = 2;
             AutoFormatExpression = '';
         }
         field(38; Discount; Boolean)

--- a/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/ClosedCustContLineSubp.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/ClosedCustContLineSubp.Page.al
@@ -119,6 +119,8 @@ page 8080 "Closed Cust. Cont. Line Subp."
                     ToolTip = 'Specifies the base amount from which the price will be calculated.';
                     BlankZero = true;
                     Editable = false;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Calculation Base %"; ServiceCommitment."Calculation Base %")
                 {
@@ -127,6 +129,8 @@ page 8080 "Closed Cust. Cont. Line Subp."
                     ToolTip = 'Specifies the percent at which the price of the Subscription Line will be calculated. 100% means that the price corresponds to the Base Price.';
                     BlankZero = true;
                     Editable = false;
+                    DecimalPlaces = 0 : 5;
+                    AutoFormatType = 0;
                 }
                 field(Price; ServiceCommitment.Price)
                 {
@@ -134,6 +138,8 @@ page 8080 "Closed Cust. Cont. Line Subp."
                     ToolTip = 'Specifies the price of the Subscription Line with quantity of 1 in the billing period. The price is calculated from Base Price and Base Price %.';
                     Editable = false;
                     BlankZero = true;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Price (LCY)"; ServiceCommitment."Price (LCY)")
                 {
@@ -142,6 +148,8 @@ page 8080 "Closed Cust. Cont. Line Subp."
                     Visible = false;
                     BlankZero = true;
                     Editable = false;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = '';
                 }
                 field("Discount %"; ServiceCommitment."Discount %")
                 {
@@ -151,6 +159,8 @@ page 8080 "Closed Cust. Cont. Line Subp."
                     MinValue = 0;
                     MaxValue = 100;
                     Editable = false;
+                    DecimalPlaces = 0 : 5;
+                    AutoFormatType = 0;
                 }
                 field("Discount Amount"; ServiceCommitment."Discount Amount")
                 {
@@ -159,6 +169,8 @@ page 8080 "Closed Cust. Cont. Line Subp."
                     BlankZero = true;
                     MinValue = 0;
                     Editable = false;
+                    AutoFormatType = 1;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Discount Amount (LCY)"; ServiceCommitment."Discount Amount (LCY)")
                 {
@@ -174,6 +186,8 @@ page 8080 "Closed Cust. Cont. Line Subp."
                     ToolTip = 'Specifies the amount for the Subscription Line including discount.';
                     BlankZero = true;
                     Editable = false;
+                    AutoFormatType = 1;
+                    AutoFormatExpression = '';
                 }
                 field("Service Amount (LCY)"; ServiceCommitment."Amount (LCY)")
                 {
@@ -182,6 +196,8 @@ page 8080 "Closed Cust. Cont. Line Subp."
                     Visible = false;
                     BlankZero = true;
                     Editable = false;
+                    AutoFormatType = 1;
+                    AutoFormatExpression = '';
                 }
                 field("Billing Base Period"; ServiceCommitment."Billing Base Period")
                 {
@@ -272,6 +288,8 @@ page 8080 "Closed Cust. Cont. Line Subp."
                     Visible = false;
                     BlankZero = true;
                     Editable = false;
+                    DecimalPlaces = 0 : 15;
+                    AutoFormatType = 0;
                 }
                 field("Currency Factor Date"; ServiceCommitment."Currency Factor Date")
                 {

--- a/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/CustomerContractLineSubp.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/CustomerContractLineSubp.Page.al
@@ -159,6 +159,8 @@ page 8068 "Customer Contract Line Subp."
                     BlankZero = true;
                     Editable = not IsCommentLineEditable;
                     Enabled = not IsCommentLineEditable;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
 
                     trigger OnValidate()
                     begin
@@ -173,6 +175,8 @@ page 8068 "Customer Contract Line Subp."
                     BlankZero = true;
                     Editable = not IsCommentLineEditable;
                     Enabled = not IsCommentLineEditable;
+                    DecimalPlaces = 0 : 5;
+                    AutoFormatType = 0;
 
                     trigger OnValidate()
                     begin
@@ -182,6 +186,9 @@ page 8068 "Customer Contract Line Subp."
                 field("Unit Cost (LCY)"; ServiceCommitment."Unit Cost (LCY)")
                 {
                     ToolTip = 'Specifies the unit cost of the item.';
+                    AutoFormatType = 2;
+                    AutoFormatExpression = '';
+
                     trigger OnValidate()
                     begin
                         UpdateServiceCommitmentOnPage(ServiceCommitment.FieldNo("Unit Cost (LCY)"));
@@ -193,6 +200,8 @@ page 8068 "Customer Contract Line Subp."
                     ToolTip = 'Specifies the price of the Subscription Line with quantity of 1 in the billing period. The price is calculated from Base Price and Base Price %.';
                     Editable = false;
                     BlankZero = true;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Price (LCY)"; ServiceCommitment."Price (LCY)")
                 {
@@ -202,6 +211,8 @@ page 8068 "Customer Contract Line Subp."
                     BlankZero = true;
                     Editable = not IsCommentLineEditable;
                     Enabled = not IsCommentLineEditable;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = '';
 
                     trigger OnValidate()
                     begin
@@ -217,6 +228,8 @@ page 8068 "Customer Contract Line Subp."
                     MaxValue = 100;
                     Editable = (not IsCommentLineEditable) and (not IsDiscountLine);
                     Enabled = (not IsCommentLineEditable) and (not IsDiscountLine);
+                    DecimalPlaces = 0 : 5;
+                    AutoFormatType = 0;
 
                     trigger OnValidate()
                     begin
@@ -231,6 +244,8 @@ page 8068 "Customer Contract Line Subp."
                     MinValue = 0;
                     Editable = (not IsCommentLineEditable) and (not IsDiscountLine);
                     Enabled = (not IsCommentLineEditable) and (not IsDiscountLine);
+                    AutoFormatType = 1;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
 
                     trigger OnValidate()
                     begin
@@ -245,6 +260,9 @@ page 8068 "Customer Contract Line Subp."
                     BlankZero = true;
                     Editable = (not IsCommentLineEditable) and (not IsDiscountLine);
                     Enabled = (not IsCommentLineEditable) and (not IsDiscountLine);
+                    AutoFormatType = 1;
+                    AutoFormatExpression = '';
+
                     trigger OnValidate()
                     begin
                         UpdateServiceCommitmentOnPage(ServiceCommitment.FieldNo("Discount Amount (LCY)"));
@@ -257,6 +275,8 @@ page 8068 "Customer Contract Line Subp."
                     BlankZero = true;
                     Editable = not IsCommentLineEditable;
                     Enabled = not IsCommentLineEditable;
+                    AutoFormatType = 1;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
 
                     trigger OnValidate()
                     begin
@@ -271,6 +291,8 @@ page 8068 "Customer Contract Line Subp."
                     BlankZero = true;
                     Editable = not IsCommentLineEditable;
                     Enabled = not IsCommentLineEditable;
+                    AutoFormatType = 1;
+                    AutoFormatExpression = '';
 
                     trigger OnValidate()
                     begin
@@ -445,6 +467,8 @@ page 8068 "Customer Contract Line Subp."
                     BlankZero = true;
                     Editable = not IsCommentLineEditable;
                     Enabled = not IsCommentLineEditable;
+                    DecimalPlaces = 0 : 15;
+                    AutoFormatType = 0;
 
                     trigger OnValidate()
                     begin

--- a/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/CustomerContractLines.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/CustomerContractLines.Page.al
@@ -105,6 +105,8 @@ page 8075 "Customer Contract Lines"
                     ToolTip = 'Specifies the price of the Subscription Line with quantity of 1 in the billing period. The price is calculated from Base Price and Base Price %.';
                     Editable = false;
                     BlankZero = true;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Discount %"; ServiceCommitment."Discount %")
                 {
@@ -121,12 +123,16 @@ page 8075 "Customer Contract Lines"
                     ToolTip = 'Specifies the amount of the discount for the Subscription Line.';
                     BlankZero = true;
                     MinValue = 0;
+                    AutoFormatType = 1;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Service Amount"; ServiceCommitment.Amount)
                 {
                     Caption = 'Amount';
                     ToolTip = 'Specifies the amount for the Subscription Line including discount.';
                     BlankZero = true;
+                    AutoFormatType = 1;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Next Billing Date"; ServiceCommitment."Next Billing Date")
                 {
@@ -141,6 +147,8 @@ page 8075 "Customer Contract Lines"
                     Caption = 'Calculation Base Amount';
                     ToolTip = 'Specifies the base amount from which the price will be calculated.';
                     BlankZero = true;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Calculation Base %"; ServiceCommitment."Calculation Base %")
                 {
@@ -148,6 +156,8 @@ page 8075 "Customer Contract Lines"
                     Caption = 'Calculation Base %';
                     ToolTip = 'Specifies the percent at which the price of the Subscription Line will be calculated. 100% means that the price corresponds to the Base Price.';
                     BlankZero = true;
+                    DecimalPlaces = 0 : 5;
+                    AutoFormatType = 0;
                 }
                 field("Billing Base Period"; ServiceCommitment."Billing Base Period")
                 {

--- a/src/Apps/W1/Subscription Billing/App/Import/Tables/ImportedSubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Import/Tables/ImportedSubscriptionLine.Table.al
@@ -82,7 +82,7 @@ table 8009 "Imported Subscription Line"
             Caption = 'Calculation Base Amount';
             MinValue = 0;
             BlankZero = true;
-            AutoFormatType = 1;
+            AutoFormatType = 2;
             AutoFormatExpression = Rec."Currency Code";
         }
         field(16; "Calculation Base %"; Decimal)

--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubLineArchive.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubLineArchive.Table.al
@@ -70,7 +70,7 @@ table 8069 "Sales Sub. Line Archive"
             Caption = 'Calculation Base Amount';
             MinValue = 0;
             BlankZero = true;
-            AutoFormatType = 1;
+            AutoFormatType = 2;
             AutoFormatExpression = Rec."Currency Code";
         }
         field(16; "Calculation Base %"; Decimal)
@@ -95,7 +95,7 @@ table 8069 "Sales Sub. Line Archive"
             MinValue = 0;
             MaxValue = 100;
             BlankZero = true;
-            DecimalPlaces = 0 : 2;
+            DecimalPlaces = 0 : 5;
             AutoFormatType = 0;
         }
         field(19; "Discount Amount"; Decimal)

--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
@@ -82,7 +82,7 @@ table 8068 "Sales Subscription Line"
             Caption = 'Calculation Base Amount';
             MinValue = 0;
             BlankZero = true;
-            AutoFormatType = 1;
+            AutoFormatType = 2;
             AutoFormatExpression = Rec."Currency Code";
 
             trigger OnValidate()

--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
@@ -83,7 +83,7 @@ table 8059 "Subscription Line"
             Caption = 'Calculation Base Amount';
             MinValue = 0;
             BlankZero = true;
-            AutoFormatType = 1;
+            AutoFormatType = 2;
             AutoFormatExpression = Rec."Currency Code";
 
             trigger OnValidate()

--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLineArchive.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLineArchive.Table.al
@@ -65,7 +65,7 @@ table 8073 "Subscription Line Archive"
             Caption = 'Calculation Base Amount';
             MinValue = 0;
             BlankZero = true;
-            AutoFormatType = 1;
+            AutoFormatType = 2;
             AutoFormatExpression = Rec."Currency Code";
         }
         field(12; "Calculation Base %"; Decimal)

--- a/src/Apps/W1/Subscription Billing/App/Vendor Contracts/Pages/ClosedVendContLineSubp.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Vendor Contracts/Pages/ClosedVendContLineSubp.Page.al
@@ -94,6 +94,8 @@ page 8089 "Closed Vend. Cont. Line Subp."
                 {
                     Editable = false;
                     ToolTip = 'Specifies the number of units of Subscription.';
+                    AutoFormatType = 0;
+                    DecimalPlaces = 0 : 5;
 
                     trigger OnDrillDown()
                     begin
@@ -107,6 +109,8 @@ page 8089 "Closed Vend. Cont. Line Subp."
                     ToolTip = 'Specifies the base amount from which the price will be calculated.';
                     BlankZero = true;
                     Editable = false;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Calculation Base %"; ServiceCommitment."Calculation Base %")
                 {
@@ -122,6 +126,8 @@ page 8089 "Closed Vend. Cont. Line Subp."
                     ToolTip = 'Specifies the price of the Subscription Line with quantity of 1 in the billing period. The price is calculated from Base Price and Base Price %.';
                     Editable = false;
                     BlankZero = true;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Price (LCY)"; ServiceCommitment."Price (LCY)")
                 {
@@ -130,6 +136,8 @@ page 8089 "Closed Vend. Cont. Line Subp."
                     Visible = false;
                     BlankZero = true;
                     Editable = false;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Discount %"; ServiceCommitment."Discount %")
                 {
@@ -139,6 +147,8 @@ page 8089 "Closed Vend. Cont. Line Subp."
                     MinValue = 0;
                     MaxValue = 100;
                     Editable = false;
+                    AutoFormatType = 1;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Discount Amount"; ServiceCommitment."Discount Amount")
                 {
@@ -147,6 +157,8 @@ page 8089 "Closed Vend. Cont. Line Subp."
                     BlankZero = true;
                     MinValue = 0;
                     Editable = false;
+                    AutoFormatType = 1;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Discount Amount (LCY)"; ServiceCommitment."Discount Amount (LCY)")
                 {
@@ -155,6 +167,8 @@ page 8089 "Closed Vend. Cont. Line Subp."
                     Visible = false;
                     BlankZero = true;
                     Editable = false;
+                    AutoFormatType = 1;
+                    AutoFormatExpression = '';
                 }
                 field("Service Amount"; ServiceCommitment.Amount)
                 {
@@ -162,6 +176,8 @@ page 8089 "Closed Vend. Cont. Line Subp."
                     ToolTip = 'Specifies the amount for the Subscription Line including discount.';
                     BlankZero = true;
                     Editable = false;
+                    AutoFormatType = 1;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Service Amount (LCY)"; ServiceCommitment."Amount (LCY)")
                 {
@@ -170,6 +186,8 @@ page 8089 "Closed Vend. Cont. Line Subp."
                     Visible = false;
                     BlankZero = true;
                     Editable = false;
+                    AutoFormatType = 1;
+                    AutoFormatExpression = '';
                 }
                 field("Billing Base Period"; ServiceCommitment."Billing Base Period")
                 {
@@ -260,6 +278,8 @@ page 8089 "Closed Vend. Cont. Line Subp."
                     Visible = false;
                     BlankZero = true;
                     Editable = false;
+                    DecimalPlaces = 0 : 15;
+                    AutoFormatType = 0;
                 }
                 field("Currency Factor Date"; ServiceCommitment."Currency Factor Date")
                 {

--- a/src/Apps/W1/Subscription Billing/App/Vendor Contracts/Pages/VendorContractLineSubpage.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Vendor Contracts/Pages/VendorContractLineSubpage.Page.al
@@ -122,6 +122,8 @@ page 8078 "Vendor Contract Line Subpage"
                 {
                     Caption = 'Quantity';
                     ToolTip = 'Specifies the number of units of Subscription.';
+                    AutoFormatType = 0;
+                    DecimalPlaces = 0 : 5;
 
                     trigger OnValidate()
                     begin
@@ -136,6 +138,8 @@ page 8078 "Vendor Contract Line Subpage"
                     BlankZero = true;
                     Editable = not IsCommentLineEditable;
                     Enabled = not IsCommentLineEditable;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
 
                     trigger OnValidate()
                     begin
@@ -150,6 +154,8 @@ page 8078 "Vendor Contract Line Subpage"
                     BlankZero = true;
                     Editable = not IsCommentLineEditable;
                     Enabled = not IsCommentLineEditable;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
 
                     trigger OnValidate()
                     begin
@@ -162,6 +168,8 @@ page 8078 "Vendor Contract Line Subpage"
                     ToolTip = 'Specifies the price of the Subscription Line with quantity of 1 in the billing period. The price is calculated from Base Price and Base Price %.';
                     Editable = false;
                     BlankZero = true;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
                 }
                 field("Price (LCY)"; ServiceCommitment."Price (LCY)")
                 {
@@ -171,6 +179,8 @@ page 8078 "Vendor Contract Line Subpage"
                     BlankZero = true;
                     Editable = not IsCommentLineEditable;
                     Enabled = not IsCommentLineEditable;
+                    AutoFormatType = 2;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
 
                     trigger OnValidate()
                     begin
@@ -186,6 +196,8 @@ page 8078 "Vendor Contract Line Subpage"
                     MaxValue = 100;
                     Editable = (not IsCommentLineEditable) and (not IsDiscountLine);
                     Enabled = (not IsCommentLineEditable) and (not IsDiscountLine);
+                    DecimalPlaces = 0 : 5;
+                    AutoFormatType = 0;
 
                     trigger OnValidate()
                     begin
@@ -200,6 +212,8 @@ page 8078 "Vendor Contract Line Subpage"
                     MinValue = 0;
                     Editable = (not IsCommentLineEditable) and (not IsDiscountLine);
                     Enabled = (not IsCommentLineEditable) and (not IsDiscountLine);
+                    AutoFormatType = 1;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
 
                     trigger OnValidate()
                     begin
@@ -214,6 +228,9 @@ page 8078 "Vendor Contract Line Subpage"
                     BlankZero = true;
                     Editable = (not IsCommentLineEditable) and (not IsDiscountLine);
                     Enabled = (not IsCommentLineEditable) and (not IsDiscountLine);
+                    AutoFormatType = 1;
+                    AutoFormatExpression = '';
+
                     trigger OnValidate()
                     begin
                         UpdateServiceCommitmentOnPage(ServiceCommitment.FieldNo("Discount Amount (LCY)"));
@@ -226,6 +243,8 @@ page 8078 "Vendor Contract Line Subpage"
                     BlankZero = true;
                     Editable = not IsCommentLineEditable;
                     Enabled = not IsCommentLineEditable;
+                    AutoFormatType = 1;
+                    AutoFormatExpression = ServiceCommitment."Currency Code";
 
                     trigger OnValidate()
                     begin
@@ -240,6 +259,8 @@ page 8078 "Vendor Contract Line Subpage"
                     BlankZero = true;
                     Editable = not IsCommentLineEditable;
                     Enabled = not IsCommentLineEditable;
+                    AutoFormatType = 1;
+                    AutoFormatExpression = '';
 
                     trigger OnValidate()
                     begin
@@ -414,6 +435,8 @@ page 8078 "Vendor Contract Line Subpage"
                     BlankZero = true;
                     Editable = not IsCommentLineEditable;
                     Enabled = not IsCommentLineEditable;
+                    DecimalPlaces = 0 : 15;
+                    AutoFormatType = 0;
 
                     trigger OnValidate()
                     begin


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This commit fixes formatting for amounts and percentages in the Subscription Billing app. It standardizes currency handling by adjusting `AutoFormatType` and `AutoFormatExpression` to properly reflect the correct currency, and increases precision for percentage fields. Overall, it improves consistency and clarity in how values are displayed across subscription tables and pages.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #5719

Fixes [AB#615410](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/615410)

