### PR TITLE
Fix milestone assignment for release branch PRs

### DIFF
--- a/.github/workflows/WorkitemValidation.yaml
+++ b/.github/workflows/WorkitemValidation.yaml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Validate work items for pull request
         env:
@@ -48,8 +46,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Link work items to pull request if possible
         env:
@@ -70,8 +66,18 @@ jobs:
         run: |
           gh api /repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels  -f "labels[]=Linked" -H "Accept: application/vnd.github.v3+json" -H "X-GitHub-Api-Version: 2022-11-28"
 
+      - name: Get repo version from target branch
+        id: get-repo-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $settingsContent = gh api "/repos/${{ github.repository }}/contents/.github/AL-Go-Settings.json?ref=${{ github.event.pull_request.base.ref }}" -H "Accept: application/vnd.github.raw+json" -H "X-GitHub-Api-Version: 2022-11-28" | ConvertFrom-Json
+          $repoVersion = $settingsContent.repoVersion
+          Write-Host "Repo version on target branch: $repoVersion"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "repoVersion=$repoVersion"
+
       - name: Add milestone to PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          build/scripts/PullRequestValidation/AddMilestoneToPullRequest.ps1 -PullRequestNumber ${{ github.event.pull_request.number }} -Repository ${{ github.repository }}
+          build/scripts/PullRequestValidation/AddMilestoneToPullRequest.ps1 -PullRequestNumber ${{ github.event.pull_request.number }} -Repository ${{ github.repository }} -RepoVersion ${{ steps.get-repo-version.outputs.repoVersion }}

--- a/build/scripts/PullRequestValidation/AddMilestoneToPullRequest.ps1
+++ b/build/scripts/PullRequestValidation/AddMilestoneToPullRequest.ps1
@@ -4,9 +4,10 @@ param(
     [Parameter(Mandatory = $true)]
     [string] $PullRequestNumber,
     [Parameter(Mandatory = $true)]
-    [string] $Repository
+    [string] $Repository,
+    [Parameter(Mandatory = $true)]
+    [string] $RepoVersion
 )
-Import-Module $PSScriptRoot\..\EnlistmentHelperFunctions.psm1
 
 $pullRequest = [GitHubPullRequest]::Get($PullRequestNumber, $Repository)
 
@@ -18,9 +19,7 @@ if ($pullRequest.PullRequest.labels -and ($pullRequest.PullRequest.labels.name -
     return # Don't set milestone on automation PRs
 }
 
-# Get milestone
-$repoVersion = Get-ConfigValue -Key "repoVersion" -ConfigType AL-GO
-$milestone = "Version $repoVersion"
+$milestone = "Version $RepoVersion"
 
 Write-Host "Setting milestone '$milestone' on PR $PullRequestNumber"
 $pullRequest.SetMilestone($milestone)


### PR DESCRIPTION
#### Summary
Fix the WorkitemValidation workflow to correctly assign milestones to PRs targeting release branches.

The workflow uses `pull_request_target` which, with a bare `actions/checkout`, always checks out the default branch (`main`). This means PRs targeting release branches (e.g. `releases/27.3`) get the milestone from `main` (e.g. "Version 28.0") instead of the correct release branch milestone.

The fix adds `ref: ${{ github.event.pull_request.base.ref }}` to the checkout steps so the correct branch is checked out.

#### Work Item(s)
Fixes [AB#620875](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620875)


