### PR TITLE
[Shopify] Fix currency formatting in Order Totals factbox for LCY orders

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrderTotalsFactBox.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrderTotalsFactBox.Page.al
@@ -171,7 +171,7 @@ page 30172 "Shpfy Order Totals FactBox"
                 field(TotalAmountExclVAT; TotalSalesLine.Amount)
                 {
                     ApplicationArea = All;
-                    AutoFormatExpression = CurrencyCode;
+                    AutoFormatExpression = SalesHeader."Currency Code";
                     AutoFormatType = 1;
                     CaptionClass = DocumentTotals.GetTotalExclVATCaption(CurrencyCode);
                     Caption = 'Total Amount Excl. VAT';
@@ -180,7 +180,7 @@ page 30172 "Shpfy Order Totals FactBox"
                 field("Total VAT Amount"; VATAmount)
                 {
                     ApplicationArea = All;
-                    AutoFormatExpression = CurrencyCode;
+                    AutoFormatExpression = SalesHeader."Currency Code";
                     AutoFormatType = 1;
                     CaptionClass = DocumentTotals.GetTotalVATCaption(CurrencyCode);
                     Caption = 'Total VAT';
@@ -189,7 +189,7 @@ page 30172 "Shpfy Order Totals FactBox"
                 field("Total Amount Incl. VAT"; TotalSalesLine."Amount Including VAT")
                 {
                     ApplicationArea = All;
-                    AutoFormatExpression = CurrencyCode;
+                    AutoFormatExpression = SalesHeader."Currency Code";
                     AutoFormatType = 1;
                     CaptionClass = DocumentTotals.GetTotalInclVATCaption(CurrencyCode);
                     Caption = 'Total Amount Incl. VAT';


### PR DESCRIPTION
## Summary
- Fixed the Order Totals factbox showing wrong currency symbol (e.g., "kr" instead of "$") for sales document amounts when the order currency matches the Local Currency (LCY)
- The `AutoFormatExpression` in the Sales Document section was using a resolved `CurrencyCode` variable (set to the LCY Code like `'USD'`), but BC's AutoFormat expects blank for LCY currencies. When it couldn't find a Currency record for the LCY code, it fell back to locale-based formatting.
- Changed to use `SalesHeader."Currency Code"` which preserves the blank convention for LCY, while keeping the resolved code in `CaptionClass` for correct caption display

Fixes [AB#624646](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624646)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


