### PR TITLE
Moving assignment of document date before the validation of "invoice no." when finalizing the e-document

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
@@ -137,13 +137,13 @@ codeunit 6117 "E-Doc. Create Purchase Invoice" implements IEDocumentFinishDraft,
             Error(InvoiceAlreadyExistsErr, VendorInvoiceNo, EDocumentPurchaseHeader."[BC] Vendor No.");
         end;
 
-        PurchaseHeader.Validate("Vendor Invoice No.", VendorInvoiceNo);
-        PurchaseHeader.Insert(true);
-
         if EDocumentPurchaseHeader."Document Date" <> 0D then
             PurchaseHeader.Validate("Document Date", EDocumentPurchaseHeader."Document Date");
         if EDocumentPurchaseHeader."Due Date" <> 0D then
             PurchaseHeader.Validate("Due Date", EDocumentPurchaseHeader."Due Date");
+        PurchaseHeader.Validate("Vendor Invoice No.", VendorInvoiceNo);
+        PurchaseHeader.Insert(true);
+
         PurchaseHeader."Invoice Received Date" := PurchaseHeader."Document Date";
         PurchaseHeader.Modify();
 


### PR DESCRIPTION
#### Summary 
Moving up the validation to unblock ES scenario where it fails due to the document date not being available at the time of validating the "Vendor Invoice No."

#### Work Item(s) 
Fixes [AB#621694](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/621694)


