### PR TITLE
Change order of ContextProperties param in MicrosoftUserFeedback.Codeunit.al

### DIFF
--- a/src/System Application/App/Microsoft User Feedback/src/MicrosoftUserFeedback.Codeunit.al
+++ b/src/System Application/App/Microsoft User Feedback/src/MicrosoftUserFeedback.Codeunit.al
@@ -18,6 +18,7 @@ codeunit 1590 "Microsoft User Feedback"
     /// Requests general feedback for a feature, optionally specifying if it is a Copilot feature and its area.
     /// </summary>
     /// <param name="FeatureName">The name of the feature for which feedback is requested.</param>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure RequestFeedback(FeatureName: Text)
     var
@@ -28,6 +29,7 @@ codeunit 1590 "Microsoft User Feedback"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         this.FeedbackImpl.RequestFeedback(FeatureName, '', '', EmptyContextFiles, EmptyContextProperties, CallerModuleInfo);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Requests general feedback for a feature, optionally specifying if it is a Copilot feature and its area.
@@ -35,6 +37,7 @@ codeunit 1590 "Microsoft User Feedback"
     /// <param name="FeatureName">The name of the feature for which feedback is requested.</param>
     /// <param name="FeatureArea">The area or sub-area of the feature. ID on OCV.</param>
     /// <param name="FeatureAreaDisplayName">The display name of the feature area.</param>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure RequestFeedback(FeatureName: Text; FeatureArea: Text; FeatureAreaDisplayName: Text)
     var
@@ -45,6 +48,7 @@ codeunit 1590 "Microsoft User Feedback"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         this.FeedbackImpl.RequestFeedback(FeatureName, FeatureArea, FeatureAreaDisplayName, EmptyContextFiles, EmptyContextProperties, CallerModuleInfo);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Requests general feedback for a feature, optionally specifying if it is a Copilot feature and its area.
@@ -54,6 +58,7 @@ codeunit 1590 "Microsoft User Feedback"
     /// <param name="FeatureAreaDisplayName">The display name of the feature area.</param>
     /// <param name="ContextFiles">Map of filename to base64 file to attach to the feedback. Must contain the filename in the extension.</param>
     /// <param name="ContextProperties">Additional data to pass properties to the feedback mechanism.</param>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure RequestFeedback(FeatureName: Text; FeatureArea: Text; FeatureAreaDisplayName: Text; ContextFiles: Dictionary of [Text, Text]; ContextProperties: Dictionary of [Text, Text])
     var
@@ -62,11 +67,13 @@ codeunit 1590 "Microsoft User Feedback"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         this.FeedbackImpl.RequestFeedback(FeatureName, FeatureArea, FeatureAreaDisplayName, ContextFiles, ContextProperties, CallerModuleInfo);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Requests a 'like' (positive) feedback for a feature, optionally specifying if it is a Copilot feature and its area.
     /// </summary>
     /// <param name="FeatureName">The name of the feature for which like feedback is requested.</param>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure RequestLikeFeedback(FeatureName: Text)
     var
@@ -77,6 +84,7 @@ codeunit 1590 "Microsoft User Feedback"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         this.FeedbackImpl.RequestLikeFeedback(FeatureName, '', '', EmptyContextFiles, EmptyContextProperties, CallerModuleInfo);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Requests a 'like' (positive) feedback for a feature, optionally specifying if it is a Copilot feature and its area.
@@ -84,6 +92,7 @@ codeunit 1590 "Microsoft User Feedback"
     /// <param name="FeatureName">The name of the feature for which like feedback is requested.</param>
     /// <param name="FeatureArea">The area or sub-area of the feature. ID on OCV.</param>
     /// <param name="FeatureAreaDisplayName">The display name of the feature area.</param>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure RequestLikeFeedback(FeatureName: Text; FeatureArea: Text; FeatureAreaDisplayName: Text)
     var
@@ -94,6 +103,7 @@ codeunit 1590 "Microsoft User Feedback"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         this.FeedbackImpl.RequestLikeFeedback(FeatureName, FeatureArea, FeatureAreaDisplayName, EmptyContextFiles, EmptyContextProperties, CallerModuleInfo);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Requests a 'like' (positive) feedback for a feature, optionally specifying if it is a Copilot feature and its area.
@@ -102,6 +112,7 @@ codeunit 1590 "Microsoft User Feedback"
     /// <param name="FeatureArea">The area or sub-area of the feature.</param>
     /// <param name="ContextFiles">Map of filename to base64 file to attach to the feedback. Must contain the filename in the extension.</param>
     /// <param name="ContextProperties">Additional data to pass properties to the feedback mechanism.</param>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure RequestLikeFeedback(FeatureName: Text; FeatureArea: Text; FeatureAreaDisplayName: Text; ContextFiles: Dictionary of [Text, Text]; ContextProperties: Dictionary of [Text, Text])
     var
@@ -110,11 +121,13 @@ codeunit 1590 "Microsoft User Feedback"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         this.FeedbackImpl.RequestLikeFeedback(FeatureName, FeatureArea, FeatureAreaDisplayName, ContextFiles, ContextProperties, CallerModuleInfo);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Requests a 'dislike' (negative) feedback for a feature, optionally specifying if it is a Copilot feature and its area.
     /// </summary>
     /// <param name="FeatureName">The name of the feature for which dislike feedback is requested.</param>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure RequestDislikeFeedback(FeatureName: Text)
     var
@@ -125,6 +138,7 @@ codeunit 1590 "Microsoft User Feedback"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         this.FeedbackImpl.RequestDislikeFeedback(FeatureName, '', '', EmptyContextFiles, EmptyContextProperties, CallerModuleInfo);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Requests a 'dislike' (negative) feedback for a feature, optionally specifying if it is a Copilot feature and its area.
@@ -132,6 +146,7 @@ codeunit 1590 "Microsoft User Feedback"
     /// <param name="FeatureName">The name of the feature for which dislike feedback is requested.</param>
     /// <param name="FeatureArea">The area or sub-area of the feature. ID of the sub-area on OCV.</param>
     /// <param name="FeatureAreaDisplayName">The display name of the feature area.</param>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure RequestDislikeFeedback(FeatureName: Text; FeatureArea: Text; FeatureAreaDisplayName: Text)
     var
@@ -142,6 +157,7 @@ codeunit 1590 "Microsoft User Feedback"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         this.FeedbackImpl.RequestDislikeFeedback(FeatureName, FeatureArea, FeatureAreaDisplayName, EmptyContextFiles, EmptyContextProperties, CallerModuleInfo);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Requests a 'dislike' (negative) feedback for a feature, optionally specifying if it is a Copilot feature and its area.
@@ -151,6 +167,7 @@ codeunit 1590 "Microsoft User Feedback"
     /// <param name="FeatureAreaDisplayName">The display name of the feature area.</param>
     /// <param name="ContextFiles">Map of filename to base64 file to attach to the feedback. Must contain the filename in the extension.</param>
     /// <param name="ContextProperties">Additional data to pass properties to the feedback mechanism.</param>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure RequestDislikeFeedback(FeatureName: Text; FeatureArea: Text; FeatureAreaDisplayName: Text; ContextFiles: Dictionary of [Text, Text]; ContextProperties: Dictionary of [Text, Text])
     var
@@ -159,18 +176,21 @@ codeunit 1590 "Microsoft User Feedback"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         this.FeedbackImpl.RequestDislikeFeedback(FeatureName, FeatureArea, FeatureAreaDisplayName, ContextFiles, ContextProperties, CallerModuleInfo);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Sets whether the General/Like/Dislike feedback being collected is for an AI feature.
     /// </summary>
     /// <param name="IsAIFeedback">True if the feedback is for an AI feature; otherwise, false.</param>
     /// <returns>The current instance of the "Microsoft User Feedback Impl" codeunit.</returns>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure SetIsAIFeedback(IsAIFeedback: Boolean): Codeunit "Microsoft User Feedback"
     begin
         this.FeedbackImpl := this.FeedbackImpl.SetIsAIFeedback(IsAIFeedback);
         exit(this);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Sets a custom question to be included in the feedback prompt.
@@ -178,24 +198,28 @@ codeunit 1590 "Microsoft User Feedback"
     /// <param name="Question">The text of the custom question.</param>
     /// <param name="QuestionDisplay">The display text of the custom question.</param>
     /// <returns>The current instance of the "Microsoft User Feedback Impl" codeunit.</returns>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure WithCustomQuestion(Question: Text; QuestionDisplay: Text): Codeunit "Microsoft User Feedback"
     begin
         this.FeedbackImpl := this.FeedbackImpl.WithCustomQuestion(Question, QuestionDisplay);
         exit(this);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Sets the type of the custom question to be included in the feedback prompt.
     /// </summary>
     /// <param name="QuestionType">The type of the custom question.</param>
     /// <returns>The current instance of the "Microsoft User Feedback Impl" codeunit.</returns>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure WithCustomQuestionType(QuestionType: Enum FeedbackQuestionType): Codeunit "Microsoft User Feedback"
     begin
         this.FeedbackImpl := this.FeedbackImpl.WithCustomQuestionType(QuestionType);
         exit(this);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Sets the required behavior for the custom question to be included in the feedback prompt.
@@ -203,24 +227,28 @@ codeunit 1590 "Microsoft User Feedback"
     /// <param name="RequiredBehavior">The behaviour.</param>
     /// <param name="Enabled">If true, enables the specified required behavior; if false, disables it.</param>
     /// <returns>The current instance of the "Microsoft User Feedback Impl" codeunit.</returns>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure WithCustomQuestionRequiredBehavior(RequiredBehavior: Enum FeedbackRequiredBehavior; Enabled: Boolean): Codeunit "Microsoft User Feedback"
     begin
         this.FeedbackImpl := this.FeedbackImpl.WithCustomQuestionRequiredBehavior(RequiredBehavior, Enabled);
         exit(this);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Sets the required behavior for the custom question to be included in the feedback prompt.
     /// </summary>
     /// <param name="RequiredBehavior">A dictionary defining the required behavior for the custom question.</param>
     /// <returns>The current instance of the "Microsoft User Feedback Impl" codeunit.</returns>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure WithCustomQuestionRequiredBehavior(RequiredBehavior: Dictionary of [Enum FeedbackRequiredBehavior, Text]): Codeunit "Microsoft User Feedback"
     begin
         this.FeedbackImpl := this.FeedbackImpl.WithCustomQuestionRequiredBehavior(RequiredBehavior);
         exit(this);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Adds an answer option for the custom question to be included in the feedback prompt.
@@ -228,35 +256,41 @@ codeunit 1590 "Microsoft User Feedback"
     /// <param name="AnswerOption">The answer option.</param>
     /// <param name="AnswerDisplayText">The display text for the answer option.</param>
     /// <returns>The current instance of the "Microsoft User Feedback Impl" codeunit.</returns>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure WithCustomQuestionAnswerOption(AnswerOption: Text; AnswerDisplayText: Text): Codeunit "Microsoft User Feedback"
     begin
         this.FeedbackImpl := this.FeedbackImpl.WithCustomQuestionAnswerOption(AnswerOption, AnswerDisplayText);
         exit(this);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Sets the answer options for the custom question to be included in the feedback prompt.
     /// </summary>
     /// <param name="AnswerOptions">A dictionary defining the answer options for the custom question.</param>
     /// <returns>The current instance of the "Microsoft User Feedback Impl" codeunit.</returns>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure WithCustomQuestionAnswerOptions(AnswerOptions: Dictionary of [Text, Text]): Codeunit "Microsoft User Feedback"
     begin
         this.FeedbackImpl := this.FeedbackImpl.WithCustomQuestionAnswerOptions(AnswerOptions);
         exit(this);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Clears any previously set custom question.
     /// </summary>
     /// <returns>The current instance of the "Microsoft User Feedback" codeunit.</returns>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure ClearCustomQuestion(): Codeunit "Microsoft User Feedback"
     begin
         this.FeedbackImpl := this.FeedbackImpl.ClearCustomQuestion();
         exit(this);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Starts or stops a survey timer activity. This is used to start a timer to count up user usage
@@ -264,6 +298,7 @@ codeunit 1590 "Microsoft User Feedback"
     /// </summary>
     /// <param name="ActivityName">The name of the activity for which the timer is started or stopped.</param>
     /// <param name="Start">If true, starts the timer; if false, stops the timer.</param>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure SurveyTimerActivity(ActivityName: Text; Start: Boolean)
     var
@@ -272,12 +307,14 @@ codeunit 1590 "Microsoft User Feedback"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         this.FeedbackImpl.SurveyTimerActivity(ActivityName, Start, CallerModuleInfo);
     end;
+#pragma warning restore AS0022
 
     /// <summary>
     /// Sends a one-time trigger event based on a specific activity name.
     /// The event could be, for example, a user clicking a button
     /// </summary>
     /// <param name="ActivityName">The name of the activity that triggers the survey.</param>
+#pragma warning disable AS0022
     [Scope('OnPrem')]
     procedure SurveyTriggerActivity(ActivityName: Text)
     var
@@ -286,6 +323,7 @@ codeunit 1590 "Microsoft User Feedback"
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         this.FeedbackImpl.SurveyTriggerActivity(ActivityName, CallerModuleInfo);
     end;
+#pragma warning restore AS0022
 
     var
         FeedbackImpl: Codeunit "Microsoft User Feedback Impl";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
The `RequestDislikeFeedback` method had ContextFiles and ContextProperties in a different order than the other methods, which could lead to bugs.

While on paper, this is a breaking change, it is an internal only API, and has very little usage. So, I believe that we can except it in this case, after speaking with quentin

Also, made the methods scope on prem to indicate non-public use

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#615526](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/615526)






