### PR TITLE
[Shopify] Move presentment currency fields to Invoice Details fasttab

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
@@ -230,62 +230,11 @@ page 30113 "Shpfy Order"
                     Editable = false;
                     ToolTip = 'Specifies whether a sales order has been created for the Shopify Order.';
                 }
-                group(ProcessedCurrHanndling)
-                {
-                    ShowCaption = false;
-                    Visible = Rec.Processed;
-
-                    field(ProcessedCurrencyHandling; Rec."Processed Currency Handling")
-                    {
-                        ApplicationArea = All;
-                        Caption = 'Processed Currency Handling';
-                        Importance = Additional;
-                        Editable = false;
-                        ToolTip = 'Specifies how the currency was handled when processing the order.';
-                    }
-                }
                 field(FinancialStatus; Rec."Financial Status")
                 {
                     ApplicationArea = All;
                     Editable = false;
                     ToolTip = 'Specifies the status of payments associated with the order. Valid values are: pending, authorized, partially paid, paid, partially refunded, refunded, voided.';
-                }
-                group(PresentmentCurrency)
-                {
-                    ShowCaption = false;
-                    Visible = PresentmentVisible;
-
-                    field("Presentment Subtotal Amount"; Rec."Presentment Subtotal Amount")
-                    {
-                        ApplicationArea = All;
-                        Editable = false;
-                    }
-                    field("Pres. Shipping Charges Amount"; Rec."Pres. Shipping Charges Amount")
-                    {
-                        ApplicationArea = All;
-                        Editable = false;
-                    }
-                    field("Presentment Total Amount"; Rec."Presentment Total Amount")
-                    {
-                        ApplicationArea = All;
-                        Editable = false;
-                        Importance = Promoted;
-                    }
-                    field("Presentment VAT Amount"; Rec."Presentment VAT Amount")
-                    {
-                        ApplicationArea = All;
-                        Editable = false;
-                    }
-                    field("Presentment Discount Amount"; Rec."Presentment Discount Amount")
-                    {
-                        ApplicationArea = All;
-                        Editable = false;
-                    }
-                    field("Presentment Currency Code"; Rec."Presentment Currency Code")
-                    {
-                        ApplicationArea = All;
-                        Editable = false;
-                    }
                 }
                 field(FulfillmentStatus; Rec."Fulfillment Status")
                 {
@@ -398,12 +347,62 @@ page 30113 "Shpfy Order"
                     Editable = false;
                     ToolTip = 'Specifies if any tax line on the order is liable to be charged by the sales channel.';
                 }
-
                 field(CurrencyCode; Rec."Currency Code")
                 {
                     ApplicationArea = All;
                     Editable = false;
                     ToolTip = 'Specifies the currency of amounts on the document.';
+                }
+                group(ProcessedCurrHandling)
+                {
+                    ShowCaption = false;
+                    Visible = Rec.Processed;
+
+                    field(ProcessedCurrencyHandling; Rec."Processed Currency Handling")
+                    {
+                        ApplicationArea = All;
+                        Caption = 'Processed Currency Handling';
+                        Importance = Additional;
+                        Editable = false;
+                        ToolTip = 'Specifies how the currency was handled when processing the order.';
+                    }
+                }
+                group(PresentmentCurrency)
+                {
+                    ShowCaption = false;
+                    Visible = PresentmentVisible;
+
+                    field("Presentment Subtotal Amount"; Rec."Presentment Subtotal Amount")
+                    {
+                        ApplicationArea = All;
+                        Editable = false;
+                    }
+                    field("Pres. Shipping Charges Amount"; Rec."Pres. Shipping Charges Amount")
+                    {
+                        ApplicationArea = All;
+                        Editable = false;
+                    }
+                    field("Presentment Total Amount"; Rec."Presentment Total Amount")
+                    {
+                        ApplicationArea = All;
+                        Editable = false;
+                        Importance = Promoted;
+                    }
+                    field("Presentment VAT Amount"; Rec."Presentment VAT Amount")
+                    {
+                        ApplicationArea = All;
+                        Editable = false;
+                    }
+                    field("Presentment Discount Amount"; Rec."Presentment Discount Amount")
+                    {
+                        ApplicationArea = All;
+                        Editable = false;
+                    }
+                    field("Presentment Currency Code"; Rec."Presentment Currency Code")
+                    {
+                        ApplicationArea = All;
+                        Editable = false;
+                    }
                 }
             }
             group(ShippingAndBilling)

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrderTotalsFactBox.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrderTotalsFactBox.Page.al
@@ -37,51 +37,120 @@ page 30172 "Shpfy Order Totals FactBox"
                         Page.Run(Page::"Shpfy Order", Rec);
                     end;
                 }
-                field("Subtotal Amount"; Rec."Subtotal Amount")
+                group(ShopifyTotals)
                 {
-                    ApplicationArea = All;
-                    AutoFormatExpression = Rec."Currency Code";
-                    AutoFormatType = 1;
-                    ToolTip = 'Specifies the subtotal amount of the order.';
+                    Caption = 'Shopify Totals';
+                    ShowCaption = false;
+                    Visible = not PresentmentVisible;
+
+                    field("Subtotal Amount"; Rec."Subtotal Amount")
+                    {
+                        ApplicationArea = All;
+                        AutoFormatExpression = Rec."Currency Code";
+                        AutoFormatType = 1;
+                        ToolTip = 'Specifies the subtotal amount of the order.';
+                    }
+                    field("Shipping Charges Amount"; Rec."Shipping Charges Amount")
+                    {
+                        ApplicationArea = All;
+                        AutoFormatExpression = Rec."Currency Code";
+                        AutoFormatType = 1;
+                        ToolTip = 'Specifies the shipping charges amount of the order.';
+                    }
+                    field("Total Amount"; Rec."Total Amount")
+                    {
+                        ApplicationArea = All;
+                        AutoFormatExpression = Rec."Currency Code";
+                        AutoFormatType = 1;
+                        ToolTip = 'Specifies the total amount of the order.';
+                    }
+                    field(VATAmount; Rec."VAT Amount")
+                    {
+                        ApplicationArea = All;
+                        AutoFormatExpression = Rec."Currency Code";
+                        AutoFormatType = 1;
+                        CaptionClass = DocumentTotals.GetTotalVATCaption(Rec."Currency Code");
+                        ToolTip = 'Specifies the sum of tax amounts on all lines in the document.';
+                    }
+                    field(RoundingAmount; Rec."Payment Rounding Amount")
+                    {
+                        ApplicationArea = All;
+                        AutoFormatExpression = Rec."Currency Code";
+                        AutoFormatType = 1;
+                        ToolTip = 'Specifies the amount of rounding applied to the total amount of the document.';
+                    }
                 }
-                field("Shipping Charges Amount"; Rec."Shipping Charges Amount")
+                group(ShopifyPresentmentTotals)
                 {
-                    ApplicationArea = All;
-                    AutoFormatExpression = Rec."Currency Code";
-                    AutoFormatType = 1;
-                    ToolTip = 'Specifies the shipping charges amount of the order.';
-                }
-                field("Total Amount"; Rec."Total Amount")
-                {
-                    ApplicationArea = All;
-                    AutoFormatExpression = Rec."Currency Code";
-                    AutoFormatType = 1;
-                    ToolTip = 'Specifies the total amount of the order.';
-                }
-                field(VATAmount; Rec."VAT Amount")
-                {
-                    ApplicationArea = All;
-                    AutoFormatExpression = Rec."Currency Code";
-                    AutoFormatType = 1;
-                    CaptionClass = DocumentTotals.GetTotalVATCaption(Rec."Currency Code");
-                    ToolTip = 'Specifies the sum of tax amounts on all lines in the document.';
-                }
-                field(RoundingAmount; Rec."Payment Rounding Amount")
-                {
-                    ApplicationArea = All;
-                    AutoFormatExpression = Rec."Currency Code";
-                    AutoFormatType = 1;
-                    ToolTip = 'Specifies the amount of rounding applied to the total amount of the document.';
+                    Caption = 'Shopify Presentment Totals';
+                    ShowCaption = false;
+                    Visible = PresentmentVisible;
+
+                    field("Presentment Subtotal Amount"; Rec."Presentment Subtotal Amount")
+                    {
+                        ApplicationArea = All;
+                        AutoFormatExpression = Rec."Presentment Currency Code";
+                        AutoFormatType = 1;
+                        ToolTip = 'Specifies the presentment subtotal amount of the order.';
+                    }
+                    field("Presentment Shipping Charges Amount"; Rec."Pres. Shipping Charges Amount")
+                    {
+                        ApplicationArea = All;
+                        AutoFormatExpression = Rec."Presentment Currency Code";
+                        AutoFormatType = 1;
+                        ToolTip = 'Specifies the presentment shipping charges amount of the order.';
+                    }
+                    field("Presentment Total Amount"; Rec."Presentment Total Amount")
+                    {
+                        ApplicationArea = All;
+                        AutoFormatExpression = Rec."Presentment Currency Code";
+                        AutoFormatType = 1;
+                        ToolTip = 'Specifies the presentment total amount of the order.';
+                    }
+                    field("Presentment VAT Amount"; Rec."Presentment VAT Amount")
+                    {
+                        ApplicationArea = All;
+                        AutoFormatExpression = Rec."Presentment Currency Code";
+                        AutoFormatType = 1;
+                        CaptionClass = DocumentTotals.GetTotalVATCaption(Rec."Presentment Currency Code");
+                        ToolTip = 'Specifies the sum of presentment tax amounts on all lines in the document.';
+                    }
+                    field("Presentment Payment Rounding Amount"; Rec."Pres. Payment Rounding Amount")
+                    {
+                        ApplicationArea = All;
+                        AutoFormatExpression = Rec."Presentment Currency Code";
+                        AutoFormatType = 1;
+                        ToolTip = 'Specifies the amount of presentment rounding applied to the total amount of the document.';
+                    }
                 }
                 field("VAT Included"; Rec."VAT Included")
                 {
                     ApplicationArea = All;
                     ToolTip = 'Specifies if tax is included in the unit price.';
                 }
-                field("Currency Code"; Rec."Currency Code")
+                group(ShopifyCurrency)
                 {
-                    ApplicationArea = All;
-                    ToolTip = 'Specifies the currency of amounts on the document.';
+                    Caption = 'Currency';
+                    ShowCaption = false;
+                    Visible = not PresentmentVisible;
+
+                    field("Currency Code"; Rec."Currency Code")
+                    {
+                        ApplicationArea = All;
+                        ToolTip = 'Specifies the currency of amounts on the document.';
+                    }
+                }
+                group(ShopifyPresentmentCurrency)
+                {
+                    Caption = 'Presentment Currency';
+                    ShowCaption = false;
+                    Visible = PresentmentVisible;
+
+                    field("Presentment Currency Code"; Rec."Presentment Currency Code")
+                    {
+                        ApplicationArea = All;
+                        ToolTip = 'Specifies the presentment currency of amounts on the document.';
+                    }
                 }
             }
             group(SalesDocument)
@@ -161,6 +230,7 @@ page 30172 "Shpfy Order Totals FactBox"
         SalesLine: Record "Sales Line";
         GeneralLedgerSetup: Record "General Ledger Setup";
     begin
+        PresentmentVisible := Rec.IsPresentmentCurrencyOrder();
         if Rec."Sales Order No." <> '' then
             if not SalesHeader.Get(SalesHeader."Document Type"::Order, Rec."Sales Order No.") then
                 exit;
@@ -171,7 +241,7 @@ page 30172 "Shpfy Order Totals FactBox"
 
         DocumentNo := SalesHeader."No.";
         PricesIncludingVAT := SalesHeader."Prices Including VAT";
-        if CurrencyCode <> '' then
+        if SalesHeader."Currency Code" <> '' then
             CurrencyCode := SalesHeader."Currency Code"
         else begin
             GeneralLedgerSetup.Get();
@@ -190,6 +260,7 @@ page 30172 "Shpfy Order Totals FactBox"
         DocumentTotals: Codeunit "Document Totals";
         DocumentNo: Text[20];
         PricesIncludingVAT: Boolean;
+        PresentmentVisible: Boolean;
         NumberOfLines: Integer;
         CurrencyCode: Code[10];
         VATAmount: Decimal;


### PR DESCRIPTION
## Summary
The presentment currency fields were incorrectly placed on the General fasttab of the Shopify Order page. This PR moves them to the Invoice Details fasttab where they logically belong alongside other invoice-related amounts.

## Changes

### ShpfyOrder.Page.al (Page 30113)
- Moved `ProcessedCurrHandling` group from General to Invoice Details fasttab
- Moved `PresentmentCurrency` group from General to Invoice Details fasttab
- Fixed typo in group name: `ProcessedCurrHanndling` → `ProcessedCurrHandling`

### ShpfyOrderTotalsFactBox.Page.al (Page 30172)
- Added conditional visibility to show either shop currency or presentment currency amounts based on order type
- Added new `ShopifyPresentmentTotals` group with presentment amounts (Subtotal, Shipping, Total, VAT, Rounding)
- Added `ShopifyPresentmentCurrency` group to display presentment currency code
- Both standard and presentment groups toggle visibility based on `IsPresentmentCurrencyOrder()`

## Fields in Invoice Details (when presentment currency is used)
| Field | Description |
|-------|-------------|
| Processed Currency Handling | Shows how currency was handled when processing (visible when order is processed) |
| Presentment Subtotal Amount | Subtotal in customer's currency |
| Pres. Shipping Charges Amount | Shipping charges in customer's currency |
| Presentment Total Amount | Total in customer's currency |
| Presentment VAT Amount | Tax amount in customer's currency |
| Presentment Discount Amount | Discount in customer's currency |
| Presentment Currency Code | The currency code used |

Fixes [AB#619504](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/619504)
Fixes [AB#619505](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/619505)


