### PR TITLE
[Bug][SubscriptionBilling]Apply customer/vendor "Format Region" when creating document lines for 28.x

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/CreateBillingDocuments.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/CreateBillingDocuments.Codeunit.al
@@ -4,6 +4,7 @@ using Microsoft.Inventory.Item;
 using Microsoft.Purchases.Document;
 using Microsoft.Sales.Document;
 using Microsoft.Sales.Posting;
+using System.Globalization;
 using System.IO;
 using System.Utilities;
 
@@ -376,8 +377,11 @@ codeunit 8060 "Create Billing Documents"
 
         OnBeforeInsertPurchaseLineFromContractLine(PurchaseLine, TempBillingLine);
         PurchaseLine.Insert(false);
+
+        Language.SetOverrideFormatRegion(Language.GetFormatRegionOrDefault(PurchaseHeader."Format Region"), false);
         InsertDescriptionPurchaseLine(
              StrSubstNo(GetBillingPeriodDescriptionTxt(PurchaseHeader."Language Code"), PurchaseLine."Recurring Billing from", PurchaseLine."Recurring Billing to"), PurchaseLine."Line No.");
+        Language.SetOverrideFormatRegion('', false);
 
         if CreateContractInvoice then
             BillingLine.SetRange("Billing Template Code", '');
@@ -1164,10 +1168,14 @@ codeunit 8060 "Create Billing Documents"
                 if ServiceObject."Serial No." <> '' then
                     DescriptionText := ServiceObject.GetSerialNoDescription();
             ContractInvoiceTextType::"Billing Period":
-                DescriptionText := StrSubstNo(
-                                                GetBillingPeriodDescriptionTxt(),
-                                                ParentSalesLine."Recurring Billing from",
-                                                ParentSalesLine."Recurring Billing to");
+                begin
+                    Language.SetOverrideFormatRegion(Language.GetFormatRegionOrDefault(SalesHeader."Format Region"), false);
+                    DescriptionText := StrSubstNo(
+                                                    GetBillingPeriodDescriptionTxt(),
+                                                    ParentSalesLine."Recurring Billing from",
+                                                    ParentSalesLine."Recurring Billing to");
+                    Language.SetOverrideFormatRegion('', false);
+                end;
             ContractInvoiceTextType::"Primary attribute":
                 DescriptionText := ServiceObject.GetPrimaryAttributeValue();
             else begin
@@ -1366,6 +1374,7 @@ codeunit 8060 "Create Billing Documents"
         ServiceContractSetup: Record "Subscription Contract Setup";
         TranslationHelper: Codeunit "Translation Helper";
         DocumentChangeManagement: Codeunit "Document Change Management";
+        Language: Codeunit Language;
         DocumentDate: Date;
         PostingDate: Date;
         CustomerRecurringBillingGrouping: Enum "Customer Rec. Billing Grouping";

--- a/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingDocsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingDocsTest.Codeunit.al
@@ -151,6 +151,130 @@ codeunit 139687 "Recurring Billing Docs Test"
     end;
 
     [Test]
+    [HandlerFunctions('CreateCustomerBillingDocsContractPageHandler,ExchangeRateSelectionModalPageHandler,MessageHandler')]
+    procedure CheckBillingPeriodDescriptionUsesDocumentFormatRegionForSalesDocuments()
+    var
+        Customer: Record Customer;
+        ServiceContractSetup: Record "Subscription Contract Setup";
+        CreateBillingDocs: Codeunit "Create Billing Documents";
+        LanguageMgt: Codeunit Language;
+        ExpectedDescription: Text;
+        GermanFormatRegionTok: Label 'de-DE', Locked = true;
+        UsFormatRegionTok: Label 'en-US', Locked = true;
+    begin
+        // [SCENARIO] When the operator uses German format region and creates a Sales Invoice for a US customer,
+        // the billing period dates in the sales line description should use the document's format region (en-US) and NOT the operator's region.
+        Initialize();
+        LibrarySetupStorage.Save(Database::"Subscription Contract Setup");
+
+        // [GIVEN] Service contract setup with "Billing Period" as main description
+        ServiceContractSetup.Get();
+        ServiceContractSetup."Contract Invoice Description" := Enum::"Contract Invoice Text Type"::"Billing Period";
+        ServiceContractSetup.Modify(false);
+
+        // [GIVEN] Customer contract with subscription lines
+        ContractTestLibrary.CreateCustomerContractAndCreateContractLinesForItems(CustomerContract, ServiceObject, '');
+
+        // [GIVEN] Customer has US format region (en-US)
+        Customer.Get(CustomerContract."Bill-to Customer No.");
+        Customer."Format Region" := UsFormatRegionTok;
+        Customer.Modify(false);
+
+        // [GIVEN] A billing proposal
+        ContractTestLibrary.CreateBillingProposal(BillingTemplate, Enum::"Service Partner"::Customer);
+
+        // [GIVEN] Operator uses German format region (simulates a German user session)
+        LanguageMgt.SetOverrideFormatRegion(GermanFormatRegionTok, false);
+
+        // [WHEN] Create billing documents
+        CreateBillingDocuments(false);
+
+        // Ensure format region override is cleared after billing
+        LanguageMgt.SetOverrideFormatRegion('', false);
+
+        // [THEN] Sales line billing period description uses the document's format region (en-US)
+        BillingLine.Reset();
+        BillingLine.SetRange("Billing Template Code", BillingTemplate.Code);
+        BillingLine.SetRange(Partner, BillingTemplate.Partner);
+        BillingLine.FindFirst();
+        BillingLine.TestField("Document Type", BillingLine."Document Type"::Invoice);
+
+        SalesLine.Reset();
+        FilterSalesLineOnDocumentLine(BillingLine.GetSalesDocumentTypeFromBillingDocumentType(), BillingLine."Document No.", BillingLine."Document Line No.");
+        SalesLine.FindFirst();
+
+        // Build expected description using the document's format region (en-US)
+        LanguageMgt.SetOverrideFormatRegion(UsFormatRegionTok, false);
+        ExpectedDescription := StrSubstNo(CreateBillingDocs.GetBillingPeriodDescriptionTxt(), SalesLine."Recurring Billing from", SalesLine."Recurring Billing to");
+        LanguageMgt.SetOverrideFormatRegion('', false);
+
+        Assert.AreEqual(ExpectedDescription, SalesLine.Description,
+            'Billing period description should use the document format region (en-US), not the operator format region (de-DE)');
+    end;
+
+    [Test]
+    [HandlerFunctions('CreateVendorBillingDocsContractPageHandler,ExchangeRateSelectionModalPageHandler,MessageHandler')]
+    procedure CheckBillingPeriodDescriptionUsesDocumentFormatRegionForPurchaseDocuments()
+    var
+        Vendor: Record Vendor;
+        CreateBillingDocs: Codeunit "Create Billing Documents";
+        LanguageMgt: Codeunit Language;
+        ExpectedDescription: Text;
+        GermanFormatRegionTok: Label 'de-DE', Locked = true;
+        UsFormatRegionTok: Label 'en-US', Locked = true;
+    begin
+        // [SCENARIO] When the operator uses German format region and creates a Purchase Invoice for a US vendor,
+        // the billing period dates in the attached description line should use the document's format region (en-US) and NOT the operator's region.
+        // Note: unlike sales, the billing period text is always placed in a separate attached description line on purchase documents;
+        // "Contract Invoice Description" setup has no effect on purchase documents.
+        Initialize();
+
+        // [GIVEN] Vendor contract with subscription lines
+        ContractTestLibrary.CreateVendorContractAndCreateContractLinesForItems(VendorContract, ServiceObject, '');
+
+        // [GIVEN] Vendor has US format region (en-US)
+        Vendor.Get(VendorContract."Pay-to Vendor No.");
+        Vendor."Format Region" := UsFormatRegionTok;
+        Vendor.Modify(false);
+
+        // [GIVEN] A billing proposal
+        ContractTestLibrary.CreateBillingProposal(BillingTemplate, Enum::"Service Partner"::Vendor);
+
+        // [GIVEN] Operator uses German format region (simulates a German user session)
+        LanguageMgt.SetOverrideFormatRegion(GermanFormatRegionTok, false);
+
+        // [WHEN] Create billing documents
+        CreateBillingDocuments(false);
+
+        // Ensure format region override is cleared after billing
+        LanguageMgt.SetOverrideFormatRegion('', false);
+
+        // [THEN] Attached description line billing period uses the document's format region (en-US)
+        BillingLine.Reset();
+        BillingLine.SetRange("Billing Template Code", BillingTemplate.Code);
+        BillingLine.SetRange(Partner, BillingTemplate.Partner);
+        BillingLine.FindFirst();
+        BillingLine.TestField("Document Type", BillingLine."Document Type"::Invoice);
+
+        PurchaseLine.Reset();
+        FilterPurchaseLineOnDocumentLine(BillingLine.GetPurchaseDocumentTypeFromBillingDocumentType(), BillingLine."Document No.", BillingLine."Document Line No.");
+        PurchaseLine.FindFirst();
+
+        // Build expected description using the document's format region (en-US)
+        // Dates are read from the main purchase line; the actual billing period text lives in the attached description line
+        LanguageMgt.SetOverrideFormatRegion(UsFormatRegionTok, false);
+        ExpectedDescription := StrSubstNo(CreateBillingDocs.GetBillingPeriodDescriptionTxt(), PurchaseLine."Recurring Billing from", PurchaseLine."Recurring Billing to");
+        LanguageMgt.SetOverrideFormatRegion('', false);
+
+        PurchaseLine.SetRange("Line No.");
+        PurchaseLine.SetRange("Attached to Line No.", BillingLine."Document Line No.");
+        PurchaseLine.FindFirst();
+
+        Assert.AreEqual(ExpectedDescription, PurchaseLine.Description,
+            'Billing period description should use the document format region (en-US), not the operator format region (de-DE)');
+    end;
+
+    [Test]
     [HandlerFunctions('CreateCustomerBillingDocsBillToCustomerPageHandler,ExchangeRateSelectionModalPageHandler,MessageHandler')]
     procedure CheckContractNamesAreTransferredToSalesDocumentOnBillingPerBillToContractOptionsOn()
     var


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This is a backport of the PR https://github.com/microsoft/BCApps/pull/6911

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #6680