### PR TITLE
[Bug][SubscriptionBilling]: Printing multiple posted sales invoices from subscription contracts fails with duplicate record error for 28.x

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/SubContractBillingPrintout.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/SubContractBillingPrintout.Codeunit.al
@@ -17,6 +17,9 @@ codeunit 8064 "Sub. Contract Billing Printout"
         SalesDocuments: Codeunit "Sales Documents";
         EntryNo: Integer;
     begin
+        TempJobLedgerEntryBuffer.Reset();
+        TempJobLedgerEntryBuffer.DeleteAll();
+        Clear(ColumnHeaders);
         if not SalesInvoiceHeader."Recurring Billing" then
             exit;
 

--- a/src/Apps/W1/Subscription Billing/App/Billing/Report Extensions/ContractStandardSalesInv.ReportExt.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Report Extensions/ContractStandardSalesInv.ReportExt.al
@@ -219,6 +219,8 @@ reportextension 8008 "Contract Standard Sales Inv." extends "Standard Sales - In
 
     local procedure FillTempContractBillingDetailsGroupingBuffer()
     begin
+        TempContractBillingDetailsGroupingBuffer.Reset();
+        TempContractBillingDetailsGroupingBuffer.DeleteAll();
         TempContractBillingDetailsBuffer.Reset();
         if TempContractBillingDetailsBuffer.FindSet() then
             repeat


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This is a backport of the PR  BCApps/pull/7128

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->

Fixes [AB#630427](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630427)

630427



