### PR TITLE
Add E-Document Core documentation (CLAUDE.md + docs/)

### DIFF
--- a/src/Apps/W1/EDocument/App/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/CLAUDE.md
@@ -1,0 +1,53 @@
+# E-Document Core
+
+The E-Document Core app is a plugin framework for electronic document exchange in Business Central. Think of it as a three-layer sandwich: format (how to serialize a BC document into XML/JSON), service (where to send/receive it), and processing (what to do with incoming data). The framework itself ships with PEPPOL BIS 3.0 as a built-in format but does not ship any service connectors -- those come from country-specific extensions and third-party ISVs.
+
+## Quick reference
+
+- ID ranges: 6100-6199, 6208-6209, 6231-6232, 6234
+- No external dependencies (foundation layer)
+- InternalsVisibleTo: E-Document Core Tests, E-Document AI Tests, E-Document Core Demo Data, Payables Agent, Payables Agent Tests
+
+## How it works
+
+The `E-Document` table (6121) is the central entity that links a Business Central document (via Document Record ID) to its electronic representation. Each e-document flows through a state machine tracked at two levels: the document-level Status and the per-service E-Document Service Status. For outbound, posting a sales/service document triggers e-document creation, the format interface serializes it to a blob, mapping rules apply transformations, and then the service integration sends it over HTTP. For inbound, a service connector polls an external API, downloads documents, and feeds them into an import pipeline.
+
+The inbound import pipeline exists in two versions. V1 (legacy) is a single-step process that directly creates a purchase document. V2 is a four-stage pipeline: Structure (convert PDF to JSON via ADI/MLLM or pass through already-structured XML), Read into Draft (populate staging tables), Prepare Draft (resolve vendors, match items, apply AI), and Finish Draft (create the actual BC document). Each stage is a separate interface implementation that can be swapped per document -- the implementation selectors live as enum fields directly on the E-Document record.
+
+The framework also supports a clearance model (tax authority pre-approval) used by countries like Spain and Italy, batch processing for both send and receive, async response polling, and Copilot-powered order line matching. It does NOT implement any specific country localizations, service connectors, or tax authority integrations -- those are all extension points.
+
+## Structure
+
+- `src/Document/` -- the E-Document table, direction/type enums, status state machines, and the format interface definition
+- `src/Service/` -- service configuration, supported document types, service participants (customer/vendor enrollment)
+- `src/Integration/` -- IDocumentSender, IDocumentReceiver, context objects (SendContext, ReceiveContext, ActionContext), and the V1 legacy integration interface
+- `src/Processing/` -- the core orchestration: export, import pipeline (V1 + V2), order matching, Copilot AI tools, API endpoints, and all processing interfaces
+- `src/Processing/Import/` -- V2 import pipeline: structuring, draft read, draft preparation, finish draft, purchase staging tables, PO matching
+- `src/Processing/OrderMatching/` -- imported line normalization, match proposals, Copilot matching
+- `src/Logging/` -- E-Document Log (state transitions), Integration Log (HTTP pairs), Data Storage (blob storage)
+- `src/Mapping/` -- user-defined field mappings with find/replace and transformation rules
+- `src/Format/` -- PEPPOL BIS 3.0 export/import implementations, structured format enum
+- `src/ClearanceModel/` -- QR code handling for clearance-model countries
+- `src/Extensions/` -- table and page extensions to purchase headers, vendors, posted documents, sending profiles, role centers
+- `src/Helpers/` -- error helper, import helper, JSON helper, log helper
+- `src/DataExchange/` -- data exchange definition integration (alternative to code-based format)
+
+## Documentation
+
+- [docs/data-model.md](docs/data-model.md) -- tables, relationships, and the dual status pattern
+- [docs/business-logic.md](docs/business-logic.md) -- outbound/inbound flows, import pipeline, error handling
+- [docs/extensibility.md](docs/extensibility.md) -- how to implement formats, connectors, and import processors
+- [docs/patterns.md](docs/patterns.md) -- non-obvious architectural patterns and legacy patterns
+
+## Things to know
+
+- The E-Document table is the god object. It has fields for both outbound and inbound, implementation selector enums for all four import stages, clearance model timestamps, and blob storage pointers. Everything hangs off its Entry No.
+- There are three parallel state machines: `E-Document.Status` (document-level), `E-Document Service Status.Status` (per-service), and `E-Document Service Status."Import Processing Status"` (import pipeline stage). The import processing status auto-cascades to service status via OnValidate.
+- Blob storage is indirect. The E-Document has `Unstructured Data Entry No.` (PDF/binary) and `Structured Data Entry No.` (XML/JSON), both pointing to `E-Doc. Data Storage`. Logs also reference data storage entries. This separation lets blobs have independent lifecycles from log entries.
+- V1 and V2 import processes coexist. The `E-Document Service."Import Process"` field determines which path runs. V1 uses the legacy `E-Document Integration` interface. V2 uses the four-stage pipeline with IStructureReceivedEDocument, IStructuredFormatReader, IProcessStructuredData, and IEDocumentFinishDraft.
+- Implementation selectors cascade. During Structure, the output can override Read into Draft implementation. During Read into Draft, the output can set the Process Draft implementation. This means the actual code path for an import is determined dynamically, not just by service configuration.
+- Draft tables are ephemeral. `E-Document Purchase Header` and `E-Document Purchase Line` are staging areas deleted after Finish Draft creates the real BC document. They have parallel field structures: external fields (raw from sender) and BC-resolved fields (prefixed with `[BC]`).
+- SystemId-based linking. The `E-Doc. Record Link` table uses SystemIds (not primary keys) to link draft records to BC records. This survives record renaming but not table recreation.
+- The Commit-Run-Log pattern is everywhere. The framework calls Commit() before running interface implementations via Codeunit.Run(), catches failures, and logs errors per document. This allows batch processing to continue when individual documents fail.
+- Context objects (SendContext, ReceiveContext, ActionContext) carry HTTP message state, temp blobs, and status. They are the primary data exchange mechanism between framework and connector implementations.
+- Historical learning tables (`E-Doc. Purchase Line History`, `E-Doc. Vendor Assign. History`) record past resolutions so future imports can auto-match vendors and line items based on prior decisions.

--- a/src/Apps/W1/EDocument/App/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/docs/business-logic.md
@@ -1,0 +1,111 @@
+# Business logic
+
+## Overview
+
+All e-document processing is driven by two flows: outbound (BC document to external service) and inbound (external service to BC document). Both flows are orchestrated through `EDocumentProcessing` (codeunit 6108), which manages status transitions and delegates to format interfaces and service connectors. Workflow integration is optional -- `EDocumentWorkFlowProcessing` hooks into BC's workflow engine to allow approval steps.
+
+The framework processes documents per-service. A single BC document can be sent to multiple services, and each service tracks its own status independently. Batch processing is supported for both send and receive, controlled by service configuration flags.
+
+## Outbound: export and send
+
+Outbound starts when a sales/service document is posted. `EDocumentSubscribers` (codeunit 6103) subscribes to posting events across sales invoices, credit memos, service invoices, service credit memos, finance charge memos, reminders, transfer shipments, and more. On post, for each active service that supports the document type and passes export eligibility evaluation, it creates an E-Document record and triggers export.
+
+Export is handled by `EDocExport` (in `src/Processing/EDocExport.Codeunit.al`). It resolves the document format -- either a code-based implementation of the "E-Document" interface or a Data Exchange Definition -- serializes the BC document to a blob, applies any mapping rules configured on the service, and stores the result in a log entry with status Exported.
+
+After export, `EDocIntegrationManagement` (codeunit 6134) orchestrates the send. It retrieves the exported blob from the log, sets up a SendContext with the blob and default status (Sent), and calls the IDocumentSender implementation. The connector does its HTTP work using the context object. If the connector supports batch sending (`Use Batch Processing` on the service), multiple exported documents are sent together.
+
+For async services, the IDocumentResponseHandler interface handles polling. A background job periodically calls `GetResponse` for documents in "Pending Response" status. The connector checks the external service and updates status via the context object.
+
+```mermaid
+flowchart TD
+    A[Document posted] --> B{Service supports doc type?}
+    B -->|No| Z[Skip]
+    B -->|Yes| C{Export eligibility check}
+    C -->|Fails| Z
+    C -->|Passes| D[Create E-Document record]
+    D --> E[Export: format interface creates blob]
+    E --> F[Apply mapping rules]
+    F --> G[Store blob, status = Exported]
+    G --> H{Batch processing?}
+    H -->|Yes| I[Queue for batch send]
+    H -->|No| J[Send via IDocumentSender]
+    J --> K{Async?}
+    K -->|Yes| L[Status = Pending Response]
+    K -->|No| M[Status = Sent]
+    L --> N[Background job: poll via IDocumentResponseHandler]
+```
+
+Post-send actions (approval, cancellation) are handled by `ISentDocumentActions`. These are separate from the send flow -- they use `ActionContext` and the `IDocumentAction` interface for custom operations. The built-in implementations in `src/Integration/Actions/Implementations/` provide approval and cancellation workflows.
+
+## Inbound: receive
+
+Receiving is triggered by a background job or manual action. `EDocIntegrationManagement.ReceiveDocuments` calls the IDocumentReceiver implementation, which returns a list of document metadata blobs (one per document found on the external service). For each document, the framework calls `DownloadDocument` to get the actual content, creates an E-Document record with Direction = Incoming, stores the blob in data storage, and sets the service status to Imported.
+
+The V2 receive path in `EDocIntegrationManagement` handles both single and batch receives. After receiving, the `IReceivedDocumentMarker` interface (if implemented by the connector) can mark documents as downloaded on the external service to prevent re-downloading.
+
+## Inbound: import pipeline (V2)
+
+The V2 import pipeline is the core of inbound processing. It runs in `ImportEDocumentProcess` (codeunit 6104) and consists of four sequential stages. Each stage can be run independently and can be undone (reversed), enabling the user to go back and re-process with different settings.
+
+```mermaid
+flowchart TD
+    A[Received document] --> B[Structure received data]
+    B --> C{Structured data produced?}
+    C -->|No| ERR1[Log warning, continue with unstructured]
+    C -->|Yes| D[Store structured blob]
+    D --> E[Read into Draft]
+    E --> F[Populate staging tables]
+    F --> G[Prepare Draft]
+    G --> H{Vendor resolved?}
+    H -->|No| WAIT1[Status = Ready for review]
+    H -->|Yes| I{Lines matched?}
+    I -->|Partial| WAIT2[Status = Ready for review]
+    I -->|Yes| J[Finish Draft]
+    J --> K{Create PO or PI?}
+    K -->|Purchase Invoice| L[Create Purchase Invoice]
+    K -->|Purchase Order| M[Match to existing PO]
+    K -->|Journal Line| N[Create Journal Line]
+    L --> O[Link E-Document to BC doc]
+    M --> O
+    N --> O
+```
+
+**Stage 1: Structure received data.** `ImportEDocumentProcess.StructureReceivedData` takes the unstructured blob (e.g., PDF) and converts it to structured data (e.g., JSON). The implementation is selected by the `Structure Data Impl.` field on the E-Document. If unspecified, the file format's `PreferredStructureDataImplementation` is used. For PDFs, this typically means calling Azure Document Intelligence (ADI) or an MLLM. For XML, the "Already Structured" implementation passes through unchanged. The output determines which Read into Draft implementation to use next.
+
+**Stage 2: Read into Draft.** `ImportEDocumentProcess.ReadIntoDraft` takes the structured blob and populates the staging tables (`E-Document Purchase Header`, `E-Document Purchase Line`). The implementation is selected by `Read into Draft Impl.` -- which may have been set by the Structure stage. The built-in PEPPOL reader (`EDocumentPEPPOLHandler`) parses PEPPOL BIS 3.0 XML. The output sets the Process Draft implementation for the next stage.
+
+**Stage 3: Prepare Draft.** `ImportEDocumentProcess.PrepareDraft` calls `IProcessStructuredData.PrepareDraft`, which resolves the draft against BC master data. The default implementation (`PreparePurchaseEDocDraft` in `src/Processing/Import/PrepareDraft/`) uses provider interfaces (IVendorProvider, IItemProvider, IUnitOfMeasureProvider, etc.) to resolve each entity. It queries historical learning tables for auto-matching, applies user override mappings, and uses Copilot matching if enabled. After preparation, the user can review and edit the draft on the Purchase Draft page.
+
+**Stage 4: Finish Draft.** `ImportEDocumentProcess.FinishDraft` calls `IEDocumentFinishDraft.ApplyDraftToBC`, which reads the prepared staging tables and creates the actual BC document (Purchase Invoice, Purchase Order match, or Journal Line). The resulting document's RecordId is stored on the E-Document as `Document Record ID`. Staging tables are cleaned up afterward.
+
+Each stage runs inside a Commit-Run-Log pattern: the framework commits before calling the interface implementation via `Codeunit.Run()`, catches any runtime error, and logs it. This means a failure at any stage is recoverable -- the user can fix data, undo the step, and re-run.
+
+## Order matching
+
+When the vendor's `Receive E-Document To` setting is "Purchase Order", the import pipeline takes a different path at Finish Draft. Instead of creating a new purchase invoice, it matches the incoming lines against existing purchase order lines.
+
+Three matching modes exist:
+
+- **Manual:** The user opens the Order Line Matching page (`EDocOrderLineMatching` in `src/Processing/OrderMatching/`), sees imported lines alongside PO lines, and manually creates matches.
+- **Automatic:** `EDocLineMatching` (codeunit in `src/Processing/OrderMatching/`) runs rule-based matching using item references, descriptions, quantities, and prices. Tolerances are configured in `E-Doc. PO Matching Setup`.
+- **Copilot:** `EDocPOCopilotMatching` (in `src/Processing/OrderMatching/Copilot/`) uses AI function calling to propose matches. It leverages the historical matching data and fuzzy description matching via `EDocSimilarDescriptions` and `EDocHistoricalMatching` AI tools.
+
+After matching, `EDocPOMatching` (in `src/Processing/Import/Purchase/PurchaseOrderMatching/`) creates `E-Doc. Purchase Line PO Match` records that link imported lines to PO lines and receipt lines. The Finish Draft step then uses these to create purchase invoice lines against the matched receipts.
+
+## Clearance model workflow
+
+The clearance model supports countries where outbound invoices must be pre-approved by a tax authority before reaching the customer. After sending a document, the framework sets `Clearance Date` and `Last Clearance Request Time` on the E-Document. The service connector polls the authority for approval status. On approval, the framework generates a QR code (via `EDocumentQRCodeManagement` in `src/ClearanceModel/`) and attaches it to the posted document via table extensions on posted sales/service invoices and credit memos.
+
+The clearance model is framework infrastructure only -- the actual authority interaction is implemented by country extensions (e.g., FacturaE for Spain).
+
+## Error handling patterns
+
+The framework uses a consistent error handling approach across all processing.
+
+**Commit-Run-Log.** Before calling any interface implementation, the framework calls `Commit()` to persist the current state. Then it runs the implementation via `Codeunit.Run()` (which creates an implicit transaction). If the run fails, the error is caught and logged against the E-Document using `EDocumentErrorHelper`. This pattern is used in `EDocIntegrationManagement` for send/receive and in `ImportEDocumentProcess` for all V2 import stages.
+
+**Per-document error tracking in batches.** When processing multiple documents, the framework tracks error counts before and after processing each document (via `EDocumentErrorHelper.ErrorMessageCount`). This allows batch processing to continue when individual documents fail, rather than rolling back the entire batch.
+
+**Error Message table integration.** Errors are stored in the standard BC Error Message table, linked to the E-Document. `EDocumentErrorHelper` (in `src/Helpers/`) provides typed methods for logging simple errors, field-level errors, and warnings. New code should always use this helper rather than manipulating Error Message records directly.
+
+**Step undo/redo.** V2 import stages can be undone and re-run. When undoing, the `Step Undone` flag is set on the relevant log entry, and the processing status is rolled back. This allows users to fix data issues and re-process without starting from scratch.

--- a/src/Apps/W1/EDocument/App/docs/data-model.md
+++ b/src/Apps/W1/EDocument/App/docs/data-model.md
@@ -1,0 +1,118 @@
+# Data model
+
+## Document lifecycle core
+
+The `E-Document` table is the central entity. Every electronic document -- incoming or outgoing -- gets exactly one record here. It links to the originating or resulting BC document via `Document Record ID` (a RecordId pointing to e.g. a posted sales invoice or a purchase header). It also links to its data through two blob pointers: `Unstructured Data Entry No.` (the raw PDF or binary) and `Structured Data Entry No.` (the XML or JSON), both foreign keys to `E-Doc. Data Storage`.
+
+Each e-document has one `E-Document Service Status` record per service it has been sent to or received from. This is the per-service state tracker with a composite key of Entry No + Service Code. The service status has its own import-specific sub-status (`Import Processing Status`) that auto-cascades to the parent service status via OnValidate -- so setting the import status to Processed automatically flips the service status to "Imported Document Created".
+
+Notifications are tracked per document in `E-Document Notification`, used to surface user-facing alerts.
+
+```mermaid
+erDiagram
+    E-DOCUMENT ||--o{ E-DOCUMENT-SERVICE-STATUS : "tracked per service"
+    E-DOCUMENT ||--o{ E-DOCUMENT-NOTIFICATION : "alerts"
+    E-DOCUMENT }o--|| E-DOC-DATA-STORAGE : "unstructured blob"
+    E-DOCUMENT }o--|| E-DOC-DATA-STORAGE : "structured blob"
+```
+
+The key gotcha here is the dual status pattern. `E-Document.Status` is a rollup -- it is recomputed from all `E-Document Service Status` records. If any service is in error, the document is in error. If all services are processed, the document is processed. If some are still in progress, the document is in progress. The rollup logic lives in `EDocumentProcessing.ModifyEDocumentStatus` and delegates to `IEDocumentStatus` interface implementations per service status enum value. This means adding new service status values requires implementing that interface.
+
+## Service configuration
+
+Each `E-Document Service` defines an integration endpoint: which format to use (PEPPOL BIS 3 code-based or Data Exchange Definition), which transport connector (Service Integration V2 enum), and behavioral flags for import (validate receiving company, resolve UOM, lookup item references, etc.). The old `Service Integration` enum field is obsolete -- always use `Service Integration V2`.
+
+`E-Doc. Service Supported Type` is a many-to-many join between Service and Document Type, controlling which document types a service handles.
+
+`Service Participant` enrolls specific customers or vendors in a service with their external identifiers (PEPPOL ID, GLN, etc.). When exporting, the framework checks if the customer is a participant of the service to determine whether to send.
+
+```mermaid
+erDiagram
+    E-DOCUMENT-SERVICE ||--o{ E-DOC-SERVICE-SUPPORTED-TYPE : "handles"
+    E-DOCUMENT-SERVICE ||--o{ SERVICE-PARTICIPANT : "enrolls"
+    E-DOCUMENT-SERVICE ||--o{ E-DOCUMENT-SERVICE-STATUS : "status per doc"
+```
+
+Note that `E-Document Service` also has an `Import Process` field that determines V1 vs V2 import path. This is a critical routing decision -- V1 and V2 use completely different code paths and interfaces.
+
+## Import draft (V2)
+
+When the V2 import pipeline runs the "Read into Draft" stage, it populates ephemeral staging tables. `E-Document Purchase Header` holds header-level data with a deliberate split: external fields (vendor name, VAT registration, addresses as received from the sender) and BC-resolved fields (prefixed `[BC]` -- the actual vendor no, currency code, etc. resolved during Prepare Draft). `E-Document Purchase Line` follows the same pattern at line level.
+
+`E-Document Header Mapping` and `E-Document Line Mapping` store user overrides -- when a user manually corrects a vendor or item resolution on the draft page, these mappings record the correction so it can be learned from.
+
+`E-Doc. Record Link` connects draft entities to real BC records using SystemIds. This is ephemeral -- all these records are cleaned up after Finish Draft creates the BC document.
+
+```mermaid
+erDiagram
+    E-DOCUMENT ||--|| E-DOCUMENT-PURCHASE-HEADER : "draft header"
+    E-DOCUMENT-PURCHASE-HEADER ||--o{ E-DOCUMENT-PURCHASE-LINE : "draft lines"
+    E-DOCUMENT-PURCHASE-LINE ||--o{ E-DOC-RECORD-LINK : "links to BC records"
+    E-DOCUMENT ||--o{ E-DOCUMENT-HEADER-MAPPING : "user overrides"
+    E-DOCUMENT ||--o{ E-DOCUMENT-LINE-MAPPING : "user overrides"
+```
+
+The important thing about draft tables is that they are designed to be thrown away. The Finish Draft step reads from them, creates a real Purchase Invoice or Purchase Order in BC, and then the cleanup deletes the draft records. If you need to undo the finish, `IEDocumentFinishDraft.RevertDraftActions` reverses the BC document creation but the draft data must still exist.
+
+## Order matching
+
+When an incoming e-document needs to be matched against an existing purchase order, a parallel set of tables handles the matching process. `E-Doc. Imported Line` is a normalized view of the incoming lines, supporting partial matching through `Matched Quantity` vs `Quantity` fields.
+
+`E-Doc. Order Match` holds proposed matches between imported lines and PO lines. Each match proposal tracks price discrepancies and has a `Learn Matching Rule` flag that, when set, records the match in history for future auto-matching.
+
+`E-Doc. Purchase Line PO Match` is the finalized three-way match linking a PO line, a receipt line, and an invoice line. This is what Finish Draft uses to create the actual purchase invoice lines against receipts.
+
+`E-Doc. PO Matching Setup` configures matching behavior per vendor or globally -- tolerances, auto-match thresholds, and receipt matching requirements.
+
+```mermaid
+erDiagram
+    E-DOC-IMPORTED-LINE ||--o{ E-DOC-ORDER-MATCH : "proposed matches"
+    E-DOC-ORDER-MATCH }o--|| E-DOC-PURCHASE-LINE-PO-MATCH : "finalized"
+    E-DOC-PO-MATCHING-SETUP ||--o{ E-DOC-ORDER-MATCH : "configures"
+```
+
+## Logging
+
+The logging model separates three concerns: state transitions, HTTP communication, and blob storage.
+
+`E-Document Log` records every state transition for an e-document within a service. Not every log entry has attached data -- only entries where content was created or modified link to a data storage record. The `Step Undone` flag marks entries where the user has reversed a processing step (supported in V2 import).
+
+`E-Document Integration Log` stores HTTP request/response pairs as blobs. Every call to a service connector that uses the context object's HTTP message state gets logged here automatically.
+
+`E-Doc. Data Storage` is the blob store (PDF, XML, JSON). It is deliberately separate from logs so that blob lifecycle can be managed independently. Multiple log entries can reference the same data storage entry (e.g., batch imports where one blob contains multiple documents).
+
+`E-Doc. Mapping Log` records which mapping rules fired during export, providing an audit trail of field transformations.
+
+```mermaid
+erDiagram
+    E-DOCUMENT ||--o{ E-DOCUMENT-LOG : "state transitions"
+    E-DOCUMENT ||--o{ E-DOCUMENT-INTEGRATION-LOG : "HTTP pairs"
+    E-DOCUMENT-LOG }o--o| E-DOC-DATA-STORAGE : "attached blob"
+    E-DOCUMENT ||--o{ E-DOC-MAPPING-LOG : "mapping audit"
+```
+
+## Historical learning
+
+Two tables support the learning system that improves import accuracy over time.
+
+`E-Doc. Purchase Line History` records immutable history of how incoming lines were resolved to BC items, G/L accounts, or charge items. It has multiple indices to support fuzzy matching by vendor, description, item reference, and more. When a new incoming line arrives, the Prepare Draft step queries this history to propose matches.
+
+`E-Doc. Vendor Assign. History` records how external vendor identifiers (VAT registration numbers, PEPPOL IDs, names) were resolved to BC vendor numbers. This allows automatic vendor resolution for repeat senders.
+
+```mermaid
+erDiagram
+    E-DOC-PURCHASE-LINE-HISTORY }o--|| E-DOCUMENT : "learned from"
+    E-DOC-VENDOR-ASSIGN-HISTORY }o--|| E-DOCUMENT : "learned from"
+```
+
+Both tables are append-only. They accumulate knowledge from every successfully processed import, and the AI matching tools (Copilot) query them alongside the fuzzy matching logic.
+
+## Cross-cutting concerns
+
+**SystemId linking.** The `E-Doc. Record Link` table and several foreign key relationships use SystemId (Guid) rather than primary key values. This is intentional -- it survives record renaming and works across table boundaries. But it means you cannot rely on simple Get() calls; you need GetBySystemId().
+
+**Dual status machines.** The three-level status (E-Document.Status, Service Status.Status, Service Status."Import Processing Status") is the most confusing part of the data model. E-Document.Status is always a rollup. Service Status.Status covers the full lifecycle. Import Processing Status tracks only the V2 import pipeline progress and auto-cascades upward. When writing code that checks status, be explicit about which level you are querying.
+
+**Blob storage indirection.** Never assume a log entry has blob data. Always check `E-Doc. Data Storage Entry No.` before trying to read. The data storage table has a `File Format` enum that tells you what kind of content is inside (XML, JSON, PDF, etc.) -- use this rather than guessing from file extensions.
+
+**V1 vs V2 coexistence.** Tables like `E-Document Service` have fields relevant to both V1 and V2 import. The `Import Process` field (Version 1.0 vs Version 2.0) is the routing switch. V1 tables and flows are being obsoleted but still exist in the schema behind `CLEAN` compiler directives. New development should always target V2.

--- a/src/Apps/W1/EDocument/App/docs/extensibility.md
+++ b/src/Apps/W1/EDocument/App/docs/extensibility.md
@@ -1,0 +1,173 @@
+# Extensibility
+
+## Add a new document format
+
+**What it enables:** Serialize BC documents into a different format (e.g., XRechnung, ZUGFeRD, OIOUBL) for outbound, and optionally parse that format for inbound.
+
+**Interface:** `"E-Document"` (in `src/Document/Interfaces/EDocument.Interface.al`). This is the format interface, confusingly named the same as the table.
+
+**How to wire it:** Extend the `E-Document Format` enum with a new value and implement the interface. The implementation handles both export (creating the blob from a BC document) and import (parsing the blob into BC fields).
+
+```al
+enumextension 50100 "My Format" extends "E-Document Format"
+{
+    value(50100; "My Custom Format")
+    {
+        Implementation = "E-Document" = "My Custom Format Impl.";
+    }
+}
+
+codeunit 50100 "My Custom Format Impl." implements "E-Document"
+{
+    // Implement Create, CreateBatch, GetBasicInfo, GetBasicInfoFromReceivedDocument, etc.
+}
+```
+
+The key methods to implement are `Create` (serialize a single document), `CreateBatch` (serialize multiple documents), and the import-side methods. The built-in PEPPOL implementation in `src/Format/EDocPEPPOLBIS30.Codeunit.al` is the reference implementation.
+
+## Add a service connector
+
+**What it enables:** Send e-documents to and receive them from an external service (Avalara, Pagero, a custom API, etc.).
+
+**Interfaces:**
+
+- `IDocumentSender` (required for outbound) -- sends a single or batch of documents. Gets a `SendContext` with the blob and HTTP state.
+- `IDocumentReceiver` (required for inbound) -- polls for available documents and downloads them. Gets a `ReceiveContext`.
+- `IDocumentResponseHandler` (optional) -- polls for async responses after send. Implement if your service doesn't return final status synchronously.
+- `ISentDocumentActions` (optional) -- provides approval/cancellation workflows for sent documents.
+- `IReceivedDocumentMarker` (optional) -- marks documents as processed on the external service after download.
+- `IConsentManager` (optional) -- customizes the privacy consent flow when connecting to the service.
+
+**How to wire it:** Extend the `Service Integration` enum (the V2 one, `ServiceIntegration.Enum.al`):
+
+```al
+enumextension 50100 "My Connector" extends "Service Integration"
+{
+    value(50100; "My API")
+    {
+        Implementation =
+            IDocumentSender = "My API Sender",
+            IDocumentReceiver = "My API Receiver",
+            IDocumentResponseHandler = "My API Response Handler",
+            ISentDocumentActions = "My API Actions",
+            IReceivedDocumentMarker = "My API Marker";
+    }
+}
+```
+
+The send implementation receives a `SendContext` that carries the document blob, HTTP message state, and an action status object. Populate the HTTP request message on the context and the framework will automatically log the request/response to the integration log. See `src/Integration/Interfaces/IDocumentSender.Interface.al` for the documented contract with code examples.
+
+## Customize import processing
+
+**What it enables:** Override how incoming documents are resolved against BC master data (vendor matching, item matching, account assignment) or how the final BC document is created.
+
+**Interfaces for the Prepare Draft stage:**
+
+- `IProcessStructuredData` -- the top-level orchestrator for draft preparation. Calls the provider interfaces below. Extend the `E-Doc. Process Draft` enum.
+- `IPrepareDraft` -- a simpler alternative if you only need to customize the preparation step.
+- `IVendorProvider` -- resolve the incoming vendor identity to a BC Vendor record.
+- `IItemProvider` -- resolve an incoming line to a BC Item.
+- `IUnitOfMeasureProvider` -- resolve UOM codes.
+- `IPurchaseLineProvider` -- customize how draft purchase lines are populated.
+- `IPurchaseLineAccountProvider` -- assign G/L accounts to non-item lines.
+- `IPurchaseOrderProvider` -- find the matching purchase order for PO-based imports.
+
+**Interface for the Finish Draft stage:**
+
+- `IEDocumentFinishDraft` -- creates the actual BC document from prepared draft data. Implement `ApplyDraftToBC` (returns the RecordId of the created document) and `RevertDraftActions` (reverses creation if the user undoes the step). Extend the `E-Doc. Create Purchase Invoice` enum.
+
+```al
+enumextension 50100 "My Draft Processor" extends "E-Doc. Process Draft"
+{
+    value(50100; "My Custom Processor")
+    {
+        Implementation = IProcessStructuredData = "My Draft Processor Impl.";
+    }
+}
+```
+
+The default implementation in `PreparePurchaseEDocDraft` (in `src/Processing/Import/PrepareDraft/`) delegates to provider interfaces via `EDocProviders` (in the same folder). If you only need to override one aspect (e.g., vendor matching), implement just that provider interface and register it.
+
+## Add a structured format handler
+
+**What it enables:** Support a new input format for incoming documents (e.g., a proprietary XML schema, a new PDF extraction service, or a custom JSON format).
+
+**Interfaces:**
+
+- `IStructureReceivedEDocument` -- converts unstructured data (PDF, image) into structured data (XML, JSON). Returns an `IStructuredDataType` that specifies the resulting format and content. Extend the `Structure Received E-Doc.` enum.
+- `IStructuredFormatReader` -- reads structured data into the draft staging tables. Returns the `E-Doc. Process Draft` enum value that will handle Prepare Draft. Extend the `E-Doc. Read into Draft` enum.
+
+```al
+enumextension 50100 "My Structurer" extends "Structure Received E-Doc."
+{
+    value(50100; "My OCR Service")
+    {
+        Implementation = IStructureReceivedEDocument = "My OCR Structurer";
+    }
+}
+```
+
+The built-in structurers are in `src/Processing/Import/StructureReceivedEDocument/`: `EDocumentADIHandler` (Azure Document Intelligence), `EDocumentMLLMHandler` (multimodal LLM), and `EDocumentPEPPOLHandler` (passthrough for already-structured PEPPOL). The file format implementations in `src/Processing/Import/FileFormat/` (PDF, XML, JSON) determine the default structurer for each file type.
+
+## Customize export eligibility
+
+**What it enables:** Control which documents should be exported to a given service based on custom business rules (e.g., only export to a service if the customer is in a specific country).
+
+**Interface:** `IExportEligibilityEvaluator` -- implement `ShouldExport` to return true/false based on the service, document header, and document type. Extend the `Export Eligibility Evaluator` enum.
+
+```al
+enumextension 50100 "My Eligibility" extends "Export Eligibility Evaluator"
+{
+    value(50100; "Country Filter")
+    {
+        Implementation = IExportEligibilityEvaluator = "My Country Filter Eval.";
+    }
+}
+```
+
+## Add custom actions
+
+**What it enables:** Add custom operations that can be performed on sent documents beyond the built-in approval/cancellation.
+
+**Interface:** `IDocumentAction` -- implement `InvokeAction` which receives an `ActionContext` and returns whether the action should update the E-Document status. Wire it through the `Integration Action Type` enum.
+
+```al
+enumextension 50100 "My Actions" extends "Integration Action Type"
+{
+    value(50100; "My Custom Action")
+    {
+        Implementation = IDocumentAction = "My Action Impl.";
+    }
+}
+```
+
+The action runner in `src/Integration/Actions/EDocumentActionRunner.Codeunit.al` orchestrates the execution and logging.
+
+## Key integration events
+
+The framework publishes integration events at critical processing points. These are useful when you need to hook into the flow without implementing a full interface.
+
+**Export events** (in `EDocExport.Codeunit.al`):
+
+- `OnBeforeCreateEDocument` / `OnAfterCreateEDocument` -- before and after e-document record creation during export
+- `OnBeforeExportEdocument` / `OnAfterExportEdocument` -- before and after format serialization
+
+**Import events** (in `EDocImport.Codeunit.al`):
+
+- `OnBeforeCreatePurchaseDocumentFromEDocument` / `OnAfterCreatePurchaseDocumentFromEDocument` -- bracket BC document creation from import (V1)
+- `OnBeforeProcessImportedDocument` / `OnAfterProcessImportedDocument` -- bracket the full import processing
+- `OnBeforeInsertImportedEdocument` -- allows interception before the E-Document record is inserted during receive
+
+**Send/receive events** (in `EDocIntegrationManagement.Codeunit.al`):
+
+- `OnBeforeSendDocument` / `OnAfterSendDocument` -- bracket the IDocumentSender call
+- `OnGetDocumentCountInBatch` -- allows overriding batch document count detection
+
+**Status events** (in `EDocumentProcessing.Codeunit.al`):
+
+- `OnAfterModifyServiceStatus` -- fired after any service status change. The business events codeunit (`EDocumentBusinessEvents`) subscribes to this to emit Power Automate external business events.
+
+**Business events** (in `src/Processing/API/EDocumentBusinessEvents.Codeunit.al`):
+
+- `EDocumentStatusChanged` -- external business event for Power Automate when document-level status changes
+- `EDocumentServiceStatusChanged` -- external business event when per-service status changes

--- a/src/Apps/W1/EDocument/App/docs/patterns.md
+++ b/src/Apps/W1/EDocument/App/docs/patterns.md
@@ -1,0 +1,116 @@
+# Patterns
+
+## Interface-driven plugin architecture
+
+**Problem:** The framework needs to support arbitrary document formats and service connectors without modification.
+
+**How it works:** Format and service implementations are wired via AL enum extensions with interface implementations. The `E-Document Format` enum maps to the `"E-Document"` interface (format serialization). The `Service Integration` enum maps to multiple integration interfaces (IDocumentSender, IDocumentReceiver, etc.). Adding a new format or connector means extending the enum and providing implementations -- no framework code changes needed.
+
+The same pattern repeats throughout the import pipeline: `Structure Received E-Doc.` enum maps to IStructureReceivedEDocument, `E-Doc. Read into Draft` maps to IStructuredFormatReader, `E-Doc. Process Draft` maps to IProcessStructuredData, and `E-Doc. Create Purchase Invoice` maps to IEDocumentFinishDraft.
+
+**Key files:** `src/Document/EDocumentFormat.Enum.al`, `src/Integration/ServiceIntegration.Enum.al`, `src/Processing/Import/StructureReceivedEDoc.Enum.al`, `src/Processing/Import/EDocReadIntoDraft.Enum.al`, `src/Processing/Import/EDocProcessDraft.Enum.al`.
+
+**Gotcha:** The enum value on the E-Document record determines which implementation runs. During import, these values cascade -- the output of one stage can override the implementation selector for the next stage. This means the actual execution path is determined at runtime, not by static configuration alone. See `ImportEDocumentProcess.StructureReceivedData` where the returned IStructuredDataType can set `Read into Draft Impl.`.
+
+## Dual status pattern
+
+**Problem:** An e-document can be sent to multiple services, each with its own lifecycle. The framework needs document-level status for the user and per-service status for processing.
+
+**How it works:** Three parallel state machines operate simultaneously:
+
+1. `E-Document.Status` -- the document-level rollup (Error, In Progress, Processed). Computed by iterating all service status records and applying worst-case logic (any error = error, any in-progress = in-progress, all done = processed).
+2. `E-Document Service Status.Status` -- per-service lifecycle (Created, Exported, Sent, Imported, etc.). This is what the processing logic actually reads and writes.
+3. `E-Document Service Status."Import Processing Status"` -- import-specific sub-status (Received, Structured, Read, Prepared, Processed). Auto-cascades to Service Status via OnValidate.
+
+**Key files:** `src/Document/Status/EDocumentServiceStatus.Enum.al` (each value implements `IEDocumentStatus` to map back to document-level status), `src/Processing/EDocumentProcessing.Codeunit.al` (the rollup logic in `ModifyEDocumentStatus`), `src/Service/EDocumentServiceStatus.Table.al` (the OnValidate cascade).
+
+**Gotcha:** Adding a new service status enum value requires implementing the `IEDocumentStatus` interface to specify which document-level status it maps to. The status codeunits in `src/Document/Status/` (EDocErrorStatus, EDocInProgressStatus, EDocProcessedStatus) show how existing values are mapped.
+
+## Commit-Run-Log error handling
+
+**Problem:** Interface implementations can fail with runtime errors. The framework needs to catch these failures without rolling back previously committed work, especially in batch scenarios.
+
+**How it works:** Before calling any interface implementation, the framework calls `Commit()` to persist the current transaction. Then it calls the implementation via `Codeunit.Run()`, which creates an implicit savepoint. If the run fails, the error is caught via `GetLastErrorText()`, logged using `EDocumentErrorHelper`, and processing continues to the next document or step.
+
+**Key files:** `src/Integration/EDocIntegrationManagement.Codeunit.al` (RunSend, RunReceive methods), `src/Processing/Import/ImportEDocumentProcess.Codeunit.al` (the OnRun trigger wraps the step execution).
+
+**Gotcha:** The `Commit()` before `Codeunit.Run()` means you cannot roll back work done before the commit. This is by design -- it prevents a failing document from undoing the processing of previously successful documents in a batch. But it also means interface implementations should not assume they can roll back framework-level state changes.
+
+## Context objects
+
+**Problem:** Interface implementations need access to HTTP state, blob content, and status-setting capabilities, but these should be framework-managed with automatic logging.
+
+**How it works:** Three context codeunits -- `SendContext`, `ReceiveContext`, and `ActionContext` -- carry state between the framework and connector implementations. Each context provides:
+
+- `GetTempBlob()` / `SetTempBlob()` -- the document blob being sent or received
+- `Http()` -- returns an `HttpMessageState` codeunit holding the request and response messages
+- `Status()` -- returns an `IntegrationActionStatus` codeunit for setting the resulting service status
+
+The framework pre-populates the context (e.g., setting the blob from the export log) and post-processes it (e.g., logging the HTTP messages to the integration log). Connector implementations just need to fill in the HTTP request and call the API.
+
+**Key files:** `src/Integration/Send/SendContext.Codeunit.al`, `src/Integration/Receive/ReceiveContext.Codeunit.al`, `src/Integration/Actions/ActionContext.Codeunit.al`, `src/Integration/Actions/HttpMessageState.Codeunit.al`.
+
+**Gotcha:** If a connector implementation does not populate the HTTP request/response on the context, no communication log entry is created. The framework logs whatever is on the context's Http() state after the call returns, so make sure to set it even for non-standard HTTP flows.
+
+## Draft-based import with ephemeral staging tables
+
+**Problem:** Incoming e-documents need human review before becoming BC documents. The raw external data and BC-resolved data need to coexist during review.
+
+**How it works:** The V2 import pipeline uses `E-Document Purchase Header` and `E-Document Purchase Line` as staging areas. These tables have a deliberate dual-field design: external fields hold raw data from the sender (vendor name, external item IDs, free-text descriptions) while `[BC]`-prefixed fields hold resolved BC values (vendor no., item no., G/L account). The Prepare Draft stage populates the BC fields; the user can review and override them on the draft page; the Finish Draft stage reads the BC fields to create the actual document.
+
+After Finish Draft succeeds, the staging records are deleted by `IProcessStructuredData.CleanUpDraft`. The `E-Doc. Record Link` table that connected staging records to BC records via SystemId is also cleaned up.
+
+**Key files:** `src/Processing/Import/Purchase/EDocumentPurchaseHeader.Table.al`, `src/Processing/Import/Purchase/EDocumentPurchaseLine.Table.al`, `src/Processing/EDocRecordLink.Table.al`.
+
+**Gotcha:** Draft tables are ephemeral -- if you need to debug or audit what the draft contained, you must look at the E-Document logs and data storage, not the staging tables (they are gone after processing). Also, `E-Document Purchase Line.OnDelete` cascades to clean up PO match records, so deleting draft lines has side effects.
+
+## Metadata-driven mapping system
+
+**Problem:** Different services and countries need different field transformations during export without writing custom code.
+
+**How it works:** The `E-Doc. Mapping` table stores user-defined rules per service, specifying a table/field, a find value, a replace value, and an optional transformation rule (from BC's standard Transformation Rule table). During export, `EDocExport` applies all active mappings for the service. Each application is logged to `E-Doc. Mapping Log` for audit.
+
+Mappings can be flagged `For Import` to apply during inbound processing as well. The `Indent` field controls ordering within a mapping set. The `Used` flag tracks whether a mapping actually fired during processing.
+
+**Key files:** `src/Mapping/EDocMapping.Table.al`, `src/Mapping/EDocMappingLog.Table.al`.
+
+**Gotcha:** Mappings apply to field values after the format interface has created the blob. For code-based formats, this means they operate on the serialized output. For Data Exchange Definitions, they operate on the intermediate data. The interaction between mapping and format is format-specific.
+
+## Historical learning system
+
+**Problem:** Repeated imports from the same vendor should improve over time -- auto-matching vendors and line items based on past decisions.
+
+**How it works:** Two history tables accumulate knowledge:
+
+- `E-Doc. Purchase Line History` records how each incoming line was resolved (which BC item or account, which vendor, what description matched). It has indices for fuzzy matching by vendor + description, vendor + item reference, and vendor + external item code.
+- `E-Doc. Vendor Assign. History` records how external vendor identifiers were resolved to BC vendor numbers.
+
+During Prepare Draft, the provider interfaces query these tables before falling back to other resolution strategies. The Copilot AI tools (`EDocHistoricalMatching` in `src/Processing/AI/Tools/`) also query history as a function calling tool.
+
+**Key files:** `src/Processing/Import/Purchase/History/EDocPurchaseLineHistory.Table.al`, `src/Processing/Import/Purchase/History/EDocVendorAssignHistory.Table.al`, `src/Processing/Import/Purchase/History/EDocPurchaseHistMapping.Codeunit.al`.
+
+**Gotcha:** History is append-only. There is no deduplication or aging. Over time, history tables can grow large for high-volume vendors. The matching queries use multiple index paths, so query performance depends on having the right keys -- check the table's key definitions if you see slow matching.
+
+## AI tool provider pattern
+
+**Problem:** Copilot needs structured access to matching logic, but the AI system should not embed business logic directly.
+
+**How it works:** Four codeunits in `src/Processing/AI/Tools/` implement AI function calling tools that Copilot can invoke: `EDocDeferralMatching` (spread amounts across periods), `EDocGLAccountMatching` (find G/L accounts), `EDocHistoricalMatching` (query purchase line history), and `EDocSimilarDescriptions` (fuzzy-match item descriptions). The AI processor in `src/Processing/AI/EDocAIToolProcessor.Codeunit.al` registers these tools with the AI runtime and handles the function call dispatch.
+
+**Key files:** `src/Processing/AI/Tools/`, `src/Processing/AI/EDocAIToolProcessor.Codeunit.al`.
+
+**Gotcha:** The AI tools use buffer tables (`EDocHistoricalMatchBuffer`, `EDocLineMatchBuffer`) to communicate results back to the Copilot runtime. These are temporary tables, not persisted. The `IEDocAISystem` interface (in `src/Processing/Interfaces/`) allows overriding the AI system configuration.
+
+## Legacy patterns
+
+### V1 "E-Document Integration" interface
+
+The original integration interface (`src/Integration/EDocumentIntegration.Interface.al`) combined sending and receiving into a single interface. It is obsolete and wrapped behind `CLEAN26` compiler directives. New connectors should implement IDocumentSender and IDocumentReceiver separately. The V1 interface required connectors to manage HTTP requests directly and return blobs, while V2 connectors use context objects that handle logging automatically.
+
+### V1 import process
+
+The V1 import (`ImportEDocumentProcess.ProcessEDocumentV1`) is a single-step process that directly creates a purchase document from the received blob without staging tables. It uses the `E-Document Integration` interface's `GetBasicInfo` and then `EDocImport` (in `src/Processing/EDocImport.Codeunit.al`) to create the document. V1 does not support undo/redo, draft review, or AI matching. It is still the default when `E-Document Service."Import Process"` is set to "Version 1.0".
+
+### Direct Error Message manipulation
+
+Older parts of the codebase manipulate `Error Message` records directly. This is fragile because it requires knowing the correct context and filtering. All new code should use `EDocumentErrorHelper` (in `src/Helpers/EDocumentErrorHelper.Codeunit.al`), which provides properly scoped methods: `LogSimpleErrorMessage`, `LogErrorMessage` (with field reference), `LogWarningMessage`, and `ErrorMessageCount`. The helper ensures errors are linked to the correct E-Document and visible on the document card.

--- a/src/Apps/W1/EDocument/App/src/ClearanceModel/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/ClearanceModel/docs/CLAUDE.md
@@ -1,0 +1,24 @@
+# Clearance model
+
+Framework support for tax authority clearance workflows used in countries like Spain, Italy, and India. When a government tax authority "clears" an invoice, it returns a QR code or unique identifier that must be stored on the posted document and printed on invoices.
+
+## What this folder does (and does not do)
+
+This folder handles the result of clearance -- storing and displaying QR codes on posted documents. The clearance workflow itself (submitting to the tax authority, polling for approval, handling rejections) is service-specific and implemented by country localization apps. E-Document Core provides the hooks; localizations provide the integration.
+
+## QR code storage
+
+`EDocumentQRCodeManagement.Codeunit.al` handles QR code generation and storage. `EDocQRBuffer.Table.al` is a temporary buffer used during QR code processing.
+
+The QR code is stored as a base64-encoded image in blob fields added by table extensions to four posted document tables:
+
+- Posted Sales Invoice (`PostedSalesInvoicewithQR.TableExt.al`)
+- Posted Sales Credit Memo (`PostedSalesCrdMemoWithQR.TableExt.al`)
+- Posted Service Invoice (`PostedServiceInvoiceWithQR.TableExt.al`)
+- Posted Service Credit Memo (`PostedServiceCrMemoWithQR.TableExt.al`)
+
+## Display
+
+Matching page extensions add QR code display to each posted document page. Report extensions (`PostedSalesInvoiceWithQR.ReportExt.al`, etc.) embed the QR code in printed and PDF invoice output. Two viewer pages (`EDocumentQRViewer.Page.al` and `EDocumentQRCodeViewer.Page.al`) provide standalone QR code display.
+
+The table extensions in `src/Extensions/` for QR code fields on posted documents are the other half of this story -- they add the storage fields that this folder's codeunits populate.

--- a/src/Apps/W1/EDocument/App/src/DataExchange/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/DataExchange/docs/CLAUDE.md
@@ -1,0 +1,17 @@
+# Data exchange
+
+Alternative format path that uses BC's Data Exchange Framework instead of code-based codeunits. This is the configuration-driven approach to e-document XML generation and parsing.
+
+## Root files
+
+`EDocDataExchangeImpl.Codeunit.al` implements the "E-Document" interface by delegating to Data Exchange Definitions rather than building XML directly. `EDocServiceDataExchDef.Table.al` links an e-document service to specific Data Exchange Definition codes for each document type and direction (import vs export). The page (`EDocServiceDataExchSub.Page.al`) surfaces this configuration on the service card.
+
+## PEPPOL Data Exchange Definition subfolder
+
+The `PEPPOL Data Exchange Definition/` subfolder contains pre-mapping codeunits and event subscribers that run before and after the Data Exchange Framework processes the XML. These handle edge cases where the generic framework's column-to-field mapping is not sufficient -- for example, mapping PEPPOL's nested party structures to flat BC fields.
+
+## When to use which approach
+
+Microsoft's own guidance notes that the Data Exchange Definitions shipped here "likely can't be used as is" -- they are templates. In practice, most country localizations implement the code-based approach (a codeunit in `src/Format/` or their own app) because it gives full control over XML structure and is easier to debug.
+
+The Data Exchange approach works best when an organization needs to support a non-standard format variation without deploying custom AL code, or when the XML structure closely matches BC's field layout. For complex mappings with nested structures and conditional logic, the code-based path is more maintainable.

--- a/src/Apps/W1/EDocument/App/src/Document/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Document/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Document
+
+The E-Document table (6121) is the central transactional entity in the E-Document framework. Every inbound or outbound electronic document -- invoice, credit memo, order, reminder -- gets exactly one record here. It is the unit of work that the rest of the framework (export, integration, import processing) operates on.
+
+## How it works
+
+An E-Document is created with a Direction (Incoming or Outgoing) and a Document Type from the `E-Document Type` enum, which covers sales, purchase, service, finance charge, and reminder document types. For outgoing documents, `Document Record ID` is a `RecordId` pointing back to the source BC document (e.g., a posted sales invoice). For incoming documents, the link is built in the other direction -- once import processing creates a purchase invoice, the `Document Record ID` is set to point at it.
+
+The status model has two independent dimensions. The top-level `E-Document Status` enum has three values: "In Progress", "Processed", and "Error". This status is not stored directly -- it is calculated from the per-service status. The `E-Document Service Status` enum has roughly 20 values (Created, Exported, Sent, Pending Response, Approved, Imported, etc.) and each value implements the `IEDocumentStatus` interface. When the framework needs to compute the overall E-Document status, it calls `GetEDocumentStatus()` on the current service status value. For example, `EDocErrorStatus` returns `Error`, `EDocProcessedStatus` returns `Processed`, and `EDocInProgressStatus` returns `In Progress`. This means new service status values automatically map to the correct overall status just by choosing the right interface implementation in the enum declaration.
+
+For incoming V2 documents, a third status dimension exists: `Import Processing Status` on the `E-Document Service Status` table, which tracks the progress of structured import processing independently from the service-level status.
+
+## Things to know
+
+- `Document Record ID` is a `RecordId` field that bidirectionally links the E-Document to its source or target BC document. When it changes, the `OnValidate` trigger moves document attachments to the new record.
+- Two data storage pointers exist: `Unstructured Data Entry No.` (for raw content like PDF) and `Structured Data Entry No.` (for parsed content like XML). Both point to `E-Doc. Data Storage` records.
+- `Workflow Step Instance ID` and `Job Queue Entry ID` enable async processing. Workflows fire on status changes, and background jobs handle polling for responses.
+- Status implementations drive the overall status -- adding a new `E-Document Service Status` value only requires choosing the right `IEDocumentStatus` implementation (one of the three existing codeunits) in the enum declaration.
+- The `E-Document Type` enum also implements `IEDocumentFinishDraft`, which controls how import processing finalizes a draft document. For example, "Purchase Invoice" maps to `"E-Doc. Create Purchase Invoice"`.
+- Deletion is guarded: processed documents and documents linked to BC records cannot be deleted. Non-duplicate documents require user confirmation.
+- The notification subsystem (`EDocumentNotification.Table.al`, `EDocumentNotification.Codeunit.al`) stores per-user, per-document messages for surfacing import errors or processing results in the UI.

--- a/src/Apps/W1/EDocument/App/src/Extensions/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Extensions/docs/CLAUDE.md
@@ -1,0 +1,24 @@
+# Extensions
+
+Integration surface between E-Document Core and the BC base app. This is the largest subfolder (~40 files) because every BC document page that participates in e-document exchange needs a page extension to wire up actions and status indicators.
+
+## Table extensions
+
+The critical one is `EDocPurchaseHeader.TableExt.al`, which adds two fields to Purchase Header. "E-Document Link" is a bidirectional Guid that joins a Purchase Header record to its originating E-Document record -- the framework uses this to navigate between the two without a rigid foreign key. "Amount Incl. VAT To Inv." supports partial invoicing during the import flow. `EDocPurchaseLine.TableExt.al` adds a matching amount field at the line level.
+
+`EDocumentVendor.TableExt.al` adds "Receive E-Document To" (an enum controlling whether incoming e-documents create purchase orders or purchase invoices) and "E-Document Default Line Type". These fields drive routing decisions in the import pipeline. `EDocPurchPayablesSetup.TableExt.al` adds org-wide defaults for the same settings.
+
+The posted document table extensions (`PostedSalesInvoicewithQR`, `PostedSalesCrdMemoWithQR`, etc.) add QR code blob fields to support the clearance model -- see `src/ClearanceModel/` for the full story.
+
+## Page extensions
+
+Most follow one of two patterns:
+
+- Outbound document pages (Sales Invoice, Service Order, etc.) get a "Send E-Document" action
+- Posted document pages get an e-document status factbox and navigation to the E-Document card
+
+## Subfolders
+
+`Sending/` handles Document Sending Profile integration. `EDocSendingProfile.Codeunit.al` hooks into BC's sending profile framework so that selecting an e-document profile on a customer triggers the e-document workflow instead of the standard email/print path.
+
+`RoleCenter/` provides cue tiles and the E-Document Activities page for role center integration, giving users at-a-glance counts of pending, failed, and processed e-documents.

--- a/src/Apps/W1/EDocument/App/src/Format/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Format/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# Format
+
+PEPPOL BIS 3.0 implementation -- the built-in format that ships with E-Document Core. This is the reference implementation that localization teams study when building country-specific formats.
+
+## Two format paths
+
+E-Document Core supports two fundamentally different approaches to XML generation:
+
+- **Code-based** (this folder) -- AL codeunits directly build/parse XML. `EDocPEPPOLBIS30.Codeunit.al` implements the "E-Document" interface for export. `EDocImportPEPPOLBIS30.Codeunit.al` implements `IStructuredFormatReader` for import. Full control, straightforward debugging.
+- **Data-exchange-based** (see `src/DataExchange/`) -- uses BC's Data Exchange Framework with transformation rules configured in the UI. More flexible for non-developers but harder to troubleshoot.
+
+The `EDocumentStructuredFormat.Enum.al` enum ("E-Document Structured Format") is the extensible enum that localizations extend to register their own formats. PEPPOL BIS 3.0 is registered via `EDocPEPPOLBIS30.EnumExt.al`.
+
+## Key files
+
+`EDocPEPPOLBIS30.Codeunit.al` is the export workhorse -- it builds the full UBL 2.1 XML structure. `EDocImportPEPPOLBIS30.Codeunit.al` handles import by reading structured XML fields into the e-document's intermediate representation. `EDocPEPPOLValidation.Codeunit.al` validates PEPPOL-specific business rules before export.
+
+`EDocShipmentExportToXml.Codeunit.al` and `EDocTransferShptToXML.Codeunit.al` handle shipment document types, which use a different UBL schema than invoices and credit memos. `FinResultsPEPPOLBIS30.XmlPort.al` handles financial charge memo export.
+
+Most country localizations bypass this folder entirely and implement their own format codeunit registered against their own enum value. PEPPOL BIS 3.0 serves as the W1 default and the pattern to follow.

--- a/src/Apps/W1/EDocument/App/src/Integration/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Integration/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Integration
+
+The service integration layer is the bridge between E-Document Core and external e-invoicing services. It owns the entire lifecycle of sending documents out, receiving documents in, and executing post-send actions like approval and cancellation checks. Nothing in this layer knows about document formats -- it operates on opaque blobs that the format layer has already produced.
+
+## How it works
+
+Every service integration call flows through `EDocIntegrationManagement.Codeunit.al`, which orchestrates the commit-run-log pattern used throughout. The pattern works like this: commit current state, run the interface call inside a dedicated runner codeunit (so runtime errors are caught by `if not Codeunit.Run()`), then log the result and update statuses. The runner codeunits -- `SendRunner`, `GetResponseRunner`, `EDocumentActionRunner`, `ReceiveDocuments`, `DownloadDocument`, `MarkFetched` -- each wrap a single interface call and exist primarily so the framework can trap errors without losing the transaction.
+
+Context objects (`SendContext`, `ReceiveContext`, `ActionContext`) are the connective tissue. They carry an `Http()` accessor for request/response messages and a `Status()` accessor for controlling which service status gets written. When an interface implementor populates the HTTP request and response on the context, the framework automatically writes integration log entries with the full HTTP payload -- no extra work needed by the connector.
+
+Async sending is determined by a type check, not a flag. After calling `IDocumentSender.Send()`, the `SendRunner` checks whether the sender also implements `IDocumentResponseHandler`. If it does, the document enters "Pending Response" status and a background job (`EDocumentGetResponse`) polls `GetResponse()` until it returns true or logs an error. If the sender does not implement the response handler, the send is treated as synchronous and the status resolves immediately.
+
+## Things to know
+
+- Context objects (`SendContext`, `ReceiveContext`, `ActionContext`) all share the same shape: `Http()` for HTTP state and `Status()` for controlling the resulting service status. Populating `Http()` is how you get automatic communication logging.
+- The runners use commit-run-log: `Commit()` before the interface call, catch errors via `if not Codeunit.Run()`, then log the error text against the E-Document. This means interface implementations run in their own transaction scope.
+- Async vs sync is purely structural: if your `IDocumentSender` implementation also implements `IDocumentResponseHandler`, the framework treats the send as async. There is no configuration flag.
+- `IReceivedDocumentMarker` is optional. During receive, the framework checks `IDocumentReceiver is IReceivedDocumentMarker` and only calls `MarkFetched` if the type test passes. If the external service does not need to be told that documents were fetched, skip this interface entirely.
+- Receive is a two-phase process: `ReceiveDocuments` returns metadata as a `Temp Blob List` (one blob per document), then `DownloadDocument` is called individually for each entry to fetch the actual content.
+- Built-in action types ("Sent Document Approval", "Sent Document Cancellation") delegate to `ISentDocumentActions` via a type check on the sender. Custom actions extend the `Integration Action Type` enum and implement `IDocumentAction` directly.
+- The `Service Integration` enum (V2) implements `IDocumentSender`, `IDocumentReceiver`, and `IConsentManager` simultaneously. Connectors extend this single enum to plug into all three contracts.

--- a/src/Apps/W1/EDocument/App/src/Integration/docs/extensibility.md
+++ b/src/Apps/W1/EDocument/App/src/Integration/docs/extensibility.md
@@ -1,0 +1,96 @@
+# Integration extensibility
+
+This guide covers the six main extension points in the integration layer, grouped by what you are trying to accomplish.
+
+## 1. Build a service connector
+
+This is the minimum viable integration. You need to extend the `Service Integration` enum and implement `IDocumentSender` (and optionally `IDocumentReceiver`).
+
+The `Service Integration` enum in `ServiceIntegration.Enum.al` implements three interfaces simultaneously: `IDocumentSender`, `IDocumentReceiver`, and `IConsentManager`. When you add a new enum value, the compiler requires implementations for all three. Use `"E-Document No Integration"` as the `IDocumentReceiver` implementation if your connector is send-only.
+
+`IDocumentSender` has a single method:
+
+- `Send(var EDocument, var EDocumentService, SendContext)` -- read the document blob from `SendContext.GetTempBlob()`, transmit it, and populate `SendContext.Http()` with the request/response for automatic logging. Set `SendContext.Status().SetStatus()` if you need a status other than the default "Sent".
+
+For receiving, implement `IDocumentReceiver` with two methods:
+
+- `ReceiveDocuments(var EDocumentService, DocumentsMetadata, ReceiveContext)` -- call the external API to discover available documents and add one `Temp Blob` per document to the `DocumentsMetadata` list. Each blob carries whatever metadata your connector needs to identify the document later (e.g., a JSON object with a document ID).
+- `DownloadDocument(var EDocument, var EDocumentService, DocumentMetadata, ReceiveContext)` -- given the metadata blob from the previous step, download the actual document content and store it in `ReceiveContext.GetTempBlob()`. Set `ReceiveContext.SetName()` and `ReceiveContext.SetFileFormat()` to control how the file is stored.
+
+Example enum extension:
+
+```al
+enumextension 50100 "My Service Integration" extends "Service Integration"
+{
+    value(50100; "My Service")
+    {
+        Implementation =
+            IDocumentSender = "My Service Impl.",
+            IDocumentReceiver = "My Service Impl.",
+            IConsentManager = "My Service Impl.";
+    }
+}
+```
+
+## 2. Handle async responses
+
+If the external service does not confirm delivery synchronously, your `IDocumentSender` implementation should also implement `IDocumentResponseHandler` (in `Interfaces/IDocumentResponseHandler.Interface.al`). The framework detects this through a runtime type check -- `IDocumentSender is IDocumentResponseHandler` -- and automatically sets the service status to "Pending Response" instead of "Sent".
+
+`IDocumentResponseHandler` has one method:
+
+- `GetResponse(var EDocument, var EDocumentService, SendContext): Boolean` -- return `true` when the service confirms the document was received, `false` if still pending. If you log an error message against the E-Document, the framework treats it as a terminal failure and stops polling.
+
+A background job (`EDocumentGetResponse`) polls all documents in "Pending Response" status. It calls `GetResponse` for each, updates the status, and reschedules itself if any documents remain pending.
+
+## 3. Support post-send actions (approval and cancellation)
+
+After a document is sent, users may need to check approval status or request cancellation. Implement `ISentDocumentActions` on your sender codeunit (the same codeunit that implements `IDocumentSender`).
+
+`ISentDocumentActions` in `Interfaces/ISentDocumentActions.Interface.al` has two methods:
+
+- `GetApprovalStatus(var EDocument, var EDocumentService, ActionContext): Boolean` -- check with the service whether the document is approved. Return `true` to update the E-Document status (defaults to "Approved"), `false` to leave it unchanged. Use `ActionContext.Status().SetStatus()` to override the resulting status.
+- `GetCancellationStatus(var EDocument, var EDocumentService, ActionContext): Boolean` -- same pattern for cancellation. Default success status is "Canceled".
+
+The framework discovers this through a type check in `SentDocumentApproval.Codeunit.al`: it resolves the sender from the service's `Service Integration V2` enum, checks `IDocumentSender is ISentDocumentActions`, and delegates if the check passes. No registration step is needed -- just implement the interface on your sender.
+
+## 4. Add custom actions
+
+For actions beyond the built-in approval and cancellation, implement `IDocumentAction` and extend the `Integration Action Type` enum.
+
+`IDocumentAction` in `Interfaces/IDocumentAction.Interface.al` has one method:
+
+- `InvokeAction(var EDocument, var EDocumentService, ActionContext): Boolean` -- perform the action and return `true` if the E-Document status should be updated. Use `ActionContext.Status().SetStatus()` to control the success status and `ActionContext.Status().SetErrorStatus()` to control the error status.
+
+Example enum extension:
+
+```al
+enumextension 50101 "My Action Types" extends "Integration Action Type"
+{
+    value(50100; "My Custom Action")
+    {
+        Implementation = IDocumentAction = "My Custom Action Impl.";
+    }
+}
+```
+
+Call your custom action through `EDocIntegrationManagement.InvokeAction()` with the corresponding enum value.
+
+## 5. Mark received documents as fetched
+
+Some services require you to acknowledge that documents were downloaded. Implement `IReceivedDocumentMarker` on the same codeunit that implements `IDocumentReceiver`.
+
+`IReceivedDocumentMarker` in `Interfaces/IReceivedDocumentMarker.Interface.al` has one method:
+
+- `MarkFetched(var EDocument, var EDocumentService, var DocumentBlob, ReceiveContext)` -- call the service API to acknowledge receipt. If this fails (throws an error), the document is not created in Business Central.
+
+The framework checks `IDocumentReceiver is IReceivedDocumentMarker` after downloading each document. If the type test passes, `MarkFetched` runs before the document is committed to the log. This is intentional -- if you cannot confirm receipt with the service, the document should not appear as imported.
+
+## 6. Manage consent
+
+Every `Service Integration` enum value must implement `IConsentManager`. The framework calls `ObtainPrivacyConsent()` when a user first selects your integration on the E-Document Service card.
+
+`IConsentManager` in `Interfaces/IConsentManager.Interface.al` has one method:
+
+- `ObtainPrivacyConsent(): Boolean` -- display a privacy consent dialog and return whether the user agreed. If you have no special consent requirements, delegate to `"Consent Manager Default Impl."` which ships with the framework.
+
+The default implementation is already wired as `DefaultImplementation` on the `Service Integration` enum, so if you do not specify an `IConsentManager` implementation on your enum value, the default kicks in automatically.

--- a/src/Apps/W1/EDocument/App/src/Logging/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Logging/docs/CLAUDE.md
@@ -1,0 +1,19 @@
+# Logging
+
+Three-tier logging design separating business events, technical details, and document content into independent tables with different lifecycles and retention policies.
+
+## The three tiers
+
+**E-Document Log** (`EDocumentLog.Table.al`, table 6105) tracks business-level state transitions. Every status change on an e-document creates a new log entry. The "Step Undone" flag marks entries that were rolled back -- the entry remains for audit but is excluded from status calculations. Each entry can link to an E-Doc. Data Storage record for the document content at that point in time.
+
+**E-Document Integration Log** (`EDocumentIntegrationLog.Table.al`, table 6106) captures HTTP request/response pairs from service communication. Stores method, URL, status code, and request/response blobs. This is where you look when a service call fails -- the raw HTTP exchange is preserved here regardless of whether the business-level status was updated.
+
+**E-Doc. Data Storage** (`EDocDataStorage.Table.al`, table 6107) holds the actual document content (XML, JSON, PDF) as blobs, decoupled from the log entries that reference them. The "File Format" enum determines which viewer renders the content. "Data Storage Size" is a cached field to avoid reading blobs just to show file sizes in lists.
+
+## Design decisions
+
+Not every log entry has associated blob content -- only export and import statuses store the document payload. The separation of data storage from logs means content can be purged independently of the audit trail.
+
+`EDocumentLog.Codeunit.al` is the logging utility codeunit. All log writes go through here rather than direct table inserts, ensuring consistent log entry creation across the framework. When an e-document is deleted, `CleanupDocument` in the core handles orphaned data storage records.
+
+Retention policies are configurable per log type through BC's standard retention policy framework, allowing organizations to keep integration logs shorter than document logs.

--- a/src/Apps/W1/EDocument/App/src/Mapping/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Mapping/docs/CLAUDE.md
@@ -1,0 +1,19 @@
+# Mapping
+
+Metadata-driven field value transformation during import and export. Lets administrators configure find-and-replace rules per service without writing code.
+
+## How it works
+
+`EDocMapping.Table.al` stores user-defined mapping rules: a Find Value, a Replace Value, and an optional Transformation Rule reference. Each rule is scoped to a service (linked by Code) and flagged for import, export, or both via the "For Import" field. Rules are evaluated in sequence during document processing.
+
+`EDocMapping.Codeunit.al` applies the rules using RecordRef for dynamic field access -- it does not need compile-time knowledge of the target table structure. This means mappings work across any document type without per-table code.
+
+The system leverages BC's existing Transformation Rule framework, so all standard transformations are available -- uppercase, lowercase, trim, regex replacement, date formatting, and custom rules. This avoids reinventing transformation logic.
+
+## Mapping log
+
+`EDocMappingLog.Table.al` records every rule that fired for each document, creating an audit trail of transformations. This is critical for debugging "why did field X end up with value Y?" questions -- you can trace back through the log to see which mapping rule changed it and what the original value was.
+
+## UI
+
+`EDocMapping.Page.al` and `EDocMappingPart.Page.al` provide the configuration interface, typically accessed from the E-Document Service card. `EDocChangesPreview.Page.al` and `EDocChangesPart.Page.al` let users preview what mappings would do before committing, which is useful when setting up a new service connection.

--- a/src/Apps/W1/EDocument/App/src/Processing/AI/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/AI/docs/CLAUDE.md
@@ -1,0 +1,20 @@
+# AI
+
+AI-powered tools for the e-document import pipeline, invoked through BC's Copilot framework. Each tool is a specialized codeunit that handles one aspect of the matching problem.
+
+## Tool architecture
+
+`EDocAIToolProcessor.Codeunit.al` is the orchestrator that registers and dispatches to individual AI tools. The Copilot framework calls this processor, which selects and invokes the appropriate tools based on the matching context.
+
+`EDocHistoricalMatchBuffer.Table.al` and `EDocLineMatchBuffer.Table.al` are temporary buffer tables that hold intermediate results during AI processing -- they accumulate candidate matches from multiple tools before a final ranking step.
+
+## Tools
+
+Each tool in the `Tools/` subfolder handles a different matching strategy:
+
+- `EDocHistoricalMatching.Codeunit.al` -- looks up E-Doc. Purchase Line History to find how previous invoices from the same vendor were matched. If vendor X's line "Widget A" was mapped to item 1000 three times before, it suggests the same mapping again. This is the highest-confidence tool.
+- `EDocGLAccountMatching.Codeunit.al` -- for invoice lines that do not map to inventory items, suggests G/L accounts based on the line description and existing account mappings.
+- `EDocDeferralMatching.Codeunit.al` -- identifies lines that match deferral patterns (subscriptions, prepayments) and suggests appropriate deferral templates.
+- `EDocSimilarDescriptions.Codeunit.al` -- fuzzy text matching for cases where vendor product codes do not match the buyer's item numbers but descriptions are semantically similar.
+
+System prompts that define the LLM behavior live in `.resources/Prompts/` at the app level. The tools pass structured context (line data, history, account lists) and the LLM returns ranked match proposals.

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/docs/CLAUDE.md
@@ -1,0 +1,66 @@
+# Import
+
+The Import subfolder implements the V2 multi-step import pipeline for incoming
+e-documents. It owns the state machine orchestrator, the draft staging tables, user
+override mappings, and all the subfolder logic for purchase document creation,
+historical matching, PO reconciliation, and file format handling.
+
+## How it works
+
+The pipeline is orchestrated by `ImportEDocumentProcess.Codeunit.al`, which executes
+a single configured step per `Run()` invocation. The caller (`EDocImport`) drives the
+state machine by computing which steps need to run (or undo) to reach a desired
+status, then calls `ConfigureImportRun` + `Run()` in a loop.
+
+The four stages populate and refine draft tables before creating a real BC document.
+The `E-Document Purchase Header` and `E-Document Purchase Line` tables serve as the
+staging area -- they hold both the external data extracted from the incoming file
+(fields 2-100, read-only) and BC-resolved data (fields 101+, prefixed `[BC]`, user-
+editable). This dual-field design lets users see exactly what the original document
+said alongside the BC entity the system resolved it to.
+
+Historical matching is vendor-scoped. When a draft line has a product code or
+description that was previously mapped for the same vendor, the system reuses that
+mapping automatically. History is stored in `E-Doc. Purchase Line History` and
+`E-Doc. Vendor Assign. History`, both linked to the posted purchase invoice via
+SystemId. History records are immutable once created.
+
+PO matching (in Purchase/PurchaseOrderMatching/) handles the three-way match scenario:
+an incoming invoice references a purchase order, and the system matches invoice lines
+to PO lines and receipt lines. The `E-Doc. PO Matching Setup` table controls matching
+behavior per vendor or globally (fall back when no vendor-specific setup exists).
+
+## Things to know
+
+- The V2 status progression is: Unprocessed -> Readable -> Ready for draft ->
+  Draft ready -> Processed. Each transition is one step, each step is independently
+  undoable.
+
+- Draft tables are ephemeral. They exist only while the e-document is between
+  "Ready for draft" and "Processed" states. The `E-Document Purchase Header` row is
+  created during Read into Draft and deleted when the BC document is finalized (or
+  when the e-document is deleted).
+
+- `E-Document Header Mapping` and `E-Document Line Mapping` store user overrides.
+  When the user changes the vendor, item, or UOM on the draft page, the mapping
+  record captures that choice so it persists across re-processing.
+
+- PO matching setup can be per-vendor (via `"Vendor No."` on `E-Doc. PO Matching
+  Setup`) or global (blank vendor). The `GetSetup` procedure falls back from
+  vendor-specific to global.
+
+- The AdditionalFields/ subfolder provides an extensibility mechanism for
+  service-specific fields on draft lines. `E-Document Line - Field` is a key-value
+  table keyed by (E-Document Entry No., Line No., Field No.) that stores typed
+  values (Text, Decimal, Date, Boolean, Code, Integer). The field definitions come
+  from `ED Purchase Line Field Setup`.
+
+- `EDocImportParameters.Table.al` is a temporary table -- it is never persisted. It
+  configures a single processing run: which step to execute, whether to target a
+  specific status, V1 behavior overrides, and an optional existing document RecordId
+  for linking instead of creating.
+
+- File format handlers in FileFormat/ (PDF, XML, JSON) implement `IEDocFileFormat`
+  and provide the file extension and preferred structuring implementation. They do not
+  parse content -- that is the job of `IStructureReceivedEDocument` implementations
+  in StructureReceivedEDocument/.

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/docs/data-model.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/docs/data-model.md
@@ -1,0 +1,127 @@
+# Import data model
+
+## Draft purchase documents
+
+The core staging area for incoming e-documents. The `E-Document` record is the
+parent; the purchase header and line tables hold the parsed data; mapping tables
+capture user overrides.
+
+```mermaid
+erDiagram
+    E-Document ||--|| E-Document-Purchase-Header : "1:1 by Entry No"
+    E-Document ||--o{ E-Document-Purchase-Line : "1:N by Entry No"
+    E-Document ||--o| E-Document-Header-Mapping : "0..1 user override"
+    E-Document ||--o{ E-Document-Line-Mapping : "0..N user overrides"
+```
+
+`E-Document Purchase Header` (`EDocumentPurchaseHeader.Table.al`) and `E-Document
+Purchase Line` (`EDocumentPurchaseLine.Table.al`) use a deliberate split-field design.
+Fields 2-100 hold external data extracted from the incoming file (vendor name, product
+code, amounts) -- these are read-only once populated. Fields 101+ hold BC-resolved
+values (prefixed `[BC]` in the caption: `[BC] Vendor No.`, `[BC] Purchase Line Type`,
+`[BC] Purchase Type No.`). The BC fields are editable by the user on the draft page
+and are what the Finish draft step uses to create the real purchase document.
+
+`E-Document Header Mapping` (`EDocumentHeaderMapping.Table.al`) captures user
+overrides at the header level -- primarily vendor number and purchase order number.
+`E-Document Line Mapping` (`EDocumentLineMapping.Table.al`) captures line-level
+overrides: purchase line type, item/GL account number, UOM, deferral code, dimensions,
+item reference, and variant code. These mapping records persist across re-processing
+so the user does not lose manual corrections.
+
+Both purchase draft tables are ephemeral -- they are created during Read into Draft
+and deleted when the e-document reaches Processed status or is deleted.
+
+## Purchase order matching
+
+For the three-way match scenario (invoice against PO and receipt), a separate set
+of tables tracks the matching configuration and results.
+
+```mermaid
+erDiagram
+    E-Document-Purchase-Line ||--o{ E-Doc-Purchase-Line-PO-Match : "matched to PO"
+    E-Doc-Purchase-Line-PO-Match }o--|| Purchase-Line : "PO line"
+    E-Doc-Purchase-Line-PO-Match }o--|| Purch-Rcpt-Line : "receipt line"
+    E-Doc-PO-Matching-Setup ||--o| Vendor : "per-vendor or global"
+```
+
+`E-Doc. Purchase Line PO Match` (`EDocPurchaseLinePOMatch.Table.al`) records the
+finalized three-way match. Its composite key is (E-Doc Purchase Line SystemId,
+Purchase Line SystemId, Receipt Line SystemId) -- one draft line can match to
+multiple PO line + receipt line combinations.
+
+`E-Doc. PO Matching Setup` (`EDocPOMatchingSetup.Table.al`) controls matching
+behavior. It can be scoped to a specific vendor via `"Vendor No."` or left blank
+for a global default. The `GetSetup` procedure tries vendor-specific first, then
+falls back to global. Key settings include receipt matching configuration and whether
+to receive G/L account lines.
+
+## Historical learning
+
+After a purchase invoice is posted, the system captures the mapping decisions as
+immutable history records. These are used to auto-resolve future e-documents from the
+same vendor.
+
+```mermaid
+erDiagram
+    E-Doc-Purchase-Line-History }o--|| Purch-Inv-Line : "linked via SystemId"
+    E-Doc-Purchase-Line-History }o--|| Vendor : "scoped by Vendor No"
+    E-Doc-Vendor-Assign-History }o--|| Purch-Inv-Header : "linked via SystemId"
+```
+
+`E-Doc. Purchase Line History` (`EDocPurchaseLineHistory.Table.al`) stores the
+product code and description from the draft line alongside the SystemId of the posted
+`Purch. Inv. Line` it was mapped to. The table has multiple secondary keys optimized
+for lookup: (Vendor No., Product Code, Description), (Vendor No., Product Code), and
+(Vendor No., Description). This is what enables historical matching during the Prepare
+draft step -- the system finds prior confirmed mappings for the same vendor and
+product code.
+
+`E-Doc. Vendor Assign. History` (`EDocVendorAssignHistory.Table.al`) stores the
+vendor identification fields from the e-document header (company name, address, VAT
+ID, GLN) alongside the SystemId of the posted `Purch. Inv. Header`. The `"Vendor No
+From Purch. Header"` FlowField resolves the actual vendor number. This enables
+automatic vendor assignment for future e-documents with matching identification data.
+
+Both history tables are append-only. They grow over time as more invoices are
+processed and provide progressively better auto-matching.
+
+## Additional fields
+
+The additional fields mechanism provides extensibility for service-specific data on
+draft lines that does not fit into the standard purchase line fields.
+
+```mermaid
+erDiagram
+    E-Document-Purchase-Line ||--o{ E-Document-Line-Field : "custom field values"
+    E-Document-Line-Field }o--|| ED-Purchase-Line-Field-Setup : "field definition"
+```
+
+`E-Document Line - Field` (`EDocumentLineField.Table.al`) is a key-value store keyed
+by (E-Document Entry No., Line No., Field No.). It supports multiple typed value
+columns (Text, Decimal, Date, Boolean, Code, Integer) so the caller picks the
+appropriate one. The `"E-Document Service"` field scopes the custom field to a
+specific service.
+
+`ED Purchase Line Field Setup` (`EDocPurchLineFieldSetup.Table.al`) defines the
+available custom fields -- their names, types, and which service they belong to. The
+AdditionalFields/ subfolder includes pages for setup and editing.
+
+## Cross-cutting patterns
+
+**External vs BC-resolved field split**: The draft tables consistently use fields
+2-100 for external data and 101+ for BC-resolved data. This is a deliberate design
+decision -- it keeps the original document data immutable while allowing the BC
+mapping to be independently corrected and re-run.
+
+**SystemId linking**: The framework uses SystemId (Guid) rather than RecordId for
+cross-table references, particularly in `E-Doc. Record Link`, `E-Doc. Purchase Line
+PO Match`, and the history tables. SystemId survives record modifications and is
+globally unique, which matters because draft records are frequently modified during
+processing.
+
+**Ephemeral lifecycle**: Draft tables (`E-Document Purchase Header`, `E-Document
+Purchase Line`, `E-Doc. Record Link`) exist only during active processing. They are
+created during Read into Draft and cleaned up during Finish draft. If the user deletes
+the created purchase document, the framework undoes the Finish draft step and restores
+the Draft ready state, recreating the ephemeral records.

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/docs/CLAUDE.md
@@ -1,0 +1,17 @@
+# Order matching
+
+Line-level matching between incoming e-invoices and existing purchase orders. This is the core of the purchase invoice import flow -- when a vendor sends an invoice referencing a PO, each invoice line must be matched to the correct PO line before the purchase invoice can be created.
+
+## Data model
+
+`EDocImportedLine.Table.al` holds a normalized view of the imported invoice lines, extracted from whatever XML format the e-document arrived in. This abstraction lets the matching logic work identically regardless of source format. Key fields include quantity, unit price, and UOM -- plus "Matched Quantity" to track partial matches.
+
+`EDocOrderMatch.Table.al` stores proposed matches between imported lines and PO lines. It tracks whether the match is a precise quantity match, flags price discrepancies between what the vendor invoiced and what the PO specifies, and has a "Learn Matching Rule" flag that tells the system to remember this match for future documents from the same vendor.
+
+## Three matching modes
+
+- **Manual** -- users work through matches in the `EDocOrderLineMatching.Page.al` UI, dragging imported lines to PO lines
+- **Automatic** -- `EDocLineMatching.Codeunit.al` matches on Type, No., Unit Price, and UOM. Fast but only catches exact matches.
+- **Copilot** -- the `Copilot/` subfolder contains `EDocPOCopilotMatching.Codeunit.al` which uses AI to propose matches for ambiguous cases where descriptions or codes differ between vendor and buyer systems
+
+Partial matching is supported throughout -- a single PO line for 100 units can be matched against an invoice line for 60 units, leaving the remainder open for a future invoice. Price discrepancies are tracked and surfaced in the UI rather than silently accepted.

--- a/src/Apps/W1/EDocument/App/src/Processing/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/docs/CLAUDE.md
@@ -1,0 +1,63 @@
+# Processing
+
+Processing is the core orchestration layer of the E-Document framework. It owns both
+the outbound export pipeline (turning BC documents into electronic documents) and the
+inbound import pipeline (turning received files into BC purchase documents or journal
+lines). Every e-document flows through this folder at some point in its lifecycle.
+
+## How it works
+
+**Export** is driven by `EDocExport.Codeunit.al`. When a sales or purchase document
+is posted, `EDocumentSubscribers.Codeunit.al` hooks the posting events and calls
+`EDocExport.CreateEDocument`. The export codeunit resolves the Document Sending
+Profile, discovers which E-Document Services apply via the workflow, maps fields using
+`E-Doc. Mapping` records, and calls the format interface (`"E-Document"` interface) to
+produce the output blob. Batch mode is supported -- the service can opt into
+`"Use Batch Processing"` to defer the format call until multiple documents are
+collected.
+
+**Import** has two codepaths. V1 (`EDocImport.Codeunit.al`) calls `GetBasicInfo` and
+`GetCompleteInfo` directly on the format interface, then creates a purchase document or
+journal line in one shot. V2 (`ImportEDocumentProcess.Codeunit.al` in the Import/
+subfolder) is a four-stage state machine -- Structure, Read, Prepare, Finish -- where
+each stage is backed by a separate interface from the Interfaces/ subfolder. V2
+introduces draft tables (`E-Document Purchase Header` / `E-Document Purchase Line`)
+as an intermediate staging area that users can review and correct before the final BC
+document is created. The `EDocImport` codeunit acts as the entry point for both paths
+and delegates to `ImportEDocumentProcess` for V2.
+
+The Interfaces/ subfolder defines the contract layer: 18 interfaces covering every
+pluggable step of the import pipeline (structuring, reading, vendor/item resolution,
+PO matching, draft finalization) plus export eligibility and AI system integration.
+
+## Things to know
+
+- V1 vs V2 is determined per service via `GetImportProcessVersion()`. V1 only uses
+  the "Finish draft" step, which internally calls the old `V1_ProcessEDocument` path.
+  V2 uses all four steps and the draft tables.
+
+- `EDocumentSubscribers.Codeunit.al` subscribes to posting events for Sales, Purchase,
+  Service, Finance Charge Memos, Reminders, and Transfer Shipments. It also hooks
+  `OnBeforeOnDelete` on Purchase Header to undo the draft when a linked purchase
+  document is deleted.
+
+- Every processing step follows the commit-run-log pattern: `Commit()` first, then
+  `Codeunit.Run()` inside a TryFunction boundary so errors are captured rather than
+  propagated. Errors are logged via `EDocumentErrorHelper` and the service status is
+  updated accordingly.
+
+- `EDocRecordLink.Table.al` provides SystemId-based links between draft records and
+  their corresponding BC records. These links are ephemeral -- they exist only while
+  the draft is active and are cleaned up when the draft is finalized or reverted.
+
+- The AI/ subfolder contains `EDocAIToolProcessor.Codeunit.al` and buffer tables for
+  AI-assisted matching (historical line matching, GL account suggestion). These are
+  invoked during the Prepare draft step when Copilot capabilities are enabled.
+
+- `EDocAttachmentProcessor.Codeunit.al` extracts PDF attachments from structured
+  documents (typically PEPPOL XML with embedded base64 PDFs) and stores them as
+  Document Attachments. Attachments are moved from the E-Document to the final
+  purchase document during the Finish draft step.
+
+- Export uses `IExportEligibilityEvaluator` to let services decide per-document
+  whether export should happen, beyond just document type support.

--- a/src/Apps/W1/EDocument/App/src/Processing/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/docs/business-logic.md
@@ -1,0 +1,152 @@
+# Processing business logic
+
+## Export flow
+
+Export is initiated when a BC document is posted and the Document Sending Profile
+routes it to the E-Document framework. `EDocumentSubscribers.Codeunit.al` subscribes
+to posting events (`OnAfterPostSalesDoc`, `OnAfterPostPurchaseDoc`,
+`OnAfterPostServiceDoc`, etc.) and calls `EDocExport.CreateEDocument`.
+
+The export sequence in `EDocExport.Codeunit.al`:
+
+1. Resolve the Document Sending Profile for the customer/vendor, then look up the
+   workflow to find which E-Document Services apply.
+2. Filter services to those supporting the document type, using
+   `IExportEligibilityEvaluator` for per-document opt-out.
+3. Create the `E-Document` record (Direction = Outgoing, Status = In Progress).
+4. Populate header fields from the source document using RecordRef field reads.
+5. For each applicable service, map fields via `E-Doc. Mapping` records (the mapping
+   supports both import and export directions), then call the format interface's
+   `Create` procedure to produce the output blob.
+6. Log the result and update the service status to Exported or Export Error.
+
+**Batch mode**: When `"Use Batch Processing"` is set on the service, `ExportEDocument`
+is skipped during the initial loop. Instead, `ExportEDocumentBatch` accumulates all
+mapped headers and lines into a single call to `CreateEDocumentBatch`, which invokes
+the format interface once for the entire batch.
+
+A deliberate design choice: the export uses RecordRef throughout rather than typed
+records. This lets the same codeunit handle Sales, Purchase, Service, Finance Charge,
+Reminder, and Transfer Shipment documents without separate code paths.
+
+## V2 import pipeline
+
+The V2 import is a four-stage state machine defined in
+`ImportEDocumentProcess.Codeunit.al`. Each stage transitions the e-document to a new
+processing status, and each can be individually run or undone.
+
+```mermaid
+flowchart TD
+    A["Unprocessed<br/>(raw file received)"] -->|"Structure received data"| B["Readable<br/>(structured format)"]
+    B -->|"Read into Draft"| C["Ready for draft<br/>(draft tables populated)"]
+    C -->|"Prepare draft"| D["Draft ready<br/>(vendor/items resolved)"]
+    D -->|"Finish draft"| E["Processed<br/>(BC document created)"]
+
+    B -.->|"undo"| A
+    C -.->|"undo"| B
+    D -.->|"undo"| C
+    E -.->|"undo"| D
+
+    A2["PDF / Image"] -->|"ADI or MLLM"| B
+    A3["PEPPOL XML"] -->|"Already Structured"| B
+    B2["XML"] -->|"PEPPOL Reader"| C
+    B3["JSON (ADI output)"] -->|"ADI Reader"| C
+```
+
+**Stage 1 -- Structure received data** (Unprocessed -> Readable): The
+`IStructureReceivedEDocument` interface converts raw input (PDF, image, XML) into a
+structured format. For PEPPOL XML, the implementation is "Already Structured" -- it
+just passes through. For PDFs and images, Azure Document Intelligence (ADI) or a
+multimodal LLM (MLLM) extracts the data. The structured result specifies which
+`IStructuredFormatReader` should handle the next stage.
+
+**Stage 2 -- Read into Draft** (Readable -> Ready for draft): The
+`IStructuredFormatReader` interface parses the structured data and populates the
+`E-Document Purchase Header` and `E-Document Purchase Line` staging tables. At this
+point the draft contains only external data (vendor name, product codes, amounts) --
+no BC entity resolution has happened.
+
+**Stage 3 -- Prepare draft** (Ready for draft -> Draft ready): The
+`IProcessStructuredData` / `IPrepareDraft` interface resolves external data to BC
+entities. This is where `IVendorProvider` matches vendor names/VAT IDs to Vendor
+records, `IItemProvider` and `IPurchaseLineProvider` resolve product codes to Items or
+G/L Accounts, and `IPurchaseLineAccountProvider` handles GL account mapping. AI
+matching tools (historical matching, similar description matching) run here when
+enabled. The user can review and correct the draft on the Purchase Draft page.
+
+**Stage 4 -- Finish draft** (Draft ready -> Processed): The `IEDocumentFinishDraft`
+interface creates the actual BC purchase document. For purchase invoices, this is
+handled by `EDocCreatePurchaseInvoice.Codeunit.al` in the FinishDraft/ subfolder.
+Attachments are moved from the E-Document to the created purchase document. The draft
+tables and record links are cleaned up.
+
+The pipeline supports bidirectional navigation: `EDocImport.GetEDocumentToDesiredStatus`
+can undo steps to return to an earlier state, then re-run forward. This is how the
+"re-process" action on the draft page works.
+
+## V1 vs V2 difference
+
+V1 (the original import path in `EDocImport.Codeunit.al`) does everything in a single
+pass: `GetBasicInfo` extracts header-level data, `GetCompleteInfo` parses lines into
+temporary Purchase Header/Line RecordRefs, then the codeunit immediately creates the
+BC purchase document or journal line. There is no staging area, no draft review, no
+undo capability.
+
+V2 decouples these concerns into four explicit stages with persistent draft tables.
+The V1 path is preserved for backward compatibility -- when
+`GetImportProcessVersion()` returns "Version 1.0", the `ImportEDocumentProcess`
+codeunit short-circuits to the old `V1_ProcessEDocument` call, but only on the
+"Finish draft" step.
+
+## Purchase document creation
+
+`EDocumentCreatePurchDoc.Codeunit.al` handles V1 purchase document creation. It
+receives temporary RecordRefs for header and lines and creates real Purchase Header /
+Purchase Line records using field-by-field validation through RecordRef.
+
+The document type is determined by the vendor configuration:
+
+- If `Vendor."Receive E-Document To"` is set to Purchase Order and the incoming
+  document is not a credit memo, the framework tries to match an existing PO. If a PO
+  with matching `"Order No."` exists, lines are imported and the PO is linked via
+  `"E-Document Link"`. If no PO is found, the user can select one or a new PO is
+  created.
+- Otherwise, a Purchase Invoice or Purchase Credit Memo is created based on the
+  document type from the incoming data.
+
+The codeunit fires integration events at key points (`OnBeforeProcessHeaderFieldsAssignment`,
+`OnBeforeProcessLineFieldsValidation`, etc.) so extensions can inject additional field
+handling.
+
+## Journal line creation
+
+`EDocumentCreateJnlLine.Codeunit.al` provides an alternative import path that creates
+a General Journal Line instead of a purchase document. This is configured per service
+via `"Create Journal Lines"`. The codeunit reads the journal template and batch from
+the service configuration, creates the journal line with amounts from the e-document,
+and optionally applies text-to-account mapping for automatic G/L account assignment.
+
+## Attachment processing
+
+`EDocAttachmentProcessor.Codeunit.al` handles PDF attachments that are embedded in
+structured e-documents (common in PEPPOL XML, where the original PDF invoice is
+base64-encoded inside the XML). The `Insert` procedure stores the attachment as a
+Document Attachment linked to the E-Document. During the Finish draft step,
+`MoveAttachmentsAndDelete` transfers attachments to the final purchase document and
+cleans up the E-Document copies.
+
+## AI matching tools
+
+The AI/ subfolder contains `EDocAIToolProcessor.Codeunit.al` with buffer tables
+`EDocHistoricalMatchBuffer` and `EDocLineMatchBuffer`. These support Copilot-powered
+matching during the Prepare draft step:
+
+- **Historical matching**: Looks up `E-Doc. Purchase Line History` for previously
+  confirmed mappings from the same vendor with similar product codes or descriptions.
+- **GL account suggestion**: Uses AI to suggest appropriate G/L accounts when no item
+  match is found.
+- **Similar description matching**: Finds items with similar descriptions using AI
+  text comparison.
+
+The AI system integration point is defined by the `IEDocAISystem` interface in the
+Interfaces/ subfolder.

--- a/src/Apps/W1/EDocument/App/src/Service/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Service/docs/CLAUDE.md
@@ -1,0 +1,21 @@
+# Service
+
+The E-Document Service (table 6103) is the configuration hub that binds a document format to a transport integration and defines all the behavioral flags for import processing. Each service represents one endpoint -- a specific e-invoicing network, tax authority, or clearance provider -- and an E-Document is processed through exactly one service at a time.
+
+## How it works
+
+Format and transport are independent dimensions. `Document Format` selects how the document is serialized (PEPPOL via code-based format, or Data Exchange Definition for custom mappings), while `Service Integration V2` selects the transport connector that sends and receives over the wire. This separation means the same PEPPOL format can be sent through different service connectors, or the same connector can carry different formats.
+
+The service carries a large set of import behavior flags that control what happens when an inbound document is processed: `Validate Receiving Company`, `Resolve Unit Of Measure`, `Lookup Item GTIN`, `Lookup Item Reference`, `Lookup Account Mapping`, `Validate Line Discount`, `Apply Invoice Discount`, `Verify Totals`, and `Verify Purch. Total Amounts`. These flags are consulted by the import processing pipeline and allow each service to tune validation strictness independently.
+
+The `Import Process` field is a critical fork: "Version 1.0" routes through the legacy import path while "Version 2.0" uses the new structured import pipeline with its own draft-based processing model and `Import Processing Status` tracking. The `Automatic Import Processing` flag controls whether imported documents are processed immediately or left for manual review. Batch processing is configured through `Use Batch Processing`, `Batch Mode` (threshold-based or time-based), and related scheduling fields that manage background job queue entries.
+
+## Things to know
+
+- `Import Process` V1 vs V2 selects entirely different code paths. V2 uses `Structure Data Impl.`, `Read into Draft Impl.`, and `Process Draft Impl.` on the E-Document to drive a multi-step pipeline. V1 uses the monolithic `V1_ProcessImportedDocument` path.
+- `E-Doc. Service Supported Type` (table 6122) filters which E-Document Types a service handles. If no supported types are configured, the service accepts all types.
+- Auto import scheduling is driven by `Auto Import`, `Import Start Time`, and `Import Minutes between runs`. These fields create and manage a recurrent job queue entry stored in `Import Recurrent Job Id`.
+- Service Participants (`ServiceParticipant.Table.al`) link customers or vendors to a service with an external `Participant Identifier`. This is how the framework resolves which service to use for a given trading partner and provides the external ID (like a PEPPOL participant ID) needed by the service connector.
+- The `Service Integration V2` field triggers `IConsentManager.ObtainPrivacyConsent()` when first set to a non-empty value, ensuring GDPR consent before any data flows to an external service.
+- Batch sending is configured per-service with its own job queue entry (`Batch Recurrent Job Id`). The `Batch Mode` enum controls whether batching triggers on document count threshold or on a time schedule.
+- The `Embed PDF in export` flag causes the framework to generate a PDF from Report Selection as a background process and embed it into the export file during posting.

--- a/src/Apps/W1/EDocument/App/src/Workflow/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Workflow/docs/CLAUDE.md
@@ -1,0 +1,23 @@
+# Workflow
+
+Workflow integration that drives the outbound e-document processing pipeline. E-document sending is not a direct API call -- it flows through BC's workflow engine using "when event, then response" rules.
+
+## Architecture
+
+`EDocumentWorkFlowSetup.Codeunit.al` installs workflow templates on module setup and subscribes to the events that trigger e-document processing. The key templates are "Send to one service" and "Send to multiple services" -- these define the standard outbound paths.
+
+`EDocumentWorkFlowProcessing.Codeunit.al` orchestrates the actual workflow execution. When a workflow fires, this codeunit coordinates the export-then-send sequence through the service interface.
+
+`EDocumentCreatedFlow.Codeunit.al` handles the initial "E-Document Created" event that kicks off the pipeline.
+
+## Clearance model support
+
+For countries using tax authority clearance (Spain, Italy, India), workflows support multi-step chains: export to clearance service, wait for "Cleared" status, export to delivery service, send. This is configured by chaining workflow steps rather than requiring custom code.
+
+## How workflows get selected
+
+Document Sending Profiles on customer records determine which workflow fires for a given document. When a user posts a sales invoice, the customer's sending profile routes it to the correct e-document workflow. The `Sending/` subfolder in `src/Extensions/` handles this integration point.
+
+## Extension points
+
+`EDocWorkflowStepArgument.TableExt.al` and `EDocWorkflowResponseOptions.PageExt.al` extend BC's standard workflow step arguments to carry e-document-specific parameters (service selection, format options). The archived version (`EDocWorkflowStepArgumentArch.TableExt.al`) preserves these parameters for completed workflows.


### PR DESCRIPTION
## Summary

- Bootstrap hierarchical documentation for the E-Document Core app
- 22 files across 15 directories covering architecture, data model, business logic, extensibility, and patterns
- Documents the interface-driven plugin architecture, dual status machines, V2 import pipeline, order matching, and AI-assisted matching

### App-level docs (5 files)
- `CLAUDE.md` -- mental model, structure, key design decisions
- `docs/data-model.md` -- conceptual data model with mermaid ER diagrams
- `docs/business-logic.md` -- outbound/inbound flows with mermaid flowcharts
- `docs/extensibility.md` -- 28 interfaces grouped by developer intent with code examples
- `docs/patterns.md` -- 8 architectural patterns + 3 legacy patterns

### Subfolder CLAUDE.md files (14 files)
Processing, Processing/Import, Integration, Document, Service, Extensions, Format, Logging, Mapping, Workflow, DataExchange, Processing/OrderMatching, Processing/AI, ClearanceModel

### Subfolder specialized docs (3 files)
- `src/Processing/docs/business-logic.md` -- V2 import pipeline, export flow
- `src/Processing/Import/docs/data-model.md` -- draft tables, PO matching, historical learning
- `src/Integration/docs/extensibility.md` -- connector extension points

## Test plan

- [ ] Verify all 22 files render correctly on GitHub (especially mermaid diagrams)
- [ ] Verify cross-references between docs resolve correctly
- [ ] Review content accuracy against source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
