### PR TITLE
[releases/28.x] Table Info: Don't return to the saved position for non-AL defined indices

### DIFF
--- a/src/System Application/App/Table Information/permissions/TableInformationObjects.PermissionSet.al
+++ b/src/System Application/App/Table Information/permissions/TableInformationObjects.PermissionSet.al
@@ -15,5 +15,6 @@ permissionset 8702 "Table Information - Objects"
                   page "Table Information Cache Part" = X,
                   page "Table Information Card" = X,
                   page "Indexes List Part" = X,
+                  page "Index Details" = X,
                   page "Table Information" = X;
 }

--- a/src/System Application/App/Table Information/src/IndexDetails.page.al
+++ b/src/System Application/App/Table Information/src/IndexDetails.page.al
@@ -1,0 +1,46 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.DataAdministration;
+
+using System.Diagnostics;
+
+/// <summary>
+/// Displays additional details for a specific index.
+/// </summary>
+page 8706 "Index Details"
+{
+    Caption = 'Index Details';
+
+    PageType = CardPart;
+    ApplicationArea = All;
+    UsageCategory = Administration;
+    SourceTable = "Database Index";
+    Permissions = tabledata "Database Index" = r;
+
+    layout
+    {
+        area(Content)
+        {
+            group(Fields)
+            {
+                Caption = 'Key Fields';
+
+                field(FieldNames; Rec."Column Names")
+                {
+                    Caption = 'Fields in Index';
+                    ToolTip = 'Specifies the fields that are part of this index.';
+                    MultiLine = true;
+                }
+                field("Included Fields"; Rec."Included Fields")
+                {
+                    Caption = 'Included Fields';
+                    ToolTip = 'Specifies the fields that are included in this index but not part of the key.';
+                    MultiLine = true;
+                }
+            }
+        }
+    }
+}

--- a/src/System Application/App/Table Information/src/IndexesListPart.Page.al
+++ b/src/System Application/App/Table Information/src/IndexesListPart.Page.al
@@ -133,8 +133,11 @@ page 8704 "Indexes List Part"
                 var
                     IndexManagement: Codeunit "Index Management";
                     RecordIDOfCurrentPosition: RecordId;
+                    IsMetadataDefined: Boolean;
                 begin
-                    if not Rec."Metadata Defined" then
+                    IsMetadataDefined := Rec."Metadata Defined";
+
+                    if not IsMetadataDefined then
                         if not Dialog.Confirm(TurnOffIndexWarningQst) then
                             exit;
 
@@ -144,7 +147,9 @@ page 8704 "Indexes List Part"
 
                     Rec.DeleteAll(); // Clear the temporary table to make sure the disabled index is not shown.
                     BuildInMemoryList(Rec.TableId); // Rebuild the in-memory list to get the updated index status.
-                    Rec.Get(RecordIDOfCurrentPosition); // Return to the same position in the list after refreshing the data.
+
+                    if IsMetadataDefined then
+                        if Rec.Get(RecordIDOfCurrentPosition) then; // Done to avoid throwing an error, returning to the right position is of secondary importance.
 
                     CurrPage.Update(false);
                 end;
@@ -162,8 +167,11 @@ page 8704 "Indexes List Part"
                     DatabaseIndex: Record "Database Index";
                     IndexManagement: Codeunit "Index Management";
                     RecordIDOfCurrentPosition: RecordId;
+                    IsMetadataDefined: Boolean;
                 begin
-                    if not Rec."Metadata Defined" then
+                    IsMetadataDefined := Rec."Metadata Defined";
+
+                    if not IsMetadataDefined then
                         if not Dialog.Confirm(TurnOffIndexWarningQst) then
                             exit;
 
@@ -177,7 +185,9 @@ page 8704 "Indexes List Part"
 
                     Rec.DeleteAll(); // Clear the temporary table to make sure the disabled index is not shown.
                     BuildInMemoryList(Rec.TableId); // Rebuild the in-memory list to get the updated index status.
-                    Rec.Get(RecordIDOfCurrentPosition); // Return to the same position in the list after refreshing the data.
+
+                    if IsMetadataDefined then
+                        if Rec.Get(RecordIDOfCurrentPosition) then; // Done to avoid throwing an error, returning to the right position is of secondary importance.
 
                     CurrPage.Update(false);
                 end;
@@ -188,6 +198,7 @@ page 8704 "Indexes List Part"
                 Enabled = not Rec.Enabled and Rec."Metadata Defined" and not Rec.Unique;
                 Image = Add;
                 ToolTip = 'Enqueues the index to be turned on in the subsequent maintenance window.';
+
 
                 trigger OnAction()
                 var

--- a/src/System Application/App/Table Information/src/TableInformationCard.Page.al
+++ b/src/System Application/App/Table Information/src/TableInformationCard.Page.al
@@ -73,10 +73,17 @@ page 8705 "Table Information Card"
                     ToolTip = 'Specifies the last time the database engine was started. Index statistics are reset when SQL Server is restarted.';
                 }
             }
-
             part(IndexLines; "Indexes List Part")
             {
                 SubPageLink = TableId = field(ID);
+            }
+            part(IndexDetails; "Index Details")
+            {
+                Provider = IndexLines;
+                SubPageLink = TableId = field(TableId),
+                              "Company Name" = field("Company Name"),
+                              "Source App ID" = field("Source App ID"),
+                              "Index Name" = field("Index Name");
             }
         }
     }


### PR DESCRIPTION
This pull request backports #6782 to releases/28.x

Problem:
When an non-AL defined index is disabled (turned off) it doesn't exist anymore (neither in Database Index VT or Key VT), so it will no longer exist in the temp table, leading to an error.

Solution:
Don't attempt to return to the position for non-AL defined indices after disabling them. Instead the position will just be the first index.

This PR also adds another page which shows the index's fields and include fields.

Fixes [AB#623117](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/623117)



