### PR TITLE
[Agent] Remove NotBlank property from SelectAgentPermissions

### DIFF
--- a/src/System Application/App/Agent/Setup/AccessControls/SelectAgentPermissionsPart.Page.al
+++ b/src/System Application/App/Agent/Setup/AccessControls/SelectAgentPermissionsPart.Page.al
@@ -35,7 +35,6 @@ page 4340 "Select Agent Permissions Part"
                     ToolTip = 'Specifies the ID of a security role that has been assigned to this Windows login in the current database.';
                     Style = Unfavorable;
                     StyleExpr = PermissionSetNotFound;
-                    NotBlank = true;
 
                     trigger OnLookup(var Text: Text): Boolean
                     var
@@ -52,6 +51,9 @@ page 4340 "Select Agent Permissions Part"
 
                     trigger OnValidate()
                     begin
+                        if Rec."Role ID" = '' then
+                            Error(RoleIdMustBeFilledInErr);
+
                         PermissionSetLookupRecord.SetRange("Role ID", Rec."Role ID");
                         if PermissionSetLookupRecord.FindFirst() then begin
                             if PermissionSetLookupRecord.Count() > 1 then
@@ -221,4 +223,5 @@ page 4340 "Select Agent Permissions Part"
         GlobalSingleCompanyName: Text[30];
         MultipleRoleIDErr: Label 'The permission set %1 is defined multiple times in this context. Use the lookup button to select the relevant permission set.', Comment = '%1 will be replaced with a Role ID code value from the Permission Set table';
         ShowSingleCompanyQst: Label 'This agent currently has permissions in only one company. By showing the Company field, you will be able to assign permissions in other companies, making the agent available there. The agent may not have been designed to work cross companies.\\Do you want to continue?';
+        RoleIdMustBeFilledInErr: Label 'Role ID must be filled in.';
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Removing the NotBlank property from the Role ID field since it prevented clicking on Assign My Permissions action on an empty list of permissions (sunshine scenario when doing a first time setup). By using validation trigger code, we prevent users from entering empty values, yet we unblock the action.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#619697](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/619697)


