### PR TITLE
Vendor information was never sent in the G/L accounts' LLM call

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/AI/Tools/EDocGLAccountMatching.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/AI/Tools/EDocGLAccountMatching.Codeunit.al
@@ -112,6 +112,7 @@ codeunit 6126 "E-Doc. GL Account Matching" implements "AOAI Function", IEDocAISy
         UserMessage: JsonArray;
         UserMessageTxt: Text;
     begin
+        if EDocumentPurchaseLine.FindFirst() then;
         EDocumentPurchaseHeader.SetRange("E-Document Entry No.", EDocumentPurchaseLine."E-Document Entry No.");
         if EDocumentPurchaseHeader.FindFirst() then
             if Vendor.Get(EDocumentPurchaseHeader."[BC] Vendor No.") then;


### PR DESCRIPTION
#### Summary 
See CreateUserMessage in EDocGLAccountMatching.Codeunit.al, it attempts to get the vendor from the header of the line.

However, at this point that line is empty, it only has the filters set, it comes all the way from PreparePurchaseEDocDraft.Codeunit.al, where the record is never loaded.

So the header is not found, and the vendor is not found, and it's not added. This results in the vendor info not being sent for G/L account assignment, which was the original intention

#### Work Item(s) 
Fixes [AB#621525](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/621525)

