### PR TITLE
[Subcontracting] Bugs 617394 - Disable warnings to enable ADO PRs

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcCalcSubcontractsExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcCalcSubcontractsExt.Codeunit.al
@@ -11,7 +11,9 @@ using Microsoft.Manufacturing.WorkCenter;
 
 codeunit 99001529 "Subc. Calc Subcontracts Ext."
 {
+#pragma warning disable AL0432
     [EventSubscriber(ObjectType::Report, Report::"Calculate Subcontracts", OnAfterTransferProdOrderRoutingLine, '', false, false)]
+#pragma warning restore AL0432
     local procedure OnAfterTransferProdOrderRoutingLine(var RequisitionLine: Record "Requisition Line"; ProdOrderRoutingLine: Record "Prod. Order Routing Line")
     var
         WorkCenter: Record "Work Center";

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcSubcontWorksheet.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcSubcontWorksheet.PageExt.al
@@ -6,7 +6,9 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Journal;
 
+#pragma warning disable AL0432
 pageextension 99001509 "Subc. Subcont. Worksheet" extends "Subcontracting Worksheet"
+#pragma warning restore AL0432
 {
     layout
     {

--- a/src/Apps/W1/Subcontracting/App/src/Setup/Tables/SubcManagementSetup.Table.al
+++ b/src/Apps/W1/Subcontracting/App/src/Setup/Tables/SubcManagementSetup.Table.al
@@ -29,13 +29,17 @@ table 99001501 "Subc. Management Setup"
         field(40; "Subcontracting Template Name"; Code[10])
         {
             Caption = 'Subcontracting Journal Template Name';
+#pragma warning disable AL0432
             TableRelation = "Req. Wksh. Template" where(Type = const("For. Labor"));
+#pragma warning restore AL0432
         }
         field(50; "Subcontracting Batch Name"; Code[10])
         {
             Caption = 'Subcontracting Journal Batch Name';
+#pragma warning disable AL0432
             TableRelation = "Requisition Wksh. Name".Name where("Template Type" = const("For. Labor"),
                                                                 "Worksheet Template Name" = field("Subcontracting Template Name"));
+#pragma warning restore AL0432                                                                
         }
         field(60; "Direct Transfer"; Boolean)
         {

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2079,7 +2079,9 @@ Comment = '|%1 = Transfer Order No.';
 
         LibraryInventory.NoSeriesSetup(InventorySetup);
         InventorySetup."Inventory Put-away Nos." := LibraryUtility.GetGlobalNoSeriesCode();
+#pragma warning disable AL0432
         InventorySetup."Direct Transfer Posting" := InventorySetup."Direct Transfer Posting"::"Direct Transfer";
+#pragma warning restore AL0432
         InventorySetup.Modify();
         LibraryInventory.UpdateInventoryPostingSetup(Location);
     end;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
We have PRs in ADO that obsolete objects/fields in ADO and move those objects/fields to Subcontracting App. As build pipelines build BCApps, the PR that obsolete fails because there are referances to the objects that we are obsoleting. This is a chicken and egg problem. We will disable the warnings in BCApps and afer ADO changes are checking, we will make changes to BCApps.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#617394](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617394)



