### PR TITLE
Issue6429-Inspection fields are now no longer editable when the status is finished

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
@@ -41,6 +41,7 @@ page 20406 "Qlty. Inspection"
             group(General)
             {
                 Caption = 'General';
+                Editable = IsOpen;
 
                 field("No."; Rec."No.")
                 {
@@ -57,7 +58,6 @@ page 20406 "Qlty. Inspection"
                 }
                 field("Template Code"; Rec."Template Code")
                 {
-                    Editable = false;
                 }
                 field(Description; Rec.Description)
                 {
@@ -218,6 +218,7 @@ page 20406 "Qlty. Inspection"
             }
             part(Lines; "Qlty. Inspection Subform")
             {
+                Editable = IsOpen;
                 Caption = 'Lines';
                 SubPageLink = "Inspection No." = field("No."),
                               "Re-inspection No." = field("Re-inspection No.");
@@ -225,7 +226,6 @@ page 20406 "Qlty. Inspection"
             group(ControlInfo)
             {
                 Caption = 'Control Information';
-
                 field("Source Table No."; Rec."Source Table No.")
                 {
                     Editable = false;
@@ -819,6 +819,7 @@ page 20406 "Qlty. Inspection"
         QltyMiscHelpers: Codeunit "Qlty. Misc Helpers";
         Camera: Codeunit Camera;
         CameraAvailable: Boolean;
+        IsOpen: Boolean;
         CanReopen: Boolean;
         CanFinish: Boolean;
         CanCreateReinspection: Boolean;
@@ -859,6 +860,7 @@ page 20406 "Qlty. Inspection"
     var
         TempItemTrackingSetup: Record "Item Tracking Setup" temporary;
     begin
+        IsOpen := Rec.Status = Rec.Status::Open;
         CanReopen := QltyPermissionMgmt.CanReopenInspection() and not Rec.HasMoreRecentReinspection();
         CanFinish := QltyPermissionMgmt.CanFinishInspection() and not (Rec.Status = Rec.Status::Finished);
         CanCreateReinspection := QltyPermissionMgmt.CanCreateReinspection();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
When the status is finished setting a bool which is then used to help trigger the editability of the main field group and subform.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #6429 
Fixes [AB#619990](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/619990)


