### PR TITLE
[Bug][SubscriptionBilling]: Customer cannot be changed on contract with closed subscription lines

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
@@ -880,7 +880,7 @@ table 8059 "Subscription Line"
         OnAfterCalculateServiceAmount(Rec, CalledByFieldNo);
     end;
 
-    local procedure SetUpdateRequiredOnBillingLines()
+    internal procedure SetUpdateRequiredOnBillingLines()
     var
         BillingLine: Record "Billing Line";
     begin
@@ -1339,7 +1339,9 @@ table 8059 "Subscription Line"
             repeat
 #pragma warning disable AA0214
                 ServiceCommitment.ResetAmountsAndCurrencyFromLCY();
-                ServiceCommitment.Modify(true);
+                ServiceCommitment.SetUpdateRequiredOnBillingLines();
+                ServiceCommitment.ArchiveServiceCommitment();
+                ServiceCommitment.Modify(false);
 #pragma warning restore AA0214
             until ServiceCommitment.Next() = 0;
     end;
@@ -1363,7 +1365,9 @@ table 8059 "Subscription Line"
                     CurrencyCode := ServiceCommitment."Currency Code";
                 ServiceCommitment.SetCurrencyData(CurrencyFactor, CurrencyFactorDate, CurrencyCode);
                 ServiceCommitment.RecalculateAmountsFromCurrencyData();
-                ServiceCommitment.Modify(true);
+                ServiceCommitment.SetUpdateRequiredOnBillingLines();
+                ServiceCommitment.ArchiveServiceCommitment();
+                ServiceCommitment.Modify(false);
             until ServiceCommitment.Next() = 0;
     end;
 

--- a/src/Apps/W1/Subscription Billing/App/Service Objects/Tables/SubscriptionHeader.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Objects/Tables/SubscriptionHeader.Table.al
@@ -1909,9 +1909,10 @@ table 8057 "Subscription Header"
                     if FieldCaption(Quantity) <> ChangedFieldName then
                         ServiceCommitment.CalculateCalculationBaseAmount();
                     ServiceCommitment.Validate("Calculation Base Amount");
-                    if SkipArchiving then
-                        ServiceCommitment.SetSkipArchiving(true);
-                    ServiceCommitment.Modify(true);
+                    ServiceCommitment.SetUpdateRequiredOnBillingLines();
+                    if not SkipArchiving then
+                        ServiceCommitment.ArchiveServiceCommitment();
+                    ServiceCommitment.Modify(false);
                 until ServiceCommitment.Next() = 0;
         end else
             if (not Confirmed) and (FieldCaption("Variant Code") = ChangedFieldName) then

--- a/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractsTest.Codeunit.al
@@ -2049,6 +2049,44 @@ codeunit 148155 "Contracts Test"
         Assert.AreEqual(TestDesc, ServiceCommitment.Description, StrSubstNo(SubscLineDescErr, TestDesc));
     end;
 
+    [Test]
+    procedure ChangeSellToCustomerOnContractWithClosedSubscriptionLines()
+    var
+        Customer: Record Customer;
+        CustomerContract: Record "Customer Subscription Contract";
+        CustomerContractLine: Record "Cust. Sub. Contract Line";
+        NewCustomer: Record Customer;
+        ServiceCommitment: Record "Subscription Line";
+        ServiceObject: Record "Subscription Header";
+    begin
+        // [SCENARIO] Changing the Sell-to Customer on a contract that has closed subscription lines should succeed without error.
+        Initialize();
+
+        // [GIVEN] A customer contract with a service commitment linked to a contract line.
+        SetupServiceObjectForNewItemWithServiceCommitment(Customer, ServiceObject, false, false);
+        ContractTestLibrary.CreateCustomerContractAndCreateContractLinesForItems(CustomerContract, ServiceObject, Customer."No.");
+
+        // [GIVEN] The contract line and its subscription line are both marked as closed (as done by UpdateServiceCommitmentAndCloseCustomerContractLine).
+        CustomerContractLine.SetRange("Subscription Contract No.", CustomerContract."No.");
+        CustomerContractLine.SetRange("Contract Line Type", Enum::"Contract Line Type"::Item);
+        CustomerContractLine.FindFirst();
+        CustomerContractLine.GetServiceCommitment(ServiceCommitment);
+        ServiceCommitment.Closed := true;
+        ServiceCommitment.Modify(false);
+        CustomerContractLine.Closed := true;
+        CustomerContractLine.Modify(false);
+
+        // [GIVEN] A second customer to change the contract to.
+        ContractTestLibrary.CreateCustomerInLCY(NewCustomer);
+
+        // [WHEN] Changing the Sell-to Customer - should not throw an error even though closed subscription lines exist.
+        CustomerContract.SetHideValidationDialog(true);
+        CustomerContract.Validate("Sell-to Customer No.", NewCustomer."No.");
+
+        // [THEN] The customer is changed successfully.
+        CustomerContract.TestField("Sell-to Customer No.", NewCustomer."No.");
+    end;
+
     #endregion Tests
 
     #region Procedures


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This pull request introduces several important changes to the handling of service commitments and subscription lines, focusing on improving update and archiving logic, as well as adding a new test to ensure correct behavior when changing the sell-to customer on contracts with closed lines. The main changes are grouped below:

**Service Commitment Update and Archiving Logic Improvements:**

* Changed the `SetUpdateRequiredOnBillingLines` procedure in `Subscription Line` from `local` to `internal` to allow external access.
* Updated logic in multiple places to call `SetUpdateRequiredOnBillingLines()` and `ArchiveServiceCommitment()` before modifying service commitments, and switched `Modify(true)` calls to `Modify(false)` to ensure proper update and archiving sequencing. [[1]](diffhunk://#diff-3cb00ad3638130f3ff01b7e27c36490d089869402ad9a45eb6c718be4d46f940L1342-R1344) [[2]](diffhunk://#diff-3cb00ad3638130f3ff01b7e27c36490d089869402ad9a45eb6c718be4d46f940L1366-R1370) [[3]](diffhunk://#diff-89ec9f968eb6c7c3a5e0923cb0bfa8ef1f32c9e26ea140a482b5573bafef4713L1912-R1915)

**Testing Enhancements:**

* Added a new test `ChangeSellToCustomerOnContractWithClosedSubscriptionLines` to verify that changing the sell-to customer on a contract with closed subscription lines does not result in an error, ensuring robustness in contract updates.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #6970
Fixes [AB#624594](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624594)
