### PR TITLE
[PowerBI] [Reports] [Setup] Add a ABC Analysis Setup action on the power bi reports setup page

### DIFF
--- a/src/Apps/W1/PowerBIReports/App/Core/Pages/PowerBIReportsSetup.Page.al
+++ b/src/Apps/W1/PowerBIReports/App/Core/Pages/PowerBIReportsSetup.Page.al
@@ -5,6 +5,7 @@
 namespace Microsoft.PowerBIReports;
 
 using Microsoft.Finance.PowerBIReports;
+using Microsoft.Inventory.Analysis;
 using System.DateTime;
 using System.Environment;
 
@@ -580,6 +581,14 @@ page 36951 "PowerBI Reports Setup"
                 Image = CodesList;
                 RunObject = page "PBI Close Income Stmt. SC.";
             }
+            action(ABCAnalysisSetup)
+            {
+                ApplicationArea = All;
+                Caption = 'ABC Analysis Setup';
+                ToolTip = 'Set up your ABC analysis thresholds in the Power BI Inventory reports.';
+                Image = Percentage;
+                RunObject = page "ABC Analysis Setup";
+            }
         }
 
         area(Promoted)
@@ -596,6 +605,9 @@ page 36951 "PowerBI Reports Setup"
                 {
                 }
                 actionref(CloseIncomeStatementSourceCodes_Promoted; CloseIncomeStatementSourceCodes)
+                {
+                }
+                actionref(ABCAnalysisSetup_Promoted; ABCAnalysisSetup)
                 {
                 }
             }


### PR DESCRIPTION
Fixes [AB#624874](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624874)

New action:

<img width="1952" height="807" alt="image" src="https://github.com/user-attachments/assets/db1d50dd-df23-46c0-ae38-dd69c0cd0227" />

It opens this page:

<img width="1953" height="937" alt="image" src="https://github.com/user-attachments/assets/357023cf-3f69-44a6-a6b6-b433a684279e" />


