### PR TITLE
[28.0] [Quality Mgmt.] aligning the Deletion UX of Qlty Test with standard BC: delete from c…

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTest.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTest.Table.al
@@ -366,7 +366,7 @@ table 20401 "Qlty. Test"
 
     trigger OnDelete()
     begin
-        CheckDeleteConstraints(false);
+        CheckDeleteConstraints(true);
     end;
 
     procedure CheckDeleteConstraints(AskQuestion: Boolean)

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
@@ -16,7 +16,6 @@ page 20479 "Qlty. Test Card"
     Caption = 'Quality Test';
     AboutTitle = 'About Quality Test details';
     AboutText = 'Use this page to define questions, measurements, allowed values, and default passing conditions. Add tests to templates to use them in quality inspections.';
-    DeleteAllowed = false;
     PageType = Card;
     SourceTable = "Qlty. Test";
     SourceTableView = sorting(Code);
@@ -545,32 +544,7 @@ page 20479 "Qlty. Test Card"
         }
     }
 
-    actions
-    {
-        area(Processing)
-        {
-            action(DeleteRecordSafe)
-            {
-                Caption = 'Delete';
-                Image = Delete;
-                ToolTip = 'Deletes this test. A test can only be deleted if it is not being used on an existing inspection.';
 
-                trigger OnAction()
-                begin
-                    Rec.CheckDeleteConstraints(true);
-                    Rec.Delete(true);
-                    CurrPage.Update(false);
-                end;
-            }
-        }
-
-        area(Promoted)
-        {
-            actionref(DeleteRecordSafe_Promoted; DeleteRecordSafe)
-            {
-            }
-        }
-    }
 
     var
         QltyResultConditionMgmt: Codeunit "Qlty. Result Condition Mgmt.";

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTests.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTests.Page.al
@@ -20,7 +20,6 @@ page 20401 "Qlty. Tests"
     CardPageId = "Qlty. Test Card";
     Editable = false;
     InsertAllowed = false;
-    DeleteAllowed = false;
     RefreshOnActivate = true;
     PageType = List;
     SourceTable = "Qlty. Test";
@@ -219,32 +218,7 @@ page 20401 "Qlty. Tests"
         }
     }
 
-    actions
-    {
-        area(Processing)
-        {
-            action(DeleteRecordSafe)
-            {
-                Caption = 'Delete';
-                Image = Delete;
-                Scope = Repeater;
-                ToolTip = 'Deletes this test. A test can only be deleted if it is not being used on an existing inspection.';
 
-                trigger OnAction()
-                begin
-                    Rec.CheckDeleteConstraints(true);
-                    Rec.Delete(true);
-                    CurrPage.Update(false);
-                end;
-            }
-        }
-        area(Promoted)
-        {
-            actionref(DeleteRecordSafe_Promoted; DeleteRecordSafe)
-            {
-            }
-        }
-    }
 
     var
         QltyResultConditionMgmt: Codeunit "Qlty. Result Condition Mgmt.";
@@ -270,10 +244,7 @@ page 20401 "Qlty. Tests"
     begin
     end;
 
-    trigger OnDeleteRecord(): Boolean
-    begin
-        Rec.CheckDeleteConstraints(true);
-    end;
+
 
     trigger OnAfterGetRecord()
     begin


### PR DESCRIPTION
Removed the custom delete actions from the list and card pages.
Allowed normal deletion from the list and card pages.
Moved the deletion checks to the source table's OnDelete trigger.

Fixes [AB#622622](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622622)


