### PR TITLE
[Shopify] Skip FindMapping API calls during customer sync update

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCustomerExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCustomerExport.Codeunit.al
@@ -29,15 +29,22 @@ codeunit 30116 "Shpfy Customer Export"
         if Customer.FindSet(false) then begin
             CustomerMapping.SetShop(Shop);
             repeat
-                CustomerId := CustomerMapping.FindMapping(Customer, CreateCustomers);
-                if CustomerId = 0 then begin
-                    if CreateCustomers then
-                        CreateShopifyCustomer(Customer);
+                if CreateCustomers then begin
+                    CustomerId := CustomerMapping.FindMapping(Customer, CreateCustomers);
+                    if CustomerId = 0 then
+                        CreateShopifyCustomer(Customer)
+                    else begin
+                        ShopifyCustomer.Get(CustomerId);
+                        if ShopifyCustomer."Customer SystemId" <> Customer.SystemId then
+                            SkippedRecord.LogSkippedRecord(Customer.RecordId, CustomerWithPhoneNoOrEmailExistsLbl, Shop)
+                        else
+                            if Shop."Can Update Shopify Customer" then
+                                UpdateShopifyCustomer(Customer, ShopifyCustomer);
+                    end;
                 end else begin
-                    ShopifyCustomer.Get(CustomerId);
-                    if ShopifyCustomer."Customer SystemId" <> Customer.SystemId then
-                        SkippedRecord.LogSkippedRecord(Customer.RecordId, CustomerWithPhoneNoOrEmailExistsLbl, Shop)
-                    else
+                    ShopifyCustomer.SetRange("Shop Id", Shop."Shop Id");
+                    ShopifyCustomer.SetRange("Customer SystemId", Customer.SystemId);
+                    if ShopifyCustomer.FindFirst() then
                         if Shop."Can Update Shopify Customer" then
                             UpdateShopifyCustomer(Customer, ShopifyCustomer);
                 end;


### PR DESCRIPTION
## Summary
- When `CreateCustomers = false` (sync/update path), replaced `FindMapping()` calls with a local DB lookup on `Shpfy Customer` by `Shop Id` and `Customer SystemId`
- This avoids sending a GraphQL query to Shopify for every BC customer when running "Sync Customers" with "Can Update Shopify Customer" enabled
- Only customers that already have a Shopify mapping are processed for updates

Fixes [AB#625597](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625597)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


