### PR TITLE
Revert Privacy opt-in for Semantic Data Search (#6919)

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotAICapabilities.Page.al
@@ -240,92 +240,22 @@ page 7775 "Copilot AI Capabilities"
                             UpdateBingSearchOptIn();
                         end;
                     }
-                    field(BingSearchServiceAgreement; MSServiceAgreementLbl)
+                    field(BingSearchServiceAgreement; BingMSServiceAgreementLbl)
                     {
                         ShowCaption = false;
 
                         trigger OnDrillDown()
                         begin
-                            Hyperlink(MSServiceAgreementDocLinkLbl);
+                            Hyperlink(BingMSServiceAgreementDocLinkLbl);
                         end;
                     }
-                    field(BingSearchPrivacyStatement; MSPrivacyStatementLbl)
+                    field(BingSearchPrivacyStatement; BingMSPrivacyStatementLbl)
                     {
                         ShowCaption = false;
 
                         trigger OnDrillDown()
                         begin
-                            Hyperlink(MSPrivacyStatementDocLinkLbl);
-                        end;
-                    }
-                }
-            }
-
-            group(SemanticDataSearchOptIn)
-            {
-                ShowCaption = false;
-                Visible = true;
-
-                group(SemanticDataSearchAllowedDataMovementOffInfo)
-                {
-                    ShowCaption = false;
-                    Visible = true;
-                    InstructionalText = 'Some features use semantic data similarity. To get the most out of these features, you must enable Semantic Data Search.';
-                }
-                field(SemanticDataSearchServiceAgreement; MSServiceAgreementLbl)
-                {
-                    ShowCaption = false;
-
-                    trigger OnDrillDown()
-                    begin
-                        Hyperlink(MSServiceAgreementDocLinkLbl);
-                    end;
-                }
-                field(SemanticDataSearchPrivacyStatement; MSPrivacyStatementLbl)
-                {
-                    ShowCaption = false;
-
-                    trigger OnDrillDown()
-                    begin
-                        Hyperlink(MSPrivacyStatementDocLinkLbl);
-                    end;
-                }
-                group(SemanticDataSearchDataMovementGroup)
-                {
-                    ShowCaption = false;
-                    label(SemanticDataSearchCaption)
-                    {
-                        ApplicationArea = All;
-                        Caption = 'By enabling Semantic Data Search, you agree to data being processed by the Azure Open AI Service outside of your environment''s geographic region or compliance boundary if Azure Open AI Service is not available in your region.';
-                    }
-                    field(SemanticDataSearchAreaDataMovement; SemanticDataSearchOptIn)
-                    {
-                        ApplicationArea = All;
-                        Caption = 'Enable Semantic Search';
-                        ToolTip = 'Specifies whether to enable Semantic Data Search. This is required for some features to use Semantic Data Search in your environment.';
-                        Editable = true;
-
-                        trigger OnValidate()
-                        begin
-                            UpdateSemanticDataSearchOptIn();
-                        end;
-                    }
-                    field(SemanticDataSearchAOAIServiceLocated; AOAIServiceLocatedLbl)
-                    {
-                        ShowCaption = false;
-
-                        trigger OnDrillDown()
-                        begin
-                            Hyperlink(AOAIServiceLocatedDocLinkLbl);
-                        end;
-                    }
-                    field(SemanticDataSearchDataProcess; DataProcessByAOAILbl)
-                    {
-                        ShowCaption = false;
-
-                        trigger OnDrillDown()
-                        begin
-                            Hyperlink(DataProcessByAOAIDocLinkLbl);
+                            Hyperlink(BingMSPrivacyStatementDocLinkLbl);
                         end;
                     }
                 }
@@ -420,7 +350,6 @@ page 7775 "Copilot AI Capabilities"
         end;
 
         BingOptIn := PrivacyNotice.GetPrivacyNoticeApprovalState(SystemPrivacyNoticeReg.GetBingPrivacyNoticeName(), true) = Enum::"Privacy Notice Approval State"::Agreed;
-        SemanticDataSearchOptIn := PrivacyNotice.GetPrivacyNoticeApprovalState(SystemPrivacyNoticeReg.GetSemanticDataSearchPrivacyNoticeName(), true) = Enum::"Privacy Notice Approval State"::Agreed;
     end;
 
     trigger OnPageBackgroundTaskCompleted(TaskId: Integer; Results: Dictionary of [Text, Text])
@@ -499,18 +428,6 @@ page 7775 "Copilot AI Capabilities"
         CopilotNotifications.ShowCapabilityChange();
     end;
 
-    local procedure UpdateSemanticDataSearchOptIn()
-    var
-        SystemPrivacyNoticeReg: Codeunit "System Privacy Notice Reg.";
-    begin
-        if SemanticDataSearchOptIn then
-            PrivacyNotice.SetApprovalState(SystemPrivacyNoticeReg.GetSemanticDataSearchPrivacyNoticeName(), "Privacy Notice Approval State"::Agreed)
-        else
-            PrivacyNotice.SetApprovalState(SystemPrivacyNoticeReg.GetSemanticDataSearchPrivacyNoticeName(), "Privacy Notice Approval State"::Disagreed);
-
-        CopilotNotifications.ShowCapabilityChange();
-    end;
-
     [IntegrationEvent(false, false)]
     local procedure OnRegisterCopilotCapability()
     begin
@@ -540,9 +457,8 @@ page 7775 "Copilot AI Capabilities"
         BingOptIn: Boolean;
         BingFeaturesLbl: Label 'Features using Bing Search';
         BingFeaturesDocLinkLbl: Label 'https://go.microsoft.com/fwlink/?linkid=2298540', Locked = true;
-        MSServiceAgreementLbl: Label 'Microsoft Services Agreement';
-        MSServiceAgreementDocLinkLbl: Label 'https://aka.ms/msa', Locked = true;
-        MSPrivacyStatementLbl: Label 'Microsoft Privacy Statement';
-        MSPrivacyStatementDocLinkLbl: Label 'https://go.microsoft.com/fwlink?LinkId=521839', Locked = true;
-        SemanticDataSearchOptIn: Boolean;
+        BingMSServiceAgreementLbl: Label 'Microsoft Services Agreement';
+        BingMSServiceAgreementDocLinkLbl: Label 'https://aka.ms/msa', Locked = true;
+        BingMSPrivacyStatementLbl: Label 'Microsoft Privacy Statement';
+        BingMSPrivacyStatementDocLinkLbl: Label 'https://go.microsoft.com/fwlink?LinkId=521839', Locked = true;
 }

--- a/src/System Application/App/Privacy Notice/src/SystemPrivacyNoticeReg.Codeunit.al
+++ b/src/System Application/App/Privacy Notice/src/SystemPrivacyNoticeReg.Codeunit.al
@@ -21,7 +21,6 @@ codeunit 1566 "System Privacy Notice Reg."
         PowerAutomateLabelTxt: Label 'Microsoft Power Automate', Locked = true; // Product names are not translated and it's important this entry exists.
         MicrosoftLearnTxt: Label 'Microsoft Learn', Locked = true; // Product names are not translated and it's important this entry exists.
         BingTxt: Label 'Bing', Locked = true; // Product names are not translated and it's important this entry exists.
-        SemanticDataSearchTxt: Label 'Semantic Data Search', Locked = true;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Privacy Notice", OnRegisterPrivacyNotices, '', false, false)]
     local procedure CreatePrivacyNoticeRegistrations(var TempPrivacyNotice: Record "Privacy Notice" temporary)
@@ -38,9 +37,6 @@ codeunit 1566 "System Privacy Notice Reg."
         if not TempPrivacyNotice.Insert() then;
         TempPrivacyNotice.ID := BingTxt;
         TempPrivacyNotice."Integration Service Name" := BingTxt;
-        if not TempPrivacyNotice.Insert() then;
-        TempPrivacyNotice.ID := SemanticDataSearchTxt;
-        TempPrivacyNotice."Integration Service Name" := SemanticDataSearchTxt;
         if not TempPrivacyNotice.Insert() then;
     end;
 
@@ -87,15 +83,6 @@ codeunit 1566 "System Privacy Notice Reg."
     procedure GetBingPrivacyNoticeName(): Code[50]
     begin
         exit(BingTxt);
-    end;
-
-    /// <summary>
-    /// Gets the Semantic Data Search privacy notice name.
-    /// </summary>
-    /// <returns>The privacy notice name for Semantic Data Search.</returns>
-    procedure GetSemanticDataSearchPrivacyNoticeName(): Code[50]
-    begin
-        exit(SemanticDataSearchTxt);
     end;
 
     [TryFunction]


### PR DESCRIPTION
This PR reverts the changes introduced in #6919 (Privacy opt-in for Semantic Data Search). Changes: Reverts modifications to CopilotAICapabilities.Page.al and SystemPrivacyNoticeReg.Codeunit.al

Fixes [AB#624110](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624110)



