### PR TITLE
HighCharts Addin turboTreshhold changed from deafult 1000 to 5000

### DIFF
--- a/src/System Application/App/ControlAddIns/Resources/BusinessChart/js/BusinessChartAddIn.js
+++ b/src/System Application/App/ControlAddIns/Resources/BusinessChart/js/BusinessChartAddIn.js
@@ -445,6 +445,7 @@ function getSeries(chartData, xAxisType) {
       lineWidth: getSerieLineWidth(chartData, measure),
       marker: getSerieMarker(chartData, measure),
       name: measure,
+      turboThreshold: 5000,
       stack: stack,
       step: getSerieLineStep(chartData, measure),
       type: getSerieType(chartData, measure),

--- a/src/System Application/App/Resources/BusinessChart/js/BusinessChartAddIn.js
+++ b/src/System Application/App/Resources/BusinessChart/js/BusinessChartAddIn.js
@@ -445,6 +445,7 @@ function getSeries(chartData, xAxisType) {
       lineWidth: getSerieLineWidth(chartData, measure),
       marker: getSerieMarker(chartData, measure),
       name: measure,
+      turboThreshold: 5000,
       stack: stack,
       step: getSerieLineStep(chartData, measure),
       type: getSerieType(chartData, measure),


### PR DESCRIPTION
#### Summary 
HighCharts Addin didn't render if there were over 1000 datapoints. After testing performed by Christian Andersen the decision was to change the turboThreshold from the deafult 1000 to 5000. 

#### Work Item(s) 
Fixes [AB#547547](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/547547)



