### PR TITLE
[releases/27.x] [Shopify] Respect unit of measure factors when exporting variant weights

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyCreateProduct.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyCreateProduct.Codeunit.al
@@ -103,7 +103,7 @@ codeunit 30174 "Shpfy Create Product"
                                 TempShopifyVariant.SKU := GetVariantSKU(TempShopifyVariant.Barcode, Item."No.", ItemVariant.Code, Item."Vendor Item No.");
                                 TempShopifyVariant."Tax Code" := Item."Tax Group Code";
                                 TempShopifyVariant.Taxable := true;
-                                TempShopifyVariant.Weight := Item."Gross Weight";
+                                TempShopifyVariant.Weight := ItemUnitofMeasure."Qty. per Unit of Measure" > 0 ? Item."Gross Weight" * ItemUnitofMeasure."Qty. per Unit of Measure" : Item."Gross Weight";
                                 TempShopifyVariant."Option 1 Name" := 'Variant';
                                 TempShopifyVariant."Option 1 Value" := ItemVariant.Code;
                                 TempShopifyVariant."Option 2 Name" := Shop."Option Name for UoM";
@@ -153,7 +153,7 @@ codeunit 30174 "Shpfy Create Product"
                         TempShopifyVariant.SKU := GetVariantSKU(TempShopifyVariant.Barcode, Item."No.", '', Item."Vendor Item No.");
                         TempShopifyVariant."Tax Code" := Item."Tax Group Code";
                         TempShopifyVariant.Taxable := true;
-                        TempShopifyVariant.Weight := Item."Gross Weight";
+                        TempShopifyVariant.Weight := ItemUnitofMeasure."Qty. per Unit of Measure" > 0 ? Item."Gross Weight" * ItemUnitofMeasure."Qty. per Unit of Measure" : Item."Gross Weight";
                         TempShopifyVariant."Option 1 Name" := Shop."Option Name for UoM";
                         TempShopifyVariant."Option 1 Value" := ItemUnitofMeasure.Code;
                         TempShopifyVariant."Shop Code" := Shop.Code;

--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductExport.Codeunit.al
@@ -361,7 +361,7 @@ codeunit 30178 "Shpfy Product Export"
             end;
             ShopifyVariant."Tax Code" := Item."Tax Group Code";
             ShopifyVariant.Taxable := true;
-            ShopifyVariant.Weight := Item."Gross Weight";
+            ShopifyVariant.Weight := ItemUnitofMeasure."Qty. per Unit of Measure" > 0 ? Item."Gross Weight" * ItemUnitofMeasure."Qty. per Unit of Measure" : Item."Gross Weight";
             ShopifyVariant."Option 1 Name" := Shop."Option Name for UoM";
             ShopifyVariant."Option 1 Value" := ItemUnitofMeasure.Code;
             ShopifyVariant."Shop Code" := Shop.Code;
@@ -472,7 +472,7 @@ codeunit 30178 "Shpfy Product Export"
             end;
             ShopifyVariant."Tax Code" := Item."Tax Group Code";
             ShopifyVariant.Taxable := true;
-            ShopifyVariant.Weight := Item."Gross Weight";
+            ShopifyVariant.Weight := ItemUnitofMeasure."Qty. per Unit of Measure" > 0 ? Item."Gross Weight" * ItemUnitofMeasure."Qty. per Unit of Measure" : Item."Gross Weight";
             ShopifyVariant."Option 1 Name" := 'Variant';
             ShopifyVariant."Option 1 Value" := ItemVariant.Code;
             ShopifyVariant."Option 2 Name" := Shop."Option Name for UoM";


### PR DESCRIPTION
This pull request backports #5626 to releases/27.x

Fixes [AB#617038](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617038)


