### PR TITLE
[Subscription Billing]Subscription Lines Deletion Fix

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Service Objects/Tables/SubscriptionHeader.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Objects/Tables/SubscriptionHeader.Table.al
@@ -992,6 +992,7 @@ table 8057 "Subscription Header"
         if not ServiceCommitment.IsEmpty() then
             Error(CannotDeleteBecauseServiceCommitmentExistsErr, "No.", ServiceCommitment.TableCaption);
 
+        ServiceCommitment.SetRange("Subscription Contract No.");
         ServiceCommitment.DeleteAll(true);
 
         ServiceCommitmentArchive.SetRange("Subscription Header No.", Rec."No.");

--- a/src/Apps/W1/Subscription Billing/Test/Service Objects/ServiceObjectTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Objects/ServiceObjectTest.Codeunit.al
@@ -342,6 +342,57 @@ codeunit 148157 "Service Object Test"
     end;
 
     [Test]
+    procedure CheckSubscriptionLinesAreDeletedWhenSubscriptionHeaderIsDeleted()
+    var
+        Item: Record Item;
+        SubscriptionLine: Record "Subscription Line";
+        SubscriptionHeader: Record "Subscription Header";
+    begin
+        // [SCENARIO] When deleting a subscription header, all unassigned subscription lines should be deleted
+        Initialize();
+
+        // [GIVEN] A subscription header with subscription lines not assigned to contracts
+        SetupServiceObjectWithServiceCommitment(Item, SubscriptionHeader, false, false);
+
+        // Verify Subscription Lines exist
+        SubscriptionLine.SetRange("Subscription Header No.", SubscriptionHeader."No.");
+        Assert.RecordIsNotEmpty(SubscriptionLine);
+
+        // [WHEN] The subscription header is deleted
+        SubscriptionHeader.Delete(true);
+
+        // [THEN] The subscription lines are deleted
+        SubscriptionLine.Reset();
+        SubscriptionLine.SetRange("Subscription Header No.", SubscriptionHeader."No.");
+        Assert.RecordIsEmpty(SubscriptionLine);
+    end;
+
+    [Test]
+    procedure ExpectErrorWhenDeletingSubscriptionHeaderWithAssignedSubscriptionLines()
+    var
+        Item: Record Item;
+        SubscriptionLine: Record "Subscription Line";
+        SubscriptionHeader: Record "Subscription Header";
+        CannotDeleteBecauseServiceCommitmentExistsErr: Label 'Cannot delete %1 while %2 connected to a contract exists.', Comment = '%1 = No., %2 = TableCaption', Locked = true;
+    begin
+        // [SCENARIO] When trying to delete a subscription header with subscription lines assigned to a contract, an error should be thrown
+        Initialize();
+
+        // [GIVEN] A subscription header with subscription lines
+        SetupServiceObjectWithServiceCommitment(Item, SubscriptionHeader, false, false);
+
+        // [GIVEN] Subscription lines are assigned to a contract
+        SubscriptionLine.SetRange("Subscription Header No.", SubscriptionHeader."No.");
+        SubscriptionLine.ModifyAll("Subscription Contract No.", LibraryRandom.RandText(20));
+
+        // [WHEN] Attempting to delete the subscription header
+        asserterror SubscriptionHeader.Delete(true);
+
+        // [THEN] An error is thrown preventing the deletion
+        Assert.ExpectedError(StrSubstNo(CannotDeleteBecauseServiceCommitmentExistsErr, SubscriptionHeader."No.", SubscriptionLine.TableCaption));
+    end;
+
+    [Test]
     [HandlerFunctions('AssignServiceCommitmentsModalPageHandler')]
 
     procedure CheckInvoicingItemNoInServiceObjectWithServiceCommitmentItem()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This pull request introduces improvements to the deletion logic for subscription headers and adds comprehensive tests to ensure correct handling of associated subscription lines. The main focus is to ensure that unassigned subscription lines are deleted when their header is deleted, while headers with assigned lines are protected from deletion.

### Deletion logic improvements

* Added a missing `SetRange("Subscription Contract No.")` filter before deleting service commitments in `table 8057 "Subscription Header"` to ensure only relevant records are deleted.

### Test coverage enhancements

* Added a test to verify that unassigned subscription lines are deleted when their subscription header is deleted in `codeunit 148157 "Service Object Test"`.
* Added a test to ensure an error is raised when attempting to delete a subscription header with subscription lines assigned to a contract, protecting data integrity.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #6314




Fixes [AB#620365](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620365)

