### PR TITLE
[Quality Management] [28.0] Enable periodic inspections and improve schedule…

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/JobQueue/QltyJobQueueManagement.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/JobQueue/QltyJobQueueManagement.Codeunit.al
@@ -50,20 +50,22 @@ codeunit 20455 "Qlty. Job Queue Management"
     /// Common usage: Called when setting up inspection generation rules to ensure scheduled execution infrastructure exists.
     /// </summary>
     /// <param name="ScheduleGroup">The schedule group code to check and potentially create a job queue entry for</param>
-    internal procedure PromptCreateJobQueueEntryIfMissing(ScheduleGroup: Code[20])
+    internal procedure PromptCreateJobQueueEntryIfMissing(ScheduleGroup: Code[20]) JobQueueEntryCreated: Boolean
     begin
         if IsJobQueueCreated(ScheduleGroup) then
-            exit;
+            exit(true);
 
         if GuiAllowed() then
             if not Confirm(StrSubstNo(ThereIsNoJobQueueForThisScheduleGroupYetDoYouWantToCreateQst, ScheduleGroup)) then
-                exit;
+                exit(false);
 
         CreateJobQueueEntry(ScheduleGroup);
 
         if GuiAllowed() then
             if Confirm(StrSubstNo(JobQueueEntryMadeDoYouWantToSeeQst, ScheduleGroup)) then
                 RunPageLookupJobQueueEntriesForScheduleGroup(ScheduleGroup);
+
+        exit(true);
     end;
 
     /// <summary>

--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRule.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRule.Table.al
@@ -65,7 +65,10 @@ table 20404 "Qlty. Inspection Gen. Rule"
                     if Rec."Schedule Group" <> '' then begin
                         QltyJobQueueManagement.CheckIfGenerationRuleCanBeScheduled(Rec);
                         Rec.Modify();
-                        QltyJobQueueManagement.PromptCreateJobQueueEntryIfMissing(Rec."Schedule Group");
+                        if not QltyJobQueueManagement.PromptCreateJobQueueEntryIfMissing(Rec."Schedule Group") then begin
+                            Rec."Schedule Group" := xRec."Schedule Group";
+                            Rec.Modify();
+                        end;
                     end else
                         QltyJobQueueManagement.DeleteJobQueueIfNothingElseIsUsingThisGroup(Rec, xRec."Schedule Group");
             end;

--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRules.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRules.Page.al
@@ -160,7 +160,10 @@ page 20405 "Qlty. Inspection Gen. Rules"
                             if Rec."Schedule Group" = '' then begin
                                 Rec."Schedule Group" := DefaultScheduleGroupLbl;
                                 Rec.Modify(false);
-                                QltyJobQueueManagement.PromptCreateJobQueueEntryIfMissing(Rec."Schedule Group");
+                                if not QltyJobQueueManagement.PromptCreateJobQueueEntryIfMissing(Rec."Schedule Group") then begin
+                                    Rec."Schedule Group" := '';
+                                    Rec.Modify(false);
+                                end
                             end else
                                 QltyJobQueueManagement.RunPageLookupJobQueueEntriesForScheduleGroup(Rec."Schedule Group")
                     end;

--- a/src/Apps/W1/Quality Management/app/src/Configuration/QltyAutoConfigure.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/QltyAutoConfigure.Codeunit.al
@@ -90,6 +90,8 @@ codeunit 20402 "Qlty. Auto Configure"
         ProdRoutingToInspectDescriptionTxt: Label 'Prod. Order Routing Line to Inspection', MaxLength = 100;
         AssemblyOutputToInspectTok: Label 'ASMOUTPUTTOINSPECT', MaxLength = 20, Locked = true;
         AssemblyOutputToInspectDescriptionTxt: Label 'Posted Assembly Header to Inspection', MaxLength = 100;
+        OpenLedgerToInspectTok: Label 'ITEMLDGROPENINSPECT', MaxLength = 20, Locked = true;
+        OpenLedgerToInspectDescriptionTxt: Label 'Open Item Ledger Entry to Inspection', MaxLength = 100;
 
     internal procedure GetDefaultPassResult(): Text
     begin
@@ -242,6 +244,7 @@ codeunit 20402 "Qlty. Auto Configure"
         CreateDefaultProductionAndAssemblyConfiguration();
         CreateDefaultReceivingConfiguration();
         CreateDefaultWarehousingConfiguration();
+        CreateDefaultItemLedgerEntryOpenToInspectConfiguration();
     end;
 
     local procedure CreateDefaultTrackingSpecificationToInspectConfiguration()
@@ -1255,6 +1258,75 @@ codeunit 20402 "Qlty. Auto Configure"
         EnsureSourceConfigLineExists(
             QltyInspectSourceConfig,
             TempItemLedgerEntry.FieldNo(Quantity),
+            Database::"Qlty. Inspection Header",
+            TempQltyInspectionHeader.FieldNo("Source Quantity (Base)"),
+            '');
+        EnsureSourceConfigLineExists(
+            QltyInspectSourceConfig,
+            TempItemLedgerEntry.FieldNo("Variant Code"),
+            Database::"Qlty. Inspection Header",
+            TempQltyInspectionHeader.FieldNo("Source Variant Code"),
+            '');
+        EnsureSourceConfigLineExists(
+            QltyInspectSourceConfig,
+            TempItemLedgerEntry.FieldNo("Lot No."),
+            Database::"Qlty. Inspection Header",
+            TempQltyInspectionHeader.FieldNo("Source Lot No."),
+            '');
+        EnsureSourceConfigLineExists(
+            QltyInspectSourceConfig,
+            TempItemLedgerEntry.FieldNo("Serial No."),
+            Database::"Qlty. Inspection Header",
+            TempQltyInspectionHeader.FieldNo("Source Serial No."),
+            '');
+        EnsureSourceConfigLineExists(
+            QltyInspectSourceConfig,
+            TempItemLedgerEntry.FieldNo("Package No."),
+            Database::"Qlty. Inspection Header",
+            TempQltyInspectionHeader.FieldNo("Source Package No."),
+            '');
+        EnsureSourceConfigLineExists(
+            QltyInspectSourceConfig,
+            TempItemLedgerEntry.FieldNo(Description),
+            Database::"Qlty. Inspection Header",
+            TempQltyInspectionHeader.FieldNo(Description),
+            '');
+        EnsureSourceConfigLineExists(
+            QltyInspectSourceConfig,
+            TempItemLedgerEntry.FieldNo("Location Code"),
+            Database::"Qlty. Inspection Header",
+            TempQltyInspectionHeader.FieldNo("Location Code"),
+            '');
+    end;
+
+    local procedure CreateDefaultItemLedgerEntryOpenToInspectConfiguration()
+    var
+        QltyInspectSourceConfig: Record "Qlty. Inspect. Source Config.";
+        TempItemLedgerEntry: Record "Item Ledger Entry" temporary;
+        TempQltyInspectionHeader: Record "Qlty. Inspection Header" temporary;
+    begin
+        EnsureSourceConfigWithFilterExists(
+            OpenLedgerToInspectTok,
+            OpenLedgerToInspectDescriptionTxt,
+            Database::"Item Ledger Entry",
+            Database::"Qlty. Inspection Header",
+            QltyInspectSourceConfig,
+            'WHERE(Open=CONST(true))');
+        EnsureSourceConfigLineExists(
+            QltyInspectSourceConfig,
+            TempItemLedgerEntry.FieldNo("Document No."),
+            Database::"Qlty. Inspection Header",
+            TempQltyInspectionHeader.FieldNo("Source Document No."),
+            '');
+        EnsureSourceConfigLineExists(
+            QltyInspectSourceConfig,
+            TempItemLedgerEntry.FieldNo("Item No."),
+            Database::"Qlty. Inspection Header",
+            TempQltyInspectionHeader.FieldNo("Source Item No."),
+            '');
+        EnsureSourceConfigLineExists(
+            QltyInspectSourceConfig,
+            TempItemLedgerEntry.FieldNo("Remaining Quantity"),
             Database::"Qlty. Inspection Header",
             TempQltyInspectionHeader.FieldNo("Source Quantity (Base)"),
             '');


### PR DESCRIPTION
- Enable item ledger entry as an inspection source so users can create inspections against open inventory (periodic/stock inspections)
- Allow the Schedule Inspection report to be used for bulk creating inspections without requiring a schedule group, not just via job queue
- Revert accidental change that bypassed the "please choose a record first" validation in the Create Inspection report
- Restore schedule group value when the user declines to create a job queue entry, preventing orphaned schedule groups

Fixes [AB#623947](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/623947)

