### PR TITLE
[releases/28.x] Exposing the copying of the AgentSetupBuffer

### DIFF
--- a/src/System Application/App/Agent/Setup/SetupPart/AgentSetup.Codeunit.al
+++ b/src/System Application/App/Agent/Setup/SetupPart/AgentSetup.Codeunit.al
@@ -39,7 +39,7 @@ codeunit 4324 "Agent Setup"
     procedure CopySetupRecord(var Target: Record "Agent Setup Buffer"; var Source: Record "Agent Setup Buffer")
     begin
         FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
-        AgentSetupImpl.CopyAgentSetupBuffer(Target, Source);
+        AgentSetupImpl.CopySetupRecord(Target, Source);
     end;
 
     /// <summary>

--- a/src/System Application/App/Agent/Setup/SetupPart/AgentSetupImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Setup/SetupPart/AgentSetupImpl.Codeunit.al
@@ -204,7 +204,7 @@ codeunit 4325 "Agent Setup Impl."
         exit(NewSummaryText);
     end;
 
-    internal procedure CopyAgentSetupBuffer(var Target: Record "Agent Setup Buffer"; var Source: Record "Agent Setup Buffer")
+    internal procedure CopySetupRecord(var Target: Record "Agent Setup Buffer"; var Source: Record "Agent Setup Buffer")
     var
         TempUserSettings: Record "User Settings" temporary;
         TempAccessControl: Record "Agent Access Control" temporary;

--- a/src/System Application/App/Agent/Setup/SetupPart/AgentSetupPart.Page.al
+++ b/src/System Application/App/Agent/Setup/SetupPart/AgentSetupPart.Page.al
@@ -122,7 +122,7 @@ page 4310 "Agent Setup Part"
     var
         AgentSetupImpl: Codeunit "Agent Setup Impl.";
     begin
-        AgentSetupImpl.CopyAgentSetupBuffer(AgentSetupBuffer, Rec);
+        AgentSetupImpl.CopySetupRecord(AgentSetupBuffer, Rec);
     end;
 
     /// <summary>
@@ -136,7 +136,7 @@ page 4310 "Agent Setup Part"
     var
         AgentSetupImpl: Codeunit "Agent Setup Impl.";
     begin
-        AgentSetupImpl.CopyAgentSetupBuffer(Rec, AgentSetupBuffer);
+        AgentSetupImpl.CopySetupRecord(Rec, AgentSetupBuffer);
         AgentSummary := AgentSetupImpl.GetAgentSummary(AgentSetupBuffer);
         UpdateAgentSummaryDisplayText();
         UpdateAgentPublisherText();


### PR DESCRIPTION
This pull request backports #6816 to releases/28.x

Fixes [AB#617049](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617049)


