### PR TITLE
Bug 619580: [Payables agent] Agent task number is not populated on the inbound e-document page

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Document/Inbound/InboundEDocuments.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Document/Inbound/InboundEDocuments.Page.al
@@ -100,9 +100,21 @@ page 6105 "Inbound E-Documents"
                         TaskPane.ShowTask(Task);
                     end;
                 }
+#if not CLEAN28
                 field(TaskStatus; AgentTask.Status)
                 {
                     Caption = 'Task Status';
+                    ToolTip = 'Specifies the status of the agent task for this document.';
+                    Editable = false;
+                    Visible = false;
+                    ObsoleteState = Pending;
+                    ObsoleteReason = 'Replaced by the AgentTaskStatus field.';
+                    ObsoleteTag = '28.0';
+                }
+#endif
+                field(AgentTaskStatus; AgentTaskStatus)
+                {
+                    Caption = 'Agent Task Status';
                     ToolTip = 'Specifies the status of the agent task for this document.';
                     Editable = false;
                 }
@@ -437,6 +449,9 @@ page 6105 "Inbound E-Documents"
         AgentTask.SetRange("External ID", Format(Rec."Entry No"));
         if not AgentTask.FindFirst() then
             Clear(AgentTask);
+        AgentTaskStatus := '';
+        if AgentTask.ID <> 0 then
+            AgentTaskStatus := Format(AgentTask.Status);
     end;
 
     trigger OnOpenPage()
@@ -563,7 +578,7 @@ page 6105 "Inbound E-Documents"
         EDocumentPurchaseHeader: Record "E-Document Purchase Header";
         AgentTask: Record "Agent Task";
         EDocumentHelper: Codeunit "E-Document Helper";
-        RecordLinkTxt, DocumentNameTxt, DocumentTypeStyleTxt, ConfirmedVendorTxt : Text;
+        RecordLinkTxt, DocumentNameTxt, DocumentTypeStyleTxt, ConfirmedVendorTxt, AgentTaskStatus : Text;
         HasPdf: Boolean;
 #if not CLEAN27
         EmailVisibilityFlag: Boolean;


### PR DESCRIPTION
Call FindFirst instead of IsEmpty when finding the agent task
Replace the current agent status task with the new field that has Text variable in the source expression. This is done to show the blank agent task status when there is no agent task behind the certain inbound e-document.

Fixes [AB#619580](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/619580)

