### PR TITLE
Add Shopify Connector documentation

### DIFF
--- a/src/Apps/W1/Shopify/App/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/CLAUDE.md
@@ -1,0 +1,60 @@
+# Shopify Connector
+
+Bidirectional synchronization between Shopify and Business Central for orders, products, customers, inventory, and B2B companies.
+
+## Quick reference
+
+- **Runtime**: 29.0.0.0
+- **Dependencies**: None
+- **ID range**: 30100-30460
+- **Object count**: 65 tables, 329 codeunits, 76 pages, 22 interfaces, 74 enums, 18 table extensions
+
+## Structure
+
+- **Base** -- Core shop configuration (Shpfy Shop table 30102), authentication, tags, logging mode, synchronization tracking
+- **Bulk Operations** -- Asynchronous GraphQL bulk mutation processing for high-volume operations like product price updates
+- **Catalogs** -- B2B catalog pricing and market-to-catalog relationship management
+- **Companies** -- B2B company entities, company locations, contact permissions, and company-to-customer mapping
+- **Customers** -- Customer import/export, address management, tax exemptions, and customer-to-BC customer mapping
+- **Document Links** -- Navigation between Shopify and BC documents (orders, invoices, returns, shipments)
+- **Gift Cards** -- Gift card tracking and sales order line handling
+- **GraphQL** -- GraphQL query templates, rate limiting, API versioning (2026-01), and query cost management
+- **Helpers** -- Utility codeunits for JSON, math, hash calculation, and string manipulation
+- **Integration** -- OAuth 2.0 authentication, registered store management, and API communication
+- **Inventory** -- Stock level synchronization, inventory policies, stock calculation interfaces
+- **Invoicing** -- Posted invoice synchronization to Shopify for payment tracking
+- **Logs** -- Diagnostic logging (requests, responses, errors), skipped records, retention policies
+- **Metafields** -- Custom metadata synchronization for products, variants, customers, companies (namespace/key/value)
+- **Order Fulfillments** -- Fulfillment creation, tracking numbers, fulfillment service integration
+- **Order handling** -- Order import, sales document creation, order-to-sales mapping, risk assessment
+- **Order Refunds** -- Refund header/lines, refund transactions, restocking logic
+- **Order Return Refund Processing** -- Business logic for processing returns and refunds into BC credit memos
+- **Order Returns** -- Return header/lines, return reasons, approve/decline workflow
+- **Order Risks** -- Fraud analysis results (risk level, recommendation, message) from Shopify
+- **Payments** -- Payment gateway tracking, order transactions, payment method mapping
+- **PermissionSets** -- Security permissions for Shopify connector users
+- **Products** -- Product/variant export and import, SKU mapping, image sync, status management
+- **Shipping** -- Shipment export to Shopify, fulfillment creation, tracking number sync, shipping agent mapping
+- **Staff** -- Shopify staff member tracking (currently minimal implementation)
+- **Transactions** -- Payment transaction history, transaction type/status tracking
+- **Translations** -- Product and variant name translations for multi-language shops
+- **Webhooks** -- Webhook registration for order creation and bulk operation completion events
+
+## Documentation
+
+- [docs/data-model.md](docs/data-model.md) -- Table relationships and data structure
+- [docs/business-logic.md](docs/business-logic.md) -- Processing flows and event architecture
+- [docs/patterns.md](docs/patterns.md) -- Code patterns used in this app
+
+## Key concepts
+
+- **Shop as configuration root** -- All synchronization settings live in the Shpfy Shop table (30102), which controls import ranges, auto-creation flags, mapping types, and currency handling
+- **SystemId-based linking** -- Tables use SystemId (Guid) fields to link Shopify records to BC records (e.g., "Item SystemId" links Shpfy Product to Item) rather than traditional No. fields
+- **Dual currency support** -- Orders track both shop currency (Currency Code) and customer presentment currency (Presentment Currency Code) with separate amount fields for each
+- **Interface-driven extensibility** -- 22 interfaces enable pluggable behavior for customer mapping, county parsing, product status, stock calculation, and document source handling
+- **Hash-based change detection** -- Products, variants, and metafields use hash codes ("Image Hash", "Tags Hash", "Description Html Hash") to detect changes and avoid unnecessary API calls
+- **GraphQL-first API** -- All communication uses Shopify's GraphQL Admin API with bulk operations for high-volume scenarios and rate limit tracking
+- **Event-driven synchronization** -- Three event codeunits (Order Events, Customer Events, Product Events) provide 70+ integration events for extending sync behavior
+- **Webhook automation** -- Optional webhooks trigger automatic order import when orders are created in Shopify and notify when bulk operations complete
+- **B2B commerce support** -- Full support for Shopify Plus B2B features: companies, company locations, catalogs, payment terms, purchase orders
+- **Bidirectional sync control** -- Separate flags control each direction: "Can Update Shopify Products" vs "Shopify Can Update Items", preventing sync conflicts

--- a/src/Apps/W1/Shopify/App/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/docs/business-logic.md
@@ -1,0 +1,470 @@
+# Business logic
+
+## Overview
+
+The Shopify Connector orchestrates bidirectional synchronization through API-focused codeunits organized by business domain. All API communication flows through Shpfy Communication Mgt. (30103), which handles authentication, GraphQL execution, rate limiting, and error logging. Processing follows an import-map-create pattern: import Shopify entities, map to BC records via interfaces, create or update BC documents.
+
+## Key codeunits by domain
+
+### Core communication (Base)
+
+**Shpfy Communication Mgt. (30103)** -- Central API gateway
+- Manages GraphQL query execution via ExecuteGraphQL() methods
+- Handles API authentication via Shpfy Authentication Mgt.
+- Implements rate limiting and throttling (NextExecutionTime tracking)
+- Provides CreateWebRequestURL() for REST endpoint construction
+- Uses API version 2026-01 (VersionTok)
+- SingleInstance codeunit to maintain state across calls
+
+**Shpfy Authentication Mgt. (30146)** -- OAuth 2.0 flow
+- InstallShopifyApp() - initiates OAuth authorization
+- AccessTokenExist() - validates stored credentials
+- AssertValidShopUrl() - validates shop URL format
+- Token storage in isolated storage (not in DB)
+
+**Shpfy Shop Mgt. (30100)** -- Shop configuration helpers
+- GetShopSettings() - retrieves shop metadata (B2B enabled, weight unit)
+- TestConnection() - validates API connectivity
+- CheckApiVersionExpiryDate() - monitors API version lifecycle
+
+**Shpfy Background Syncs (30188)** -- Async job scheduling
+- Schedules product sync, customer sync, inventory sync, order sync as job queue entries
+- Respects "Allow Background Syncs" shop setting
+
+**Shpfy Initial Import (30189)** -- Guided import wizard
+- Batch imports historical data (products, customers, orders) with date range filters
+- Uses Shpfy Initial Import Line table for wizard state
+
+**Shpfy Communication Events (30148)** -- Communication extensibility
+- Events for before/after API calls for logging or modification
+
+### Product synchronization (Products)
+
+**Shpfy Product Export (30178)** -- BC Item → Shopify Product
+- OnRun trigger: exports products with filter "Item SystemId" <> null
+- UpdateProductData() - synchronizes product metadata and variants
+- CreateProductBody() - builds HTML description from extended text, marketing text, attributes
+- OnlyUpdatePrice mode for bulk price updates via Shpfy Bulk Operation Mgt.
+- Checks "Can Update Shopify Products" before updating existing products
+- Handles variant option creation from item attributes
+
+**Shpfy Product Import (30175)** -- Shopify Product → BC Item
+- RetrieveShopifyProduct() - fetches product via GraphQL
+- CreateProduct() - creates new items using Shpfy Create Item (30176)
+- UpdateProduct() - updates existing items using Shpfy Update Item (30179)
+- Mapping via Item SystemId field
+- Checks "Shopify Can Update Items" before updating BC items
+
+**Shpfy Create Product (30174)** -- New product creation in Shopify
+- AddProductVariantToExport() - queues products for export
+- Uses Shpfy Product API (30172) to execute GraphQL mutations
+- Applies "Status for Created Products" setting (Draft/Active)
+
+**Shpfy Product API (30172)** -- GraphQL product operations
+- AddProduct() - productCreate mutation
+- UpdateProduct() - productUpdate mutation
+- AddProductImage() - creates product images
+- UpdateProductVariant() - variantUpdate mutation
+- All methods use GraphQL queries from Shpfy GraphQL Queries (30154)
+
+**Shpfy Variant API (30173)** -- Variant-specific operations
+- UpdateProductPrice() - synchronizes pricing
+- UpdateInventoryPolicy() - sets overselling behavior
+- GetProductVariants() - retrieves variant list for a product
+
+**Shpfy Product Price Calc. (30180)** -- Price calculation logic
+- CalcPrice() - calculates selling price with events for customization
+- Handles catalog-specific pricing for B2B
+- Supports currency conversion
+
+**Shpfy Product Mapping (30183)** -- Item to Product association
+- FindMapping() - locates existing product for an item
+- CreateMapping() - links new products to items via SystemId
+
+**Shpfy Product Events (30177)** -- 35+ integration events
+- OnAfterCreateItem, OnBeforeCreateItem
+- OnAfterCreateProductBodyHtml
+- OnBeforeUpdateProductMetafields
+- OnAfterSetProductTitle
+- Enables extensive product sync customization
+
+**Shpfy Create Item (30176)** -- Shopify Product → new BC Item
+- Run trigger: creates item from Shpfy Product record
+- Applies item template from shop settings
+- Creates item variants if product Has Variants = true
+- Handles SKU, barcode, pricing, weight, images
+
+**Shpfy Update Item (30179)** -- Updates existing BC items from Shopify
+- Selective field updates based on hash change detection
+- Respects "Shopify Can Update Items" flag
+
+**Shpfy Sync Products (30181)** -- Orchestrates product sync
+- SyncProducts() - imports products from Shopify to BC
+- Handles bulk product retrieval via bulk operations
+- Processes product collections (categories)
+
+### Order processing (Order handling)
+
+**Shpfy Process Orders (30167)** -- Order orchestration
+- OnRun trigger: processes unprocessed orders for a shop
+- ProcessShopifyOrder() - single order processing with error handling
+- ProcessShopifyOrders() - batch processing with commit after each
+- ProcessShopifyRefunds() - processes refunds after orders
+
+**Shpfy Process Order (30168)** -- Single order processor
+- Run trigger: creates BC sales document from Shpfy Order Header
+- Executes order import, customer mapping, sales doc creation
+- Handles both Sales Order and Sales Invoice creation based on fulfillment status
+- Sets "Use Shopify Order No." if shop configured for manual numbering
+
+**Shpfy Import Order (30169)** -- Shopify Order → Shpfy Order Header
+- ImportOrder() - retrieves order from Shopify API via GraphQL
+- ImportOrderLine() - creates order lines with product/variant linking
+- ImportTaxLines() - imports tax details
+- ImportTransactions() - imports payment transactions
+- ImportRisks() - imports fraud analysis
+- Handles dual currency (shop + presentment)
+
+**Shpfy Order Mapping (30170)** -- Order to Sales Doc linking
+- CreateSalesHeader() - creates Sales Header from Shpfy Order Header
+- CreateSalesLine() - creates Sales Lines from Shpfy Order Lines
+- MapCustomerAndAddress() - assigns customer and addresses
+- MapShippingAgentAndMethod() - assigns shipping method
+- MapPaymentTerms() - assigns payment terms for B2B orders
+- Uses IsHandled pattern for extensibility (15 IsHandled checks)
+
+**Shpfy Orders API (30171)** -- GraphQL order operations
+- RetrieveOrders() - bulk order import with date filter
+- GetOrdersToImport() - queries orders since last sync
+- UpdateOrderAttributes() - sends BC document numbers back to Shopify
+
+**Shpfy Orders (30165)** -- Order sync orchestrator
+- SyncOrders() - imports orders with date range filter
+- Uses webhooks for real-time import if "Order Created Webhooks" enabled
+- Respects "Customer Import From Shopify" setting
+
+**Shpfy Order Events (30166)** -- 19 integration events
+- OnBeforeCreateSalesHeader, OnAfterCreateSalesHeader
+- OnBeforeCreateSalesLine, OnAfterCreateSalesLine
+- OnBeforeSendCreateSalesDocument
+- OnAfterCalcSalesPrice
+- Enables order processing customization
+
+### Customer synchronization (Customers)
+
+**Shpfy Customer Import (30117)** -- Shopify Customer → BC Customer
+- OnRun trigger: imports customer and addresses from Shopify
+- CustomerMapping.FindMapping() - locates existing customer
+- CreateCustomer - creates new BC customer if auto-create enabled
+- UpdateCustomer - updates existing customer if "Shopify Can Update Customer" enabled
+
+**Shpfy Customer Mapping (30116)** -- Customer association logic
+- FindMapping() - implements customer matching strategy via ICustomerMapping interface
+- Direction parameter: To Shopify or From Shopify
+- Strategies: By Email/Phone, By Bill-to Info, Always New, By Default Customer
+
+**Shpfy Customer API (30118)** -- GraphQL customer operations
+- RetrieveShopifyCustomer() - retrieves customer details
+- GetCustomers() - bulk customer import
+- UpdateCustomer() - sends customer updates to Shopify
+- AddCustomer() - creates customer in Shopify
+
+**Shpfy Create Customer (30119)** -- Shopify → new BC Customer
+- Run trigger: creates BC customer from Shpfy Customer Address
+- Applies customer template from shop settings or event
+- Calls CustomerMapping to establish link via SystemId
+
+**Shpfy Update Customer (30120)** -- Updates BC customer from Shopify
+- Selective updates based on "Shopify Can Update Customer" setting
+
+**Shpfy Sync Customers (30121)** -- Customer sync orchestrator
+- SyncCustomers() - imports customers from Shopify
+- Respects "Customer Import From Shopify" range setting
+
+**Shpfy Customer Events (30115)** -- 7 integration events
+- OnBeforeCreateCustomer, OnAfterCreateCustomer
+- OnBeforeSendCreateShopifyCustomer
+- OnBeforeFindCustomerTemplate
+- OnBeforeFindMapping, OnAfterFindMapping
+
+**Shpfy Cust By Email/Phone (30122)**, **Shpfy Cust By Bill-to (30123)**, **Shpfy Cust By Default (30124)** -- ICustomerMapping implementations
+
+**Shpfy Name is Company Name (30125)**, **Shpfy Name is First+Last (30126)**, **Shpfy Name is Last+First (30127)** -- ICustomerName implementations for name parsing
+
+**Shpfy County Code/Name (30128/30129)**, **Shpfy County From Json Code/Name (30130/30131)** -- ICounty and ICountyFromJson implementations for state/province handling
+
+### Inventory synchronization (Inventory)
+
+**Shpfy Sync Inventory (30197)** -- Stock level sync orchestrator
+- OnRun trigger: syncs inventory levels bidirectionally
+- ImportStock() - retrieves stock from Shopify
+- ExportStock() - sends BC stock to Shopify per shop location
+- Respects "Stock Calculation" setting on shop location
+
+**Shpfy Inventory API (30198)** -- GraphQL inventory operations
+- SetInventoryQuantities() - bulk inventory update mutation
+- GetInventory() - retrieves current stock levels
+- Uses inventorySetQuantities GraphQL mutation
+
+**Shpfy Stock Calc. Default (30199)**, **Shpfy Stock Available (30200)** -- IStockCalculation and IStockAvailable interface implementations for available stock calculation
+
+**Shpfy Inventory Events (30201)** -- 1 integration event
+- OnAfterCalculateAvailableInventory
+
+### Return and refund processing (Order Return Refund Processing)
+
+**Shpfy Create Sales Doc Refund (30145)** -- Refund → BC Credit Memo
+- CreateCreditMemo() - creates sales credit memo from Shpfy Refund Header
+- ProcessRefundLines() - creates credit memo lines from refund lines
+- ProcessRefundShipping() - handles shipping charge refunds
+- Respects "Return and Refund Process" setting (Import Only vs Auto Create)
+
+**Shpfy Refund Process Events (30146)** -- 6 integration events
+- OnBeforeCreateCreditMemo, OnAfterCreateCreditMemo
+- OnBeforeProcessRefundLine, OnAfterProcessRefundLine
+
+**Shpfy Import Refund (30147)**, **Shpfy Only Refund (30148)**, **Shpfy Auto Cr.Memo Refund (30149)** -- IReturnRefundProcess implementations for different refund handling modes
+
+**Document source implementations (30150-30154)** -- IDocumentSource and IExtendedDocumentSource for return source tracking
+
+### Shipping and fulfillment (Shipping, Order Fulfillments)
+
+**Shpfy Export Shipments (30122)** -- BC Shipment → Shopify Fulfillment
+- ExportShipments() - creates fulfillments from posted sales shipments
+- SendShippingConfirmation() - notifies customer via Shopify
+- CreateFulfillmentFromShipment() - maps shipment to fulfillment
+
+**Shpfy Fulfillment Orders Sync (30202)** -- Fulfillment order import
+- ImportFulfillmentOrders() - retrieves fulfillment orders
+- Handles third-party fulfillment service integration
+
+**Shpfy Shipping Events (30123)** -- 2 integration events
+- OnBeforeCreateFulfillment, OnAfterCreateFulfillment
+- Enables shipping workflow customization
+
+### Invoicing
+
+**Shpfy Posted Invoice Sync (30202)** -- Posted Invoice → Shopify
+- SyncPostedInvoice() - sends posted invoice details to Shopify for payment tracking
+- Respects "Posted Invoice Sync" shop setting
+
+### GraphQL infrastructure (GraphQL)
+
+**Shpfy GraphQL Queries (30154)** -- Query template library
+- GetGraphQLType() - returns query template for operation
+- Contains 100+ pre-built GraphQL query templates
+- Uses {{Parameters}} placeholder substitution
+- IsHandled pattern for query customization (15 IsHandled)
+
+**Shpfy GraphQL Rate Limit (30155)** -- Throttling management
+- CheckRateLimit() - enforces Shopify rate limits
+- Uses TryFunction to handle throttled requests
+- Tracks throttle count and sleep duration
+
+**IGraphQL Interface** -- Pluggable query provider
+- GetGraphQL() - returns query text
+- GetExpectedCost() - returns query cost estimate
+
+### Bulk operations
+
+**Shpfy Bulk Operation Mgt. (30156)** -- Async operation handler
+- SendBulkMutation() - submits bulk GraphQL mutation
+- GetBulkOperationResult() - retrieves operation status
+- ProcessBulkOperationResult() - processes JSONL result file
+- Used for product price updates, inventory sync
+
+**Shpfy Bulk Operation API (30157)** -- Bulk operation GraphQL
+- ExecuteBulkOperation() - submits bulkOperationRunQuery mutation
+- PollBulkOperationStatus() - checks completion status
+
+**Shpfy Bulk Update Product Image (30158)** -- IBulkOperation implementation for image updates
+
+### Metafields
+
+**Shpfy Metafield API (30159)** -- Metafield CRUD operations
+- GetMetafields() - retrieves metafields for owner entity
+- SetMetafield() - creates or updates metafield
+- DeleteMetafield() - removes metafield
+- Uses metafieldsSet mutation
+
+**Shpfy Metafield Type implementations (30160-30180)** -- IMetafieldType implementations for 50+ Shopify metafield types (Money, Weight, Dimension, Volume, Date, etc.)
+
+### Webhooks
+
+**Shpfy Webhooks Mgt. (30203)** -- Webhook lifecycle management
+- EnableOrderCreatedWebhook() - registers order/create webhook
+- DisableOrderCreatedWebhook() - removes webhook
+- EnableBulkOperationsWebhook() - registers bulk operation webhook
+- ProcessWebhook() - handles incoming webhook POST
+
+### Companies (B2B)
+
+**Shpfy Company Mapping (30204)** -- Company association
+- FindMapping() - implements company matching via ICompanyMapping interface
+- Strategies: By Tax ID, By Email/Phone, By Default Company, None
+
+**Shpfy Sync Companies (30205)** -- Company import
+- SyncCompanies() - imports Shopify companies
+- Respects "Company Import From Shopify" range setting
+
+**Shpfy Comp By Tax ID (30206)**, **Shpfy Comp By Email/Phone (30207)**, **Shpfy Comp By Default (30208)** -- ICompanyMapping implementations
+
+## Processing flows
+
+### Product sync: BC Item → Shopify
+
+1. User runs "Sync Item" action or background job executes
+2. **Shpfy Sync Products** (30181) calls **Shpfy Product Export** (30178)
+3. **Product Export** filters products with "Item SystemId" linked
+4. For each product: **Product Export** → **Product API** (30172) → **Communication Mgt.** (30103)
+5. **Communication Mgt.** executes GraphQL productUpdate or productCreate mutation
+6. **Product API** processes response, updates Shpfy Product record
+7. If OnlyUpdatePrice = true, uses bulk operations for 100+ variants
+8. **Product Export** synchronizes images via **Product Image Export** (30181)
+9. **Product Export** synchronizes metafields via **Metafield API** (30159)
+10. Hash fields updated to track changes (Image Hash, Tags Hash, Description Html Hash)
+
+### Product sync: Shopify → BC Item
+
+1. User runs "Import Product" or sync from catalog
+2. **Shpfy Sync Products** (30181) calls **Shpfy Product Import** (30175)
+3. **Product Import** → **Product API** → **Communication Mgt.** for GraphQL product query
+4. **Product Import** creates/updates Shpfy Product record
+5. **Product Mapping** (30183) checks if Item exists via SystemId
+6. If no item found and "Auto Create Unknown Items" = true:
+   - **Create Item** (30176) creates BC Item from product
+   - Applies item template, sets SKU, pricing, weight
+   - Creates item variants if Has Variants = true
+7. If item exists and "Shopify Can Update Items" = true:
+   - **Update Item** (30179) updates BC Item fields
+8. **Product Import** fires OnAfterCreateItem / OnAfterUpdateItem events
+
+### Order sync: Shopify → BC Sales Document
+
+1. Webhook triggers or user runs "Import Orders"
+2. **Shpfy Orders** (30165) calls **Orders API** (30171) to retrieve orders
+3. **Orders API** → **Communication Mgt.** executes GraphQL ordersQuery
+4. **Import Order** (30169) creates Shpfy Order Header + Lines from JSON
+5. **Import Order** calls ImportTaxLines, ImportTransactions, ImportRisks
+6. **Process Orders** (30167) calls **Process Order** (30168) for each unprocessed order
+7. **Process Order** → **Order Mapping** (30170) begins sales doc creation:
+   a. MapCustomer: **Customer Mapping** (30116) finds/creates BC Customer
+   b. CreateSalesHeader: Creates Sales Header with customer, addresses, dates
+   c. CreateSalesLine: Creates Sales Lines from Order Lines
+   d. MapShippingAgentAndMethod: Assigns shipping method
+   e. MapPaymentTerms: Assigns payment terms (B2B)
+8. **Order Mapping** fires OnBeforeCreateSalesHeader, OnAfterCreateSalesLine, etc.
+9. **Process Order** sets Shpfy Order Header.Processed = true
+10. If "Auto Release Sales Orders" = true, sales order is released
+11. If fulfillment status = Fulfilled and "Create Invoices From Orders" = true, creates Sales Invoice instead of Sales Order
+
+### Customer sync: Shopify → BC Customer
+
+1. Order import triggers customer import, or user runs "Sync Customers"
+2. **Shpfy Sync Customers** (30121) calls **Customer Import** (30117)
+3. **Customer Import** → **Customer API** (30118) retrieves customer via GraphQL
+4. **Customer API** creates Shpfy Customer + Customer Address records
+5. **Customer Mapping** (30116) executes FindMapping with configured strategy:
+   - By Email/Phone: Matches on email or phone number
+   - By Bill-to Info: Matches on billing address
+   - Always New: Never maps to existing
+   - By Default: Uses default customer no.
+6. If no mapping found and "Auto Create Unknown Customers" = true:
+   - **Create Customer** (30119) creates BC Customer
+   - Applies customer template via OnBeforeFindCustomerTemplate event
+   - Links via Customer SystemId field
+7. If mapping exists and "Shopify Can Update Customer" = true:
+   - **Update Customer** (30120) updates BC Customer fields
+8. **Customer Import** fires OnAfterCreateCustomer event
+
+### Inventory sync: BC → Shopify
+
+1. Background job or user runs "Sync Inventory"
+2. **Shpfy Sync Inventory** (30197) processes each Shpfy Shop Location
+3. For each location where "Stock Calculation" <> Disabled:
+   a. **Inventory API** (30198) queries Shpfy Shop Inventory table
+   b. For each variant, calculates available stock via IStockCalculation interface
+   c. Groups stock updates by location
+4. **Inventory API** executes inventorySetQuantities bulk mutation via **Communication Mgt.**
+5. Shopify updates inventory levels for all variants in single request
+
+### Return/Refund processing: Shopify → BC Credit Memo
+
+1. **Import Order** (30169) imports Shpfy Return Header and Shpfy Refund Header
+2. **Process Orders** (30167) calls ProcessShopifyRefunds() after order processing
+3. If "Return and Refund Process" = "Auto Create Credit Memo":
+   a. **Create Sales Doc Refund** (30145) creates Sales Credit Memo
+   b. ProcessRefundLines creates credit memo lines from Shpfy Refund Lines
+   c. ProcessRefundShipping adds shipping refund line if applicable
+   d. Links credit memo to original sales document via Get Sales Document action
+4. If "Return and Refund Process" = "Import Only":
+   - Records imported but no BC document created
+   - User manually processes returns
+
+### Payment tracking: Order → Transactions
+
+1. **Import Order** (30169) calls ImportTransactions()
+2. **Orders API** (30171) retrieves transactions via GraphQL
+3. Shpfy Order Transaction records created with Type (Authorization, Capture, Sale, Refund), Status, Gateway, Amount
+4. Multiple transactions per order (auth + capture, partial payments)
+5. Transactions visible on Shopify Order page for reconciliation
+
+## Event architecture
+
+The connector provides 70+ integration events across three event codeunits for customization without modifying base code.
+
+### Shpfy Order Events (30166) -- 19 events
+- **OnBeforeCreateSalesHeader** -- Modify sales header before creation
+- **OnAfterCreateSalesHeader** -- Customize sales header after creation
+- **OnBeforeCreateSalesLine** -- Modify sales line before creation
+- **OnAfterCreateSalesLine** -- Customize sales line after creation
+- **OnBeforeCalcSalesPrice** -- Override price calculation
+- **OnAfterCalcSalesPrice** -- Adjust calculated price
+- **OnBeforeSendCreateSalesDocument** -- Validate before document creation
+- **OnAfterImportOrder** -- Post-import processing
+- **OnBeforeMapCustomer** -- Custom customer mapping logic
+- **OnAfterMapCustomer** -- Post-mapping adjustments
+- **OnBeforeImportOrderLine** -- Filter or modify imported lines
+- **OnAfterImportOrderLine** -- Line-level customization
+
+### Shpfy Customer Events (30115) -- 7 events
+- **OnBeforeCreateCustomer** -- Validate or prevent customer creation
+- **OnAfterCreateCustomer** -- Customize created customer
+- **OnBeforeSendCreateShopifyCustomer** -- Modify before sending to Shopify
+- **OnBeforeSendUpdateShopifyCustomer** -- Modify before updating Shopify
+- **OnBeforeFindCustomerTemplate** -- Custom template selection
+- **OnBeforeFindMapping** -- Custom mapping logic
+- **OnAfterFindMapping** -- Post-mapping processing
+
+### Shpfy Product Events (30177) -- 35+ events
+- **OnAfterCreateItem** -- Customize created item
+- **OnBeforeCreateItem** -- Validate or prevent item creation
+- **OnAfterCreateItemVariant** -- Customize created variant
+- **OnAfterCreateProductBodyHtml** -- Modify product description HTML
+- **OnAfterSetProductTitle** -- Customize product title
+- **OnBeforeUpdateProductMetafields** -- Modify metafields before sync
+- **OnAfterCreateTempShopifyProduct** -- Customize product before export
+- **OnAfterFindItemTemplate** -- Custom template selection
+- **OnAfterProductsToSynchronizeFiltersSet** -- Custom product filters
+
+## Integration points
+
+### To Business Central
+- **Sales Documents**: Creates Sales Orders, Sales Invoices, Sales Credit Memos
+- **Customers**: Creates/updates Customer records
+- **Items**: Creates/updates Item and Item Variant records
+- **Inventory**: Reads available inventory from Item Ledger Entries
+- **General Ledger**: Posts via standard sales posting (sales invoices, credit memos)
+- **Job Queue**: Schedules background sync tasks
+
+### From Business Central
+- **Sales Shipment**: Triggers fulfillment creation in Shopify
+- **Posted Sales Invoice**: Optionally syncs to Shopify for payment tracking
+- **Item Changes**: Triggers product update in Shopify
+- **Inventory Changes**: Triggers stock level update in Shopify
+
+### External (Shopify)
+- **Admin GraphQL API**: All communication uses GraphQL (API version 2026-01)
+- **Webhooks**: Receives order/create and bulk operation completion notifications
+- **OAuth 2.0**: Handles app installation and token refresh
+- **Carrier Service API**: Optional integration for calculated shipping rates

--- a/src/Apps/W1/Shopify/App/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/docs/data-model.md
@@ -1,0 +1,374 @@
+# Data model
+
+## Overview
+
+The Shopify Connector data model supports bidirectional synchronization between Shopify and Business Central. It uses SystemId-based linking rather than traditional No. field relationships, enabling flexible mapping between Shopify entities and BC master data. The model supports B2B commerce, multi-currency orders, and comprehensive order lifecycle tracking from creation through fulfillment and returns.
+
+## Tables grouped by domain
+
+### Shop configuration
+
+**Shpfy Shop (30102)** -- Primary configuration table
+- **Primary key**: Code (Code[20])
+- **Key fields**: Shopify URL, Shop Id (hash of URL), Enabled
+- **Relationships**: Referenced by all entity tables via "Shop Code" field
+- **Purpose**: Stores all synchronization settings: import ranges, auto-creation flags, mapping types, currency handling, webhook configuration, B2B settings
+- **Key settings**: Sync Item, Auto Create Orders, Customer/Company Mapping Type, Currency Code, Logging Mode, Allow Outgoing Requests
+
+**Shpfy Synchronization Info (30163)** -- Last sync timestamp tracking
+- **Primary key**: Shop Code, Synchronization Type
+- **Purpose**: Tracks last sync time for Orders, Products, Customers, Companies to enable incremental synchronization
+
+**Shpfy Shop Location (30113)** -- Shopify location to BC location mapping
+- **Primary key**: Shop Code, Id
+- **Relationships**: TableRelation to Shpfy Shop, Location Filter links to BC Location
+- **Purpose**: Maps Shopify fulfillment locations to BC inventory locations for stock synchronization
+
+### Product catalog
+
+**Shpfy Product (30127)** -- Shopify product master
+- **Primary key**: Id (BigInteger)
+- **Key fields**: Item SystemId (Guid), Shop Code, Title, Status, Has Variants
+- **Relationships**: Links to BC Item via SystemId, parent of Shpfy Variant
+- **Change tracking**: Image Hash, Tags Hash, Description Html Hash, Last Updated by BC
+- **Purpose**: Represents Shopify products with sync metadata
+
+**Shpfy Variant (30129)** -- Product variants
+- **Primary key**: Id (BigInteger)
+- **Key fields**: Product Id, Item SystemId, Item Variant SystemId, SKU, Barcode
+- **Relationships**: Parent Product Id → Shpfy Product, links to BC Item/Item Variant via SystemId
+- **Pricing**: Price, Compare at Price, UoM, Tax Code
+- **Purpose**: Represents sellable SKUs; one variant per product for non-variant products
+
+**Shpfy Product Image (30130)** -- Product images
+- **Primary key**: Id (BigInteger)
+- **Relationships**: Product Id → Shpfy Product, Media Content → Blob
+- **Purpose**: Stores product images for bidirectional sync
+
+**Shpfy Catalog Price (30153)** -- B2B catalog pricing
+- **Primary key**: Company Location Id, Variant Id
+- **Purpose**: Context-specific pricing for B2B company locations
+
+### Customer management
+
+**Shpfy Customer (30105)** -- Shopify customer master
+- **Primary key**: Id (BigInteger)
+- **Key fields**: Customer SystemId (Guid), Shop Id, Email, Phone No., State
+- **Relationships**: Links to BC Customer via SystemId
+- **Purpose**: Shopify customer with marketing preferences, tax exemption, currency
+
+**Shpfy Customer Address (30109)** -- Customer addresses
+- **Primary key**: Customer Id, Id (BigInteger)
+- **Relationships**: Customer Id → Shpfy Customer
+- **Fields**: Standard address fields (Name, Address, City, Zip, Country/Region, County) plus Shopify Id for sync
+- **Purpose**: Stores multiple addresses per customer; default address flagged
+
+**Shpfy Tax Area (30147)** -- Tax jurisdiction mapping
+- **Primary key**: Shop Code, Country/Region Code, County
+- **Relationships**: TableRelation to Tax Area
+- **Purpose**: Maps Shopify locations to BC tax areas for sales tax calculation
+
+### B2B and company
+
+**Shpfy Company (30150)** -- Shopify B2B companies
+- **Primary key**: Id (BigInteger)
+- **Key fields**: Customer SystemId (Guid), Shop Code, Shop Id, Name
+- **Relationships**: Links to BC Customer via SystemId, Main Contact Customer Id links to Shpfy Customer
+- **Purpose**: Represents B2B company entities for Shopify Plus
+
+**Shpfy Company Location (30151)** -- Company billing/shipping addresses
+- **Primary key**: Id (BigInteger)
+- **Relationships**: Company Id → Shpfy Company
+- **Fields**: Standard address fields, Tax Exemptions, Locale, Buyer Experience Config
+- **Purpose**: Company-specific shipping and billing locations with tax settings
+
+**Shpfy Market Catalog Relation (30400)** -- Market to catalog mapping
+- **Primary key**: Shop Code, Market Id, Catalog Id
+- **Purpose**: Links Shopify markets to catalogs for B2B pricing
+
+### Order processing
+
+**Shpfy Order Header (30118)** -- Order master
+- **Primary key**: Shopify Order Id (BigInteger)
+- **Key fields**: Shop Code, Shopify Order No., Customer Id, Company Id, Sell-to Customer No., Sales Order No., Processed
+- **Dual currency**: Currency Code + amounts, Presentment Currency Code + Pres. amounts
+- **Status tracking**: Financial Status, Fulfillment Status, Return Status, Confirmed, Closed
+- **Relationships**: Customer Id → Shpfy Customer, Company Id → Shpfy Company, links to Sales Header via Sales Order No./Sales Invoice No.
+- **Address sets**: Bill-to, Ship-to, Sell-to (First Name, Last Name, Address, City, Post Code, Country/Region, County)
+- **Amounts**: Total Amount, Subtotal Amount, VAT Amount, Shipping Charges, Discount Amount, Total Tip Received (in both currencies)
+- **B2B fields**: Company Id, Company Main Contact Id, PO Number, Due Date, Payment Terms Type/Name
+- **Purpose**: Complete order header with all metadata needed for BC sales document creation
+
+**Shpfy Order Line (30119)** -- Order line items
+- **Primary key**: Shopify Order Id, Line Id (BigInteger)
+- **Key fields**: Shopify Product Id, Shopify Variant Id, Quantity, Unit Price, Discount Amount
+- **Relationships**: Parent order, product, and variant links; Location Id → Shpfy Shop Location
+- **Special line types**: Gift Card (Boolean), Tip (Boolean), Taxable (Boolean)
+- **Purpose**: Order line details for sales document creation
+
+**Shpfy Order Tax Line (30135)** -- Tax line details
+- **Primary key**: Parent Id, Line Id (BigInteger)
+- **Relationships**: Parent Id can be Order Id or Order Line Id (header-level or line-level tax)
+- **Fields**: Rate, Title, Tax Amount, Channel Liable (marketplace facilitator tax)
+- **Purpose**: Detailed tax breakdown for order processing
+
+**Shpfy Order Shipping Charges (30134)** -- Shipping cost breakdown
+- **Primary key**: Shopify Order Id, Id (BigInteger)
+- **Fields**: Title, Presentment Amount, Amount, Discounted Presentment Amount, Discounted Amount
+- **Purpose**: Shipping charges to map to BC sales line
+
+**Shpfy Order Risk (30136)** -- Fraud analysis
+- **Primary key**: Order Id, Id (BigInteger)
+- **Fields**: Level (enum: Low, Medium, High), Recommendation (enum: Accept, Investigate, Cancel), Message
+- **Purpose**: Shopify fraud detection results for order review
+
+### Fulfillment
+
+**Shpfy Order Fulfillment (30120)** -- Fulfillment records
+- **Primary key**: Shopify Fulfillment Id (BigInteger)
+- **Relationships**: Shopify Order Id → Shpfy Order Header
+- **Fields**: Status, Tracking Company, Tracking Numbers, Tracking Urls, Shipment Status
+- **Purpose**: Tracks shipment status and tracking information
+
+**Shpfy Fulfillment Order Header (30460)** -- Fulfillment orders
+- **Primary key**: Shopify Fulfillment Order Id (BigInteger)
+- **Relationships**: Shopify Order Id → Shpfy Order Header
+- **Fields**: Status, Request Status, Assigned Location Id, Fulfill At
+- **Purpose**: Shopify fulfillment order entity for third-party fulfillment
+
+**Shpfy Fulfillment Order Line (30461)** -- Fulfillment line items
+- **Primary key**: Id (BigInteger)
+- **Relationships**: Fulfillment Order Id → parent header, Order Line Id → Shpfy Order Line
+- **Fields**: Quantity, Remaining Quantity
+- **Purpose**: Line-level fulfillment tracking
+
+**Shpfy Fulfillment Line (30121)** -- Shipment line details
+- **Primary key**: Shopify Fulfillment Id, Id (BigInteger)
+- **Relationships**: Links fulfillment to order line
+- **Purpose**: Connects fulfillment records to specific order lines
+
+### Returns and refunds
+
+**Shpfy Return Header (30140)** -- Return requests
+- **Primary key**: Id (BigInteger)
+- **Relationships**: Order Id → Shpfy Order Header
+- **Status**: Return Status (Canceled, Closed, Open, Declined), Decline Reason
+- **Fields**: Total Quantity, Total Return Line Price Amount, Name (return number)
+- **Purpose**: Return authorization from customer
+
+**Shpfy Return Line (30141)** -- Return line items
+- **Primary key**: Return Id, Id (BigInteger)
+- **Relationships**: Links to Order Line, Refund Line
+- **Fields**: Quantity, Return Reason, Return Reason Note, Restock, Refund Price, Refund Tax
+- **Purpose**: Specific items being returned with quantities and reasons
+
+**Shpfy Refund Header (30142)** -- Refund records
+- **Primary key**: Id (BigInteger)
+- **Relationships**: Order Id → Shpfy Order Header, Return Id → Shpfy Return Header (optional)
+- **Fields**: Total Refunded Amount (dual currency), Note, Restock
+- **Purpose**: Financial refund issued for returns or order adjustments
+
+**Shpfy Refund Line (30143)** -- Refund line items
+- **Primary key**: Refund Id, Id (BigInteger)
+- **Relationships**: Line Id → Shpfy Order Line, Location Id → Shpfy Shop Location
+- **Fields**: Quantity, Subtotal, Total Tax, Restock Type
+- **Purpose**: Line-level refund details for credit memo creation
+
+**Shpfy Refund Shipping Line (30144)** -- Shipping refunds
+- **Primary key**: Refund Id, Id (BigInteger)
+- **Fields**: Amount, Maximum Refundable, Full Refund
+- **Purpose**: Tracks refunded shipping charges
+
+### Payments and financial
+
+**Shpfy Order Transaction (30133)** -- Payment transactions
+- **Primary key**: Shopify Transaction Id (BigInteger)
+- **Relationships**: Shopify Order Id → Shpfy Order Header
+- **Fields**: Amount, Type (enum: Authorization, Capture, Sale, Refund, Void), Status (enum: Pending, Success, Failure, Error), Gateway, Message, Authorization, Parent Id
+- **Purpose**: Payment transaction history for reconciliation
+
+**Shpfy Gift Card (30110)** -- Gift card usage
+- **Primary key**: Id (BigInteger)
+- **Relationships**: Order Id → Shpfy Order Header
+- **Fields**: Amount, Last Characters, Line Item Id
+- **Purpose**: Tracks gift card payments applied to orders
+
+### Metadata and tags
+
+**Shpfy Tag (30114)** -- Entity tags
+- **Primary key**: Parent Table No., Parent Id, Tag
+- **Relationships**: Polymorphic parent (Product, Customer, Order)
+- **Purpose**: Stores Shopify tags for filtering and categorization
+
+**Shpfy Metafield (30101)** -- Custom metadata
+- **Primary key**: Id (BigInteger)
+- **Key fields**: Parent Table No., Owner Id, Namespace, Name (key)
+- **Relationships**: Polymorphic owner (Product, Variant, Customer, Company, Order)
+- **Value fields**: Value (Text[2048]), Type (enum defining 50+ Shopify metafield types)
+- **Purpose**: Stores custom fields from Shopify metafields for bidirectional sync
+
+### System and infrastructure
+
+**Shpfy Log Entry (30115)** -- Diagnostic logging
+- **Primary key**: Id (BigInteger)
+- **Fields**: Time, Message, Context, Severity, Area, Tag, User, Company, Linked To Table, Linked To Id
+- **Purpose**: Detailed request/response logging when Logging Mode = All
+
+**Shpfy Skipped Record (30159)** -- Failed sync tracking
+- **Primary key**: Table ID, Shopify Id (BigInteger)
+- **Fields**: Error, System Created At
+- **Purpose**: Tracks records that failed to sync for later review
+
+**Shpfy Data Capture (30162)** -- GraphQL response cache
+- **Primary key**: Entry No. (BigInteger)
+- **Relationships**: Linked To Table, Linked To Id (polymorphic)
+- **Fields**: Request Id (Guid), Data (Blob), Captured At
+- **Purpose**: Stores raw JSON responses for troubleshooting
+
+**Shpfy Bulk Operation (30148)** -- Async operation tracking
+- **Primary key**: Id (BigInteger)
+- **Relationships**: Shop Code → Shpfy Shop
+- **Fields**: Status (enum: Created, Running, Completed, Failed, Canceled), Type (enum), Error Code, Created At, Completed At, Object Count
+- **Purpose**: Tracks long-running bulk mutations (e.g., updating 1000s of prices)
+
+**Shpfy Initial Import Line (30164)** -- Import wizard state
+- **Primary key**: Primary Key (Code[10])
+- **Fields**: Entity Type, Action, Start Date, End Date, Import Range
+- **Purpose**: Temporary table for guided initial data import
+
+**Shpfy Shipment Method Mapping (30123)** -- Shipping method mapping
+- **Primary key**: Shop Code, Name (Shopify shipping method name)
+- **Relationships**: TableRelation to Shipment Method
+- **Purpose**: Maps Shopify shipping methods to BC shipment methods
+
+**Shpfy Province (30160)** -- Country/state reference data
+- **Primary key**: Id (BigInteger)
+- **Fields**: Code, Name, Country Code
+- **Purpose**: Shopify province/state data for address validation
+
+**Shpfy Registered Store New (30138)** -- OAuth registration
+- **Primary key**: Shopify URL
+- **Fields**: Secret, Scope, Settings
+- **Purpose**: Stores OAuth configuration for shop authentication
+
+**Shpfy Cue (30167)** -- Role center counters
+- **Primary key**: Primary Key (Code[1])
+- **FlowFields**: Count of unprocessed orders, products with errors, etc.
+- **Purpose**: Drives role center KPIs and cues
+
+**Shpfy Templates Warnings (30168)** -- Template validation
+- **Primary key**: Id (Integer)
+- **Fields**: Template Type, Template Code, Warning
+- **Purpose**: Stores warnings about customer/item template configuration
+
+## Table extensions
+
+The app extends BC base tables to store Shopify-specific metadata:
+
+**Sales Header (30100)** -- Shopify Order Id (BigInteger)
+**Sales Header Archive (30101)** -- Shopify Order Id (BigInteger)
+**Sales Line (30102)** -- Shopify Order Line Id, Product Id, Variant Id
+**Sales Line Archive (30103)** -- Shopify Order Line Id, Product Id, Variant Id
+**Sales Invoice Header (30104)** -- Shopify Order Id (BigInteger)
+**Sales Invoice Line (30105)** -- Shopify Order Line Id, Product Id, Variant Id
+**Sales Cr.Memo Header (30106)** -- Shopify Return Id, Refund Id
+**Sales Cr.Memo Line (30107)** -- Shopify Refund Line Id
+**Sales Shipment Header (30108)** -- Shopify Order Id, Fulfillment Id
+**Sales Shipment Line (30109)** -- Shopify Order Line Id, Fulfillment Line Id
+**Return Receipt Header (30110)** -- Shopify Return Id (BigInteger)
+**Return Receipt Line (30111)** -- Shopify Return Line Id (BigInteger)
+**Cust. Ledger Entry (30112)** -- Shopify Order Id (BigInteger)
+**Gen. Journal Line (30113)** -- Shopify Order Id (BigInteger)
+**Shipping Agent (30114)** -- Shopify Carrier Name (Text[100])
+**Item Attribute (30115)** -- Shpfy Incl. in Product Sync (enum: No, As Variant, As Option)
+
+Purpose: These extensions enable navigation from BC documents back to Shopify entities and support document link validation.
+
+## Key enums
+
+**Shpfy Customer Mapping** (30107) -- By Email/Phone, By Bill-to Info, Always Create New, By Default Customer
+**Shpfy Company Mapping** (30162) -- By Tax ID, By Email/Phone, By Default Company, None
+**Shpfy Name Source** (30108) -- None, Company Name, First+Last Name, Last+First Name
+**Shpfy County Source** (30109) -- Code, Name
+**Shpfy Customer Import Range** (30101) -- None, All, With Order Import
+**Shpfy Company Import Range** (30158) -- None, All, With Order Import
+**Shpfy SKU Mapping** (30114) -- Item No., Variant Code, Item No. + Variant Code, Barcode, Item Reference
+**Shpfy Product Status** (30116) -- Active, Draft, Archived
+**Shpfy Inventory Policy** (30115) -- Deny, Continue (allow overselling)
+**Shpfy Financial Status** (30106) -- Pending, Authorized, Partially Paid, Paid, Partially Refunded, Refunded, Voided
+**Shpfy Order Fulfill. Status** (30103) -- Unfulfilled, Partial, Fulfilled
+**Shpfy ReturnRefund ProcessType** (30155) -- Import Only, Auto Create Credit Memo
+**Shpfy Transaction Type** (30128) -- Authorization, Capture, Sale, Refund, Void
+**Shpfy Transaction Status** (30129) -- Pending, Success, Failure, Error
+**Shpfy Logging Mode** (30104) -- None, All, Errors Only
+**Shpfy Synchronization Type** (30165) -- Products, Customers, Companies, Orders, Inventory
+**Shpfy Currency Handling** (30176) -- Shop Currency, Presentment Currency
+
+## Relationship diagram
+
+```
+Shpfy Shop (30102)
+  ├─> Shpfy Shop Location (30113) [1:N]
+  ├─> Shpfy Synchronization Info (30163) [1:N]
+  ├─> Shpfy Product (30127) [1:N]
+  │     ├─> Shpfy Variant (30129) [1:N]
+  │     │     └─> Shpfy Catalog Price (30153) [1:N]
+  │     ├─> Shpfy Product Image (30130) [1:N]
+  │     ├─> Shpfy Tag (30114) [polymorphic]
+  │     └─> Shpfy Metafield (30101) [polymorphic]
+  ├─> Shpfy Customer (30105) [1:N]
+  │     ├─> Shpfy Customer Address (30109) [1:N]
+  │     ├─> Shpfy Tag (30114) [polymorphic]
+  │     └─> Shpfy Metafield (30101) [polymorphic]
+  ├─> Shpfy Company (30150) [1:N]
+  │     ├─> Shpfy Company Location (30151) [1:N]
+  │     ├─> Shpfy Tag (30114) [polymorphic]
+  │     └─> Shpfy Metafield (30101) [polymorphic]
+  ├─> Shpfy Order Header (30118) [1:N]
+  │     ├─> Shpfy Order Line (30119) [1:N]
+  │     │     └─> Shpfy Order Tax Line (30135) [1:N]
+  │     ├─> Shpfy Order Tax Line (30135) [1:N] (header-level)
+  │     ├─> Shpfy Order Shipping Charges (30134) [1:N]
+  │     ├─> Shpfy Order Risk (30136) [1:N]
+  │     ├─> Shpfy Order Transaction (30133) [1:N]
+  │     ├─> Shpfy Gift Card (30110) [1:N]
+  │     ├─> Shpfy Order Fulfillment (30120) [1:N]
+  │     │     └─> Shpfy Fulfillment Line (30121) [1:N]
+  │     ├─> Shpfy Fulfillment Order Header (30460) [1:N]
+  │     │     └─> Shpfy Fulfillment Order Line (30461) [1:N]
+  │     ├─> Shpfy Return Header (30140) [1:N]
+  │     │     └─> Shpfy Return Line (30141) [1:N]
+  │     ├─> Shpfy Refund Header (30142) [1:N]
+  │     │     ├─> Shpfy Refund Line (30143) [1:N]
+  │     │     └─> Shpfy Refund Shipping Line (30144) [1:N]
+  │     ├─> Shpfy Tag (30114) [polymorphic]
+  │     └─> Shpfy Metafield (30101) [polymorphic]
+  ├─> Shpfy Bulk Operation (30148) [1:N]
+  ├─> Shpfy Log Entry (30115) [1:N]
+  └─> Shpfy Data Capture (30162) [1:N]
+
+BC Entity Links (via SystemId):
+  Item <─SystemId─ Shpfy Product.Item SystemId
+  Item <─SystemId─ Shpfy Variant.Item SystemId
+  Item Variant <─SystemId─ Shpfy Variant.Item Variant SystemId
+  Customer <─SystemId─ Shpfy Customer.Customer SystemId
+  Customer <─SystemId─ Shpfy Company.Customer SystemId
+  Sales Header <─No.─ Shpfy Order Header.Sales Order No.
+```
+
+## Design patterns
+
+### Header-line pattern
+Order Header/Line, Return Header/Line, Refund Header/Line, Fulfillment Order Header/Line -- standard BC header-detail structure
+
+### Dual currency tracking
+Shpfy Order Header stores both Currency Code (shop currency) and Presentment Currency Code (customer's display currency) with parallel amount fields (Total Amount vs Presentment Total Amount)
+
+### SystemId linking
+Tables use Guid SystemId fields to reference BC entities instead of Code/No. fields, enabling more flexible mapping logic
+
+### Hash-based change detection
+Shpfy Product stores Image Hash, Tags Hash, Description Html Hash to detect changes without comparing full field values; "Last Updated by BC" timestamp tracks BC-initiated changes
+
+### Polymorphic ownership
+Shpfy Tag and Shpfy Metafield use "Parent Table No." + "Parent Id"/"Owner Id" to support multiple parent entity types (Product, Customer, Order, Company)

--- a/src/Apps/W1/Shopify/App/docs/patterns.md
+++ b/src/Apps/W1/Shopify/App/docs/patterns.md
@@ -1,0 +1,556 @@
+# Patterns
+
+## IsHandled pattern
+
+The IsHandled pattern enables event subscribers to prevent default behavior execution by setting a boolean `var IsHandled: Boolean` parameter to true. This pattern appears 114 times across 17 files.
+
+### Purpose
+Allows complete replacement of default logic without modifying base code. When IsHandled is set to true, the default implementation is skipped.
+
+### Implementation structure
+```al
+var
+    IsHandled: Boolean;
+begin
+    IsHandled := false;
+    OnBeforeDoSomething(Parameters, IsHandled);
+    if IsHandled then
+        exit;
+
+    // Default implementation runs only if IsHandled remains false
+    DefaultImplementation();
+end;
+```
+
+### Example: Custom product export filter
+From `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Codeunits\ShpfyProductExport.Codeunit.al`:
+```al
+ShopifyProduct.SetFilter("Item SystemId", '<>%1', NullGuid);
+ShopifyProduct.SetFilter("Shop Code", Rec.GetFilter(Code));
+
+ProductEvents.OnAfterProductsToSynchronizeFiltersSet(ShopifyProduct, Shop, OnlyUpdatePrice);
+```
+Subscribers can modify the ShopifyProduct filter to change which products sync, adding custom criteria like "only items with specific attribute values" or "only items in certain categories."
+
+### Example: Custom GraphQL query
+From `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\GraphQL\Codeunits\ShpfyGraphQLQueries.Codeunit.al`:
+```al
+IsHandled := false;
+OnBeforeGetGrapQLInfo(GraphQLType, Parameters, IGraphQL, GraphQL, ExpectedCost, IsHandled);
+if not IsHandled then begin
+    GraphQL := IGraphQL.GetGraphQL();
+    ExpectedCost := IGraphQL.GetExpectedCost();
+end;
+```
+Subscribers can completely replace the GraphQL query for a given operation, such as adding custom fields to product queries or modifying order filters.
+
+### Example: Custom order line processing
+From `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Codeunits\ShpfyOrderMapping.Codeunit.al`:
+```al
+OrderEvents.OnBeforeCreateSalesLine(ShopifyOrderHeader, ShopifyOrderLine, SalesHeader, SalesLine, IsHandled);
+if not IsHandled then begin
+    // Create standard sales line from order line
+    CreateSalesLineFromOrderLine(ShopifyOrderLine, SalesLine);
+end;
+```
+Subscribers can prevent standard sales line creation and implement custom logic, such as splitting lines, adding related items, or applying custom pricing.
+
+### Common use cases
+- **Skip default customer mapping**: Implement custom logic to find or create customers based on proprietary fields
+- **Override price calculation**: Use custom price lists or discount engines
+- **Custom sales document creation**: Create purchase orders for dropship items or special order types
+- **Filter synchronization scope**: Limit products/customers/orders synced based on business rules
+- **Replace GraphQL queries**: Add custom fields to Shopify queries or modify filters
+
+## Interface + Enum pattern
+
+The app defines 22 interfaces with corresponding enums to enable pluggable behavior. Each enum value implements the interface, creating a strategy pattern for swappable logic.
+
+### Purpose
+Provides type-safe, compile-time validated extension points for core business logic. Unlike events (runtime extensibility), interfaces enable algorithm replacement with IntelliSense support.
+
+### Implementation structure
+1. Define interface with required procedures
+2. Define enum with strategy options
+3. Enum implements interface with different codeunits per value
+4. Business logic uses `IInterface := EnumValue` syntax
+
+### Key interface implementations
+
+#### ICustomerMapping -- Customer association strategy (4 implementations)
+**Interface**: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Customers\Interfaces\ShpfyICustomerMapping.Interface.al`
+```al
+interface "Shpfy ICustomerMapping"
+{
+    procedure FindCustomer(ShopifyCustomer: Record "Shpfy Customer"; var Customer: Record Customer): Boolean;
+}
+```
+
+**Enum**: Shpfy Customer Mapping (30107)
+- **By Email/Phone**: Matches Customer."E-Mail" or "Phone No." to Shopify customer
+- **By Bill-to Info**: Matches billing address fields
+- **Always Create New**: Never maps to existing, always creates
+- **By Default Customer**: Always uses default customer no. from shop settings
+
+**Usage in** `ShpfyCustomerMapping.Codeunit.al`:
+```al
+procedure FindMapping(var ShopifyCustomer: Record "Shpfy Customer"): Boolean
+var
+    ICustomerMapping: Interface "Shpfy ICustomerMapping";
+begin
+    ICustomerMapping := Shop."Customer Mapping Type";
+    exit(ICustomerMapping.FindCustomer(ShopifyCustomer, Customer));
+end;
+```
+
+#### ICompanyMapping -- B2B company association (4 implementations)
+**Interface**: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Companies\Interfaces\ShpfyICompanyMapping.Interface.al`
+- **By Tax ID**: Matches company tax registration ID
+- **By Email/Phone**: Matches main contact info
+- **By Default Company**: Uses default company no.
+- **None**: Disables company mapping
+
+#### IStockCalculation -- Inventory calculation (2 implementations)
+**Interface**: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Inventory\Interface\ShpfyStockCalculation.Interface.al`
+```al
+interface "Shpfy Stock Calculation"
+{
+    procedure GetStock(var ShopifyShopInventory: Record "Shpfy Shop Inventory"): Decimal;
+}
+```
+
+**Implementations**:
+- **Default**: Uses standard available inventory calculation
+- **Projected Available Balance**: Uses planning calculation
+
+Shop Location."Stock Calculation" field determines which implementation to use.
+
+#### IMetafieldType -- Type-specific metafield handling (50+ implementations)
+**Interface**: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Metafields\Interfaces\ShpfyIMetafieldType.Interface.al`
+```al
+interface "Shpfy IMetafield Type"
+{
+    procedure HasValue(Metafield: Record "Shpfy Metafield"): Boolean;
+    procedure GetValue(Metafield: Record "Shpfy Metafield"): Text;
+    procedure SetValue(var Metafield: Record "Shpfy Metafield"; Value: Text);
+}
+```
+
+**Sample implementations**: Money, Weight, Dimension, Volume, Date, DateTime, Number (Decimal/Integer), Single Line Text, Multi Line Text, JSON, etc.
+
+Each type knows how to parse JSON values from Shopify and format them for storage/display.
+
+#### IGraphQL -- Query template provider
+**Interface**: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\GraphQL\Interfaces\ShpfyIGraphQL.Interface.al`
+```al
+interface "Shpfy IGraphQL"
+{
+    procedure GetGraphQL(): Text;
+    procedure GetExpectedCost(): Integer;
+}
+```
+
+Each GraphQL query type (product query, order query, customer query, etc.) implements this interface to provide the query template and cost estimate for rate limiting.
+
+**Example**: Shpfy GraphQL Type enum has 100+ values, each providing a different query template.
+
+#### IReturnRefundProcess -- Return processing strategy (3 implementations)
+**Interface**: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order Return Refund Processing\Interfaces\ShpfyIReturnRefundProcess.Interface.al`
+- **Import Only**: Stores refund data but creates no BC documents
+- **Auto Create Credit Memo**: Automatically creates BC credit memos from refunds
+- **Only Refund**: Handles refunds without associated returns
+
+#### IDocumentSource -- Return source tracking (5+ implementations)
+**Interface**: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order Return Refund Processing\Interfaces\ShpfyIDocumentSource.Interface.al`
+
+Implementations for Sales Order, Sales Invoice, Posted Sales Invoice, Posted Sales Shipment, Posted Sales Credit Memo -- enables return tracing to original document.
+
+#### IOpenBCDocument / IOpenShopifyDocument -- Document navigation (13+ implementations)
+**Interfaces**: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Document Links\Interfaces\`
+
+Implementations for opening different document types (Sales Order, Posted Invoice, Shipment, Return, Refund, etc.) from links. Enables navigation from Shopify → BC and BC → Shopify.
+
+### Benefits
+- **Compile-time safety**: Interface contract enforced by compiler
+- **Centralized extension**: All implementations in one enum
+- **IntelliSense discovery**: Developers can see all available strategies
+- **No event subscription**: Simpler than events for strategy pattern
+- **Testability**: Easy to test individual strategy implementations
+
+## TryFunction error handling
+
+The TryFunction attribute marks procedures that catch errors and return boolean success/failure instead of propagating errors. Used 14 times across 10 files.
+
+### Purpose
+Enables graceful error handling without breaking transaction scope. Particularly useful for API calls that may fail due to rate limiting, network issues, or validation errors.
+
+### Implementation pattern
+```al
+[TryFunction]
+local procedure TryExecuteGraphQL(Parameters): Boolean
+var
+    Result: JsonToken;
+begin
+    Result := ExecuteGraphQL(Parameters);
+    exit(true);
+end;
+```
+
+### Example: Rate limit handling
+From `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\GraphQL\Codeunits\ShpfyGraphQLRateLimit.Codeunit.al`:
+```al
+[TryFunction]
+local procedure TryExecuteGraphQL(GraphQLType: Enum "Shpfy GraphQL Type"; Parameters: Dictionary of [Text, Text]; var JResponse: JsonToken)
+begin
+    JResponse := CommunicationMgt.ExecuteGraphQL(GraphQLType, Parameters, true);
+end;
+
+procedure ExecuteGraphQLWithRateLimit(): JsonToken
+var
+    JResponse: JsonToken;
+    Success: Boolean;
+    ThrottleCount: Integer;
+begin
+    repeat
+        Success := TryExecuteGraphQL(GraphQLType, Parameters, JResponse);
+        if not Success then begin
+            ThrottleCount += 1;
+            Sleep(CalculateThrottleDelay(ThrottleCount));
+        end;
+    until Success or (ThrottleCount > MaxRetries);
+    exit(JResponse);
+end;
+```
+This pattern allows the app to retry throttled requests without rolling back the transaction.
+
+### Example: JSON parsing safety
+From `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Helpers\Codeunits\ShpfyJsonHelper.Codeunit.al`:
+```al
+[TryFunction]
+procedure TryGetJsonValue(JObject: JsonObject; Path: Text; var JValue: JsonValue)
+begin
+    JObject.SelectToken(Path, JToken);
+    JValue := JToken.AsValue();
+end;
+
+procedure GetValueAsText(JObject: JsonObject; Path: Text; MaxLength: Integer): Text
+var
+    JValue: JsonValue;
+begin
+    if TryGetJsonValue(JObject, Path, JValue) then
+        exit(CopyStr(JValue.AsText(), 1, MaxLength));
+    exit('');
+end;
+```
+Returns empty string instead of error if JSON path doesn't exist.
+
+### Example: Bulk operation result processing
+From `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Bulk Operations\Codeunits\ShpfyBulkOperationAPI.Codeunit.al`:
+```al
+[TryFunction]
+local procedure TryDownloadBulkResult(Url: Text; var TempBlob: Codeunit "Temp Blob")
+var
+    Client: HttpClient;
+    Response: HttpResponseMessage;
+begin
+    Client.Get(Url, Response);
+    Response.Content.ReadAs(TempBlob);
+end;
+```
+Prevents bulk operation failures from crashing the entire sync process.
+
+### Common use cases
+- **API retries**: Try API call, retry on throttle/timeout
+- **Optional fields**: Try parse field, continue if missing
+- **Validation**: Try validate data, log error if invalid
+- **File operations**: Try download/upload, handle failure gracefully
+
+## Partial records (SetLoadFields)
+
+SetLoadFields optimizes database queries by loading only specified fields, reducing memory and improving performance for large tables.
+
+### Purpose
+Minimizes data transfer when only a subset of fields is needed. Critical for performance when processing thousands of orders/products.
+
+### Usage locations
+Found in 5+ files:
+- `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Codeunits\ShpfyImportOrder.Codeunit.al`
+- `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Codeunits\ShpfyProductExport.Codeunit.al`
+- `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Page Extensions\ShpfyItemCard.PageExt.al`
+
+### Example: Order line processing
+```al
+ShopifyOrderLine.SetLoadFields("Shopify Order Id", "Line Id", "Shopify Product Id", "Shopify Variant Id", Quantity, "Unit Price");
+if ShopifyOrderLine.FindSet() then
+    repeat
+        ProcessLine(ShopifyOrderLine);
+    until ShopifyOrderLine.Next() = 0;
+```
+Loads only 6 fields instead of 50+, improving loop performance by 3-5x for large order imports.
+
+### Example: Item lookup
+```al
+Item.SetLoadFields(SystemId, "No.", Description, Blocked);
+if Item.Get(ItemNo) then
+    if not Item.Blocked then
+        ProcessItem(Item);
+```
+Loads minimal fields for validation check, then loads full record only if needed.
+
+### Best practices
+- **Use before FindSet()**: Most beneficial for loops over large datasets
+- **Include primary key**: Always include key fields for proper record identification
+- **Combine with filters**: Use with SetRange/SetFilter for maximum benefit
+- **Load full record when updating**: Call Get() without SetLoadFields before Modify()
+
+## GraphQL query template pattern
+
+All GraphQL queries use parameterized templates with `{{Placeholder}}` syntax for dynamic value substitution. This centralizes query definitions and enables modification via events.
+
+### Template structure
+Queries are stored as text constants with placeholder tokens:
+```graphql
+query {
+  products(first: {{MaxItems}}, query: "{{ProductFilter}}") {
+    edges {
+      node {
+        id
+        title
+        variants(first: 10) {
+          edges {
+            node { id sku price }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Parameter substitution
+From `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\GraphQL\Codeunits\ShpfyGraphQLQueries.Codeunit.al`:
+```al
+internal procedure GetQuery(GraphQLType: enum "Shpfy GraphQL Type"; Parameters: Dictionary of [Text, Text]) GraphQL: Text
+var
+    IGraphQL: Interface "Shpfy IGraphQL";
+begin
+    IGraphQL := GraphQLType;
+    GraphQL := IGraphQL.GetGraphQL();
+
+    if Parameters.Count > 0 then
+        foreach Param in Parameters.Keys do
+            GraphQL := GraphQL.Replace('{{' + Param + '}}', Parameters.Get(Param));
+    exit(GraphQL);
+end;
+```
+
+### Example: Product export query
+From `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Codeunits\ShpfyProductAPI.Codeunit.al`:
+```al
+GraphQuery.Append('{"query":"mutation {productCreate(product: {');
+GraphQuery.Append('title: \"');
+GraphQuery.Append(CommunicationMgt.EscapeGraphQLData(ShopifyProduct.Title));
+GraphQuery.Append('\"');
+// ... build mutation dynamically
+GraphQuery.Append('}) {product {legacyResourceId, onlineStoreUrl}, userErrors {field, message}}}"}');
+
+JResponse := CommunicationMgt.ExecuteGraphQL(GraphQuery.ToText());
+```
+
+### Benefits
+- **Centralized queries**: All queries in one codeunit (Shpfy GraphQL Queries 30154)
+- **Version safety**: API version changes require updates in one place
+- **Event extensibility**: OnBeforeGetGraphQLInfo event allows query replacement
+- **Type safety**: Enum-based query selection with IntelliSense
+- **Cost tracking**: Each query template includes expected API cost
+
+### Extension pattern
+```al
+[EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy GraphQL Queries", 'OnBeforeGetGrapQLInfo', '', true, true)]
+local procedure OnBeforeGetProductQuery(GraphQLType: Enum "Shpfy GraphQL Type"; var GraphQL: Text; var IsHandled: Boolean)
+begin
+    if GraphQLType = GraphQLType::GetProducts then begin
+        GraphQL := 'query { products(first: 50) { edges { node { id title myCustomField } } } }';
+        IsHandled := true;
+    end;
+end;
+```
+This replaces the default product query to include custom metafields.
+
+## Event-driven extensibility
+
+The connector exposes 70+ integration events across three event codeunits, enabling deep customization without modifying base code.
+
+### Event categories
+
+#### Pre-processing events (On**Before**)
+Allow validation, modification, or cancellation before an operation:
+- **OnBeforeCreateCustomer**: Validate customer data, set IsHandled to prevent creation
+- **OnBeforeCreateSalesLine**: Modify line data, add custom logic
+- **OnBeforeSendCreateShopifyProduct**: Adjust product before sending to Shopify
+- **OnBeforeGetGraphQLInfo**: Replace GraphQL query entirely
+
+#### Post-processing events (On**After**)
+Allow customization after an operation completes:
+- **OnAfterCreateCustomer**: Set custom fields on newly created customer
+- **OnAfterCreateSalesHeader**: Add custom dimensions, apply business logic
+- **OnAfterImportOrder**: Trigger custom workflows, send notifications
+- **OnAfterCalculateAvailableInventory**: Apply custom stock reservations
+
+#### Decision events (OnBefore**Find**)
+Allow custom logic for lookups and mappings:
+- **OnBeforeFindCustomerTemplate**: Select template based on custom rules
+- **OnBeforeFindMapping**: Implement custom customer/product matching
+- **OnBeforeFindItemTemplate**: Select item template by category
+
+### Example: Custom customer mapping
+```al
+[EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Customer Events", 'OnBeforeFindMapping', '', true, true)]
+local procedure OnBeforeFindCustomerMapping(Direction: Enum "Shpfy Mapping Direction"; var ShopifyCustomer: Record "Shpfy Customer"; var Customer: Record Customer; var Handled: Boolean)
+begin
+    if Direction = Direction::"From Shopify" then begin
+        // Custom logic: match by loyalty program ID stored in metafield
+        if FindCustomerByLoyaltyId(ShopifyCustomer, Customer) then
+            Handled := true;
+    end;
+end;
+```
+
+### Example: Custom sales line pricing
+```al
+[EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Order Events", 'OnAfterCalcSalesPrice', '', true, true)]
+local procedure OnAfterCalculatePrice(ShopifyOrderLine: Record "Shpfy Order Line"; var SalesLine: Record "Sales Line")
+begin
+    // Apply custom pricing logic after standard calculation
+    if ShopifyOrderLine."Discount Amount" > 1000 then
+        SalesLine.Validate("Line Discount Amount", ShopifyOrderLine."Discount Amount" * 0.9);
+end;
+```
+
+### Example: Post-import workflow trigger
+```al
+[EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Order Events", 'OnAfterImportOrder', '', true, true)]
+local procedure OnAfterOrderImport(ShopifyOrderHeader: Record "Shpfy Order Header")
+begin
+    // Trigger custom approval workflow for high-value orders
+    if ShopifyOrderHeader."Total Amount" > 10000 then
+        SendApprovalRequest(ShopifyOrderHeader);
+end;
+```
+
+### Event discovery
+All events documented in event codeunits:
+- **Shpfy Order Events (30166)** -- 19 events for order processing
+- **Shpfy Customer Events (30115)** -- 7 events for customer sync
+- **Shpfy Product Events (30177)** -- 35+ events for product sync
+- **Shpfy Shipping Events (30123)** -- 2 events for fulfillment
+- **Shpfy Inventory Events (30201)** -- 1 event for stock calculation
+- **Shpfy Refund Process Events (30146)** -- 6 events for return/refund processing
+- **Shpfy Communication Events (30148)** -- Events for API call logging/modification
+
+## Header-line pattern
+
+Standard AL pattern for master-detail relationships. Used for orders, returns, refunds, fulfillments.
+
+### Structure
+- **Header table**: Stores document-level data (customer, totals, status)
+- **Line table**: Stores line-level data (item, quantity, price)
+- **Primary key relationship**: Line table includes header's primary key
+
+### Implementation examples
+
+**Order processing**:
+- Shpfy Order Header (30118) ← Shpfy Order Line (30119)
+- Shpfy Order Line includes "Shopify Order Id" linking to header
+
+**Returns**:
+- Shpfy Return Header (30140) ← Shpfy Return Line (30141)
+- Shpfy Return Line includes "Return Id" linking to header
+
+**Refunds**:
+- Shpfy Refund Header (30142) ← Shpfy Refund Line (30143)
+- Multiple refund lines per refund header
+
+**Fulfillments**:
+- Shpfy Order Fulfillment (30120) ← Shpfy Fulfillment Line (30121)
+- Shpfy Fulfillment Order Header (30460) ← Shpfy Fulfillment Order Line (30461)
+
+### Cascade delete pattern
+Headers implement OnDelete trigger to delete child lines:
+```al
+trigger OnDelete()
+var
+    ShopifyOrderLine: Record "Shpfy Order Line";
+begin
+    ShopifyOrderLine.SetRange("Shopify Order Id", "Shopify Order Id");
+    if not ShopifyOrderLine.IsEmpty then
+        ShopifyOrderLine.DeleteAll(true);
+end;
+```
+
+## Hash-based change detection
+
+Products and variants use integer hash codes to detect changes without comparing full field values. Improves performance and reduces API calls.
+
+### Hash fields in Shpfy Product (30127)
+- **Image Hash**: Detects image changes
+- **Tags Hash**: Detects tag list changes
+- **Description Html Hash**: Detects description changes
+- **Last Updated by BC**: Timestamp of last BC-initiated update
+
+### Hash calculation
+From Shpfy Hash codeunit:
+```al
+procedure CalcHash(Value: Text): Integer
+var
+    MD5: Codeunit "Cryptography Management";
+begin
+    exit(MD5.GenerateHash(Value, 2)); // 2 = MD5
+end;
+```
+
+### Change detection workflow
+```al
+procedure UpdateProductIfChanged(var Product: Record "Shpfy Product")
+var
+    Hash: Codeunit "Shpfy Hash";
+    NewDescriptionHash: Integer;
+begin
+    NewDescriptionHash := Hash.CalcHash(Product.GetDescriptionHtml());
+    if NewDescriptionHash <> Product."Description Html Hash" then begin
+        // Description changed, update Shopify
+        Product."Description Html Hash" := NewDescriptionHash;
+        UpdateProductInShopify(Product);
+    end;
+end;
+```
+
+### Benefits
+- **Efficient comparison**: Integer comparison faster than text comparison
+- **Null-safe**: Hash of empty text is valid integer
+- **Prevents unnecessary API calls**: Only sync when content actually changes
+- **Bidirectional tracking**: "Last Updated by BC" prevents circular updates
+- **Audit trail**: Hash changes indicate modification history
+
+### Example: Tag sync optimization
+```al
+procedure CalcTagsHash(): Integer
+var
+    Hash: Codeunit "Shpfy Hash";
+begin
+    exit(Hash.CalcHash(Rec.GetCommaSeparatedTags()));
+end;
+
+procedure UpdateTagsIfChanged(CommaSeparatedTags: Text)
+var
+    Hash: Codeunit "Shpfy Hash";
+    NewHash: Integer;
+begin
+    NewHash := Hash.CalcHash(CommaSeparatedTags);
+    if NewHash <> Rec."Tags Hash" then begin
+        Rec.UpdateTags(CommaSeparatedTags);
+        Rec."Tags Hash" := NewHash;
+    end;
+end;
+```
+Only sends tag updates to Shopify when the comma-separated list actually changes.

--- a/src/Apps/W1/Shopify/App/src/Base/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Base/docs/CLAUDE.md
@@ -1,0 +1,43 @@
+# Base
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Core infrastructure for the Shopify Connector, including shop configuration, synchronization tracking, tag management, and shared utilities.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Shop (30102) | Central shop configuration and settings |
+| Table | Shpfy Synchronization Info (30103) | Tracks last sync time per sync type |
+| Table | Shpfy Tag (30104) | Stores tags for products, customers, orders |
+| Table | Shpfy Initial Import Line (30137) | Guided initial import workflow |
+| Table | Shpfy Cue (30138) | Activity cue counts for role center |
+| Codeunit | Shpfy Communication Mgt. (30100) | HTTP communication and GraphQL requests |
+| Codeunit | Shpfy Shop Mgt. (30101) | Shop management operations |
+| Codeunit | Shpfy Installer (30102) | App installation and upgrade |
+| Codeunit | Shpfy Filter Mgt. (30103) | Filter parsing and manipulation |
+| Codeunit | Shpfy Initial Import (30104) | Initial data import orchestration |
+| Codeunit | Shpfy Background Syncs (30105) | Background job queue sync tasks |
+| Codeunit | Shpfy Guided Experience (30106) | Assisted setup and onboarding |
+| Codeunit | Shpfy Upgrade Mgt. (30107) | Upgrade code for schema changes |
+| Codeunit | Shpfy Communication Events (30108) | Event publishers for HTTP/GraphQL |
+| Enum | Shpfy Synchronization Type (30100) | Products, Customers, Orders, etc. |
+| Enum | Shpfy Logging Mode (30101) | Disabled, Error Only, Verbose |
+| Enum | Shpfy Mapping Direction (30102) | ShopifyToBC, BCToShopify |
+| Enum | Shpfy Import Action (30103) | Create, Update, Skip |
+| Page | Shpfy Shops (30100) | Shop list page |
+| Page | Shpfy Shop Card (30101) | Shop configuration card |
+| Page | Shpfy Tags (30102) | Tag list page |
+| Page | Shpfy Activities (30103) | Activity page for role center |
+
+## Key concepts
+
+- Shop as central configuration: Shpfy Shop table stores all settings for a Shopify store connection
+- Multi-shop support: Single BC environment can connect to multiple Shopify shops
+- Synchronization tracking: Shpfy Synchronization Info records last sync timestamp for each sync type (Products, Customers, Orders, etc.)
+- Tag management: Shpfy Tag table stores tags for multiple entity types (products, customers, orders) using Parent Table No. and Parent Id
+- Initial import workflow: Shpfy Initial Import Line tracks import jobs for guided setup
+- Communication abstraction: Shpfy Communication Mgt. handles all HTTP/GraphQL communication with Shopify API
+- Logging modes: Configurable logging (Disabled, Error Only, Verbose) for troubleshooting
+- Background jobs: Shpfy Background Syncs creates job queue entries for automated sync

--- a/src/Apps/W1/Shopify/App/src/Base/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/src/Base/docs/data-model.md
@@ -1,0 +1,238 @@
+# Base data model
+
+## Tables
+
+### Shpfy Shop (30102)
+Central configuration table for Shopify shop connection.
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Base\Tables\ShpfyShop.Table.al`
+
+**Key fields (first 300 lines shown):**
+
+**Connection:**
+- `Code` (Code[20]) -- Primary key, shop identifier
+- `Shopify URL` (Text[250]) -- Admin URL (e.g., https://mystore.myshopify.com/admin)
+- `Enabled` (Boolean) -- Shop enabled for sync
+- `Shop Id` (Integer) -- Calculated from Shopify URL hash
+
+**Logging:**
+- `Logging Mode` (Enum Shpfy Logging Mode) -- Disabled, Error Only, Verbose
+
+**Product sync:**
+- `Sync Item` (Option) -- " ", "To Shopify", "From Shopify"
+- `Sync Item Images` (Option) -- " ", "To Shopify", "From Shopify"
+- `Sync Item Extended Text` (Boolean) -- Include extended text in product body
+- `Sync Item Attributes` (Boolean) -- Include item attributes in product body
+- `Sync Item Marketing Text` (Boolean) -- Include marketing text
+- `Can Update Shopify Products` (Boolean) -- Allow BC to update existing Shopify products
+- `SKU Mapping` (Enum Shpfy SKU Mapping) -- How SKU maps to BC
+- `UoM as Variant` (Boolean) -- Represent units of measure as variants
+- `Status for Created Products` (Enum Shpfy Cr Prod Status Value) -- Active or Draft
+- `Action for Removed Products` (Enum Shpfy Remove Product Action) -- Status change when removed
+
+**Item creation:**
+- `Auto Create Unknown Items` (Boolean) -- Create BC items from Shopify products
+- `Item Templ. Code` (Code[20]) -- Template for new items
+- `Shopify Can Update Items` (Boolean) -- Allow Shopify to update BC items
+
+**Customer sync:**
+- `Customer Import From Shopify` (Enum Shpfy Customer Import Range) -- AllCustomers, WithOrderImport, None
+- `Auto Create Unknown Customers` (Boolean) -- Create BC customers from Shopify
+- `Customer Templ. Code` (Code[20]) -- Template for new customers
+- `Shopify Can Update Customer` (Boolean) -- Allow Shopify to update BC customers
+- `Can Update Shopify Customer` (Boolean) -- Allow BC to update Shopify customers
+- `Customer Mapping Type` (Enum Shpfy Customer Mapping) -- By Email/Phone, By Bill-to, DefaultCustomer
+- `Default Customer No.` (Code[20]) -- Default customer for all orders
+- `Name Source`, `Name 2 Source`, `Contact Source` (Enum Shpfy Name Source) -- Name derivation
+- `County Source` (Enum Shpfy County Source) -- Code or Name
+
+**Pricing:**
+- `Customer Price Group` (Code[10]) -- For price calculation
+- `Customer Discount Group` (Code[20]) -- For discount calculation
+
+**GL accounts:**
+- `Shipping Charges Account` (Code[20]) -- G/L account for shipping
+- (Additional accounts for tips, sold gift cards, etc.)
+
+**Language and currency:**
+- `Language Code` (Code[10]) -- Default language for sync
+- (Currency settings in other fields)
+
+**Additional configuration fields:**
+- Order processing settings
+- Inventory sync settings
+- Tax and VAT settings
+- B2B company settings
+- Webhook settings
+- Initial import settings
+
+**Methods:**
+- `SetLastSyncTime(SyncType, DateTime)` -- Updates Shpfy Synchronization Info
+- `CalcShopId()` -- Calculates Shop Id from URL hash
+
+**Relationships:**
+- 1:N with all Shopify entity tables (Product, Customer, Order, etc.)
+- 1:N with Shpfy Synchronization Info
+- 1:N with Shpfy Initial Import Line
+
+**Indexes:**
+- PK: Code (clustered)
+
+### Shpfy Synchronization Info (30103)
+Tracks last synchronization timestamp for each sync type.
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Base\Tables\ShpfySynchronizationInfo.Table.al`
+
+**Key fields:**
+- `Shop Code` (Code[20]) -- Part of PK
+- `Synchronization Type` (Enum Shpfy Synchronization Type) -- Part of PK
+- `Last Sync Time` (DateTime) -- Last successful sync timestamp
+
+**Synchronization Types (from enum):**
+- Products
+- Customers
+- Companies
+- Orders
+- Inventory
+- Images
+- Payments
+- Payouts
+- (Additional types for webhooks, bulk operations, etc.)
+
+**Usage:** Used to perform incremental syncs (only sync records updated since Last Sync Time).
+
+**Indexes:**
+- PK: Shop Code, Synchronization Type (clustered)
+
+### Shpfy Tag (30104)
+Stores tags for multiple entity types.
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Base\Tables\ShpfyTag.Table.al`
+
+**Key fields:**
+- `Parent Table No.` (Integer) -- Table ID (e.g., Database::"Shpfy Product")
+- `Parent Id` (BigInteger) -- Record ID in parent table
+- `Tag` (Text[255]) -- Tag value
+
+**Constraint:** Maximum 250 tags per parent record (enforced in OnInsert trigger).
+
+**Methods:**
+- `GetCommaSeparatedTags(ParentId)` -- Returns "tag1,tag2,tag3"
+- `UpdateTags(ParentTableNo, ParentId, CommaSeparatedTags)` -- Replaces all tags for record
+
+**Usage:** Used by Shpfy Product, Shpfy Customer, Shpfy Order to store Shopify tags.
+
+**Indexes:**
+- PK: Parent Id, Tag (clustered)
+
+### Shpfy Initial Import Line (30137)
+Tracks initial import jobs for guided setup.
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Base\Tables\ShpfyInitialImportLine.Table.al`
+
+**Key fields:**
+- `Name` (Code[20]) -- Import step name (e.g., "Products", "Customers"), primary key
+- `Dependency Filter` (Text[250]) -- Steps that must complete first
+- `Session ID` (Integer) -- Session running the job
+- `Job Status` (Option) -- " ", Success, "In Process", Error
+- `Job Queue Entry ID` (Guid) -- Link to Job Queue Entry
+- `Job Queue Entry Status` (Option) -- Mirrors job queue status
+- `Shop Code` (Code[20]) -- Shop being imported
+- `Page ID` (Integer) -- Page to open after completion
+- `Demo Import` (Boolean) -- Demo data import flag
+
+**Flow:**
+1. Initial import creates lines for each sync type (Products, Customers, etc.)
+2. Dependency Filter ensures correct order (e.g., Customers before Orders)
+3. Job Queue Entry created for each line
+4. Job Status updated as import progresses
+
+**Indexes:**
+- Key1: Name (clustered)
+
+### Shpfy Cue (30138)
+Activity cue counts for role center.
+
+**Fields:**
+- Counts of orders, products, customers by status
+- Used in Shpfy Activities page for drill-down
+
+## Enums
+
+### Shpfy Synchronization Type (30100)
+Identifies sync operation type for Shpfy Synchronization Info.
+
+**Values:**
+- Products
+- Customers
+- Companies
+- Orders
+- Inventory
+- Images
+- Payments
+- Payouts
+- Webhooks
+- BulkOperations
+- (Additional types)
+
+### Shpfy Logging Mode (30101)
+Controls logging verbosity.
+
+**Values:**
+- `Disabled` (0) -- No logging
+- `Error Only` (1) -- Log errors only
+- `Verbose` (2) -- Log all requests/responses
+
+**Used by:** Shpfy Communication Mgt. to determine what to log in Shpfy Log Entry table.
+
+### Shpfy Mapping Direction (30102)
+Direction of mapping operation.
+
+**Values:**
+- `ShopifyToBC` (0) -- Import: Map Shopify record to BC record
+- `BCToShopify` (1) -- Export: Map BC record to Shopify record
+
+**Used by:** Product Mapping, Customer Mapping, Company Mapping to determine search direction.
+
+### Shpfy Import Action (30103)
+Action to take when importing record.
+
+**Values:**
+- `Create` -- Create new BC record
+- `Update` -- Update existing BC record
+- `Skip` -- Skip record
+
+## Relationships
+
+```
+Shpfy Shop (1) ----< (N) Shpfy Synchronization Info
+       |
+       +----< (N) Shpfy Initial Import Line
+       |
+       +----< (N) Shpfy Product
+       |
+       +----< (N) Shpfy Customer
+       |
+       +----< (N) Shpfy Company
+       |
+       +----< (N) Shpfy Order
+       |
+       +----< (N) ... (all entity tables)
+
+Shpfy Tag -- generic, linked via Parent Table No. + Parent Id
+  (Used by Shpfy Product, Shpfy Customer, Shpfy Order)
+```
+
+## Key indexes
+
+**Shpfy Shop:**
+- PK: Code (clustered)
+
+**Shpfy Synchronization Info:**
+- PK: Shop Code, Synchronization Type (clustered)
+
+**Shpfy Tag:**
+- PK: Parent Id, Tag (clustered)
+
+**Shpfy Initial Import Line:**
+- Key1: Name (clustered)

--- a/src/Apps/W1/Shopify/App/src/Bulk Operations/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Bulk Operations/docs/CLAUDE.md
@@ -1,0 +1,31 @@
+# Bulk operations
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Manages Shopify bulk operations for large-scale data updates like product prices and images using GraphQL mutations.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Bulk Operation (30148) | Tracks bulk operation status and stores request/response data |
+| Interface | Shpfy IBulk Operation | Defines contract for bulk operation implementations |
+| Codeunit | Shpfy Bulk Operation Mgt. (30270) | Manages bulk operation lifecycle and webhook processing |
+| Codeunit | Shpfy Bulk Operation API (30XXX) | GraphQL API calls for bulk operations |
+| Codeunit | Shpfy Bulk Update Product Price (30XXX) | Implementation for product price bulk updates |
+| Codeunit | Shpfy Bulk Update Product Image (30XXX) | Implementation for product image bulk updates |
+| Page | Shpfy Bulk Operations | List view of bulk operations with status |
+| Enum | Shpfy Bulk Operation Type (30XXX) | Product Price Update, Product Image Update, etc. |
+| Enum | Shpfy Bulk Operation Status (30XXX) | Created, Running, Completed, Failed, Canceled |
+
+## Key concepts
+
+- Bulk operations use Shopify's asynchronous bulk mutation API for large datasets
+- Each bulk operation type implements the IBulk Operation interface
+- Interface methods: GetGraphQL, GetInput, GetName, GetType, RevertFailedRequests, RevertAllRequests
+- Webhook notifications inform BC when bulk operation status changes
+- Request Data stored as JSON array for rollback if operation fails
+- Only one active bulk operation (Created or Running status) allowed per type per shop
+- Processed flag prevents duplicate processing of status changes
+- URL and Partial Data URL fields provide access to operation results
+- OnModify trigger automatically reverts changes based on operation status

--- a/src/Apps/W1/Shopify/App/src/Catalogs/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Catalogs/docs/CLAUDE.md
@@ -1,0 +1,32 @@
+# Catalogs
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Manages Shopify catalogs for B2B pricing, enabling different price lists for different companies or markets.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Catalog (30152) | Stores catalog definitions with pricing and tax configuration |
+| Table | Shpfy Catalog Price (30153) | Temporary table for catalog-specific product variant prices |
+| Table | Shpfy Market Catalog Relation (30400) | Links catalogs to Shopify markets |
+| Codeunit | Shpfy Sync Catalog Prices (30XXX) | Synchronizes prices to catalogs based on BC price lists |
+| Codeunit | Shpfy Catalog API (30XXX) | GraphQL API calls for catalog operations |
+| Report | Shpfy Sync Catalogs | Imports catalog definitions from Shopify |
+| Report | Shpfy Sync Catalog Prices | Exports catalog prices to Shopify |
+| Page | Shpfy Catalogs | List view of catalogs |
+| Page | Shpfy Market Catalogs | View market-catalog relationships |
+| Page | Shpfy Market Catalog Relations | List of market-catalog relations |
+| Enum | Shpfy Catalog Type (30XXX) | Enumeration of catalog types |
+
+## Key concepts
+
+- Catalogs enable B2B pricing by linking Shopify companies to specific price lists
+- Each catalog can have its own customer price group, discount group, and posting groups
+- Catalog pricing can be based on a specific BC customer or use catalog-level settings
+- Market catalog relations determine which catalogs are available in which Shopify markets
+- Prices Including VAT setting controls whether catalog prices are tax-inclusive
+- Customer No. assignment makes customer-specific settings override catalog settings
+- Sync Prices flag controls whether prices are actively synchronized to Shopify
+- Currency Code allows catalog-specific currency pricing

--- a/src/Apps/W1/Shopify/App/src/Companies/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Companies/docs/CLAUDE.md
@@ -1,0 +1,42 @@
+# Companies
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Handles B2B company and company location synchronization between Business Central customers and Shopify B2B companies, supporting multi-location B2B scenarios.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Company (30150) | Stores Shopify B2B company data with BC customer mapping |
+| Table | Shpfy Company Location (30151) | Stores company locations (ship-to addresses) |
+| Codeunit | Shpfy Sync Companies (30153) | Orchestrates bidirectional company sync |
+| Codeunit | Shpfy Company Import (30154) | Imports companies from Shopify to BC |
+| Codeunit | Shpfy Company Export (30155) | Exports BC customers to Shopify companies |
+| Codeunit | Shpfy Company Mapping (30156) | Maps Shopify companies to BC customers |
+| Codeunit | Shpfy Company API (30157) | GraphQL API calls for companies |
+| Codeunit | Shpfy Comp. By Email/Phone (30158) | Mapping by email or phone |
+| Codeunit | Shpfy Comp. By Tax Id (30159) | Mapping by tax registration ID |
+| Codeunit | Shpfy Comp. By Default Comp. (30160) | Always use default company |
+| Codeunit | Shpfy Tax Registration No. (30161) | Tax ID mapping via Tax Registration No. |
+| Codeunit | Shpfy VAT Registration No. (30162) | Tax ID mapping via VAT Registration No. |
+| Enum | Shpfy Company Mapping (30151) | By Email/Phone, By Tax Id, DefaultCompany |
+| Enum | Shpfy Company Import Range (30152) | AllCompanies, WithOrderImport, None |
+| Enum | Shpfy Comp Tax Id Mapping (30153) | Tax Registration No., VAT Registration No. |
+| Enum | Shpfy Default Cont Permission (30154) | Location permissions for default contact |
+| Report | Shpfy Sync Companies (30115) | Manual company sync |
+| Report | Shpfy Add Company to Shopify (30116) | Export BC customer as company |
+| Report | Shpfy Add Cust as Locations (30117) | Add BC customers as locations |
+| Page | Shpfy Companies (30140) | Company list page |
+| Page | Shpfy Company Card (30141) | Company detail page |
+| Page | Shpfy Comp Locations (30142) | Company locations page |
+
+## Key concepts
+
+- B2B support: Companies represent B2B customers in Shopify, distinct from regular customers
+- Company locations: Each company can have multiple locations (ship-to addresses) with separate billing/shipping
+- Location-to-customer mapping: Company locations can map to separate BC customers for sell-to/bill-to
+- Main contact: Each company has a main contact (Shopify customer) for login
+- Tax ID mapping: Map companies by Tax Registration No. or VAT Registration No.
+- Payment terms: Company locations can have Shopify-specific payment terms
+- Extensible mapping: Interface-based mapping supports custom strategies

--- a/src/Apps/W1/Shopify/App/src/Companies/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/src/Companies/docs/data-model.md
@@ -1,0 +1,142 @@
+# Companies data model
+
+## Tables
+
+### Shpfy Company (30150)
+Stores Shopify B2B company master data.
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Companies\Tables\ShpfyCompany.Table.al`
+
+**Key fields:**
+- `Id` (BigInteger) -- Shopify company ID, primary key
+- `Name` (Text[500]) -- Company name
+- `Note` (Blob) -- Company notes
+- `Created At`, `Updated At` (DateTime) -- Shopify timestamps
+- `Last Updated by BC` (DateTime) -- BC modification timestamp
+- `Customer SystemId` (Guid) -- Link to BC Customer (company level)
+- `Shop Id` (Integer) -- Link to shop
+- `Shop Code` (Code[20]) -- Shop code
+- `Main Contact Customer Id` (BigInteger) -- Link to Shpfy Customer (main contact)
+- `Main Contact Id` (BigInteger) -- Shopify contact ID
+- `Location Id` (BigInteger) -- Default location ID
+- `External Id` (Text[500]) -- External system ID
+
+**Calculated fields:**
+- `Customer No.` (Code[20]) -- FlowField from Customer
+
+**Methods:**
+- `GetNote()` -- Reads note from blob
+- `SetNote(Text)` -- Writes note to blob
+
+**Relationships:**
+- N:1 with Customer (via Customer SystemId)
+- 1:N with Shpfy Company Location (via Company SystemId)
+- N:1 with Shpfy Customer (main contact, via Main Contact Customer Id)
+
+**OnDelete trigger:** Deletes associated Shpfy Company Location records.
+
+**Indexes:**
+- PK: Id (clustered)
+- Idx1: Customer SystemId
+- Idx2: Shop Id
+
+### Shpfy Company Location (30151)
+Stores company locations (ship-to addresses).
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Companies\Tables\ShpfyCompanyLocation.Table.al`
+
+**Key fields:**
+- `Id` (BigInteger) -- Location ID, primary key
+- `Company SystemId` (Guid) -- Parent company
+- `Name` (Text[100]) -- Location name (editable = false)
+- `Recipient` (Text[100]) -- Company/Attention recipient
+- `Address` (Text[100]) -- Address line 1
+- `Address 2` (Text[100]) -- Address line 2
+- `Zip` (Code[20]) -- Postal code
+- `City` (Text[50]) -- City
+- `Province Code` (Code[10]) -- Province/state code
+- `Province Name` (Text[50]) -- Province/state name
+- `Country/Region Code` (Code[2]) -- 2-letter country code
+- `Phone No.` (Text[30]) -- Phone number
+- `Tax Registration Id` (Text[150]) -- Tax registration ID
+- `Default` (Boolean) -- Default location for company
+- `Shpfy Payment Terms Id` (BigInteger) -- Shopify payment terms
+- `Sell-to Customer No.` (Code[20]) -- BC customer for sell-to
+- `Bill-to Customer No.` (Code[20]) -- BC customer for bill-to
+- `Customer Id` (Guid) -- Associated customer system ID
+
+**Calculated fields:**
+- `Company Name` (Text[500]) -- FlowField from Shpfy Company.Name
+- `Shpfy Payment Term` (Text[150]) -- FlowField from Shpfy Payment Terms
+
+**Validation:**
+- Bill-to Customer No. requires Sell-to Customer No.
+
+**Indexes:**
+- PK: Id (clustered)
+- Idx1: Company SystemId
+
+## Enums
+
+### Shpfy Company Mapping (30151)
+Defines how Shopify companies map to BC customers (extensible, implements ICompany Mapping interface).
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Companies\Enums\ShpfyCompanyMapping.Enum.al`
+
+- `By Email/Phone` (0) -- Match by main contact email/phone
+  - Implementation: Shpfy Comp. By Email/Phone (30158)
+- `DefaultCompany` (2) -- Always use default company
+  - Implementation: Shpfy Comp. By Default Comp. (30160)
+- `By Tax Id` (3) -- Match by tax registration ID
+  - Implementation: Shpfy Comp. By Tax Id (30159)
+
+### Shpfy Company Import Range (30152)
+Controls which companies are imported.
+
+- `AllCompanies` -- Import all companies from Shopify
+- `WithOrderImport` -- Import only companies associated with orders
+- `None` -- No company import
+
+### Shpfy Comp Tax Id Mapping (30153)
+How to map Shopify Tax Registration Id to BC (extensible, implements Shpfy Tax Registration Id Mapping interface).
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Companies\Enums\ShpfyCompTaxIdMapping.Enum.al`
+
+- `Tax Registration No.` (0) -- Use BC Customer."Tax Registration No." field
+  - Implementation: Shpfy Tax Registration No. (30161)
+- `VAT Registration No.` (1) -- Use BC Customer."VAT Registration No." field
+  - Implementation: Shpfy VAT Registration No. (30162)
+
+### Shpfy Default Cont Permission (30154)
+Default contact permissions for company locations.
+
+- `None` -- No permissions
+- `Ordering_only` -- Can place orders only
+- `Full` -- Full permissions
+
+## Relationships
+
+```
+Shpfy Shop (1) ----< (N) Shpfy Company
+                         |
+                         +----< (N) Shpfy Company Location
+                         |
+                         +--- (N:1) Shpfy Customer (main contact)
+
+Customer (1) ----< (N) Shpfy Company
+         |
+         +----< (N) Shpfy Company Location (via Sell-to/Bill-to Customer No.)
+
+Shpfy Payment Terms (1) ----< (N) Shpfy Company Location
+```
+
+## Key indexes
+
+**Shpfy Company:**
+- PK: Id (clustered)
+- Idx1: Customer SystemId (for reverse lookup from BC)
+- Idx2: Shop Id (for shop-scoped queries)
+
+**Shpfy Company Location:**
+- PK: Id (clustered)
+- Idx1: Company SystemId (find locations for company)

--- a/src/Apps/W1/Shopify/App/src/Customers/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Customers/docs/CLAUDE.md
@@ -1,0 +1,50 @@
+# Customers
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Handles customer and address synchronization between Business Central customers and Shopify customers, including mapping strategies and county/tax area resolution.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Customer (30105) | Stores Shopify customer data with BC customer mapping |
+| Table | Shpfy Customer Address (30106) | Stores customer addresses from Shopify |
+| Table | Shpfy Tax Area (30109) | Maps country/county to BC tax area and VAT groups |
+| Codeunit | Shpfy Sync Customers (30123) | Orchestrates bidirectional customer sync |
+| Codeunit | Shpfy Customer Import (30117) | Imports customers from Shopify to BC |
+| Codeunit | Shpfy Customer Export (30119) | Exports BC customers to Shopify |
+| Codeunit | Shpfy Customer Mapping (30118) | Maps Shopify customers to BC customers |
+| Codeunit | Shpfy Customer API (30120) | GraphQL API calls for customers |
+| Codeunit | Shpfy Customer Events (30121) | Event publishers for extensibility |
+| Codeunit | Shpfy Create Customer (30122) | Creates BC customers from Shopify |
+| Codeunit | Shpfy Update Customer (30116) | Updates BC customers from Shopify data |
+| Codeunit | Shpfy Cust. By Email/Phone (30112) | Mapping by email or phone |
+| Codeunit | Shpfy Cust. By Bill-to (30113) | Mapping by bill-to customer |
+| Codeunit | Shpfy Cust. By Default Cust. (30114) | Always use default customer |
+| Codeunit | Shpfy County Code (30124) | County resolution by code |
+| Codeunit | Shpfy County Name (30125) | County resolution by name |
+| Codeunit | Shpfy County From Json Code/Name (30126/30127) | JSON-based county parsing |
+| Codeunit | Shpfy Sync Countries (30128) | Syncs countries and provinces |
+| Enum | Shpfy Customer Mapping (30106) | By Email/Phone, By Bill-to Info, DefaultCustomer |
+| Enum | Shpfy Customer Import Range (30107) | AllCustomers, WithOrderImport, None |
+| Enum | Shpfy Customer State (30108) | Disabled, Invited, Enabled, Declined |
+| Enum | Shpfy Name Source (30109) | How to derive customer name |
+| Enum | Shpfy County Source (30110) | Code or Name |
+| Enum | Shpfy Tax By (30111) | Tax or VAT |
+| Report | Shpfy Sync Customers (30110) | Manual customer sync |
+| Report | Shpfy Sync Countries (30111) | Sync country/province data |
+| Page | Shpfy Customers (30107) | Customer list page |
+| Page | Shpfy Customer Card (30108) | Customer detail page |
+| Page | Shpfy Tax Areas (30109) | Tax area mapping page |
+
+## Key concepts
+
+- Bidirectional sync: Import from Shopify or export to Shopify based on shop settings
+- Mapping strategies: Match by email/phone, by bill-to info, or always use default customer (extensible via interface)
+- County resolution: Maps Shopify province code/name to BC county for tax calculations
+- Tax area mapping: Shpfy Tax Area table maps country/county to Tax Area Code and VAT Bus. Posting Group
+- Name derivation: Configurable rules for deriving BC customer Name, Name 2, Contact from Shopify First/Last Name and Company
+- Address synchronization: Imports all customer addresses; default address used for BC customer
+- Customer state: Tracks whether customer is Enabled, Invited, Disabled, or Declined in Shopify
+- Template-based creation: Uses Customer Template for creating new BC customers

--- a/src/Apps/W1/Shopify/App/src/Customers/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/src/Customers/docs/business-logic.md
@@ -1,0 +1,215 @@
+# Customers business logic
+
+## Synchronization flows
+
+### Import from Shopify (Shpfy Sync Customers, Shpfy Customer Import)
+
+**Location:**
+- `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Customers\Codeunits\ShpfySyncCustomers.Codeunit.al`
+- `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Customers\Codeunits\ShpfyCustomerImport.Codeunit.al`
+
+**Trigger:** Shop."Customer Import From Shopify" = AllCustomers or WithOrderImport
+
+**Flow:**
+1. Shpfy Sync Customers.Run(Shop) calls ImportCustomersFromShopify(CreateCustomers)
+   - CreateCustomers = true if "Customer Import From Shopify" = AllCustomers
+   - CreateCustomers = false if "Customer Import From Shopify" = WithOrderImport
+2. Retrieve customer IDs via Shpfy Customer API.RetrieveShopifyCustomerIds() (returns Dictionary of [BigInteger, DateTime])
+3. For each customer ID:
+   - If customer exists locally and Updated At > Customer."Updated At" and Customer."Last Updated by BC", mark for import
+   - If customer doesn't exist and CreateCustomers = true, mark for import
+   - If customer doesn't exist and CreateCustomers = false, skip (only import when referenced by order)
+4. For each marked customer:
+   - Shpfy Customer Import.Run() retrieves full customer data via CustomerApi.RetrieveShopifyCustomer()
+   - Retrieve addresses via CustomerApi (stored in Shpfy Customer Address)
+   - Attempt mapping via Shpfy Customer Mapping.FindMapping()
+   - If mapping found and Shop."Shopify Can Update Customer", call Shpfy Update Customer
+   - If no mapping and Shop."Auto Create Unknown Customers", call Shpfy Create Customer
+5. Update Shop."Last Sync Time" (Shpfy Synchronization Info, type = Customers)
+
+### Export to Shopify (Shpfy Sync Customers, Shpfy Customer Export)
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Customers\Codeunits\ShpfyCustomerExport.Codeunit.al`
+
+**Trigger:** Shop."Can Update Shopify Customer" = true
+
+**Flow:**
+1. Shpfy Sync Customers calls SyncCustomersToShopify()
+2. Shpfy Customer Export.Run(Customer) processes BC customers
+3. For each customer, if mapped to Shopify customer:
+   - Update Shopify customer data via Shpfy Customer API
+   - Update addresses
+   - Set Last Updated by BC timestamp
+
+**Manual export:** Report "Shpfy Add Customer to Shopify" creates new Shopify customers.
+
+## Mapping strategies
+
+### By Email/Phone (Shpfy Cust. By Email/Phone)
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Customers\Codeunits\ShpfyCustByEmailPhone.Codeunit.al`
+
+**Shopify to BC:**
+1. If Shpfy Customer.Email is not empty:
+   - Search BC Customer where "E-Mail" matches (case-insensitive)
+   - If found, map to that customer
+2. If not found and Phone No. is not empty:
+   - Create phone filter (handles various formats)
+   - Search BC Customer where "Phone No." matches
+   - If found, map to that customer
+3. If not found and AllowCreate = true, create new BC customer from template
+
+**BC to Shopify:**
+1. Search Shpfy Customer where "Customer SystemId" = BC Customer.SystemId
+2. If not found, search Shopify by email via CustomerApi.FindIdByEmail()
+3. If not found, search Shopify by phone via CustomerApi.FindIdByPhone()
+4. If found, map; if not found and CreateCustomersInShopify = true, create new Shopify customer
+
+### By Bill-to Info (Shpfy Cust. By Bill-to)
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Customers\Codeunits\ShpfyCustByBillto.Codeunit.al`
+
+**Shopify to BC:**
+1. Get default address (Shpfy Customer Address where Default = true)
+2. Match BC Customer by bill-to address fields:
+   - Name, Address, City, Post Code, County, Country/Region Code
+   - Uses fuzzy matching on name and address
+3. If found, map to that customer
+4. Falls back to email/phone matching if address match fails
+
+### Default Customer (Shpfy Cust. By Default Cust.)
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Customers\Codeunits\ShpfyCustByDefaultCust.Codeunit.al`
+
+**Always returns Shop."Default Customer No."** -- all Shopify customers map to same BC customer.
+
+**Use case:** For shops that don't need individual customer tracking in BC.
+
+## Customer creation (from Shopify)
+
+### Shpfy Create Customer (30122)
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Customers\Codeunits\ShpfyCreateCustomer.Codeunit.al`
+
+**Flow:**
+1. Read Shpfy Customer and default Shpfy Customer Address
+2. Create BC Customer from template (Shop."Customer Templ. Code")
+3. Derive name fields using Name Source rules:
+   - Name: Apply Shop."Name Source" to First Name, Last Name, Company
+   - Name 2: Apply Shop."Name 2 Source"
+   - Contact: Apply Shop."Contact Source"
+4. Set contact fields:
+   - "E-Mail" from Email
+   - "Phone No." from Phone No.
+5. Set address from default Shpfy Customer Address:
+   - Address, Address 2, City, Post Code
+   - Country/Region Code
+   - County via county resolution (see below)
+6. Set tax fields from Shpfy Tax Area lookup:
+   - Tax Area Code, Tax Liable (if Tax By = Tax)
+   - VAT Bus. Posting Group (if Tax By = VAT)
+7. Set Currency Code from ISO Currency Code
+8. Set Shpfy Customer."Customer SystemId" = new customer.SystemId
+
+## County resolution
+
+### County interfaces and implementations
+
+**Interface:** Shpfy ICounty (maps province to BC county)
+
+**Implementations:**
+- **Shpfy County Code (30124)** -- Uses Province Code directly as County
+- **Shpfy County Name (30125)** -- Uses Province Name directly as County
+
+**Interface:** Shpfy ICounty From Json (parses county from JSON address)
+
+**Implementations:**
+- **Shpfy County From Json Code (30126)** -- Extracts province_code from JSON
+- **Shpfy County From Json Name (30127)** -- Extracts province from JSON
+
+**Selection:** Shop."County Source" enum selects implementation.
+
+### Tax area lookup
+
+After resolving county, lookup Shpfy Tax Area:
+
+```al
+TaxArea.Get(CountryRegionCode, County);
+Customer."Tax Area Code" := TaxArea."Tax Area Code";
+Customer."Tax Liable" := TaxArea."Tax Liable";
+Customer."VAT Bus. Posting Group" := TaxArea."VAT Bus. Posting Group";
+```
+
+**Setup:** Shpfy Tax Areas page (30109) allows manual mapping of country/county to tax configuration.
+
+## Name derivation
+
+### Name Source enum logic
+
+Implemented via Shpfy ICustomer Name interface.
+
+**Implementations:**
+- **Shpfy Name is Empty (30130)** -- Returns empty string
+- **Shpfy Name is First Last Name (30131)** -- Returns "First Last"
+- **Shpfy Name is Last First Name (30132)** -- Returns "Last, First"
+- **Shpfy Name is Company Name (30133)** -- Returns Company field
+
+**Application:**
+- Shop."Name Source" → Customer.Name
+- Shop."Name 2 Source" → Customer."Name 2"
+- Shop."Contact Source" → Customer.Contact
+
+**Example:**
+If Name Source = CompanyName, Name 2 Source = FirstAndLastName:
+- Customer.Name = "Acme Corp"
+- Customer."Name 2" = "John Smith"
+
+## Address synchronization
+
+**Multiple addresses:** All addresses imported to Shpfy Customer Address table.
+
+**Default address:** Address where Default = true used to populate BC Customer address fields.
+
+**Updates:** If Shopify customer updated, BC customer address updated if "Shopify Can Update Customer" = true.
+
+## Events for extensibility
+
+### Shpfy Customer Events (30121)
+
+**Published events:**
+- OnBeforeFindMapping, OnAfterFindMapping -- override or supplement mapping logic
+- OnBeforeCreateCustomer, OnAfterCreateCustomer -- customize customer creation
+- OnBeforeUpdateCustomer, OnAfterUpdateCustomer -- customize customer updates
+
+## Key configuration (Shpfy Shop fields)
+
+**Customer import:**
+- `Customer Import From Shopify` -- AllCustomers, WithOrderImport, None
+- `Auto Create Unknown Customers` -- Create BC customers from Shopify
+- `Customer Templ. Code` -- Template for new customers
+- `Shopify Can Update Customer` -- Allow Shopify to update BC customers
+
+**Customer export:**
+- `Can Update Shopify Customer` -- Allow BC to update Shopify customers
+
+**Mapping:**
+- `Customer Mapping Type` -- By EMail/Phone, By Bill-to Info, DefaultCustomer
+- `Default Customer No.` -- Used when mapping type = DefaultCustomer
+
+**Name and address:**
+- `Name Source`, `Name 2 Source`, `Contact Source` -- Name derivation rules
+- `County Source` -- Code, Name, JsonCode, JsonName
+
+## Country and province sync
+
+### Shpfy Sync Countries (30128)
+
+**Purpose:** Downloads country and province data from Shopify to populate tax area mapping.
+
+**Report:** "Shpfy Sync Countries" (30111)
+
+**Flow:**
+1. Retrieve countries via GraphQL (countries query)
+2. For each country, retrieve provinces
+3. Can be used to pre-populate Shpfy Tax Area with all countries/provinces
+4. User then manually maps to BC Tax Area Code or VAT Bus. Posting Group

--- a/src/Apps/W1/Shopify/App/src/Customers/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/src/Customers/docs/data-model.md
@@ -1,0 +1,190 @@
+# Customers data model
+
+## Tables
+
+### Shpfy Customer (30105)
+Stores Shopify customer master data.
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Customers\Tables\ShpfyCustomer.Table.al`
+
+**Key fields:**
+- `Id` (BigInteger) -- Shopify customer ID, primary key
+- `First Name` (Text[100]) -- Customer first name
+- `Last Name` (Text[100]) -- Customer last name
+- `Email` (Text[100]) -- Email address
+- `Phone No.` (Text[30]) -- Phone number
+- `Accepts Marketing` (Boolean) -- Opted in to marketing
+- `Accepts Marketing Update At` (DateTime) -- When marketing preference changed
+- `ISO Currency Code` (Code[3]) -- Preferred currency
+- `Tax Exempt` (Boolean) -- Exempt from tax
+- `Verified Email` (Boolean) -- Email verified
+- `State` (Enum Shpfy Customer State) -- Disabled, Invited, Enabled, Declined
+- `Note` (Blob) -- Customer notes
+- `Created At`, `Updated At` (DateTime) -- Shopify timestamps
+- `Last Updated by BC` (DateTime) -- BC modification timestamp
+- `Customer SystemId` (Guid) -- Link to BC Customer
+- `Shop Id` (Integer) -- Link to shop
+
+**Calculated fields:**
+- `Customer No.` (Code[20]) -- FlowField from Customer
+
+**Methods:**
+- `GetCommaSeparatedTags()` -- Returns customer tags
+- `GetNote()` -- Reads note from blob
+- `SetNote(Text)` -- Writes note to blob
+- `UpdateTags(Text)` -- Updates tags via Shpfy Tag table
+
+**Relationships:**
+- N:1 with Customer (via Customer SystemId)
+- 1:N with Shpfy Customer Address (via Customer Id)
+- 1:N with Shpfy Tag (via Parent Id)
+
+**Indexes:**
+- PK: Id (clustered)
+- Idx1: Customer SystemId
+- Idx2: Shop Id
+
+### Shpfy Customer Address (30106)
+Stores customer addresses.
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Customers\Tables\ShpfyCustomerAddress.Table.al`
+
+**Key fields:**
+- `Id` (BigInteger) -- Address ID, primary key
+- `Customer Id` (BigInteger) -- Parent customer
+- `Company` (Text[100]) -- Company name
+- `First Name` (Text[50]) -- First name
+- `Last Name` (Text[50]) -- Last name
+- `Address 1` (Text[100]) -- Address line 1
+- `Address 2` (Text[100]) -- Address line 2
+- `Zip` (Code[20]) -- Postal code
+- `City` (Text[50]) -- City
+- `Country/Region Code` (Code[2]) -- 2-letter country code
+- `Country/Region Name` (Text[50]) -- Country name
+- `Province Code` (Code[10]) -- Province/state code
+- `Province Name` (Text[50]) -- Province/state name
+- `Phone` (Text[30]) -- Phone number
+- `Default` (Boolean) -- Default address for customer
+- `CustomerSystemId` (Guid) -- Link to BC Customer
+
+**Calculated fields:**
+- `Customer No.` (Code[20]) -- FlowField from Customer
+
+**Trigger logic:**
+- OnInsert: Auto-generates negative ID if Id = 0; ensures at least one default address per customer
+
+**Indexes:**
+- PK: Id (clustered)
+- Key2: Customer Id, Default
+
+### Shpfy Tax Area (30109)
+Maps country/county to BC tax configuration.
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Customers\Tables\ShpfyTaxArea.Table.al`
+
+**Key fields:**
+- `Country/Region Code` (Code[20]) -- Country code, part of PK
+- `County` (Text[50]) -- County/province name, part of PK
+- `Tax Area Code` (Code[20]) -- BC Tax Area
+- `Tax Liable` (Boolean) -- Tax liability flag
+- `VAT Bus. Posting Group` (Code[20]) -- VAT business posting group
+- `County Code` (Code[10]) -- County code for lookup
+
+**Usage:** Looked up during customer/order import to set tax fields on BC customer or sales document.
+
+**Indexes:**
+- PK: Country/Region Code, County (clustered)
+- Indx01: Country/Region Code, County Code
+
+## Enums
+
+### Shpfy Customer Mapping (30106)
+Defines how Shopify customers map to BC customers (extensible, implements ICustomer Mapping interface).
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Customers\Enums\ShpfyCustomerMapping.Enum.al`
+
+- `By EMail/Phone` (0) -- Match by email or phone, create if not found
+  - Implementation: Shpfy Cust. By Email/Phone (30112)
+- `By Bill-to Info` (1) -- Match by bill-to address info
+  - Implementation: Shpfy Cust. By Bill-to (30113)
+- `DefaultCustomer` (2) -- Always use Shop."Default Customer No."
+  - Implementation: Shpfy Cust. By Default Cust. (30114)
+
+### Shpfy Customer Import Range (30107)
+Controls which customers are imported.
+
+- `AllCustomers` -- Import all customers from Shopify
+- `WithOrderImport` -- Import only customers associated with orders
+- `None` -- No customer import
+
+### Shpfy Customer State (30108)
+Shopify customer account state.
+
+- `Disabled` (0)
+- `Invited` (1) -- Invited to create account
+- `Enabled` (2) -- Active account
+- `Declined` (3) -- Declined invitation
+
+### Shpfy Name Source (30109)
+How to derive BC customer name fields from Shopify data.
+
+- `None` -- Leave empty
+- `FirstAndLastName` -- "First Last"
+- `LastAndFirstName` -- "Last, First"
+- `CompanyName` -- Use company field
+
+**Used for:**
+- Shop."Name Source" -- Customer.Name
+- Shop."Name 2 Source" -- Customer."Name 2"
+- Shop."Contact Source" -- Customer.Contact
+
+### Shpfy County Source (30110)
+How to resolve county from Shopify address.
+
+- `Code` -- Use Province Code
+- `Name` -- Use Province Name
+- `JsonCode` -- Parse from JSON
+- `JsonName` -- Parse from JSON
+
+### Shpfy Tax By (30111)
+Tax calculation method.
+
+- `Tax`
+- `VAT`
+
+### Shpfy Tax Type (30112)
+Tax type (used in obsolete Shpfy Province table).
+
+- `Normal`
+- `Harmonized`
+
+## Relationships
+
+```
+Shpfy Shop (1) ----< (N) Shpfy Customer
+                         |
+                         +----< (N) Shpfy Customer Address
+                         |
+                         +----< (N) Shpfy Tag (by Parent Id)
+
+Customer (1) ----< (N) Shpfy Customer
+         |
+         +----< (N) Shpfy Customer Address
+
+Shpfy Tax Area -- lookup table (no direct FK)
+```
+
+## Key indexes
+
+**Shpfy Customer:**
+- PK: Id (clustered)
+- Idx1: Customer SystemId (for reverse lookup from BC)
+- Idx2: Shop Id (for shop-scoped queries)
+
+**Shpfy Customer Address:**
+- PK: Id (clustered)
+- Key2: Customer Id, Default (find default address)
+
+**Shpfy Tax Area:**
+- PK: Country/Region Code, County (clustered)
+- Indx01: Country/Region Code, County Code (alternative lookup)

--- a/src/Apps/W1/Shopify/App/src/Document Links/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Document Links/docs/CLAUDE.md
@@ -1,0 +1,25 @@
+# Document Links
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Tracks bidirectional links between Shopify documents (orders, returns, refunds) and Business Central sales documents throughout the posting lifecycle.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Doc. Link To Doc. (30146) | Stores links between Shopify and BC documents |
+| Interface | Shpfy IOpenBCDocument | Opens a BC document by number |
+| Interface | Shpfy IOpenShopifyDocument | Opens a Shopify document by ID |
+| Enum | Shpfy Document Type | BC document types with open implementations |
+| Enum | Shpfy Shop Document Type | Shopify document types (Order, Return, Refund) |
+| Codeunit | Shpfy Document Link Mgt. (30262) | Event subscribers for posting lifecycle |
+| Codeunit | Shpfy BC Document Type Convert (30259) | Converts between Sales and Shpfy enums |
+
+## Key concepts
+
+- Links are created when Shopify documents are imported to BC sales documents
+- Links are automatically updated when BC documents are posted or deleted
+- Event subscribers track posting lifecycle: Sales Order -> Posted Shipment, Posted Invoice
+- Interface-based opening allows navigating from either side (BC to Shopify or Shopify to BC)
+- Document type conversion handles mapping between Sales Document Type enum and Shpfy Document Type enum

--- a/src/Apps/W1/Shopify/App/src/Document Links/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/src/Document Links/docs/business-logic.md
@@ -1,0 +1,89 @@
+# Business logic
+
+## Overview
+
+Document Links maintain referential integrity between Shopify and Business Central documents as they transition through states (unposted -> posted, combined documents, etc.).
+
+## Key codeunits
+
+### Shpfy Document Link Mgt. (30262)
+
+- **Key procedures**: CreateNewDocumentLink (internal)
+- **Event subscribers**:
+  - OnAfterDeleteEvent (Sales Header): deletes links when order deleted
+  - OnAfterDelete (PostSales-Delete): creates links to posted documents before source deleted
+  - OnBeforeDeleteAfterPosting: creates links for "Ship and Invoice" scenario
+  - OnAfterPostSalesDoc: creates links to posted documents, handles invoice-from-shipment scenario
+- **Data flow**: Listens for posting events, reads existing links, creates new links to posted documents
+
+### Shpfy BC Document Type Convert (30259)
+
+- **Key procedures**:
+  - Convert (Sales Document Type -> Shpfy Document Type)
+  - Convert (Variant -> Shpfy Document Type): accepts Sales Header, Shipment Header, Invoice Header, etc.
+  - Convert (Shpfy Document Type -> Sales Document Type): reverse direction
+  - CanConvert: validates conversion is supported
+- **Mapping**: Order <-> Sales Order, Invoice <-> Sales Invoice, Return Order <-> Sales Return Order, Credit Memo <-> Sales Credit Memo
+
+## Processing flows
+
+### Link creation on import
+
+1. Shopify order imported to BC
+2. Sales Order created with Shopify Order ID
+3. CreateNewDocumentLink called with (Shopify Shop Order, OrderId, Sales Order, OrderNo)
+4. Link record inserted
+
+### Link update on posting (Ship and Invoice)
+
+1. Sales Order posted with Ship and Invoice
+2. OnAfterPostSalesDoc event fires
+3. Event finds existing link for Sales Order
+4. Calls CreateNewDocumentLink for Posted Sales Shipment
+5. Calls CreateNewDocumentLink for Posted Sales Invoice
+6. Original Sales Order link remains until deletion
+
+### Link update on deletion
+
+1. Sales Order deleted (or auto-deleted after posting)
+2. OnAfterDelete or OnBeforeDeleteAfterPosting fires
+3. Event reads Shopify document type and ID from existing link
+4. Calls CreateNewDocumentLink for each posted document (Shipment, Invoice, Return Receipt, Credit Memo)
+5. Original link deleted by DeleteAll
+
+### Invoice from shipment scenario
+
+1. Sales Shipment posted with link to Shopify Order
+2. Later: Invoice created and posted, references Shipment No. in lines
+3. OnAfterPostSalesDoc event fires
+4. Event reads shipment lines to find related shipments
+5. For each shipment with existing link: creates link from same Shopify document to new Invoice
+6. Result: Shopify Order linked to both Posted Shipment and Posted Invoice
+
+### Document type conversion
+
+- **Sales Document Type** (BC standard): Quote, Order, Invoice, Credit Memo, Blanket Order, Return Order
+- **Shpfy Document Type** (internal): Sales Order, Sales Invoice, Sales Return Order, Sales Credit Memo, Posted Sales Shipment, Posted Return Receipt, Posted Sales Invoice, Posted Sales Credit Memo
+- Conversion required because Shpfy tracks both unposted and posted states
+- CanConvert checks if enum value is supported (e.g., Quote not supported)
+
+### Supported types
+
+#### BC document types (Shpfy Document Type enum)
+
+- Sales Order -> Sales Order page
+- Sales Invoice -> Sales Invoice page
+- Sales Return Order -> Sales Return Order page
+- Sales Credit Memo -> Sales Credit Memo page
+- Posted Sales Shipment -> Posted Sales Shipment page
+- Posted Return Receipt -> Posted Return Receipt page
+- Posted Sales Invoice -> Posted Sales Invoice page
+- Posted Sales Credit Memo -> Posted Sales Credit Memo page
+
+#### Shopify document types (Shpfy Shop Document Type enum)
+
+- Shopify Shop Order -> Shpfy Order page
+- Shopify Shop Return -> Shpfy Return page
+- Shopify Shop Refund -> Shpfy Refund page
+
+Each enum value bound to interface implementation codeunit that opens the appropriate page.

--- a/src/Apps/W1/Shopify/App/src/GraphQL/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/docs/CLAUDE.md
@@ -1,0 +1,29 @@
+# GraphQL
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Provides GraphQL query execution infrastructure for communicating with the Shopify API, including query dispatch, rate limiting, and cost management.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Interface | Shpfy IGraphQL | Defines contract for GraphQL query providers (GetGraphQL, GetExpectedCost) |
+| Enum | Shpfy GraphQL Type | Registry of 147 query types, each implementing IGraphQL for specific operations |
+| Codeunit | Shpfy GraphQL Queries (30154) | Central dispatcher for GraphQL queries with parameter substitution |
+| Codeunit | Shpfy GraphQL Rate Limit (30153) | Rate limit enforcement using restore rate and cost tracking |
+| Codeunit | Shpfy GQL Customer (30127) | Example: retrieves customer data with metafields |
+| Codeunit | Shpfy GQL CustomerIds (30128) | Example: retrieves updated customer IDs with pagination |
+| Codeunit | Shpfy GQL MetafieldsSet (30350) | Mutation: sets metafields in batch |
+| Codeunit | Shpfy GQL BulkOperation (30282) | Retrieves bulk operation status |
+| Codeunit | Shpfy GQL CreateWebhookSub (30393) | Creates webhook subscriptions |
+
+## Key concepts
+
+- Each GraphQL query type is implemented as a separate codeunit implementing the IGraphQL interface
+- The Shpfy GraphQL Type enum binds each query type to its implementation codeunit
+- Queries use double-brace parameter substitution (e.g., `{{CustomerId}}`) replaced at runtime
+- Rate limiting uses Shopify's restore rate (points per second) and cost tracking to prevent throttling
+- The ExecuteGraphQL pattern delegates to ShpfyGraphQLQueries.GetQuery for parameter replacement
+- Expected cost is declared per query type and used for rate limit scheduling
+- Queries are categorized by operation: retrieval (Get*), pagination (GetNext*), mutations (Create*, Update*, Delete*)

--- a/src/Apps/W1/Shopify/App/src/GraphQL/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/docs/business-logic.md
@@ -1,0 +1,61 @@
+# Business logic
+
+## Overview
+
+The GraphQL module handles all API communication with Shopify using GraphQL queries and mutations. It manages query construction, parameter substitution, rate limiting, and cost tracking.
+
+## Key codeunits
+
+### Shpfy GraphQL Queries (30154)
+
+- **Key procedures**: GetQuery (two overloads with/without cost output)
+- **Data flow**:
+  1. Receives GraphQLType enum and parameters dictionary
+  2. Instantiates IGraphQL interface from enum
+  3. Calls GetGraphQL and GetExpectedCost on interface
+  4. Replaces `{{ParamName}}` placeholders with values from dictionary
+  5. Returns query text and expected cost
+
+### Shpfy GraphQL Rate Limit (30153)
+
+- **Key procedures**: SetQueryCost, WaitForRequestAvailable
+- **Data flow**:
+  1. Tracks last request time, restore rate (points/sec), and currently available points
+  2. Before each request: calculates if sufficient points available
+  3. If insufficient: calculates wait time = `(needed - available) / restoreRate * 1000ms`
+  4. Sleeps until sufficient points restored
+  5. After response: updates available points from throttleStatus
+
+## Processing flows
+
+### Query execution
+
+1. Caller identifies GraphQLType enum value (e.g., GetCustomer, GetCustomerIds)
+2. Caller builds parameters dictionary with keys matching template placeholders
+3. ShpfyGraphQLQueries.GetQuery resolves interface, extracts template, substitutes parameters
+4. Rate limiter checks cost vs available quota
+5. Query executes via Communication Mgt
+6. Response includes throttleStatus with currentlyAvailable and restoreRate
+7. Rate limiter updates state for next request
+
+### Query structure
+
+- **Simple retrieval**: Single object by ID (e.g., GQL Customer: `customer(id: "gid://shopify/Customer/{{CustomerId}}")`)
+- **Paginated retrieval**: Returns edges with cursor (e.g., GQL CustomerIds: `customers(first:200, query: "updated_at:>''{{LastSync}}''")`)
+- **Next page**: Uses cursor from previous response (NextCustomerIds pattern)
+- **Mutations**: Modify data (e.g., MetafieldsSet: `mutation { metafieldsSet(metafields: [{{Metafields}}]) }`)
+- **Bulk operations**: Long-running queries that return URL to download results
+
+### Parameter substitution
+
+- Query templates contain `{{ParameterName}}` placeholders
+- Parameters dictionary maps names to values
+- ShpfyGraphQLQueries replaces all `{{Key}}` with dictionary values
+- No validation -- missing parameters result in malformed queries
+
+### Categories of queries
+
+- **Get**: Initial retrieval with filters (e.g., GetCustomerIds, GetLocations)
+- **GetNext**: Pagination continuation using cursor (e.g., GetNextCustomerIds)
+- **Create/Update/Delete**: Mutations (e.g., CreateWebhookSubscription, UpdateOrderAttributes)
+- **Bulk**: Async operations for large datasets (RunBulkOperationMutation, GetBulkOperation)

--- a/src/Apps/W1/Shopify/App/src/Inventory/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Inventory/docs/CLAUDE.md
@@ -1,0 +1,31 @@
+# Inventory
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Synchronizes inventory levels between Business Central and Shopify, supporting multiple stock calculation strategies and location mappings.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Shop Inventory (30114) | Stores inventory levels per product variant and location |
+| Table | Shpfy Shop Location (30113) | Maps Shopify locations to BC locations with stock calculation settings |
+| Interface | Shpfy IStock Available | Determines if location can have stock |
+| Interface | Shpfy Stock Calculation | Calculates available stock for an item |
+| Interface | Shpfy Extended Stock Calculation | Extended calculation with location parameter |
+| Enum | Shpfy Stock Calculation | Stock calculation strategies: Disabled, Projected Available Balance Today, Non-reserved Inventory |
+| Codeunit | Shpfy Sync Inventory (30197) | Orchestrates import and export of stock levels |
+| Codeunit | Shpfy Inventory API (30195) | GraphQL-based stock retrieval and update operations |
+| Codeunit | Shpfy Balance Today (30212) | Calculates projected available balance |
+| Codeunit | Shpfy Free Inventory (stock calc) | Calculates non-reserved inventory |
+| Codeunit | Shpfy Can Have Stock (30271) | IStockAvailable implementation (returns true) |
+| Codeunit | Shpfy Can Not Have Stock | IStockAvailable implementation (returns false) |
+
+## Key concepts
+
+- Each Shopify location mapped to BC location filter and stock calculation method
+- Stock calculation strategies implemented as interface-based plugins
+- Inventory sync is bidirectional: import from Shopify (current levels) and export to Shopify (calculated BC stock)
+- Unit of measure conversions applied when variant option specifies UOM
+- Rate limiting handled via batch updates (max 250 inventory items per mutation)
+- Non-inventory and service items excluded from sync

--- a/src/Apps/W1/Shopify/App/src/Inventory/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/src/Inventory/docs/business-logic.md
@@ -1,0 +1,98 @@
+# Business logic
+
+## Overview
+
+Inventory synchronization maintains stock level parity between BC and Shopify. It supports flexible location mapping, multiple calculation strategies, and handles UOM conversions.
+
+## Key codeunits
+
+### Shpfy Sync Inventory (30197)
+
+- **Key procedures**: OnRun trigger (TableNo = Shpfy Shop Inventory)
+- **Data flow**:
+  1. Filters shop locations by shop code and stock calculation <> Disabled
+  2. Calls InventoryAPI.ImportStock for each location
+  3. Calls InventoryAPI.ExportStock with all shop inventory records
+  4. Removes unused inventory IDs (variants deleted in Shopify)
+
+### Shpfy Inventory API (30195)
+
+- **Key procedures**:
+  - ImportStock: retrieves inventory levels from Shopify
+  - ExportStock: sends calculated stock to Shopify
+  - GetStock: calculates BC stock for a variant/location
+- **Data flow**:
+  - Import: ExecuteGraphQL(GetInventoryEntries) -> ImportInventoryLevels -> update Shopify Stock field
+  - Export: CalcStock for each record -> build JSON quantities array -> ExecuteGraphQL(ModifyInventory)
+  - Pagination: HasNextResults checks pageInfo.hasNextPage, GetNext* queries continue with cursor
+
+## Processing flows
+
+### Stock import from Shopify
+
+1. ImportStock called with ShopLocation
+2. Builds parameters with LocationId
+3. Executes GetInventoryEntries GraphQL query
+4. ImportInventoryLevels parses JSON:
+   - Extracts InventoryItemId, VariantId, ProductId, Stock from edges.node
+   - Updates or inserts Shpfy Shop Inventory record
+   - Sets Shopify Stock field (not calculated Stock field)
+   - Removes processed inventory ID from tracking list
+5. Repeats with GetNextInventoryEntries if hasNextPage
+6. RemoveUnusedInventoryIds deletes records still in list (deleted variants)
+
+### Stock export to Shopify
+
+1. ExportStock called with shop inventory recordset
+2. For each record: CalcStock determines if update needed
+3. If Stock <> Shopify Stock and location CanHaveStock:
+   - Builds JSON quantity object: `{inventoryItemId, locationId, quantity, changeFromQuantity: null}`
+   - Adds to JQuantities array
+4. When batch reaches 250: ExecuteInventoryGraphQL sends mutation
+5. Mutation uses idempotency key to prevent duplicates on retry
+6. Retries up to 3 times if concurrency errors (IDEMPOTENCY_CONCURRENT_REQUEST, CHANGE_FROM_QUANTITY_STALE)
+
+### Stock calculation strategies
+
+#### Projected Available Balance Today (Shpfy Balance Today)
+
+- Implementation: calls ItemAvailabilityFormsMgt.CalcAvailQuantities
+- Returns: ProjAvailableBalance (inventory + supply - demand through today)
+- Use case: prevent overselling by considering future demand
+
+#### Non-reserved Inventory (Shpfy Free Inventory)
+
+- Implementation: calculates Inventory - Reserved Quantity
+- Returns: unreserved stock available for new orders
+- Use case: prevent selling reserved inventory
+
+#### Disabled (Shpfy Disabled Value)
+
+- Returns: 0
+- CanHaveStock: false
+- Use case: exclude location from sync
+
+### Location mapping
+
+- **Shpfy Shop Location** table stores Shopify location properties:
+  - Id: Shopify location ID
+  - Name: Shopify location name
+  - Location Filter: BC location code filter (e.g., "BLUE|RED|GREEN")
+  - Default Location Code: BC location for sales documents
+  - Stock Calculation: which strategy to use
+  - Active, Is Primary, Is Fulfillment Service: Shopify flags
+- When calculating stock:
+  1. ShopLocation.Location Filter applied to Item."Location Filter"
+  2. ShopLocation."Stock Calculation" determines which interface implementation
+  3. If variant has UOM in option: stock converted from base UOM to sales UOM
+
+### Unit of measure conversion
+
+1. GetStock retrieves item's Sales Unit of Measure
+2. If variant has UoM Option Id (1, 2, or 3):
+   - Extracts UOM code from Option 1/2/3 Value
+3. StockCalculation.GetStock returns quantity in base UOM
+4. If UOM <> Base UOM:
+   - Looks up Item Unit of Measure record
+   - Divides stock by Qty. per Unit of Measure
+5. Returns converted quantity

--- a/src/Apps/W1/Shopify/App/src/Invoicing/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Invoicing/docs/CLAUDE.md
@@ -1,0 +1,29 @@
+# Invoicing
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Enables export of posted sales invoices from Business Central to Shopify as draft orders.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Invoice Header (30161) | Tracks which Shopify orders were created from BC invoices |
+| Codeunit | Shpfy Posted Invoice Export (30362) | Exports posted sales invoices to Shopify as draft orders |
+| Codeunit | Shpfy Draft Orders API (30XXX) | GraphQL API calls for draft order creation and completion |
+| Codeunit | Shpfy Fulfillment API (30XXX) | Creates fulfillments for invoice-originated orders |
+| Codeunit | Shpfy Update Sales Invoice (30XXX) | Updates sales invoice headers with Shopify order info |
+| Report | Shpfy Sync Invoices to Shpfy | Batch export of posted sales invoices to Shopify |
+| PageExt | Shpfy Sales Invoice Update | Adds Shopify sync action to posted sales invoice |
+
+## Key concepts
+
+- Posted sales invoices can be exported to Shopify as completed draft orders
+- Invoice export validates customer exists in Shopify (as company or customer)
+- Payment terms on invoice must exist in Shopify for B2B scenarios
+- Draft order is created first, then completed to generate a Shopify order
+- Fulfillments are automatically created for the order after completion
+- Shpfy Order Id on invoice tracks the created Shopify order
+- Shpfy Order Id of -1 indicates export failure, -2 indicates not exportable
+- Invoice lines map to draft order line items with quantities and prices
+- Document links created to connect BC invoice with Shopify order

--- a/src/Apps/W1/Shopify/App/src/Logs/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Logs/docs/CLAUDE.md
@@ -1,0 +1,31 @@
+# Logs
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Provides logging, data capture, and error tracking for Shopify integration operations.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Log Entry (30115) | Stores HTTP request/response logs for API calls with status and error info |
+| Table | Shpfy Data Capture (30114) | Stores JSON snapshots of imported records for troubleshooting |
+| Table | Shpfy Skipped Record (30159) | Tracks records that failed to process with reason codes |
+| Codeunit | Shpfy Log Entries (30XXX) | Manages log entry creation and retrieval |
+| Codeunit | Shpfy Log Entries Delete (30XXX) | Batch deletion of old log entries |
+| Codeunit | Shpfy Skipped Record (30XXX) | Logs skipped records with reasons |
+| Page | Shpfy Log Entries | List view of API call logs |
+| Page | Shpfy Log Entry Card | Detail view of individual log entry |
+| Page | Shpfy Data Capture List | View captured JSON data |
+| Page | Shpfy Skipped Records | List of skipped records with actions |
+
+## Key concepts
+
+- Log entries capture all GraphQL API requests and responses as BLOBs
+- Request Preview and Response Preview fields show first 50 characters for quick scanning
+- Data Capture stores JSON snapshots linked to specific table records via SystemId
+- Hash No. in Data Capture prevents duplicate snapshots of unchanged data
+- Skipped records track processing failures with table, record ID, and reason
+- Retry Count and Query Cost fields help monitor API usage and performance
+- Shpfy Request Id tracks Shopify's request identifier for support cases
+- Data Capture automatically deleted when parent records are deleted

--- a/src/Apps/W1/Shopify/App/src/Metafields/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Metafields/docs/CLAUDE.md
@@ -1,0 +1,29 @@
+# Metafields
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Synchronizes custom metadata fields between Business Central and Shopify for customers, products, variants, and companies.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Metafield (30101) | Stores metafield data with namespace, key, value, type, and owner reference |
+| Interface | Shpfy IMetafield Type | Validates and assists editing values for a metafield type |
+| Interface | Shpfy IMetafield Owner Type | Handles owner-specific operations (retrieve IDs, get shop code, check edit permission) |
+| Enum | Shpfy Metafield Type | 25+ supported types (boolean, date, integer, money, url, references, etc.) |
+| Enum | Shpfy Metafield Owner Type | Owner resources: Customer, Product, ProductVariant, Company |
+| Codeunit | Shpfy Metafield API (30316) | Bidirectional sync logic between BC and Shopify |
+| Codeunit | Shpfy Metafields (30418) | Public API for metafield operations |
+| Codeunit | Shpfy Mtfld Type Boolean (30338) | Example type validator for boolean values |
+| Codeunit | Shpfy Metafield Owner Product (30334) | Owner-specific logic for products |
+
+## Key concepts
+
+- Metafields are custom key-value pairs attached to Shopify resources (products, customers, etc.)
+- Each metafield has a namespace (default: "Microsoft.Dynamics365.BusinessCentral"), key, value, and type
+- Type validation ensures values match Shopify's expected format (e.g., boolean must be "true"/"false")
+- Owner type determines parent table, retrieval logic, and edit permissions
+- Synchronization is bidirectional: BC to Shopify (create/update) and Shopify to BC (import)
+- Batch updates use MetafieldsSet mutation (max 25 metafields per call)
+- Only metafields updated in BC since last Shopify update are synced (timestamp comparison)

--- a/src/Apps/W1/Shopify/App/src/Metafields/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/src/Metafields/docs/business-logic.md
@@ -1,0 +1,64 @@
+# Business logic
+
+## Overview
+
+Metafields enable storing custom structured data on Shopify resources. The module handles type conversion, bidirectional synchronization, and owner-specific logic.
+
+## Key codeunits
+
+### Shpfy Metafield API (30316)
+
+- **Key procedures**:
+  - SyncMetafieldToShopify (single record)
+  - SyncMetafieldsToShopify (batch for owner)
+  - UpdateMetafieldsFromShopify (import from JSON)
+  - GetMetafieldDefinitions (retrieve schema)
+- **Data flow**:
+  1. Sync to Shopify: CollectMetafieldsInBC filters changed records, CreateMetafieldQuery builds GraphQL, UpdateMetafields executes
+  2. Sync from Shopify: UpdateMetafieldsFromShopify parses JSON array, UpdateMetadataField creates/updates records
+  3. Definitions: GetMetafieldDefinitions creates empty metafield records from Shopify schema
+
+### Shpfy Metafields (30418)
+
+- **Key procedures**: GetMetafieldDefinitions, SyncMetafieldToShopify, SyncMetafieldsToShopify
+- **Purpose**: Public API wrapper for MetafieldAPI codeunit
+
+## Processing flows
+
+### Sync to Shopify
+
+1. Caller invokes SyncMetafieldsToShopify with ParentTableNo, OwnerId, ShopCode
+2. RetrieveMetafieldsFromShopify calls owner-specific interface to get metafield IDs + timestamps
+3. CollectMetafieldsInBC filters local metafields: changed since last sync OR new (not in retrieved list)
+4. CreateMetafieldQuery builds JSON for each metafield: `{key, namespace, ownerId, value, type}`
+5. UpdateMetafields sends batches of 25 to MetafieldsSet mutation
+6. Shopify returns legacyResourceId for new metafields
+
+### Sync from Shopify
+
+1. Caller invokes UpdateMetafieldsFromShopify with JMetafields JSON array, ParentTableNo, OwnerId
+2. CollectMetafieldIds builds list of existing BC metafield IDs
+3. For each JSON node: UpdateMetadataField creates/modifies record, removes from list
+4. DeleteUnusedMetafields removes IDs still in list (deleted in Shopify)
+5. Skips metafields with value > 2048 chars or unsupported types
+
+### Type conversion
+
+- Each metafield type implements IMetafield Type interface
+- IsValidValue: checks if value matches type format (e.g., boolean validator uses Evaluate(DummyBoolean, Value, 9))
+- GetExampleValue: provides sample for error messages (e.g., "true" for boolean)
+- HasAssistEdit/AssistEdit: optional UI for complex types
+- GetTypeName: converts enum to Shopify API string (e.g., "boolean", "money", "product_reference")
+
+### Owner types
+
+- **Customer**: Table 30105, retrieves via GQL CustomerMetafieldIds, editable if sync enabled
+- **Product**: Table 30108, retrieves via GQL ProductMetafieldIds, editable if "Sync Item = To Shopify" and "Can Update Shopify Products"
+- **ProductVariant**: Table 30109, retrieves via GQL VariantMetafieldIds, same edit rules as Product
+- **Company**: Table 30126, retrieves via GQL CompanyMetafieldIds, editable if B2B enabled
+
+Each owner type codeunit provides:
+- GetTableId: returns BC table number
+- RetrieveMetafieldIdsFromShopify: executes GraphQL query, parses IDs + timestamps
+- GetShopCode: retrieves shop from owner record
+- CanEditMetafields: checks shop settings for permission

--- a/src/Apps/W1/Shopify/App/src/Order Fulfillments/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Fulfillments/docs/CLAUDE.md
@@ -1,0 +1,34 @@
+# Order Fulfillments
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Tracks fulfillment orders and fulfillment lines, which represent assigned inventory locations and delivery methods for order lines.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy FulFillment Order Header (30143) | Fulfillment order header (assigned to location) |
+| Table | Shpfy FulFillment Order Line (30144) | Line items within fulfillment order |
+| Table | Shpfy Order Fulfillment (30144) | Completed fulfillments (shipments) |
+| Table | Shpfy Fulfillment Line (30145) | Line items within completed fulfillment |
+| Codeunit | Shpfy Order Fulfillments (30170) | Processes fulfillments and updates order status |
+| Codeunit | Shpfy Fulfillment Orders API (30171) | GraphQL operations for fulfillment orders |
+| Enum | Shpfy FulFillment Status (30140) | Status of fulfillment (Open, In Progress, Success, Cancelled, etc.) |
+| Enum | Shpfy Order Fulfill. Status (30118) | Order-level fulfillment status (Unfulfilled, Partial, Fulfilled) |
+| Enum | Shpfy Delivery Method Type (30141) | Shipping, local delivery, pickup, etc. |
+| Enum | Shpfy FF Request Status (30142) | Fulfillment request status |
+| Page | Shpfy Fulfillment Orders (30143) | List of fulfillment orders |
+| Page | Shpfy Fulfillment Order Card (30144) | Details of fulfillment order |
+| Page | Shpfy Order Fulfillments (30145) | List of completed fulfillments |
+| Page | Shpfy Order Fulfillment (30146) | Details of completed fulfillment |
+
+## Key concepts
+
+- **Fulfillment order**: Shopify assigns each order line to a fulfillment location (warehouse, store, 3PL) based on inventory availability and business rules. Each assignment is a fulfillment order.
+- **Fulfillment order line**: Individual line item within a fulfillment order, linking to the original order line and specifying quantity to fulfill from that location.
+- **Fulfillment**: A completed shipment or handoff, recording tracking info, carrier, and shipment status. Multiple fulfillments can exist per order (split shipments).
+- **Fulfillment line**: Line item within a fulfillment, recording quantity shipped.
+- **Delivery method type**: Enum values Shipping, PickUp, Local, None, Retail track how the order will be delivered.
+- **Status tracking**: Fulfillment orders have status (Open, In Progress, Closed), fulfillments have status (Success, Cancelled, Failure), orders have fulfillment status (Unfulfilled, Partial, Fulfilled).
+- **Relationship to BC**: Fulfillment orders are imported during order import and used to set `Location Id` and `Delivery Method Type` on order lines. Fulfillments can be created from BC posted shipments.

--- a/src/Apps/W1/Shopify/App/src/Order Refunds/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/docs/CLAUDE.md
@@ -1,0 +1,32 @@
+# Order Refunds
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Tracks financial refunds issued to customers, including refunded line items, shipping costs, and restock information.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Refund Header (30142) | Refund header with total amounts and status |
+| Table | Shpfy Refund Line (30145) | Refunded line items with amounts and quantities |
+| Table | Shpfy Refund Shipping Line (30146) | Refunded shipping costs |
+| Codeunit | Shpfy Refunds API (30174) | GraphQL operations for refunds |
+| Codeunit | Shpfy Refund Enum Convertor (30175) | Converts Shopify refund enums to BC enums |
+| Enum | Shpfy Restock Type (30140) | How refunded items are restocked |
+| Page | Shpfy Refunds (30142) | List of refunds |
+| Page | Shpfy Refund (30143) | Refund details card |
+| Page | Shpfy Refund Lines (30144) | Refund line subpage |
+| Page | Shpfy Refund Shipping Lines (30145) | Refund shipping line subpage |
+
+## Key concepts
+
+- **Refund**: Financial transaction returning money to customer; can be partial or full.
+- **Refund header**: Stores total refunded amount (shop and presentment currency), creation date, related order ID, optional return ID, and notes.
+- **Refund line**: Records which order line was refunded, quantity, amount, subtotal, tax amounts, and restock information.
+- **Refund shipping line**: Tracks refunded shipping costs, including amount and tax amounts.
+- **Restock type**: Enum values (Cancel, Legacy Restock, No Restock, Return) indicate how inventory should be adjusted. Cancel = order was cancelled before fulfillment; Return = goods physically returned; No Restock = no inventory adjustment.
+- **Processing error tracking**: Refund header has fields `Has Processing Error`, `Last Error Description` (Blob), `Last Error Call Stack` (Blob) for troubleshooting auto-credit-memo failures.
+- **Can Create Credit Memo**: Boolean field on refund line determines if line is eligible for auto-credit-memo creation. Set to false for lines that cannot be mapped to BC sales lines.
+- **Import control**: Shop setting `Return and Refund Process` determines if refunds are imported and whether they auto-create credit memos.
+- **FlowFields**: Refund header calculates `Is Processed` by checking if any BC credit memo links exist for the refund.

--- a/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/docs/CLAUDE.md
@@ -1,0 +1,38 @@
+# Order Return Refund Processing
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Manages the processing of Shopify returns and refunds into Business Central credit memos (or import-only mode).
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Interface | Shpfy IReturnRefund Process (30240) | Defines processing strategy for returns and refunds |
+| Interface | Shpfy IDocument Source (30241) | Provides error tracking for source documents |
+| Interface | Shpfy Extended IDocument Source (30242) | Extends IDocument Source with call stack tracking |
+| Codeunit | Shpfy RetRefProc Cr.Memo (30243) | Auto create credit memo strategy |
+| Codeunit | Shpfy RetRefProc ImportOnly (30245) | Import only strategy (no BC document creation) |
+| Codeunit | Shpfy RetRefProc Default (30244) | Default/fallback strategy |
+| Codeunit | Shpfy IDocSource Default (30246) | Default document source implementation |
+| Codeunit | Shpfy IDocSource Refund (30247) | Refund-specific document source |
+| Codeunit | Shpfy Create Sales Doc. Refund (30248) | Creates BC credit memo from refund |
+| Codeunit | Shpfy Refund Process Events (30249) | Integration events |
+| Enum | Shpfy ReturnRefund ProcessType (30240) | Processing mode selection |
+| Enum | Shpfy Source Document Type (30241) | Return or Refund |
+| Table Ext. | Shpfy Sales Cr.Memo Header (30244) | Adds Shopify fields to posted credit memo |
+| Table Ext. | Shpfy Sales Cr.Memo Line (30245) | Adds Shopify fields to posted credit memo line |
+| Table Ext. | Shpfy Return Receipt Header (30246) | Adds Shopify fields to return receipt |
+| Table Ext. | Shpfy Return Receipt Line (30247) | Adds Shopify fields to return receipt line |
+| Page Ext. | Shpfy Sales Credit Memo (30244) | Shows Shopify fields on credit memo card |
+| Page Ext. | Shpfy Sales Credit Memos (30245) | Shows Shopify fields on credit memo list |
+| Page Ext. | Shpfy Posted Sales Cr.Memos (30246) | Shows Shopify fields on posted credit memo list |
+
+## Key concepts
+
+- **Processing strategy**: Shop setup field `Return and Refund Process` selects implementation via interface pattern (Auto Create Credit Memo, Import Only, or custom).
+- **Auto Create Credit Memo**: Automatically generates BC credit memo when refund is imported; only creates if refund lines have `Can Create Credit Memo` = true.
+- **Import Only**: Imports return and refund data to BC tables but does not create credit memos; useful for reporting or manual processing.
+- **Refund vs. Return**: Refunds track financial transactions (money back to customer); Returns track physical goods coming back to warehouse. Refunds can exist without returns (e.g., restocking fee waived).
+- **Processing trigger**: When shop processes orders (codeunit `Shpfy Process Orders`), it calls `ProcessShopifyRefunds` which iterates unprocessed refunds and calls the selected strategy's `CreateSalesDocument` method.
+- **Error tracking**: Document source interfaces store error messages and call stacks on refund/return headers for troubleshooting.

--- a/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/docs/business-logic.md
@@ -1,0 +1,196 @@
+# Order Return Refund Processing business logic
+
+Details the strategy pattern for processing returns and refunds.
+
+## Interface design
+
+### IReturnRefund Process interface
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order Return Refund Processing\Interfaces\ShpfyIReturnRefundProcess.Interface.al`
+
+Three required procedures:
+
+1. **IsImportNeededFor**(SourceDocumentType): Returns true if returns or refunds should be imported from Shopify
+   - Return false to skip API calls entirely
+   - Reduces API usage if returns/refunds not needed
+
+2. **CanCreateSalesDocumentFor**(SourceDocumentType, SourceDocumentId, ErrorInfo): Returns true if source document can be converted to BC sales document
+   - Validates preconditions (e.g., order is processed, refund not already processed)
+   - Populates ErrorInfo with detailed message if cannot create
+   - Used before attempting creation to avoid errors
+
+3. **CreateSalesDocument**(SourceDocumentType, SourceDocumentId): Creates and returns BC Sales Header
+   - Main entry point for document creation
+   - Commits transaction after success/failure
+   - Returns empty Sales Header if creation failed
+
+## Strategy implementations
+
+### Auto Create Credit Memo (30243)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order Return Refund Processing\Codeunits\ShpfyRetRefProcCrMemo.Codeunit.al`
+
+**IsImportNeededFor**: Returns true (always import returns and refunds)
+
+**CanCreateSalesDocumentFor** (lines 17-61):
+
+Validation checks for refunds:
+1. Refund must exist
+2. Refund must not be already processed (check flowfield `Is Processed`)
+3. Order must exist for the refund
+4. Order must be processed in BC (has Sales Order No. or Sales Invoice No.)
+
+Returns ErrorInfo with:
+- **ErrorType**: Client
+- **DetailedMessage**: Specific reason (e.g., "You must process Shopify order #1001 first")
+- **Message**: Composite message for display
+- **RecordId**, **SystemId**, **TableId**: For linking to source record
+- **Verbosity**: Error (block creation) or Warning (already processed)
+
+**CreateSalesDocument** (lines 63-97):
+
+Steps:
+1. Check `CanCreateSalesDocumentFor`; exit if ErrorInfo.Verbosity = Error
+2. Check if any refund lines have `Can Create Credit Memo` = false; exit if so
+3. Instantiate `Shpfy Create Sales Doc. Refund` codeunit
+4. Set source = refund ID, target document type = Credit Memo
+5. Commit to save state
+6. Run codeunit; if succeeds:
+   - Get created Sales Header
+   - Clear error on refund header
+7. If fails:
+   - Store error text and call stack on refund header via IDocument Source interface
+8. Commit again
+
+### Import Only (30245)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order Return Refund Processing\Codeunits\ShpfyRetRefProcImportOnly.Codeunit.al`
+
+**IsImportNeededFor**: Returns true (import but don't process)
+
+**CanCreateSalesDocumentFor**: Returns false (never create documents)
+
+**CreateSalesDocument**: Returns empty Sales Header (no-op)
+
+Use case: Import return/refund data for reporting, analytics, or manual credit memo creation.
+
+### Default strategy (30244)
+
+Placeholder for future custom logic. Currently inherits behavior from base interface.
+
+## Document source interfaces
+
+### IDocument Source interface
+
+Provides error tracking for source documents (returns or refunds):
+
+- **SetErrorInfo**(SourceDocumentId, ErrorText): Stores error message on source record
+- Implemented by `Shpfy IDocSource Default` and `Shpfy IDocSource Refund`
+
+### Extended IDocument Source interface
+
+Extends IDocument Source with:
+
+- **SetErrorCallStack**(SourceDocumentId, CallStack): Stores full call stack for debugging
+
+Implemented by `Shpfy IDocSource Refund`.
+
+### IDocSource Refund implementation (30247)
+
+Uses enum `Shpfy Source Document Type` to resolve to Refund Header table:
+
+**SetErrorInfo**:
+1. Get refund header by ID
+2. Set `Has Processing Error` = true
+3. Write error text to blob field `Last Error Description`
+4. Modify record
+
+**SetErrorCallStack**:
+1. Get refund header by ID
+2. Write call stack to blob field `Last Error Call Stack`
+3. Modify record
+
+## Credit memo creation flow
+
+Codeunit: `Shpfy Create Sales Doc. Refund` (30248)
+
+Referenced in `ShpfyRetRefProcCrMemo.Codeunit.al` lines 85-96.
+
+Entry point: `SetSource(RefundId)`, `SetTargetDocumentType(CreditMemo)`, then `Run()`
+
+Process (inferred from usage):
+1. Load Shpfy Refund Header by ID
+2. Load Shpfy Order Header for original order
+3. Get original BC sales document (order or invoice)
+4. Create Sales Header with Document Type = Credit Memo
+5. Copy customer, addresses, currency from original document
+6. For each Shpfy Refund Line:
+   - Create Sales Line with negative quantity
+   - Match to original order line via `Order Line Id`
+   - Set item, variant, UOM, price
+   - Apply refund amount and tax adjustments
+7. Handle refund shipping lines (if shipping cost refunded)
+8. Apply rounding adjustments
+9. Trigger events for customization
+10. Store link in `Shpfy Doc. Link To Doc.` table
+11. Mark refund as processed (via flowfield calculation)
+
+## Processing trigger
+
+Entry point: `Shpfy Process Orders` codeunit (30167), procedure `ProcessShopifyRefunds` (line 96)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Codeunits\ShpfyProcessOrders.Codeunit.al`
+
+Logic:
+1. Check shop setting `Return and Refund Process`
+2. If set to "Auto Create Credit Memo":
+   - Get IReturnRefundProcess implementation from enum
+   - Filter Shpfy Refund Header for `Is Processed` = false
+   - Loop through each refund
+   - Call `IReturnRefundProcess.CreateSalesDocument(Refund, RefundId)`
+   - Commit after each refund
+
+Note: This runs after processing orders, so refunds are created for already-processed orders.
+
+## Refund line eligibility
+
+Field `Can Create Credit Memo` on Shpfy Refund Line determines if line can be included in auto-created credit memo.
+
+Set to false when:
+- Refund line has no corresponding order line (e.g., shipping refund without order line)
+- Refund line references a line that was not in the original BC sales document
+- Refund line has zero quantity
+
+Logic in `ShpfyImportOrder.Codeunit.al` function `ConsiderRefundsInQuantityAndAmounts` (line 195):
+- If refund lines exist with `Can Create Credit Memo` = false and order is processed, set order state error
+
+## Error handling
+
+All error handling uses ErrorInfo record:
+
+**ErrorInfo fields populated**:
+- **ErrorType**: Client (user-fixable) or Internal (system error)
+- **Message**: User-facing message
+- **DetailedMessage**: Technical details
+- **RecordId**, **SystemId**, **TableId**: Link to source record
+- **Verbosity**: Error, Warning, or Informational
+- **Collectible**: Can be added to error list
+
+**Error storage**:
+- Refund Header: `Has Processing Error` (Boolean), `Last Error Description` (Blob), `Last Error Call Stack` (Blob)
+- Return Header: Similar fields
+
+**Error display**:
+- Page extensions show error fields
+- Users can view error details and call stack for troubleshooting
+- Can retry processing after fixing issue (e.g., processing parent order first)
+
+## Integration events
+
+Codeunit `Shpfy Refund Process Events` (30249) provides extension points for customization.
+
+Expected events (not detailed in read files):
+- OnBeforeCreateCreditMemo
+- OnAfterCreateCreditMemo
+- OnBeforeValidateRefundLine
+- OnAfterValidateRefundLine

--- a/src/Apps/W1/Shopify/App/src/Order Returns/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Returns/docs/CLAUDE.md
@@ -1,0 +1,32 @@
+# Order Returns
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Tracks customer returns of physical goods, including return reasons, status, and quantities.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Return Header (30147) | Return request header |
+| Table | Shpfy Return Line (30141) | Return line items |
+| Codeunit | Shpfy Returns API (30172) | GraphQL operations for returns |
+| Codeunit | Shpfy Return Enum Convertor (30173) | Converts Shopify return enums to BC enums |
+| Enum | Shpfy Return Status (30143) | Return workflow status (Open, Closed, Cancelled, etc.) |
+| Enum | Shpfy Order Return Status (30144) | Order-level return status |
+| Enum | Shpfy Return Decline Reason (30145) | Why return was declined |
+| Enum | Shpfy Return Reason (30146) | Why customer is returning item |
+| Enum | Shpfy Return Line Type (30147) | Type of return line |
+| Page | Shpfy Returns (30147) | List of returns |
+| Page | Shpfy Return (30148) | Return details card |
+| Page | Shpfy Return Lines (30149) | Return line subpage |
+
+## Key concepts
+
+- **Return**: Customer initiates return for delivered items; Shopify creates return record with return lines.
+- **Return status**: Workflow states include Open (pending approval), Requested (waiting for items), Inspection (items received, being checked), Closed (completed), Cancelled, Declined.
+- **Return reason**: Customer-provided reason (Unwanted, Size Too Small, Size Too Large, Defective, Style, Color, Wrong Item, Other).
+- **Return decline**: Merchant can decline return with reason (Final Sale, Other, Product Not As Described, etc.) and optional note.
+- **Return lines**: Track which order lines are being returned, quantity, weight, and whether they can be refunded or restocked.
+- **Relationship to refunds**: Returns track physical goods; refunds track money. A return can trigger a refund, but refunds can also occur without returns (e.g., discount adjustment).
+- **Import control**: Shop setting `Return and Refund Process` determines if returns are imported (Auto Create Credit Memo and Import Only both import; other modes may skip).

--- a/src/Apps/W1/Shopify/App/src/Order handling/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order handling/docs/CLAUDE.md
@@ -1,0 +1,42 @@
+# Order handling
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Manages the import and processing of Shopify orders into Business Central sales documents (orders or invoices).
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Order Header (30118) | Header-level order data including customer, addresses, amounts, status |
+| Table | Shpfy Order Line (30119) | Line items within orders (products, variants, quantities, prices) |
+| Table | Shpfy Order Attribute (30116) | Custom attributes attached to orders |
+| Table | Shpfy Order Line Attribute (30149) | Custom attributes attached to order lines |
+| Table | Shpfy Order Tax Line (30122) | Tax breakdown per line and header |
+| Table | Shpfy Order Disc.Appl. (30117) | Discount applications on orders |
+| Table | Shpfy Order Payment Gateway (30120) | Payment gateway information |
+| Table | Shpfy Orders to Import (30120) | Queue of orders to import |
+| Codeunit | Shpfy Process Orders (30167) | Entry point for processing multiple orders |
+| Codeunit | Shpfy Process Order (30166) | Creates sales header and lines from a single order |
+| Codeunit | Shpfy Import Order (30161) | Retrieves order data from Shopify API via GraphQL |
+| Codeunit | Shpfy Order Mapping (30163) | Maps Shopify customers, items, variants to BC entities |
+| Codeunit | Shpfy Order Mgt. (30165) | Helper functions for order processing |
+| Codeunit | Shpfy Orders API (30164) | GraphQL operations on orders |
+| Codeunit | Shpfy Order Events (30160) | Integration events for customization |
+| Enum | Shpfy Financial Status (30117) | Payment status (Pending, Paid, Refunded, etc.) |
+| Enum | Shpfy Order Fulfill. Status (30118) | Fulfillment status (Unfulfilled, Partial, Fulfilled) |
+| Enum | Shpfy Cancel Reason (30116) | Reason for order cancellation |
+| Enum | Shpfy Processing Method (30121) | How Shopify processes the order |
+| Enum | Shpfy Currency Handling (30122) | Shop vs. presentment currency |
+| Page | Shpfy Orders (30119) | List page for imported orders |
+| Page | Shpfy Order (30118) | Card page for single order |
+
+## Key concepts
+
+- **Import flow**: Orders are retrieved from Shopify via GraphQL (see `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Codeunits\ShpfyImportOrder.Codeunit.al`), parsed into header and line records, then queued for processing.
+- **Processing flow**: `ShpfyProcessOrders` iterates unprocessed orders; for each, `ShpfyProcessOrder` maps customers/items, creates sales header, lines, applies discounts, and optionally releases the document (see `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Codeunits\ShpfyProcessOrder.Codeunit.al`).
+- **Mapping**: `ShpfyOrderMapping` resolves Shopify customer IDs to BC customers, variant IDs to items, shipping methods to BC codes (see `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Codeunits\ShpfyOrderMapping.Codeunit.al`).
+- **Currency handling**: Supports shop currency or presentment currency based on configuration (field `Currency Handling` in shop setup).
+- **B2B orders**: Separate processing path for company orders using company location and main contact mapping.
+- **Fulfillment and financial status**: Enums track payment and shipment state; when fulfilled and paid, orders can be auto-closed.
+- **Attributes and tags**: Custom key-value pairs from Shopify are stored in separate tables and can be synced back to Shopify.

--- a/src/Apps/W1/Shopify/App/src/Order handling/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/src/Order handling/docs/business-logic.md
@@ -1,0 +1,270 @@
+# Order handling business logic
+
+Describes the order import and processing flows.
+
+## Order import flow
+
+Entry point: `Shpfy Import Order` codeunit (30161)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Codeunits\ShpfyImportOrder.Codeunit.al`
+
+### Import steps
+
+1. **Retrieve order header JSON** via GraphQL query `GetOrderHeader`:
+   - Fetches order metadata (customer, addresses, totals, status)
+   - Stores raw JSON in `Shpfy Data Capture` table for audit
+
+2. **Retrieve order lines JSON** via paginated GraphQL query `GetOrderLines`:
+   - Fetches line items with product/variant IDs, quantities, prices, discounts
+   - May require multiple API calls if order has many lines (pagination via `After` cursor)
+
+3. **Parse and insert order header**:
+   - Call `SetNewOrderHeaderValuesFromJson` to populate Shpfy Order Header fields
+   - Call `SetEditableOrderHeaderValuesFromJson` for status/amount fields
+   - Create record if new, update if existing
+
+4. **Parse and insert order lines**:
+   - Call `SetOrderLineValuesFromJson` for each line
+   - Insert into Shpfy Order Line table
+   - Calculate `Line Items Redundancy Code` (hash of line IDs) to detect changes
+
+5. **Create related records**:
+   - Tax lines (header and line-level)
+   - Custom attributes (order and line-level)
+   - Shipping charges (separate table)
+   - Payment gateway transactions
+   - Tags
+   - Risk assessments
+   - Fulfillment orders
+   - Returns and refunds (if enabled)
+
+6. **Adjust for refunds**:
+   - Call `ConsiderRefundsInQuantityAndAmounts` to subtract refunded quantities and amounts from order totals
+   - Delete zero-quantity lines
+
+7. **Detect conflicts**:
+   - If order is already processed in BC and Shopify data changed, set `Has Order State Error`
+   - Prevents overwriting BC documents with stale Shopify data
+
+8. **Auto-close if configured**:
+   - If order is fulfilled, paid, and shop setting `Archive Processed Orders` is enabled, close order in Shopify
+
+### Currency translation
+
+Function `TranslateCurrencyCode` (line 646):
+- Maps Shopify ISO code (e.g., "USD") to BC currency code
+- Returns blank if currency matches LCY
+- Uses Currency table field "ISO Code"
+
+### Customer name construction
+
+Functions `GetName`, `GetName2`, `GetContactName` (lines 824-859):
+- Use shop configuration interfaces `ICustomer Name` to derive Name, Name 2, Contact Name
+- Can use FirstName + LastName, CompanyName, or combination
+- Ensures BC customer record has correct display name
+
+## Order processing flow
+
+Entry point: `Shpfy Process Orders` codeunit (30167)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Codeunits\ShpfyProcessOrders.Codeunit.al`
+
+### Processing steps
+
+1. **Filter orders**: Set filter for Shop Code, Processed = false
+2. **Loop through orders**: For each unprocessed order, call `ProcessShopifyOrder`
+3. **Single order processing** (`Shpfy Process Order` codeunit 30166):
+   - Map customers, items, variants (see Mapping section below)
+   - Create sales header
+   - Create sales lines
+   - Apply global discounts
+   - Optionally release document
+4. **Mark as processed** or capture error
+5. **Process refunds** (if shop setting is "Auto Create Credit Memo")
+
+## Mapping flow
+
+Entry point: `Shpfy Order Mapping` codeunit (30163)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Codeunits\ShpfyOrderMapping.Codeunit.al`
+
+### Header mapping
+
+Function `DoMapping` (line 29):
+1. **Customer mapping**:
+   - For B2C: Call `MapHeaderFields` which uses `Shpfy Customer Mapping` to resolve Shopify customer ID to BC customer
+   - For B2B: Call `MapB2BHeaderFields` which uses `Shpfy Company Mapping` to resolve company ID/location to BC customer
+   - Falls back to default customer if mapping fails
+   - Creates customer if `Auto Create Unknown Customers` is enabled
+
+2. **Contact mapping**:
+   - Call `FindContactNo` to link BC contact to customer using contact name
+   - Separate contacts for Sell-to, Bill-to, Ship-to
+
+3. **Shipping method mapping**:
+   - `MapShippingMethodCode`: Maps Shopify shipping title to BC shipment method code
+
+4. **Shipping agent mapping**:
+   - `MapShippingAgent`: Maps to BC shipping agent and service code
+
+5. **Payment method mapping**:
+   - `MapPaymentMethodCode`: Maps Shopify gateway to BC payment method code
+
+### Line mapping
+
+Function `MapVariant` (line 191):
+1. **Lookup Shpfy Variant** record by Shopify Variant Id
+2. If variant not found or not linked to BC item:
+   - Call `Shpfy Product Import` to import/sync product from Shopify
+   - Retry variant lookup
+3. **Get BC item and variant**:
+   - Read `Item SystemId` from Shpfy Variant
+   - Read `Item Variant SystemId` from Shpfy Variant
+   - Populate order line fields: Item No., Variant Code, Unit of Measure Code
+
+### Customer mapping details
+
+Function `MapHeaderFields` (line 86):
+1. Build JSON object with Sell-to address fields
+2. Call `Shpfy Customer Mapping.DoMapping(CustomerId, JAddress, ShopCode, TemplateCode, AllowCreate)`
+3. Repeat for Bill-to address
+4. If Sell-to customer is blank, use Bill-to customer
+5. Events `OnBeforeMapCustomer` and `OnAfterMapCustomer` allow customization
+
+### B2B mapping details
+
+Function `MapB2BHeaderFields` (line 141):
+1. If `Company Location Id` exists, call `MapSellToBillToCustomersFromCompanyLocation` to use location-specific customer
+2. Otherwise, call `Shpfy Company Mapping.DoMapping(CompanyId, TemplateCode, AllowCreate)`
+3. Use same customer for both Sell-to and Bill-to
+4. Map location code for inventory purposes
+
+## Sales document creation
+
+Entry point: `Shpfy Process Order` codeunit (30166)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Codeunits\ShpfyProcessOrder.Codeunit.al`
+
+### Create sales header
+
+Function `CreateHeaderFromShopifyOrder` (line 65):
+
+1. **Determine document type**:
+   - If order is fulfilled and shop setting `Create Invoices From Orders` is enabled: Create invoice
+   - Otherwise: Create sales order
+
+2. **Initialize sales header**:
+   - Insert with `SetHideValidationDialog(true)` to skip UI prompts
+   - Optionally use Shopify order number as BC document number (if `Use Shopify Order No.` is true)
+
+3. **Populate header fields**:
+   - Sell-to Customer No., Name, Address, City, Country/Region Code, etc.
+   - Bill-to Customer No., Name, Address, etc.
+   - Ship-to Name, Address, etc.
+   - Prices Including VAT (from order `VAT Included`)
+   - Currency Code (based on `Currency Handling` setting)
+   - Document Date (from order `Document Date`)
+   - External Document No. (from order `PO Number`)
+   - Due Date (from payment terms)
+   - Tax Area Code (if tax area mapping exists)
+   - Shipment Method Code, Shipping Agent Code, Payment Method Code
+   - Payment Terms Code (mapped from payment terms type/name)
+   - Salesperson Code (from staff member)
+
+4. **Set work description**: Copy order notes (blob field)
+
+5. **Track in link table**: Insert `Shpfy Doc. Link To Doc.` to relate Shopify order to BC document
+
+6. **Trigger events**: `OnBeforeCreateSalesHeader`, `OnAfterCreateSalesHeader`
+
+### Create sales lines
+
+Function `CreateLinesFromShopifyOrder` (line 208):
+
+1. **Optional info line**: If shop setting `Shopify Order No. on Doc. Line` is enabled, insert description-only line with Shopify order number
+
+2. **Loop through order lines**:
+   - Create sales line for each order line
+   - Set type based on flags:
+     - Tip → G/L Account (shop field `Tip Account`)
+     - Gift Card → G/L Account (shop field `Sold Gift Card Account`)
+     - Regular item → Type = Item, No. = mapped item
+   - Validate Unit of Measure Code, Variant Code
+   - Validate Quantity
+   - Validate Unit Price and Line Discount Amount (use shop or presentment currency based on setting)
+   - Store Shopify Line Id in `Shpfy Order Line Id` field
+   - Auto-reserve if item and reservation policy is Always
+
+3. **Shipping charge lines**:
+   - Loop through `Shpfy Order Shipping Charges` records
+   - Create line with Type = G/L Account or Charge (Item) based on shipment method mapping
+   - Set quantity = 1, unit price = shipping amount
+   - If Type = Charge (Item), call `AssignItemCharges` to allocate charge to item lines equally
+
+4. **Rounding line**:
+   - If `Payment Rounding Amount` or `Pres. Payment Rounding Amount` is non-zero:
+     - Create line with Type = G/L Account (shop field `Cash Roundings Account`)
+     - Quantity = 1, Unit Price = rounding amount
+     - Description = "Cash rounding"
+
+5. **Trigger events**: `OnBeforeCreateItemSalesLine`, `OnAfterCreateItemSalesLine`, `OnBeforeCreateShippingCostSalesLine`, `OnAfterCreateShippingCostSalesLine`
+
+### Apply global discounts
+
+Function `ApplyGlobalDiscounts` (line 185):
+1. Calculate order-level discount: `Order.Discount Amount - Sum(Line.Discount Amount) - Sum(Shipping.Discount Amount)`
+2. If positive, call `Sales - Calc Discount By Type.ApplyInvDiscBasedOnAmt` to create invoice discount on sales header
+
+### Item charge assignment
+
+Functions `AssignItemCharges`, `PrepareAssignItemChargesLines`, `GetItemChargeAssgntLineAmt`, `GetAssignableQty` (lines 351-432):
+1. Calculate assignable quantity and line amount for shipping charge
+2. Call `Item Charge Assgnt. (Sales).AssignItemCharges` with "Assign Equally" option
+3. Creates `Item Charge Assignment (Sales)` records linking shipping charge to all item lines proportionally
+
+## Order state conflict detection
+
+Function `IsImportedOrderConflictingExistingOrder` (line 236 in ShpfyImportOrder):
+
+Conflict occurs when order is already processed in BC and Shopify data changed:
+1. **Quantity change**: `Current Total Items Quantity` increased
+2. **Line change**: Hash of line IDs changed (new lines added, lines removed)
+3. **Shipping change**: `Shipping Charges Amount` changed
+
+When conflict detected:
+- Set `Has Order State Error` = true
+- Set `Error Message` = "The order has already been processed..."
+- User must manually reconcile BC document with Shopify changes
+
+## Events for customization
+
+Codeunit `Shpfy Order Events` (30160) exposes integration events:
+
+- `OnBeforeProcessSalesDocument`: Before mapping and creating sales document
+- `OnAfterProcessSalesDocument`: After sales document created
+- `OnBeforeCreateSalesHeader`: Before sales header insert
+- `OnAfterCreateSalesHeader`: After sales header created
+- `OnBeforeCreateItemSalesLine`: Before each item line insert
+- `OnAfterCreateItemSalesLine`: After each item line created
+- `OnBeforeCreateShippingCostSalesLine`: Before shipping line insert
+- `OnAfterCreateShippingCostSalesLine`: After shipping line created
+- `OnBeforeMapCustomer`: Before customer mapping
+- `OnAfterMapCustomer`: After customer mapped
+- `OnBeforeMapCompany`: Before B2B company mapping
+- `OnAfterMapCompany`: After company mapped
+- `OnAfterImportShopifyOrderHeader`: After order header imported from Shopify
+- `OnAfterCreateShopifyOrderAndLines`: After complete order import
+- `OnAfterConsiderRefundsInQuantityAndAmounts`: After refund adjustments
+- `OnBeforeConvertToFinancialStatus`, `OnBeforeConvertToFulfillmentStatus`, `OnBeforeConvertToOrderReturnStatus`: Custom enum conversion
+
+## Payment gateway and transactions
+
+Table `Shpfy Order Payment Gateway` stores gateway information.
+
+Codeunit `Shpfy Transactions` imports transaction records (authorization, capture, sale, refund) and populates the `Gateway` field on order header with the gateway name from the first successful transaction.
+
+## Auto-release
+
+If shop setting `Auto Release Sales Orders` is enabled:
+- Call `Release Sales Document.Run(SalesHeader)` after creating lines (line 51 in ShpfyProcessOrder)
+- Released orders can be posted immediately

--- a/src/Apps/W1/Shopify/App/src/Order handling/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/src/Order handling/docs/data-model.md
@@ -1,0 +1,255 @@
+# Order handling data model
+
+Detailed schema for order-related tables in the Shopify Connector.
+
+## Order Header table (30118)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Tables\ShpfyOrderHeader.Table.al`
+
+**Primary key**: Shopify Order Id (BigInteger)
+
+### Core order identification
+
+- **Shopify Order Id**: Unique Shopify identifier (legacy resource ID)
+- **Shopify Order No.**: Human-readable order number (e.g., "#1001")
+- **Shop Code**: Links to Shpfy Shop configuration
+- **Customer Id**: Shopify customer legacy ID
+
+### Addresses
+
+Three address groups (Sell-to, Ship-to, Bill-to), each with:
+
+- First Name, Last Name, Name, Name 2
+- Address, Address 2, City, Post Code, County
+- Country/Region Code, Country/Region Name
+- Contact Name, Contact No. (for integration with BC contacts)
+- Ship-to also includes Latitude, Longitude
+
+### Amounts and currency
+
+All monetary fields auto-format using currency code expressions.
+
+**Shop currency fields**:
+- Total Amount, Subtotal Amount, VAT Amount
+- Discount Amount, Shipping Charges Amount
+- Total Tip Received, Total Items Amount
+- Payment Rounding Amount, Refund Rounding Amount
+
+**Presentment currency fields** (if shop uses presentment currency):
+- Presentment Total Amount, Presentment Subtotal Amount
+- Presentment VAT Amount, Presentment Discount Amount
+- Pres. Shipping Charges Amount, Presentment Total Tip Received
+- Pres. Payment Rounding Amount, Pres. Refund Rounding Amount
+
+**Currency codes**:
+- Currency Code (shop money, translated to BC currency)
+- Presentment Currency Code (customer-facing currency)
+
+### Status fields
+
+- **Financial Status** (Enum): Pending, Authorized, Paid, Partially Paid, Refunded, Partially Refunded, Voided, Expired
+- **Fulfillment Status** (Enum): (blank), Unfulfilled, Partial, Fulfilled
+- **Return Status** (Enum): Return status tracking
+- **Fully Paid** (Boolean): True when payment complete
+- **Unpaid** (Boolean): True when not paid
+- **Refundable** (Boolean): Can be refunded
+- **Confirmed** (Boolean): Order confirmed by customer
+- **Closed** (Boolean): Order archived
+- **Cancelled At** (DateTime), **Cancel Reason** (Enum)
+- **Closed At**, **Processed At**, **Created At**, **Updated At** (DateTime)
+
+### Processing and mapping
+
+- **Sell-to Customer No.**, **Bill-to Customer No.**: Mapped BC customers
+- **Sales Order No.**, **Sales Invoice No.**: Created BC documents
+- **Processed** (Boolean): True when converted to BC sales document
+- **Has Error** (Boolean), **Error Message** (Text[2048])
+- **Has Order State Error** (Boolean): Conflict between Shopify and BC state
+- **Customer Templ. Code**: Template for auto-creating customers
+
+### Shipping and payment
+
+- **Shipping Method Code**, **Shipping Agent Code**, **Shipping Agent Service Code**
+- **Payment Method Code**: Mapped to BC payment methods
+- **Payment Terms Type**, **Payment Terms Name**: B2B payment terms
+- **Gateway** (Text[50]): Payment gateway name (from transactions)
+
+### B2B fields
+
+- **B2B** (Boolean): True for company orders
+- **Company Id**, **Company Location Id**: Shopify company identifiers
+- **Company Main Contact Id**, **Company Main Contact Email**, **Company Main Contact Phone No.**
+- **Company Main Contact Cust. Id**: BC customer for main contact
+- **PO Number**: Purchase order number from company
+
+### Additional fields
+
+- **Document Date**, **Due Date**: BC document dates
+- **Work Description** (Blob): Order notes
+- **Test** (Boolean): Test order flag
+- **Edited** (Boolean): Order was edited after creation
+- **Total Weight** (Decimal): Sum of line weights
+- **Discount Code**, **Discount Codes**: Applied discount codes
+- **VAT Included** (Boolean): Prices include tax
+- **Channel Name**, **App Name**: Source of order
+- **Source Name**: Order source identifier
+- **Retail Location Id**, **Retail Location Name**: Physical store location
+- **Salesperson Code**: Assigned salesperson (from staff member)
+- **Use Shopify Order No.** (Boolean): Use Shopify number as BC doc number
+- **Processed Currency Handling** (Enum): Currency mode when processed
+- **Current Total Amount**, **Current Total Items Quantity**: After refunds
+- **Line Items Redundancy Code** (Integer): Hash for detecting line changes
+- **High Risk** (FlowField): Calculated from risk assessments
+- **Channel Liable Taxes** (FlowField): True if any tax is channel-liable
+
+### FlowFields
+
+- **Total Quantity of Items**: Sum of order line quantities (excluding gifts/tips)
+- **Number of Lines**: Count of order lines
+
+### Relationships
+
+Deletes cascade to:
+- Shpfy Order Line (30119)
+- Shpfy Return Header (30147)
+- Shpfy Refund Header (30142)
+- Shpfy Data Capture (raw JSON)
+- Shpfy FulFillment Order Header (30143)
+- Shpfy Order Fulfillment (30144)
+
+## Order Line table (30119)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Tables\ShpfyOrderLine.Table.al`
+
+**Primary key**: Shopify Order Id, Line Id
+
+### Core fields
+
+- **Line Id** (BigInteger): Unique line identifier
+- **Shopify Order Id** (BigInteger): Parent order
+- **Shopify Product Id**, **Shopify Variant Id**: Product references
+- **Description** (Text[100]): Line description
+- **Variant Description** (Text[50]): Variant title
+
+### Quantity and pricing
+
+- **Quantity** (Decimal, 0:5): Ordered quantity
+- **Unit Price** (Decimal): Price in shop currency
+- **Presentment Unit Price** (Decimal): Price in presentment currency
+- **Discount Amount** (Decimal): Shop currency discount
+- **Presentment Discount Amount** (Decimal): Presentment currency discount
+- **Fulfillable Quantity** (Decimal): Remaining to fulfill
+- **Weight** (Decimal): Line item weight
+
+### Flags
+
+- **Taxable** (Boolean): Line is taxable
+- **Gift Card** (Boolean): Line is a gift card
+- **Tip** (Boolean): Line is a tip
+- **Product Exists** (Boolean): Product exists in Shopify
+
+### Mapping
+
+- **Item No.** (Code[20]): BC item
+- **Variant Code** (Code[10]): BC item variant
+- **Unit of Measure Code** (Code[10]): BC UOM
+
+### Additional
+
+- **Fulfillment Service** (Text[100]): Service handling fulfillment
+- **Location Id** (BigInteger): Shopify location
+- **Delivery Method Type** (Enum): Shipping, pickup, etc.
+
+**Keys**:
+- Primary: Shopify Order Id, Line Id
+- SumIndex: Shopify Order Id, Gift Card, Tip (for quantity sums)
+
+## Order Attribute table (30116)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Tables\ShpfyOrderAttribute.Table.al`
+
+**Primary key**: Order Id, Key
+
+- **Order Id** (BigInteger)
+- **Key** (Text[100]): Attribute name
+- **Attribute Value** (Text[2048]): Attribute value
+
+Custom attributes are key-value pairs attached to the order (e.g., gift message, special instructions).
+
+## Order Line Attribute table (30149)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Tables\ShpfyOrderLineAttribute.Table.al`
+
+**Primary key**: Order Id, Order Line Id, Key
+
+- **Order Id** (BigInteger)
+- **Order Line Id** (Guid): SystemId of order line
+- **Key** (Text[100]): Attribute name
+- **Value** (Text[250]): Attribute value
+
+Custom attributes at line level (e.g., engraving text, color preference).
+
+## Order Tax Line table (30122)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Tables\ShpfyOrderTaxLine.Table.al`
+
+**Primary key**: Parent Id, Line No.
+
+**Parent Id** can be:
+- Order header ID (for order-level taxes)
+- Order line ID (for line-level taxes)
+
+Fields:
+- **Title** (Code[20]): Tax name (e.g., "VAT", "GST")
+- **Rate** (Decimal): Tax rate as decimal (e.g., 0.25)
+- **Rate %** (Decimal): Tax rate as percentage (e.g., 25)
+- **Amount** (Decimal): Tax amount in shop currency
+- **Presentment Amount** (Decimal): Tax amount in presentment currency
+- **Channel Liable** (Boolean): Marketplace is responsible for tax
+
+Line No. auto-increments on insert.
+
+## Order Discount Application table (30117)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Tables\ShpfyOrderDiscAppl.Table.al`
+
+**Primary key**: Order Id, Line No.
+
+Describes discount rules applied to the order (not final amounts -- those are in header/line discount fields).
+
+Fields:
+- **Type** (Text[50]): Discount type (e.g., "DiscountCodeApplication")
+- **Code** (Text[50]): Discount code used
+- **Allocation Method** (Enum): How discount is distributed (Across, Each, One)
+- **Target Selection** (Enum): What is targeted (All, Entitled, Explicit)
+- **Target Type** (Enum): Line item or shipping line
+- **Value Type** (Enum): Fixed amount or percentage
+- **Value** (Decimal): Discount value
+
+## Enums
+
+### Shpfy Financial Status (30117)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Enums\ShpfyFinancialStatus.Enum.al`
+
+Values: (blank), Pending, Authorized, Partially Paid, Paid, Partially Refunded, Refunded, Voided, Expired, Unknown
+
+### Shpfy Order Fulfill. Status (30118)
+
+Values: (blank), Unfulfilled, Partial, Fulfilled, Restocked
+
+### Shpfy Cancel Reason (30116)
+
+Values: (blank), Customer, Declined, Fraud, Inventory, Other, Staff
+
+### Shpfy Shipment Status (30119)
+
+File: `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Order handling\Enums\ShpfyShipmentStatus.Enum.al`
+
+Values: (blank), Label Printed, Label Purchased, Ready for Pickup, Confirmed, In Transit, Out for Delivery, Delivered, Failure, Attempted Delivery
+
+### Shpfy Currency Handling (30122)
+
+Values: Shop Currency, Presentment Currency
+
+Determines which currency fields are used when creating BC sales documents.

--- a/src/Apps/W1/Shopify/App/src/Payments/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Payments/docs/CLAUDE.md
@@ -1,0 +1,38 @@
+# Payments
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Manages Shopify Payments data including payment transactions, payouts, disputes, and payment terms for B2B orders.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Payment Transaction (30124) | Stores individual payment transaction records associated with payouts |
+| Table | Shpfy Payout (30125) | Stores payout records from Shopify Payments with summary amounts |
+| Table | Shpfy Dispute (30155) | Stores payment dispute records (chargebacks and inquiries) |
+| Table | Shpfy Payment Terms (30158) | Stores payment terms from Shopify for B2B orders with mapping to BC payment terms |
+| Codeunit | Shpfy Payments (30XXX) | Processes payment data from Shopify |
+| Codeunit | Shpfy Payments API (30XXX) | GraphQL API calls for payment transactions and payouts |
+| Codeunit | Shpfy Payment Terms API (30XXX) | GraphQL API calls for payment terms |
+| Report | Shpfy Sync Payments | Synchronizes payment transactions and payouts from Shopify |
+| Report | Shpfy Sync Disputes | Synchronizes dispute records from Shopify |
+| Page | Shpfy Payment Transactions | List view of payment transactions |
+| Page | Shpfy Payouts | List view of payouts |
+| Page | Shpfy Disputes | List view of disputes |
+| Page | Shpfy Payment Terms Mapping | Configure payment terms mappings |
+| Enum | Shpfy Payment Trans. Type (30127) | Charge, Refund, Adjustment, and 100+ other transaction types |
+| Enum | Shpfy Payout Status (30128) | Scheduled, In Transit, Paid, Failed, Canceled |
+| Enum | Shpfy Dispute Type (30155) | Inquiry, Chargeback |
+| Enum | Shpfy Dispute Reason | Reason codes for disputes |
+| Enum | Shpfy Dispute Status | Status of dispute resolution |
+
+## Key concepts
+
+- Payment transactions are individual line items within payouts, showing fees and amounts
+- Payouts aggregate multiple payment transactions into a single bank transfer
+- Each payout includes breakdown of charges, refunds, adjustments, and fees
+- Disputes track chargebacks and inquiries with deadlines for evidence submission
+- Payment terms support Shopify B2B functionality, mapping to BC payment terms
+- Payment Transaction Source Type and Source Id link back to orders or other entities
+- Multiple currency support via Currency field on transactions and payouts

--- a/src/Apps/W1/Shopify/App/src/Payments/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/src/Payments/docs/data-model.md
@@ -1,0 +1,175 @@
+# Payments data model
+
+## Tables
+
+### Shpfy Payment Transaction (30124)
+
+Individual payment transaction records within payouts.
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Payments\Tables\ShpfyPaymentTransaction.Table.al`
+
+**Key fields:**
+- Id (PK)
+- Type (Enum: Shpfy Payment Trans. Type)
+- Test (Boolean)
+- Payout Id
+- Currency (Code 10)
+- Amount, Fee, Net Amount (Decimal)
+- Source Id, Source Type (Enum)
+- Source Order Transaction Id
+- Source Order Id
+- Processed At (DateTime)
+- Shop Code
+
+**Calculated fields:**
+- Invoice No. (from Sales Invoice Header via Source Order Id)
+
+**Keys:**
+- PK: Id
+- Idx1: Payout Id
+- Idx2: Shop Code
+
+### Shpfy Payout (30125)
+
+Payout records from Shopify Payments.
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Payments\Tables\ShpfyPayout.Table.al`
+
+**Key fields:**
+- Id (PK)
+- Status (Enum: Scheduled, In Transit, Paid, Failed, Canceled)
+- Date
+- Currency (Code 10)
+- Amount (total payout amount)
+- Adjustments Fee Amount, Adjustments Gross Amount
+- Charges Fee Amount, Charges Gross Amount
+- Refunds Fee Amount, Refunds Gross Amount
+- Reserved Funds Fee Amount, Reserved Funds Gross Amount
+- Retried Payouts Fee Amount, Retried Payouts Gross Amount
+- External Trace Id
+
+**Keys:**
+- PK: Id
+- Key1: Date
+
+### Shpfy Dispute (30155)
+
+Payment dispute records.
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Payments\Tables\ShpfyDispute.Table.al`
+
+**Access:** Internal
+
+**Key fields:**
+- Id (PK)
+- Source Order Id (TableRelation: Shpfy Order Header)
+- Type (Enum: Inquiry, Chargeback)
+- Currency (Code 10)
+- Amount
+- Reason (Enum: Shpfy Dispute Reason)
+- Network Reason Code
+- Status (Enum: Shpfy Dispute Status)
+- Evidence Due By (DateTime)
+- Evidence Sent On (DateTime)
+- Finalized On (DateTime)
+
+### Shpfy Payment Terms (30158)
+
+Payment terms from Shopify for B2B orders.
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Payments\Tables\ShpfyPaymentTerms.Table.al`
+
+**Access:** Internal
+
+**Key fields:**
+- Shop Code (PK)
+- Id (PK)
+- Name (not editable)
+- Due In Days (not editable)
+- Description (not editable)
+- Type (Code 20, not editable)
+- Is Primary (Boolean, validated)
+- Payment Terms Code (TableRelation: Payment Terms)
+
+**Validation:**
+- Only one payment term can be marked as primary
+
+## Relationships
+
+```
+Shpfy Payment Transaction
+├── Shpfy Payout (via Payout Id)
+├── Shpfy Shop (via Shop Code)
+├── Shpfy Order Transaction (via Source Order Transaction Id)
+├── Shpfy Order Header (via Source Order Id)
+└── Sales Invoice Header (via Source Order Id, FlowField)
+
+Shpfy Payout
+└── Shpfy Payment Transaction (1:many via Payout Id)
+
+Shpfy Dispute
+└── Shpfy Order Header (via Source Order Id)
+
+Shpfy Payment Terms
+├── Shpfy Shop (via Shop Code)
+└── Payment Terms (via Payment Terms Code)
+```
+
+## Enums
+
+### Shpfy Payment Trans. Type (30127)
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Payments\Enums\ShpfyPaymentTransType.Enum.al`
+
+Primary values:
+- Charge
+- Refund
+- Adjustment
+
+Deprecated (kept for legacy support):
+- Dispute, Reserve, Credit, Debit, Payout, Payout Failure, Payout Cancellation, Payment Refund
+
+Extended values (100+ total):
+- Shop Cash Credit, Anomaly Debit, Application Fee Refund, Balance Transfer Inbound, Billing Debit
+- Channel Credit/Debit variations, Chargeback Fee/Hold variations
+- Shipping Label adjustments, Tax Adjustment variations, Transfer variations
+- VAT Refund Credit, Advance Funding, and many others
+
+### Shpfy Payout Status (30128)
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Payments\Enums\ShpfyPayoutStatus.Enum.al`
+
+Values:
+- Unknown (blank)
+- Scheduled
+- In Transit
+- Paid
+- Failed
+- Canceled
+
+### Shpfy Dispute Type (30155)
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Payments\Enums\ShpfyDisputeType.Enum.al`
+
+Values:
+- Unknown (blank)
+- Inquiry
+- Chargeback
+
+### Shpfy Dispute Reason
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Payments\Enums\ShpfyDisputeReason.Enum.al`
+
+Enumeration of dispute reason codes.
+
+### Shpfy Dispute Status
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Payments\Enums\ShpfyDisputeStatus.Enum.al`
+
+Enumeration of dispute status values.
+
+### Shpfy Payment Trans. Source (30XXX)
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Payments\Enums\ShpfyPaymentTransSource.Enum.al`
+
+Enumeration indicating the source entity type for a payment transaction.

--- a/src/Apps/W1/Shopify/App/src/Products/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Products/docs/CLAUDE.md
@@ -1,0 +1,46 @@
+# Products
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Handles product and variant synchronization between Business Central items and Shopify products, including mapping, price calculation, and image sync.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Product (30127) | Stores Shopify product data with BC item mapping |
+| Table | Shpfy Variant (30129) | Stores Shopify variant data with BC item variant mapping |
+| Table | Shpfy Inventory Item (30126) | Inventory tracking metadata for variants |
+| Table | Shpfy Sales Channel (30125) | Product publication channels in Shopify |
+| Table | Shpfy Product Collection (30128) | Product collections (grouped products) |
+| Codeunit | Shpfy Sync Products (30185) | Orchestrates bidirectional product sync |
+| Codeunit | Shpfy Product Import (30180) | Imports products from Shopify to BC |
+| Codeunit | Shpfy Product Export (30178) | Exports BC items to Shopify products |
+| Codeunit | Shpfy Product Mapping (30181) | Maps Shopify products/variants to BC items |
+| Codeunit | Shpfy Product Price Calc. (30182) | Calculates prices using BC sales pricing |
+| Codeunit | Shpfy Create Product (30177) | Creates new products in Shopify from items |
+| Codeunit | Shpfy Product API (30176) | GraphQL API calls for products |
+| Codeunit | Shpfy Variant API (30179) | GraphQL API calls for variants |
+| Codeunit | Shpfy Product Events (30183) | Event publishers for extensibility |
+| Codeunit | Shpfy Sync Product Image (30184) | Synchronizes product images |
+| Codeunit | Shpfy Create Item (30175) | Creates BC items from Shopify products |
+| Codeunit | Shpfy Update Item (30174) | Updates BC items from Shopify data |
+| Enum | Shpfy Product Status (30130) | Active, Archived, Draft |
+| Enum | Shpfy SKU Mapping (30132) | How SKU maps to BC (Item No., Variant Code, etc.) |
+| Enum | Shpfy Variant Create Strategy (30165) | DEFAULT or REMOVE_STANDALONE_VARIANT |
+| Enum | Shpfy Remove Product Action (30131) | Status change when product removed |
+| Report | Shpfy Sync Products (30104) | Manual product sync report |
+| Report | Shpfy Add Item to Shopify (30105) | Add BC items to Shopify |
+| Page | Shpfy Products (30122) | Product list page |
+| Page | Shpfy Variants (30123) | Variant list page |
+
+## Key concepts
+
+- Product-variant hierarchy: Shopify products contain one or more variants; BC items can map to products or variants
+- SKU mapping strategies: Configurable mapping from Shopify SKU to BC Item No., Variant Code, Barcode, or Vendor Item No.
+- Bidirectional sync: "To Shopify" exports BC items; "From Shopify" imports and creates/updates BC items
+- Price calculation: Uses BC sales pricing engine (customer price groups, discounts) to calculate Shopify prices
+- Image synchronization: Separate sync for product and variant images via Shpfy Sync Product Image
+- Hash tracking: Image Hash, Tags Hash, Description Html Hash track changes for incremental updates
+- UoM as Variant: Option to represent BC units of measure as Shopify variants
+- Product status: Controls whether products are Active (published), Draft (unpublished), or Archived

--- a/src/Apps/W1/Shopify/App/src/Products/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/src/Products/docs/business-logic.md
@@ -1,0 +1,199 @@
+# Products business logic
+
+## Synchronization flows
+
+### Export to Shopify (Shpfy Sync Products, Shpfy Product Export)
+
+**Location:**
+- `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Codeunits\ShpfySyncProducts.Codeunit.al`
+- `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Codeunits\ShpfyProductExport.Codeunit.al`
+
+**Trigger:** Shop."Sync Item" = "To Shopify"
+
+**Flow:**
+1. Shpfy Sync Products.Run(Shop) calls ExportItemsToShopify()
+2. Shpfy Product Export filters Shpfy Product where "Item SystemId" is not null
+3. For each product:
+   - If Shop."Can Update Shopify Products" or OnlyUpdatePrice, call UpdateProductData()
+   - Export creates product body HTML from extended text, marketing text, and attributes (CreateProductBody)
+   - Calculate prices using Shpfy Product Price Calc (see Price calculation)
+   - Update product and variants via Shpfy Product API and Shpfy Variant API
+4. Optionally use bulk operations for price updates
+
+**Only price sync:** SetOnlySyncPriceOn() skips product fields, updates only variant prices.
+
+### Import from Shopify (Shpfy Sync Products, Shpfy Product Import)
+
+**Location:**
+- `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Codeunits\ShpfyProductImport.Codeunit.al`
+
+**Trigger:** Shop."Sync Item" = "From Shopify"
+
+**Flow:**
+1. Shpfy Sync Products calls ImportProductsFromShopify()
+2. Retrieve product IDs via Shpfy Product API.RetrieveShopifyProductIds() (returns Dictionary of [BigInteger, DateTime])
+3. For each product ID:
+   - If product exists locally and Updated At > Product."Updated At" and Product."Last Updated by BC", mark for import
+   - If product doesn't exist locally, mark for import
+4. For each marked product:
+   - Shpfy Product Import.Run() retrieves full product data via ProductApi.RetrieveShopifyProduct()
+   - Retrieve variant IDs via VariantApi.RetrieveShopifyProductVariantIds()
+   - For each variant, retrieve full data via VariantApi.RetrieveShopifyVariant()
+5. Attempt mapping via Shpfy Product Mapping.FindMapping()
+6. If mapping found and Shop."Shopify Can Update Items", call Shpfy Update Item
+7. If no mapping and Shop."Auto Create Unknown Items", call Shpfy Create Item
+8. If error, store in Product."Has Error" and "Error Message"
+
+**Last sync time:** Stored in Shpfy Synchronization Info after successful sync.
+
+## Mapping strategies
+
+### Product/variant to item mapping (Shpfy Product Mapping)
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Codeunits\ShpfyProductMapping.Codeunit.al`
+
+**Direction: Shopify to BC (DoFindMapping, ShopifyToBC)**
+
+Strategy based on Shop."SKU Mapping":
+
+1. **Item No.** -- If variant.SKU matches Item."No.", map to that item
+2. **Vendor Item No.** -- If variant.SKU matches Item Vendor."Vendor Item No.", map to item (optionally filtered by product.Vendor)
+3. **Variant Code** -- Split SKU into item no. + variant code, map to Item Variant
+4. **Item No. + Variant Code** -- SKU = Item No. + separator + Variant Code
+5. **Bar Code** -- Check Item."Bar Code" or Item Reference."Reference No."
+
+**Variant mapping logic:**
+- If product."Has Variants" = false, variant maps to item (Mapped By Item = true)
+- If product."Has Variants" = true:
+  - Variant can map to Item Variant (Item Variant SystemId set)
+  - Or variant can map directly to item if it's a UoM variant (UoM Option Id set)
+
+**Events:** OnBeforeFindProductMapping allows subscribers to override mapping.
+
+### Item to product mapping (reverse direction)
+
+**Direction: BC to Shopify**
+
+Used when exporting items. Searches Shpfy Product/Variant by Item SystemId.
+
+## Price calculation
+
+### Shpfy Product Price Calc. (30182)
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Codeunits\ShpfyProductPriceCalc.Codeunit.al`
+
+**Single instance codeunit** -- maintains state across calls.
+
+**Method:** CalcPrice(Item, ItemVariant, UnitOfMeasure, var UnitCost, var Price, var ComparePrice)
+
+**Logic:**
+1. Create temporary Sales Header with:
+   - Customer No. or shop code as sell-to
+   - Customer Price Group, Customer Disc. Group from shop or customer
+   - Gen. Bus. Posting Group, VAT Bus. Posting Group, Tax Area Code from shop
+   - Currency Code, Prices Including VAT
+2. Create temporary Sales Line:
+   - Type = Item, No. = Item."No."
+   - Variant Code, Quantity = 1
+   - Validate Unit of Measure Code
+3. BC pricing engine calculates:
+   - UnitCost from Sales Line."Unit Cost"
+   - ComparePrice from Sales Line."Unit Price" (before discount)
+   - Price from Sales Line."Line Amount" (after discount)
+4. If ComparePrice <= Price, set ComparePrice = 0 (Shopify shows compare-at only if higher)
+
+**Events:**
+- OnBeforeCalculateUnitPrice, OnAfterCalculateUnitPrice -- allow price override
+
+**Catalog support:** If Catalog is set, pricing can be catalog-specific.
+
+## Image synchronization
+
+### Shpfy Sync Product Image (30184)
+
+**Trigger:** Report "Shpfy Sync Images" or automatic after product export
+
+**Flow:**
+1. Shpfy Product Image Export and Shpfy Variant Image Export retrieve images from Item."Picture" or Item Variant."Picture"
+2. Upload via GraphQL (productCreateMedia, productVariantAppendMedia mutations)
+3. Update Product."Image Hash" or Variant."Image Hash" to track changes
+4. Only sync if hash changed (incremental sync)
+
+**Hash calculation:** Shpfy Hash codeunit computes hash of image binary data.
+
+## Product creation
+
+### Shpfy Create Product (30177)
+
+**Flow:**
+1. Create Shpfy Product record from Item
+2. Set product.Title from Item.Description
+3. Set product.Status from Shop."Status for Created Products" (Active or Draft)
+4. Create variants:
+   - If item has Item Variants, create one Shpfy Variant per Item Variant
+   - Variant.SKU set according to Shop."SKU Mapping"
+   - Variant options (Option 1/2/3) set from Item Attribute or UoM
+5. Call Shpfy Product API.CreateProduct() (GraphQL productCreate mutation)
+6. Store product ID and variant IDs
+
+**Strategy:** Uses Shpfy Variant Create Strategy enum for variant creation behavior.
+
+## Item creation (from Shopify)
+
+### Shpfy Create Item (30175)
+
+**Flow:**
+1. Read Shpfy Variant data
+2. If Shop."Auto Create Unknown Items" enabled, create Item from template (Shop."Item Templ. Code")
+3. Set Item."No." from SKU or generate new number
+4. Set Item.Description from Variant."Display Name" or Product.Title
+5. If product."Has Variants" and variant has Item Variant Code, create Item Variant
+6. Set Item."Unit Price", "Unit Cost" from variant
+7. Set Item."Vendor No." from product.Vendor
+8. If creation fails, store error in Product."Has Error"
+
+## Tag synchronization
+
+**Storage:** Shpfy Tag table (Parent Table No. = Database::"Shpfy Product", Parent Id = product.Id)
+
+**Methods:**
+- Product.GetCommaSeparatedTags() reads tags
+- Product.UpdateTags(CommaSeparatedTags) writes tags
+- Tags.Hash tracks changes
+
+**Sync:** Included in product export/import.
+
+## Events for extensibility
+
+### Shpfy Product Events (30183)
+
+**Published events:**
+- OnBeforeCreateProductBodyHtml, OnAfterCreateProductbodyHtml -- customize HTML description
+- OnAfterProductsToSynchronizeFiltersSet -- filter products for sync
+- OnBeforeCalculateUnitPrice, OnAfterCalculateUnitPrice -- override pricing
+- OnBeforeFindProductMapping -- override mapping logic
+- OnAfterGetCommaSeparatedTags -- customize tags
+
+## Key configuration (Shpfy Shop fields)
+
+**Product sync:**
+- `Sync Item` -- " ", "To Shopify", "From Shopify"
+- `Can Update Shopify Products` -- Allow BC to update existing Shopify products
+- `Status for Created Products` -- Active or Draft
+
+**Item creation:**
+- `Auto Create Unknown Items` -- Create BC items from Shopify products
+- `Item Templ. Code` -- Template for new items
+- `Shopify Can Update Items` -- Allow Shopify to update BC items
+
+**SKU and mapping:**
+- `SKU Mapping` -- How SKU maps to BC (Item No., Variant Code, etc.)
+- `UoM as Variant` -- Represent units of measure as variants
+
+**Content:**
+- `Sync Item Extended Text` -- Include extended text in product body
+- `Sync Item Marketing Text` -- Include marketing text
+- `Sync Item Attributes` -- Include item attributes as HTML
+
+**Images:**
+- `Sync Item Images` -- "To Shopify", "From Shopify", or disabled

--- a/src/Apps/W1/Shopify/App/src/Products/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/src/Products/docs/data-model.md
@@ -1,0 +1,171 @@
+# Products data model
+
+## Tables
+
+### Shpfy Product (30127)
+Stores Shopify product master data.
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Tables\ShpfyProduct.Table.al`
+
+**Key fields:**
+- `Id` (BigInteger) -- Shopify product ID, primary key
+- `Title` (Text[100]) -- Product title
+- `Description` (Text[250]) -- Plain text description
+- `Description as HTML` (Blob) -- HTML body stored as blob
+- `Product Type` (Text[50]) -- Product categorization
+- `Vendor` (Text[100]) -- Vendor/manufacturer
+- `Status` (Enum Shpfy Product Status) -- Active, Archived, Draft
+- `Has Variants` (Boolean) -- True if product has multiple variants
+- `Shop Code` (Code[20]) -- Link to Shpfy Shop
+- `Item SystemId` (Guid) -- Link to BC Item
+- `Image Id` (BigInteger) -- Default product image
+- `Created At`, `Updated At` (DateTime) -- Shopify timestamps
+- `Last Updated by BC` (DateTime) -- BC modification timestamp
+- `Image Hash`, `Tags Hash`, `Description Html Hash` (Integer) -- Change tracking hashes
+- `Has Error` (Boolean), `Error Message` (Text[2048]) -- Item creation error tracking
+
+**Methods:**
+- `GetCommaSeparatedTags()` -- Returns tags as comma-separated string
+- `GetDescriptionHtml()` -- Reads HTML description from blob
+- `SetDescriptionHtml(Text)` -- Writes HTML description and updates hash
+- `UpdateTags(Text)` -- Updates tags via Shpfy Tag table
+
+**Relationships:**
+- 1:N with Shpfy Variant (via Product Id)
+- N:1 with Item (via Item SystemId)
+- N:1 with Shpfy Shop
+
+### Shpfy Variant (30129)
+Stores Shopify product variant data (one or more per product).
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Tables\ShpfyVariant.Table.al`
+
+**Key fields:**
+- `Id` (BigInteger) -- Shopify variant ID, primary key
+- `Product Id` (BigInteger) -- Parent product
+- `SKU` (Text[50]) -- Stock keeping unit
+- `Barcode` (Text[50]) -- Barcode
+- `Price` (Decimal) -- Selling price
+- `Compare at Price` (Decimal) -- Original/compare-at price
+- `Unit Cost` (Decimal) -- Cost
+- `Title` (Text[100]) -- Variant title (e.g., "Small / Red")
+- `Display Name` (Text[250]) -- Full display name
+- `Option 1/2/3 Name/Value` (Text[50]) -- Up to 3 variant options (e.g., Size=Small, Color=Red)
+- `Weight` (Decimal) -- Product weight
+- `Taxable` (Boolean) -- Subject to tax
+- `Shop Code` (Code[20])
+- `Item SystemId` (Guid) -- Link to BC Item
+- `Item Variant SystemId` (Guid) -- Link to BC Item Variant
+- `Mapped By Item` (Boolean) -- True if variant maps to item (not item variant)
+- `UoM Option Id` (Integer) -- Which option represents unit of measure
+- `Image Id` (BigInteger) -- Variant-specific image
+- `Image Hash` (Integer) -- Image change tracking
+- `Created At`, `Updated At` (DateTime)
+- `Last Updated by BC` (DateTime)
+
+**Calculated fields:**
+- `Item No.` (Code[20]) -- FlowField from Item
+- `Variant Code` (Code[10]) -- FlowField from Item Variant
+
+**Relationships:**
+- N:1 with Shpfy Product (via Product Id)
+- N:1 with Item (via Item SystemId)
+- N:1 with Item Variant (via Item Variant SystemId)
+- 1:N with Shpfy Inventory Item (via Variant Id)
+
+### Shpfy Inventory Item (30126)
+Inventory metadata for variants (internal access only).
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Tables\ShpfyInventoryItem.Table.al`
+
+**Key fields:**
+- `Id` (BigInteger) -- Inventory item ID
+- `Variant Id` (BigInteger) -- Parent variant
+- `Tracked` (Boolean) -- Inventory tracking enabled
+- `Requires Shipping` (Boolean)
+- `Country/Region of Origin` (Text[50])
+- `Unit Cost` (Decimal)
+
+### Shpfy Sales Channel (30125)
+Product publication channels.
+
+**Key fields:**
+- `Id` (BigInteger) -- Channel ID
+- `Name` (Text[100]) -- Channel name (e.g., "Online Store")
+- `Shop Code` (Code[20])
+
+### Shpfy Product Collection (30128)
+Product collections for grouping.
+
+**Key fields:**
+- `Id` (BigInteger) -- Collection ID
+- `Handle` (Text[255]) -- URL handle
+- `Title` (Text[255]) -- Collection title
+- `Shop Code` (Code[20])
+
+## Enums
+
+### Shpfy Product Status (30130)
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Enums\ShpfyProductStatus.Enum.al`
+
+- `Active` (0) -- Published and visible
+- `Archived` (1) -- Archived, not visible
+- `Draft` (2) -- Unpublished draft
+
+### Shpfy SKU Mapping (30132)
+Defines how variant SKU maps to BC.
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Enums\ShpfySKUMapping.Enum.al`
+
+- `" "` (0) -- No mapping
+- `Item No.` (1) -- SKU = Item."No."
+- `Variant Code` (2) -- SKU = Item Variant.Code
+- `Item No. + Variant Code` (3) -- SKU = concatenation
+- `Vendor Item No.` (4) -- SKU = Item Vendor."Vendor Item No."
+- `Bar Code` (5) -- SKU = Item."Bar Code" or Item Reference
+
+### Shpfy Variant Create Strategy (30165)
+Strategy for creating variants via GraphQL.
+
+**Location:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Products\Enums\ShpfyVariantCreateStrategy.Enum.al`
+
+- `DEFAULT` (0)
+- `REMOVE_STANDALONE_VARIANT` (1) -- Removes default variant when adding new ones
+
+### Shpfy Remove Product Action (30131)
+Action when product removed from BC.
+
+- Values: Status To Draft, Status To Archived, Do Nothing (via interface implementations)
+
+### Shpfy Incl In Product Sync (30166)
+Controls item inclusion in product sync.
+
+- All Items
+- By Item Category Code
+- By Product Collection Mapping
+
+## Relationships
+
+```
+Shpfy Shop (1) ----< (N) Shpfy Product
+                         |
+                         +----< (N) Shpfy Variant ----< (N) Shpfy Inventory Item
+                                      |
+                                      |
+Item (1) ----< (N) Shpfy Variant
+       |
+       +----< (N) Item Variant (1) ----< (N) Shpfy Variant
+
+Shpfy Product (N) ----< (N) Shpfy Tag (by Parent Id, Parent Table No.)
+Shpfy Product (N) ----< (N) Shpfy Metafield
+Shpfy Variant (N) ----< (N) Shpfy Metafield
+```
+
+## Key indexes
+
+**Shpfy Product:**
+- PK: Id (clustered)
+- Key2: Shop Code, Item SystemId
+
+**Shpfy Variant:**
+- PK: Id (clustered)

--- a/src/Apps/W1/Shopify/App/src/Shipping/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Shipping/docs/CLAUDE.md
@@ -1,0 +1,35 @@
+# Shipping
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Manages shipment export to Shopify, shipping method mappings, and shipping charge handling for orders.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Shipment Method Mapping (30131) | Maps Shopify shipping methods to BC shipment methods and shipping agents |
+| Table | Shpfy Order Shipping Charges (30130) | Stores shipping line items from Shopify orders with amounts and discounts |
+| Codeunit | Shpfy Export Shipments (30190) | Creates fulfillments in Shopify from posted sales shipments |
+| Codeunit | Shpfy Shipping Methods (30XXX) | Manages shipping method mapping and synchronization |
+| Codeunit | Shpfy Shipping Charges (30XXX) | Processes shipping charges from orders |
+| Codeunit | Shpfy Shipping Events (30XXX) | Event publisher for shipping-related integration events |
+| Codeunit | Shpfy Update Sales Shipment (30XXX) | Updates sales shipment headers with Shopify tracking info |
+| Report | Shpfy Sync Shipm. to Shopify | Exports posted sales shipments to Shopify as fulfillments |
+| Page | Shpfy Shipment Methods Mapping | Configure shipment method mappings |
+| Page | Shpfy Order Shipping Charges | View shipping charges for orders |
+| TableExt | Shpfy Sales Shipment Header | Extends Sales Shipment Header with Shpfy Order Id and Shpfy Fulfillment Id |
+| TableExt | Shpfy Sales Shipment Line | Extends Sales Shipment Line with Shpfy Order Line Id |
+| TableExt | Shpfy Shipping Agent | Extends Shipping Agent with Shopify Tracking Company enum |
+| PageExt | Shpfy Sales Shipment Update | Adds Shopify sync action to posted sales shipment |
+| PageExt | Shpfy Shipping Agents | Adds Shopify Tracking Company field to shipping agents page |
+
+## Key concepts
+
+- Shipment export creates fulfillments in Shopify when BC sales shipments are posted
+- Shipment method mapping connects Shopify shipping method names to BC shipment methods
+- Shipping charges can be mapped to G/L accounts, items, or item charges for order processing
+- Shipping agent tracking company enum maps BC shipping agents to Shopify's predefined tracking companies
+- Fulfillment orders are created per shipment, with tracking information included
+- Shipping lines support both shop currency and presentment currency amounts
+- Partial fulfillments are supported when shipments don't include all order lines

--- a/src/Apps/W1/Shopify/App/src/Transactions/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Transactions/docs/CLAUDE.md
@@ -1,0 +1,34 @@
+# Transactions
+
+Part of [Shopify Connector](../../CLAUDE.md).
+
+Manages Shopify order transactions and payment method mappings for processing customer payments.
+
+## AL objects
+
+| Type | Name | Purpose |
+|------|------|---------|
+| Table | Shpfy Order Transaction (30133) | Stores transaction details from Shopify orders including payment gateway, status, amounts, and credit card info |
+| Table | Shpfy Payment Method Mapping (30134) | Maps Shopify payment gateways and credit card companies to Business Central payment methods |
+| Table | Shpfy Suggest Payment (30154) | Temporary table for suggesting payment journal entries based on transactions |
+| Table | Shpfy Credit Card Company (30132) | Lookup table of credit card companies extracted from transactions |
+| Table | Shpfy Transaction Gateway (30135) | Lookup table of payment gateways extracted from transactions |
+| Codeunit | Shpfy Transactions (30194) | Retrieves and imports transaction data from Shopify GraphQL API |
+| Codeunit | Shpfy Suggest Payments (30311) | Event subscriber for transferring transaction IDs to customer ledger entries |
+| Report | Shpfy Suggest Payments | Generates payment journal suggestions from order transactions |
+| Page | Shpfy Order Transactions | List view of order transactions |
+| Page | Shpfy Payment Methods Mapping | Configure payment method mappings |
+| Page | Shpfy Credit Card Companies | Lookup page for credit card companies |
+| Page | Shpfy Transaction Gateways | Lookup page for transaction gateways |
+| Enum | Shpfy Transaction Type (30134) | Authorization, Capture, Sale, Void, Refund |
+| Enum | Shpfy Transaction Status (30133) | Pending, Failure, Success, Error, Awaiting Response, Unknown |
+
+## Key concepts
+
+- Order transactions represent individual payment activities (authorization, capture, refund) on Shopify orders
+- Payment method mapping connects Shopify gateway and credit card company combinations to BC payment methods
+- Transactions include both shop currency and presentment currency amounts for multi-currency support
+- Gift card transactions are tracked via Gift Card Id field
+- Transaction gateway and credit card company tables are auto-populated when importing transactions
+- Suggest Payment functionality creates payment journal entries linked to specific transactions
+- Customer ledger entries track which transaction was used via Shpfy Transaction Id field

--- a/src/Apps/W1/Shopify/App/src/Transactions/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/src/Transactions/docs/data-model.md
@@ -1,0 +1,154 @@
+# Transactions data model
+
+## Tables
+
+### Shpfy Order Transaction (30133)
+
+Stores transaction details from Shopify orders.
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Transactions\Tables\ShpfyOrderTransaction.Table.al`
+
+**Key fields:**
+- Shopify Transaction Id (PK)
+- Shopify Order Id
+- Type (Enum: Authorization, Capture, Sale, Void, Refund)
+- Status (Enum: Pending, Failure, Success, Error, Awaiting Response, Unknown)
+- Gateway (Text 30)
+- Credit Card Company (Text 50)
+- Amount, Currency
+- Presentment Amount, Presentment Currency
+- Gift Card Id
+- Parent Id (self-reference for transaction hierarchy)
+- Refund Id
+- Created At
+- Manual Payment Gateway (Boolean)
+- Shop (Code 20)
+
+**Calculated fields:**
+- Sales Document No. (from Sales Header)
+- Posted Invoice No. (from Sales Invoice Header)
+- Payment Method (from Shpfy Payment Method Mapping)
+- Used (Boolean, exists in Cust. Ledger Entry)
+
+**Internal fields (Access = Internal):**
+- Credit Card Bin, Credit Card Number
+- AVS Result Code, CVV Result Code
+
+**Keys:**
+- PK: Shopify Transaction Id
+- Idx001: Gift Card Id (SumIndex on Amount)
+- Idx002: Created At
+- Idx003: Type
+- Key5: Shopify Order Id, Status
+
+### Shpfy Payment Method Mapping (30134)
+
+Maps Shopify payment gateways to Business Central payment methods.
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Transactions\Tables\ShpfyPaymentMethodMapping.Table.al`
+
+**Access:** Internal
+
+**Key fields:**
+- Shop Code (PK)
+- Gateway (PK, TableRelation: Shpfy Transaction Gateway)
+- Credit Card Company (PK, TableRelation: Shpfy Credit Card Company)
+- Payment Method Code (TableRelation: Payment Method)
+- Manual Payment Gateway (Boolean, not editable)
+
+### Shpfy Suggest Payment (30154)
+
+Temporary table for suggesting payment journal entries.
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Transactions\Tables\ShpfySuggestPayment.Table.al`
+
+**Access:** Internal
+**TableType:** Temporary
+
+**Key fields:**
+- Entry No. (PK)
+- Shop Code
+- Shpfy Transaction Id
+- Customer Ledger Entry No.
+- Customer No.
+- Invoice No., Credit Memo No.
+- Amount, Currency Code
+- Gateway
+- Shpfy Order Id, Shpfy Gift Card Id
+- Payment Method Code
+
+**Calculated fields:**
+- Shpfy Order No. (from Shpfy Order Header)
+
+### Shpfy Credit Card Company (30132)
+
+Lookup table of credit card companies.
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Transactions\Tables\ShpfyCreditCardCompany.Table.al`
+
+**Access:** Internal
+
+**Key fields:**
+- Name (PK, Text 50)
+
+### Shpfy Transaction Gateway (30135)
+
+Lookup table of transaction gateways.
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Transactions\Tables\ShpfyTransactionGateway.Table.al`
+
+**Access:** Internal
+
+**Key fields:**
+- Name (PK, Text 30)
+
+## Relationships
+
+```
+Shpfy Order Transaction
+├── Shpfy Order Header (via Shopify Order Id)
+├── Sales Header (via Shopify Order Id)
+├── Sales Invoice Header (via Shopify Order Id)
+├── Shpfy Order Transaction (self-reference via Parent Id)
+├── Cust. Ledger Entry (via Shopify Transaction Id)
+└── Shpfy Payment Method Mapping (via Shop, Gateway, Credit Card Company)
+    ├── Payment Method
+    ├── Shpfy Transaction Gateway (via Gateway)
+    └── Shpfy Credit Card Company (via Credit Card Company)
+
+Shpfy Suggest Payment
+├── Shpfy Shop (via Shop Code)
+├── Shpfy Order Transaction (via Shpfy Transaction Id)
+├── Cust. Ledger Entry (via Customer Ledger Entry No.)
+├── Customer (via Customer No.)
+├── Sales Invoice Header (via Invoice No.)
+├── Sales Cr.Memo Header (via Credit Memo No.)
+└── Currency (via Currency Code)
+```
+
+## Enums
+
+### Shpfy Transaction Type (30134)
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Transactions\Enums\ShpfyTransactionType.Enum.al`
+
+Values:
+- (blank)
+- Authorization
+- Capture
+- Sale
+- Void
+- Refund
+
+### Shpfy Transaction Status (30133)
+
+**File:** `C:\repos\NAV\App\BCApps\src\Apps\W1\Shopify\App\src\Transactions\Enums\ShpfyTransactionStatus.Enum.al`
+
+Values:
+- (blank)
+- Pending
+- Failure
+- Success
+- Error
+- Awaiting Response
+- Unknown


### PR DESCRIPTION
## Summary
- Bootstrap comprehensive hierarchical documentation for the Shopify Connector app
- 39 markdown files covering app-level overview + 20 functional subfolders
- Documentation generated from analysis of actual AL source code (638 .al files)

### App-level docs
- `CLAUDE.md` -- App overview, structure, key architectural concepts
- `docs/data-model.md` -- 65 tables across 10 domains, relationships, enums
- `docs/business-logic.md` -- Processing flows (orders, products, customers, inventory), 70+ events
- `docs/patterns.md` -- IsHandled, Interface+Enum, TryFunction, GraphQL templates, hash detection

### Subfolder docs (MUST_DOCUMENT, score 7+)
12 subfolders with CLAUDE.md + data-model/business-logic docs:
GraphQL, Order handling, Products, Customers, Metafields, Base, Companies, Inventory, Transactions, Document Links, Order Return Refund Processing, Payments

### Subfolder docs (SHOULD_DOCUMENT, score 4-6)
8 subfolders with CLAUDE.md only:
Shipping, Order Fulfillments, Order Returns, Order Refunds, Catalogs, Logs, Invoicing, Bulk Operations



