### PR TITLE
[Shopify] Add developer documentation for Shopify Connector

### DIFF
--- a/src/Apps/W1/Shopify/App/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/CLAUDE.md
@@ -1,0 +1,59 @@
+# Shopify Connector
+
+The Shopify Connector synchronizes products, orders, customers, companies, inventory, payments, fulfillments, returns, and refunds between Business Central and Shopify. It treats Shopify as the storefront and BC as the ERP -- orders flow in, products and inventory flow out, and customers are mapped between the two systems. The connector uses Shopify's GraphQL Admin API exclusively, with interface-based strategy patterns for every configurable behavior.
+
+## Quick reference
+
+- **ID range**: 30100--30460
+- **API version**: `2026-01` (hardcoded in `ShpfyCommunicationMgt`, with Azure Key Vault-driven expiry checking)
+- **Dependencies**: None (self-contained on the base application platform)
+
+## How it works
+
+The `Shpfy Shop` table (30102) is the god object. Every shop record holds configuration for products, customers, companies, orders, inventory, returns, metafields, and more. Most boolean pairs follow a mutual-exclusion pattern -- "Shopify Can Update Items" disables "Can Update Shopify Products" and vice versa -- which enforces a single source of truth per entity type.
+
+Synchronization runs as background job queue entries or manually from the Shop Card. Each sync type (products, orders, customers, companies, inventory) has its own `Shpfy Sync*` codeunit that orchestrates the flow. Products sync bidirectionally -- import retrieves product IDs from Shopify, skips unchanged ones via `UpdatedAt`/`LastUpdatedByBC` timestamp comparison, and creates or updates BC Items. Export reads the product table filtered to items with a mapped `Item SystemId` and pushes changes back, using bulk operations for large price updates. Orders flow inbound only: a scheduled poll (or webhook) populates `OrdersToImport`, then `ImportOrder` fetches full details via GraphQL and writes `OrderHeader`/`OrderLine`, then `ProcessOrder` maps everything and creates a Sales Order or Sales Invoice in BC.
+
+The connector never syncs directly between BC and Shopify entities. Every Shopify entity is first stored in a connector-owned staging table (Shpfy Product, Shpfy Customer, Shpfy Order Header, etc.), and the connector manages the link between those staging records and BC master data via `SystemId` fields. This two-step approach means the connector can operate with delayed or partial connectivity and provides a full audit trail through `DataCapture` records.
+
+The connector does not manage Shopify store settings, themes, or checkout configuration. It does not handle B2C marketing, analytics, or multi-storefront content management. It does not sync BC purchase orders, production orders, or warehouse documents. Returns and refunds are import-only from Shopify -- BC never pushes return/refund data back.
+
+## Structure
+
+- `src/Base/` -- Shop table, CommunicationMgt, background sync scheduler, installer, upgrade
+- `src/Products/` -- Product/Variant/InventoryItem tables, import/export/mapping, price calculation, image sync
+- `src/Order handling/` -- OrdersToImport staging, OrderHeader/Line, import, mapping, processing into Sales documents
+- `src/Customers/` -- Customer table, mapping strategies (ByEmail, ByBillto, ByDefault), import/export, name formatting
+- `src/Companies/` -- B2B company/location tables, mapping strategies, company export
+- `src/Inventory/` -- Stock calculation interfaces, location mapping, inventory sync (BC to Shopify only)
+- `src/Order Fulfillments/` -- FulfillmentOrderHeader/Line, fulfillment creation, shipping confirmation
+- `src/Order Returns/` -- Return header/line, return API
+- `src/Order Refunds/` -- Refund header/line, refund shipping lines, refund API
+- `src/Order Return Refund Processing/` -- IReturnRefund Process interface, credit memo creation
+- `src/Transactions/` -- OrderTransaction, PaymentMethodMapping, gateway/card brand resolution
+- `src/Payments/` -- Disputes, payment transactions, payouts (bank deposits)
+- `src/Bulk Operations/` -- JSONL-based bulk mutations for large batches (price updates, image updates)
+- `src/GraphQL/` -- 130+ GraphQL query codeunits, rate limit management, query builder
+- `src/Metafields/` -- Polymorphic metafield storage with type validation
+- `src/Catalogs/` -- B2B catalog/price list management
+- `src/Logs/` -- LogEntry, DataCapture (audit trail with hash dedup), SkippedRecord
+- `src/Document Links/` -- DocLinkToDoc many-to-many between Shopify docs and BC docs
+
+## Documentation
+
+- [docs/data-model.md](docs/data-model.md) -- How the data fits together
+- [docs/business-logic.md](docs/business-logic.md) -- Processing flows and gotchas
+- [docs/patterns.md](docs/patterns.md) -- Recurring code patterns
+
+## Things to know
+
+- The Shop table uses a hash-based `Shop Id` derived from the URL, not the Code field, for order sync timing. Orders use `Shop Id` as the `SynchronizationInfo` key so that renaming a shop code doesn't lose sync state.
+- `CommunicationMgt` is a SingleInstance codeunit -- it holds the current shop context across the entire session. You must call `SetShop()` before any API call.
+- The GraphQL rate limiter (`ShpfyGraphQLRateLimit`) is also SingleInstance. It dynamically calculates wait times from Shopify's `extensions.cost.throttleStatus` response, using `(ExpectedCost - Available) / RestoreRate` to avoid throttling. If throttled anyway, the main loop retries until the `THROTTLED` error clears.
+- Bulk operations have a 100-item threshold (`GetBulkOperationThreshold`). Below that, the connector uses individual GraphQL mutations. Above it, it uploads JSONL to Shopify's staged upload URL and runs `bulkOperationRunMutation`.
+- New metafield records get negative IDs (starting at -1, decrementing). This prevents collisions with Shopify-assigned IDs before the first sync.
+- `DataCapture.Add()` uses hash dedup -- if the hash of the new data matches the last capture for the same record, it skips the insert. This keeps audit trails manageable.
+- Every amount field has a dual-currency pair: `"Amount"` (shop currency) and `"Presentment Amount"` (customer-facing currency). The Shop's `"Currency Handling"` setting determines which one feeds into BC Sales documents.
+- The `ProcessOrders` codeunit does `Commit()` between each order so that one failed order doesn't roll back the entire batch. On failure, it cleans up the partially created Sales document via `CleanUpLastCreatedDocument()`.
+- Order conflict detection uses `LineItemsRedundancyCode` -- a hash of all line IDs. If a re-imported order has different line IDs or quantities than the already-processed version, it flags the order as conflicting rather than silently overwriting.
+- The connector uses `#region` / `#endregion` to organize the three address blocks (Sell-to, Ship-to, Bill-to) in `ShpfyImportOrder`, which is unusual for AL code but makes the 900+ line codeunit navigable.

--- a/src/Apps/W1/Shopify/App/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/docs/business-logic.md
@@ -1,0 +1,85 @@
+# Business logic
+
+## Product synchronization
+
+Product sync is bidirectional, controlled by the Shop's `Sync Item` setting.
+
+**Import (From Shopify)**: `ShpfySyncProducts.ImportProductsFromShopify` calls `ProductApi.RetrieveShopifyProductIds` to get all product IDs with their `UpdatedAt` timestamps. It then filters: if a product already exists locally and both `Product."Updated At"` and `Product."Last Updated by BC"` are newer than Shopify's timestamp, the product is skipped. This is the first-pass optimization -- no API call is made for unchanged products.
+
+For each product that passes the filter, `ShpfyProductImport.SetProduct` calls `ProductApi.RetrieveShopifyProduct` (a GraphQL query) to fetch full product data, then `VariantApi.RetrieveShopifyProductVariantIds` and `VariantApi.RetrieveShopifyVariant` for each variant. The import creates or updates local `Shpfy Product` and `Shpfy Variant` records.
+
+Then `ShpfyProductImport.OnRun` iterates variants and calls `ProductMapping.FindMapping` to link each variant to a BC Item + Item Variant. The mapping strategy depends on the Shop's `SKU Mapping` setting -- it can match by Item No., Vendor Item No., Barcode, or a compound SKU with a configurable separator. If no mapping is found and `Auto Create Unknown Items` is enabled, `ShpfyCreateItem` runs (with a `Commit()` before each attempt for isolation). Failures are captured as product errors rather than thrown.
+
+**Export (To Shopify)**: `ShpfyProductExport.OnRun` iterates all `Shpfy Product` records that have a non-empty `Item SystemId` (meaning they are mapped to a BC item). For each product, it calls `UpdateProductData`, which recalculates prices via `ProductPriceCalc`, rebuilds the HTML body from extended text + marketing text + attributes, updates variants, and pushes changes via `ProductApi` / `VariantApi` GraphQL mutations.
+
+For price-only sync, the export uses bulk operations. It accumulates JSONL input and, if the count exceeds 100 items, calls `BulkOperationMgt.SendBulkMutation`. If the bulk operation fails (e.g., another is already running), it falls back to individual `VariantAPI.UpdateProductPrice` calls per variant.
+
+**Image sync** runs separately via `ShpfySyncProductImage` and `ShpfyProductImageExport`/`ShpfyVariantImageExport`. Image changes are detected by comparing the `Image Hash` on the product/variant. Bulk image updates use `ShpfyBulkUpdateProductImage`.
+
+**UoM as Variant**: When `UoM as Variant` is enabled on the Shop, the connector treats BC Units of Measure as Shopify variant options. The `UoM Option Id` on the variant tracks which option slot (1, 2, or 3) holds the UoM value. During order mapping, the UoM option value becomes the `Unit of Measure Code` on the order line.
+
+## Order import and processing
+
+Order import is a multi-step pipeline.
+
+**Step 1 -- Retrieval**: `ShpfyOrders.OnRun` queries Shopify for order IDs updated since the last sync time. For each order, it inserts a row into `Shpfy Orders to Import`. Webhooks (`Order Created Webhooks`) can also populate this staging table in near-real-time.
+
+**Step 2 -- Import**: `ShpfyImportOrder.ImportOrderAndCreateOrUpdate` is the main import procedure. It calls GraphQL to get the full order JSON (header, addresses, B2B purchasing entity, payment terms). Then it retrieves order lines in paginated batches via `GetOrderLines` / `GetNextOrderLines`. It writes the data into `Shpfy Order Header` and `Shpfy Order Line` records.
+
+During import, it also fetches: fulfillment orders (for location/delivery method), shipping charges, transactions, returns (if configured), refunds (if configured), and risk assessments. The `DataCapture.Add()` call stores the raw JSON for each header and line as an audit trail.
+
+If the order was already processed in BC and the re-import detects changes (different line IDs via `LineItemsRedundancyCode`, different quantities, or different shipping amounts), the order is flagged as conflicting (`Has Order State Error = true`) rather than silently overwriting. This is critical -- the connector refuses to modify already-processed orders automatically.
+
+After import, `ConsiderRefundsInQuantityAndAmounts` subtracts refunded quantities and amounts from order lines. Then `DeleteZeroQuantityLines` removes fully-refunded lines. If the order is fully fulfilled and paid, `CheckToCloseOrder` / `CloseOrder` closes it in Shopify.
+
+**Step 3 -- Mapping**: `ShpfyOrderMapping.DoMapping` resolves Shopify entities to BC entities. For B2C orders, it uses `CustomerMapping.DoMapping` with the configured strategy (ByEmail/Phone, ByBillto, ByDefault). For B2B orders, it uses `CompanyMapping.DoMapping`. The CustomerTemplate table provides per-country overrides.
+
+For order lines, `MapVariant` looks up the Shopify Variant, resolves the `Item SystemId` to a BC Item No., the `Item Variant SystemId` to a Variant Code, and extracts the UoM from the variant option. If the variant is unmapped, it triggers `ProductImport` on the spot to try to create the mapping.
+
+Payment method mapping uses `MapPaymentMethodCode`, which looks at successful Sale/Capture/Authorization transactions and resolves via `PaymentMethodMapping` (gateway + card brand to BC method). If multiple distinct payment methods are found, it leaves the field blank for manual resolution.
+
+**Step 4 -- Processing**: `ShpfyProcessOrders.ProcessShopifyOrder` runs `ShpfyProcessOrder.OnRun` within a TryFunction pattern. `ProcessOrder` calls `DoMapping` one more time, then `CreateHeaderFromShopifyOrder` creates a BC Sales Header (Sales Order or Sales Invoice, depending on fulfillment status and the `Create Invoices From Orders` setting). It populates all three address blocks, sets currency based on `Currency Handling`, assigns tax area, payment method, shipping method, and salesperson.
+
+`CreateLinesFromShopifyOrder` creates Sales Lines. Tips map to the `Tip Account` G/L account, gift cards to `Sold Gift Card Account`, and regular items to type Item with location derived from `ShpfyShopLocation`. Shipping charges become G/L Account lines (or Item Charge lines if configured in `ShipmentMethodMapping`). Cash rounding adjustments get their own line from `Cash Roundings Account`.
+
+The `DocLinkToDoc` record is always created to link the Shopify order to the BC document. If `Order Attributes To Shopify` is enabled, the BC document number is written back to Shopify as a custom order attribute.
+
+On failure, `ProcessOrders` catches the error, stores it on the order header, and calls `CleanUpLastCreatedDocument()` to delete the partially-created Sales document. The `Commit()` between each order ensures isolation.
+
+## Customer and company sync
+
+**Customer mapping** uses strategy interfaces. The `Shpfy Customer Mapping` enum maps to implementations: `ByEMail/Phone` (`ShpfyCustByEmailPhone`), `ByBilltoInfo` (`ShpfyCustByBillto`), and `ByDefaultCustomer` (`ShpfyCustByDefaultCust`). The mapping codeunit `ShpfyCustomerMapping.DoMapping` checks if the order has name info -- if both Name and Name2 are empty, it falls back to ByEmail/Phone regardless of the configured strategy.
+
+The `DoFindMapping` method in `ShpfyCustomerMapping` does bidirectional lookup: Shopify-to-BC searches BC Customers by email filter (`'@' + email`) then phone filter (digits-only with wildcards), while BC-to-Shopify searches the Shopify Customer table by `Customer SystemId`, then calls the Shopify API to find by email/phone.
+
+**Customer import** can be set to `None`, `WithOrderImport`, or `AllCustomers` via the `Customer Import From Shopify` enum. With `None`, the default customer is used. With `WithOrderImport`, customers are imported on-demand during order processing. With `AllCustomers`, a full sync pulls all customer IDs.
+
+**Company mapping (B2B)** follows the same pattern with the `Shpfy Company Mapping` enum: `ByTaxId`, `ByEmailPhone`, `ByDefaultCompany`. The B2B order path in `OrderMapping.MapB2BHeaderFields` tries to resolve from the company location first (which can have its own Sell-to/Bill-to customer overrides), then from the company level, then from the default.
+
+**Name formatting** uses the `Shpfy ICustomer Name` interface, with implementations for CompanyName, FirstAndLastName, LastAndFirstName, and None. The Shop configures which source to use for Name, Name2, and Contact. County resolution similarly uses `Shpfy ICounty From Json` with Code and Name implementations.
+
+## Inventory sync
+
+Inventory sync is one-way: BC to Shopify. `ShpfySyncInventory.OnRun` iterates shop locations that have a non-Disabled `Stock Calculation` setting. For each location, `InventoryApi.ImportStock` reads the current Shopify inventory levels, then `InventoryApi.ExportStock` pushes BC-calculated stock.
+
+Stock calculation uses the `Shpfy IStock Available` interface. Implementations include `ShpfyCanHaveStock` and `ShpfyCanNotHaveStock` (for the basic toggle), and `ShpfyFreeInventory`, `ShpfyBalanceToday`, etc. for actual calculations. The `Shpfy Stock Calculation` enum on the Shop Location determines which implementation runs. There is also an `Extended Stock Calculation` interface for custom calculations.
+
+## Returns and refunds
+
+Returns and refunds are import-only from Shopify. During order import, `ShpfyImportOrder.SetAndCreateRelatedRecords` conditionally fetches returns via `ReturnsAPI.GetReturns` and refunds via `RefundsAPI.GetRefunds`, controlled by the `IReturnRefund Process` interface's `IsImportNeededFor` method.
+
+The `Return and Refund Process` enum has two values: `Import Only` and `Auto Create Credit Memo`. With `Import Only`, the data is stored but no BC documents are created. With `Auto Create Credit Memo`, `ProcessOrders.ProcessShopifyRefunds` iterates unprocessed refund headers and calls `IReturnRefundProcess.CreateSalesDocument` to generate Sales Credit Memos.
+
+The `Return Location Priority` enum controls where returned items go: the shop's default return location, the fulfillment location, or the order's original location.
+
+## Extension points
+
+The connector exposes events throughout its processing chain. The main event codeunits are:
+
+- `ShpfyOrderEvents` -- Before/After CreateSalesHeader, CreateItemSalesLine, CreateShippingCostSalesLine, ProcessSalesDocument, MapCustomer, MapCompany, MapShipmentMethod, MapPaymentMethod, and enum conversion hooks
+- `ShpfyProductEvents` -- Before/After FindProductMapping, CreateProductBodyHtml, GetCommaSeparatedTags, ProductsToSynchronizeFiltersSet
+- `ShpfyCustomerEvents` -- Before/After FindMapping (both directions)
+- `ShpfyCommunicationEvents` -- OnClientSend, OnClientPost, OnClientGet, OnGetContent, OnGetAccessToken (used extensively by the test app to mock API responses)
+- `ShpfyInventoryEvents` -- for stock calculation customization
+
+If you want to customize how orders are created, subscribe to `OnBeforeCreateSalesHeader` and set `IsHandled = true`. If you want to change product mapping, subscribe to `OnBeforeFindProductMapping`. If you want to add custom stock calculation logic, implement `Shpfy Stock Calculation` or `Shpfy Extended Stock Calculation` interface.

--- a/src/Apps/W1/Shopify/App/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/docs/data-model.md
@@ -1,0 +1,81 @@
+# Data model
+
+## Core configuration
+
+The `Shpfy Shop` table (30102) is the central configuration hub. Every sync behavior, mapping strategy, template selection, G/L account assignment, and feature toggle lives here. It has over 80 fields spanning product sync direction, customer/company mapping types, order processing options, B2B settings, metafield sync toggles, webhook configuration, and more. Two mutual-exclusion field pairs enforce single-direction sync: "Shopify Can Update Items" vs "Can Update Shopify Products", and equivalents for customers and companies. Validating one to `true` forces the other to `false`.
+
+The `Shpfy Synchronization Info` table tracks the last sync timestamp per shop and sync type (Products, Orders, Customers, etc.). Orders are special -- they key on `Shop Id` (a hash of the Shopify URL) rather than the `Code` field, so renaming a shop code preserves order sync state. The `GetLastSyncTime` / `SetLastSyncTime` methods on the Shop table manage this transparently.
+
+The `Shpfy Registered Store New` table holds OAuth access tokens per store, keyed by store name. `CommunicationMgt.GetAccessToken()` validates that the stored scope matches the current expected scope before returning the token.
+
+## Product catalog
+
+Products follow a three-level hierarchy: `Shpfy Product` (30127) owns `Shpfy Variant` (30129), each variant owns `Shpfy Inventory Item` records. The Product holds title, description, vendor, status, and image metadata. The Variant holds SKU, price, compare-at-price, barcode, weight, up to three option name/value pairs, and inventory policy.
+
+Both Product and Variant link to BC via `Item SystemId` (a Guid). The Variant additionally has `Item Variant SystemId` for BC Item Variants and `Mapped By Item` to indicate a variant mapped at the item level without a specific variant code. These SystemId links survive BC item renumbering -- the connector never stores `Item."No."` as a foreign key; it uses FlowFields (`CalcFormula = lookup`) to resolve the display number from the SystemId on demand.
+
+Change detection uses integer hash fields: `Image Hash`, `Tags Hash`, and `Description Html Hash` on the Product, plus `Image Hash` on the Variant. The `Shpfy Hash` codeunit generates these. During export, the connector compares the current hash to the stored one to skip unchanged data without expensive string comparisons.
+
+Products also carry dual timestamps: `Updated At` (from Shopify) and `Last Updated by BC` (set locally on export). The import loop in `ShpfySyncProducts.ImportProductsFromShopify` skips a product if both timestamps are older than Shopify's `UpdatedAt` for that product ID, which prevents circular updates.
+
+The `Shpfy Product Collection` and `Shpfy Shop Collection Map` tables handle Shopify's Smart/Custom collections, mapped from BC Tax Groups or VAT Product Posting Groups via the Shop's `Product Collection` setting.
+
+## Customer and company (B2B)
+
+The `Shpfy Customer` table stores Shopify customer data with a `Customer SystemId` linking to BC's Customer table. The `Shpfy Customer Address` table holds address details. The `Shpfy Customer Template` table provides country-specific overrides -- keyed by Shop Code and Country/Region Code, it can set a per-country Default Customer No. and Customer Template Code. During order mapping, if a template exists for the ship-to country, its default customer takes precedence over the shop-level default.
+
+The `Shpfy Tax Area` table maps Shopify country/province combinations to BC Tax Area Codes. The Shop's `Tax Area Priority` enum controls the lookup order: ship-to country first, then bill-to, or vice versa.
+
+For B2B, the `Shpfy Company` table links to a BC Customer via `Customer SystemId` (again, a Guid, resolved through a FlowField). The `Shpfy Company Location` table represents billing/shipping locations within a company, each with optional `Sell-to Customer No.` and `Bill-to Customer No.` overrides. The order mapping in `ShpfyOrderMapping.MapSellToBillToCustomersFromCompanyLocation` checks the location first, then falls back to the company-level customer.
+
+## Order lifecycle
+
+Orders arrive through a two-stage pipeline. Stage one: the `Shpfy Orders to Import` table (30121) acts as a lightweight staging area populated by scheduled sync or webhook. Each row holds the Shopify order ID, order number, timestamps, and basic status flags (test, confirmed, fully paid, financial/fulfillment status). The `Shop Id` field (not `Shop Code`) links to the shop, which allows webhook-delivered orders to find their shop without knowing the BC code.
+
+Stage two: `ShpfyImportOrder` reads the staging row, calls GraphQL to get the full order JSON, and writes into `Shpfy Order Header` (30118) and `Shpfy Order Line` (30119). The header carries three complete address blocks -- Sell-to, Ship-to, and Bill-to -- each with first name, last name, company name, address lines, city, country, county, and post code. It also stores dual-currency amounts everywhere: `Total Amount` / `Presentment Total Amount`, `Subtotal Amount` / `Presentment Subtotal Amount`, `VAT Amount` / `Presentment VAT Amount`, `Discount Amount` / `Presentment Discount Amount`, and so on.
+
+The `Line Items Redundancy Code` on the header is a hash of all line IDs (pipe-separated, sorted ascending). When an order is re-imported after processing, the connector compares the new redundancy code to the stored one. A mismatch -- meaning Shopify edits added, removed, or changed lines -- sets `Has Order State Error` to flag the conflict for manual resolution.
+
+Related tables include `Shpfy Order Attribute` (custom attributes), `Shpfy Order Line Attribute`, `Shpfy Order Tax Line` (per-line and per-order tax breakdowns), `Shpfy Order Shipping Charges`, and `Shpfy Order Payment Gateway`.
+
+## Fulfillments
+
+Fulfillments have two distinct models. `Shpfy Fulfillment Order Header` / `Shpfy Fulfillment Order Line` represent Shopify's FulfillmentOrder concept -- the *intent* to fulfill from a specific location. These are fetched per-order during import and used to determine `Location Id` and `Delivery Method Type` on order lines.
+
+`Shpfy Order Fulfillment` / `Shpfy Fulfillment Line` represent actual fulfillments -- shipments that have been made. These track tracking numbers, carriers, and which line items were shipped. The connector creates fulfillments in Shopify when BC posts a Sales Shipment, if `Send Shipping Confirmation` is enabled.
+
+## Returns and refunds
+
+Returns and refunds are separate concepts. A `Shpfy Return Header` / `Shpfy Return Line` represents the physical return of goods -- what items the customer is sending back. A `Shpfy Refund Header` / `Shpfy Refund Line` represents the money side -- what amounts were refunded to the customer. A single order can have returns without refunds, refunds without returns, or both.
+
+The `Shpfy Refund Shipping Line` tracks shipping cost refunds separately. Refund lines link back to order lines via `Order Line Id`, and the import process in `ShpfyImportOrder.ConsiderRefundsInQuantityAndAmounts` subtracts refunded quantities and amounts directly from the order lines before processing.
+
+The `Return and Refund Process` enum on the Shop controls behavior: `Import Only` just stores the data, while `Auto Create Credit Memo` creates BC Sales Credit Memos from refunds via the `IReturnRefund Process` interface.
+
+## Payments and transactions
+
+The `Shpfy Order Transaction` table (30133) stores payment transactions per order -- gateway name, type (Sale/Capture/Authorization/Refund), status (Pending/Success/Failure/Error), amount, and currency. Transactions have parent linking via `Parent Id` for chained operations (e.g., an authorization followed by a capture).
+
+The `Shpfy Payment Method Mapping` table (30134) maps the combination of gateway name + credit card company to a BC Payment Method Code. Its primary key is `(Shop Code, Gateway, Credit Card Company)`, so you can map "shopify_payments" + "Visa" differently from "shopify_payments" + "Mastercard". The `Shpfy Transaction Gateway` and `Shpfy Credit Card Company` tables serve as lookup masters populated from observed transactions.
+
+The `Shpfy Payment Transaction` and `Shpfy Payout` tables handle Shopify Payments-specific data: individual payment transactions and bank deposit payouts. The `Shpfy Dispute` table tracks payment disputes.
+
+## Catalogs and pricing (B2B)
+
+The `Shpfy Catalog` table represents B2B catalogs. `Shpfy Catalog Price` holds per-catalog price overrides. `Shpfy Market Catalog Relation` links catalogs to markets. Catalog sync supports creating price lists via `GQLCreatePriceList` and updating prices via `GQLUpdateCatalogPrices`.
+
+## Cross-cutting patterns
+
+**Metafields** use a polymorphic design. The `Shpfy Metafield` table (30101) stores metafields for products, variants, customers, and companies in a single table. The `Owner Type` enum determines the entity type, and `Parent Table No.` (an integer) stores the AL database table number. The `Owner Id` (BigInteger) holds the Shopify entity ID. On insert, new metafields get negative IDs (starting at -1, decrementing) to avoid collisions with Shopify-assigned IDs until the first sync pushes them.
+
+**Tags** follow the same polymorphic pattern. The `Shpfy Tag` table uses `Parent Table No.` + parent ID to associate comma-separated tags with any entity.
+
+**DocLinkToDoc** provides many-to-many linking between Shopify documents (orders, returns, refunds) and BC documents (Sales Orders, Invoices, Credit Memos). It uses `Shpfy Document Type` + `Shopify Document Id` on one side and `Document Type` + `Document No.` on the other.
+
+**LogEntry** stores API request/response data in Blob fields, with a configurable `Logging Mode` (All, Error Only, or disabled). A retention policy setup auto-enables when logging is turned on.
+
+**DataCapture** (30114) is the audit trail. Every API response for orders, products, etc. gets stored with a hash. The `Add()` method checks if the hash matches the last capture for the same record and skips the insert if so, preventing unbounded table growth for unchanging data.
+
+**SkippedRecord** tracks records that could not be synced, with the reason.
+
+**BulkOperation** (in the Bulk Operations folder) tracks asynchronous Shopify bulk operations -- their status, result URLs, and request data.

--- a/src/Apps/W1/Shopify/App/docs/patterns.md
+++ b/src/Apps/W1/Shopify/App/docs/patterns.md
@@ -1,0 +1,165 @@
+# Patterns
+
+## Interface-based strategy
+
+The connector uses AL's "enum implements interface" pattern extensively. An enum value on the Shop table selects the behavior at runtime. The pattern looks like this:
+
+The `Shpfy Customer Mapping` enum declares `implements "Shpfy ICustomer Mapping"`. Each enum value (`"By EMail/Phone"`, `"By Billto Info"`, `"By Default Customer"`) maps to a codeunit that implements the interface. At runtime, `ShpfyCustomerMapping.DoMapping` does:
+
+```
+IMapping := LocalShop."Customer Mapping Type";
+exit(IMapping.DoMapping(...));
+```
+
+This pattern appears in at least 10 places:
+
+- **Customer mapping**: `Shpfy Customer Mapping` enum / `Shpfy ICustomer Mapping` interface -- `ShpfyCustByEmailPhone`, `ShpfyCustByBillto`, `ShpfyCustByDefaultCust`
+- **Company mapping**: `Shpfy Company Mapping` enum / `Shpfy ICompany Mapping` -- `ShpfyCompByTaxId`, `ShpfyCompByEmailPhone`, `ShpfyCompByDefaultComp`
+- **Name formatting**: `Shpfy Name Source` enum / `Shpfy ICustomer Name` -- `ShpfyNameisCompanyName`, `ShpfyNameisFirstLastName`, `ShpfyNameisLastFirstName`, `ShpfyNameisEmpty`
+- **County resolution**: `Shpfy County Source` enum / `Shpfy ICounty From Json` -- `ShpfyCountyFromJsonCode`, `ShpfyCountyFromJsonName`
+- **Stock calculation**: `Shpfy Stock Calculation` enum / `Shpfy IStock Available` -- `ShpfyCanHaveStock`, `ShpfyCanNotHaveStock`, `ShpfyFreeInventory`, `ShpfyBalanceToday`, `ShpfyDisabledValue`
+- **Product status on create**: `Shpfy Cr. Prod. Status Value` enum / `Shpfy ICreateProductStatusValue` -- `ShpfyCreateProdStatusActive`, `ShpfyCreateProdStatusDraft`
+- **Remove product action**: `Shpfy Remove Product Action` enum / `Shpfy IRemoveProductAction` -- `ShpfyRemoveProductDoNothing`, `ShpfyToArchivedProduct`, `ShpfyToDraftProduct`
+- **Return/refund processing**: `Shpfy ReturnRefund ProcessType` enum / `Shpfy IReturnRefund Process`
+- **Bulk operations**: `Shpfy Bulk Operation Type` enum / `Shpfy IBulk Operation` -- `ShpfyBulkUpdateProductPrice`, `ShpfyBulkUpdateProductImage`
+- **Metafield types**: `Shpfy Metafield Type` enum / `Shpfy IMetafield Type` -- type validation and example values
+- **Metafield owner types**: `Shpfy Metafield Owner Type` enum / `Shpfy IMetafield Owner Type` -- resolves table ID and shop code from owner
+
+The key advantage: new strategies can be added by extending the enum from another extension without modifying connector code.
+
+## GraphQL communication
+
+All Shopify API calls go through `ShpfyCommunicationMgt` (30103), a `SingleInstance` codeunit. You must call `SetShop()` before any API call -- this sets the internal `Shop` record variable that provides the URL and access token.
+
+The `ExecuteGraphQL` overloads accept either a raw query string or a `Shpfy GraphQL Type` enum value. The enum-based path calls `GraphQLQueries.GetQuery(GraphQLType, Parameters, ExpectedCost)`, which dispatches to one of ~130 `ShpfyGQL*` codeunits in `src/GraphQL/Codeunits/`. Each codeunit implements the `Shpfy IGraphQL` interface and returns the query string, parameter substitution, and expected cost.
+
+Rate limiting is handled by `ShpfyGraphQLRateLimit` (also `SingleInstance`). After each response, `SetQueryCost` reads the `extensions.cost.throttleStatus` from the response JSON to track `RestoreRate` and `currentlyAvailable` tokens. Before each request, `WaitForRequestAvailable(ExpectedCost)` calculates the needed wait:
+
+```
+WaitTime = Max(ExpectedCost - LastAvailable, 0) / RestoreRate * 1000 - (CurrentDateTime - LastRequestedOn)
+```
+
+If the request still gets throttled (response contains `THROTTLED`), the main loop in `ExecuteGraphQL` retries:
+
+```
+while JResponse.AsObject().Contains('errors') and Format(JResponse).Contains('THROTTLED') do begin
+    ShpfyGraphQLRateLimit.WaitForRequestAvailable(ExpectedCost);
+    // re-execute query...
+end;
+```
+
+For REST-level throttling (HTTP 429) and server errors (5xx), `EvaluateResponse` returns `Retry = true` with a 2-second or 10-second sleep, up to `MaxRetries` (default 5 for web requests, 3 for GraphQL).
+
+The API version is a hardcoded label (`VersionTok: Label '2026-01'`). Version expiry is checked via Azure Key Vault on SaaS (with a 10-day cache in IsolatedStorage). If the version is expired, the connector raises an error and refuses all API calls.
+
+Query length is capped at 50,000 characters (`GetGraphQueryLengthThreshold`). Product create mutations get a special error message mentioning marketing text and embedded images as likely causes.
+
+## Bulk operations
+
+For large batches (>100 items, per `GetBulkOperationThreshold`), the connector uses Shopify's Bulk Operation API instead of individual mutations. The flow:
+
+1. The caller (e.g., `ShpfyProductExport`) accumulates mutation inputs as JSONL in a `TextBuilder` and request metadata in a `JsonArray`.
+2. At the end, it calls `BulkOperationMgt.SendBulkMutation(Shop, BulkOperationType, Jsonl, RequestData)`.
+3. `SendBulkMutation` checks if another bulk operation of the same type is already running. If so, it returns `false` and the caller falls back to individual mutations.
+4. If no conflict, `BulkOperationAPI.CreateBulkOperationMutation` uploads the JSONL via staged upload (GraphQL `createUploadUrl` mutation, then POST to the S3 URL), then calls `bulkOperationRunMutation`.
+5. Shopify processes asynchronously. When done, it fires a webhook to the BC endpoint.
+6. `ProcessBulkOperationNotification` handles the webhook, updating the `Shpfy Bulk Operation` record with status, result URL, and error code.
+
+The `Shpfy IBulk Operation` interface provides `GetGraphQL()` (the mutation template), `GetType()` (mutation vs query), and `GetName()`. Current implementations: `ShpfyBulkUpdateProductPrice` and `ShpfyBulkUpdateProductImage`.
+
+## Data capture and audit trail
+
+The `Shpfy Data Capture` table (30114) stores a copy of every API response linked to the record it pertains to. The `Add()` method takes a table number, the record's SystemId, and the data (text, JsonToken, or JsonObject). It computes a hash via `Shpfy Hash.CalcHash()` and compares it to the hash of the last entry for the same `(Linked To Table, Linked To Id)`. If the hashes match, the insert is skipped entirely. This means the table only grows when data actually changes.
+
+The data is stored as a UTF-8 Blob. `GetData()` reads it back through an InStream via `TypeHelper.ReadAsTextWithSeparator`.
+
+Data capture is used during order import (both header and each line), product import, and other API-driven operations. Combined with the `Shpfy Log Entry` table (which stores request/response at the HTTP level), this gives two layers of auditability: the raw API traffic and the parsed data per business record.
+
+## Error handling philosophy
+
+The connector does not throw exceptions from its main processing loops. Instead, it wraps processing in `Codeunit.Run()` / TryFunction patterns and captures failures:
+
+In `ShpfyProcessOrders.ProcessShopifyOrder`:
+```
+if not ProcessOrder.Run(ShopifyOrderHeader) then begin
+    ShopifyOrderHeader."Has Error" := true;
+    ShopifyOrderHeader."Error Message" := CopyStr(Format(Time) + ' ' + GetLastErrorText(), ...);
+    ProcessOrder.CleanUpLastCreatedDocument();
+end else begin
+    ShopifyOrderHeader."Has Error" := false;
+    ShopifyOrderHeader.Processed := true;
+end;
+ShopifyOrderHeader.Modify(true);
+Commit();
+```
+
+The `Commit()` after each order is deliberate -- it ensures one failed order doesn't roll back successfully processed ones. The `CleanUpLastCreatedDocument()` call deletes the partially-created Sales document on failure, tracked via the `LastCreatedDocumentId` Guid variable.
+
+In product import, item creation follows the same pattern:
+```
+Commit();
+ItemCreated := CreateItem.Run(ShopifyVariant);
+SetProductConflict(ShopifyProduct.Id, ItemCreated);
+```
+
+The `Commit()` before `CreateItem.Run()` isolates the transaction so that if item creation fails, only that item is rolled back.
+
+The `Shpfy Skipped Record` table captures records that were skipped during sync with the reason (blocked item, missing mapping, etc.) for user review.
+
+## Hash-based change detection
+
+The `Shpfy Hash` codeunit produces integer hashes used throughout:
+
+- `Product."Description Html Hash"` -- set in `SetDescriptionHtml()` to detect body changes without comparing potentially large HTML blobs
+- `Product."Tags Hash"` -- `CalcTagsHash()` hashes the comma-separated tag string
+- `Product."Image Hash"` / `Variant."Image Hash"` -- detect image changes
+- `DataCapture."Hash No."` -- dedup identical API responses
+- `OrderHeader."Line Items Redundancy Code"` -- hash of pipe-separated sorted line IDs for edit detection
+- `Shop."Shop Id"` -- hash of the Shopify URL for stable identity
+
+The hash is a standard integer hash, not cryptographic. It is used purely for equality comparison to avoid expensive string operations on potentially large texts.
+
+## Dual-currency architecture
+
+Every monetary amount on orders carries two values: shop currency and presentment currency. For example, `Shpfy Order Header` has `"Total Amount"` and `"Presentment Total Amount"`, `"VAT Amount"` and `"Presentment VAT Amount"`, etc. `Shpfy Order Line` has `"Unit Price"` and `"Presentment Unit Price"`, `"Discount Amount"` and `"Presentment Discount Amount"`.
+
+The Shop's `Currency Handling` enum (`Shop Currency` or `Presentment Currency`) controls which value feeds into the BC Sales document. This is consistently applied in `ShpfyProcessOrder.CreateLinesFromShopifyOrder`:
+
+```
+case ShopifyShop."Currency Handling" of
+    "Shop Currency":
+        begin
+            SalesLine.Validate("Unit Price", ShopifyOrderLine."Unit Price");
+            SalesLine.Validate("Line Discount Amount", ShopifyOrderLine."Discount Amount");
+        end;
+    "Presentment Currency":
+        begin
+            SalesLine.Validate("Unit Price", ShopifyOrderLine."Presentment Unit Price");
+            SalesLine.Validate("Line Discount Amount", ShopifyOrderLine."Presentment Discount Amount");
+        end;
+end;
+```
+
+Currency codes from Shopify (ISO codes) are translated to BC currency codes via `TranslateCurrencyCode`, which matches on `Currency."ISO Code"`. If the resulting code matches BC's LCY Code, it is cleared to empty (BC convention for local currency).
+
+## Negative ID strategy for new records
+
+New metafields that have not yet been synced to Shopify receive negative IDs. In `Shpfy Metafield.OnInsert`:
+
+```
+if Id = 0 then
+    if Metafield.FindFirst() and (Metafield.Id < 0) then
+        Id := Metafield.Id - 1
+    else
+        Id := -1;
+```
+
+This ensures new records are valid (non-zero primary key) and cannot collide with Shopify-assigned positive IDs. When the metafield is synced and Shopify returns a real ID, the connector updates it.
+
+## Polymorphic relationships via ParentTableNo
+
+Several tables use an integer `Parent Table No.` field to create polymorphic relationships. The `Shpfy Metafield` table stores metafields for products, variants, customers, and companies in a single table, discriminated by `Parent Table No.` (which holds the AL database table number, e.g., `Database::"Shpfy Product"`) and `Owner Id` (the Shopify entity ID).
+
+The `Shpfy Tag` table follows the same pattern. `ShpfyTag.UpdateTags(Database::"Shpfy Product", Id, CommaSeparatedTags)` stores product tags, while the same table can hold tags for other entity types.
+
+This avoids the need for separate metafield/tag tables per entity type, at the cost of losing strong foreign key relationships. The connector compensates by having OnDelete triggers that clean up related metafields and tags -- see `Shpfy Product.OnDelete` and `Shpfy Variant.OnDelete`.

--- a/src/Apps/W1/Shopify/App/src/Base/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Base/docs/CLAUDE.md
@@ -1,0 +1,22 @@
+# Base
+
+Foundational infrastructure for the Shopify Connector: the shop configuration hub, HTTP communication, installation, synchronization orchestration, and shared primitives used across all other modules.
+
+## How it works
+
+The `Shpfy Shop` table (30102) is the central configuration record. Almost every setting -- customer mapping type, name sources, sync directions, logging mode, default customer, item templates, currency -- lives as a field on this table. Other modules receive a Shop record and read their configuration from it rather than maintaining their own settings tables.
+
+`ShpfyCommunicationMgt` is the single HTTP gateway to Shopify's Admin API. It is a `SingleInstance` codeunit that constructs URLs from `Shop."Shopify URL"` + the API version (a `Label` constant, currently `2026-01`), manages OAuth authentication, executes GraphQL queries (delegating query text resolution to `ShpfyGraphQLQueries` in the GraphQL module), and handles response parsing, logging, and retry. It also enforces API version expiry by checking against a Key Vault secret.
+
+Synchronization timing is tracked per shop per entity type in `ShpfySynchronizationInfo` (keyed on shop code + `SynchronizationType` enum: Products, Orders, Customers, Companies). Each sync writes its start time via `Shop.SetLastSyncTime` and reads it back on the next run to do delta queries. `ShpfyBackgroundSyncs` orchestrates all sync jobs -- products, orders, customers, companies, inventory, payouts, images -- by constructing XML parameters and enqueuing `Job Queue Entry` records.
+
+`ShpfyInstaller` runs on app install to register retention policies for log entries, data captures, and skipped records (all defaulting to 1-month retention, disabled), and sets up cue thresholds. It also subscribes to company-copy and environment-cleanup events to auto-disable shops in non-production environments.
+
+## Things to know
+
+- `ShpfyTag` uses a generic `Parent Table No.` + `Parent Id` pattern so the same tag table serves customers, products, orders, and any future entity. Maximum 250 tags per parent, enforced in `OnInsert`.
+- `ShpfyFilterMgt.CleanFilterValue` escapes AL filter metacharacters (`(`, `)`, `*`, `.`, `<`, `>`, `=`) with `?` wildcards and prepends `@` for case-insensitive matching. This is used throughout the connector when building record filters from Shopify data.
+- `ShpfyInitialImportLine` tracks the wizard-driven first-time import with job queue integration. It shifts `Job Queue Entry.Status` option values by +1 to accommodate a leading blank state.
+- The `LoggingMode` enum has three values: `Error Only` (default), `All`, and `Disabled`. This controls what `ShpfyCommunicationMgt` logs to the `Shpfy Log Entry` table.
+- `ShpfyBackgroundSyncs` splits each sync into two passes: one for shops with `"Allow Background Syncs" = true` (enqueued as job queue entries) and one for shops with it false (run inline via `Report.Execute`).
+- The `MappingDirection` enum (`ShopifyToBC`, `BCToShopify`) is consumed by customer and company mapping to determine which direction a find-mapping operation is running.

--- a/src/Apps/W1/Shopify/App/src/Catalogs/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Catalogs/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# Catalogs
+
+B2B catalog pricing for Shopify. This module manages price lists that are tied to specific companies or markets, allowing different customers to see different prices for the same products. It is separate from the Products module (which handles base product data) because catalogs layer company-specific or market-specific pricing on top.
+
+## How it works
+
+The `Shpfy Catalog` table (30152) represents a Shopify catalog, linked to a company via `Company SystemId` and to a shop. Each catalog carries pricing configuration: `Customer Price Group`, `Customer Discount Group`, `Gen. Bus. Posting Group`, `VAT Bus. Posting Group`, `Tax Area Code`, `Prices Including VAT`, `Allow Line Disc.`, and a `Customer No.` override. When a `Customer No.` is set, its discount and price group settings take precedence over the catalog-level fields. The `Sync Prices` flag controls whether price sync is active, and `Catalog Type` (from `ShpfyCatalogType.Enum.al`) distinguishes catalog categories.
+
+`Shpfy Catalog Price` (table 30153) is a temporary table that holds pre-calculated prices per variant and price list. It stores the computed `Price` and `Compare at Price` along with the price list currency. `ShpfySyncCatalogPrices.Codeunit.al` calculates these prices using BC's pricing engine with the catalog's posting group and pricing configuration, then pushes them to Shopify.
+
+`Shpfy Market Catalog Relation` (table 30400) is a many-to-many junction between markets and catalogs, storing the market name and catalog title. This supports Shopify's market-based catalog assignment, where a single catalog can serve multiple markets. `ShpfyCatalogAPI.Codeunit.al` handles the API interactions for creating and syncing catalogs.
+
+## Things to know
+
+- The `Catalog Price` table is `TableType = Temporary` -- prices are calculated on the fly and never persisted in BC.
+- Catalog creation can be triggered automatically during company export when the shop's `Auto Create Catalog` flag is set.
+- The catalog primary key is composite (`Id`, `Company SystemId`), so the same Shopify catalog ID can appear with different company associations.
+- Deleting a catalog automatically clears its `MarketCatalogRelation` records via the `OnDelete` trigger.
+- Market catalog relations are imported from Shopify and displayed on the `ShpfyMarketCatalogs.Page.al` and `ShpfyMarketCatalogRelations.Page.al` pages.
+- The `Currency Code` field on the catalog allows overriding the price list currency independently of the shop currency.

--- a/src/Apps/W1/Shopify/App/src/Companies/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Companies/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Companies
+
+B2B company management for the Shopify Connector. This module handles the bidirectional sync of Shopify companies to BC customers, separate from the individual-customer (B2C) flow in the adjacent Customers module. The key distinction is that a company has multiple locations, each of which can map to a different sell-to/bill-to customer.
+
+## How it works
+
+The data model is `Shpfy Company` (table 30150) -> `Shpfy Company Location` (table 30151) -> main contact (`Shpfy Customer`). A company stores the Shopify ID, a link to a BC customer via `Customer SystemId`, and a reference to a main contact customer. Each `CompanyLocation` carries its own address, tax registration ID, payment terms, and separate `Sell-to Customer No.` / `Bill-to Customer No.` fields -- so a single Shopify company can route different locations to different BC customers.
+
+Company-to-customer matching is driven by the `Shpfy ICompany Mapping` interface (`ShpfyICompanyMapping.Interface.al`). The shop's `Company Mapping Type` setting selects the strategy: `ShpfyCompByTaxId.Codeunit.al` matches on tax registration ID via a secondary `Shpfy Tax Registration Id Mapping` interface, `ShpfyCompByEmailPhone.Codeunit.al` matches on the main contact's email or phone, and `ShpfyCompByDefaultComp.Codeunit.al` always returns the shop's default company. All three implement both `ICompany Mapping` and `IFind Company Mapping` (the latter adds a `FindMapping` method that checks whether a mapping already exists before creating one).
+
+Import flows through `ShpfyCompanyImport.Codeunit.al` -- it retrieves the company from the Shopify API, updates locations, then calls `FindMapping`. If no match is found and auto-create is enabled, it creates a new BC customer. Export flows through `ShpfyCompanyExport.Codeunit.al`, which iterates BC customers and either creates or updates Shopify companies, including auto-creating catalogs when `Auto Create Catalog` is enabled on the shop.
+
+## Things to know
+
+- The `Bill-to Customer No.` on `CompanyLocation` requires `Sell-to Customer No.` to be set first -- clearing sell-to clears bill-to automatically.
+- `FindMapping` has a self-healing pattern: if `Customer SystemId` points to a deleted customer, it clears the GUID and retries matching.
+- `ShpfyCompanyExport` uses a generic `HasDiff` helper that compares all fields via `RecordRef` to decide whether an API update is needed.
+- Export requires a non-empty email on the BC customer; missing email logs a skipped record rather than erroring.
+- Payment terms mapping is per-location: `ShpfyCompanyLocation` stores a `Shpfy Payment Terms Id` that links to the shop-specific `Shpfy Payment Terms` table.
+- Tax registration ID mapping is itself interface-driven (`ShpfyTaxRegistrationIdMapping.Interface.al`) with implementations for VAT Registration No. and Tax Registration No.
+- When exporting, the module checks for duplicate `External Id` (set to `Customer."No."`) to avoid creating duplicate companies in Shopify.

--- a/src/Apps/W1/Shopify/App/src/Customers/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Customers/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Customers
+
+Maps Shopify customers to Business Central customer records and handles bidirectional synchronization. This module owns the identity-resolution problem -- given a Shopify order, which BC customer should it land on? -- and keeps that boundary clean from the Orders module by exposing mapping through `ShpfyCustomerMapping.Codeunit.al`.
+
+## How it works
+
+When a Shopify customer needs to be resolved, `ShpfyCustomerMapping` dispatches to one of three strategies via the `ICustomerMapping` interface. The strategy is selected from `Shop."Customer Mapping Type"`, but if both Name and Name2 are blank in the incoming JSON, it falls back to `ByEMail/Phone` regardless of configuration. `ShpfyCustByEmailPhone` imports the customer from Shopify and creates a BC customer from the default address. `ShpfyCustByBillto` matches on the full bill-to address (address, zip, city, country) plus the computed name, iterating over all addresses for that Shopify customer. `ShpfyCustByDefaultCust` simply returns `Shop."Default Customer No."` -- no lookup at all.
+
+Name computation is polymorphic too: `Shop."Name Source"`, `"Name 2 Source"`, and `"Contact Source"` each point to an `ICustomerName` implementation (CompanyName, FirstAndLastName, LastAndFirstName, or Empty). County resolution works the same way through `ICounty` and `ICountyFromJson` -- either the province code or the province name, controlled by `Shop."County Source"`.
+
+Customer creation uses `ShpfyCreateCustomer`, which picks a `CustomerTemplate` by country code (the `ShpfyCustomerTemplate` table keyed on shop + country). If no country-specific template exists, it auto-creates an empty row and falls back to the shop-level default. Tax area mapping happens in `ShpfyUpdateCustomer.FillInCustomerFields` -- a `ShpfyTaxArea` record keyed on country + province name sets tax area code, tax liable, and VAT bus. posting group on the BC customer.
+
+## Things to know
+
+- Phone matching in `ShpfyCustomerMapping.CreatePhoneFilter` strips all non-digits, trims leading zeros, then inserts a wildcard `*` before every digit -- so `+1 (555) 012-3456` becomes `*5*5*5*0*1*2*3*4*5*6`. This is intentionally fuzzy to handle formatting differences.
+- `ShpfyCustomerAddress.OnInsert` auto-assigns negative IDs (starting at -1, decrementing) for locally-created addresses that have not yet been synced to Shopify. The first address for a customer is automatically set as default.
+- The old `ShpfyProvince` table (30108) is removed as of v25; it was replaced by `ShpfyTaxArea` which keys on country code + county name instead of Shopify province IDs.
+- `ShpfySyncCountries` reads province data from an embedded YAML resource (`data/provinces.yml`) using `NavApp.GetResource`, not from the Shopify API. It populates `ShpfyTaxArea` rows during country sync.
+- The `CustomerImportRange` enum controls when customers are pulled: `None` skips import entirely, `WithOrderImport` only imports customers encountered during order sync, and `AllCustomers` does a full pull via `RetrieveShopifyCustomerIds`.
+- `ShpfyCustomerEvents` exposes integration events at every lifecycle point (before/after create, update, find mapping, find template). These are the primary extensibility mechanism for partner customizations.
+- When exporting customers to Shopify, multi-value email fields (semicolon or comma separated) are split and only the first address is sent.

--- a/src/Apps/W1/Shopify/App/src/Document Links/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Document Links/docs/CLAUDE.md
@@ -1,0 +1,19 @@
+# Document links
+
+Cross-referencing between Shopify documents and BC documents. This module maintains a many-to-many mapping table that tracks which Shopify orders, returns, and refunds correspond to which BC sales orders, invoices, shipments, credit memos, and return receipts. It is separate from the order-processing modules because it is a shared lookup used by multiple areas.
+
+## How it works
+
+The `Shpfy Doc. Link To Doc.` table (30146) stores links with a composite key of (`Shopify Document Type`, `Shopify Document Id`, `Document Type`, `Document No.`). The Shopify side uses the `Shpfy Shop Document Type` enum (30144) with values for Order, Return, and Refund. The BC side uses the `Shpfy Document Type` enum (30143) covering Sales Order, Sales Invoice, Sales Credit Memo, Sales Return Order, Posted Sales Shipment, Posted Return Receipt, Posted Sales Invoice, and Posted Sales Credit Memo.
+
+Both enums implement interface-driven document opening. `Shpfy Shop Document Type` implements `Shpfy IOpenShopifyDocument` -- each value maps to a codeunit like `ShpfyOpenOrder.Codeunit.al` or `ShpfyOpenRefund.Codeunit.al`. `Shpfy Document Type` implements `Shpfy IOpenBCDocument` with codeunits like `ShpfyOpenSalesOrder.Codeunit.al` and `ShpfyOpenPostedSalesInvoice.Codeunit.al`. The table itself exposes `OpenShopifyDocument` and `OpenBCDocument` methods that dispatch through these interfaces.
+
+The lifecycle management happens in `ShpfyDocumentLinkMgt.Codeunit.al`, which subscribes to Sales-Post events. When a sales order is posted, it automatically creates links to the resulting posted invoice, shipment, credit memo, or return receipt. It also handles the `OnDeleteSalesHeader` event to clean up links, and `OnBeforeDeleteAfterPosting` to transfer links from the unposted document to the posted document. It additionally links invoices back to shipments when posting standalone invoices that reference shipment lines.
+
+## Things to know
+
+- Links propagate automatically on posting -- you do not need to manually create links to posted documents.
+- The `CreateNewDocumentLink` helper silently skips blank document numbers and zero IDs, so it is safe to call unconditionally after posting.
+- The module uses secondary indexes on both the Shopify side (`Idx01`) and the BC side (`Idx02`) for efficient lookups in either direction.
+- Unsupported document types fall through to `ShpfyOpenBCDocNotSupported.Codeunit.al` / `ShpfyOpenDocNotSupported.Codeunit.al`, which are the default implementations.
+- Both enums are extensible, so partners can add new Shopify or BC document types.

--- a/src/Apps/W1/Shopify/App/src/GraphQL/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# GraphQL
+
+Contains all Shopify GraphQL query and mutation definitions used by the connector. This is the largest module (~145 codeunits) but is intentionally mechanical -- it defines *what* to ask Shopify, not *how* to communicate. The HTTP layer lives in `Base/ShpfyCommunicationMgt`.
+
+## How it works
+
+Every query or mutation is a codeunit implementing the `IGraphQL` interface (`ShpfyIGraphQL.Interface.al`), which requires two methods: `GetGraphQL()` returns the raw JSON-wrapped GraphQL string, and `GetExpectedCost()` returns the estimated query cost for rate limiting. The `ShpfyGraphQLType` enum maps each variant to its implementing codeunit, so callers pass an enum value and a parameters dictionary to `ShpfyCommunicationMgt.ExecuteGraphQL`, which delegates to `ShpfyGraphQLQueries` to resolve the query text. Parameters are injected by simple `{{ParamName}}` placeholder replacement.
+
+Pagination follows a "base + Next" convention: `ShpfyGQLCustomerIds` fetches the first page, `ShpfyGQLNextCustomerIds` adds an `after:"{{After}}"` cursor argument for subsequent pages. The calling code (e.g., `ShpfyCustomerAPI.RetrieveShopifyCustomerIds`) loops, switching from the base enum value to the Next variant after the first response, checking `pageInfo.hasNextPage` to terminate.
+
+Rate limiting is handled by `ShpfyGraphQLRateLimit`, a `SingleInstance` codeunit that tracks Shopify's `currentlyAvailable` and `restoreRate` from the throttle status in each response. Before every request, `WaitForRequestAvailable` calculates the required sleep time based on the expected cost vs. available budget, then calls `Sleep()` if needed.
+
+## Things to know
+
+- The naming convention is `ShpfyGQL[Entity][Action]` -- e.g., `ShpfyGQLFulfillOrder`, `ShpfyGQLCustomerIds`, `ShpfyGQLMetafieldsSet`. "Next" prefixed variants handle cursor pagination.
+- `ShpfyGraphQLQueries` fires several `InternalEvent` hooks (`OnBeforeSetInterfaceCodeunit`, `OnBeforeGetGrapQLInfo`, `OnBeforeReplaceParameters`, etc.) that allow internal extensions to override queries or parameters without modifying the GQL codeunits.
+- Each codeunit's `GetExpectedCost` is a hardcoded estimate, not computed from the query. If Shopify changes its cost model, these values become stale, but the rate limiter self-corrects from the response's `currentlyAvailable`.
+- The API version is a `Label` constant in `ShpfyCommunicationMgt` (`VersionTok: Label '2026-01'`), not in this module. All queries are version-agnostic text.
+- The `MetafieldSet` mutation accepts batches of up to 25 metafields per call -- the batching logic lives in `Metafields/ShpfyMetafieldAPI`, not here.
+- `ShpfyGQLBulkOperation` and `ShpfyGQLBulkOpMutation` support Shopify's async bulk operations for large data sets.

--- a/src/Apps/W1/Shopify/App/src/Inventory/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Inventory/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Inventory
+
+Stock level synchronization from BC to Shopify. This module calculates available inventory using configurable strategies, maps BC locations to Shopify locations, and pushes stock quantities via the GraphQL `inventorySetQuantities` mutation. It is separate from the Products module, which handles item/variant metadata -- Inventory only deals with numeric stock levels.
+
+## How it works
+
+The core loop runs in `ShpfySyncInventory.Codeunit.al`: it iterates each `Shpfy Shop Location` where `Stock Calculation` is not Disabled, imports current Shopify stock levels via `ShpfyInventoryAPI.Codeunit.al`, then exports recalculated BC stock back to Shopify. The `ShpfyShopLocation` table (30113) maps a Shopify location ID to a `Location Filter` (a BC location code filter) and a `Default Location Code` used on sales documents.
+
+Stock calculation is interface-driven via `Shpfy Stock Calculation` (`ShpfyStockCalculation.Interface.al`). The `Shpfy Stock Calculation` enum (30135) implements two interfaces simultaneously: `Shpfy Stock Calculation` for the actual computation and `Shpfy IStock Available` for the boolean "can this location have stock" check. Built-in strategies are `ShpfyBalanceToday.Codeunit.al` (projected available balance from `ItemAvailabilityFormsMgt.CalcAvailQuantities`) and `ShpfyFreeInventory.Codeunit.al` (on-hand inventory minus reserved). The enum is extensible, so partners can add custom strategies. There is also an `Shpfy Extended Stock Calculation` interface that adds a `ShopLocation` parameter for location-aware calculations.
+
+Export batches up to 250 quantity updates per GraphQL call in `ExportStock`, using an idempotency key and retry logic (up to 3 attempts) for `IDEMPOTENCY_CONCURRENT_REQUEST` and `CHANGE_FROM_QUANTITY_STALE` errors. The `ShpfyShopInventory` table (30112) tracks both the last Shopify-imported stock and the last BC-calculated stock, only sending updates when they differ.
+
+## Things to know
+
+- The `Stock Calculation` enum's `Disabled` value uses `Shpfy Can Not Have Stock` for `IStock Available`, so disabled locations are silently skipped during export rather than zeroed.
+- UoM conversion is applied during stock calculation: if the variant's UoM option differs from the item's base UoM, the stock is divided by `Qty. per Unit of Measure`.
+- Negative calculated stock is clamped to zero before sending to Shopify (`CalcStock` in `ShpfyInventoryAPI`).
+- `SetInventoryIds` / `RemoveUnusedInventoryIds` form a garbage-collection pair -- they track all existing `ShpfyShopInventory` records before import, then delete any that were not refreshed.
+- `ShpfyShopLocation` prevents mixing standard Shopify locations with fulfillment service locations for `Default Product Location`.
+- Non-Inventory and Service type items are excluded from stock calculation entirely.
+- The `OnAfterCalculationStock` event in `ShpfyInventoryEvents.Codeunit.al` allows partners to adjust stock after calculation.

--- a/src/Apps/W1/Shopify/App/src/Logs/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Logs/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# Logs
+
+API logging, diagnostics, and data capture for the Shopify Connector. This module provides three storage mechanisms for troubleshooting sync issues: structured API log entries, raw JSON data captures, and skipped record tracking. It is a shared infrastructure module used by all other Shopify modules.
+
+## How it works
+
+`Shpfy Log Entry` (table 30115) records every HTTP request to the Shopify API. Each entry stores the URL, method, status code, status description, request and response bodies as blobs, and a `Has Error` flag. The `Request Preview` and `Response Preview` fields hold the first 50 characters of each blob for quick scanning without loading the full payload. A `Query Cost` field tracks the GraphQL query cost for monitoring API quota consumption, and `Retry Count` records how many retries were needed. The `Shpfy Request Id` field stores Shopify's request ID for cross-referencing with Shopify's own logs. `ShpfyLogEntries.Codeunit.al` manages creation of log entries, and `ShpfyLogEntriesDelete.Codeunit.al` handles cleanup.
+
+`Shpfy Data Capture` (table 30114) stores raw JSON snapshots linked to specific records in other tables via (`Linked To Table`, `Linked To Id`). The `Add` method computes a hash of the incoming data and skips storage if the hash matches the last capture for that record -- this deduplication prevents storing identical snapshots on repeated syncs without changes. The hash is stored in `Hash No.` for comparison.
+
+`Shpfy Skipped Record` (table 30159) logs records that were intentionally skipped during import or export, with a `Skipped Reason` explanation, the source `Record ID`, and a `Shopify Id`. It provides a `ShowPage` method that navigates to the related BC record via `PageManagement`, and a `DeleteEntries` method for age-based cleanup.
+
+## Things to know
+
+- Log entry request/response bodies are blob fields read via `TypeHelper.ReadAsTextWithSeparator` -- they can be arbitrarily large.
+- The `SetRequest` / `SetResponse` methods automatically populate the 50-character preview fields, so the list page can show a snippet without CalcFields.
+- Data capture hash dedup means that if the same JSON is returned on consecutive syncs, only one copy is stored -- this significantly reduces database growth.
+- Data captures are cleaned up by the owning table's `OnDelete` trigger (e.g., deleting an order transaction deletes its captures).
+- Skipped records resolve their `Table Name` and `Description` dynamically from `AllObjWithCaption` and `RecordRef` -- special handling exists for `Shpfy Catalog` to show the catalog name instead of a key filter.
+- The `ShpfySkippedRecord.Codeunit.al` provides helper methods for logging skipped records from various modules, accepting different parameter combinations (record ID, Shopify ID, or both).

--- a/src/Apps/W1/Shopify/App/src/Metafields/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Metafields/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Metafields
+
+Manages Shopify metafields as a polymorphic, owner-agnostic system. Metafields are arbitrary key-value pairs that extend Shopify entities (products, variants, customers, companies) with custom data. This module handles type validation, bidirectional sync, and definition management.
+
+## How it works
+
+The `Shpfy Metafield` table (30101) stores all metafields in a single table, disambiguated by `Owner Type` (an enum: Customer, Product, ProductVariant, Company) and `Owner Id`. Setting `Owner Type` triggers its `IMetafieldOwnerType` implementation to derive `Parent Table No.`, and vice versa. Each owner type codeunit (e.g., `ShpfyMetafieldOwnerProduct`) knows how to retrieve existing metafield IDs from Shopify via GraphQL, look up the shop code from the owner record, and determine whether editing is allowed based on shop configuration.
+
+Type validation is driven by the `IMetafieldType` interface. The `ShpfyMetafieldType` enum maps ~25 types (boolean, color, date, money, number_integer, single_line_text_field, url, volume, weight, various references, etc.) to implementing codeunits. Each provides `IsValidValue`, `HasAssistEdit`, `AssistEdit`, and `GetExampleValue`. When the `Value` field is validated on the table, the appropriate type implementation is invoked. The legacy `string` and `integer` types are blocked with an error directing users to `single_line_text_field` and `number_integer` respectively.
+
+Syncing to Shopify goes through `ShpfyMetafieldAPI.CreateOrUpdateMetafieldsInShopify`, which compares local `"Last Updated by BC"` timestamps against Shopify's `updatedAt` to decide what to push. Shopify's `metafieldsSet` mutation accepts at most 25 metafields per call, so the code batches accordingly. Syncing from Shopify uses `UpdateMetafieldsFromShopify`, which processes a JSON array of metafield edges, creates or updates local records, and deletes any that no longer exist on the Shopify side.
+
+## Things to know
+
+- New metafields get auto-assigned negative IDs on insert (starting at -1, decrementing), similar to customer addresses. The namespace defaults to `Microsoft.Dynamics365.BusinessCentral` if left blank.
+- The `money` type enforces that the currency code in the JSON value matches the shop's currency (or the LCY code from General Ledger Setup). Validation calls `ShpfyMtfldTypeMoney.TryExtractValues` which parses the `{"amount": "...", "currency_code": "..."}` JSON and verifies the currency exists in the Currency table.
+- `rating` and `rich_text_field` types are intentionally commented out in the enum -- they are unsupported in BC.
+- Metafield values longer than 2048 characters are silently skipped during import from Shopify, since `Value` is a `Text[2048]` field.
+- The public API surface is `ShpfyMetafields` (codeunit 30418) with three methods: `GetMetafieldDefinitions`, `SyncMetafieldToShopify`, and `SyncMetafieldsToShopify`. Internal callers like `ShpfyCustomerExport` use this facade.
+- Metafield definitions can be pulled from Shopify (first 50 per owner type) to pre-populate the namespace, key, and type without requiring manual entry.
+- The `OnModify` trigger on the metafield table auto-stamps `"Last Updated by BC"`, which drives the delta-sync logic.

--- a/src/Apps/W1/Shopify/App/src/Order Fulfillments/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Fulfillments/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# Order fulfillments
+
+Shipment fulfillment tracking for Shopify orders. This module manages two tiers of fulfillment data: what needs to ship (fulfillment orders) and what actually shipped (fulfillments). It is separate from the Shipping module, which handles the export of BC shipments to Shopify -- this module focuses on the Shopify-side data model and import.
+
+## How it works
+
+The data model has two levels. `Shpfy FulFillment Order Header` (table 30143) and `Shpfy FulFillment Order Line` (table 30144) represent Shopify's fulfillment orders -- these are the "requests to ship" assigned to a location, with status, delivery method type, and request status. Each line tracks total quantity, remaining quantity, and quantity to fulfill. The second level is `Shpfy Order Fulfillment` (table 30111) and `Shpfy Fulfillment Line` (table 30139), representing actual completed shipments with tracking numbers, URLs, tracking companies, status, and per-line quantities.
+
+`ShpfyOrderFulfillments.Codeunit.al` handles import of fulfillments from the Shopify API. The `GetFulfillments` method queries for an order's fulfillments via GraphQL and calls `ImportFulfillment` for each. Import processes tracking info (supporting multiple tracking numbers per fulfillment via comma-separated `Tracking Numbers`/`Tracking URLs`/`Tracking Companies` fields), creates fulfillment line records, and pages through results when line items exceed the initial batch. After import, it checks the `Contains Gift Cards` FlowField and triggers gift card retrieval when applicable.
+
+`ShpfyFulfillmentOrdersAPI.Codeunit.al` manages the fulfillment orders side, including accepting pending fulfillment requests from third-party fulfillment services.
+
+## Things to know
+
+- The `Contains Gift Cards` FlowField on `OrderFulfillment` is a CalcFormula checking `Shpfy Fulfillment Line` for `Is Gift Card = true` -- gift card fulfillments trigger a separate API call to retrieve gift card codes.
+- Fulfillment line import uses pagination: `ImportFulfillment` loops with `hasNextPage` / `endCursor` to handle large fulfillments.
+- `FulFillmentOrderLine` has a `Quantity to Fulfill` decimal field (not integer) to support fractional quantities from UoM conversion during export.
+- The `Delivery Method Type` enum covers shipping, pickup, local delivery, and other Shopify delivery methods.
+- `FulFillmentOrderLine` has multiple key combinations for lookup by variant, by fulfillment status, and by line item ID.
+- Data captures (raw JSON snapshots) are stored for both fulfillment order headers and order fulfillments, and cleaned up on delete.

--- a/src/Apps/W1/Shopify/App/src/Order Refunds/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/docs/CLAUDE.md
@@ -1,0 +1,23 @@
+# Order refunds
+
+Refund data model for Shopify refunds. This module stores the financial side of the return/refund flow -- how much money is being refunded, for which line items, and any shipping cost refunds. It is separate from Order Returns (the physical-return side) and Order Return Refund Processing (which creates BC documents).
+
+## How it works
+
+The data model is `Shpfy Refund Header` (table 30142) -> `Shpfy Refund Line` (table 30145) + `Shpfy Refund Shipping Line` (table 30162). A refund header links to its parent order via `Order Id` and optionally to a return via `Return Id`. It stores `Total Refunded Amount` in shop currency and `Pres. Tot. Refunded Amount` in presentment currency, plus timestamps, a note blob, and currency codes. The `Is Processed` FlowField checks `DocLinkToDoc` for the existence of a linked Shopify Shop Refund document.
+
+Each refund line links to the original order line via `Order Line Id` and carries quantity, restock type (`ShpfyRestockType.Enum.al`: Return, Cancel, No Restock, Legacy Restock), a restocked boolean, and amounts in both shop and presentment currency (amount, subtotal, total tax). FlowFields resolve `Item No.`, `Description`, `Variant Code`, `Gift Card`, and `Unit of Measure Code` from the linked order line. The `Can Create Credit Memo` boolean flag controls whether the processing module should include this line.
+
+Refund shipping lines are separate records with their own subtotal and tax amounts in both currencies, identified by title. `ShpfyRefundsAPI.Codeunit.al` handles import from the Shopify API, and `ShpfyRefundEnumConvertor.Codeunit.al` converts API strings to enum values.
+
+Error handling is built into the header: `Has Processing Error` is a boolean flag, and `Last Error Description` / `Last Error Call Stack` are blobs that store the full error details from failed credit memo creation attempts.
+
+## Things to know
+
+- A refund can exist without a return (`Return Id = 0`) -- for example, a merchant may issue a refund without requiring the customer to send anything back.
+- The `Restock Type` on refund lines drives different sales line creation in the processing module: `No Restock` uses a G/L account instead of an item, `Cancel` uses the refund account.
+- Refund lines resolve their currency code by traversing `Order Line` -> `Order Header`, not from the refund header directly, because the order carries the shop currency.
+- Presentment currency on refund lines comes from the refund header's `Presentment Currency Code` field.
+- The `Location Id` on refund lines maps to a Shopify location, used by the processing module to set the BC return location on credit memo lines.
+- Error blobs are set via `SetLastErrorDescription` which also toggles the `Has Processing Error` flag -- clearing the error text clears the flag.
+- Data captures are stored and cleaned up on delete for headers, lines, and shipping lines.

--- a/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Order return refund processing
+
+Processing logic for creating BC sales documents from Shopify returns and refunds. This module sits between the data-import modules (Order Returns, Order Refunds) and the BC sales document layer. It decides whether and how to create credit memos or return orders based on the shop's configured processing type.
+
+## How it works
+
+The `Shpfy IReturnRefund Process` interface (`ShpfyIReturnRefundProcess.Interface.al`) defines three methods: `IsImportNeededFor`, `CanCreateSalesDocumentFor`, and `CreateSalesDocument`. The `Shpfy ReturnRefund ProcessType` enum (30139) selects the implementation: blank (default, no processing), `Import Only` (`ShpfyRetRefProcImportOnly.Codeunit.al`, imports data but creates no documents), or `Auto Create Credit Memo` (`ShpfyRetRefProcCrMemo.Codeunit.al`, creates credit memos automatically).
+
+The credit memo flow in `ShpfyRetRefProcCrMemo` validates prerequisites -- the refund must not already be processed (checked via `DocLinkToDoc`), and the parent order must already be processed in BC. It then delegates to `ShpfyCreateSalesDocRefund.Codeunit.al`, which builds a full Sales Header and Sales Lines from the refund data. Sales lines are created from refund lines, with special handling for different restock types: `Return` and `Legacy Restock` create item lines, `No Restock` creates a G/L account line using the shop's `Refund Acc. non-restock Items`, `Cancel` creates a G/L account line using `Refund Account`, and gift card refunds use the `Sold Gift Card Account`. After all lines, a balancing line ensures the credit memo total matches Shopify's refund amount exactly, and a rounding line handles cash rounding from transactions.
+
+The module also extends `Sales Credit Memo`, `Sales Cr.Memo Header/Line`, and `Return Receipt Header/Line` with Shopify fields via table and page extensions.
+
+## Things to know
+
+- The `CanCreateSalesDocumentFor` method populates an `ErrorInfo` record with structured error details rather than throwing -- callers check the result and log errors via the `IDocumentSource` interface.
+- If refund lines have `Can Create Credit Memo = false`, the entire credit memo creation is skipped silently.
+- When a refund has no refund lines but does have a `Return Id`, the system falls back to creating sales lines from return lines instead.
+- Currency handling respects the order's `Processed Currency Handling` setting -- either shop currency or presentment currency amounts are used on the sales lines.
+- The credit memo is automatically released after creation via `ReleaseSalesDocument.Run`.
+- Refund shipping lines create separate G/L account lines using the shop's `Shipping Charges Account`.
+- The `OnBeforeCreateSalesHeader` and `OnAfterCreateItemSalesLine` events in `ShpfyRefundProcessEvents.Codeunit.al` allow partners to customize the document creation.

--- a/src/Apps/W1/Shopify/App/src/Order Returns/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Returns/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# Order returns
+
+Return data model for Shopify returns. This module stores the physical-return side of the return/refund flow -- which items a customer is sending back, why, and in what quantities. It is separate from Order Refunds (the financial side) and Order Return Refund Processing (which creates BC documents from either).
+
+## How it works
+
+The data model is `Shpfy Return Header` (table 30147) -> `Shpfy Return Line` (table 30141). A return header links to its parent order via `Order Id`, carries a `Return No.`, status (Open, Closed, Requested, Declined via `ShpfyReturnStatus.Enum.al`), total quantity, and an optional decline reason with a decline note blob. FlowFields pull customer names and the Shopify order number from the order header.
+
+Each return line links back to the original order via `Fulfillment Line Id` and `Order Line Id`, so the system knows exactly which fulfilled item is being returned. Lines carry quantity, refundable quantity, refunded quantity, weight, and a discounted total amount in both shop and presentment currency. Return reason tracking uses three fields: `Return Reason Name` (human-readable), `Return Reason Handle` (machine key), and a `Return Reason Note` blob for free-text explanation. There is also a per-line `Customer Note` blob for the buyer's comments. The `Type` field (`ShpfyReturnLineType.Enum.al`) distinguishes default return lines from other types.
+
+`ShpfyReturnsAPI.Codeunit.al` handles the API import of return data from Shopify. `ShpfyReturnEnumConvertor.Codeunit.al` converts Shopify API string values to the corresponding AL enum values for status, decline reason, and return reason.
+
+## Things to know
+
+- Return lines use FlowFields for `Item No.`, `Description`, `Variant Code`, and `Unit of Measure Code` -- all resolved from the linked `Shpfy Order Line`, not stored directly.
+- The `Discounted Total Amount` on the header is a SumIndexField CalcFormula summing line amounts, enabling efficient totals without iterating lines.
+- Decline notes and return reason notes are stored as blobs with UTF-8 encoding, accessed via `GetDeclineNote`/`SetDeclineNote` and `GetReturnReasonNote`/`SetReturnReasonNote` helper methods.
+- The `Location Id` on return lines is used by the processing module to map returns to BC warehouse locations via `ShpfyShopLocation`.
+- A return is a physical concept; the financial refund may or may not exist. The `Return Id` field on `Shpfy Refund Header` links the two when both exist.
+- Data captures are cleaned up on delete for both headers and lines.

--- a/src/Apps/W1/Shopify/App/src/Order handling/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order handling/docs/CLAUDE.md
@@ -1,0 +1,18 @@
+# Order handling
+
+This module manages the full lifecycle of Shopify orders inside Business Central: retrieving orders from the Shopify GraphQL API, staging them for review, mapping them to BC customers and items, and converting them into Sales Orders or Sales Invoices. It also handles order cancellation, fulfillment tracking, refund adjustment, and conflict detection for already-processed orders.
+
+## How it works
+
+The flow has three distinct phases. First, `ShpfyOrdersAPI` retrieves lightweight order summaries into the `Shpfy Orders to Import` staging table via paginated GraphQL queries. This table carries enough data (financial status, fulfillment status, amounts, tags, risk level) for users to review and filter before committing to a full import. Second, `ShpfyImportOrder` performs the detailed import: it fetches the complete order JSON, populates `Shpfy Order Header` and `Shpfy Order Line` records, pulls in related data (tax lines, shipping charges, transactions, fulfillment orders, returns, refunds), and runs conflict detection against previously processed orders. Third, `ShpfyProcessOrder` takes a fully-imported order through mapping (customer resolution, item/variant resolution, shipping/payment method mapping) and creates a BC Sales Order or Sales Invoice depending on the fulfillment status and the shop's "Create Invoices From Orders" setting.
+
+Each order is processed inside its own `Commit()` boundary in `ShpfyProcessOrders` so that a failure on one order does not roll back others. When `ProcessOrder.Run` fails, the codeunit captures the error in the header's `Has Error` / `Error Message` fields and cleans up any partially-created sales document via `CleanUpLastCreatedDocument`.
+
+## Things to know
+
+- Every monetary amount on the order header exists in two forms: shop currency (e.g. `Total Amount`, `VAT Amount`) and presentment currency (e.g. `Presentment Total Amount`, `Presentment VAT Amount`). Which set drives the sales document depends on the shop's `Currency Handling` setting -- either `Shop Currency` or `Presentment Currency`.
+- The order header stores three complete denormalized addresses -- sell-to, bill-to, and ship-to -- each with first/last name, company, address lines, city, county, post code, and country code. These are populated from different JSON paths (`displayAddress`, `billingAddress`, `shippingAddress`).
+- B2B orders are identified by `Company Id` / `Company Location Id` on the header (populated from `purchasingEntity.company` / `purchasingEntity.location` in the JSON). When `B2B = true`, the mapping path switches to `MapB2BHeaderFields` which resolves via `Shpfy Company Mapping` instead of `Shpfy Customer Mapping`.
+- Conflict detection uses `Line Items Redundancy Code` -- a hash of all line IDs -- plus `Current Total Items Quantity` and shipping charges to detect whether a re-imported order has changed since it was last processed. Conflicts set `Has Order State Error = true` and leave the order in an error state that requires manual resolution.
+- Refunds adjust order lines in place: `ConsiderRefundsInQuantityAndAmounts` subtracts refund line quantities and amounts directly from the order header and lines before processing, and lines reduced to zero quantity are deleted.
+- The `ShpfyProcessOrder` codeunit decides between Sales Order and Sales Invoice based on fulfillment status: if `Fulfillment Status = Fulfilled` and `Create Invoices From Orders` is enabled on the shop, it creates an Invoice; otherwise it creates an Order.

--- a/src/Apps/W1/Shopify/App/src/Order handling/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/src/Order handling/docs/business-logic.md
@@ -1,0 +1,41 @@
+# Business logic
+
+## Overview
+
+Order handling follows a three-stage pipeline: retrieval into a staging table, detailed import into order header/line records, and processing into BC sales documents. Each stage is separated by a commit boundary and can be retried independently.
+
+## Order retrieval and staging
+
+`ShpfyOrdersAPI.GetOrdersToImport` queries Shopify's GraphQL API using paginated cursor-based queries. On the first sync (no last-sync timestamp), it uses `GetOpenOrdersToImport` which filters to non-closed orders; on subsequent syncs it uses `GetOrdersToImport` which fetches everything modified since the last sync time. The response is parsed by `ExtractShopifyOrdersToImport`, which writes one row per order into `Shpfy Orders to Import`. Each row records whether the order is `New` or an `Update` to an existing header, and closed orders that have never been imported are excluded. The staging table also captures custom attributes, tags, risk assessments, and purchasing entity type (Customer vs Company for B2B).
+
+## Detailed order import
+
+`ShpfyImportOrder.ImportOrderAndCreateOrUpdate` does the heavy lifting. It ensures an `Shpfy Order Header` record exists, retrieves the full order JSON via a separate GraphQL query (`GetOrderHeader`), and populates header fields from three JSON regions -- `displayAddress` for sell-to, `shippingAddress` for ship-to, and `billingAddress` for bill-to. Currency codes are translated from ISO codes to BC currency codes via `TranslateCurrencyCode`, which clears the code if it matches the LCY code.
+
+Order lines are retrieved separately through `GetOrderLines` / `GetNextOrderLines` (paginated), parsed into temporary records, then inserted or updated. Each line captures both shop and presentment prices (`Unit Price` vs `Presentment Unit Price`, `Discount Amount` vs `Presentment Discount Amount`). Discount allocations are summed across all allocation entries on each line via `GetTotalLineDiscountAmount`. After line insertion, the codeunit computes `Line Items Redundancy Code` -- a hash of all sorted line IDs -- which is stored on the header for later conflict detection.
+
+Related records are created in `SetAndCreateRelatedRecords`: tax lines, shipping charges, transactions, fulfillment orders, returns, and refunds are all imported. The codeunit then calls `ConsiderRefundsInQuantityAndAmounts` to subtract refund quantities and amounts directly from header totals and line quantities, and deletes any lines reduced to zero.
+
+If the order was already processed and the import detects a change -- different redundancy hash, increased item quantity, or changed shipping charges -- it sets `Has Order State Error = true` with a descriptive conflict message. This prevents the stale BC sales document from silently diverging from the Shopify order.
+
+## Customer and item mapping
+
+`ShpfyOrderMapping.DoMapping` orchestrates header and line mapping. For non-B2B orders, `MapHeaderFields` resolves sell-to and bill-to customers via `Shpfy Customer Mapping`, falling back to the shop's default customer when no match is found. For B2B orders, `MapB2BHeaderFields` uses `Shpfy Company Mapping` and can resolve sell-to/bill-to from `Shpfy Company Location` records when a `Company Location Id` is present on the order.
+
+Shipping method, shipping agent, and payment method are resolved from their own mapping tables. Payment method mapping in particular looks at successful order transactions and only assigns a code when all transactions share a single payment method -- mixed-payment orders get no code so the user can decide.
+
+Line mapping in `MapVariant` resolves each order line's `Shopify Variant Id` to a BC `Item No.`, `Variant Code`, and `Unit of Measure Code`. It first checks whether the variant already has a linked `Item SystemId`; if not, it triggers a product import for that product to create the mapping on the fly. The `UoM Option Id` on the variant determines which option slot provides the unit-of-measure code.
+
+## Sales document creation
+
+`ShpfyProcessOrder` converts a fully-mapped order into a BC Sales Order or Sales Invoice. The choice is configuration-driven: fulfilled orders become invoices when the shop's `Create Invoices From Orders` flag is set. The codeunit creates the header with all three address blocks copied from the order, validates the currency based on `Currency Handling` (shop currency or presentment currency), and sets document date, external document number (from `PO Number`), and payment/shipping terms.
+
+Lines are created with explicit unit price and line discount amount from the Shopify order, bypassing BC's normal price calculation. Tip lines post to the shop's "Tip Account" G/L account; gift card lines post to "Sold Gift Card Account". Shipping charges become G/L account lines (or item charge lines when the shipment method mapping specifies a charge type). After all lines, a cash rounding line is added if the order has a `Payment Rounding Amount`.
+
+Global discounts -- the portion of the order discount not already allocated to individual lines or shipping -- are applied as an invoice discount via `SalesCalcDiscountByType.ApplyInvDiscBasedOnAmt`.
+
+After successful creation, the order header is marked `Processed = true` and the `Processed Currency Handling` field snapshots which currency mode was used. If `Auto Release Sales Orders` is enabled, the sales document is released immediately. If the order is fully paid and fully fulfilled, and `Archive Processed Orders` is on, the import codeunit closes the order in Shopify via a `CloseOrder` GraphQL mutation.
+
+## Error handling
+
+Processing wraps each order in `ProcessOrder.Run` (a TryFunction-style pattern via `Codeunit.Run`). On failure, the partially created sales document is deleted via `CleanUpLastCreatedDocument`, the error text is stored in `Error Message` with a timestamp prefix, and `Sales Order No.` / `Sales Invoice No.` are cleared. The outer loop in `ShpfyProcessOrders` commits after each order so failures are isolated.

--- a/src/Apps/W1/Shopify/App/src/Payments/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Payments/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# Payments
+
+Payout, payment transaction, and dispute management for Shopify Payments. This module handles the financial reconciliation layer -- payouts that Shopify deposits into the merchant's bank account, the individual transactions that compose each payout, and any chargebacks or disputes. It is separate from Transactions (which handles per-order payment transactions) because payouts and disputes operate at the shop level, days after orders are placed.
+
+## How it works
+
+The sync orchestrator is `ShpfyPayments.Codeunit.al`, which exposes two main flows: `SyncPayouts` and `SyncDisputes`. Payout sync runs four steps in sequence: (1) update `Payout Id` on payment transactions that were imported before their payout existed, (2) refresh statuses of pending/in-transit payouts, (3) import new payment transactions since the last known ID, and (4) import new payouts since the last known ID. Dispute sync similarly updates unfinished disputes (those not Won or Lost) and imports new ones.
+
+The `Shpfy Payout` table (30125) is a financial summary record with breakdowns for charges, refunds, adjustments, reserved funds, and retried payouts -- each split into fee and gross amounts. Every payout has a status (Scheduled, InTransit, Paid, Failed, Canceled) and an `External Trace Id` for bank reconciliation. The `Shpfy Payment Transaction` table (30124) links each transaction to a payout via `Payout Id` and to the source order via `Source Order Id`. It carries amount, fee, and net amount, plus a `Source Order Transaction Id` for cross-referencing with the Transactions module.
+
+The `Shpfy Dispute` table (30155) tracks chargebacks with type (Chargeback, Inquiry, etc.), reason, status, evidence deadlines, and amounts. The `ShpfyPaymentTerms` table and `ShpfyPaymentTermsAPI.Codeunit.al` handle payment terms mapping for B2B scenarios.
+
+## Things to know
+
+- Payout ID assignment is retroactive -- payment transactions are imported before their payout exists, then patched up in `UpdatePaymentTransactionPayoutIds`.
+- Payment transaction updates are batched in groups of 200 IDs to avoid oversized API calls.
+- Pending payout statuses are refreshed every sync to detect transitions from Scheduled to InTransit to Paid.
+- The `Shpfy Payment Transaction` has a FlowField `Invoice No.` that looks up the posted sales invoice via the source order ID.
+- Disputes are only updated while unfinalized (not Won/Lost) -- once a dispute reaches a terminal state, it is no longer polled.
+- The module includes `ShpfySyncPayments.Report.al` and `ShpfySyncDisputes.Report.al` as entry points for scheduled sync.

--- a/src/Apps/W1/Shopify/App/src/Products/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Products/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Products
+
+This module owns the bidirectional synchronization of product catalog data between Shopify and Business Central. It covers product creation, export, import, mapping to BC Items, variant handling, image sync, price calculation, and SKU resolution -- essentially everything required to keep the two product catalogs in agreement.
+
+## How it works
+
+Synchronization direction is controlled by the Shop card's "Sync Item" setting and dispatched by `ShpfySyncProducts.Codeunit.al`. The **import path** (`From Shopify`) retrieves product IDs via GraphQL through `ShpfyProductAPI`, compares `Updated At` and `Last Updated by BC` timestamps to skip unchanged records, then hands each product to `ShpfyProductImport`. Import iterates every variant, delegates to `ShpfyProductMapping` to resolve the Shopify variant to a BC Item + Item Variant, and -- if no match is found and "Auto Create Unknown Items" is enabled -- runs `ShpfyCreateItem` to mint new Items from an item template.
+
+The **export path** (`To Shopify`) is driven by `ShpfyProductExport`. It walks every `Shpfy Product` record that already has an `Item SystemId`, calls `FillInProductFields` and one of several `FillInProductVariantData` overloads to build the desired state from BC data, then diff-checks the result against the current Shopify record via `RecordRef` field comparison. Only changed records are pushed through `ProductApi.UpdateProduct` or `VariantApi.UpdateProductVariants`. A dedicated `OnlyUpdatePrice` mode skips all non-price fields and can batch updates via bulk mutation.
+
+Product-to-Item mapping in `ShpfyProductMapping` is driven by the shop's "SKU Mapping" enum (`Item No.`, `Variant Code`, `Item No. + Variant Code`, `Vendor Item No.`, `Bar Code`). The mapping code attempts a direct lookup first, then falls back to barcode-based item reference resolution. When "UoM as Variant" is active, the `UoM Option Id` field on the variant tells the mapper which option slot (1, 2, or 3) holds the unit-of-measure value.
+
+## Things to know
+
+- Products link to BC Items via `Item SystemId` (a Guid), not `Item No.`. The `Item No.` field on both `Shpfy Product` and `Shpfy Variant` is a FlowField that reverse-looks-up through `SystemId`. This means Item renames do not break the mapping.
+- A product with `Has Variants = false` still has exactly one variant row in `Shpfy Variant`. The flag controls whether the mapping logic requires an `Item Variant SystemId` or accepts a bare Item match.
+- Image export in `ShpfyProductImageExport` uses a hash comparison (`Image Hash` field) computed from `CalcItemImageHash` to avoid re-uploading unchanged pictures. The same pattern applies to tags (`Tags Hash`) and HTML descriptions (`Description Html Hash`).
+- Price calculation in `ShpfyProductPriceCalc` works by creating a temporary Sales Quote header with the shop's posting groups and customer price group, then inserting a temporary Sales Line. This picks up all BC pricing rules, discounts, and VAT logic automatically.
+- The `UoM Option Id` field on `Shpfy Variant` records which of the three Shopify option slots carries the unit-of-measure value. When UoM-as-variant is enabled with item variants, variants occupy option 1 and UoM occupies option 2 (so `UoM Option Id = 2`). Without item variants, UoM sits in option 1.
+- Item attributes marked with `Shpfy Incl. in Product Sync = "As Option"` can drive Shopify product options instead of the Variant/UoM pattern. `ShpfyProductExport` validates that no more than three attributes are flagged, that every item variant has values for all of them, and that no duplicate option combinations exist.
+- Each product import calls `Commit()` before `CreateItem.Run` so that a failure on one product does not roll back all preceding products. Errors are captured per-product in the `Has Error` / `Error Message` fields.

--- a/src/Apps/W1/Shopify/App/src/Products/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/src/Products/docs/data-model.md
@@ -1,0 +1,33 @@
+# Data model
+
+## Overview
+
+The product data model mirrors Shopify's own hierarchy -- Product, Variant, InventoryItem -- but adds BC-side linking fields and change-tracking hashes. A `Shpfy Product` record always has at least one child `Shpfy Variant`, and each variant has at most one child `Shpfy Inventory Item`. This three-level structure exists because Shopify treats them as distinct API resources with independent IDs and lifecycles: a product carries catalog metadata, a variant carries price/SKU/option values, and an inventory item carries fulfillment-related properties like country of origin and tracking.
+
+## Product-to-Item linking
+
+Both `Shpfy Product` (field 101) and `Shpfy Variant` (field 101) carry an `Item SystemId` Guid that points at the BC Item's `SystemId`. The `Item No.` fields (103/104) are FlowFields computed from that Guid. This design decouples the mapping from the Item's natural key, so Item number series changes or renames leave the Shopify link intact. On the variant level, `Item Variant SystemId` (field 102) similarly links to a BC `Item Variant` record. The `Mapped By Item` boolean (field 107) is set when a variant was matched at the Item level only, with no corresponding Item Variant -- this happens for single-variant products and for the UoM-only-variant pattern.
+
+## Change-detection hashes
+
+`Shpfy Product` stores three integer hash fields: `Image Hash` (104), `Tags Hash` (105), and `Description Html Hash` (106). These are computed via `Shpfy Hash` and compared before export to avoid unnecessary API calls. On the variant side, `Shpfy Variant` carries its own `Image Hash` (field 108) for per-variant image tracking. The image export codeunit (`ShpfyProductImageExport`) computes a fresh hash from the BC Item picture and short-circuits when it matches the stored value.
+
+## Dual timestamps
+
+Every product and variant carries an `Updated At` timestamp reflecting the last modification time reported by Shopify, plus a `Last Updated by BC` timestamp set whenever BC pushes changes outward. During import, the sync logic in `ShpfySyncProducts.ImportProductsFromShopify` skips a product when both `Updated At` and `Last Updated by BC` are older than the incoming Shopify timestamp -- this prevents re-importing data that BC itself pushed.
+
+## HasVariants and single-variant products
+
+The `Has Variants` boolean on `Shpfy Product` is `false` for products where Shopify shows a single "Default Title" variant. Even so, a `Shpfy Variant` row always exists. The mapping logic in `ShpfyProductMapping.FindMapping` uses this flag to decide whether it needs to resolve an `Item Variant SystemId`: when `Has Variants` is false, a bare Item match is sufficient and the variant row stores only `Item SystemId`.
+
+## UoM Option Id
+
+When the shop's "UoM as Variant" toggle is on, each Item Unit of Measure becomes a separate Shopify variant. The `UoM Option Id` integer (field 106 on `Shpfy Variant`) records which of the three Shopify option slots (1, 2, or 3) holds the unit-of-measure code. In the simplest case -- no item variants, only UoM variants -- option 1 carries the UoM and `UoM Option Id` is 1. When both item variants and UoM are present, option 1 is "Variant" (the item variant code) and option 2 is the UoM, so `UoM Option Id` is 2. The export, import, and mapping codeunits all use this field to locate the UoM value dynamically rather than hard-coding a slot.
+
+## Inventory item and shop locations
+
+`Shpfy Inventory Item` (table 30126) sits below `Shpfy Variant`, linked by `Variant Id`. It holds fulfillment-related metadata -- country/province of origin, tracking status, unit cost -- that Shopify manages separately from the variant's pricing data. Stock levels are not stored here; those are reconciled through `Shpfy Shop Inventory` and `Shpfy Shop Location` tables (defined outside this module) that pair inventory items with specific Shopify locations and BC location codes.
+
+## Collections
+
+`Shpfy Product Collection` and `Shpfy Shop Collection Map` support Shopify's collection concept. The map table ties a shop code to a collection ID, and `ShpfyProductCollectionAPI` handles the GraphQL retrieval. Collections do not affect product sync directly but appear in the UI for filtering.

--- a/src/Apps/W1/Shopify/App/src/Shipping/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Shipping/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# Shipping
+
+Shipping method mapping and shipment export from BC to Shopify. This module handles the outbound fulfillment flow -- when a BC sales shipment is posted, it creates Shopify fulfillments with tracking information. It is separate from Order Fulfillments (which imports fulfillment data from Shopify) because this module drives the BC-to-Shopify direction.
+
+## How it works
+
+The `Shpfy Shipment Method Mapping` table (30131) maps a Shopify shipping method name to a BC `Shipment Method Code`, shipping charges type/number (G/L Account, Item, or Charge), and a shipping agent with service code. This mapping is used during order import to set the correct shipment method on sales documents, and during export to identify the tracking company.
+
+`ShpfyExportShipments.Codeunit.al` is the core export engine. For each posted sales shipment with a `Shpfy Order Id` and no existing `Shpfy Fulfillment Id`, it builds a GraphQL `fulfillmentCreate` mutation. The process matches sales shipment lines to `Shpfy FulFillment Order Line` records by `Line Item Id`, distributing shipped quantities across fulfillment order lines and respecting remaining quantities. It constructs the mutation with tracking info from the sales shipment header (tracking number, shipping agent mapped to a `Shpfy Tracking Company` enum, and tracking URL from `ShippingAgent.GetTrackingInternetAddr`). Results up to 250 line items per request, splitting into multiple mutations if needed.
+
+The `Shpfy Order Shipping Charges` table (30130) stores per-shipping-line details from the order (title, amount, discount, code, and presentment currency equivalents). The shipping agent table extension (`ShpfyShippingAgent.TableExt.al`) adds a `Shpfy Tracking Company` enum field that maps BC shipping agents to Shopify's known tracking company list.
+
+## Things to know
+
+- A fulfillment ID of `-1` on a sales shipment header means the export was attempted but failed -- it prevents repeated retries.
+- The export handles third-party fulfillment services: fulfillment orders assigned to non-BC fulfillment services are skipped, and pending fulfillment requests are auto-accepted before fulfilling.
+- Tracking URL retrieval can be overridden via the `OnBeforeRetrieveTrackingUrl` event in `ShpfyShippingEvents.Codeunit.al`.
+- Customer notification on fulfillment is controlled by the shop's `Send Shipping Confirmation` setting, overridable via the `OnGetNotifyCustomer` event.
+- `ShpfyUpdateSalesShipment.Codeunit.al` and the `ShpfySalesShipmentUpdate.PageExt.al` allow manual updates to shipment Shopify fields.
+- Shipping charges on the mapping can be G/L Account, Item, or Item Charge -- the G/L account is validated against the shop's allowed account rules.

--- a/src/Apps/W1/Shopify/App/src/Transactions/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Transactions/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Transactions
+
+Per-order payment transaction handling. This module imports and manages the individual payment transactions attached to Shopify orders -- authorizations, captures, refunds, voids -- and maps Shopify payment gateways to BC payment methods. It is separate from Payments (which deals with shop-level payouts) because transactions are order-scoped and drive the payment method on sales documents.
+
+## How it works
+
+`ShpfyTransactions.Codeunit.al` fetches transactions for an order via the `GetOrderTransactions` GraphQL query and upserts them into `Shpfy Order Transaction` (table 30133). Each transaction has a type (Sale, Authorization, Capture, Refund, Void, etc. from `ShpfyTransactionType.Enum.al`), a status, dual currency amounts (`Amount`/`Currency` for shop money, `Presentment Amount`/`Presentment Currency` for customer-facing), and a `Parent Id` for parent-child linking (e.g., a Capture is a child of an Authorization). The `Refund Id` field links refund-type transactions back to the Order Refunds module.
+
+Payment method resolution works through the `Shpfy Payment Method Mapping` table (30134), keyed on (`Shop Code`, `Gateway`, `Credit Card Company`). When a new transaction is imported, `ExtractShopifyOrderTransaction` auto-creates entries in `Shpfy Transaction Gateway` and `Shpfy Credit Card Company` lookup tables, then ensures a mapping row exists. The `Payment Method` FlowField on `OrderTransaction` resolves through this mapping to a BC `Payment Method Code`. The `Manual Payment Gateway` flag distinguishes gateways like COD or bank transfer from automated processors.
+
+The module also extends `Cust. Ledger Entry` and `Gen. Journal Line` with Shopify transaction fields, and provides `ShpfySuggestPayments.Codeunit.al` with its companion report for suggesting payment journal lines from Shopify transactions.
+
+## Things to know
+
+- Currency codes are translated via `ImportOrder.TranslateCurrencyCode` after insertion -- the raw Shopify codes may not match BC currency codes directly.
+- The `Used` FlowField checks whether a `Cust. Ledger Entry` with the transaction ID exists, preventing double application.
+- Transaction gateway and credit card company tables are auto-populated as new values appear -- they serve as lookup lists, not configuration.
+- `DataCapture.Add` is called for every transaction to store the raw JSON snapshot for diagnostics.
+- Rounding amounts (`Rounding Amount`, `Rounding Currency`, and presentment equivalents) are separate fields to handle Shopify's cash rounding on orders.
+- The `Gift Card Id` is extracted from the transaction's `receiptJson`, not from the main transaction payload.
+- The `ShpfyCashReceiptJournal.PageExt.al` adds Shopify columns to the Cash Receipt Journal for payment reconciliation.


### PR DESCRIPTION
## Summary

- Bootstrap comprehensive developer-facing documentation for the Shopify Connector app (24 markdown files)
- App-level docs: CLAUDE.md (overview), data-model.md, business-logic.md, patterns.md
- Subfolder docs: CLAUDE.md for each of the 18 key modules (Products, Orders, Customers, GraphQL, Base, Metafields, Companies, Inventory, Document Links, Payments, Transactions, Order Fulfillments, Order Return Refund Processing, Shipping, Order Returns, Catalogs, Logs, Order Refunds)
- Additional deep-dive docs: Products/data-model.md, Order handling/business-logic.md

## Test plan

- [ ] Verify all 24 markdown files render correctly on GitHub
- [ ] Spot-check that documented behavior matches actual AL source code
- [ ] Confirm no .al files or app behavior is modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
