### PR TITLE
[Shopify] Fix Total Amount not reduced by refunded tax after order edit

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
@@ -192,7 +192,7 @@ codeunit 30161 "Shpfy Import Order"
         OrderLine.DeleteAll();
     end;
 
-    local procedure ConsiderRefundsInQuantityAndAmounts(var OrderHeader: Record "Shpfy Order Header")
+    internal procedure ConsiderRefundsInQuantityAndAmounts(var OrderHeader: Record "Shpfy Order Header")
     var
         OrderLine: Record "Shpfy Order Line";
         RefundLine: Record "Shpfy Refund Line";
@@ -222,9 +222,9 @@ codeunit 30161 "Shpfy Import Order"
             RefundLine.CalcSums(Quantity, Amount, "Presentment Amount", "Subtotal Amount", "Presentment Subtotal Amount", "Total Tax Amount", "Presentment Total Tax Amount");
             OrderLine.Quantity -= RefundLine.Quantity;
             OrderLine.Modify();
-            OrderHeader."Total Amount" -= RefundLine."Subtotal Amount";
+            OrderHeader."Total Amount" -= RefundLine."Subtotal Amount" + RefundLine."Total Tax Amount";
             OrderHeader."Subtotal Amount" -= RefundLine."Subtotal Amount";
-            OrderHeader."Presentment Total Amount" -= RefundLine."Presentment Subtotal Amount";
+            OrderHeader."Presentment Total Amount" -= RefundLine."Presentment Subtotal Amount" + RefundLine."Presentment Total Tax Amount";
             OrderHeader."Presentment Subtotal Amount" -= RefundLine."Presentment Subtotal Amount";
             OrderHeader."VAT Amount" -= RefundLine."Total Tax Amount";
             OrderHeader."Presentment VAT Amount" -= RefundLine."Presentment Total Tax Amount";

--- a/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
@@ -519,6 +519,58 @@ codeunit 139611 "Shpfy Order Refund Test"
         ResetProcessOnRefund(RefundId);
     end;
 
+    [Test]
+    procedure UnitTestConsiderRefundsSubtractsTaxFromTotalAmount()
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        Shop: Record "Shpfy Shop";
+        OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
+        ImportOrder: Codeunit "Shpfy Import Order";
+        OrderId: BigInteger;
+        OrderLineId: BigInteger;
+        RefundId: BigInteger;
+        SubtotalAmount: Decimal;
+        VATAmount: Decimal;
+        RefundSubtotalAmount: Decimal;
+        RefundTaxAmount: Decimal;
+    begin
+        // [SCENARIO] Total Amount is correctly reduced by both subtotal and tax when processing refunds.
+        Initialize();
+
+        // [GIVEN] Amounts for an order with tax
+        SubtotalAmount := 1200;
+        VATAmount := 300;
+        RefundSubtotalAmount := 1000;
+        RefundTaxAmount := 250;
+
+        // [GIVEN] A processed Shopify order with Total Amount = Subtotal + VAT
+        CreateProcessedShopifyOrderWithVAT(OrderId, OrderLineId, SubtotalAmount, VATAmount);
+
+        // [GIVEN] Shop with "Return and Refund Process" set to "Import Only"
+        Shop := InitializeTest.CreateShop();
+        Shop."Return and Refund Process" := "Shpfy ReturnRefund ProcessType"::"Import Only";
+        Shop.Modify(false);
+
+        // [GIVEN] A refund with both subtotal and tax amounts
+        OrderRefundsHelper.SetDefaultSeed();
+        RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, 0, RefundSubtotalAmount + RefundTaxAmount, Shop.Code);
+        OrderRefundsHelper.CreateRefundLineWithTaxAmount(RefundId, OrderLineId, RefundSubtotalAmount, RefundTaxAmount);
+
+        // [WHEN] ConsiderRefundsInQuantityAndAmounts is executed
+        OrderHeader.Get(OrderId);
+        ImportOrder.SetShop(Shop.Code);
+        ImportOrder.ConsiderRefundsInQuantityAndAmounts(OrderHeader);
+
+        // [THEN] Total Amount = original total - (refund subtotal + refund tax)
+        LibraryAssert.AreEqual(SubtotalAmount + VATAmount - RefundSubtotalAmount - RefundTaxAmount, OrderHeader."Total Amount", 'Total Amount must be reduced by refund subtotal and tax.');
+        // [THEN] Presentment Total Amount is also correctly reduced
+        LibraryAssert.AreEqual(SubtotalAmount + VATAmount - RefundSubtotalAmount - RefundTaxAmount, OrderHeader."Presentment Total Amount", 'Presentment Total Amount must be reduced by refund subtotal and tax.');
+        // [THEN] VAT Amount is reduced by refund tax
+        LibraryAssert.AreEqual(VATAmount - RefundTaxAmount, OrderHeader."VAT Amount", 'VAT Amount must be reduced by refund tax.');
+        // [THEN] Subtotal Amount is reduced by refund subtotal
+        LibraryAssert.AreEqual(SubtotalAmount - RefundSubtotalAmount, OrderHeader."Subtotal Amount", 'Subtotal Amount must be reduced by refund subtotal.');
+    end;
+
     local procedure Initialize()
     var
         OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
@@ -604,6 +656,28 @@ codeunit 139611 "Shpfy Order Refund Test"
         ReturnId := OrderRefundsHelper.CreateReturn(OrderId);
         OrderRefundsHelper.CreateReturnLine(ReturnId, OrderId, '');
         OrderRefundsHelper.CreateUnverifiedReturnLine(ReturnId, '');
+    end;
+
+    local procedure CreateProcessedShopifyOrderWithVAT(var OrderId: BigInteger; var OrderLineId: BigInteger; SubtotalAmount: Decimal; VATAmount: Decimal)
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
+    begin
+        OrderRefundsHelper.SetDefaultSeed();
+        OrderId := OrderRefundsHelper.CreateShopifyOrder();
+        OrderHeader.Get(OrderId);
+        OrderHeader."Subtotal Amount" := SubtotalAmount;
+        OrderHeader."Total Amount" := SubtotalAmount + VATAmount;
+        OrderHeader."VAT Amount" := VATAmount;
+        OrderHeader."Presentment Subtotal Amount" := SubtotalAmount;
+        OrderHeader."Presentment Total Amount" := SubtotalAmount + VATAmount;
+        OrderHeader."Presentment VAT Amount" := VATAmount;
+        OrderHeader."Shipping Charges Amount" := 0;
+        OrderHeader.Processed := true;
+        OrderHeader.Modify(false);
+
+        OrderLineId := OrderRefundsHelper.CreateOrderLine(OrderId, 10000, Any.IntegerInRange(100000, 999999), Any.IntegerInRange(100000, 999999));
+        OrderRefundsHelper.ProcessShopifyOrder(OrderId);
     end;
 
     local procedure CreateLocation(var Location: Record Location)

--- a/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundsHelper.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundsHelper.Codeunit.al
@@ -345,6 +345,24 @@ codeunit 139564 "Shpfy Order Refunds Helper"
         RefundLine.Modify(false);
     end;
 
+    internal procedure CreateRefundLineWithTaxAmount(RefundId: BigInteger; OrderLineId: BigInteger; SubtotalAmount: Decimal; TaxAmount: Decimal)
+    var
+        RefundLine: Record "Shpfy Refund Line";
+    begin
+        RefundLine."Refund Line Id" := Any.IntegerInRange(100000, 999999);
+        RefundLine."Refund Id" := RefundId;
+        RefundLine."Order Line Id" := OrderLineId;
+        RefundLine.Quantity := 1;
+        RefundLine.Amount := SubtotalAmount + TaxAmount;
+        RefundLine."Subtotal Amount" := SubtotalAmount;
+        RefundLine."Total Tax Amount" := TaxAmount;
+        RefundLine."Presentment Amount" := SubtotalAmount + TaxAmount;
+        RefundLine."Presentment Subtotal Amount" := SubtotalAmount;
+        RefundLine."Presentment Total Tax Amount" := TaxAmount;
+        RefundLine."Can Create Credit Memo" := false;
+        RefundLine.Insert();
+    end;
+
     local procedure GetItem(): Record Item
     var
         InitializeTest: Codeunit "Shpfy Initialize Test";


### PR DESCRIPTION
## Summary
- Fix `ConsiderRefundsInQuantityAndAmounts` to subtract both `Subtotal Amount` and `Total Tax Amount` from `Total Amount` (and presentment equivalents) when processing refunds from order edits
- Previously only `Subtotal Amount` was subtracted, leaving `Total Amount` overstated by the refunded tax amount

Fixes [AB#629296](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/629296)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


