### PR TITLE
[Shopify] Variant option extensibility

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductEvents.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductEvents.Codeunit.al
@@ -405,4 +405,31 @@ codeunit 30177 "Shpfy Product Events"
     internal procedure OnAfterProductsToSynchronizeFiltersSet(var ShopifyProduct: Record "Shpfy Product"; Shop: Record "Shpfy Shop"; OnlyUpdatePrice: Boolean)
     begin
     end;
+
+    /// <summary>
+    /// Raised after the product variant data has been filled from Business Central Item, Item Variant, and Item Unit of Measure.
+    /// This event allows customization of the Shopify variant after all standard fields are set, but only when an Item Variant is present.
+    /// </summary>
+    /// <param name="ShopifyVariant">The Shopify variant record to be customized.</param>
+    /// <param name="Item">The source Item record.</param>
+    /// <param name="ItemVariant">The source Item Variant record.</param>
+    /// <param name="ItemUnitofMeasure">The source Item Unit of Measure record.</param>
+    /// <param name="Shop">The Shopify shop context.</param>
+    [IntegrationEvent(false, false)]
+    internal procedure OnAfterFillInProductVariantDataFromVariant(var ShopifyVariant: Record "Shpfy Variant"; Item: Record Item; ItemVariant: Record "Item Variant"; ItemUnitofMeasure: Record "Item Unit of Measure"; Shop: Record "Shpfy Shop")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised after the product variant data has been filled from Business Central Item and Item Variant (without Unit of Measure).
+    /// This event allows customization of the Shopify variant after all standard fields are set.
+    /// </summary>
+    /// <param name="ShopifyVariant">The Shopify variant record to be customized.</param>
+    /// <param name="Item">The source Item record.</param>
+    /// <param name="ItemVariant">The source Item Variant record.</param>
+    /// <param name="Shop">The Shopify shop context.</param>
+    [IntegrationEvent(false, false)]
+    internal procedure OnAfterFillInProductVariantData(var ShopifyVariant: Record "Shpfy Variant"; Item: Record Item; ItemVariant: Record "Item Variant"; Shop: Record "Shpfy Shop")
+    begin
+    end;
 }

--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductExport.Codeunit.al
@@ -429,6 +429,7 @@ codeunit 30178 "Shpfy Product Export"
             ShopifyVariant."Item SystemId" := Item.SystemId;
             ShopifyVariant."Item Variant SystemId" := ItemVariant.SystemId;
             ShopifyVariant."UoM Option Id" := 2;
+            ProductEvents.OnAfterFillInProductVariantData(ShopifyVariant, Item, ItemVariant, Shop);
         end;
     end;
 
@@ -481,6 +482,7 @@ codeunit 30178 "Shpfy Product Export"
             ShopifyVariant."Item SystemId" := Item.SystemId;
             ShopifyVariant."Item Variant SystemId" := ItemVariant.SystemId;
             ShopifyVariant."UoM Option Id" := 2;
+            ProductEvents.OnAfterFillInProductVariantDataFromVariant(ShopifyVariant, Item, ItemVariant, ItemUnitofMeasure, Shop);
         end;
     end;
 


### PR DESCRIPTION
Fixes #5867 

Shopify Connector: Custom Variant Naming for Item Variants

BC Idea: https://experience.dynamics.com/ideas/idea/?ideaid=244315e3-d8bb-f011-aa43-7c1e52a6c1f4

Adds logic to recalculate and set custom variant names after standard data fill-in, using a new event (OnAfterFillInProductVariantDataFromVariant).


Fixes [AB#617325](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617325)





