### PR TITLE
Expand allowed shell tools for AuditDocs CI agent

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyBackgroundSyncs.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyBackgroundSyncs.Codeunit.al
@@ -16,7 +16,7 @@ codeunit 30101 "Shpfy Background Syncs"
     Access = Internal;
 
     var
-        SyncDescriptionTxt: Label 'Shopify Sync of %1 for shop(s) %2', Comment = '%1 = Synchronization Type, %2 = Synchronization Code';
+        SyncDescriptionTxt: Label 'Shopify Sync of %1 for shop(s) %2', Comment = '%1 = Synchronization Tyep, %2 = Synchronization Code';
         InventorySyncTypeTxt: Label 'Inventory';
         OrderSyncTypeTxt: Label 'Order';
         PayoutsSyncTypeTxt: Label 'Payouts';


### PR DESCRIPTION
## Summary

- Fix grep failure on percentage numbers
- Add read-only shell permissions (`find`, `wc`, `sort`, `uniq`, `jq`, `git diff`) to the AuditDocs copilot invocation
[AB#626733](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/626733)

















