### PR TITLE
[Bug][SubscriptionBilling]: Customer cannot be changed on contract with closed subscription lines

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
@@ -1335,6 +1335,7 @@ table 8059 "Subscription Line"
         ServiceCommitment: Record "Subscription Line";
     begin
         ServiceCommitment.FilterOnContract(PartnerType, ContractNo);
+        ServiceCommitment.SetRange(Closed, false);
         if ServiceCommitment.FindSet() then
             repeat
 #pragma warning disable AA0214
@@ -1352,6 +1353,7 @@ table 8059 "Subscription Line"
         ServiceCommitment: Record "Subscription Line";
     begin
         ServiceCommitment.FilterOnContract(PartnerType, ContractNo);
+        ServiceCommitment.SetRange(Closed, false);
         UpdateCurrencyDataOnServiceCommitments(ServiceCommitment, CurrencyFactor, CurrencyFactorDate, CurrencyCode, true);
     end;
 

--- a/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractsTest.Codeunit.al
@@ -2049,6 +2049,44 @@ codeunit 148155 "Contracts Test"
         Assert.AreEqual(TestDesc, ServiceCommitment.Description, StrSubstNo(SubscLineDescErr, TestDesc));
     end;
 
+    [Test]
+    procedure ChangeSellToCustomerOnContractWithClosedSubscriptionLines()
+    var
+        Customer: Record Customer;
+        CustomerContract: Record "Customer Subscription Contract";
+        CustomerContractLine: Record "Cust. Sub. Contract Line";
+        NewCustomer: Record Customer;
+        ServiceCommitment: Record "Subscription Line";
+        ServiceObject: Record "Subscription Header";
+    begin
+        // [SCENARIO] Changing the Sell-to Customer on a contract that has closed subscription lines should succeed without error.
+        Initialize();
+
+        // [GIVEN] A customer contract with a service commitment linked to a contract line.
+        SetupServiceObjectForNewItemWithServiceCommitment(Customer, ServiceObject, false, false);
+        ContractTestLibrary.CreateCustomerContractAndCreateContractLinesForItems(CustomerContract, ServiceObject, Customer."No.");
+
+        // [GIVEN] The contract line and its subscription line are both marked as closed (as done by UpdateServiceCommitmentAndCloseCustomerContractLine).
+        CustomerContractLine.SetRange("Subscription Contract No.", CustomerContract."No.");
+        CustomerContractLine.SetRange("Contract Line Type", Enum::"Contract Line Type"::Item);
+        CustomerContractLine.FindFirst();
+        CustomerContractLine.GetServiceCommitment(ServiceCommitment);
+        ServiceCommitment.Closed := true;
+        ServiceCommitment.Modify(false);
+        CustomerContractLine.Closed := true;
+        CustomerContractLine.Modify(false);
+
+        // [GIVEN] A second customer to change the contract to.
+        ContractTestLibrary.CreateCustomerInLCY(NewCustomer);
+
+        // [WHEN] Changing the Sell-to Customer - should not throw an error even though closed subscription lines exist.
+        CustomerContract.SetHideValidationDialog(true);
+        CustomerContract.Validate("Sell-to Customer No.", NewCustomer."No.");
+
+        // [THEN] The customer is changed successfully.
+        CustomerContract.TestField("Sell-to Customer No.", NewCustomer."No.");
+    end;
+
     #endregion Tests
 
     #region Procedures


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This pull request improves the handling of closed subscription lines in the service commitments logic and adds a new test to ensure correct behavior when changing the Sell-to Customer on contracts with closed lines. The key changes are grouped below:

**Service Commitments Filtering:**

* Updated logic in `table 8059 "Subscription Line"` to filter out closed subscription lines by adding `SetRange(Closed, false)` in relevant methods, ensuring only open lines are considered in processing. [[1]](diffhunk://#diff-3cb00ad3638130f3ff01b7e27c36490d089869402ad9a45eb6c718be4d46f940R1338) [[2]](diffhunk://#diff-3cb00ad3638130f3ff01b7e27c36490d089869402ad9a45eb6c718be4d46f940R1356)

**Testing and Validation:**

* Added a new test `ChangeSellToCustomerOnContractWithClosedSubscriptionLines` in `codeunit 148155 "Contracts Test"` to verify that changing the Sell-to Customer on a contract with closed subscription lines does not result in errors, confirming the robustness of the new filtering logic.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #6970


Fixes [AB#624594](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624594)

