### PR TITLE
[Shopify] Auto-populate Unit of Measure when selecting Item on Shopify Order Lines

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrderSubform.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrderSubform.Page.al
@@ -5,6 +5,8 @@
 
 namespace Microsoft.Integration.Shopify;
 
+using Microsoft.Inventory.Item;
+
 /// <summary>
 /// Page Shpfy Order Subform (ID 30122).
 /// </summary>
@@ -41,6 +43,17 @@ page 30122 "Shpfy Order Subform"
                     ApplicationArea = All;
                     ShowMandatory = true;
                     ToolTip = 'Specifies the item number.';
+
+                    trigger OnValidate()
+                    var
+                        Item: Record Item;
+                    begin
+                        if Item.Get(Rec."Item No.") then
+                            if Item."Sales Unit of Measure" <> '' then
+                                Rec."Unit of Measure Code" := Item."Sales Unit of Measure"
+                            else
+                                Rec."Unit of Measure Code" := Item."Base Unit of Measure";
+                    end;
                 }
                 field(UnitOfMeasureCode; Rec."Unit of Measure Code")
                 {


### PR DESCRIPTION
### Summary
Enhanced the Shopify Order Subform page to automatically set the Unit of Measure Code when an Item is selected on an order line.

### Changes
**File:** ShpfyOrderSubform.Page.al

- Added `OnValidate` trigger to the "Item No." field that automatically populates the "Unit of Measure Code" based on the selected item:
  - If the item has a "Sales Unit of Measure" defined, it uses that value
  - Otherwise, it falls back to the item's "Base Unit of Measure"

### Motivation
When users manually map Shopify order lines to Business Central items, they previously had to manually enter the Unit of Measure Code. This change improves the user experience by automatically defaulting the UoM based on the item's configuration, reducing manual data entry and potential errors.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#617019](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617019)


