### PR TITLE
Reenable GetTaxSubtotalInfo test

### DIFF
--- a/src/Apps/W1/PEPPOL/Test/DisabledTests/PEPPOL30ManagementTests.json
+++ b/src/Apps/W1/PEPPOL/Test/DisabledTests/PEPPOL30ManagementTests.json
@@ -1,7 +1,0 @@
-[
-    {
-        "codeunitId": 139235,
-        "CodeunitName": "PEPPOL30 Management Tests",
-        "Method": "GetTaxSubtotalInfo"
-    }
-]


### PR DESCRIPTION
#### Summary
Reenable the GetTaxSubtotalInfo test that was disabled in PR #6376.

#### Work Item(s)
[AB#563709](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/563709)
