### PR TITLE
Bug 626601: [28.x] Payment Practice Lines are not shown as before if you click on Generate on the Payment Practice page.

### DIFF
--- a/src/Apps/W1/PaymentPractices/App/src/Pages/PaymentPracticeCard.Page.al
+++ b/src/Apps/W1/PaymentPractices/App/src/Pages/PaymentPracticeCard.Page.al
@@ -99,7 +99,7 @@ page 687 "Payment Practice Card"
                 ApplicationArea = All;
                 SubPageLink = "Header No." = field("No.");
                 UpdatePropagation = Both;
-                Visible = Rec."Lines Exist";
+                Visible = true;
             }
         }
     }

--- a/src/Apps/W1/PaymentPractices/Test/src/PaymentPracticesUT.Codeunit.al
+++ b/src/Apps/W1/PaymentPractices/Test/src/PaymentPracticesUT.Codeunit.al
@@ -571,6 +571,40 @@ codeunit 134197 "Payment Practices UT"
         PaymentPracticeLine.TestField("Modified Manually");
     end;
 
+    [Test]
+    procedure PaymentPracticeCardLinesPartAlwaysVisible()
+    var
+        PaymentPracticeHeader: Record "Payment Practice Header";
+        PaymentPracticeCard: TestPage "Payment Practice Card";
+        VendorNo: Code[20];
+    begin
+        // [FEATURE] [AI test 0.3]
+        // [SCENARIO 626602] Lines part on Payment Practice Card is visible after clicking Generate
+        Initialize();
+
+        // [GIVEN] Vendor "V" with company size and an entry in the period
+        VendorNo := PaymentPracticesLibrary.CreateVendorNoWithSizeAndExcl(CompanySizeCodes[1], false);
+        MockVendorInvoice(VendorNo, WorkDate(), WorkDate());
+
+        // [GIVEN] A payment practice header "PPH"
+        PaymentPracticesLibrary.CreatePaymentPracticeHeaderSimple(PaymentPracticeHeader);
+
+        // [WHEN] Open the Payment Practice Card for "PPH"
+        PaymentPracticeCard.OpenEdit();
+        PaymentPracticeCard.Filter.SetFilter("No.", Format(PaymentPracticeHeader."No."));
+
+        // [THEN] Lines part is visible even before generating
+        Assert.IsTrue(PaymentPracticeCard.Lines.Visible(), 'Lines part should be visible before generating.');
+
+        // [WHEN] Generate the payment practice lines
+        PaymentPracticeCard.Generate.Invoke();
+
+        // [THEN] Lines part is still visible after generating
+        Assert.IsTrue(PaymentPracticeCard.Lines.Visible(), 'Lines part should be visible after generating.');
+
+        PaymentPracticeCard.Close();
+    end;
+
     local procedure Initialize()
     begin
         LibraryTestInitialize.OnTestInitialize(Codeunit::"Payment Practices UT");


### PR DESCRIPTION
**ISSUE:**
The Payment Practice Lines subpage is not shown after the lines were generated. The card page should be reopened.

**CAUSE:**
The Lines subpage part on Payment Practice Card used dynamic Visible = Rec."Lines Exist" which did not re-evaluate after Generate.

**SOLUTION:**
Always show the subpage, so lines appear immediately.

Fixes
[AB#626601](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/626601)
