### PR TITLE
[Suggestion] Add workflow to automatically rerun failed workflows 

### DIFF
--- a/.github/workflows/RerunUnstableFailures.yaml
+++ b/.github/workflows/RerunUnstableFailures.yaml
@@ -23,13 +23,13 @@ jobs:
       MAX_ATTEMPTS: 1 # Maximum number of attempts to rerun a failed job
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Create GitHub App Token
         id: app-token
         if: vars.APP_ID != ''
         continue-on-error: true
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/RerunUnstableFailures.yaml
+++ b/.github/workflows/RerunUnstableFailures.yaml
@@ -1,0 +1,56 @@
+name: Rerun Unstable Failures
+on:
+  workflow_dispatch:
+    inputs:
+      WhatIf:
+        description: 'WhatIf'
+        type: boolean
+        default: false
+  schedule:
+    - cron: '0 * * * *'
+
+permissions: read-all
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  RerunUnstableFailures:
+    runs-on: ubuntu-slim
+    permissions:
+      actions: write
+      contents: read
+    env:
+      MAX_FAILED_JOBS: 3 # Maximum number of failed jobs in order to consider rerunning
+      MIN_TOTAL_JOBS: 10 # Minimum number of jobs that has run in order to consider rerunning
+      MAX_ATTEMPTS: 1 # Maximum number of attempts to rerun a failed job
+      LOOKBACK_HOURS: 24 # How far back to look for failed jobs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create GitHub App Token
+        id: app-token
+        if: vars.APP_ID != ''
+        continue-on-error: true
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Rerun unstable failures
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.YOURPAT }}
+        run: |
+          $whatIf = '${{ inputs.WhatIf }}'
+          $params = @{
+            Owner = "microsoft"
+            Repo = "BCApps"
+            MaxFailedJobs = $env:MAX_FAILED_JOBS
+            MinTotalJobs = $env:MIN_TOTAL_JOBS
+            MaxAttempts = $env:MAX_ATTEMPTS
+            LookbackHours = $env:LOOKBACK_HOURS
+          }
+          if ($whatIf -ne 'false') { $params.WhatIf = $true }
+          build/scripts/RerunUnstableFailures.ps1 @params

--- a/.github/workflows/RerunUnstableFailures.yaml
+++ b/.github/workflows/RerunUnstableFailures.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Rerun unstable failures
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.YOURPAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RERUNPAT }}
         run: |
           $whatIf = '${{ inputs.WhatIf }}'
           $params = @{

--- a/.github/workflows/RerunUnstableFailures.yaml
+++ b/.github/workflows/RerunUnstableFailures.yaml
@@ -1,13 +1,8 @@
 name: Rerun Unstable Failures
 on:
-  workflow_dispatch:
-    inputs:
-      WhatIf:
-        description: 'WhatIf'
-        type: boolean
-        default: false
-  schedule:
-    - cron: '0 * * * *'
+  workflow_run:
+    workflows: ['Pull Request Build']
+    types: [completed]
 
 permissions: read-all
 
@@ -17,6 +12,7 @@ defaults:
 
 jobs:
   RerunUnstableFailures:
+    if: github.repository_owner == 'microsoft' && github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-slim
     permissions:
       actions: write
@@ -25,7 +21,6 @@ jobs:
       MAX_FAILED_JOBS: 3 # Maximum number of failed jobs in order to consider rerunning
       MIN_TOTAL_JOBS: 10 # Minimum number of jobs that has run in order to consider rerunning
       MAX_ATTEMPTS: 1 # Maximum number of attempts to rerun a failed job
-      LOOKBACK_HOURS: 24 # How far back to look for failed jobs
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,14 +38,12 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RERUNPAT }}
         run: |
-          $whatIf = '${{ inputs.WhatIf }}'
           $params = @{
-            Owner = "microsoft"
-            Repo = "BCApps"
+            Owner = $env:GITHUB_REPOSITORY_OWNER
+            Repo = $env:GITHUB_REPOSITORY.Split('/')[1]
+            RunId = ${{ github.event.workflow_run.id }}
             MaxFailedJobs = $env:MAX_FAILED_JOBS
             MinTotalJobs = $env:MIN_TOTAL_JOBS
             MaxAttempts = $env:MAX_ATTEMPTS
-            LookbackHours = $env:LOOKBACK_HOURS
           }
-          if ($whatIf -ne 'false') { $params.WhatIf = $true }
           build/scripts/RerunUnstableFailures.ps1 @params

--- a/build/scripts/RerunUnstableFailures.ps1
+++ b/build/scripts/RerunUnstableFailures.ps1
@@ -34,12 +34,12 @@ if ($run.run_attempt -gt $MaxAttempts) {
 Write-Host "--- Checking run $($run.id): $($run.display_title) ---"
 
 # Fetch all jobs (paginated)
-$jobsJson = gh api "/repos/$Owner/$Repo/actions/runs/$RunId/jobs?filter=latest&per_page=100" --paginate 2>&1
+$jobsJson = gh api "/repos/$Owner/$Repo/actions/runs/$RunId/jobs?filter=latest&per_page=100" --paginate --jq '.jobs[]' 2>&1
 if ($LASTEXITCODE -ne 0) {
     Write-Host "::warning::Failed to fetch jobs for run $RunId"
     exit 1
 }
-$jobs = ($jobsJson | ConvertFrom-Json).jobs
+$jobs = $jobsJson | ConvertFrom-Json
 
 # Exclude utility jobs that are not actual build jobs
 $excludedJobs = @("Pull Request Status Check", "Initialization")

--- a/build/scripts/RerunUnstableFailures.ps1
+++ b/build/scripts/RerunUnstableFailures.ps1
@@ -1,0 +1,106 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $Owner,
+    [Parameter(Mandatory = $true)]
+    [string] $Repo,
+    [Parameter(Mandatory = $false)]
+    [int] $MaxFailedJobs = 3,
+    [Parameter(Mandatory = $false)]
+    [int] $MinTotalJobs = 10,
+    [Parameter(Mandatory = $false)]
+    [int] $MaxAttempts = 1,
+    [Parameter(Mandatory = $false)]
+    [int] $LookbackHours = 2,
+    [Parameter(Mandatory = $false)]
+    [switch] $WhatIf
+)
+
+$cutoff = (Get-Date).ToUniversalTime().AddHours(-$LookbackHours).ToString("yyyy-MM-ddTHH:mm:ssZ")
+$workflowFiles = @("CICD.yaml", "PullRequestHandler.yaml")
+
+foreach ($workflowFile in $workflowFiles) {
+    Write-Host "===== Processing workflow: $workflowFile ====="
+
+    # Get recent completed runs
+    $runsJson = gh api "/repos/$Owner/$Repo/actions/workflows/$workflowFile/runs?status=completed&created=%3E$cutoff&per_page=100" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "::warning::Failed to fetch runs for $workflowFile"
+        continue
+    }
+    $runs = ($runsJson | ConvertFrom-Json).workflow_runs
+
+    # Filter to failures on first attempt only
+    $failedRuns = $runs | Where-Object { $_.conclusion -eq 'failure' -and $_.run_attempt -le $MaxAttempts }
+    if (-not $failedRuns) {
+        Write-Host "No eligible failed runs found."
+        continue
+    }
+
+    # For PR builds: deduplicate by PR number, keep latest per PR, skip if latest run for that PR is not a failure
+    if ($workflowFile -eq "PullRequestHandler.yaml") {
+        $candidates = @()
+        $prGroups = $runs | Where-Object { $_.pull_requests.Count -gt 0 } | Group-Object { ($_.pull_requests | Select-Object -First 1).number }
+        foreach ($group in $prGroups) {
+            $latest = $group.Group | Sort-Object created_at -Descending | Select-Object -First 1
+            if ($latest.conclusion -eq 'failure' -and $latest.run_attempt -le $MaxAttempts) {
+                $candidates += $latest
+            }
+        }
+        $failedRuns = $candidates
+    }
+
+    if (-not $failedRuns) {
+        Write-Host "No eligible failed runs after deduplication."
+        continue
+    }
+
+    foreach ($run in $failedRuns) {
+        Write-Host "--- Checking run $($run.id): $($run.display_title) ---"
+
+        # Count failed jobs
+        $jobsJson = gh api "/repos/$Owner/$Repo/actions/runs/$($run.id)/jobs?filter=latest&per_page=100" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "::warning::Failed to fetch jobs for run $($run.id)"
+            continue
+        }
+        $jobs = ($jobsJson | ConvertFrom-Json).jobs
+        # Exclude utility jobs that are not actual build jobs
+        $excludedJobs = @("Pull Request Status Check", "Initialization")
+        $buildJobs = $jobs | Where-Object { $_.name -notin $excludedJobs -and $_.conclusion -ne 'skipped' }
+        $buildJobCount = ($buildJobs | Measure-Object).Count
+        $failedJobs = $buildJobs | Where-Object { $_.conclusion -eq 'failure' }
+        $failedCount = ($failedJobs | Measure-Object).Count
+
+        if ($failedCount -eq 0) {
+            Write-Host "No failed build jobs found. Skipping."
+            continue
+        }
+
+        if ($buildJobCount -lt $MinTotalJobs) {
+            Write-Host "Too few build jobs ($buildJobCount < $MinTotalJobs). Run likely didn't reach the large matrix. Skipping."
+            continue
+        }
+
+        if ($failedCount -gt $MaxFailedJobs) {
+            Write-Host "Too many failed jobs ($failedCount > $MaxFailedJobs). Skipping."
+            continue
+        }
+
+        Write-Host "Rerunning $failedCount failed job(s):"
+        $failedJobs | ForEach-Object { Write-Host "  - $($_.name)" }
+
+        $runUrl = "https://github.com/$Owner/$Repo/actions/runs/$($run.id)"
+        if ($WhatIf) {
+            Write-Host "::notice::WhatIf: Would rerun '$($run.display_title)': $runUrl"
+        } else {
+            gh run rerun $run.id --failed --repo "$Owner/$Repo" 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "::warning::Failed to rerun run $($run.id)"
+            } else {
+                Write-Host "::notice::Rerun triggered for '$($run.display_title)': $runUrl"
+            }
+        }
+    }
+}
+
+Write-Host "===== Done ====="

--- a/build/scripts/RerunUnstableFailures.ps1
+++ b/build/scripts/RerunUnstableFailures.ps1
@@ -3,104 +3,74 @@ param(
     [string] $Owner,
     [Parameter(Mandatory = $true)]
     [string] $Repo,
+    [Parameter(Mandatory = $true)]
+    [long] $RunId,
     [Parameter(Mandatory = $false)]
     [int] $MaxFailedJobs = 3,
     [Parameter(Mandatory = $false)]
     [int] $MinTotalJobs = 10,
     [Parameter(Mandatory = $false)]
-    [int] $MaxAttempts = 1,
-    [Parameter(Mandatory = $false)]
-    [int] $LookbackHours = 2,
-    [Parameter(Mandatory = $false)]
-    [switch] $WhatIf
+    [int] $MaxAttempts = 1
 )
 
-$cutoff = (Get-Date).ToUniversalTime().AddHours(-$LookbackHours).ToString("yyyy-MM-ddTHH:mm:ssZ")
-$workflowFiles = @("CICD.yaml", "PullRequestHandler.yaml")
+# Fetch the run to verify it's a failure on first attempt
+$runJson = gh api "/repos/$Owner/$Repo/actions/runs/$RunId" 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "::warning::Failed to fetch run $RunId"
+    exit 1
+}
+$run = $runJson | ConvertFrom-Json
 
-foreach ($workflowFile in $workflowFiles) {
-    Write-Host "===== Processing workflow: $workflowFile ====="
-
-    # Get recent completed runs
-    $runsJson = gh api "/repos/$Owner/$Repo/actions/workflows/$workflowFile/runs?status=completed&created=%3E$cutoff&per_page=100" 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "::warning::Failed to fetch runs for $workflowFile"
-        continue
-    }
-    $runs = ($runsJson | ConvertFrom-Json).workflow_runs
-
-    # Filter to failures on first attempt only
-    $failedRuns = $runs | Where-Object { $_.conclusion -eq 'failure' -and $_.run_attempt -le $MaxAttempts }
-    if (-not $failedRuns) {
-        Write-Host "No eligible failed runs found."
-        continue
-    }
-
-    # For PR builds: deduplicate by PR number, keep latest per PR, skip if latest run for that PR is not a failure
-    if ($workflowFile -eq "PullRequestHandler.yaml") {
-        $candidates = @()
-        $prGroups = $runs | Where-Object { $_.pull_requests.Count -gt 0 } | Group-Object { ($_.pull_requests | Select-Object -First 1).number }
-        foreach ($group in $prGroups) {
-            $latest = $group.Group | Sort-Object created_at -Descending | Select-Object -First 1
-            if ($latest.conclusion -eq 'failure' -and $latest.run_attempt -le $MaxAttempts) {
-                $candidates += $latest
-            }
-        }
-        $failedRuns = $candidates
-    }
-
-    if (-not $failedRuns) {
-        Write-Host "No eligible failed runs after deduplication."
-        continue
-    }
-
-    foreach ($run in $failedRuns) {
-        Write-Host "--- Checking run $($run.id): $($run.display_title) ---"
-
-        # Count failed jobs
-        $jobsJson = gh api "/repos/$Owner/$Repo/actions/runs/$($run.id)/jobs?filter=latest&per_page=100" 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "::warning::Failed to fetch jobs for run $($run.id)"
-            continue
-        }
-        $jobs = ($jobsJson | ConvertFrom-Json).jobs
-        # Exclude utility jobs that are not actual build jobs
-        $excludedJobs = @("Pull Request Status Check", "Initialization")
-        $buildJobs = $jobs | Where-Object { $_.name -notin $excludedJobs -and $_.conclusion -ne 'skipped' }
-        $buildJobCount = ($buildJobs | Measure-Object).Count
-        $failedJobs = $buildJobs | Where-Object { $_.conclusion -eq 'failure' }
-        $failedCount = ($failedJobs | Measure-Object).Count
-
-        if ($failedCount -eq 0) {
-            Write-Host "No failed build jobs found. Skipping."
-            continue
-        }
-
-        if ($buildJobCount -lt $MinTotalJobs) {
-            Write-Host "Too few build jobs ($buildJobCount < $MinTotalJobs). Run likely didn't reach the large matrix. Skipping."
-            continue
-        }
-
-        if ($failedCount -gt $MaxFailedJobs) {
-            Write-Host "Too many failed jobs ($failedCount > $MaxFailedJobs). Skipping."
-            continue
-        }
-
-        Write-Host "Rerunning $failedCount failed job(s):"
-        $failedJobs | ForEach-Object { Write-Host "  - $($_.name)" }
-
-        $runUrl = "https://github.com/$Owner/$Repo/actions/runs/$($run.id)"
-        if ($WhatIf) {
-            Write-Host "::notice::WhatIf: Would rerun '$($run.display_title)': $runUrl"
-        } else {
-            gh run rerun $run.id --failed --repo "$Owner/$Repo" 2>&1
-            if ($LASTEXITCODE -ne 0) {
-                Write-Host "::warning::Failed to rerun run $($run.id)"
-            } else {
-                Write-Host "::notice::Rerun triggered for '$($run.display_title)': $runUrl"
-            }
-        }
-    }
+if ($run.conclusion -ne 'failure') {
+    Write-Host "Run $RunId concluded with '$($run.conclusion)', not 'failure'. Skipping."
+    exit 0
 }
 
-Write-Host "===== Done ====="
+if ($run.run_attempt -gt $MaxAttempts) {
+    Write-Host "Run $RunId is on attempt $($run.run_attempt) (max $MaxAttempts). Skipping."
+    exit 0
+}
+
+Write-Host "--- Checking run $($run.id): $($run.display_title) ---"
+
+# Count failed jobs
+$jobsJson = gh api "/repos/$Owner/$Repo/actions/runs/$RunId/jobs?filter=latest&per_page=100" 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "::warning::Failed to fetch jobs for run $RunId"
+    exit 1
+}
+$jobs = ($jobsJson | ConvertFrom-Json).jobs
+
+# Exclude utility jobs that are not actual build jobs
+$excludedJobs = @("Pull Request Status Check", "Initialization")
+$buildJobs = $jobs | Where-Object { $_.name -notin $excludedJobs -and $_.conclusion -ne 'skipped' }
+$buildJobCount = ($buildJobs | Measure-Object).Count
+$failedJobs = $buildJobs | Where-Object { $_.conclusion -eq 'failure' }
+$failedCount = ($failedJobs | Measure-Object).Count
+
+if ($failedCount -eq 0) {
+    Write-Host "No failed build jobs found. Skipping."
+    exit 0
+}
+
+if ($buildJobCount -lt $MinTotalJobs) {
+    Write-Host "Too few build jobs ($buildJobCount < $MinTotalJobs). Run likely didn't reach the large matrix. Skipping."
+    exit 0
+}
+
+if ($failedCount -gt $MaxFailedJobs) {
+    Write-Host "Too many failed jobs ($failedCount > $MaxFailedJobs). Skipping."
+    exit 0
+}
+
+Write-Host "Rerunning $failedCount failed job(s):"
+$failedJobs | ForEach-Object { Write-Host "  - $($_.name)" }
+
+$runUrl = "https://github.com/$Owner/$Repo/actions/runs/$RunId"
+gh run rerun $RunId --failed --repo "$Owner/$Repo" 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "::warning::Failed to rerun run $RunId"
+    exit 1
+} else {
+    Write-Host "::notice::Rerun triggered for '$($run.display_title)': $runUrl"
+}

--- a/build/scripts/RerunUnstableFailures.ps1
+++ b/build/scripts/RerunUnstableFailures.ps1
@@ -33,8 +33,8 @@ if ($run.run_attempt -gt $MaxAttempts) {
 
 Write-Host "--- Checking run $($run.id): $($run.display_title) ---"
 
-# Count failed jobs
-$jobsJson = gh api "/repos/$Owner/$Repo/actions/runs/$RunId/jobs?filter=latest&per_page=100" 2>&1
+# Fetch all jobs (paginated)
+$jobsJson = gh api "/repos/$Owner/$Repo/actions/runs/$RunId/jobs?filter=latest&per_page=100" --paginate 2>&1
 if ($LASTEXITCODE -ne 0) {
     Write-Host "::warning::Failed to fetch jobs for run $RunId"
     exit 1


### PR DESCRIPTION
Fixes [AB#632025](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632025)

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below * https://github.com/microsoft/BCApps/Contributing.md --> #### Summary <!-- Provide a general summary of your changes --> Add workflow to automatically rerun failed workflows when we think it is an instability. Right now we consider a workflow failed on instabilities if:  * At least 10 jobs ran  * 3 or less jobs failed  * The workflow hasn't already been rerun   #### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. --> Fixes #   



