### PR TITLE
Add AL documentation for Shopify Connector

### DIFF
--- a/src/Apps/W1/Shopify/App/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/CLAUDE.md
@@ -1,0 +1,63 @@
+# Shopify Connector
+
+The Shopify Connector provides bidirectional synchronization between Shopify stores and Business Central. It imports orders, products, customers, and companies from Shopify, converts them into BC sales documents, and pushes inventory levels, product updates, and shipment fulfillments back. It uses the Shopify GraphQL Admin API exclusively -- there is no REST API usage.
+
+## Quick reference
+
+- **ID range**: 30100--30460
+- **Dependencies**: None (zero-dependency app, only references the BC base application)
+
+## How it works
+
+Everything flows through the **Shop table** (`Shpfy Shop`, table 30102). This is the god object -- a single record controls which direction products sync, how customers map, whether orders auto-create, what currency model to use, which GL accounts receive tips and gift cards, and dozens more settings. Every sync operation starts by reading its Shop record and branching on its configuration fields.
+
+The core sync loop is timestamp-based. The connector fetches ID+UpdatedAt pairs from Shopify via GraphQL, compares them against stored `Updated At` and `Last Updated by BC` timestamps, and only processes records that changed since the last sync. The `Last Updated by BC` field prevents ping-pong: when BC pushes an update to Shopify, it stamps this field so the next import cycle skips the record Shopify just confirmed. Each entity domain (products, customers, companies, orders) follows this same pattern.
+
+Records that need importing are collected into a **temporary record set**, then processed one at a time inside a `Commit(); ClearLastError(); if not Codeunit.Run() then ...` loop. This isolates failures per record -- if one product fails to import, the error is captured and the loop continues. The Commit before Run ensures prior successful work is saved. This is the connector's primary error isolation strategy.
+
+The connector links Shopify entities to BC records using **SystemId (GUID) fields** rather than Code fields. For example, `Shpfy Product."Item SystemId"` points to the Item's SystemId, and a CalcFormula FlowField derives the readable Item No. This means renumbering items in BC does not break the link. The same pattern applies to customers, companies, and variants.
+
+The connector does NOT run Shopify operations in real-time from BC UI transactions. All syncs are batch operations, typically run via Job Queue entries through the `Shpfy Background Syncs` codeunit. It does not support real-time webhooks for all entity types -- only order creation and bulk operations have webhook support.
+
+## Structure
+
+- **Base/** -- Shop table (the config god object), background sync orchestration, communication layer, hashing, tags, cue table
+- **GraphQL/** -- IGraphQL interface and 145+ query/mutation codeunits, rate limit management, query registry
+- **Products/** -- Product/variant tables, import/export/sync codeunits, product events, SKU mapping, image sync
+- **Customers/** -- Customer/address tables, customer mapping interfaces (by email, phone, name+address), sync and export
+- **Companies/** -- B2B company/location tables, company mapping interfaces, tax registration ID mapping
+- **Order handling/** -- Order header/line tables, order import from Shopify, order-to-sales-document processing, order mapping
+- **Order Fulfillments/** -- Fulfillment order/line tables, shipment export to Shopify
+- **Order Returns/** -- Return header/line tables imported from Shopify
+- **Order Refunds/** -- Refund header/line tables, refund shipping lines
+- **Order Return Refund Processing/** -- IReturnRefundProcess interface, credit memo auto-creation from refunds
+- **Inventory/** -- Shop location mapping, stock calculation interfaces, inventory sync to Shopify
+- **Payments/** -- Payout, dispute, and payment terms tables
+- **Transactions/** -- Order transaction tables, payment method mapping, credit card companies
+- **Metafields/** -- Generic metafield table with IMetafieldType and IMetafieldOwnerType interfaces
+- **Catalogs/** -- B2B catalog/price list tables for company-specific pricing
+- **Bulk Operations/** -- Async bulk operation support with webhook callbacks
+- **Document Links/** -- Shpfy Doc. Link To Doc. table connecting Shopify documents to BC documents
+- **Shipping/** -- Shipment method mapping, shipping charges, shipping events
+- **Translations/** -- Language/translation tables for multi-language product sync
+- **Webhooks/** -- Webhook subscription management for order creation and bulk operations
+
+## Documentation
+
+- [docs/data-model.md](docs/data-model.md) -- How the data fits together
+- [docs/business-logic.md](docs/business-logic.md) -- Processing flows and gotchas
+- [docs/extensibility.md](docs/extensibility.md) -- Extension points and how to customize
+- [docs/patterns.md](docs/patterns.md) -- Recurring code patterns (and legacy ones to avoid)
+
+## Things to know
+
+- The Shop table has ~100+ fields and controls ALL sync behavior. When debugging, always start there.
+- Every monetary field in the order hierarchy exists in TWO versions: shop currency (e.g. `Total Amount`) and presentment currency (e.g. `Presentment Total Amount`). The `Currency Handling` field on Shop determines which set feeds into BC sales documents.
+- Shopify IDs are `BigInteger` everywhere. New metafields created locally get negative IDs (starting at -1, decrementing) until Shopify assigns real IDs.
+- The `Shpfy Tag` table is a generic many-to-many using `Parent Table No.` + `Parent Id` -- shared by products, orders, and customers. Maximum 250 tags per entity, enforced in the OnInsert trigger.
+- The `Shpfy Doc. Link To Doc.` table is the central place linking Shopify documents (orders, refunds) to BC documents (sales orders, credit memos). Check `Is Processed` FlowFields on refund/order headers -- they CalcFormula against this table.
+- `Order Created Webhooks` on the Shop table enables push-based order notification, but it requires a specific user context (`Order Created Webhook User Id`). If the user is deleted, the webhook silently stops working.
+- The `Fulfillment Service Activated` field on Shop enables BC as a Shopify fulfillment service, which means Shopify sends fulfillment requests TO BC rather than BC polling for them.
+- Product sync direction is controlled by `Sync Item` (To Shopify / From Shopify). Setting it to "To Shopify" runs `ProductExport`; "From Shopify" runs `ProductImport`. They never run both directions in one sync.
+- The app uses `internal` access on almost all procedures and events. Extensions must subscribe to `[IntegrationEvent]` publishers (not `[InternalEvent]`). Check the event attribute before assuming you can subscribe from an external app.
+- The `Return and Refund Process` field controls whether refunds are import-only or auto-create credit memos. Auto-creating credit memos requires `Auto Create Orders` to be enabled -- this is enforced bidirectionally in field validation triggers.

--- a/src/Apps/W1/Shopify/App/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/docs/business-logic.md
@@ -1,0 +1,123 @@
+# Business logic
+
+## Product sync
+
+Product sync is driven by `Shpfy Sync Products` (codeunit 30185), which reads `Shop."Sync Item"` to decide direction.
+
+**Import from Shopify** (`ImportProductsFromShopify`): The `Product API` fetches a `Dictionary of [BigInteger, DateTime]` -- product IDs and their `UpdatedAt` timestamps. For each ID, the code checks whether a local `Shpfy Product` exists. If it does, it compares `Product."Updated At" < UpdatedAt` AND `Product."Last Updated by BC" < UpdatedAt`. Only products that pass both checks are added to a temporary record set. New products (no local record) are always added. The temporary set is then processed one-at-a-time through `Shpfy Product Import`, wrapped in the standard `Commit(); ClearLastError(); if not Run()` error isolation loop.
+
+**Export to Shopify** (`ExportItemsToShopify`): Delegates to `Shpfy Product Export`, which iterates BC Items matching the shop's filters, builds temporary Shpfy Product and Variant records from Item data, compares them against existing Shopify records using hash fields (`Description Html Hash`, `Tags Hash`, `Image Hash`), and pushes only changed data via GraphQL mutations. The export can be limited to prices only via `SetOnlyUpdatePriceOn`.
+
+Key gotcha: product sync direction is one-way per shop configuration. There is no bidirectional merge. If `Sync Item` is "To Shopify", the import path never runs, and vice versa. Changing direction mid-stream does not reconcile differences.
+
+## Customer sync
+
+`Shpfy Sync Customers` (codeunit 30123) handles both directions in a single run, controlled by shop settings.
+
+**Import**: When `Customer Import From Shopify` is `AllCustomers`, it fetches all customer IDs and imports new/changed ones (same timestamp comparison as products). When set to `WithOrderImport` and `Shopify Can Update Customer` is on, it imports only previously-known customers (skips creating new ones from the ID list). The import uses `Shpfy Customer Import` per customer, wrapped in the Commit/ClearLastError loop.
+
+**Export**: When `Can Update Shopify Customer` is on, `Shpfy Customer Export` pushes BC customer changes to Shopify. Note: creating new customers in Shopify is done via a separate "Add Customer to Shopify" action, not the sync.
+
+Customer mapping is pluggable via the `ICustomerMapping` interface. The `Customer Mapping Type` enum on Shop selects the strategy. The interface's `DoMapping` method receives a Shopify customer ID, a JSON object with address fields, and the shop code, and returns a BC Customer No. Strategies include mapping by email, phone, name+city combinations, or always using a default customer.
+
+Mutual exclusion: `Shopify Can Update Customer` and `Can Update Shopify Customer` are mutually exclusive -- enabling one disables the other in field validation triggers. This prevents update loops.
+
+## Order import and processing
+
+Order handling is the most complex flow. It has two distinct phases: **import** (fetching from Shopify) and **processing** (creating BC documents).
+
+### Import phase
+
+The import phase runs via `Shpfy Sync Orders from Shopify` (report 30104), which fetches orders from Shopify, creates/updates `Shpfy Orders to Import` staging records, then creates/updates `Shpfy Order Header` and `Shpfy Order Line` records. During import, it also resolves customers, companies, shipping methods, and payment methods via mapping events.
+
+### Processing phase
+
+`Shpfy Process Orders` (codeunit 30167) iterates unprocessed orders and calls `Shpfy Process Order` (codeunit 30166) for each one. The processing flow:
+
+```mermaid
+flowchart TD
+    A[Unprocessed Order] --> B{DoMapping succeeds?}
+    B -->|No| C[Error: Not everything can be mapped]
+    B -->|Yes| D{Fulfillment Status = Fulfilled AND Create Invoices From Orders?}
+    D -->|Yes| E[Create Sales Invoice]
+    D -->|No| F[Create Sales Order]
+    E --> G[Populate header fields from Shopify order]
+    F --> G
+    G --> H{Use Shopify Order No.?}
+    H -->|Yes| I[Set document No. = Shopify Order No.]
+    H -->|No| J[Auto-number from series]
+    I --> K[Create item lines from order lines]
+    J --> K
+    K --> L{Line is Tip?}
+    L -->|Yes| M[G/L Account line from Tip Account]
+    L -->|No| N{Line is Gift Card?}
+    N -->|Yes| O[G/L Account line from Sold Gift Card Account]
+    N -->|No| P[Item line with variant, UoM, location]
+    M --> Q[Create shipping charge lines]
+    O --> Q
+    P --> Q
+    Q --> R{Currency Handling?}
+    R -->|Shop Currency| S[Use shop currency amounts]
+    R -->|Presentment Currency| T[Use presentment currency amounts]
+    S --> U[Apply global discounts]
+    T --> U
+    U --> V[Create rounding line if needed]
+    V --> W{Auto Release?}
+    W -->|Yes| X[Release Sales Document]
+    W -->|No| Y[Done]
+    X --> Y
+    Y --> Z[Insert Doc Link To Doc record]
+    Z --> AA[Mark order as Processed]
+```
+
+The dual-currency branching is pervasive. In `CreateLinesFromShopifyOrder`, every monetary assignment has a `case ShopifyShop."Currency Handling"` block choosing between shop-currency and presentment-currency fields. This applies to line unit prices, discounts, shipping charges, and rounding amounts.
+
+Error handling: `Process Orders` wraps each order in a `if not ProcessOrder.Run() then` block. On failure, it records the error message on the order header, clears the sales order/invoice number, calls `CleanUpLastCreatedDocument` to delete the partially-created sales document, and continues to the next order. On success, it marks the order as Processed and stamps `Processed Currency Handling`.
+
+After processing orders, `Process Orders` also handles refunds. If `Return and Refund Process` is "Auto Create Credit Memo", it iterates unprocessed refund headers and calls `IReturnRefundProcess.CreateSalesDocument` for each one.
+
+### Order mapping
+
+Before processing, `Shpfy Order Mapping.DoMapping` runs. This resolves:
+
+- **Customer mapping** via events (`OnBeforeMapCustomer`, `OnAfterMapCustomer`) -- if not handled by an event subscriber, uses the `ICustomerMapping` interface selected by the shop's `Customer Mapping Type`
+- **Company mapping** for B2B orders via `OnBeforeMapCompany`
+- **Shipment method** via `OnBeforeMapShipmentMethod` -- falls back to `Shpfy Shipment Method Mapping` table lookup
+- **Payment method** via `OnBeforeMapPaymentMethod` -- falls back to `Shpfy Payment Method Mapping` table lookup
+
+Mapping must fully succeed or the order will not process. The `MappingErr` error aborts processing for that order.
+
+## Fulfillment sync
+
+Fulfillment works in the opposite direction -- BC shipments push to Shopify. When a sales shipment is posted for an order that originated from Shopify (identified by `Shpfy Order No.` on the shipment header, transferred via an event subscriber on `Sales-Post`), the connector can create a fulfillment in Shopify.
+
+The fulfillment sync reads `Shpfy Fulfillment Order Header` and `Shpfy Fulfillment Order Line` records (Shopify's fulfillment order concept), matches them against posted shipment lines, and calls the `GQL FulfillOrder` mutation with tracking numbers, URLs, and the notify-customer flag.
+
+The `Send Shipping Confirmation` field on Shop controls whether Shopify emails the customer when a fulfillment is created.
+
+When the shop has `Fulfillment Service Activated`, BC acts as a Shopify fulfillment service. In this mode, Shopify sends fulfillment requests to BC (via `Shpfy Fulfillment Order Header` with `Request Status`), and BC accepts/fulfills them. The `GQL AcceptFFRequest` mutation handles acceptance.
+
+## Return and refund processing
+
+Returns and refunds are imported as part of order sync. `Shpfy Return Header` and `Shpfy Return Line` are purely informational -- they record what the customer is returning.
+
+`Shpfy Refund Header` represents the actual money movement. A refund may or may not be linked to a return (via `Return Id`). Processing depends on the `Return and Refund Process` shop setting:
+
+- **Import Only**: Refunds are imported but no BC documents are created. This is the default.
+- **Auto Create Credit Memo**: After order processing, unprocessed refunds are picked up by `ProcessShopifyRefunds`, which uses the `IReturnRefundProcess` interface to create sales credit memos. The interface implementation creates a credit memo header, adds lines for refunded items (or G/L lines for non-restockable items using the `Refund Acc. non-restock Items` account), and links the result via `Shpfy Doc. Link To Doc.`.
+
+The `CheckCanCreateDocument` method on Refund Header checks the doc link table to prevent duplicate credit memos. Error tracking uses Blob fields (`Last Error Description`, `Last Error Call Stack`) for full error details.
+
+Key constraint: `Auto Create Credit Memo` requires `Auto Create Orders` to be enabled. This is enforced in both directions -- disabling auto-create orders when refund processing is set to auto-create will raise an error, and vice versa.
+
+## Inventory sync
+
+`Shpfy Sync Inventory` pushes BC stock levels to Shopify. For each `Shpfy Shop Location` that has a `Stock Calculation` other than Disabled, it uses the `Shpfy Stock Calculation` interface to compute available stock. The interface has multiple implementations (projected available balance, non-negative inventory, etc.) selected by the enum on the location record.
+
+After calculating stock, it compares against the current Shopify inventory level and uses the `GQL ModifyInventory` mutation to adjust. The `OnAfterCalculationStock` event allows extensions to adjust the computed stock value before it is sent.
+
+## Company sync (B2B)
+
+`Shpfy Sync Companies` follows the same pattern as customer sync -- fetch IDs with timestamps, filter by `Updated At`/`Last Updated by BC`, import changed records in a Commit/ClearLastError loop. Company mapping uses the `ICompanyMapping` interface, selected by `Company Mapping Type` on Shop. The `Auto Create Catalog` flag triggers automatic catalog creation for new companies.
+
+B2B orders carry `Company Id`, `Company Location Id`, and `Company Main Contact` fields on the order header. The `B2B` boolean flag distinguishes B2B from DTC orders.

--- a/src/Apps/W1/Shopify/App/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/docs/data-model.md
@@ -1,0 +1,148 @@
+# Data model
+
+## Entity relationship diagrams
+
+### Product catalog
+
+```mermaid
+erDiagram
+    "Shpfy Shop" ||--o{ "Shpfy Product" : "Shop Code"
+    "Shpfy Product" ||--o{ "Shpfy Variant" : "Product Id"
+    "Shpfy Product" }o--|| "BC Item" : "Item SystemId"
+    "Shpfy Variant" }o--o| "BC Item Variant" : "Item Variant SystemId"
+    "Shpfy Variant" ||--o| "Shpfy Inventory Item" : "Variant Id"
+```
+
+### Customers and companies
+
+```mermaid
+erDiagram
+    "Shpfy Shop" ||--o{ "Shpfy Customer" : "Shop Id"
+    "Shpfy Customer" ||--o{ "Shpfy Customer Address" : "Customer Id"
+    "Shpfy Customer" }o--|| "BC Customer" : "Customer SystemId"
+    "Shpfy Shop" ||--o{ "Shpfy Company" : "Shop Id"
+    "Shpfy Company" ||--o{ "Shpfy Company Location" : "Company SystemId"
+    "Shpfy Company" }o--|| "BC Customer" : "Customer SystemId"
+```
+
+### Order lifecycle
+
+```mermaid
+erDiagram
+    "Shpfy Order Header" ||--o{ "Shpfy Order Line" : "Order Id"
+    "Shpfy Order Header" ||--o{ "Shpfy Refund Header" : "Order Id"
+    "Shpfy Order Header" ||--o{ "Shpfy Return Header" : "Order Id"
+    "Shpfy Order Header" ||--o{ "Shpfy Order Transaction" : "Order Id"
+    "Shpfy Doc Link To Doc" }o--|| "Shpfy Order Header" : "Shopify Document Id"
+```
+
+### Fulfillments and shipping
+
+```mermaid
+erDiagram
+    "Shpfy Order Header" ||--o{ "Shpfy FF Order Header" : "Order Id"
+    "Shpfy FF Order Header" ||--o{ "Shpfy FF Order Line" : "FF Order Id"
+    "Shpfy Order Header" ||--o{ "Shpfy Order Fulfillment" : "Order Id"
+    "Shpfy Shop" ||--o{ "Shpfy Shop Location" : "Shop Code"
+    "Shpfy Shop Location" ||--o{ "Shpfy Shop Inventory" : "Location Id"
+```
+
+### Refunds, returns, and payments
+
+```mermaid
+erDiagram
+    "Shpfy Refund Header" ||--o{ "Shpfy Refund Line" : "Refund Id"
+    "Shpfy Refund Header" }o--o| "Shpfy Return Header" : "Return Id"
+    "Shpfy Return Header" ||--o{ "Shpfy Return Line" : "Return Id"
+    "Shpfy Payout" ||--o{ "Shpfy Payment Transaction" : "Payout Id"
+```
+
+## Shop and configuration
+
+The `Shpfy Shop` table (30102) is the central configuration record. One record per Shopify store. Its primary key is a `Code[20]`, but it also has a computed `Shop Id` (Integer) derived by hashing the Shopify URL. The `Shop Id` is used as a foreign key by customers and companies (which span shops), while `Shop Code` is used by products and orders (which belong to exactly one shop).
+
+The Shop table holds references to BC posting groups, customer templates, G/L accounts (shipping charges, tips, gift cards, refunds, cash roundings), and enums controlling sync direction, customer mapping type, company mapping type, SKU mapping, stock calculation, currency handling, and return/refund processing. It also stores webhook IDs and user context for order-created webhooks.
+
+The `Shpfy Synchronization Info` table tracks `Last Sync Time` per shop per sync type. For orders, the key is `Shop Id` (not `Shop Code`) -- this is a deliberate design choice so that renaming a shop code does not lose order sync state.
+
+## Products and variants
+
+`Shpfy Product` (30127) stores one record per Shopify product. It links to a BC Item via `Item SystemId` (Guid), with a FlowField `Item No.` that resolves the readable code. The `Last Updated by BC` timestamp prevents re-importing a product that BC just pushed to Shopify.
+
+`Shpfy Variant` (30129) hangs off Product via `Product Id`. Each variant links to both `Item SystemId` and optionally `Item Variant SystemId`. Variants carry three option name/value pairs (Option 1..3), price, compare-at price, SKU, barcode, and weight. The `UoM Option Id` field supports the "UoM as Variant" feature where BC units of measure become Shopify variant options.
+
+Hash-based change detection is used for product descriptions and tags. `Shpfy Product` stores `Description Html Hash`, `Tags Hash`, and `Image Hash` -- all computed via `Shpfy Hash.CalcHash()`. On export, the connector compares current hashes against stored ones to decide whether to push an update, avoiding unnecessary API calls.
+
+`Shpfy Inventory Item` tracks the Shopify inventory item ID per variant. `Shpfy Shop Inventory` holds per-location inventory levels. `Shpfy Shop Location` maps Shopify locations to BC locations with a `Location Filter` for stock calculation and a `Default Location Code` for sales document creation.
+
+`Shpfy Sales Channel` and `Shpfy Product Collection` track product publication and collection membership. `Shpfy Shop Collection Map` links collections to BC tax groups or VAT product posting groups.
+
+## Orders
+
+`Shpfy Order Header` (30118) is keyed by `Shopify Order Id` (BigInteger). It stores full sell-to, ship-to, and bill-to address blocks, financial/fulfillment/return status enums, and processing state (`Processed`, `Has Error`, `Error Message`, `Sales Order No.`, `Sales Invoice No.`).
+
+The dual-currency model is prominent here. Every monetary field exists twice:
+
+- **Shop currency**: `Total Amount`, `Subtotal Amount`, `VAT Amount`, `Discount Amount`, `Shipping Charges Amount`, `Total Tip Received` -- formatted using `Currency Code`
+- **Presentment currency**: `Presentment Total Amount`, `Presentment Subtotal Amount`, `Presentment VAT Amount`, `Presentment Discount Amount`, `Pres. Shipping Charges Amount`, `Presentment Total Tip Received` -- formatted using `Presentment Currency Code`
+
+The `Currency Handling` enum on Shop controls which set is used when creating BC sales documents. Once processed, the order stamps `Processed Currency Handling` so that the display remains consistent even if the shop setting changes later.
+
+`Shpfy Order Line` (30119) is keyed by `(Shopify Order Id, Line Id)`. Lines carry `Item No.`, `Variant Code`, and `Unit of Measure Code` for the resolved BC mapping. Lines also have presentment variants of unit price and discount. Special boolean flags `Gift Card` and `Tip` cause the line to map to G/L accounts (from Shop config) rather than Items.
+
+`Shpfy Orders to Import` is a staging table for the order import pipeline. Orders land here first during sync, then get processed into Order Header/Line records.
+
+Supporting tables:
+
+- `Shpfy Order Shipping Charges` -- one per shipping line, with both currency amounts and discount
+- `Shpfy Order Tax Line` -- tax breakdown, with a `Channel Liable` flag for marketplace tax collection
+- `Shpfy Order Attribute` / `Shpfy Order Line Attribute` -- key-value pairs from Shopify order attributes
+- `Shpfy Order Discount Appl.` -- discount application details
+- `Shpfy Order Payment Gateway` -- payment gateway names per order
+- `Shpfy Order Risk` -- risk assessments, with a `Level` enum used by the `High Risk` FlowField on the header
+
+## Customers and companies
+
+`Shpfy Customer` (30105) stores Shopify customer data, linked to BC Customer via `Customer SystemId`. The `Shop Id` field ties the customer to a shop's hash ID. Customers have addresses in `Shpfy Customer Address` (one per Shopify address) and can have metafields and tags.
+
+`Shpfy Company` (30150) is the B2B equivalent -- a Shopify company with `Customer SystemId` linking to BC Customer. Companies have `Shpfy Company Location` records for their physical locations. The `Main Contact Customer Id` links to the Shopify customer record of the company's main contact.
+
+`Shpfy Customer Template` provides per-country customer template overrides beyond the default template on the Shop.
+
+`Shpfy Province` and `Shpfy Tax Area` support tax area resolution. `Tax Area Priority` on Shop controls the lookup order (by city, county, state, country).
+
+## Refunds, returns, and fulfillments
+
+`Shpfy Return Header` (30147) and `Shpfy Return Line` represent Shopify returns. Returns are informational -- they track what the customer wants to send back, with status, decline reason, and discounted total amounts.
+
+`Shpfy Refund Header` (30142) and `Shpfy Refund Line` represent actual refunds. A refund optionally links to a return via `Return Id`. Refund headers carry both currency amounts (`Total Refunded Amount` and `Pres. Tot. Refunded Amount`) and error tracking fields (`Has Processing Error`, `Last Error Description` as Blob). `Shpfy Refund Shipping Line` tracks refunded shipping costs.
+
+The `Is Processed` field on Refund Header is a FlowField checking `Shpfy Doc. Link To Doc.` for a linked BC credit memo. This is the same pattern used by Order Header.
+
+`Shpfy Order Fulfillment` (30111) records Shopify fulfillments with tracking numbers, URLs, and companies. `Shpfy Fulfillment Order Header` (30143) and `Shpfy Fulfillment Order Line` represent Shopify's fulfillment order concept -- the request to fulfill, which may come from Shopify to BC when BC acts as a fulfillment service.
+
+## Payments and transactions
+
+`Shpfy Order Transaction` stores individual payment transactions per order. `Shpfy Payment Transaction` and `Shpfy Payout` track Shopify Payments data. `Shpfy Dispute` tracks payment disputes.
+
+`Shpfy Payment Method Mapping` maps Shopify payment gateways to BC payment methods. `Shpfy Shipment Method Mapping` maps Shopify shipping method titles to BC shipment methods (and optionally to item charge types for shipping cost lines).
+
+`Shpfy Payment Terms` maps Shopify payment terms to BC payment terms codes, keyed by type + name + shop code.
+
+## Metafields
+
+`Shpfy Metafield` (30101) is a single generic table for all metafield owner types (Product, ProductVariant, Customer, Company). The `Owner Type` enum and `Parent Table No.` integer work together -- setting one triggers the other via the `IMetafieldOwnerType` interface. The `Type` enum has an `IMetafieldType` interface for validation (`IsValidValue`, `GetExampleValue`).
+
+New metafields created locally in BC get **negative IDs** (starting at -1, decrementing in the OnInsert trigger) until they are synced to Shopify, which assigns real positive IDs. The `Last Updated by BC` timestamp prevents re-importing metafields that BC just pushed.
+
+The money metafield type enforces that the currency code matches the shop's currency via `CheckShopCurrency`.
+
+## Tags
+
+`Shpfy Tag` (30104) is a polymorphic tag table keyed by `(Parent Id, Tag)`. The `Parent Table No.` field identifies the owner type (Product, Order, Customer). Maximum 250 tags per parent, enforced in OnInsert. The `UpdateTags` procedure does a delete-all/re-insert on every update -- there is no diffing.
+
+## Document links
+
+`Shpfy Doc. Link To Doc.` (30146) maps Shopify documents to BC documents with a four-part key: `(Shopify Document Type, Shopify Document Id, Document Type, Document No.)`. It supports multiple BC documents per Shopify document (e.g., an order could produce both a sales order and later a posted invoice). Both the order header's `Processed` flag and the refund header's `Is Processed` FlowField rely on existence checks against this table.
+
+The table uses two interfaces -- `IOpenShopifyDocument` and `IOpenBCDocument` -- to navigate to the respective document pages, dispatched by enum value.

--- a/src/Apps/W1/Shopify/App/docs/extensibility.md
+++ b/src/Apps/W1/Shopify/App/docs/extensibility.md
@@ -1,0 +1,159 @@
+# Extensibility
+
+The Shopify Connector exposes extension points through two mechanisms: **integration events** (subscribable from any extension) and **interfaces** (implementable by adding enum values). Events follow a Before/After pattern where Before events carry an `IsHandled`/`Handled` boolean to let subscribers take over the default logic.
+
+Important: many events are marked `[InternalEvent(false)]` rather than `[IntegrationEvent(false, false)]`. Internal events can only be subscribed to by extensions listed in `internalsVisibleTo` in app.json (currently only the test app). Check the attribute before planning your subscription.
+
+## Customize order creation
+
+The order processing pipeline in `Shpfy Process Order` (codeunit 30166) and `Shpfy Order Events` (codeunit 30162) offers the most extension points.
+
+**Take over sales header creation entirely** -- subscribe to `OnBeforeCreateSalesHeader`. Set `Handled := true` to skip the default header creation. You receive the `ShopifyOrderHeader` and a `var SalesHeader` to populate yourself.
+
+```al
+[EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Order Events", 'OnBeforeCreateSalesHeader', '', false, false)]
+local procedure MyBeforeCreateSalesHeader(ShopifyOrderHeader: Record "Shpfy Order Header"; var SalesHeader: Record "Sales Header"; var LastCreatedDocumentId: Guid; var Handled: Boolean)
+```
+
+**Modify the sales header after default creation** -- subscribe to `OnAfterCreateSalesHeader`:
+
+```al
+[EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Order Events", 'OnAfterCreateSalesHeader', '', false, false)]
+local procedure MyAfterCreateSalesHeader(OrderHeader: Record "Shpfy Order Header"; var SalesHeader: Record "Sales Header")
+```
+
+**Control individual item line creation** -- subscribe to `OnBeforeCreateItemSalesLine` (set `Handled` to skip default logic) or `OnAfterCreateItemSalesLine` to modify the created line:
+
+```al
+[EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Order Events", 'OnBeforeCreateItemSalesLine', '', false, false)]
+local procedure MyBeforeItemLine(ShopifyOrderHeader: Record "Shpfy Order Header"; ShopifyOrderLine: Record "Shpfy Order Line"; SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line"; var Handled: Boolean)
+
+[EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Order Events", 'OnAfterCreateItemSalesLine', '', false, false)]
+local procedure MyAfterItemLine(ShopifyOrderHeader: Record "Shpfy Order Header"; ShopifyOrderLine: Record "Shpfy Order Line"; SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line")
+```
+
+**Control shipping cost line creation** -- same Before/After pattern with `OnBeforeCreateShippingCostSalesLine` and `OnAfterCreateShippingCostSalesLine`.
+
+**Hook into the full process** -- `OnBeforeProcessSalesDocument` fires before any mapping or document creation. `OnAfterProcessSalesDocument` fires after the complete sales document (header + lines) is created and optionally released.
+
+## Override customer mapping
+
+Customer mapping runs during order import and can be overridden at two levels.
+
+**Replace the entire mapping** -- subscribe to `OnBeforeMapCustomer` on `Shpfy Order Events` and set `Handled := true`. Populate `ShopifyOrderHeader."Sell-to Customer No."` yourself:
+
+```al
+[EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Order Events", 'OnBeforeMapCustomer', '', false, false)]
+local procedure MyCustomerMapping(var ShopifyOrderHeader: Record "Shpfy Order Header"; var Handled: Boolean)
+```
+
+**Adjust after default mapping** -- subscribe to `OnAfterMapCustomer`:
+
+```al
+[EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Order Events", 'OnAfterMapCustomer', '', false, false)]
+local procedure MyAfterMapCustomer(var ShopifyOrderHeader: Record "Shpfy Order Header")
+```
+
+**Plug in a custom mapping strategy** -- the `ICustomerMapping` interface (in `src/Customers/Interfaces/`) defines `DoMapping(CustomerId, JCustomerInfo, ShopCode)`. Add a new value to the `Shpfy Customer Mapping` enum and implement the interface. Your strategy will be selectable in the Shop card's `Customer Mapping Type` field.
+
+**Override customer find/create** -- `Shpfy Customer Events` (codeunit 30115) has:
+
+- `OnBeforeFindMapping` / `OnAfterFindMapping` -- control how Shopify customers map to BC customers
+- `OnBeforeCreateCustomer` / `OnAfterCreateCustomer` -- intercept or modify BC customer creation from Shopify data
+- `OnBeforeUpdateCustomer` / `OnAfterUpdateCustomer` -- control how Shopify updates flow to BC customer records
+- `OnBeforeFindCustomerTemplate` / `OnAfterFindCustomerTemplate` -- override template selection for new customers
+
+## Override company mapping (B2B)
+
+Same pattern as customers. The `ICompanyMapping` interface supports custom strategies via the `Shpfy Company Mapping` enum. Events on `Shpfy Order Events`:
+
+```al
+[EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Order Events", 'OnBeforeMapCompany', '', false, false)]
+local procedure MyCompanyMapping(var ShopifyOrderHeader: Record "Shpfy Order Header"; var Handled: Boolean)
+```
+
+The `IFindCompanyMapping` interface and `Shpfy Comp. Tax Id Mapping` enum provide pluggable strategies for finding existing BC customers by tax registration ID.
+
+## Customize product sync
+
+`Shpfy Product Events` (codeunit 30177) is the richest event codeunit. Key extension points organized by goal:
+
+**Control how items map to products** -- `OnBeforeFindProductMapping` lets you override the SKU/barcode/item-no matching. Set `Handled := true` and populate the `Item` and `ItemVariant` records yourself.
+
+**Customize product data sent to Shopify** -- `OnAfterCreateTempShopifyProduct` fires after the temp product/variant/tag records are built from a BC Item. Modify them before they are diffed and sent. `OnAfterFillInShopifyProductFields` fires after standard fields are populated on the Shopify product record. `OnBeforeSendCreateShopifyProduct` and `OnBeforeSendUpdateShopifyProduct` fire right before the API call.
+
+**Override product body HTML** -- `OnBeforeCreateProductBodyHtml` (set `Handled`) or `OnAfterCreateProductBodyHtml` to modify the generated HTML description.
+
+**Override product title** -- `OnBeforSetProductTitle` (set `Handled`) or `OnAfterSetProductTitle`.
+
+**Override pricing** -- `OnBeforeCalculateUnitPrice` (set `Handled` to skip default price calculation) or `OnAfterCalculateUnitPrice` to adjust computed prices. Both receive `Item`, `VariantCode`, `UnitOfMeasure`, `Shop`, `Catalog`, and `var` price/compare-price/unit-cost parameters.
+
+**Override barcode lookup** -- `OnBeforGetBarcode` / `OnAfterGetBarcode`.
+
+**Control item creation from Shopify** -- `OnBeforeCreateItem` (set `Handled`) and `OnAfterCreateItem`. Same for variants: `OnBeforeCreateItemVariant` / `OnAfterCreateItemVariant`. `OnBeforeCreateItemVariantCode` lets you override variant code generation.
+
+**Control item update from Shopify** -- `OnBeforeUpdateItem` / `OnAfterUpdateItem`, `OnBeforeUpdateItemVariant` / `OnAfterUpdateItemVariant`. `OnDoUpdateItemBeforeModify` fires after fields are set but before the Item.Modify, with a `var IsModifiedByEvent` flag.
+
+**Override template selection** -- `OnBeforeFindItemTemplate` / `OnAfterFindItemTemplate`.
+
+**Filter products for export** -- `OnAfterProductsToSynchronizeFiltersSet` fires after the product record set is filtered but before iteration. Add additional filters to exclude products.
+
+## Custom stock calculation
+
+The `Shpfy Stock Calculation` interface (in `src/Inventory/Interface/`) defines `GetStock(var Item): Decimal`. Implement this interface on a new enum value in the `Shpfy Stock Calculation` enum. Your implementation will be selectable per Shopify location in the `Shpfy Shop Location` table's `Stock Calculation` field.
+
+There is also `Shpfy ExtendedStockCalculation` for extended scenarios, and `Shpfy IStock Available` for determining whether a variant can carry stock.
+
+After stock calculation, the `OnAfterCalculationStock` event on `Shpfy Inventory Events` (codeunit 30196) fires:
+
+```al
+[EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Inventory Events", 'OnAfterCalculationStock', '', false, false)]
+local procedure MyStockAdjustment(Item: Record Item; ShopifyShop: Record "Shpfy Shop"; LocationFilter: Text; var StockResult: Decimal)
+```
+
+## Customize shipping and fulfillment
+
+`Shpfy Shipping Events` (codeunit 30192) provides:
+
+- `OnBeforeRetrieveTrackingUrl` -- override tracking URL resolution for a sales shipment. Set `IsHandled := true` and populate `TrackingUrl`.
+- `OnGetNotifyCustomer` -- control whether Shopify sends a shipping notification email per fulfillment.
+
+```al
+[EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Shipping Events", 'OnBeforeRetrieveTrackingUrl', '', false, false)]
+local procedure MyTrackingUrl(var SalesShipmentHeader: Record "Sales Shipment Header"; var TrackingUrl: Text; var IsHandled: Boolean)
+```
+
+## Customize shipment method and payment method mapping
+
+`Shpfy Order Events` provides Before/After pairs for both:
+
+- `OnBeforeMapShipmentMethod` / `OnAfterMapShipmentMethod`
+- `OnBeforeMapShipmentAgent` / `OnAfterMapShipmentAgent`
+- `OnBeforeMapPaymentMethod` / `OnAfterMapPaymentMethod`
+
+Set `Handled := true` on the Before events and populate the mapping fields on the order header yourself.
+
+## Customize refund/return processing
+
+`Shpfy Refund Process Events` (codeunit 30247) provides:
+
+- `OnBeforeCreateSalesHeader` / `OnAfterCreateSalesHeader` -- control credit memo header creation from refunds
+- `OnBeforeCreateItemSalesLine` / `OnAfterCreateItemSalesLine` -- control credit memo line creation from refund lines
+- `OnAfterProcessSalesDocument` -- hook after the complete credit memo is created
+- `OnBeforeCreateSalesLinesFromRemainingAmount` -- control or skip the auto-balance line that catches remaining refund amounts not covered by item lines (set `SkipBalancing := true`)
+
+The `IReturnRefundProcess` interface (in `src/Order Return Refund Processing/Interfaces/`) allows adding new processing strategies via the `Shpfy ReturnRefund ProcessType` enum.
+
+## Customize metafield handling
+
+The `IMetafieldType` interface validates metafield values and provides example values. The `IMetafieldOwnerType` interface resolves owner type to table ID and shop code. Both are extended by adding values to their respective enums.
+
+## Override order import behavior
+
+`OnAfterImportShopifyOrderHeader` fires after an order header is imported/updated from Shopify, with an `IsNew` flag. `OnAfterCreateShopifyOrderAndLines` fires after both header and lines are created.
+
+These events let you reject orders (by modifying fields that will fail mapping), enrich order data from external sources, or trigger custom workflows.
+
+## Intercept API communication
+
+`Shpfy Communication Events` (codeunit 30200) provides internal events for HTTP interception -- `OnClientSend`, `OnClientPost`, `OnClientGet`, `OnGetAccessToken`, `OnGetContent`. These are `[InternalEvent]` so only available to apps in the `internalsVisibleTo` list (the test app). They are primarily used for test mocking.

--- a/src/Apps/W1/Shopify/App/docs/patterns.md
+++ b/src/Apps/W1/Shopify/App/docs/patterns.md
@@ -1,0 +1,208 @@
+# Patterns
+
+## GraphQL gateway pattern
+
+The connector communicates with Shopify exclusively through GraphQL. The `Shpfy IGraphQL` interface (in `src/GraphQL/Interfaces/`) defines two methods:
+
+- `GetGraphQL(): Text` -- returns the JSON-encoded GraphQL query or mutation string
+- `GetExpectedCost(): Integer` -- returns the estimated query cost for rate limit budgeting
+
+There are 145+ codeunits in `src/GraphQL/Codeunits/` that implement this interface, each encapsulating a single query or mutation. For example, `Shpfy GQL CustomerIds` (codeunit 30128):
+
+```al
+codeunit 30128 "Shpfy GQL CustomerIds" implements "Shpfy IGraphQL"
+{
+    internal procedure GetGraphQL(): Text
+    begin
+        exit('{"query":"{customers(first:200, query: \"updated_at:>''{{LastSync}}''\"){pageInfo{hasNextPage} edges{cursor node{id updatedAt}}}}"}');
+    end;
+
+    internal procedure GetExpectedCost(): Integer
+    begin
+        exit(12);
+    end;
+}
+```
+
+The `Shpfy GraphQL Queries` codeunit (30xxx) acts as a registry, mapping enum values to interface implementations. Callers never instantiate query codeunits directly -- they go through the communication layer which handles rate limiting, retry, and logging.
+
+`Shpfy GraphQL Rate Limit` manages Shopify's cost-based rate limiting. Each query declares its expected cost, and the rate limiter ensures the bucket has sufficient capacity before sending.
+
+Naming convention: query codeunits are prefixed `ShpfyGQL` followed by a descriptive name. Paginated queries come in pairs: `ShpfyGQLCustomerIds` for the first page and `ShpfyGQLNextCustomerIds` for subsequent pages (using cursor-based pagination).
+
+This pattern has clear benefits -- each query is independently versioned and testable. The downside is the sheer number of codeunits (145+), which can be overwhelming when searching for a specific query.
+
+## Timestamp-based incremental sync
+
+Every entity sync follows the same pattern to avoid re-processing unchanged records.
+
+The connector fetches a list of `(Id, UpdatedAt)` pairs from Shopify. For each ID, it compares two timestamps:
+
+```al
+if ((Product."Updated At" < UpdatedAt) and (Product."Last Updated by BC" < UpdatedAt)) then
+    // needs import
+```
+
+- `Updated At` -- when Shopify last changed the record. If the local copy is older, Shopify has changes to import.
+- `Last Updated by BC` -- when BC last pushed an update. If this is recent, the Shopify change was caused by BC itself, so skip it.
+
+Both conditions must be true to trigger an import. This prevents the "ping-pong" problem where BC exports a change, Shopify bumps its `Updated At`, and the next sync imports the same change back.
+
+The `Last Updated by BC` field exists on `Shpfy Product`, `Shpfy Variant`, `Shpfy Customer`, `Shpfy Company`, and `Shpfy Metafield`.
+
+Sync start times are tracked in `Shpfy Synchronization Info` via `Shop.GetLastSyncTime()` / `Shop.SetLastSyncTime()`. Order sync uses `Shop Id` (integer hash of URL) as the key rather than `Shop Code`, so renaming a shop doesn't reset the sync watermark.
+
+## Temporary record batching with error isolation
+
+All bulk import operations use the same structure:
+
+```al
+// Phase 1: Build temporary record set
+Clear(TempRecord);
+if TempRecord.FindSet(false) then begin
+    repeat
+        ImportCodeunit.SetRecord(TempRecord);
+        Commit();                    // save prior successful work
+        ClearLastError();            // reset error state
+        if not ImportCodeunit.Run() then  // Run() catches runtime errors
+            ErrMsg := GetLastErrorText;   // capture but continue
+    until TempRecord.Next() = 0;
+end;
+```
+
+This pattern appears in `Shpfy Sync Products.ImportProductsFromShopify`, `Shpfy Sync Customers.ImportCustomersFromShopify`, `Shpfy Sync Companies`, and `Shpfy Process Orders.ProcessShopifyOrders`.
+
+The `Commit()` before `Run()` is essential -- without it, a failure in `Run()` would roll back all prior successful imports in the same transaction. The `ClearLastError()` resets the error state so `GetLastErrorText` correctly reflects the current iteration's error.
+
+The temporary record set acts as a filter -- only IDs that need processing are included. This keeps the actual API/database work inside the `Run()` call, where failures are isolated.
+
+Gotcha: the `Commit()` means partial progress is saved even if the entire batch fails partway through. There is no rollback-the-whole-batch option. Each record either succeeds permanently or fails with an error message.
+
+## Event-based mapping with fallback (IsHandled pattern)
+
+The connector uses the standard BC "IsHandled" pattern for extensible mapping. The general structure:
+
+```al
+OnBeforeMapCustomer(ShopifyOrderHeader, Handled);
+if not Handled then begin
+    // default mapping logic
+end;
+OnAfterMapCustomer(ShopifyOrderHeader);
+```
+
+The Before event lets subscribers set `Handled := true` to completely replace the default logic. The After event lets subscribers adjust the result. This pattern is used for:
+
+- Customer mapping (`OnBeforeMapCustomer` / `OnAfterMapCustomer`)
+- Company mapping (`OnBeforeMapCompany` / `OnAfterMapCompany`)
+- Shipment method mapping (`OnBeforeMapShipmentMethod` / `OnAfterMapShipmentMethod`)
+- Payment method mapping (`OnBeforeMapPaymentMethod` / `OnAfterMapPaymentMethod`)
+- Sales header creation (`OnBeforeCreateSalesHeader` with `var Handled`)
+- Sales line creation (`OnBeforeCreateItemSalesLine` with `var Handled`)
+- Item creation from Shopify (`OnBeforeCreateItem` with `var Handled`)
+- Product body HTML generation (`OnBeforeCreateProductBodyHtml` with `var Handled`)
+
+When subscribing to Before events, always set `Handled` explicitly. If you don't set it to `true`, the default logic runs AND your modifications may be overwritten.
+
+## Multi-strategy factory pattern
+
+Several domains use AL interfaces as strategy patterns, with the Shop table holding an enum that selects the implementation.
+
+**Customer mapping**: `ICustomerMapping` interface, `Shpfy Customer Mapping` enum on `Shop."Customer Mapping Type"`. Implementations handle different matching strategies (by email, by phone, by name+address).
+
+**Company mapping**: `ICompanyMapping` interface, `Shpfy Company Mapping` enum on `Shop."Company Mapping Type"`.
+
+**Stock calculation**: `Shpfy Stock Calculation` interface, `Shpfy Stock Calculation` enum on `ShpfyShopLocation."Stock Calculation"`. Each Shopify location can use a different stock calculation method.
+
+**Product status on creation**: `ICreateProductStatusValue` interface, `Shpfy Cr. Prod. Status Value` enum on `Shop."Status for Created Products"`.
+
+**Action for removed products**: `IRemoveProductAction` interface, `Shpfy Remove Product Action` enum on `Shop."Action for Removed Products"`. Called in `Shpfy Product.OnDelete()`.
+
+**Return/refund processing**: `IReturnRefundProcess` interface, `Shpfy ReturnRefund ProcessType` enum on `Shop."Return and Refund Process"`.
+
+**Metafield types**: `IMetafieldType` interface, `Shpfy Metafield Type` enum on `Shpfy Metafield."Type"`. Validates values and provides examples.
+
+**Metafield owner types**: `IMetafieldOwnerType` interface, `Shpfy Metafield Owner Type` enum on `Shpfy Metafield."Owner Type"`. Resolves table IDs and shop codes.
+
+**Customer name formatting**: `ICustomerName` interface for different name composition strategies (FirstAndLastName, CompanyName, etc.).
+
+**County resolution**: `ICounty` / `ICountyFromJson` interfaces for parsing county/province data from Shopify responses.
+
+**Document navigation**: `IOpenBCDocument` / `IOpenShopifyDocument` interfaces on the `Shpfy Doc. Link To Doc.` table's enum fields.
+
+To add a new strategy: extend the relevant enum, implement the interface on your enum value, and the Shop card's dropdown will automatically include your option.
+
+## Bulk operations async pattern
+
+For large data sets, the connector uses Shopify's bulk operations API. The flow:
+
+1. Submit a bulk operation mutation via `GQL BulkOpMutation`
+2. Register a webhook to receive completion notification (`Shpfy Webhooks Mgt.`)
+3. Store the operation in `Shpfy Bulk Operation` table with status tracking
+4. When the webhook fires, download the JSONL result file and process it
+
+The `IBulkOperation` interface (in `src/Bulk Operations/Interfaces/`) defines the contract for bulk operation handlers. The Shop table stores `Bulk Operation Webhook Id` and `Bulk Operation Webhook User Id` for the webhook context.
+
+This pattern is used for large product catalog syncs where paginated GraphQL queries would be too slow or hit rate limits.
+
+## SystemId linking
+
+The connector links Shopify records to BC records using `SystemId` (Guid) fields rather than `No.` (Code) fields. Examples:
+
+- `Shpfy Product."Item SystemId"` -> `Item.SystemId`
+- `Shpfy Variant."Item SystemId"` -> `Item.SystemId`
+- `Shpfy Variant."Item Variant SystemId"` -> `Item Variant.SystemId`
+- `Shpfy Customer."Customer SystemId"` -> `Customer.SystemId`
+- `Shpfy Company."Customer SystemId"` -> `Customer.SystemId`
+
+Each table also has a FlowField (e.g., `"Item No."`, `"Customer No."`) that resolves the human-readable code via CalcFormula lookup. This means renumbering a BC entity does not break the Shopify link, since SystemId is immutable.
+
+The tradeoff: you cannot just look at the table data and know which Item an entry points to without calculating the FlowField.
+
+## Negative ID allocation for new records
+
+When creating metafields locally in BC (before syncing to Shopify), the `Shpfy Metafield.OnInsert` trigger assigns negative IDs:
+
+```al
+if Id = 0 then
+    if Metafield.FindFirst() and (Metafield.Id < 0) then
+        Id := Metafield.Id - 1
+    else
+        Id := -1;
+```
+
+This avoids collision with Shopify-assigned positive IDs. When the metafield is synced to Shopify, the real positive ID replaces the negative one.
+
+## Polymorphic tag table
+
+`Shpfy Tag` (table 30104) uses `Parent Table No.` (Integer) + `Parent Id` (BigInteger) to attach tags to any entity. The table is shared across products, orders, and customers. The `UpdateTags` procedure takes a comma-separated string, deletes all existing tags for the parent, and re-inserts them. There is no incremental diff -- it's always a full replace.
+
+The OnInsert trigger enforces a maximum of 250 tags per parent (Shopify's limit).
+
+## Dual-currency branching
+
+Throughout the order processing pipeline, monetary values branch on `Shop."Currency Handling"`:
+
+```al
+case ShopifyShop."Currency Handling" of
+    Enum::"Shpfy Currency Handling"::"Shop Currency":
+        SalesLine.Validate("Unit Price", ShopifyOrderLine."Unit Price");
+    Enum::"Shpfy Currency Handling"::"Presentment Currency":
+        SalesLine.Validate("Unit Price", ShopifyOrderLine."Presentment Unit Price");
+end;
+```
+
+This pattern repeats for every monetary field assignment -- line prices, discounts, shipping charges, rounding amounts, refund totals. It appears in `CreateHeaderFromShopifyOrder`, `CreateLinesFromShopifyOrder`, `CreateRoundingLine`, and the refund processing codeunits.
+
+The order header stamps `Processed Currency Handling` after processing, so display logic on already-processed orders uses the setting that was active at processing time, not the current shop setting.
+
+## Legacy patterns to avoid
+
+**Mixed-responsibility sync codeunits**: Some older sync codeunits (e.g., the original product sync flow) handle both API communication and data transformation in the same codeunit. Newer code separates API calls (in dedicated codeunits) from import/export logic.
+
+**Large case statements in tax area lookup**: The tax area resolution (`Shpfy Order Mgt.FindTaxArea`) uses a priority-based lookup controlled by `Shop."Tax Area Priority"` that cascades through city, county, state, and country combinations. The logic involves nested conditional checks that are hard to extend. If you need custom tax area logic, override it via events rather than trying to understand the cascade.
+
+**Repeated Commit/ClearLastError without abstraction**: The `Commit(); ClearLastError(); if not Codeunit.Run() then ErrMsg := GetLastErrorText` pattern is duplicated verbatim in every sync codeunit. There is no shared helper -- each sync codeunit reimplements the same loop structure. When adding new sync logic, copy the pattern from an existing sync codeunit (e.g., `Shpfy Sync Products.ImportProductsFromShopify`) to ensure consistency.
+
+**Delete-all/re-insert for tags**: `Shpfy Tag.UpdateTags` deletes all tags and reinserts them on every update. This works but generates unnecessary delete/insert operations for unchanged tags. If you're debugging tag-related performance issues, this is a likely contributor.
+
+**Blob fields for error details**: Refund headers use Blob fields (`Last Error Description`, `Last Error Call Stack`) for error storage, requiring stream-based read/write helpers. Order headers use `Text[2048]` for `Error Message`. The inconsistency means different error retrieval patterns depending on which entity you're looking at.

--- a/src/Apps/W1/Shopify/App/src/Base/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Base/docs/CLAUDE.md
@@ -1,0 +1,38 @@
+# Base
+
+The Base folder contains the Shopify Connector's core infrastructure -- the Shop configuration table, sync orchestration, tags, installer/upgrade, and UI shell.
+
+## Shpfy Shop table
+
+`ShpfyShop.Table.al` is the central configuration object. Virtually every sync codeunit takes a Shop record as its `TableNo` or via `SetShop`. It holds settings for customers (`Customer Mapping Type`, `Name Source`, `Name 2 Source`, `Contact Source`, `County Source`, `Default Customer No.`, `Auto Create Unknown Customers`), products, orders, companies, inventory, and more. Enabling a shop requires a valid Shopify URL and user consent confirmation. The `Shopify Can Update Customer` / `Can Update Shopify Customer` pair is mutually exclusive -- setting one clears the other -- establishing a clear one-way sync direction per shop.
+
+## Sync orchestration
+
+`ShpfyBackgroundSyncs.Codeunit.al` is the central dispatcher for all sync operations (customers, companies, products, inventory, orders, payouts, images, catalog prices). Each method constructs XML parameters for a report and enqueues a Job Queue Entry. Shops with `Allow Background Syncs = true` run in the background; others run inline. The codeunit also manages user notifications for background jobs and provides a "don't show again" mechanism via `My Notifications`.
+
+## Tag system
+
+`ShpfyTag.Table.al` implements a polymorphic parent-child tag model. Tags are keyed by `(Parent Id, Tag)` with `Parent Table No.` identifying the owner type. `UpdateTags` does a delete-and-reinsert on every update. A hard limit of 250 tags per parent is enforced on insert. The Tag table is used by customers, products, and orders -- any entity with a Shopify `tags` field.
+
+## Initial import
+
+`ShpfyInitialImport.Codeunit.al` manages the first-time sync wizard. It creates `Shpfy Initial Import Line` records for ITEM, CUSTOMER, and ITEM IMAGE, with dependency ordering (ITEM IMAGE depends on ITEM). The `Start` procedure finds lines with all dependencies finished and enqueues them. Job queue entry status changes trigger re-evaluation so dependent jobs start automatically. Demo companies get a capped import of 25 products.
+
+## Synchronization info tracking
+
+`ShpfySynchronizationInfo.Table.al` stores the last sync timestamp per shop and sync type (keyed by Shop Code + Synchronization Type enum). The Shop table's `SetLastSyncTime` method writes here after each sync completes.
+
+## Cues and activities
+
+`ShpfyCue.Table.al` provides FlowFields for the role center: unmapped customers, unmapped products, unprocessed orders, unprocessed shipments, sync errors, and unmapped companies. `ShpfyActivities.Page.al` displays these. The installer sets up color thresholds (green < 1, yellow < 5, red >= 5).
+
+## Installer and upgrade
+
+`ShpfyInstaller.Codeunit.al` runs on install: sets up retention policies (1-month default for log entries, data capture, skipped records) and cue color thresholds. It also disables shops on company copy and environment cleanup to prevent accidental production API calls. `ShpfyUpgradeMgt.Codeunit.al` handles schema migrations across versions.
+
+## Other notable pieces
+
+- `ShpfyCommunicationMgt.Codeunit.al` / `ShpfyCommunicationEvents.Codeunit.al` -- HTTP client wrapper for Shopify API calls with event hooks
+- `ShpfyShopMgt.Codeunit.al` -- shop-level helper operations
+- `ShpfyConnectorGuide.Page.al` -- the assisted setup wizard
+- Role center page extensions (`ShpfyBusinessManagerRC`, `ShpfyOrderProcessorRC`, `ShpfySalesRelMgrRC`) embed the Shopify activities cue

--- a/src/Apps/W1/Shopify/App/src/Bulk Operations/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Bulk Operations/docs/CLAUDE.md
@@ -1,0 +1,13 @@
+# Bulk operations
+
+Async bulk mutation pattern via Shopify's `bulkOperationRunMutation` API, used when updates exceed a threshold (100 items per `GetBulkOperationThreshold`).
+
+The `Shpfy IBulk Operation` interface (`ShpfyIBulkOperation.Interface.al`) defines the contract: `GetGraphQL` (the mutation template), `GetInput` (the JSONL line template with placeholders), `GetName`, `GetType` (mutation or query), `RevertFailedRequests`, and `RevertAllRequests`. The `Shpfy Bulk Operation Type` enum implements this interface with two values -- `UpdateProductImage` and `UpdateProductPrice`. The enum is `Extensible = true`.
+
+The flow in `ShpfyBulkOperationMgt.Codeunit.al`: first check no other bulk operation is already running for this shop+type (if one exists, poll its status). Then upload the JSONL payload via a staged upload (create URL, multipart POST), submit the bulk mutation referencing the uploaded file, and create a `Shpfy Bulk Operation` record with status Created. The request data (a JSON array of the original values) is stored as a BLOB on the record so failures can be reverted.
+
+Completion is webhook-driven. `ProcessBulkOperationNotification` receives the webhook, queries the final status/URL via `GetBulkOperation` GraphQL, and updates the record. The `OnModify` trigger on `Shpfy Bulk Operation` table dispatches to the interface: on Completed, it calls `RevertFailedRequests` (parse the JSONL result, find which variants succeeded, revert the rest); on Canceled/Failed, it calls `RevertAllRequests` (revert everything to the pre-sync values). The `Processed` flag prevents double-processing.
+
+For price updates (`ShpfyBulkUpdateProductPrice.Codeunit.al`), revert means restoring the variant's Price, Compare at Price, Updated At, and Unit Cost from the stored request data. For image updates (`ShpfyBulkUpdateProductImage.Codeunit.al`), only `RevertAllRequests` is implemented (restores the image hash); `RevertFailedRequests` is a no-op since partial image failures are acceptable.
+
+Enabling bulk operations requires a licensed BC user (validated via `WebhookManagement.IsValidNotificationRunAsUser`) because it registers a webhook subscription.

--- a/src/Apps/W1/Shopify/App/src/Catalogs/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Catalogs/docs/CLAUDE.md
@@ -1,0 +1,13 @@
+# Catalogs
+
+B2B and market-based catalog model for per-audience pricing in Shopify.
+
+The `Shpfy Catalog` table (`ShpfyCatalog.Table.al`) represents a Shopify catalog, with `Catalog Type` distinguishing Company catalogs (B2B, linked to a `Shpfy Company` via `Company SystemId`) from Market catalogs (linked to Shopify markets). The table is heavily configured for pricing: it holds Customer Price Group, Customer Discount Group, Gen. Bus. Posting Group, VAT Bus. Posting Group, Tax Area Code, Tax Liable, VAT Country/Region Code, Prices Including VAT, Allow Line Disc., and a Customer No. When a customer number is set, its discount/price group settings take precedence over the catalog-level fields.
+
+`Shpfy Market Catalog Relation` (`ShpfyMarketCatalogRelation.Table.al`) is the junction table between markets and catalogs, keyed by Market Id + Catalog Id. `ShpfyCatalogAPI` fetches these relations via `GetCatalogMarkets` GraphQL queries and rebuilds them on each sync.
+
+Price sync works through `ShpfySyncCatalogPrices.Codeunit.al`. For each catalog with `Sync Prices = true`, it fetches current Shopify prices into the temporary `Shpfy Catalog Price` table, then walks every variant, calculates the BC price using `Shpfy Product Price Calc.`, and batches `UpdateCatalogPrices` GraphQL mutations in groups of 250. The compare-at-price is only sent when it exceeds the actual price; otherwise it is nulled out.
+
+`ShpfyCatalogAPI.Codeunit.al` handles catalog CRUD. Creating a company catalog also creates a publication and a price list in Shopify. Market catalogs are imported via `GetMarketCatalogs`. The API also validates currency consistency -- if the catalog's stored currency doesn't match Shopify's price list currency, the sync is skipped and logged as a skipped record.
+
+The `Shpfy Sync Catalogs` report syncs catalog metadata (both company and market types), while `Shpfy Sync Catalog Prices` handles price export. Both can be scoped by catalog type and, for company catalogs, by company ID.

--- a/src/Apps/W1/Shopify/App/src/Companies/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Companies/docs/CLAUDE.md
@@ -1,0 +1,33 @@
+# Companies
+
+The Companies folder handles Shopify B2B company/location import and export. It mirrors the Customers folder's architecture but targets Shopify's company model, where a company has locations and a main contact (who is a Shopify customer).
+
+## Sync flow
+
+`ShpfySyncCompanies.Codeunit.al` orchestrates bidirectional sync, controlled by `Company Import From Shopify` and `Can Update Shopify Companies` on the Shop card. Import fetches company IDs from Shopify, filters by `Updated At` / `Last Updated by BC` timestamps, then runs `ShpfyCompanyImport.Codeunit.al` per company. The import codeunit retrieves the company, updates its locations via the API, then attempts mapping -- falling back to customer creation if `Auto Create Unknown Companies` is enabled.
+
+## Mapping strategies
+
+The `Shpfy ICompany Mapping` interface dispatches via the `Shpfy Company Mapping` enum. Three implementations:
+
+- **By Email/Phone** (`ShpfyCompByEmailPhone.Codeunit.al`) -- finds a BC Customer by the main contact's email or phone. Reuses `CreatePhoneFilter` from the customer mapping codeunit for phone normalization.
+- **Default Company** (`ShpfyCompByDefaultComp.Codeunit.al`) -- always returns `Shop."Default Company No."`.
+- **By Tax Id** (`ShpfyCompByTaxId.Codeunit.al`) -- looks up the company's location, reads its `Tax Registration Id`, and matches via the `Shpfy Tax Registration Id Mapping` interface.
+
+A key design point: `Shpfy IFind Company Mapping` extends `Shpfy ICompany Mapping` with `FindMapping`. In `ShpfyCompanyMapping.Codeunit.al`, if the active mapping implements `IFind Company Mapping`, it's used directly; otherwise the code falls back to `Comp. By Email/Phone`. This means all three implementations actually implement `IFind Company Mapping`, making the fallback a safety net rather than a common path.
+
+## Tax registration ID mapping
+
+The `Shpfy Tax Registration Id Mapping` interface (with `Shpfy Comp. Tax Id Mapping` enum) provides two implementations: `Registration No.` and `VAT Registration No.`. These control which BC customer field is matched against and updated from the Shopify company location's `Tax Registration Id`. The interface has three methods: `GetTaxRegistrationId`, `SetMappingFiltersForCustomers`, and `UpdateTaxRegistrationId`.
+
+## Company location model
+
+`Shpfy Company Location` (`ShpfyCompanyLocation.Table.al`) stores address data per Shopify location. Notable fields include `Sell-to Customer No.` and `Bill-to Customer No.` which allow per-location override of which BC customer is used for order processing -- `Bill-to` requires `Sell-to` to be set first (enforced by OnValidate). The `Customer Id` Guid field links the location to a specific BC customer for multi-location export scenarios.
+
+## Default contact permission
+
+The `Shpfy Default Cont. Permission` enum defines three levels: `No permission`, `Ordering only`, `Location admin`. This controls what access the main contact gets when a company is created in Shopify.
+
+## Export
+
+`ShpfyCompanyExport.Codeunit.al` exports BC customers as Shopify companies. It first creates the customer as a Shopify contact (via `Shpfy Customer Export`), then creates the company with its location. Duplicate detection uses `External Id` (set to the BC customer number). When `Auto Create Catalog` is enabled on the shop, a catalog is automatically created for new companies.

--- a/src/Apps/W1/Shopify/App/src/Customers/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Customers/docs/CLAUDE.md
@@ -1,0 +1,33 @@
+# Customers
+
+Customer sync is bidirectional -- import from Shopify, export from BC -- controlled by `Shpfy Shop` fields `Customer Import From Shopify` and `Can Update Shopify Customer`. `ShpfySyncCustomers.Codeunit.al` orchestrates both directions in a single run, using `Updated At` / `Last Updated by BC` timestamps to skip unchanged records.
+
+## Mapping strategies
+
+The `Shpfy ICustomer Mapping` interface (`ShpfyICustomerMapping.Interface.al`) dispatches via the `Shpfy Customer Mapping` enum on the Shop card. Three implementations exist:
+
+- **By Email/Phone** (`ShpfyCustByEmailPhone.Codeunit.al`) -- imports the Shopify customer if not already local, then resolves by `Customer SystemId`. Falls back to creating a BC customer via `Shpfy Create Customer` when `AllowCreate` is true.
+- **By Bill-to** (`ShpfyCustByBillto.Codeunit.al`) -- matches on address fields (Address, Zip, City, Country) plus the computed Name/Name2 using the shop's name source settings. The most complex strategy because it iterates all addresses for a Shopify customer and tries both name and address equality.
+- **Default Customer** (`ShpfyCustByDefaultCust.Codeunit.al`) -- always returns `Shop."Default Customer No."`. No matching logic at all.
+
+A subtlety in `ShpfyCustomerMapping.Codeunit.al`: when both Name and Name2 from the order are empty, the mapping silently overrides to `By EMail/Phone` regardless of the shop setting. This prevents the Bill-to strategy from failing on anonymous checkouts.
+
+## SystemId-based linking
+
+`Shpfy Customer` links to BC via `Customer SystemId` (a Guid), not `Customer No.`. The `Customer No.` field is a FlowField calculated from the SystemId. `FindMapping` in `ShpfyCustomerMapping.Codeunit.al` validates the link on every call -- if `GetBySystemId` fails (customer deleted), it clears the Guid and re-runs discovery. The BCToShopify direction also queries the Shopify API by email/phone as a fallback.
+
+## Customer name parsing
+
+`Shpfy ICustomer Name` interface with four implementations controlled by the `Shpfy Name Source` enum: `CompanyName`, `FirstAndLastName`, `LastAndFirstName`, and `None` (empty). The Shop card exposes three independent name-source fields -- `Name Source`, `Name 2 Source`, `Contact Source` -- each choosing an implementation independently. On export, `SpiltNameIntoFirstAndLastName` in `ShpfyCustomerExport.Codeunit.al` reverses the process, splitting a BC name string back into Shopify first/last name fields.
+
+## County mapping
+
+Two parallel interfaces: `Shpfy ICounty` resolves county from a `Shpfy Customer Address` or `Shpfy Company Location` record, while `Shpfy ICounty From Json` resolves from raw JSON during import. The `Shpfy County Source` enum implements both, with `Code` and `Name` variants. County resolution depends on the `Shpfy Tax Area` table for province code/name lookups.
+
+## Address negative ID allocation
+
+`ShpfyCustomerAddress.Table.al` uses negative IDs for BC-created addresses (OnInsert assigns `Min(-1, lowest existing Id - 1)`). This reserves the positive ID space for Shopify-assigned identifiers, so locally created addresses never collide with real Shopify addresses.
+
+## Customer templates
+
+`Shpfy Customer Template` (keyed by Shop Code + Country/Region Code) lets you assign different `Customer Templ. Code` and `Default Customer No.` per country. `ShpfyCreateCustomer.Codeunit.al` looks up the template by the address's country code, falling back to the shop-level `Customer Templ. Code` if no country-specific override exists. Templates that don't exist yet are auto-inserted as blank rows for later configuration.

--- a/src/Apps/W1/Shopify/App/src/Document Links/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Document Links/docs/CLAUDE.md
@@ -1,0 +1,24 @@
+# Document links
+
+This folder tracks the relationship between Shopify documents (orders, returns, refunds) and BC documents (sales orders, invoices, shipments, credit memos, return receipts) through the `Shpfy Doc. Link To Doc.` table.
+
+## Core table
+
+`ShpfyDocLinkToDoc.Table.al` has a four-part key: `(Shopify Document Type, Shopify Document Id, Document Type, Document No.)`. This is a many-to-many link -- one Shopify order can produce multiple BC documents (a sales order, then a posted shipment, then a posted invoice), and the table accumulates all of them. Two secondary indexes support lookup from either side. The table exposes `OpenShopifyDocument` and `OpenBCDocument` which dispatch to the appropriate interface implementation to open the relevant card page.
+
+## Interface-driven navigation
+
+Two interfaces handle document opening:
+
+- `Shpfy IOpenShopifyDocument` -- implemented by the `Shpfy Shop Document Type` enum. Values are `Shopify Shop Order`, `Shopify Shop Return`, `Shopify Shop Refund`, each with a codeunit that opens the corresponding Shopify record card. Unsupported types fall through to `Shpfy OpenDoc NotSupported`.
+- `Shpfy IOpenBCDocument` -- implemented by the `Shpfy Document Type` enum. Covers `Sales Order`, `Sales Invoice`, `Sales Return Order`, `Sales Credit Memo`, `Posted Sales Shipment`, `Posted Return Receipt`, `Posted Sales Invoice`, `Posted Sales Credit Memo`. Each has a dedicated codeunit (e.g., `ShpfyOpenSalesOrder.Codeunit.al`) that runs the appropriate page.
+
+Both enums are extensible, so third-party extensions can add new document types.
+
+## Automatic link propagation
+
+`ShpfyDocumentLinkMgt.Codeunit.al` subscribes to sales posting events to propagate links as documents move through the BC lifecycle. When a sales order is posted, links are created to the resulting posted shipment, posted invoice, posted return receipt, and posted credit memo. When a sales header is deleted after posting (via `PostSales-Delete`), existing links are carried forward to the posted documents. The `OnAfterSalesPosting` handler also traces shipment-to-invoice relationships for standalone invoice posting, walking `Sales Invoice Line."Shipment No."` to find the originating Shopify order link.
+
+## IsProcessed
+
+Order processing status is determined by the existence of document links -- a Shopify order is considered processed once at least one BC document link exists for it. This is why link creation is critical to the overall sync workflow.

--- a/src/Apps/W1/Shopify/App/src/GraphQL/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# GraphQL
+
+This folder is the typed query catalog for all Shopify Admin API calls. Every GraphQL query or mutation the connector can issue is encapsulated in its own codeunit implementing the `Shpfy IGraphQL` interface. The folder exists so that API surface changes (field renames, pagination tweaks, new endpoints) are isolated to small, single-purpose files rather than scattered across business logic.
+
+## How it works
+
+The `Shpfy IGraphQL` interface defines two methods: `GetGraphQL()` returns the raw JSON-encoded GraphQL query string with `{{Param}}` placeholders, and `GetExpectedCost()` returns an integer estimate of the query's point cost for rate limiting. Each implementing codeunit is registered in the `Shpfy GraphQL Type` enum (`ShpfyGraphQLType.Enum.al`), which maps enum values to implementations via AL's `implements` keyword.
+
+Callers never instantiate these codeunits directly. The flow is: caller passes a `Shpfy GraphQL Type` enum value plus a `Dictionary of [Text, Text]` of parameters to `CommunicationMgt.ExecuteGraphQL`. That method delegates to `ShpfyGraphQLQueries.GetQuery`, which resolves the enum to its `IGraphQL` implementation, calls `GetGraphQL()` and `GetExpectedCost()`, then does string replacement of `{{key}}` placeholders with the provided parameter values. The assembled query and cost are returned to `CommunicationMgt`, which feeds the cost to `ShpfyGraphQLRateLimit.WaitForRequestAvailable` before posting the HTTP request to Shopify's `graphql.json` endpoint.
+
+Rate limiting is cooperative. `ShpfyGraphQLRateLimit` is a SingleInstance codeunit that tracks the `currentlyAvailable` cost bucket and `restoreRate` from Shopify's `extensions.cost.throttleStatus` response. Before each request, it compares the expected cost to available points and sleeps if necessary. This avoids 429s without requiring retry loops for most queries.
+
+## Things to know
+
+- Each codeunit is deliberately tiny -- typically just `GetGraphQL` returning a string literal and `GetExpectedCost` returning a small integer (commonly 2-12). Do not refactor them into a single file; the one-codeunit-per-query pattern is intentional for discoverability and diff isolation.
+- Naming convention: codeunit names use the `ShpfyGQL` prefix (e.g. `ShpfyGQLFindVariantBySKU`). Pagination queries use a `Next` prefix variant (e.g. `ShpfyGQLNextCustomerIds`).
+- The `ShpfyGraphQLQueries` codeunit is SingleInstance and fires several internal events (`OnBeforeSetInterfaceCodeunit`, `OnBeforeGetGrapQLInfo`, `OnBeforeReplaceParameters`, etc.) that allow other modules or tests to intercept or replace queries at runtime.
+- Parameter substitution is plain string replacement of `{{ParamName}}`. There is no escaping at this layer -- callers are responsible for passing already-escaped values (the `CommunicationMgt.EscapeGraphQLData` helper exists for this).
+- The enum is `Extensible = true`, so partner extensions can add new query types without modifying the base connector.
+- The `GraphQL Type` enum currently has ~145 values spanning products, orders, customers, companies, inventory, fulfillment, returns, refunds, catalogs, webhooks, payments, disputes, translations, metafields, and bulk operations. If you are adding a new Shopify API call, add a new enum value, a new codeunit implementing `IGraphQL`, and call it via `CommunicationMgt.ExecuteGraphQL`.
+- Bulk operations use a separate path (`ShpfyBulkOperationAPI`) but still go through the same `ExecuteGraphQL` mechanism for the initial mutation and polling queries.

--- a/src/Apps/W1/Shopify/App/src/Inventory/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Inventory/docs/CLAUDE.md
@@ -1,0 +1,13 @@
+# Inventory
+
+Stock calculation and export to Shopify, driven by a per-location strategy pattern.
+
+Each Shopify location (`Shpfy Shop Location` table) carries a `Stock Calculation` enum that implements two interfaces simultaneously -- `Shpfy Stock Calculation` (computes the number) and `Shpfy IStock Available` (decides whether the location can hold stock at all). The built-in strategies are "Disabled" (returns 0, marks location as non-stocking), "Projected Available Balance Today" (`ShpfyBalanceToday.Codeunit.al` -- uses `ItemAvailabilityFormsMgt.CalcAvailQuantities`), and "Non-reserved Inventory" (`ShpfyFreeInventory.Codeunit.al` -- `Inventory - Reserved Qty. on Inventory`). The enum is `Extensible = true`, so partners can add custom calculations.
+
+The `Shpfy Extended Stock Calculation` interface extends `Shpfy Stock Calculation` with a location-aware overload. `ShpfyInventoryAPI` checks at runtime whether the resolved implementation supports the extended interface and calls the appropriate overload -- this lets custom implementations filter by BC location without the connector knowing the details.
+
+Location mapping is central. `Shpfy Shop Location` has a `Location Filter` field (a BC location code filter expression) that scopes the Item record before stock calculation, plus a `Default Location Code` used on sales documents. The report `ShpfyCreateLocationFilter.Report.al` provides a picker UI to build the filter string. Locations are synced from Shopify via `ShpfySyncShopLocations.Codeunit.al`, which also manages fulfillment service callback URLs.
+
+The sync flow in `ShpfySyncInventory.Codeunit.al` first imports current Shopify inventory levels per location (via paginated GraphQL), then exports calculated BC stock using `inventorySetQuantities` mutations batched in groups of 250. Export uses an idempotency key and retries up to 3 times on `IDEMPOTENCY_CONCURRENT_REQUEST` / `CHANGE_FROM_QUANTITY_STALE` errors. Negative stock is clamped to 0. UoM conversion happens when the variant's UoM option differs from the item's base UoM.
+
+The `OnAfterCalculationStock` integration event in `ShpfyInventoryEvents.Codeunit.al` fires after every stock calculation with the Item, Shop, LocationFilter, and a `var StockResult` -- this is the primary extension point for partners who want to adjust the final number without replacing the entire strategy.

--- a/src/Apps/W1/Shopify/App/src/Logs/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Logs/docs/CLAUDE.md
@@ -1,0 +1,9 @@
+# Logs
+
+HTTP request/response logging, raw data capture for audit, and skipped record tracking.
+
+`Shpfy Log Entry` (`ShpfyLogEntry.Table.al`) records every Shopify API call. Request and response bodies are stored as BLOBs (with 50-char preview fields for list display). Key diagnostic fields: `Status Code`, `Has Error`, `Retry Count`, `Query Cost` (the GraphQL cost returned by Shopify), `Shpfy Request Id` (Shopify's correlation ID for support escalation), URL, and HTTP method. The `ShpfyLogEntries.Codeunit.al` provides download helpers for request/response JSON and an escalation report generator that bundles all details into a text file for Shopify support -- gated behind a connection test and limited to status-500 entries within the last 14 days.
+
+`Shpfy Data Capture` (`ShpfyDataCapture.Table.al`) stores raw JSON payloads linked to specific records via `Linked To Table` (table number) and `Linked To Id` (SystemId). It uses a hash-based dedup -- new captures are skipped if the hash matches the previous entry for the same record. This is used throughout the connector (transactions, payouts, payment transactions) to preserve the original Shopify JSON for audit purposes. Records clean up via cascade delete when the parent is deleted.
+
+`Shpfy Skipped Record` (`ShpfySkippedRecord.Table.al`) tracks records that were intentionally skipped during sync, with a `Skipped Reason` and a link back to the source `Record ID`. The `ShpfySkippedRecord.Codeunit.al` sends a one-time notification in the UI when records are skipped and respects the shop's `Logging Mode` setting (skips are not logged when logging is disabled). Both log entries and skipped records support age-based deletion and integrate with BC's retention policy framework via `ShpfyLogEntriesDelete.Codeunit.al`.

--- a/src/Apps/W1/Shopify/App/src/Metafields/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Metafields/docs/CLAUDE.md
@@ -1,0 +1,31 @@
+# Metafields
+
+Metafields are Shopify's key-value extension mechanism. This folder implements a single `Shpfy Metafield` table that stores metafields across all owner types, with type-safe validation and bidirectional sync.
+
+## Multi-owner polymorphism
+
+The `Shpfy Metafield` table uses two fields to identify ownership: `Owner Type` (enum) and `Parent Table No.` (integer). These are kept in sync -- validating either one sets the other via `GetOwnerType` (a case statement mapping table IDs to enum values) and the `Shpfy IMetafield Owner Type` interface (which returns the table ID). Four owner types exist: `Customer`, `Product`, `ProductVariant`, `Company`, each backed by a codeunit in `Codeunits/IOwnerType/` that implements `GetTableId`, `RetrieveMetafieldIdsFromShopify`, `GetShopCode`, and `CanEditMetafields`.
+
+The composite key `(Parent Table No., Owner Id)` indexes metafields by owner, while the primary key is just the Shopify `Id`.
+
+## Negative ID allocation
+
+BC-created metafields get negative IDs via the OnInsert trigger: find the lowest existing Id, subtract 1 (minimum -1). This mirrors the pattern used in `Shpfy Customer Address`. When synced to Shopify, the real positive ID replaces the placeholder. The default namespace for BC-created metafields is `Microsoft.Dynamics365.BusinessCentral`.
+
+## Type-safe value validation
+
+The `Shpfy IMetafield Type` interface provides four methods: `HasAssistEdit`, `IsValidValue`, `AssistEdit`, and `GetExampleValue`. The `Shpfy Metafield Type` enum maps ~25 Shopify types to implementations in `Codeunits/IMetafieldType/`. The Value field's OnValidate trigger calls `IMetafieldType.IsValidValue` and errors with the example value on failure. The `money` type additionally validates that the currency code matches the shop's currency.
+
+Notable: `string` and `integer` are legacy types that error on assignment, directing users to `single_line_text_field` and `number_integer` respectively. `rating` and `rich_text_field` are intentionally commented out as unsupported.
+
+## Adding a new type
+
+To add a new metafield type:
+
+1. Add a value to the `Shpfy Metafield Type` enum with an `Implementation` pointing to a new codeunit
+2. Create the codeunit implementing `Shpfy IMetafield Type` in `Codeunits/IMetafieldType/`
+3. Implement the four interface methods (validation logic, example value, optional assist edit)
+
+## Sync API
+
+`ShpfyMetafields.Codeunit.al` is the public facade (Access = Public). It delegates to `ShpfyMetafieldAPI.Codeunit.al` for the actual Shopify GraphQL calls. Three operations: `GetMetafieldDefinitions` (pulls definitions from Shopify), `SyncMetafieldToShopify` (single metafield), `SyncMetafieldsToShopify` (all metafields for an owner, filtered by `Last Updated by BC`).

--- a/src/Apps/W1/Shopify/App/src/Order Fulfillments/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Fulfillments/docs/CLAUDE.md
@@ -1,0 +1,28 @@
+# Order Fulfillments
+
+This folder models two distinct Shopify concepts that are easy to confuse: **fulfillment orders** (what needs to be shipped) and **fulfillments** (what has been shipped).
+
+## Fulfillment orders vs fulfillments
+
+A **fulfillment order** (`Shpfy FulFillment Order Header` / `Line`) represents Shopify's instruction to ship specific line items from a specific location. It has a status (OPEN, CLOSED, etc.) and a request status tracking the fulfillment service handshake. A single Shopify order can have multiple fulfillment orders -- one per location or fulfillment service.
+
+A **fulfillment** (`Shpfy Order Fulfillment` / `Shpfy Fulfillment Line`) represents an actual shipment that was created. It carries tracking info (number, URL, company) and a status (Success, Cancelled, etc.). Fulfillments are imported during order import via `ShpfyOrderFulfillments.GetFulfillments`.
+
+## Delivery method types
+
+The `Shpfy Delivery Method Type` enum covers: Local, None, Pick Up, Retail, Shipping, Pickup Point. This is stored on the fulfillment order header and propagated to fulfillment order lines and then to order lines.
+
+## Request status lifecycle
+
+The `Shpfy FF Request Status` enum models the fulfillment service protocol: Unsubmitted -> Submitted -> Accepted (or Rejected). Cancellation flows through Cancellation Requested -> Cancellation Accepted/Rejected. The connector auto-accepts pending fulfillment requests during shipment export when the fulfillment order is OPEN with status SUBMITTED (see `AcceptPendingFulfillmentRequests` in `ShpfyExportShipments`).
+
+## How BC shipments become Shopify fulfillments
+
+`ShpfyFulfillmentOrdersAPI.GetShopifyFulfillmentOrdersFromShopifyOrder` fetches fulfillment orders for an order during import. When BC posts a Sales Shipment, `ShpfyExportShipments.CreateShopifyFulfillment` matches shipment lines to fulfillment order lines (by `Line Item Id`), builds a `fulfillmentCreate` GraphQL mutation, and sends it. The resulting fulfillment is imported back and stored. If the shop has a registered fulfillment service (auto-registered on first outgoing request), the connector also queries for assigned fulfillment orders via `GetAssignedFulfillmentOrders`.
+
+## Key files
+
+- `ShpfyFulfillmentOrdersAPI.Codeunit.al` -- GraphQL operations for fulfillment orders, including registration, extraction, and acceptance.
+- `ShpfyOrderFulfillments.Codeunit.al` -- imports fulfillment data (tracking, lines, gift card detection).
+- `ShpfyFulFillmentOrderHeader.Table.al` / `ShpfyFulFillmentOrderLine.Table.al` -- fulfillment order data model.
+- `ShpfyOrderFulfillment.Table.al` / `ShpfyFulfillmentLine.Table.al` -- actual fulfillment data model.

--- a/src/Apps/W1/Shopify/App/src/Order Refunds/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/docs/CLAUDE.md
@@ -1,0 +1,30 @@
+# Order Refunds
+
+This folder models Shopify refunds -- the financial side of returning money to a customer. A refund may or may not be associated with a return.
+
+## Data model
+
+`Shpfy Refund Header` (table 30142) carries the refund total (`"Total Refunded Amount"` / `"Pres. Tot. Refunded Amount"`), timestamps, a link to the parent order and optionally to a return, a note (blob), and error tracking fields (`"Has Processing Error"`, `"Last Error Description"`, `"Last Error Call Stack"` -- all blobs). The `"Is Processed"` field is a FlowField checking for a linked BC document in `Shpfy Doc. Link To Doc.`.
+
+`Shpfy Refund Line` (table 30145) stores per-line-item refund data:
+
+- Quantity and restock type (`Shpfy Restock Type`: NoRestock, Cancel, Return, LegacyRestock).
+- Amounts in dual currencies: `Amount` / `"Presentment Amount"` (price), `"Subtotal Amount"` / `"Presentment Subtotal Amount"`, and `"Total Tax Amount"` / `"Presentment Total Tax Amount"`.
+- `"Can Create Credit Memo"` -- a critical flag. It is true when the refund has a non-zero refunded amount or is linked to a return, or when the restock type is Return. Lines without this flag are the ones that were already deducted from the order during import (see `ConsiderRefundsInQuantityAndAmounts` in the order import logic) and should not produce duplicate credit memo lines.
+- `"Location Id"` -- resolved from the refund JSON or, for return-based refunds, from the return's reverse fulfillment order locations.
+
+`Shpfy Refund Shipping Line` (table in this folder) captures refunded shipping amounts with subtotal and tax in dual currencies.
+
+## Import flow
+
+`ShpfyRefundsAPI.GetRefunds` processes refund nodes from the order JSON. For each refund:
+
+1. Fetches or updates the refund header via GraphQL, including currency translation through `ImportOrder.TranslateCurrencyCode`.
+2. Collects return locations if the refund is linked to a return (delegates to `ReturnsAPI.GetReturnLocations`).
+3. Fetches refund lines with pagination, setting `"Can Create Credit Memo"` based on `IsNonZeroOrReturnRefund`.
+4. Fetches refund shipping lines.
+5. Links refund transactions back to order transactions by setting `"Refund Id"` on matching `Shpfy Order Transaction` records.
+
+## The "Can Create Credit Memo" flag
+
+This is the key to understanding how refunds interact with orders. During order import, refund line quantities are subtracted from order line quantities. Those "absorbed" refund lines get `"Can Create Credit Memo" = false`. Only refund lines that represent actual returns or have a non-zero total refunded amount (i.e., money was actually sent back to the customer beyond what was absorbed into the order) get `true`. The credit memo creation code in Order Return Refund Processing skips refunds where any line has this flag set to false.

--- a/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/docs/CLAUDE.md
@@ -1,0 +1,53 @@
+# Order Return Refund Processing
+
+This folder orchestrates the creation of BC credit memos from Shopify refunds. It uses an interface-based strategy pattern to support different processing modes.
+
+## Processing modes
+
+The `Shpfy ReturnRefund ProcessType` enum (extensible) maps to implementations of `Shpfy IReturnRefund Process`:
+
+- **Default (blank)** -- `ShpfyRetRefProcDefault`. Does nothing: `IsImportNeededFor` returns false, no documents are created. Returns and refunds are not imported at all.
+- **Import Only** -- `ShpfyRetRefProcImportOnly`. Imports returns and refunds (`IsImportNeededFor` returns true) but never creates sales documents.
+- **Auto Create Credit Memo** -- `ShpfyRetRefProcCrMemo`. Imports returns/refunds and auto-creates credit memos from refunds.
+
+The mode is set on the Shop record as `"Return and Refund Process"`. The interface is consumed in two places: during order import (to decide whether to fetch returns/refunds) and during order processing (to create credit memos).
+
+## The IReturnRefundProcess interface
+
+Three methods:
+
+- `IsImportNeededFor(SourceDocumentType)` -- controls whether returns or refunds are fetched during order import.
+- `CanCreateSalesDocumentFor(SourceDocumentType, SourceDocumentId, ErrorInfo)` -- validates preconditions: the refund must not already be processed, the parent order must exist and be processed. Returns detailed error info on failure.
+- `CreateSalesDocument(SourceDocumentType, SourceDocumentId)` -- creates the sales document.
+
+## Credit memo auto-creation
+
+`ShpfyRetRefProcCrMemo.CreateSalesDocument` is the entry point. It:
+
+1. Validates via `CanCreateSalesDocumentFor` -- checks the refund is not already linked to a BC document, the order exists and is processed.
+2. Skips if any refund line has `"Can Create Credit Memo" = false` (these were already absorbed into the order).
+3. Delegates to `ShpfyCreateSalesDocRefund` (codeunit 30246), which runs inside `codeunit.Run()` for error isolation.
+
+`ShpfyCreateSalesDocRefund.CreateSalesDocument` does the actual work:
+
+1. Creates a Sales Credit Memo header copying addresses, customer, currency, and tax area from the original order. Uses `"Processed Currency Handling"` from the order to pick the right currency -- important because the order may have been processed with a different currency setting than the shop currently has.
+2. Creates lines from refund lines, handling each restock type differently:
+   - **Return / Legacy Restock** -- creates Item lines with the refunded item, variant, UoM, and location (from the refund's resolved location or the shop's default return location based on `"Return Location Priority"`).
+   - **No Restock** -- creates G/L Account lines using `"Refund Acc. non-restock Items"`.
+   - **Cancel** -- creates G/L Account lines using `"Refund Account"`.
+3. If no refund lines exist but a return ID is present, falls back to creating lines from return lines instead.
+4. Creates lines for refund shipping amounts.
+5. Adds a balancing "remaining amount" line to ensure the credit memo total matches the refund's total refunded amount exactly (accounts for rounding, tax differences, etc.).
+6. Auto-releases the credit memo.
+
+## Error handling
+
+Errors during credit memo creation are captured and stored on the refund header as blob fields (`"Last Error Description"`, `"Last Error Call Stack"`). The `Shpfy IDocument Source` / `Shpfy Extended IDocument Source` interfaces provide the `SetErrorInfo` / `SetErrorCallStack` callbacks used by the processing code to persist error details. The `"Has Processing Error"` flag on the refund header enables filtering for failed refunds.
+
+## Key files
+
+- `ShpfyRetRefProcCrMemo.Codeunit.al` -- the "Auto Create Credit Memo" strategy implementation.
+- `ShpfyCreateSalesDocRefund.Codeunit.al` -- the actual credit memo creation logic.
+- `ShpfyRetRefProcDefault.Codeunit.al` / `ShpfyRetRefProcImportOnly.Codeunit.al` -- the no-op and import-only strategies.
+- `ShpfyIReturnRefundProcess.Interface.al` -- the strategy interface.
+- `ShpfyRefundProcessEvents.Codeunit.al` -- event publishers for extensibility (OnBefore/AfterCreateSalesHeader, OnBefore/AfterCreateItemSalesLine, etc.).

--- a/src/Apps/W1/Shopify/App/src/Order Returns/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Returns/docs/CLAUDE.md
@@ -1,0 +1,32 @@
+# Order Returns
+
+This folder models Shopify returns -- the customer's request to send items back. Returns are distinct from refunds: a return tracks what is being sent back, while a refund tracks the money.
+
+## Data model
+
+`Shpfy Return Header` (table 30147) holds the return metadata: status, total quantity, decline reason/note, and links to the parent order. FlowFields pull customer names and order numbers from the order header.
+
+`Shpfy Return Line` (table 30141) has two types controlled by the `Type` field:
+
+- **Default** -- a verified return line item linked to a fulfillment line and order line. Carries quantity, refundable/refunded quantities, weight, discounted total amounts (shop and presentment currency), return reason name/handle, and customer/return reason notes (stored as blobs).
+- **Unverified** -- an `UnverifiedReturnLineItem` from Shopify's API, which lacks a fulfillment line link and instead carries a unit price and currency. These represent items not yet verified against a fulfillment.
+
+## Return status lifecycle
+
+The `Shpfy Return Status` enum models: Open, Closed, Cancelled, Requested, Declined. The `Shpfy Return Decline Reason` enum captures why a return was declined (e.g. FinalSale, ReturnPeriodEnded, Other).
+
+## Import flow
+
+`ShpfyReturnsAPI.GetReturns` is called during order import (if the return/refund processing mode requires it). It:
+
+1. Iterates return nodes from the order JSON, fetching each return header via `GetReturnHeader`.
+2. Resolves return locations by querying reverse fulfillment orders (`GetReturnLocations`). This determines which BC location the returned items go back to. If an item was restocked to multiple locations, the location is intentionally left unresolved (logged via telemetry).
+3. Fetches return lines with pagination. Default lines are linked to fulfillment lines and order lines. Unverified lines lack these links.
+
+## Relationship to refunds
+
+A return can be associated with a refund through the refund header's `"Return Id"` field. The refund processing code uses return lines as a fallback source for credit memo lines when refund lines are absent (see Order Return Refund Processing).
+
+## Location resolution
+
+The `GetReturnLocations` procedure queries Shopify's `reverseFulfillmentOrders` to find where items were restocked. It collects disposition locations per order line ID. If dispositions disagree (restocked to multiple locations), the order line is excluded from the dictionary and the location remains unknown on the return/refund line.

--- a/src/Apps/W1/Shopify/App/src/Order handling/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order handling/docs/CLAUDE.md
@@ -1,0 +1,36 @@
+# Order handling
+
+This folder owns the full lifecycle of a Shopify order inside BC -- from API fetch through to a posted Sales Order or Sales Invoice.
+
+## Import flow
+
+Orders arrive in two stages. `ShpfyOrdersAPI` (codeunit 30165) runs a GraphQL cursor-paginated query against the Shopify Orders API and writes lightweight rows into `Shpfy Orders to Import`. On first sync (no previous sync time) it fetches only open orders; subsequent syncs fetch by `updatedAt`. `ShpfyImportOrder` (codeunit 30161) then retrieves the full order JSON per order, populates `Shpfy Order Header` and `Shpfy Order Line`, and pulls in related records -- fulfillment orders, shipping charges, transactions, returns, and refunds -- all inside `SetAndCreateRelatedRecords`. Refund lines are subtracted from order line quantities and header amounts in `ConsiderRefundsInQuantityAndAmounts` so the order reflects the net position.
+
+## Dual currency model
+
+Every monetary field on the header and lines exists in two flavours: shop currency (e.g. `"Total Amount"`, `"Unit Price"`) and presentment currency (e.g. `"Presentment Total Amount"`, `"Presentment Unit Price"`). The shop's `"Currency Handling"` setting -- either `Shop Currency` or `Presentment Currency` -- selects which set flows into the BC Sales Document. This choice is recorded on the order header as `"Processed Currency Handling"` at processing time so credit memos created later use the same currency the order was processed in.
+
+## Mapping chain
+
+`ShpfyOrderMapping` (codeunit 30163) resolves everything the Sales Header needs before document creation. The chain is:
+
+- **Customer / Company** -- B2C orders use `ShpfyCustomerMapping`, B2B orders use `ShpfyCompanyMapping`. Falls back to `"Default Customer No."` / `"Default Company No."` on the shop. B2B orders with a company location try to resolve sell-to and bill-to from the location record first.
+- **Shipment method** -- looked up via `Shpfy Shipment Method Mapping` keyed on (Shop Code, shipping charge title).
+- **Shipping agent** -- same mapping table, separate fields for agent code and service code.
+- **Payment method** -- resolved from `Shpfy Order Transaction` records; only set when all successful sale/capture/authorization transactions agree on a single payment method.
+
+## Tax area priority
+
+`ShpfyOrderMgt.FindTaxArea` implements a configurable address priority (`"Tax Area Priority"` on the shop) to decide which address (ship-to, sell-to, bill-to) determines the tax area code. Six permutations are supported. Presence is determined by whether the city field is non-empty.
+
+## Processing -- Sales Order vs Sales Invoice
+
+`ShpfyProcessOrder` (codeunit 30166) decides the document type: if the order's fulfillment status is `Fulfilled` and the shop has `"Create Invoices From Orders"` enabled, it creates a Sales Invoice; otherwise a Sales Order. Line creation handles tips (G/L Account from `"Tip Account"`), gift cards (`"Sold Gift Card Account"`), and regular items. Shipping charges create additional lines -- either from the shop's `"Shipping Charges Account"` or from the shipment method mapping's custom type/no. if configured (which can be G/L Account, Item, or Item Charge). After lines, a global discount residual (order discount minus sum of line discounts) is applied as an invoice discount. The document is optionally auto-released via `"Auto Release Sales Orders"`.
+
+## The "Processed" flag
+
+`OrderHeader.Processed` is set to `true` after successful document creation. It is also set if a Shopify Invoice already existed at import time. The `IsProcessed()` function is broader -- it also checks the `Shpfy Doc. Link To Doc.` table for any linked BC document, so even if someone clears the Processed flag, the link table still prevents reprocessing. When re-importing a processed order, the system detects conflicts (changed line items, quantities, or shipping amounts) and sets `"Has Order State Error"` to flag the order for manual review.
+
+## Archive / close
+
+If `"Archive Processed Orders"` is enabled, the import step calls `CheckToCloseOrder`. An order is closed in Shopify when it is fulfilled, fully paid, and has no outstanding sales line quantities (for orders) or simply has a Sales Invoice No. and is fulfilled (for invoices).

--- a/src/Apps/W1/Shopify/App/src/Order handling/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/src/Order handling/docs/business-logic.md
@@ -1,0 +1,100 @@
+# Order handling -- business logic
+
+## Order import
+
+`ShpfyOrdersAPI.GetOrdersToImport` cursor-paginates through the Shopify GraphQL Orders API. It writes rows into `Shpfy Orders to Import` -- a staging table displayed in the "Orders to Import" page. Each row carries lightweight summary data (amounts, statuses, tags, risk, channel info). The `"Import Action"` field is set to `New` or `Update` depending on whether a matching `Shpfy Order Header` already exists. Closed orders that have never been imported are skipped.
+
+`ShpfyImportOrder.ImportOrderAndCreateOrUpdate` does the heavy lifting per order:
+
+1. Ensures an `Shpfy Order Header` record exists (insert if new).
+2. Retrieves the full order JSON via `GetOrderHeader` GraphQL query.
+3. Retrieves all order lines with cursor pagination (`GetOrderLines` / `GetNextOrderLines`).
+4. If the order was already processed and is not already in a conflict state, compares the incoming data against the existing order (item quantities, line ID hash, shipping amounts) to detect edits. Sets `"Has Order State Error"` on conflict.
+5. Populates header fields from JSON -- three address blocks (sell-to, ship-to, bill-to), B2B purchasing entity, retail location.
+6. Calls `SetAndCreateRelatedRecords`: fulfillment orders, shipping charges, transactions, returns (if import needed), refunds (if import needed).
+7. Inserts order lines, computing a hash-based redundancy code for future conflict detection.
+8. Subtracts refunded quantities and amounts from lines and header.
+9. Deletes zero-quantity lines.
+10. Optionally closes the order in Shopify and marks as processed if a Shopify Invoice already exists.
+
+```mermaid
+flowchart TD
+    A[Shopify GraphQL: Orders] -->|cursor pagination| B[Orders to Import staging table]
+    B -->|per order| C[Import Order]
+    C --> D{Order exists?}
+    D -->|No| E[Insert Order Header]
+    D -->|Yes| F[Check for conflicts]
+    F -->|conflict| G[Set Has Order State Error]
+    E --> H[Fetch full order JSON]
+    F --> H
+    H --> I[Populate header fields]
+    I --> J[Fetch & insert order lines]
+    J --> K[Import related: fulfillment orders, shipping, transactions, returns, refunds]
+    K --> L[Subtract refund quantities/amounts]
+    L --> M[Delete zero-quantity lines]
+    M --> N{Archive enabled & fully fulfilled & paid?}
+    N -->|Yes| O[Close order in Shopify]
+    N -->|No| P[Done]
+```
+
+## Order processing
+
+`ShpfyProcessOrders` iterates unprocessed orders for a shop and delegates each to `ShpfyProcessOrder`. On failure the error is captured, the Sales Header (if partially created) is deleted via `CleanUpLastCreatedDocument`, and the order is flagged with `"Has Error"` / `"Error Message"`.
+
+`ShpfyProcessOrder.OnRun` orchestrates:
+
+1. **Mapping** -- `ShpfyOrderMapping.DoMapping` resolves customer, shipment method, shipping agent, payment method, and (for B2B) company location. If mapping fails, the order errors.
+2. **Header creation** -- `CreateHeaderFromShopifyOrder` creates a Sales Order or Sales Invoice (see decision below), sets all address and metadata fields, validates currency, tax area, shipping method, payment method, and payment terms.
+3. **Line creation** -- `CreateLinesFromShopifyOrder` creates lines for each order line (items, tips, gift cards), then shipping charge lines, then a cash rounding line if needed.
+4. **Global discount** -- `ApplyGlobalDiscounts` computes the residual discount (order-level discount minus sum of line-level and shipping discounts) and applies it as an invoice discount.
+5. **Auto-release** -- if `"Auto Release Sales Orders"` is enabled, the document is released.
+
+After processing, `ProcessShopifyRefunds` runs if the shop's return/refund process is "Auto Create Credit Memo", iterating unprocessed refund headers and creating credit memos.
+
+```mermaid
+flowchart TD
+    A[Process Orders] --> B[Filter: Processed = false]
+    B --> C{Next order}
+    C --> D[DoMapping]
+    D -->|fail| E[Set Has Error, clean up]
+    D -->|ok| F{Fulfilled AND Create Invoices?}
+    F -->|Yes| G[Create Sales Invoice]
+    F -->|No| H[Create Sales Order]
+    G --> I[Create lines: items, tips, gift cards]
+    H --> I
+    I --> J[Create shipping charge lines]
+    J --> K[Apply global discount residual]
+    K --> L{Auto Release?}
+    L -->|Yes| M[Release Sales Document]
+    L -->|No| N[Mark Processed]
+    M --> N
+    N --> C
+    C -->|done| O[Process Shopify Refunds]
+```
+
+## Sales Order vs Sales Invoice decision
+
+The decision happens in `CreateHeaderFromShopifyOrder`: if fulfillment status is `Fulfilled` **and** the shop setting `"Create Invoices From Orders"` is true, a Sales Invoice is created. Otherwise a Sales Order. This means partially-fulfilled orders always become Sales Orders.
+
+## Currency selection
+
+Controlled by `Shop."Currency Handling"`. When set to `Shop Currency`, the Sales Header gets `Shop."Currency Code"` and line prices use the `shopMoney` amounts from Shopify. When set to `Presentment Currency`, it uses the order's `"Presentment Currency Code"` and `presentmentMoney` amounts. The currency code is translated through BC's Currency table (ISO Code lookup) and blanked if it matches LCY.
+
+## Fulfillment status checks
+
+During import, the connector fetches fulfillment orders from Shopify and stores them as `Shpfy FulFillment Order Header` / `Line` records. These drive location and delivery method on order lines -- `UpdateLocationIdAndDeliveryMethodOnOrderLine` copies the fulfillment order's location and delivery method onto the order line when quantities match.
+
+## Shipment sync to Shopify
+
+Handled by `ShpfyExportShipments` (in the Shipping folder). When a BC Sales Shipment is posted against a Shopify order, the connector builds a `fulfillmentCreate` GraphQL mutation. It matches shipment lines to fulfillment order lines by `Shpfy Order Line Id`, respects remaining quantities, and auto-accepts pending fulfillment requests. Tracking info (number, URL, company) comes from the Sales Shipment Header and Shipping Agent.
+
+## Error handling and retry
+
+Each order is processed inside a `ProcessOrder.Run()` call (codeunit.Run with error isolation). If it fails:
+
+- The partially-created Sales Header is deleted.
+- `"Has Error"` and `"Error Message"` are set on the order header.
+- `"Sales Order No."` and `"Sales Invoice No."` are cleared.
+- `Commit()` is called, so the error state persists and the next order can proceed.
+
+Orders with errors remain `Processed = false` and will be retried on the next sync run. The `"Has Order State Error"` flag (for conflict detection) is separate from `"Has Error"` (for processing failures) -- both must be addressed, but through different paths (manual resolution vs. retry).

--- a/src/Apps/W1/Shopify/App/src/Payments/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Payments/docs/CLAUDE.md
@@ -1,0 +1,13 @@
+# Payments
+
+Shopify Payments account data -- payouts, balance transactions, disputes, and payment terms mapping. This is distinct from the `Transactions/` folder, which handles order-level transactions.
+
+The `Shpfy Payments` codeunit (`ShpfyPayments.Codeunit.al`) orchestrates two sync flows. `SyncPayouts` first backfills payout IDs on orphaned payment transactions, updates pending payout statuses, then imports new transactions and payouts (all via `ShpfyPaymentsAPI`). `SyncDisputes` updates unfinished disputes, then imports new ones. Both are triggered by the reports `Shpfy Sync Payments` and `Shpfy Sync Disputes`.
+
+`Shpfy Payment Transaction` (`ShpfyPaymentTransaction.Table.al`) represents a Shopify Payments balance transaction -- the line items that roll up into a payout. Each record has Amount, Fee, and Net Amount, plus links to the source order and payout. The `Shpfy Payment Trans. Type` enum is enormous (100+ values covering charges, refunds, chargebacks, adjustments, shipping labels, collective transactions, etc.) -- many older values are kept only for backward compatibility.
+
+`Shpfy Payout` (`ShpfyPayout.Table.al`) is the actual bank transfer. It carries a detailed summary breakdown: adjustments, charges, refunds, reserved funds, and retried payouts, each split into fee and gross amounts. Status lifecycle is Scheduled -> In Transit -> Paid (or Failed/Canceled).
+
+`Shpfy Dispute` (`ShpfyDispute.Table.al`) tracks chargebacks and inquiries. It has type (Inquiry/Chargeback), reason (13 values from Fraudulent to Subscription Cancelled), status (Needs Response -> Under Review -> Won/Lost), evidence deadlines, and a link back to the source order.
+
+`Shpfy Payment Terms` (`ShpfyPaymentTerms.Table.al`) maps Shopify payment terms templates to BC payment terms codes. `ShpfyPaymentTermsAPI` pulls them via GraphQL. Only one can be marked `Is Primary`. The table stores name, due-in-days, description, and type from Shopify alongside the user-assigned BC `Payment Terms Code`.

--- a/src/Apps/W1/Shopify/App/src/Products/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Products/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Products
+
+This module owns the bidirectional sync between Shopify products/variants and BC Items/Item Variants. It also handles image sync, product-to-collection assignment, and sales channel publication. The separation exists because the product data model is the densest mapping in the connector -- a single BC Item fans out into a Shopify Product, one or more Variants, Inventory Items, and optionally collection memberships.
+
+## How it works
+
+Sync direction is controlled by `Shop."Sync Item"`. "To Shopify" runs `ShpfyProductExport`, which iterates all `Shpfy Product` records that already have an `Item SystemId` and pushes field changes detected via RecordRef comparison. "From Shopify" runs `ShpfySyncProducts.ImportProductsFromShopify`, which fetches product IDs from the API, skips anything whose `Updated At` has not changed, then hands each product to `ShpfyProductImport`. Import attempts mapping first (`ShpfyProductMapping.FindMapping`), then either updates the existing BC Item or auto-creates one depending on shop settings.
+
+Mapping (`ShpfyProductMapping.DoFindMapping`) resolves a Shopify variant to a BC Item+Item Variant using the `SKU Mapping` enum on the shop -- Item No., Variant Code, Item No. + Variant Code, Bar Code, or Vendor Item No. Each strategy parses the variant's SKU field differently and falls back to barcode-based lookup via Item References. The linking is stored as `Item SystemId` (Guid) on both Product and Variant tables, plus `Item Variant SystemId` on Variant -- never by "No." directly.
+
+Export supports a price-only fast path (`SetOnlyUpdatePriceOn`) that skips product field updates and can batch variant price changes through a bulk mutation. When `Shop."UoM as Variant"` is enabled, each Item Unit of Measure becomes a separate Shopify variant; the `UoM Option Id` field (1, 2, or 3) records which option slot holds the UoM value. Product creation (`ShpfyCreateProduct`) builds temporary Product+Variant records, optionally maps BC Item Attributes marked "As Option" to Shopify's 3 product option slots, validates uniqueness of option combinations, then posts via `ProductAPI.CreateProduct`.
+
+## Things to know
+
+- Linking uses `SystemId` (Guid), not `"No."`. The `"Item No."` and `"Variant Code"` fields on `Shpfy Product` and `Shpfy Variant` are FlowFields that look up through `SystemId`. If an Item is renumbered, the link survives.
+- `"Has Variants"` on `Shpfy Product` is set to `true` when the BC Item has Item Variants or when `"UoM as Variant"` creates multiple Shopify variants. When false, a single "Default Title" variant is created. The mapping logic uses this flag to decide whether it needs to resolve `Item Variant SystemId`.
+- `"Mapped By Item"` on `Shpfy Variant` is true when mapping found an Item but no specific Item Variant -- the variant is linked at the Item level only.
+- Image sync uses integer hash comparison (`"Image Hash"` on both Product and Variant). `ShpfyProductImageExport` computes a hash of the BC Item picture; if it matches the stored hash, the export is skipped. Images flow through a staged upload URL pattern.
+- `"Description as HTML"` is a Blob field with its own `"Description Html Hash"` for change detection. `SetDescriptionHtml` writes the blob and updates the hash in one call.
+- Product removal is dispatched through `IRemoveProductAction` -- an interface enum with three implementations: DoNothing, StatusToArchived, StatusToDraft. This runs on the `OnDelete` trigger of `Shpfy Product`.
+- Shopify enforces a maximum of 2048 variants per product. `CreateProduct` checks this limit before sending the create mutation. Item Attributes marked "As Option" are capped at 3 (matching Shopify's product option limit).

--- a/src/Apps/W1/Shopify/App/src/Products/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/src/Products/docs/data-model.md
@@ -1,0 +1,30 @@
+# Products data model
+
+```mermaid
+erDiagram
+    "Shpfy Product" ||--o{ "Shpfy Variant" : "Product Id"
+    "Shpfy Product" }o--|| "BC Item" : "Item SystemId"
+    "Shpfy Variant" }o--o| "BC Item Variant" : "Item Variant SystemId"
+    "Shpfy Variant" ||--o| "Shpfy Inventory Item" : "Variant Id"
+    "Shpfy Product" }o--|| "Shpfy Shop" : "Shop Code"
+```
+
+## Key relationships
+
+`Shpfy Product` links to a BC Item through `Item SystemId` (Guid). The `"Item No."` field is a FlowField that resolves through this Guid -- it is never stored directly. This means renumbering an Item does not break the link.
+
+`Shpfy Variant` carries both `Item SystemId` and `Item Variant SystemId`. When a product has no variants in the BC sense (no Item Variants), only `Item SystemId` is populated and `"Mapped By Item"` is set to true. When `"Has Variants"` is true on the parent product, each variant is expected to resolve to a distinct `Item Variant SystemId` unless it was mapped at the item level only.
+
+`Shpfy Inventory Item` is keyed by its own Shopify `Id` and links back to a single `Shpfy Variant` via `Variant Id`. It stores inventory-tracking metadata (tracked, cost, country of origin) but not stock quantities -- those live in the Inventory module.
+
+## Hash fields
+
+Three integer hash fields on `Shpfy Product` drive change detection during export: `Image Hash` (computed from BC Item picture bytes), `Tags Hash` (from comma-separated tags), and `Description Html Hash` (from the HTML blob content). `Shpfy Variant` has its own `Image Hash`. The connector skips API calls when the hash has not changed since the last sync.
+
+## UoM Option Id
+
+When `Shop."UoM as Variant"` is on, each Item Unit of Measure becomes a separate Shopify variant. The `UoM Option Id` field (1, 2, or 3) records which of the variant's three option slots holds the UoM value. For a variant-only product (no UoM expansion), it is set to 0 or left unset. For UoM-only (no BC Item Variants), it is 1. For Item Variant + UoM, the variant code goes in Option 1 and UoM in Option 2, so `UoM Option Id` is 2. The export and mapping logic use this field to know which option value to match when looking up the UoM.
+
+## Obsolete table
+
+`Shpfy Shop Collection Map` (30128) is obsolete as of v28 and will be removed in v31. It was previously used for mapping tax groups/VAT posting groups to Shopify collections. The replacement is `Shpfy Product Collection` which uses a simpler model with an item filter blob.

--- a/src/Apps/W1/Shopify/App/src/Shipping/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Shipping/docs/CLAUDE.md
@@ -1,0 +1,35 @@
+# Shipping
+
+This folder handles the mapping between Shopify shipping methods and BC shipment methods / shipping agents, plus the export of BC shipments as Shopify fulfillments.
+
+## Shipping method mapping
+
+`Shpfy Shipment Method Mapping` (table 30131) is keyed on (Shop Code, Name) where Name is the Shopify shipping rate title (e.g. "Standard Shipping"). It maps to:
+
+- **Shipment Method Code** -- a BC `Shipment Method` used on the Sales Header.
+- **Shipping Agent Code** / **Shipping Agent Service Code** -- used both on the Sales Header and on individual shipping charge sales lines.
+- **Shipping Charges Type** / **Shipping Charges No.** -- optionally overrides the shop-level `"Shipping Charges Account"`. Can be G/L Account, Item, or Charge (Item). When set to Charge (Item), the connector auto-assigns the item charge equally across shipment lines.
+
+The mapping is consumed during order processing in `ShpfyOrderMapping.MapShippingMethodCode` and `MapShippingAgent`, and again in `ShpfyProcessOrder.CreateLinesFromShopifyOrder` when creating shipping charge sales lines.
+
+## Shipping agent -> Shopify carrier
+
+The `Shpfy Shipping Agent` table extension adds a `"Shpfy Tracking Company"` enum field to BC's Shipping Agent table. During shipment export (`ShpfyExportShipments`), the connector uses this to tell Shopify which carrier the tracking number belongs to. If the tracking company is blank, it falls back to the agent's Name or Code.
+
+## Fulfillment location mapping
+
+During order import, fulfillment order lines carry a `Shopify Location Id`. This is matched to `Shpfy Shop Location` records to determine the BC `"Default Location Code"` for the sales line. The location on the fulfillment order line is propagated to the order line only when the total quantity across fulfillment order lines matches the order line quantity.
+
+## Shipment export flow
+
+`ShpfyExportShipments.CreateShopifyFulfillment` is the entry point. It:
+
+1. Finds the Shopify order header from the Sales Shipment's `"Shpfy Order Id"`.
+2. Matches shipment lines to fulfillment order lines by `Line Item Id`, splitting quantities across multiple fulfillment orders if needed.
+3. Auto-accepts pending fulfillment requests (SUBMITTED status) before fulfilling.
+4. Skips fulfillment orders assigned to third-party fulfillment services.
+5. Builds one or more `fulfillmentCreate` GraphQL mutations (batching at 250 lines per request).
+6. Includes tracking info from the Shipment Header and Shipping Agent.
+7. Writes the Shopify fulfillment ID back to the Sales Shipment Header.
+
+The `ShpfySyncShipmToShopify.Report.al` report drives the batch export flow.

--- a/src/Apps/W1/Shopify/App/src/Transactions/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Transactions/docs/CLAUDE.md
@@ -1,0 +1,11 @@
+# Transactions
+
+Order-level payment transactions imported from Shopify, plus the "Suggest Payments" machinery that generates cash receipt journal lines.
+
+`Shpfy Order Transaction` (`ShpfyOrderTransaction.Table.al`) is the core table -- one record per Shopify transaction, keyed by `Shopify Transaction Id`. It stores amount in both shop currency and presentment currency (including rounding amounts), the gateway name, credit card details (company, BIN, AVS/CVV codes), type (Authorization/Capture/Sale/Void/Refund), and status. FlowFields link to the sales document, posted invoice, and the mapped BC payment method.
+
+`ShpfyTransactions.Codeunit.al` pulls transactions via GraphQL (`GetOrderTransactions`) and auto-populates three lookup tables as side effects: `Shpfy Transaction Gateway` (distinct gateway names), `Shpfy Credit Card Company` (distinct card brands), and `Shpfy Payment Method Mapping` (shop + gateway + card company -> BC payment method code). This auto-creation means new gateways appear in the mapping table with a blank payment method code, waiting for the user to assign one.
+
+The `Suggest Payments` report (`ShpfySuggestPayments.Report.al`) is the bridge to BC's cash receipt journal. It iterates successful Capture/Sale/Refund transactions, matches them to open customer ledger entries via posted invoices or credit memos, and generates journal lines with the correct applies-to document. The temporary `Shpfy Suggest Payment` table accumulates matches before flushing to `Gen. Journal Line`. Rounding amounts are included in the applied amount. Gift card transactions get special description formatting.
+
+Table extensions on `Cust. Ledger Entry` and `Gen. Journal Line` add a `Shpfy Transaction Id` field. The `ShpfySuggestPayments.Codeunit.al` event subscribers ensure this ID flows through posting and gets cleared on reversal -- this is how the `Used` FlowField on the transaction knows whether a journal line has already been posted for a given transaction.

--- a/src/Apps/W1/Shopify/App/src/Translations/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Translations/docs/CLAUDE.md
@@ -1,0 +1,11 @@
+# Translations
+
+Multi-language product translation sync from BC item translations to Shopify's `translationsRegister` API.
+
+`Shpfy Language` (`ShpfyLanguage.Table.al`) maps a Shopify locale (2-char code like "fr", "de") to a BC Language Code. Each record belongs to a shop. The `Sync Translations` flag controls whether translations are pushed for that locale -- it requires a Language Code to be set first. `ShpfyTranslationApi.PullLanguages` syncs the list from Shopify, skipping the primary locale (which is handled by the shop's own language setting) and removing locales that no longer exist in Shopify.
+
+`Shpfy Translation` (`ShpfyTranslation.Table.al`) is a temporary-style record keyed by Resource Type + Resource ID + Locale + Name. The value is stored as a BLOB to handle long text. The `AddTranslation` method compares against the persisted table and only keeps entries where the text actually changed -- unchanged translations are deleted from the temp set so they don't generate unnecessary API calls.
+
+The `Shpfy ICreate Translation` interface dispatches by `Shpfy Resource Type` (currently only `Product`). `ShpfyCreateTranslProduct.Codeunit.al` implements it: it reads the BC item translation for the mapped language code (via `ShpfyTranslationMgt.GetItemTranslation`) to populate the `title` key, and uses `ProductExport.CreateProductBody` for the `body_html` key. Each key is matched against a translatable content digest fetched from Shopify via `RetrieveTranslatableContentDigests` -- the digest is required by Shopify's API to identify which version of the source content the translation applies to.
+
+`ShpfyTranslationApi.CreateOrUpdateTranslations` builds the GraphQL mutation by concatenating translation objects and calling `translationsRegister`. The escaping in `EscapeGrapQLData` handles backslashes and quotes for inline GraphQL strings.


### PR DESCRIPTION
## Summary

- Bootstrap hierarchical AL documentation for the Shopify Connector app
- 27 files across app-level docs and 20 subfolder-level docs
- Covers data model (with mermaid ER diagrams), business logic (with flowcharts), extensibility points (organized by developer goal), and code patterns (including legacy patterns to avoid)
- Generated from deep analysis of the AL source code and enriched with Microsoft Learn context

## Documentation structure

**App level** (5 files): CLAUDE.md, docs/data-model.md, docs/business-logic.md, docs/extensibility.md, docs/patterns.md

**MUST_DOCUMENT subfolders** (8 folders): Products, Order handling, Customers, Metafields, Companies, Base, Document Links, GraphQL -- with CLAUDE.md + additional docs where needed

**SHOULD_DOCUMENT subfolders** (12 folders): Inventory, Transactions, Order Return Refund Processing, Shipping, Order Fulfillments, Payments, Catalogs, Logs, Order Refunds, Bulk Operations, Translations, Order Returns -- CLAUDE.md only

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify mermaid diagrams render in data-model.md and business-logic.md
- [ ] Spot-check 3-5 docs against source code for accuracy
- [ ] Verify cross-references between docs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

