### PR TITLE
[Subcontracting] Bug 629884: Item Tracking page does not open on purchase line

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubcPurchaseLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubcPurchaseLineExt.Codeunit.al
@@ -95,8 +95,8 @@ codeunit 99001534 "Subc. Purchase Line Ext"
     [EventSubscriber(ObjectType::Table, Database::"Purchase Line", OnBeforeOpenItemTrackingLines, '', false, false)]
     local procedure OpenProdOrderLineItemTrackingOnBeforeOpenItemTrackingLines(PurchaseLine: Record "Purchase Line"; var IsHandled: Boolean)
     begin
-        OpenItemTrackingOfProdOrderLine(PurchaseLine, false);
-        IsHandled := true;
+        if OpenItemTrackingOfProdOrderLine(PurchaseLine, false) then
+            IsHandled := true;
     end;
 
     local procedure CheckItem(PurchaseLine: Record "Purchase Line")
@@ -143,7 +143,7 @@ codeunit 99001534 "Subc. Purchase Line Ext"
         end;
     end;
 
-    local procedure OpenItemTrackingOfProdOrderLine(var PurchaseLine: Record "Purchase Line"; SkipOverDeliveryCheck: Boolean)
+    local procedure OpenItemTrackingOfProdOrderLine(var PurchaseLine: Record "Purchase Line"; SkipOverDeliveryCheck: Boolean): Boolean
     var
         ProdOrderLine: Record "Prod. Order Line";
         TrackingSpecification: Record "Tracking Specification";
@@ -152,14 +152,14 @@ codeunit 99001534 "Subc. Purchase Line Ext"
         SecondSourceQtyArray: array[3] of Decimal;
     begin
         if PurchaseLine."Subc. Purchase Line Type" = "Subc. Purchase Line Type"::None then
-            exit;
+            exit(false);
         CheckItem(PurchaseLine);
         if PurchaseLine."Subc. Purchase Line Type" = "Subc. Purchase Line Type"::NotLastOperation then
             Error(NotLastOperationLineErr);
         if PurchaseLine."Subc. Purchase Line Type" <> "Subc. Purchase Line Type"::LastOperation then
-            exit;
+            exit(false);
         if not PurchaseLine.IsSubcontractingLineWithLastOperation(ProdOrderLine) then
-            exit;
+            exit(false);
 
         SecondSourceQtyArray[1] := Database::"Warehouse Receipt Line";
         SecondSourceQtyArray[2] := PurchaseLine.CalcBaseQtyFromQuantity(PurchaseLine."Qty. to Receive", PurchaseLine.FieldCaption("Qty. Rounding Precision"), PurchaseLine.FieldCaption("Qty. to Receive"), PurchaseLine.FieldCaption("Qty. to Receive (Base)"));
@@ -172,6 +172,7 @@ codeunit 99001534 "Subc. Purchase Line Ext"
         ItemTrackingLines.SetSourceSpec(TrackingSpecification, ProdOrderLine."Due Date");
         ItemTrackingLines.SetSecondSourceQuantity(SecondSourceQtyArray);
         ItemTrackingLines.RunModal();
+        exit(true);
     end;
 
     internal procedure ShowProductionOrder(OverDeliveryErrorInfo: ErrorInfo)

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -8,6 +8,7 @@ using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Setup;
 using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Location;
+using Microsoft.Inventory.Tracking;
 using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Routing;
@@ -47,6 +48,7 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         IsInitialized: Boolean;
         ErrorCounter: Integer;
         ErrorMessageDescriptionList: List of [Text];
+        ItemTrackingWasOpened: Boolean;
         UnitCostCalculation: Option Time,Units;
 
     [Test]
@@ -259,6 +261,58 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         // [TEARDOWN]
         UpdateSubMgmtCommonWorkCenter('');
         UpdateSubMgmtRoutingLink('');
+    end;
+
+    [Test]
+    [HandlerFunctions('ItemTrackingLinesSimpleHandler')]
+    procedure ItemTrackingLinesCanBeOpenedOnNonSubcontractingPurchaseLine()
+    var
+        Item: Record Item;
+        ItemTrackingCode: Record "Item Tracking Code";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        Vendor: Record Vendor;
+    begin
+        // [SCENARIO] Opening item tracking lines on a regular (non-subcontracting) purchase line succeeds
+        // [FEATURE] Bug 629884 - The subcontracting extension must not intercept OnBeforeOpenItemTrackingLines for non-subcontracting lines
+
+        Initialize();
+
+        // [GIVEN] An item with lot purchase inbound tracking
+        LibraryInventory.CreateItemTrackingCode(ItemTrackingCode);
+        ItemTrackingCode.Validate("Lot Purchase Inbound Tracking", true);
+        ItemTrackingCode.Modify(true);
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Item Tracking Code", ItemTrackingCode.Code);
+        Item.Modify(true);
+
+        // [GIVEN] A purchase order with a regular (non-subcontracting) purchase line
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", LibraryRandom.RandIntInRange(1, 10));
+
+        // [VERIFY] The purchase line has no subcontracting link (Subc. Purchase Line Type = None)
+        Assert.AreEqual(
+            "Subc. Purchase Line Type"::None, PurchaseLine."Subc. Purchase Line Type",
+            'Purchase line must have Subc. Purchase Line Type = None for this test');
+
+        // [WHEN] Open item tracking lines on the non-subcontracting purchase line
+        // Before fix: the event subscriber always set IsHandled = true, preventing the standard
+        // item tracking page from opening even when the purchase line was not a subcontracting line.
+        ItemTrackingWasOpened := false;
+        PurchaseLine.OpenItemTrackingLines();
+
+        // [THEN] The standard item tracking lines page was opened
+        Assert.IsTrue(
+            ItemTrackingWasOpened,
+            'Item tracking lines page must open for a non-subcontracting purchase line');
+    end;
+
+    [ModalPageHandler]
+    procedure ItemTrackingLinesSimpleHandler(var ItemTrackingLines: TestPage "Item Tracking Lines")
+    begin
+        ItemTrackingWasOpened := true;
+        ItemTrackingLines.OK().Invoke();
     end;
 
     [PageHandler]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
PR https://github.com/microsoft/BCApps/pull/6751 created regression where invoking Item Tracking on purchase line on a purchase order did nothing. The reason is that the subscriber sets IsHandled to true even when the purchase line is not linked to any subcontracting operation. The fix is to ensure IsHandled is not set to true when it is not truely handled.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#629884](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/629884)

