### PR TITLE
[MCP] Add explicit ToolTips to MCP configuration pages

### DIFF
--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
@@ -26,15 +26,18 @@ page 8351 "MCP Config Card"
                 Caption = 'General';
                 field(Name; Rec.Name)
                 {
+                    ToolTip = 'Specifies the name of the MCP configuration.';
                     Editable = not IsDefault and not Rec.Active;
                 }
                 field(Description; Rec.Description)
                 {
+                    ToolTip = 'Specifies the description of the MCP configuration.';
                     Editable = not IsDefault and not Rec.Active;
                     MultiLine = true;
                 }
                 field(Active; Rec.Active)
                 {
+                    ToolTip = 'Specifies whether the MCP configuration is active.';
                     Editable = not IsDefault;
 
                     trigger OnValidate()
@@ -45,6 +48,7 @@ page 8351 "MCP Config Card"
                 }
                 field(EnableDynamicToolMode; Rec.EnableDynamicToolMode)
                 {
+                    ToolTip = 'Specifies whether to enable dynamic tool mode for this MCP configuration. When enabled, clients can search for tools within the configuration dynamically.';
                     Editable = not IsDefault and not Rec.Active;
 
                     trigger OnValidate()
@@ -58,10 +62,12 @@ page 8351 "MCP Config Card"
                 }
                 field(DiscoverReadOnlyObjects; Rec.DiscoverReadOnlyObjects)
                 {
+                    ToolTip = 'Specifies whether to allow discovery of read-only objects not defined in the configuration. Only supported with dynamic tool mode.';
                     Editable = not IsDefault and Rec.EnableDynamicToolMode and not Rec.Active;
                 }
                 field(AllowProdChanges; Rec.AllowProdChanges)
                 {
+                    ToolTip = 'Allows create, update and delete tools for the specified MCP configuration. Disallowing this will make the tools read-only.';
                     Editable = not IsDefault and not Rec.Active;
 
                     trigger OnValidate()

--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigList.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigList.Page.al
@@ -32,11 +32,26 @@ page 8350 "MCP Config List"
         {
             repeater(Control1)
             {
-                field(Name; Rec.Name) { }
-                field(Description; Rec.Description) { }
-                field(Active; Rec.Active) { }
-                field(EnableDynamicToolMode; Rec.EnableDynamicToolMode) { }
-                field(DiscoverReadOnlyObjects; Rec.DiscoverReadOnlyObjects) { }
+                field(Name; Rec.Name)
+                {
+                    ToolTip = 'Specifies the name of the MCP configuration.';
+                }
+                field(Description; Rec.Description)
+                {
+                    ToolTip = 'Specifies the description of the MCP configuration.';
+                }
+                field(Active; Rec.Active)
+                {
+                    ToolTip = 'Specifies whether the MCP configuration is active.';
+                }
+                field(EnableDynamicToolMode; Rec.EnableDynamicToolMode)
+                {
+                    ToolTip = 'Specifies whether to enable dynamic tool mode for this MCP configuration. When enabled, clients can search for tools within the configuration dynamically.';
+                }
+                field(DiscoverReadOnlyObjects; Rec.DiscoverReadOnlyObjects)
+                {
+                    ToolTip = 'Specifies whether to allow discovery of read-only objects not defined in the configuration. Only supported with dynamic tool mode.';
+                }
             }
         }
     }

--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigToolList.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigToolList.Page.al
@@ -26,9 +26,13 @@ page 8352 "MCP Config Tool List"
             repeater(Control1)
             {
                 ShowCaption = false;
-                field("Object Type"; Rec."Object Type") { }
+                field("Object Type"; Rec."Object Type")
+                {
+                    ToolTip = 'Specifies the type of the object.';
+                }
                 field("Object Id"; Rec."Object Id")
                 {
+                    ToolTip = 'Specifies the ID of the object.';
 
                     trigger OnLookup(var Text: Text): Boolean
                     var
@@ -88,21 +92,28 @@ page 8352 "MCP Config Tool List"
                         MCPConfigImplementation.ValidateAPIVersion(Rec."Object Id", Rec."API Version");
                     end;
                 }
-                field("Allow Read"; Rec."Allow Read") { }
+                field("Allow Read"; Rec."Allow Read")
+                {
+                    ToolTip = 'Specifies whether read operations are allowed for this tool.';
+                }
                 field("Allow Create"; Rec."Allow Create")
                 {
+                    ToolTip = 'Specifies whether create operations are allowed for this tool.';
                     Editable = AllowCreateEditable and AllowCreateUpdateDeleteTools;
                 }
                 field("Allow Modify"; Rec."Allow Modify")
                 {
+                    ToolTip = 'Specifies whether modify operations are allowed for this tool.';
                     Editable = AllowModifyEditable and AllowCreateUpdateDeleteTools;
                 }
                 field("Allow Delete"; Rec."Allow Delete")
                 {
+                    ToolTip = 'Specifies whether delete operations are allowed for this tool.';
                     Editable = AllowDeleteEditable and AllowCreateUpdateDeleteTools;
                 }
                 field("Allow Bound Actions"; Rec."Allow Bound Actions")
                 {
+                    ToolTip = 'Specifies whether bound actions are allowed for this tool.';
                     Editable = AllowCreateUpdateDeleteTools;
                 }
             }


### PR DESCRIPTION
ToolTips on MCP Config List, MCP Config Card, and MCP Config Tool List pages are not visible in the UI because tooltip inheritance from source tables is currently broken. This PR copies the tooltip text from the MCP Configuration and MCP Configuration Tool table field definitions directly into the page fields as a workaround until the platform bug is fixed.

**Changes:**
- **MCPConfigList.Page.al** — Added ToolTips to 5 fields (Name, Description, Active, EnableDynamicToolMode, DiscoverReadOnlyObjects)
- **MCPConfigCard.Page.al** — Added ToolTips to 6 fields (Name, Description, Active, EnableDynamicToolMode, DiscoverReadOnlyObjects, AllowProdChanges)
- **MCPConfigToolList.Page.al** — Added ToolTips to 7 fields (Object Type, Object Id, Allow Read, Allow Create, Allow Modify, Allow Delete, Allow Bound Actions)

Fixes [AB#621982](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/621982)
Fixes [AB#622147](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622147)


