### PR TITLE
Bug 617495: [Subcontracting] Unsorted namespaces in Subcontracting app causes build failures

### DIFF
--- a/src/Apps/W1/Production Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubPurchPostExt.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubPurchPostExt.Codeunit.al
@@ -4,15 +4,15 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
+using Microsoft.Foundation.Enums;
 using Microsoft.Foundation.UOM;
 using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Journal;
 using Microsoft.Inventory.Ledger;
+using Microsoft.Manufacturing.Capacity;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
 using Microsoft.Purchases.Posting;
-using Microsoft.Foundation.Enums;
-using Microsoft.Manufacturing.Capacity;
 codeunit 99001535 "Sub. Purch. Post Ext"
 {
     var

--- a/src/Apps/W1/Production Subcontracting/App/src/Process/Codeunits/Extensions/SubItemJnlPostLineExt.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/App/src/Process/Codeunits/Extensions/SubItemJnlPostLineExt.Codeunit.al
@@ -4,12 +4,12 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
+using Microsoft.Inventory.Costing;
 using Microsoft.Inventory.Journal;
 using Microsoft.Inventory.Ledger;
 using Microsoft.Inventory.Posting;
 using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
-using Microsoft.Inventory.Costing;
 
 codeunit 99001515 "Sub. ItemJnlPostLine Ext"
 {

--- a/src/Apps/W1/Production Subcontracting/App/src/Process/Codeunits/Extensions/Transfer/SubTransOrderPostTransExt.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/App/src/Process/Codeunits/Extensions/Transfer/SubTransOrderPostTransExt.Codeunit.al
@@ -4,13 +4,13 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
+using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Journal;
+using Microsoft.Inventory.Ledger;
+using Microsoft.Inventory.Posting;
+using Microsoft.Inventory.Tracking;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.Document;
-using Microsoft.Inventory.Ledger;
-using Microsoft.Inventory.Tracking;
-using Microsoft.Inventory.Posting;
-using Microsoft.Inventory.Item;
 
 codeunit 99001547 "Sub. TransOrderPostTrans Ext"
 {

--- a/src/Apps/W1/Production Subcontracting/App/src/Process/Codeunits/SubPriceManagement.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/App/src/Process/Codeunits/SubPriceManagement.Codeunit.al
@@ -11,12 +11,12 @@ using Microsoft.Foundation.UOM;
 using Microsoft.Inventory.Costing;
 using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Requisition;
+using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.Setup;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Document;
-using Microsoft.Manufacturing.Capacity;
 
 codeunit 99001508 "Sub. Price Management"
 {

--- a/src/Apps/W1/Production Subcontracting/App/src/Process/Codeunits/SubSynchronizeManagement.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/App/src/Process/Codeunits/SubSynchronizeManagement.Codeunit.al
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
+using Microsoft.Foundation.Enums;
 using Microsoft.Foundation.UOM;
 using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Ledger;
@@ -11,7 +12,6 @@ using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
-using Microsoft.Foundation.Enums;
 
 codeunit 99001511 "Sub. Synchronize Management"
 {

--- a/src/Apps/W1/Production Subcontracting/App/src/Process/Codeunits/SubcontractingMgmt.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/App/src/Process/Codeunits/SubcontractingMgmt.Codeunit.al
@@ -6,6 +6,8 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Finance.Dimension;
 using Microsoft.Finance.GeneralLedger.Setup;
+using Microsoft.Foundation.Company;
+using Microsoft.Foundation.Enums;
 using Microsoft.Foundation.UOM;
 using Microsoft.Inventory.Costing;
 using Microsoft.Inventory.Item;
@@ -17,17 +19,15 @@ using Microsoft.Inventory.Planning;
 using Microsoft.Inventory.Requisition;
 using Microsoft.Inventory.Tracking;
 using Microsoft.Inventory.Transfer;
+using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Routing;
+using Microsoft.Manufacturing.Setup;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 using Microsoft.Utilities;
 using System.Utilities;
-using Microsoft.Manufacturing.Capacity;
-using Microsoft.Foundation.Enums;
-using Microsoft.Foundation.Company;
-using Microsoft.Manufacturing.Setup;
 
 codeunit 99001505 "Subcontracting Mgmt."
 {

--- a/src/Apps/W1/Production Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubRelProdOrder.PageExt.al
+++ b/src/Apps/W1/Production Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubRelProdOrder.PageExt.al
@@ -4,9 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
+using Microsoft.Inventory.Ledger;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
-using Microsoft.Inventory.Ledger;
 pageextension 99001504 "Sub. Rel. Prod. Order" extends "Released Production Order"
 {
     actions

--- a/src/Apps/W1/Production Subcontracting/App/src/Process/Prod Order Creation Wizard/Codeunits/SubCreateProdOrdOpt.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/App/src/Process/Prod Order Creation Wizard/Codeunits/SubCreateProdOrdOpt.Codeunit.al
@@ -9,6 +9,7 @@ using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Location;
 using Microsoft.Inventory.Requisition;
 using Microsoft.Inventory.Tracking;
+using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Routing;
@@ -16,7 +17,6 @@ using Microsoft.Manufacturing.Setup;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
-using Microsoft.Manufacturing.Capacity;
 codeunit 99001556 "Sub. Create Prod. Ord. Opt."
 {
     TableNo = "Purchase Line";

--- a/src/Apps/W1/Production Subcontracting/App/src/Process/Prod Order Creation Wizard/Codeunits/SubProdOrderCreateBind.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/App/src/Process/Prod Order Creation Wizard/Codeunits/SubProdOrderCreateBind.Codeunit.al
@@ -5,9 +5,9 @@
 namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Document;
-using Microsoft.Purchases.Vendor;
-using Microsoft.Purchases.Document;
 using Microsoft.Manufacturing.ProductionBOM;
+using Microsoft.Purchases.Document;
+using Microsoft.Purchases.Vendor;
 
 codeunit 99001555 "Sub. ProdOrderCreateBind"
 {

--- a/src/Apps/W1/Production Subcontracting/App/src/Process/Prod Order Creation Wizard/Codeunits/SubTempDataInitializer.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/App/src/Process/Prod Order Creation Wizard/Codeunits/SubTempDataInitializer.Codeunit.al
@@ -6,13 +6,13 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Location;
+using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.Setup;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
-using Microsoft.Manufacturing.Capacity;
 
 codeunit 99001552 "Sub. Temp Data Initializer"
 {

--- a/src/Apps/W1/Production Subcontracting/App/src/Process/Reports/SubDispatchingList.Report.al
+++ b/src/Apps/W1/Production Subcontracting/App/src/Process/Reports/SubDispatchingList.Report.al
@@ -5,6 +5,7 @@
 namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.CRM.Contact;
+using Microsoft.CRM.Interaction;
 using Microsoft.CRM.Segment;
 using Microsoft.CRM.Team;
 using Microsoft.Finance.Currency;
@@ -28,7 +29,6 @@ using Microsoft.Utilities;
 using System.Email;
 using System.Globalization;
 using System.Utilities;
-using Microsoft.CRM.Interaction;
 
 report 99001504 "Sub. Dispatching List"
 {

--- a/src/Apps/W1/Production Subcontracting/App/src/Process/Tableextensions/Manufacturing/SubProdOrderCompExt.TableExt.al
+++ b/src/Apps/W1/Production Subcontracting/App/src/Process/Tableextensions/Manufacturing/SubProdOrderCompExt.TableExt.al
@@ -4,12 +4,12 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
+using Microsoft.Inventory.Ledger;
 using Microsoft.Inventory.Location;
+using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
 using Microsoft.Warehouse.Structure;
-using Microsoft.Inventory.Ledger;
-using Microsoft.Inventory.Transfer;
 
 tableextension 99001502 "Sub. Prod Order Comp Ext." extends "Prod. Order Component"
 {

--- a/src/Apps/W1/Production Subcontracting/App/src/Process/Tableextensions/Transfer/SubDirectTransHeaderExt.TableExt.al
+++ b/src/Apps/W1/Production Subcontracting/App/src/Process/Tableextensions/Transfer/SubDirectTransHeaderExt.TableExt.al
@@ -4,10 +4,10 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
-using Microsoft.Inventory.Transfer;
-using Microsoft.Sales.Customer;
 using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Transfer;
 using Microsoft.Purchases.Vendor;
+using Microsoft.Sales.Customer;
 
 tableextension 99001524 "Sub. DirectTransHeader Ext." extends "Direct Trans. Header"
 {

--- a/src/Apps/W1/Production Subcontracting/App/src/Process/Tableextensions/Transfer/SubTransferHeader.TableExt.al
+++ b/src/Apps/W1/Production Subcontracting/App/src/Process/Tableextensions/Transfer/SubTransferHeader.TableExt.al
@@ -4,11 +4,11 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
+using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Location;
 using Microsoft.Inventory.Transfer;
-using Microsoft.Sales.Customer;
-using Microsoft.Inventory.Item;
 using Microsoft.Purchases.Vendor;
+using Microsoft.Sales.Customer;
 
 tableextension 99001520 "Sub. Transfer Header" extends "Transfer Header"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Libraries/SubCreateProdOrdWizLibrary.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Libraries/SubCreateProdOrdWizLibrary.Codeunit.al
@@ -4,17 +4,17 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Purchases.Document;
-using Microsoft.Inventory.Location;
-using Microsoft.Manufacturing.WorkCenter;
-using Microsoft.Manufacturing.Capacity;
-using Microsoft.Manufacturing.Setup;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Setup;
-using Microsoft.Purchases.Vendor;
 using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Location;
+using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Routing;
+using Microsoft.Manufacturing.Setup;
+using Microsoft.Manufacturing.WorkCenter;
+using Microsoft.Purchases.Document;
+using Microsoft.Purchases.Vendor;
 
 codeunit 139986 "Sub. CreateProdOrdWizLibrary"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Libraries/SubLibraryMfgManagement.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Libraries/SubLibraryMfgManagement.Codeunit.al
@@ -4,17 +4,17 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Manufacturing.Setup;
-using Microsoft.Manufacturing.WorkCenter;
-using Microsoft.Purchases.Vendor;
 using Microsoft.Finance.GeneralLedger.Setup;
-using Microsoft.Manufacturing.MachineCenter;
-using Microsoft.Manufacturing.Routing;
+using Microsoft.Inventory.Requisition;
 using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
-using Microsoft.Inventory.Requisition;
-using Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Manufacturing.Journal;
+using Microsoft.Manufacturing.MachineCenter;
+using Microsoft.Manufacturing.Routing;
+using Microsoft.Manufacturing.Setup;
+using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Manufacturing.WorkCenter;
+using Microsoft.Purchases.Vendor;
 #if CLEAN27
 using Microsoft.Inventory.Setup;
 #endif

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Libraries/SubLibraryMfgManagement.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Libraries/SubLibraryMfgManagement.Codeunit.al
@@ -6,6 +6,9 @@ namespace Microsoft.Manufacturing.Subcontracting.Test;
 
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Inventory.Requisition;
+#if CLEAN27
+using Microsoft.Inventory.Setup;
+#endif
 using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Journal;
@@ -15,9 +18,6 @@ using Microsoft.Manufacturing.Setup;
 using Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Vendor;
-#if CLEAN27
-using Microsoft.Inventory.Setup;
-#endif
 
 codeunit 139984 "Sub. Library Mfg. Management"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Libraries/SubManagementLibrary.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Libraries/SubManagementLibrary.Codeunit.al
@@ -4,10 +4,10 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Item;
-using Microsoft.Purchases.Vendor;
+using Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Manufacturing.WorkCenter;
+using Microsoft.Purchases.Vendor;
 
 codeunit 139983 "Sub. Management Library"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Libraries/SubProdOrderCheckLib.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Libraries/SubProdOrderCheckLib.Codeunit.al
@@ -4,15 +4,15 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Purchases.Document;
 using Microsoft.Manufacturing.Document;
-using Microsoft.Manufacturing.Subcontracting;
-using Microsoft.Purchases.Vendor;
-using Microsoft.Manufacturing.WorkCenter;
-using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.MachineCenter;
+using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.Setup;
+using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Manufacturing.WorkCenter;
+using Microsoft.Purchases.Document;
+using Microsoft.Purchases.Vendor;
 
 codeunit 139987 "Sub. ProdOrderCheckLib"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Libraries/SubSetupLibrary.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Libraries/SubSetupLibrary.Codeunit.al
@@ -4,11 +4,11 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Manufacturing.WorkCenter;
-using Microsoft.Manufacturing.Routing;
-using Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Item;
+using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.Setup;
+using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Manufacturing.WorkCenter;
 
 codeunit 139988 "Sub. Setup Library"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubLocationHandlerTest.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubLocationHandlerTest.Codeunit.al
@@ -4,17 +4,17 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Purchases.Document;
-using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Foundation.Company;
+using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Journal;
 using Microsoft.Inventory.Location;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.Document;
-using Microsoft.Purchases.Vendor;
-using Microsoft.Inventory.Item;
-using Microsoft.Inventory.Journal;
-using Microsoft.Manufacturing.Setup;
-using Microsoft.Foundation.Company;
 using Microsoft.Manufacturing.Routing;
+using Microsoft.Manufacturing.Setup;
+using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Purchases.Document;
+using Microsoft.Purchases.Vendor;
 
 codeunit 139981 "Sub. Location Handler Test"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubPurchSubcontTest.Codeunit.al
@@ -4,19 +4,19 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Inventory.Location;
-using Microsoft.Manufacturing.Document;
-using Microsoft.Purchases.Document;
-using Microsoft.Manufacturing.Routing;
-using Microsoft.Manufacturing.Subcontracting;
-using Microsoft.Purchases.Vendor;
-using Microsoft.Manufacturing.WorkCenter;
-using Microsoft.Inventory.Item;
-using System.Utilities;
-using Microsoft.Manufacturing.Capacity;
-using Microsoft.Manufacturing.Setup;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Setup;
+using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Location;
+using Microsoft.Manufacturing.Capacity;
+using Microsoft.Manufacturing.Document;
+using Microsoft.Manufacturing.Routing;
+using Microsoft.Manufacturing.Setup;
+using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Manufacturing.WorkCenter;
+using Microsoft.Purchases.Document;
+using Microsoft.Purchases.Vendor;
+using System.Utilities;
 
 codeunit 139991 "Sub. Purch. Subcont. Test"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizBOMRtngTest.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizBOMRtngTest.Codeunit.al
@@ -4,11 +4,11 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Manufacturing.Subcontracting;
-using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Document;
-using Microsoft.Purchases.Document;
+using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Routing;
+using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Purchases.Document;
 
 codeunit 139995 "Sub. Sub. Wiz. BOM/Rtng Test"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizChangeTest.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizChangeTest.Codeunit.al
@@ -4,13 +4,13 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Manufacturing.Subcontracting;
-using Microsoft.Manufacturing.Document;
-using Microsoft.Purchases.Document;
 using Microsoft.Inventory.Item;
-using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Manufacturing.Capacity;
+using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Setup;
+using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Manufacturing.WorkCenter;
+using Microsoft.Purchases.Document;
 
 codeunit 139980 "Sub. Sub. Wiz. Change Test"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizConfigTest.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizConfigTest.Codeunit.al
@@ -4,8 +4,8 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Purchases.Document;
 using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Purchases.Document;
 
 codeunit 139994 "Sub. Sub. Wiz. Config Test"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizGeneralTest.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizGeneralTest.Codeunit.al
@@ -4,9 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
+using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Purchases.Document;
-using Microsoft.Manufacturing.Document;
 
 codeunit 139993 "Sub. Sub. Wiz. General Test"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizPutAwayTest.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizPutAwayTest.Codeunit.al
@@ -4,13 +4,13 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Manufacturing.Document;
-using Microsoft.Purchases.Document;
-using Microsoft.Manufacturing.Subcontracting;
-using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Inventory.Location;
 using Microsoft.Manufacturing.Capacity;
+using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Setup;
+using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Manufacturing.WorkCenter;
+using Microsoft.Purchases.Document;
 
 codeunit 139999 "Sub. Sub. Wiz. Put-Away Test"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizSaveTest.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizSaveTest.Codeunit.al
@@ -4,13 +4,13 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Manufacturing.Subcontracting;
-using Microsoft.Manufacturing.Document;
-using Microsoft.Purchases.Document;
 using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Location;
-using Microsoft.Manufacturing.Routing;
+using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.ProductionBOM;
+using Microsoft.Manufacturing.Routing;
+using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Purchases.Document;
 
 codeunit 139998 "Sub. Sub. Wiz. Save Test"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizSourceTest.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizSourceTest.Codeunit.al
@@ -4,9 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
+using Microsoft.Inventory.Location;
 using Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Purchases.Document;
-using Microsoft.Inventory.Location;
 
 codeunit 139997 "Sub. Sub. Wiz. Source Test"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizVariantTest.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubWizVariantTest.Codeunit.al
@@ -4,13 +4,13 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Purchases.Document;
-using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Location;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Routing;
-using Microsoft.Inventory.Item;
-using Microsoft.Inventory.Location;
+using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Purchases.Document;
 
 codeunit 139996 "Sub. Sub. Wiz. Variant Test"
 {

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubcontractingSyncTest.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubcontractingSyncTest.Codeunit.al
@@ -4,23 +4,23 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Inventory.Item;
-using Microsoft.Manufacturing.MachineCenter;
-using Microsoft.Manufacturing.ProductionBOM;
-using Microsoft.Manufacturing.Document;
-using Microsoft.Purchases.Document;
-using Microsoft.Inventory.Requisition;
-using Microsoft.Manufacturing.Subcontracting;
-using Microsoft.Manufacturing.WorkCenter;
-using Microsoft.Manufacturing.Planning;
-using Microsoft.Inventory.Location;
-using Microsoft.Manufacturing.Routing;
-using Microsoft.Purchases.Vendor;
-using Microsoft.Manufacturing.Capacity;
-using Microsoft.Manufacturing.Setup;
-using Microsoft.Foundation.NoSeries;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Setup;
+using Microsoft.Foundation.NoSeries;
+using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Location;
+using Microsoft.Inventory.Requisition;
+using Microsoft.Manufacturing.Capacity;
+using Microsoft.Manufacturing.Document;
+using Microsoft.Manufacturing.MachineCenter;
+using Microsoft.Manufacturing.Planning;
+using Microsoft.Manufacturing.ProductionBOM;
+using Microsoft.Manufacturing.Routing;
+using Microsoft.Manufacturing.Setup;
+using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Manufacturing.WorkCenter;
+using Microsoft.Purchases.Document;
+using Microsoft.Purchases.Vendor;
 
 codeunit 139992 "Sub. Subcontracting Sync Test"
 { // [FEATURE] Subcontracting Management

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubcontractingTest.Codeunit.al
@@ -4,37 +4,37 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using Microsoft.Manufacturing.Subcontracting;
-using Microsoft.Inventory.Item;
-using Microsoft.Manufacturing.MachineCenter;
-using Microsoft.Manufacturing.Document;
-using Microsoft.Purchases.Document;
-using Microsoft.Manufacturing.WorkCenter;
-using Microsoft.Manufacturing.ProductionBOM;
-using Microsoft.Inventory.Transfer;
-using Microsoft.Inventory.Location;
-using Microsoft.Warehouse.Structure;
-using Microsoft.Inventory.Requisition;
-using Microsoft.Purchases.Vendor;
-using Microsoft.Manufacturing.Planning;
-using Microsoft.Manufacturing.Routing;
-using Microsoft.Purchases.Comment;
-using Microsoft.Sales.Customer;
-using Microsoft.Inventory.Planning;
-using Microsoft.Sales.Document;
-using Microsoft.Purchases.History;
-using Microsoft.Inventory.Ledger;
-using Microsoft.Warehouse.Document;
-using Microsoft.Manufacturing.Capacity;
-using Microsoft.Manufacturing.Setup;
-using Microsoft.Foundation.NoSeries;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Setup;
+using Microsoft.Foundation.Enums;
+using Microsoft.Foundation.NoSeries;
+using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Journal;
+using Microsoft.Inventory.Ledger;
+using Microsoft.Inventory.Location;
+using Microsoft.Inventory.Planning;
+using Microsoft.Inventory.Requisition;
 using Microsoft.Inventory.Setup;
 using Microsoft.Inventory.Tracking;
-using Microsoft.Inventory.Journal;
-using Microsoft.Foundation.Enums;
+using Microsoft.Inventory.Transfer;
+using Microsoft.Manufacturing.Capacity;
+using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Journal;
+using Microsoft.Manufacturing.MachineCenter;
+using Microsoft.Manufacturing.Planning;
+using Microsoft.Manufacturing.ProductionBOM;
+using Microsoft.Manufacturing.Routing;
+using Microsoft.Manufacturing.Setup;
+using Microsoft.Manufacturing.Subcontracting;
+using Microsoft.Manufacturing.WorkCenter;
+using Microsoft.Purchases.Comment;
+using Microsoft.Purchases.Document;
+using Microsoft.Purchases.History;
+using Microsoft.Purchases.Vendor;
+using Microsoft.Sales.Customer;
+using Microsoft.Sales.Document;
+using Microsoft.Warehouse.Document;
+using Microsoft.Warehouse.Structure;
 
 codeunit 139989 "Sub. Subcontracting Test"
 { // [FEATURE] Subcontracting Management
@@ -1584,7 +1584,7 @@ Comment = '|%1 = Transfer Order No.';
         Assert.Equal(Vendor."Subcontr. Location Code", PlanningComponent."Location Code");
     end;
 
-//    [Test]
+    //    [Test]
     procedure TestPostItemChargeAssignedToSubcontractingLing_ValueEntryWithCapacityRelation()
     var
         ItemCharge: Record "Item Charge";

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubcontractingUITest.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubcontractingUITest.Codeunit.al
@@ -4,14 +4,14 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
-using System.Reflection;
+using Microsoft.Inventory.Planning;
+using Microsoft.Inventory.Requisition;
+using Microsoft.Manufacturing.Journal;
+using Microsoft.Manufacturing.ProductionBOM;
+using Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
-using Microsoft.Inventory.Requisition;
-using Microsoft.Manufacturing.ProductionBOM;
-using Microsoft.Inventory.Planning;
-using Microsoft.Manufacturing.Subcontracting;
-using Microsoft.Manufacturing.Journal;
+using System.Reflection;
 
 codeunit 139990 "Sub. Subcontracting UI Test"
 {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Unsorted namespaces in Production Subcontracting app causes compilation errors in all build tasks in the pipeline.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#617495](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617495)



