### PR TITLE
Disable unstable Shopify tests.

### DIFF
--- a/src/Apps/W1/Shopify/Test/DisabledTests/ShpfyCatalogPricesTest.json
+++ b/src/Apps/W1/Shopify/Test/DisabledTests/ShpfyCatalogPricesTest.json
@@ -1,0 +1,14 @@
+[
+    {
+        "bug": "621557",
+        "codeunitId": 139646,
+        "CodeunitName": "Shpfy Catalog Prices Test",
+        "Method": "UnitTestCalcCatalogPrice"
+    },
+    {
+        "bug": "621557",
+        "codeunitId": 139646,
+        "CodeunitName": "Shpfy Catalog Prices Test",
+        "Method": "UnitTestCalcMarketCatalogPrice"
+    }
+]

--- a/src/Apps/W1/Shopify/Test/DisabledTests/ShpfyProductPriceCalcTest.json
+++ b/src/Apps/W1/Shopify/Test/DisabledTests/ShpfyProductPriceCalcTest.json
@@ -1,0 +1,8 @@
+[
+    {
+        "bug": "621557",
+        "codeunitId": 139605,
+        "CodeunitName": "Shpfy Product Price Calc. Test",
+        "Method": "UnitTestCalcPriceTest"
+    }
+]


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->
This pull request adds two new JSON files to track tests that are currently disabled due to bug 621557. These files document specific unit test methods in the Shopify-related test suites that are affected by this bug.

**Disabled test tracking:**

* Added `src/Apps/W1/Shopify/Test/DisabledTests/ShpfyCatalogPricesTest.json` to list disabled methods (`UnitTestCalcCatalogPrice`, `UnitTestCalcMarketCatalogPrice`) in the `Shpfy Catalog Prices Test` codeunit due to bug 621557.
* Added `src/Apps/W1/Shopify/Test/DisabledTests/ShpfyProductPriceCalcTest.json` to list the disabled method (`UnitTestCalcPriceTest`) in the `Shpfy Product Price Calc. Test` codeunit due to bug 621557.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#621557](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/621557)



