### PR TITLE
Disable test TestPostItemChargeAssignedToSubcontractingLing_ValueEntryWithCapacityRelation as it is blocking uptake

### DIFF
--- a/src/Apps/W1/Production Subcontracting/Test/DisabledTests/SubcontractingTests.json
+++ b/src/Apps/W1/Production Subcontracting/Test/DisabledTests/SubcontractingTests.json
@@ -1,0 +1,8 @@
+[
+    {
+        "bug": "617432",
+        "codeunitId": 139989,
+        "codeunitName": "Sub. Subcontracting Test",
+        "method": "TestPostItemChargeAssignedToSubcontractingLing_ValueEntryWithCapacityRelation"
+    }
+]

--- a/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Production Subcontracting/Test/src/Codeunits/Tests/SubSubcontractingTest.Codeunit.al
@@ -1585,7 +1585,7 @@ Comment = '|%1 = Transfer Order No.';
         Assert.Equal(Vendor."Subcontr. Location Code", PlanningComponent."Location Code");
     end;
 
-//    [Test]
+    [Test]
     procedure TestPostItemChargeAssignedToSubcontractingLing_ValueEntryWithCapacityRelation()
     var
         ItemCharge: Record "Item Charge";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
TestPostItemChargeAssignedToSubcontractingLing_ValueEntryWithCapacityRelation test failure in CZ blocks the BCArtifact uptake. Disable it to enable the uptake
#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#617432](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617432)





