### PR TITLE
Lock E-Document telemetry labels to prevent translation

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseDraft.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseDraft.Page.al
@@ -760,8 +760,8 @@ page 6181 "E-Document Purchase Draft"
         HasErrorsOrWarnings, HasErrors : Boolean;
         ShowFinalizeDraftAction: Boolean;
         ShowAnalyzeDocumentAction: Boolean;
-        FinalizeDraftInvokedTxt: Label 'User invoked Finalize Draft action.';
-        FinalizeDraftPerformedTxt: Label 'User completed Finalize Draft action.';
+        FinalizeDraftInvokedTxt: Label 'User invoked Finalize Draft action.', Locked = true;
+        FinalizeDraftPerformedTxt: Label 'User completed Finalize Draft action.', Locked = true;
         ProcessingDocumentMsg: Label 'Processing document...';
         ResetDraftQst: Label 'All the changes that you may have made on the document draft will be lost. Do you want to continue?';
         PageEditable, HasPDFSource : Boolean;

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseHeader.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseHeader.Table.al
@@ -287,6 +287,6 @@ table 6100 "E-Document Purchase Header"
 
     var
         FeatureTelemetry: Codeunit "Feature Telemetry";
-        DeleteDraftPerformedTxt: Label 'User deleted the draft.';
+        DeleteDraftPerformedTxt: Label 'User deleted the draft.', Locked = true;
 
 }

--- a/src/Apps/W1/EDocument/App/src/Workflow/EDocumentWorkFlowProcessing.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Workflow/EDocumentWorkFlowProcessing.Codeunit.al
@@ -187,7 +187,7 @@ codeunit 6135 "E-Document WorkFlow Processing"
         WorkflowManagement: Codeunit "Workflow Management";
         EDocumentWorkflowSetup: Codeunit "E-Document Workflow Setup";
         Telemetry: Codeunit Telemetry;
-        NoEDocumentServiceFoundINPrevResponseLbl: Label 'No E-Document Service found in previous Send or Export response step in workflow.';
+        NoEDocumentServiceFoundINPrevResponseLbl: Label 'No E-Document Service found in previous Send or Export response step in workflow.', Locked = true;
     begin
         PrevWorkflowStepInstance.SetFilter("Function Name", '%1|%2', EDocumentWorkflowSetup.EDocSendEDocResponseCode(), EDocumentWorkflowSetup.ResponseEDocExport());
         while WorkflowManagement.FindResponse(PrevWorkflowStepInstance, WorkflowStepInstance) do begin
@@ -259,7 +259,7 @@ codeunit 6135 "E-Document WorkFlow Processing"
     var
         EDocumentServiceStatus: Record "E-Document Service Status";
         Telemetry: Codeunit Telemetry;
-        WrongWorkflowEventRecordTypeErr: Label 'The record type %1 is not supported in E-Document workflow events.', Comment = '%1 - Table ID';
+        WrongWorkflowEventRecordTypeErr: Label 'The record type %1 is not supported in E-Document workflow events.', Comment = '%1 - Table ID', Locked = true;
     begin
         case RecordRef.Number() of
             Database::"E-Document":
@@ -320,7 +320,7 @@ codeunit 6135 "E-Document WorkFlow Processing"
         WorkflowManagement: Codeunit "Workflow Management";
         EDocumentWorkflowSetup: Codeunit "E-Document Workflow Setup";
         Telemetry: Codeunit Telemetry;
-        EDocTelemetryNoFilterForNextEventLbl: Label 'No filter set on E-Document to execute next workflow step.';
+        EDocTelemetryNoFilterForNextEventLbl: Label 'No filter set on E-Document to execute next workflow step.', Locked = true;
     begin
         // Commit before execute next workflow step
         Commit();


### PR DESCRIPTION
## Summary
- Added `Locked = true` to 5 telemetry labels in E-Document module that were missing the lock attribute
- Telemetry labels should never be translated as they are used for internal telemetry logging and analysis

## Files changed
- `EDocumentPurchaseDraft.Page.al` - Locked `FinalizeDraftInvokedTxt` and `FinalizeDraftPerformedTxt`
- `EDocumentPurchaseHeader.Table.al` - Locked `DeleteDraftPerformedTxt`
- `EDocumentWorkFlowProcessing.Codeunit.al` - Locked `NoEDocumentServiceFoundINPrevResponseLbl`, `WrongWorkflowEventRecordTypeErr`, `EDocTelemetryNoFilterForNextEventLbl`

## Test plan
- [x] Verify telemetry labels are no longer subject to translation
- [x] Verify telemetry events still log correctly

Fixes [AB#625579](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625579)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



