### PR TITLE
Add OnInstallAppPerCompany trigger to PEPPOL30 Initialize (28.x backport)

### DIFF
--- a/src/Apps/W1/PEPPOL/App/src/Install/PEPPOL30Initialize.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Install/PEPPOL30Initialize.Codeunit.al
@@ -13,6 +13,11 @@ codeunit 37204 "PEPPOL30 Initialize"
     InherentPermissions = X;
     Access = Internal;
 
+    trigger OnInstallAppPerCompany()
+    begin
+        CreateElectronicDocumentFormats();
+    end;
+
     internal procedure CreateElectronicDocumentFormats()
     var
         ElectronicDocumentFormat: Record "Electronic Document Format";


### PR DESCRIPTION
## Summary
- Backport to 28.x: The PEPPOL30 Initialize codeunit was missing the `OnInstallAppPerCompany` install trigger, so electronic document formats were never created when the PEPPOL extension was installed.
- Adds the trigger that calls `CreateElectronicDocumentFormats()`.

[AB#624762](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624762)

## Test plan
- [ ] Install the PEPPOL extension on a clean company and verify PEPPOL BIS3 electronic document formats are created automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

