### PR TITLE
[releases/28.x] Remove DotNet version binding and unsupported object for MailKit and …

### DIFF
--- a/src/System Application/App/DotNet Aliases/src/dotnet.al
+++ b/src/System Application/App/DotNet Aliases/src/dotnet.al
@@ -1203,8 +1203,6 @@ dotnet
 
     assembly("MailKit")
     {
-        Version = '2.15.0.0';
-        Culture = 'neutral';
         PublicKeyToken = '4e064fe7c44a8f1b';
 
         type("MailKit.Net.Smtp.SmtpClient"; "SmtpClient")
@@ -1238,8 +1236,6 @@ dotnet
 
     assembly("MimeKit")
     {
-        Version = '2.15.0.0';
-        Culture = 'neutral';
         PublicKeyToken = 'bede1c8a46c66814';
 
         type("MimeKit.BodyBuilder"; "MimeBodyBuilder")
@@ -1275,10 +1271,6 @@ dotnet
         }
 
         type("MimeKit.MimePart"; "MimePart")
-        {
-        }
-
-        type("MimeKit.ContentObject"; "MimeContentObject")
         {
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

Backport from MimeKit (#7029)

Remove version and culture information from MailKit and MimeKit aliases. Remove unsupported object MimeKit.ContentObject.

Both changes are prerequisite for the mandatory update to assembly version 4.15.1 with a coming platform uptake



#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#624494](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624494)



