### PR TITLE
28.x: Add option to hide zero-activity accounts in Trial Balance Excel report

### DIFF
--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalanceExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalanceExcel.Report.al
@@ -38,6 +38,13 @@ report 4405 "EXR Trial Balance Excel"
 
             trigger OnAfterGetRecord()
             begin
+                if HideAccountsWithNoActivity then begin
+                    TrialBalanceData.SetRange("G/L Account No.", GLAccounts."No.");
+                    if TrialBalanceData.IsEmpty() then
+                        CurrReport.Skip();
+                    TrialBalanceData.SetRange("G/L Account No.");
+                end;
+
                 IndentedAccountName := PadStr('', GLAccounts.Indentation * 2, ' ') + GLAccounts.Name;
             end;
         }
@@ -96,6 +103,12 @@ report 4405 "EXR Trial Balance Excel"
                 {
                     Caption = 'Options';
 
+                    field(HideAccountsWithNoActivityField; HideAccountsWithNoActivity)
+                    {
+                        ApplicationArea = All;
+                        Caption = 'Hide Accounts with No Activity';
+                        ToolTip = 'Specifies whether to exclude G/L accounts that have no activity for the selected period. When enabled, only accounts with at least one non-zero value across opening balance, turnover, or closing balance are shown.';
+                    }
                     // Used to set the date filter on the report header across multiple languages
                     field(RequestDateFilter; DateFilter)
                     {
@@ -156,6 +169,7 @@ report 4405 "EXR Trial Balance Excel"
     var
         ExcelReportsTelemetry: Codeunit "Excel Reports Telemetry";
         DateFilter: Text;
+        HideAccountsWithNoActivity: Boolean;
 
     protected var
         CompanyInformation: Record "Company Information";

--- a/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
@@ -47,6 +47,33 @@ codeunit 139544 "Trial Balance Excel Reports"
     end;
 
     [Test]
+    [HandlerFunctions('EXRTrialBalanceHideNoActivityHandler')]
+    procedure TrialBalanceHidesZeroActivityAccounts()
+    var
+        GLAccount: Record "G/L Account";
+        Variant: Variant;
+        RequestPageXml: Text;
+        ActiveAccountNo: Code[20];
+    begin
+        // [SCENARIO] With Hide Accounts with No Activity enabled, only accounts with activity are exported
+        // [GIVEN] 5 G/L Accounts, only 1 with activity
+        Initialize();
+        CreateSampleGLAccounts(5, GLAccount);
+        ActiveAccountNo := GLAccount."No.";
+        CreateGLEntryWithAmount(ActiveAccountNo, '', '', '', WorkDate(), 100);
+        Commit();
+        // [WHEN] Running the report with Hide Accounts with No Activity enabled
+        RequestPageXml := Report.RunRequestPage(Report::"EXR Trial Balance Excel", RequestPageXml);
+        LibraryReportDataset.RunReportAndLoad(Report::"EXR Trial Balance Excel", Variant, RequestPageXml);
+        // [THEN] Only the active account should be exported
+        LibraryReportDataset.SetXmlNodeList('DataItem[@name="GLAccounts"]');
+        Assert.AreEqual(1, LibraryReportDataset.RowCount(), 'Only the account with activity should be exported');
+        LibraryReportDataset.GetNextRow();
+        LibraryReportDataset.FindCurrentRowValue('AccountNumber', Variant);
+        Assert.AreEqual(ActiveAccountNo, Format(Variant), 'The exported account should be the one with activity');
+    end;
+
+    [Test]
     [HandlerFunctions('EXRTrialBalanceBudgetExcelHandler')]
     procedure TrialBalanceBudgetExportsAsManyItemsAsGLAccounts()
     var
@@ -783,6 +810,14 @@ codeunit 139544 "Trial Balance Excel Reports"
     procedure EXRTrialBalanceExcelHandler(var EXRTrialBalanceExcel: TestRequestPage "EXR Trial Balance Excel")
     begin
         EXRTrialBalanceExcel.GLAccounts.SetFilter("Date Filter", Format(DMY2Date(1, 1, Date2DMY(WorkDate(), 3))) + '..' + Format(DMY2Date(31, 12, Date2DMY(WorkDate(), 3))));
+        EXRTrialBalanceExcel.OK().Invoke();
+    end;
+
+    [RequestPageHandler]
+    procedure EXRTrialBalanceHideNoActivityHandler(var EXRTrialBalanceExcel: TestRequestPage "EXR Trial Balance Excel")
+    begin
+        EXRTrialBalanceExcel.GLAccounts.SetFilter("Date Filter", Format(DMY2Date(1, 1, Date2DMY(WorkDate(), 3))) + '..' + Format(DMY2Date(31, 12, Date2DMY(WorkDate(), 3))));
+        EXRTrialBalanceExcel.HideAccountsWithNoActivityField.SetValue(true);
         EXRTrialBalanceExcel.OK().Invoke();
     end;
 


### PR DESCRIPTION
Fixes [AB#629451](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/629451)

Cherry-pick of #7441. Adds a "Hide Accounts with No Activity" toggle to the Trial Balance (Excel) report request page.

