### PR TITLE
[Shopify] Shopify Order Number as Document Number

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -534,7 +534,6 @@ page 30101 "Shpfy Shop Card"
                 field(UseShopifyOrderNo; Rec."Use Shopify Order No.")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies whether the Shopify order number is used as the document number on the created Sales Order or Sales Invoice. The number series must have Allow Manual Nos. enabled.';
                 }
                 field(ArchiveProcessOrders; Rec."Archive Processed Orders")
                 {

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -531,6 +531,11 @@ page 30101 "Shpfy Shop Card"
                 {
                     ApplicationArea = All;
                 }
+                field(UseShopifyOrderNo; Rec."Use Shopify Order No.")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies whether the Shopify order number is used as the document number on the created Sales Order or Sales Invoice. The number series must have Allow Manual Nos. enabled.';
+                }
                 field(ArchiveProcessOrders; Rec."Archive Processed Orders")
                 {
                     ApplicationArea = All;

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -776,6 +776,11 @@ table 30102 "Shpfy Shop"
             Caption = 'Currency Handling';
             InitValue = "Shop Currency";
         }
+        field(136; "Use Shopify Order No."; Boolean)
+        {
+            Caption = 'Use Shopify Order No.';
+            ToolTip = 'Specifies whether the Shopify order number is used as the document number on the created Sales Order or Sales Invoice. The number series must have Allow Manual Nos. enabled.';
+        }
         field(200; "Shop Id"; Integer)
         {
             DataClassification = SystemMetadata;

--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
@@ -367,6 +367,7 @@ codeunit 30161 "Shpfy Import Order"
             exit(false);
         OrderHeader."Shopify Order Id" := OrderId;
         OrderHeader."Shop Code" := Shop.Code;
+        OrderHeader."Use Shopify Order No." := Shop."Use Shopify Order No.";
         ICountyFromJson := Shop."County Source";
 
         OrderHeaderRecordRef.GetTable(OrderHeader);

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
@@ -91,7 +91,6 @@ page 30113 "Shpfy Order"
                 {
                     ApplicationArea = All;
                     Editable = not Rec.Processed;
-                    ToolTip = 'Specifies whether the Shopify order number is used as the document number for this specific order.';
                 }
                 field(Closed; Rec.Closed)
                 {

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
@@ -87,6 +87,12 @@ page 30113 "Shpfy Order"
                     ApplicationArea = All;
                     ToolTip = 'Specifies the purchase order number that is associated with the Shopify order.';
                 }
+                field(UseShopifyOrderNo; Rec."Use Shopify Order No.")
+                {
+                    ApplicationArea = All;
+                    Editable = not Rec.Processed;
+                    ToolTip = 'Specifies whether the Shopify order number is used as the document number for this specific order.';
+                }
                 field(Closed; Rec.Closed)
                 {
                     ApplicationArea = All;

--- a/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderHeader.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderHeader.Table.al
@@ -693,7 +693,6 @@ table 30118 "Shpfy Order Header"
         {
             Caption = 'Use Shopify Order No.';
             DataClassification = SystemMetadata;
-            InitValue = false;
             ToolTip = 'Specifies whether the Shopify order number is used as the document number for this specific order.';
         }
         field(500; "Shop Code"; Code[20])

--- a/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderHeader.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderHeader.Table.al
@@ -689,6 +689,13 @@ table 30118 "Shpfy Order Header"
             FieldClass = FlowField;
             CalcFormula = exist("Shpfy Order Tax Line" where("Parent Id" = field("Shopify Order Id"), "Channel Liable" = const(true)));
         }
+        field(135; "Use Shopify Order No."; Boolean)
+        {
+            Caption = 'Use Shopify Order No.';
+            DataClassification = SystemMetadata;
+            InitValue = false;
+            ToolTip = 'Specifies whether the Shopify order number is used as the document number for this specific order.';
+        }
         field(500; "Shop Code"; Code[20])
         {
             Caption = 'Shop Code';


### PR DESCRIPTION
# Implementation Description - Shopify Order Number as Document Number

## Summary
This PR introduces a configurable option to use Shopify order numbers as document numbers for Sales Orders and Sales Invoices in Business Central, enabling consistent order identifiers across both systems and improving traceability.

## Changes

### New Functionality:

1. **Configuration Setting in Shop Card**: 
   - Added "Use Shopify Order No." field to **Shpfy Shop** table (field 136) and **Shpfy Shop Card** page.
   - When enabled, Shopify order numbers become the document numbers for created Sales Orders and Sales Invoices.

2. **Order-Level Override**:
   - Added "Use Shopify Order No." field to **Shpfy Order Header** table (field 135) and **Shpfy Order** page.
   - Field is editable only when the order hasn't been processed yet.
   - Allows per-order override of the shop-level setting.

3. **Document Number Assignment Logic**:
   - Modified **ShpfyProcessOrder** codeunit to assign Shopify order number when the feature is enabled.
   - Applies to both Sales Orders and Sales Invoices.

4. **Character Validation**:
   - Validates that Shopify order numbers don't start with "@" character.
   - Prevents document creation failures due to BC's document number constraints.

5. **Order Import Integration**:
   - Modified **ShpfyImportOrder** codeunit to propagate shop settings to imported orders.
   - Sets `OrderHeader."Use Shopify Order No." := Shop."Use Shopify Order No."` during import.

### Prerequisites:

- **Number Series Configuration**: Sales Order and Sales Invoice number series must have "Manual Nos." enabled to accept Shopify order numbers.
- **Shopify Connector Setup**: Connector must be configured with valid shop credentials.
- **Valid Order Numbers**: Shopify order numbers cannot start with "@" character.
- **Feature Enablement**: Needs to be explicitly enabled in the Shop Card configuration, or directly in the Shopify order.

## Tests

Added comprehensive test coverage in **ShpfyOrdersAPITest** codeunit:

1. **Configuration Propagation Tests**:
   - `UnitTestImportOrderPropagatesUseShopifyOrderNo()`: Verifies setting propagates when enabled.
   - `UnitTestImportOrderPropagatesUseShopifyOrderNoDisabled()`: Verifies setting propagates when disabled.

2. **Sales Order Creation Tests**:
   - `UnitTestCreateSalesOrderWithShopifyOrderNo()`: Sales Order uses Shopify number when enabled.
   - `UnitTestCreateSalesOrderWithoutShopifyOrderNo()`: Sales Order uses BC number series when disabled.

3. **Validation Tests**:
   - `UnitTestCreateSalesOrderWithShopifyOrderNoInvalidChar()`: Error handling for "@" prefix.

4. **Sales Invoice Creation Tests**:
   - `UnitTestCreateSalesInvoiceWithShopifyOrderNo()`: Sales Invoice uses Shopify number for fulfilled orders.

5. **Test Helper Methods**:
   - `SetManualNosOnOrderNoSeries()`: Enables manual numbers on order series.
   - `SetManualNosOnInvoiceNoSeries()`: Enables manual numbers on invoice series.

Fixes [AB#623380](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/623380)



