### PR TITLE
[External File Storage]: Fix folder selection: return current directory for ".." entry

### DIFF
--- a/src/System Application/App/External File Storage/src/FileStorage/ExternalFileStorageImpl.Codeunit.al
+++ b/src/System Application/App/External File Storage/src/FileStorage/ExternalFileStorageImpl.Codeunit.al
@@ -160,9 +160,9 @@ codeunit 9455 "External File Storage Impl."
         if TempFileAccountContent.Type <> TempFileAccountContent.Type::Directory then
             exit('');
 
-        // If user selected the ".." navigation entry, return the parent directory directly
+        // The ".." entry represents the current directory for selection purposes
         if TempFileAccountContent.Name = '..' then
-            exit(TempFileAccountContent."Parent Directory");
+            exit(StorageBrowser.GetCurrentDirectory());
 
         exit(CombinePath(TempFileAccountContent."Parent Directory", TempFileAccountContent.Name));
     end;


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Issue:
When using the folder selection dialog, if a user navigates into a directory and then selects the ".." (back/parent) entry and clicks OK, the function returns an invalid path containing the literal ".." segment (e.g., Docs/mine/2025/../).

Fix:
Added a check to detect when the ".." navigation entry is selected and return the current directory path directly instead of combining it with the ".." literal.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #5893





Fixes [AB#616797](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/616797)

