### PR TITLE
[Shopify] Fix Tax Lines showing all orders when order has no lines

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
@@ -1031,10 +1031,14 @@ page 30113 "Shpfy Order"
                     OrderLine.SetRange("Shopify Order Id", Rec."Shopify Order Id");
                     if OrderLine.FindSet() then
                         repeat
-                            FilterTxt += Format(OrderLine."Line Id") + '|';
+                            if FilterTxt <> '' then
+                                FilterTxt += '|';
+                            FilterTxt += Format(OrderLine."Line Id");
                         until OrderLine.Next() = 0;
-                    FilterTxt := FilterTxt.TrimEnd('|');
-                    TaxLine.SetFilter("Parent Id", FilterTxt);
+                    if FilterTxt = '' then
+                        TaxLine.SetRange("Parent Id", 0)
+                    else
+                        TaxLine.SetFilter("Parent Id", FilterTxt);
                     Page.Run(Page::"Shpfy Order Tax Lines", TaxLine);
                 end;
             }


### PR DESCRIPTION
## Summary
- When a Shopify order has all lines removed, clicking "Tax Lines" showed tax lines from **all** orders instead of an empty list
- Root cause: empty `FilterTxt` passed to `SetFilter` removes the filter entirely in AL
- Fix: when there are no order lines, use `SetRange("Parent Id", 0)` to ensure no results are returned

Fixes [AB#625303](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625303)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



