### PR TITLE
[Bug][SubscriptionBilling]: Invoicing Item on Subscription Package Line ignored for "Subscription Item" type items

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Import/Codeunits/CreateSubscriptionLine.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Import/Codeunits/CreateSubscriptionLine.Codeunit.al
@@ -57,8 +57,6 @@ codeunit 8006 "Create Subscription Line"
     local procedure CreateServiceCommitment()
     var
         ServiceCommitment: Record "Subscription Line";
-        ServiceObject: Record "Subscription Header";
-        ContractsItemManagement: Codeunit "Sub. Contracts Item Management";
     begin
         ServiceCommitment.Init();
         ServiceCommitment.Validate("Subscription Header No.", ImportedServiceCommitment."Subscription Header No.");
@@ -71,13 +69,7 @@ codeunit 8006 "Create Subscription Line"
         OnAfterSubscriptionLineInsert(ServiceCommitment, ImportedServiceCommitment);
 
         ServiceCommitment."Invoicing via" := ImportedServiceCommitment."Invoicing via";
-        if ImportedServiceCommitment."Invoicing Item No." <> '' then
-            ServiceCommitment."Invoicing Item No." := ImportedServiceCommitment."Invoicing Item No."
-        else
-            if ServiceObject.Get(ServiceCommitment."Subscription Header No.") then
-                if ServiceObject.IsItem() then
-                    if ContractsItemManagement.IsServiceCommitmentItem(ServiceObject."Source No.") then
-                        ServiceCommitment."Invoicing Item No." := ServiceObject."Source No.";
+        ServiceCommitment."Invoicing Item No." := ImportedServiceCommitment.GetInvoicingItemNo();
         ServiceCommitment.Template := ImportedServiceCommitment."Template Code";
         ServiceCommitment.Validate("Subscription Package Code", ImportedServiceCommitment."Subscription Package Code");
         ServiceCommitment.Partner := ImportedServiceCommitment.Partner;

--- a/src/Apps/W1/Subscription Billing/App/Import/Tables/ImportedSubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Import/Tables/ImportedSubscriptionLine.Table.al
@@ -314,4 +314,17 @@ table 8009 "Imported Subscription Line"
                 "Currency Factor" := CurrExchRate.ExchangeRate("Currency Factor Date", "Currency Code");
         end
     end;
+
+    internal procedure GetInvoicingItemNo(): Code[20]
+    var
+        SubscriptionHeader: Record "Subscription Header";
+        ContractsItemManagement: Codeunit "Sub. Contracts Item Management";
+    begin
+        if Rec."Invoicing Item No." <> '' then
+            exit(Rec."Invoicing Item No.");
+        if SubscriptionHeader.Get(Rec."Subscription Header No.") then
+            if SubscriptionHeader.IsItem() then
+                if ContractsItemManagement.IsServiceCommitmentItem(SubscriptionHeader."Source No.") then
+                    exit(SubscriptionHeader."Source No.");
+    end;
 }

--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Codeunits/SalesSubscriptionLineMgmt.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Codeunits/SalesSubscriptionLineMgmt.Codeunit.al
@@ -360,7 +360,11 @@ codeunit 8069 "Sales Subscription Line Mgmt."
         Item.Get(ItemNo);
         case Item."Subscription Option" of
             Item."Subscription Option"::"Service Commitment Item":
-                exit(Item."No.");
+                begin
+                    if ServiceCommitmentPackageLine."Invoicing Item No." <> '' then
+                        exit(ServiceCommitmentPackageLine."Invoicing Item No.");
+                    exit(Item."No.");
+                end;
             Item."Subscription Option"::"Sales with Service Commitment":
                 begin
                     if ServiceCommitmentPackageLine."Invoicing via" = Enum::"Invoicing Via"::Contract then

--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionPackageLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionPackageLine.Table.al
@@ -308,4 +308,12 @@ table 8056 "Subscription Package Line"
         if (Format("Billing Base Period") <> '') and (Format("Billing Rhythm") <> '') then
             DateFormulaManagement.CheckIntegerRatioForDateFormulas("Billing Base Period", FieldCaption("Billing Base Period"), "Billing Rhythm", FieldCaption("Billing Rhythm"));
     end;
+
+    internal procedure GetInvoicingItemNo(Item: Record Item): Code[20]
+    begin
+        if Rec."Invoicing Item No." <> '' then
+            exit(Rec."Invoicing Item No.");
+        if Item.IsServiceCommitmentItem() then
+            exit(Item."No.");
+    end;
 }

--- a/src/Apps/W1/Subscription Billing/App/Service Objects/Tables/SubscriptionHeader.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Objects/Tables/SubscriptionHeader.Table.al
@@ -1913,10 +1913,7 @@ table 8057 "Subscription Header"
                         ServiceCommitment.Template := ServiceCommPackageLine.Template;
                         ServiceCommitment.Description := ServiceCommPackageLine.Description;
                         ServiceCommitment."Invoicing via" := ServiceCommPackageLine."Invoicing via";
-                        if Item.IsServiceCommitmentItem() then
-                            ServiceCommitment."Invoicing Item No." := Item."No."
-                        else
-                            ServiceCommitment."Invoicing Item No." := ServiceCommPackageLine."Invoicing Item No.";
+                        ServiceCommitment."Invoicing Item No." := ServiceCommPackageLine.GetInvoicingItemNo(Item);
                         ServiceCommitment."Customer Price Group" := ServiceCommitmentPackage."Price Group";
 
                         if ServiceAndCalculationStartDate <> 0D then

--- a/src/Apps/W1/Subscription Billing/Test/Base/ContractTestLibrary.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Base/ContractTestLibrary.Codeunit.al
@@ -652,7 +652,7 @@ codeunit 139685 "Contract Test Library"
     var
         Item: Record Item;
     begin
-        if (InvoicingVia = InvoicingVia::Contract) and (ItemNo = '') then begin
+        if (InvoicingVia = InvoicingVia::Contract) and (ItemNo = '') and not CreateDiscountLine then begin
             CreateItemWithServiceCommitmentOption(Item, Enum::"Item Service Commitment Type"::"Invoicing Item");
             ItemNo := Item."No.";
         end;
@@ -780,11 +780,12 @@ codeunit 139685 "Contract Test Library"
 
         CreateServiceCommitmentTemplate(ServiceCommitmentTemplate, '', LibraryRandom.RandDec(100, 2), NewInvoicingVia, Enum::"Calculation Base Type"::"Item Price", false);
 
-        if ServiceCommitmentTemplate."Invoicing via" = ServiceCommitmentTemplate."Invoicing via"::Contract then begin
-            CreateItemWithServiceCommitmentOption(Item2, Enum::"Item Service Commitment Type"::"Invoicing Item");
-            ServiceCommitmentTemplate.Validate("Invoicing Item No.", Item2."No.");
-            ServiceCommitmentTemplate.Modify(false);
-        end;
+        if ServiceCommitmentTemplate."Invoicing via" = ServiceCommitmentTemplate."Invoicing via"::Contract then
+            if not Item.IsServiceCommitmentItem() then begin
+                CreateItemWithServiceCommitmentOption(Item2, Enum::"Item Service Commitment Type"::"Invoicing Item");
+                ServiceCommitmentTemplate.Validate("Invoicing Item No.", Item2."No.");
+                ServiceCommitmentTemplate.Modify(false);
+            end;
 
         CreateServiceCommitmentPackage(ServiceCommitmentPackage);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This pull request introduces improvements to how the "Invoicing Item No." is determined and assigned in subscription billing, refactoring logic into reusable methods and simplifying code in multiple places. 


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #6679






Fixes [AB#625944](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625944)
