### PR TITLE
Bugs/622177 add translation hints for agent pages

### DIFF
--- a/src/System Application/App/Agent/Interaction/Internal/AgentTaskList.Page.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentTaskList.Page.al
@@ -14,7 +14,7 @@ page 4300 "Agent Task List"
     ApplicationArea = All;
     UsageCategory = Administration;
     SourceTable = "Agent Task";
-    Caption = 'Agent Tasks', Comment = 'Agent in this page should be translated as Tasks that AI agents were assigned.';
+    Caption = 'Agent Tasks', Comment = 'Agent Tasks in this page should be translated as Tasks that AI agents were assigned.';
     InsertAllowed = false;
     ModifyAllowed = false;
     DeleteAllowed = false;

--- a/src/System Application/App/Agent/Setup/AgentList.Page.al
+++ b/src/System Application/App/Agent/Setup/AgentList.Page.al
@@ -13,7 +13,7 @@ page 4316 "Agent List"
     ApplicationArea = All;
     UsageCategory = Administration;
     SourceTable = "Agent";
-    Caption = 'Agents', Comment = 'This page should be translated as AI agents. It is listing the AI agents that users have setup to help with automating tasks.';
+    Caption = 'Agents', Comment = 'Agents in this page should be translated as AI agents. It is listing the AI agents that users have setup to help with automating tasks.';
     CardPageId = "Agent Card";
     AdditionalSearchTerms = 'Agent, Agents, Copilot, Automation, AI';
     Editable = false;


### PR DESCRIPTION
#### Summary 
Add translation hints for two Agent pages

#### Work Item(s) 
Fixes [AB#622177](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622177)


