### PR TITLE
[releases/27.x] [Shopify] Allow creation of credit memos for refunds with restock type return

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order Refunds/Codeunits/ShpfyRefundsAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/Codeunits/ShpfyRefundsAPI.Codeunit.al
@@ -166,7 +166,7 @@ codeunit 30228 "Shpfy Refunds API"
         JsonHelper.GetValueIntoField(JLine, 'totalTaxSet.presentmentMoney.amount', RefundLineRecordRef, RefundLine.FieldNo("Presentment Total Tax Amount"));
         RefundLineRecordRef.SetTable(RefundLine);
 
-        RefundLine."Can Create Credit Memo" := NonZeroOrReturnRefund;
+        RefundLine."Can Create Credit Memo" := NonZeroOrReturnRefund or (RefundLine."Restock Type" = RefundLine."Restock Type"::Return);
         RefundLine."Location Id" := JsonHelper.GetValueAsBigInteger(JLine, 'location.legacyResourceId');
 
         // If refund was created from a return, the location needs to come from the return

--- a/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
@@ -145,6 +145,7 @@ codeunit 139611 "Shpfy Order Refund Test"
         RefundId1: BigInteger;
         RefundId2: BigInteger;
         RefundId3: BigInteger;
+        RefundId4: BigInteger;
     begin
         // [SCENARIO] Can create credit memo check returns
         // Non-zero refund = true
@@ -158,11 +159,14 @@ codeunit 139611 "Shpfy Order Refund Test"
         RefundId2 := ShopifyIds.Get('Refund').Get(4);
         // [GIVEN] Zero and not linked refund
         RefundId3 := ShopifyIds.Get('Refund').Get(6);
+        // [GIVEN] Zero refund with restock type return
+        RefundId4 := ShopifyIds.Get('Refund').Get(7);
 
         // [WHEN] Execute VerifyRefundCanCreateCreditMemo
         RefundsAPI.VerifyRefundCanCreateCreditMemo(RefundId1);
         RefundsAPI.VerifyRefundCanCreateCreditMemo(RefundId2);
-        asserterror RefundsAPI.VerifyRefundCanCreateCreditMemo(RefundId3);
+        RefundsAPI.VerifyRefundCanCreateCreditMemo(RefundId3);
+        asserterror RefundsAPI.VerifyRefundCanCreateCreditMemo(RefundId4);
 
         // [THEN] Only RefundId3 throws an error
         LibraryAssert.ExpectedError('The refund imported from Shopify can''t be used to create a credit memo. Only refunds for paid items can be used to create credit memos.');
@@ -262,7 +266,7 @@ codeunit 139611 "Shpfy Order Refund Test"
         // [GIVEN] Refund Header
         RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, ReturnId, 156.38, Shop.Code);
         // [GIVEN] Refund line without location
-        OrderRefundsHelper.CreateRefundLine(RefundId, OrderLineId, 0);
+        OrderRefundsHelper.CreateRefundLine(RefundId, OrderLineId, 0, "Shpfy Restock Type"::Return);
 
         // [WHEN] Execute create credit memo
         IReturnRefundProcess := Enum::"Shpfy ReturnRefund ProcessType"::"Auto Create Credit Memo";
@@ -308,7 +312,7 @@ codeunit 139611 "Shpfy Order Refund Test"
         // [GIVEN] Refund Header
         RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, ReturnId, 156.38, Shop.Code);
         // [GIVEN] Refund line without location
-        OrderRefundsHelper.CreateRefundLine(RefundId, OrderLineId, LocationId);
+        OrderRefundsHelper.CreateRefundLine(RefundId, OrderLineId, LocationId, "Shpfy Restock Type"::Return);
 
         // [WHEN] Execute create credit memo
         IReturnRefundProcess := Enum::"Shpfy ReturnRefund ProcessType"::"Auto Create Credit Memo";


### PR DESCRIPTION
This pull request backports #5115 to releases/27.x

Fixes [AB#617038](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617038)


