### PR TITLE
Add E-Document Core hierarchical documentation

### DIFF
--- a/src/Apps/W1/EDocument/App/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/CLAUDE.md
@@ -1,0 +1,55 @@
+# E-Document Core
+
+E-Document Core is Business Central's foundation layer for electronic document exchange. It provides the framework for sending outbound e-invoices (sales invoices, credit memos, reminders, shipments, transfer documents) and receiving inbound e-invoices (purchase invoices, purchase orders), with pluggable format and integration layers so that country-specific apps only need to implement the "how to serialize" and "how to transmit" parts. The app has zero dependencies -- every other e-document app depends on it.
+
+## Quick reference
+
+- **ID range**: 6100-6199, 6208-6209, 6231-6232, 6234
+- **Dependencies**: None (self-contained foundation layer)
+
+## How it works
+
+The core design is a two-layer plugin model: **Format** (how to transform a BC document into XML/JSON and back) and **Integration** (how to transmit that blob to/from an external service). Both are stored as enum values on the `E-Document Service` table, resolved at runtime to interface implementations. This means a PEPPOL format can be paired with any integration connector, and vice versa.
+
+Outbound flow starts when a sales document is posted. `EDocumentSubscribers` catches the posting event, `EDocExport` transforms the document using the format interface, and `EDocIntegrationManagement` sends it using the integration interface. The workflow engine (`EDocumentWorkFlowProcessing`) orchestrates multi-step flows like export-then-send or export-then-email. Batch sending supports three modes: threshold-based accumulation, recurrent job queue, and custom extension events.
+
+Inbound flow has two distinct paths. The legacy V1 path calls `GetBasicInfo` then `GetCompleteInfo` on the format interface to directly populate a purchase document in a single step. The V2 path is a four-stage pipeline: Structure (convert PDF to XML via ADI/MLLM/PEPPOL), Read (parse into draft tables), Prepare (resolve vendor/items via provider interfaces), and Finish (create the actual BC purchase document). Each stage is independently undoable. The V2 path stores intermediate state in `E-Document Purchase Header/Line` tables with raw external data alongside `[BC]`-prefixed validated fields.
+
+Status is a three-tier state machine. The top-level `E-Document.Status` (Error, In Progress, Processed) is derived by scanning all `E-Document Service Status` records -- any error wins, then any in-progress, otherwise processed. For imports, the service status also carries an `Import Processing Status` (Unprocessed, Readable, Ready for draft, Draft ready, Processed) that drives the V2 pipeline progression.
+
+## Structure
+
+- `src/Document/` -- The `E-Document` table, status enums, inbound/outbound list pages, and the `E-Document` format interface
+- `src/Service/` -- `E-Document Service` configuration, service status tracking, supported document types, and service participants
+- `src/Integration/` -- Send/receive context objects, interface definitions for `IDocumentSender`/`IDocumentReceiver`/`IDocumentResponseHandler`, and action runners for approval/cancellation
+- `src/Processing/` -- The export pipeline (`EDocExport`), subscribers that hook into BC posting events, and the import subsystem under `Import/` with its four-stage pipeline, provider interfaces, and purchase order matching
+- `src/Processing/AI/` -- Copilot-powered line matching tools (historical matching, GL account matching, deferral matching)
+- `src/Processing/OrderMatching/` -- Purchase order line matching with Copilot proposal support
+- `src/Format/` -- PEPPOL BIS 3.0 export/import codeunits and shipment XML generation
+- `src/Logging/` -- `E-Doc. Data Storage` (binary blob store), `E-Document Log`, and `E-Document Integration Log` tables
+- `src/Mapping/` -- Find/replace transformation rules applied during export/import
+- `src/Workflow/` -- BC Workflow integration for multi-step document processing flows
+- `src/Extensions/` -- Table/page extensions to Purchase Header, Vendor, Document Sending Profile, role centers, etc.
+- `src/ClearanceModel/` -- QR code generation for clearance-model countries (Spain, India, Mexico, Italy)
+- `src/DataExchange/` -- PEPPOL Data Exchange Definition integration for legacy import paths
+- `src/Helpers/` -- Error handling, JSON utilities, import helpers
+
+## Documentation
+
+- [docs/data-model.md](docs/data-model.md) -- Tables, relationships, and storage design
+- [docs/business-logic.md](docs/business-logic.md) -- Outbound and inbound processing flows
+- [docs/extensibility.md](docs/extensibility.md) -- Interfaces, events, and how to build connectors
+- [docs/patterns.md](docs/patterns.md) -- Recurring design patterns and legacy conventions
+
+## Things to know
+
+- The `E-Document` table links to its source BC document via `Document Record ID` (a RecordId field), not a foreign key. This means it can point at any posted document type without schema coupling.
+- V1 import and V2 import coexist. The `E-Document Import Process` enum on the service determines which path runs. V1 skips straight to "Finish draft" and calls the old `GetCompleteInfo` interface. V2 runs all four stages.
+- `E-Doc. Data Storage` is a shared blob store. Multiple log entries can reference the same storage entry. The unstructured blob (PDF) and structured blob (XML) are stored separately and linked via `Unstructured Data Entry No.` and `Structured Data Entry No.` on the E-Document.
+- The `[BC]` prefix convention on `E-Document Purchase Header/Line` fields distinguishes validated Business Central values from raw external data. When you see `Vendor Name` vs `[BC] Vendor No.`, the first is what the sender wrote and the second is what the system resolved.
+- Duplicate detection for incoming documents uses a composite key of (Incoming E-Document No., Bill-to/Pay-to No., Document Date).
+- Error handling uses the try-commit-run pattern: commit before calling interface implementations via `Codeunit.Run()`, then catch failures with `GetLastErrorText()` and log them. This prevents partial state corruption from rolling back the caller's transaction.
+- The `Service Integration V2` enum replaces the obsolete `Service Integration` enum. Code gated by `#if not CLEAN26` handles the transition. The old `E-Document Integration` interface is replaced by the split `IDocumentSender`/`IDocumentReceiver`/`IDocumentResponseHandler` interfaces.
+- Workflow is not optional for outbound -- the Document Sending Profile must reference an enabled Workflow with an "Extended E-Document Service Flow" entry. The workflow steps determine which services process the document and in what order.
+- The `InternalsVisibleTo` list includes Payables Agent, meaning the AI agent can directly access internal procedures for automated invoice processing.
+- Historical matching (`EDocPurchaseLineHistory`, `EDocVendorAssignHistory`) is vendor-scoped and learns from posted purchase invoices to improve future automatic matching.

--- a/src/Apps/W1/EDocument/App/Permissions/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/Permissions/docs/CLAUDE.md
@@ -1,0 +1,22 @@
+# Permissions
+
+Permission sets controlling access to E-Document Core tables, codeunits, and pages. The model follows a layered hierarchy where higher-level sets include lower-level ones.
+
+## How it works
+
+The active permission hierarchy is:
+
+- **Admin** (`E-Doc. Core - Admin`, 6104) -- Full Insert/Modify/Delete on service configuration tables (E-Document Service, Mapping, Service Data Exch. Def., Service Supported Type). Includes User.
+- **User** (`E-Doc. Core - User`, 6105) -- Insert/Modify/Delete on operational tables (E-Document, logs, mapping logs, data storage, order matching, purchase drafts, sample invoices). Includes Read. This is the standard permission set for users who process e-documents.
+- **Read** (`E-Doc. Core - Read`, 6101) -- Read-only access to all E-Document tables. Includes Objects.
+- **Objects** (`E-Doc. Core - Objects`, 6100) -- Execute permission on all tables, codeunits, and pages. Not assignable directly (`Assignable = false`, `Access = Internal`).
+
+Four permission set extensions grant E-Document access to holders of standard D365 permission sets: `D365 BUS FULL ACCESS`, `D365 BUS PREMIUM`, `D365 READ`, and `D365 TEAM MEMBER`.
+
+## Things to know
+
+- **Basic** (6103) and **Edit** (6102) are obsolete (pending removal in v27). They are replaced by **User** and **Admin** respectively. Code gated by `#if not CLEAN27` keeps them available during the transition.
+- **Objects** is the foundation layer and is not user-assignable. It exists purely to grant Execute permissions so the other sets can focus on data access (R/I/M/D).
+- **Admin** vs **User** -- the key difference is that Admin gets full IMD on service configuration tables, while User only gets IM (insert/modify but not delete on services). Admin can delete and reconfigure services; User can only use existing ones.
+- The D365 permission set extensions ensure that users with standard BC licenses automatically get some level of E-Document access without explicit per-user assignment.
+- The Objects permission set is the definitive list of all AL objects in the E-Document Core app. If you add a new table, codeunit, or page, it must be added here.

--- a/src/Apps/W1/EDocument/App/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/docs/business-logic.md
@@ -1,0 +1,112 @@
+# Business logic
+
+## Outbound flow (export and send)
+
+The outbound pipeline begins when a BC document is posted. `EDocumentSubscribers.Codeunit.al` subscribes to posting events across sales, service, reminders, finance charge memos, shipments, and transfer documents. On each posting event, it calls `EDocExport.CheckEDocument` for pre-validation, then `EDocExport.CreateEDocument` to produce the E-Document record and its exported blob.
+
+The check phase resolves the Document Sending Profile for the source document, finds the associated Workflow, and iterates over all E-Document Services linked to that workflow. For each service, it calls the format interface's `Check` method (from the `E-Document` interface in `EDocument.Interface.al`), which validates that all required fields exist for the target format. If any check fails, posting is blocked.
+
+The create phase follows a similar pattern but writes data. It inserts the `E-Document` record, populates it from the source document header, then calls the format interface's `Create` method to produce the blob. The blob is stored in `E-Doc. Data Storage` and logged with status "Exported". After export, the workflow engine determines the next step -- typically sending.
+
+Sending is handled by `EDocIntegrationManagement.Send` in `EDocIntegrationManagement.Codeunit.al`. It retrieves the exported blob from the log, wraps it in a `SendContext` (which provides access to the blob, HTTP message state, and status control), and calls the integration interface's `Send` method. If the sender returns asynchronously, the status is set to "Pending Response" and a background job polls `IDocumentResponseHandler.GetResponse` until the service confirms receipt.
+
+```mermaid
+flowchart TD
+    A[BC document posted] --> B[EDocumentSubscribers catches event]
+    B --> C[EDocExport.CheckEDocument]
+    C --> D{Check passes?}
+    D -->|No| E[Posting blocked with error]
+    D -->|Yes| F[EDocExport.CreateEDocument]
+    F --> G[Format interface Create produces blob]
+    G --> H[Blob stored, status = Exported]
+    H --> I[Workflow determines next step]
+    I --> J[EDocIntegrationManagement.Send]
+    J --> K{Async?}
+    K -->|No| L[Status = Sent]
+    K -->|Yes| M[Status = Pending Response]
+    M --> N[Background job polls GetResponse]
+    N --> O{Response ready?}
+    O -->|No| M
+    O -->|Yes| L
+```
+
+### Batch sending
+
+Batch mode is controlled by `Use Batch Processing` and `Batch Mode` on the E-Document Service. Three modes exist:
+
+- **Threshold**: Documents accumulate until a configurable count is reached, then all are sent in one call via `IDocumentSender.Send` with a filtered record set.
+- **Recurrent**: A job queue entry periodically sweeps all unsent documents and sends them as a batch. Managed by `EDocRecurrentBatchSend.Codeunit.al`.
+- **Custom**: Fires the `OnBatchSendWithCustomBatchMode` event so extensions can implement their own accumulation/trigger logic.
+
+### Email sending
+
+The workflow can include email steps. `EDocumentWorkFlowProcessing.SendEDocFromEmail` resolves the correct report usage and customer/vendor, then delegates to `EDocumentEmailing` which handles attachment type selection (PDF, E-Document blob, or both) based on the Document Sending Profile configuration.
+
+## Inbound flow (receive and import)
+
+### Receiving documents
+
+`EDocIntegrationManagement.ReceiveDocuments` (the V2 path) calls `IDocumentReceiver.ReceiveDocuments` which returns a metadata list as `Temp Blob List` -- each blob contains service-specific metadata about an available document. For each entry, it calls `DownloadDocument` to fetch the actual content, stores the blob in `E-Doc. Data Storage`, creates the `E-Document` record with status "Imported", and optionally calls `IReceivedDocumentMarker.MarkFetched` to acknowledge receipt with the external service.
+
+### V2 import pipeline
+
+The four-stage pipeline lives in `ImportEDocumentProcess.Codeunit.al`. Each stage runs as a `Codeunit.Run()` call (enabling try-catch via the error boundary pattern), and each stage can be independently undone.
+
+**Stage 1 -- Structure received data**: Takes the unstructured blob (typically PDF) and converts it to structured XML/JSON. The `IStructureReceivedEDocument` interface selects the conversion strategy -- `EDocumentADIHandler` uses Azure Document Intelligence, `EDocumentMLLMHandler` uses a multimodal LLM via Copilot, and `EDocumentPEPPOLHandler` handles already-structured PEPPOL XML. The output is stored as a new `E-Doc. Data Storage` entry, and the E-Document's `Structured Data Entry No.` is updated. Status moves to "Readable".
+
+**Stage 2 -- Read into draft**: The `IStructuredFormatReader` interface parses the structured blob and populates `E-Document Purchase Header` and `E-Document Purchase Line` tables with raw external data. The implementation is selected based on the structured format (PEPPOL XML reader, ADI JSON reader, etc.). Status moves to "Ready for draft".
+
+**Stage 3 -- Prepare draft**: The `IProcessStructuredData` interface resolves Business Central values. It calls provider interfaces (`IVendorProvider`, `IItemProvider`, `IUnitOfMeasureProvider`, `IPurchaseLineAccountProvider`) to match external identifiers to BC records, populating the `[BC]`-prefixed fields on the draft tables. Vendor resolution triggers the `OnFoundVendorNo` event. Status moves to "Draft ready".
+
+**Stage 4 -- Finish draft**: The `IEDocumentFinishDraft` interface creates the actual BC document. `ApplyDraftToBC` returns the `RecordId` of the newly created Purchase Invoice or Purchase Order, which is stored in `E-Document.Document Record ID`. `RevertDraftActions` handles undo. Status moves to "Processed".
+
+```mermaid
+flowchart TD
+    A[Document received from service] --> B[Blob stored, E-Document created]
+    B --> C[Stage 1: Structure]
+    C --> D{PDF or already XML?}
+    D -->|PDF| E[ADI / MLLM converts to XML]
+    D -->|XML| F[Already structured, skip conversion]
+    E --> G[Status = Readable]
+    F --> G
+    G --> H[Stage 2: Read into Draft]
+    H --> I[Parse XML/JSON into Purchase Header/Line tables]
+    I --> J[Status = Ready for draft]
+    J --> K[Stage 3: Prepare Draft]
+    K --> L[Resolve vendor, items, accounts via providers]
+    L --> M[Status = Draft ready]
+    M --> N[Stage 4: Finish Draft]
+    N --> O{Create Purchase Invoice or Order?}
+    O --> P[BC document created]
+    P --> Q[Status = Processed]
+```
+
+### V1 import (legacy)
+
+V1 import collapses all four stages into a single "Finish draft" step. It calls `EDocImport.V1_ProcessEDocument` which uses the format interface's `GetBasicInfo` and `GetCompleteInfo` methods to directly populate a purchase document or journal line. The `E-Document Import Process` enum on the service determines whether V1 or V2 runs -- V1 is "Version 1.0", V2 is "Version 2.0".
+
+## Status transitions
+
+Status management is split across three concerns in `EDocumentProcessing.Codeunit.al`:
+
+- **Document-level status** (`ModifyEDocumentStatus`): Scans all service status records. Uses the `IEDocumentStatus` interface implemented per service status enum value (`EDocErrorStatus`, `EDocInProgressStatus`, `EDocProcessedStatus`) to map service statuses to document statuses. Any error wins, then any in-progress, otherwise processed.
+- **Service-level status** (`ModifyServiceStatus`): Directly sets the `E-Document Service Status.Status` enum value and fires `OnAfterModifyServiceStatus`.
+- **Import processing status** (`ModifyEDocumentProcessingStatus`): Sets the `Import Processing Status` on the service status record, which auto-triggers a `Status` update via the field's OnValidate trigger.
+
+## Error handling
+
+The codebase uses a consistent try-commit-run pattern for calling interface implementations. Before calling an external interface (format or integration), the system commits the current transaction. The interface call runs via `Codeunit.Run()`, which creates an implicit try-catch boundary. If the call fails, `GetLastErrorText()` captures the error message, which is logged to both `E-Document Log` and the error message list via `EDocumentErrorHelper`. The E-Document's status is then set to the appropriate error state.
+
+This pattern is critical because interface implementations are third-party code. Without the commit-before-call pattern, a runtime error in a connector would roll back the E-Document record itself, losing the audit trail. The explicit commit ensures the E-Document and its logs survive even when the external call fails.
+
+Errors are surfaced through BC's standard error message framework and through `E-Document Notification` records that appear in the user's notification center.
+
+## Background processing
+
+`EDocumentBackgroundJobs.Codeunit.al` manages job queue entries for asynchronous operations:
+
+- **Recurrent batch send**: Periodically sweeps unsent documents and sends them as a batch
+- **Get response**: Polls for async send confirmations on documents in "Pending Response" state
+- **Import**: Runs the receive-and-import cycle for configured services
+
+These jobs are automatically created/removed when service configuration changes (enabling/disabling batch processing, for example).

--- a/src/Apps/W1/EDocument/App/docs/data-model.md
+++ b/src/Apps/W1/EDocument/App/docs/data-model.md
@@ -1,0 +1,92 @@
+# Data model
+
+## E-Document lifecycle (core)
+
+The `E-Document` table (6121) is the central record. It links to its source BC document via a `Document Record ID` field (a RecordId, not a foreign key), which means it can point at any posted document type -- sales invoices, credit memos, service invoices, reminders, shipments, or transfer documents -- without schema coupling. For incoming documents, the same field gets populated when the import pipeline creates the BC purchase document at the "Finish draft" stage.
+
+Each E-Document tracks two content blobs by reference: `Unstructured Data Entry No.` (typically a PDF) and `Structured Data Entry No.` (XML or JSON after conversion). These point into `E-Doc. Data Storage`, a shared blob table. The E-Document itself stays slim -- all binary content lives in storage.
+
+The `E-Document Service Status` table (6138) is the workhorse of status tracking. It creates a 1:N relationship between an E-Document and the services processing it, keyed on (E-Document Entry No, Service Code). The `Status` field tracks the outbound/inbound service-level state (Exported, Sent, Pending Response, Sending Error, Imported, etc.), while `Import Processing Status` tracks the V2 import pipeline progression. The trigger on `Import Processing Status` auto-updates `Status` -- when processing reaches "Processed", the service status flips to "Imported Document Created".
+
+The document-level `E-Document.Status` is derived, not stored independently. `EDocumentProcessing.ModifyEDocumentStatus` scans all service status records: any error means Error, any in-progress means In Progress, otherwise Processed.
+
+```mermaid
+erDiagram
+    E-Document ||--o{ E-Document-Service-Status : "tracked by"
+    E-Document ||--o{ E-Document-Log : "audited in"
+    E-Document-Log }o--|| E-Doc-Data-Storage : "content in"
+    E-Document }o--o| E-Doc-Data-Storage : "unstructured blob"
+    E-Document }o--o| E-Doc-Data-Storage : "structured blob"
+```
+
+## Service configuration
+
+`E-Document Service` (6103) is where the plugin model lives. The `Document Format` enum selects the format interface (how to serialize/deserialize), and the `Service Integration V2` enum selects the integration interface (how to transmit). This separation means a PEPPOL format can be paired with any HTTP connector. The table also carries processing flags like `Validate Receiving Company`, `Lookup Account Mapping`, and `Apply Invoice Discount` that control import behavior.
+
+`E-Doc. Service Supported Type` (6122) is a simple N:M join between services and document types. If a document type is not listed for a service, the service silently skips it during export.
+
+`Service Participant` (6104) maps BC Customers and Vendors to their external identifiers within a specific service. This is how the system knows that BC Vendor 10000 is "IT12345678" in the Peppol network.
+
+```mermaid
+erDiagram
+    E-Document-Service ||--o{ E-Doc-Service-Supported-Type : "handles"
+    E-Document-Service ||--o{ Service-Participant : "identifies"
+    E-Document-Service ||--o{ E-Doc-Service-Data-Exch-Def : "uses"
+```
+
+## Data storage and logging
+
+`E-Doc. Data Storage` (6125) is a generic blob store. Each entry has a `Data Storage` blob field, a `Name`, and a `File Format` enum (XML, JSON, PDF, etc.). Multiple log entries can reference the same storage entry -- this is intentional to avoid duplicating large blobs.
+
+`E-Document Log` (6124) is the per-operation audit trail. Each entry records what happened (exported, sent, received, error) with a reference to the associated data storage entry. `E-Document Integration Log` (6127) captures the HTTP level -- request blob, response blob, status code, URL, method. Together they give you both the business view ("document was exported") and the technical view ("POST to https://api.example.com returned 500").
+
+`E-Doc. Mapping Log` (6123) records when transformation rules from `E-Doc. Mapping` were applied, providing an audit trail of find/replace operations on the document content.
+
+```mermaid
+erDiagram
+    E-Document ||--o{ E-Document-Log : "operations"
+    E-Document ||--o{ E-Document-Integration-Log : "HTTP calls"
+    E-Document-Log }o--o| E-Doc-Data-Storage : "blob content"
+    E-Document-Integration-Log }o--o| E-Doc-Data-Storage : "request/response"
+```
+
+## Import staging (V2 draft tables)
+
+The V2 import pipeline uses dedicated staging tables to hold intermediate state before creating actual BC documents. `E-Document Purchase Header` (6100) has a 1:1 relationship with the incoming E-Document and stores both raw external data (vendor name, address as the sender wrote them) and `[BC]`-prefixed validated fields (`[BC] Vendor No.`, `[BC] Currency Code`). This dual-field convention is the key to understanding the draft tables -- unprefixed fields are what the external system said, `[BC]` fields are what the system resolved.
+
+`E-Document Purchase Line` (6101) follows the same pattern at the line level with raw description/unit price alongside `[BC] No.` and `[BC] Unit of Measure`. Lines also support dimensions and link to additional fields via the EAV table `E-Document Line - Field` (6110), which uses type-specific value columns (Text, Decimal, Date, Boolean, Code, Integer) to allow dynamic schema extension without table modifications.
+
+The legacy V1 tables `E-Document Header Mapping` (6102) and `E-Document Line Mapping` (6105) still exist for the V1 import path but are not used by V2.
+
+```mermaid
+erDiagram
+    E-Document ||--o| E-Document-Purchase-Header : "draft header"
+    E-Document-Purchase-Header ||--o{ E-Document-Purchase-Line : "draft lines"
+    E-Document-Purchase-Line ||--o{ E-Document-Line-Field : "additional fields"
+```
+
+## Matching and linking
+
+The matching subsystem handles both purchase order matching and the generic record linking needed during import.
+
+`E-Doc. Record Link` (6141) provides SystemId-based linking between draft purchase lines and actual Purchase Lines. It is a generic join table -- not specific to any document type -- and gets deleted once the document is posted.
+
+For purchase order matching, `E-Doc. PO Matching Setup` (6116) controls matching behavior per vendor or globally, including whether to create receipts. `E-Doc. Purchase Line PO Match` (6114) implements three-way matching: E-Doc Line to PO Line to Receipt Line, all via SystemId references. `E-Doc. Imported Line` (6165) and `E-Doc. Order Match` (6164) are buffer tables for the matching UI, tracking matched quantities and match proposals respectively.
+
+Historical matching tables (`E-Doc. Purchase Line History` at 6140 and `E-Doc. Vendor Assign. History` at 6108) learn from posted invoices. They store (Vendor, Product Code, Description) to Posted Purchase Invoice Line mappings so the system can automatically match items on future imports from the same vendor.
+
+```mermaid
+erDiagram
+    E-Document-Purchase-Line }o--o{ Purchase-Line : "via E-Doc Record Link"
+    E-Doc-Purchase-Line-PO-Match }o--|| E-Document-Purchase-Line : "e-doc side"
+    E-Doc-Purchase-Line-PO-Match }o--|| Purchase-Line : "PO side"
+    E-Doc-Purchase-Line-PO-Match }o--o| Purchase-Receipt-Line : "receipt side"
+```
+
+## Key gotchas
+
+- Three status fields exist and serve different purposes: `E-Document.Status` (derived document-level), `Service Status.Status` (per-service), and `Service Status.Import Processing Status` (V2 import pipeline). Confusing them is a common source of bugs.
+- SystemId-based linking is used throughout. This is schema-agnostic but makes SQL queries harder -- you cannot join on readable business keys, only on GUIDs.
+- The `E-Doc. Data Storage` table is intentionally shared. Do not assume a 1:1 relationship between log entries and storage entries.
+- V1 and V2 import tables coexist. The `E-Document Import Process` enum on the service determines which path runs. If you are writing new import logic, use V2.
+- Table extensions to `Purchase Header`, `Purchase Line`, `Vendor`, `Location`, and `Document Sending Profile` add e-document support fields. The `Purchase Header` extension adds an `E-Document Link` GUID and a flowfield for `Amount Incl. VAT To Inv.`.

--- a/src/Apps/W1/EDocument/App/docs/extensibility.md
+++ b/src/Apps/W1/EDocument/App/docs/extensibility.md
@@ -1,0 +1,80 @@
+# Extensibility
+
+## Building a new e-document connector
+
+The most common extension scenario is adding support for a new country's e-invoicing standard. This requires two things: a format implementation and an integration implementation.
+
+**Format implementation**: Create an enum extension for `E-Document Format` (in `EDocumentFormat.Enum.al`) and implement the `E-Document` interface (in `src/Document/Interfaces/EDocument.Interface.al`). Your implementation needs five methods: `Check` (validate before posting), `Create` (produce the outbound blob), `CreateBatch` (produce a batch blob), `GetBasicInfoFromReceivedDocument` (extract header info from an inbound blob), and `GetCompleteInfoFromReceivedDocument` (fully populate a purchase document from an inbound blob). The last two are V1-era methods -- for V2 import, you implement the reader interfaces instead, but the format interface is still required for the enum registration.
+
+**Integration implementation**: Create an enum extension for `Service Integration V2` (in `ServiceIntegration.Enum.al`) and implement the relevant interfaces from `src/Integration/Interfaces/`. At minimum you need `IDocumentSender` for outbound. For inbound, implement `IDocumentReceiver` (list available documents and download them) plus `IReceivedDocumentMarker` (acknowledge receipt). For async sending, add `IDocumentResponseHandler`. For approval/cancellation workflows, add `ISentDocumentActions`. For custom actions, implement `IDocumentAction`.
+
+The context objects (`SendContext`, `ReceiveContext`, `ActionContext`) are your API surface during transmission. They provide access to the document blob, HTTP message state (for automatic communication logging), and status control. If you populate `SendContext.Http().GetHttpRequestMessage()` and the response message, the framework automatically logs the HTTP exchange to `E-Document Integration Log`.
+
+## Customizing the V2 import pipeline
+
+Each stage of the import pipeline is independently extensible via interfaces in `src/Processing/Interfaces/`.
+
+### How do I support a new input format (e.g., custom JSON)?
+
+Extend the `Structure Received E-Doc.` enum and implement `IStructureReceivedEDocument`. Your implementation receives the raw `E-Doc. Data Storage` record and returns an `IStructuredDataType` that wraps the converted content. If the input is already structured (e.g., native XML), return it as-is with `Structure Received E-Doc.::Already Structured`.
+
+Also extend the `E-Doc. Read into Draft` enum and implement `IStructuredFormatReader`. The `ReadIntoDraft` method receives the structured blob and populates `E-Document Purchase Header` and `E-Document Purchase Line` records. Return the `E-Doc. Process Draft` enum value that tells the framework which `IProcessStructuredData` implementation should handle stage 3.
+
+### How do I customize vendor/item resolution?
+
+Implement the provider interfaces: `IVendorProvider`, `IItemProvider`, `IUnitOfMeasureProvider`, `IPurchaseLineAccountProvider`, or `IPurchaseOrderProvider`. These are called during the "Prepare draft" stage via `EDocProviders.Codeunit.al`. The default implementation uses historical matching tables (`EDocPurchaseLineHistory`, `EDocVendorAssignHistory`) and BC's standard cross-reference lookups. Your implementation can add custom lookup logic -- for example, matching items by GTIN, vendor-specific product codes, or external catalog references.
+
+### How do I control what BC document gets created?
+
+Implement `IEDocumentFinishDraft` by extending the `E-Document Type` enum. The default implementations create Purchase Invoices (`EDocCreatePurchaseInvoice.Codeunit.al`) or update Purchase Orders, but you can implement your own to create journal lines, purchase credit memos, or any other document type. The `RevertDraftActions` method must undo whatever `ApplyDraftToBC` did.
+
+### How do I add custom fields to import lines?
+
+Use the EAV tables `E-Document Line - Field` (6110) and `E-Doc. Purchase Line Field Setup` (6109/6111). Register your custom fields in the setup table, then populate values in the line field table during the "Read into draft" stage. The UI pages (`EDocLineAdditionalFields`, `EDocFieldValueEdit`) automatically render configured fields.
+
+## Integration events by intent
+
+### Customizing outbound document creation
+
+- `OnBeforeEDocumentCheck` / `OnAfterEDocumentCheck` in `EDocExport.Codeunit.al` -- Intercept or extend pre-posting validation. Use `IsHandled` to skip the standard check entirely.
+- `OnAfterCreateEDocument` in `EDocExport.Codeunit.al` -- Modify the E-Document record or its blob after format creation but before sending.
+- `OnAfterGetTypeFromSourceDocument` in `EDocExport.Codeunit.al` -- Override how the source BC document type maps to `E-Document Type`.
+
+### Customizing send behavior
+
+- `OnBeforeSendDocument` / `OnAfterSendDocument` in `EDocIntegrationManagement.Codeunit.al` -- Pre/post hooks around the integration Send call.
+- `OnGetBatch` in `EDocIntegrationManagement.Codeunit.al` -- Customize batch assembly before sending.
+- `OnBatchSendWithCustomBatchMode` in `EDocumentWorkFlowProcessing.Codeunit.al` -- Implement custom batch triggering logic.
+
+### Customizing inbound processing
+
+- `OnAfterProcessIncomingEDocument` in `EDocImport.Codeunit.al` -- Hook after V1 import completes.
+- `OnBeforePrepareReceivedDoc` / `OnBeforeCreateDocument` in `EDocImport.Codeunit.al` -- Modify draft data or override document creation in V1.
+- `OnFoundVendorNo` in `ImportEDocumentProcess.Codeunit.al` -- React when vendor resolution succeeds during V2 prepare stage.
+- `OnADIProcessingCompleted` in `ImportEDocumentProcess.Codeunit.al` -- Hook after Azure Document Intelligence processing for custom post-processing.
+- Events on `EDocumentCreatePurchDoc.Codeunit.al` -- Fine-grained control over purchase header/line creation during V1 import.
+
+### Customizing PEPPOL processing
+
+- `OnBeforeInsertEDocPEPPOLBIS30` / `OnAfterInsertEDocPEPPOLBIS30` in `EDocPEPPOLBIS30.Codeunit.al` -- Customize PEPPOL XML generation.
+- `OnBeforeProcessImportedPEPPOLDocument` / `OnAfterProcessImportedPEPPOLDocument` in `EDocImportPEPPOLBIS30.Codeunit.al` -- Customize PEPPOL import parsing.
+- `OnBeforePEPPOLPreMapDocument` in `EDocDEDPEPPOLPreMapping.Codeunit.al` -- Override Data Exchange Definition pre-mapping.
+
+### Reacting to status changes
+
+- `OnAfterModifyEDocumentStatus` in `EDocumentProcessing.Codeunit.al` -- Fires when the document-level status changes.
+- `OnAfterModifyServiceStatus` in `EDocumentProcessing.Codeunit.al` -- Fires when a service-level status changes.
+- `EDocumentStatusChanged` / `EDocumentServiceStatusChanged` in `EDocumentBusinessEvents.Codeunit.al` -- External business events for Power Automate / Logic Apps integration.
+
+### Extending the service configuration
+
+- `OnAfterInsertEDocService` in `EDocumentService.Table.al` -- React to new service creation.
+- `OnBeforeOpenServiceIntegrationSetupPage` in `EDocumentService.Page.al` -- Open a custom setup page for your integration.
+
+## Consent management
+
+When a user configures a new service integration, the framework calls `IConsentManager.ObtainPrivacyConsent` (via the `Consent Manager Default Impl.` codeunit) before enabling the integration. Implement this interface if your connector needs custom privacy consent flows beyond the default dialog.
+
+## API endpoints
+
+The `src/Processing/API/Endpoints/` directory contains API pages for external integrations. The external business events (`EDocumentStatusChanged`, `EDocumentServiceStatusChanged`) allow Power Automate flows to react to e-document lifecycle changes without polling.

--- a/src/Apps/W1/EDocument/App/docs/patterns.md
+++ b/src/Apps/W1/EDocument/App/docs/patterns.md
@@ -1,0 +1,85 @@
+# Patterns
+
+## Service/connector plugin model
+
+**Problem**: Country-specific e-invoicing standards require different serialization formats and different transmission protocols, but the core lifecycle (create, export, send, receive, import) is the same everywhere.
+
+**Solution**: The `E-Document Service` table stores two enum fields: `Document Format` (how to serialize) and `Service Integration V2` (how to transmit). Each enum value maps to an interface implementation resolved at runtime. This means PEPPOL BIS 3.0 format can be paired with any HTTP connector, and a new country only needs to add enum extensions and implement the relevant interfaces.
+
+**Example**: `EDocExport.Codeunit.al` resolves the format interface via `EDocumentInterface := EDocumentService."Document Format"` and then calls `EDocumentInterface.Check(...)` and `EDocumentInterface.Create(...)`. The integration side works the same way in `EDocIntegrationManagement.Codeunit.al`.
+
+**Gotcha**: The enum-to-interface binding is compile-time in AL. You cannot dynamically register implementations -- you must create an enum extension in your app. If two apps extend the same enum value, you get a compile error.
+
+## Dual-level status state machine
+
+**Problem**: An E-Document can be processed by multiple services simultaneously (e.g., sent to both a tax authority and an archival service). Each service can be at a different stage, but the user needs a single overall status.
+
+**Solution**: Three-tier status: `E-Document.Status` (document-level, derived), `E-Document Service Status.Status` (per-service, set directly), and `E-Document Service Status.Import Processing Status` (V2 import pipeline, drives service status via OnValidate trigger). The document-level status is computed by scanning all service statuses -- any error wins, then any in-progress, otherwise processed.
+
+**Example**: `EDocumentProcessing.ModifyEDocumentStatus` iterates service status records using the `IEDocumentStatus` interface (implemented by `EDocErrorStatus`, `EDocInProgressStatus`, `EDocProcessedStatus` in `src/Document/Status/`).
+
+**Gotcha**: The import processing status auto-updates the service status via an OnValidate trigger on the `Import Processing Status` field. If you modify it directly via SQL or skip validation, the service status and document status will be out of sync.
+
+## Staged import processing (V2 pipeline)
+
+**Problem**: Converting a received e-invoice into a BC purchase document involves multiple fallible steps (OCR, vendor matching, item matching, document creation). If any step fails, you want to retry from that point, not start over.
+
+**Solution**: Four independent stages, each wrapped in `Codeunit.Run()` with explicit undo support. `ImportEDocumentProcess.Codeunit.al` dispatches to the correct stage based on the `Import E-Document Steps` enum. Each stage advances the `Import Processing Status` (Unprocessed to Readable to Ready for draft to Draft ready to Processed). Each stage can be undone independently -- `UndoProcessingStep` clears the relevant fields and reverts the status.
+
+**Example**: The "Structure received data" stage calls `IStructureReceivedEDocument.StructureReceivedEDocument`, stores the result, and updates `Structured Data Entry No.`. Undoing it clears `Structured Data Entry No.` back to 0.
+
+**Gotcha**: V1 and V2 coexist. `ImportEDocumentProcess.OnRun` checks `GetImportProcessVersion()` and branches -- V1 skips to "Finish draft" and calls the legacy single-step import. If the service is configured for V1, stages 1-3 are no-ops.
+
+## Provider pattern
+
+**Problem**: Different countries and business configurations need different logic for resolving vendors, items, accounts, and units of measure from external e-document data.
+
+**Solution**: The `IVendorProvider`, `IItemProvider`, `IUnitOfMeasureProvider`, `IPurchaseLineAccountProvider`, and `IPurchaseOrderProvider` interfaces in `src/Processing/Interfaces/` are called during the "Prepare draft" stage. `EDocProviders.Codeunit.al` orchestrates the calls. Default implementations use historical matching tables and BC cross-references; extensions can override with custom lookup logic.
+
+**Example**: `IVendorProvider.GetVendor` receives the E-Document record and returns a `Vendor` record. The default implementation checks `E-Doc. Vendor Assign. History` first, then falls back to VAT registration number lookups.
+
+**Gotcha**: Provider implementations must handle the "not found" case gracefully by returning an empty record, not by throwing an error. The pipeline will log a warning and allow manual resolution via the draft UI.
+
+## Context objects for integration calls
+
+**Problem**: Integration implementations need access to the document blob, HTTP state for logging, and a way to control the resulting status -- but passing all these as separate parameters creates unwieldy signatures.
+
+**Solution**: `SendContext`, `ReceiveContext`, and `ActionContext` codeunits (in `src/Integration/Send/`, `src/Integration/Receive/`, `src/Integration/Actions/`) bundle the blob, HTTP message state, and status control into a single parameter. The framework reads from these after the call to automatically log HTTP exchanges and determine the next status.
+
+**Example**: In `EDocIntegrationManagement.Send`, the framework creates a `SendContext`, sets the blob, and passes it to `IDocumentSender.Send`. After the call, it reads `SendContext.Http().GetHttpRequestMessage()` and `SendContext.Http().GetHttpResponseMessage()` to populate the integration log, and `SendContext.Status().GetStatus()` to determine the service status.
+
+**Gotcha**: If your integration sets `SendContext.Status().SetStatus(Enum::"E-Document Service Status"::"Pending Response")`, you must also implement `IDocumentResponseHandler` or the document will stay in "Pending Response" forever. The framework does not validate this at configuration time.
+
+## Try-commit-run error boundary
+
+**Problem**: Format and integration implementations are third-party code. A runtime error in an implementation would roll back the calling transaction, losing the E-Document record and audit trail.
+
+**Solution**: Before calling any interface implementation, the framework commits the current transaction. The interface call runs via `Codeunit.Run()`, which creates an implicit try-catch. If it fails, `GetLastErrorText()` captures the error and logs it via `EDocumentErrorHelper`. The E-Document and its logs survive because they were committed before the failing call.
+
+**Example**: `EDocIntegrationManagement.Send` commits, then calls `RunSend` (which uses `Codeunit.Run` internally). On failure, it calls `AddLogAndUpdateEDocument` with a "Sending Error" status.
+
+**Gotcha**: This means interface implementations see a committed database state. If they make their own database writes and then fail partway through, those writes are also committed and not rolled back. Extension authors must be aware that partial state from a failed implementation call persists.
+
+## Workflow-driven orchestration
+
+**Problem**: Outbound e-document processing involves multiple steps (export, send, email, batch) that vary by business configuration. Hard-coding the sequence is inflexible.
+
+**Solution**: The framework uses BC's standard Workflow engine. `EDocumentWorkFlowProcessing.Codeunit.al` registers entry points (document created) and response steps (export, send, send via email, evaluate batch). The Document Sending Profile must reference an enabled Workflow that contains E-Document Service steps. This allows administrators to configure multi-step flows like "export with PEPPOL, send to tax authority, then email PDF to customer" without code changes.
+
+**Example**: `EDocumentWorkFlowSetup.Codeunit.al` registers the available workflow events and response steps. `EDocumentCreatedFlow.Codeunit.al` provides the entry point event.
+
+**Gotcha**: Workflows are required even for simple send scenarios. If a Document Sending Profile references an E-Document Service Flow that is not enabled or does not exist, posting will fail with an error from `EDocExport.CheckEDocument`.
+
+## Legacy patterns
+
+### The obsolete `Service Integration` enum and `E-Document Integration` interface
+
+Before v26, there was a single `Service Integration` enum and a monolithic `E-Document Integration` interface that combined send, receive, and response handling. This has been replaced by `Service Integration V2` with split interfaces (`IDocumentSender`, `IDocumentReceiver`, `IDocumentResponseHandler`, `IReceivedDocumentMarker`, `ISentDocumentActions`). Code gated by `#if not CLEAN26` handles backward compatibility. New connectors should always use V2.
+
+### V1 import path
+
+The V1 import path uses `GetBasicInfoFromReceivedDocument` and `GetCompleteInfoFromReceivedDocument` on the `E-Document` format interface to directly create a purchase document in a single step. It does not use the draft tables, the provider pattern, or the staged pipeline. It is preserved for backward compatibility with existing format implementations but should not be used for new development. The V2 path provides better error recovery, user review via the draft UI, and pluggable matching logic.
+
+### Direct table mapping vs. draft tables
+
+V1 used `E-Document Header Mapping` (6102) and `E-Document Line Mapping` (6105) as lightweight mapping records during import. V2 replaced these with the richer `E-Document Purchase Header` (6100) and `E-Document Purchase Line` (6101) tables that carry both raw and resolved data. The V1 mapping tables still exist in the schema but are only populated when the V1 import path runs.

--- a/src/Apps/W1/EDocument/App/src/ClearanceModel/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/ClearanceModel/docs/CLAUDE.md
@@ -1,0 +1,19 @@
+# Clearance model
+
+QR code display support for government clearance e-invoicing jurisdictions (Spain, India, Mexico, Italy). In a clearance model, the government must approve an invoice before it is legally valid, and the QR code is the proof of that approval.
+
+## How it works
+
+Table extensions add `QR Code Image` (MediaSet) and `QR Code Base64` (Blob) fields to four posted document tables: Sales Invoice Header, Sales Cr.Memo Header, Service Invoice Header, and Service Cr.Memo Header. Country-specific connector apps populate these fields after receiving clearance approval from the government API -- this module only handles the display side.
+
+The `EDocumentQRCodeManagement` codeunit (6197) provides the viewer: `InitializeAndRunQRCodeViewer` takes a RecordRef for any of the four supported tables, reads the Base64 blob, copies it into a temporary `EDoc QR Buffer` record, and opens the QR viewer page. It also has `ExportQRCodeToFile` to decode the Base64 and save a PNG, and `SetQRCodeImageFromBase64` to convert the Base64 blob into a MediaSet for inline display on reports.
+
+Page extensions add a "View QR Code" action to the four posted document pages. Report extensions add the QR code image to the standard invoice/credit memo report layouts.
+
+## Things to know
+
+- `EDoc QR Buffer` (table 6166) is `TableType = Temporary` -- it never persists to the database. It exists only to pass QR data to the viewer page.
+- The QR code content is stored as Base64 text in a Blob field, not as a direct image. The codeunit decodes it to PNG on demand for export or MediaSet conversion.
+- This module does not generate QR codes or interact with government APIs. That responsibility belongs to country-specific connector apps. The clearance model module only provides storage fields and UI for displaying the result.
+- Four table extensions, four page extensions, and four report extensions follow the same pattern for Sales Invoice, Sales Credit Memo, Service Invoice, and Service Credit Memo. Transfer documents and purchase documents are not covered.
+- The `EDocumentQRViewer.Page.al` and `EDocumentQRCodeViewer.Page.al` are two separate pages -- one shows the QR as an image, the other provides export functionality.

--- a/src/Apps/W1/EDocument/App/src/ClearanceModel/docs/data-model.md
+++ b/src/Apps/W1/EDocument/App/src/ClearanceModel/docs/data-model.md
@@ -1,0 +1,17 @@
+# Clearance model data model
+
+## QR code storage
+
+QR code data is stored directly on the posted document headers via table extensions. The temporary buffer table exists only for viewer page interaction.
+
+```mermaid
+erDiagram
+    SALES-INVOICE-HEADER ||--o| QR-CODE-FIELDS : "table extension"
+    SALES-CR-MEMO-HEADER ||--o| QR-CODE-FIELDS : "table extension"
+    SERVICE-INVOICE-HEADER ||--o| QR-CODE-FIELDS : "table extension"
+    SERVICE-CR-MEMO-HEADER ||--o| QR-CODE-FIELDS : "table extension"
+```
+
+Each table extension adds the same two fields: `QR Code Image` (MediaSet for inline display) and `QR Code Base64` (Blob holding the Base64-encoded PNG). These fields are populated externally by country-specific connector apps after government clearance is obtained.
+
+The `EDoc QR Buffer` temporary table holds `Document Type`, `Document No.`, `QR Code Base64`, and `QR Code Image`. It is populated by `EDocumentQRCodeManagement` when a user clicks "View QR Code" -- the codeunit reads the Base64 from the source table, copies it into the buffer, optionally decodes it to a MediaSet, and passes the buffer to the viewer page.

--- a/src/Apps/W1/EDocument/App/src/DataExchange/PEPPOL Data Exchange Definition/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/DataExchange/PEPPOL Data Exchange Definition/docs/CLAUDE.md
@@ -1,0 +1,23 @@
+# PEPPOL Data Exchange Definition
+
+Pre-mapping codeunits for PEPPOL import through BC's Data Exchange framework. This is the legacy import path that translates PEPPOL XML fields into BC purchase document fields using the Data Exchange Definition infrastructure.
+
+## How it works
+
+The Data Exchange framework reads PEPPOL XML into intermediate staging tables. Before those staged values can populate Purchase Header/Line records, the pre-mapping codeunit (`EDocDEDPEPPOLPreMapping`, codeunit 6156) runs to resolve values that need business logic -- vendor lookup, currency validation, document type detection, and line item matching.
+
+The pre-mapping codeunit operates on `Data Exch.` records. It first processes headers: validates currency codes, determines whether the document is an invoice or credit memo, resolves buy-from and pay-to vendors by GLN or VAT registration number, finds related invoices for credit memos, and persists header data. Then it processes lines: resolves items and accounts, applies invoice charges, and sets line-level fields.
+
+Four line-level pre-mapping codeunits handle export-side field population for the Data Exchange Definition subscribers: `PreMapSalesInvLine`, `PreMapSalesCrMemoLine`, `PreMapServiceInvLine`, `PreMapServiceCrMemoLine`. These populate the intermediate data exchange columns with values from BC document lines.
+
+`EDocDEDPEPPOLSubscribers` (codeunit 6162) is a SingleInstance codeunit that subscribes to Data Exchange events. It handles tax subtotal loops, allowance/charge loops, document attachment numbering, and rounding line detection during PEPPOL export.
+
+`EDocDEDPEPPOLExternal` (codeunit 6155) is a placeholder -- a dummy codeunit required by the Data Exchange Definition infrastructure but containing no logic.
+
+## Things to know
+
+- This is the legacy import path used when the E-Document Service's import process is configured for Data Exchange. The newer V2 import pipeline in `Processing/Import/` has largely superseded this for new implementations.
+- Vendor resolution tries GLN first, then VAT Registration Number, then Company Establishment No. If buy-from and pay-to are different, both are resolved independently.
+- The pre-mapping validates that all line currencies match the header currency -- mismatches raise errors.
+- Credit memo import requires that the referenced invoice is already posted in BC. If it exists as a purchase invoice but is not yet posted, a specific error message tells the user to post it first.
+- `EDocDEDPEPPOLSubscribers` uses `SingleInstance = true` to maintain state across multiple event callbacks during a single Data Exchange processing run. The `ClearInstance` / `InitInstance` pattern resets and configures this state.

--- a/src/Apps/W1/EDocument/App/src/DataExchange/PEPPOL Data Exchange Definition/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/src/DataExchange/PEPPOL Data Exchange Definition/docs/business-logic.md
@@ -1,0 +1,31 @@
+# PEPPOL Data Exchange Definition business logic
+
+## Pre-mapping flow
+
+The pre-mapping codeunit runs after the Data Exchange framework has parsed PEPPOL XML into staging tables but before the values are written to Purchase Header/Line records.
+
+```mermaid
+flowchart TD
+    A[Data Exchange triggers pre-mapping] --> B[Find distinct header record numbers]
+    B --> C[Validate currency codes match across document]
+    C --> D[Detect document type: Invoice or Credit Memo]
+    D --> E{Credit Memo?}
+    E -->|Yes| F[Find related posted invoice to apply to]
+    E -->|No| G[Continue]
+    F --> G
+    G --> H[Resolve buy-from vendor by GLN / VAT Reg. No.]
+    H --> I[Resolve pay-to vendor by GLN / VAT Reg. No.]
+    I --> J[Persist header data to intermediate columns]
+    J --> K[Process lines: resolve items, accounts, charges]
+    K --> L[Apply invoice charges as separate lines]
+```
+
+## Vendor resolution
+
+Vendor lookup follows a priority chain. For each vendor role (buy-from, pay-to), the codeunit searches by GLN, then by VAT Registration Number, then by Company Establishment No. The first match wins. If no vendor is found, the codeunit raises a detailed error message that includes the vendor name, GLN, and VAT number from the electronic document so the user knows which vendor card to create.
+
+## Line processing
+
+For each document line, the pre-mapping resolves the line type (Item, G/L Account, or Charge). Item resolution uses the `E-Document Import Helper` codeunit. For lines that cannot be matched to an item, the codeunit falls back to text-to-account mapping. Invoice charge lines (AllowanceCharge elements in PEPPOL) are converted to separate purchase lines with a charge reason code.
+
+The four `PreMap*Line` codeunits work in the opposite direction -- they read from BC document lines and populate Data Exchange columns for export. Each handles its specific document type's line structure (sales invoice lines have different fields from service credit memo lines).

--- a/src/Apps/W1/EDocument/App/src/Document/Status/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Document/Status/docs/CLAUDE.md
@@ -1,0 +1,25 @@
+# Status
+
+Status tracking for e-documents operates at two levels: a document-level status and a per-service status. This directory contains the enums and interface implementations that make the status state machine work. The `IEDocumentStatus` interface bridges between the fine-grained service statuses and the coarse document-level status.
+
+## How it works
+
+The `E-Document Service Status` enum (`EDocumentServiceStatus.Enum.al`) has roughly 20 values covering the full outbound and inbound lifecycle -- Created, Exported, Sent, Pending Response, Approved, Rejected, Canceled, Imported, Order Linked, and so on. Each enum value carries a `DefaultImplementation` of `IEDocumentStatus` that maps it to one of three document-level states. The mapping is baked into the enum declaration itself: each value specifies which codeunit implements `IEDocumentStatus`.
+
+Three trivial codeunits implement the interface -- `EDocErrorStatus` (returns Error), `EDocInProgressStatus` (returns In Progress), and `EDocProcessedStatus` (returns Processed). The default for any value without an explicit implementation is `EDocInProgressStatus`. This is the entire status aggregation logic: the processing layer calls `GetEDocumentStatus()` on a service status enum value and gets back the document-level status.
+
+The document-level `E-Document Status` enum has only three values: In Progress (0), Processed (1), and Error (2). The aggregation is pessimistic -- if any service associated with a document is in an error state, the document status becomes Error. If any is in-progress, the document is In Progress. Only when all services reach a "processed" terminal state does the document become Processed.
+
+## Things to know
+
+- The enum-implements-interface pattern means you cannot look at the three codeunits in isolation and understand the status mapping. You must read the `E-Document Service Status` enum declaration to see which service statuses map to which document statuses.
+
+- Service statuses that lack an explicit `Implementation` line default to `EDocInProgressStatus` via `DefaultImplementation` on the enum. This means any new enum value is automatically treated as "in progress" unless you explicitly wire it to Error or Processed.
+
+- Error statuses: Sending Error, Cancel Error, Export Error, Imported Document Processing Error, and Approval Error. All map to `EDocErrorStatus`.
+
+- Processed statuses: Exported, Canceled, Imported Document Created, Journal Line Created, Sent, Approved, Rejected, and Cleared. Note that Rejected is treated as Processed (terminal), not Error.
+
+- The clearance model statuses (Not Cleared = 30, Cleared = 31) live in a reserved range (30-40) and follow the same pattern.
+
+- Status transition is not enforced by these objects. The enum values define the mapping; the actual state machine transitions happen in `E-Document Processing` and `E-Doc. Integration Management`.

--- a/src/Apps/W1/EDocument/App/src/Document/Status/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/src/Document/Status/docs/business-logic.md
@@ -1,0 +1,58 @@
+# Status business logic
+
+## Status aggregation
+
+The document-level status is derived from per-service statuses. The processing layer queries each `E-Document Service Status` record for a given E-Document, calls `IEDocumentStatus.GetEDocumentStatus()` on each, and applies pessimistic aggregation.
+
+```mermaid
+flowchart TD
+    A[Service status changes] --> B{Any service in Error state?}
+    B -->|Yes| C[Document Status = Error]
+    B -->|No| D{Any service In Progress?}
+    D -->|Yes| E[Document Status = In Progress]
+    D -->|No| F[Document Status = Processed]
+```
+
+## Service status to document status mapping
+
+Each `E-Document Service Status` enum value maps to exactly one of three document-level states via the `IEDocumentStatus` interface. The mapping is declared on the enum value itself, not in procedural code.
+
+The default implementation is `E-Doc In Progress Status`, so any service status without an explicit `Implementation` line is treated as in-progress. This is intentional -- new statuses are safe by default because they keep the document in a non-terminal state until the developer explicitly categorizes them.
+
+## Outbound status flow
+
+```mermaid
+flowchart TD
+    Created --> Exported
+    Exported --> Sent
+    Exported --> PendingResponse["Pending Response"]
+    Exported --> SendingError["Sending Error"]
+    PendingResponse --> Sent
+    PendingResponse --> SendingError
+    Sent --> Approved
+    Sent --> Rejected
+    Sent --> ApprovalError["Approval Error"]
+    Sent --> Canceled
+    Sent --> CancelError["Cancel Error"]
+    Exported --> PendingBatch["Pending Batch"]
+    PendingBatch --> Sent
+    Created --> ExportError["Export Error"]
+```
+
+## Inbound status flow
+
+```mermaid
+flowchart TD
+    Imported --> Pending["Pending (document link)"]
+    Imported --> OrderLinked["Order Linked"]
+    Imported --> ImportedDocCreated["Imported Document Created"]
+    Imported --> JournalLineCreated["Journal Line Created"]
+    Imported --> ImportedDocProcError["Imported Document Processing Error"]
+    BatchImported --> Imported
+    Pending --> OrderLinked
+    OrderLinked --> ImportedDocCreated
+```
+
+## Error recovery
+
+Error statuses are non-terminal in practice -- the UI allows reprocessing from error states. For outbound, `Sending Error` and `Export Error` allow resending. For inbound, `Imported Document Processing Error` allows reprocessing. The status codeunits themselves do not enforce transitions; they only provide the mapping. Actual transition guards live in `E-Doc. Integration Management` (e.g., `IsEDocumentInStateToSend` checks that service status is Exported or Sending Error before allowing a send).

--- a/src/Apps/W1/EDocument/App/src/Document/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Document/docs/CLAUDE.md
@@ -1,0 +1,25 @@
+# Document
+
+The central entity layer of E-Document Core. The `E-Document` table (6121) is the master record that tracks every electronic document -- inbound or outbound -- through its full lifecycle. Everything else in the module ultimately points back to an entry in this table.
+
+## How it works
+
+An E-Document is created either by posting a BC sales/service document (outbound) or by receiving a file from an external service (inbound). The `Direction` enum (`EDocumentDirection.Enum.al`) distinguishes the two flows. For outbound documents, `Document Record ID` links back to the originating BC record (posted invoice, credit memo, etc.). For inbound documents, the record starts with Direction = Incoming and no linked document -- it acquires a `Document Record ID` only after the import pipeline successfully creates a purchase document or journal line.
+
+Content is stored externally via two Data Storage pointers: `Unstructured Data Entry No.` holds the raw file (PDF, image), while `Structured Data Entry No.` holds the machine-readable representation (XML, JSON). Both reference `E-Doc. Data Storage` records. This split is fundamental -- a single e-document can have both a human-readable PDF and a PEPPOL XML simultaneously.
+
+The `E-Document Type` enum (`EDocumentType.Enum.al`) covers the full range of BC document types from Sales Quote through Transfer Shipment. It implements `IEDocumentFinishDraft` -- the Purchase Invoice value carries a concrete implementation (`E-Doc. Create Purchase Invoice`) while all others fall back to a default no-op. The `E-Document Format` enum is extensible and implements the `E-Document` interface, which is the contract for creating/parsing documents in a specific wire format (PEPPOL BIS 3.0, Data Exchange, or custom).
+
+## Things to know
+
+- The table has three separate status tracking systems: `Status` (document-level, from the `E-Document Status` enum), the per-service status in `E-Document Service Status` table, and the newer `Import Processing Status` flow field. They serve different purposes but interact -- document-level status is derived pessimistically from service statuses.
+
+- Duplicate detection uses Key3: `Incoming E-Document No.` + `Bill-to/Pay-to No.` + `Document Date`. The `IsDuplicate` procedure checks this composite. Deleting a non-duplicate requires user confirmation (or errors entirely if `GuiAllowed()` is false).
+
+- You cannot delete a Processed e-document, and you cannot delete one that is linked to a BC document (`Document Record ID.TableNo <> 0`). The `CleanupDocument` procedure handles cascading deletes of logs, service statuses, attachments, mapping logs, and imported lines.
+
+- `EDocumentsSetup.Table.al` is obsolete (tagged for removal in 28.0). It was a feature-flag table for the "new e-document experience" that is now the default for most country codes.
+
+- The `E-Document Processing Phase` enum (Create, Release, Prepayment, Post, Map) controls when validation runs during document lifecycle -- the format interface's `Check` procedure receives this phase so it can apply context-appropriate validation.
+
+- `Source Type` (Customer, Vendor, Location, Company) identifies the trading partner type, distinct from `Document Type` which identifies the BC document kind.

--- a/src/Apps/W1/EDocument/App/src/Extensions/RoleCenter/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Extensions/RoleCenter/docs/CLAUDE.md
@@ -1,0 +1,14 @@
+# RoleCenter extensions
+
+Page extensions that embed the `E-Document Activities` cue group into standard BC role centers so users see e-document status without navigating away from their home page.
+
+## How it works
+
+Five page extensions -- Accountant, AP Admin Activities, Business Manager, Inventory Manager, and Ship/Receive/WMS -- each add the `E-Document Activities` CardPart after the approvals section. The activities part (`EDocumentActivities.Page.al` in the parent `Extensions/` directory) shows counts for outgoing and incoming e-documents grouped by status: Processed, In Progress, and Error. Each count is drillable, opening the filtered E-Documents list.
+
+## Things to know
+
+- The activities page uses `RefreshOnActivate = true` so counts update every time the role center is displayed, not just on first load.
+- Adding E-Document activities to a new role center only requires a one-line page extension embedding the existing `E-Document Activities` part -- no new codeunit work.
+- The AP Admin Activities extension (`EDocAPAdminActivities.PageExt.al`) is separate from the Accountant RC extension because AP Admin has a different page structure for its activity groups.
+- All extensions use `ApplicationArea = Basic, Suite`, making them visible in all license tiers that include those areas.

--- a/src/Apps/W1/EDocument/App/src/Extensions/Sending/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Extensions/Sending/docs/CLAUDE.md
@@ -1,0 +1,15 @@
+# Sending profile extensions
+
+Extends the Document Sending Profile to support E-Document workflows. This is the user-facing configuration point where "post and send this invoice" becomes "export to PEPPOL and transmit via my connector."
+
+## How it works
+
+The table extension (`EDocumentSendingProfile.TableExt.al`) adds `Electronic Service Flow` -- a Code[20] that references a Workflow record filtered to category `EDOC`. When the `Electronic Document` enum is set to `Extended E-Document Service Flow` (added by `EDocSendProfileElecDoc.EnumExt.al`), the workflow code determines which E-Document services process the document.
+
+The `E-Mail Attachment` enum is extended with two values: `E-Document` and `PDF & E-Document` (`EDocSendingProfAttType.EnumExt.al`). These let users attach the generated e-document XML alongside or instead of a PDF when sending by email. Selecting either of these values validates that the profile has an active e-document workflow configured.
+
+## Things to know
+
+- The sending profile's `OnAfterValidate` trigger on `E-Mail Attachment` enforces that if you pick `PDF & E-Document` or `E-Document`, the electronic document mode must be `Extended E-Document Service Flow` and the referenced workflow must be enabled. This prevents misconfiguration.
+- `Electronic Service Flow` links to `Workflow.Code` where `Template = false` and `Category = 'EDOC'` -- only non-template e-document workflows are valid targets.
+- The page extensions (`EDocSelectSendingOptions.PageExt.al`, `EDocumentSendingProfile.PageExt.al`) surface the workflow selection field on the sending profile card and the send options dialog.

--- a/src/Apps/W1/EDocument/App/src/Extensions/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Extensions/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# Extensions
+
+Table and page extensions that stitch E-Document Core into the base BC application. Without these, no standard BC page would know about e-documents -- they create the "seams" that let users see, configure, and interact with e-document state from their normal workflows.
+
+## How it works
+
+The table extensions add fields to existing BC tables that E-Document Core needs. The most important is the `E-Document Link` Guid on Purchase Header (`EDocPurchaseHeader.TableExt.al`), which is how a BC purchase document links back to its source E-Document record. The Vendor table extension (`EDocumentVendor.TableExt.al`) adds `Receive E-Document To` -- a per-vendor preference controlling whether incoming e-documents create Purchase Orders or Purchase Invoices. The Purchase Line extension adds `Amount Incl. VAT To Inv.`, a computed field that prorates VAT by qty-to-invoice for order matching.
+
+Page extensions surface e-document information on roughly 30 existing BC pages. Posted sales/purchase invoices and credit memos get E-Document factboxes. Sales, purchase, and service document pages gain e-document related fields. The `E-Document Activities` page (`EDocumentActivities.Page.al`) is a CardPart showing outgoing/incoming document counts by status (Processed, In Progress, Error) and is embedded into role centers via the `RoleCenter/` subdirectory.
+
+The `Sending/` subdirectory extends Document Sending Profile to add e-document workflow selection -- this is the user-facing configuration that connects "post and send" to the E-Document pipeline.
+
+## Things to know
+
+- `E-Document Link` on Purchase Header is a Guid, not an integer FK. It matches `E-Document.SystemId`, not `Entry No`. The `IsLinkedToEDoc` helper checks both non-null and not-equal-to-excluded.
+- The `Receive E-Document To` enum on Vendor defaults to Purchase Order. This drives whether inbound e-documents create POs (for three-way matching) or go straight to Purchase Invoice.
+- `EDocPurchPayablesSetup.TableExt.al` adds `E-Document Matching Difference %` -- a tolerance threshold for automatic line matching during import.
+- Document Attachment gets `E-Document Attachment` boolean and `E-Document Entry No.` FK, letting attachments be linked back to their originating e-document.
+- Location gets `Transfer Doc. Sending Profile` for transfer shipment e-document support.
+- The `.al.orig` files (e.g., `EDocPostedSalesInv.PageExt.al.orig`) are merge artifacts and should be ignored.

--- a/src/Apps/W1/EDocument/App/src/Extensions/docs/data-model.md
+++ b/src/Apps/W1/EDocument/App/src/Extensions/docs/data-model.md
@@ -1,0 +1,23 @@
+# Extensions data model
+
+## Purchase document linking
+
+The key relationship is between Purchase Header and E-Document. The `E-Document Link` Guid on Purchase Header joins to `E-Document.SystemId`, creating a soft reference that survives table renumbering.
+
+```mermaid
+erDiagram
+    E-DOCUMENT ||--o| PURCHASE-HEADER : "SystemId = E-Document Link"
+    PURCHASE-HEADER ||--|{ PURCHASE-LINE : "Document No."
+    PURCHASE-LINE }o--o{ E-DOC-ORDER-MATCH : "Document Order No. + Line No."
+    VENDOR ||--o{ PURCHASE-HEADER : "Buy-from Vendor No."
+```
+
+Purchase Line's `Amount Incl. VAT To Inv.` is a data field (not FlowField) recomputed via OnValidate: `Round("Amount Including VAT" * "Qty. to Invoice" / Quantity)`. The Purchase Header has a matching FlowField that sums these across lines for display.
+
+## Vendor configuration
+
+Vendor and Vendor Template both carry `Receive E-Document To` (enum: Purchase Order, Purchase Invoice). This is read during inbound processing to decide the target document type. The Vendor Template version ensures new vendors created from templates inherit the preference.
+
+## Document sending profile extension
+
+The Sending Profile extension (`EDocumentSendingProfile.TableExt.al`) adds `Electronic Service Flow` (Code[20]) linking to a Workflow record filtered to category `EDOC`. The `Electronic Document` enum is extended with `Extended E-Document Service Flow` to enable the E-Document pipeline. These two fields together -- the enum value and the workflow code -- are what makes a sending profile "e-document aware."

--- a/src/Apps/W1/EDocument/App/src/Format/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Format/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Format
+
+PEPPOL BIS 3.0 format implementation and shipment XML generators. This is the only built-in document format -- all other formats (OIOUBL, Factura-e, FatturaPA, etc.) come from country localization apps that implement the same `E-Document` interface.
+
+## How it works
+
+`EDocPEPPOLBIS30` (codeunit 6165) implements the `E-Document` interface with `Check`, `Create`, `CreateBatch`, and `GetBasicInfo`/`GetCompleteInfo` procedures. The `Check` procedure delegates to existing PEPPOL validation codeunits based on the source document type. The `Create` procedure builds XML by calling the appropriate BC PEPPOL export XMLport (`FinResultsPEPPOLBIS30.XmlPort.al`) and writes the result to a TempBlob. It handles sales invoices, credit memos, service documents, reminders, finance charge memos, and shipments.
+
+`EDocImportPEPPOLBIS30` (codeunit 6166) handles the inbound side. `ParseBasicInfo` reads just enough XML to populate the E-Document header (vendor ID, document number, dates, amounts). `ParseCompleteInfo` fully parses the PEPPOL XML into temporary Purchase Header and Purchase Line records. Both methods detect whether the document is an Invoice or CreditNote from the root XML element.
+
+Two separate codeunits handle non-PEPPOL shipment formats: `EDocShipmentExportToXml` (6130) generates XML for Sales Shipments and `EDocTransferShptToXML` (6127) for Transfer Shipments. These use a simpler custom XML schema rather than PEPPOL, with company info, customer/delivery info, and line details.
+
+`EDocPEPPOLValidation` (codeunit 6172) adds validation for document types not covered by the base BC PEPPOL validation -- specifically Reminders and Finance Charge Memos.
+
+## Things to know
+
+- The `E-Document Structured Format` enum in this directory is obsolete (pending removal in v26). It was part of the V1 import path and is replaced by the V2 pipeline's `Structure Received E-Doc.` and `E-Doc. Read into Draft` interfaces.
+- Shipment XML generation optionally embeds a PDF (`GeneratePDF` boolean). When enabled, the report PDF is Base64-encoded and included in the XML payload.
+- `EDocPEPPOLBIS30.Create` dispatches to different export methods based on `SourceDocumentHeader.Number` -- there is a large case statement covering every supported document type. Unrecognized table numbers raise an error.
+- Import parsing uses `XML Buffer` (temporary table) for XML traversal rather than direct XmlDocument manipulation. This is a BC pattern inherited from the original PEPPOL import code.
+- The import side only handles Invoice and CreditNote. Other PEPPOL document types (DespatchAdvice, etc.) are not supported for inbound processing.

--- a/src/Apps/W1/EDocument/App/src/Format/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/src/Format/docs/business-logic.md
@@ -1,0 +1,47 @@
+# Format business logic
+
+## Export flow
+
+When an E-Document is exported, the format interface's `Create` procedure is called with the source document RecordRef and an empty TempBlob. The flow depends on the document type.
+
+```mermaid
+flowchart TD
+    A[Create called with SourceDocumentHeader] --> B{Document type?}
+    B -->|Sales Invoice/Cr.Memo| C[Run PEPPOL XMLport]
+    B -->|Service Invoice/Cr.Memo| D[Run PEPPOL Service XMLport]
+    B -->|Reminder/Fin.Charge| E[Run PEPPOL Debit Note XMLport]
+    B -->|Sales Shipment| F[Run EDocShipmentExportToXml]
+    B -->|Transfer Shipment| G[Run EDocTransferShptToXML]
+    B -->|Unposted Sales/Service| H[Error - must post first]
+    C --> I[Write XML to TempBlob]
+    D --> I
+    E --> I
+    F --> I
+    G --> I
+```
+
+For standard PEPPOL documents, the codeunit runs the `FinResultsPEPPOLBIS30` XMLport which produces UBL 2.1 compliant XML. Shipment documents use custom XML structures generated programmatically via `XML DOM Management`.
+
+## Import flow
+
+The import side has two entry points: `ParseBasicInfo` for initial document identification and `ParseCompleteInfo` for full document parsing into purchase structures.
+
+```mermaid
+flowchart TD
+    A[ParseBasicInfo] --> B[Load XML into TempXMLBuffer]
+    B --> C{Root element type?}
+    C -->|Invoice| D[Parse invoice header fields]
+    C -->|CreditNote| E[Parse credit memo header fields]
+    D --> F[Set E-Document fields: vendor, dates, amounts, currency]
+    E --> F
+    G[ParseCompleteInfo] --> H[Load XML into TempXMLBuffer]
+    H --> I{Root element type?}
+    I -->|Invoice| J[CreateInvoice: populate temp PurchaseHeader + PurchaseLines]
+    I -->|CreditNote| K[CreateCreditMemo: populate temp PurchaseHeader + PurchaseLines]
+```
+
+`ParseBasicInfo` extracts vendor identification (VAT number, GLN, name), document reference numbers, dates, currency, and total amounts. `ParseCompleteInfo` fully populates temporary Purchase Header and Purchase Line records including line-level details (item descriptions, quantities, unit prices, tax amounts). The parsed output is consumed by the import pipeline to create actual BC purchase documents.
+
+## Validation
+
+The `Check` procedure runs before export. It delegates to three different validation codeunits depending on document type: `PEPPOL Validation` (from the base app, for sales documents), `PEPPOL Service Validation` (for service documents), and `E-Doc. PEPPOL Validation` (local to this module, for reminders and finance charge memos). Validation failures raise errors that block the export.

--- a/src/Apps/W1/EDocument/App/src/Helpers/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Helpers/docs/CLAUDE.md
@@ -1,0 +1,25 @@
+# Helpers
+
+Utility codeunits for connector and localization developers. These are the recommended public API for common operations that third-party apps need when building E-Document integrations.
+
+## How it works
+
+Five codeunits provide distinct utility surfaces:
+
+`E-Document Error Helper` (codeunit 6115) wraps BC's Error Message framework with E-Document context. Every method takes an E-Document record to set the error context, then delegates to `Error Message` table operations. This ensures errors are associated with the right E-Document and show up in the E-Document's error list. Key methods: `LogSimpleErrorMessage`, `LogErrorMessage` (with related record and field), `LogWarningMessage`, `HasErrors`, `ClearErrorMessages`, and count methods.
+
+`E-Document Helper` (codeunit 6148) is the general-purpose utility. `IsElectronicDocument` checks whether a source document's sending profile enables the E-Document pipeline. `GetEDocumentBlob` retrieves the imported document blob from logs. `AllowEDocumentCoreHttpCalls` enables HttpClient permissions for the E-Document Core extension. `GetServicesInWorkflow` returns the E-Document services used in a specific workflow.
+
+`E-Document Import Helper` (codeunit 6109) provides resolution logic for inbound documents: `ResolveUnitOfMeasureFromDataImport` (tries Code, then International Standard Code, then Description), `FindItemReferenceByItemReference` (lookup by item reference), and vendor resolution utilities. These are the building blocks that format implementations call during import parsing.
+
+`E-Document Log Helper` (codeunit 6131) is a thin public facade over the internal `E-Document Log` codeunit. It exposes `InsertIntegrationLog` and `InsertLog` for connector developers who need to log additional HTTP calls or status changes from their integration code.
+
+`EDocument Json Helper` (codeunit 6121, Internal access) parses the specific JSON structure returned by AI document intelligence services -- extracting header fields and line arrays from the `outputs.1.result` path. This is not a general-purpose JSON utility.
+
+## Things to know
+
+- Error Helper and Import Helper have Public access -- they are the intended API for connector developers. The Json Helper is Internal and specific to the ADI integration path.
+- `LogSimpleErrorMessage` is the most common error logging method. It takes just an E-Document and a message string, without needing a related record or field number.
+- Import Helper's UOM resolution has a three-step fallback: exact Code match, International Standard Code match, Description match. This handles the variety of UOM representations in PEPPOL documents.
+- `AllowEDocumentCoreHttpCalls` directly manipulates `NAV App Setting` records using the hardcoded E-Document Core extension ID. This is an admin-level operation.
+- Log Helper exists because the main `E-Document Log` codeunit has Internal access. Third-party apps cannot call it directly, so the helper provides the subset of logging operations that connector developers need.

--- a/src/Apps/W1/EDocument/App/src/Helpers/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/src/Helpers/docs/business-logic.md
@@ -1,0 +1,41 @@
+# Helpers business logic
+
+## Error logging flow
+
+All E-Document errors flow through the Error Helper to ensure consistent context association.
+
+```mermaid
+flowchart TD
+    A[Operation fails in format/integration code] --> B{Error type?}
+    B -->|Simple message| C[LogSimpleErrorMessage]
+    B -->|Field-level error| D[LogErrorMessage with RecordRef + FieldNo]
+    B -->|Warning| E[LogWarningMessage]
+    C --> F[ErrorMessage.SetContext with E-Document RecordId]
+    D --> F
+    E --> F
+    F --> G[ErrorMessage.LogMessage persists to Error Message table]
+    G --> H[E-Document page shows errors via ErrorMessageCount]
+```
+
+The pattern used in format and integration codeunits is: catch an error condition, call the appropriate Error Helper method, then either continue (for warnings) or exit (for errors). The E-Document page's error factbox reads from the Error Message table filtered to the E-Document's RecordId.
+
+## Import resolution chain
+
+When an inbound e-document contains a unit of measure code, the Import Helper resolves it through progressively fuzzier matching.
+
+```mermaid
+flowchart TD
+    A[UOM value from e-document] --> B{Exact Code match?}
+    B -->|Yes| C[Use matched UOM Code]
+    B -->|No| D{International Standard Code match?}
+    D -->|Yes| C
+    D -->|No| E{Description match?}
+    E -->|Yes| C
+    E -->|No| F[Log error: UOM not found]
+```
+
+Item resolution in Import Helper follows a similar pattern: search by Item Reference, then by GTIN/Barcode, then by Vendor Item No., then by Item No. directly. Each step narrows or expands the search until a match is found or an error is logged.
+
+## Integration logging via Log Helper
+
+Connector developers call `InsertIntegrationLog` after each HTTP call to their external service. The Log Helper delegates to the internal `E-Document Log` codeunit, which creates an `E-Document Integration Log` record with the request/response blobs, URL, HTTP method, and status code. This enables full HTTP-level diagnostics without the connector needing direct table permissions.

--- a/src/Apps/W1/EDocument/App/src/Integration/Actions/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Integration/Actions/docs/CLAUDE.md
@@ -1,0 +1,25 @@
+# Actions
+
+The extensible action framework for post-send operations on e-documents. Actions are operations that happen after a document has been sent -- checking approval status, requesting cancellation, or performing custom connector-specific operations. The framework uses the `Integration Action Type` enum as a dispatch table, with each enum value mapping to an `IDocumentAction` implementation.
+
+## How it works
+
+`E-Doc. Integration Management.InvokeAction` is the entry point. It receives an `ActionContext` and an `Integration Action Type`, then delegates to `E-Document Action Runner`. The runner resolves the `IDocumentAction` interface from the enum value and calls `InvokeAction`. The action returns a Boolean indicating whether the E-Document's service status should be updated -- some actions are purely informational polls that should not change state.
+
+Two built-in action types exist: "Sent Document Approval" and "Sent Document Cancellation". Their implementations (`SentDocumentApproval.Codeunit.al`, `SentDocumentCancellation.Codeunit.al`) follow an identical pattern: set default success and error statuses on the `ActionContext`, resolve `IDocumentSender` from the service enum, check `if IDocumentSender is ISentDocumentActions`, then delegate to the connector's `GetApprovalStatus` or `GetCancellationStatus`.
+
+`ActionContext` (`ActionContext.Codeunit.al`) provides HTTP state via `Http()` and status management via `Status()`. The status object (`IntegrationActionStatus`) carries both a success status and an error status. The built-in approval action pre-sets success to Approved and error to "Approval Error"; the cancellation action pre-sets success to Canceled and error to "Cancel Error". Connectors can override these via `ActionContext.Status().SetStatus(...)`.
+
+`HttpMessageState` (`HttpMessageState.Codeunit.al`) is the shared HTTP request/response container used by both `SendContext` and `ActionContext`. It is the same codeunit in both contexts -- a simple getter/setter pair for `HttpRequestMessage` and `HttpResponseMessage`.
+
+## Things to know
+
+- The `Integration Action Type` enum is extensible. Connector apps can add custom action types that implement `IDocumentAction` and invoke them through the standard `InvokeAction` path.
+
+- The `IDocumentAction.InvokeAction` return value is critical: `true` means "update the service status to whatever is in `ActionContext.Status().GetStatus()`"; `false` means "do not touch the status." The framework always logs HTTP communication regardless of the return value.
+
+- The built-in approval/cancellation actions cast from `IDocumentSender` to `ISentDocumentActions` using `is`/`as`. This means your connector's sender codeunit must also implement `ISentDocumentActions` for these actions to work -- it is not a separate registration.
+
+- `E-Document Action Runner` uses the "if codeunit.Run()" pattern. If the action throws a runtime error, the framework catches it, logs the error, and sets the service status to the error status from `ActionContext.Status().GetErrorStatus()`.
+
+- The `"No Action"` enum value maps to `Empty Integration Action`, which is the null-object implementation.

--- a/src/Apps/W1/EDocument/App/src/Integration/Actions/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/src/Integration/Actions/docs/business-logic.md
@@ -1,0 +1,50 @@
+# Actions business logic
+
+## Action dispatch flow
+
+```mermaid
+flowchart TD
+    A[InvokeAction called] --> B[Verify Service Integration V2 is set]
+    B --> C[Run E-Document Action Runner via if codeunit.Run]
+    C --> D{Runner succeeded without errors?}
+    D -->|No| E[Set status to ActionContext error status]
+    D -->|Yes| F{Action returned true -- update status?}
+    F -->|Yes| G[Set status to ActionContext success status]
+    F -->|No| H[Skip status update]
+    E --> I[Log HTTP communication]
+    G --> I
+    H --> I
+```
+
+## Built-in approval action flow
+
+The "Sent Document Approval" action follows a delegation pattern -- the framework sets default statuses, then hands off to the connector.
+
+```mermaid
+flowchart TD
+    A[Sent Document Approval invoked] --> B[Set error status = Approval Error]
+    B --> C[Set success status = Approved]
+    C --> D[Resolve IDocumentSender from enum]
+    D --> E{Sender implements ISentDocumentActions?}
+    E -->|No| F[Return false -- no status update]
+    E -->|Yes| G[Cast to ISentDocumentActions]
+    G --> H[Call GetApprovalStatus]
+    H --> I{Connector returns true?}
+    I -->|Yes| J[Framework sets status to Approved]
+    I -->|No| K[Framework leaves status unchanged]
+```
+
+## Built-in cancellation action flow
+
+Identical to approval, with Canceled/Cancel Error as the default statuses and `GetCancellationStatus` as the connector method.
+
+## Action context status management
+
+The `IntegrationActionStatus` codeunit holds two status values: a success status and an error status. This dual-status design exists because the framework needs to know which status to apply in both the success and error paths without requiring the action implementation to handle error-status logic.
+
+The built-in actions pre-set both values before calling the connector:
+
+- Approval: success = Approved, error = Approval Error
+- Cancellation: success = Canceled, error = Cancel Error
+
+Connectors can override the success status via `ActionContext.Status().SetStatus(...)` if their API returns a different terminal state. The error status is typically left at the default.

--- a/src/Apps/W1/EDocument/App/src/Integration/Interfaces/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Integration/Interfaces/docs/CLAUDE.md
@@ -1,0 +1,31 @@
+# Integration interfaces
+
+The contracts that connector apps implement to integrate with the E-Document framework. These seven interfaces define the full surface area for sending, receiving, acknowledging, polling async responses, checking approval/cancellation, executing custom actions, and managing privacy consent.
+
+## How it works
+
+A connector app extends the `Service Integration` enum with a new value and provides implementations for the interfaces it supports. At minimum, a connector must implement `IDocumentSender` or `IDocumentReceiver` (or both). The framework discovers capabilities at runtime using `is` checks -- for example, `SendRunner` checks `if IDocumentSender is IDocumentResponseHandler` to determine whether sending is async.
+
+The interfaces are organized by operation:
+
+- **Sending**: `IDocumentSender` -- the core send method. A single `Send` procedure handles both individual and batch sends (batch is indicated by a filtered EDocument recordset).
+- **Async response**: `IDocumentResponseHandler` -- polled by a background job when the sender supports async. Returns `true` when the external service has accepted the document, `false` if still pending.
+- **Receiving**: `IDocumentReceiver` -- two-phase: `ReceiveDocuments` gets a list of available document metadata, `DownloadDocument` fetches the actual content for each.
+- **Acknowledge receipt**: `IReceivedDocumentMarker` -- optional. Tells the external API that a document has been fetched so it is not served again.
+- **Post-send actions**: `ISentDocumentActions` -- approval and cancellation status checks for sent documents.
+- **Custom actions**: `IDocumentAction` -- extensible action dispatch via the `Integration Action Type` enum.
+- **Consent**: `IConsentManager` -- GDPR privacy consent. Called once when a service integration is first configured.
+
+## Things to know
+
+- `IDocumentSender` is the only send interface. Batch vs. single is not a separate method in V2 -- the framework sets filters on the EDocument record. Connectors check `EDocument.Count()` if they need to branch.
+
+- `IDocumentResponseHandler` is discovered via `is` check, not via a separate enum registration. If your codeunit that implements `IDocumentSender` also implements `IDocumentResponseHandler`, sending is automatically treated as async.
+
+- `IReceivedDocumentMarker` is also discovered via `is` check on the `IDocumentReceiver` implementor. This is the "tell the API we got it" step -- if your connector does not implement it, the framework skips the acknowledgment.
+
+- `IDocumentAction.InvokeAction` returns a Boolean indicating whether the framework should update the E-Document's service status. Returning `false` is valid -- some actions are polling checks that should not change status if the external state has not changed.
+
+- All interfaces receive context codeunits (`SendContext`, `ReceiveContext`, `ActionContext`) rather than raw HTTP objects. The context encapsulates temp blobs, HTTP request/response, and status. Connectors must use `Context.Http().GetHttpRequestMessage()` and `Context.Http().GetHttpResponseMessage()` -- the framework auto-logs whatever is in these objects after the call.
+
+- `ISentDocumentActions` is cast from `IDocumentSender` using `as`. The concrete pattern in `SentDocumentApproval.Codeunit.al` is: get the `IDocumentSender` from the enum, check `if IDocumentSender is ISentDocumentActions`, then cast and call.

--- a/src/Apps/W1/EDocument/App/src/Integration/Interfaces/docs/extensibility.md
+++ b/src/Apps/W1/EDocument/App/src/Integration/Interfaces/docs/extensibility.md
@@ -1,0 +1,115 @@
+# Extending the E-Document integration layer
+
+## How do I send documents to my service?
+
+Extend the `Service Integration` enum with your connector's value and implement `IDocumentSender`. The framework passes you a `SendContext` containing the exported document blob and HTTP state objects.
+
+```al
+enumextension 50100 "My Connector" extends "Service Integration"
+{
+    value(50100; "My Connector")
+    {
+        Implementation =
+            IDocumentSender = "My Connector Impl.",
+            IDocumentReceiver = "My Connector Impl.",
+            IConsentManager = "My Connector Impl.";
+    }
+}
+
+codeunit 50100 "My Connector Impl."
+    implements IDocumentSender, IDocumentReceiver, IConsentManager
+{
+    procedure Send(var EDocument: Record "E-Document";
+                   var EDocumentService: Record "E-Document Service";
+                   SendContext: Codeunit SendContext)
+    var
+        TempBlob: Codeunit "Temp Blob";
+        Request: HttpRequestMessage;
+        Response: HttpResponseMessage;
+        Client: HttpClient;
+    begin
+        TempBlob := SendContext.GetTempBlob();
+        Request := SendContext.Http().GetHttpRequestMessage();
+        // Build your request from TempBlob, send via Client
+        Client.Send(Request, Response);
+        SendContext.Http().SetHttpResponseMessage(Response);
+    end;
+}
+```
+
+Key points:
+
+- The document blob in `SendContext` is the formatted output (PEPPOL XML, etc.) already produced by the format layer.
+- You must populate the HTTP request/response on the context -- the framework auto-logs them to integration logs.
+- Set `SendContext.Status().SetStatus(...)` if you want a non-default service status (default is Sent).
+
+## How do I support async sending?
+
+Also implement `IDocumentResponseHandler` on the same codeunit. The framework detects this via `is` check and automatically:
+
+1. Sets the service status to "Pending Response" after send.
+2. Schedules a background job that polls `GetResponse`.
+
+```al
+codeunit 50100 "My Connector Impl."
+    implements IDocumentSender, IDocumentResponseHandler
+{
+    procedure GetResponse(var EDocument: Record "E-Document";
+                          var EDocumentService: Record "E-Document Service";
+                          SendContext: Codeunit SendContext): Boolean
+    begin
+        // Poll your API. Return true when the service confirms receipt.
+        // Return false to stay in "Pending Response" and retry later.
+    end;
+}
+```
+
+## How do I receive documents?
+
+Implement `IDocumentReceiver`. The framework calls your connector in two phases:
+
+1. `ReceiveDocuments` -- return a list of document metadata (one `Temp Blob` per document).
+2. `DownloadDocument` -- called once per document to fetch the actual content.
+
+```al
+procedure ReceiveDocuments(var EDocumentService: Record "E-Document Service";
+                           DocumentsMetadata: Codeunit "Temp Blob List";
+                           ReceiveContext: Codeunit ReceiveContext)
+begin
+    // Call your API to list available documents.
+    // Add one Temp Blob per document to DocumentsMetadata.
+end;
+
+procedure DownloadDocument(var EDocument: Record "E-Document";
+                           var EDocumentService: Record "E-Document Service";
+                           DocumentMetadata: Codeunit "Temp Blob";
+                           ReceiveContext: Codeunit ReceiveContext)
+begin
+    // Read the metadata blob to get a document ID.
+    // Download the document and write it into ReceiveContext.GetTempBlob().
+end;
+```
+
+## How do I acknowledge that a document was fetched?
+
+Also implement `IReceivedDocumentMarker` on your `IDocumentReceiver` codeunit. The framework calls `MarkFetched` after each successful download. If this call fails, the E-Document is not created -- ensuring you never silently lose documents by acknowledging receipt without storing them.
+
+## How do I handle approval and cancellation?
+
+Implement `ISentDocumentActions` on the same codeunit that implements `IDocumentSender`. The framework casts your sender to `ISentDocumentActions` at runtime. Return `true` from `GetApprovalStatus` or `GetCancellationStatus` to update the E-Document's status; return `false` if the external state has not changed.
+
+## How do I add custom actions?
+
+Extend the `Integration Action Type` enum with a new value and implement `IDocumentAction`:
+
+```al
+enumextension 50101 "My Custom Action" extends "Integration Action Type"
+{
+    value(50100; "My Custom Action")
+    {
+        Implementation = IDocumentAction = "My Custom Action Impl.";
+    }
+}
+```
+
+Then call `EDocIntegrationManagement.InvokeAction(EDocument, EDocService, Enum::"Integration Action Type"::"My Custom Action", ActionContext)` from your page action or processing code.

--- a/src/Apps/W1/EDocument/App/src/Integration/Send/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Integration/Send/docs/CLAUDE.md
@@ -1,0 +1,25 @@
+# Send
+
+The outbound sending infrastructure. This directory contains the context codeunit that connectors interact with, the runner codeunits that isolate connector execution, and the background job machinery for async response polling and recurrent batch sends.
+
+## How it works
+
+The send flow starts in `E-Doc. Integration Management.Send`, which populates a `SendContext` with the exported document blob and default status (Sent), then delegates to `Send Runner`. The runner resolves the `IDocumentSender` from the service's `Service Integration V2` enum and calls `Send`. After the call returns, the runner checks `if IDocumentSender is IDocumentResponseHandler` to determine if the send was async -- there is no explicit `IsAsync` parameter in V2.
+
+`SendContext` (`SendContext.Codeunit.al`) is the public-facing context object. It encapsulates three things: the document blob (`GetTempBlob`/`SetTempBlob`), HTTP state (`Http()` returns an `HttpMessageState` codeunit for request/response), and status (`Status()` returns an `IntegrationActionStatus` codeunit). Connectors read the blob, populate the HTTP objects, and optionally override the default status.
+
+For async sends, `E-Document Get Response` (`EDocumentGetResponse.Codeunit.al`) runs as a job queue entry. It finds all E-Document Service Status records in "Pending Response" state and calls `Get Response Runner` for each. The runner resolves the `IDocumentResponseHandler` interface and calls `GetResponse`. If the result is `true`, the service status advances to whatever the connector set via `SendContext.Status()` (default: Sent). If `false`, it stays at "Pending Response" and the job reschedules itself.
+
+`E-Doc. Recurrent Batch Send` (`EDocRecurrentBatchSend.Codeunit.al`) handles the scheduled batch sending flow. It finds all E-Documents in "Pending Batch" status for a given service, groups them by document type, exports each group, then calls `SendBatch` on the integration management layer.
+
+## Things to know
+
+- `Send Runner` uses the "if codeunit.Run()" pattern -- it is executed via `SendRunner.Run()`, and failures are caught by the caller. A `Commit()` happens before the run. This means connector errors do not roll back framework state.
+
+- The V1 path (behind `#if not CLEAN26`) still exists in `Send Runner`. It routes through the obsolete `E-Document Integration` interface and passes raw `HttpRequestMessage`/`HttpResponseMessage` instead of `SendContext`. After V1 calls, the runner retroactively populates `SendContext.Http()` so the caller sees a uniform interface.
+
+- `GetResponseRunner` also discovers async capability via `is` check: `if IDocumentSender is IDocumentResponseHandler`. If the connector's sender does not implement the response handler, `GetResponse` silently does nothing.
+
+- The response polling job re-schedules itself if any documents remain in "Pending Response" state. There is no exponential backoff -- it relies on the job queue's configured interval.
+
+- Batch send groups documents by `Document Type` before exporting and sending. Different document types in the same batch period produce separate API calls.

--- a/src/Apps/W1/EDocument/App/src/Integration/Send/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/src/Integration/Send/docs/business-logic.md
@@ -1,0 +1,85 @@
+# Send business logic
+
+## Single document send flow
+
+```mermaid
+flowchart TD
+    A[Send called] --> B{Service integration configured?}
+    B -->|No| Z[Exit -- no integration]
+    B -->|Yes| C{Document in valid state?}
+    C -->|No| Z2[Show message and exit]
+    C -->|Yes| D[Get exported blob from E-Document Log]
+    D --> E{Blob found?}
+    E -->|No| F[Log error, set Sending Error]
+    E -->|Yes| G[Create SendContext with blob]
+    G --> H[Set default status = Sent]
+    H --> I[Run Send Runner via if codeunit.Run]
+    I --> J{Runner succeeded?}
+    J -->|No| K[Log error from GetLastErrorText]
+    J -->|Yes| L{Is sender also IDocumentResponseHandler?}
+    L -->|Yes| M[IsAsync = true]
+    L -->|No| N[IsAsync = false]
+    M --> O[Status = Pending Response]
+    N --> P[Status = SendContext.Status]
+    K --> Q[Status = Sending Error]
+    O --> R[Insert log, update service status, log HTTP]
+    P --> R
+    Q --> R
+    R --> S{IsAsync?}
+    S -->|Yes| T[Schedule GetResponse background job]
+    S -->|No| U[Done]
+```
+
+## Async response polling flow
+
+The `E-Document Get Response` codeunit runs as a job queue entry. It processes all documents in "Pending Response" state.
+
+```mermaid
+flowchart TD
+    A[Job queue fires] --> B{Any documents Pending Response?}
+    B -->|No| Z[Exit]
+    B -->|Yes| C[For each Pending Response document]
+    C --> D[Run GetResponse Runner]
+    D --> E{Runner succeeded without errors?}
+    E -->|No| F[Status = Sending Error]
+    E -->|Yes| G{GetResponse returned true?}
+    G -->|Yes| H[Status = SendContext.Status -- default Sent]
+    G -->|No| I[Status = Pending Response -- unchanged]
+    F --> J[Insert log and update status]
+    H --> J
+    I --> J
+    J --> K[Next document]
+    K --> L{Still documents in Pending Response?}
+    L -->|Yes| M[Reschedule job]
+    L -->|No| N[Done]
+```
+
+## Batch send flow
+
+Recurrent batch send is triggered by a scheduled job queue entry tied to a specific E-Document Service.
+
+```mermaid
+flowchart TD
+    A[Job fires for service] --> B[Find all Pending Batch service statuses]
+    B --> C{Any found?}
+    C -->|No| Z[Exit]
+    C -->|Yes| D[Group documents by Document Type]
+    D --> E[For each document type group]
+    E --> F[Export batch to single blob]
+    F --> G[For each document: check export errors]
+    G --> H{Export error?}
+    H -->|Yes| I[Status = Export Error]
+    H -->|No| J[Status = Exported]
+    J --> K[Collect exported entry numbers]
+    I --> L[Log and update per-document status]
+    K --> L
+    L --> M[Store shared data blob]
+    M --> N[Call SendBatch on integration management]
+    N --> O{Async?}
+    O -->|Yes| P[Schedule GetResponse job]
+    O -->|No| Q[Handle workflow events]
+```
+
+## State guard for sending
+
+`IsEDocumentInStateToSend` prevents sending from invalid states. Only documents with service status `Exported` or `Sending Error` are eligible. This enables retry-from-error without requiring manual status reset, while preventing duplicate sends from other states like "Sent" or "Pending Response".

--- a/src/Apps/W1/EDocument/App/src/Integration/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Integration/docs/CLAUDE.md
@@ -1,0 +1,27 @@
+# Integration
+
+The orchestration layer between the E-Document processing pipeline and external services. `EDocIntegrationManagement.Codeunit.al` is the single entry point for all send, receive, and action operations. This directory does not implement any specific connector -- it provides the framework that connector apps plug into via the interfaces defined in `Interfaces/`.
+
+## How it works
+
+`E-Doc. Integration Management` (codeunit 6134) orchestrates three major flows: Send, Receive, and Actions. For sending, it retrieves the exported blob from the E-Document Log, populates a `SendContext`, invokes the connector's `IDocumentSender.Send` through a `Send Runner` codeunit (using the `if codeunit.Run()` error-isolation pattern), then logs the HTTP communication and updates statuses. Batch sending follows the same pattern but iterates over filtered E-Document records.
+
+For receiving, the flow is two-phase: first `ReceiveDocuments` gets a list of document metadata blobs from the connector, then `ReceiveSingleDocument` downloads each document individually. If the connector implements `IReceivedDocumentMarker`, the framework also calls `MarkFetched` to acknowledge receipt to the external API -- this is critical for services that won't re-serve already-fetched documents.
+
+The action flow routes through `InvokeAction`, which delegates to `E-Document Action Runner`. The `Integration Action Type` enum maps action types to `IDocumentAction` implementations. Two built-in actions exist: "Sent Document Approval" and "Sent Document Cancellation", which in turn delegate to the connector's `ISentDocumentActions` interface.
+
+The `Service Integration` enum (`ServiceIntegration.Enum.al`) is the V2 extensible enum that connector apps extend. It implements `IDocumentSender`, `IDocumentReceiver`, and `IConsentManager`. The obsolete `E-Document Integration` enum and interface (`EDocumentIntegration.Enum.al`, `EDocumentIntegration.Interface.al`) are the V1 equivalents being removed in CLEAN26.
+
+## Things to know
+
+- Every external call uses the "if codeunit.Run()" pattern -- a `Commit()` before the runner codeunit call, then `GetLastErrorText()` if the run fails. This isolates connector errors from the framework transaction.
+
+- After every interface call, the framework re-reads both EDocument and EDocumentService from the database. Connectors are allowed to modify these records during their execution.
+
+- `E-Document No Integration` (codeunit 6128) is the null-object implementation. It does nothing for all operations and returns `true` for consent. It is wired to the `"No Integration"` enum value.
+
+- The `IConsentManager` interface is invoked when a user first sets a Service Integration value on an `E-Document Service` record. The default implementation shows a GDPR privacy consent dialog.
+
+- The legacy V1 `ReceiveDocument` path (behind `#if not CLEAN26`) handles batch reception differently -- it uses `GetDocumentCountInBatch` to determine how many documents are in a single blob. The V2 path uses `Temp Blob List` where count is implicit.
+
+- `DetermineServiceStatus` in the send flow has three outcomes: `Sending Error` if the connector errored, `Pending Response` if async, or whatever status the connector set via `SendContext.Status()` if sync.

--- a/src/Apps/W1/EDocument/App/src/Logging/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Logging/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# Logging
+
+Multi-level audit trail for e-document operations, separating business-level logging (what happened) from HTTP-level logging (what was sent over the wire) with a shared binary blob store underneath both.
+
+## How it works
+
+Every significant operation on an E-Document -- export, send, receive, status check -- creates an `E-Document Log` entry (table 6124) via the `E-Document Log` codeunit (6132). The log records which E-Document, which service, and what status resulted. When the operation produces or consumes a document blob (XML, PDF, JSON), that content goes into `E-Doc. Data Storage` (table 6125) and the log entry references it by entry number.
+
+HTTP-level details go into `E-Document Integration Log` (table 6127). Each API call to an external service logs the request/response bodies as BLOBs, the HTTP method, URL, and response status code. This is only populated when the service has an actual integration configured (not "No Integration").
+
+The `E-Document Log` codeunit is the central entry point. It uses a builder pattern: call `SetFields` to configure the E-Document and service context, optionally call `SetBlob` to attach content, then call `InsertLog` to persist. The codeunit also handles integration log insertion and mapping log insertion in one place.
+
+## Things to know
+
+- `E-Doc. Data Storage` is referenced from multiple places: `E-Document Log.E-Doc. Data Storage Entry No.`, plus `E-Document.Unstructured Data Entry No.` and `Structured Data Entry No.` from the main Document table. Deleting a log entry deletes its associated data storage record via `OnDelete`, but the same blob may be referenced from the E-Document itself.
+- Integration log stores request and response as separate BLOBs on the same record, not in Data Storage. This is a different storage pattern from the business log -- integration blobs live inline on the record.
+- The `E-Doc. File Format` enum (Unspecified, PDF, XML, JSON) on Data Storage describes the blob content type. It replaced an earlier integer `Data Type` field (removed in v26).
+- `ExportDataStorage` on the log table creates a downloadable file named `E-Document_Log_{EntryNo}` -- useful for diagnostics. There is an `OnBeforeExportDataStorage` event if you need to customize the filename.
+- The log codeunit has multiple `InsertLog` overloads. The newer builder-style (`SetFields` / `SetBlob` / `ConfigureLogToInsert` / `InsertLog()`) avoids passing many parameters. The older overloads taking all parameters inline still exist for backward compatibility.
+- `GetDocumentBlobFromLog` finds the last log entry matching a specific E-Document, service, status, and format, then extracts the blob. It filters to `Processing Status = Unprocessed` to avoid picking up already-consumed entries.

--- a/src/Apps/W1/EDocument/App/src/Logging/docs/data-model.md
+++ b/src/Apps/W1/EDocument/App/src/Logging/docs/data-model.md
@@ -1,0 +1,23 @@
+# Logging data model
+
+## Log tables and blob storage
+
+The three tables form a two-tier logging system with shared blob storage. Business logs and integration logs both link back to the same E-Document but track different concerns.
+
+```mermaid
+erDiagram
+    E-DOCUMENT ||--|{ E-DOCUMENT-LOG : "Entry No"
+    E-DOCUMENT ||--|{ E-DOCUMENT-INTEGRATION-LOG : "E-Doc. Entry No"
+    E-DOCUMENT-LOG }o--o| E-DOC-DATA-STORAGE : "E-Doc. Data Storage Entry No."
+    E-DOCUMENT-SERVICE ||--|{ E-DOCUMENT-LOG : "Service Code"
+```
+
+`E-Document Log` is the business-level record. It carries `Status` (the service status enum -- Exported, Imported, Sent, etc.), `Processing Status` (the import pipeline stage), and a reference to the blob in Data Storage. The composite key on `(Status, Service Code, Document Format, Service Integration V2)` supports efficient filtering when looking up the latest log for a specific operation type.
+
+`E-Document Integration Log` is the HTTP-level record. Request and response bodies are stored as BLOBs directly on the record (not in Data Storage). The `Request URL` field was widened from Text[250] to Text[2048] in v28 to accommodate longer API endpoints.
+
+`E-Doc. Data Storage` is a simple blob table with an auto-increment key. Each record holds one binary payload and its metadata (name, size, file format). It is intentionally dumb -- all logic for creating and linking storage entries lives in the `E-Document Log` codeunit.
+
+## Deletion behavior
+
+When an `E-Document Log` record is deleted, its `OnDelete` trigger deletes the associated `E-Doc. Data Storage` record. However, there is no reference counting -- if the E-Document table also references the same Data Storage entry number (via `Unstructured Data Entry No.` or `Structured Data Entry No.`), that reference becomes dangling. In practice this is not a problem because log deletion is rare and typically happens only during full E-Document cleanup.

--- a/src/Apps/W1/EDocument/App/src/Mapping/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Mapping/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Mapping
+
+Field-level find/replace transformation rules applied during export and import. This is how a BC field value gets translated to an external format value (or vice versa) without modifying the format codeunit itself.
+
+## How it works
+
+The `E-Doc. Mapping` table (6118) stores rules per E-Document Service. Each rule targets a specific table/field combination (or acts as a wildcard when Table ID or Field ID is zero) and defines either a find/replace pair or a reference to a BC Transformation Rule. The `For Import` boolean distinguishes import-direction rules from export-direction ones.
+
+The `E-Doc. Mapping` codeunit (6118) applies these rules using `MapRecord`. It works in three passes over the target record: first, rules with both Table ID and Field ID set (specific field on specific table), then rules with Table ID but no Field ID (any text/code field on that table), then fully generic rules (Table ID = 0, Field ID = 0, applied to every text/code field). Only Normal class fields of type Text or Code are eligible -- FlowFields and non-text types are skipped.
+
+Mapping always operates on a temporary copy of the record. The codeunit errors if you pass a non-temporary RecordRef. Each transformation that actually changes a value is recorded in a `TempEDocMapping` temporary record, which can later be persisted to `E-Doc. Mapping Log` (table 6123) via the logging codeunit.
+
+The `PreviewMapping` procedure lets users see what would change before committing. It opens a service picker, runs the mapping against the current document header and lines, then displays the results in `E-Doc. Changes Preview`.
+
+## Things to know
+
+- Rules are applied in specificity order: exact field match first, then table-wide, then global. Within each tier, all matching rules run in `FindSet` order.
+- Transformation Rule integration uses BC's standard `Transformation Rule` table. If a rule has a `Transformation Rule` code, the find/replace fields are ignored and the transformation rule's logic runs instead.
+- The `Used` boolean on mapping records is toggled during processing to track which rules fired. It is reset to false before each mapping run via `ModifyAll(Used, false)`.
+- Mapping only touches Text and Code fields. If you need to transform an Option or Integer value, you would need to handle that in your format codeunit.
+- `E-Doc. Mapping Log` links to both `E-Document Log` (which specific operation) and `E-Document` (which document), recording the before/after values for audit purposes.

--- a/src/Apps/W1/EDocument/App/src/Processing/API/Endpoints/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/API/Endpoints/docs/CLAUDE.md
@@ -1,0 +1,25 @@
+# API endpoints
+
+OData/REST API v1.0 pages for external integration with the E-Document framework. These pages expose e-document data and operations to external systems -- ERP connectors, document management platforms, and automation tools.
+
+## How it works
+
+Five API pages under `APIGroup = 'edocument'`, `APIPublisher = 'microsoft'`, `APIVersion = 'v1.0'`:
+
+- `EDocumentsAPI` (6112) -- read-only list of all E-Documents with key fields (entry number, document type, status, amounts, dates, direction). Includes a subpage part for `E-Document Service Status`.
+- `NewEDocumentsAPI` -- writable endpoint for creating new incoming e-documents via API. External systems post document data here to trigger import processing.
+- `EDocumentServicesAPI` -- exposes E-Document Service configuration.
+- `EDocumentServiceStatusAPI` -- per-service status records for monitoring processing state.
+- `EDocFileContentAPI` -- access to the blob content stored in `E-Doc. File Content API Buffer`, allowing external systems to upload or download document files.
+
+Supporting objects in the parent `API/` directory include `EDocFileContentAPIBuffer` (buffer table for file content transfer), `EDocumentBusinessEvents` (codeunit that raises business events for external automation), and `EDocEventCategory` (enum extension for the event category).
+
+## Things to know
+
+- All API pages use `SystemId` as OData key, not entry number. This follows the BC API v2 convention for stable external identifiers.
+
+- The `EDocumentsAPI` page is read-only (`Editable = false`, `DataAccessIntent = ReadOnly`). Creating documents is done through `NewEDocumentsAPI`.
+
+- Business events in `EDocumentBusinessEvents` fire on key state transitions, allowing external systems to subscribe to webhooks for document creation, export completion, import processing, and errors.
+
+- The `EDocFileContentAPI` uses a buffer table pattern rather than directly exposing blob storage, which allows content to be streamed through the API without loading entire blobs into memory on the server.

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/AdditionalFields/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/AdditionalFields/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Additional fields
+
+An EAV (Entity-Attribute-Value) pattern that lets administrators configure arbitrary additional fields on import purchase lines without schema changes. This allows per-service customization of which `Purch. Inv. Line` fields are carried from historical invoices into new e-document drafts.
+
+## How it works
+
+`ED Purchase Line Field Setup` (6112) defines which fields from `Purch. Inv. Line` should be tracked per E-Document Service. Administrators select fields via a setup page, and the system persists which field numbers are enabled.
+
+When an e-document draft line is being prepared, `E-Document Line - Field` (6110) stores the actual values. Its `Get` procedure follows a three-tier resolution: first check for a physical record (user-customized value), then fall back to historical values from `E-Doc. Purchase Line History`, and finally default to blank. The source is returned as an option so the UI can show provenance.
+
+The pages (`EDocAdditionalFieldsSetup`, `EDocLineAdditionalFields`, `EDocFieldValueEdit`, `EDocLineValues`, `EDocOptionValueSelector`, `EDocPurchLineFields`) provide the administration and per-line editing UI.
+
+## Things to know
+
+- The setup table explicitly omits fields that are already part of the draft tables (amount, quantity, description, type, etc.) and document-specific fields (document no., line no., blanket order references). The `FieldsToOmit` list in `EDPurchaseLineFieldSetup` enforces this.
+
+- Field values are stored in typed columns (`Text Value`, `Decimal Value`, `Date Value`, `Boolean Value`, `Code Value`, `Integer Value`). The correct column is chosen based on the `Field.Type` metadata from the `Purch. Inv. Line` table definition.
+
+- The old `EDoc. Purch. Line Field Setup` (6109) is obsolete and replaced by `ED Purchase Line Field Setup` (6112), which adds per-service scoping via the `E-Document Service` field in the primary key.
+
+- Historical value loading works through `E-Doc. Purchase Line History` -- when a previous invoice was posted for the same vendor/line pattern, the system reads the field value from the posted `Purch. Inv. Line` via RecordRef and FieldRef.

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/AdditionalFields/docs/data-model.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/AdditionalFields/docs/data-model.md
@@ -1,0 +1,33 @@
+# Additional fields data model
+
+## EAV structure
+
+The additional fields system uses an Entity-Attribute-Value pattern to store arbitrary field values on e-document purchase lines without adding columns to the draft tables.
+
+```mermaid
+erDiagram
+    ED-Purchase-Line-Field-Setup ||--o{ E-Document-Line-Field : "defines available fields"
+    E-Document-Purchase-Line ||--o{ E-Document-Line-Field : "values per line"
+    E-Doc-Purchase-Line-History ||--o| E-Document-Line-Field : "historical fallback"
+    E-Document-Service ||--o{ ED-Purchase-Line-Field-Setup : "per-service config"
+```
+
+## Tables
+
+**ED Purchase Line Field Setup** (6112) -- configuration table. Primary key is `(Field No., E-Document Service)`. Each record says "this Purch. Inv. Line field should be tracked for this service." The setup page lets admins toggle fields on/off, and `ApplySetup` persists or removes the record accordingly.
+
+**E-Document Line - Field** (6110) -- value storage. Primary key is `(E-Document Entry No., Line No., Field No.)`. A physical record means the value was explicitly customized by the user. Absence of a record triggers historical lookup via the `Get` procedure. The return value is an option: `Customized`, `Historic`, or `Default`.
+
+**EDoc. Purch. Line Field Setup** (6109) -- obsolete predecessor without per-service scoping. Removed in CLEAN26.
+
+## Value resolution flow
+
+When the draft page renders a line's additional field, the `Get` procedure on `E-Document Line - Field` executes:
+
+1. Try `Rec.Get` with the composite key -- if found, it is a user customization
+2. Look up `E-Doc. Purchase Line History` via the line's history ID
+3. Open a RecordRef on `Purch. Inv. Line`, get by SystemId from history
+4. Read the field value via FieldRef and store it in the appropriate typed column
+5. If no history exists, return defaults (blank/zero)
+
+This means the table is sparse -- only customized values are persisted. Historical and default values are computed on read.

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/PurchaseOrderMatching/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/PurchaseOrderMatching/docs/CLAUDE.md
@@ -1,0 +1,19 @@
+# Purchase order matching (V2)
+
+Three-way matching between e-document lines, purchase order lines, and receipt lines for the V2 import pipeline. This is the mechanism that handles the "receive e-document against an existing PO" scenario, where the e-document represents an invoice for goods already ordered and potentially already received.
+
+## How it works
+
+When the prepare draft step finds a matching purchase order (via `IPurchaseOrderProvider`), the system enters PO matching mode. `E-Doc. Purchase Line PO Match` (6114) links e-doc purchase lines to PO lines and optionally to receipt lines using SystemId-based foreign keys. The `E-Doc. PO Matching Setup` (6116) controls matching behavior per vendor -- whether receipt lines should be selected automatically or always prompted, and whether G/L account lines should be received.
+
+The `EDocLineByReceipt` query joins purchase lines with receipt lines to find receivable quantities. The selection pages (`EDocSelectPOLines`, `EDocSelectReceiptLines`) let users manually pick which PO lines and receipt lines correspond to each e-document line.
+
+## Things to know
+
+- The match table's primary key is `(E-Doc. Purchase Line SystemId, Purchase Line SystemId, Receipt Line SystemId)` -- all three Guids. This means a single e-doc line can match to multiple PO lines (split deliveries) and a single PO line can match to multiple receipt lines.
+
+- Setup has two levels: vendor-specific and global. `GetSetup(VendorNo)` first looks for a vendor-specific record, then falls back to the global setup (blank vendor no.). If neither exists, defaults are "Always ask" for receipt config and true for receiving G/L lines.
+
+- The `E-Doc. PO M. Configuration` enum controls the overall matching mode, while `E-Doc. PO M. Config. Receipt` controls receipt line selection specifically.
+
+- This is separate from the V1 `OrderMatching/` directory. V2 PO matching works on draft `E-Document Purchase Line` records; V1 PO matching works on `E-Doc. Imported Line` records.

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/PurchaseOrderMatching/docs/data-model.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/PurchaseOrderMatching/docs/data-model.md
@@ -1,0 +1,23 @@
+# Purchase order matching data model
+
+## Matching relationships
+
+The PO matching tables link e-document draft lines to purchase order lines and receipt lines for three-way verification.
+
+```mermaid
+erDiagram
+    E-Document-Purchase-Line ||--o{ E-Doc-Purchase-Line-PO-Match : "matched via SystemId"
+    Purchase-Line ||--o{ E-Doc-Purchase-Line-PO-Match : "matched via SystemId"
+    Purch-Rcpt-Line ||--o{ E-Doc-Purchase-Line-PO-Match : "optional receipt link"
+    E-Doc-PO-Matching-Setup ||--|| Vendor : "per-vendor config"
+```
+
+## Tables
+
+**E-Doc. Purchase Line PO Match** (6114) -- the core match record. Every field is a SystemId reference, making the table resilient to record renumbering. The composite primary key of three Guids means you can have many-to-many relationships: one e-doc line matched against multiple PO lines, or multiple e-doc lines against one PO line.
+
+**E-Doc. PO Matching Setup** (6116) -- controls matching behavior. The `PO Matching Config. Receipt` enum determines whether receipt lines are auto-selected, always prompted, or skipped. The `Receive G/L Account Lines` boolean controls whether non-item lines go through the receipt flow. Vendor-specific overrides take priority over the global (blank vendor) setup.
+
+## Query
+
+**EDocLineByReceipt** -- a query object that joins `Purchase Line` with receipt data to compute available-to-match quantities. Used by the selection pages to show only lines with remaining receivable quantities.

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Purchase
+
+Pages and tables for the purchase import UI and the core `E-Document Purchase Line` table. This is where users review and edit draft purchase data before it becomes a real BC purchase document. Also contains the `History/` subdirectory for tracking vendor assignment and line mapping history across invoices.
+
+## How it works
+
+`E-Document Purchase Line` (6101) is the primary draft line table. Its fields are split into two regions: external data fields (3-100) that hold raw values from the source document (product code, description, unit price, quantity), and `[BC]` fields (101+) that hold resolved BC values (purchase line type, type no., unit of measure code, item reference). The prepare draft step populates the `[BC]` fields; the external fields are populated during the read-into-draft step.
+
+The pages -- `EDocReadablePurchaseDoc`, `EDocReadPurchLines`, `EDocDraftFeedback` -- provide the read-only and editable views for the draft. `EDocDraftFeedback` is used to display validation results and warnings to the user.
+
+The `History/` subdirectory contains `E-Doc. Purchase Line History` and `E-Doc. Vendor Assign. History` tables plus the `EDocPurchaseHistMapping` codeunit that finds previous invoices for the same vendor and copies line-level settings (account, deferral, dimensions) to new drafts.
+
+## Things to know
+
+- `E-Document Line Mapping` (6105) is the V1 line mapping table. In V1, users manually set the purchase line type, type number, UOM, and dimensions per line. In V2, this is replaced by the `[BC]` fields on `E-Document Purchase Line` plus the additional fields EAV system.
+
+- The `E-Doc. Purchase Line History` table stores the SystemId of the `Purch. Inv. Line` that was created when a previous e-document was posted. This enables the "copy from history" pattern used by both the additional fields system and the prepare draft step.
+
+- `E-Doc. Vendor Assign. History` tracks which vendor was assigned to previous e-documents from the same source, enabling automatic vendor resolution for repeat senders.
+
+- The `EDocPurchaseHistMapping` codeunit ties historical mapping together -- it searches for past invoices from the same vendor, matches lines by description similarity, and copies the resolved values to the new draft.

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Structure received E-Document
+
+Implementations of `IStructureReceivedEDocument` and `IStructuredFormatReader` that convert unstructured or structured blobs into draft table data. This is where format-specific parsing lives -- PEPPOL XML, ADI JSON, and MLLM output.
+
+## How it works
+
+The V2 pipeline's first step calls `IStructureReceivedEDocument.StructureReceivedEDocument` to convert raw data into structured data. For PDF/image inputs, this means calling an external service (Azure Document Intelligence or MLLM) and returning the result as an `IStructuredDataType`. For already-structured formats like XML, it returns the input unchanged.
+
+The PEPPOL handler (`EDocumentPEPPOLHandler`) implements `IStructuredFormatReader` -- it reads UBL Invoice XML into `E-Document Purchase Header` and `E-Document Purchase Line` records. It parses xpath-based fields (supplier party, monetary totals, invoice lines) and returns `"Purchase Document"` as the process draft enum, routing to the standard purchase draft preparation.
+
+## Things to know
+
+- `EDocumentPEPPOLHandler` only supports Invoice documents. Credit notes throw an error. This is a deliberate limitation -- credit note support would require a separate document type flow.
+
+- The PEPPOL reader sets currency by comparing against `General Ledger Setup."LCY Code"`. If the document currency matches LCY, it stores blank (BC convention for local currency). This applies to both header and line-level currency codes.
+
+- ADI and MLLM structuring implementations are not in this directory -- they live in `Processing/AI/`. The `Structure Received E-Doc.` enum routes to them. This directory only contains the PEPPOL reader and supporting code.
+
+- The "Already Structured" implementation (for XML/JSON inputs) simply copies the unstructured data entry number to the structured data entry number -- no conversion needed, but the step still fires to set up the correct `Read into Draft Impl.` value.
+
+- PEPPOL parsing uses XML namespace prefixes (`cac:`, `cbc:`, `inv:`) that match the UBL 2.1 schema. If a vendor sends non-standard namespace prefixes, the parsing will fail silently (XPath returns no matches) and fields will be blank.

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/docs/business-logic.md
@@ -1,0 +1,39 @@
+# Structure received E-Document business logic
+
+## PEPPOL XML parsing
+
+The `EDocumentPEPPOLHandler.ReadIntoDraft` procedure parses a UBL 2.1 Invoice XML document into draft tables. The flow is straightforward but has important ordering dependencies.
+
+```mermaid
+flowchart TD
+    A[ReadIntoDraft called with TempBlob] --> B[Insert E-Document Purchase Header]
+    B --> C[Parse XML with UBL namespaces]
+    C --> D{Root element?}
+    D -- INVOICE --> E[PopulatePurchaseInvoiceHeader]
+    D -- CREDITNOTE --> F[Error: not supported]
+    E --> G[Extract supplier party, amounts, dates]
+    G --> H[InsertPurchaseInvoiceLines]
+    H --> I[For each cac:InvoiceLine]
+    I --> J[Extract quantity, UOM, price, product ID]
+    J --> K[Insert E-Document Purchase Line]
+    K --> L[Return Process Draft = Purchase Document]
+```
+
+The header parsing extracts values in a specific priority order for vendor identification:
+
+1. `AccountingSupplierParty/Party/PartyTaxScheme/CompanyID` for VAT ID
+2. `AccountingSupplierParty/Party/EndpointID` with `schemeID="0088"` for GLN
+3. `PayeeParty` fields as fallback when payee differs from seller
+
+For invoice lines, product identification cascades: `SellersItemIdentification/ID` is tried first, then `StandardItemIdentification/ID`. Description is taken from `Item/Name`, with fallback to `Item/Description` and then the line `Note`.
+
+## Structuring step logic
+
+The structuring step in `ImportEDocumentProcess.StructureReceivedData` handles the transition from raw blob to structured data:
+
+1. If no structuring implementation is specified on the E-Document, the file format's `PreferredStructureDataImplementation` is used
+2. The structuring implementation runs and returns an `IStructuredDataType`
+3. If the data was not "already structured", the original blob is saved as an attachment and the new structured content is logged
+4. The `IStructuredDataType.GetReadIntoDraftImpl()` can override the reader implementation -- this is how ADI processing routes to its own JSON reader
+
+The "Read into Draft" implementation follows a similar fallback chain: if the structuring step did not set one, and the E-Document does not have one, the service default is used.

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/docs/CLAUDE.md
@@ -1,0 +1,27 @@
+# Import
+
+The staged import pipeline (V2) for incoming e-documents. This directory owns the state machine that takes an e-document from raw blob through structured data, draft population, BC value resolution, and finally to a real purchase document. It also contains the `E-Doc. Import Parameters` table that configures how each import run behaves.
+
+## How it works
+
+`ImportEDocumentProcess` is the core codeunit. It is configured with a step and an undo flag, then executed via `Codeunit.Run`. Each run transitions the e-document by one step. The caller (`EDocImport.GetEDocumentToDesiredStatus`) loops through steps to reach a target status, undoing steps first if going backward.
+
+The four steps are: "Structure received data" (convert blob to XML/JSON), "Read into Draft" (parse structured data into `E-Document Purchase Header/Line`), "Prepare draft" (resolve vendor, items, UOM, apply Copilot matching), and "Finish draft" (create real BC purchase document). Each step dispatches to an interface implementation selected by enum values that cascade from previous steps.
+
+The `E-Doc. Import Parameters` table is temporary -- it is never persisted. It configures a single processing run: which step to execute (or which final status to reach), V1 fallback behavior, and an optional `Existing Doc. RecordId` for linking to pre-existing purchase documents.
+
+## Things to know
+
+- The pipeline supports both forward and backward traversal. "Undo" cleans up the artifacts of a step -- for example, undoing "Prepare draft" deletes header mappings and clears vendor assignments. This makes reprocessing safe.
+
+- V1 documents tunnel through the V2 state machine. When `ImportProcessVersion` is V1, only the "Finish draft" step fires, which calls the legacy `V1_ProcessEDocument` path. All other steps are skipped.
+
+- `ImportEDocProcStatus` and `ImportEDocumentSteps` are tightly coupled enums. Status values 0-4 map to step transitions: Unprocessed-to-Readable is step 0 ("Structure received data"), Readable-to-ReadyForDraft is step 1, etc.
+
+- The `EDocImportParameters."Step to Run / Desired Status"` option switches between two modes: run-a-specific-step (which undoes and reruns that step) vs reach-a-desired-status (which runs/undoes as many steps as needed).
+
+- `EDocUnspecifiedImpl` is the fallback for unset enum values -- it provides no-op implementations of the pipeline interfaces to prevent runtime errors when an e-document has not yet been assigned a specific processing path.
+
+- The `PrepareDraft/` subdirectory contains the default `IProcessStructuredData` implementation for purchase documents, including Copilot-powered line matching (historical, GL account, deferral).
+
+- The `FileFormat/` subdirectory has XML and JSON `IEDocFileFormat` implementations that declare themselves as "already structured" since they need no conversion step.

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/docs/business-logic.md
@@ -1,0 +1,50 @@
+# Import business logic
+
+## Pipeline step execution
+
+Each step runs inside `Codeunit.Run` with a preceding `Commit()`. This means interface implementation failures are caught without rolling back the E-Document record. On failure, the error is logged and the import processing status is not advanced.
+
+```mermaid
+flowchart TD
+    A[ConfigureImportRun called] --> B[OnRun triggers]
+    B --> C{V1 or V2?}
+    C -- V1 --> D[ProcessEDocumentV1 -- only fires on Finish draft step]
+    C -- V2 --> E{Undo step?}
+    E -- Yes --> F[UndoProcessingStep -- clean up artifacts]
+    E -- No --> G{Which step?}
+    G --> H[StructureReceivedData]
+    G --> I[ReadIntoDraft]
+    G --> J[PrepareDraft]
+    G --> K[FinishDraft]
+    H --> L[Update Import Processing Status]
+    I --> L
+    J --> L
+    K --> L
+    F --> L
+```
+
+## Structure received data step
+
+This step is where PDF-to-XML conversion happens. The file format's `PreferredStructureDataImplementation` determines the structuring strategy (ADI, MLLM, or "Already Structured" for XML/JSON).
+
+When conversion produces structured output, the original unstructured blob is saved as an attachment on the E-Document, and the new structured content is stored as a new log entry. The `Structured Data Entry No.` on the E-Document points to this new entry. If the document was already structured (e.g., PEPPOL XML), the structured entry just points to the same blob as the unstructured entry.
+
+The structuring step can also override the "Read into Draft" implementation. For example, ADI processing returns a JSON schema that requires the ADI-specific reader, overriding whatever the service default was.
+
+## Prepare draft step
+
+This is the most complex step. `PreparePurchaseEDocDraft` (the default `IProcessStructuredData` for purchase documents) performs:
+
+1. Vendor resolution via `IVendorProvider` -- matches by GLN, VAT ID, service participant, or name+address
+2. Purchase order lookup via `IPurchaseOrderProvider` -- matches against `Purchase Order No.` from the source
+3. Historical mapping via `EDocPurchaseHistMapping` -- finds previous invoices for this vendor and copies header-level settings
+4. Line-by-line resolution: UOM mapping, then item reference lookup, then text-to-account mapping
+5. Copilot-powered matching in three passes: historical pattern matching, GL account matching, deferral matching
+
+The Copilot matching is executed via `Codeunit.Run` on separate codeunits with `Commit()` barriers, so AI failures do not block the rest of the draft preparation.
+
+## Finish draft step
+
+Dispatched by `E-Document Type` enum. The purchase invoice finish draft creates a real `Purchase Header` and `Purchase Line` records, copies values from the draft tables (including additional fields from the EAV store), links the E-Document to the new document, and optionally links to an existing document if `Existing Doc. RecordId` was set in the import parameters.
+
+Undo of this step deletes the created purchase document and clears the `Document Record ID` on the E-Document.

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/docs/data-model.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/docs/data-model.md
@@ -1,0 +1,40 @@
+# Import data model
+
+## Draft tables
+
+The V2 import pipeline stages external data into draft tables before creating real BC documents. The `E-Document Purchase Header` and `E-Document Purchase Line` tables hold two categories of fields: raw external data (vendor name, product codes, amounts as received) and `[BC]` prefixed fields (resolved vendor no., item no., UOM code). This separation makes it obvious which values came from the source document vs which were resolved by the system.
+
+```mermaid
+erDiagram
+    E-Document ||--|| E-Document-Purchase-Header : "1:1 by Entry No"
+    E-Document ||--o{ E-Document-Purchase-Line : "1:many by Entry No"
+    E-Document-Purchase-Line ||--o{ E-Document-Line-Field : "additional fields EAV"
+    E-Document ||--o| E-Document-Header-Mapping : "V2 mapping overrides"
+    E-Document ||--o{ E-Document-Line-Mapping : "V1 line mappings"
+```
+
+## Mapping tables
+
+`E-Document Header Mapping` (6102) stores V2 per-document overrides for vendor and purchase order number. It is keyed by E-Document Entry No and is created/deleted during the prepare draft step.
+
+`E-Document Line Mapping` (6105) is the V1 equivalent for lines. It stores user-chosen purchase line type, type number, UOM, deferral code, dimensions, and item reference. In V2, this role is filled by the `[BC]` fields directly on `E-Document Purchase Line`.
+
+## Import parameters
+
+`E-Doc. Import Parameters` (6106) is a temporary table -- it exists only for the duration of a processing call. It carries:
+
+- Whether to target a specific step or a desired status
+- V1-specific options (create journal line vs purchase document)
+- An `Existing Doc. RecordId` for linking to pre-existing documents instead of creating new ones
+
+The service provides default import parameters via `GetDefaultImportParameters`, which the automatic import job uses. Manual processing can override these.
+
+## Status progression
+
+Import Processing Status lives on `E-Document Service Status`, not on the draft tables. It flows through five values:
+
+- **Unprocessed** -- blob received, nothing parsed
+- **Readable** -- structured data exists (XML/JSON from PDF conversion or already-structured source)
+- **Ready for draft** -- draft tables populated with raw + resolved values
+- **Draft ready** -- vendor assigned, items matched, ready for document creation
+- **Processed** -- real BC document created and linked

--- a/src/Apps/W1/EDocument/App/src/Processing/Interfaces/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Interfaces/docs/CLAUDE.md
@@ -1,0 +1,25 @@
+# Processing interfaces
+
+All interfaces that define how the V2 import pipeline and the export eligibility system are extended live here. These are the primary extension points for partners and localization apps building on the E-Document framework.
+
+## How it works
+
+The import pipeline interfaces form a chain. `IStructureReceivedEDocument` converts raw blobs (PDF, images) into structured data, returning an `IStructuredDataType` that carries the content and its file format. `IStructuredFormatReader` then reads that structured content (XML, JSON) into the E-Document draft tables. `IProcessStructuredData` takes the populated draft and resolves BC values -- vendor, items, accounts. Finally, `IEDocumentFinishDraft` creates real BC documents from the draft.
+
+Provider interfaces (`IVendorProvider`, `IItemProvider`, `IUnitOfMeasureProvider`, `IPurchaseLineProvider`, `IPurchaseLineAccountProvider`, `IPurchaseOrderProvider`) are consumed during the "prepare draft" step. They are implemented by default in `EDocProviders.Codeunit.al` and dispatched through the `Processing Customizations` enum, making them swappable per-service.
+
+On the export side, `IExportEligibilityEvaluator` lets services control which documents they accept for export beyond the type-support check. `IEDocFileFormat` defines file-format metadata (extension, preview, preferred structuring).
+
+## Things to know
+
+- `IStructuredDataType` is a return value from `IStructureReceivedEDocument`, not a standalone extension point. It carries format, content, and crucially the `GetReadIntoDraftImpl()` that tells the pipeline which reader to use next.
+
+- `IEDocumentFinishDraft` is dispatched via the `E-Document Type` enum, not the service. This means the "Purchase Invoice" type enum value implements `ApplyDraftToBC` differently from "Purchase Order".
+
+- `IProcessStructuredData` is dispatched via the `E-Doc. Process Draft` enum, which is returned by `IStructuredFormatReader.ReadIntoDraft`. This creates a two-step dispatch chain: the reader picks the processor.
+
+- `IBlobType` and `IBlobToStructuredDataConverter` are obsolete (CLEAN26). They are replaced by `IEDocFileFormat` and `IStructureReceivedEDocument`.
+
+- `IPrepareDraft` exists as a simpler alternative to `IProcessStructuredData` for scenarios that only need to determine the document type without full vendor/line resolution.
+
+- Provider interfaces return records, not codes. `IVendorProvider.GetVendor` returns a `Vendor` record -- a blank `"No."` means no vendor was found, which is handled gracefully in the pipeline rather than throwing errors.

--- a/src/Apps/W1/EDocument/App/src/Processing/Interfaces/docs/extensibility.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Interfaces/docs/extensibility.md
@@ -1,0 +1,41 @@
+# Extensibility via interfaces
+
+## Import pipeline dispatch chain
+
+The V2 import pipeline uses a series of enum-dispatched interfaces, where each step's output determines the next step's implementation. Understanding this chain is essential for extending the import flow.
+
+```mermaid
+flowchart TD
+    A["E-Doc. Data Storage (blob)"] --> B["IEDocFileFormat\n(from File Format enum)"]
+    B -->|PreferredStructureDataImplementation| C["IStructureReceivedEDocument\n(from Structure Received E-Doc. enum)"]
+    C -->|returns IStructuredDataType| D["IStructuredFormatReader\n(from Read into Draft enum)"]
+    D -->|returns E-Doc. Process Draft enum| E["IProcessStructuredData\n(from Process Draft enum)"]
+    E -->|returns E-Document Type| F["IEDocumentFinishDraft\n(from E-Document Type enum)"]
+```
+
+Each arrow represents a handoff. The enum value chosen at each stage determines the concrete implementation for the next. For example, the PEPPOL handler (an `IStructuredFormatReader`) returns `"Purchase Document"` as the process draft enum, which routes to `PreparePurchaseEDocDraft`.
+
+## Provider interfaces
+
+Provider interfaces are aggregated behind the `E-Doc. Proc. Customizations` enum. A single enum value implements all provider interfaces simultaneously:
+
+- `IVendorProvider` -- resolves external vendor identifiers (VAT ID, GLN, name) to a BC Vendor record
+- `IItemProvider` -- resolves external product codes to BC Item records
+- `IUnitOfMeasureProvider` -- maps external UOM strings to BC Unit of Measure codes
+- `IPurchaseLineProvider` -- populates `[BC]` fields on `E-Document Purchase Line` from item references and text-to-account mappings
+- `IPurchaseLineAccountProvider` -- resolves G/L accounts for non-item lines
+- `IPurchaseOrderProvider` -- finds an existing purchase order to link against
+
+The default implementation (`EDocProviders` codeunit) handles all of these. Partners can create a new enum extension to swap in their own resolution logic.
+
+## Export eligibility
+
+`IExportEligibilityEvaluator` is dispatched via the `Export Eligibility Evaluator` enum on the E-Document Service. The `DefaultExportEligibility` codeunit always returns true. Localization apps can extend this to skip documents based on country-specific rules (for example, only export invoices above a threshold, or skip certain customer types).
+
+## Key design decisions
+
+- Interfaces return records and enums, never error. Errors during import are handled by the pipeline's `Codeunit.Run` wrapper and logged through the error helper. Interface implementations should surface issues through the E-Document error message framework rather than throwing runtime errors.
+
+- The `IStructuredDataType` is intentionally a value object, not a persisted record. Its `GetContent()` return is stored as a log blob by the pipeline, so implementations do not need to persist anything themselves.
+
+- `IStructuredFormatReader.View` is separate from `ReadIntoDraft` because viewing structured data (showing the user a parsed XML tree) should not modify draft tables or trigger processing side effects.

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/docs/CLAUDE.md
@@ -1,0 +1,25 @@
+# Copilot order matching
+
+AI-powered matching proposals for the V1 purchase order matching flow. Uses Azure OpenAI to suggest which imported e-document lines correspond to which purchase order lines, then grounds the AI suggestions against actual quantity and cost constraints.
+
+## How it works
+
+`EDocPOCopilotMatching` builds prompts from e-document imported lines and purchase order lines, filtering to only include PO lines within a cost difference threshold (configurable in `Purchases & Payables Setup."E-Document Matching Difference"`). It sends these to Azure OpenAI via the AOAI SDK using a function-calling pattern -- the model returns structured match proposals through `EDocPOAOAIFunction`.
+
+The AI proposals are stored in `E-Doc. PO Match Prop. Buffer` (temporary table) and optionally "grounded" -- meaning each AI-suggested match is validated against actual available quantities by calling `EDocLineMatching.MatchOneToOne`. Proposals that fail grounding (zero matched quantity) are deleted.
+
+The `EDocPOCopilotProp` page displays the AI proposals for user review before they are accepted into the real match table.
+
+## Things to know
+
+- The system prompt is fetched from Azure Key Vault (`EDocumentMappingPromptV2`), not hardcoded. If the secret is missing, the entire Copilot matching silently fails with a telemetry error.
+
+- Prompt batching: if the combined token count exceeds 22,000 (about two-thirds of the GPT-4 32K limit), the system splits into multiple API calls. Each call processes whatever lines have accumulated since the last send.
+
+- Temperature is set to 0 for deterministic matching. The model is GPT-4.1 Latest, and the function-calling pattern means the model returns structured JSON, not free text.
+
+- Grounding is optional (`SetGrounding` method). When enabled, every AI proposal is validated by actually attempting the match. When disabled, proposals are taken at face value -- useful for testing but risky in production.
+
+- The Copilot capability is registered as `"E-Document Matching Assistance"` and only on SaaS infrastructure. On-premises deployments do not get the registration.
+
+- Cost filtering happens before prompting: only PO lines within the `CostDifferenceThreshold` of the imported line's cost (accounting for discounts) are included in the prompt. This pre-filtering is critical for prompt quality and token efficiency.

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/docs/CLAUDE.md
@@ -1,0 +1,25 @@
+# Order matching (V1)
+
+The V1 purchase order line matching system. When an incoming e-document is linked to an existing purchase order, this module lets users (or the automatic matcher) pair imported e-document lines with PO lines, adjusting quantities and costs before the PO is updated.
+
+## How it works
+
+`EDocLineMatching` is the central codeunit. It provides automatic matching (filter on UOM, cost, discount, then check description similarity at 80% threshold or item reference/text-to-account mapping match), manual matching (user-selected pairs with validation), and the `ApplyToPurchaseOrder` procedure that commits matches by updating purchase line costs and quantities.
+
+`E-Doc. Imported Line` (6165) is a buffer table that holds parsed e-document line data in a form suitable for matching. Lines are inserted during V1 import processing from the parsed purchase lines. `E-Doc. Order Match` (6164) is the many-to-many join between imported lines and PO lines, storing matched quantity, unit costs from both sides, and descriptions for the matching UI.
+
+The matching pages (`EDocOrderLineMatching`, `EDocImportedLineSub`, `EDocPurchaseOrderSub`, `EDocOrderMatch`, `EDocOrderMatchAct`) provide side-by-side views of imported and PO lines with match/unmatch actions.
+
+## Things to know
+
+- Automatic matching uses string nearness (80% threshold via `RecordMatchMgt.CalculateStringNearness`) as a fallback when no item reference or text-to-account mapping exists. This means description-only matches require high similarity.
+
+- When matching many imported lines to one PO line, all imported lines must have identical unit cost, discount %, and UOM. The system validates this strictly and errors if they differ.
+
+- `ApplyToPurchaseOrder` validates all imported lines are fully matched before proceeding. Partial matches are rejected at the point of applying to the PO.
+
+- The `CreateMatchingRule` procedure creates `Item Reference` or `Text-to-Account Mapping` records when the user checks "Learn Matching Rule" -- this teaches the system for future automatic matching.
+
+- `CreatePurchaseOrderLine` allows creating a new PO line directly from the matching page when no suitable PO line exists for an imported line.
+
+- This module is distinct from `Import/Purchase/PurchaseOrderMatching/` which handles V2 matching. V1 works on `E-Doc. Imported Line`; V2 works on `E-Document Purchase Line`.

--- a/src/Apps/W1/EDocument/App/src/Processing/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/docs/CLAUDE.md
@@ -1,0 +1,27 @@
+# Processing
+
+The orchestration layer for the E-Document app. Every outbound document export, inbound document import, status transition, and background job flows through codeunits in this directory. It sits between the E-Document data model (tables, logs, services) and the format-specific or integration-specific code, acting as the central coordinator.
+
+## How it works
+
+Outbound flow: when a BC document is posted and has an electronic document sending profile, `EDocExport` creates an `E-Document` record, populates it from the source RecordRef (sales invoice, purchase credit memo, etc.), runs field mappings, invokes the `IEDocument` format interface to produce a blob, logs the result, and kicks off a workflow via `EDocumentBackgroundJobs`. Batch processing is supported -- multiple documents can be exported in a single call.
+
+Inbound flow: `EDocImport` is the entry point. It delegates to `ImportEDocumentProcess` which runs a configurable step-based pipeline (V2) or falls back to the monolithic V1 path. The V2 pipeline walks through statuses -- Unprocessed, Readable, Ready for draft, Draft ready, Processed -- executing or undoing steps as needed. V1 does everything in one shot: parse XML, resolve vendors/items, create purchase documents.
+
+`EDocumentProcessing` is the shared utility. It manages service status records, derives document types from RecordRefs, computes the aggregate E-Document status from per-service statuses ("any error = error, any in-progress = in-progress, else processed"), and provides telemetry dimensions.
+
+## Things to know
+
+- The V1 vs V2 split is driven by `EDocumentService.GetImportProcessVersion()`. V1 code lives in procedures prefixed with `V1_` in `EDocImport`. V2 delegates to `ImportEDocumentProcess` which is in the `Import/` subfolder.
+
+- `EDocRecordLink.Table.al` is a generic SystemId-to-SystemId linking table used by the purchase draft historical mapping. It links draft purchase headers/lines to real Purchase Header/Line records and is cleaned up when the invoice posts.
+
+- `EDocumentBackgroundJobs` schedules via Job Queue. The get-response job runs every 5 minutes. Import and batch export jobs are recurrent and configured per-service with start times and intervals.
+
+- `EDocExport.IsDocumentSupported` checks two things: the document type is in the service's supported type list, AND the `IExportEligibilityEvaluator` interface says it should export. The default evaluator always returns true.
+
+- The `EDocumentCreate` codeunit is a `Codeunit.Run` wrapper -- it exists so that format interface calls can be isolated inside try-function semantics (commit + run + catch last error).
+
+- `EDocumentProcessing.ModifyEDocumentStatus` uses priority: error beats in-progress beats processed. If any service has an error, the whole E-Document is error.
+
+- The `EDocumentSubscribers` codeunit wires into BC posting events (sales, purchase, service documents) to trigger e-document creation automatically.

--- a/src/Apps/W1/EDocument/App/src/Processing/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/docs/business-logic.md
@@ -1,0 +1,77 @@
+# Processing business logic
+
+## Export pipeline
+
+The export path runs synchronously during posting unless batch processing is enabled. `EDocExport.CreateEDocument` is the public entry point called from workflow subscribers.
+
+```mermaid
+flowchart TD
+    A[Posted document triggers workflow] --> B{Document Sending Profile has E-Doc flow?}
+    B -- No --> Z[Exit]
+    B -- Yes --> C[Filter services that support this doc type]
+    C --> D{Any supported services?}
+    D -- No --> Z
+    D -- Yes --> E[Insert E-Document record]
+    E --> F[PopulateEDocument from RecordRef]
+    F --> G[Insert Service Status per service]
+    G --> H{Batch processing?}
+    H -- Yes --> I[Skip export -- batch job handles it]
+    H -- No --> J[ExportEDocument per service]
+    J --> K[Map fields via E-Doc. Mapping]
+    K --> L[Call IEDocument.Create on format interface]
+    L --> M{Errors?}
+    M -- Yes --> N[Log Export Error status]
+    M -- No --> O[Log Exported status + blob]
+    O --> P[Start E-Document Created Flow background job]
+```
+
+The `CheckEDocument` path runs during release/pre-posting validation. It calls `IEDocument.Check` on the format interface -- this lets format implementations validate required fields before the document actually posts.
+
+## Import pipeline -- V2
+
+The V2 pipeline is a state machine. `EDocImport.GetEDocumentToDesiredStatus` computes the steps needed to reach a target status from the current status, undoing steps if the target is earlier than current (for reprocessing).
+
+```mermaid
+flowchart TD
+    A[Unprocessed] -->|Structure received data| B[Readable]
+    B -->|Read into Draft| C[Ready for draft]
+    C -->|Prepare draft| D[Draft ready]
+    D -->|Finish draft| E[Processed]
+    E -.->|Undo finish draft| D
+    D -.->|Undo prepare draft| C
+    C -.->|Undo read into draft| B
+    B -.->|Undo structure| A
+```
+
+Each step is executed inside `Codeunit.Run` with a commit barrier, so failures are caught and logged as `Imported Document Processing Error` without corrupting the transaction.
+
+## Import pipeline -- V1
+
+V1 is the legacy monolithic path. It processes everything in `V1_ProcessImportedDocument`: get basic info, parse document lines, resolve vendor, then branch on vendor settings.
+
+```mermaid
+flowchart TD
+    A[V1_ProcessEDocument] --> B[GetDocumentBasicInfo via IEDocument]
+    B --> C{Errors?}
+    C -- Yes --> ERR[Log error, exit]
+    C -- No --> D[ParseDocumentLines via IEDocument]
+    D --> E{Vendor found?}
+    E -- No --> ERR
+    E -- Yes --> F{Self-billing vendor?}
+    F -- Yes --> ERR
+    F -- No --> G{Vendor.Receive E-Document To = Purchase Order?}
+    G -- Yes --> H{Order exists?}
+    H -- Yes --> I[ProcessExistingOrder -- link to PO]
+    H -- No --> J{GUI available?}
+    J -- Yes --> K[User selects PO or creates new]
+    J -- No --> L[Set status Pending]
+    G -- No --> M[Create purchase invoice/credit memo]
+```
+
+V1 documents only respond to the "Finish draft" step in the V2 state machine -- all other steps are no-ops.
+
+## Status management
+
+`EDocumentProcessing.ModifyEDocumentStatus` aggregates per-service statuses into a single E-Document status using short-circuit logic: the first error found sets the document to Error and returns. Otherwise, any in-progress service means the document is in-progress. Only if all services are done does it become Processed.
+
+The `Import Processing Status` is a separate dimension tracked on `E-Document Service Status` and only applies to incoming documents. It represents position in the V2 pipeline and is independent of the overall service status.

--- a/src/Apps/W1/EDocument/App/src/SampleInvoice/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/SampleInvoice/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Sample invoice
+
+Demo/sample purchase invoice generation for testing and onboarding. Lets users and connector developers test the inbound e-document pipeline with realistic data without needing a real external vendor to send them an electronic invoice.
+
+## How it works
+
+`E-Doc Sample Purchase Invoice` (codeunit 6209) is the main builder. It uses a fluent pattern: call `AddInvoice` with a vendor number, external document number, and scenario description to set up a header, then call `AddLine` repeatedly to add line items. The codeunit populates temporary `E-Document Purchase Header` and `E-Document Purchase Line` records and can generate a sample PDF via the `E-Doc Sample Purchase Invoice` report. It resolves real data from the current company -- posting dates from the last G/L Entry, vendor details from the Vendor table, item details from the Item table.
+
+`E-Doc Sample Purch.Inv. PDF` (codeunit 6208) is a facade for PDF generation from the temporary purchase header/line buffers. It takes header and line records, feeds them to the report, and returns a TempBlob containing the PDF.
+
+The `E-Doc Sample Purch. Inv File` table (6120) stores generated sample files with their content (Blob), filename, scenario description, and vendor name. The `E-Doc Sample Purch. Inv. Files` page provides a list view.
+
+Three `.docx` report layouts (`EDocSamplePurchInvoice.docx`, `EDocSamplePurchInvoice2.docx`, `EDocSamplePurchInvoice3.docx`) provide different visual styles for the sample invoices. The codeunit can optionally mix layouts across multiple invoices for variety.
+
+## Things to know
+
+- Sample invoices use real vendor and item data from the current company. If the company has no vendors or items, sample generation will fail.
+- The `MixLayoutsForPDFGeneration` flag on the codeunit cycles through the three report layouts so a batch of sample invoices looks varied rather than identical.
+- `GetSampleInvoicePostingDate` finds the last G/L Entry's posting date to ensure the sample invoice date falls within a valid posting period. It falls back to `WorkDate()` if no entries exist.
+- The table uses `Access = Internal` -- sample invoice files are managed entirely through the codeunit API, not through direct table manipulation.
+- The `Scenario` field (Text[2048]) provides a human-readable description of what each sample invoice demonstrates (e.g., "Invoice with multiple tax rates" or "Credit memo referencing existing invoice").

--- a/src/Apps/W1/EDocument/App/src/Service/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Service/docs/CLAUDE.md
@@ -1,0 +1,29 @@
+# Service
+
+Configuration layer for e-document processing. The `E-Document Service` table (6103) is the central configuration entity that ties together a document format, a service integration, processing flags, and scheduling parameters. Each service defines how documents should be exported, sent, received, and processed.
+
+## How it works
+
+An E-Document Service is a named configuration (e.g., "PEPPOL-Pagero", "MSEOCADI") that combines two key choices: which `Document Format` enum value to use for creating/parsing document content, and which `Service Integration V2` enum value to use for communicating with the external API. When a document is posted, the framework looks up the service associated with it and uses these two enum values to resolve the format interface and the connector interfaces at runtime.
+
+The `E-Doc. Service Supported Type` table (6122) is a simple N:M bridge -- it lists which `E-Document Type` values a service handles. If a service only handles Sales Invoices and Sales Credit Memos, only those two rows exist. The processing pipeline uses this to determine which service should process a given document type.
+
+`Service Participant` table (6104) maps customers and vendors to their external identifiers for a given service. This is where PEPPOL IDs, endpoint identifiers, and other service-specific participant codes are stored. The primary key is (Service, Participant Type, Participant), meaning a single vendor can have different identifiers for different services.
+
+The `E-Document Service Status` table (6138) tracks the per-service status of each E-Document. Its primary key is (E-Document Entry No, E-Document Service Code), creating the one-to-many relationship between an E-Document and the services processing it. The `Import Processing Status` field is a V2 addition for the new import pipeline.
+
+## Things to know
+
+- The Service table is heavily configuration-driven. Boolean flags control inbound processing steps: `Validate Receiving Company`, `Resolve Unit Of Measure`, `Lookup Item Reference`, `Lookup Item GTIN`, `Lookup Account Mapping`, `Validate Line Discount`, `Apply Invoice Discount`, `Verify Totals`. Each flag toggles a specific step in the import processing pipeline.
+
+- `Service Integration V2` replaces the obsolete `Service Integration` (V1). When the V2 field is validated, the framework resolves `IConsentManager` from the enum and calls `ObtainPrivacyConsent`. If consent is denied, the field reverts to its previous value.
+
+- Batch processing is configured per-service with `Use Batch Processing`, `Batch Mode` (Threshold or Recurrent), `Batch Threshold`, and scheduling fields. Toggling `Use Batch Processing` automatically creates or removes a recurrent job queue entry via `E-Document Background Jobs`.
+
+- Auto-import is similarly scheduled per-service: `Auto Import` + `Import Start Time` + `Import Minutes between runs`. Each toggle change reconfigures the job queue entry.
+
+- The `MSEOCADI` service code is a built-in service for Azure Document Intelligence PDF processing. `GetPDFReaderService` auto-creates it on first access.
+
+- You cannot delete a service that is used in an active workflow -- the `OnDelete` trigger checks for active workflow references.
+
+- `GetDefaultFileExtension` defaults to `.xml` but fires an integration event (`OnAfterGetDefaultFileExtension`) allowing connectors to override it for JSON or other formats.

--- a/src/Apps/W1/EDocument/App/src/Service/docs/data-model.md
+++ b/src/Apps/W1/EDocument/App/src/Service/docs/data-model.md
@@ -1,0 +1,65 @@
+# Service data model
+
+## Service configuration
+
+The service table is the central configuration entity. It references two extensible enums that determine runtime behavior: the format (how to serialize/deserialize documents) and the integration (how to communicate with the external API).
+
+```mermaid
+erDiagram
+    EDocumentService ||--o{ EDocServiceSupportedType : "supports"
+    EDocumentService ||--o{ ServiceParticipant : "has participants"
+    EDocumentService ||--o{ EDocumentServiceStatus : "tracks status per document"
+    EDocumentServiceStatus }o--|| EDocument : "belongs to"
+
+    EDocumentService {
+        Code Code_20 PK
+        DocumentFormat enum
+        ServiceIntegrationV2 enum
+    }
+    EDocServiceSupportedType {
+        ServiceCode Code_20 PK
+        SourceDocumentType enum PK
+    }
+    ServiceParticipant {
+        Service Code_20 PK
+        ParticipantType enum PK
+        Participant Code_20 PK
+    }
+```
+
+`E-Doc. Service Supported Type` is a bridge table with a composite key -- one row per (service, document type) pair. It has no additional fields beyond the key.
+
+`Service Participant` maps trading partners to their external identifiers. A customer might be `"C10000"` in BC but `"0192:987654321"` (a PEPPOL participant ID) when exchanging documents through a specific service. The `Participant Identifier` field (Text[200]) holds this external ID.
+
+## Service status per document
+
+Each E-Document has one status record per service that processes it. This is the junction between the document and service layers.
+
+```mermaid
+erDiagram
+    EDocument ||--o{ EDocumentServiceStatus : "has"
+    EDocumentServiceStatus }o--|| EDocumentService : "for service"
+
+    EDocument {
+        EntryNo Integer PK
+        Status enum
+        Direction enum
+    }
+    EDocumentServiceStatus {
+        EDocumentEntryNo Integer PK
+        EDocumentServiceCode Code_20 PK
+        Status enum
+        ImportProcessingStatus enum
+    }
+    EDocumentService {
+        Code Code_20 PK
+    }
+```
+
+The `Status` field on `E-Document Service Status` uses the `E-Document Service Status` enum (the fine-grained 20+ value status). The `Status` field on `E-Document` uses the coarse three-value `E-Document Status` enum, derived pessimistically from all associated service statuses.
+
+The `Import Processing Status` field is a V2 import pipeline addition. Its `OnValidate` trigger automatically syncs the service status: when import processing reaches "Processed", the service status is set to "Imported Document Created"; otherwise it stays at "Imported".
+
+## Service scheduling
+
+The service table contains two sets of scheduling fields -- one for batch sending and one for auto-importing. Both create `Job Queue Entry` records. The service stores the job queue entry GUIDs in `Batch Recurrent Job Id` and `Import Recurrent Job Id` so they can be managed (paused, removed) when configuration changes.

--- a/src/Apps/W1/EDocument/App/src/Workflow/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Workflow/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# Workflow
+
+Integration with BC's Workflow engine for multi-step e-document processing. This is how outbound e-documents get exported, sent, and emailed in configurable sequences -- workflow is not optional for outbound e-documents.
+
+## How it works
+
+`EDocumentWorkflowSetup` (codeunit 6139, Public access) defines the event and response codes that plug into BC's Workflow framework. Events include `EDOCCREATEDEVENT` (document created), `EDOCRECEIVED` (document imported), `EDOCSENT` (status changed), and `Event-EDOC-EXPORTED`. Responses include export, send, send-by-email, and get-response actions. The codeunit also provides two built-in workflow templates: single-service (export + send) and multi-service (export to multiple services in sequence).
+
+`EDocumentWorkFlowProcessing` (codeunit 6135) is the execution engine. When a workflow response fires, this codeunit handles the actual work: `SendEDoc` runs the export-then-send pipeline, `SendEDocFromEmail` generates the document and emails it (with PDF, e-document XML, or both as attachments), and `GetEDocResponse` checks async send status. Each response step reads its configuration from `Workflow Step Argument`, which is extended with an `E-Document Service` field (Code[20]) that specifies which service to use for that step.
+
+`EDocumentCreatedFlow` (codeunit 6143) is a Job Queue handler. When an E-Document is created, a job queue entry fires this codeunit, which tells the Workflow Management to handle the `EDOCCREATEDEVENT`. This decouples document creation from workflow execution.
+
+## Things to know
+
+- The Document Sending Profile must reference an enabled Workflow with `Electronic Document = Extended E-Document Service Flow`. Without this, outbound e-documents will not be processed.
+- Each workflow step can target a different E-Document Service via the `Workflow Step Argument` extension. This enables multi-service scenarios like "export to PEPPOL, send to Pagero, then email a copy."
+- `IsServiceUsedInActiveWorkflow` iterates all enabled workflows to check if a service is referenced in any step argument. This is used to prevent deletion of in-use services.
+- Workflow templates are inserted with `Template = true` so users can create workflows from them but cannot modify the templates directly.
+- The `EDocWorkflowStepArgumentArch.TableExt.al` extends the archived step argument too, so completed workflow instances retain their E-Document Service reference for historical tracking.
+- Email sending determines the report usage, customer number, and document type by switching on `EDocument."Document Type"` -- the large case statement in `SendEDocFromEmail` covers all supported outbound document types.

--- a/src/Apps/W1/EDocument/App/src/Workflow/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/src/Workflow/docs/business-logic.md
@@ -1,0 +1,35 @@
+# Workflow business logic
+
+## Outbound document flow
+
+When a sales document is posted and has an e-document-enabled sending profile, the following sequence runs.
+
+```mermaid
+flowchart TD
+    A[Document posted] --> B[EDocumentSubscribers catches posting event]
+    B --> C[E-Document record created]
+    C --> D[Job Queue Entry created for EDocumentCreatedFlow]
+    D --> E[EDocumentCreatedFlow.Code runs]
+    E --> F[WorkflowManagement.HandleEvent EDOCCREATEDEVENT]
+    F --> G{Workflow response type?}
+    G -->|Export + Send| H[EDocWorkFlowProcessing.SendEDoc]
+    G -->|Send by Email| I[EDocWorkFlowProcessing.SendEDocFromEmail]
+    G -->|Get Response| J[EDocWorkFlowProcessing.GetEDocResponse]
+    H --> K[Export document via format interface]
+    K --> L[Send via integration interface]
+    I --> M[Generate report PDF / e-document XML]
+    M --> N[Email with configured attachment type]
+```
+
+## Workflow step validation
+
+Each workflow step validates its configuration before executing. `ValidateFlowStep` checks that the referenced E-Document Service exists, is properly configured, and matches the current document. For send steps, the service must have a valid integration configured. For email steps, argument validation is relaxed (the `false` parameter to `ValidateFlowStep`).
+
+## Template structure
+
+The single-service template creates a two-step workflow:
+
+1. Event: E-Document Created
+2. Response: Export and Send E-Document (with a service argument)
+
+The multi-service template chains multiple send responses, each with a different service argument. Both templates insert themselves as non-templates first (to allow modification during setup), configure the steps, then flip back to template mode.


### PR DESCRIPTION
## Summary

- Add 53 documentation files (CLAUDE.md + docs/) across 30 directories for the E-Document Core app
- Covers data model, business logic (outbound/inbound flows), extensibility (interfaces, events, provider pattern), and patterns (service plugin model, staged import, legacy V1)
- Documentation is prose-based with mermaid ER diagrams and flowcharts -- no mechanical field/procedure listings
- Generated via `/al-docs init` from the al-docs plugin

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Verify mermaid diagrams render in data-model.md and business-logic.md files
- [ ] Spot-check that file references in docs match actual AL files in the codebase
- [ ] Review app-level CLAUDE.md for accuracy of "How it works" and "Things to know" sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)
