### PR TITLE
[Bug][SubscriptionBilling]: Enable "Assign Contract Line" for G/L Account lines in Purchase Invoices

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Table Extensions/PurchaseLine.TableExt.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Table Extensions/PurchaseLine.TableExt.al
@@ -90,12 +90,19 @@ tableextension 8065 "Purchase Line" extends "Purchase Line"
     var
         Item: Record Item;
     begin
-        if not (Rec.Type = Enum::"Purchase Line Type"::Item) then
-            exit;
-        if not Item.Get(Rec."No.") then
-            exit;
-        exit((Item."Subscription Option" in [Enum::"Item Service Commitment Type"::"Service Commitment Item", Enum::"Item Service Commitment Type"::"Invoicing Item"])
-                                       and (not Rec.IsLineAttachedToBillingLine()));
+        case Rec.Type of
+            Enum::"Purchase Line Type"::Item:
+                begin
+                    if not Item.Get(Rec."No.") then
+                        exit(false);
+                    exit((Item."Subscription Option" in [Enum::"Item Service Commitment Type"::"Service Commitment Item", Enum::"Item Service Commitment Type"::"Invoicing Item"])
+                                               and (not Rec.IsLineAttachedToBillingLine()));
+                end;
+            Enum::"Purchase Line Type"::"G/L Account":
+                exit(not Rec.IsLineAttachedToBillingLine());
+            else
+                exit(false);
+        end;
     end;
 
     internal procedure AssignVendorContractLine()

--- a/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingDocsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingDocsTest.Codeunit.al
@@ -73,7 +73,7 @@ codeunit 139687 "Recurring Billing Docs Test"
 
     [Test]
     [HandlerFunctions('MessageHandler,GetVendorContractLinesPageHandler,ExchangeRateSelectionModalPageHandler')]
-    procedure AssignVendorContractLinesToExistingPurchaseInvoiceLine()
+    procedure AssignItemVendorContractLineToPurchaseInvoiceLine()
     var
         Item: Record Item;
         Vendor: Record Vendor;
@@ -108,6 +108,52 @@ codeunit 139687 "Recurring Billing Docs Test"
         Assert.RecordIsNotEmpty(BillingLine);
         BillingLine.CalcSums(Amount);
         Assert.AreEqual(PurchaseLine."Line Amount", BillingLine.Amount, 'Service amount was not taken from purchase line');
+
+        // [THEN] If Purchase Line is deleted, billing lines are deleted as well
+        PurchaseLine.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+        PurchaseLine.Delete(true);
+        BillingLine.Reset();
+        BillingLine.FilterBillingLineOnDocumentLine(BillingLine.GetBillingDocumentTypeFromPurchaseDocumentType(PurchaseLine."Document Type"), PurchaseLine."Document No.", PurchaseLine."Line No.");
+        Assert.RecordIsEmpty(BillingLine);
+    end;
+
+    [Test]
+    [HandlerFunctions('GetVendorContractLinesPageHandler')]
+    procedure AssignGLAccountVendorContractLineToPurchaseInvoiceLine()
+    var
+        Vendor: Record Vendor;
+    begin
+        // [SCENARIO] Test if Vendor Subscription Contract line with G/L Account can be assigned to G/L Account purchase invoice line
+        Initialize();
+
+        // [GIVEN] A Vendor Subscription Contract with a G/L Account line
+        ContractTestLibrary.DeleteAllContractRecords();
+        ContractTestLibrary.CreateVendor(Vendor);
+        ContractTestLibrary.CreateVendorContract(VendorContract, Vendor."No.");
+        ContractTestLibrary.InsertVendorContractGLAccountLine(VendorContract, VendorContractLine);
+        GetVendorContractServiceCommitment(VendorContract."No.");
+        ServiceCommitment."Billing Rhythm" := ServiceCommitment."Billing Base Period";
+        ServiceCommitment.Modify(false);
+
+        // [GIVEN] A Purchase Invoice with a G/L Account line for the same G/L Account
+        LibraryPurchase.CreatePurchaseInvoiceForVendorNo(PurchaseHeader, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, "Purchase Line Type"::"G/L Account", VendorContractLine."No.", 1);
+        PurchaseLine.Validate("Direct Unit Cost", LibraryRandom.RandDec(100, 2));
+        PurchaseLine.Modify(false);
+
+        // [WHEN] Assign Contract Line to the G/L Account purchase invoice line
+        PurchaseLine.AssignVendorContractLine();
+
+        // [THEN] Purchase header is marked as Recurring billing
+        PurchaseHeader.Get(PurchaseHeader."Document Type", PurchaseHeader."No.");
+        PurchaseHeader.TestField("Recurring Billing", true);
+
+        // [THEN] Billing lines exist and amount matches purchase line amount
+        BillingLine.Reset();
+        BillingLine.FilterBillingLineOnDocumentLine(BillingLine.GetBillingDocumentTypeFromPurchaseDocumentType(PurchaseLine."Document Type"), PurchaseLine."Document No.", PurchaseLine."Line No.");
+        Assert.RecordIsNotEmpty(BillingLine);
+        BillingLine.CalcSums(Amount);
+        Assert.AreEqual(PurchaseLine."Line Amount", BillingLine.Amount, 'Service amount was not taken from G/L Account purchase line');
 
         // [THEN] If Purchase Line is deleted, billing lines are deleted as well
         PurchaseLine.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This pull request enhances the handling of vendor contract lines in purchase invoices, particularly by improving support for G/L Account lines. It updates the logic for determining eligibility for assigning vendor contract lines and adds comprehensive test coverage for these scenarios.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #6926


Fixes [AB#624265](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624265)

