### PR TITLE
Subscriptions are not printed in the Sales Order confirmation

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Report Extensions/ContractSalesOrderConf.ReportExt.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Report Extensions/ContractSalesOrderConf.ReportExt.al
@@ -24,7 +24,7 @@ reportextension 8010 "Contract Sales Order Conf." extends "Standard Sales - Orde
                 SalesReportPrintoutMgmt.ExcludeItemFromTotals(Line, TotalSubTotal, TotalInvDiscAmount, TotalAmount, TotalAmountVAT, TotalAmountInclVAT);
             end;
         }
-        addlast(AssemblyLine)
+        addlast(Line)
         {
             dataitem(ServiceCommitmentHeaderForSalesLine; "Integer")
             {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This commit restores printing of subscription details on the Sales Order Confirmation (1305) in BC27 for both RDLC and Word “Subscription Billing” layouts, so that subscription lines appear under the sales lines again, matching the behavior in BC26 and in the Sales Quote report.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #5722
[AB#615577](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/615577)



