### PR TITLE
[Shopify] Test failure in UnitTestUpdateTaxRegistrationIdForVATRegistrationNo for Belgian customers

### DIFF
--- a/src/Apps/W1/Shopify/Test/Companies/ShpfyTaxIdMappingTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Companies/ShpfyTaxIdMappingTest.Codeunit.al
@@ -171,6 +171,11 @@ codeunit 134246 "Shpfy Tax Id Mapping Test"
         NewTaxRegistrationId := LibraryERM.GenerateVATRegistrationNo(CompanyInformation."Country/Region Code");
         // [GIVEN] Customer with empty VAT Registration No.
         CreateCustomerWithVATRegNo(Customer, '');
+        if CompanyInformation."Country/Region Code" = 'BE' then begin
+            Customer."Country/Region Code" := 'DE'; // VAT Reg No. not allowed for BE Customers
+            Customer.Modify();
+            NewTaxRegistrationId := LibraryERM.GenerateVATRegistrationNo(Customer."Country/Region Code");
+        end;
         // [GIVEN] TaxRegistrationIdMapping interface is "VAT Registration No."
         TaxRegistrationIdMapping := Enum::"Shpfy Comp. Tax Id Mapping"::"VAT Registration No.";
 


### PR DESCRIPTION
#### Problem
The unit test `UnitTestUpdateTaxRegistrationIdForVATRegistrationNo` in `Shpfy Tax Id Mapping Test` codeunit was failing when running on the Belgian (BE) localization. 

The test was attempting to validate a VAT Registration No. on a Customer record, but Belgian localization requires customers to use the "Enterprise No." field instead of "VAT Registration No." for Belgian customers. This triggered the validation error:
> "You must use Enterprise No. for Belgian customers."

#### Root Cause
When the Company Information has `Country/Region Code` = 'BE', the `Customer.VAT Registration No.` field validation rejects VAT Registration numbers because Belgian regulations require the use of the Enterprise No. field instead.

#### Solution
Added a condition in the test to detect when running on Belgian localization and handle it by:
1. Setting the customer's `Country/Region Code` to 'DE' (Germany) to bypass the Belgian-specific validation
2. Regenerating a valid VAT Registration No. for the German country code

#### Changes
- ShpfyTaxIdMappingTest.Codeunit.al: Added conditional logic to handle Belgian localization in `UnitTestUpdateTaxRegistrationIdForVATRegistrationNo` test

```al
if CompanyInformation."Country/Region Code" = 'BE' then begin
    Customer."Country/Region Code" := 'DE'; // VAT Reg No. not allowed for BE Customers
    Customer.Modify();
    NewTaxRegistrationId := LibraryERM.GenerateVATRegistrationNo(Customer."Country/Region Code");
end;
```

Fixes [AB#618120](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/618120)




