### PR TITLE
Revert incorrect change for inbound e-document page

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Document/Inbound/InboundEDocuments.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Document/Inbound/InboundEDocuments.Page.al
@@ -187,6 +187,7 @@ page 6105 "Inbound E-Documents"
                 AllowedFileExtensions = '.pdf';
                 AllowMultipleFiles = true;
                 Image = SendAsPDF;
+                Visible = false;
 
                 trigger OnAction(Files: List of [FileUpload])
                 begin


### PR DESCRIPTION
Reverting unnecessary change to the inbound e-documents page that make the Import PDF action visible
Fixes [AB#579972](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/579972)



