### PR TITLE
[releases/28.x] [Shopify] Skip empty inventory API call when batch size is exact multiple of 250

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Inventory/Codeunits/ShpfyInventoryAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Inventory/Codeunits/ShpfyInventoryAPI.Codeunit.al
@@ -149,7 +149,8 @@ codeunit 30195 "Shpfy Inventory API"
                 end;
             until ShopInventory.Next() = 0;
 
-            ExecuteInventoryGraphQL(JGraphQL, IGraphQL.GetExpectedCost());
+            if InputSize > 0 then
+                ExecuteInventoryGraphQL(JGraphQL, IGraphQL.GetExpectedCost());
         end;
     end;
 


### PR DESCRIPTION
## Summary
- Guard the final `ExecuteInventoryGraphQL` call in `ExportStock` with `if InputSize > 0` to avoid sending an unnecessary empty request when the number of inventory items is an exact multiple of the 250-item batch size

Fixes [AB#625962](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625962)

🤖 Generated with [Claude Code](https://claude.com/claude-code)





