### PR TITLE
[Quality Managment] The Re-Open button is active when the status of an inspection is Open on Quality Inspection List.

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
@@ -863,7 +863,7 @@ page 20406 "Qlty. Inspection"
         IsOpen := Rec.Status = Rec.Status::Open;
         StatusStyleExpr := Rec.GetStatusStyleExpression();
 
-        CanReopen := (Rec.Status = Rec.Status::Finished) and not Rec.HasMoreRecentReinspection();
+        CanReopen := (Rec.Status <> Rec.Status::Open) and not Rec.HasMoreRecentReinspection();
         CanFinish := Rec.Status <> Rec.Status::Finished;
         if IsOpen then
             if QltyPermissionMgmt.CanChangeItemTracking() then begin

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
@@ -863,7 +863,7 @@ page 20406 "Qlty. Inspection"
         IsOpen := Rec.Status = Rec.Status::Open;
         StatusStyleExpr := Rec.GetStatusStyleExpression();
 
-        CanReopen := not Rec.HasMoreRecentReinspection();
+        CanReopen := (Rec.Status = Rec.Status::Finished) and not Rec.HasMoreRecentReinspection();
         CanFinish := Rec.Status <> Rec.Status::Finished;
         if IsOpen then
             if QltyPermissionMgmt.CanChangeItemTracking() then begin

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
@@ -717,7 +717,7 @@ page 20408 "Qlty. Inspection List"
         CanUnassign := false;
         RowActionsAreEnabled := not IsNullGuid(Rec.SystemId);
         CanCreateReinspection := RowActionsAreEnabled;
-        CanReopen := RowActionsAreEnabled and not Rec.HasMoreRecentReinspection();
+        CanReopen := RowActionsAreEnabled and (Rec.Status = Rec.Status::Finished) and not Rec.HasMoreRecentReinspection();
         CanFinish := RowActionsAreEnabled and (Rec.Status <> Rec.Status::Finished);
         StatusStyleExpr := Rec.GetStatusStyleExpression();
 

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
@@ -717,7 +717,7 @@ page 20408 "Qlty. Inspection List"
         CanUnassign := false;
         RowActionsAreEnabled := not IsNullGuid(Rec.SystemId);
         CanCreateReinspection := RowActionsAreEnabled;
-        CanReopen := RowActionsAreEnabled and (Rec.Status = Rec.Status::Finished) and not Rec.HasMoreRecentReinspection();
+        CanReopen := RowActionsAreEnabled and (Rec.Status <> Rec.Status::Open) and not Rec.HasMoreRecentReinspection();
         CanFinish := RowActionsAreEnabled and (Rec.Status <> Rec.Status::Finished);
         StatusStyleExpr := Rec.GetStatusStyleExpression();
 


### PR DESCRIPTION
Fixes [AB#623792](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/623792)






