### PR TITLE
[Shopify] Fix Shop Card tooltip and field visibility regressions

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -97,12 +97,10 @@ page 30101 "Shpfy Shop Card"
                 field(LoggingMode; Rec."Logging Mode")
                 {
                     ApplicationArea = All;
-                    Importance = Additional;
                 }
                 field(AllowBackgroudSyncs; Rec."Allow Background Syncs")
                 {
                     ApplicationArea = All;
-                    Importance = Additional;
                 }
                 field("Allow Outgoing Requests"; Rec."Allow Outgoing Requests")
                 {

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -453,7 +453,7 @@ table 30102 "Shpfy Shop"
         field(52; "Currency Code"; Code[10])
         {
             Caption = 'Currency Code';
-            ToolTip = 'Specifies the currency used by your Shopify store. Leave blank if it matches the local currency (LCY). When set, exchange rates must be configured. This field works together with the "Currency Handling" field in the Order section, which determines how order currencies are processed.';
+            ToolTip = 'Specifies the currency used by your Shopify store. Leave blank if it matches the local currency (LCY). When set, exchange rates must be configured. This currency is used when calculating product prices to sync to Shopify and works together with the "Currency Handling" field in the Order section, which determines how order currencies are processed.';
             DataClassification = CustomerContent;
             TableRelation = Currency.Code;
 


### PR DESCRIPTION
## Summary
- **Bug 630218**: Add missing price calculation context to the Currency Code tooltip — it now mentions that this currency is used when calculating product prices to sync to Shopify
- **Bug 630219**: Remove `Importance = Additional` from Logging Mode and Allow Background Syncs fields, restoring them to default (Standard) visibility — these were accidentally reverted in #7400

Fixes [AB#630218](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630218)
Fixes [AB#630219](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630219)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


