### PR TITLE
[Subscription Billing] Make Subscription Billing Exchange Rate Selection reusable

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
@@ -1332,7 +1332,7 @@ table 8059 "Subscription Line"
         end;
     end;
 
-    internal procedure OpenExchangeSelectionPage(var NewCurrencyFactorDate: Date; var NewCurrencyFactor: Decimal; CurrencyCode: Code[10]; NewMessageTxt: Text; CalledFromServiceObject: Boolean): Boolean
+    procedure OpenExchangeSelectionPage(var NewCurrencyFactorDate: Date; var NewCurrencyFactor: Decimal; CurrencyCode: Code[10]; NewMessageTxt: Text; CalledFromServiceObject: Boolean): Boolean
     var
         ExchangeRateSelectionPage: Page "Exchange Rate Selection";
     begin

--- a/src/Apps/W1/Subscription Billing/App/Service Objects/Pages/ExchangeRateSelection.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Objects/Pages/ExchangeRateSelection.Page.al
@@ -60,12 +60,12 @@ page 8088 "Exchange Rate Selection"
                 Error(CurrencyCodeChangePriceMustBeUpdatedErr);
     end;
 
-    internal procedure SetIsCalledFromServiceObject(CalledFromServiceObject: Boolean)
+    procedure SetIsCalledFromServiceObject(CalledFromServiceObject: Boolean)
     begin
         IsCalledFromServiceObject := CalledFromServiceObject;
     end;
 
-    internal procedure SetData(NewKeyDate: Date; NewCurrencyCode: Code[10]; NewMessage: Text)
+    procedure SetData(NewKeyDate: Date; NewCurrencyCode: Code[10]; NewMessage: Text)
     begin
         KeyDate := NewKeyDate;
         CurrencyCode := NewCurrencyCode;
@@ -75,7 +75,7 @@ page 8088 "Exchange Rate Selection"
         MessageTxt := NewMessage;
     end;
 
-    internal procedure GetData(var NewKeyDate: Date; var NewExchangeRate: Decimal)
+    procedure GetData(var NewKeyDate: Date; var NewExchangeRate: Decimal)
     begin
         NewKeyDate := KeyDate;
         NewExchangeRate := ExchangeRate;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

This commit exposes (makes public) the following functions so the standard Exchange Rate Selection flow from Subscription Billing can be reused by other extensions:

Table 8059 ΓÇ£Subscription LineΓÇ¥ - procedure OpenExchangeSelectionPage(...)
Page 8088 ΓÇ£Exchange Rate SelectionΓÇ¥ - procedures: SetData(...), GetData(...), SetIsCalledFromServiceObject(...)

Change: internal ΓåÆ public
#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #6045



Fixes [AB#617698](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617698)

