### PR TITLE
Fixes for various payables agent bugs

### DIFF
--- a/src/Apps/W1/EDocument/App/app.json
+++ b/src/Apps/W1/EDocument/App/app.json
@@ -37,11 +37,6 @@
       "id": "967eceac-106e-4102-b76a-fe5dc3d799e5",
       "name": "Payables Agent Tests",
       "publisher": "Microsoft"
-    },
-    {
-      "id": "fdeb586e-beff-49d8-947d-1e73ce980b35",
-      "name": "E-Document for Italy",
-      "publisher": "Microsoft"
     }
   ],
   "screenshots": [],

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
@@ -138,7 +138,6 @@ codeunit 6117 "E-Doc. Create Purchase Invoice" implements IEDocumentFinishDraft,
         if EDocumentPurchaseHeader."Due Date" <> 0D then
             PurchaseHeader.Validate("Due Date", EDocumentPurchaseHeader."Due Date");
         PurchaseHeader."Invoice Received Date" := PurchaseHeader."Document Date";
-        OnBeforeModifyPurchHeader(PurchaseHeader, EDocumentPurchaseHeader);
         PurchaseHeader.Modify();
 
         // Validate of currency has to happen after insert.
@@ -264,11 +263,6 @@ codeunit 6117 "E-Doc. Create Purchase Invoice" implements IEDocumentFinishDraft,
         PurchaseLine.SetRange("Document No.", DocumentNo);
         if PurchaseLine.FindLast() then
             exit(PurchaseLine."Line No.");
-    end;
-
-    [IntegrationEvent(false, false)]
-    local procedure OnBeforeModifyPurchHeader(var PurchaseHeader: Record "Purchase Header"; EDocumentPurchaseHeader: Record "E-Document Purchase Header")
-    begin
     end;
 
 }


### PR DESCRIPTION
Current pull requests contain changes for the following bugs:
- 'View Pdf" option does not work correctly. The fix contains two parts:
1. Different implementation of the HasPDFSource variable that is responsible for the visibility of the 'View pdf' action on the draft page
2. Adding the '.pdf' extension to the file name of the sample invoice which is previously resulted in the "not supported" file when calling this line of code:
`3. File.ViewFromStream(TempBlob.CreateInStream(), FileName, true)`

Fixes [AB#617937](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/617937/)








