### PR TITLE
[Bug][SubscriptionBilling]Usage Data Billing unit price calculation allows custom pricing logic

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
@@ -1830,7 +1830,7 @@ table 8059 "Subscription Line"
         Page.RunModal(Page::"Usage Data Billing Metadata", UsageDataBillingMetadata);
     end;
 
-    internal procedure UnitPriceForPeriod(ChargePeriodStart: Date; ChargePeriodEnd: Date) UnitPrice: Decimal
+    procedure UnitPriceForPeriod(ChargePeriodStart: Date; ChargePeriodEnd: Date) UnitPrice: Decimal
     var
         UnitCost: Decimal;
         UnitCostLCY: Decimal;

--- a/src/Apps/W1/Subscription Billing/App/Service Objects/Tables/SubscriptionHeader.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Objects/Tables/SubscriptionHeader.Table.al
@@ -1727,7 +1727,7 @@ table 8057 "Subscription Header"
             exit(true);
     end;
 
-    internal procedure InsertServiceCommitmentsFromStandardServCommPackages()
+    procedure InsertServiceCommitmentsFromStandardServCommPackages()
     begin
         if SkipInsertServiceCommitments then
             exit;
@@ -1735,7 +1735,7 @@ table 8057 "Subscription Header"
         InsertServiceCommitmentsFromStandardServCommPackages(0D)
     end;
 
-    internal procedure InsertServiceCommitmentsFromStandardServCommPackages(ServiceAndCalculationStartDate: Date)
+    procedure InsertServiceCommitmentsFromStandardServCommPackages(ServiceAndCalculationStartDate: Date)
     var
         ItemServCommitmentPackage: Record "Item Subscription Package";
         ServiceCommitmentPackage: Record "Subscription Package";

--- a/src/Apps/W1/Subscription Billing/App/Usage Based Billing/Codeunits/ProcessUsageDataBilling.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Usage Based Billing/Codeunits/ProcessUsageDataBilling.Codeunit.al
@@ -311,7 +311,9 @@ codeunit 8026 "Process Usage Data Billing"
             Amount := 0;
             exit;
         end;
+        OnBeforeCalculateUsageDataUnitPriceForPeriod(UnitPrice, ServiceCommitment, UsageDataBilling);
         UnitPrice := ServiceCommitment.UnitPriceForPeriod(UsageDataBilling."Charge Start Date", UsageDataBilling."Charge End Date");
+        OnAfterCalculateUsageDataUnitPriceForPeriod(UnitPrice, ServiceCommitment, UsageDataBilling);
         Amount := UnitPrice * Quantity;
     end;
 
@@ -371,9 +373,34 @@ codeunit 8026 "Process Usage Data Billing"
     begin
     end;
 
-
     [IntegrationEvent(false, false)]
     local procedure OnAfterProcessSubscriptionLine(var SubscriptionLine: Record "Subscription Line")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before UnitPriceForPeriod is called in CalculateUsageDataPrices.
+    /// Passes the UnitPrice that was calculated prior to the period scaling (for example, a tier-calculated
+    /// per-unit price from GetSalesPriceForItem). Subscribers can observe this value and store it for later use.
+    /// No code is skipped - UnitPriceForPeriod always runs after this event.
+    /// </summary>
+    /// <param name="UnitPrice">The unit price before period scaling (read-only for subscribers).</param>
+    /// <param name="ServiceCommitment">The subscription line for the current billing.</param>
+    /// <param name="UsageDataBilling">The usage data billing record for the current period.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCalculateUsageDataUnitPriceForPeriod(UnitPrice: Decimal; var ServiceCommitment: Record "Subscription Line"; var UsageDataBilling: Record "Usage Data Billing")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised after the unit price for the billing period has been calculated via UnitPriceForPeriod.
+    /// Subscribers can override UnitPrice with a custom value (for example, a price from a different source or price list).
+    /// </summary>
+    /// <param name="UnitPrice">The calculated unit price for the period. Subscribers can override this value.</param>
+    /// <param name="ServiceCommitment">The subscription line for the current billing.</param>
+    /// <param name="UsageDataBilling">The usage data billing record for the current period.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterCalculateUsageDataUnitPriceForPeriod(var UnitPrice: Decimal; var ServiceCommitment: Record "Subscription Line"; var UsageDataBilling: Record "Usage Data Billing")
     begin
     end;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Allows the possibility, for Usage Based Billing, to implement custom pricing model or alternative logic for determining the Unit price.
**OnBeforeCalculateUsageDataUnitPriceForPeriod** integration event where subscribers can observe this value and store it for later use.
**OnAfterCalculateUsageDataUnitPriceForPeriod** integration event allowing subscribers to override it with a custom value.

And setting additional procedures from internal to public to be accessible for ISV.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #7063


Fixes [AB#625941](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625941)
