### PR TITLE
[Shopify] Do not create multiple links for the same invoice

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Document Links/Codeunits/ShpfyDocumentLinkMgt.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Document Links/Codeunits/ShpfyDocumentLinkMgt.Codeunit.al
@@ -105,8 +105,14 @@ codeunit 30262 "Shpfy Document Link Mgt."
                             SalesShipments.Add(SalesInvoiceLine."Shipment No.");
                             DocLinkToBCDoc.SetRange("Document Type", DocLinkToBCDoc."Document Type"::"Posted Sales Shipment");
                             DocLinkToBCDoc.SetRange("Document No.", SalesShipmentHeader."No.");
-                            if DocLinkToBCDoc.FindFirst() then
-                                CreateNewDocumentLink(DocLinkToBCDoc."Shopify Document Type", DocLinkToBCDoc."Shopify Document Id", "Shpfy Document Type"::"Posted Sales Invoice", SalesInvHdrNo);
+                            if DocLinkToBCDoc.FindFirst() then begin
+                                DocLinkToBCDoc.SetRange("Shopify Document Type", DocLinkToBCDoc."Shopify Document Type");
+                                DocLinkToBCDoc.SetRange("Shopify Document Id", DocLinkToBCDoc."Shopify Document Id");
+                                DocLinkToBCDoc.SetRange("Document Type", "Shpfy Document Type"::"Posted Sales Invoice");
+                                DocLinkToBCDoc.SetRange("Document No.", SalesInvHdrNo);
+                                if DocLinkToBCDoc.IsEmpty() then
+                                    CreateNewDocumentLink(DocLinkToBCDoc."Shopify Document Type", DocLinkToBCDoc."Shopify Document Id", "Shpfy Document Type"::"Posted Sales Invoice", SalesInvHdrNo);
+                            end;
                         end;
                 until SalesInvoiceLine.Next() = 0;
         end;


### PR DESCRIPTION
### Fix: Duplicate document link error when posting consolidated invoice for multi-location Shopify orders

#### Problem
When posting a sales invoice that consolidates shipments from the same Shopify order, the system throws the error:
> "The record in table Doc. Link To BC Doc. already exists. Identification fields and values: Shopify Document Type='Shopify Order' Shopify Document Id='...' Document Type='Posted Sales Invoice', Document No.='...'"

This occurs when:
- A Shopify order contains items from multiple locations
- Each location is shipped separately, creating multiple posted sales shipments
- Both shipments are combined into a single consolidated invoice using "Get Shipment Lines"

The issue is that the code iterates through all shipment lines being invoiced and attempts to insert a document link for each shipment. When multiple shipments belong to the same Shopify order, it tries to create duplicate links to the same posted sales invoice.

#### Solution
Before creating a new document link from a Shopify order to the posted sales invoice, the code now checks if a link already exists for that specific combination of:
- Shopify Document Type
- Shopify Document Id  
- Document Type (Posted Sales Invoice)
- Document No. (Invoice number)

Only if no existing link is found will a new one be created, preventing the duplicate record error.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#617360](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617360)


