### PR TITLE
[releases/28.x] Shopify: Item Attributes - new "Include in Product Sync" field is available in the list, but not in the card Page 7503

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Page Extensions/ShpfyItemAttributeCard.PageExt.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Page Extensions/ShpfyItemAttributeCard.PageExt.al
@@ -1,0 +1,33 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify;
+
+using Microsoft.Inventory.Item.Attribute;
+
+pageextension 30128 "Shpfy Item Attribute Card" extends "Item Attribute"
+{
+    layout
+    {
+        addlast(content)
+        {
+            field("Shpfy Incl. in Product Sync"; Rec."Shpfy Incl. in Product Sync")
+            {
+                ApplicationArea = All;
+                Visible = ShopifyEnabled;
+            }
+        }
+    }
+
+    var
+        ShopifyEnabled: Boolean;
+
+    trigger OnOpenPage()
+    var
+        ShopMgt: Codeunit "Shpfy Shop Mgt.";
+    begin
+        ShopifyEnabled := ShopMgt.IsEnabled();
+    end;
+}


### PR DESCRIPTION
## Summary
Backport of bug #624264 to releases/28.x.

Fixes [AB#629289](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/629289)

Original PR(s): #7022

