### PR TITLE
[Shopify] Check fulfillment service exists before querying assigned fulfillment orders

### DIFF
--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLHasFFService.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLHasFFService.Codeunit.al
@@ -1,0 +1,33 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify;
+
+/// <summary>
+/// Codeunit Shpfy GQL HasFFService (ID 30455).
+/// Implements the IGraphQL interface for checking if the app has an associated fulfillment service.
+/// </summary>
+codeunit 30455 "Shpfy GQL HasFFService" implements "Shpfy IGraphQL"
+{
+    Access = Internal;
+
+    /// <summary>
+    /// GetGraphQL.
+    /// </summary>
+    /// <returns>Return value of type Text.</returns>
+    internal procedure GetGraphQL(): Text
+    begin
+        exit('{"query":"{ locations(first: 1, includeLegacy: true, query: \"name:''{{Name}}''\") { nodes { name }}}"}');
+    end;
+
+    /// <summary>
+    /// GetExpectedCost.
+    /// </summary>
+    /// <returns>Return value of type Integer.</returns>
+    internal procedure GetExpectedCost(): Integer
+    begin
+        exit(6);
+    end;
+}

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Enums/ShpfyGraphQLType.Enum.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Enums/ShpfyGraphQLType.Enum.al
@@ -731,4 +731,9 @@ enum 30111 "Shpfy GraphQL Type" implements "Shpfy IGraphQL"
         Caption = 'Get Payouts By Ids';
         Implementation = "Shpfy IGraphQL" = "Shpfy GQL PayoutsByIds";
     }
+    value(147; HasFulfillmentService)
+    {
+        Caption = 'Has Fulfillment Service';
+        Implementation = "Shpfy IGraphQL" = "Shpfy GQL HasFFService";
+    }
 }

--- a/src/Apps/W1/Shopify/App/src/Shipping/Reports/ShpfySyncShipmToShopify.Report.al
+++ b/src/Apps/W1/Shopify/App/src/Shipping/Reports/ShpfySyncShipmToShopify.Report.al
@@ -50,8 +50,10 @@ report 30109 "Shpfy Sync Shipm. to Shopify"
                         Shop.Get(ShopifyOrderHeader."Shop Code");
 
                         // Get assigned fulfillment orders if not already retrieved for this shop
-                        if not AssignedFulfillmentOrderIds.Values.Contains(Shop.Code) then
+                        if not QueriedShopCodes.Contains(Shop.Code) then begin
                             FulfillmentOrdersAPI.GetAssignedFulfillmentOrders(Shop, AssignedFulfillmentOrderIds);
+                            QueriedShopCodes.Add(Shop.Code);
+                        end;
 
                         FulfillmentOrdersAPI.GetShopifyFulfillmentOrdersFromShopifyOrder(Shop, "Sales Shipment Header"."Shpfy Order Id");
                         ExportShipments.CreateShopifyFulfillment("Sales Shipment Header", AssignedFulfillmentOrderIds);
@@ -65,6 +67,7 @@ report 30109 "Shpfy Sync Shipm. to Shopify"
         ExportShipments: Codeunit "Shpfy Export Shipments";
         FulfillmentOrdersAPI: Codeunit "Shpfy Fulfillment Orders API";
         AssignedFulfillmentOrderIds: Dictionary of [BigInteger, Code[20]];
+        QueriedShopCodes: List of [Code[20]];
         NoLinesApplicableLbl: Label 'No lines applicable for fulfillment.';
         ShopifyOrderNotExistsLbl: Label 'Shopify order %1 does not exist.', Comment = '%1 = Shopify Order Id';
 }


### PR DESCRIPTION
When syncing shipments to Shopify, the `assignedFulfillmentOrders` GraphQL call fails with "The api_client is not associated with any fulfillment service" if the fulfillment service was disassociated on Shopify's side (e.g., app reinstall, store migration).

## Changes

- **New GraphQL query** (`HasFulfillmentService`): Queries Shopify locations by name to verify the fulfillment service location exists before calling `assignedFulfillmentOrders`.
- **`GetAssignedFulfillmentOrders`**: After the existing `Fulfillment Service Activated` flag check, queries Shopify to confirm the service actually exists. If not, resets the flag to `false` and exits gracefully.
- **`ShpfySyncShipmToShopify`**: Tracks queried shop codes separately to avoid redundant API calls when a shop has no assigned fulfillment orders.

Fixes [AB#623365](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/623365)




