### PR TITLE
[27.2] Agent Task SDK - Bugfixes

### DIFF
--- a/src/System Application/App/Agent/Interaction/AgentTask.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/AgentTask.Codeunit.al
@@ -39,7 +39,9 @@ codeunit 4303 "Agent Task"
         AgentTask: Record "Agent Task";
     begin
         FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
-        AgentTask.Get(AgentUserSecurityId, ExternalId);
+        AgentTask.SetRange("Agent User Security ID", AgentUserSecurityId);
+        AgentTask.SetRange("External ID", ExternalId);
+        AgentTask.FindFirst();
         exit(AgentTask);
     end;
 

--- a/src/System Application/App/Agent/Interaction/AgentTaskMessageBuilder.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/AgentTaskMessageBuilder.Codeunit.al
@@ -242,11 +242,13 @@ codeunit 4316 "Agent Task Message Builder"
     /// Get the last attachment that was added to the task message.
     /// </summary>
     /// <returns>
-    /// The last attachment that was added to the task message.
+    /// True if any attachments exist for the task message, false otherwise.
     /// </returns>
-    procedure GetAttachments(var TempAttachments: Record "Agent Task File" temporary)
+#pragma warning disable AS0102
+    procedure GetAttachments(var TempAttachments: Record "Agent Task File" temporary): Boolean
     begin
         FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
-        AgentTaskMsgBuilderImpl.GetAttachments(TempAttachments);
+        exit(AgentTaskMsgBuilderImpl.GetAttachments(TempAttachments));
     end;
+#pragma warning restore AS0102
 }

--- a/src/System Application/App/Agent/Interaction/Internal/AgentMessageImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentMessageImpl.Codeunit.al
@@ -46,7 +46,7 @@ codeunit 4308 "Agent Message Impl."
         if AgentTaskMessage.Type <> AgentTaskMessage.Type::Output then
             exit(false);
 
-        exit(AgentTaskMessage.Status = AgentTaskMessage.Status::Draft);
+        exit((AgentTaskMessage.Status = AgentTaskMessage.Status::Draft) or (AgentTaskMessage.Status = AgentTaskMessage.Status::" "));
     end;
 
     procedure SetStatusToSent(var AgentTaskMessage: Record "Agent Task Message")
@@ -168,7 +168,7 @@ codeunit 4308 "Agent Message Impl."
         File.DownloadFromStream(InStream, DownloadDialogTitleLbl, '', '', FileName);
     end;
 
-    procedure GetAttachments(TaskID: BigInteger; MessageID: Guid; TempAgentTaskFile: Record "Agent Task File" temporary)
+    procedure GetAttachments(TaskID: BigInteger; MessageID: Guid; var TempAgentTaskFile: Record "Agent Task File" temporary)
     var
         AgentTaskMessageAttachment: Record "Agent Task Message Attachment";
         AgentTaskFile: Record "Agent Task File";

--- a/src/System Application/App/Agent/Interaction/Internal/AgentTaskMsgBuilderImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentTaskMsgBuilderImpl.Codeunit.al
@@ -184,13 +184,17 @@ codeunit 4311 "Agent Task Msg. Builder Impl."
     end;
 
     [Scope('OnPrem')]
-    procedure GetAttachments(var TempAttachments: record "Agent Task File" temporary)
+    procedure GetAttachments(var TempAttachments: record "Agent Task File" temporary): Boolean
     begin
-        TempAgentTaskFileToAttach.FindSet();
+        if not TempAgentTaskFileToAttach.FindSet() then
+            exit(false);
+
         repeat
             TempAgentTaskFileToAttach.Copy(TempAttachments);
             TempAttachments.Insert();
         until TempAgentTaskFileToAttach.Next() = 0;
+
+        exit(true);
     end;
 
     local procedure VerifyMandatoryFieldsSet()


### PR DESCRIPTION
#### Summary 
This PR fixes various issues in the SDK discovered after a new testing suite was implemented.

AgentTaskMessageBuilder.GetAttachments(TempAgentTaskFile); should not throw on empty
GetTaskByExternalId <- bug in get and should return Boolean
IsEditable - Should return true for type = None


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#615537](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/615537)









