### PR TITLE
[Subcontracting] Unused Return Values fix

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcFactboxMgmt.Codeunit.al
@@ -601,7 +601,7 @@ codeunit 99001507 "Subc. Factbox Mgmt."
         end;
     end;
 
-    procedure ShowTransferOrdersAndReturnOrder(RecRelatedVariant: Variant; LookUpPage: Boolean; IsReturn: Boolean): Integer
+    procedure ShowTransferOrdersAndReturnOrder(RecRelatedVariant: Variant; LookUpPage: Boolean; IsReturn: Boolean)
     var
         ProdOrderComponent: Record "Prod. Order Component";
         ProdOrderLine: Record "Prod. Order Line";
@@ -615,7 +615,7 @@ codeunit 99001507 "Subc. Factbox Mgmt."
         NoTransferExistsTxt: Label 'No transfer order exists for this purchase order.';
     begin
         if not RecRelatedVariant.IsRecord() then
-            exit(0);
+            exit;
 
         DataTypeManagement.GetRecordRef(RecRelatedVariant, RecRef);
 
@@ -642,7 +642,7 @@ codeunit 99001507 "Subc. Factbox Mgmt."
                         exit;
                 end;
             else
-                exit(0)
+                exit;
         end;
 
         TransferLine.SetCurrentKey("Prod. Order No.", "Prod. Order Line No.", "Routing Reference No.", "Routing No.", "Operation No.");
@@ -671,7 +671,7 @@ codeunit 99001507 "Subc. Factbox Mgmt."
                 until TransferLine.Next() = 0;
             end;
 
-        if LookUpPage then begin
+        if LookUpPage then
             if TempTransferHeader.Count() > 1 then
                 Page.Run(Page::"Transfer Orders", TempTransferHeader)
             else
@@ -679,8 +679,6 @@ codeunit 99001507 "Subc. Factbox Mgmt."
                     Page.Run(Page::"Transfer Order", TempTransferHeader)
                 else
                     Message(NoTransferExistsTxt);
-        end else
-            exit(TempTransferHeader.Count());
     end;
 
     procedure GetSubcontractorNo(ProdOrderRoutingLine: Record "Prod. Order Routing Line"): Code[20]
@@ -834,7 +832,7 @@ codeunit 99001507 "Subc. Factbox Mgmt."
         exit(ProdOrderComponent.Count());
     end;
 
-    procedure ShowProdOrderComponents(ProdOrderRoutingLine: Record "Prod. Order Routing Line"): Decimal
+    procedure ShowProdOrderComponents(ProdOrderRoutingLine: Record "Prod. Order Routing Line")
     var
         ProdOrderComponent: Record "Prod. Order Component";
     begin


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary 

Procedures with Unused Return Values

1. ShowTransferOrdersAndReturnOrder - Returns Integer (unused in 11 locations)

Definition: SubcFactboxMgmt.Codeunit.al:604

Calls where return value is ignored:
SubcPurchaseLineFactbox.Page.al:38
SubcPurchaseLineFactbox.Page.al:48
SubcPurchaseLineFactbox.Page.al:58
SubcRoutingInfoFactbox.Page.al:71
SubcRoutingInfoFactbox.Page.al:83
SubcPOSubform.PageExt.al:77
SubcPOSubform.PageExt.al:88
SubcWhseRcptLinesExt.PageExt.al:68
SubcWhseRcptLinesExt.PageExt.al:81
SubcWhseRcptSubformExt.PageExt.al:68
SubcWhseRcptSubformExt.PageExt.al:81

2. ShowProdOrderComponents - Returns Decimal (unused in 1 location)

Definition: SubcFactboxMgmt.Codeunit.al:837

Calls where return value is ignored:
SubcRoutingInfoFactbox.Page.al:122

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#620432](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620432)


