### PR TITLE
[Bug][SubscriptionBilling]: Outdated ship-to address used on invoice when contract sell-to address is updated

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Customer Contracts/Tables/CustomerSubscriptionContract.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Customer Contracts/Tables/CustomerSubscriptionContract.Table.al
@@ -430,6 +430,7 @@ table 8052 "Customer Subscription Contract"
 
             trigger OnValidate()
             begin
+                UpdateShipToAddressFromSellToAddress(FieldNo("Ship-to Address"));
                 ModifyCustomerAddress();
             end;
         }
@@ -440,6 +441,7 @@ table 8052 "Customer Subscription Contract"
 
             trigger OnValidate()
             begin
+                UpdateShipToAddressFromSellToAddress(FieldNo("Ship-to Address 2"));
                 ModifyCustomerAddress();
             end;
         }
@@ -468,6 +470,7 @@ table 8052 "Customer Subscription Contract"
             begin
                 PostCode.ValidateCity(
                   "Sell-to City", "Sell-to Post Code", "Sell-to County", "Sell-to Country/Region Code", (CurrFieldNo <> 0) and GuiAllowed);
+                UpdateShipToAddressFromSellToAddress(FieldNo("Ship-to City"));
                 ModifyCustomerAddress();
             end;
         }
@@ -492,6 +495,7 @@ table 8052 "Customer Subscription Contract"
 
             trigger OnValidate()
             begin
+                UpdateShipToAddressFromSellToAddress(FieldNo("Ship-to Contact"));
                 ModifyCustomerAddress();
             end;
         }
@@ -576,6 +580,7 @@ table 8052 "Customer Subscription Contract"
 
                 PostCode.ValidatePostCode(
                   "Sell-to City", "Sell-to Post Code", "Sell-to County", "Sell-to Country/Region Code", (CurrFieldNo <> 0) and GuiAllowed);
+                UpdateShipToAddressFromSellToAddress(FieldNo("Ship-to Post Code"));
                 ModifyCustomerAddress();
             end;
         }
@@ -587,6 +592,7 @@ table 8052 "Customer Subscription Contract"
 
             trigger OnValidate()
             begin
+                UpdateShipToAddressFromSellToAddress(FieldNo("Ship-to County"));
                 ModifyCustomerAddress();
             end;
         }
@@ -598,6 +604,7 @@ table 8052 "Customer Subscription Contract"
 
             trigger OnValidate()
             begin
+                UpdateShipToAddressFromSellToAddress(FieldNo("Ship-to Country/Region Code"));
                 ModifyCustomerAddress();
             end;
         }
@@ -1700,6 +1707,35 @@ table 8052 "Customer Subscription Contract"
         exit(IsShipToAddressEqualToSellToAddress(xRec, Rec));
     end;
 
+    internal procedure ShipToAddressEqualsSellToAddress(): Boolean
+    begin
+        exit(IsShipToAddressEqualToSellToAddress(Rec, Rec));
+    end;
+
+    local procedure UpdateShipToAddressFromSellToAddress(FieldNumber: Integer)
+    begin
+        if ("Ship-to Code" = '') and ShipToAddressEqualsOldSellToAddress() then
+            case FieldNumber of
+                FieldNo("Ship-to Address"):
+                    "Ship-to Address" := "Sell-to Address";
+                FieldNo("Ship-to Address 2"):
+                    "Ship-to Address 2" := "Sell-to Address 2";
+                FieldNo("Ship-to City"), FieldNo("Ship-to Post Code"):
+                    begin
+                        "Ship-to City" := "Sell-to City";
+                        "Ship-to Post Code" := "Sell-to Post Code";
+                        "Ship-to County" := "Sell-to County";
+                        "Ship-to Country/Region Code" := "Sell-to Country/Region Code";
+                    end;
+                FieldNo("Ship-to County"):
+                    "Ship-to County" := "Sell-to County";
+                FieldNo("Ship-to Country/Region Code"):
+                    "Ship-to Country/Region Code" := "Sell-to Country/Region Code";
+                FieldNo("Ship-to Contact"):
+                    "Ship-to Contact" := "Sell-to Contact";
+            end;
+    end;
+
     local procedure IsShipToAddressEqualToSellToAddress(CustomerContractWithSellTo: Record "Customer Subscription Contract"; CustomerContractWithShipTo: Record "Customer Subscription Contract"): Boolean
     var
         Result: Boolean;
@@ -1895,7 +1931,7 @@ table 8052 "Customer Subscription Contract"
         ModifyCustomerAddressNotification.Recall();
     end;
 
-    local procedure GetModifyCustomerAddressNotificationId(): Guid
+    internal procedure GetModifyCustomerAddressNotificationId(): Guid
     begin
         exit('D2EAE122-76DB-4D6D-B6ED-7A6EF9DC7F3D');
     end;
@@ -2010,7 +2046,7 @@ table 8052 "Customer Subscription Contract"
     end;
 
     /// <summary>
-    /// Creates customer subscription contract line from subscription line which are not already assigned to a customer subscription contract line. 
+    /// Creates customer subscription contract line from subscription line which are not already assigned to a customer subscription contract line.
     /// </summary>
     /// <param name="TempServiceCommitment">Temporary VAR Record "Subscription Line".</param>
     procedure CreateCustomerContractLinesFromServiceCommitments(var TempServiceCommitment: Record "Subscription Line" temporary)

--- a/src/Apps/W1/Subscription Billing/App/Vendor Contracts/Tables/VendorSubscriptionContract.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Vendor Contracts/Tables/VendorSubscriptionContract.Table.al
@@ -1426,12 +1426,12 @@ table 8063 "Vendor Subscription Contract"
         ModifyVendorAddressNotification.Recall();
     end;
 
-    local procedure GetModifyVendorAddressNotificationId(): Guid
+    internal procedure GetModifyVendorAddressNotificationId(): Guid
     begin
         exit('70D33B2A-0A18-44FB-9D27-2429FC5167ED');
     end;
 
-    local procedure GetModifyPayToVendorAddressNotificationId(): Guid
+    internal procedure GetModifyPayToVendorAddressNotificationId(): Guid
     begin
         exit('CCEDACB9-211A-4457-919B-5B841759EBB5');
     end;
@@ -1456,54 +1456,49 @@ table 8063 "Vendor Subscription Contract"
         if PayToAddressEqualsOldBuyFromAddress() then
             case FieldNumber of
                 FieldNo("Pay-to Address"):
-                    if xRec."Buy-from Address" = "Pay-to Address" then
-                        "Pay-to Address" := "Buy-from Address";
+                    "Pay-to Address" := "Buy-from Address";
                 FieldNo("Pay-to Address 2"):
-                    if xRec."Buy-from Address 2" = "Pay-to Address 2" then
-                        "Pay-to Address 2" := "Buy-from Address 2";
+                    "Pay-to Address 2" := "Buy-from Address 2";
                 FieldNo("Pay-to City"), FieldNo("Pay-to Post Code"):
                     begin
-                        if xRec."Buy-from City" = "Pay-to City" then
-                            "Pay-to City" := "Buy-from City";
-                        if xRec."Buy-from Post Code" = "Pay-to Post Code" then
-                            "Pay-to Post Code" := "Buy-from Post Code";
-                        if xRec."Buy-from County" = "Pay-to County" then
-                            "Pay-to County" := "Buy-from County";
-                        if xRec."Buy-from Country/Region Code" = "Pay-to Country/Region Code" then
-                            "Pay-to Country/Region Code" := "Buy-from Country/Region Code";
+                        "Pay-to City" := "Buy-from City";
+                        "Pay-to Post Code" := "Buy-from Post Code";
+                        "Pay-to County" := "Buy-from County";
+                        "Pay-to Country/Region Code" := "Buy-from Country/Region Code";
                     end;
                 FieldNo("Pay-to County"):
-                    if xRec."Buy-from County" = "Pay-to County" then
-                        "Pay-to County" := "Buy-from County";
+                    "Pay-to County" := "Buy-from County";
                 FieldNo("Pay-to Country/Region Code"):
-                    if xRec."Buy-from Country/Region Code" = "Pay-to Country/Region Code" then
-                        "Pay-to Country/Region Code" := "Buy-from Country/Region Code";
+                    "Pay-to Country/Region Code" := "Buy-from Country/Region Code";
             end;
     end;
 
     local procedure PayToAddressEqualsOldBuyFromAddress(): Boolean
     begin
-        if (xRec."Buy-from Address" = "Pay-to Address") and
-           (xRec."Buy-from Address 2" = "Pay-to Address 2") and
-           (xRec."Buy-from City" = "Pay-to City") and
-           (xRec."Buy-from County" = "Pay-to County") and
-           (xRec."Buy-from Post Code" = "Pay-to Post Code") and
-           (xRec."Buy-from Country/Region Code" = "Pay-to Country/Region Code")
-        then
-            exit(true);
+        exit(IsPayToAddressEqualToBuyFromAddress(xRec, Rec));
     end;
 
     internal procedure BuyFromAddressEqualsPayToAddress(): Boolean
     begin
-        exit(
-          ("Pay-to Address" = "Buy-from Address") and
-          ("Pay-to Address 2" = "Buy-from Address 2") and
-          ("Pay-to City" = "Buy-from City") and
-          ("Pay-to County" = "Buy-from County") and
-          ("Pay-to Post Code" = "Buy-from Post Code") and
-          ("Pay-to Country/Region Code" = "Buy-from Country/Region Code") and
-          ("Pay-to Contact No." = "Buy-from Contact No.") and
-          ("Pay-to Contact" = "Buy-from Contact"));
+        exit(IsPayToAddressEqualToBuyFromAddress(Rec, Rec));
+    end;
+
+    local procedure IsPayToAddressEqualToBuyFromAddress(VendorContractWithBuyFrom: Record "Vendor Subscription Contract"; VendorContractWithPayTo: Record "Vendor Subscription Contract"): Boolean
+    var
+        Result: Boolean;
+    begin
+        Result :=
+          (VendorContractWithBuyFrom."Buy-from Address" = VendorContractWithPayTo."Pay-to Address") and
+          (VendorContractWithBuyFrom."Buy-from Address 2" = VendorContractWithPayTo."Pay-to Address 2") and
+          (VendorContractWithBuyFrom."Buy-from City" = VendorContractWithPayTo."Pay-to City") and
+          (VendorContractWithBuyFrom."Buy-from County" = VendorContractWithPayTo."Pay-to County") and
+          (VendorContractWithBuyFrom."Buy-from Post Code" = VendorContractWithPayTo."Pay-to Post Code") and
+          (VendorContractWithBuyFrom."Buy-from Country/Region Code" = VendorContractWithPayTo."Pay-to Country/Region Code") and
+          (VendorContractWithBuyFrom."Buy-from Contact No." = VendorContractWithPayTo."Pay-to Contact No.") and
+          (VendorContractWithBuyFrom."Buy-from Contact" = VendorContractWithPayTo."Pay-to Contact");
+
+        OnAfterIsPayToAddressEqualToBuyFromAddress(VendorContractWithBuyFrom, VendorContractWithPayTo, Result);
+        exit(Result);
     end;
 
     local procedure SetPurchaserCode(PurchaserCodeToCheck: Code[20]; var PurchaserCodeToAssign: Code[20])
@@ -1581,7 +1576,7 @@ table 8063 "Vendor Subscription Contract"
         if VendorContractLine.FindSet() then
             repeat
                 if not TempServiceObject.Get(VendorContractLine."Subscription Header No.") then begin
-#pragma warning disable AA0214                    
+#pragma warning disable AA0214
                     ServiceObject.Get(VendorContractLine."Subscription Header No.");
                     ServiceObject.UpdateServicesDates();
                     ServiceObject.Modify(false);
@@ -1805,6 +1800,11 @@ table 8063 "Vendor Subscription Contract"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterCreateDimDimSource(VendorSubscriptionContract: Record "Vendor Subscription Contract"; CurrFieldNo: Integer; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]])
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterIsPayToAddressEqualToBuyFromAddress(VendorContractWithBuyFrom: Record "Vendor Subscription Contract"; VendorContractWithPayTo: Record "Vendor Subscription Contract"; var Result: Boolean)
     begin
     end;
 }

--- a/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractsTest.Codeunit.al
@@ -2087,6 +2087,63 @@ codeunit 148155 "Contracts Test"
         CustomerContract.TestField("Sell-to Customer No.", NewCustomer."No.");
     end;
 
+    [Test]
+    procedure ShipToAddressIsUpdatedWhenSellToAddressIsChanged()
+    var
+        Customer: Record Customer;
+        CustomerContract: Record "Customer Subscription Contract";
+    begin
+        // [SCENARIO] Ship-To address fields are in sync with Sell-To address fields when Ship-to Code is blank
+        Initialize();
+
+        // [GIVEN] A customer contract where sell-to and ship-to addresses are equal
+        ContractTestLibrary.CreateCustomer(Customer);
+        ContractTestLibrary.CreateCustomerContract(CustomerContract, Customer."No.");
+        CustomerContract.DontNotifyCurrentUserAgain(CustomerContract.GetModifyBillToCustomerAddressNotificationId());
+        CustomerContract.DontNotifyCurrentUserAgain(CustomerContract.GetModifyCustomerAddressNotificationId());
+
+        Assert.AreEqual('', CustomerContract."Ship-to Code", 'Ship-to Code should be blank for default (sell-to) address.');
+        Assert.IsTrue(CustomerContract.ShipToAddressEqualsSellToAddress(), 'Setup: Ship-to and Sell-to address should be equal before the test.');
+
+        // [WHEN] Changing the sell-to address fields on the contract
+        CustomerContract.Validate("Sell-to Address", CopyStr(LibraryRandom.RandText(MaxStrLen(CustomerContract."Sell-to Address")), 1, MaxStrLen(CustomerContract."Sell-to Address")));
+        CustomerContract.Validate("Sell-to Address 2", CopyStr(LibraryRandom.RandText(MaxStrLen(CustomerContract."Sell-to Address 2")), 1, MaxStrLen(CustomerContract."Sell-to Address 2")));
+        CustomerContract.Validate("Sell-to Contact", CopyStr(LibraryRandom.RandText(MaxStrLen(CustomerContract."Sell-to Contact")), 1, MaxStrLen(CustomerContract."Sell-to Contact")));
+        CustomerContract.Modify(true);
+
+        // [THEN] Ship-To address fields are updated to match Sell-To address fields
+        Assert.IsTrue(CustomerContract.ShipToAddressEqualsSellToAddress(), 'Ship-to address fields should be in sync with Sell-to address fields.');
+    end;
+
+    [Test]
+    procedure ShipToAddressIsNotUpdatedWhenShipToCodeIsSet()
+    var
+        Customer: Record Customer;
+        CustomerContract: Record "Customer Subscription Contract";
+        ShipToAddress: Record "Ship-to Address";
+    begin
+        // [SCENARIO] Ship-To address fields are NOT updated when an alternate Ship-to Code is set
+        Initialize();
+
+        // [GIVEN] A customer contract with an alternate ship-to address
+        ContractTestLibrary.CreateCustomer(Customer);
+        ContractTestLibrary.CreateCustomerContract(CustomerContract, Customer."No.");
+        CustomerContract.DontNotifyCurrentUserAgain(CustomerContract.GetModifyBillToCustomerAddressNotificationId());
+        CustomerContract.DontNotifyCurrentUserAgain(CustomerContract.GetModifyCustomerAddressNotificationId());
+
+        ShipToAddress.SetRange("Customer No.", Customer."No.");
+        ShipToAddress.FindFirst();
+        CustomerContract.Validate("Ship-to Code", ShipToAddress.Code);
+        CustomerContract.Modify(true);
+
+        // [WHEN] Changing the sell-to address on the contract
+        CustomerContract.Validate("Sell-to Address", CopyStr(LibraryRandom.RandText(MaxStrLen(CustomerContract."Sell-to Address")), 1, MaxStrLen(CustomerContract."Sell-to Address")));
+        CustomerContract.Modify(true);
+
+        // [THEN] Ship-To address is NOT updated (it retains the alternate ship-to address)
+        Assert.AreNotEqual(CustomerContract."Sell-to Address", CustomerContract."Ship-to Address", 'Ship-to Address should not be changed when Ship-to Code is set.');
+    end;
+
     #endregion Tests
 
     #region Procedures

--- a/src/Apps/W1/Subscription Billing/Test/Vendor Contracts/VendorContractsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Vendor Contracts/VendorContractsTest.Codeunit.al
@@ -755,6 +755,54 @@ codeunit 148154 "Vendor Contracts Test"
         VendorContract.TestField("Contract Type", ContractType.Code);
     end;
 
+    [Test]
+    procedure PayToAddressIsUpdatedWhenBuyFromAddressIsChanged()
+    begin
+        // [SCENARIO] Pay-To address fields are in sync with Buy-From address fields when Pay-to Vendor No. equals Buy-from Vendor No.
+        Initialize();
+
+        // [GIVEN] A vendor contract where buy-from and pay-to addresses are equal
+        ContractTestLibrary.CreateVendor(Vendor);
+        ContractTestLibrary.CreateVendorContract(VendorContract, Vendor."No.");
+        VendorContract.DontNotifyCurrentUserAgain(VendorContract.GetModifyVendorAddressNotificationId());
+        VendorContract.DontNotifyCurrentUserAgain(VendorContract.GetModifyPayToVendorAddressNotificationId());
+
+        AssertThat.IsTrue(VendorContract.BuyFromAddressEqualsPayToAddress(), 'Setup: Buy-from and Pay-to address should be equal before the test.');
+
+        // [WHEN] Changing the buy-from address fields on the contract
+        VendorContract.Validate("Buy-from Address", CopyStr(LibraryRandom.RandText(MaxStrLen(VendorContract."Buy-from Address")), 1, MaxStrLen(VendorContract."Buy-from Address")));
+        VendorContract.Validate("Buy-from Address 2", CopyStr(LibraryRandom.RandText(MaxStrLen(VendorContract."Buy-from Address 2")), 1, MaxStrLen(VendorContract."Buy-from Address 2")));
+        VendorContract.Modify(true);
+
+        // [THEN] Pay-To address fields are updated to match Buy-From address fields
+        AssertThat.IsTrue(VendorContract.BuyFromAddressEqualsPayToAddress(), 'Pay-to address fields should be in sync with Buy-from address fields.');
+    end;
+
+    [Test]
+    procedure PayToAddressIsNotUpdatedWhenPayToVendorIsDifferent()
+    begin
+        // [SCENARIO] Pay-To address fields are NOT updated when Pay-to Vendor differs from Buy-from Vendor
+        Initialize();
+
+        // [GIVEN] A vendor contract with a different pay-to vendor
+        ContractTestLibrary.CreateVendor(Vendor);
+        ContractTestLibrary.CreateVendorInLCY(Vendor2);
+        ContractTestLibrary.CreateVendorContract(VendorContract, Vendor."No.");
+        VendorContract.DontNotifyCurrentUserAgain(VendorContract.GetModifyVendorAddressNotificationId());
+        VendorContract.DontNotifyCurrentUserAgain(VendorContract.GetModifyPayToVendorAddressNotificationId());
+
+        VendorContract.SetHideValidationDialog(true);
+        VendorContract.Validate("Pay-to Vendor No.", Vendor2."No.");
+        VendorContract.Modify(true);
+
+        // [WHEN] Changing the buy-from address on the contract
+        VendorContract.Validate("Buy-from Address", CopyStr(LibraryRandom.RandText(MaxStrLen(VendorContract."Buy-from Address")), 1, MaxStrLen(VendorContract."Buy-from Address")));
+        VendorContract.Modify(true);
+
+        // [THEN] Pay-To address is NOT updated (it retains the alternate pay-to vendor address)
+        AssertThat.AreNotEqual(VendorContract."Buy-from Address", VendorContract."Pay-to Address", 'Pay-to Address should not be changed when Pay-to Vendor differs from Buy-from Vendor.');
+    end;
+
     #endregion Tests
 
     #region Procedures


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
When the sell-to address was changed on a Customer Subscription Contract with Ship-to Code blank (default), the ship-to address fields were not updated, causing invoices to use the outdated ship-to address.

- Add UpdateShipToAddressFromSellToAddress to sync ship-to fields from sell-to on Customer Subscription Contract (aligned with Sales Header)
- Add ShipToAddressEqualsSellToAddress and IsShipToAddressEqualToSellToAddress helper with integration event
- Refactor UpdatePayToAddressFromBuyFromAddress on Vendor Subscription Contract with shared IsPayToAddressEqualToBuyFromAddress helper (aligned with Purchase Header)
- Promote notification ID getters to internal for testability
- Add tests for both customer and vendor contract address sync

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #6974



Fixes [AB#631934](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/631934)

