### PR TITLE
[Bug][SubscriptionBilling]: Missing Global Dimension fields on contract/subscription lines + unclear “Dimensions” window title for Subscription Lines for 28.x

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/ClosedCustContLineSubp.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/ClosedCustContLineSubp.Page.al
@@ -1,5 +1,6 @@
 namespace Microsoft.SubscriptionBilling;
 
+using Microsoft.Finance.Dimension;
 using Microsoft.Inventory.Item;
 
 page 8080 "Closed Cust. Cont. Line Subp."
@@ -298,6 +299,24 @@ page 8080 "Closed Cust. Cont. Line Subp."
                     Visible = false;
                     Editable = false;
                 }
+                field("Shortcut Dimension 1 Code"; ServiceCommitment."Shortcut Dimension 1 Code")
+                {
+                    ApplicationArea = Dimensions;
+                    Caption = 'Shortcut Dimension 1 Code';
+                    CaptionClass = '1,2,1';
+                    ToolTip = 'Specifies the code for Shortcut Dimension 1, which is one of two global dimension codes that you set up in the General Ledger Setup window.';
+                    Visible = false;
+                    Editable = false;
+                }
+                field("Shortcut Dimension 2 Code"; ServiceCommitment."Shortcut Dimension 2 Code")
+                {
+                    ApplicationArea = Dimensions;
+                    Caption = 'Shortcut Dimension 2 Code';
+                    CaptionClass = '1,2,2';
+                    ToolTip = 'Specifies the code for Shortcut Dimension 2, which is one of two global dimension codes that you set up in the General Ledger Setup window.';
+                    Visible = false;
+                    Editable = false;
+                }
             }
         }
     }
@@ -309,6 +328,21 @@ page 8080 "Closed Cust. Cont. Line Subp."
             {
                 Caption = 'Contract Line';
                 Image = "Item";
+                action(Dimensions)
+                {
+                    AccessByPermission = tabledata Dimension = R;
+                    ApplicationArea = Dimensions;
+                    Caption = 'Dimensions';
+                    Image = Dimensions;
+                    Scope = Repeater;
+                    ShortcutKey = 'Shift+Ctrl+D';
+                    ToolTip = 'View or edit dimensions, such as area, project, or department, that you can assign to sales and purchase documents to distribute costs and analyze transaction history.';
+
+                    trigger OnAction()
+                    begin
+                        ServiceCommitment.EditDimensionSet();
+                    end;
+                }
                 action(ShowArchivedBillingLines)
                 {
                     Caption = 'Archived Billing Lines';

--- a/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/CustomerContractLineSubp.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/CustomerContractLineSubp.Page.al
@@ -493,6 +493,50 @@ page 8068 "Customer Contract Line Subp."
                         UpdateServiceCommitmentOnPage(ServiceCommitment.FieldNo("Currency Factor Date"));
                     end;
                 }
+                field("Shortcut Dimension 1 Code"; ServiceCommitment."Shortcut Dimension 1 Code")
+                {
+                    ApplicationArea = Dimensions;
+                    Caption = 'Shortcut Dimension 1 Code';
+                    CaptionClass = '1,2,1';
+                    ToolTip = 'Specifies the code for Shortcut Dimension 1, which is one of two global dimension codes that you set up in the General Ledger Setup window.';
+                    Visible = false;
+                    Editable = not IsCommentLineEditable;
+                    Enabled = not IsCommentLineEditable;
+
+                    trigger OnLookup(var Text: Text): Boolean
+                    begin
+                        DimMgt.LookupDimValueCode(1, ServiceCommitment."Shortcut Dimension 1 Code");
+                        Text := ServiceCommitment."Shortcut Dimension 1 Code";
+                        exit(true);
+                    end;
+
+                    trigger OnValidate()
+                    begin
+                        UpdateServiceCommitmentOnPage(ServiceCommitment.FieldNo("Shortcut Dimension 1 Code"));
+                    end;
+                }
+                field("Shortcut Dimension 2 Code"; ServiceCommitment."Shortcut Dimension 2 Code")
+                {
+                    ApplicationArea = Dimensions;
+                    Caption = 'Shortcut Dimension 2 Code';
+                    CaptionClass = '1,2,2';
+                    ToolTip = 'Specifies the code for Shortcut Dimension 2, which is one of two global dimension codes that you set up in the General Ledger Setup window.';
+                    Visible = false;
+                    Editable = not IsCommentLineEditable;
+                    Enabled = not IsCommentLineEditable;
+
+                    trigger OnLookup(var Text: Text): Boolean
+                    begin
+                        DimMgt.LookupDimValueCode(2, ServiceCommitment."Shortcut Dimension 2 Code");
+                        Text := ServiceCommitment."Shortcut Dimension 2 Code";
+                        exit(true);
+                    end;
+
+                    trigger OnValidate()
+                    begin
+                        UpdateServiceCommitmentOnPage(ServiceCommitment.FieldNo("Shortcut Dimension 2 Code"));
+                    end;
+                }
             }
         }
     }
@@ -616,6 +660,7 @@ page 8068 "Customer Contract Line Subp."
 
     var
         ContractsGeneralMgt: Codeunit "Sub. Contracts General Mgt.";
+        DimMgt: Codeunit DimensionManagement;
         NextBillingDateStyleExpr: Text;
         ContractLineQty: Decimal;
         VariantCode: Code[10];

--- a/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/ServCommWOCustContract.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/ServCommWOCustContract.Page.al
@@ -116,6 +116,18 @@ page 8069 "Serv. Comm. WO Cust. Contract"
                         ContactManagement.OpenContactCard(ServiceObject."End-User Contact No.");
                     end;
                 }
+                field("Shortcut Dimension 1 Code"; Rec."Shortcut Dimension 1 Code")
+                {
+                    ApplicationArea = Dimensions;
+                    Visible = false;
+                    Editable = false;
+                }
+                field("Shortcut Dimension 2 Code"; Rec."Shortcut Dimension 2 Code")
+                {
+                    ApplicationArea = Dimensions;
+                    Visible = false;
+                    Editable = false;
+                }
             }
         }
     }

--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Pages/ServiceCommitments.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Pages/ServiceCommitments.Page.al
@@ -266,6 +266,16 @@ page 8064 "Service Commitments"
                     ApplicationArea = All;
                     ToolTip = 'Specifies the sequence number of the related reference.';
                 }
+                field("Shortcut Dimension 1 Code"; Rec."Shortcut Dimension 1 Code")
+                {
+                    ApplicationArea = Dimensions;
+                    Visible = false;
+                }
+                field("Shortcut Dimension 2 Code"; Rec."Shortcut Dimension 2 Code")
+                {
+                    ApplicationArea = Dimensions;
+                    Visible = false;
+                }
 
             }
         }

--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Pages/ServiceCommitmentsList.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Pages/ServiceCommitmentsList.Page.al
@@ -148,12 +148,12 @@ page 8014 "Service Commitments List"
                 }
                 field("Shortcut Dimension 1 Code"; Rec."Shortcut Dimension 1 Code")
                 {
-                    ToolTip = 'Specifies the code for Shortcut Dimension 1, which is one of two global dimension codes that you set up in the General Ledger Setup window.';
+                    ApplicationArea = Dimensions;
                     Visible = false;
                 }
                 field("Shortcut Dimension 2 Code"; Rec."Shortcut Dimension 2 Code")
                 {
-                    ToolTip = 'Specifies the code for Shortcut Dimension 2, which is one of two global dimension codes that you set up in the General Ledger Setup window.';
+                    ApplicationArea = Dimensions;
                     Visible = false;
                 }
                 field("Price (LCY)"; Rec."Price (LCY)")

--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
@@ -300,6 +300,7 @@ table 8059 "Subscription Line"
         {
             CaptionClass = '1,2,1';
             Caption = 'Shortcut Dimension 1 Code';
+            ToolTip = 'Specifies the code for Shortcut Dimension 1, which is one of two global dimension codes that you set up in the General Ledger Setup window.';
             TableRelation = "Dimension Value".Code where("Global Dimension No." = const(1),
                                                           Blocked = const(false));
 
@@ -312,6 +313,7 @@ table 8059 "Subscription Line"
         {
             CaptionClass = '1,2,2';
             Caption = 'Shortcut Dimension 2 Code';
+            ToolTip = 'Specifies the code for Shortcut Dimension 2, which is one of two global dimension codes that you set up in the General Ledger Setup window.';
             TableRelation = "Dimension Value".Code where("Global Dimension No." = const(2),
                                                           Blocked = const(false));
 
@@ -1051,6 +1053,10 @@ table 8059 "Subscription Line"
                         Validate("Unit Cost (LCY)", "Unit Cost (LCY)");
                     FieldNo("Create Contract Deferrals"):
                         Validate("Create Contract Deferrals", "Create Contract Deferrals");
+                    FieldNo("Shortcut Dimension 1 Code"):
+                        Validate("Shortcut Dimension 1 Code", "Shortcut Dimension 1 Code");
+                    FieldNo("Shortcut Dimension 2 Code"):
+                        Validate("Shortcut Dimension 2 Code", "Shortcut Dimension 2 Code");
                 end;
                 Modify(true);
             end;
@@ -1066,7 +1072,7 @@ table 8059 "Subscription Line"
 
         OldDimSetID := "Dimension Set ID";
         "Dimension Set ID" := DimMgt.EditDimensionSet(
-            "Dimension Set ID", "Subscription Header No." + '' + Format("Entry No."),
+            "Dimension Set ID", "Subscription Header No." + ' ' + FieldCaption("Entry No.") + ' ' + Format("Entry No."),
             "Shortcut Dimension 1 Code", "Shortcut Dimension 2 Code");
 
         if OldDimSetID <> "Dimension Set ID" then begin
@@ -1083,8 +1089,10 @@ table 8059 "Subscription Line"
         OnBeforeValidateShortcutDimCode(Rec, xRec, FieldNumber, ShortcutDimCode);
         OldDimSetID := "Dimension Set ID";
         DimMgt.ValidateShortcutDimValues(FieldNumber, ShortcutDimCode, "Dimension Set ID");
-        if OldDimSetID <> "Dimension Set ID" then
+        if OldDimSetID <> "Dimension Set ID" then begin
             Modify();
+            UpdateRelatedVendorServiceCommDimensions(OldDimSetID, "Dimension Set ID");
+        end;
 
         OnAfterValidateShortcutDimCode(Rec, xRec, FieldNumber, ShortcutDimCode);
     end;

--- a/src/Apps/W1/Subscription Billing/App/Vendor Contracts/Pages/ClosedVendContLineSubp.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Vendor Contracts/Pages/ClosedVendContLineSubp.Page.al
@@ -1,5 +1,7 @@
 namespace Microsoft.SubscriptionBilling;
 
+using Microsoft.Finance.Dimension;
+
 page 8089 "Closed Vend. Cont. Line Subp."
 {
 
@@ -288,6 +290,24 @@ page 8089 "Closed Vend. Cont. Line Subp."
                     Visible = false;
                     Editable = false;
                 }
+                field("Shortcut Dimension 1 Code"; ServiceCommitment."Shortcut Dimension 1 Code")
+                {
+                    ApplicationArea = Dimensions;
+                    Caption = 'Shortcut Dimension 1 Code';
+                    CaptionClass = '1,2,1';
+                    ToolTip = 'Specifies the code for Shortcut Dimension 1, which is one of two global dimension codes that you set up in the General Ledger Setup window.';
+                    Visible = false;
+                    Editable = false;
+                }
+                field("Shortcut Dimension 2 Code"; ServiceCommitment."Shortcut Dimension 2 Code")
+                {
+                    ApplicationArea = Dimensions;
+                    Caption = 'Shortcut Dimension 2 Code';
+                    CaptionClass = '1,2,2';
+                    ToolTip = 'Specifies the code for Shortcut Dimension 2, which is one of two global dimension codes that you set up in the General Ledger Setup window.';
+                    Visible = false;
+                    Editable = false;
+                }
             }
         }
     }
@@ -299,6 +319,21 @@ page 8089 "Closed Vend. Cont. Line Subp."
             {
                 Caption = 'Contract Line';
                 Image = "Item";
+                action(Dimensions)
+                {
+                    AccessByPermission = tabledata Dimension = R;
+                    ApplicationArea = Dimensions;
+                    Caption = 'Dimensions';
+                    Image = Dimensions;
+                    Scope = Repeater;
+                    ShortcutKey = 'Shift+Ctrl+D';
+                    ToolTip = 'View or edit dimensions, such as area, project, or department, that you can assign to sales and purchase documents to distribute costs and analyze transaction history.';
+
+                    trigger OnAction()
+                    begin
+                        ServiceCommitment.EditDimensionSet();
+                    end;
+                }
                 action(ShowArchivedBillingLines)
                 {
                     Caption = 'Archived Billing Lines';

--- a/src/Apps/W1/Subscription Billing/App/Vendor Contracts/Pages/ServCommWOVendContract.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Vendor Contracts/Pages/ServCommWOVendContract.Page.al
@@ -116,6 +116,18 @@ page 8076 "Serv. Comm. WO Vend. Contract"
                         ContactManagement.OpenContactCard(ServiceObject."End-User Contact No.");
                     end;
                 }
+                field("Shortcut Dimension 1 Code"; Rec."Shortcut Dimension 1 Code")
+                {
+                    ApplicationArea = Dimensions;
+                    Visible = false;
+                    Editable = false;
+                }
+                field("Shortcut Dimension 2 Code"; Rec."Shortcut Dimension 2 Code")
+                {
+                    ApplicationArea = Dimensions;
+                    Visible = false;
+                    Editable = false;
+                }
             }
         }
     }

--- a/src/Apps/W1/Subscription Billing/App/Vendor Contracts/Pages/VendorContractLineSubpage.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Vendor Contracts/Pages/VendorContractLineSubpage.Page.al
@@ -461,6 +461,50 @@ page 8078 "Vendor Contract Line Subpage"
                         UpdateServiceCommitmentOnPage(ServiceCommitment.FieldNo("Currency Factor Date"));
                     end;
                 }
+                field("Shortcut Dimension 1 Code"; ServiceCommitment."Shortcut Dimension 1 Code")
+                {
+                    ApplicationArea = Dimensions;
+                    Caption = 'Shortcut Dimension 1 Code';
+                    CaptionClass = '1,2,1';
+                    ToolTip = 'Specifies the code for Shortcut Dimension 1, which is one of two global dimension codes that you set up in the General Ledger Setup window.';
+                    Visible = false;
+                    Editable = not IsCommentLineEditable;
+                    Enabled = not IsCommentLineEditable;
+
+                    trigger OnLookup(var Text: Text): Boolean
+                    begin
+                        DimMgt.LookupDimValueCode(1, ServiceCommitment."Shortcut Dimension 1 Code");
+                        Text := ServiceCommitment."Shortcut Dimension 1 Code";
+                        exit(true);
+                    end;
+
+                    trigger OnValidate()
+                    begin
+                        UpdateServiceCommitmentOnPage(ServiceCommitment.FieldNo("Shortcut Dimension 1 Code"));
+                    end;
+                }
+                field("Shortcut Dimension 2 Code"; ServiceCommitment."Shortcut Dimension 2 Code")
+                {
+                    ApplicationArea = Dimensions;
+                    Caption = 'Shortcut Dimension 2 Code';
+                    CaptionClass = '1,2,2';
+                    ToolTip = 'Specifies the code for Shortcut Dimension 2, which is one of two global dimension codes that you set up in the General Ledger Setup window.';
+                    Visible = false;
+                    Editable = not IsCommentLineEditable;
+                    Enabled = not IsCommentLineEditable;
+
+                    trigger OnLookup(var Text: Text): Boolean
+                    begin
+                        DimMgt.LookupDimValueCode(2, ServiceCommitment."Shortcut Dimension 2 Code");
+                        Text := ServiceCommitment."Shortcut Dimension 2 Code";
+                        exit(true);
+                    end;
+
+                    trigger OnValidate()
+                    begin
+                        UpdateServiceCommitmentOnPage(ServiceCommitment.FieldNo("Shortcut Dimension 2 Code"));
+                    end;
+                }
             }
         }
     }
@@ -582,6 +626,7 @@ page 8078 "Vendor Contract Line Subpage"
 
     var
         ContractsGeneralMgt: Codeunit "Sub. Contracts General Mgt.";
+        DimMgt: Codeunit DimensionManagement;
         NextBillingDateStyleExpr: Text;
         IsDiscountLine: Boolean;
         IsCommentLineEditable: Boolean;

--- a/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractDimensionsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractDimensionsTest.Codeunit.al
@@ -1,6 +1,10 @@
 namespace Microsoft.SubscriptionBilling;
 
 using Microsoft.Finance.Dimension;
+using Microsoft.Finance.GeneralLedger.Setup;
+using Microsoft.Inventory.Item;
+using Microsoft.Purchases.Vendor;
+using Microsoft.Sales.Customer;
 
 codeunit 139693 "Contract Dimensions Test"
 {
@@ -13,7 +17,9 @@ codeunit 139693 "Contract Dimensions Test"
         ServiceContractSetup: Record "Subscription Contract Setup";
         ContractTestLibrary: Codeunit "Contract Test Library";
         DimensionManagement: Codeunit DimensionManagement;
+        LibraryDimension: Codeunit "Library - Dimension";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
+        Assert: Codeunit Assert;
         IsInitialized: Boolean;
 
     #region Tests
@@ -47,6 +53,108 @@ codeunit 139693 "Contract Dimensions Test"
         TempDimensionSetEntry.TestField("Dimension Value Code", CustomerContract."No.");
     end;
 
+    [Test]
+    procedure ValidateShortcutDim1CodeOnSubscriptionLineUpdatesDimSetID()
+    var
+        Customer: Record Customer;
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        DimensionValue: Record "Dimension Value";
+        ServiceObject: Record "Subscription Header";
+        SubscriptionLine: Record "Subscription Line";
+    begin
+        // [SCENARIO] Validating Shortcut Dimension 1 Code on a Subscription Line updates its Dimension Set ID
+        Initialize();
+
+        // [GIVEN] A Subscription Line exists
+        ContractTestLibrary.CreateCustomerInLCY(Customer);
+        ContractTestLibrary.CreateCustomerContractAndCreateContractLinesForItems(CustomerContract, ServiceObject, Customer."No.");
+        FindFirstCustomerSubscriptionLine(SubscriptionLine, ServiceObject."No.");
+
+        // [GIVEN] A dimension value for Global Dimension 1 exists
+        GeneralLedgerSetup.Get();
+        LibraryDimension.CreateDimensionValue(DimensionValue, GeneralLedgerSetup."Global Dimension 1 Code");
+
+        // [WHEN] Shortcut Dimension 1 Code is validated on the Subscription Line
+        SubscriptionLine.Validate("Shortcut Dimension 1 Code", DimensionValue.Code);
+
+        // [THEN] The Dimension Set ID is updated and contains the correct dimension value
+        Assert.AreNotEqual(0, SubscriptionLine."Dimension Set ID", 'Dimension Set ID should be non-zero after setting Shortcut Dimension 1 Code');
+        VerifyDimensionInDimensionSet(SubscriptionLine."Dimension Set ID", GeneralLedgerSetup."Global Dimension 1 Code", DimensionValue.Code);
+    end;
+
+    [Test]
+    procedure ValidateShortcutDim2CodeOnSubscriptionLineUpdatesDimSetID()
+    var
+        Customer: Record Customer;
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        DimensionValue: Record "Dimension Value";
+        ServiceObject: Record "Subscription Header";
+        SubscriptionLine: Record "Subscription Line";
+    begin
+        // [SCENARIO] Validating Shortcut Dimension 2 Code on a Subscription Line updates its Dimension Set ID
+        Initialize();
+
+        // [GIVEN] A Subscription Line exists
+        ContractTestLibrary.CreateCustomerInLCY(Customer);
+        ContractTestLibrary.CreateCustomerContractAndCreateContractLinesForItems(CustomerContract, ServiceObject, Customer."No.");
+        FindFirstCustomerSubscriptionLine(SubscriptionLine, ServiceObject."No.");
+
+        // [GIVEN] A dimension value for Global Dimension 2 exists
+        GeneralLedgerSetup.Get();
+        LibraryDimension.CreateDimensionValue(DimensionValue, GeneralLedgerSetup."Global Dimension 2 Code");
+
+        // [WHEN] Shortcut Dimension 2 Code is validated on the Subscription Line
+        SubscriptionLine.Validate("Shortcut Dimension 2 Code", DimensionValue.Code);
+
+        // [THEN] The Dimension Set ID is updated and contains the correct dimension value
+        Assert.AreNotEqual(0, SubscriptionLine."Dimension Set ID", 'Dimension Set ID should be non-zero after setting Shortcut Dimension 2 Code');
+        VerifyDimensionInDimensionSet(SubscriptionLine."Dimension Set ID", GeneralLedgerSetup."Global Dimension 2 Code", DimensionValue.Code);
+    end;
+
+    [Test]
+    procedure ValidateShortcutDim1CodeOnCustSubLinePropagatesChangesToVendorLine()
+    var
+        Customer: Record Customer;
+        Vendor: Record Vendor;
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        DimensionValue: Record "Dimension Value";
+        ServiceObject: Record "Subscription Header";
+        CustomerSubscriptionLine: Record "Subscription Line";
+        VendorSubscriptionLine: Record "Subscription Line";
+        VendorContract: Record "Vendor Subscription Contract";
+        Item: Record Item;
+    begin
+        // [SCENARIO] Changing Shortcut Dimension 1 Code on a Customer Subscription Line propagates to related Vendor Subscription Line
+        Initialize();
+
+        // [GIVEN] A Service Object with both Customer and Vendor Subscription Lines from the same package
+        ContractTestLibrary.CreateServiceObjectForItemWithServiceCommitments(ServiceObject, Enum::"Invoicing Via"::Contract, false, Item, 1, 1);
+        ContractTestLibrary.CreateCustomerInLCY(Customer);
+        ServiceObject.SetHideValidationDialog(true);
+        ServiceObject.Validate("End-User Customer No.", Customer."No.");
+        ServiceObject.Modify(false);
+
+        // [GIVEN] Customer Contract with the Customer Subscription Line
+        ContractTestLibrary.CreateCustomerContractAndCreateContractLinesForItems(CustomerContract, ServiceObject, Customer."No.");
+        FindFirstCustomerSubscriptionLine(CustomerSubscriptionLine, ServiceObject."No.");
+
+        // [GIVEN] Vendor Contract with the Vendor Subscription Line
+        ContractTestLibrary.CreateVendorInLCY(Vendor);
+        ContractTestLibrary.CreateVendorContractAndCreateContractLinesForItems(VendorContract, ServiceObject, Vendor."No.");
+        FindFirstVendorSubscriptionLine(VendorSubscriptionLine, ServiceObject."No.");
+
+        // [GIVEN] A dimension value for Global Dimension 1 exists
+        GeneralLedgerSetup.Get();
+        LibraryDimension.CreateDimensionValue(DimensionValue, GeneralLedgerSetup."Global Dimension 1 Code");
+
+        // [WHEN] Shortcut Dimension 1 Code is changed on the Customer Subscription Line
+        CustomerSubscriptionLine.Validate("Shortcut Dimension 1 Code", DimensionValue.Code);
+
+        // [THEN] The Vendor Subscription Line's Dimension Set ID is updated with the same dimension
+        VendorSubscriptionLine.Get(VendorSubscriptionLine."Entry No.");
+        VerifyDimensionInDimensionSet(VendorSubscriptionLine."Dimension Set ID", GeneralLedgerSetup."Global Dimension 1 Code", DimensionValue.Code);
+    end;
+
     #endregion Tests
 
     #region Procedures
@@ -63,6 +171,31 @@ codeunit 139693 "Contract Dimensions Test"
         ContractTestLibrary.InitContractsApp();
         IsInitialized := true;
         LibraryTestInitialize.OnAfterTestSuiteInitialize(Codeunit::"Contract Dimensions Test");
+    end;
+
+    local procedure FindFirstCustomerSubscriptionLine(var SubscriptionLine: Record "Subscription Line"; SubscriptionHeaderNo: Code[20])
+    begin
+        SubscriptionLine.SetRange("Subscription Header No.", SubscriptionHeaderNo);
+        SubscriptionLine.SetRange(Partner, Enum::"Service Partner"::Customer);
+        SubscriptionLine.FindFirst();
+    end;
+
+    local procedure FindFirstVendorSubscriptionLine(var SubscriptionLine: Record "Subscription Line"; SubscriptionHeaderNo: Code[20])
+    begin
+        SubscriptionLine.SetRange("Subscription Header No.", SubscriptionHeaderNo);
+        SubscriptionLine.SetRange(Partner, Enum::"Service Partner"::Vendor);
+        SubscriptionLine.FindFirst();
+    end;
+
+    local procedure VerifyDimensionInDimensionSet(DimensionSetID: Integer; DimensionCode: Code[20]; DimensionValueCode: Code[20])
+    var
+        TempDimensionSetEntry: Record "Dimension Set Entry" temporary;
+    begin
+        DimensionManagement.GetDimensionSet(TempDimensionSetEntry, DimensionSetID);
+        TempDimensionSetEntry.SetRange("Dimension Code", DimensionCode);
+        Assert.RecordIsNotEmpty(TempDimensionSetEntry);
+        TempDimensionSetEntry.FindFirst();
+        TempDimensionSetEntry.TestField("Dimension Value Code", DimensionValueCode);
     end;
 
     #endregion Procedures


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This is a backport: BCApps/pull/6968

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->

Fixed [AB#630285](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630285)




