### PR TITLE
[releases/28.0] [Shopify] When deleting a Shopify refund/return the Shopify refund/return line for all other refund/return are deleted

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order Refunds/Tables/ShpfyRefundHeader.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/Tables/ShpfyRefundHeader.Table.al
@@ -166,11 +166,11 @@ table 30142 "Shpfy Refund Header"
         RefundShippingLine: Record "Shpfy Refund Shipping Line";
         DataCapture: Record "Shpfy Data Capture";
     begin
-        RefundLine.SetRange("Refund Id");
+        RefundLine.SetRange("Refund Id", Rec."Refund Id");
         if not RefundLine.IsEmpty() then
             RefundLine.DeleteAll(true);
 
-        RefundShippingLine.SetRange("Refund Id");
+        RefundShippingLine.SetRange("Refund Id", Rec."Refund Id");
         if not RefundShippingLine.IsEmpty() then
             RefundShippingLine.DeleteAll(true);
 

--- a/src/Apps/W1/Shopify/App/src/Order Returns/Tables/ShpfyReturnHeader.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order Returns/Tables/ShpfyReturnHeader.Table.al
@@ -130,7 +130,7 @@ table 30147 "Shpfy Return Header"
         ReturnLine: Record "Shpfy Return Line";
         DataCapture: Record "Shpfy Data Capture";
     begin
-        ReturnLine.SetRange("Return Id");
+        ReturnLine.SetRange("Return Id", Rec."Return Id");
         if not ReturnLine.IsEmpty() then
             ReturnLine.DeleteAll(true);
 


### PR DESCRIPTION
## Summary
Backport of bug #626081 to releases/28.0.

Fixes [AB#629294](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/629294)

Original PR(s): #7320

