### PR TITLE
[28.0] E-Document Import - check length for GTIN

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Helpers/EDocumentImportHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Helpers/EDocumentImportHelper.Codeunit.al
@@ -138,6 +138,9 @@ codeunit 6109 "E-Document Import Helper"
         if GTIN = '' then
             exit(false);
 
+        if StrLen(GTIN) > MaxStrLen(Item.GTIN) then
+            exit(false);
+
         Item.SetRange(GTIN, GTIN);
         if not Item.FindFirst() then
             exit(false);


### PR DESCRIPTION
## Summary
- Backport of #6806 to releases/28.0
- Adds a check that ensures an invalid GTIN (longer than the field length) doesn't fail the SetRange when importing E-Documents.

Fixes [AB#623325](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/623325)
