### PR TITLE
Send To Email Printer Docs

### DIFF
--- a/src/Apps/W1/SendToEmailPrinter/App/CLAUDE.md
+++ b/src/Apps/W1/SendToEmailPrinter/App/CLAUDE.md
@@ -1,0 +1,118 @@
+# Send To Email Printer
+
+Cloud printing solution that sends report output as PDF attachments to a
+printer's email address. Any printer with an email interface (HP ePrint,
+Google Cloud Print-compatible devices, etc.) can receive jobs from Business
+Central without VPN or direct network access.
+
+## Quick reference
+
+**Entry point:** Printer Management page extension adds "Add an email printer"
+action. Opens Email Printer Settings card.
+
+**Core flow:**
+1. User configures printer via Email Printer Settings (2650) -- name,
+   destination address, paper size, orientation
+2. SetupPrinters codeunit (2650) subscribes to platform SetupPrinters event,
+   broadcasts all configured email printers as JSON with paper tray config
+3. User selects email printer in report request page or Printer Selection
+4. OnDocumentPrintReady platform event fires when report renders to PDF
+5. DocumentPrintReady codeunit (2651) looks up settings, constructs email
+   with PDF attachment, sends via Email module using "Email Printer" scenario
+
+**ID ranges:** 2650-2655, 5650-5660 (18 objects total)
+
+## How it works
+
+### Platform integration
+
+Business Central's print architecture uses JSON-based printer discovery.
+SetupPrinters codeunit subscribes to OnSetupPrinters and emits one JSON
+printer entry per Email Printer Settings record:
+
+```json
+{
+  "name": "HP Warehouse Printer",
+  "paperTrays": [{
+    "papersource": "Main Tray",
+    "paperkind": "Custom",
+    "units": "HI",
+    "width": 830,
+    "height": 1170,
+    "landscape": false
+  }]
+}
+```
+
+Width/height are multiplied by 100 (platform expects hundredths of unit).
+Units are "HI" (hundredths of inch) or "HMM" (hundredths of millimeter).
+
+When a report prints to an email printer, the platform renders the PDF and
+fires OnDocumentPrintReady with printer name and document stream.
+
+### Email construction
+
+DocumentPrintReady builds an email using the Email module:
+- **To:** Email Address from settings
+- **Subject:** configurable subject line (can include {1} placeholder for printer name)
+- **Body:** configurable body text
+- **Attachment:** PDF stream from platform, named "Document.pdf"
+
+Uses "Email Printer" scenario (enum extension adds value 202 to base Email
+Scenario enum). No retry logic -- send failures surface to user immediately.
+
+### Configuration validation
+
+Email Printer Settings card enforces:
+- Email address format validation
+- Privacy notification when entering email address
+- Progressive disclosure (custom paper dimension fields only shown when
+  Paper Size = Custom)
+- Default to A4 dimensions (8.3" x 11.7") if custom size fields empty
+- Delete blocked if printer referenced in Printer Selection table
+
+## Structure
+
+**Table:** Email Printer Settings (2650) -- singleton per printer. 10 fields:
+ID, Description, Email Address, Email Subject/Body, Paper Size enum, Paper
+Height/Width/Unit, Landscape boolean.
+
+**Codeunits:**
+- SetupPrinters (2650) -- platform event subscribers for printer discovery
+  and settings page launch
+- DocumentPrintReady (2651) -- OnDocumentPrintReady subscriber, email send logic
+
+**UI:** Email Printer Settings card (2650), Printer Management page extension
+
+**Enums:** Email Printer Paper Unit (inches/millimeters), Email Printer
+Scenario (enum extension)
+
+**Permissions:** 11 permission objects for various roles (5650-5660)
+
+## Dependencies
+
+None. Uses platform Email module APIs and print events.
+
+## Things to know
+
+- **No authentication:** Relies on printer accepting email from any sender.
+  Some printers require sender whitelist configuration.
+
+- **Synchronous send:** Email send happens in OnDocumentPrintReady event
+  handler. Long SMTP timeouts or failures block the print operation.
+
+- **No job tracking:** No correlation between print job and email message ID.
+  Can't query whether printer received/processed the job.
+
+- **Custom paper defaults:** If Paper Size = Custom but dimensions are empty,
+  defaults to A4 (8.3" x 11.7" in inches). User must switch units explicitly
+  if millimeters desired.
+
+- **Telemetry events:**
+  - `0001JHV` -- Discovered (page opened)
+  - `0002JHW` -- Setup (printer configured)
+  - `0003JHX` -- Used (print job sent)
+
+- **Email scenario:** Extends base Email Scenario enum with "Email Printer"
+  value. Uses Email module's connector and account selection logic. If no
+  email account configured for scenario, send fails with actionable error.

--- a/src/Apps/W1/SendToEmailPrinter/App/docs/business-logic.md
+++ b/src/Apps/W1/SendToEmailPrinter/App/docs/business-logic.md
@@ -1,0 +1,89 @@
+# Business logic
+
+This document describes the core business logic of the Send To Email Printer feature.
+
+## Print flow
+
+The email printer handles print jobs through a platform event-driven flow:
+
+1. **Platform trigger**: The Business Central platform fires the `OnDocumentPrintReady` event when a document is ready to print
+2. **Event handler**: Codeunit 2651 "Email Printer Document Ready" subscribes to this event
+3. **Early exit conditions**: The handler exits immediately if:
+   - The `Success` parameter is already true (another printer handled it)
+   - The payload object type is not a Report
+4. **Printer identification**: Extracts the `printername` value from the `ObjectPayload` JSON
+5. **Settings lookup**: Retrieves the Email Printer Settings record matching the printer name
+6. **Email validation**: Validates that a valid email address is configured
+7. **Account selection**: Gets the appropriate email account for the "Email Printer" scenario
+8. **Email construction**: Builds the email message with:
+   - Subject and body text from Email Printer Settings
+   - PDF attachment from the `DocumentStream` parameter
+   - Attachment filename parsed from the `objectname` field in ObjectPayload plus MIME type extension
+9. **Send**: Calls `Email.Send()` to deliver the message
+10. **Telemetry**: Logs telemetry data for monitoring and diagnostics
+
+```mermaid
+flowchart TD
+    A[Platform fires OnDocumentPrintReady] --> B[Codeunit 2651 receives event]
+    B --> C{Success already true?}
+    C -->|Yes| D[Exit]
+    C -->|No| E{Is object type Report?}
+    E -->|No| D
+    E -->|Yes| F[Extract printer name from ObjectPayload JSON]
+    F --> G[Look up Email Printer Settings]
+    G --> H{Valid email address?}
+    H -->|No| D
+    H -->|Yes| I[Get email account for Email Printer scenario]
+    I --> J[Construct email message]
+    J --> K[Set subject and body from settings]
+    K --> L[Attach PDF from DocumentStream]
+    L --> M[Parse attachment name from objectname]
+    M --> N[Call Email.Send]
+    N --> O[Log telemetry]
+    O --> P[Set Success = true]
+```
+
+## Setup registration
+
+The platform discovers available printers through a registration mechanism:
+
+1. **Platform query**: The platform queries for available printers by firing the `SetupPrinters` event
+2. **Registration handler**: Codeunit 2650 "Email Printer Setup" subscribes to this event
+3. **Iteration**: The handler iterates through all Email Printer Settings records
+4. **JSON construction**: For each printer, builds a JSON structure containing:
+   - Printer version information
+   - Description text
+   - Array of paper trays with properties:
+     - Paper source name
+     - Paper kind (e.g., A4, Letter, Custom)
+     - Landscape orientation flag
+     - Height in hundredths of units
+     - Width in hundredths of units
+     - Unit type (inches or millimeters)
+5. **Validation**: Skips printers with empty ID values
+6. **Fallback handling**: For custom paper sizes, falls back to A4 dimensions if configured dimensions are invalid
+
+## Configuration
+
+Page 2650 "Email Printer Setup Card" provides the user interface for configuring email printers:
+
+- **Progressive disclosure**: Uses a card layout that reveals configuration options as needed
+- **Defaults on new record**: When creating a new printer, applies these defaults:
+  - Paper size: A4
+  - Orientation: Portrait
+  - Email subject: "Printed Copy"
+- **Email validation**: When the email address field changes:
+  - Calls `MailManagement.CheckValidEmailAddress()` to validate format
+  - Displays a privacy notification to inform users about data handling
+- **Save validation**: When the user attempts to close the page:
+  - Validates that an email address is configured
+  - For custom paper sizes, validates that dimensions are greater than zero
+
+## Deletion
+
+The system prevents accidental deletion of email printers that are in use:
+
+- **Usage check**: Before allowing deletion, checks if the printer appears in the Printer Selection table
+- **Deletion block**: If the printer is referenced by any records, blocks the delete operation and informs the user
+
+This protects against breaking existing printer configurations and ensures data integrity across the system.

--- a/src/Apps/W1/SendToEmailPrinter/App/docs/extensibility.md
+++ b/src/Apps/W1/SendToEmailPrinter/App/docs/extensibility.md
@@ -1,0 +1,76 @@
+# Extensibility
+
+This document describes the extensibility model of the Send To Email Printer feature.
+
+## Extension architecture
+
+The Send To Email Printer feature is designed as a **closed functional feature**. It is not intended to be extended by partners or ISVs. Instead, it demonstrates a pattern that partners can follow to implement their own printer types.
+
+## Platform integration points
+
+The feature integrates with Business Central through two platform event subscriptions:
+
+### SetupPrinters event
+
+- **Purpose**: Registers available email printers with the platform
+- **Handler**: Codeunit 2650 "Email Printer Setup"
+- **Behavior**: Iterates through Email Printer Settings records and builds JSON descriptors for each printer
+
+### OnDocumentPrintReady event
+
+- **Purpose**: Handles print jobs directed to email printers
+- **Handler**: Codeunit 2651 "Email Printer Document Ready"
+- **Behavior**: Processes the document stream and sends it via email
+
+## Enum extensions
+
+### Email Printer Scenario
+
+The feature extends the base Email Scenario enum to register a new scenario type:
+
+- **Enum value**: 202 ("Email Printer")
+- **Purpose**: Identifies which email account to use when sending printed documents
+- **ID range**: Uses a value outside the normal range with suppressed warnings to avoid conflicts
+
+## Page extensions
+
+### Printer Management extension
+
+The feature extends the Printer Management page to add discoverability:
+
+- **Action**: "Add an email printer" in the creation area
+- **Purpose**: Provides a clear entry point for users to configure email printers
+
+## API surface
+
+All codeunit procedures are marked as **internal**. There is no public API surface for ISVs or partners to call. This is an intentional design decision that reinforces the feature's purpose as a complete, self-contained printer implementation rather than an extensible framework.
+
+## Enum extensibility
+
+The Email Printer Paper Unit enum is **not extensible**. It is locked to two values:
+
+- Inches
+- Millimeters
+
+This restriction ensures consistent paper dimension handling across the platform.
+
+## Pattern for partners
+
+While this feature itself is not extensible, it demonstrates an **event-driven architecture** that partners can replicate:
+
+1. Subscribe to the `SetupPrinters` event to register custom printer types
+2. Subscribe to the `OnDocumentPrintReady` event to handle print jobs
+3. In the event handler, check if the printer belongs to your implementation (by name or other identifier)
+4. Exit early if the printer is not yours, allowing other subscribers to handle it
+5. Set the `Success` parameter to true if you successfully handle the job
+
+This pattern allows **multiple printer extensions to coexist** peacefully. Each subscriber checks whether the print job is directed at "their" printer type and exits if not, creating a cooperative chain of handlers.
+
+## Design philosophy
+
+The closed design reflects these principles:
+
+- **Completeness**: The feature provides a complete, working printer implementation out of the box
+- **Pattern demonstration**: It serves as a reference implementation for partners building their own printer types
+- **Stability**: By not exposing internal APIs, the implementation can evolve without breaking partner code
+- **Coexistence**: The event-driven model allows multiple printer types to work together without conflicts


### PR DESCRIPTION
## Summary
- Bootstrap documentation for **Send To Email Printer**
- Generated by `/al-docs init`

[AB#626091](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/626091)




