### PR TITLE
Move date assignment before FindPostedDocumentWithSameExternalDocNo

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
@@ -127,6 +127,10 @@ codeunit 6117 "E-Doc. Create Purchase Invoice" implements IEDocumentFinishDraft,
         PurchaseHeader."Document Type" := "Purchase Document Type"::Invoice;
         PurchaseHeader."Pay-to Vendor No." := EDocumentPurchaseHeader."[BC] Vendor No.";
         PurchaseHeader."Posting Description" := EDocumentPurchaseHeader."Posting Description";
+        if EDocumentPurchaseHeader."Document Date" <> 0D then
+            PurchaseHeader.Validate("Document Date", EDocumentPurchaseHeader."Document Date");
+        if EDocumentPurchaseHeader."Due Date" <> 0D then
+            PurchaseHeader.Validate("Due Date", EDocumentPurchaseHeader."Due Date");
 
         VendorInvoiceNo := CopyStr(EDocumentPurchaseHeader."Sales Invoice No.", 1, MaxStrLen(PurchaseHeader."Vendor Invoice No."));
         VendorLedgerEntry.SetLoadFields("Entry No.");
@@ -137,10 +141,6 @@ codeunit 6117 "E-Doc. Create Purchase Invoice" implements IEDocumentFinishDraft,
             Error(InvoiceAlreadyExistsErr, VendorInvoiceNo, EDocumentPurchaseHeader."[BC] Vendor No.");
         end;
 
-        if EDocumentPurchaseHeader."Document Date" <> 0D then
-            PurchaseHeader.Validate("Document Date", EDocumentPurchaseHeader."Document Date");
-        if EDocumentPurchaseHeader."Due Date" <> 0D then
-            PurchaseHeader.Validate("Due Date", EDocumentPurchaseHeader."Due Date");
         PurchaseHeader.Validate("Vendor Invoice No.", VendorInvoiceNo);
         PurchaseHeader.Insert(true);
 


### PR DESCRIPTION
## Summary
- Move the assignment of Document Date and Due Date before the explicit call to `FindPostedDocumentWithSameExternalDocNo` in `EDocCreatePurchaseInvoice`
- In ES localization, the date is needed to perform the duplicate invoice validation, so it must be set before that check runs

Fixes [AB#624573](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624573)

