### PR TITLE
[28.x] Bug 623232: [28.x][BCApps #6850]MS Graph module, fix for Certificate auth

### DIFF
--- a/src/System Application/App/MicrosoftGraph/src/Authorization/GraphAuthClientCredentials.Codeunit.al
+++ b/src/System Application/App/MicrosoftGraph/src/Authorization/GraphAuthClientCredentials.Codeunit.al
@@ -36,7 +36,7 @@ codeunit 9357 "Graph Auth. Client Credentials" implements "Graph Authorization"
         ClientCredentialsType := ClientCredentialsType::Certificate;
         AadTenantId := NewAadTenantId;
         ClientId := NewClientId;
-        Certificate := Certificate;
+        Certificate := NewCertificate;
         CertificatePassword := NewCertificatePassword;
         Scopes := NewScopes;
     end;


### PR DESCRIPTION
The certificate SetParameters overload was assigning `Certificate := Certificate` (self-assignment) instead of `Certificate := NewCertificate`, causing certificate-based auth to always send an empty certificate.

This will fix authorization with certificate for Microsoft Graph and SharePoint Graph API modules.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #6851
Fixes [AB#623232](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/623232)