### PR TITLE
[releases/27.x] Add channel liable tax tracking for Shopify orders

### DIFF
--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLNextOpenOrdToImport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLNextOpenOrdToImport.Codeunit.al
@@ -11,11 +11,11 @@ codeunit 30206 "Shpfy GQL NextOpenOrdToImport" implements "Shpfy IGraphQL"
 
     internal procedure GetGraphQL(): Text
     begin
-        exit('{"query": "{orders(first:150, after:\"{{After}}\", query: \"status:open updated_at:>''{{Time}}''\"){pageInfo{hasNextPage} edges{cursor node{legacyResourceId name createdAt updatedAt channel { name } test fullyPaid unpaid displayFinancialStatus displayFulfillmentStatus subtotalLineItemsQuantity totalPriceSet{shopMoney{amount currencyCode}} customAttributes{key value} tags risk { assessments { riskLevel }} displayAddress { countryCodeV2 } shippingAddress { countryCodeV2 } billingAddress { countryCodeV2 } totalTaxSet { presentmentMoney { amount } shopMoney { amount } } purchasingEntity { ... on PurchasingCompany { company { id }}}}}}}"}');
+        exit('{"query": "{orders(first:150, after:\"{{After}}\", query: \"status:open updated_at:>''{{Time}}''\"){pageInfo{hasNextPage} edges{cursor node{legacyResourceId name createdAt updatedAt channel { name } test fullyPaid unpaid displayFinancialStatus displayFulfillmentStatus subtotalLineItemsQuantity totalPriceSet{shopMoney{amount currencyCode}} customAttributes{key value} tags risk { assessments { riskLevel }} displayAddress { countryCodeV2 } shippingAddress { countryCodeV2 } billingAddress { countryCodeV2 } totalTaxSet { presentmentMoney { amount } shopMoney { amount } } taxLines { channelLiable } purchasingEntity { ... on PurchasingCompany { company { id }}}}}}}"}');
     end;
 
     internal procedure GetExpectedCost(): Integer
     begin
-        exit(602);
+        exit(612);
     end;
 }

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLNextOrdersToImport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLNextOrdersToImport.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 30138 "Shpfy GQL NextOrdersToImport" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Text.</returns>
     internal procedure GetGraphQL(): Text
     begin
-        exit('{"query": "{orders(first:25, after:\"{{After}}\", query: \"updated_at:>''{{Time}}''\"){ pageInfo { hasNextPage } edges { cursor node { legacyResourceId name createdAt updatedAt channel { name } test fullyPaid unpaid closed displayFinancialStatus displayFulfillmentStatus subtotalLineItemsQuantity totalPriceSet { shopMoney { amount currencyCode } } customAttributes { key value } tags risk { assessments { riskLevel }} displayAddress { countryCodeV2 } shippingAddress { countryCodeV2 } billingAddress { countryCodeV2 } totalTaxSet { presentmentMoney { amount } shopMoney { amount } } purchasingEntity { ... on PurchasingCompany { company { id }}}}}}}"}');
+        exit('{"query": "{orders(first:25, after:\"{{After}}\", query: \"updated_at:>''{{Time}}''\"){ pageInfo { hasNextPage } edges { cursor node { legacyResourceId name createdAt updatedAt channel { name } test fullyPaid unpaid closed displayFinancialStatus displayFulfillmentStatus subtotalLineItemsQuantity totalPriceSet { shopMoney { amount currencyCode } } customAttributes { key value } tags risk { assessments { riskLevel }} displayAddress { countryCodeV2 } shippingAddress { countryCodeV2 } billingAddress { countryCodeV2 } totalTaxSet { presentmentMoney { amount } shopMoney { amount } } taxLines { channelLiable } purchasingEntity { ... on PurchasingCompany { company { id }}}}}}}"}');
     end;
 
     /// <summary>
@@ -27,6 +27,6 @@ codeunit 30138 "Shpfy GQL NextOrdersToImport" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Integer.</returns>
     internal procedure GetExpectedCost(): Integer
     begin
-        exit(153);
+        exit(159);
     end;
 }

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLNextShipmentLines.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLNextShipmentLines.Codeunit.al
@@ -9,7 +9,7 @@ codeunit 30222 "Shpfy GQL NextShipmentLines" implements "Shpfy IGraphQL"
 {
     internal procedure GetGraphQL(): Text
     begin
-        exit('{"query":"{order(id: \"gid://shopify/Order/{{OrderId}}\") {shippingLines(first: 10, after:\"{{After}}\") { pageInfo { endCursor hasNextPage } nodes { id title code source discountAllocations { allocatedAmountSet { presentmentMoney { amount } shopMoney { amount }}} originalPriceSet { presentmentMoney { amount } shopMoney { amount }} discountedPriceSet { presentmentMoney { amount } shopMoney { amount }} taxLines { title rate ratePercentage priceSet { presentmentMoney { amount } shopMoney {amount}}}}}}}"}');
+        exit('{"query":"{order(id: \"gid://shopify/Order/{{OrderId}}\") {shippingLines(first: 10, after:\"{{After}}\") { pageInfo { endCursor hasNextPage } nodes { id title code source discountAllocations { allocatedAmountSet { presentmentMoney { amount } shopMoney { amount }}} originalPriceSet { presentmentMoney { amount } shopMoney { amount }} discountedPriceSet { presentmentMoney { amount } shopMoney { amount }} taxLines { channelLiable title rate ratePercentage priceSet { presentmentMoney { amount } shopMoney {amount}}}}}}}"}');
     end;
 
     internal procedure GetExpectedCost(): Integer

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLOpenOrdersToImport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLOpenOrdersToImport.Codeunit.al
@@ -11,11 +11,11 @@ codeunit 30205 "Shpfy GQL OpenOrdersToImport" implements "Shpfy IGraphQL"
 
     internal procedure GetGraphQL(): Text
     begin
-        exit('{"query": "{orders(first:25, query: \"status:open updated_at:>''{{Time}}''\"){ pageInfo { hasNextPage } edges { cursor node { legacyResourceId name createdAt updatedAt channel { name } test fullyPaid unpaid displayFinancialStatus displayFulfillmentStatus subtotalLineItemsQuantity totalPriceSet { shopMoney { amount currencyCode } } customAttributes { key value } tags risk { assessments { riskLevel }} displayAddress { countryCodeV2 } shippingAddress { countryCodeV2 } billingAddress { countryCodeV2 } totalTaxSet { presentmentMoney { amount } shopMoney { amount } } purchasingEntity { ... on PurchasingCompany { company { id }}}}}}}"}');
+        exit('{"query": "{orders(first:25, query: \"status:open updated_at:>''{{Time}}''\"){ pageInfo { hasNextPage } edges { cursor node { legacyResourceId name createdAt updatedAt channel { name } test fullyPaid unpaid displayFinancialStatus displayFulfillmentStatus subtotalLineItemsQuantity totalPriceSet { shopMoney { amount currencyCode } } customAttributes { key value } tags risk { assessments { riskLevel }} displayAddress { countryCodeV2 } shippingAddress { countryCodeV2 } billingAddress { countryCodeV2 } totalTaxSet { presentmentMoney { amount } shopMoney { amount } } taxLines { channelLiable } purchasingEntity { ... on PurchasingCompany { company { id }}}}}}}"}');
     end;
 
     internal procedure GetExpectedCost(): Integer
     begin
-        exit(152);
+        exit(158);
     end;
 }

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLOrdersToImport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLOrdersToImport.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 30145 "Shpfy GQL OrdersToImport" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Text.</returns>
     internal procedure GetGraphQL(): Text
     begin
-        exit('{"query": "{orders(first:25, query: \"updated_at:>''{{Time}}''\"){pageInfo{hasNextPage} edges{cursor node{legacyResourceId name createdAt updatedAt channel { name } test fullyPaid unpaid closed displayFinancialStatus displayFulfillmentStatus subtotalLineItemsQuantity totalPriceSet{shopMoney{amount currencyCode}} customAttributes{key value} tags risk { assessments { riskLevel }} displayAddress { countryCodeV2 } shippingAddress { countryCodeV2 } billingAddress { countryCodeV2 } totalTaxSet { presentmentMoney { amount } shopMoney { amount } } purchasingEntity { ... on PurchasingCompany { company { id }}}}}}}"}');
+        exit('{"query": "{orders(first:25, query: \"updated_at:>''{{Time}}''\"){pageInfo{hasNextPage} edges{cursor node{legacyResourceId name createdAt updatedAt channel { name } test fullyPaid unpaid closed displayFinancialStatus displayFulfillmentStatus subtotalLineItemsQuantity totalPriceSet{shopMoney{amount currencyCode}} customAttributes{key value} tags risk { assessments { riskLevel }} displayAddress { countryCodeV2 } shippingAddress { countryCodeV2 } billingAddress { countryCodeV2 } totalTaxSet { presentmentMoney { amount } shopMoney { amount } } taxLines { channelLiable } purchasingEntity { ... on PurchasingCompany { company { id }}}}}}}"}');
     end;
 
     /// <summary>
@@ -27,6 +27,6 @@ codeunit 30145 "Shpfy GQL OrdersToImport" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Integer.</returns>
     internal procedure GetExpectedCost(): Integer
     begin
-        exit(153);
+        exit(159);
     end;
 }

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLShipmentLines.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLShipmentLines.Codeunit.al
@@ -9,7 +9,7 @@ codeunit 30216 "Shpfy GQL ShipmentLines" implements "Shpfy IGraphQL"
 {
     internal procedure GetGraphQL(): Text
     begin
-        exit('{"query":"{order(id: \"gid://shopify/Order/{{OrderId}}\") {shippingLines(first: 10) { pageInfo { endCursor hasNextPage } nodes { id title code source discountAllocations { allocatedAmountSet { presentmentMoney { amount } shopMoney { amount }}} originalPriceSet { presentmentMoney { amount } shopMoney { amount }} discountedPriceSet { presentmentMoney { amount } shopMoney { amount }} taxLines { title rate ratePercentage priceSet { presentmentMoney { amount } shopMoney {amount}}}}}}}"}');
+        exit('{"query":"{order(id: \"gid://shopify/Order/{{OrderId}}\") {shippingLines(first: 10) { pageInfo { endCursor hasNextPage } nodes { id title code source discountAllocations { allocatedAmountSet { presentmentMoney { amount } shopMoney { amount }}} originalPriceSet { presentmentMoney { amount } shopMoney { amount }} discountedPriceSet { presentmentMoney { amount } shopMoney { amount }} taxLines { channelLiable title rate ratePercentage priceSet { presentmentMoney { amount } shopMoney {amount}}}}}}}"}');
     end;
 
     internal procedure GetExpectedCost(): Integer

--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
@@ -802,6 +802,7 @@ codeunit 30161 "Shpfy Import Order"
             JsonHelper.GetValueIntoField(JToken, 'ratePercentage', RecordRef, OrderTaxLine.FieldNo("Rate %"));
             JsonHelper.GetValueIntoField(JToken, 'priceSet.shopMoney.amount', RecordRef, OrderTaxLine.FieldNo(Amount));
             JsonHelper.GetValueIntoField(JToken, 'priceSet.presentmentMoney.amount', RecordRef, OrderTaxLine.FieldNo("Presentment Amount"));
+            JsonHelper.GetValueIntoField(JToken, 'channelLiable', RecordRef, OrderTaxLine.FieldNo("Channel Liable"));
             RecordRef.Insert(true);
             RecordRef.Close();
         end;

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
@@ -353,6 +353,13 @@ page 30113 "Shpfy Order"
                     ApplicationArea = All;
                     ToolTip = 'Specifies if tax is included in the unit price.';
                 }
+                field("Channel Liable Taxes"; Rec."Channel Liable Taxes")
+                {
+                    ApplicationArea = All;
+                    Editable = false;
+                    ToolTip = 'Specifies if any tax line on the order is liable to be charged by the sales channel.';
+                }
+
                 field(CurrencyCode; Rec."Currency Code")
                 {
                     ApplicationArea = All;

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrderTaxLines.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrderTaxLines.Page.al
@@ -46,6 +46,11 @@ page 30168 "Shpfy Order Tax Lines"
                     ApplicationArea = All;
                     ToolTip = 'Specifies the rate percentage of the tax line.';
                 }
+                field("Channel Liable"; Rec."Channel Liable")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies if the channel that submitted the tax line is liable for remitting.';
+                }
             }
         }
     }

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrders.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrders.Page.al
@@ -152,6 +152,12 @@ page 30115 "Shpfy Orders"
                     ApplicationArea = All;
                     ToolTip = 'Specifies the sum of the line amounts on all lines in the document minus any discount amounts plus the shipping costs.';
                 }
+                field("Channel Liable Taxes"; Rec."Channel Liable Taxes")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies if any tax line on the order is liable to be charged by the channel.';
+                    Visible = false;
+                }
                 field(Processed; Rec.Processed)
                 {
                     ApplicationArea = All;

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrdersToImport.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrdersToImport.Page.al
@@ -99,6 +99,11 @@ page 30121 "Shpfy Orders to Import"
                     ApplicationArea = All;
                     ToolTip = 'Specifies the order''s status in terms of fulfilled line items. Valid values are: Fulfilled, null, partial, restocked.';
                 }
+                field("Channel Liable Taxes"; Rec."Channel Liable Taxes")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies if any tax line on the order is liable to be collected by the sales channel.';
+                }
                 field(ChannelName; Rec."Channel Name")
                 {
                     ApplicationArea = All;

--- a/src/Apps/W1/Shopify/App/src/Order handling/Reports/ShpfySyncOrdersfromShopify.Report.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Reports/ShpfySyncOrdersfromShopify.Report.al
@@ -25,7 +25,7 @@ report 30104 "Shpfy Sync Orders from Shopify"
             {
                 DataItemLink = "Shop Code" = field(Code);
                 DataItemLinkReference = Shop;
-                RequestFilterFields = "Fully Paid", "Financial Status", "Fulfillment Status", Confirmed, "Import Action", "Attribute Key Filter", "Attribute Key Exists", "Channel Name", "Order No.", "High Risk", "Sell-to Country/Region Code", "Ship-to Country/Region Code", "Bill-to Country/Region Code", "VAT Amount";
+                RequestFilterFields = "Fully Paid", "Financial Status", "Fulfillment Status", Confirmed, "Import Action", "Attribute Key Filter", "Attribute Key Exists", "Channel Name", "Channel Liable Taxes", "Order No.", "High Risk", "Sell-to Country/Region Code", "Ship-to Country/Region Code", "Bill-to Country/Region Code", "VAT Amount";
 
                 trigger OnPreDataItem()
                 var

--- a/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderHeader.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderHeader.Table.al
@@ -686,6 +686,13 @@ table 30118 "Shpfy Order Header"
             AutoFormatType = 1;
             AutoFormatExpression = "Currency Code";
         }
+        field(134; "Channel Liable Taxes"; Boolean)
+        {
+            Caption = 'Channel Liable Taxes';
+            Editable = false;
+            FieldClass = FlowField;
+            CalcFormula = exist("Shpfy Order Tax Line" where("Parent Id" = field("Shopify Order Id"), "Channel Liable" = const(true)));
+        }
         field(500; "Shop Code"; Code[20])
         {
             Caption = 'Shop Code';

--- a/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderTaxLine.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderTaxLine.Table.al
@@ -75,6 +75,12 @@ table 30122 "Shpfy Order Tax Line"
             Editable = false;
             AutoFormatType = 0;
         }
+        field(9; "Channel Liable"; Boolean)
+        {
+            Caption = 'Channel Liable';
+            DataClassification = SystemMetadata;
+            Editable = false;
+        }
     }
     keys
     {

--- a/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrdersToImport.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrdersToImport.Table.al
@@ -217,6 +217,12 @@ table 30121 "Shpfy Orders to Import"
             AutoFormatType = 1;
             AutoFormatExpression = "Currency Code";
         }
+        field(30; "Channel Liable Taxes"; Boolean)
+        {
+            Caption = 'Channel Liable Taxes';
+            DataClassification = SystemMetadata;
+            Editable = false;
+        }
         field(100; "Import Action"; Enum "Shpfy Import Action")
         {
             Caption = 'Import Action';


### PR DESCRIPTION
This pull request backports #5200 to releases/27.x

Fixes [AB#617038](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617038)
