### PR TITLE
[Shopify] Add "Incl. in Product Sync" field to Item Attribute Card

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Page Extensions/ShpfyItemAttributeCard.PageExt.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Page Extensions/ShpfyItemAttributeCard.PageExt.al
@@ -1,0 +1,33 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify;
+
+using Microsoft.Inventory.Item.Attribute;
+
+pageextension 30128 "Shpfy Item Attribute Card" extends "Item Attribute"
+{
+    layout
+    {
+        addlast(content)
+        {
+            field("Shpfy Incl. in Product Sync"; Rec."Shpfy Incl. in Product Sync")
+            {
+                ApplicationArea = All;
+                Visible = ShopifyEnabled;
+            }
+        }
+    }
+
+    var
+        ShopifyEnabled: Boolean;
+
+    trigger OnOpenPage()
+    var
+        ShopMgt: Codeunit "Shpfy Shop Mgt.";
+    begin
+        ShopifyEnabled := ShopMgt.IsEnabled();
+    end;
+}


### PR DESCRIPTION
## Summary
- The "Shpfy Incl. in Product Sync" field was visible on the Item Attributes list page but missing from the Item Attribute Card (page 7503)
- Added a new page extension (30128) for the Item Attribute Card with the same field and dynamic Shopify visibility

Fixes [AB#624264](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624264)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



