### PR TITLE
[Shopify] Product metafields extensibility

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
@@ -41,7 +41,6 @@ codeunit 30284 "Shpfy Company Export"
         Shop: Record "Shpfy Shop";
         CompanyAPI: Codeunit "Shpfy Company API";
         CatalogAPI: Codeunit "Shpfy Catalog API";
-        MetafieldAPI: Codeunit "Shpfy Metafield API";
         SkippedRecord: Codeunit "Shpfy Skipped Record";
         CreateCustomers: Boolean;
         CountyCodeTooLongLbl: Label 'Can not export customer %1 %2. The length of the string is %3, but it must be less than or equal to %4 characters. Value: %5, field: %6', Comment = '%1 - Customer No., %2 - Customer Name, %3 - Length, %4 - Max Length, %5 - Value, %6 - Field Name';
@@ -213,7 +212,6 @@ codeunit 30284 "Shpfy Company Export"
         Shop := ShopifyShop;
         CompanyAPI.SetShop(Shop);
         CatalogAPI.SetShop(Shop);
-        MetafieldAPI.SetShop(Shop);
     end;
 
     local procedure UpdateShopifyCompany(Customer: Record Customer; CompanyId: BigInteger)
@@ -252,8 +250,10 @@ codeunit 30284 "Shpfy Company Export"
     end;
 
     local procedure UpdateMetafields(ComppanyId: BigInteger)
+    var
+        Metafields: Codeunit "Shpfy Metafields";
     begin
-        MetafieldAPI.CreateOrUpdateMetafieldsInShopify(Database::"Shpfy Company", ComppanyId);
+        Metafields.SyncMetafieldsToShopify(Database::"Shpfy Company", ComppanyId, Shop.Code);
     end;
 
     internal procedure SetCreateCompanies(NewCustomers: Boolean)

--- a/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCustomerExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCustomerExport.Codeunit.al
@@ -49,7 +49,6 @@ codeunit 30116 "Shpfy Customer Export"
     var
         Shop: Record "Shpfy Shop";
         CustomerApi: Codeunit "Shpfy Customer API";
-        MetafieldAPI: Codeunit "Shpfy Metafield API";
         SkippedRecord: Codeunit "Shpfy Skipped Record";
         CreateCustomers: Boolean;
         CountyCodeTooLongLbl: Label 'Can not export customer %1 %2. The length of the string is %3, but it must be less than or equal to %4 characters. Value: %5, field: %6', Comment = '%1 - Customer No., %2 - Customer Name, %3 - Length, %4 - Max Length, %5 - Value, %6 - Field Name';
@@ -228,7 +227,6 @@ codeunit 30116 "Shpfy Customer Export"
     begin
         Shop := ShopifyShop;
         CustomerApi.SetShop(Shop);
-        MetafieldAPI.SetShop(Shop)
     end;
 
     /// <summary> 
@@ -286,7 +284,9 @@ codeunit 30116 "Shpfy Customer Export"
     end;
 
     local procedure UpdateMetafields(CustomerId: BigInteger)
+    var
+        Metafields: Codeunit "Shpfy Metafields";
     begin
-        MetafieldAPI.CreateOrUpdateMetafieldsInShopify(Database::"Shpfy Customer", CustomerId);
+        Metafields.SyncMetafieldsToShopify(Database::"Shpfy Customer", CustomerId, Shop.Code);
     end;
 }

--- a/src/Apps/W1/Shopify/App/src/Metafields/Codeunits/ShpfyMetafields.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Metafields/Codeunits/ShpfyMetafields.Codeunit.al
@@ -1,0 +1,51 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify;
+
+/// <summary>
+/// Provides functionality for managing Shopify metafields.
+/// </summary>
+codeunit 30418 "Shpfy Metafields"
+{
+    Access = Public;
+
+    var
+        MetafieldAPI: Codeunit "Shpfy Metafield API";
+
+    /// <summary>
+    /// Retrieves the metafield definitions from Shopify for the specified resource.
+    /// </summary>
+    /// <param name="ParentTableNo">Table id of the parent resource (e.g., Database::"Shpfy Product").</param>
+    /// <param name="OwnerId">Id of the parent resource in Shopify.</param>
+    /// <param name="ShopCode">The code of the Shopify shop.</param>
+    procedure GetMetafieldDefinitions(ParentTableNo: Integer; OwnerId: BigInteger; ShopCode: Code[20])
+    begin
+        MetafieldAPI.GetMetafieldDefinitions(ParentTableNo, OwnerId, ShopCode);
+    end;
+
+    /// <summary>
+    /// Synchronizes a single metafield to Shopify, creating or updating it as needed.
+    /// </summary>
+    /// <param name="Metafield">The metafield record to synchronize to Shopify.</param>
+    /// <param name="ShopCode">The code of the Shopify shop.</param>
+    /// <returns>The Shopify Id of the metafield.</returns>
+    procedure SyncMetafieldToShopify(var Metafield: Record "Shpfy Metafield"; ShopCode: Code[20]): BigInteger
+    begin
+        exit(MetafieldAPI.SyncMetafieldToShopify(Metafield, ShopCode));
+    end;
+
+    /// <summary>
+    /// Synchronizes all metafields for the specified resource to Shopify.
+    /// Only metafields that have been updated in BC since the last sync will be sent.
+    /// </summary>
+    /// <param name="ParentTableNo">Table id of the parent resource (e.g., Database::"Shpfy Product").</param>
+    /// <param name="OwnerId">Id of the parent resource in Shopify.</param>
+    /// <param name="ShopCode">The code of the Shopify shop.</param>
+    procedure SyncMetafieldsToShopify(ParentTableNo: Integer; OwnerId: BigInteger; ShopCode: Code[20])
+    begin
+        MetafieldAPI.SyncMetafieldsToShopify(ParentTableNo, OwnerId, ShopCode);
+    end;
+}

--- a/src/Apps/W1/Shopify/App/src/PermissionSets/ShpfyObjects.PermissionSet.al
+++ b/src/Apps/W1/Shopify/App/src/PermissionSets/ShpfyObjects.PermissionSet.al
@@ -299,6 +299,7 @@ permissionset 30104 "Shpfy - Objects"
         codeunit "Shpfy Log Entries Delete" = X,
         codeunit "Shpfy Math" = X,
         codeunit "Shpfy Metafield API" = X,
+        codeunit "Shpfy Metafields" = X,
         codeunit "Shpfy Metafield Owner Company" = X,
         codeunit "Shpfy Metafield Owner Customer" = X,
         codeunit "Shpfy Metafield Owner Product" = X,

--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductEvents.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductEvents.Codeunit.al
@@ -82,6 +82,15 @@ codeunit 30177 "Shpfy Product Events"
     begin
     end;
 
+    /// <summary>
+    /// Raised before updating product metafields in Shopify.
+    /// </summary>
+    /// <param name="ProductId">The Shopify product Id.</param>
+    [IntegrationEvent(false, false)]
+    internal procedure OnBeforeUpdateProductMetafields(ProductId: BigInteger)
+    begin
+    end;
+
 #pragma warning disable AS0027
     /// <summary> 
     /// Raised After Find Item Template.

--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductExport.Codeunit.al
@@ -68,7 +68,6 @@ codeunit 30178 "Shpfy Product Export"
         ProductEvents: Codeunit "Shpfy Product Events";
         ProductPriceCalc: Codeunit "Shpfy Product Price Calc.";
         VariantApi: Codeunit "Shpfy Variant API";
-        MetafieldAPI: Codeunit "Shpfy Metafield API";
         SkippedRecord: Codeunit "Shpfy Skipped Record";
         OnlyUpdatePrice: Boolean;
         RecordCount: Integer;
@@ -578,7 +577,6 @@ codeunit 30178 "Shpfy Product Export"
         ProductApi.SetShop(Shop);
         VariantApi.SetShop(Shop);
         ProductPriceCalc.SetShop(Shop);
-        MetafieldAPI.SetShop(Shop);
     end;
 
     /// <summary> 
@@ -765,17 +763,20 @@ codeunit 30178 "Shpfy Product Export"
     local procedure UpdateMetafields(ProductId: BigInteger)
     var
         ShpfyVariant: Record "Shpfy Variant";
+        Metafields: Codeunit "Shpfy Metafields";
     begin
         if OnlyUpdatePrice then
             exit;
 
-        MetafieldAPI.CreateOrUpdateMetafieldsInShopify(Database::"Shpfy Product", ProductId);
+        ProductEvents.OnBeforeUpdateProductMetafields(ProductId);
+
+        Metafields.SyncMetafieldsToShopify(Database::"Shpfy Product", ProductId, Shop.Code);
 
         ShpfyVariant.SetRange("Product Id", ProductId);
         ShpfyVariant.ReadIsolation := IsolationLevel::ReadCommitted;
         if ShpfyVariant.FindSet() then
             repeat
-                MetafieldAPI.CreateOrUpdateMetafieldsInShopify(Database::"Shpfy Variant", ShpfyVariant.Id);
+                Metafields.SyncMetafieldsToShopify(Database::"Shpfy Variant", ShpfyVariant.Id, Shop.Code);
             until ShpfyVariant.Next() = 0;
     end;
 


### PR DESCRIPTION
### Summary
This PR adds extensibility for Shopify product metafields, allowing external developers to programmatically manage metafields through a public facade codeunit and integration events.

### Problem
External developers cannot programmatically:
- Retrieve metafield definitions for products/variants
- Add metafields with values when missing
- Force-sync metafields to Shopify outside of the standard item sync

### Solution
Implemented a public facade pattern (similar to existing `Shpfy Product` and `Shpfy Orders` codeunits) for metafield management.

### Changes

- **ShpfyMetafields.Codeunit.al** - Public facade codeunit with:
  - `GetMetafieldDefinitions(ParentTableNo, OwnerId, ShopCode)` - Retrieve metafield definitions from Shopify
  - `SyncMetafieldToShopify(Metafield, ShopCode): BigInteger` - Sync a single metafield to Shopify
  - `SyncMetafieldsToShopify(ParentTableNo, OwnerId, ShopCode)` - Sync all metafields for a resource

- **ShpfyProductEvents.Codeunit.al**
  - Added `OnBeforeUpdateProductMetafields(ProductId: BigInteger)` integration event

- **ShpfyProductExport.Codeunit.al**
  - Raises `OnBeforeUpdateProductMetafields` event before syncing metafields
  - Refactored to use public facade for metafield operations

- **ShpfyMetafields.Page.al**
  - Added "Sync to Shopify" action with multi-select support
  - Refactored to use public facade for all metafield operations

- **ShpfyCustomerExport.Codeunit.al**
  - Refactored to use public facade for metafield sync

- **ShpfyCompanyExport.Codeunit.al**
  - Refactored to use public facade for metafield sync

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#617035](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617035)


