### PR TITLE
[27.x]-616047-NoSeriesCode is not visible anymore

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
@@ -28,7 +28,7 @@ codeunit 304 "No. Series - Impl."
     var
         NoSeries: Record "No. Series";
     begin
-        TestManualInternal(NoSeriesCode, StrSubstNo(CannotAssignManuallyErr, NoSeries.FieldCaption("Manual Nos."), NoSeries.TableCaption(), NoSeries.Code));
+        TestManualInternal(NoSeriesCode, StrSubstNo(CannotAssignManuallyErr, NoSeries.FieldCaption("Manual Nos."), NoSeries.TableCaption(), NoSeriesCode));
     end;
 
     procedure TestManual(NoSeriesCode: Code[20]; DocumentNo: Code[20])
@@ -275,17 +275,17 @@ codeunit 304 "No. Series - Impl."
         NoSeries: Record "No. Series";
         NoSeriesRelationship: Record "No. Series Relationship";
     begin
-            NoSeriesRelationship.SetRange(Code, OriginalNoSeriesCode);
-            if NoSeriesRelationship.FindSet() then
-                repeat
-                    NoSeries.Code := NoSeriesRelationship."Series Code";
-                    NoSeries.Mark := true;
-                until NoSeriesRelationship.Next() = 0;
+        NoSeriesRelationship.SetRange(Code, OriginalNoSeriesCode);
+        if NoSeriesRelationship.FindSet() then
+            repeat
+                NoSeries.Code := NoSeriesRelationship."Series Code";
+                NoSeries.Mark := true;
+            until NoSeriesRelationship.Next() = 0;
 
-            // Mark the original series
-            NoSeries.Code := OriginalNoSeriesCode;
-            NoSeries.Mark := true;
-            NoSeries.MarkedOnly := true;
+        // Mark the original series
+        NoSeries.Code := OriginalNoSeriesCode;
+        NoSeries.Mark := true;
+        NoSeries.MarkedOnly := true;
 
         // If DefaultHighlightedNoSeriesCode is set, make sure we select it by default on the page
         if DefaultHighlightedNoSeriesCode <> '' then


### PR DESCRIPTION
[AB#616047](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/616047)

[Bug 616047](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/616047): [27.x] [All-E] No. Series Code is not visible anymore as before on the errors related to missing Manual No. Series setting.

