### PR TITLE
Fix SetAnswerForQnAEvaluation: initialize Test Output Json before Add

### DIFF
--- a/src/Tools/AI Test Toolkit/src/AITTestContextImpl.Codeunit.al
+++ b/src/Tools/AI Test Toolkit/src/AITTestContextImpl.Codeunit.al
@@ -106,6 +106,7 @@ codeunit 149043 "AIT Test Context Impl."
     var
         CurrentTestOutputJson: Codeunit "Test Output Json";
     begin
+        CurrentTestOutputJson.Initialize();
         CurrentTestOutputJson.Add(AnswerTok, Answer);
         CopyElementToOutput(ContextTok, CurrentTestOutputJson);
         CopyElementToOutput(QuestionTok, CurrentTestOutputJson);


### PR DESCRIPTION
## Summary

`SetAnswerForQnAEvaluation` in `AITTestContextImpl.Codeunit.al` called `CurrentTestOutputJson.Add(...)` without first calling `Initialize()`, causing the runtime error:

> The data output is not initialized or is of the wrong type. It must be an Json object or array.

## Root cause

`Codeunit "Test Output Json"` requires `Initialize()` before any `Add` call. All other procedures in the same codeunit (`SetQueryResponse`, `AddMessage`, `SetTestOutput`) already call `Initialize()` correctly ΓÇö `SetAnswerForQnAEvaluation` was the only one missing it.

## Fix

Added `CurrentTestOutputJson.Initialize();` as the first statement in `SetAnswerForQnAEvaluation`, before the first `Add` call, in `src/Tools/AI Test Toolkit/src/AITTestContextImpl.Codeunit.al`.
Fixes [AB#625927](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625927)
