### PR TITLE
[releases/28.x] [Shopify] Duplicate Sales Line error when creating refund Credit Memo with pre-existing lines

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyCreateSalesDocRefund.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyCreateSalesDocRefund.Codeunit.al
@@ -141,11 +141,14 @@ codeunit 30246 "Shpfy Create Sales Doc. Refund"
     var
         SalesLine: Record "Sales Line";
     begin
+        SalesLine.SetLoadFields("Document Type", "Document No.", "Line No.");
         SalesLine.SetRange("Document Type", DocumentType);
         SalesLine.SetRange("Document No.", DocumentNo);
-        SalesLine.LoadFields("Line No.");
-        if SalesLine.FindLast() then
-            exit(SalesLine."Line No.");
+        if SalesLine.IsEmpty() then
+            exit(10000)
+        else
+            if SalesLine.FindLast() then
+                exit(SalesLine."Line No." + 10000);
     end;
 
     local procedure CreateSalesLines(RefundHeader: Record "Shpfy Refund Header"; var SalesHeader: Record "Sales Header")
@@ -201,7 +204,7 @@ codeunit 30246 "Shpfy Create Sales Doc. Refund"
                 "Shpfy Restock Type"::Return,
                 "Shpfy Restock Type"::"No Restock":
                     begin
-                        LineNo += 10000;
+                        LineNo := GetLastLineNo(SalesHeader."Document Type", SalesHeader."No.");
 
                         RefundProcessEvents.OnBeforeCreateItemSalesLine(RefundHeader, RefundLine, SalesHeader, SalesLine, LineNo, IsHandled);
                         if not IsHandled then begin
@@ -277,7 +280,7 @@ codeunit 30246 "Shpfy Create Sales Doc. Refund"
                     end;
                 "Shpfy Restock Type"::Cancel:
                     begin
-                        LineNo += 10000;
+                        LineNo := GetLastLineNo(SalesHeader."Document Type", SalesHeader."No.");
                         SalesLine.Init();
                         SalesLine.SetHideValidationDialog(true);
                         SalesLine.Validate("Document Type", SalesHeader."Document Type");
@@ -310,7 +313,7 @@ codeunit 30246 "Shpfy Create Sales Doc. Refund"
         IsHandled: Boolean;
     begin
         repeat
-            LineNo += 10000;
+            LineNo := GetLastLineNo(SalesHeader."Document Type", SalesHeader."No.");
             RefundProcessEvents.OnBeforeCreateItemSalesLineFromReturnLine(RefundHeader, ReturnLine, SalesHeader, SalesLine, LineNo, IsHandled);
             if not IsHandled then begin
                 SalesLine.Init();
@@ -358,7 +361,7 @@ codeunit 30246 "Shpfy Create Sales Doc. Refund"
         RefundShippingLine.SetRange("Refund Id", RefundHeader."Refund Id");
         if RefundShippingLine.FindSet() then
             repeat
-                LineNo += 10000;
+                LineNo := GetLastLineNo(SalesHeader."Document Type", SalesHeader."No.");
                 SalesLine.Init();
                 SalesLine.SetHideValidationDialog(true);
                 SalesLine.Validate("Document Type", SalesHeader."Document Type");
@@ -393,7 +396,7 @@ codeunit 30246 "Shpfy Create Sales Doc. Refund"
     local procedure FillRemainingAmountLineFields(RefundHeader: Record "Shpfy Refund Header"; SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line"; var LineNo: Integer)
     begin
         Shop.TestField("Refund Account");
-        LineNo += 10000;
+        LineNo := GetLastLineNo(SalesHeader."Document Type", SalesHeader."No.");
         SalesLine.Init();
         SalesLine.SetHideValidationDialog(true);
         SalesLine.Validate("Document Type", SalesHeader."Document Type");
@@ -476,7 +479,7 @@ codeunit 30246 "Shpfy Create Sales Doc. Refund"
         CashRoundingLbl: Label 'Cash rounding';
     begin
         if RefundRoundingAmount <> 0 then begin
-            LineNo += 10000;
+            LineNo := GetLastLineNo(SalesHeader."Document Type", SalesHeader."No.");
             SalesLine.Init();
             SalesLine.SetHideValidationDialog(true);
             SalesLine.Validate("Document Type", SalesHeader."Document Type");

--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyProcessOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyProcessOrder.Codeunit.al
@@ -455,6 +455,7 @@ codeunit 30166 "Shpfy Process Order"
     var
         SalesLine: Record "Sales Line";
     begin
+        SalesLine.SetLoadFields("Document Type", "Document No.", "Line No.");
         SalesLine.SetRange("Document Type", SalesHeader."Document Type");
         SalesLine.SetRange("Document No.", SalesHeader."No.");
         if SalesLine.IsEmpty() then


### PR DESCRIPTION
## Summary
Backport of bug #626533 to releases/28.x.

Fixes [AB#629293](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/629293)

Original PR(s): #7326

