### PR TITLE
[releases/28.0] finalizing action shouldn't relink e-document in case the visibility hasn't been updated in the draft page

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseDraft.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseDraft.Page.al
@@ -300,6 +300,12 @@ page 6181 "E-Document Purchase Draft"
                         EDocImportParameters: Record "E-Doc. Import Parameters";
                     begin
                         Session.LogMessage('0000PCO', FinalizeDraftInvokedTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', EDocumentPurchaseHeader.FeatureName());
+                        Rec.SetAutoCalcFields("Import Processing Status");
+                        if Rec.Get(Rec."Entry No") then
+                            if Rec."Import Processing Status" = "Import E-Doc. Proc. Status"::Processed then begin
+                                Rec.ShowRecord();
+                                exit;
+                            end;
                         FinalizeEDocument(EDocImportParameters);
                     end;
                 }


### PR DESCRIPTION
Fixes [AB#623183](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/623183)


