### PR TITLE
OpenPasswordChangeDialog allow change password without entering old password

### DIFF
--- a/src/System Application/App/Password/src/PasswordDialog.Page.al
+++ b/src/System Application/App/Password/src/PasswordDialog.Page.al
@@ -79,6 +79,7 @@ page 9810 "Password Dialog"
     trigger OnQueryClosePage(CloseAction: Action): Boolean
     begin
         if CloseAction = Action::OK then begin
+            PasswordDialogImpl.ValidateOldPasswordMatch(CurrentPasswordToCompare, OldPasswordValue);
             ValidPassword := PasswordDialogImpl.ValidatePassword(
                 RequiresPasswordConfirmation,
                 RequiresPasswordValidation,

--- a/src/System Application/Test/Password/src/PasswordDialogTest.Codeunit.al
+++ b/src/System Application/Test/Password/src/PasswordDialogTest.Codeunit.al
@@ -268,6 +268,27 @@ codeunit 135033 "Password Dialog Test"
         Assert.AreEqual(AnotherValidPasswordTxt, GetPasswordValue(Password), 'A diferrent password was expected.')
     end;
 
+    [Test]
+    [HandlerFunctions('ChangePasswordDialogWithCurrentPasswordEmptyModalPageHandler')]
+    procedure OpenPasswordChangeDialogWithCurrentPasswordEmptyTest();
+    var
+        Password: SecretText;
+        CurrentPassword: SecretText;
+    begin
+        // [SCENARIO] Open Password dialog in change password mode.
+        // The old password has been passed on. However, we do not enter OldPassword 
+        // and expect an error stating that the old password does not match the entered (empty) password.
+        PermissionsMock.Set('All Objects');
+
+        // [GIVEN] The old password is for comparison that the old password matches the entered user and 
+        // the new password does not match the old password.
+        CurrentPassword := SecretStrSubstNo(ValidPasswordTxt);
+
+        // [WHEN] The password dialog is opened in change password mode.
+        // [THEN] An error is expected, as we will not fill in OldPassword.
+        PasswordDialogManagement.OpenPasswordChangeDialog(CurrentPassword, Password);
+    end;
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Password Dialog Management", 'OnSetMinPasswordLength', '', true, true)]
     local procedure OnSetMinimumPAsswordLength(var MinPasswordLength: Integer);
     begin
@@ -311,6 +332,19 @@ codeunit 135033 "Password Dialog Test"
         PasswordDialog.Password.SetValue(AnotherValidPasswordTxt);
         PasswordDialog.ConfirmPassword.SetValue(AnotherValidPasswordTxt);
         PasswordDialog.OK().Invoke();
+    end;
+
+    [ModalPageHandler]
+    procedure ChangePasswordDialogWithCurrentPasswordEmptyModalPageHandler(var PasswordDialog: TestPage "Password Dialog");
+    begin
+        Assert.IsTrue(PasswordDialog.OldPassword.Visible(), 'Old Password Field should be visible.');
+        Assert.IsTrue(PasswordDialog.ConfirmPassword.Visible(), 'Confirm Password Field should be visible.');
+        PasswordDialog.Password.SetValue(AnotherValidPasswordTxt);
+        PasswordDialog.ConfirmPassword.SetValue(AnotherValidPasswordTxt);
+
+        //As we forgot to enter previous password, we expect an error
+        asserterror PasswordDialog.OK().Invoke();
+        Assert.ExpectedError(CurrentPasswordMismatchErr);
     end;
 
     [ConfirmHandler]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

Handle scenario when OpenPasswordChangeDialog is called, but OldPassword is not entered, so we expect an error about password mismatch.
Add test for that scenario as well.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #5587


Fixes [AB#616472](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/616472)

