### PR TITLE
[Shopify] Add order number to Order Transactions page

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Transactions/Pages/ShpfyOrderTransactions.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Transactions/Pages/ShpfyOrderTransactions.Page.al
@@ -39,6 +39,11 @@ page 30131 "Shpfy Order Transactions"
 
                     ToolTip = 'Specifies a unique identifier for the order.';
                 }
+                field(ShpfyOrderNo; Rec."Shpfy Order No.")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the order number from Shopify.';
+                }
                 field(Type; Rec.Type)
                 {
                     ApplicationArea = All;

--- a/src/Apps/W1/Shopify/App/src/Transactions/Tables/ShpfyOrderTransaction.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Transactions/Tables/ShpfyOrderTransaction.Table.al
@@ -271,6 +271,12 @@ table 30133 "Shpfy Order Transaction"
             Caption = 'Shop Code';
             TableRelation = "Shpfy Shop";
         }
+        field(109; "Shpfy Order No."; Text[50])
+        {
+            Caption = 'Shopify Order No.';
+            FieldClass = FlowField;
+            CalcFormula = lookup("Shpfy Order Header"."Shopify Order No." where("Shopify Order Id" = field("Shopify Order Id")));
+        }
     }
 
     keys


### PR DESCRIPTION
## Summary
- Add `Shpfy Order No.` FlowField to the Order Transaction table, looking up the human-friendly order number from the Order Header
- Display the field as a visible column on the Shopify Order Transactions page

Fixes [AB#629705](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/629705)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

