### PR TITLE
[28.x][Subscription Billing]Vendor Subscription Price Update Errors - G/L Account Purchase Price Not Updating – Computed Price ≤ 0

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Base/Codeunits/SubContractsItemManagement.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Base/Codeunits/SubContractsItemManagement.Codeunit.al
@@ -213,6 +213,65 @@ codeunit 8055 "Sub. Contracts Item Management"
         exit(Item."Unit Cost");
     end;
 
+    internal procedure CreateTempPurchaseHeader(var TempPurchaseHeader: Record "Purchase Header" temporary; DocumentType: Enum "Purchase Document Type"; PayToVendorNo: Code[20]; OrderDate: Date; CurrencyCode: Code[10])
+    begin
+        TempPurchaseHeader.SetHideValidationDialog(true);
+        TempPurchaseHeader.Init();
+        TempPurchaseHeader.Validate("Document Type", DocumentType);
+        TempPurchaseHeader.Validate(Status, TempPurchaseHeader.Status::Open);
+        TempPurchaseHeader.InitRecord();
+        if PayToVendorNo <> '' then
+            TempPurchaseHeader.Validate("Pay-to Vendor No.", PayToVendorNo);
+        TempPurchaseHeader.Validate("Currency Code", CurrencyCode);
+        TempPurchaseHeader."Order Date" := OrderDate;
+    end;
+
+    internal procedure CreateTempPurchaseLine(var TempPurchaseLine: Record "Purchase Line" temporary; var TempPurchaseHeader: Record "Purchase Header" temporary; ServiceObject: Record "Subscription Header"; OrderDate: Date)
+    begin
+        CreateTempPurchaseLine(TempPurchaseLine, TempPurchaseHeader, ServiceObject.Type, ServiceObject."Source No.", ServiceObject.Quantity, OrderDate);
+    end;
+
+    local procedure CreateTempPurchaseLine(var TempPurchaseLine: Record "Purchase Line" temporary; var TempPurchaseHeader: Record "Purchase Header" temporary; ServiceObjectType: enum "Service Object Type"; SourceNo: Code[20]; Quantity: Decimal; OrderDate: Date)
+    begin
+        CreateTempPurchaseLine(TempPurchaseLine, TempPurchaseHeader, ServiceObjectType, SourceNo, Quantity, OrderDate, '');
+    end;
+
+    internal procedure CreateTempPurchaseLine(var TempPurchaseLine: Record "Purchase Line" temporary; var TempPurchaseHeader: Record "Purchase Header" temporary; ServiceObjectType: enum "Service Object Type"; SourceNo: Code[20]; Quantity: Decimal; OrderDate: Date; VariantCode: Code[10])
+    begin
+        TempPurchaseLine.Init();
+        TempPurchaseLine.SuspendStatusCheck(true);
+        TempPurchaseLine.Validate("Document Type", TempPurchaseHeader."Document Type");
+        TempPurchaseLine."Document No." := TempPurchaseHeader."No.";
+        case ServiceObjectType of
+            ServiceObjectType::Item:
+                TempPurchaseLine.Type := TempPurchaseLine.Type::Item;
+            ServiceObjectType::"G/L Account":
+                TempPurchaseLine.Type := TempPurchaseLine.Type::"G/L Account";
+        end;
+        TempPurchaseLine."Pay-to Vendor No." := TempPurchaseHeader."Pay-to Vendor No.";
+        TempPurchaseLine."Buy-from Vendor No." := TempPurchaseHeader."Buy-from Vendor No.";
+        TempPurchaseLine."VAT Bus. Posting Group" := TempPurchaseHeader."VAT Bus. Posting Group";
+        TempPurchaseLine."No." := SourceNo;
+        TempPurchaseLine.Quantity := Quantity;
+        TempPurchaseLine."Currency Code" := TempPurchaseHeader."Currency Code";
+        if OrderDate <> 0D then
+            TempPurchaseLine."Expected Receipt Date" := OrderDate;
+    end;
+
+    procedure CalculateDirectUnitCost(var TempPurchaseHeader: Record "Purchase Header" temporary; var TempPurchaseLine: Record "Purchase Line" temporary): Decimal
+    var
+        PriceCalculation: Interface "Price Calculation";
+        Line: Variant;
+    begin
+        TempPurchaseLine.GetPriceCalculationHandler(TempPurchaseHeader, PriceCalculation);
+        PriceCalculation.ApplyDiscount();
+        PriceCalculation.ApplyPrice(TempPurchaseLine.FieldNo("No."));
+        PriceCalculation.GetLine(Line);
+        TempPurchaseLine := Line;
+
+        exit(TempPurchaseLine."Direct Unit Cost");
+    end;
+
     [EventSubscriber(ObjectType::Table, Database::"Price List Line", OnAfterValidateEvent, "Allow Invoice Disc.", false, false)]
     local procedure ErrorIfAllowInvoiceDiscountForPriceListLineForServiceCommitmentItem(var Rec: Record "Price List Line")
     var

--- a/src/Apps/W1/Subscription Billing/App/Contract Price Update/Tables/SubContrPriceUpdateLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Contract Price Update/Tables/SubContrPriceUpdateLine.Table.al
@@ -1,6 +1,7 @@
 namespace Microsoft.SubscriptionBilling;
 
 using Microsoft.Finance.Currency;
+using Microsoft.Purchases.Document;
 using Microsoft.Sales.Document;
 
 table 8004 "Sub. Contr. Price Update Line"
@@ -258,6 +259,8 @@ table 8004 "Sub. Contr. Price Update Line"
     internal procedure CalculateNewCalculationBaseAmount()
     var
         ServiceObject: Record "Subscription Header";
+        TempPurchaseHeader: Record "Purchase Header" temporary;
+        TempPurchaseLine: Record "Purchase Line" temporary;
         TempSalesHeader: Record "Sales Header" temporary;
         TempSalesLine: Record "Sales Line" temporary;
         ContractsItemManagement: Codeunit "Sub. Contracts Item Management";
@@ -273,6 +276,11 @@ table 8004 "Sub. Contr. Price Update Line"
             "Service Partner"::Vendor:
                 if ServiceObject.IsItem() then
                     Rec."New Calculation Base" := ContractsItemManagement.CalculateUnitCost(ServiceObject."Source No.");
+            else begin
+                ContractsItemManagement.CreateTempPurchaseHeader(TempPurchaseHeader, TempPurchaseHeader."Document Type"::Order, Rec."Partner No.", Rec."Perform Update On", Rec."Currency Code");
+                ContractsItemManagement.CreateTempPurchaseLine(TempPurchaseLine, TempPurchaseHeader, ServiceObject, Rec."Perform Update On");
+                Rec."New Calculation Base" := ContractsItemManagement.CalculateDirectUnitCost(TempPurchaseHeader, TempPurchaseLine);
+            end;
         end;
     end;
 

--- a/src/Apps/W1/Subscription Billing/Test/Contract Price Update/ContractPriceProposalTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Contract Price Update/ContractPriceProposalTest.Codeunit.al
@@ -1,7 +1,11 @@
 namespace Microsoft.SubscriptionBilling;
 
 using Microsoft.Finance.Currency;
+using Microsoft.Finance.GeneralLedger.Account;
 using Microsoft.Inventory.Item;
+using Microsoft.Pricing.Asset;
+using Microsoft.Pricing.PriceList;
+using Microsoft.Pricing.Source;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
 using Microsoft.Purchases.Vendor;
@@ -26,6 +30,7 @@ codeunit 139690 "Contract Price Proposal Test"
         Currency: Record Currency;
         Customer: Record Customer;
         Customer2: Record Customer;
+        GLAccount: Record "G/L Account";
         Item: Record Item;
         PriceUpdateTemplateCustomer: Record "Price Update Template";
         PriceUpdateTemplateVendor: Record "Price Update Template";
@@ -39,6 +44,7 @@ codeunit 139690 "Contract Price Proposal Test"
         Assert: Codeunit Assert;
         ContractTestLibrary: Codeunit "Contract Test Library";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
+        LibraryPriceCalculation: Codeunit "Library - Price Calculation";
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryRandom: Codeunit "Library - Random";
         LibrarySales: Codeunit "Library - Sales";
@@ -668,6 +674,36 @@ codeunit 139690 "Contract Price Proposal Test"
         Assert.AreEqual(ServiceCommitment."Next Price Update", ContractPriceUpdateLine."Perform Update On", 'UpdatePerformUpdateOn did not return correct value');
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandlerYes')]
+    procedure CreateVendorGLAccountPriceUpdateProposalRecentItemPrices()
+    var
+        PriceListHeader: Record "Price List Header";
+        PriceListLine: Record "Price List Line";
+        VendorContract: Record "Vendor Subscription Contract";
+    begin
+        // [SCENARIO 622207] Verify that a price update proposal line is created for a vendor contract with a G/L Account service commitment using Recent Item Prices.
+        Initialize();
+
+        // [GIVEN] Create a vendor in LCY with a G/L Account service commitment in a vendor contract
+        SetupVendorGLAccountContractForPriceUpdate(VendorContract);
+
+        // [GIVEN] Create an active All Vendors purchase price list with a direct unit cost for G/L Account
+        LibraryPriceCalculation.CreatePriceHeader(PriceListHeader, "Price Type"::Purchase, "Price Source Type"::"All Vendors", '');
+        LibraryPriceCalculation.CreatePurchPriceLine(PriceListLine, PriceListHeader.Code, "Price Source Type"::"All Vendors", '', "Price Asset Type"::"G/L Account", GLAccount."No.");
+        PriceListHeader.Validate(Status, PriceListHeader.Status::Active);
+        PriceListHeader.Modify(true);
+
+        // [WHEN] Create a price update proposal with Recent Item Prices method.
+        ContractTestLibrary.CreatePriceUpdateTemplate(PriceUpdateTemplateVendor, "Service Partner"::Vendor, "Price Update Method"::"Recent Item Prices", 0, '<12M>', '<12M>', '<12M>');
+        PriceUpdateManagement.CreatePriceUpdateProposal(PriceUpdateTemplateVendor.Code, CalcDate(PriceUpdateTemplateVendor.InclContrLinesUpToDateFormula, WorkDate()), WorkDate());
+
+        // [THEN] Verify a price update line is created with New Calculation Base matching the G/L Account purchase price.
+        ContractPriceUpdateLine.SetRange("Price Update Template Code", PriceUpdateTemplateVendor.Code);
+        Assert.RecordIsNotEmpty(ContractPriceUpdateLine);
+        ContractPriceUpdateLine.FindFirst();
+        Assert.AreEqual(PriceListLine."Direct Unit Cost", ContractPriceUpdateLine."New Calculation Base", 'New Calculation Base must equal the purchase price of the G/L Account');
+    end;
     #endregion Tests
 
     #region Procedures
@@ -864,6 +900,16 @@ codeunit 139690 "Contract Price Proposal Test"
             until ServiceCommitment.Next() = 0;
     end;
 
+    local procedure SetupVendorGLAccountContractForPriceUpdate(var VendorContract: Record "Vendor Subscription Contract")
+    var
+        VendorContractLine: Record "Vend. Sub. Contract Line";
+    begin
+        ContractTestLibrary.CreateVendorInLCY(Vendor);
+        ContractTestLibrary.CreateVendorContract(VendorContract, Vendor."No.");
+        ContractTestLibrary.InsertVendorContractGLAccountLine(VendorContract, VendorContractLine);
+        GLAccount.Get(VendorContractLine."No.");
+    end;
+
     #endregion Procedures
 
     #region Handlers
@@ -895,6 +941,12 @@ codeunit 139690 "Contract Price Proposal Test"
     procedure StrMenuHandler(Option: Text[1024]; var Choice: Integer; Instruction: Text[1024])
     begin
         Choice := LibraryVariableStorage.DequeueInteger();
+    end;
+
+    [ConfirmHandler]
+    procedure ConfirmHandlerYes(Question: Text[1024]; var Reply: Boolean)
+    begin
+        Reply := true;
     end;
 
     #endregion Handlers


### PR DESCRIPTION
[AB#624704](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624704)

Workitem :

[Bug 624704](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/624704): [28.x][all-e][Subscription Billing]Vendor Subscription Price Update Errors - G/L Account Purchase Price Not Updating – Computed Price ≤ 0


