### PR TITLE
Now the quality inspection card shows the status in bold + green if open

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
@@ -864,11 +864,7 @@ page 20406 "Qlty. Inspection"
         TempItemTrackingSetup: Record "Item Tracking Setup" temporary;
     begin
         IsOpen := Rec.Status = Rec.Status::Open;
-        
-        StatusStyleExpr :=
-            IsOpen ? 'Favorable' :
-            (Rec.Status = Rec.Status::Finished) ? 'Strong' :
-            'None';
+        StatusStyleExpr := Rec.GetStatusStyleExpression();
 
         CanReopen := not Rec.HasMoreRecentReinspection();
         CanFinish := Rec.Status <> Rec.Status::Finished;

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
@@ -1574,6 +1574,18 @@ table 20405 "Qlty. Inspection Header"
         exit((Rec."Re-inspection No." = 0) ? Rec."No." : StrSubstNo(InspectionLbl, Rec."No.", Rec."Re-inspection No."));
     end;
 
+    procedure GetStatusStyleExpression(): Text
+    begin
+        case Rec.Status of
+            Rec.Status::Open:
+                exit('Favorable');
+            Rec.Status::Finished:
+                exit('Strong');
+            else
+                exit('None');
+        end;
+    end;
+
     local procedure VerifyPassAndFailQuantities()
     var
         DifferenceInPassFailQuantity: Decimal;

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
@@ -704,18 +704,6 @@ page 20408 "Qlty. Inspection List"
         CanReopen := RowActionsAreEnabled and not Rec.HasMoreRecentReinspection();
         CanFinish := RowActionsAreEnabled and (Rec.Status <> Rec.Status::Finished);
         CanCreateReinspection := RowActionsAreEnabled;
-        StatusStyleExpr :=
-            Rec.Status = Rec.Status::Open ? 'Favorable' :
-            (Rec.Status = Rec.Status::Finished) ? 'Strong' :
-            'None';
-    end;
-
-    trigger OnAfterGetRecord()
-    begin
-        StatusStyleExpr :=
-            Rec.Status = Rec.Status::Open ? 'Favorable' :
-            (Rec.Status = Rec.Status::Finished) ? 'Strong' :
-            'None';
     end;
 
     trigger OnAfterGetCurrRecord()
@@ -725,10 +713,7 @@ page 20408 "Qlty. Inspection List"
         RowActionsAreEnabled := not IsNullGuid(Rec.SystemId);
         CanReopen := RowActionsAreEnabled and not Rec.HasMoreRecentReinspection();
         CanFinish := RowActionsAreEnabled and (Rec.Status <> Rec.Status::Finished);
-        StatusStyleExpr :=
-            Rec.Status = Rec.Status::Open ? 'Favorable' :
-            (Rec.Status = Rec.Status::Finished) ? 'Strong' :
-            'None';
+        StatusStyleExpr := Rec.GetStatusStyleExpression();
 
         if (Rec."Assigned User ID" = '') or ((Rec."Assigned User ID" <> UserId()) and QltyPermissionMgmt.CanChangeOtherInspections()) then
             CanAssignToSelf := RowActionsAreEnabled;


### PR DESCRIPTION
Fixes [AB#622626](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622626)

Now if the Status is "Open" the Quality Inspection Card shows it in bold/green.
<img width="821" height="305" alt="image" src="https://github.com/user-attachments/assets/393089c5-eab5-4e1f-af03-69cbb1b03d07" />
However, I was wondering if it makes sense also to propagate this change to the Quality Inspection List, like this:
<img width="849" height="148" alt="image" src="https://github.com/user-attachments/assets/591987ed-1ac4-4877-88c5-4bee630e85b4" />
The commit only includes the Card part (first image), therefore if you want, I can also push the second part to have the same format in the list.


Also Attila and I were wondering if we want the other status to be bold (but not green), not just default. Like for finished in "Sales Order"




