### PR TITLE
[MCP] Add partner telemetry for MCP Configuration lifecycle events

### DIFF
--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
@@ -36,11 +36,6 @@ page 8351 "MCP Config Card"
                 field(Active; Rec.Active)
                 {
                     Editable = not IsDefault;
-
-                    trigger OnValidate()
-                    begin
-                        MCPConfigImplementation.ActivateConfiguration(Rec.SystemId, Rec.Active);
-                    end;
                 }
                 field(EnableDynamicToolMode; Rec.EnableDynamicToolMode)
                 {
@@ -48,8 +43,6 @@ page 8351 "MCP Config Card"
 
                     trigger OnValidate()
                     begin
-                        MCPConfigImplementation.EnableDynamicToolMode(Rec.SystemId, Rec.EnableDynamicToolMode);
-
                         if not Rec.EnableDynamicToolMode then
                             Rec.DiscoverReadOnlyObjects := false;
                     end;
@@ -57,17 +50,13 @@ page 8351 "MCP Config Card"
                 field(DiscoverReadOnlyObjects; Rec.DiscoverReadOnlyObjects)
                 {
                     Editable = not IsDefault and Rec.EnableDynamicToolMode;
-
-                    trigger OnValidate()
-                    begin
-                        MCPConfigImplementation.EnableDiscoverReadOnlyObjects(Rec.SystemId, Rec.DiscoverReadOnlyObjects);
-                    end;
                 }
                 field(AllowProdChanges; Rec.AllowProdChanges)
                 {
                     trigger OnValidate()
                     begin
-                        MCPConfigImplementation.AllowCreateUpdateDeleteTools(Rec.SystemId, Rec.AllowProdChanges);
+                        if not Rec.AllowProdChanges then
+                            MCPConfigImplementation.DisableCreateUpdateDeleteToolsInConfig(Rec.SystemId);
                         CurrPage.Update();
                     end;
                 }
@@ -107,6 +96,21 @@ page 8351 "MCP Config Card"
     trigger OnAfterGetRecord()
     begin
         IsDefault := MCPConfigImplementation.IsDefaultConfiguration(Rec);
+    end;
+
+    trigger OnDeleteRecord(): Boolean
+    begin
+        MCPConfigImplementation.LogConfigurationDeleted(Rec);
+    end;
+
+    trigger OnInsertRecord(BelowxRec: Boolean): Boolean
+    begin
+        MCPConfigImplementation.LogConfigurationCreated(Rec);
+    end;
+
+    trigger OnModifyRecord(): Boolean
+    begin
+        MCPConfigImplementation.LogConfigurationModified(Rec, xRec);
     end;
 
     var


### PR DESCRIPTION
### Summary
Adds partner telemetry and audit logging for MCP Configuration lifecycle events.

### Changes
- Added `Session.LogMessage` with `TelemetryScope::All` for created, modified, and deleted events
- Added `Session.LogAuditMessage` with `AuditCategory::ApplicationManagement` for all lifecycle events
- Modified events use a single telemetry tag and only include Old/New dimensions for settings that changed
- Centralized telemetry in `MCPConfigImplementation`, removed duplicate logging from page

### Telemetry Events
| Event | Message |
|-------|---------|
| Create | MCP Configuration created |
| Modify | MCP Configuration modified |
| Delete | MCP Configuration deleted |

### Custom Dimensions
- `MCPConfigurationName` - always included
- `Old/New` prefixed dimensions only for changed settings: `Active`, `AllowProdChanges`, `EnableDynamicToolMode`, `DiscoverReadOnlyObjects`

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#617875](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617875)






