### PR TITLE
Wrap E-Document participation field in group on Company Information page

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocCompanyInformation.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocCompanyInformation.PageExt.al
@@ -18,19 +18,24 @@ pageextension 6165 "E-Doc. Company Information" extends "Company Information"
     {
         addafter(GLN)
         {
-            field("E-Document Service Participation Ids"; ParticipantIdCount)
+            group(ElectronicDocumentServiceGroup)
             {
-                ApplicationArea = All;
-                Caption = 'E-Document Service Participation';
-                DrillDown = true;
-                Editable = false;
-                ToolTip = 'Specifies the company participation for the E-Document services.';
+                ShowCaption = false;
                 Visible = EDocumentServiceExists;
 
-                trigger OnDrillDown()
-                begin
-                    ServiceParticipant.RunServiceParticipantPage(Enum::"E-Document Source Type"::Company, '');
-                end;
+                field("E-Document Service Participation Ids"; ParticipantIdCount)
+                {
+                    ApplicationArea = All;
+                    Caption = 'E-Document Service Participation';
+                    DrillDown = true;
+                    Editable = false;
+                    ToolTip = 'Specifies the company participation for the E-Document services.';
+
+                    trigger OnDrillDown()
+                    begin
+                        ServiceParticipant.RunServiceParticipantPage(Enum::"E-Document Source Type"::Company, '');
+                    end;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Wrap the E-Document Service Participation field in a group (`ElectronicDocumentServiceGroup`) on the Company Information page extension
- Move the `Visible` property from the field to the group level so the entire section is hidden when no E-Document service exists
- Set `ShowCaption = false` on the group to preserve the existing visual layout

## Test plan
- [x] Open the Company Information page with an E-Document service configured and verify the participation field is visible
- [x] Open the Company Information page without any E-Document service and verify the field/group is hidden
- [x] Verify drill-down on the participation field still opens the Service Participant page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AB#624743](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624743)




