### PR TITLE
[Shopify] Make Contact No. fields editable on Shopify Order page

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
@@ -5,6 +5,7 @@
 
 namespace Microsoft.Integration.Shopify;
 
+using Microsoft.CRM.Contact;
 using Microsoft.Inventory.Item;
 using Microsoft.Sales.Customer;
 using Microsoft.Sales.Document;
@@ -66,7 +67,7 @@ page 30113 "Shpfy Order"
                 {
                     ApplicationArea = All;
                     Caption = 'Sell-to Contact No.';
-                    Editable = false;
+                    TableRelation = Contact;
                     Visible = false;
                     ToolTip = 'Specifies the number of the contact person at the sell-to customer.';
                 }
@@ -478,7 +479,7 @@ page 30113 "Shpfy Order"
                     {
                         ApplicationArea = All;
                         Caption = 'Ship-to Contact No.';
-                        Editable = false;
+                        TableRelation = Contact;
                         Visible = false;
                         ToolTip = 'Specifies the number of the contact person at the ship-to address.';
                     }
@@ -549,7 +550,7 @@ page 30113 "Shpfy Order"
                     {
                         ApplicationArea = All;
                         Caption = 'Bill-to Contact No.';
-                        Editable = false;
+                        TableRelation = Contact;
                         Visible = false;
                         ToolTip = 'Specifies the number of the contact person at the bill-to customer.';
                     }


### PR DESCRIPTION
## Summary
- Removed `Editable = false` from Sell-to, Bill-to, and Ship-to Contact No. fields on the Shopify Order page so users can manually populate and adjust them
- Added `TableRelation = Contact` to all three fields to enable contact lookup

Fixes [AB#624380](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624380)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
