### PR TITLE
Use correct DataScope for Deletion of IsolatedStorage

### DIFF
--- a/src/Apps/W1/External File Storage - Azure Blob Service Connector/App/src/ExtBlobStorageAccount.Table.al
+++ b/src/Apps/W1/External File Storage - Azure Blob Service Connector/App/src/ExtBlobStorageAccount.Table.al
@@ -71,7 +71,8 @@ table 4560 "Ext. Blob Storage Account"
     trigger OnDelete()
     begin
         if not IsNullGuid(Rec."Secret Key") then
-            if IsolatedStorage.Delete(Rec."Secret Key") then;
+            if IsolatedStorage.Contains(Rec."Secret Key", DataScope::Company) then
+                IsolatedStorage.Delete(Rec."Secret Key", DataScope::Company);
     end;
 
     procedure SetSecret(Secret: SecretText)

--- a/src/Apps/W1/External File Storage - Azure File Service Connector/App/src/ExtFileShareAccount.Table.al
+++ b/src/Apps/W1/External File Storage - Azure File Service Connector/App/src/ExtFileShareAccount.Table.al
@@ -69,7 +69,8 @@ table 4570 "Ext. File Share Account"
     trigger OnDelete()
     begin
         if not IsNullGuid(Rec."Secret Key") then
-            if IsolatedStorage.Delete(Rec."Secret Key") then;
+            if IsolatedStorage.Contains(Rec."Secret Key", DataScope::Company) then
+                IsolatedStorage.Delete(Rec."Secret Key", DataScope::Company);
     end;
 
     procedure SetSecret(Secret: SecretText)

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccount.Table.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccount.Table.al
@@ -170,8 +170,10 @@ table 4580 "Ext. SharePoint Account"
 
     local procedure TryDeleteIsolatedStorageValue(StorageKey: Guid)
     begin
-        if not IsNullGuid(StorageKey) then
-            if IsolatedStorage.Delete(StorageKey) then;
+        if IsNullGuid(StorageKey) then
+            exit;
+        if IsolatedStorage.Contains(StorageKey, DataScope::Company) then
+            IsolatedStorage.Delete(StorageKey, DataScope::Company);
     end;
 
     local procedure SetIsolatedStorageValue(StorageKey: Guid; Value: SecretText; ErrorMessage: Text)


### PR DESCRIPTION
#### Summary
Use the correct DataScope for the IsolatedStorage used in the external storage apps.

#### Work Item(s)
Fixes #6086 

Fixes [AB#617660](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617660)