### PR TITLE
[Shopify] Fix Shopify API warning when SinceId = 0

### DIFF
--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLDisputes.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLDisputes.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 30388 "Shpfy GQL Disputes" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Text.</returns>
     procedure GetGraphQL(): Text
     begin
-        exit('{"query":"{ shopifyPaymentsAccount { disputes(first: 100, query: \"id:>{{SinceId}}\") { edges { cursor node { amount { amount currencyCode } reasonDetails { networkReasonCode reason } order { id } evidenceDueBy evidenceSentOn finalizedOn id status type } } pageInfo { hasNextPage } } } }"}');
+        exit('{"query":"{ shopifyPaymentsAccount { disputes(first: 100, query: \"id:>={{SinceId}}\") { edges { cursor node { amount { amount currencyCode } reasonDetails { networkReasonCode reason } order { id } evidenceDueBy evidenceSentOn finalizedOn id status type } } pageInfo { hasNextPage } } } }"}');
     end;
 
     /// <summary>

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLNextDisputes.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLNextDisputes.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 30389 "Shpfy GQL NextDisputes" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Text.</returns>
     procedure GetGraphQL(): Text
     begin
-        exit('{"query":"{ shopifyPaymentsAccount { disputes(first: 100, query: \"id:>{{SinceId}}\", after: \"{{After}}\") { edges { cursor node { amount { amount currencyCode } reasonDetails { networkReasonCode reason } order { id } evidenceDueBy evidenceSentOn finalizedOn id status type } } pageInfo { hasNextPage } } } }"}');
+        exit('{"query":"{ shopifyPaymentsAccount { disputes(first: 100, query: \"id:>={{SinceId}}\", after: \"{{After}}\") { edges { cursor node { amount { amount currencyCode } reasonDetails { networkReasonCode reason } order { id } evidenceDueBy evidenceSentOn finalizedOn id status type } } pageInfo { hasNextPage } } } }"}');
     end;
 
     /// <summary>

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLNextPaymTransactions.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLNextPaymTransactions.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 30387 "Shpfy GQL NextPaymTransactions" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Text.</returns>
     procedure GetGraphQL(): Text
     begin
-        exit('{"query":"{ shopifyPaymentsAccount { balanceTransactions(first: 100, query: \"id:>{{SinceId}}\", after: \"{{After}}\") { edges { node { id test associatedPayout { id } amount { amount currencyCode } fee { amount currencyCode } net { amount currencyCode } sourceId sourceOrderTransactionId transactionDate type associatedOrder { id } } cursor } pageInfo { hasNextPage } } } }"}');
+        exit('{"query":"{ shopifyPaymentsAccount { balanceTransactions(first: 100, query: \"id:>={{SinceId}}\", after: \"{{After}}\") { edges { node { id test associatedPayout { id } amount { amount currencyCode } fee { amount currencyCode } net { amount currencyCode } sourceId sourceOrderTransactionId transactionDate type associatedOrder { id } } cursor } pageInfo { hasNextPage } } } }"}');
     end;
 
     /// <summary>

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLNextPayouts.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLNextPayouts.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 30392 "Shpfy GQL NextPayouts" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Text.</returns>
     procedure GetGraphQL(): Text
     begin
-        exit('{"query":"{ shopifyPaymentsAccount { payouts(first: 100, query: \"id:>{{SinceId}}\", after: \"{{After}}\") { edges { cursor node { id status summary { adjustmentsFee { amount } adjustmentsGross { amount } chargesFee { amount } chargesGross { amount } refundsFee { amount } refundsFeeGross { amount } reservedFundsFee { amount } reservedFundsGross { amount } retriedPayoutsFee { amount } retriedPayoutsGross { amount currencyCode } } issuedAt net { amount currencyCode } } } pageInfo { hasNextPage } } } }"}');
+        exit('{"query":"{ shopifyPaymentsAccount { payouts(first: 100, query: \"id:>={{SinceId}}\", after: \"{{After}}\") { edges { cursor node { id status summary { adjustmentsFee { amount } adjustmentsGross { amount } chargesFee { amount } chargesGross { amount } refundsFee { amount } refundsFeeGross { amount } reservedFundsFee { amount } reservedFundsGross { amount } retriedPayoutsFee { amount } retriedPayoutsGross { amount currencyCode } } issuedAt net { amount currencyCode } } } pageInfo { hasNextPage } } } }"}');
     end;
 
     /// <summary>

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLPaymentTransactions.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLPaymentTransactions.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 30386 "Shpfy GQL PaymentTransactions" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Text.</returns>
     procedure GetGraphQL(): Text
     begin
-        exit('{"query":"{ shopifyPaymentsAccount { balanceTransactions(first: 100, query: \"id:>{{SinceId}}\") { edges { node { id test associatedPayout { id } amount { amount currencyCode } fee { amount currencyCode } net { amount currencyCode } sourceId sourceOrderTransactionId transactionDate type associatedOrder { id } } cursor } pageInfo { hasNextPage } } } }"}');
+        exit('{"query":"{ shopifyPaymentsAccount { balanceTransactions(first: 100, query: \"id:>={{SinceId}}\") { edges { node { id test associatedPayout { id } amount { amount currencyCode } fee { amount currencyCode } net { amount currencyCode } sourceId sourceOrderTransactionId transactionDate type associatedOrder { id } } cursor } pageInfo { hasNextPage } } } }"}');
     end;
 
     /// <summary>

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLPayouts.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLPayouts.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 30391 "Shpfy GQL Payouts" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Text.</returns>
     procedure GetGraphQL(): Text
     begin
-        exit('{"query":"{ shopifyPaymentsAccount { payouts(first: 100, query: \"id:>{{SinceId}}\") { edges { cursor node { id status summary { adjustmentsFee { amount } adjustmentsGross { amount } chargesFee { amount } chargesGross { amount } refundsFee { amount } refundsFeeGross { amount } reservedFundsFee { amount } reservedFundsGross { amount } retriedPayoutsFee { amount } retriedPayoutsGross { amount currencyCode } } issuedAt net { amount currencyCode } } } pageInfo { hasNextPage } } } }"}');
+        exit('{"query":"{ shopifyPaymentsAccount { payouts(first: 100, query: \"id:>={{SinceId}}\") { edges { cursor node { id status summary { adjustmentsFee { amount } adjustmentsGross { amount } chargesFee { amount } chargesGross { amount } refundsFee { amount } refundsFeeGross { amount } reservedFundsFee { amount } reservedFundsGross { amount } retriedPayoutsFee { amount } retriedPayoutsGross { amount currencyCode } } issuedAt net { amount currencyCode } } } pageInfo { hasNextPage } } } }"}');
     end;
 
     /// <summary>

--- a/src/Apps/W1/Shopify/App/src/Payments/Codeunits/ShpfyPaymentsAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Payments/Codeunits/ShpfyPaymentsAPI.Codeunit.al
@@ -30,7 +30,7 @@ codeunit 30385 "Shpfy Payments API"
         Parameters: Dictionary of [Text, Text];
     begin
         GraphQLType := GraphQLType::GetPaymentTransactions;
-        Parameters.Add('SinceId', Format(SinceId));
+        Parameters.Add('SinceId', Format(SinceId + 1));
         repeat
             JResponse := CommunicationMgt.ExecuteGraphQL(GraphQLType, Parameters);
             if JsonHelper.GetJsonObject(JResponse, JPaymentsAccount, 'data.shopifyPaymentsAccount') then
@@ -96,7 +96,7 @@ codeunit 30385 "Shpfy Payments API"
         Parameters: Dictionary of [Text, Text];
     begin
         GraphQLType := GraphQLType::GetPayouts;
-        Parameters.Add('SinceId', Format(SinceId));
+        Parameters.Add('SinceId', Format(SinceId + 1));
         repeat
             JResponse := CommunicationMgt.ExecuteGraphQL(GraphQLType, Parameters);
             if JsonHelper.GetJsonObject(JResponse, JPaymentsAccount, 'data.shopifyPaymentsAccount') then
@@ -236,7 +236,7 @@ codeunit 30385 "Shpfy Payments API"
         Parameters: Dictionary of [Text, Text];
     begin
         GraphQLType := GraphQLType::GetDisputes;
-        Parameters.Add('SinceId', Format(SinceId));
+        Parameters.Add('SinceId', Format(SinceId + 1));
         repeat
             JResponse := CommunicationMgt.ExecuteGraphQL(GraphQLType, Parameters);
             if JsonHelper.GetJsonObject(JResponse, JPaymentsAccount, 'data.shopifyPaymentsAccount') then


### PR DESCRIPTION
## Problem
When calling Shopify APIs with `SinceId = 0`, Shopify returns a warning about expecting a positive integer.

This occurs because the GraphQL queries use `id:>{{SinceId}}` which becomes `id:>0` when no records exist yet.

## Solution
- Changed 6 GraphQL query templates from `id:>{{SinceId}}` to `id:>={{SinceId}}`
- Updated `ShpfyPaymentsAPI.Codeunit.al` to pass `SinceId + 1` instead of `SinceId`

This results in `id:>=1` being sent when `SinceId = 0` (fetches all records without warning), and `id:>=N+1` when `SinceId = N` (correctly fetches records after ID N).

## Modified Files
- ShpfyGQLPaymentTransactions.Codeunit.al
- ShpfyGQLNextPaymTransactions.Codeunit.al
- ShpfyGQLPayouts.Codeunit.al
- ShpfyGQLNextPayouts.Codeunit.al
- ShpfyGQLDisputes.Codeunit.al
- ShpfyGQLNextDisputes.Codeunit.al
- ShpfyPaymentsAPI.Codeunit.al

Fixes [AB#618775](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/618775)



