### PR TITLE
Enable and correct failing test for Subscription Billing

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
@@ -804,21 +804,22 @@ table 8059 "Subscription Line"
     end;
 
     internal procedure UpdateTermUntilUsingExtensionTerm(): Boolean
+    var
+        PreviousTermUntil: Date;
     begin
-        if (IsExtensionTermEmpty() or
-            (("Term Until" = 0D) and ("Subscription Line Start Date" = 0D))) then
+        if IsExtensionTermEmpty() or
+            (("Term Until" = 0D) and ("Subscription Line Start Date" = 0D))
+        then
             exit(false);
-        if "Term Until" <> 0D then begin
-            if DateTimeManagement.IsLastDayOfMonth("Term until") then begin
-                "Term Until" := CalcDate("Extension Term", "Term Until");
-                DateTimeManagement.MoveDateToLastDayOfMonth("Term until");
-            end else
-                "Term Until" := CalcDate("Extension Term", "Term Until");
-        end else begin
-            "Term Until" := CalcDate("Extension Term", "Subscription Line Start Date");
-            if DateTimeManagement.IsLastDayOfMonth("Subscription Line Start Date") then
-                DateTimeManagement.MoveDateToLastDayOfMonth("Term until");
+        if "Term Until" <> 0D then
+            PreviousTermUntil := "Term Until"
+        else begin
+            PreviousTermUntil := "Subscription Line Start Date";
+            PreviousTermUntil := CalcDate('<-1D>', PreviousTermUntil);
         end;
+        "Term Until" := CalcDate("Extension Term", PreviousTermUntil);
+        if DateTimeManagement.IsLastDayOfMonth(PreviousTermUntil) then
+            DateTimeManagement.MoveDateToLastDayOfMonth("Term until");
         exit(true);
     end;
 

--- a/src/Apps/W1/Subscription Billing/Test/DisabledTests/ServiceObjectTest.json
+++ b/src/Apps/W1/Subscription Billing/Test/DisabledTests/ServiceObjectTest.json
@@ -1,8 +1,0 @@
-[
-    {
-        "bug": "615089",
-        "codeunitId": 148157,
-        "CodeunitName": "Service Object Test",
-        "Method": "UT_UpdateServiceDatesDoesNotCalculateCancellationPossibleUntilAndTermUntilWhenNoticePeriodIsEmpty"
-    }
-]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This commit fixes subscription billing date logic and reÔÇæenables a test.  

- **Logic update:** `"Term Until"` now aligns correctly with monthÔÇæend and notice periods.  
- **Testing:** A previously failing test was corrected and reÔÇæenabled.  
- **Cleanup:** Removed obsolete test configuration file.  

­ƒæë Overall: improves reliability of subscription term calculations and restores automated test coverage.


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #5731


Fixes [AB#615855](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/615855)

