### PR TITLE
[MCP] Fix connection string for on-prem environments

### DIFF
--- a/src/System Application/Test Library/MCP/src/MCPConfigTestLibrary.Codeunit.al
+++ b/src/System Application/Test Library/MCP/src/MCPConfigTestLibrary.Codeunit.al
@@ -48,4 +48,9 @@ codeunit 130131 "MCP Config Test Library"
     begin
         exit(MCPConfigImplementation.GetHighestAPIVersion(PageMetadata));
     end;
+
+    procedure GenerateConnectionString(ConfigurationName: Text[100]): Text
+    begin
+        exit(MCPConfigImplementation.GenerateConnectionString(ConfigurationName));
+    end;
 }

--- a/src/System Application/Test/MCP/src/MCPConfigTest.Codeunit.al
+++ b/src/System Application/Test/MCP/src/MCPConfigTest.Codeunit.al
@@ -888,6 +888,30 @@ codeunit 130130 "MCP Config Test"
         Assert.RecordCount(MCPConfigurationTool, 2);
     end;
 
+    [Test]
+    procedure TestConnectionStringOnPremDoesNotContainTenantIdOrEnvironmentName()
+    var
+        ConfigName: Text[100];
+        ConnectionString: Text;
+    begin
+        // [GIVEN] A configuration name (test environment runs as on-prem)
+        ConfigName := CopyStr(Format(CreateGuid()), 1, 100);
+
+        // [WHEN] Connection string is generated
+        ConnectionString := MCPConfigTestLibrary.GenerateConnectionString(ConfigName);
+
+        // [THEN] Connection string contains the configuration name and company
+        Assert.IsTrue(ConnectionString.Contains('"ConfigurationName": "' + ConfigName + '"'), 'ConfigurationName not found in connection string');
+        Assert.IsTrue(ConnectionString.Contains('"Company": "' + CompanyName() + '"'), 'Company not found in connection string');
+
+        // [THEN] Connection string does not contain TenantId or EnvironmentName headers
+        Assert.IsFalse(ConnectionString.Contains('"TenantId"'), 'TenantId should not be present in on-prem connection string');
+        Assert.IsFalse(ConnectionString.Contains('"EnvironmentName"'), 'EnvironmentName should not be present in on-prem connection string');
+
+        // [THEN] Connection string URL contains /mcp suffix
+        Assert.IsTrue(ConnectionString.Contains('/mcp'), 'On-prem URL should contain /mcp suffix');
+    end;
+
     local procedure CreateMCPConfig(Active: Boolean; DynamicToolMode: Boolean; AllowCreateUpdateDeleteTools: Boolean; DiscoverReadOnlyObjects: Boolean): Guid
     var
         MCPConfiguration: Record "MCP Configuration";


### PR DESCRIPTION
## Summary
Fix MCP connection string showing incorrect data for on-premises deployments.

### Problem
When generating an MCP connection string on an on-premises BC instance:
- The URL was a hardcoded SaaS URL instead of the actual server URL
- TenantId and EnvironmentName headers were included, which don't apply on-prem

### Changes
- Detect SaaS vs on-prem via `EnvironmentInformation.IsSaaS()`
- **On-prem**: Derive MCP URL from `GetUrl(ClientType::Api)`, strip the `/api` suffix, and append `/mcp` to produce the correct URL (e.g. `http://server:7047/instance/mcp`)
- **On-prem**: Omit `TenantId` and `EnvironmentName` headers from the connection string
- **SaaS**: Keep existing TIE/Prod URL logic and all headers unchanged
- Add test validating on-prem connection string format
- Expose `GenerateConnectionString` in test library

Fixes [AB#622243](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622243)

