### PR TITLE
Issue 5819, Remerge commit 0619af82fbdf14484d80e0f151a744fb5bc6ab64 from PR 5838

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspecGenRuleMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspecGenRuleMgmt.Codeunit.al
@@ -207,7 +207,7 @@ codeunit 20405 "Qlty. Inspec. Gen. Rule Mgmt."
                 Clear(TemporaryInspectionMatchRecordRef);
                 TemporaryInspectionMatchRecordRef.Open(TargetRecordRef.Number(), true);
                 TemporaryInspectionMatchRecordRef.Copy(TargetRecordRef);
-                if TemporaryInspectionMatchRecordRef.Insert(false) then;
+                TemporaryInspectionMatchRecordRef.Insert(false);
                 TemporaryInspectionMatchRecordRef.Reset();
                 TemporaryInspectionMatchRecordRef.SetView(QltyInspectionGenRule."Condition Filter");
                 if TemporaryInspectionMatchRecordRef.FindFirst() then
@@ -245,7 +245,7 @@ codeunit 20405 "Qlty. Inspec. Gen. Rule Mgmt."
                     TempAlreadySearchedsQltyInspectSourceConfig.Reset();
                     if not TempAlreadySearchedsQltyInspectSourceConfig.Get(TempAvailableQltyInspectSourceConfig.Code) then begin
                         TempAlreadySearchedsQltyInspectSourceConfig := TempAvailableQltyInspectSourceConfig;
-                        if TempAlreadySearchedsQltyInspectSourceConfig.Insert() then;
+                        TempAlreadySearchedsQltyInspectSourceConfig.Insert();
                         if QltyTraversal.FindFromTableLinkedRecordWithToTable(true, false, TempAvailableQltyInspectSourceConfig, TargetRecordRef, FoundLinkRecordRef) then
                             if FindFirstGenerationRuleAndRecordBasedOnRecursive(CurrentRecursionDepth, UseActivationFilter, IsManualCreation, FoundLinkRecordRef, OptionalItem, TempAvailableQltyInspectSourceConfig, TempAlreadySearchedsQltyInspectSourceConfig, OptionalSpecificTemplate, TempQltyInspectionGenRule) then begin
                                 Found := true;

--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRule.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRule.Table.al
@@ -337,7 +337,7 @@ table 20404 "Qlty. Inspection Gen. Rule"
         if Rec."Template Code" = '' then
             Error(ChooseTemplateFirstErr);
         if IsNullGuid(Rec.SystemId) and not Rec.IsTemporary() then
-            if Rec.Insert() then;
+            Rec.Insert();
         Filter := QltyInspecGenRuleMgmt.GetFilterForAvailableConfigurations();
         QltyFilterHelpers.RunModalLookupTable(Rec."Source Table No.", Filter);
         Rec.CalcFields("Table Caption");

--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRules.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRules.Page.al
@@ -627,7 +627,7 @@ page 20405 "Qlty. Inspection Gen. Rules"
             if QltyInspectionGenRule.FindSet() then
                 repeat
                     QltyInspectionGenRule.SetIntentAndDefaultTriggerValuesFromSetup();
-                    if QltyInspectionGenRule.Modify() then;
+                    QltyInspectionGenRule.Modify();
                 until QltyInspectionGenRule.Next() = 0;
     end;
 }

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultEvaluation.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultEvaluation.Codeunit.al
@@ -173,7 +173,7 @@ codeunit 20410 "Qlty. Result Evaluation"
         ValidateInspectionLineWithAllowableValues(QltyInspectionLine, OptionalQltyInspectionHeader, true, Modify);
     end;
 
-    procedure ValidateInspectionLineWithAllowableValues(var QltyInspectionLine: Record "Qlty. Inspection Line"; var OptionalQltyInspectionHeader: Record "Qlty. Inspection Header"; CheckForAllowableValues: Boolean; Modify: Boolean)
+    procedure ValidateInspectionLineWithAllowableValues(var QltyInspectionLine: Record "Qlty. Inspection Line"; var OptionalQltyInspectionHeader: Record "Qlty. Inspection Header"; CheckForAllowableValues: Boolean; UpdateHeader: Boolean)
     var
         QltyTest: Record "Qlty. Test";
         QltyInspectionResult: Record "Qlty. Inspection Result";
@@ -203,13 +203,13 @@ codeunit 20410 "Qlty. Result Evaluation"
 
         QltyInspectionLine.Validate("Result Code", Result);
 
-        if Modify then
+        if UpdateHeader then
             QltyInspectionLine.Modify(true);
 
         if (not QltyInspectionLine.IsTemporary()) and (OptionalQltyInspectionHeader."No." <> '') and (QltyInspectionLine."Inspection No." <> '') then begin
             OptionalQltyInspectionHeader.UpdateResultFromLines();
             OptionalQltyInspectionHeader.Validate("Result Code");
-            if Modify then
+            if UpdateHeader and not IsNullGuid(OptionalQltyInspectionHeader.SystemId) then
                 if OptionalQltyInspectionHeader.Modify(true) then;
         end;
     end;

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyLookupCodePart.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyLookupCodePart.Page.al
@@ -397,9 +397,6 @@ page 20435 "Qlty. Lookup Code Part"
 
     trigger OnInsertRecord(BelowxRec: Boolean): Boolean
     begin
-        if QltyTest.Code <> '' then
-            if QltyTest.Modify(true) then;
-
         UpdateResultOptions();
         CurrPage.Update(false);
     end;

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTest.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTest.Table.al
@@ -525,12 +525,16 @@ table 20401 "Qlty. Test"
                     OfChoices := Rec."Allowable Values".Split(',');
                     foreach Choice in OfChoices do begin
                         Choice := Choice.Trim();
+                        if not TempBufferQltyLookupCode.Get(Rec.Code, CopyStr(Choice, 1, MaxStrLen(TempBufferQltyLookupCode.Code))) then begin
+                            TempBufferQltyLookupCode.Init();
+                            TempBufferQltyLookupCode."Group Code" := Rec.Code;
                         TempBufferQltyLookupCode.Code := CopyStr(Choice, 1, MaxStrLen(TempBufferQltyLookupCode.Code));
                         TempBufferQltyLookupCode.Description := CopyStr(Choice, 1, MaxStrLen(TempBufferQltyLookupCode.Description));
                         TempBufferQltyLookupCode."Custom 1" := CopyStr(Choice, 1, MaxStrLen(TempBufferQltyLookupCode."Custom 1"));
                         TempBufferQltyLookupCode."Custom 2" := TempBufferQltyLookupCode."Custom 1".ToLower();
                         TempBufferQltyLookupCode."Custom 3" := TempBufferQltyLookupCode."Custom 1".ToUpper();
-                        if TempBufferQltyLookupCode.Insert() then;
+                            TempBufferQltyLookupCode.Insert();
+                        end;
                     end;
                 end;
         end;

--- a/src/Apps/W1/Quality Management/app/src/Dispositions/Purchase/QltyDispPurchaseReturn.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Dispositions/Purchase/QltyDispPurchaseReturn.Codeunit.al
@@ -155,8 +155,10 @@ codeunit 20441 "Qlty. Disp. Purchase Return" implements "Qlty. Disposition"
             ReturnOrderPurchaseHeader."Vendor Cr. Memo No." := VendorCreditMemoNotMemo;
 
         ReturnOrderPurchaseHeader.Insert(true);
+        if TempCreatedBufferPurchaseHeader."No." <> ReturnOrderPurchaseHeader."No." then begin
         TempCreatedBufferPurchaseHeader := ReturnOrderPurchaseHeader;
-        if TempCreatedBufferPurchaseHeader.Insert() then;
+            TempCreatedBufferPurchaseHeader.Insert();
+        end;
     end;
 
     local procedure CreatePurchaseReturnOrderLine(var QltyInspectionHeader: Record "Qlty. Inspection Header"; var TempQuantityToActQltyDispositionBuffer: Record "Qlty. Disposition Buffer" temporary; var PurchRcptLine: Record "Purch. Rcpt. Line"; var ReturnOrderPurchaseHeader: Record "Purchase Header")

--- a/src/Apps/W1/Quality Management/app/src/Dispositions/PutAway/QltyDispInternalPutAway.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Dispositions/PutAway/QltyDispInternalPutAway.Codeunit.al
@@ -143,7 +143,7 @@ codeunit 20447 "Qlty. Disp. Internal Put-away" implements "Qlty. Disposition"
         if (TempWarehouseEntry."Lot No." <> '') or (TempWarehouseEntry."Serial No." <> '') or (TempWarehouseEntry."Package No." <> '') then
             WhseInternalPutAwayLine.SetItemTrackingLines(TempWarehouseEntry, Quantity);
 
-        if WhseInternalPutAwayLine.Modify() then;
+        WhseInternalPutAwayLine.Modify();
     end;
 
     /// <summary>

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
@@ -333,13 +333,13 @@ table 20405 "Qlty. Inspection Header"
 
                     Rec."Finished By User ID" := CopyStr(UserId(), 1, MaxStrLen(Rec."Finished By User ID"));
                     Rec."Finished Date" := CurrentDateTime();
-                    if Rec.Modify(false) then;
+                    Rec.Modify(false);
                     OnInspectionFinished(Rec);
 
                     QltyStartWorkflow.StartWorkflowInspectionFinished(Rec);
                 end else
                     if (xRec.Status = xRec.Status::Finished) and (Rec.Status = Rec.Status::Open) then begin
-                        if Rec.Modify(false) then;
+                        Rec.Modify(false);
                         OnInspectionReopen(Rec);
                         QltyStartWorkflow.StartWorkflowInspectionReopens(Rec);
                     end
@@ -1190,7 +1190,7 @@ table 20405 "Qlty. Inspection Header"
         if TempTrackingSpecification."Lot No." <> Rec."Source Lot No." then begin
             Rec."Source Lot No." := TempTrackingSpecification."Lot No.";
             if not Rec.IsTemporary() then
-                if Rec.Modify() then;
+                Rec.Modify();
         end;
     end;
 
@@ -1258,7 +1258,7 @@ table 20405 "Qlty. Inspection Header"
         if TempTrackingSpecification."Package No." <> Rec."Source Package No." then begin
             Rec."Source Package No." := TempTrackingSpecification."Package No.";
             if not Rec.IsTemporary() then
-                if Rec.Modify() then;
+                Rec.Modify();
         end;
     end;
 
@@ -1322,7 +1322,7 @@ table 20405 "Qlty. Inspection Header"
         if TempTrackingSpecification."Serial No." <> Rec."Source Serial No." then begin
             Rec."Source Serial No." := TempTrackingSpecification."Serial No.";
             if not Rec.IsTemporary() then
-                if Rec.Modify() then;
+                Rec.Modify();
         end;
     end;
 

--- a/src/Apps/W1/Quality Management/app/src/Integration/Manufacturing/QltyProdGenRuleWizard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Manufacturing/QltyProdGenRuleWizard.Page.al
@@ -813,7 +813,7 @@ page 20462 "Qlty. Prod. Gen. Rule Wizard"
             QltyInspectionGenRule."Assembly Trigger" := QltyAssemblyTrigger;
             QltyManagementSetup."Assembly Trigger" := QltyAssemblyTrigger;
         end;
-        if QltyManagementSetup.Modify(false) then;
+        QltyManagementSetup.Modify(false);
         QltyInspectionGenRule."Item Filter" := ItemRuleFilter;
         QltyInspectionGenRule.Modify();
 

--- a/src/Apps/W1/Quality Management/app/src/Integration/Receiving/QltyRecGenRuleWizard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Receiving/QltyRecGenRuleWizard.Page.al
@@ -924,7 +924,7 @@ page 20461 "Qlty. Rec. Gen. Rule Wizard"
                 end;
         end;
 
-        if QltyManagementSetup.Modify(false) then;
+        QltyManagementSetup.Modify(false);
         QltyInspectionGenRule."Item Filter" := ItemRule;
         QltyInspectionGenRule.Modify();
 

--- a/src/Apps/W1/Quality Management/app/src/Integration/Warehouse/QltyWarehouseIntegration.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Warehouse/QltyWarehouseIntegration.Codeunit.al
@@ -54,7 +54,8 @@ codeunit 20438 "Qlty. - Warehouse Integration"
         TempTrackingSpecification."Variant Code" := WarehouseEntry."Variant Code";
         TempTrackingSpecification."Lot No." := WarehouseEntry."Lot No.";
         TempTrackingSpecification."Serial No." := WarehouseEntry."Serial No.";
-        if TempTrackingSpecification.Insert(false) then;
+        TempTrackingSpecification."Package No." := WarehouseEntry."Package No.";
+        TempTrackingSpecification.Insert(false);
 
         if GetOptionalSourceVariantForWarehouseJournalLine(WarehouseJournalLine, DoNotSendSourceVariant) then
             CollectSourceItemTracking(DoNotSendSourceVariant, TempTrackingSpecification);

--- a/src/Apps/W1/Quality Management/app/src/Integration/Warehouse/QltyWhseGenRuleWizard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Warehouse/QltyWhseGenRuleWizard.Page.al
@@ -673,7 +673,7 @@ page 20460 "Qlty. Whse. Gen. Rule Wizard"
         QltyInspectionGenRule.Modify();
         QltyManagementSetup.Get();
         QltyManagementSetup."Warehouse Trigger" := QltyWarehouseTrigger;
-        if QltyManagementSetup.Modify(false) then;
+        QltyManagementSetup.Modify(false);
 
         ExistingQltyInspectionGenRule.SetRange("Template Code", QltyInspectionGenRule."Template Code");
         ExistingQltyInspectionGenRule.SetRange("Source Table No.", QltyInspectionGenRule."Source Table No.");

--- a/src/Apps/W1/Quality Management/app/src/Reports/QltyReportSelectionQM.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Reports/QltyReportSelectionQM.Page.al
@@ -89,7 +89,10 @@ page 20442 "Qlty. Report Selection - QM"
     local procedure SetUsageFilter(ModifyRec: Boolean)
     begin
         if ModifyRec then
-            if Rec.Modify() then;
+            if IsNullGuid(Rec.SystemId) then
+                Rec.Insert()
+            else
+                Rec.Modify();
         Rec.FilterGroup(2);
 
         case QltyReportSelectionUsage of

--- a/src/Apps/W1/Quality Management/app/src/Utilities/QltyMiscHelpers.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Utilities/QltyMiscHelpers.Codeunit.al
@@ -225,6 +225,9 @@ codeunit 20599 "Qlty. Misc Helpers"
         DummyText: Text;
         TableFilter: Text;
     begin
+        if TempBufferQltyLookupCode.IsTemporary() then
+            TempBufferQltyLookupCode.DeleteAll();
+
         ReasonableMaximum := GetDefaultMaximumRowsFieldLookup();
 
         TableFilter := QltyExpressionMgmt.EvaluateTextExpression(QltyTest."Lookup Table Filter", OptionalContextQltyInspectionHeader, OptionalContextQltyInspectionLine);
@@ -333,7 +336,7 @@ codeunit 20599 "Qlty. Misc Helpers"
                     if (TempBufferQltyLookupCode.Description = '') and (TempBufferQltyLookupCode."Custom 1" <> '') then
                         TempBufferQltyLookupCode.Description := TempBufferQltyLookupCode."Custom 1";
 
-                    if TempBufferQltyLookupCode.Insert() then;
+                    TempBufferQltyLookupCode.Insert();
                     if HasAtLeastOne then
                         CSVSimpleText += ',';
                     CSVSimpleText += TempBufferQltyLookupCode."Custom 1";

--- a/src/Apps/W1/Quality Management/app/src/Utilities/QltyNotificationMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Utilities/QltyNotificationMgmt.Codeunit.al
@@ -406,7 +406,7 @@ codeunit 20437 "Qlty. Notification Mgmt."
             if QltyInspectionHeader.Get(InspectionRecordId) then begin
                 QltyInspectionHeader.AssignToSelf();
 #pragma warning disable AA0214
-                if QltyInspectionHeader.Modify() then;
+                QltyInspectionHeader.Modify();
 #pragma warning restore AA0214
             end;
     end;


### PR DESCRIPTION
Remerge of commit 0619af82fbdf14484d80e0f151a744fb5bc6ab64 from PR 5838 with object renames considered.

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->

#### Summary <!-- Provide a general summary of your changes -->
In short - using this pattern risks silent failures, which can introduce inconsistencies or other bugs when used as part of a larger process. To answer your question, we do use it also, but only in cases where we are 100% sure that it will not cause other issues or in some test setups. If that is the case, then ok, otherwise, would be better to remove the pattern.


1. QltyGenerationRuleMgmt.Codeunit.al 227,60: if TemporaryTestMatchRecordRef.Insert(false) then; 
Analysis: This did exist because a failure here was inconsequential to the remaining process.
Resolution: I've removed the pattern.

2. 265,79: if TempAlreadySearchedsQltyInspectSourceConfig.Insert() then; 
Analysis: This was here as a safety mechanism to avoid a failure with a repeated insert from a chained configuration, however there is another safety above it with the get().  A failure is inconsequential to the workflow, however the earlier safety should prevent the problem.
Resolution: I've removed the pattern.

3. 314,56: if TempQltyInTestGenerationRule.Insert() then;
Analysis: This is there to help avoid duplicate buffer records. A failed insert here should not fail the usage.
Resolution: I've kept this.

4. QltyInTestGenerationRule.Table.al 319,27: if Rec.Insert() then;
Analysis: This was here to help workaround a timing issue in BC with the feature of validating a field causing a record insert/modify if fast data entry occurs while a record is being added. Some initial testing with BC27 shows this doesn't seem to occur anymore. A failure is inconsequential to the workflow.
Resolution: I've removed this.

5. QltyInTestGeneratRules.Page.al 663,56: if QltyInTestGenerationRule.Modify() then;
Analysis: This was to help work with fast data entry that no longer seems to be an issue. A failure is inconsequential to the workflow.
Resolution: I've removed this.

6. QltyGradeEvaluation.Codeunit.al 262,64: if OptionalQltyInspectionTestHeader.Modify(true) then; 
Analysis: A failure here is inconsequential to workflow, but does not appear to be necessary.
Resolution: I've removed this.

7. 551,60: if TempNumericalQltyInspectionTestLine.Insert(false) then; 
Analysis: This is used with a buffer record where a failed insert must not cause a failure on the calling method.
Resolution: I've kept this.

8. 702,48: if TempTestStringValueQltyField.Insert() then;
Analysis: This change already appears to have been done in the main branch, or it otherwise doesn't appear to exist in the 'main' branch of the public version of the repo.
Resolution: No change made, appears to already have been done or otherwise not in the public repo.

9. QltyTraversal.Codeunit.al 217,52: if TemporaryTestMatchRecordRef.Insert(false) then;
Analysis: This is in ApplySourceFields, where the source record details are copied to a buffer record to allow copying. A failure of the insert must not cause a failure upstream.
Resolution: No change made.

10. QltyField.Table.al 527,60: if TempBufferQltyLookupCode.Insert() then;
Analysis: This was a safety to prevent human entered duplicates.
Resolution: I've changed the safety approach to Get() on the buffer record first intead.

11. QltyFieldExprCardPart.Page.al 505,33: if QltyField.Insert() then;
Analysis: This does not appear to exist in the 'main' branch on the public repo.
Resolution: Either this change was already made elsewhere, or is otherwise not in the public repo.

12. QltyFieldNumberCardPart.Page.al 1040,33: if QltyField.Insert() then;
Analysis: This does not appear to exist in the 'main' branch on the public repo.
Resolution: Either this change was already made elsewhere, or is otherwise not in the public repo.

13. QltyFieldWizard.Page.al 348,49: if QltyField.Delete() then;
Analysis: A failure here should not cause a problem and is ideally silent for the workflow of the wizard closing the page.
Resolution: I've left this.

14. QltyLookupCodePart.Page.al 406,37: if QltyField.Modify(true) then; 
Analysis: Based on code history on the full version that this code is derived from this appears to be another workaround for timing issues when the modify-on-field-change feature was initially implemented in BC. I cannot reproduce the original issue in the latest BC 27, so I've removed this workaround as it no longer seems necessary as far as I can tell.
Resolution: I've removed this code.

15. 506,33: if QltyField.Insert() then;
Analysis: This does not appear to exist in the 'main' branch on the public repo.
Resolution: Either this change was already made elsewhere, or is otherwise not in the public repo.

16. QltyDispMoveWorksheet.Codeunit.al 169,49: if TempCreatedsWhseWorksheetLine.Insert() then;
Analysis: This is a safety condition. TempCreatedWhseWorksheetLine should be cleared in PerformDisposition, and prior to the buffer being inserted it is based on a newly created worksheet line. In a perfect scenario there wouldn't be an error. However, an error should also not stop the flow since it's effectively just used to filter the lines that end up getting used to create a movement document. 
Resolution: I've left this, it's more important in this scenario to not error and in the unlikely event of a duplicate buffer record an error building the buffer should not stop the objective of a movement document being made.

17. QltyDispPurchaseReturn.Codeunit.al 156,51: if TempCreatedBufferPurchaseHeader.Insert() then;
Analysis: This is a safety, where a failed buffer insert should not be stopping the creation of a purchase return header. The safety could be done differently.
Resolution: I've changed the safety approach.

18. QltyDispInternalPutAway.Codeunit.al 151,43: if WhseInternalPutAwayLine.Modify() then;
Analysis: This is a safety, but doesn't appear necessary.
Resolution: I've removed this.

19. QltyInspectionTestHeader.Table.al 350,40: if Rec.Modify(false) then; 
Analysis: This is a safety, but doesn't appear necessary.
Resolution: I've removed this.

20. 356,44: if Rec.Modify(false) then; 
Analysis: This is a safety, but doesn't appear necessary.
Resolution: I've removed this.

21. 1191,31: if Rec.Modify() then; 
Analysis: This should not be here, a failure in the modify when changing the lot should cause a failure to the user.
Resolution: I've removed this.

22. 1255,31: if Rec.Modify() then; 
Analysis: This should not be here, a failure in the modify as the package is changed should cause a failure to the user.
Resolution: I've removed this.

23. 1315,31: if Rec.Modify() then;
Analysis: This should not be here, a failure in the modify as the package is changed should cause a failure to the user.
Resolution: I've removed this.

24. QltyProdGenRuleWizard.Page.al 815,44: if QltyManagementSetup.Modify(false) then;
Analysis: This was intended to help configurators that were allowed to change the rules but not necessarily the setup, which is an unnecessary flow in the foundation version.
Resolution: I've removed this.

25. QltyProductionIntegration.Codeunit.al 405,49: if QltyInspectionTestHeader.Modify(false) then; 
Analysis: This is here because the source document information not updating is not critical path especially with how it's triggered (such as a prod order changing to finished status). (An error here preventing a finish is worse than an error here stopping the transaction, finishing a prod order is important, updating an information field is not as important).
Resolution: I've left this, however the feature of updating the source details may not be necessary at all for foundation.

26. 425,49: if QltyInspectionTestHeader.Modify(false) then; 
Same as above.

27. 445,49: if QltyInspectionTestHeader.Modify(false) then;
Same as above.

28. QltyRecGenRuleWizard.Page.al 927,44: if QltyManagementSetup.Modify(false) then;
Analysis: This was intended to help configurators that were allowed to change the rules but not necessarily the setup, which is an unnecessary flow in the foundation version.
Resolution: I've removed this.

29. QltyWarehouseIntegration.Codeunit.al 67,50: if TempTrackingSpecification.Insert(false) then; 
Analysis: This was just a safety for the buffer record.
Resolution: I've removed this.

30. 157,56: if TempOutTrackingSpecification.Insert() then;
Analysis: This does not appear to exist in the 'main' branch on the public repo.
Resolution: Either this change was already made elsewhere, or is otherwise not in the public repo.

31. QltyWhseGenRuleWizard.Page.al 681,44: if QltyManagementSetup.Modify(false) then;
Analysis: This was intended to help configurators that were allowed to change the rules but not necessarily the setup, which is an unnecessary flow in the foundation version.
Resolution: I've removed this.

32. QltyInventoryAvailability.Codeunit.al 78,54: if TempOutBinContent.Insert(false) then; 

33. 97,54: if TempOutBinContent.Insert(false) then;
Analysis: This does not appear to exist in the 'main' branch on the public repo.
Resolution: Either this change was already made elsewhere, or is otherwise not in the public repo.

34. QltyReportSelection.Page.al 94,27: if Rec.Modify() then;
Analysis: This appears to be a workaround for a timing issue.
Resolution: A different safety has been added instead.

35. QltyInspectionActivities.Page.al 65,27: if Rec.Insert() then;
Analysis: This is to prevent an error where if someone uses the role center but doesn't have permission to insert the cue record it will prevent the role center from crashing.
Resolution: I've kept this.

36. QltyMiscHelpers.Codeunit.al 296,56: if TempBufferQltyLookupCode.Insert() then;
Analysis: This is to help prevent an error for an inconsequential setup issue, for example if someone configures the field to look up values that are not unique, this can help prevent an error. i.e A,B,A in the source data, the expected result would be A,B.
It looks like there is another safety checker for this same scenario with DuplicateChecker.
Resolution: I've removed this.

37. QltyNotificationMgmt.Codeunit.al 406,52: if QltyInspectionTestHeader.Modify() then;
Analysis: A failure here should probably fail to the user.
Resolution: I've removed this.



#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #5819 ([AB#611285](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611285)) 



