### PR TITLE
Issue 5503 - Added action to copy grades to existing templates

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/Grade/QltyGradeConditionMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Grade/QltyGradeConditionMgmt.Codeunit.al
@@ -245,6 +245,28 @@ codeunit 20409 "Qlty. Grade Condition Mgmt."
     end;
 
     /// <summary>
+    /// This will copy any grade configurations configured to automatically copy to all existing templates.
+    /// This leverages how CopyGradeConditionsFromFieldToTemplateLine will already update fields via CopyGradeConditionsFromDefaultToField 
+    /// when a specific grade is supplied.
+    /// </summary>
+    procedure CopyGradeConditionsFromDefaultToAllTemplates()
+    var
+        QltInspectionGrade: Record "Qlty. Inspection Grade";
+        QltyInspectionTemplateLine: Record "Qlty. Inspection Template Line";
+    begin
+        QltInspectionGrade.SetRange("Copy Behavior", QltInspectionGrade."Copy Behavior"::"Automatically copy the grade");
+        if QltInspectionGrade.FindSet() then
+            repeat
+                if QltyInspectionTemplateLine.FindSet(false) then
+                    repeat
+                        // We're using 'false' here because we do not want to replace the conditions, only add new ones.
+                        // We do not want to remove grades that were previously added to templates.
+                        CopyGradeConditionsFromFieldToTemplateLine(QltyInspectionTemplateLine."Template Code", QltyInspectionTemplateLine."Line No.", QltInspectionGrade.Code, false);
+                    until (QltyInspectionTemplateLine.Next() = 0);
+            until (QltInspectionGrade.Next() = 0);
+    end;
+
+    /// <summary>
     /// Copies the default grade conditions into the specified field.
     /// </summary>
     /// <param name="FieldCode"></param>

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Grade/QltyInspectionGradeList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Grade/QltyInspectionGradeList.Page.al
@@ -162,6 +162,26 @@ page 20416 "Qlty. Inspection Grade List"
         }
     }
 
+    actions
+    {
+        area(Processing)
+        {
+            action(CopyGradesToAllTemplates)
+            {
+                ApplicationArea = QualityManagement;
+                Caption = 'Copy Grades to Existing Templates';
+                ToolTip = 'Use this to add newly created grades configured to Automatically Copy on to existing fields and existing templates.';
+                Image = Copy;
+                trigger OnAction()
+                var
+                    QltyGradeConditionMgmt: Codeunit "Qlty. Grade Condition Mgmt.";
+                begin
+                    QltyGradeConditionMgmt.CopyGradeConditionsFromDefaultToAllTemplates();
+                end;
+            }
+        }
+    }
+
     var
         MustChangePriorityErr: Label 'Evaluation Sequence must be unique, you cannot have two grades with the same evaluation sequence. Grade [%1/%2] already has the same evaluation sequence.', Comment = '%1=The grade code, %2=the grade condition';
 


### PR DESCRIPTION
Clean rebase wasn't successful because of the object renames and file deletions.
This commit is redone in PR 
https://github.com/microsoft/BCApps/pull/6088

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Adds an action on the grade list to help the scenario of adding additional grades. This scenario is not a primary use case as grades are typically configured at the start of the project and tend to remain unchanged.
<img width="1125" height="315" alt="image" src="https://github.com/user-attachments/assets/81ec290e-4834-40de-a310-14512a0f2815" />


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #5503 by implementing an action on the grade list.


