### PR TITLE
[Bug][SubscriptionBilling] Fix "Qty. to Invoice" incorrectly set on subscription item after partial shipment

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/SalesDocuments.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/SalesDocuments.Codeunit.al
@@ -411,7 +411,7 @@ codeunit 8063 "Sales Documents"
         //The function makes sure that amounts are reset to previous values for Sales Lines with Subscription Items
         //The function makes sure that Qty. To Invoice for Subscription Items is properly set to 0 as it should never have the non-zero value
         //The Qty. To Invoice is normally being set to Qty. to Ship at this point
-        ShouldModifySalesLine := SalesLineShouldSkipInvoicing(TempSalesLine);
+        ShouldModifySalesLine := SalesLineShouldSkipInvoicing(TempSalesLine, true);
         OnSetQtyToInvoiceToZeroOnBeforePostUpdateOrderLineModifyTempLineOnAfterCalcShouldModifySalesLine(TempSalesLine, ShouldModifySalesLine);
         if not ShouldModifySalesLine then
             exit;
@@ -424,8 +424,7 @@ codeunit 8063 "Sales Documents"
             TempSalesLine.UpdateAmounts();
         end;
 
-        if TempSalesLine."Qty. to Ship" <> 0 then
-            TempSalesLine.Validate("Qty. to Invoice", 0);
+        TempSalesLine.Validate("Qty. to Invoice", 0);
     end;
 
     local procedure CheckResetValueForServiceCommitmentItems(var TempSalesLine: Record "Sales Line") ResetValueForServiceCommitmentItems: Boolean

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
@@ -598,6 +598,43 @@ codeunit 139915 "Sales Service Commitment Test"
     end;
 
     [Test]
+    procedure CheckSalesLineQtyToInvoiceAfterPartialShipment()
+    var
+        ReleaseSalesDoc: Codeunit "Release Sales Document";
+    begin
+        // [SCENARIO] After posting a partial (ship-only) shipment for a subscription item, "Qty. to Invoice" must stay 0.
+        //            A subsequent Ship+Invoice posting of the remaining quantity must succeed without error
+        Initialize();
+        SetupAdditionalServiceCommPackageLine(Enum::"Service Partner"::Vendor);
+        ContractTestLibrary.SetupSalesServiceCommitmentItemAndAssignToServiceCommitmentPackage(
+            Item, Enum::"Item Service Commitment Type"::"Service Commitment Item", ServiceCommitmentPackage.Code);
+
+        // [GIVEN] Sales order for a subscription item with quantity 2; first shipment covers 1 piece
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, '');
+        LibrarySales.CreateSalesLineWithShipmentDate(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", WorkDate(), 2);
+        SalesLine.Validate("Qty. to Ship", 1);
+        SalesLine.Modify(false);
+
+        // [WHEN] Post ship-only for the first piece
+        LibrarySales.PostSalesDocument(SalesHeader, true, false);
+
+        // [THEN] "Qty. to Invoice" on the remaining order line must be 0
+        SalesLine.Get(SalesLine."Document Type", SalesLine."Document No.", SalesLine."Line No.");
+        Assert.AreEqual(0, SalesLine."Qty. to Invoice", '"Qty. to Invoice" must be 0 for subscription item after partial shipment.');
+
+        // [WHEN] Post ship+invoice for the remaining piece - must succeed without error
+        ReleaseSalesDoc.PerformManualReopen(SalesHeader);
+        SalesLine.Validate("Qty. to Ship", 1);
+        SalesLine.Modify(false);
+        LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] All quantity has been shipped and "Qty. to Invoice" is still 0
+        SalesLine.Get(SalesLine."Document Type", SalesLine."Document No.", SalesLine."Line No.");
+        Assert.AreEqual(2, SalesLine."Quantity Shipped", '"Quantity Shipped" must equal the full quantity after complete shipment.');
+        Assert.AreEqual(0, SalesLine."Qty. to Invoice", '"Qty. to Invoice" must remain 0 for subscription item after full shipment.');
+    end;
+
+    [Test]
     procedure CheckSalesLineQtyToInvoiceAfterSalesQuoteToOrder()
     var
         SalesOrder: Record "Sales Header";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This pull request improves the handling of the "Qty. to Invoice" field for subscription items on sales documents, ensuring that it remains correctly set to zero after partial shipments. It also adds a new automated test to verify this behavior, preventing potential invoicing errors for subscription items.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #6319



Fixes [AB#624268](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624268)

