### PR TITLE
Prevented blank text expression formulas from causion recursion loops.

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionLine.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionLine.Table.al
@@ -416,6 +416,7 @@ table 20406 "Qlty. Inspection Line"
         QltyInspectionTemplateLine.SetRange("Template Code", Rec."Template Code");
         QltyInspectionTemplateLine.SetFilter("Test Value Type", '%1', QltyInspectionTemplateLine."Test Value Type"::"Value Type Text Expression");
         QltyInspectionTemplateLine.SetFilter("Test Code", '<>%1', Rec."Test Code");
+        QltyInspectionTemplateLine.SetFilter("Expression Formula", '<>''''');
         QltyInspectionTemplateLine.SetAutoCalcFields("Test Value Type");
         if QltyInspectionTemplateLine.FindSet() then
             repeat

--- a/src/Apps/W1/Quality Management/app/src/Utilities/QltyExpressionMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Utilities/QltyExpressionMgmt.Codeunit.al
@@ -76,6 +76,9 @@ codeunit 20416 "Qlty. Expression Mgmt."
         if not QltyInspectionTemplateLine.FindFirst() then
             Error(RecreateInspectionErr, QltyInspectionLine.RecordId(), QltyInspectionLine."Test Code", QltyInspectionTemplateLine.GetFilters());
 
+        if QltyInspectionTemplateLine."Expression Formula" = '' then
+            exit('');
+
         Value := EvaluateTextExpression(QltyInspectionTemplateLine."Expression Formula", CurrentQltyInspectionHeader, QltyInspectionLine);
         OnEvaluateTextExpressionOnInspectionLine(QltyInspectionLine, CurrentQltyInspectionHeader, QltyInspectionTemplateLine, QltyInspectionTemplateLine."Expression Formula", Value);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This resolves an issue where two blank text expression fields can cause a recursion loop.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes # [AB#619341](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/619341)

