### PR TITLE
FixReplaceInvalidFilterCharIncludesEqual

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Base/Codeunits/TextManagement.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Base/Codeunits/TextManagement.Codeunit.al
@@ -26,8 +26,7 @@ codeunit 8021 "Text Management"
 
     procedure ReplaceInvalidFilterChar(var BaseText: Text)
     begin
-        BaseText := ConvertStr(BaseText, '()', '??');
-        BaseText := ConvertStr(BaseText, '<>', '??');
+        BaseText := ConvertStr(BaseText, '()<>=', '?????');
     end;
 
     procedure ShowFieldText(var RRef: RecordRef; FieldNo: Integer)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This commit updates ReplaceInvalidFilterChar() in codeunit 8021 Text Management to also sanitize the = character, preventing invalid SETFILTER errors when Subscription Package Code contains = (e.g., INVALID=) during subscription creation.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #5813


Fixes [AB#616471](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/616471)

