### PR TITLE
[releases/28.x] Fix TestManual throws "No. Series does not exist" error for blank code

### DIFF
--- a/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
+++ b/src/Business Foundation/App/NoSeries/src/Single/NoSeriesImpl.Codeunit.al
@@ -41,6 +41,8 @@ codeunit 304 "No. Series - Impl."
         NoSeries: Record "No. Series";
         NoSeriesErrorsImpl: Codeunit "No. Series - Errors Impl.";
     begin
+        if NoSeriesCode = '' then
+            exit;
         NoSeries.Get(NoSeriesCode);
         if not NoSeries."Manual Nos." then
             NoSeriesErrorsImpl.Throw(ErrorText, NoSeriesCode, NoSeriesErrorsImpl.OpenNoSeriesLinesAction());
@@ -275,17 +277,17 @@ codeunit 304 "No. Series - Impl."
         NoSeries: Record "No. Series";
         NoSeriesRelationship: Record "No. Series Relationship";
     begin
-            NoSeriesRelationship.SetRange(Code, OriginalNoSeriesCode);
-            if NoSeriesRelationship.FindSet() then
-                repeat
-                    NoSeries.Code := NoSeriesRelationship."Series Code";
-                    NoSeries.Mark := true;
-                until NoSeriesRelationship.Next() = 0;
+        NoSeriesRelationship.SetRange(Code, OriginalNoSeriesCode);
+        if NoSeriesRelationship.FindSet() then
+            repeat
+                NoSeries.Code := NoSeriesRelationship."Series Code";
+                NoSeries.Mark := true;
+            until NoSeriesRelationship.Next() = 0;
 
-            // Mark the original series
-            NoSeries.Code := OriginalNoSeriesCode;
-            NoSeries.Mark := true;
-            NoSeries.MarkedOnly := true;
+        // Mark the original series
+        NoSeries.Code := OriginalNoSeriesCode;
+        NoSeries.Mark := true;
+        NoSeries.MarkedOnly := true;
 
         // If DefaultHighlightedNoSeriesCode is set, make sure we select it by default on the page
         if DefaultHighlightedNoSeriesCode <> '' then

--- a/src/Business Foundation/Test/NoSeries/src/NoSeriesTests.Codeunit.al
+++ b/src/Business Foundation/Test/NoSeries/src/NoSeriesTests.Codeunit.al
@@ -895,6 +895,35 @@ codeunit 134530 "No. Series Tests"
     end;
 
     [Test]
+    procedure TestManualShouldAllowBlankNoSeriesCode()
+    var
+        NoSeriesCU: Codeunit "No. Series";
+    begin
+        // [SCENARIO] TestManual should allow blank No. Series Code to enable users to enter manual numbers
+        // when no number series is configured in the setup page.
+        Initialize();
+
+        // [GIVEN] No number series is configured (empty code)
+        // [WHEN] TestManual is called with blank code
+        // [THEN] No error should be thrown - blank codes indicate manual entry is allowed
+        NoSeriesCU.TestManual('');
+    end;
+
+    [Test]
+    procedure TestManualWithDocNoShouldAllowBlankNoSeriesCode()
+    var
+        NoSeriesCU: Codeunit "No. Series";
+    begin
+        // [SCENARIO] TestManual with DocumentNo should allow blank No. Series Code
+        Initialize();
+
+        // [GIVEN] No number series is configured (empty code)
+        // [WHEN] TestManual is called with blank code and a document number
+        // [THEN] No error should be thrown
+        NoSeriesCU.TestManual('', 'MANUAL-001');
+    end;
+
+    [Test]
     [HandlerFunctions('NoSeriesLinesPageHandler')]
     procedure TestEditNoSeriesLinePreservesFilter()
     var


### PR DESCRIPTION
This pull request backports #7133 to releases/28.x

Fixes [AB#625540](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625540)

