### PR TITLE
[27.x] [Subscription Billing] Fix VendorContractNo in Sales Quote Subform

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Page Extensions/SalesQuoteSubform.PageExt.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Page Extensions/SalesQuoteSubform.PageExt.al
@@ -86,7 +86,7 @@ pageextension 8075 "Sales Quote Subform" extends "Sales Quote Subform"
     local procedure InitializePageVariables()
     begin
         CustomerContractNo := Rec.RetrieveFirstContractNo("Service Partner"::Customer, Enum::Process::"Contract Renewal");
-        VendorContractNo := Rec.RetrieveFirstContractNo("Service Partner"::Customer, Enum::Process::"Contract Renewal");
+        VendorContractNo := Rec.RetrieveFirstContractNo("Service Partner"::Vendor, Enum::Process::"Contract Renewal");
     end;
 
     var


### PR DESCRIPTION
#### Summary 
Show the correct value for the VendorContractNo in the sales quote subform.
Backport of https://github.com/microsoft/BCApps/pull/6096

#### Work Item(s) 
Fixes #6094 
[AB#618050](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/618050)




