### PR TITLE
Add regression test for E-Document Inventory Pick posting (#7132)

### DIFF
--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocInvtPickTest.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocInvtPickTest.Codeunit.al
@@ -6,6 +6,7 @@ namespace Microsoft.eServices.EDocument.Test;
 
 using Microsoft.eServices.EDocument;
 using Microsoft.eServices.EDocument.Integration;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Journal;
 using Microsoft.Inventory.Ledger;
@@ -193,6 +194,7 @@ codeunit 139896 "E-Doc. Invt. Pick Test"
     var
         EDocument: Record "E-Document";
         EDocumentServiceStatus: Record "E-Document Service Status";
+        GLSetup: Record "General Ledger Setup";
     begin
         LibraryLowerPermission.SetOutsideO365Scope();
         LibraryVariableStorage.Clear();
@@ -200,6 +202,10 @@ codeunit 139896 "E-Doc. Invt. Pick Test"
         EDocument.DeleteAll();
         EDocumentServiceStatus.DeleteAll();
         EDocumentService.DeleteAll();
+
+        GLSetup.GetRecordOnce();
+        GLSetup."VAT Reporting Date Usage" := GLSetup."VAT Reporting Date Usage"::Disabled;
+        GLSetup.Modify();
 
         LibraryEDoc.SetupStandardVAT();
         LibraryEDoc.SetupStandardSalesScenario(Customer, EDocumentService, Enum::"E-Document Format"::Mock, Enum::"Service Integration"::"Mock");


### PR DESCRIPTION
## Summary

- Add regression test codeunit `E-Doc. Invt. Pick Test` (139896) for bug 625438
- Test 1: Verifies failed Inventory Pick posting (wrong lot on bin) creates no Posted Sales Shipment, ILE, or E-Document
- Test 2: Verifies successful Inventory Pick posting creates shipment, ILE, and deferred E-Document via `OnAfterPostWhseActivityCompleted`

Companion test for the fix in #7132.

## Test plan
- [x] Both tests pass on the server

[AB#625588](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625588)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


