### PR TITLE
[Bug]: Shopify Connector: Creating a Sales Credit Memo from Shopify Refund mixes Amounts with Presentment Amounts

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyCreateSalesDocRefund.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyCreateSalesDocRefund.Codeunit.al
@@ -340,7 +340,7 @@ codeunit 30246 "Shpfy Create Sales Doc. Refund"
                     "Shpfy Currency Handling"::"Shop Currency":
                         SalesLine.Validate("Unit Price", ReturnLine."Discounted Total Amount" / ReturnLine.Quantity);
                     "Shpfy Currency Handling"::"Presentment Currency":
-                        SalesLine.Validate("Unit Price", "Presentment Disc. Total Amt." / ReturnLine.Quantity);
+                        SalesLine.Validate("Unit Price", ReturnLine."Presentment Disc. Total Amt." / ReturnLine.Quantity);
                 end;
             end;
             SalesLine."Shpfy Refund Id" := RefundHeader."Refund Id";


### PR DESCRIPTION
Fixes #6138

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md

#### Summary 
implemented currency handling logic in procedure "CreateSalesLinesFromReturnLines"

#### Work Item(s) 
#6138


Fixes [AB#618713](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/618713)



