### PR TITLE
[Shopify] Allow third-party extensions to skip auto-balance remaining amount on refunds

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyCreateSalesDocRefund.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyCreateSalesDocRefund.Codeunit.al
@@ -411,12 +411,17 @@ codeunit 30246 "Shpfy Create Sales Doc. Refund"
         SalesLine: Record "Sales Line";
         Currency: Record Currency;
         OrderHeader: Record "Shpfy Order Header";
+        SkipBalancing: Boolean;
         RoundingAmount: Decimal;
     begin
         SalesHeader.CalcFields(Amount, "Amount Including VAT");
         Currency.Initialize(SalesHeader."Currency Code");
         RoundingAmount := CreateRoundingLine(RefundHeader, SalesHeader, LineNo);
         OrderHeader.Get(RefundHeader."Order Id");
+
+        RefundProcessEvents.OnBeforeCreateSalesLinesFromRemainingAmount(RefundHeader, SalesHeader, SkipBalancing);
+        if SkipBalancing then
+            exit;
 
         case OrderHeader."Processed Currency Handling" of
             "Shpfy Currency Handling"::"Shop Currency":

--- a/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyRefundProcessEvents.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyRefundProcessEvents.Codeunit.al
@@ -66,4 +66,15 @@ codeunit 30247 "Shpfy Refund Process Events"
     internal procedure OnAfterProcessSalesDocument(RefundHeader: Record "Shpfy Refund Header"; var SalesHeader: Record "Sales Header")
     begin
     end;
+
+    [IntegrationEvent(false, false)]
+    /// <summary>
+    /// Raised before creating the auto-balance line from the remaining refund amount.
+    /// </summary>
+    /// <param name="RefundHeader">Parameter of type Record "Shpfy Refund Header".</param>
+    /// <param name="SalesHeader">Parameter of type Record "Sales Header".</param>
+    /// <param name="SkipBalancing">Set to true to skip the auto-balance remaining amount calculation.</param>
+    internal procedure OnBeforeCreateSalesLinesFromRemainingAmount(RefundHeader: Record "Shpfy Refund Header"; var SalesHeader: Record "Sales Header"; var SkipBalancing: Boolean)
+    begin
+    end;
 }


### PR DESCRIPTION
## Summary

When creating a sales document from a Shopify refund, the connector automatically adds a balancing line to reconcile the difference between the total refunded amount from Shopify and the sum of the individual sales lines. While this is correct for most scenarios, some third-party extensions need to disable this auto-balance because they handle refund line amounts differently or manage the reconciliation themselves.

## Changes

**ShpfyRefundProcessEvents.Codeunit.al** - Added a new `[IntegrationEvent]`:
- `OnBeforeCreateSalesLinesFromRemainingAmount(RefundHeader, var SalesHeader, var SkipBalancing)`

**ShpfyCreateSalesDocRefund.Codeunit.al** - Fire the event inside `CreateSalesLinesFromRemainingAmount`, after the rounding line is created but before the balancing logic runs. The rounding line (which comes from Shopify) is always created regardless of `SkipBalancing`.

## Why an event instead of an interface

The interface + enum pattern in this codebase (e.g., `Shpfy IReturnRefund Process`, `Shpfy Stock Calculation`, `Shpfy ICustomer Mapping`) is designed for strategy choices with multiple meaningful implementations - different stock calculation methods, different customer mapping strategies, etc. The auto-balance behavior is fundamentally binary: you either want it or you don't. Creating an interface, an extensible enum, and a default implementation codeunit for a single on/off toggle would be overengineered. Furthermore, without a Shop table field to persist the enum value, we would need an event anyway to swap the implementation at runtime (like the GraphQL pattern), which means the interface adds complexity on top of the event rather than replacing it. A single integration event keeps the change minimal, predictable, and consistent with the existing extensibility points already in `ShpfyRefundProcessEvents`.

Fixes [AB#621978](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/621978)


