### PR TITLE
Add new feature for matching purchase invoices

### DIFF
--- a/src/System Application/App/Resources/Files/EarlyAccessPreviewFeatures.json
+++ b/src/System Application/App/Resources/Files/EarlyAccessPreviewFeatures.json
@@ -75,5 +75,12 @@
       "Category": "Shopify",
       "HelpURL": "",
       "VideoURL": ""
+    },
+    {
+      "FeatureName": "Match purchase invoices to multiple order and receipt lines",
+      "Description": "Improve invoice accuracy by matching each invoice line to all relevant purchase order lines and receipts, even when receipts don't yet exist. To get started, open a purchase invoice and use the \"Get Order Lines\" action to select received or unreceived order lines. Review and adjust matches on the \"Matched Order Lines\" page, and explore the \"Receipt on Invoice\" toggle on purchase orders if you want receipts created automatically during posting.",
+      "Category": "Purchase",
+      "HelpURL": "",
+      "VideoURL": ""
     }
 ]


### PR DESCRIPTION
This pull request adds a new early access preview feature to the application, enhancing how purchase invoices can be matched to order and receipt lines.

New feature addition:

* Added the "Match purchase invoices to multiple order and receipt lines" feature to `EarlyAccessPreviewFeatures.json`, allowing users to match invoice lines with all relevant purchase order lines and receipts, including those not yet received, and providing new actions and toggles to streamline the process.

Fixes [AB#617639](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617639)

