### PR TITLE
[releases/27.3][Shopify] Trial stores with different admin URL cannot connect (#6546)

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -857,7 +857,7 @@ table 30102 "Shpfy Shop"
     begin
         Store := GetStoreName();
         if Store <> '' then
-            AuthenticationMgt.InstallShopifyApp(Store);
+            AuthenticationMgt.InstallShopifyApp(Store, Rec);
     end;
 
     internal procedure HasAccessToken(): Boolean
@@ -885,6 +885,11 @@ table 30102 "Shpfy Shop"
         if Store.Contains(':') then
             Store := Store.Split(':').Get(2);
         Store := Store.TrimStart('/').TrimEnd('/');
+    end;
+
+    internal procedure SetStoreName(Store: Text)
+    begin
+        Rec.Validate("Shopify URL", Store);
     end;
 
     /// <summary>


### PR DESCRIPTION
### Problem
When users create Shopify trial stores, Shopify provisions the store with a random internal URL (e.g., `fwlifjsl-rr.myshopify.com`) but displays a different "friendly" URL to the user (e.g., `cable-masters-2.myshopify.com`).

During the OAuth flow:
1. User enters the friendly URL they see in Shopify admin
2. OAuth completes successfully, but Shopify returns the **real internal `myshopify_domain`** in the callback
3. The access token gets saved under the internal URL
4. Business Central tries to use the token with the original user-entered URL → **fails with "No access token" error**

### Solution
When the store URL returned from Shopify during OAuth differs from what the user entered, prompt the user to correct the store URL. If confirmed, the Shop record is updated to use the actual `myshopify_domain` that Shopify uses internally.

### Changes

**ShpfyAuthenticationMgt.Codeunit.al**
- Modified `InstallShopifyApp` to accept a `var Shop` parameter
- Added store URL mismatch detection after OAuth callback
- When mismatch detected, prompts user to correct the URL with confirmation dialog
- Fixed typo: `InstalllToStore` → `InstallToStore`

**ShpfyShop.Table.al**
- Added `SetStoreName(Store: Text)` procedure to update the Shopify URL with validation
- Updated `RequestAccessToken()` to pass the Shop record to `InstallShopifyApp`

Fixes
[AB#625404](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625404)

