### PR TITLE
[26.X]-611675-NoSeriesCode is not visible anymore

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
@@ -35,7 +35,7 @@ codeunit 304 "No. Series - Impl."
         NoSeriesManagement.OnBeforeTestManual(NoSeriesCode, IsHandled);
         if not IsHandled then
             if NoSeriesCode <> '' then
-                TestManualInternal(NoSeriesCode, StrSubstNo(CannotAssignManuallyErr, NoSeries.FieldCaption("Manual Nos."), NoSeries.TableCaption(), NoSeriesCode)
+                TestManualInternal(NoSeriesCode, StrSubstNo(CannotAssignManuallyErr, NoSeries.FieldCaption("Manual Nos."), NoSeries.TableCaption(), NoSeriesCode));
         NoSeriesManagement.OnAfterTestManual(NoSeriesCode);
     end;
 #pragma warning restore AL0432


### PR DESCRIPTION
[AB#611675](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611675)

[Bug 611675](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/611675): [All-E] No. Series Code is not visible anymore as before on the errors related to missing Manual No. Series setting.


