### PR TITLE
Add CLEAN29 to preprocessorsymbols

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -20,7 +20,8 @@
           "CLEAN25",
           "CLEAN26",
           "CLEAN27",
-          "CLEAN28"
+          "CLEAN28",
+          "CLEAN29"
         ]
       }
     },


### PR DESCRIPTION
Add CLEAN29 to preprocessorsymbols

Fixes [AB#620871](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620871)

