### PR TITLE
Fix attachment upload from E-Document factbox (Bug 619590)

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/EDocAttachmentProcessor.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocAttachmentProcessor.Codeunit.al
@@ -181,6 +181,38 @@ codeunit 6169 "E-Doc. Attachment Processor"
         DocumentAttachment.FilterGroup(0);
     end;
 
+    [EventSubscriber(ObjectType::Page, Page::"Doc. Attachment List Factbox", OnAfterGetRecRefFail, '', false, false)]
+    local procedure OnAfterGetRecRefFailForEDocs(var DocumentAttachment: Record "Document Attachment"; var RecRef: RecordRef)
+    var
+        EDocument: Record "E-Document";
+        EDocumentEntryNo: Integer;
+        EDocumentEntryNoText: Text;
+    begin
+        DocumentAttachment.FilterGroup(4);
+        EDocumentEntryNoText := DocumentAttachment.GetFilter("E-Document Entry No.");
+        DocumentAttachment.FilterGroup(0);
+        if EDocumentEntryNoText = '' then
+            exit;
+
+        Evaluate(EDocumentEntryNo, EDocumentEntryNoText);
+        if not EDocument.Get(EDocumentEntryNo) then
+            exit;
+
+        RecRef.GetTable(EDocument);
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"Document Attachment", OnBeforeInsertAttachment, '', false, false)]
+    local procedure OnBeforeInsertAttachmentForEDocs(var DocumentAttachment: Record "Document Attachment"; var RecRef: RecordRef)
+    var
+        EDocument: Record "E-Document";
+    begin
+        if RecRef.Number() <> Database::"E-Document" then
+            exit;
+
+        DocumentAttachment.Validate("E-Document Attachment", true);
+        DocumentAttachment.Validate("E-Document Entry No.", RecRef.Field(EDocument.FieldNo("Entry No")).Value());
+    end;
+
     var
         MissingEDocumentTypeErr: Label 'E-Document type %1 is not supported for attachments', Comment = '%1 - E-Document document type';
 

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocAttachmentTest.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocAttachmentTest.Codeunit.al
@@ -1,0 +1,89 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Test;
+
+using Microsoft.eServices.EDocument;
+using Microsoft.Foundation.Attachment;
+using System.Utilities;
+
+codeunit 139896 "E-Doc. Attachment Test"
+{
+    Subtype = Test;
+    TestType = IntegrationTest;
+    Permissions = tabledata "E-Document" = rimd,
+                  tabledata "Document Attachment" = rimd;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure UploadAttachmentToEDocSetsEDocFields()
+    var
+        EDocument: Record "E-Document";
+        DocumentAttachment: Record "Document Attachment";
+        TempBlob: Codeunit "Temp Blob";
+        RecRef: RecordRef;
+        OutStream: OutStream;
+        InStream: InStream;
+    begin
+        // [FEATURE] [E-Document] [Attachment]
+        // [SCENARIO] Bug 619590: When uploading an attachment to an E-Document via the factbox,
+        // the Document Attachment record must have "E-Document Attachment" = true and
+        // "E-Document Entry No." set. Without OnBeforeInsertAttachment subscriber, these
+        // fields are not populated and the attachment won't appear in the factbox.
+
+        // [GIVEN] An E-Document record exists
+        EDocument.Init();
+        EDocument."Document Type" := "E-Document Type"::"Purchase Invoice";
+        EDocument.Direction := "E-Document Direction"::Incoming;
+        EDocument.Insert(true);
+
+        // [GIVEN] A RecRef pointing to the E-Document
+        // (In the real flow, OnAfterGetRecRefFail constructs this from the factbox SubPageLink filters)
+        RecRef.GetTable(EDocument);
+
+        // [WHEN] We save an attachment via SaveAttachmentFromStream (same path as factbox upload)
+        TempBlob.CreateOutStream(OutStream);
+        OutStream.WriteText('Test attachment content for bug 619590');
+        TempBlob.CreateInStream(InStream);
+        DocumentAttachment.Init();
+        DocumentAttachment.SaveAttachmentFromStream(InStream, RecRef, 'test-edoc-attachment.txt');
+
+        // [THEN] The Document Attachment is created with Table ID = E-Document
+        DocumentAttachment.Reset();
+        DocumentAttachment.SetRange("Table ID", Database::"E-Document");
+        DocumentAttachment.SetRange("No.", Format(EDocument."Entry No"));
+        DocumentAttachment.FindFirst();
+
+        // [THEN] E-Document fields are set by the OnBeforeInsertAttachment subscriber
+        Assert.IsTrue(DocumentAttachment."E-Document Attachment",
+            'E-Document Attachment should be true — OnBeforeInsertAttachment subscriber must set this field');
+        Assert.AreEqual(EDocument."Entry No", DocumentAttachment."E-Document Entry No.",
+            'E-Document Entry No. should match the E-Document — OnBeforeInsertAttachment subscriber must set this field');
+    end;
+
+    [Test]
+    procedure GetRefTableReturnsFalseForTableIdZero()
+    var
+        DocumentAttachment: Record "Document Attachment";
+        DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
+        RecRef: RecordRef;
+    begin
+        // [FEATURE] [E-Document] [Attachment]
+        // [SCENARIO] Bug 619590: Verify precondition — GetRefTable returns false when Table ID = 0
+        // This is the state of Rec in the factbox when no attachments exist (SubPageLink
+        // does not set Table ID).
+
+        // [GIVEN] A Document Attachment with Table ID = 0
+        DocumentAttachment.Init();
+        DocumentAttachment."Table ID" := 0;
+
+        // [WHEN] GetRefTable is called
+        // [THEN] It returns false because Table ID = 0 is not handled
+        Assert.IsFalse(
+            DocumentAttachmentMgmt.GetRefTable(RecRef, DocumentAttachment),
+            'GetRefTable should return false for Table ID = 0');
+    end;
+}

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocPDFMock.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocPDFMock.Codeunit.al
@@ -23,7 +23,6 @@ codeunit 139782 "E-Doc PDF Mock" implements IStructureReceivedEDocument, IStruct
             EDocumentPurchaseHeader.Insert();
         end;
         exit(Enum::"E-Doc. Process Draft"::"Purchase Document");
-#pragma warning restore AL0432
     end;
 
     procedure View(EDocument: Record "E-Document"; TempBlob: Codeunit "Temp Blob")

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocPDFMock.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocPDFMock.Codeunit.al
@@ -22,7 +22,6 @@ codeunit 139782 "E-Doc PDF Mock" implements IStructureReceivedEDocument, IStruct
             EDocumentPurchaseHeader."Vendor VAT Id" := '1111111111234';
             EDocumentPurchaseHeader.Insert();
         end;
-#pragma warning disable AL0432
         exit(Enum::"E-Doc. Process Draft"::"Purchase Document");
 #pragma warning restore AL0432
     end;

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocPDFMock.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocPDFMock.Codeunit.al
@@ -22,7 +22,9 @@ codeunit 139782 "E-Doc PDF Mock" implements IStructureReceivedEDocument, IStruct
             EDocumentPurchaseHeader."Vendor VAT Id" := '1111111111234';
             EDocumentPurchaseHeader.Insert();
         end;
+#pragma warning disable AL0432
         exit(Enum::"E-Doc. Process Draft"::"Purchase Document");
+#pragma warning restore AL0432
     end;
 
     procedure View(EDocument: Record "E-Document"; TempBlob: Codeunit "Temp Blob")


### PR DESCRIPTION
## Summary
- Fix "The record is not open" error when uploading attachments from the E-Document page factbox when no attachments exist yet
- Add `OnAfterGetRecRefFail` subscriber to initialize RecRef from E-Document Entry No. (SubPageLink FilterGroup 4) when `GetRefTable` fails for Table ID = 0
- Add `OnBeforeInsertAttachment` subscriber to set `E-Document Attachment` and `E-Document Entry No.` fields so the attachment appears in the factbox

## Root cause
The E-Document page factbox links via `SubPageLink = "E-Document Entry No." = field("Entry No"), "E-Document Attachment" = const(true)` — it does not set `"Table ID"`. When there are no existing attachments (empty factbox), `Rec."Table ID" = 0`. The upload flow calls `GetRefTable(RecRef, Rec)`, which immediately returns `false` for Table ID = 0 **before** firing `OnAfterGetRefTable` (where the E-Document subscriber lives). The uninitialized `RecRef` is then passed to `SaveAttachment` → `InsertAttachment` → `RecRef.Find()` → platform error.

## Test plan
- [x] New test `UploadAttachmentToEDocSetsEDocFields` fails without the fix (Assert.IsTrue on E-Document Attachment field)
- [x] New test `GetRefTableReturnsFalseForTableIdZero` confirms the precondition
- [x] Both tests pass with the fix
- [x] Manual: open an E-Document with no attachments, upload a file from the factbox, verify it appears

[AB#619590](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/619590)






