### PR TITLE
[releases/27.x] [Shopify] Catalog products pagination is missing priceList node

### DIFF
--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLNextCatalogProducts.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLNextCatalogProducts.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 30310 "Shpfy GQL NextCatalogProducts" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Text.</returns>
     internal procedure GetGraphQL(): Text
     begin
-        exit('{"query":"{catalog(id: \"gid://shopify/Catalog/{{CatalogId}}\"){ id publication { id products(first: 250, after:\"{{After}}\") { edges { cursor node { id }} pageInfo { hasNextPage }}}}}"}');
+        exit('{"query":"{catalog(id: \"gid://shopify/Catalog/{{CatalogId}}\"){ id priceList { currency } publication { id products(first: 250, after:\"{{After}}\") { edges { cursor node { id }} pageInfo { hasNextPage }}}}}"}');
     end;
 
     /// <summary>


### PR DESCRIPTION
This pull request backports #5777 to releases/27.x

Fixes [AB#615940](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/615940)


