### PR TITLE
[Quality Management] Remove unused integration events and parameters from various pages and codeunits

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCardPart.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCardPart.Page.al
@@ -175,16 +175,5 @@ page 20437 "Qlty. Test Card Part"
             Rec."Test Value Type"::"Value Type Boolean",
             Rec."Test Value Type"::"Value Type Text"]);
         IsNumber := Rec.IsNumericFieldType();
-
-        OnAfterUpdateControlVisibilityState(Rec);
-    end;
-
-    /// <summary>
-    /// Use this to update the control visibility state with any page extensions.
-    /// </summary>
-    /// <param name="QltyTest"></param>
-    [IntegrationEvent(true, false)]
-    local procedure OnAfterUpdateControlVisibilityState(var QltyTest: Record "Qlty. Test")
-    begin
     end;
 }

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestWizard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestWizard.Page.al
@@ -366,7 +366,7 @@ page 20432 "Qlty. Test Wizard"
         IsMovingForward := Step > CurrentStepCounter;
 
         if IsMovingForward then
-            LeavingStepMovingForward(CurrentStepCounter, Step);
+            LeavingStepMovingForward(CurrentStepCounter);
 
         EvaluateStep(Step);
         CurrentStepCounter := Step;
@@ -375,7 +375,6 @@ page 20432 "Qlty. Test Wizard"
 
     local procedure EvaluateStep(Step: Integer)
     begin
-        OnBeforeEvaluateStep(Step, IsBackEnabled, IsNextEnabled, IsFinishEnabled);
         case Step of
             Step1NewOrExisting:
                 begin
@@ -413,9 +412,8 @@ page 20432 "Qlty. Test Wizard"
         CurrPage."Qlty. Choose Existing Tests".Page.GetTestsToAdd(TestsToAdd);
     end;
 
-    local procedure LeavingStepMovingForward(LeavingThisStep: Integer; var MovingToStep: Integer);
+    local procedure LeavingStepMovingForward(LeavingThisStep: Integer);
     begin
-        OnBeforeLeavingStepMovingForward(LeavingThisStep, MovingToStep);
         case LeavingThisStep of
             Step2AddNewTest:
                 AddOrUpdateInternalField();
@@ -440,7 +438,6 @@ page 20432 "Qlty. Test Wizard"
     begin
         FinishActionChosen := true;
         AddOrUpdateInternalField();
-        OnFinishActionOnAfterAddUpdateInternalField();
         AddedOrChooseATest := NewTest or EditingExistingTest or (ChooseExistingTestOrTests and (TestsToAdd.Count() > 0));
 
         if AddedOrChooseATest and NewTest then
@@ -624,18 +621,4 @@ page 20432 "Qlty. Test Wizard"
         end;
     end;
 
-    [IntegrationEvent(false, false)]
-    local procedure OnBeforeLeavingStepMovingForward(LeavingThisStep: Integer; var MovingToStep: Integer);
-    begin
-    end;
-
-    [IntegrationEvent(false, false)]
-    local procedure OnBeforeEvaluateStep(Step: Integer; var IsBackEnabled: Boolean; var IsNextEnabled: Boolean; var IsFinishEnabled: Boolean)
-    begin
-    end;
-
-    [IntegrationEvent(false, false)]
-    local procedure OnFinishActionOnAfterAddUpdateInternalField()
-    begin
-    end;
 }

--- a/src/Apps/W1/Quality Management/app/src/Reports/QltyReportSelectionQM.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Reports/QltyReportSelectionQM.Page.al
@@ -104,19 +104,7 @@ page 20442 "Qlty. Report Selection - QM"
                 Rec.SetRange(Usage, Rec."Usage"::"Quality Management - General Purpose Inspection");
         end;
 
-        OnSetUsageFilterOnAfterSetFiltersByReportUsage(Rec, QltyReportSelectionUsage);
         Rec.FilterGroup(0);
         CurrPage.Update();
-    end;
-
-    /// <summary>
-    /// OnSetUsageFilterOnAfterSetFiltersByReportUsage gives an opportunity to extend the report usage filtering.
-    /// </summary>
-    /// <param name="ReportSelections">var Record "Report Selections".</param>
-    /// <param name="ReportSelectionUsage">Enum "Qlty. Report Selection Usage".</param>
-
-    [IntegrationEvent(false, false)]
-    local procedure OnSetUsageFilterOnAfterSetFiltersByReportUsage(var ReportSelections: Record "Report Selections"; ReportSelectionUsage: Enum "Qlty. Report Selection Usage")
-    begin
     end;
 }

--- a/src/Apps/W1/Quality Management/app/src/Utilities/QltyMiscHelpers.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Utilities/QltyMiscHelpers.Codeunit.al
@@ -95,12 +95,8 @@ codeunit 20599 "Qlty. Misc Helpers"
     internal procedure GetDefaultMaximumRowsFieldLookup() ResultRowsCount: Integer
     var
         QltyManagementSetup: Record "Qlty. Management Setup";
-        IsHandled: Boolean;
     begin
         ResultRowsCount := DefaultMaxRowsFieldLookup();
-        OnBeforeGetDefaultMaximumRowsToShowInLookup(ResultRowsCount, IsHandled);
-        if IsHandled then
-            exit;
 
         if not QltyManagementSetup.GetSetupRecord() then
             exit;
@@ -772,7 +768,6 @@ codeunit 20599 "Qlty. Misc Helpers"
     /// Automatically determines the correct page to display based on the source record type.
     /// 
     /// Behavior:
-    /// - Fires OnBeforeNavigateToSourceDocument event for extensibility
     /// - Exits if no source document is linked (Source RecordId is empty)
     /// - Uses Page Management to find the appropriate page for the record type
     /// - Opens the page in modal mode displaying the source document
@@ -787,12 +782,7 @@ codeunit 20599 "Qlty. Misc Helpers"
         RecordRefToNavigateTo: RecordRef;
         VariantContainer: Variant;
         CurrentPage: Integer;
-        IsHandled: Boolean;
     begin
-        OnBeforeNavigateToSourceDocument(QltyInspectionHeader, IsHandled);
-        if IsHandled then
-            exit;
-
         if QltyInspectionHeader."Source RecordId".TableNo() = 0 then
             exit;
 
@@ -947,27 +937,5 @@ codeunit 20599 "Qlty. Misc Helpers"
             exit(false);
 
         exit(RecordRef.Number() <> 0);
-    end;
-
-    /// <summary>
-    /// Provides an ability to override the handling of navigating to a source document.
-    /// </summary>
-    /// <param name="QltyInspectionHeader"></param>
-    /// <param name="IsHandled"></param>
-    [IntegrationEvent(false, false)]
-    local procedure OnBeforeNavigateToSourceDocument(var QltyInspectionHeader: Record "Qlty. Inspection Header"; var IsHandled: Boolean)
-    begin
-    end;
-
-    /// <summary>
-    /// Provides an opportunity for customizations to alter the default maximum rows shown
-    /// for a table lookup in a quality inspector field.
-    /// Changing the default to a larger number can introduce performance issues.
-    /// </summary>
-    /// <param name="Rows"></param>
-    /// <param name="IsHandled"></param>
-    [IntegrationEvent(false, false)]
-    local procedure OnBeforeGetDefaultMaximumRowsToShowInLookup(var Rows: Integer; var IsHandled: Boolean)
-    begin
     end;
 }

--- a/src/Apps/W1/Quality Management/app/src/Utilities/QltyNotificationMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Utilities/QltyNotificationMgmt.Codeunit.al
@@ -565,12 +565,7 @@ codeunit 20437 "Qlty. Notification Mgmt."
     var
         ActionMessage: Text;
         ActionProcedureCallback: Text;
-        IsHandled: Boolean;
     begin
-        OnBeforeCreateActionNotification(NotificationToShow, CurrentMessage, AvailableOptions, IsHandled);
-        if IsHandled then
-            exit;
-
         NotificationToShow.Message(CurrentMessage);
         foreach ActionMessage in AvailableOptions.Keys do
             if AvailableOptions.Get(ActionMessage, ActionProcedureCallback) then
@@ -653,17 +648,5 @@ codeunit 20437 "Qlty. Notification Mgmt."
     local procedure GetInspectionCreatedNotificationId(): Guid
     begin
         exit('f2e838e8-c3c3-4ce2-ab34-cde0a3a3cb1f');
-    end;
-
-    /// <summary>
-    /// Use this to supplment, extend, or replace base action handling.
-    /// </summary>
-    /// <param name="NotificationToShow"></param>
-    /// <param name="CurrentMessage"></param>
-    /// <param name="Options"></param>
-    /// <param name="IsHandled"></param>
-    [IntegrationEvent(false, false)]
-    local procedure OnBeforeCreateActionNotification(var NotificationToShow: Notification; var CurrentMessage: Text; var AvailableOptions: Dictionary of [Text, Text]; var IsHandled: Boolean)
-    begin
     end;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Based on my analysis, these 8 publishers are candidates for removal as they are primarily UI-specific, internal helpers, or have very narrow use cases:

OnBeforeLeavingStepMovingForward - QltyTestWizard.Page.al
OnBeforeEvaluateStep - QltyTestWizard.Page.al
OnFinishActionOnAfterAddUpdateInternalField - QltyTestWizard.Page.al
OnAfterUpdateControlVisibilityState - QltyTestCardPart.Page.al
OnBeforeNavigateToSourceDocument - QltyMiscHelpers.Codeunit.al
OnBeforeGetDefaultMaximumRowsToShowInLookup - QltyMiscHelpers.Codeunit.al
OnSetUsageFilterOnAfterSetFiltersByReportUsage - QltyReportSelectionQM.Page.al
OnBeforeCreateActionNotification - QltyNotificationMgmt.Codeunit.al

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#610916](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/610916)

