### PR TITLE
[releases/28.x] Shopify - Presentment currency - Shipping charges amount is still in the Store currency when Order created

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyProcessOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyProcessOrder.Codeunit.al
@@ -322,8 +322,6 @@ codeunit 30166 "Shpfy Process Order"
                                 SalesLine.Validate("Line Discount Amount", OrderShippingCharges."Presentment Discount Amount");
                             end;
                     end;
-                    SalesLine.Validate("Unit Price", OrderShippingCharges.Amount);
-                    SalesLine.Validate("Line Discount Amount", OrderShippingCharges."Discount Amount");
                     SalesLine."Shpfy Order No." := ShopifyOrderHeader."Shopify Order No.";
                     SalesLine.Modify(true);
 


### PR DESCRIPTION
## Summary
Backport of bug #625285 to releases/28.x.

Fixes [AB#629291](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/629291)

Original PR(s): #7114

