### PR TITLE
Fix accessibility bug: iframe rendered by WebPageViewer is missing accessible name

### DIFF
--- a/src/System Application/App/ControlAddIns/Resources/WebPageViewer/js/WebPageViewerHelper.js
+++ b/src/System Application/App/ControlAddIns/Resources/WebPageViewer/js/WebPageViewerHelper.js
@@ -46,6 +46,7 @@ var WebPageViewerHelper = {
       iframe.setAttribute('width', width);
       iframe.setAttribute('frameBorder', '0');
       iframe.setAttribute('seamless', 'seamless');
+      iframe.setAttribute('role', 'presentation');
   
       return iframe;
     },

--- a/src/System Application/App/Resources/WebPageViewer/js/WebPageViewerHelper.js
+++ b/src/System Application/App/Resources/WebPageViewer/js/WebPageViewerHelper.js
@@ -46,6 +46,7 @@ var WebPageViewerHelper = {
       iframe.setAttribute('width', width);
       iframe.setAttribute('frameBorder', '0');
       iframe.setAttribute('seamless', 'seamless');
+      iframe.setAttribute('role', 'presentation');
   
       return iframe;
     },


### PR DESCRIPTION
#### Summary 
Accessibility Insights FastPass reports the following issue for the iframe rendered by WebPageViewer:
<img width="497" height="58" alt="image" src="https://github.com/user-attachments/assets/843e57c1-8c6b-474e-a4ab-15ef1f1ab1be" />

We set `role="presentation"` on the iframe for script control addins, but this addin renders a second iframe inside and we don't set `role="presentation"` on it. Fix that.

#### Work Item
Fixes [AB#611591](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611591)

