### PR TITLE
[Shopify] Disable Get Data action when no bulk operation data URL is available

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Bulk Operations/Pages/ShpfyBulkOperations.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Bulk Operations/Pages/ShpfyBulkOperations.Page.al
@@ -71,6 +71,7 @@ page 30152 "Shpfy Bulk Operations"
             {
                 ApplicationArea = All;
                 Caption = 'Get Data';
+                Enabled = HasDataUrl;
                 Image = Download;
                 Promoted = true;
                 PromotedCategory = Process;
@@ -135,6 +136,7 @@ page 30152 "Shpfy Bulk Operations"
     }
 
     var
+        HasDataUrl: Boolean;
         CurrentStatus: Text;
         InProgressLbl: Label 'In Progress';
         ErrorLbl: Label 'Error';
@@ -142,6 +144,7 @@ page 30152 "Shpfy Bulk Operations"
 
     trigger OnAfterGetRecord()
     begin
+        HasDataUrl := (Rec.Url <> '') or (Rec."Partial Data Url" <> '');
         if Rec.Status in [Rec.Status::Created, Rec.Status::Running, Rec.Status::Canceled] then
             CurrentStatus := InProgressLbl;
         if Rec.Status in [Rec.Status::Canceled, Rec.Status::Failed, Rec.Status::Expired] then


### PR DESCRIPTION
## Summary
- Disables the "Get Data" action on the Shopify Bulk Operations page when neither `Url` nor `Partial Data Url` is populated on the selected bulk operation
- Prevents an empty/blank message dialog from being shown to the user

Fixes [AB#624674](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624674)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

