### PR TITLE
Add PEPPOL NO to W1 PEPPOL internalsVisibleTo

### DIFF
--- a/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Common.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Common.Codeunit.al
@@ -17,7 +17,6 @@ using Microsoft.Service.History;
 /// </summary>
 codeunit 37218 "PEPPOL30 Common"
 {
-    Access = Internal;
     InherentEntitlements = X;
     InherentPermissions = X;
 


### PR DESCRIPTION
PEPPOL NO XMLPorts need access to internal PEPPOL30 Common codeunit for GetTotals, GetInvoiceRoundingLine, and SetFilters methods.

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes 
[AB#622396](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622396)








