### PR TITLE
Move retention policy manual setup to Baseapp so that could change its manual setup category

### DIFF
--- a/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Codeunit.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Codeunit.al
@@ -5,7 +5,6 @@
 
 namespace System.DataAdministration;
 
-using System.Environment.Configuration;
 
 /// <summary>
 /// This codeunit contains helper methods for retention policy setups.
@@ -141,15 +140,6 @@ codeunit 3902 "Retention Policy Setup"
     end;
 
     // these event subscribers are here because the Impl. codeunit has a manual subscriber
-
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Guided Experience", OnRegisterManualSetup, '', true, true)]
-    local procedure AddRetentionPolicyOnRegisterManualSetup(sender: Codeunit "Guided Experience")
-    var
-        RetentionPolicySetupImpl: Codeunit "Retention Policy Setup Impl.";
-    begin
-        RetentionPolicySetupImpl.AddRetentionPolicyOnRegisterManualSetup(sender)
-    end;
-
     [EventSubscriber(ObjectType::Table, Database::"Retention Period", OnBeforeDeleteEvent, '', true, true)]
     local procedure VerifyRetentionPolicySetupOnbeforeDeleteRetentionPeriod(var Rec: Record "Retention Period")
     var

--- a/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetupImpl.Codeunit.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetupImpl.Codeunit.al
@@ -5,7 +5,6 @@
 
 namespace System.DataAdministration;
 
-using System.Environment.Configuration;
 using System.Reflection;
 
 codeunit 3903 "Retention Policy Setup Impl."
@@ -21,10 +20,6 @@ codeunit 3903 "Retention Policy Setup Impl."
                   tabledata "Retention Policy Setup Line" = ri;
 
     var
-        ManualSetupTitleTxt: Label 'Retention policies';
-        ManualSetupShortTitleTxt: Label 'Retention policies';
-        ManualSetupDescriptionTxt: Label 'Set up retention policies for log tables to automatically delete expired records.';
-        ManualSetupKeyWordsTxt: Label 'Retention, Delete, Cleanup, Log';
         RetentionPeriodUsedErr: Label 'You cannot delete the retention period %1 because one or more retention policies are using it.', Comment = '%1 = a retention period code';
         RetentionPeriodLockedErr: Label 'You cannot modify the retention period %1 because one or more mandatory retention policies are using it.', Comment = '%1 = a retention period code';
         TableNotAllowedErrorLbl: Label 'Table %1 %2 is not in the list of allowed tables.', Comment = '%1 = table number, %2 = table name';
@@ -234,16 +229,6 @@ codeunit 3903 "Retention Policy Setup Impl."
         RetentionPolicyLogCategory: Enum "Retention Policy Log Category";
     begin
         exit(RetentionPolicyLogCategory::"Retention Policy - Setup")
-    end;
-
-    procedure AddRetentionPolicyOnRegisterManualSetup(GuidedExperience: Codeunit "Guided Experience")
-    var
-        ManualSetupCategory: Enum "Manual Setup Category";
-        CurrModuleInfo: ModuleInfo;
-    begin
-        NavApp.GetCurrentModuleInfo(CurrModuleInfo);
-        GuidedExperience.InsertManualSetup(ManualSetupTitleTxt, ManualSetupShortTitleTxt, ManualSetupDescriptionTxt, 5, ObjectType::Page,
-            Page::"Retention Policy Setup List", ManualSetupCategory::Uncategorized, ManualSetupKeyWordsTxt);
     end;
 
     procedure VerifyRetentionPolicySetupOnbeforeDeleteRetentionPeriod(var RetentionPeriod: Record "Retention Period")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This pull request removes support for registering retention policy setup in the Guided Experience manual setup flow. The changes focus on cleaning up unused code and labels related to this feature.

**Removal of Guided Experience manual setup integration:**

* Deleted the event subscriber `AddRetentionPolicyOnRegisterManualSetup` from `codeunit 3902 "Retention Policy Setup"` that handled manual setup registration for retention policies.
* Removed the implementation of `AddRetentionPolicyOnRegisterManualSetup` procedure from `codeunit 3903 "Retention Policy Setup Impl."`.

**Add manual setup in the BaseApp**
This would be process in [NAV PR](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_git/NAV/pullrequest/241371).


#### Result 
After removal, the uncategorized would disappear.
<img width="1944" height="1028" alt="Screenshot 2026-03-02 124445" src="https://github.com/user-attachments/assets/06c26810-f9e3-4299-9be2-fc2c1b2fa234" />

After adding to BaseApp, the result shows as:
<img width="1210" height="964" alt="Screenshot 2026-03-02 131923" src="https://github.com/user-attachments/assets/c4c3b940-8cec-46d2-b5df-2053a366aa51" />


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#622187](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/622187/)


