### PR TITLE
Switches to notifications when tests are created automatically, a page should be shown now only when a test is created manually.

### DIFF
--- a/src/Apps/W1/Quality Management/Test Library/src/QltyInspectionUtility.Codeunit.al
+++ b/src/Apps/W1/Quality Management/Test Library/src/QltyInspectionUtility.Codeunit.al
@@ -48,15 +48,10 @@ codeunit 139940 "Qlty. Inspection Utility"
 
     internal procedure EnsureSetupExists()
     var
-        QltyManagementSetup: Record "Qlty. Management Setup";
         QltyAutoConfigure: Codeunit "Qlty. Auto Configure";
         UserPermissionsLibrary: Codeunit "User Permissions Library";
     begin
         QltyAutoConfigure.EnsureBasicSetupExists(false);
-        QltyManagementSetup.Get();
-        QltyManagementSetup."When to show inspections" := QltyManagementSetup."When to show inspections"::"Never";
-        QltyManagementSetup.Modify();
-
         UserPermissionsLibrary.AssignPermissionSetToUser(UserSecurityId(), 'QltyGeneral');
     end;
 
@@ -92,7 +87,7 @@ codeunit 139940 "Qlty. Inspection Utility"
         BeforeCount := OutCreatedQltyInspectionHeader.Count();
 
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
-        ClaimedInspectionWasCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        ClaimedInspectionWasCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
 
         OutCreatedQltyInspectionHeader.Reset();
         AfterCount := OutCreatedQltyInspectionHeader.Count();
@@ -472,7 +467,7 @@ codeunit 139940 "Qlty. Inspection Utility"
     begin
         PurchaseLineRecordRef.GetTable(PurOrdPurchaseLine);
         SpecTrackingSpecification.CopyTrackingFromReservEntry(ReservationEntry);
-        InspectionCreated := QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(PurchaseLineRecordRef, SpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '');
+        InspectionCreated := QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(PurchaseLineRecordRef, SpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '');
         LibraryAssert.IsTrue(InspectionCreated, 'Quality Inspection not created.');
 
         QltyInspectionCreate.GetCreatedInspection(OutQltyInspectionHeader);
@@ -496,7 +491,7 @@ codeunit 139940 "Qlty. Inspection Utility"
     begin
         RecordRef.GetTable(WarehouseEntry);
         SpecTrackingSpecification.CopyTrackingFromReservEntry(ReservationEntry);
-        InspectionCreated := QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, SpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '');
+        InspectionCreated := QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, SpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '');
         LibraryAssert.IsTrue(InspectionCreated, 'Quality Inspection not created.');
 
         QltyInspectionCreate.GetCreatedInspection(OutQltyInspectionHeader);
@@ -516,7 +511,7 @@ codeunit 139940 "Qlty. Inspection Utility"
         InspectionCreated: Boolean;
     begin
         PurchaseLineRecordRef.GetTable(PurOrdPurchaseLine);
-        InspectionCreated := QltyInspectionCreate.CreateInspectionWithSpecificTemplate(PurchaseLineRecordRef, true, SpecificTemplate);
+        InspectionCreated := QltyInspectionCreate.CreateInspectionWithSpecificTemplate(PurchaseLineRecordRef, false, SpecificTemplate);
         LibraryAssert.IsTrue(InspectionCreated, 'Quality Inspection not created.');
 
         QltyInspectionCreate.GetCreatedInspection(OutQltyInspectionHeader);
@@ -535,7 +530,7 @@ codeunit 139940 "Qlty. Inspection Utility"
         InspectionCreated: Boolean;
     begin
         RecordRef.GetTable(WarehouseEntry);
-        InspectionCreated := QltyInspectionCreate.CreateInspection(RecordRef, true);
+        InspectionCreated := QltyInspectionCreate.CreateInspection(RecordRef, false);
         LibraryAssert.IsTrue(InspectionCreated, 'Quality Inspection not created.');
 
         QltyInspectionCreate.GetCreatedInspection(OutQltyInspectionHeader);
@@ -1247,7 +1242,7 @@ codeunit 139940 "Qlty. Inspection Utility"
     var
         QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
     begin
-        QltyInspectionCreate.CreateMultipleInspectionsForMarkedTrackingSpecification(TempTrackingSpecification);
+        QltyInspectionCreate.CreateMultipleInspectionsForMarkedTrackingSpecification(TempTrackingSpecification, false);
     end;
 
     /// <summary>

--- a/src/Apps/W1/Quality Management/Test Library/src/QltyPurOrderGenerator.Codeunit.al
+++ b/src/Apps/W1/Quality Management/Test Library/src/QltyPurOrderGenerator.Codeunit.al
@@ -239,7 +239,7 @@ codeunit 139941 "Qlty. Pur. Order Generator"
         CreatePurchaseOrder(PurchaseQuantity, Location, Item, Vendor, '', PurchaseHeader, PurchaseLine, OutReservationEntry);
         RecordRef.GetTable(PurchaseLine);
         SpecTrackingSpecification.CopyTrackingFromReservEntry(OutReservationEntry);
-        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, SpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '') then
+        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, SpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '') then
             QltyInspectionCreate.GetCreatedInspection(OutQltyInspectionHeader);
     end;
 }

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionCreate.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionCreate.Codeunit.al
@@ -272,6 +272,7 @@ codeunit 20404 "Qlty. Inspection - Create"
         RelatedItem: Record Item;
         QltyPermissionMgmt: Codeunit "Qlty. Permission Mgmt.";
         QltyStartWorkflow: Codeunit "Qlty. Start Workflow";
+        QltyNotificationMgmt: Codeunit "Qlty. Notification Mgmt.";
         RecordRefToBufferTriggeringRecord: RecordRef;
         OriginalRecordId: RecordId;
         NullRecordId: RecordId;
@@ -364,12 +365,11 @@ codeunit 20404 "Qlty. Inspection - Create"
             if IsNewlyCreatedInspection then
                 QltyStartWorkflow.StartWorkflowInspectionCreated(QltyInspectionHeader);
 
-            if GuiAllowed() then
-                if (not PreventShowingGeneratedInspectionEvenIfConfigured) and
-                   ((QltyManagementSetup."When to show inspections" = QltyManagementSetup."When to show inspections"::"Always") or
-                   (IsManualCreation and (QltyManagementSetup."When to show inspections" = QltyManagementSetup."When to show inspections"::"Only manually created inspections")))
-                then
-                    Page.Run(Page::"Qlty. Inspection", QltyInspectionHeader);
+            if GuiAllowed() and not PreventShowingGeneratedInspectionEvenIfConfigured then
+                if IsManualCreation then
+                    Page.Run(Page::"Qlty. Inspection", QltyInspectionHeader)
+                else
+                    QltyNotificationMgmt.NotifyInspectionCreated(QltyInspectionHeader);
         end else begin
             LogCreateInspectionProblem(TargetRecordRef, UnableToCreateInspectionForErr, Format(OriginalRecordId));
             if IsManualCreation and (not AvoidThrowingErrorWhenPossible) then
@@ -716,6 +716,7 @@ codeunit 20404 "Qlty. Inspection - Create"
     procedure CreateReinspection(FromThisQltyInspectionHeader: Record "Qlty. Inspection Header"; var CreatedReinspectionQltyInspectionHeader: Record "Qlty. Inspection Header")
     var
         ExistingQltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyNotificationMgmt: Codeunit "Qlty. Notification Mgmt.";
         Handled: Boolean;
     begin
         QltyManagementSetup.Get();
@@ -735,8 +736,7 @@ codeunit 20404 "Qlty. Inspection - Create"
         LastCreatedQltyInspectionHeader := CreatedReinspectionQltyInspectionHeader;
 
         if GuiAllowed() then
-            if QltyManagementSetup."When to show inspections" in [QltyManagementSetup."When to show inspections"::"Always", QltyManagementSetup."When to show inspections"::"Only manually created inspections"] then
-                Page.Run(Page::"Qlty. Inspection", CreatedReinspectionQltyInspectionHeader);
+            QltyNotificationMgmt.NotifyInspectionCreated(CreatedReinspectionQltyInspectionHeader);
 
         OnAfterCreateReinspection(FromThisQltyInspectionHeader, CreatedReinspectionQltyInspectionHeader);
     end;
@@ -804,6 +804,16 @@ codeunit 20404 "Qlty. Inspection - Create"
     /// </summary>
     /// <param name="TempTrackingSpecification">You must mark your records as a pre-requisite.</param>
     internal procedure CreateMultipleInspectionsForMarkedTrackingSpecification(var TempTrackingSpecification: Record "Tracking Specification" temporary)
+    begin
+        CreateMultipleInspectionsForMarkedTrackingSpecification(TempTrackingSpecification, true);
+    end;
+
+    /// <summary>
+    /// Use this with Marked records.
+    /// </summary>
+    /// <param name="TempTrackingSpecification">You must mark your records as a pre-requisite.</param>
+    /// <param name="IsManualCreation">Whether this is a manual test creation or automated.</param>
+    internal procedure CreateMultipleInspectionsForMarkedTrackingSpecification(var TempTrackingSpecification: Record "Tracking Specification" temporary; IsManualCreation: Boolean)
     var
         TempNotUsedOptionalFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary;
         TempRecCopyOfTrackingSpecificationRecordRef: RecordRef;
@@ -819,7 +829,7 @@ codeunit 20404 "Qlty. Inspection - Create"
                 TempRecCopyOfTrackingSpecificationRecordRef.Insert();
             until TempTrackingSpecification.Next() = 0;
 
-        CreateMultipleInspectionsForMultipleRecords(TempRecCopyOfTrackingSpecificationRecordRef, true, TempNotUsedOptionalFiltersQltyInspectionGenRule);
+        CreateMultipleInspectionsForMultipleRecords(TempRecCopyOfTrackingSpecificationRecordRef, IsManualCreation, TempNotUsedOptionalFiltersQltyInspectionGenRule);
     end;
 
     internal procedure CreateMultipleInspectionsForMultipleRecords(var SetOfRecordsRecordRef: RecordRef; IsManualCreation: Boolean)
@@ -842,15 +852,13 @@ codeunit 20404 "Qlty. Inspection - Create"
     internal procedure DisplayInspectionsIfConfigured(IsManualCreation: Boolean; var CreatedQltyInspectionIds: List of [Code[20]])
     var
         CreatedQltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyNotificationMgmt: Codeunit "Qlty. Notification Mgmt.";
         InspectionNo: Code[20];
         PipeSeparatedFilter: Text;
     begin
         QltyManagementSetup.Get();
 
-        if GuiAllowed() and
-           ((QltyManagementSetup."When to show inspections" in [QltyManagementSetup."When to show inspections"::"Always"]) or
-           (IsManualCreation and (QltyManagementSetup."When to show inspections" in [QltyManagementSetup."When to show inspections"::"Only manually created inspections"])))
-        then begin
+        if GuiAllowed() then begin
             foreach InspectionNo in CreatedQltyInspectionIds do
                 if InspectionNo <> '' then begin
                     if StrLen(PipeSeparatedFilter) > 1 then
@@ -862,10 +870,16 @@ codeunit 20404 "Qlty. Inspection - Create"
             if CreatedQltyInspectionIds.Count() = 1 then begin
                 CreatedQltyInspectionHeader.SetCurrentKey("No.", "Re-inspection No.");
                 CreatedQltyInspectionHeader.FindLast();
-                Page.Run(Page::"Qlty. Inspection", CreatedQltyInspectionHeader);
+                if IsManualCreation then
+                    Page.Run(Page::"Qlty. Inspection", CreatedQltyInspectionHeader)
+                else
+                    QltyNotificationMgmt.NotifyInspectionCreated(CreatedQltyInspectionHeader);
             end else begin
                 CreatedQltyInspectionHeader.FindSet();
-                Page.Run(Page::"Qlty. Inspection List", CreatedQltyInspectionHeader);
+                if IsManualCreation then
+                    Page.Run(Page::"Qlty. Inspection List", CreatedQltyInspectionHeader)
+                else
+                    QltyNotificationMgmt.NotifyMultipleInspectionsCreated(CreatedQltyInspectionHeader);
             end;
         end;
     end;

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/Tracking/QltyItemTrackingLines.PageExt.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/Tracking/QltyItemTrackingLines.PageExt.al
@@ -34,7 +34,7 @@ pageextension 20418 "Qlty. Item Tracking Lines" extends "Item Tracking Lines"
                         QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
                     begin
                         CurrPage.SetSelectionFilter(Rec);
-                        QltyInspectionCreate.CreateMultipleInspectionsForMarkedTrackingSpecification(Rec);
+                        QltyInspectionCreate.CreateMultipleInspectionsForMarkedTrackingSpecification(Rec, true);
                         Rec.Reset();
                     end;
                 }

--- a/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Page.al
@@ -80,14 +80,6 @@ page 20400 "Qlty. Management Setup"
                         AboutText = 'This is the maximum number of rows to fetch on data lookups. Keeping the number as low as possible will increase usability and performance.';
 
                     }
-                    field("When to show inspections"; Rec."When to show inspections")
-                    {
-                        ApplicationArea = All;
-                        ShowCaption = true;
-                        Importance = Promoted;
-                        AboutTitle = 'When To Show Inspections';
-                        AboutText = 'Specifies whether inspections are shown immediately or sent to a queue for quality inspectors. For demonstrations and training, it can be useful to show automatically created inspections immediately. In production scenarios, automatically created inspections are usually not shown, instead they are queued or dispatch for quality inspectors.';
-                    }
                     field("Additional Picture Handling"; Rec."Additional Picture Handling")
                     {
                         ApplicationArea = All;

--- a/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Table.al
@@ -42,11 +42,6 @@ table 20400 "Qlty. Management Setup"
             TableRelation = "No. Series";
             ToolTip = 'Specifies the default number series for quality inspection documents used when there isn''t a number series defined on the quality inspection template.';
         }
-        field(3; "When to show inspections"; Enum "Qlty. When to Show Inspections")
-        {
-            Caption = 'When to show inspections';
-            ToolTip = 'Specifies whether inspections are shown immediately or sent to a queue for quality inspectors. For demonstrations and training, it can be useful to show automatically created inspections immediately. In production scenarios, automatically created inspections are usually not shown, instead they are queued or dispatch for quality inspections.';
-        }
         field(4; "Inspection Creation Option"; Enum "Qlty. Inspect. Creation Option")
         {
             Caption = 'Inspection Creation Option';

--- a/src/Apps/W1/Quality Management/app/src/Setup/SetupWizard/QltyManagementSetupWizard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/SetupWizard/QltyManagementSetupWizard.Page.al
@@ -9,6 +9,7 @@ using Microsoft.QualityManagement.Configuration.GenerationRule;
 using Microsoft.QualityManagement.Document;
 using Microsoft.QualityManagement.Setup;
 using Microsoft.QualityManagement.Setup.ApplicationAreas;
+using Microsoft.QualityManagement.Utilities;
 using System.Environment;
 using System.Environment.Configuration;
 using System.Telemetry;
@@ -230,144 +231,6 @@ page 20438 "Qlty. Management Setup Wizard"
                     }
                 }
             }
-            group(SettingsFor_StepShowInspections_detectAuto)
-            {
-                Caption = 'Show Automatic Inspections?';
-                Visible = (StepShowInspections = CurrentStepCounter) and (
-                    ProductionCreateInspectionsAutomatically or
-                    ReceiveCreateInspectionsAutomaticallyPurchase or
-                    ReceiveCreateInspectionsAutomaticallyTransfer or
-                    ReceiveCreateInspectionsAutomaticallyWarehouseReceipt or
-                    ReceiveCreateInspectionsAutomaticallySalesReturn);
-                InstructionalText = 'When inspections are created automatically, should the inspection immediately show?';
-
-                group(SettingsFor_detectAuto__Show_AutoAndManual)
-                {
-                    Caption = 'Yes';
-                    InstructionalText = 'Yes, because the person doing the activity (such as posting) is also the person collecting the inspection results. Activities that trigger an inspection without direct interaction in Business Central, such as background posting or through a web service integration such as Power Automate will still create an inspection but it will not immediately be shown.';
-
-                    field(ChoosedetectAuto_Show_AutoAndManual; ShowAutoAndManual)
-                    {
-                        ApplicationArea = All;
-                        ShowCaption = false;
-                        Caption = 'Yes';
-                        ToolTip = 'Yes, because the person doing the activity (such as posting) is also the person collecting the inspection results. Activities that trigger an inspection without direct interaction in Business Central, such as background posting or through a web service integration such as Power Automate will still create an inspection but it will not immediately be shown.';
-
-                        trigger OnValidate()
-                        begin
-                            ShowOnlyManual := not ShowAutoAndManual;
-                            ShowNever := not ShowAutoAndManual;
-                        end;
-                    }
-                }
-                group(SettingsFor_detectAuto__Show_OnlyManual)
-                {
-                    Caption = 'No';
-                    InstructionalText = 'No, because the person doing the activity is not the person collecting the inspection results. Just make the inspection and do not show it.';
-
-                    field(ChoosedetectAuto_Show_OnlyManual; ShowOnlyManual)
-                    {
-                        ApplicationArea = All;
-                        ShowCaption = false;
-                        Caption = 'No';
-                        ToolTip = 'No, because the person doing the activity is not the person collecting the inspection results. Just make the inspection and do not show it.';
-
-                        trigger OnValidate()
-                        begin
-                            ShowAutoAndManual := not ShowOnlyManual;
-                            ShowNever := not ShowOnlyManual;
-                        end;
-                    }
-                }
-                group(SettingsFor_detectAuto__Show_Never)
-                {
-                    Caption = 'No, not even manually created inspections.';
-                    InstructionalText = 'No, not even inspections created by clicking a button. The person creating the inspection is not involved in completing the inspection.';
-
-                    field(ChoosedetectAuto_Show_Never; ShowNever)
-                    {
-                        ApplicationArea = All;
-                        ShowCaption = false;
-                        Caption = 'No, not even manually created inspections.';
-                        ToolTip = 'No, not even inspections created by clicking a button. The person creating the inspection is not involved in completing the inspection.';
-
-                        trigger OnValidate()
-                        begin
-                            ShowAutoAndManual := not ShowNever;
-                            ShowOnlyManual := not ShowNever;
-                        end;
-                    }
-                }
-            }
-            group(SettingsFor_StepShowInspections_DetectManualOnly)
-            {
-                Caption = 'Show Inspections As They Are Created';
-                Visible = (StepShowInspections = CurrentStepCounter) and not
-                    (ProductionCreateInspectionsAutomatically or
-                    ReceiveCreateInspectionsAutomaticallyPurchase or
-                    ReceiveCreateInspectionsAutomaticallyTransfer or
-                    ReceiveCreateInspectionsAutomaticallyWarehouseReceipt or
-                    ReceiveCreateInspectionsAutomaticallySalesReturn);
-                InstructionalText = 'When inspections are created, should they show up immediately?';
-
-                group(SettingsFor__Show_AutoAndManual)
-                {
-                    Caption = 'Show Always';
-                    InstructionalText = 'Use this when you want an inspection shown to the person who triggered the inspection. For example if you are creating inspections automatically when posting then the inspection would show to the person who posted. Do not use this option if the person doing the activity triggering the inspection is not the person recording the data.';
-
-                    field(ChooseShow_AutoAndManual; ShowAutoAndManual)
-                    {
-                        ApplicationArea = All;
-                        ShowCaption = false;
-                        Caption = 'Show Always';
-                        ToolTip = 'Use this when you want an inspection shown to the person who triggered the inspection. For example if you are creating inspections automatically when posting then the inspection would show to the person who posted. Do not use this option if the person doing the activity triggering the inspection is not the person recording the data.';
-
-                        trigger OnValidate()
-                        begin
-                            ShowOnlyManual := not ShowAutoAndManual;
-                            ShowNever := not ShowAutoAndManual;
-                        end;
-                    }
-                }
-                group(SettingsFor__Show_OnlyManual)
-                {
-                    Caption = 'Only manually created inspections';
-                    InstructionalText = 'Use this when you want inspections that were created automatically to not show up immediately. If someone presses a button to create an inspection to make sure that those show up.';
-
-                    field(ChooseShow_OnlyManual; ShowOnlyManual)
-                    {
-                        ApplicationArea = All;
-                        ShowCaption = false;
-                        Caption = 'Only manually created inspections';
-                        ToolTip = 'Use this when you want inspections that were created automatically to not show up immediately, however if someone presses a button to create an inspection to make sure that those show up.';
-
-                        trigger OnValidate()
-                        begin
-                            ShowAutoAndManual := not ShowOnlyManual;
-                            ShowNever := not ShowOnlyManual;
-                        end;
-                    }
-                }
-                group(SettingsFor__Show_Never)
-                {
-                    Caption = 'Never';
-                    InstructionalText = 'Use this to always make resulting inspections hidden. Use this when other people need to trigger inspections but should not be editing them.';
-
-                    field(ChooseShow_Never; ShowNever)
-                    {
-                        ApplicationArea = All;
-                        ShowCaption = false;
-                        Caption = 'Never immediately show.';
-                        ToolTip = 'Never immediately show.';
-
-                        trigger OnValidate()
-                        begin
-                            ShowAutoAndManual := not ShowNever;
-                            ShowOnlyManual := not ShowNever;
-                        end;
-                    }
-                }
-            }
             group(SettingsFor_StepDone)
             {
                 Visible = (StepDone = CurrentStepCounter);
@@ -487,9 +350,6 @@ page 20438 "Qlty. Management Setup Wizard"
         ReceiveCreateInspectionsAutomaticallySalesReturn: Boolean;
         ReceiveCreateInspectionsAutomaticallyWarehouseReceipt: Boolean;
         ReceiveCreateInspectionsManually: Boolean;
-        ShowAutoAndManual: Boolean;
-        ShowOnlyManual: Boolean;
-        ShowNever: Boolean;
         ShowHTMLHeader: Boolean;
         IsPremiumExperienceEnabled: Boolean;
         TopBannerVisible: Boolean;
@@ -498,7 +358,6 @@ page 20438 "Qlty. Management Setup Wizard"
         StepReceivingConfig: Integer;
         StepWhatAreYouMakingQltyInspectionsFor: Integer;
         StepProductionConfig: Integer;
-        StepShowInspections: Integer;
         StepDone: Integer;
         MaxStep: Integer;
         ReRunThisWizardWithMorePermissionErr: Label 'It looks like you need more permissions to run this wizard successfully. Please ask your Business Central administrator to grant more permission.';
@@ -518,8 +377,7 @@ page 20438 "Qlty. Management Setup Wizard"
         StepWhatAreYouMakingQltyInspectionsFor := 3;
         StepProductionConfig := 4;
         StepReceivingConfig := 5;
-        StepShowInspections := 6;
-        StepDone := 7;
+        StepDone := 6;
 
         MaxStep := StepDone;
     end;
@@ -591,12 +449,6 @@ page 20438 "Qlty. Management Setup Wizard"
                     IsNextEnabled := true;
                     IsFinishEnabled := false;
                 end;
-            StepShowInspections:
-                begin
-                    IsBackEnabled := true;
-                    IsNextEnabled := true;
-                    IsFinishEnabled := false;
-                end;
             StepDone:
                 begin
                     IsBackEnabled := true;
@@ -628,14 +480,14 @@ page 20438 "Qlty. Management Setup Wizard"
                     WhatForReceiving:
                         MovingToThisStep := StepReceivingConfig;
                     else
-                        MovingToThisStep := StepShowInspections;
+                        MovingToThisStep := StepDone;
                 end;
             StepProductionConfig:
                 case true of
                     WhatForReceiving:
                         MovingToThisStep := StepReceivingConfig;
                     else
-                        MovingToThisStep := StepShowInspections;
+                        MovingToThisStep := StepDone;
                 end;
         end;
     end;
@@ -657,6 +509,7 @@ page 20438 "Qlty. Management Setup Wizard"
         GuidedExperience: Codeunit "Guided Experience";
         EnvironmentInformation: Codeunit "Environment Information";
         QltyApplicationAreaMgmt: Codeunit "Qlty. Application Area Mgmt.";
+        QltyNotificationMgmt: Codeunit "Qlty. Notification Mgmt.";
         CustomDimensions: Dictionary of [Text, Text];
     begin
         GuidedExperience.CompleteAssistedSetup(ObjectType::Page, Page::"Qlty. Management Setup Wizard");
@@ -709,14 +562,7 @@ page 20438 "Qlty. Management Setup Wizard"
             end;
         end;
 
-        case true of
-            ShowAutoAndManual:
-                QltyManagementSetup."When to show inspections" := QltyManagementSetup."When to show inspections"::"Always";
-            ShowOnlyManual:
-                QltyManagementSetup."When to show inspections" := QltyManagementSetup."When to show inspections"::"Only manually created inspections";
-            ShowNever:
-                QltyManagementSetup."When to show inspections" := QltyManagementSetup."When to show inspections"::"Never";
-        end;
+        QltyNotificationMgmt.EnsureDefaultNotifications();
 
         if QltyManagementSetup.Visibility = QltyManagementSetup.Visibility::Hide then
             QltyManagementSetup.Validate(Visibility, QltyManagementSetup.Visibility::Show);
@@ -758,9 +604,6 @@ page 20438 "Qlty. Management Setup Wizard"
                 ReceiveCreateInspectionsAutomaticallyWarehouseReceipt or
                 ReceiveCreateInspectionsAutomaticallySalesReturn);
 
-            ShowAutoAndManual := QltyManagementSetup."When to show inspections" = QltyManagementSetup."When to show inspections"::"Always";
-            ShowOnlyManual := QltyManagementSetup."When to show inspections" = QltyManagementSetup."When to show inspections"::"Only manually created inspections";
-            ShowNever := QltyManagementSetup."When to show inspections" = QltyManagementSetup."When to show inspections"::"Never";
         end
     end;
 

--- a/src/Apps/W1/Quality Management/app/src/Utilities/QltyNotificationMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Utilities/QltyNotificationMgmt.Codeunit.al
@@ -9,6 +9,7 @@ using Microsoft.QualityManagement.Dispositions;
 using Microsoft.QualityManagement.Document;
 using Microsoft.Utilities;
 using Microsoft.Warehouse.Activity;
+using System.Environment.Configuration;
 using System.Reflection;
 
 /// <summary>
@@ -60,6 +61,74 @@ codeunit 20437 "Qlty. Notification Mgmt."
         SerialMsg: Label ' Serial: %1', Comment = '%1=serial no.';
         PackageMsg: Label ' Package: %1', Comment = '%1=package no.';
         OriginTok: Label 'origin', Locked = true;
+        InspectionCreatedMsg: Label 'Quality Inspection %1 has been created.', Comment = '%1=the test friendly identifier';
+        MultipleInspectionsCreatedMsg: Label '%1 Quality Inspections have been created.', Comment = '%1=the number of inspections';
+        ViewTheInspectionsPageLbl: Label 'View the created inspections';
+        MultipleInspectionsNotificationDataFilterTok: Label 'InspectionsFilter', Locked = true;
+        HandleOpenMultipleInspectionsTok: Label 'HandleOpenMultipleInspections', Locked = true;
+        OpenTheInspectionPageLbl: Label 'Open the inspection';
+        AssignToYourselfTok: Label 'Assign Quality Inspection to yourself', Locked = true;
+        AssignToYourselfDescriptionTxt: Label 'Show a notification to provide the opportunity to assign the Quality Inspection to yourself.';
+        InspectionCreatedNameTok: Label 'Quality Inspection created', Locked = true;
+        InspectionCreatedDescriptionTxt: Label 'Show a notification that a Quality Inspection has been created.';
+
+    /// <summary>
+    /// Ensures that configurable notifications are inserted.
+    /// </summary>
+    procedure EnsureDefaultNotifications()
+    var
+        MyNotifications: Record "My Notifications";
+    begin
+        MyNotifications.InsertDefault(GetAssignToYourselfNotificationId(), AssignToYourselfTok, AssignToYourselfDescriptionTxt, true);
+        MyNotifications.InsertDefault(GetInspectionCreatedNotificationId(), InspectionCreatedNameTok, InspectionCreatedDescriptionTxt, true);
+    end;
+
+    /// <summary>
+    /// Creates a notification that an inspection has been created.
+    /// </summary>
+    /// <param name="QltyInspectionHeader"></param>
+    procedure NotifyInspectionCreated(QltyInspectionHeader: Record "Qlty. Inspection Header")
+    var
+        MyNotifications: Record "My Notifications";
+        NotificationInspectionCreated: Notification;
+        Message: Text;
+        NotificationOptions: Dictionary of [Text, Text];
+    begin
+        if not GuiAllowed() then
+            exit;
+        EnsureDefaultNotifications();
+        if not MyNotifications.IsEnabled(GetInspectionCreatedNotificationId()) then
+            exit;
+        Message := StrSubstNo(InspectionCreatedMsg, QltyInspectionHeader.GetFriendlyIdentifier());
+        NotificationOptions.Add(OpenTheInspectionPageLbl, HandleOpenDocumentTok);
+        NotificationInspectionCreated.SetData(NotificationDataRelatedRecordIdTok, Format(QltyInspectionHeader.RecordId));
+        CreateActionNotification(NotificationInspectionCreated, Message, NotificationOptions);
+    end;
+
+    /// <summary>
+    /// Creates a notification that multiple inspections have been created.
+    /// </summary>
+    /// <param name="QltyInspectionHeader"></param>
+    procedure NotifyMultipleInspectionsCreated(QltyInspectionHeader: Record "Qlty. Inspection Header")
+    var
+        MyNotifications: Record "My Notifications";
+        NotificationTestCreated: Notification;
+        Message: Text;
+        NotificationOptions: Dictionary of [Text, Text];
+    begin
+        if not GuiAllowed() then
+            exit;
+        EnsureDefaultNotifications();
+        if not MyNotifications.IsEnabled(GetInspectionCreatedNotificationId()) then
+            exit;
+        Message := StrSubstNo(
+            MultipleInspectionsCreatedMsg,
+            QltyInspectionHeader.Count()
+        );
+        NotificationOptions.Add(ViewTheInspectionsPageLbl, HandleOpenMultipleInspectionsTok);
+        NotificationTestCreated.SetData(MultipleInspectionsNotificationDataFilterTok, QltyInspectionHeader.GetView());
+        CreateActionNotification(NotificationTestCreated, Message, NotificationOptions);
+    end;
 
     /// <summary>
     /// Call this to create a notification if you want to assign to yourself.
@@ -67,12 +136,18 @@ codeunit 20437 "Qlty. Notification Mgmt."
     /// <param name="QltyInspectionHeader"></param>
     procedure NotifyDoYouWantToAssignToYourself(QltyInspectionHeader: Record "Qlty. Inspection Header")
     var
+        MyNotifications: Record "My Notifications";
         AssignToSelfNotification: Notification;
         AvailableOptions: Dictionary of [Text, Text];
     begin
+        if not GuiAllowed() then
+            exit;
+        EnsureDefaultNotifications();
+        if not MyNotifications.IsEnabled(GetAssignToYourselfNotificationId()) then
+            exit;
         AvailableOptions.Add(AssignToSelfLbl, HandleNotificationActionAssignToSelfTok);
         AvailableOptions.Add(IgnoreLbl, HandleNotificationActionIgnoreTok);
-        AssignToSelfNotification.Id := QltyInspectionHeader.SystemId;
+        AssignToSelfNotification.Id := GetAssignToYourselfNotificationId();
         AssignToSelfNotification.SetData(NotificationDataInspectionRecordIdTok, Format(QltyInspectionHeader.RecordId()));
         CreateActionNotification(AssignToSelfNotification, StrSubstNo(YouHaveAlteredDoYouWantToAutoAssignQst, QltyInspectionHeader."No."), AvailableOptions);
     end;
@@ -348,7 +423,7 @@ codeunit 20437 "Qlty. Notification Mgmt."
     end;
 
     /// <summary>
-    /// procedure name *must* mah tcHandleOpenDocumentTok 
+    /// procedure name *must* match HandleOpenDocumentTok 
     /// This is the event handle for the 'open the document' 
     /// </summary>
     /// <param name="NotificationToShow">The notification that triggered the action.</param>
@@ -389,6 +464,18 @@ codeunit 20437 "Qlty. Notification Mgmt."
 
                 Page.RunModal(CurrentPage, RecordRefVariant);
             end;
+    end;
+
+    /// <summary>
+    /// procedure name must match HandleOpenMultipleInspectionsTok.
+    /// </summary>
+    /// <param name="pNotification"></param>
+    internal procedure HandleOpenMultipleInspections(pNotification: Notification)
+    var
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+    begin
+        QltyInspectionHeader.SetView(pNotification.GetData(MultipleInspectionsNotificationDataFilterTok));
+        Page.RunModal(Page::"Qlty. Inspection List", QltyInspectionHeader);
     end;
 
     /// <summary>
@@ -556,6 +643,16 @@ codeunit 20437 "Qlty. Notification Mgmt."
             TextBuilder.Append(StrSubstNo(ExpDateMsg, Format(TempInstructionQltyDispositionBuffer."New Expiration Date")));
 
         exit(TextBuilder.ToText());
+    end;
+
+    local procedure GetAssignToYourselfNotificationId(): Guid
+    begin
+        exit('de535e9b-2727-4d23-8be4-e2ff33a2c586');
+    end;
+
+    local procedure GetInspectionCreatedNotificationId(): Guid
+    begin
+        exit('f2e838e8-c3c3-4ce2-ab34-cde0a3a3cb1f');
     end;
 
     /// <summary>

--- a/src/Apps/W1/Quality Management/app/src/Workflow/QltyWorkflowResponse.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Workflow/QltyWorkflowResponse.Codeunit.al
@@ -130,7 +130,7 @@ codeunit 20424 "Qlty. Workflow Response"
             case WorkflowResponse."Function Name" of
                 QltyWorkflowSetup.GetWorkflowResponseCreateInspection():
                     begin
-                        if QltyInspectionCreate.CreateInspection(PrimaryRecordRefInWorkflow, GuiAllowed()) then
+                        if QltyInspectionCreate.CreateInspection(PrimaryRecordRefInWorkflow, false) then
                             QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
                         ResponseExecuted := true;

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsCreateInspect.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsCreateInspect.Codeunit.al
@@ -67,7 +67,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
 
         // [WHEN] CreateInspection is called with AlwaysCreate set to true
-        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionGenRule.Delete();
 
         // [THEN] The function claims an inspection was found or created
@@ -122,7 +122,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
 
         // [GIVEN] A first inspection is created
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
-        QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(CreatedFirstQltyInspectionHeader);
 
         // [GIVEN] The Inspection Creation Option is set to "Always create new inspection"
@@ -138,7 +138,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
 
         // [WHEN] CreateInspection is called again for the same routing line
-        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(CreatedSecondQltyInspectionHeader);
 
         QltyManagementSetup."Inspection Creation Option" := QltyCreateInspectBehavior;
@@ -182,7 +182,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
 
         // [GIVEN] A first inspection is created
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
-        QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(FirstCreatedQltyInspectionHeader);
 
         // [GIVEN] The Inspection Creation Option is set to "Always create re-inspection"
@@ -196,7 +196,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         ClearLastError();
 
         // [WHEN] CreateInspection is called again for the same routing line
-        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(SecondCreatedQltyInspectionHeader);
 
         QltyManagementSetup."Inspection Creation Option" := QltyCreateInspectBehavior;
@@ -240,7 +240,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
 
         // [GIVEN] A first inspection is created
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
-        QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(FirstCreatedQltyInspectionHeader);
 
         // [GIVEN] The Inspection Creation Option is set to "Create re-inspection if matching inspection is finished"
@@ -253,7 +253,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         BeforeCount := QltyInspectionHeader.Count();
 
         // [WHEN] CreateInspection is called again for the same routing line when the first inspection is not finished
-        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(SecondCreatedQltyInspectionHeader);
 
         QltyManagementSetup."Inspection Creation Option" := QltyCreateInspectBehavior;
@@ -297,7 +297,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
 
         // [GIVEN] A first inspection is created
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
-        QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(FirstCreatedQltyInspectionHeader);
 
         // [GIVEN] The Inspection Creation Option is set to "Create re-inspection if matching inspection is finished"
@@ -314,7 +314,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         BeforeCount := QltyInspectionHeader.Count();
 
         // [WHEN] CreateInspection is called again for the same routing line with the first inspection finished
-        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(SecondCreatedQltyInspectionHeader);
 
         QltyManagementSetup."Inspection Creation Option" := QltyCreateInspectBehavior;
@@ -358,7 +358,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
 
         // [GIVEN] A first inspection is created
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
-        QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(FirstCreatedQltyInspectionHeader);
 
         // [GIVEN] The Inspection Creation Option is set to "Use existing open inspection if available"
@@ -375,7 +375,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         BeforeCount := QltyInspectionHeader.Count();
 
         // [WHEN] CreateInspection is called again for the same routing line with the first inspection finished
-        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(SecondCreatedQltyInspectionHeader);
 
         QltyManagementSetup."Inspection Creation Option" := QltyCreateInspectBehavior;
@@ -418,7 +418,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
 
         // [GIVEN] A first inspection is created and left open
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
-        QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(FirstCreatedQltyInspectionHeader);
 
         // [GIVEN] The Inspection Creation Option is set to "Use existing open inspection if available"
@@ -431,7 +431,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         BeforeCount := QltyInspectionHeader.Count();
 
         // [WHEN] CreateInspection is called again for the same routing line with the first inspection still open
-        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(SecondCreatedQltyInspectionHeader);
 
         QltyManagementSetup."Inspection Creation Option" := QltyCreateInspectBehavior;
@@ -474,7 +474,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
 
         // [GIVEN] A first inspection is created
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
-        QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(FirstCreatedQltyInspectionHeader);
 
         // [GIVEN] The Inspection Creation Option is set to "Use any existing inspection if available"
@@ -491,7 +491,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         BeforeCount := QltyInspectionHeader.Count();
 
         // [WHEN] CreateInspection is called again for the same routing line
-        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(SecondCreatedQltyInspectionHeader);
 
         QltyManagementSetup."Inspection Creation Option" := PreviousQltyCreateInspectBehavior;
@@ -541,7 +541,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
 
         // [WHEN] CreateInspection is called when no existing inspection exists
-        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
 
         QltyManagementSetup."Inspection Creation Option" := QltyCreateInspectBehavior;
         QltyManagementSetup.Modify();
@@ -584,7 +584,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
 
         // [WHEN] CreateInspectionWithVariant is called with AlwaysCreate set to true
-        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLineRecordRefRecordRef, true);
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLineRecordRefRecordRef, false);
 
         // [THEN] An inspection is claimed to be created
         LibraryAssert.IsTrue(ClaimedInspectionWasFoundOrCreated, 'An inspection should have been claimed to be created.');
@@ -643,7 +643,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
 
         // [WHEN] CreateInspectionWithVariantAndTemplate is called with specific template code
-        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspectionWithVariantAndTemplate(ProdOrderRoutingLineRecordRefRecordRef, true, QltyInspectionTemplateHdr.Code);
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspectionWithVariantAndTemplate(ProdOrderRoutingLineRecordRefRecordRef, false, QltyInspectionTemplateHdr.Code);
 
         // [THEN] An inspection is claimed to be created
         LibraryAssert.IsTrue(ClaimedInspectionWasFoundOrCreated, 'An inspection should have been claimed to be created');
@@ -1158,7 +1158,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
 
         // [WHEN] CreateInspectionWithSpecificTemplate is called with the template code
         // [WHEN] CreateInspectionWithSpecificTemplate is called with the template code
-        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspectionWithSpecificTemplate(ProdOrderRoutingLineRecordRefRecordRef, true, QltyInspectionTemplateHdr.Code);
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspectionWithSpecificTemplate(ProdOrderRoutingLineRecordRefRecordRef, false, QltyInspectionTemplateHdr.Code);
 
         QltyInspectionGenRule.Delete();
 
@@ -1195,11 +1195,11 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
     var
         ProdOrderRoutingLine: Record "Prod. Order Routing Line";
         QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
-        InspectionSecondQltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
         ProdProductionOrder: Record "Production Order";
         Item: Record Item;
         QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
         ProdOrderRoutingLineRecordRefRecordRef: RecordRef;
+        BlankTemplateTok: Label '', Locked = true;
     begin
         // [SCENARIO] Verify error when creating inspection with specific template but generation rule and template do not exist
 
@@ -1208,11 +1208,12 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         SetupCreateInspectionProductionOrder(QltyInspectionTemplateHdr, QltyInspectionGenRule, Item, ProdProductionOrder, ProdOrderRoutingLine);
 
         // [GIVEN] All generation rules are deleted
-        QltyInspectionGenRule.DeleteAll();
+        QltyInspectionGenRule.Reset();
+        QltyInspectionGenRule.DeleteAll(false);
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
 
         // [WHEN] CreateInspectionWithSpecificTemplate is called with a non-existent template code
-        asserterror QltyInspectionCreate.CreateInspectionWithSpecificTemplate(ProdOrderRoutingLineRecordRefRecordRef, true, InspectionSecondQltyInspectionTemplateHdr.Code);
+        asserterror QltyInspectionCreate.CreateInspectionWithSpecificTemplate(ProdOrderRoutingLineRecordRefRecordRef, true, BlankTemplateTok);
 
         // [THEN] An error is raised indicating the template cannot be found
         LibraryAssert.ExpectedError(StrSubstNo(CannotFindTemplateErr, Format(ProdOrderRoutingLineRecordRefRecordRef.RecordId())));
@@ -1282,7 +1283,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
 
         // [GIVEN] An inspection is created with a re-inspection
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
-        QltyInspectionCreate.CreateInspectionWithSpecificTemplate(ProdOrderRoutingLineRecordRefRecordRef, true, QltyInspectionTemplateHdr.Code);
+        QltyInspectionCreate.CreateInspectionWithSpecificTemplate(ProdOrderRoutingLineRecordRefRecordRef, false, QltyInspectionTemplateHdr.Code);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         QltyInspectionCreate.CreateReinspection(QltyInspectionHeader, ReQltyInspectionHeader);
@@ -1357,7 +1358,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
 
         // [GIVEN] An inspection is created with a re-inspection
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
-        QltyInspectionCreate.CreateInspectionWithSpecificTemplate(ProdOrderRoutingLineRecordRefRecordRef, true, QltyInspectionTemplateHdr.Code);
+        QltyInspectionCreate.CreateInspectionWithSpecificTemplate(ProdOrderRoutingLineRecordRefRecordRef, false, QltyInspectionTemplateHdr.Code);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         QltyInspectionCreate.CreateReinspection(QltyInspectionHeader, ReQltyInspectionHeader);
@@ -1418,7 +1419,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
 
         // [GIVEN] An inspection is created for the production order routing line
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
-        QltyInspectionCreate.CreateInspectionWithSpecificTemplate(ProdOrderRoutingLineRecordRefRecordRef, true, QltyInspectionTemplateHdr.Code);
+        QltyInspectionCreate.CreateInspectionWithSpecificTemplate(ProdOrderRoutingLineRecordRefRecordRef, false, QltyInspectionTemplateHdr.Code);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [WHEN] FindExistingInspectionWithVariant is called with the routing line
@@ -2052,7 +2053,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
 
         // [GIVEN] An inspection is created from the production order routing line
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
-        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         LibraryAssert.IsTrue(ClaimedInspectionWasFoundOrCreated, 'An inspection should have been created');
 
         // [GIVEN] The created inspection is retrieved
@@ -2093,7 +2094,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
 
         // [GIVEN] An inspection is created from the production order routing line
         ProdOrderRoutingLineRecordRefRecordRef.GetTable(ProdOrderRoutingLine);
-        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, true);
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionCreate.CreateInspection(ProdOrderRoutingLineRecordRefRecordRef, false);
         LibraryAssert.IsTrue(ClaimedInspectionWasFoundOrCreated, 'An inspection should have been created');
 
         // [GIVEN] The last created inspection is found in the database
@@ -2348,7 +2349,6 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         QltyInspectionUtility.EnsureSetupExists();
         // [GIVEN] The quality management setup is configured to show always
         QltyManagementSetup.Get();
-        QltyManagementSetup."When to show inspections" := QltyManagementSetup."When to show inspections"::"Always";
         QltyManagementSetup."Production Order Trigger" := QltyManagementSetup."Production Order Trigger"::OnProductionOutputPost;
         QltyManagementSetup.Modify();
         // [GIVEN] A quality inspection template with 3 inspections and a prioritized generation rule for Prod. Order Routing Line are created
@@ -2378,7 +2378,6 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         AfterCount := QltyInspectionHeader.Count();
 
         QltyInspectionGenRule.Delete();
-        QltyManagementSetup."When to show inspections" := QltyManagementSetup."When to show inspections"::"Never";
         QltyManagementSetup.Modify();
 
         // [THEN] 3 inspections are created (one for each production order)
@@ -2412,10 +2411,8 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         // [GIVEN] The quality management setup is initialized
         Initialize();
         QltyInspectionUtility.EnsureSetupExists();
-        // [GIVEN] The quality management setup is configured to show always
+        // [GIVEN] The quality management setup is configured to show Automatic and manually created inspections
         QltyManagementSetup.Get();
-        QltyManagementSetup."When to show inspections" := QltyManagementSetup."When to show inspections"::"Always";
-        QltyManagementSetup.Modify();
         // [GIVEN] A quality inspection template with 3 inspections and a prioritized generation rule for Prod. Order Routing Line are created
         QltyInspectionUtility.CreateTemplate(QltyInspectionTemplateHdr, 3);
         QltyInspectionUtility.CreatePrioritizedRule(QltyInspectionTemplateHdr, Database::"Prod. Order Routing Line", QltyInspectionGenRule);
@@ -2442,8 +2439,6 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         AfterCount := QltyInspectionHeader.Count();
 
         QltyInspectionGenRule.Delete();
-        QltyManagementSetup."When to show inspections" := QltyManagementSetup."When to show inspections"::"Never";
-        QltyManagementSetup.Modify();
 
         // [THEN] 1 inspection is created
         LibraryAssert.AreEqual((BeforeCount + 1), AfterCount, 'Did not create the correct number of inspections.');
@@ -2531,7 +2526,7 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         UnusedVariant2: Variant;
     begin
         PurchaseLineRecordRef.GetTable(PurOrdPurchaseLine);
-        QltyInspectionCreate2.CreateInspectionWithMultiVariantsAndTemplate(PurchaseLineRecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '');
+        QltyInspectionCreate2.CreateInspectionWithMultiVariantsAndTemplate(PurchaseLineRecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '');
         QltyInspectionCreate2.GetCreatedInspection(OutQltyInspectionHeader);
     end;
 

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsItemTracking.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsItemTracking.Codeunit.al
@@ -2500,7 +2500,7 @@ codeunit 139971 "Qlty. Tests - Item Tracking"
         RecordRef.GetTable(PurOrderPurchaseLine);
         SpecTrackingSpecification.CopyTrackingFromReservEntry(ReservationEntry);
         LotNo := ReservationEntry."Lot No.";
-        QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, SpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '');
+        QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, SpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '');
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Purchase return order is created and lines are copied from receipt
@@ -2581,7 +2581,7 @@ codeunit 139971 "Qlty. Tests - Item Tracking"
         QltyInspectionUtility.CreatePrioritizedRule(QltyInspectionTemplateHdr, Database::"Purchase Line");
         RecordRef.GetTable(PurOrderPurchaseLine);
         SpecTrackingSpecification.CopyTrackingFromReservEntry(ReservationEntry);
-        QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, SpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '');
+        QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, SpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '');
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Purchase return order is created and lines are copied from receipt
@@ -2655,7 +2655,7 @@ codeunit 139971 "Qlty. Tests - Item Tracking"
         RecordRef.GetTable(PurOrderPurchaseLine);
         SpecTrackingSpecification.CopyTrackingFromReservEntry(ReservationEntry);
         Serial := ReservationEntry."Serial No.";
-        QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, SpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '');
+        QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, SpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '');
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Purchase return order is created and lines are copied from receipt

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
@@ -494,7 +494,7 @@ codeunit 139964 "Qlty. Tests - Misc."
         QltyInspectionHeader.Reset();
 
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] An inspection line with a Salesperson/Purchaser code value
@@ -869,7 +869,7 @@ codeunit 139964 "Qlty. Tests - Misc."
         QltyInspectionHeader.Reset();
 
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] An inspection line with the lookup field and test value set to the Salesperson/Purchaser code
@@ -985,7 +985,7 @@ codeunit 139964 "Qlty. Tests - Misc."
         QltyInspectionHeader.Reset();
 
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] An inspection line with the lookup field and test value set to the first Salesperson/Purchaser code
@@ -1084,7 +1084,7 @@ codeunit 139964 "Qlty. Tests - Misc."
         QltyInspectionHeader.Reset();
 
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] An inspection line with the lookup field and test value set to the Salesperson/Purchaser code
@@ -1217,7 +1217,7 @@ codeunit 139964 "Qlty. Tests - Misc."
         QltyInspectionHeader.Reset();
 
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] An inspection line with the lookup field and test value set to the first Salesperson/Purchaser code

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
@@ -1615,10 +1615,9 @@ codeunit 139965 "Qlty. Tests - More Tests"
         QltyInspectionUtility.EnsureSetupExists();
 
         // [GIVEN] Source field configuration for Purchase Line "No." field is deleted
-        SpecificQltyInspectSrcFldConf.SetRange("From Table No.", Database::"Purchase Line");
-        SpecificQltyInspectSrcFldConf.SetRange("From Field No.", PurchaseLine.FieldNo("No."));
-        if SpecificQltyInspectSrcFldConf.FindFirst() then
-            SpecificQltyInspectSrcFldConf.Delete();
+        SpecificQltyInspectSrcFldConf.SetRange("To Table No.", Database::"Qlty. Inspection Header");
+        SpecificQltyInspectSrcFldConf.SetRange("To Field No.", QltyInspectionHeader.FieldNo("Source Item No."));
+        SpecificQltyInspectSrcFldConf.DeleteAll(false);
 
         // [GIVEN] A location and item are created
         LibraryWarehouse.CreateLocation(Location);
@@ -1693,10 +1692,9 @@ codeunit 139965 "Qlty. Tests - More Tests"
         QltyPurOrderGenerator.CreatePurchaseOrder(10, Location, Item, PurchaseHeader, PurchaseLine);
 
         // [GIVEN] Source field configuration for Purchase Line "Document No." field is deleted
-        SpecificQltyInspectSrcFldConf.SetRange("From Table No.", Database::"Purchase Line");
-        SpecificQltyInspectSrcFldConf.SetRange("From Field No.", PurchaseLine.FieldNo("Document No."));
-        if SpecificQltyInspectSrcFldConf.FindFirst() then
-            SpecificQltyInspectSrcFldConf.Delete();
+        SpecificQltyInspectSrcFldConf.SetRange("To Table No.", Database::"Qlty. Inspection Header");
+        SpecificQltyInspectSrcFldConf.SetRange("To Field No.", QltyInspectionHeader.FieldNo("Source Document No."));
+        SpecificQltyInspectSrcFldConf.DeleteAll(false);
 
         // [GIVEN] Inspection header has variant, lot, serial, and package tracking set
         QltyInspectionHeader."Source Variant Code" := 'Variant';

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsResultEval.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsResultEval.Codeunit.al
@@ -401,7 +401,7 @@ codeunit 139963 "Qlty. Tests - Result Eval."
 
         QltyInspectionHeader.Reset();
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Inspection line and test-level result conditions are retrieved
@@ -513,7 +513,7 @@ codeunit 139963 "Qlty. Tests - Result Eval."
 
         QltyInspectionHeader.Reset();
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Inspection line and test-level result conditions are retrieved
@@ -600,7 +600,7 @@ codeunit 139963 "Qlty. Tests - Result Eval."
 
         QltyInspectionHeader.Reset();
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Inspection line and test-level result conditions are retrieved
@@ -683,7 +683,7 @@ codeunit 139963 "Qlty. Tests - Result Eval."
 
         QltyInspectionHeader.Reset();
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Inspection line and test-level result conditions are retrieved
@@ -761,7 +761,7 @@ codeunit 139963 "Qlty. Tests - Result Eval."
 
         QltyInspectionHeader.Reset();
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Inspection line and test-level result conditions are retrieved
@@ -851,7 +851,7 @@ codeunit 139963 "Qlty. Tests - Result Eval."
 
         QltyInspectionHeader.Reset();
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Inspection line and test-level result conditions are retrieved
@@ -959,7 +959,7 @@ codeunit 139963 "Qlty. Tests - Result Eval."
         LibraryAssert.AreEqual(0, SanityCheckQltyInspectionResult.Count(), 'should be no blank results - e');
         QltyInspectionHeader.Reset();
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Inspection line and test-level result conditions are retrieved with no blank results
@@ -1077,7 +1077,7 @@ codeunit 139963 "Qlty. Tests - Result Eval."
 
         QltyInspectionHeader.Reset();
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Inspection line for second field (uses reference) is retrieved
@@ -1215,7 +1215,7 @@ codeunit 139963 "Qlty. Tests - Result Eval."
 
         QltyInspectionHeader.Reset();
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Inspection line for second field is retrieved with expression '1..{2+[TestCode]}'
@@ -1751,7 +1751,7 @@ codeunit 139963 "Qlty. Tests - Result Eval."
 
         QltyInspectionHeader.Reset();
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Inspection line is retrieved for test context validation
@@ -1842,7 +1842,7 @@ codeunit 139963 "Qlty. Tests - Result Eval."
 
         QltyInspectionHeader.Reset();
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Inspection line is retrieved and result conditions are set up
@@ -1946,7 +1946,7 @@ codeunit 139963 "Qlty. Tests - Result Eval."
 
         QltyInspectionHeader.Reset();
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, true);
+        QltyInspectionCreate.CreateInspectionWithVariant(ProdOrderRoutingLine, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Inspection line is retrieved for validation
@@ -2069,7 +2069,7 @@ codeunit 139963 "Qlty. Tests - Result Eval."
 
         QltyInspectionHeader.Reset();
         ClearLastError();
-        QltyInspectionCreate.CreateInspectionWithVariantAndTemplate(ProdOrderRoutingLine, true, QltyInspectionTemplateHdr.Code);
+        QltyInspectionCreate.CreateInspectionWithVariantAndTemplate(ProdOrderRoutingLine, false, QltyInspectionTemplateHdr.Code);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Inspection line for option field is retrieved

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsTestTable.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsTestTable.Codeunit.al
@@ -672,7 +672,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         // [GIVEN] An inspection is created from the second purchase line with its lot number
         RecordRef.GetTable(SecondPurchaseLine);
         TempSpecTrackingSpecification.CopyTrackingFromReservEntry(SecondReservationEntry);
-        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '') then
+        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '') then
             QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] The inspection page is opened
@@ -741,7 +741,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         // [GIVEN] An inspection is created from the purchase line with its serial number
         RecordRef.GetTable(PurchaseLine);
         TempSpecTrackingSpecification.CopyTrackingFromReservEntry(ReservationEntry);
-        QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '');
+        QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '');
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] The inspection page is opened
@@ -816,7 +816,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         // [GIVEN] An inspection is created from the second purchase line with its package number
         RecordRef.GetTable(SecondPurchaseLine);
         TempSpecTrackingSpecification.CopyTrackingFromReservEntry(SecondReservationEntry);
-        QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '');
+        QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '');
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] The inspection page is opened
@@ -888,7 +888,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         // [GIVEN] An inspection is created from the second purchase line
         RecordRef.GetTable(SecondPurchaseLine);
         TempSpecTrackingSpecification.CopyTrackingFromReservEntry(SecondReservationEntry);
-        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '') then
+        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '') then
             QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] The inspection page is opened
@@ -957,7 +957,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         // [GIVEN] An inspection is created from the purchase line
         RecordRef.GetTable(PurchaseLine);
         TempSpecTrackingSpecification.CopyTrackingFromReservEntry(ReservationEntry);
-        QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '');
+        QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '');
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] The inspection page is opened
@@ -1030,7 +1030,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         // [GIVEN] An inspection is created from the second purchase line
         RecordRef.GetTable(SecondPurchaseLine);
         TempSpecTrackingSpecification.CopyTrackingFromReservEntry(SecondReservationEntry);
-        QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '');
+        QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '');
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] The inspection page is opened
@@ -1102,7 +1102,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         // [GIVEN] An inspection is created from the second purchase order
         RecordRef.GetTable(SecondPurchaseLine);
         TempSpecTrackingSpecification.CopyTrackingFromReservEntry(SecondReservationEntry);
-        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '') then
+        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '') then
             QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] The inspection page is opened
@@ -1175,7 +1175,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         // [GIVEN] An inspection is created from the second purchase order
         RecordRef.GetTable(SecondPurchaseLine);
         TempSpecTrackingSpecification.CopyTrackingFromReservEntry(SecondReservationEntry);
-        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '') then
+        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '') then
             QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] The inspection page is opened
@@ -1248,7 +1248,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         // [GIVEN] An inspection is created from the second purchase order
         RecordRef.GetTable(SecondPurchaseLine);
         TempSpecTrackingSpecification.CopyTrackingFromReservEntry(SecondReservationEntry);
-        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '') then
+        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '') then
             QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] The inspection page is opened
@@ -1414,7 +1414,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         // [GIVEN] An inspection is created from the purchase line with tracking
         RecordRef.GetTable(PurchaseLine);
         TempSpecTrackingSpecification.CopyTrackingFromReservEntry(ReservationEntry);
-        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '') then
+        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '') then
             QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Quality setup requires only posted item tracking
@@ -1478,7 +1478,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         // [GIVEN] An inspection is created from the purchase line with tracking
         RecordRef.GetTable(PurchaseLine);
         TempSpecTrackingSpecification.CopyTrackingFromReservEntry(ReservationEntry);
-        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '') then
+        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '') then
             QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Quality setup requires only posted item tracking
@@ -1542,7 +1542,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         // [GIVEN] An inspection is created from the purchase line with tracking
         RecordRef.GetTable(PurchaseLine);
         TempSpecTrackingSpecification.CopyTrackingFromReservEntry(ReservationEntry);
-        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, true, '') then
+        if QltyInspectionCreate.CreateInspectionWithMultiVariantsAndTemplate(RecordRef, TempSpecTrackingSpecification, UnusedVariant1, UnusedVariant2, false, '') then
             QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] Quality setup requires only posted item tracking

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsWorkflows.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsWorkflows.Codeunit.al
@@ -1199,7 +1199,7 @@ codeunit 139969 "Qlty. Tests - Workflows"
         LibraryInventory.CreateItem(Item);
         QltyPurOrderGenerator.CreatePurchaseOrder(100, Location, Item, PurchaseHeader, PurchaseLine);
         RecordRef.GetTable(PurchaseHeader);
-        QltyInspectionCreate.CreateInspection(RecordRef, true);
+        QltyInspectionCreate.CreateInspection(RecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         // [GIVEN] A purchase approval workflow configured to finish inspection after approval
@@ -1258,7 +1258,7 @@ codeunit 139969 "Qlty. Tests - Workflows"
         LibraryInventory.CreateItem(Item);
         QltyPurOrderGenerator.CreatePurchaseOrder(100, Location, Item, PurchaseHeader, PurchaseLine);
         RecordRef.GetTable(PurchaseHeader);
-        QltyInspectionCreate.CreateInspection(RecordRef, true);
+        QltyInspectionCreate.CreateInspection(RecordRef, false);
         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
         QltyInspectionHeader.FinishInspection();
 


### PR DESCRIPTION
#### Summary 
Switches to notifications when tests are created automatically, a page should be shown now only when a test is created manually.

#### Work Item(s) 
Fixes [AB#610799](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/610799)



