### PR TITLE
[AI SDK] Surface billing setup errors and handle default AOAI policy for self managed resources

### DIFF
--- a/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIPolicyParams.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIPolicyParams.Codeunit.al
@@ -77,6 +77,15 @@ codeunit 7787 "AOAI Policy Params"
     end;
 
     /// <summary>
+    /// Gets whether the current Azure AOAI policy is the default one.
+    /// </summary>
+    /// <returns>True if the current policy is the default; otherwise, false.</returns>
+    procedure IsDefaultPolicy(): Boolean
+    begin
+        exit(AOAIPolicyParamsImpl.IsDefaultPolicy());
+    end;
+
+    /// <summary>
     /// Gets the AOAI policy as text based on the provided policy parameters or a Custom one.
     /// </summary>
     internal procedure GetAOAIPolicy(): Text

--- a/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIPolicyParamsImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIPolicyParamsImpl.Codeunit.al
@@ -18,6 +18,7 @@ codeunit 7788 "AOAI Policy Params Impl"
         IsXPIADetectionEnabled: Boolean;
         CustomAOAIPolicy: Text;
         Initialized: Boolean;
+        IsDefault: Boolean;
         TelemetryCouldNotResolveAOAIPolicyParamsLbl: Label 'Unable to resolve the AOAI Policy params. Returned the default AOAI Policy instead.', Locked = true;
 
     procedure GetHarmsSeverity(): Enum "AOAI Policy Harms Severity"
@@ -41,6 +42,8 @@ codeunit 7788 "AOAI Policy Params Impl"
         if not Initialized then
             InitializeDefaults();
 
+        IsDefault := false;
+
         HarmsSeverity := NewHarmsSeverity;
     end;
 
@@ -48,6 +51,8 @@ codeunit 7788 "AOAI Policy Params Impl"
     begin
         if not Initialized then
             InitializeDefaults();
+
+        IsDefault := false;
 
         IsXPIADetectionEnabled := IsEnabled;
     end;
@@ -64,6 +69,8 @@ codeunit 7788 "AOAI Policy Params Impl"
     begin
         if not Initialized then
             InitializeDefaults();
+
+        IsDefault := false;
 
         CustomAOAIPolicy := NewCustomAOAIPolicy;
     end;
@@ -105,9 +112,18 @@ codeunit 7788 "AOAI Policy Params Impl"
 
     procedure InitializeDefaults()
     begin
+        IsDefault := true;
         Initialized := true;
         HarmsSeverity := "AOAI Policy Harms Severity"::Low;
         IsXPIADetectionEnabled := true;
         CustomAOAIPolicy := '';
+    end;
+
+    procedure IsDefaultPolicy(): Boolean
+    begin
+        if not Initialized then
+            exit(true);
+
+        exit(IsDefault);
     end;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Issue 1:
We don't surface billing setup issues because an Error is raised within the try function and the operation result is never sent on the response codeunit passed by var. So the error message is never surfaced. Changing the SendRequest to return the error first.

<img width="939" height="295" alt="image" src="https://github.com/user-attachments/assets/b8e7cb29-f7ed-49b8-998f-4cac602d4d85" />

Issue 2:
AOAI policies would default to ConveservativeWithXpia which generally does not exist for self managed resources since that's something dedicated in our copilot service. Changing the SendChatCompletionRequest logic to not pass any XPIA policy for self managed resources if the policy are still the default one.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#620032](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620032), [AB#615189](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/615189)




