### PR TITLE
[E-Documents Core] - Events for attaching E-Documents when using Digital Vouchers

### DIFF
--- a/src/Apps/W1/EDocument/App/app.json
+++ b/src/Apps/W1/EDocument/App/app.json
@@ -37,6 +37,11 @@
       "id": "967eceac-106e-4102-b76a-fe5dc3d799e5",
       "name": "Payables Agent Tests",
       "publisher": "Microsoft"
+    },
+    {
+      "id": "e2ae191d-8829-44c3-a373-3749a2742d4e",
+      "name": "Enforced Digital Vouchers",
+      "publisher": "Microsoft"
     }
   ],
   "screenshots": [],

--- a/src/Apps/W1/EDocument/App/app.json
+++ b/src/Apps/W1/EDocument/App/app.json
@@ -37,11 +37,6 @@
       "id": "967eceac-106e-4102-b76a-fe5dc3d799e5",
       "name": "Payables Agent Tests",
       "publisher": "Microsoft"
-    },
-    {
-      "id": "e2ae191d-8829-44c3-a373-3749a2742d4e",
-      "name": "Enforced Digital Vouchers",
-      "publisher": "Microsoft"
     }
   ],
   "screenshots": [],

--- a/src/Apps/W1/EDocument/App/src/Processing/EDocExport.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocExport.Codeunit.al
@@ -167,6 +167,7 @@ codeunit 6102 "E-Doc. Export"
         ErrorCount := EDocumentErrorHelper.ErrorMessageCount(EDocument);
         CreateEDocument(EDocumentService, EDocument, SourceDocumentHeaderMapped, SourceDocumentLineMapped, TempBlob);
         Success := EDocumentErrorHelper.ErrorMessageCount(EDocument) = ErrorCount;
+        OnExportEDocumentAfterCreateEDocument(EDocumentService, EDocument, SourceDocumentHeaderMapped, SourceDocumentLineMapped, TempBlob, Success);
         if Success then
             EDocServiceStatus := Enum::"E-Document Service Status"::Exported
         else
@@ -528,6 +529,11 @@ codeunit 6102 "E-Doc. Export"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterCreateEDocument(var EDocument: Record "E-Document"; var SourceDocumentHeader: RecordRef)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnExportEDocumentAfterCreateEDocument(EDocumentService: Record "E-Document Service"; EDocument: Record "E-Document"; SourceDocumentHeaderMapped: RecordRef; SourceDocumentLineMapped: RecordRef; var TempBlob: Codeunit "Temp Blob"; Success: Boolean)
     begin
     end;
 }

--- a/src/Apps/W1/EDocument/App/src/Processing/EDocExport.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocExport.Codeunit.al
@@ -167,7 +167,6 @@ codeunit 6102 "E-Doc. Export"
         ErrorCount := EDocumentErrorHelper.ErrorMessageCount(EDocument);
         CreateEDocument(EDocumentService, EDocument, SourceDocumentHeaderMapped, SourceDocumentLineMapped, TempBlob);
         Success := EDocumentErrorHelper.ErrorMessageCount(EDocument) = ErrorCount;
-        OnExportEDocumentAfterCreateEDocument(EDocumentService, EDocument, SourceDocumentHeaderMapped, SourceDocumentLineMapped, TempBlob, Success);
         if Success then
             EDocServiceStatus := Enum::"E-Document Service Status"::Exported
         else
@@ -184,6 +183,7 @@ codeunit 6102 "E-Doc. Export"
         else
             EDocumentProcessing.ModifyServiceStatus(EDocument, EDocumentService, EDocServiceStatus);
         EDocumentProcessing.ModifyEDocumentStatus(EDocument);
+        OnExportEDocumentAfterCreateEDocument(EDocumentService, EDocument, SourceDocumentHeaderMapped, SourceDocumentLineMapped, TempBlob, Success);
     end;
 
     internal procedure ExportEDocumentBatch(var EDocuments: Record "E-Document"; var EDocService: Record "E-Document Service"; var TempEDocMappingLogs: Record "E-Doc. Mapping Log" temporary; var TempBlob: Codeunit "Temp Blob"; var EDocumentsErrorCount: Dictionary of [Integer, Integer])

--- a/src/Apps/W1/EDocument/App/src/Processing/EDocumentSubscribers.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocumentSubscribers.Codeunit.al
@@ -573,7 +573,9 @@ codeunit 6103 "E-Document Subscribers"
         EDocument."Document Type" := DocumentType;
         EDocument.Status := Enum::"E-Document Status"::Processed;
         EDocument.Modify(true);
-
+        
+        OnAfterUpdateToPostedPurchaseEDocument(EDocument, PostedRecord, PostedDocumentNo, DocumentType);
+        
         EDocService := EDocumentLog.GetLastServiceFromLog(EDocument);
         EDocLogHelper.InsertLog(EDocument, EDocService, Enum::"E-Document Service Status"::"Imported Document Created");
     end;
@@ -632,4 +634,8 @@ codeunit 6103 "E-Document Subscribers"
         Telemetry.LogMessage('0000PYF', DraftChangeTok, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, TelemetryDimensions);
     end;
 
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterUpdateToPostedPurchaseEDocument(var EDocument: Record "E-Document"; PostedRecord: Variant; PostedDocumentNo: Code[20]; DocumentType: Enum "E-Document Type")
+    begin
+    end;
 }


### PR DESCRIPTION
This pull request does not have a related issue as it's part of the delivery for development agreed directly with @altotovi @Groenbech96

**Implementation**

These integration events are required for the Enforced Digital Vouchers app to subscribe to E-Document processing and attach digital voucher records at the correct points in the document lifecycle.

**Events added**

OnExportEDocumentAfterCreateEDocument in EDocExport.Codeunit.al — Raised after the e-document content has been generated and the success status determined, but before the service status is logged. This placement allows the Digital Vouchers subscriber to access the finalized document blob (TempBlob) and the mapped source document records, which are needed to create and associate a digital voucher with the exported e-document.

OnAfterUpdateToPostedPurchaseEDocument in EDocumentSubscribers.Codeunit.al — Raised after a received purchase e-document is updated to its posted state (document record ID, document number, type, and status are all set). This placement allows the Digital Vouchers subscriber to link the digital voucher to the final posted purchase document, since the posted document number and record ID are only available at this point.

> [!IMPORTANT]
> This Pull request related with  https://github.com/microsoft/ALAppExtensions/pull/29793

Fixes [AB#580350](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/580350)


