### PR TITLE
[28.x]FA Scan entries The date is not valid. this is because Last time scanned is 0D

### DIFF
--- a/src/Apps/W1/DataCorrectionFA/App/src/codeunits/FACardNotifications.codeunit.al
+++ b/src/Apps/W1/DataCorrectionFA/App/src/codeunits/FACardNotifications.codeunit.al
@@ -58,8 +58,9 @@ codeunit 6091 "FA Card Notifications"
         if not FASetup.WritePermission then
             exit;
         FASetup.Get();
-        if (FASetup."Last time scanned" + GetCacheRefreshInterval()) > CurrentDateTime then
-            exit;
+        if FASetup."Last time scanned" <> 0DT then
+            if (FASetup."Last time scanned" + GetCacheRefreshInterval()) > CurrentDateTime then
+                exit;
 
         CLEAR(FASetup);
         FASetup.LockTable();


### PR DESCRIPTION
Summary

FA Scan entries The date is not valid. this is because Last time scanned is 0D. This will prevent the user open the FA card page .

Work Item(s)
Fixes [AB#624039](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624039)

