### PR TITLE
[28.x] Fix eDocument PEPPOL BIS 3.0 import errors for text-only document references and hierarchical line IDs

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Format/EDocImportPEPPOLBIS30.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Format/EDocImportPEPPOLBIS30.Codeunit.al
@@ -188,6 +188,7 @@ codeunit 6166 "EDoc Import PEPPOL BIS 3.0"
         DocumentAttachment: Record "Document Attachment";
         DocumentAttachmentData: Codeunit "Temp Blob";
         InStream: InStream;
+        LineNo: Integer;
     begin
         PurchaseHeader."Document Type" := PurchaseHeader."Document Type"::Invoice;
         PurchaseHeader."No." := CopyStr(GetNodeByPath(TempXMLBuffer, '/Invoice/cbc:ID'), 1, MaxStrLen(PurchaseHeader."No."));
@@ -198,11 +199,11 @@ codeunit 6166 "EDoc Import PEPPOL BIS 3.0"
         TempXMLBuffer.Reset();
         if TempXMLBuffer.FindSet() then
             repeat
-                ParseInvoice(EDocument, PurchaseHeader, PurchaseLine, DocumentAttachment, DocumentAttachmentData, TempXMLBuffer);
+                ParseInvoice(EDocument, PurchaseHeader, PurchaseLine, DocumentAttachment, DocumentAttachmentData, TempXMLBuffer, LineNo);
             until TempXMLBuffer.Next() = 0;
 
         // Insert last document attachment
-        if DocumentAttachment."No." <> '' then begin
+        if (DocumentAttachment."No." <> '') and (DocumentAttachment."File Name" <> '') then begin
             DocumentAttachmentData.CreateInStream(InStream, TextEncoding::UTF8);
             EDocumentAttachmentGen.Insert(EDocument, InStream, DocumentAttachment.FindUniqueFileName(DocumentAttachment."File Name", DocumentAttachment."File Extension"));
             Clear(DocumentAttachment);
@@ -222,6 +223,7 @@ codeunit 6166 "EDoc Import PEPPOL BIS 3.0"
         DocumentAttachment: Record "Document Attachment";
         DocumentAttachmentData: Codeunit "Temp Blob";
         InStream: InStream;
+        LineNo: Integer;
     begin
         PurchaseHeader."Document Type" := PurchaseHeader."Document Type"::"Credit Memo";
         PurchaseHeader."No." := CopyStr(GetNodeByPath(TempXMLBuffer, '/CreditNote/cbc:ID'), 1, MaxStrLen(PurchaseHeader."No."));
@@ -230,11 +232,11 @@ codeunit 6166 "EDoc Import PEPPOL BIS 3.0"
         TempXMLBuffer.Reset();
         if TempXMLBuffer.FindSet() then
             repeat
-                ParseCreditMemo(EDocument, PurchaseHeader, PurchaseLine, DocumentAttachment, DocumentAttachmentData, TempXMLBuffer);
+                ParseCreditMemo(EDocument, PurchaseHeader, PurchaseLine, DocumentAttachment, DocumentAttachmentData, TempXMLBuffer, LineNo);
             until TempXMLBuffer.Next() = 0;
 
         // Insert last document attachment
-        if DocumentAttachment."No." <> '' then begin
+        if (DocumentAttachment."No." <> '') and (DocumentAttachment."File Name" <> '') then begin
             DocumentAttachmentData.CreateInStream(InStream, TextEncoding::UTF8);
             EDocumentAttachmentGen.Insert(EDocument, InStream, DocumentAttachment.FindUniqueFileName(DocumentAttachment."File Name", DocumentAttachment."File Extension"));
             Clear(DocumentAttachment);
@@ -311,7 +313,7 @@ codeunit 6166 "EDoc Import PEPPOL BIS 3.0"
     /// Parses credit memo information line by line from TempXMLBuffer.
     /// We handle the insert of Purchase Order Line and Document Attachment after the call to this function.
     /// </summary>
-    local procedure ParseCreditMemo(EDocument: Record "E-Document"; var PurchaseHeader: Record "Purchase Header" temporary; var PurchaseLine: record "Purchase Line" temporary; var DocumentAttachment: Record "Document Attachment"; DocumentAttachmentData: Codeunit "Temp Blob"; var TempXMLBuffer: Record "XML Buffer" temporary)
+    local procedure ParseCreditMemo(EDocument: Record "E-Document"; var PurchaseHeader: Record "Purchase Header" temporary; var PurchaseLine: record "Purchase Line" temporary; var DocumentAttachment: Record "Document Attachment"; DocumentAttachmentData: Codeunit "Temp Blob"; var TempXMLBuffer: Record "XML Buffer" temporary; var LineNo: Integer)
     var
         Base64Convert: Codeunit "Base64 Convert";
         OutStream: OutStream;
@@ -352,7 +354,7 @@ codeunit 6166 "EDoc Import PEPPOL BIS 3.0"
                     Evaluate(PurchaseHeader.Amount, Value, 9);
             '/CreditNote/cac:AdditionalDocumentReference/cbc:ID':
                 begin
-                    if DocumentAttachment."No." <> '' then begin
+                    if (DocumentAttachment."No." <> '') and (DocumentAttachment."File Name" <> '') then begin
                         DocumentAttachmentData.CreateInStream(InStream, TextEncoding::UTF8);
                         EDocumentAttachmentGen.Insert(EDocument, InStream, DocumentAttachment.FindUniqueFileName(DocumentAttachment."File Name", DocumentAttachment."File Extension"));
                         Clear(DocumentAttachment);
@@ -381,6 +383,8 @@ codeunit 6166 "EDoc Import PEPPOL BIS 3.0"
                     PurchaseLine.Init();
                     PurchaseLine."Document Type" := PurchaseHeader."Document Type";
                     PurchaseLine."Document No." := PurchaseHeader."No.";
+                    LineNo += 10000;
+                    PurchaseLine."Line No." := LineNo;
                 end;
             '/CreditNote/cac:CreditNoteLine/cbc:CreditedQuantity':
                 if Value <> '' then
@@ -404,8 +408,6 @@ codeunit 6166 "EDoc Import PEPPOL BIS 3.0"
                 PurchaseLine."Item Reference No." := CopyStr(Value, 1, MaxStrLen(PurchaseLine."Item Reference No."));
             '/CreditNote/cac:CreditNoteLine/cac:Item/cac:StandardItemIdentification/cbc:ID':
                 PurchaseLine."No." := CopyStr(Value, 1, MaxStrLen(PurchaseLine."No."));
-            '/CreditNote/cac:CreditNoteLine/cbc:ID':
-                Evaluate(PurchaseLine."Line No.", Value, 9);
             '/CreditNote/cac:CreditNoteLine/cac:Item/cac:ClassifiedTaxCategory/cbc:Percent':
                 if Value <> '' then
                     Evaluate(PurchaseLine."VAT %", Value, 9);
@@ -425,7 +427,7 @@ codeunit 6166 "EDoc Import PEPPOL BIS 3.0"
     /// Parses invoice information line by line from TempXMLBuffer.
     /// We handle the insert of Purchase Order Line and Document Attachment after the call to this function.
     /// </summary>
-    local procedure ParseInvoice(EDocument: Record "E-Document"; var PurchaseHeader: Record "Purchase Header" temporary; var PurchaseLine: Record "Purchase Line" temporary; var DocumentAttachment: Record "Document Attachment"; DocumentAttachmentData: Codeunit "Temp Blob"; var TempXMLBuffer: Record "XML Buffer" temporary)
+    local procedure ParseInvoice(EDocument: Record "E-Document"; var PurchaseHeader: Record "Purchase Header" temporary; var PurchaseLine: Record "Purchase Line" temporary; var DocumentAttachment: Record "Document Attachment"; DocumentAttachmentData: Codeunit "Temp Blob"; var TempXMLBuffer: Record "XML Buffer" temporary; var LineNo: Integer)
     var
         Base64Convert: Codeunit "Base64 Convert";
         OutStream: OutStream;
@@ -464,7 +466,7 @@ codeunit 6166 "EDoc Import PEPPOL BIS 3.0"
                     Evaluate(PurchaseHeader."Document Date", Value, 9);
             '/Invoice/cac:AdditionalDocumentReference/cbc:ID':
                 begin
-                    if DocumentAttachment."No." <> '' then begin
+                    if (DocumentAttachment."No." <> '') and (DocumentAttachment."File Name" <> '') then begin
                         DocumentAttachmentData.CreateInStream(InStream, TextEncoding::UTF8);
                         EDocumentAttachmentGen.Insert(EDocument, InStream, DocumentAttachment.FindUniqueFileName(DocumentAttachment."File Name", DocumentAttachment."File Extension"));
                         Clear(DocumentAttachment);
@@ -493,6 +495,8 @@ codeunit 6166 "EDoc Import PEPPOL BIS 3.0"
                     PurchaseLine.Init();
                     PurchaseLine."Document Type" := PurchaseHeader."Document Type";
                     PurchaseLine."Document No." := PurchaseHeader."No.";
+                    LineNo += 10000;
+                    PurchaseLine."Line No." := LineNo;
                 end;
             '/Invoice/cac:InvoiceLine/cbc:InvoicedQuantity':
                 if Value <> '' then
@@ -517,8 +521,6 @@ codeunit 6166 "EDoc Import PEPPOL BIS 3.0"
                 PurchaseLine."Item Reference No." := CopyStr(Value, 1, MaxStrLen(PurchaseLine."Item Reference No."));
             '/Invoice/cac:InvoiceLine/cac:Item/cac:StandardItemIdentification/cbc:ID':
                 PurchaseLine."No." := CopyStr(Value, 1, MaxStrLen(PurchaseLine."No."));
-            '/Invoice/cac:InvoiceLine/cbc:ID':
-                Evaluate(PurchaseLine."Line No.", Value, 9);
             '/Invoice/cac:InvoiceLine/cac:Item/cac:ClassifiedTaxCategory/cbc:Percent':
                 if Value <> '' then
                     Evaluate(PurchaseLine."VAT %", Value, 9);

--- a/src/Apps/W1/EDocument/Test/.resources/peppol/peppol-invoice-hierarchical-lineids.xml
+++ b/src/Apps/W1/EDocument/Test/.resources/peppol/peppol-invoice-hierarchical-lineids.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+	xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+	xmlns:ccts="urn:un:unece:uncefact:documentation:2"
+	xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDatatypes-2"
+	xmlns:udt="urn:un:unece:uncefact:data:specification:UnqualifiedDataTypesSchemaModule:2"
+	xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+	<cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+	<cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+	<cbc:ID>103033</cbc:ID>
+	<cbc:IssueDate>2026-01-22</cbc:IssueDate>
+	<cbc:DueDate>2026-02-22</cbc:DueDate>
+	<cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+	<cbc:DocumentCurrencyCode>XYZ</cbc:DocumentCurrencyCode>
+	<cbc:BuyerReference>1</cbc:BuyerReference>
+	<cac:OrderReference>
+		<cbc:ID>2</cbc:ID>
+	</cac:OrderReference>
+	<cac:ContractDocumentReference>
+		<cbc:ID>103033</cbc:ID>
+	</cac:ContractDocumentReference>
+	<cac:AdditionalDocumentReference>
+		<cbc:ID>103033</cbc:ID>
+		<cbc:DocumentType />
+		<cac:Attachment>
+			<cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="test-document.pdf">dGVzdA==</cbc:EmbeddedDocumentBinaryObject>
+		</cac:Attachment>
+	</cac:AdditionalDocumentReference>
+	<cac:AccountingSupplierParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
+			<cac:PartyName>
+				<cbc:Name>CRONUS International</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Main Street, 14</cbc:StreetName>
+				<cbc:CityName>Birmingham</cbc:CityName>
+				<cbc:PostalZone>B27 4KT</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>GB</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>GB123456789</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>CRONUS International</cbc:RegistrationName>
+				<cbc:CompanyID>123456789</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>Jim Olive</cbc:Name>
+				<cbc:ElectronicMail>JO@contoso.com</cbc:ElectronicMail>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingSupplierParty>
+	<cac:AccountingCustomerParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="9932">789456278</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID schemeID="0088">8712345000004</cbc:ID>
+			</cac:PartyIdentification>
+			<cac:PartyName>
+				<cbc:Name>The Cannon Group PLC</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>192 Market Square</cbc:StreetName>
+				<cbc:CityName>Birmingham</cbc:CityName>
+				<cbc:PostalZone>B27 4KT</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>GB</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>GB789456278</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>The Cannon Group PLC</cbc:RegistrationName>
+			</cac:PartyLegalEntity>
+		</cac:Party>
+	</cac:AccountingCustomerParty>
+	<cac:PayeeParty>
+		<cac:PartyName>
+			<cbc:Name>CRONUS International</cbc:Name>
+		</cac:PartyName>
+		<cac:PartyLegalEntity>
+			<cbc:CompanyID>GB123456789</cbc:CompanyID>
+		</cac:PartyLegalEntity>
+	</cac:PayeeParty>
+	<cac:PaymentMeans>
+		<cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+		<cbc:PaymentDueDate>2026-02-22</cbc:PaymentDueDate>
+		<cac:PayeeFinancialAccount>
+			<cbc:ID>GB12CPBK08929965044991</cbc:ID>
+			<cac:FinancialInstitutionBranch>
+				<cbc:ID>BG99999</cbc:ID>
+			</cac:FinancialInstitutionBranch>
+		</cac:PayeeFinancialAccount>
+	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>1 Month/2% 8 days</cbc:Note>
+	</cac:PaymentTerms>
+	<cac:TaxTotal>
+		<cbc:TaxAmount currencyID="XYZ">1000</cbc:TaxAmount>
+		<cac:TaxSubtotal>
+			<cbc:TaxableAmount currencyID="XYZ">4000</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="XYZ">1000</cbc:TaxAmount>
+			<cac:TaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>25</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:TaxCategory>
+		</cac:TaxSubtotal>
+	</cac:TaxTotal>
+	<cac:LegalMonetaryTotal>
+		<cbc:LineExtensionAmount currencyID="XYZ">14000</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="XYZ">14000</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="XYZ">14140</cbc:TaxInclusiveAmount>
+		<cbc:AllowanceTotalAmount currencyID="XYZ">0</cbc:AllowanceTotalAmount>
+		<cbc:PrepaidAmount currencyID="XYZ">0.00</cbc:PrepaidAmount>
+		<cbc:PayableRoundingAmount currencyID="XYZ">0</cbc:PayableRoundingAmount>
+		<cbc:PayableAmount currencyID="XYZ">14140</cbc:PayableAmount>
+	</cac:LegalMonetaryTotal>
+	<cac:InvoiceLine>
+		<cbc:ID>1.1</cbc:ID>
+		<cbc:Note>Item</cbc:Note>
+		<cbc:InvoicedQuantity unitCode="PCS">1</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="XYZ">4000</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Name>Bicycle</cbc:Name>
+			<cac:StandardItemIdentification>
+				<cbc:ID>1000</cbc:ID>
+			</cac:StandardItemIdentification>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>25</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="XYZ">4000.00</cbc:PriceAmount>
+			<cbc:BaseQuantity unitCode="PCS">1</cbc:BaseQuantity>
+		</cac:Price>
+	</cac:InvoiceLine>
+	<cac:InvoiceLine>
+		<cbc:ID>1.2</cbc:ID>
+		<cbc:Note>Item</cbc:Note>
+		<cbc:InvoicedQuantity unitCode="PCS">2</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="XYZ">10000</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Name>Bicycle v2</cbc:Name>
+			<cac:StandardItemIdentification>
+				<cbc:ID>2000</cbc:ID>
+			</cac:StandardItemIdentification>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>25</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="XYZ">5000.00</cbc:PriceAmount>
+			<cbc:BaseQuantity unitCode="PCS">2</cbc:BaseQuantity>
+		</cac:Price>
+	</cac:InvoiceLine>
+</Invoice>

--- a/src/Apps/W1/EDocument/Test/.resources/peppol/peppol-invoice-textonly-docref.xml
+++ b/src/Apps/W1/EDocument/Test/.resources/peppol/peppol-invoice-textonly-docref.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+	xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+	xmlns:ccts="urn:un:unece:uncefact:documentation:2"
+	xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDatatypes-2"
+	xmlns:udt="urn:un:unece:uncefact:data:specification:UnqualifiedDataTypesSchemaModule:2"
+	xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+	<cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+	<cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+	<cbc:ID>103033</cbc:ID>
+	<cbc:IssueDate>2026-01-22</cbc:IssueDate>
+	<cbc:DueDate>2026-02-22</cbc:DueDate>
+	<cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+	<cbc:DocumentCurrencyCode>XYZ</cbc:DocumentCurrencyCode>
+	<cbc:BuyerReference>1</cbc:BuyerReference>
+	<cac:OrderReference>
+		<cbc:ID>2</cbc:ID>
+	</cac:OrderReference>
+	<cac:ContractDocumentReference>
+		<cbc:ID>103033</cbc:ID>
+	</cac:ContractDocumentReference>
+	<cac:AdditionalDocumentReference>
+		<cbc:ID>DOC-REF-001</cbc:ID>
+		<cbc:DocumentDescription>Text-only reference without attachment</cbc:DocumentDescription>
+	</cac:AdditionalDocumentReference>
+	<cac:AdditionalDocumentReference>
+		<cbc:ID>DOC-REF-002</cbc:ID>
+		<cbc:DocumentDescription>Another text-only reference</cbc:DocumentDescription>
+	</cac:AdditionalDocumentReference>
+	<cac:AdditionalDocumentReference>
+		<cbc:ID>103033</cbc:ID>
+		<cbc:DocumentType />
+		<cac:Attachment>
+			<cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="test-document.pdf">dGVzdA==</cbc:EmbeddedDocumentBinaryObject>
+		</cac:Attachment>
+	</cac:AdditionalDocumentReference>
+	<cac:AccountingSupplierParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0088">1234567890128</cbc:EndpointID>
+			<cac:PartyName>
+				<cbc:Name>CRONUS International</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Main Street, 14</cbc:StreetName>
+				<cbc:CityName>Birmingham</cbc:CityName>
+				<cbc:PostalZone>B27 4KT</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>GB</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>GB123456789</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>CRONUS International</cbc:RegistrationName>
+				<cbc:CompanyID>123456789</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>Jim Olive</cbc:Name>
+				<cbc:ElectronicMail>JO@contoso.com</cbc:ElectronicMail>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingSupplierParty>
+	<cac:AccountingCustomerParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="9932">789456278</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID schemeID="0088">8712345000004</cbc:ID>
+			</cac:PartyIdentification>
+			<cac:PartyName>
+				<cbc:Name>The Cannon Group PLC</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>192 Market Square</cbc:StreetName>
+				<cbc:CityName>Birmingham</cbc:CityName>
+				<cbc:PostalZone>B27 4KT</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>GB</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>GB789456278</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>The Cannon Group PLC</cbc:RegistrationName>
+			</cac:PartyLegalEntity>
+		</cac:Party>
+	</cac:AccountingCustomerParty>
+	<cac:PayeeParty>
+		<cac:PartyName>
+			<cbc:Name>CRONUS International</cbc:Name>
+		</cac:PartyName>
+		<cac:PartyLegalEntity>
+			<cbc:CompanyID>GB123456789</cbc:CompanyID>
+		</cac:PartyLegalEntity>
+	</cac:PayeeParty>
+	<cac:PaymentMeans>
+		<cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+		<cbc:PaymentDueDate>2026-02-22</cbc:PaymentDueDate>
+		<cac:PayeeFinancialAccount>
+			<cbc:ID>GB12CPBK08929965044991</cbc:ID>
+			<cac:FinancialInstitutionBranch>
+				<cbc:ID>BG99999</cbc:ID>
+			</cac:FinancialInstitutionBranch>
+		</cac:PayeeFinancialAccount>
+	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>1 Month/2% 8 days</cbc:Note>
+	</cac:PaymentTerms>
+	<cac:TaxTotal>
+		<cbc:TaxAmount currencyID="XYZ">1000</cbc:TaxAmount>
+		<cac:TaxSubtotal>
+			<cbc:TaxableAmount currencyID="XYZ">4000</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="XYZ">1000</cbc:TaxAmount>
+			<cac:TaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>25</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:TaxCategory>
+		</cac:TaxSubtotal>
+	</cac:TaxTotal>
+	<cac:LegalMonetaryTotal>
+		<cbc:LineExtensionAmount currencyID="XYZ">14000</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="XYZ">14000</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="XYZ">14140</cbc:TaxInclusiveAmount>
+		<cbc:AllowanceTotalAmount currencyID="XYZ">0</cbc:AllowanceTotalAmount>
+		<cbc:PrepaidAmount currencyID="XYZ">0.00</cbc:PrepaidAmount>
+		<cbc:PayableRoundingAmount currencyID="XYZ">0</cbc:PayableRoundingAmount>
+		<cbc:PayableAmount currencyID="XYZ">14140</cbc:PayableAmount>
+	</cac:LegalMonetaryTotal>
+	<cac:InvoiceLine>
+		<cbc:ID>10000</cbc:ID>
+		<cbc:Note>Item</cbc:Note>
+		<cbc:InvoicedQuantity unitCode="PCS">1</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="XYZ">4000</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Name>Bicycle</cbc:Name>
+			<cac:StandardItemIdentification>
+				<cbc:ID>1000</cbc:ID>
+			</cac:StandardItemIdentification>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>25</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="XYZ">4000.00</cbc:PriceAmount>
+			<cbc:BaseQuantity unitCode="PCS">1</cbc:BaseQuantity>
+		</cac:Price>
+	</cac:InvoiceLine>
+	<cac:InvoiceLine>
+		<cbc:ID>20000</cbc:ID>
+		<cbc:Note>Item</cbc:Note>
+		<cbc:InvoicedQuantity unitCode="PCS">2</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="XYZ">10000</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Name>Bicycle v2</cbc:Name>
+			<cac:StandardItemIdentification>
+				<cbc:ID>2000</cbc:ID>
+			</cac:StandardItemIdentification>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>25</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="XYZ">5000.00</cbc:PriceAmount>
+			<cbc:BaseQuantity unitCode="PCS">2</cbc:BaseQuantity>
+		</cac:Price>
+	</cac:InvoiceLine>
+</Invoice>

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocE2ETest.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocE2ETest.Codeunit.al
@@ -1750,6 +1750,59 @@ codeunit 139624 "E-Doc E2E Test"
         Assert.AreEqual(Enum::"E-Document Status"::"In Progress", EDocument.Status, 'E-Document should be in In Progress status.');
     end;
 
+    [Test]
+    procedure ImportPEPPOLInvoiceWithTextOnlyDocumentReferences()
+    var
+        EDocument: Record "E-Document";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        EDocImportParams: Record "E-Doc. Import Parameters";
+    begin
+        // [SCENARIO] Import a PEPPOL invoice with AdditionalDocumentReference elements
+        // that have no <cac:Attachment> child (text-only references).
+        // Previously this caused "Please choose a file to attach" error.
+        Initialize(Enum::"Service Integration"::"Mock");
+
+        EDocImportParams."Step to Run" := "Import E-Document Steps"::"Finish draft";
+        WorkDate(DMY2Date(1, 1, 2027));
+        Assert.IsTrue(
+            LibraryEDoc.CreateInboundPEPPOLDocumentToState(
+                EDocument, EDocumentService, 'peppol/peppol-invoice-textonly-docref.xml', EDocImportParams),
+            'The e-document should be processed');
+
+        EDocument.Get(EDocument."Entry No");
+        PurchaseHeader.Get(EDocument."Document Record ID");
+        PurchaseLine.SetRange("Document Type", PurchaseHeader."Document Type");
+        PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
+        Assert.AreEqual(2, PurchaseLine.Count(), 'Expected 2 purchase lines to be imported.');
+    end;
+
+    [Test]
+    procedure ImportPEPPOLInvoiceWithHierarchicalLineIds()
+    var
+        EDocument: Record "E-Document";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        EDocImportParams: Record "E-Doc. Import Parameters";
+    begin
+        // [SCENARIO] Import a PEPPOL invoice with non-integer line IDs (e.g., "1.1", "1.2").
+        // Previously this caused "The value '1.1' can't be evaluated into type Integer" error.
+        Initialize(Enum::"Service Integration"::"Mock");
+
+        EDocImportParams."Step to Run" := "Import E-Document Steps"::"Finish draft";
+        WorkDate(DMY2Date(1, 1, 2027));
+        Assert.IsTrue(
+            LibraryEDoc.CreateInboundPEPPOLDocumentToState(
+                EDocument, EDocumentService, 'peppol/peppol-invoice-hierarchical-lineids.xml', EDocImportParams),
+            'The e-document should be processed');
+
+        EDocument.Get(EDocument."Entry No");
+        PurchaseHeader.Get(EDocument."Document Record ID");
+        PurchaseLine.SetRange("Document Type", PurchaseHeader."Document Type");
+        PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
+        Assert.AreEqual(2, PurchaseLine.Count(), 'Expected 2 purchase lines to be imported.');
+    end;
+
     local procedure CheckPDFEmbedToXML(TempBlob: Codeunit "Temp Blob")
     var
         TempXMLBuffer: Record "XML Buffer" temporary;

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocumentStructuredTests.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocumentStructuredTests.Codeunit.al
@@ -192,6 +192,7 @@ codeunit 139891 "E-Document Structured Tests"
         else
             Assert.Fail(EDocumentStatusNotUpdatedErr);
     end;
+
     #endregion
 
     local procedure Initialize(Integration: Enum "Service Integration")


### PR DESCRIPTION
## Summary
- Fix "Please choose a file to attach" error when importing PEPPOL invoices/credit memos with `AdditionalDocumentReference` elements that have no `<cac:Attachment>` child (text-only references).
- Fix "The value '1.1' can't be evaluated into type Integer" error when importing documents with hierarchical line numbering (e.g., 1.1, 1.2).

[AB#626749](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/626749)


