### PR TITLE
[Qlty Mgmt.] Fix the AutoFormat property of the Pass Quantity in the Qlty Inspection Header table

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
@@ -516,7 +516,7 @@ table 20405 "Qlty. Inspection Header"
             Caption = 'Pass Quantity';
             Description = 'A manually entered test for non-sampling inspections, or derived from the quantity of passed sampling lines for sampling inspections.';
             AutoFormatType = 10;
-            AutoFormatExpression = '<precision, 0:0><standard format,0>';
+            AutoFormatExpression = '0,<precision, 0:0><standard format,0>';
             ToolTip = 'Specifies the amount that passed inspection.';
             DecimalPlaces = 0 : 5;
             MinValue = 0;
@@ -537,7 +537,7 @@ table 20405 "Qlty. Inspection Header"
             Caption = 'Fail Quantity';
             Description = 'A manually entered test for non-sampling inspections, or derived from the quantity of failed sampling lines for sampling inspections.';
             AutoFormatType = 10;
-            AutoFormatExpression = '<precision, 0:0><standard format,0>';
+            AutoFormatExpression = '0,<precision, 0:0><standard format,0>';
             ToolTip = 'Specifies the amount that failed inspection.';
             DecimalPlaces = 0 : 5;
             MinValue = 0;


### PR DESCRIPTION
Adding a subtype of 0 in the expression so that the value is not interpreted as a currency.

Fixes [AB#611323](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611323)


