### PR TITLE
[Shopify] Fix silent DB:RecordExists error when reprocessing order after unlink

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyOrdersAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyOrdersAPI.Codeunit.al
@@ -119,9 +119,13 @@ codeunit 30165 "Shpfy Orders API"
         Clear(OrderAttribute);
         OrderAttribute."Order Id" := OrderHeader."Shopify Order Id";
         OrderAttribute."Key" := CopyStr(KeyName, 1, MaxStrLen(OrderAttribute."Key"));
-        OrderAttribute."Attribute Value" := CopyStr(Value, 1, MaxStrLen(OrderAttribute."Attribute Value"));
-        if not OrderAttribute.Insert() then
+        if OrderAttribute.Get(OrderAttribute."Order Id", OrderAttribute."Key") then begin
+            OrderAttribute."Attribute Value" := CopyStr(Value, 1, MaxStrLen(OrderAttribute."Attribute Value"));
             OrderAttribute.Modify();
+        end else begin
+            OrderAttribute."Attribute Value" := CopyStr(Value, 1, MaxStrLen(OrderAttribute."Attribute Value"));
+            OrderAttribute.Insert();
+        end;
 
         Clear(OrderAttribute);
         OrderAttribute.SetRange("Order Id", OrderHeader."Shopify Order Id");


### PR DESCRIPTION
## Summary
- Replace `if not Insert() then Modify()` with a Get-first pattern in `AddOrderAttribute` to prevent a failed `Insert()` from silently setting the last error to `DB:RecordExists`
- When reprocessing an order after unlinking, the order attribute already exists from the first processing. The old pattern's `Insert()` call failed internally (setting the last error) even though `Modify()` then succeeded. The "?" view exposed this silent error to users.

Fixes [AB#626719](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/626719)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

