### PR TITLE
[MCP] Include API Version in MCP Configuration Import/Export

### DIFF
--- a/src/System Application/App/MCP/src/Configuration/Codeunits/MCPConfigImplementation.Codeunit.al
+++ b/src/System Application/App/MCP/src/Configuration/Codeunits/MCPConfigImplementation.Codeunit.al
@@ -907,6 +907,7 @@ codeunit 8351 "MCP Config Implementation"
                 Clear(ToolJson);
                 ToolJson.Add('objectType', Format(MCPConfigurationTool."Object Type"));
                 ToolJson.Add('objectId', MCPConfigurationTool."Object ID");
+                ToolJson.Add('apiVersion', MCPConfigurationTool."API Version");
                 ToolJson.Add('allowRead', MCPConfigurationTool."Allow Read");
                 ToolJson.Add('allowCreate', MCPConfigurationTool."Allow Create");
                 ToolJson.Add('allowModify', MCPConfigurationTool."Allow Modify");
@@ -994,6 +995,9 @@ codeunit 8351 "MCP Config Implementation"
 
         if ToolJson.Contains('objectId') then
             MCPConfigurationTool."Object ID" := ToolJson.GetInteger('objectId');
+
+        if ToolJson.Contains('apiVersion') then
+            MCPConfigurationTool."API Version" := CopyStr(ToolJson.GetText('apiVersion'), 1, MaxStrLen(MCPConfigurationTool."API Version"));
 
         if ToolJson.Contains('allowRead') then
             MCPConfigurationTool."Allow Read" := ToolJson.GetBoolean('allowRead');

--- a/src/System Application/Test/MCP/src/MCPConfigTest.Codeunit.al
+++ b/src/System Application/Test/MCP/src/MCPConfigTest.Codeunit.al
@@ -883,9 +883,11 @@ codeunit 130130 "MCP Config Test"
         Assert.IsTrue(MCPConfiguration.EnableDynamicToolMode, 'EnableDynamicToolMode mismatch');
         Assert.IsTrue(MCPConfiguration.DiscoverReadOnlyObjects, 'DiscoverReadOnlyObjects mismatch');
 
-        // [THEN] Tools are imported
+        // [THEN] Tools are imported with correct API version
         MCPConfigurationTool.SetRange(ID, ImportedConfigId);
         Assert.RecordCount(MCPConfigurationTool, 2);
+        MCPConfigurationTool.FindFirst();
+        Assert.AreEqual('v2.0', MCPConfigurationTool."API Version", 'API Version mismatch');
     end;
 
     local procedure CreateMCPConfig(Active: Boolean; DynamicToolMode: Boolean; AllowCreateUpdateDeleteTools: Boolean; DiscoverReadOnlyObjects: Boolean): Guid
@@ -914,6 +916,7 @@ codeunit 130130 "MCP Config Test"
         MCPConfigurationTool."Allow Modify" := false;
         MCPConfigurationTool."Allow Delete" := false;
         MCPConfigurationTool."Allow Bound Actions" := false;
+        MCPConfigurationTool."API Version" := 'v2.0';
         MCPConfigurationTool.Insert();
         exit(MCPConfigurationTool.SystemId);
     end;


### PR DESCRIPTION
## Fix: Include API Version in MCP Configuration Import/Export

### Problem

When exporting and importing MCP configurations, the `API Version` field on configuration tools was not included in the JSON payload. This meant that after a round-trip (export → import), all tools would lose their API version, silently defaulting to an empty value.

### Changes

**MCPConfigImplementation.Codeunit.al**
- **Export**: Added `apiVersion` property to each tool object in the exported JSON.
- **Import**: Added parsing of the `apiVersion` property when importing tools, populating `API Version` on the `MCP Configuration Tool` record.

**MCPConfigTest.Codeunit.al**
- `CreateMCPConfigTool` now sets `API Version := 'v2.0'` to ensure export produces a realistic payload.
- `TestImportConfiguration` now asserts that the imported tool retains the correct API version after round-trip.

### Testing

- Existing `TestExportConfiguration` and `TestImportConfiguration` tests now cover the `apiVersion` field end-to-end.

Fixes [AB#621816](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/621816)


