### PR TITLE
[Shopify] Add developer documentation for the Shopify Connector

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Base/docs/CLAUDE.md
@@ -1,0 +1,19 @@
+# Base
+
+Core infrastructure for the Shopify Connector -- shop configuration, sync bookkeeping, tags, installation, and shared utilities. If something is used across multiple modules and does not belong to a specific Shopify domain (products, orders, etc.), it lives here.
+
+## How it works
+
+The `ShpfyShop` table (in `ShpfyShop.Table.al`) is the central configuration record. It holds sync-direction flags, template codes, G/L account mappings, webhook settings, B2B state, and currency/tax configuration. Many settings come in mutually exclusive pairs -- for example `Shopify Can Update Customer` and `Can Update Shopify Customer` each disable the other on validate, enforcing one-way sync. The `Shop Id` field is computed as a hash of the Shopify URL via `CalcShopId`, with collision resolution by incrementing. This means order sync timestamps (keyed by Shop Id in `ShpfySynchronizationInfo`) survive shop code renames.
+
+`ShpfySynchronizationInfo` tracks the last sync time per sync type per shop, keyed on `(Shop Code, Synchronization Type)`. Orders are special -- they key on the numeric Shop Id rather than the Code, so renaming a shop does not lose the order sync watermark. `ShpfyFilterMgt` provides a `CleanFilterValue` helper that escapes AL filter metacharacters (`(`, `)`, `*`, `.`, `<`, `>`, `=`) to `?` and prepends `@` for case-insensitive matching.
+
+`ShpfyInstaller` handles first-install and company-copy scenarios. On install it registers retention policies for log entries, data captures, and skipped records (1-month default), and sets up cue thresholds. It also subscribes to `OnAfterCreatedNewCompanyByCopyCompany` and `OnClearCompanyConfig` to disable all shops in copied/sandbox environments, preventing accidental sync against production Shopify stores.
+
+## Things to know
+
+- The `ShpfyTag` table enforces a 250-tag limit per parent on insert and provides `GetCommaSeparatedTags` / `UpdateTags` helpers for the comma-delimited format Shopify expects. Tags are keyed on `(Parent Id, Tag)` with no table-number in the PK -- the parent table number is stored but not part of the clustered key.
+- `Currency Handling` enum controls whether prices use the shop's base currency or Shopify's presentment (customer-facing) currency. `SKU Mapping` controls how Shopify SKUs resolve to BC items -- by item no., vendor item no., bar code, or a compound key using the `SKU Field Separator`.
+- The `Logging Mode` field (off / error only / all) controls API request logging. Switching to "All" automatically enables the retention policy for the Shopify log table.
+- `ShpfyCommunicationEvents` lives here and provides the test-double seam for all HTTP calls -- every module's API layer checks `IsTestInProgress` and dispatches through these events instead of real HTTP when true.
+- `ShpfyBackgroundSyncs`, `ShpfyShopReview`, and `ShpfyGuidedExperience` handle the assisted setup wizard, background job scheduling, and shop health checks respectively.

--- a/src/Apps/W1/Shopify/App/src/Bulk Operations/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Bulk Operations/docs/CLAUDE.md
@@ -1,0 +1,17 @@
+# Bulk operations
+
+Async bulk mutation support for large-scale updates to Shopify (product prices, images). Shopify processes these asynchronously and notifies BC via webhook when complete.
+
+## How it works
+
+The flow starts in `ShpfyBulkOperationMgt.Codeunit.al`. Before sending a new mutation, it checks whether a Created or Running bulk operation already exists for the same shop and type; if so, it polls Shopify for an updated status and only proceeds if the previous operation has finished. The mutation data is uploaded as a JSONL file via a staged upload URL (created through `stagedUploadsCreate`), then the bulk mutation is submitted referencing that uploaded file. The `ShpfyBulkOperation.Table.al` record tracks the operation's lifecycle with status, error code, result URL, and partial data URL.
+
+When Shopify finishes, a `BULK_OPERATIONS_FINISH` webhook arrives and `ShpfyBulkOperationMgt.ProcessBulkOperationNotification` fetches the final status and result URL. The `OnModify` trigger on the bulk operation table drives the revert logic: on completion it calls `IBulkOperation.RevertFailedRequests` (which downloads the JSONL result, identifies successful variant IDs, and reverts local changes for any variant not in the success list), and on cancel/failure it calls `RevertAllRequests`. The `Processed` flag prevents the revert logic from firing more than once.
+
+## Things to know
+
+- The `IBulkOperation` interface has six methods: `GetGraphQL`, `GetInput`, `GetName`, `GetType`, `RevertFailedRequests`, and `RevertAllRequests`. Implementations like `ShpfyBulkUpdateProductPrice` provide the mutation template and know how to parse the JSONL result to determine which items succeeded.
+- The threshold for switching from individual API calls to bulk operations is 100 items, returned by `GetBulkOperationThreshold`.
+- Request data (the list of items being updated) is stored as a JSON array in a BLOB field on the bulk operation record, so the revert logic can restore original values for failed items.
+- Enabling bulk operations requires a valid BC licensed user because it registers a webhook subscription that runs as that user. The `OnInvalidUser` event allows test code to bypass this check.
+- Only one bulk operation per shop per type (mutation/query) can be active at a time -- the codeunit enforces this before submission.

--- a/src/Apps/W1/Shopify/App/src/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/CLAUDE.md
@@ -1,0 +1,69 @@
+# Shopify Connector
+
+The Shopify Connector synchronizes products, customers, orders, inventory, and fulfillments between Shopify stores and Business Central. It is a zero-dependency first-party app that maps Shopify's e-commerce domain model onto BC's sales and inventory domain, handling the impedance mismatch between Shopify's GraphQL API and BC's relational tables. Think of it as a bidirectional bridge where the Shop table is the control panel and each sync direction is independently configurable.
+
+## Quick reference
+
+- **ID range**: 30100--30460
+- **API version**: 2026-01 (pinned in CommunicationMgt)
+- **Namespace**: Microsoft.Integration.Shopify
+
+## How it works
+
+The app's core loop is: poll Shopify for changes since last sync, import them into staging tables, then map them to BC entities. The reverse direction (BC to Shopify) works the same way but in the opposite direction. Each sync type -- products, customers, inventory, orders, companies -- is an independent codeunit triggered either manually, by job queue, or by webhook. The Shop table stores a per-sync-type "last sync time" that drives incremental fetches. Order sync is special: its last-sync key is the Shop Id (an integer hash) rather than the Shop Code, which matters in multi-company setups where the same Shopify store is connected to multiple BC companies.
+
+All communication with Shopify goes through `Shpfy Communication Mgt.` (codeunit 30103), a SingleInstance codeunit that owns the HTTP client, API versioning, and rate limiting. Every GraphQL query is encapsulated in its own codeunit implementing the `Shpfy IGraphQL` interface, which returns the query text and its expected cost. The GraphQL module alone accounts for roughly 145 codeunits -- about 25% of all files -- because each query variant (initial fetch, pagination, mutation) gets its own implementation. This looks like overkill but makes rate-limit cost tracking precise and keeps query strings out of business logic.
+
+Entity linking between Shopify and BC is always done via SystemId (Guid), never by Code or No. The Shopify Customer, Product, Variant, and Company tables each carry a "Customer SystemId" or "Item SystemId" field, and the corresponding "Customer No." or "Item No." is a FlowField that looks up through that Guid. This means renumbering BC entities does not break the link. The app does not own any BC master data -- it creates and links to it, but never modifies it outside of the fields it controls.
+
+The app deliberately does not handle payment capture, Shopify POS, multi-location inventory routing, or complex discount rule authoring. It imports what Shopify provides and maps it to BC's sales document model. Pricing export to Shopify is supported (including B2B catalog pricing), but discount rules are Shopify-side only.
+
+## Structure
+
+- `Base/` -- Shop table, CommunicationMgt, authentication, and the shared helpers (JsonHelper, Hash, events)
+- `GraphQL/` -- One codeunit per query implementing IGraphQL; the rate limiter; the query dispatcher
+- `Products/` -- Product/Variant/InventoryItem tables, sync codeunits for import and export, image sync
+- `Customers/` -- Customer table with addresses, mapping strategy interfaces (by email, phone, bill-to, etc.)
+- `Companies/` -- B2B company and company location tables, mapping interfaces, tax ID handling
+- `Catalogs/` -- Per-company pricing catalogs for B2B, linked to Shopify price lists
+- `Order handling/` -- OrderHeader, OrderLine, order import/mapping/processing pipeline, order events
+- `Order Fulfillments/` -- Two parallel table hierarchies: FulfillmentOrderHeader (intent) and OrderFulfillment (actual shipment)
+- `Order Returns/` -- Return headers and lines (customer intent to return)
+- `Order Refunds/` -- Refund headers and lines (money movement, may or may not have a return)
+- `Order Return Refund Processing/` -- Interface-based processing strategies (import only vs. auto credit memo)
+- `Inventory/` -- Stock calculation interfaces, location mapping, sync codeunit
+- `Transactions/` -- Order transactions, payment method mapping, gateway tracking
+- `Payments/` -- Payouts, payment transactions, disputes, payment terms
+- `Webhooks/` -- Webhook subscription management, notification handler (multi-company aware)
+- `Bulk Operations/` -- Async bulk mutation support (product images, prices) via Shopify's bulk API
+- `Metafields/` -- Generic metafield storage keyed by owner type and owner id
+- `Document Links/` -- Traceability table linking Shopify documents to BC documents with interface-based navigation
+
+## Documentation
+
+- [docs/data-model.md](docs/data-model.md) -- How the data fits together
+- [docs/business-logic.md](docs/business-logic.md) -- Processing flows and gotchas
+- [docs/extensibility.md](docs/extensibility.md) -- Extension points and how to customize
+- [docs/patterns.md](docs/patterns.md) -- Recurring code patterns (and legacy ones to avoid)
+
+## Things to know
+
+- The Shop table (`Shpfy Shop`, 30102) is the god object. Nearly every sync codeunit starts by reading it. It controls sync direction, mapping strategy, currency handling, template codes, auto-creation flags, and webhook state. If something behaves unexpectedly, check the Shop settings first.
+
+- Orders carry dual currency: `Currency Code` (shop currency) and `Presentment Currency Code` (what the buyer saw). The `Currency Handling` enum on the Shop table determines which one is used when creating BC sales documents. Every monetary field on orders, refunds, and returns has a presentment counterpart.
+
+- Returns and refunds are separate concepts with separate tables. A Return is a customer's intent to send items back (with decline reason, restock type). A Refund is a financial reversal (with refund lines referencing specific order lines). They may be linked by `Return Id` on the refund, but a refund can exist without a return and vice versa.
+
+- Fulfillment has two parallel systems: `Shpfy FulFillment Order Header/Line` represents Shopify's "fulfillment orders" (the intent to fulfill from a location), while `Shpfy Order Fulfillment` and `Shpfy Fulfillment Line` represent actual shipments with tracking numbers. The connector exports from BC shipments to Shopify fulfillments, not fulfillment orders.
+
+- Hash-based change detection on products (`Image Hash`, `Tags Hash`, `Description Html Hash` on the Product table) avoids re-syncing unchanged data. These are integer hashes, not cryptographic -- used purely for "did it change?" checks.
+
+- Negative auto-incrementing IDs are used for pre-sync staging records. The `Shpfy Orders to Import` table and similar staging constructs use negative BigInteger IDs that are replaced with real Shopify IDs after the API call succeeds.
+
+- The `Shpfy Communication Mgt.` codeunit is SingleInstance and manages rate limiting via `Shpfy GraphQL Rate Limit`. Each IGraphQL implementation declares its expected cost, and the rate limiter uses Shopify's `currentlyAvailable` and `restoreRate` response fields to calculate wait times. If you add a new query, you must provide an accurate `GetExpectedCost()` or you risk throttling.
+
+- Webhooks are multi-company aware. The `Shpfy Webhook Notification` codeunit (30363) receives notifications via BC's webhook infrastructure and iterates all companies that have a matching enabled Shop, scheduling tasks via TaskScheduler in each. The webhook subscription is tied to a specific user whose credentials are used for the background task.
+
+- The `Shpfy Doc. Link To Doc.` table provides bidirectional navigation between Shopify entities and BC documents using interface-based dispatch (`IOpenShopifyDocument`, `IOpenBCDocument`). This is how the UI lets you jump from a Shopify order to the corresponding sales order and back.
+
+- B2B support requires Shopify Plus. The Shop table's `B2B Enabled` flag is set by querying Shopify's plan info. B2B orders carry Company Id, Company Location Id, PO Number, and payment terms. Catalogs provide per-company pricing via Shopify price lists.

--- a/src/Apps/W1/Shopify/App/src/Catalogs/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Catalogs/docs/CLAUDE.md
@@ -1,0 +1,17 @@
+# Catalogs
+
+B2B catalog management -- links Shopify catalogs (both company and market types) to BC pricing parameters so per-catalog variant prices can be synced.
+
+## How it works
+
+`ShpfyCatalog.Table.al` stores catalogs with a composite key of `(Id, Company SystemId)`. Each catalog carries its own pricing configuration: customer price group, customer discount group, posting groups, VAT settings, tax area, and an optional `Customer No.` whose pricing settings take precedence over catalog-level settings. Catalogs come in two types via `ShpfyCatalogType`: Company catalogs are tied to a specific Shopify company, while Market catalogs apply to geographic markets.
+
+`ShpfyCatalogAPI.Codeunit.al` handles both import and creation. For company catalogs, it queries by company ID and creates new catalogs with an associated publication and price list. For market catalogs, it imports all market-type catalogs and resolves their linked markets into `ShpfyMarketCatalogRelation` records. Price sync works by first fetching the list of products included in a catalog's publication, then retrieving the catalog's price list prices for those products. Prices are compared locally and only changed variants are pushed back via `UpdateCatalogPrices`. The URL generation for catalog admin links handles both unified markets and legacy market structures differently.
+
+## Things to know
+
+- When creating a company catalog, three Shopify resources are created in sequence: the catalog itself, a publication (to make products visible), and a price list (to hold custom prices). Missing any step means the catalog exists but cannot function.
+- The catalog currency is validated against Shopify during product sync in `ExtractShopifyCatalogProducts` -- a mismatch between the local `Currency Code` and Shopify's `priceList.currency` causes the sync to be skipped with a logged skipped record telling the user to reimport.
+- `CatalogPrice` records use a `Compare at Price` field to support Shopify's "was/now" pricing. The comparison price is cleared (set to null in GraphQL) if it would be less than or equal to the actual price.
+- Market catalog relations are fully rebuilt on each sync -- existing relations for a catalog are deleted before re-importing from Shopify.
+- The `Sync Prices` boolean on the catalog controls whether the price sync report processes that catalog at all.

--- a/src/Apps/W1/Shopify/App/src/Companies/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Companies/docs/CLAUDE.md
@@ -1,0 +1,23 @@
+# Companies
+
+The Companies module handles B2B company management for Shopify Plus stores. A Company in Shopify is an organization that places orders -- distinct from a Customer, which represents an individual person. This module maps Shopify Companies to BC Customers at the company level, with per-location sell-to/bill-to configuration.
+
+## How it works
+
+`ShpfySyncCompanies` orchestrates bidirectional sync using the same UpdatedAt-comparison pattern as the Customers module. On import, it retrieves company IDs from Shopify, filters to those that have changed, and runs `ShpfyCompanyImport` for each. The import codeunit fetches the company details and its locations via `ShpfyCompanyAPI`, then delegates to `ShpfyCompanyMapping.FindMapping` to link the company to a BC Customer.
+
+The mapping architecture has two layers. `ICompanyMapping` is the base interface with a single `DoMapping` method that takes a company ID and returns a customer number. `IFindCompanyMapping` extends it with a `FindMapping` method that also receives the company's main contact as a temp `Shpfy Customer` record. The `ShpfyCompanyMapping` codeunit checks at runtime whether the selected strategy implements the extended interface; if not, it falls back to the `ByEmailPhone` implementation for `FindMapping`.
+
+Three mapping strategies are available: `ByEmailPhone` matches the company's main contact email/phone against BC Customer email/phone (reusing the same digit-wildcard phone filter from the customer module). `ByDefaultComp` always returns the shop's default customer. `ByTaxId` matches the company location's tax registration ID against BC Customer VAT/tax registration numbers. The enum is extensible for partner customization.
+
+On export, `ShpfyCompanyExport` pushes BC Customer data to Shopify as companies. Company locations are updated by the API layer during import and carry their own sell-to and bill-to customer numbers that override the defaults for order processing.
+
+## Things to know
+
+- Company is not Customer. A Shopify Company has a `Main Contact Customer Id` linking to a `Shpfy Customer` record, but the company itself maps to a BC Customer via its own `Customer SystemId`. The main contact is used for mapping (email/phone lookup) but the BC Customer record belongs to the company.
+- `Shpfy Company Location` carries `Sell-to Customer No.` and `Bill-to Customer No.` fields. When orders arrive from a company location, these override the company-level customer mapping, enabling different billing arrangements per location.
+- Company locations also carry `Tax Registration Id` and `Shpfy Payment Terms Id`, bridging Shopify payment terms and tax registration to BC's equivalents.
+- The `IFindCompanyMapping` interface extends `ICompanyMapping`. This means strategies can implement just the base create-or-map method, or the full find+map method. The runtime type check `if IMapping is "Shpfy IFind Company Mapping"` in `ShpfyCompanyMapping.FindMapping` handles this gracefully.
+- Companies require Shopify Plus. The module will not be exercised on standard Shopify plans.
+- Cascade deletes: deleting a `Shpfy Company` deletes all its `Shpfy Company Location` rows (filtered by `Company SystemId`).
+- The `ShpfyTaxRegistrationNo` and `ShpfyVATRegistrationNo` codeunits implement the `ShpfyTaxRegistrationIdMapping` interface, providing different strategies for matching tax IDs depending on the country's tax system.

--- a/src/Apps/W1/Shopify/App/src/Customers/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Customers/docs/CLAUDE.md
@@ -1,0 +1,23 @@
+# Customers
+
+The Customers module synchronizes Shopify customers with BC Customer records. It uses a pluggable interface architecture for both mapping strategies and name formatting, so the same sync engine adapts to different business rules without code changes.
+
+## How it works
+
+`ShpfySyncCustomers` orchestrates the bidirectional sync. On import, it retrieves Shopify customer IDs and their `Updated At` timestamps, compares them against local records, and queues only changed customers into a temp table. For each queued customer, `ShpfyCustomerImport` fetches full details from Shopify, then `ShpfyCustomerMapping.FindMapping` tries to link the Shopify customer to a BC Customer. The mapping first checks the stored `Customer SystemId`; if that is empty or stale, it delegates to `DoFindMapping`, which searches BC customers by email (case-insensitive) and then by phone number (using a digit-only wildcard filter built by `CreatePhoneFilter`). If no match is found and `Auto Create Unknown Items` is enabled, `ShpfyCreateCustomer` creates a new BC Customer using a template selected from `Shpfy Customer Template` based on the customer's country code.
+
+On export, `ShpfyCustomerExport` iterates BC Customers, finds or creates their Shopify counterpart through the same mapping codeunit (but in the BCToShopify direction), and pushes updates to the API.
+
+The mapping strategy is controlled by the shop's `Customer Mapping Type` enum, which selects one of three `ICustomerMapping` implementations: `ByEmailPhone` (match on email, then phone), `ByBillto` (match on bill-to address fields), or `ByDefaultCust` (always return the shop's default customer). The enum is extensible, so partners can add custom strategies.
+
+Customer name formatting is handled separately via the `ICustomerName` interface, with four implementations: FirstLastName, LastFirstName, CompanyName, and Empty. The `ICounty` and `ICountyFromJson` interfaces resolve Shopify province codes/names to BC county values, bridging the address model differences.
+
+## Things to know
+
+- Customers link to BC via `Customer SystemId`, not `Customer No.`. The `Customer No.` field is a FlowField. This survives customer renumbering.
+- The `Shpfy Customer Template` table (keyed by Shop Code + Country/Region Code) selects which BC Customer Template and Default Customer No. to use when auto-creating customers. Country-specific rules are the norm for international shops.
+- The `Shop Id` field on `Shpfy Customer` is an integer identifying the Shopify shop, used as a filter key for BCToShopify mapping lookups. This is separate from `Shop Code`.
+- `Shpfy Customer Address` uses a negative auto-incrementing ID pattern for new records: the `OnInsert` trigger picks `Min(-1, smallest existing Id - 1)`. This avoids collisions with positive IDs coming from Shopify.
+- The `State` enum on `Shpfy Customer` tracks the Shopify customer account lifecycle (Disabled, Invited, Enabled, Declined). This is informational -- it does not gate sync behavior.
+- Cascade deletes on `Shpfy Customer` remove all related addresses, tags, and metafields.
+- The sync respects paired boolean flags on the Shop record: `Customer Import From Shopify` controls direction, `Shopify Can Update Customer` and `Can Update Shopify Customer` control write permissions in each direction.

--- a/src/Apps/W1/Shopify/App/src/Customers/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/src/Customers/docs/data-model.md
@@ -1,0 +1,33 @@
+# Data model
+
+## Overview
+
+The customer data model bridges Shopify's person-centric customer records with BC's account-centric Customer table. A Shopify customer has addresses, tags, and optional marketing consent. On the BC side, this maps to a Customer record plus whatever address and posting configuration the selected template provides.
+
+## Customer records
+
+`Shpfy Customer` (table 30105) holds the Shopify customer's identity: first name, last name, email, phone, marketing consent, tax exemption, verified email flag, and the `State` enum (Disabled/Invited/Enabled/Declined). The BC link is `Customer SystemId` -- a Guid pointing to the BC Customer record, with `Customer No.` as a FlowField resolved from it.
+
+The `Shop Id` field is a Shopify-side integer identifying which shop the customer belongs to. This is indexed (`Idx2`) and used during BCToShopify mapping to scope customer lookups to the correct shop. It is not the same as `Shop Code` -- the customer table does not carry the shop code directly.
+
+The `Note` field is a Blob storing arbitrary text notes. The `OnDelete` trigger cascades to addresses, tags, and metafields.
+
+## Addresses
+
+`Shpfy Customer Address` (table 30106) stores each address associated with a customer. Each address has its own Shopify BigInteger ID, plus company name, first/last name, two address lines, city, zip, country/region code, province code/name, and phone.
+
+The `Default` Boolean flag marks the primary address. On insert, if no other address for that customer is marked as default, the new address automatically becomes default. The `OnInsert` trigger also implements a negative auto-increment pattern: when `Id` is 0 (meaning this is a locally-created address not yet synced to Shopify), it assigns `Min(-1, smallest existing Id - 1)`. This ensures locally-created addresses never collide with Shopify-assigned positive IDs.
+
+The `CustomerSystemId` field and `Customer No.` FlowField provide a direct link from the address to the BC Customer, independent of the parent Shopify customer's mapping. This allows address-level resolution during order processing.
+
+## Tax areas
+
+`Shpfy Tax Area` (table 30109) maps Shopify's country + county combinations to BC tax configuration. Its composite primary key is `(Country/Region Code, County)`. Each row specifies a `Tax Area Code`, `Tax Liable` flag, `VAT Bus. Posting Group`, and `County Code`. A secondary index on `(Country/Region Code, County Code)` supports lookups where the province code is known but the full county name is not. This table is primarily relevant for US/CA tax scenarios where each state/province has distinct tax rules.
+
+## Customer templates
+
+`Shpfy Customer Template` (table 30107) drives auto-creation of BC Customers. Keyed by `(Shop Code, Country/Region Code)`, it specifies a `Customer Templ. Code` (BC's customer template) and a `Default Customer No.` (a fallback BC Customer for mapping strategies that use it). When a new Shopify customer arrives from a country that matches a template row, the connector applies that template to create the BC Customer with the correct posting groups, payment terms, and other defaults.
+
+## Province (obsolete)
+
+`Shpfy Province` (table 30108) was the original province-to-county mapping table but has been removed (ObsoleteState = Removed, tag 25.0) and replaced by `Shpfy Tax Area`. Code under `CLEANSCHEMA25` guards retains the schema for upgrade compatibility only.

--- a/src/Apps/W1/Shopify/App/src/Document Links/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Document Links/docs/CLAUDE.md
@@ -1,0 +1,17 @@
+# Document links
+
+Provides bidirectional navigation between Shopify documents (orders, returns, refunds) and BC documents (sales orders, invoices, shipments, credit memos). The link table tracks the full document lifecycle so that posting a sales order automatically creates links to the resulting shipment and invoice.
+
+## How it works
+
+`ShpfyDocLinkToDoc` (in `ShpfyDocLinkToDoc.Table.al`) is the central many-to-many link table with a four-part composite key: `(Shopify Document Type, Shopify Document Id, Document Type, Document No.)`. It has two secondary indexes -- one by `(Shopify Document Type, Shopify Document Id)` and one by `(Document Type, Document No.)` -- so lookups are fast from either side. Opening a document dispatches through interface-backed enums: `ShpfyDocumentType` implements `ShpfyIOpenBCDocument` with one codeunit per document type (e.g., `ShpfyOpenSalesOrder`, `ShpfyOpenPostedSalesInvoice`), and `ShpfyShopDocumentType` implements `ShpfyIOpenShopifyDocument`.
+
+The real work happens in `ShpfyDocumentLinkMgt`, which subscribes to Sales-Post events. When a sales order is posted, it finds the existing Shopify-to-SalesOrder link and creates new links for the posted shipment, invoice, return receipt, or credit memo. It also handles the case where an invoice is posted against shipments from a different sales order -- it traces back through `Sales Invoice Line."Shipment No."` to find the Shopify link. When documents are deleted, the corresponding links are cleaned up via `OnAfterDeleteEvent` on `Sales Header`.
+
+## Things to know
+
+- Both enums are extensible with `DefaultImplementation` pointing to a "NotSupported" codeunit, so extensions can add new document types without breaking existing code.
+- `ShpfyBCDocumentTypeConvert` handles mapping between BC's `Sales Document Type` enum and the connector's `ShpfyDocumentType` enum, including a `CanConvert` check and record-variant overloads that inspect the table number.
+- A single Shopify order can link to many BC documents (order + multiple partial shipments + invoice + credit memo), and a single BC document can link back to multiple Shopify documents in multi-order invoice scenarios.
+- The `ShpfyLinkedToDocuments` page surfaces these links as a factbox, letting users navigate from either side.
+- Link records use `SystemMetadata` classification -- they contain no customer data, only document identifiers.

--- a/src/Apps/W1/Shopify/App/src/GraphQL/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# GraphQL
+
+The API communication layer for the Shopify Connector. Every interaction with Shopify's Admin API goes through this module as GraphQL queries or mutations -- the connector does not use REST, except for legacy gift card endpoints handled specially in `ShpfyCommunicationMgt.CreateWebRequestURL`.
+
+## How it works
+
+Each GraphQL operation is its own codeunit implementing the `ShpfyIGraphQL` interface (in `ShpfyIGraphQL.Interface.al`). The interface has two methods: `GetGraphQL` returns the query/mutation text with `{{placeholder}}` tokens for parameters, and `GetExpectedCost` returns the estimated Shopify cost-budget units. `ShpfyGraphQLQueries` resolves a `ShpfyGraphQLType` enum value to the correct interface implementation, substitutes parameters into the template, and hands the result to `ShpfyCommunicationMgt.ExecuteGraphQL`.
+
+Rate limiting is managed by `ShpfyGraphQLRateLimit`, a SingleInstance codeunit that tracks Shopify's `currentlyAvailable` token budget and `restoreRate` from the `extensions.cost.throttleStatus` response. Before each request it calculates whether to sleep based on the expected cost. If a request still comes back `THROTTLED`, `CommunicationMgt` retries in a loop, updating the rate-limit state each time. The communication layer also enforces a 50,000-character query length cap and retries on HTTP 429/5xx responses with backoff.
+
+`ShpfyCommunicationMgt` is SingleInstance and holds the current shop context. It builds URLs with the pinned API version (currently `2026-01` via `VersionTok`), attaches the access token from `ShpfyRegisteredStoreNew`, and checks the API version expiry date from an Azure Key Vault secret cached in IsolatedStorage for 10 days.
+
+## Things to know
+
+- There are roughly 145 codeunits here because each query/mutation gets its own file. This is deliberate -- it keeps cost tracking per-operation, makes test mocking straightforward via `OnBeforeSetInterfaceCodeunit`, and gives clear ownership.
+- Paginated queries follow a naming pattern: `ShpfyGQLCustomerIds` for the first page, `ShpfyGQLNextCustomerIds` for subsequent pages, passing a cursor via the `After` parameter.
+- `ShpfyGraphQLQueries` fires several integration events (`OnBeforeGetGrapQLInfo`, `OnAfterReplaceParameters`, etc.) that let extensions override or modify any query before execution.
+- The API version is hard-coded as a label constant, not configurable. Expiry is checked against an AKV secret; when it lapses the connector errors out with `ApiVersionOutOfSupportErr` rather than silently using an unsupported version.
+- `IsTestInProgress` on `CommunicationMgt` reroutes all HTTP calls through `ShpfyCommunicationEvents`, allowing tests to inject canned responses without network access.
+- Gift card URLs skip the `/api/VERSION/` path segment entirely -- see the `StartsWith('gift_cards')` branch in `CreateWebRequestURL`.

--- a/src/Apps/W1/Shopify/App/src/Inventory/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Inventory/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# Inventory
+
+Handles stock level synchronization from BC to Shopify. This is typically one-way -- BC is the source of truth for inventory, and the connector pushes calculated stock levels to Shopify per-location.
+
+## How it works
+
+The module uses a two-tier data model. `ShpfyShopLocation` maps each Shopify location to BC locations via a `Location Filter` expression (e.g., `EAST|WEST`), and carries a `Stock Calculation` enum that controls how stock is computed. `ShpfyShopInventory` stores per-variant, per-location stock levels with both the last-calculated BC stock and the last-imported Shopify stock, plus timestamps for each.
+
+`ShpfySyncInventory` drives the sync loop: first it imports current Shopify stock levels for all enabled locations (via `ShpfyInventoryAPI.ImportStock`), then it exports any differences (via `ExportStock`). During import, inventory records that no longer exist in Shopify are tracked by SystemId and cleaned up afterward by `RemoveUnusedInventoryIds`. During export, `CalcStock` computes BC stock, compares it to `Shopify Stock`, and only pushes when they differ. The export batches up to 250 quantities per `inventorySetQuantities` mutation call, and retries up to 3 times on concurrency errors (`IDEMPOTENCY_CONCURRENT_REQUEST`, `CHANGE_FROM_QUANTITY_STALE`).
+
+Stock calculation is interface-driven. The `ShpfyStockCalculation` enum implements both `ShpfyStockCalculation` (the `GetStock` method) and `ShpfyIStockAvailable` (the `CanHaveStock` guard). Built-in options are Disabled, Projected Available Balance Today (`ShpfyBalanceToday`), and Free Inventory (`ShpfyFreeInventory`). The enum is extensible, so extensions can add custom calculation strategies. There is also `ShpfyExtendedStockCalculation` which extends the base interface with a location-aware overload.
+
+## Things to know
+
+- `ShpfyInventoryEvents.OnAfterCalculationStock` fires after every stock calculation, letting extensions adjust the final number before it is pushed to Shopify (e.g., subtracting safety stock).
+- Negative calculated stock is clamped to 0 before sending to Shopify -- see the `if ShopInventory.Stock < 0 then JQuantity.Add('quantity', 0)` branch in `CalcStock`.
+- UoM conversion is applied when a variant maps to a non-base unit of measure, dividing the stock by `Qty. per Unit of Measure`.
+- The `Default Product Location` flag on `ShpfyShopLocation` controls which locations new products are auto-added to in Shopify. You cannot mix standard locations with fulfillment service locations for this flag.
+- The `Is Fulfillment Service` field distinguishes 3PL locations from physical warehouses. Fulfillment service locations carry their own service ID and callback URL.
+- Items of type Non-Inventory and Service are excluded from stock calculation entirely.

--- a/src/Apps/W1/Shopify/App/src/Invoicing/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Invoicing/docs/CLAUDE.md
@@ -1,0 +1,17 @@
+# Invoicing
+
+Exports posted BC sales invoices to Shopify as orders, enabling B2B buyers to see invoices in their Shopify portal.
+
+## How it works
+
+`ShpfyPostedInvoiceExport.Codeunit.al` is the main entry point (runs on `Sales Invoice Header`). It first validates the invoice is exportable -- the bill-to customer must exist as a Shopify company or customer, the payment terms must be mapped in Shopify, the customer cannot be the default customer or a customer template target, lines must have valid positive integer quantities, and every typed line must have a `No.` value. Any validation failure logs a skipped record and stamps the invoice with `Shpfy Order Id = -2`.
+
+For valid invoices, the codeunit maps the header and lines into temporary `Shpfy Order Header` and `Shpfy Order Line` records, then uses `ShpfyDraftOrdersAPI.Codeunit.al` to create a Shopify draft order via raw GraphQL mutation construction (not parameterized templates). The draft order is immediately completed to convert it into a real order. After completion, fulfillment orders are fetched and immediately fulfilled (since the invoice represents already-shipped goods), a `ShpfyInvoiceHeader` tracking record is created, and a document link is added to `Shpfy Doc. Link To Doc.` for traceability. If draft order creation fails, the invoice gets `Shpfy Order Id = -1`.
+
+## Things to know
+
+- Tax lines are aggregated by VAT calculation type and percentage, then added as separate line items on the draft order (with `taxExempt: true` on the order itself) -- Shopify does not natively support BC's tax structure, so taxes are represented as custom line items.
+- The draft order includes `paymentTerms` only when the invoice has a remaining amount (is unpaid). Payment terms resolution falls back to the primary Shopify payment term if no exact code match exists.
+- Invoice quantities must be positive whole numbers -- Shopify does not support fractional or negative quantities, so such lines cause the entire invoice to be skipped.
+- The `ShpfyInvoiceHeader` table is minimal (just a Shopify Order Id) and exists solely to track which orders were created by invoice export rather than normal order import.
+- Sales invoice comments are exported as the draft order's `note` field.

--- a/src/Apps/W1/Shopify/App/src/Logs/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Logs/docs/CLAUDE.md
@@ -1,0 +1,18 @@
+# Logs
+
+API call logging, raw JSON capture, and skipped record tracking. These three facilities serve different diagnostic purposes and are used pervasively by other modules.
+
+## How it works
+
+`ShpfyLogEntry.Table.al` stores one row per API call with the request/response bodies in BLOB fields, plus metadata like URL, HTTP method, status code, retry count, query cost, and the Shopify request ID. The request and response are also previewed in 50-character text fields for quick scanning without loading the BLOBs. `ShpfyLogEntries.Codeunit.al` provides escalation support -- for 500-status entries less than 14 days old, it can generate a downloadable escalation report containing the request ID, timestamp, store URL, API version, and full request/response payloads.
+
+`ShpfyDataCapture.Table.al` stores raw JSON snapshots linked to any record via `Linked To Table` (table ID) and `Linked To Id` (SystemId). It uses hash-based deduplication: the `Add` procedure calculates a hash of the incoming JSON and skips the insert if the last capture for that record has the same hash. This prevents storage bloat when repeated syncs return identical data. Both tables participate in the BC retention policy framework through `ShpfyLogEntriesDelete.Codeunit.al`.
+
+`ShpfySkippedRecord.Codeunit.al` logs records that could not be imported during sync, with the Shopify ID, BC record ID, and a human-readable reason. It sends a one-time notification per sync session (guarded by a `NotificationSent` boolean) so the user is alerted without being spammed. Skipped record logging respects the shop's `Logging Mode` -- when disabled, nothing is written.
+
+## Things to know
+
+- Data captures are keyed by entry number but indexed on `(Linked To Table, Linked To Id)` -- always filter by those fields, not by entry number, when looking up captures for a specific record.
+- Log entries and data captures are cleaned up through BC's standard retention policy mechanism, not custom cleanup jobs.
+- The skipped record table resolves its `Table Name` and `Description` dynamically from the `Record ID` field using `AllObjWithCaption` and `RecRef`, with a special case for `Shpfy Catalog` where it uses the catalog's `Name` field instead of the PK filter.
+- The escalation report feature extracts the store domain from the log entry's URL to find the matching enabled shop, which means it will fail if the shop has been disabled since the error occurred.

--- a/src/Apps/W1/Shopify/App/src/Metafields/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Metafields/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# Metafields
+
+Handles Shopify's custom key-value metadata system. Metafields can be attached to products, variants, customers, and companies, and the connector supports bidirectional sync between BC and Shopify.
+
+## How it works
+
+The `ShpfyMetafield` table (in `ShpfyMetafield.Table.al`) stores all metafields with an `Owner Type` enum and `Owner Id` pointing to the parent Shopify record. On insert, if no namespace is set it defaults to `Microsoft.Dynamics365.BusinessCentral`. New metafields created in BC get negative IDs (starting from -1, decrementing) so they do not collide with Shopify-assigned IDs -- once synced, `ShpfyMetafieldAPI.SyncMetafieldToShopify` returns the real Shopify ID.
+
+The type system uses two extensible interface patterns. `ShpfyIMetafieldType` (implemented per enum value in `ShpfyMetafieldType.Enum.al`) provides validation (`IsValidValue`), assist-edit dialogs, and example values. `ShpfyIMetafieldOwnerType` (implemented per value in `ShpfyMetafieldOwnerType.Enum.al`) maps owner types to BC table IDs via `GetTableId`, retrieves metafield IDs from Shopify, and resolves the shop code from an owner record. The owner types are Customer, Product, ProductVariant, and Company.
+
+`ShpfyMetafieldAPI` orchestrates sync in both directions. Exporting to Shopify uses the `metafieldsSet` mutation, batching up to 25 metafields per call. It compares `Last Updated by BC` timestamps against Shopify's `updatedAt` and only pushes metafields that changed in BC since the last Shopify update. Importing from Shopify uses `UpdateMetafieldsFromShopify`, which deletes metafields that no longer exist on the Shopify side.
+
+## Things to know
+
+- The money type validates that the currency code in the value matches the shop's currency (or LCY if no shop currency is set). This validation fires on the `Value` field's OnValidate trigger.
+- Values longer than 2048 characters are silently skipped during import from Shopify, since that is the BC field length limit.
+- Deprecated types `string` and `integer` are blocked on validate -- the UI forces users to `single_line_text_field` and `number_integer` instead.
+- Metafield definitions can be pulled from Shopify via `GetMetafieldDefinitions`, which imports the first 50 definitions for a given owner type and creates placeholder metafield records.
+- The `Parent Table No.` and `Owner Type` fields are kept in sync via their respective OnValidate triggers -- setting one automatically sets the other.
+- Extensions can add new owner types by extending `ShpfyMetafieldOwnerType` enum and implementing `ShpfyIMetafieldOwnerType`, or new value types by extending `ShpfyMetafieldType` and implementing `ShpfyIMetafieldType`.

--- a/src/Apps/W1/Shopify/App/src/Order Fulfillments/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Fulfillments/docs/CLAUDE.md
@@ -1,0 +1,17 @@
+# Order fulfillments
+
+Two parallel data models for fulfillment tracking. Fulfillment orders represent Shopify's intent (what needs to be shipped from which location), while order fulfillments represent actual shipments with tracking information.
+
+## How it works
+
+`ShpfyFulfillmentOrdersAPI.Codeunit.al` imports fulfillment orders from Shopify, either for a specific order or by querying for orders assigned to BC's fulfillment service. Each fulfillment order header records the assigned location, status, delivery method type, and request status. Lines carry product/variant IDs, total quantity, and remaining quantity. The API auto-registers a fulfillment service with Shopify on first use (if `Allow Outgoing Requests` is enabled), and checks on subsequent calls whether it still exists. It also supports accepting fulfillment requests, which transitions the request status to ACCEPTED.
+
+`ShpfyOrderFulfillments.Codeunit.al` handles actual fulfillment records (shipments). It imports fulfillment data including tracking info (number, URL, company) with support for multiple tracking entries per fulfillment -- the first entry goes into dedicated fields, and all entries are concatenated into comma-separated list fields. Fulfillment lines link back to order lines and track quantities. If a fulfillment contains gift card line items (detected via a FlowField), the gift card codes are fetched in a separate call.
+
+## Things to know
+
+- Fulfillment order headers use `Updated At` as a change-detection mechanism -- if the timestamp matches, only the lines are re-fetched, skipping the header update.
+- The fulfillment service is lazily registered: `RegisterFulfillmentService` is called on the first fulfillment order sync if `Fulfillment Service Activated` is false. If Shopify no longer has the service (detected by `HasFulfillmentService`), the flag is reset to false on the shop.
+- Fulfillment line items are paginated separately from the fulfillment itself -- after importing the main fulfillment, the code loops to fetch additional pages of `fulfillmentLineItems` using `GetNextOrderFulfillmentLines`.
+- Both fulfillment order headers and order fulfillments clean up their associated `ShpfyDataCapture` records and child lines on delete.
+- The `Request Status` enum (`ShpfyFFRequestStatus`) tracks the fulfillment service handshake: UNSUBMITTED, SUBMITTED, ACCEPTED, etc. Only assigned fulfillment orders with appropriate request status should be processed by BC.

--- a/src/Apps/W1/Shopify/App/src/Order Refunds/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/docs/CLAUDE.md
@@ -1,0 +1,17 @@
+# Order refunds
+
+Imports refund data from Shopify into BC. Refunds represent the financial side of returns -- money refunded to the customer, potentially with shipping refund lines. This is separate from the Returns module which handles the physical goods.
+
+## How it works
+
+`ShpfyRefundsAPI.Codeunit.al` processes refunds by first fetching the header (with `totalRefundedSet` in both shop and presentment currencies), then the refund lines, then shipping refund lines. Each refund line records the quantity, restock type, amounts (with presentment equivalents), and a `Can Create Credit Memo` flag. The `Can Create Credit Memo` logic is key: a line is eligible only if the refund has a non-zero total amount or is linked to a return (`Return Id > 0`), or if the line's restock type is explicitly `Return`. This prevents creating credit memos for refunds that were already factored into the original order import as quantity reductions.
+
+Refund lines need location information for inventory tracking. The code first checks the refund line's own `location.legacyResourceId` from Shopify. If that is zero (common when the refund was created from a return), it falls back to location data collected from the return's line items via `CollectReturnLocations`. The `UpdateTransactions` procedure stamps `Refund Id` onto related `ShpfyOrderTransaction` records so transactions can be linked back to their refund.
+
+## Things to know
+
+- The `RefundHeader` stores processing errors in BLOB fields (`Last Error Description`, `Last Error Call Stack`) and exposes `Has Processing Error` as a boolean, giving users visibility into failed credit memo creation attempts.
+- `Is Processed` is a FlowField that checks `Shpfy Doc. Link To Doc.` for a linked credit memo -- this is how the UI knows whether a refund has already been handled.
+- Refund headers skip re-import if the existing `Updated At` timestamp is newer than or equal to the incoming one, providing idempotent sync behavior.
+- Shipping refund lines have their own table (`ShpfyRefundShippingLine`) with subtotal and tax amounts in both shop and presentment currencies.
+- The `VerifyRefundCanCreateCreditMemo` procedure blocks credit memo creation if any line has `Can Create Credit Memo = false`, enforcing an all-or-nothing approach per refund.

--- a/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Order return refund processing
+
+This module handles returns and refunds as separate but related concepts. A return tracks the physical flow of goods back from the customer. A refund tracks the monetary flow back to the customer. They can occur independently -- a refund without a return (e.g., a price adjustment), a return without a refund (e.g., an exchange), or together.
+
+## How it works
+
+The shop's "Return and Refund Process" setting, defined by the `ShpfyReturnRefundProcessType` enum, controls all behavior through the `ShpfyIReturnRefundProcess` interface. Three implementations exist: `ShpfyRetRefProcDefault` (the blank option -- skips all import and processing), `ShpfyRetRefProcImportOnly` (imports return and refund data but creates no BC documents), and `ShpfyRetRefProcCrMemo` (imports data and auto-creates credit memos from refunds).
+
+When "Auto Create Credit Memo" is active, `ShpfyProcessOrders` iterates unprocessed refund headers after order processing and calls `CreateSalesDocument` for each. `ShpfyRetRefProcCrMemo` validates preconditions -- the refund must not already be processed, the parent order must exist and be processed, and no refund lines can have `Can Create Credit Memo` = false. It then delegates to `ShpfyCreateSalesDocRefund`, which builds a credit memo from the order header's address and customer data.
+
+Sales lines on the credit memo are created differently based on the refund line's restock type. Return and Legacy Restock lines become Item lines at the refund location. No Restock lines become G/L account lines against "Refund Acc. non-restock Items". Cancel lines go to the "Refund Account" as a flat amount. After item lines, shipping refund lines and a balancing G/L line for any remaining amount difference are added to ensure the credit memo total matches the Shopify refund total.
+
+## Things to know
+
+- The `ShpfySourceDocumentType` enum distinguishes Order, Return, and Refund as source document types. Each has its own `ShpfyIDocumentSource` implementation for error tracking.
+- Restock type (`NoRestock`, `Cancel`, `Return`, `LegacyRestock`) determines how credit memo lines are created. Only Return and Legacy Restock create Item-type lines that affect BC inventory.
+- If a refund has no refund lines but has a linked return with return lines, the credit memo is built from return lines instead (see `CreateSalesLinesFromReturnLines` in `ShpfyCreateSalesDocRefund`).
+- The balancing line in `CreateSalesLinesFromRemainingAmount` catches rounding differences, refund adjustments, and any amounts not covered by the line-level refund data. It posts to the shop's "Refund Account" G/L.
+- Credit memos use the order's `Processed Currency Handling` rather than the shop's current setting, so currency handling remains consistent even if the shop setting changes after the order was originally processed.
+- Refund quantities are also netted against order lines during import (in `ShpfyImportOrder.ConsiderRefundsInQuantityAndAmounts`), so the order and refund processing are tightly coupled.
+- Integration events on `ShpfyRefundProcessEvents` allow customizing header creation, line creation, and the balancing calculation.

--- a/src/Apps/W1/Shopify/App/src/Order handling/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order handling/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Order handling
+
+This module is the core order processing engine. It imports Shopify orders into BC, maps them to customers and items, and creates sales documents. Every order passes through a three-stage pipeline -- import, mapping, processing -- before it becomes a BC sales order or invoice.
+
+## How it works
+
+`ShpfyImportOrder` retrieves order JSON via GraphQL, populates `ShpfyOrderHeader` and `ShpfyOrderLine` records, pulls in related data (shipping charges, transactions, fulfillments, returns, refunds), then considers refunds against line quantities and checks whether the order should auto-close. The `ShpfyOrdersToImport` table acts as the inbound queue -- webhooks, manual sync, and job queues all feed into it.
+
+`ShpfyOrderMapping.DoMapping` resolves Shopify data to BC master data: customer (or company for B2B), shipment method, shipping agent, and payment method. For lines, it maps Shopify variants to BC items, falling back to a product import if the variant is unknown. B2B orders take a separate path through `MapB2BHeaderFields` that resolves company locations to sell-to/bill-to customer numbers.
+
+`ShpfyProcessOrder` creates the actual BC sales document. If the order is already fulfilled and the shop has "Create Invoices From Orders" enabled, it creates a Sales Invoice; otherwise a Sales Order. It copies the triple address set (sell-to, ship-to, bill-to), applies currency handling, adds item lines, shipping charge lines, and global discount balancing via `SalesCalcDiscountByType`. It optionally auto-releases.
+
+## Things to know
+
+- Every monetary field exists in two flavors: shop currency (`Unit Price`, `Total Amount`) and presentment currency (`Presentment Unit Price`, `Presentment Total Amount`). The shop's "Currency Handling" setting controls which set flows into BC sales lines.
+- Conflict detection fires when a processed order is re-imported and the line items hash (`Line Items Redundancy Code`), current subtotal quantity, or shipping charges amount differs from what was originally processed. Conflicting orders get `Has Order State Error` set to true.
+- Refund quantities are subtracted from order line quantities during import in `ConsiderRefundsInQuantityAndAmounts`. Lines that net to zero quantity are deleted. This means the order header amounts reflect the post-refund state.
+- The order header carries three complete address blocks (sell-to, ship-to, bill-to), each parsed from different JSON paths: `displayAddress`, `shippingAddress`, `billingAddress`.
+- B2B orders populate `Company Id`, `Company Location Id`, `PO Number`, `Payment Terms Type/Name`, and `Due Date` from the `purchasingEntity` JSON node. The PO Number flows to `External Document No.` on the sales header.
+- Auto-close sends a GraphQL `orderClose` mutation when the order is fulfilled, fully paid, and has no outstanding sales order quantities. The shop must have "Archive Processed Orders" enabled.
+- Tips and gift cards are not mapped to items -- they route to G/L accounts configured on the shop (`Tip Account`, `Sold Gift Card Account`).

--- a/src/Apps/W1/Shopify/App/src/Order handling/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/src/Order handling/docs/business-logic.md
@@ -1,0 +1,70 @@
+# Business logic
+
+## Overview
+
+Order processing follows a strict import-then-map-then-process pipeline. Each stage is a separate codeunit and can fail independently. Import retrieves raw Shopify data and stores it in Shopify-specific tables. Mapping resolves that data to BC master records (customers, items, shipment methods). Processing creates the actual BC sales documents. Errors at any stage are captured on the order header and do not block other orders from processing.
+
+The pipeline is designed to be re-entrant. Re-importing an already-processed order triggers conflict detection rather than overwriting BC documents. Refunds are netted into order quantities at import time, so the mapping and processing stages always see post-refund figures.
+
+## Import
+
+The entry point is `ShpfyImportOrder`, which runs against an `ShpfyOrdersToImport` record. The core method `ImportOrderAndCreateOrUpdate` does the following:
+
+1. Ensures an `ShpfyOrderHeader` record exists (inserts a skeleton if new).
+2. Retrieves the order header JSON via `ExecuteGraphQL(GetOrderHeader)`. If B2B is enabled, the query also fetches `staffMember`.
+3. Retrieves order lines with pagination via `GetOrderLines` / `GetNextOrderLines`.
+4. If the order is already processed and has no prior state error, runs conflict detection before overwriting any fields.
+5. Sets header values from JSON. New orders get the full treatment (`SetNewOrderHeaderValuesFromJson` -- addresses, customer, currency, B2B fields). Updates only refresh editable fields (statuses, amounts, dates).
+6. Calls `SetAndCreateRelatedRecords` to pull in tax lines, custom attributes, tags, risks, fulfillment orders, shipping charges, transactions, returns, and refunds. Returns and refunds are only fetched if the shop's `Return and Refund Process` setting requires import.
+7. Inserts order lines, computing the redundancy hash (a hash of sorted line IDs used for conflict detection later).
+8. Runs `ConsiderRefundsInQuantityAndAmounts`, which subtracts refund line quantities and amounts from order lines and the header. Lines that reach zero quantity are deleted.
+9. Checks whether the order should auto-close (fulfilled + fully paid + no outstanding quantities on BC sales order).
+10. If a Shopify invoice already exists for the order, marks it as processed immediately.
+
+Currency codes from Shopify (ISO format like "USD") are translated to BC currency codes via the Currency table's ISO Code field. If the translated code matches the company's LCY Code, it becomes blank (BC convention for local currency).
+
+## Mapping
+
+`ShpfyOrderMapping.DoMapping` is called both during import (on reimport) and as the first step of processing. It returns a boolean indicating whether all mappings succeeded.
+
+For D2C orders, it tries the customer template for the ship-to country first, then falls back to the shop's default customer. `ShpfyCustomerMapping.DoMapping` handles the actual customer resolution, with an option to auto-create unknown customers. Sell-to and bill-to customer numbers are resolved separately using sell-to and bill-to address data.
+
+For B2B orders, `MapB2BHeaderFields` uses `ShpfyCompanyMapping` and additionally tries to map sell-to/bill-to from the company location record. If the company location has distinct sell-to and bill-to customer numbers configured, they are used independently.
+
+After customer mapping, the method maps shipping method (from shipping charge title to `ShpfyShipmentMethodMapping`), shipping agent (same mapping table), and payment method (from the highest-amount successful transaction's gateway). Payment method mapping skips assignment if multiple distinct payment methods are found.
+
+Line mapping in `MapVariant` resolves each Shopify variant to a BC item and variant code. If the variant is not yet synced, it triggers a product import on the fly. The unit of measure is taken from the variant's UoM option or falls back to the item's sales unit of measure.
+
+## Processing
+
+`ShpfyProcessOrder` orchestrates document creation. It re-runs mapping (which is idempotent) and errors if mapping is incomplete.
+
+The order-vs-invoice decision is simple: if fulfillment status is Fulfilled and the shop has "Create Invoices From Orders" enabled, create an invoice; otherwise create a sales order. `CreateHeaderFromShopifyOrder` builds the sales header with all three address blocks, validates currency based on the shop's currency handling setting, sets document date, external document no. (from PO Number), due date, tax area, shipment method, shipping agent, payment method, and payment terms.
+
+`CreateLinesFromShopifyOrder` iterates order lines. Tips go to the Tip Account G/L, gift cards to Sold Gift Card Account, and everything else becomes an Item line. Location code is resolved from `ShpfyShopLocation` if the line has a Shopify location ID. The currency handling setting determines whether shop currency or presentment currency prices are used.
+
+Shipping charges become separate sales lines after the item lines. Each `ShpfyOrderShippingCharges` record creates a line. If the shipment method mapping defines a specific shipping charges type (G/L Account, Item, or Charge (Item)), that is used; otherwise the shop's default Shipping Charges Account is used. Item charges get auto-assigned to the item lines.
+
+After all lines, `ApplyGlobalDiscounts` computes the difference between the header discount amount and the sum of line-level and shipping-level discounts. Any remainder is applied as an invoice discount.
+
+Cash rounding amounts (from Shopify's `totalCashRoundingAdjustment`) are added as a final G/L line against the Cash Roundings Account.
+
+If the shop has "Auto Release Sales Orders" enabled, the document is released automatically at the end.
+
+## Conflict detection
+
+`IsImportedOrderConflictingExistingOrder` fires only for orders that are already processed and have no prior state error. It checks three conditions, any of which marks the order as conflicting:
+
+1. The current subtotal line items quantity from Shopify is greater than what was stored (items were added).
+2. The redundancy hash of line IDs differs (lines were added or removed).
+3. The shipping charges amount differs.
+
+Additionally, during refund consideration, if a processed order is cancelled but has no refund lines, or if refund lines exist that are not yet eligible for credit memo creation, the order is marked as conflicting.
+
+A conflicting order gets `Has Order State Error` = true, `Has Error` = true, and a descriptive error message. This prevents the order from being processed again until the conflict is manually resolved.
+
+## Error handling
+
+Processing errors are caught by `ShpfyProcessOrders.ProcessShopifyOrder`, which wraps `ShpfyProcessOrder.Run()` in a conditional. On failure, the partially created sales document is cleaned up via `CleanUpLastCreatedDocument`, and the error message (prefixed with the current time) is stored on the order header. The order remains unprocessed so it can be retried.
+
+Three error-related fields exist on the order header: `Has Error` (general errors during processing), `Error Message` (the text), and `Has Order State Error` (specifically for conflict detection). An order can have both a processing error and a state error simultaneously.

--- a/src/Apps/W1/Shopify/App/src/Payments/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Payments/docs/CLAUDE.md
@@ -1,0 +1,17 @@
+# Payments
+
+Shopify Payments account data -- payouts, balance transactions, disputes, and payment terms. This is separate from order-level transactions (in the Transactions folder); this folder tracks the money flow through Shopify's own payment processing system.
+
+## How it works
+
+`ShpfyPayments.Codeunit.al` orchestrates sync in a specific order: first it backfills payout IDs on payment transactions that were imported before their payout existed, then it updates statuses of non-terminal payouts, then it imports new payment transactions and payouts. This ordering matters because payment transactions arrive before their associated payout is created by Shopify. Disputes follow a similar pattern -- unfinished disputes are refreshed individually, then new disputes are imported in bulk.
+
+`ShpfyPaymentsAPI.Codeunit.al` handles all GraphQL communication. Payment transactions are imported via cursor-based pagination on `shopifyPaymentsAccount.balanceTransactions`. Each transaction records the gross amount, fee, and net amount. Payouts store a summary breakdown (charges, refunds, adjustments, reserved funds, retried payouts) with separate fee and gross amounts for each category. The `ShpfyPaymentTermsAPI.Codeunit.al` pulls payment terms templates from Shopify and upserts them into `ShpfyPaymentTerms` -- these are used by the Invoicing module to set payment terms on draft orders.
+
+## Things to know
+
+- Payment transaction IDs are imported with `SinceId + 1` to avoid re-importing the last known record -- this is a Shopify REST-era pattern carried forward into GraphQL filter parameters.
+- Payout ID backfill and payout status updates are batched in groups of 200 to stay within GraphQL query limits.
+- Disputes track `Evidence Due By`, `Evidence Sent On`, and `Finalized On` timestamps. Only disputes not yet Won or Lost are refreshed during sync.
+- `ShpfyPaymentTerms` supports exactly one "Is Primary" row, enforced by a validation trigger. The primary term acts as a fallback when the invoice's BC payment terms code has no explicit Shopify mapping.
+- `ShpfyPaymentTransaction` links to its source order via `Source Order Id` and can be traced to a posted sales invoice through a FlowField.

--- a/src/Apps/W1/Shopify/App/src/Products/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Products/docs/CLAUDE.md
@@ -1,0 +1,23 @@
+# Products
+
+The Products module handles bidirectional synchronization between BC Items and Shopify Products. A BC Item becomes a Shopify Product; its Item Variants and Units of Measure become Shopify Variants. This is the highest-traffic sync area in the connector because products carry price, inventory, images, and metadata.
+
+## How it works
+
+On export, `ShpfyProductExport` iterates every `Shpfy Product` that has a non-empty `Item SystemId` and rebuilds the Shopify representation from the current BC Item. It compares old and new records field-by-field via `RecordRef` and only calls the API when something changed. Variant-level updates are batched into a temporary record set and sent through `ShpfyVariantAPI.UpdateProductVariants` in one pass. A separate "only update price" mode skips all non-price fields and can use the bulk mutation API for throughput. New products go through `ShpfyCreateProduct`, which assembles temp Product and Variant records, validates option compatibility, and hands them to `ShpfyProductAPI.CreateProduct`.
+
+On import, `ShpfyProductImport` retrieves the product and its variant IDs from Shopify, upserts local records, then delegates to `ShpfyProductMapping` to link each variant to a BC Item + Item Variant by SKU, barcode, or vendor item number (depending on the shop's `SKU Mapping` setting). If no mapping is found and `Auto Create Unknown Items` is on, `ShpfyCreateItem` creates the BC Item.
+
+Price calculation is handled by `ShpfyProductPriceCalc`, which creates a temporary Sales Quote header using the shop's (or catalog's) posting groups, customer price group, and currency. It validates a Sales Line to let the standard BC pricing engine resolve the final price, compare-at price, and unit cost. Catalog-level overrides support multi-market and B2B pricing.
+
+Image sync runs as a separate pipeline in `ShpfySyncProductImage`, exporting item pictures to Shopify or downloading Shopify images into BC Item pictures. It uses hash-based change detection on `Shpfy Product."Image Hash"` to avoid redundant uploads.
+
+## Things to know
+
+- Products link to Items via `Item SystemId` (a Guid), not `Item No.`. The `Item No.` field is a FlowField calculated from the SystemId. This means item renumbering does not break the mapping.
+- Change detection uses integer hash fields -- `Image Hash`, `Tags Hash`, `Description Html Hash` -- so the connector can skip API calls when nothing changed. The `ShpfyHash` codeunit computes these.
+- When `UoM as Variant` is enabled on the shop, each Item Unit of Measure becomes its own Shopify Variant. The `UoM Option Id` field (1, 2, or 3) on `Shpfy Variant` tracks which of the three option slots holds the UoM value. The connector searches all three slots when matching during export updates.
+- Shopify limits products to 3 option slots and 2048 variants. Item Attributes marked as "As Option" (`Shpfy Incl. in Product Sync` = `As Option`) are mapped to these option slots by `FillProductOptionsForShopifyVariants` in `ShpfyProductExport`. The connector validates uniqueness of option combinations and skips items that exceed 3 attributes.
+- The `Has Variants` flag is semantic, not structural. A single-variant product still has one `Shpfy Variant` record, but `Has Variants` is false. This affects how mapping works -- see `ShpfyProductMapping.FindMapping` where `Mapped By Item` handles the single-variant case.
+- The `IRemoveProductAction` interface (with implementations DoNothing, StatusToArchived, StatusToDraft) runs on product delete and when a blocked item is exported, controlling what happens on the Shopify side.
+- Bulk operations (`ShpfyBulkOperationMgt`) are attempted first for price updates and image updates; the connector falls back to per-record API calls if the bulk mutation fails.

--- a/src/Apps/W1/Shopify/App/src/Products/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/src/Products/docs/data-model.md
@@ -1,0 +1,33 @@
+# Data model
+
+## Overview
+
+The product data model mirrors Shopify's hierarchy: a Product contains Variants, and each Variant has exactly one Inventory Item. Stock levels are tracked per-variant per-location. Collections group products for storefront organization. Every table uses Shopify's BigInteger IDs as primary keys and links to BC entities via SystemId Guids.
+
+## Product-Variant-InventoryItem hierarchy
+
+`Shpfy Product` (table 30127) is the top-level entity. It carries the product title, description HTML (stored as a Blob), vendor, product type, status (Draft/Active/Archived), and SEO fields. The key BC link is `Item SystemId` -- a Guid pointing to the BC Item. The `Item No.` field is a FlowField resolved from that Guid, so renaming an item in BC does not sever the connection. The secondary key on `(Shop Code, Item SystemId)` supports efficient lookups during export, which filters on `Item SystemId <> NullGuid`.
+
+Three hash fields drive change detection: `Image Hash`, `Tags Hash`, and `Description Html Hash`. These are plain integers computed by `ShpfyHash.CalcHash`. On export, the connector compares the new hash against the stored one and skips the API call if they match.
+
+`Shpfy Variant` (table 30129) is the sellable unit. Every product has at least one variant. The variant carries price, compare-at price, unit cost, SKU, barcode, weight, taxable flag, and inventory policy. It links to BC via both `Item SystemId` and `Item Variant SystemId`, allowing a variant to map to a specific BC Item Variant. The `Mapped By Item` flag is true when the variant was matched at the item level (no specific variant code) -- this happens for single-variant products or when "Add Item as Variant" groups multiple items under one product.
+
+The three option slot pairs (`Option 1 Name`/`Option 1 Value` through `Option 3 Name`/`Option 3 Value`) map to Shopify's product options. When `UoM as Variant` is active, one slot holds the unit of measure code and `UoM Option Id` records which slot (1, 2, or 3) that is. This matters during export updates, where the connector must search all three slots to find an existing variant's UoM match.
+
+`Shpfy Inventory Item` (table 30126) has a 1:1 relationship with Variant, linked by `Variant Id`. It holds fulfillment-related data: country/region of origin, whether shipping is required, whether inventory tracking is enabled, and unit cost. This is the entity Shopify uses for inventory management operations.
+
+Cascade deletes flow downward: deleting a Product deletes its Variants (and their Metafields), and deleting a Variant deletes its Inventory Items (and their Metafields). The Product delete trigger also invokes the `IRemoveProductAction` interface, which may change the product's status on Shopify before the local record disappears.
+
+## Inventory tracking
+
+`Shpfy Shop Inventory` (table 30112) tracks stock levels at the intersection of shop, product, variant, and location -- its composite primary key is `(Shop Code, Product Id, Variant Id, Location Id)`. It stores both the last-imported Shopify stock and the last-calculated BC stock, with timestamps for each. The delta between these drives inventory adjustments.
+
+`Shpfy Shop Location` (table 30113) maps Shopify locations to BC locations. Each row has a `Location Filter` (a BC location code filter expression) and a `Default Location Code` used on sales documents. The `Stock Calculation` enum controls how inventory is computed for that location (or disables sync entirely). The `Is Fulfillment Service` flag distinguishes third-party fulfillment locations, which cannot be mixed with standard locations for the `Default Product Location` setting. When a location is deleted, its `Shpfy Shop Inventory` rows cascade-delete.
+
+## Collections
+
+`Shpfy Product Collection` (table 30163) represents a Shopify collection (product grouping). It stores the collection name, a `Default` flag (whether new products are auto-assigned to it), and an `Item Filter` Blob that holds a BC item filter expression. The item filter is used during export to decide which items belong to the collection. Collections are managed per-shop via `ShpfyProductCollectionAPI`.
+
+## The Has Variants subtlety
+
+Shopify always creates at least one variant per product. When a BC Item has no Item Variants and `UoM as Variant` is off, `ShpfyCreateProduct.CreateTempShopifyVariantFromItem` creates a single variant with an empty title (Shopify will display it as "Default Title") and sets `Has Variants` to false on the product. In this case, `ShpfyProductMapping` considers the mapping complete if the Item SystemId is set, even without an Item Variant SystemId. The `Mapped By Item` flag on the variant distinguishes this situation from a multi-variant product where variant-level mapping simply has not happened yet.

--- a/src/Apps/W1/Shopify/App/src/Shipping/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Shipping/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# Shipping
+
+This module handles shipping method synchronization from Shopify to BC, shipping charge management on orders, and fulfillment export from BC back to Shopify. It is the bridge between Shopify's delivery profiles and BC's shipment method / shipping agent concepts.
+
+## How it works
+
+`ShpfyShippingMethods` syncs Shopify delivery profiles into the `ShpfyShipmentMethodMapping` table. It walks the GraphQL hierarchy of delivery profiles, location groups, and zones to extract method definition names. Each unique name becomes a mapping row that the user can link to a BC Shipment Method Code, Shipping Agent Code, Shipping Agent Service Code, and optionally a specific shipping charges type (G/L Account, Item, or Item Charge).
+
+`ShpfyShippingCharges` runs during order import to populate `ShpfyOrderShippingCharges` records from the order's `shippingLines`. Each shipping line carries dual currency amounts (shop + presentment) and discount allocations. If a shipping line disappears from a re-imported order, it is deleted and the header amounts are adjusted down. New shipping line titles automatically create mapping rows if they do not already exist.
+
+`ShpfyExportShipments` converts BC posted sales shipments into Shopify fulfillments. It matches shipment lines to fulfillment order lines by `Shpfy Order Line Id`, respects remaining quantities, builds a GraphQL `fulfillmentCreate` mutation with tracking info, and sends it. Tracking company comes from the shipping agent's `Shpfy Tracking Company` enum (or falls back to the agent name). The tracking URL is resolved from the shipping agent's internet address, with an `OnBeforeRetrieveTrackingUrl` event for custom logic.
+
+## Things to know
+
+- The mapping table (`ShpfyShipmentMethodMapping`) is keyed by shop code + shipping method name (the Shopify title). One Shopify shipping method maps to one BC shipment method, one shipping agent, and one shipping agent service.
+- Shipping charges on orders can use a per-method type override. If the mapping row has a "Shipping Charges Type" of Item or Charge (Item), that is used instead of the shop's default Shipping Charges Account. Item Charges get auto-assigned equally across item lines.
+- Fulfillment export batches lines into GraphQL requests of up to 250 fulfillment order lines each. Larger shipments produce multiple API calls.
+- If a fulfillment order has a pending fulfillment request (status SUBMITTED), the export will attempt to accept it before fulfilling. Fulfillment orders assigned to third-party fulfillment services are skipped.
+- `ShpfyShippingEvents` exposes two integration events: `OnBeforeRetrieveTrackingUrl` for custom tracking URL generation, and `OnGetNotifyCustomer` for controlling whether Shopify sends a shipping confirmation email.
+- The `ShpfyUpdateSalesShipment` codeunit subscribes to the Posted Sales Shipment update page to allow editing the `Shpfy Fulfillment Id`, which can be used to re-trigger fulfillment export or clear a failed attempt.

--- a/src/Apps/W1/Shopify/App/src/Transactions/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Transactions/docs/CLAUDE.md
@@ -1,0 +1,17 @@
+# Transactions
+
+Order-level payment transactions imported from Shopify, plus a "Suggest Payments" report that generates cash receipt journal lines to reconcile them against BC invoices and credit memos.
+
+## How it works
+
+`ShpfyTransactions.Codeunit.al` pulls transaction data via the `GetOrderTransactions` GraphQL query for a given order. Each transaction is upserted into `ShpfyOrderTransaction.Table.al`, keyed by `Shopify Transaction Id`. During import, the codeunit auto-populates three side tables -- `ShpfyTransactionGateway`, `ShpfyCreditCardCompany`, and `ShpfyPaymentMethodMapping` -- by inserting any gateway or card company name it has not seen before. This means the payment method mapping table grows organically from real transaction data rather than being manually configured upfront.
+
+The `ShpfySuggestPayments.Report.al` report iterates over successful Capture, Sale, and Refund transactions and matches them to open customer ledger entries. It respects the order's `Processed Currency Handling` to decide whether to use shop currency or presentment currency amounts. For captures/sales it applies against posted invoices; for refunds it applies against credit memos. Any leftover amount after application creates a balancing G/L account line. The `ShpfySuggestPayments.Codeunit.al` handles the event subscriber plumbing that stamps `Shpfy Transaction Id` onto `Cust. Ledger Entry` during posting, and clears it on reversal.
+
+## Things to know
+
+- The `Payment Method` field on `ShpfyOrderTransaction` is a FlowField that looks up `ShpfyPaymentMethodMapping` using a composite key of Shop + Gateway + Credit Card Company -- if the mapping row has no `Payment Method Code` filled in, the FlowField returns blank and the journal line gets no bal. account.
+- Transactions carry both shop-currency and presentment-currency amounts, plus separate rounding fields for each. The Suggest Payments report picks the right pair based on how the order was originally processed.
+- The `Used` FlowField checks `Cust. Ledger Entry` for a matching `Shpfy Transaction Id`, preventing duplicate journal creation unless `IgnorePostedTransactions` is explicitly set.
+- Currency codes from Shopify are translated through `ImportOrder.TranslateCurrencyCode` after the initial RecordRef insert, because the translation cannot happen within the RecordRef flow.
+- The `Gift Card Id` is parsed from the transaction's `receiptJson` field, not from the main GraphQL response body.

--- a/src/Apps/W1/Shopify/App/src/Translations/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Translations/docs/CLAUDE.md
@@ -1,0 +1,17 @@
+# Translations
+
+Multi-language product synchronization between BC item translations and Shopify's translatable resources.
+
+## How it works
+
+`ShpfyTranslationApi.Codeunit.al` manages three concerns: pulling shop locales, retrieving translatable content digests, and registering translations. Shop locales are synced from Shopify's `shopLocales` query into the `ShpfyLanguage.Table.al`, with the primary locale skipped since it is handled by the shop's main language code setting. Languages removed from Shopify are deleted locally. Each language row maps a Shopify two-letter locale to a BC language code, and the `Sync Translations` flag must be enabled per language.
+
+Translation export uses the `ICreateTranslation` interface pattern. `ShpfyCreateTranslProduct.Codeunit.al` implements this for products: given a BC Item record and a Shopify language, it reads the BC item translation for that language code (via `ShpfyTranslationMgt.GetItemTranslation`) and the product body HTML. Before creating a translation record, the API retrieves Shopify's `translatableContentDigests` for the resource -- these digests are required by Shopify's `translationsRegister` mutation to identify which field version is being translated. The `ShpfyTranslation.Table.al` uses an `AddTranslation` method that creates a temporary record, compares it against the persisted version, and only keeps it if the value actually changed.
+
+## Things to know
+
+- The `Transl. Content Digest` field is mandatory for Shopify's translation API -- it ties the translation to a specific version of the source content. Stale digests will cause the mutation to fail silently.
+- The `ShpfyLanguage` table enforces that you cannot change the `Language Code` while `Sync Translations` is enabled, and vice versa, preventing misconfigured mappings.
+- Translation values are stored in BLOB fields because product descriptions can exceed normal text field limits.
+- The interface-based design (`ICreateTranslation`) allows adding translation support for new resource types without modifying the core API codeunit.
+- GraphQL data in translation values is escaped by double-escaping backslashes and quotes, which can produce unexpected results if the source text already contains escape sequences.

--- a/src/Apps/W1/Shopify/App/src/Webhooks/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Webhooks/docs/CLAUDE.md
@@ -1,0 +1,17 @@
+# Webhooks
+
+Event subscription management and incoming webhook processing. Handles registration of webhooks with Shopify and dispatching notifications to the correct BC company and shop.
+
+## How it works
+
+`ShpfyWebhooksMgt.Codeunit.al` is the central hub. When a `Webhook Notification` record is inserted, the `HandleOnWebhookNotificationInsert` event subscriber iterates over all BC companies and creates a `TaskScheduler` task for each, running `ShpfyWebhookNotification.Codeunit.al` in that company's context. The notification codeunit then finds all enabled shops matching the webhook's shop domain (reconstructed as `https://{SubscriptionID}.myshopify.com/`) and dispatches based on the resource type name -- `ORDERS_CREATE` triggers an order sync, `BULK_OPERATIONS_FINISH` processes the bulk operation result.
+
+Webhook registration uses `ShpfyWebhooksAPI.Codeunit.al` to create subscriptions via GraphQL. Before creating a new subscription, the existing one (if any) is deleted both locally and in Shopify. The local `Webhook Subscription` record uses the shop domain as the subscription ID and the webhook topic as the endpoint. Disabling a webhook is multi-company aware: before deleting the Shopify subscription, it checks all companies for other shops with the same URL that still have the webhook enabled, and if found, transfers ownership of the local subscription record to that company instead of deleting it.
+
+## Things to know
+
+- Webhooks are shared across companies -- a single Shopify webhook subscription serves all BC companies that have a shop with the matching Shopify URL. The `Company Name` on `Webhook Subscription` indicates the "owning" company, but all companies process the notification.
+- Each notification creates one `TaskScheduler` task per company, regardless of whether that company has a matching shop. The task's codeunit exits early if no enabled shop matches the domain.
+- Order-created webhook processing is deduplicated: before scheduling a new sync, it checks for existing `Ready`-state job queue entries for the same shop filter and skips if one exists.
+- The `Run Notification As` user ID on the webhook subscription determines which user context the webhook tasks execute under. Changing the user on one shop propagates to all other shops with the same URL via `ChangePrevWebhookUserId`.
+- Company deletion triggers automatic webhook cleanup -- the `OnBeforeDeleteEvent` subscriber on the `Company` table disables all webhooks for shops in the deleted company, but skips cleanup if the tenant license state is Suspended, Deleted, or LockedOut.

--- a/src/Apps/W1/Shopify/App/src/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/src/docs/business-logic.md
@@ -1,0 +1,71 @@
+# Business logic
+
+## Product synchronization
+
+Product sync is bidirectional, controlled by `Shop."Sync Item"` ("To Shopify" or "From Shopify"). The entry point is `Shpfy Sync Products` (30185).
+
+**Import (Shopify to BC)** starts with `ProductApi.RetrieveShopifyProductIds`, which fetches product IDs updated since the last sync time. For each ID, the full product data is fetched and written to the `Shpfy Product` and `Shpfy Variant` tables. If the product is already linked to a BC Item (via `Item SystemId`), the existing link is preserved. If not, and `Auto Create Unknown Items` is enabled on the Shop, a new Item is created from the configured item template. The sync records the timestamp so subsequent runs are incremental.
+
+**Export (BC to Shopify)** is driven by `Shpfy Product Export`, which iterates BC Items and matches them to existing Shopify products via the SystemId link. Hash-based change detection (`Image Hash`, `Tags Hash`, `Description Html Hash`) prevents unnecessary API calls. New items that have no Shopify counterpart are created via the `productCreate` mutation. Price sync can run independently of full product sync via the `OnlySyncPrice` flag, which is also exposed through the Bulk Operations system for better throughput.
+
+A subtle gotcha: product images and product data are synced by separate codeunits (`Shpfy Sync Product Image` vs `Shpfy Sync Products`). Image sync runs after product sync and uses the `Image Hash` to detect changes. Image uploads go through Shopify's staged upload mechanism (create upload URL, upload to staging, then attach to product).
+
+## Order import and processing
+
+Order processing is a three-phase pipeline: Import -> Mapping -> Processing.
+
+**Import** (`Shpfy Import Order`, `Shpfy Orders API`) fetches orders from Shopify that have been updated since the last sync. The import writes raw Shopify data to `Shpfy Order Header` and `Shpfy Order Line`. This phase also imports associated data: tax lines, shipping charges, discount applications, attributes, and refunds. The import deducts refund quantities from order line quantities -- this is the "refund netting" behavior, and it means that by the time an order reaches BC, the quantities already reflect any partial refunds. There is an event (`OnAfterDeductRefundedQuantity`) that fires after this netting for extensions that need to react.
+
+**Mapping** (`Shpfy Order Mapping`) resolves Shopify entities to BC entities: customer mapping (via the configurable `ICustomerMapping` strategy), shipment method mapping, shipping agent mapping, and payment method mapping. Each mapping step has Before/After integration events. If the order is B2B, company mapping runs instead of (or in addition to) customer mapping. Mapping can fail if a required entity cannot be resolved and auto-creation is disabled.
+
+**Processing** (`Shpfy Process Order`, 30166) creates the BC sales document. The document type is determined by fulfillment status: if the order is fully fulfilled and `Create Invoices From Orders` is enabled, a Sales Invoice is created; otherwise, a Sales Order. The codeunit copies all three address sets (sell-to, bill-to, ship-to) from the order header, handles currency selection based on the Shop's `Currency Handling` setting, and creates lines for items, shipping charges, and tips. Gift card lines are handled specially -- they go to the `Sold Gift Card Account` G/L account. Auto-release is configurable via `Auto Release Sales Orders`.
+
+A non-obvious detail: the `Use Shopify Order No.` setting causes the BC document to use the Shopify order number (e.g. "#1001") as its document No., which requires the number series to have `Allow Manual Nos.` enabled.
+
+## Customer synchronization
+
+Customer sync is more nuanced than product sync because of the mapping strategies. The `Customer Import From Shopify` enum controls when customers are imported: "All Customers" fetches everyone, "With Order Import" only imports customers referenced by orders.
+
+The mapping strategy (`Customer Mapping Type` on Shop) determines how a Shopify customer is matched to a BC customer. The `ICustomerMapping` interface has implementations for email-based, phone-based, bill-to-based, and default-customer strategies. Each strategy attempts to find an existing BC customer; if none is found and `Auto Create Unknown Customers` is enabled, a new customer is created from the template specified on the Shop.
+
+Name resolution is a separate concern from mapping. The `Name Source`, `Name 2 Source`, and `Contact Source` settings on the Shop table control how Shopify's first name, last name, and company name are assembled into BC's Name, Name 2, and Contact fields. The `County Source` setting controls whether the province code or name is used for the BC county field.
+
+Update direction is bidirectional but exclusive: `Shopify Can Update Customer` and `Can Update Shopify Customer` are mutually exclusive flags on the Shop.
+
+## Inventory synchronization
+
+`Shpfy Sync Inventory` (30197) runs in two phases: import current stock levels from Shopify, then export calculated BC stock levels back to Shopify.
+
+The import phase iterates `Shpfy Shop Location` records that have a non-disabled `Stock Calculation` method, calling `InventoryApi.ImportStock` for each. The export phase uses the `Shpfy Stock Calculation` interface to compute available stock. Built-in implementations include "Free Inventory" (on hand minus reserved) and "Balance Today" (projected balance as of today). Extensions can add custom calculations.
+
+Location mapping is critical: each `Shpfy Shop Location` maps a Shopify location to a BC location and specifies the stock calculation method to use. The `Shpfy Inventory Item` table tracks which Shopify inventory items exist and their tracking settings.
+
+The inventory API uses `inventorySetQuantities` mutations to push stock levels, which is an absolute-set operation (not a delta). The connector also supports activating inventory tracking on Shopify items via `inventoryItemUpdate`.
+
+## Return and refund processing
+
+Returns and refunds are imported as part of order sync. The `Return and Refund Process` setting on the Shop controls what happens after import.
+
+With "Import Only", return and refund data is stored in `Shpfy Return Header/Line` and `Shpfy Refund Header/Line` but no BC documents are created. This is the default and safest option.
+
+With "Auto Create Credit Memo", the `IReturnRefundProcess` interface implementation creates a BC Sales Credit Memo from the refund data. The credit memo uses the refund lines to determine quantities and amounts. The `Refund Account` and `Refund Acc. non-restock Items` G/L accounts on the Shop control where non-item refund amounts are posted.
+
+The `Return Location Priority` setting determines which BC location is used for the credit memo: the return location configured on the Shop, or the location from the original order.
+
+A key distinction: refund netting (deducting refund quantities from order lines) happens during order import regardless of the `Return and Refund Process` setting. The processing setting only controls whether a separate credit memo is created.
+
+## Fulfillment export
+
+When a BC sales shipment is posted, the connector can export it as a Shopify fulfillment. The `Shpfy Order Fulfillments` codeunit handles this, creating fulfillments via the `fulfillmentCreate` mutation. Tracking information (number, URL, company) from the BC shipment is included.
+
+The `Send Shipping Confirmation` flag on the Shop controls whether Shopify sends a shipping notification email to the customer when the fulfillment is created.
+
+Fulfillment orders (the intent side) are imported from Shopify for visibility but are not directly created or modified by the connector. The connector works with the actual fulfillment API.
+
+## Background sync
+
+Background sync is managed through BC's Job Queue infrastructure. Each sync type (products, customers, orders, inventory, companies) can be scheduled as a recurring job queue entry. The `Allow Background Syncs` flag on the Shop enables this.
+
+Webhook-driven order import is an alternative to polling. When `Order Created Webhooks` is enabled on the Shop, a Shopify webhook subscription is created. When an order is created in Shopify, the webhook fires, BC's webhook infrastructure receives it, and `Shpfy Webhook Notification` (30363) processes it. The handler is multi-company aware: it looks up the Shop by URL across all companies with that Shop enabled and schedules a task in each matching company.
+
+Bulk operations (e.g. bulk product price updates) use Shopify's async bulk mutation API. The connector submits a JSONL payload via `bulkOperationRunMutation`, then polls or receives a webhook when the operation completes. The `Shpfy Bulk Operation` table tracks the operation status and the `IBulk Operation` interface handles revert logic for failed requests.

--- a/src/Apps/W1/Shopify/App/src/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/src/docs/data-model.md
@@ -1,0 +1,85 @@
+# Data model
+
+## Shop configuration
+
+`Shpfy Shop` (30102) is the central configuration hub and the closest thing this app has to a settings table. Every sync codeunit, every API call, and every mapping decision reads from it. It stores sync direction flags (e.g. `Sync Item` = "To Shopify" or "From Shopify"), customer and company mapping strategy enums, template codes for auto-creation, currency handling, tax area configuration, G/L accounts for shipping charges and tips, and webhook state. The Shop also holds `B2B Enabled`, which is derived from the Shopify plan (Plus or Development) rather than being user-configured.
+
+Each shop tracks its last sync time per sync type via the `Shpfy Synchronization Info` table, keyed by Shop Code (or Shop Id for orders). The Shop Id is a hash of the Shopify URL, not the Shopify internal shop id -- this is important because order sync uses it as a cross-company identifier to prevent duplicate imports when the same Shopify store is connected to multiple BC companies.
+
+`Shpfy Shop Location` maps Shopify locations to BC locations and controls the stock calculation method per location via an extensible enum that resolves to a `Shpfy Stock Calculation` interface implementation.
+
+## Product catalog
+
+The product hierarchy is Product -> Variant -> InventoryItem. `Shpfy Product` (30127) is the parent, linked to a BC Item via `Item SystemId` (Guid). `Shpfy Variant` (30129) belongs to a Product and is linked to both a BC Item (`Item SystemId`) and optionally a BC Item Variant (`Item Variant SystemId`). `Shpfy Inventory Item` (30126) is the physical-inventory counterpart of a variant, carrying country of origin and tracking settings.
+
+Products support up to three option dimensions (Option 1/2/3 Name + Value on the variant), which Shopify uses for things like size/color. The `UoM as Variant` feature on the Shop table repurposes one of these option slots to represent BC units of measure as Shopify variants -- an unusual mapping that means a single BC item with multiple UoMs becomes a single Shopify product with multiple variants.
+
+Change detection uses integer hashes stored on the Product table: `Image Hash`, `Tags Hash`, and `Description Html Hash`. During export, BC computes the hash of the current state and compares it to the stored value. If unchanged, the API call is skipped. This is a performance optimization, not a conflict resolution mechanism.
+
+Products also participate in `Shpfy Product Collection` and `Shpfy Shop Collection Map` for managing Shopify collections (analogous to item categories), and `Shpfy Sales Channel` for controlling product visibility.
+
+## Customer management
+
+`Shpfy Customer` (30105) stores Shopify customer data and links to a BC Customer via `Customer SystemId`. The `Customer No.` field is a FlowField that resolves through the Guid. Customers have child `Shpfy Customer Address` records. The `Shpfy Customer Template` table allows mapping Shopify customers to different BC customer templates based on country.
+
+The customer mapping strategy is driven by the `Customer Mapping Type` enum on the Shop table, which resolves to an `ICustomerMapping` interface implementation. Strategies include: by email, by phone, by bill-to info, always use a default customer, or by email/phone combined. The mapping decision happens during order processing, not customer sync -- this matters because a customer might exist in Shopify but not yet be linked in BC when an order arrives.
+
+Name resolution is separately configurable: `Name Source`, `Name 2 Source`, and `Contact Source` fields on the Shop table control how Shopify's first/last name and company name are mapped to BC's Name, Name 2, and Contact fields using the `ICustomerName` interface.
+
+`Shpfy Tax Area` maps Shopify province/country combinations to BC tax areas, with a configurable priority (`Tax Area Priority` on Shop) for which geographic dimension takes precedence.
+
+## B2B (companies)
+
+`Shpfy Company` (30150) represents a Shopify B2B company and links to a BC Customer via `Customer SystemId` (same pattern as customers). `Shpfy Company Location` (30151) represents the company's locations in Shopify and maps to the same BC customer. Companies have a main contact that links back to a `Shpfy Customer`.
+
+`Shpfy Catalog` (30152) enables per-company pricing. Each catalog is linked to a company via `Company SystemId` and can have its own Customer Price Group and Customer Discount Group, overriding the shop-level defaults. `Shpfy Catalog Price` stores the actual price list entries synced to Shopify. `Shpfy Market Catalog Relation` tracks which Shopify markets a catalog is published to.
+
+Company mapping is controlled by `Company Mapping Type` on the Shop table, using the `ICompanyMapping` interface. Tax registration ID mapping is handled by a separate `Shpfy Comp. Tax Id Mapping` interface.
+
+## Order lifecycle
+
+`Shpfy Order Header` (30118) is the richest table in the app. It carries triple-address (sell-to, bill-to, ship-to), dual-currency amounts (shop currency and presentment currency for every monetary field), B2B fields (Company Id, Company Location Id, PO Number, Due Date, Payment Terms), financial and fulfillment status enums, and linked BC document numbers (Sales Order No., Sales Invoice No.).
+
+`Shpfy Order Line` (30119) carries the line-level detail with Shopify Product/Variant Ids, quantities, prices, discount amounts, and a `Gift Card` and `Tip` boolean for special line handling. Lines also have presentment-currency counterparts for amounts.
+
+Supporting tables include `Shpfy Order Attribute` (key-value pairs from Shopify's note attributes), `Shpfy Order Tax Line` (with channel-liable flag), `Shpfy Order Shipping Charges`, `Shpfy Order Disc. Appl.` (discount applications recording which discounts applied to which lines), and `Shpfy Order Line Attribute`.
+
+`Shpfy Orders to Import` is a staging table used during webhook-driven or manual import. Records enter here first with minimal data, then the full import fills out the Order Header.
+
+## Fulfillment
+
+Two parallel systems coexist. `Shpfy FulFillment Order Header` (30143) and `Shpfy FulFillment Order Line` (30144) represent Shopify's fulfillment orders -- the intent to fulfill specific line items from a specific location. These are imported from Shopify and represent what needs to be shipped.
+
+`Shpfy Order Fulfillment` (30111) and `Shpfy Fulfillment Line` represent actual shipments -- what has been shipped, with tracking numbers and carrier info. The connector exports BC sales shipments as Shopify fulfillments. These two hierarchies are not parent-child; they represent different stages of the fulfillment lifecycle.
+
+## Returns and refunds
+
+Returns and refunds are intentionally separate. `Shpfy Return Header` (30147) and `Shpfy Return Line` represent the customer's return request, with status tracking, decline reasons, and a `Restock Type` enum on the line level (Return, Cancel, NoRestock). Returns have a `Discounted Total Amount` and its presentment counterpart.
+
+`Shpfy Refund Header` (30142) and `Shpfy Refund Line` represent the financial reversal. A refund may link to a return via `Return Id`, but can exist independently (e.g. for an appeasement refund without a physical return). `Shpfy Refund Shipping Line` handles shipping cost refunds separately.
+
+The `Return and Refund Process` enum on the Shop table controls processing strategy: "Import Only" (just store the data) or "Auto Create Credit Memo" (automatically generate a BC sales credit memo). This is implemented via the `IReturnRefundProcess` interface.
+
+## Payments and transactions
+
+`Shpfy Order Transaction` (30117) records payment transactions against orders -- authorization, capture, refund. It links to `Shpfy Transaction Gateway` and `Shpfy Credit Card Company` for payment method identification. `Shpfy Payment Method Mapping` maps Shopify gateways to BC payment methods. `Shpfy Suggest Payment` is a helper for suggesting payment applications.
+
+`Shpfy Payout` and `Shpfy Payment Transaction` support payout reconciliation -- matching Shopify's periodic payouts to individual order transactions. `Shpfy Dispute` tracks payment disputes/chargebacks.
+
+`Shpfy Payment Terms` maps Shopify payment terms to BC payment terms, used primarily for B2B orders with net terms.
+
+## Cross-cutting patterns
+
+**SystemId linking** -- Every entity link (Product->Item, Variant->Item Variant, Customer->Customer, Company->Customer) uses a Guid `SystemId` field with a FlowField for the human-readable Code/No. This survives renumbering and works across companies.
+
+**Dual currency** -- Orders, refunds, and returns all carry amounts in both shop currency and presentment currency. The Shop's `Currency Handling` enum determines which is used for BC document creation.
+
+**Negative auto-incrementing IDs** -- Staging records (like orders to import) use negative BigInteger IDs as temporary placeholders before real Shopify IDs are assigned.
+
+**Document Link traceability** -- `Shpfy Doc. Link To Doc.` (30146) provides a generic many-to-many link between Shopify document types and BC document types, with interface-based navigation in both directions.
+
+**Metafields** -- `Shpfy Metafield` (30101) is a generic key-value store keyed by `Parent Table No.` and `Owner Id`, supporting products, variants, customers, and companies. Metafield definitions and types are handled via `IMetafieldOwnerType` and `IMetafieldType` interfaces.
+
+**Tags** -- `Shpfy Tag` is a generic tag table shared across entity types, keyed by Parent Id.
+
+**Data capture** -- The logging system (`Shpfy Log Entry`) records API requests and responses when enabled, with configurable logging mode (errors only vs. all) and automatic retention policy integration.

--- a/src/Apps/W1/Shopify/App/src/docs/extensibility.md
+++ b/src/Apps/W1/Shopify/App/src/docs/extensibility.md
@@ -1,0 +1,82 @@
+# Extensibility
+
+The Shopify Connector exposes integration events, extensible enums with interface implementations, and subscribable internal events. The primary extension surface is through events in `Shpfy Order Events` (30162), `Shpfy Product Events`, `Shpfy Inventory Events`, and the various mapping interfaces.
+
+## Customize product mapping and pricing
+
+To control how BC items map to Shopify products, subscribe to the product export events. The product export raises events before and after creating or updating each product, giving you access to both the BC Item and the Shopify product data. For custom pricing logic, you can subscribe to the price calculation events or -- for B2B -- configure catalog-level `Customer Price Group` and `Customer Discount Group` overrides on individual `Shpfy Catalog` records.
+
+For SKU mapping, the `SKU Mapping` enum on the Shop is extensible. Built-in options include Item No., Variant Code, Item No. + Variant Code, and Barcode. You can add custom SKU strategies by extending the enum and implementing the mapping.
+
+## Customize order creation
+
+Order processing in `Shpfy Process Order` fires a rich set of events at every stage.
+
+- **OnBeforeCreateSalesHeader / OnAfterCreateSalesHeader** -- Control document type (order vs. invoice), set custom fields, change the customer. The `IsHandled` pattern on `OnBeforeCreateSalesHeader` lets you completely take over header creation.
+- **OnBeforeCreateItemSalesLine / OnAfterCreateItemSalesLine** -- Modify line quantities, change the item, add dimensions, set location codes. Again, `IsHandled` on the Before event lets you replace the standard logic.
+- **OnBeforeCreateShippingCostSalesLine / OnAfterCreateShippingCostSalesLine** -- Customize how shipping charges become sales lines.
+- **OnBeforeProcessSalesDocument / OnAfterProcessSalesDocument** -- Wrap the entire processing with pre/post logic.
+
+A common extension pattern is setting dimensions on sales documents based on Shopify channel or order attributes. Subscribe to `OnAfterCreateSalesHeader`, read the order attributes from `Shpfy Order Attribute`, and set dimension values on the sales header.
+
+## Customize customer matching
+
+The `Customer Mapping Type` enum on the Shop table is extensible. To add a custom strategy:
+
+1. Extend the `Shpfy Customer Mapping` enum with your new option.
+2. Implement the `Shpfy ICustomer Mapping` interface on a codeunit.
+3. Your `DoMapping` procedure receives the Shopify customer ID, a JSON object with address info, the shop code, template code, and an AllowCreate flag.
+
+For example, to match customers by a custom field, extend the enum and write a codeunit that queries BC customers by that field using the data from the JSON parameter.
+
+The `OnBeforeMapCustomer` / `OnAfterMapCustomer` events on `Shpfy Order Events` provide an alternative: you can subscribe and set the `Sell-to Customer No.` directly on the order header before or after standard mapping runs. The `Handled` parameter on `OnBeforeMapCustomer` lets you skip standard mapping entirely.
+
+## Customize stock calculation
+
+The `Stock Calculation` enum on `Shpfy Shop Location` is extensible. To add a custom stock method:
+
+1. Extend the `Shpfy Stock Calculation` enum.
+2. Implement the `Shpfy Stock Calculation` interface (`GetStock` procedure that receives a filtered Item record and returns a decimal).
+3. Optionally implement `Shpfy IStock Available` to control whether the item is considered "in stock" at all.
+
+Additionally, `Shpfy Inventory Events` provides events for further adjustment after the stock calculation runs, useful for applying safety stock or custom availability rules.
+
+## Customize refund and return processing
+
+The `Shpfy ReturnRefund ProcessType` enum is extensible. To add a custom processing strategy:
+
+1. Extend the enum.
+2. Implement the `Shpfy IReturnRefund Process` interface.
+3. Your implementation controls three things: whether import is needed for a given source document type, whether a sales document can be created, and the actual document creation logic.
+
+The `IDocumentSource` and `IExtendedDocumentSource` interfaces provide further control over which source documents are used for credit memo creation.
+
+## Customize B2B company matching
+
+The `Company Mapping Type` enum on the Shop is extensible, following the same pattern as customer mapping. Implement `Shpfy ICompany Mapping` with a `DoMapping` procedure that receives the Shopify company ID, shop code, template code, and AllowCreate flag.
+
+The `OnBeforeMapCompany` / `OnAfterMapCompany` events on `Shpfy Order Events` let you override company mapping for orders without implementing a full strategy.
+
+Tax registration ID mapping for B2B companies is handled by the `Shpfy Comp. Tax Id Mapping` interface, which is also extensible via its enum.
+
+## Add custom GraphQL queries
+
+To add a new GraphQL query to the connector (typically in a fork or contribution):
+
+1. Create a new codeunit implementing `Shpfy IGraphQL`.
+2. `GetGraphQL()` returns the query string with `{{placeholders}}` for dynamic values.
+3. `GetExpectedCost()` returns the estimated query cost for rate limiting. This must be accurate -- underestimating causes throttling, overestimating causes unnecessary waits.
+4. Add a new value to the `Shpfy GraphQL Type` enum pointing to your codeunit.
+5. Call it through `CommunicationMgt.ExecuteGraphQL(GraphQLType)`.
+
+## Common extension examples
+
+**Show Shopify fields on sales documents** -- Use page extensions on Sales Order / Sales Invoice to show `Shpfy Order Id` and `Shpfy Order No.` fields that are added to the Sales Header table extension. Subscribe to `OnAfterCreateSalesHeader` to populate custom fields.
+
+**Custom pricing based on Shopify data** -- Subscribe to the product export price calculation events. You can read the Shopify product/variant data (including metafields and tags) and adjust the price before it is sent to Shopify.
+
+**Channel-based customer mapping** -- Subscribe to `OnBeforeMapCustomer`, read the `Channel Name` or `App Name` from the order header, and assign a different customer based on the sales channel (e.g. POS vs. online store vs. wholesale).
+
+**Order-level dimensions from Shopify attributes** -- Subscribe to `OnAfterCreateSalesHeader`, iterate `Shpfy Order Attribute` records for the order, and use `DimensionManagement` to set dimensions on the sales header based on attribute values.
+
+**Custom stock calculation with safety stock** -- Extend the `Shpfy Stock Calculation` enum, implement the interface to subtract a safety stock quantity from the standard calculation, and configure the new method on the relevant shop locations.

--- a/src/Apps/W1/Shopify/App/src/docs/patterns.md
+++ b/src/Apps/W1/Shopify/App/src/docs/patterns.md
@@ -1,0 +1,93 @@
+# Patterns
+
+## GraphQL query abstraction
+
+Every Shopify API query is encapsulated in its own codeunit implementing `Shpfy IGraphQL`. This interface has two methods: `GetGraphQL()` returns the raw query string (with `{{placeholder}}` tokens for dynamic values), and `GetExpectedCost()` returns the estimated cost in Shopify's query cost units. There are roughly 145 such codeunits in the GraphQL module.
+
+The dispatcher (`Shpfy GraphQL Queries`) resolves an enum value to the correct interface implementation and substitutes placeholders before execution. The rate limiter (`Shpfy GraphQL Rate Limit`, also SingleInstance) reads `currentlyAvailable` and `restoreRate` from each response's throttle status and calculates sleep time before the next request based on the upcoming query's declared cost.
+
+This one-codeunit-per-query pattern looks unusual but provides precise cost tracking and makes each query independently testable. When adding queries, get the expected cost right -- the rate limiter formula is `waitTime = max(expectedCost - available, 0) / restoreRate * 1000 - elapsed`, with a default restore rate of 50 points/second.
+
+## SystemId linking
+
+All entity links between Shopify and BC use `SystemId` (Guid) rather than Code or No. For example, `Shpfy Product."Item SystemId"` is a Guid field, and `Shpfy Product."Item No."` is a FlowField with `CalcFormula = lookup(Item."No." where(SystemId = field("Item SystemId")))`. The same pattern appears on Variant (Item SystemId + Item Variant SystemId), Customer (Customer SystemId), Company (Customer SystemId), and Catalog (Company SystemId).
+
+This design survives BC entity renumbering and avoids the brittle Code-based linking that older BC integrations used. The tradeoff is that you cannot filter or join on the linked entity's Code directly in queries -- you must either CalcFields the FlowField or do a separate lookup.
+
+## Hash-based change detection
+
+The Product table stores `Image Hash`, `Tags Hash`, and `Description Html Hash` as Integer fields. During export, the connector computes a hash of the current value and compares it to the stored hash. If they match, the export skips the API call for that field/entity.
+
+The hash is computed by `Shpfy Hash` (a utility codeunit) and is a non-cryptographic integer hash. It is purely an optimization -- the connector does not use it for conflict resolution or versioning. If the hash logic produces a collision, the worst case is a skipped update, which will be caught on the next sync when the stored hash is overwritten.
+
+## Dual currency architecture
+
+Orders, refunds, and returns carry every monetary field in two currencies: shop currency (`Currency Code`) and presentment currency (`Presentment Currency Code`). The shop currency is the store's base currency; the presentment currency is what the buyer saw at checkout (which may differ if the store supports multi-currency).
+
+The `Currency Handling` enum on the Shop table (`Shop Currency` vs. `Presentment Currency`) determines which set of amounts is used when creating BC sales documents. This selection happens in `Shpfy Process Order.CreateHeaderFromShopifyOrder` and flows through to all line amount assignments.
+
+This dual-currency pattern means any code that reads order amounts must be aware of which currency it is working with. The naming convention is consistent: presentment fields are prefixed with "Presentment" or "Pres." (e.g. `Presentment Total Amount`, `Pres. Shipping Charges Amount`).
+
+## Negative auto-incrementing IDs
+
+Several staging and pre-sync tables use negative BigInteger IDs as temporary identifiers. The most visible example is `Shpfy Orders to Import`, where records receive a negative ID during the initial webhook notification or manual import trigger. The real Shopify ID replaces this negative value after the full order data is fetched.
+
+This pattern avoids conflicts with real Shopify IDs (which are always positive) and makes it easy to identify records that are still in the staging phase (negative = not yet synced).
+
+## Extensible enums with interface implementation
+
+The app uses AL's extensible enum + interface pattern extensively for strategy selection. Key examples:
+
+- `Shpfy Customer Mapping` enum -> `ICustomerMapping` interface
+- `Shpfy Company Mapping` enum -> `ICompanyMapping` interface
+- `Shpfy Stock Calculation` (on Shop Location) -> `Shpfy Stock Calculation` interface
+- `Shpfy ReturnRefund ProcessType` enum -> `IReturnRefundProcess` interface
+- `Shpfy Remove Product Action` enum -> `IRemoveProductAction` interface
+- `Shpfy GraphQL Type` enum -> `IGraphQL` interface
+- `Shpfy Cr. Prod. Status Value` enum -> `ICreateProductStatusValue` interface
+
+The pattern is always the same: the Shop or related configuration table stores the enum value, and the business logic resolves it to an interface implementation at runtime. This is how third-party extensions plug in custom behavior without modifying the base app.
+
+## Data capture for debugging
+
+The `Shpfy Log Entry` table records API interactions when `Logging Mode` is set to "All" on the Shop. Each entry captures the URL, request body, response body, status code, and duration. The logging infrastructure also integrates with BC's retention policy framework -- when logging is enabled, a retention policy setup is automatically activated to prevent unbounded growth.
+
+The `Data Capture` blob fields on various tables (e.g. Order Header, Order Line) store the raw JSON from the Shopify API response that was used to populate the record. This is invaluable for debugging mapping issues: you can compare the captured JSON against the table fields to see exactly what was parsed.
+
+## Webhook-driven job queue (multi-company)
+
+Webhooks in the Shopify Connector use BC's built-in `Webhook Notification` infrastructure. The `Shpfy Webhook Notification` codeunit (30363) is registered as the handler. When a notification arrives, it extracts the shop domain from the subscription ID, then queries `Shpfy Shop` across the current company for a matching enabled shop.
+
+The multi-company aspect is handled by BC's webhook infrastructure itself, which dispatches to each company that registered the subscription. Within a company, if multiple Shop records match (unusual but possible with different shop codes pointing to the same URL), the handler iterates all of them.
+
+Webhook subscriptions are managed by `Shpfy Webhooks Mgt.`, which creates/deletes subscriptions via GraphQL mutations and stores the webhook ID and user ID on the Shop record. The user whose credentials created the subscription is the user under whose context the background task runs.
+
+## Bulk operations pattern
+
+For high-volume mutations (product image updates, price updates), the connector uses Shopify's bulk operations API. The `IBulk Operation` interface defines the contract: `GetGraphQL()` for the mutation template, `GetInput()` for the JSONL payload, and `RevertFailedRequests()` / `RevertAllRequests()` for handling failures.
+
+The flow is: submit mutation via `bulkOperationRunMutation` -> receive a bulk operation ID -> poll for completion (or receive a `BULK_OPERATIONS_FINISH` webhook) -> download results -> process successes and revert failures.
+
+The `Shpfy Bulk Operation` table tracks the lifecycle. Current implementations include `Shpfy Bulk Update Product Image` and `Shpfy Bulk Update Product Price`.
+
+## SingleInstance communication codeunit
+
+`Shpfy Communication Mgt.` (30103) is marked `SingleInstance = true`, meaning one instance persists for the lifetime of the session. It holds the current Shop record, the API version string, and coordinates with the also-SingleInstance `Shpfy GraphQL Rate Limit` codeunit.
+
+This design ensures that rate-limiting state (available points, restore rate, last request time) survives across multiple API calls within the same session. The tradeoff is that you must call `SetShop()` before any API call to ensure the codeunit is operating against the correct shop -- forgetting this will send requests to whichever shop was last configured.
+
+---
+
+## Legacy patterns to avoid
+
+These patterns exist in the codebase but should not be replicated in new code.
+
+**Large monolithic codeunits** -- Some older codeunits (e.g. `Shpfy Order Mgt.`) have grown to 50+ procedures covering multiple responsibilities. New code should split logic into focused codeunits with clear single responsibilities.
+
+**Pragma warning disable for obsolete events** -- Several event publishers use `#pragma warning disable AS0025` to suppress signature-change warnings on integration events. This was needed for backward compatibility during event evolution, but new events should be designed with stable signatures from the start.
+
+**Direct field assignment without Validate()** -- The order processing code copies many address fields from the Shopify order header to the BC sales header using direct assignment (`:=`) rather than `Validate()`. This is intentional for address fields (to avoid triggering address validation cascades) but can be confusing. New field mappings should use `Validate()` unless there is a specific reason not to, and that reason should be commented.
+
+**InternalEvent where IntegrationEvent should be used** -- Some events are marked `[InternalEvent(false)]` when they should be `[IntegrationEvent(false, false)]`. Internal events are only visible within the app, which prevents third-party extensions from subscribing. Use `IntegrationEvent` for any event that an extension might need.
+
+**Overly complex event parameter lists** -- Some events pass 5-8+ parameters (the order header, order line, sales header, sales line, plus a handled flag). This makes subscribers brittle. New events should prefer passing record parameters and letting subscribers read what they need, rather than passing individual field values.


### PR DESCRIPTION
## Summary

- Bootstrap hierarchical developer documentation for the Shopify Connector app (29 files, 934 lines across 22 directories)
- App-level docs: CLAUDE.md overview, data-model.md, business-logic.md, extensibility.md, patterns.md
- Per-module CLAUDE.md for all 21 documented subfolders (Products, Order handling, Customers, Companies, GraphQL, etc.)

Documentation focuses on intent, relationships, gotchas, and design decisions -- not mechanical field/procedure listings. Every claim traces to actual AL source code analysis.

## Test plan

- [ ] Verify docs render correctly in GitHub markdown preview
- [ ] Spot-check 2-3 docs against source code for accuracy
- [ ] Confirm no sensitive information or credentials in docs
- [ ] Verify cross-references between app-level and subfolder docs are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
