### PR TITLE
Issue 6430, clicking on a label should not have an assistedit effect

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionSubform.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionSubform.Page.al
@@ -57,6 +57,9 @@ page 20407 "Qlty. Inspection Subform"
 
                     trigger OnAssistEdit()
                     begin
+                        Rec.CalcFields("Test Value Type");
+                        if Rec."Test Value Type" = Rec."Test Value Type"::"Value Type Label" then
+                            exit;
                         UpdateRowData();
 
                         CurrPage.Update(true);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
When the value type is a label, clicking an assist edit should have no effect.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #6430 
Fixes [AB#619347](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/619347)



