### PR TITLE
[Shopify] Guard against empty document number in order attribute writeback

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyProcessOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyProcessOrder.Codeunit.al
@@ -160,6 +160,7 @@ codeunit 30166 "Shpfy Process Order"
             if ShopifyOrderHeader."Work Description".HasValue then
                 SalesHeader.SetWorkDescription(ShopifyOrderHeader.GetWorkDescription());
         end;
+        SalesHeader.TestField("No.");
         if ShopifyShop."Order Attributes To Shopify" then
             OrdersAPI.AddOrderAttribute(ShopifyOrderHeader, 'BC Doc. No.', SalesHeader."No.", ShopifyShop);
         DocLinkToBCDoc.Init();


### PR DESCRIPTION
## Summary
- When an extension handles `OnBeforeCreateSalesHeader` (sets `IsHandled := true`) without populating `SalesHeader."No."`, the connector silently wrote an empty "BC Doc. No." attribute to Shopify and created a `Doc. Link To Doc.` record with an empty document number
- Added `SalesHeader.TestField("No.")` after the `if not IsHandled` block in `CreateHeaderFromShopifyOrder` to fail fast with a clear error instead of writing invalid data

Fixes [AB#629704](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/629704)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


