### PR TITLE
Defensive UserChecklistStatus insert for Agent users #5479 - Cherry-picked from Pull Request: 5479

### DIFF
--- a/src/System Application/App/Guided Experience/src/Checklist/ChecklistImplementation.Codeunit.al
+++ b/src/System Application/App/Guided Experience/src/Checklist/ChecklistImplementation.Codeunit.al
@@ -516,7 +516,7 @@ codeunit 1993 "Checklist Implementation"
         UserChecklistStatus."Checklist Status" := ChecklistStatus;
         UserChecklistStatus."Is Visible" := IsVisible;
         UserChecklistStatus."Role ID" := RoleID;
-        UserChecklistStatus.Insert();
+        if UserChecklistStatus.Insert() then;
     end;
 
     procedure IsChecklistVisible(): Boolean


### PR DESCRIPTION
Summary
The agent users have the same login logic as normal users. Best fix would be to skip inserting for Agent users, but that might be risky.

A safer fix is to be defensive on the insert, safely stop if it fails.

Work Item(s)
Fixes [AB#604282](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/604282)

