### PR TITLE
[Shopify] Fix presentment currency shipping charges

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyProcessOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyProcessOrder.Codeunit.al
@@ -329,8 +329,6 @@ codeunit 30166 "Shpfy Process Order"
                                 SalesLine.Validate("Line Discount Amount", OrderShippingCharges."Presentment Discount Amount");
                             end;
                     end;
-                    SalesLine.Validate("Unit Price", OrderShippingCharges.Amount);
-                    SalesLine.Validate("Line Discount Amount", OrderShippingCharges."Discount Amount");
                     SalesLine."Shpfy Order No." := ShopifyOrderHeader."Shopify Order No.";
                     SalesLine.Modify(true);
 


### PR DESCRIPTION
## Summary
- Shipping charges were always set to the store currency amount, even when the shop's currency handling was set to presentment currency
- Root cause: two lines after the `case` statement in `ShpfyProcessOrder.Codeunit.al` unconditionally overwrote the unit price and discount with store currency values
- Fix: remove the duplicate lines so the `case` statement's presentment currency branch takes effect

Fixes [AB#625285](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625285)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

