### PR TITLE
[Shopify] Populate Contact No. on customer change in Shopify Order

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyOrderMapping.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyOrderMapping.Codeunit.al
@@ -225,7 +225,7 @@ codeunit 30163 "Shpfy Order Mapping"
         exit(ShopifyOrderLine."Item No." <> '');
     end;
 
-    local procedure FindContactNo(ContactName: Text[100]; CustomerNo: Code[20]): Code[20]
+    internal procedure FindContactNo(ContactName: Text[100]; CustomerNo: Code[20]): Code[20]
     var
         Contact: Record Contact;
         ContactBusinessRelation: Record "Contact Business Relation";

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
@@ -62,6 +62,14 @@ page 30113 "Shpfy Order"
                     ShowMandatory = true;
                     ToolTip = 'Specifies the number of the customer who will buy the products.';
                 }
+                field(SellToContactNo; Rec."Sell-to Contact No.")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Sell-to Contact No.';
+                    Editable = false;
+                    Visible = false;
+                    ToolTip = 'Specifies the number of the contact person at the sell-to customer.';
+                }
                 field(ShippingMethod; Rec."Shipping Method Code")
                 {
                     ApplicationArea = All;
@@ -466,6 +474,14 @@ page 30113 "Shpfy Order"
                         Editable = false;
                         ToolTip = 'Specifies the name of the customer''s country/region';
                     }
+                    field(ShipToContactNo; Rec."Ship-to Contact No.")
+                    {
+                        ApplicationArea = All;
+                        Caption = 'Ship-to Contact No.';
+                        Editable = false;
+                        Visible = false;
+                        ToolTip = 'Specifies the number of the contact person at the ship-to address.';
+                    }
                 }
                 group(BillTo)
                 {
@@ -528,6 +544,14 @@ page 30113 "Shpfy Order"
                         Caption = 'Country Name';
                         Editable = false;
                         ToolTip = 'Specifies the name of the customer''s country/region.';
+                    }
+                    field(BillToContactNo; Rec."Bill-to Contact No.")
+                    {
+                        ApplicationArea = All;
+                        Caption = 'Bill-to Contact No.';
+                        Editable = false;
+                        Visible = false;
+                        ToolTip = 'Specifies the number of the contact person at the bill-to customer.';
                     }
                 }
             }

--- a/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderHeader.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderHeader.Table.al
@@ -736,6 +736,14 @@ table 30118 "Shpfy Order Header"
             Caption = 'Sell-to Customer No.';
             DataClassification = SystemMetadata;
             TableRelation = Customer;
+
+            trigger OnValidate()
+            var
+                OrderMapping: Codeunit "Shpfy Order Mapping";
+            begin
+                "Sell-to Contact No." := OrderMapping.FindContactNo("Sell-to Contact Name", "Sell-to Customer No.");
+                "Ship-to Contact No." := OrderMapping.FindContactNo("Ship-to Contact Name", "Sell-to Customer No.");
+            end;
         }
         field(1001; "Sales Order No."; Code[20])
         {
@@ -802,6 +810,13 @@ table 30118 "Shpfy Order Header"
             Caption = 'Bill-to Customer No.';
             DataClassification = CustomerContent;
             TableRelation = Customer;
+
+            trigger OnValidate()
+            var
+                OrderMapping: Codeunit "Shpfy Order Mapping";
+            begin
+                "Bill-to Contact No." := OrderMapping.FindContactNo("Bill-to Contact Name", "Bill-to Customer No.");
+            end;
         }
         field(1012; "Shipping Method Code"; Code[10])
         {
@@ -1018,4 +1033,5 @@ table 30118 "Shpfy Order Header"
         Shop.Get(Rec."Shop Code");
         exit(Shop."Currency Handling" = "Shpfy Currency Handling"::"Presentment Currency");
     end;
+
 }


### PR DESCRIPTION
## Summary
- Added `OnValidate` triggers on `Sell-to Customer No.` and `Bill-to Customer No.` fields in the Shopify Order Header table to automatically populate Contact No. fields when the customer is changed manually
- Made `FindContactNo` in `ShpfyOrderMapping` codeunit `internal` (was `local`) so it can be reused from the table triggers
- Added `Sell-to Contact No.`, `Bill-to Contact No.`, and `Ship-to Contact No.` fields to the Shopify Order page (hidden by default, available via personalization)

Fixes [AB#624380](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624380)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



