### PR TITLE
Test Runner - Enable Data Driven tests without AI toolkint

### DIFF
--- a/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInput.Codeunit.al
+++ b/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInput.Codeunit.al
@@ -8,7 +8,7 @@ namespace System.TestTools.TestRunner;
 codeunit 130460 "Test Input"
 {
     SingleInstance = true;
-    Permissions = tabledata "Test Input" = RMID;
+    Permissions = tabledata "Test Input" = RMID, tabledata "Test Method Line" = RMID;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Test Runner - Mgt", 'OnBeforeTestMethodRun', '', false, false)]
     local procedure BeforeTestMethodRun(CodeunitID: Integer; CodeunitName: Text[30]; FunctionName: Text[128]; FunctionTestPermissions: TestPermissions; var CurrentTestMethodLine: Record "Test Method Line")


### PR DESCRIPTION
#### Summary
We are missing indirect permissions when setting up the data driven tests without the AI tests. Partners cannot run it with their license.

#### Work Item(s
Fixes [AB#578721](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/578721)


