### PR TITLE
Validation  + UI update when trying to create Quality Inspection Results records with empty fields.

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResultList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResultList.Page.al
@@ -13,7 +13,6 @@ page 20416 "Qlty. Inspection Result List"
     SourceTable = "Qlty. Inspection Result";
     SourceTableView = sorting("Evaluation Sequence");
     PageType = List;
-    DelayedInsert = true;
     ApplicationArea = QualityManagement;
     UsageCategory = Lists;
     AboutTitle = 'About Inspection Results';


### PR DESCRIPTION
The Code and Description fields now display a red asterisk to indicate that they are mandatory. An error is shown if the window is closed or if a new record is inserted or an existing one modified with empty fields.

Fixes [AB#622623](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622623)






