### PR TITLE
[Shopify] Add Data Capture support for Fulfillment Orders

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order Fulfillments/Codeunits/ShpfyFulfillmentOrdersAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Fulfillments/Codeunits/ShpfyFulfillmentOrdersAPI.Codeunit.al
@@ -72,6 +72,7 @@ codeunit 30238 "Shpfy Fulfillment Orders API"
 
     internal procedure ExtractFulfillmentOrder(var ShopifyShop: Record "Shpfy Shop"; JFulfillmentOrder: JsonToken; var Cursor: Text)
     var
+        DataCapture: Record "Shpfy Data Capture";
         FulfillmentOrderHeader: Record "Shpfy FulFillment Order Header";
         Id: BigInteger;
         JNode: JsonObject;
@@ -98,6 +99,7 @@ codeunit 30238 "Shpfy Fulfillment Orders API"
             FulfillmentOrderHeader."Delivery Method Type" := ConvertToDeliveryMethodType(JsonHelper.GetValueAsText(JNode, 'deliveryMethod.methodType'));
             if not FulfillmentOrderHeader.Insert() then
                 FulfillmentOrderHeader.Modify();
+            DataCapture.Add(Database::"Shpfy FulFillment Order Header", FulfillmentOrderHeader.SystemId, JNode);
             GetFulfillmentOrderLines(ShopifyShop, FulfillmentOrderHeader);
         end;
     end;
@@ -105,6 +107,7 @@ codeunit 30238 "Shpfy Fulfillment Orders API"
     internal procedure ExtractFulfillmentOrderLines(var ShopifyShop: Record "Shpfy Shop"; var FulfillmentOrderHeader: Record "Shpfy FulFillment Order Header"; JResponse: JsonObject; var Cursor: Text): Boolean
     var
         FulfillmentOrderLine: Record "Shpfy FulFillment Order Line";
+        DataCapture: Record "Shpfy Data Capture";
         Modified: Boolean;
         Id: BigInteger;
         JFulfillmentOrderLines: JsonArray;
@@ -165,6 +168,7 @@ codeunit 30238 "Shpfy Fulfillment Orders API"
                     end;
                 end;
             end;
+            DataCapture.Add(Database::"Shpfy FulFillment Order Header", FulfillmentOrderHeader.SystemId, JFulfillmentOrderLines.AsToken());
             exit(true);
         end;
     end;

--- a/src/Apps/W1/Shopify/App/src/Order Fulfillments/Pages/ShpfyFulFillmentOrders.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order Fulfillments/Pages/ShpfyFulFillmentOrders.Page.al
@@ -59,4 +59,39 @@ page 30141 "Shpfy Fulfillment Orders"
             }
         }
     }
+
+    actions
+    {
+        area(navigation)
+        {
+            action("Retrieved Shopify Data")
+            {
+                ApplicationArea = All;
+                Caption = 'Retrieved Shopify Data';
+                Image = Entry;
+                ToolTip = 'View the data retrieved from Shopify.';
+
+                trigger OnAction();
+                var
+                    DataCapture: Record "Shpfy Data Capture";
+                begin
+                    DataCapture.SetCurrentKey("Linked To Table", "Linked To Id");
+                    DataCapture.SetRange("Linked To Table", Database::"Shpfy FulFillment Order Header");
+                    DataCapture.SetRange("Linked To Id", Rec.SystemId);
+                    Page.Run(Page::"Shpfy Data Capture List", DataCapture);
+                end;
+            }
+        }
+        area(promoted)
+        {
+            group(Category_Inspect)
+            {
+                Caption = 'Inspect';
+
+                actionref("Retrieved Shopify Data_Promoted"; "Retrieved Shopify Data")
+                {
+                }
+            }
+        }
+    }
 }

--- a/src/Apps/W1/Shopify/App/src/Order Fulfillments/Pages/ShpfyFulfillmentOrderCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order Fulfillments/Pages/ShpfyFulfillmentOrderCard.Page.al
@@ -64,4 +64,39 @@ page 30140 "Shpfy Fulfillment Order Card"
             }
         }
     }
+
+    actions
+    {
+        area(navigation)
+        {
+            action("Retrieved Shopify Data")
+            {
+                ApplicationArea = All;
+                Caption = 'Retrieved Shopify Data';
+                Image = Entry;
+                ToolTip = 'View the data retrieved from Shopify.';
+
+                trigger OnAction();
+                var
+                    DataCapture: Record "Shpfy Data Capture";
+                begin
+                    DataCapture.SetCurrentKey("Linked To Table", "Linked To Id");
+                    DataCapture.SetRange("Linked To Table", Database::"Shpfy FulFillment Order Header");
+                    DataCapture.SetRange("Linked To Id", Rec.SystemId);
+                    Page.Run(Page::"Shpfy Data Capture List", DataCapture);
+                end;
+            }
+        }
+        area(promoted)
+        {
+            group(Category_Inspect)
+            {
+                Caption = 'Inspect';
+
+                actionref("Retrieved Shopify Data_Promoted"; "Retrieved Shopify Data")
+                {
+                }
+            }
+        }
+    }
 }

--- a/src/Apps/W1/Shopify/App/src/Order Fulfillments/Tables/ShpfyFulFillmentOrderHeader.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order Fulfillments/Tables/ShpfyFulFillmentOrderHeader.Table.al
@@ -81,9 +81,16 @@ table 30143 "Shpfy FulFillment Order Header"
     trigger OnDelete()
     var
         FulfillmentOrderLine: Record "Shpfy FulFillment Order Line";
+        DataCapture: Record "Shpfy Data Capture";
     begin
         FulfillmentOrderLine.Reset();
         FulfillmentOrderLine.SetRange("Shopify Fulfillment Order Id", Rec."Shopify Fulfillment Order Id");
         FulfillmentOrderLine.DeleteAll(true);
+
+        DataCapture.SetCurrentKey("Linked To Table", "Linked To Id");
+        DataCapture.SetRange("Linked To Table", Database::"Shpfy FulFillment Order Header");
+        DataCapture.SetRange("Linked To Id", Rec.SystemId);
+        if not DataCapture.IsEmpty then
+            DataCapture.DeleteAll(false);
     end;
 }


### PR DESCRIPTION
## Add Data Capture support for Fulfillment Orders

### Summary
This PR adds Data Capture functionality for Fulfillment Orders, mirroring the existing implementation for Order Fulfillments. This allows users to view the raw JSON data retrieved from Shopify for debugging and troubleshooting purposes.

### Changes

#### Pages
- **ShpfyFulfillmentOrderCard.Page.al**: Added "Retrieved Shopify Data" action with `actionref` in the promoted area to view captured data for the selected fulfillment order
- **ShpfyFulFillmentOrders.Page.al**: Added the same "Retrieved Shopify Data" action to the list page for quick access from the list view

#### Table
- **ShpfyFulFillmentOrderHeader.Table.al**: Extended `OnDelete` trigger to clean up associated Data Capture records when a fulfillment order header is deleted

#### Codeunit
- **ShpfyFulfillmentOrdersAPI.Codeunit.al**: 
  - Added `DataCapture.Add()` call in `ExtractFulfillmentOrder` to save the fulfillment order JSON response
  - Added `DataCapture.Add()` call in `ExtractFulfillmentOrderLines` to save the fulfillment order lines JSON response

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#616999](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/616999)


