### PR TITLE
Quality Man.-Manually created rules get Activation trigger value from…

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRule.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRule.Table.al
@@ -421,7 +421,14 @@ table 20404 "Qlty. Inspection Gen. Rule"
         if Certainty = Certainty::Yes then begin
             Rec.Intent := InferredIntent;
             SetDefaultTriggerValuesToNoTrigger();
-            if Rec."Activation Trigger" in [Rec."Activation Trigger"::"Manual or Automatic", Rec."Activation Trigger"::"Automatic only"] then
+            if Rec."Activation Trigger" in [Rec."Activation Trigger"::"Manual or Automatic", Rec."Activation Trigger"::"Automatic only"] then begin
+                Rec."Assembly Trigger" := Rec."Assembly Trigger"::NoTrigger;
+                Rec."Production Order Trigger" := Rec."Production Order Trigger"::NoTrigger;
+                Rec."Purchase Order Trigger" := Rec."Purchase Order Trigger"::NoTrigger;
+                Rec."Sales Return Trigger" := Rec."Sales Return Trigger"::NoTrigger;
+                Rec."Transfer Order Trigger" := Rec."Transfer Order Trigger"::NoTrigger;
+                Rec."Warehouse Movement Trigger" := Rec."Warehouse Movement Trigger"::NoTrigger;
+                Rec."Warehouse Receipt Trigger" := Rec."Warehouse Receipt Trigger"::NoTrigger;
                 case InferredIntent of
                     InferredIntent::Assembly:
                         Rec."Assembly Trigger" := QltyManagementSetup."Assembly Trigger";
@@ -438,6 +445,7 @@ table 20404 "Qlty. Inspection Gen. Rule"
                     InferredIntent::"Warehouse Receipt":
                         Rec."Warehouse Receipt Trigger" := QltyManagementSetup."Warehouse Receipt Trigger";
                 end;
+            end;
         end;
     end;
 


### PR DESCRIPTION
#### Summary 
[QM] Manually created inspection generation rules get Activation trigger value from previous line and do not respect the intent

#### Work Item(s) 
Fixes [AB#619131](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/619131)



