### PR TITLE
28.x: Fix Trial Balance Excel gross debit/credit columns

### DIFF
--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalPrevYearExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalPrevYearExcel.Report.al
@@ -205,31 +205,57 @@ report 4407 "EXR Trial Bal. Prev Year Excel"
     local procedure AddGLToDataset(var GLAccount: Record "G/L Account"; Dimension1Code: Code[20]; Dimension2Code: Code[20])
     var
         LocalGLAccount: Record "G/L Account";
+        LocalGLAccountBalance: Record "G/L Account";
         LocalGLAccountLastPeriod: Record "G/L Account";
+        LocalGLAccountLastPeriodBalance: Record "G/L Account";
     begin
         LocalGLAccount.Copy(GLAccount);
         LocalGLAccount.SetRange("Global Dimension 1 Filter", Dimension1Code);
         LocalGLAccount.SetRange("Global Dimension 2 Filter", Dimension2Code);
 
-        LocalGLAccount.CalcFields("Net Change", "Balance at Date", "Additional-Currency Net Change", "Add.-Currency Balance at Date");
+        LocalGLAccount.CalcFields("Net Change", "Balance at Date", "Additional-Currency Net Change", "Add.-Currency Balance at Date", "Debit Amount", "Credit Amount", "Add.-Currency Debit Amount", "Add.-Currency Credit Amount");
+        // Cumulative debit/credit for balance requires date filter ..EndDate (Debit Amount uses the full range, not upperlimit like Balance at Date)
+        LocalGLAccountBalance.Copy(LocalGLAccount);
+        LocalGLAccountBalance.SetFilter("Date Filter", '..%1', LocalGLAccount.GetRangeMax("Date Filter"));
+        LocalGLAccountBalance.CalcFields("Debit Amount", "Credit Amount", "Add.-Currency Debit Amount", "Add.-Currency Credit Amount");
+
         LocalGLAccountLastPeriod.Copy(LocalGLAccount);
         LocalGLAccountLastPeriod.SetRange("Date Filter", PriorFromDate, PriorToDate);
-        LocalGLAccountLastPeriod.CalcFields("Net Change", "Balance at Date", "Additional-Currency Net Change", "Add.-Currency Balance at Date");
+        LocalGLAccountLastPeriod.CalcFields("Net Change", "Balance at Date", "Additional-Currency Net Change", "Add.-Currency Balance at Date", "Debit Amount", "Credit Amount", "Add.-Currency Debit Amount", "Add.-Currency Credit Amount");
+        LocalGLAccountLastPeriodBalance.Copy(LocalGLAccountLastPeriod);
+        LocalGLAccountLastPeriodBalance.SetFilter("Date Filter", '..%1', PriorToDate);
+        LocalGLAccountLastPeriodBalance.CalcFields("Debit Amount", "Credit Amount", "Add.-Currency Debit Amount", "Add.-Currency Credit Amount");
 
         Clear(EXRTrialBalanceBuffer);
         EXRTrialBalanceBuffer."G/L Account No." := LocalGLAccount."No.";
         EXRTrialBalanceBuffer."Dimension 1 Code" := Dimension1Code;
         EXRTrialBalanceBuffer."Dimension 2 Code" := Dimension2Code;
 
-        EXRTrialBalanceBuffer.Validate("Net Change", LocalGLAccount."Net Change");
-        EXRTrialBalanceBuffer.Validate("Balance", LocalGLAccount."Balance at Date");
-        EXRTrialBalanceBuffer.Validate("Last Period Net", LocalGLAccountLastPeriod."Net Change");
-        EXRTrialBalanceBuffer.Validate("Last Period Bal.", LocalGLAccountLastPeriod."Balance at Date");
+        EXRTrialBalanceBuffer."Net Change" := LocalGLAccount."Net Change";
+        EXRTrialBalanceBuffer."Net Change (Debit)" := LocalGLAccount."Debit Amount";
+        EXRTrialBalanceBuffer."Net Change (Credit)" := LocalGLAccount."Credit Amount";
+        EXRTrialBalanceBuffer.Balance := LocalGLAccount."Balance at Date";
+        EXRTrialBalanceBuffer."Balance (Debit)" := LocalGLAccountBalance."Debit Amount";
+        EXRTrialBalanceBuffer."Balance (Credit)" := LocalGLAccountBalance."Credit Amount";
+        EXRTrialBalanceBuffer."Last Period Net" := LocalGLAccountLastPeriod."Net Change";
+        EXRTrialBalanceBuffer."Last Period Net (Debit)" := LocalGLAccountLastPeriod."Debit Amount";
+        EXRTrialBalanceBuffer."Last Period Net (Credit)" := LocalGLAccountLastPeriod."Credit Amount";
+        EXRTrialBalanceBuffer."Last Period Bal." := LocalGLAccountLastPeriod."Balance at Date";
+        EXRTrialBalanceBuffer."Last Period Bal. (Debit)" := LocalGLAccountLastPeriodBalance."Debit Amount";
+        EXRTrialBalanceBuffer."Last Period Bal. (Credit)" := LocalGLAccountLastPeriodBalance."Credit Amount";
 
-        EXRTrialBalanceBuffer.Validate("Net Change (ACY)", LocalGLAccount."Additional-Currency Net Change");
-        EXRTrialBalanceBuffer.Validate("Balance (ACY)", LocalGLAccount."Add.-Currency Balance at Date");
-        EXRTrialBalanceBuffer.Validate("Last Period Net (ACY)", LocalGLAccountLastPeriod."Additional-Currency Net Change");
-        EXRTrialBalanceBuffer.Validate("Last Period Bal. (ACY)", LocalGLAccountLastPeriod."Add.-Currency Balance at Date");
+        EXRTrialBalanceBuffer."Net Change (ACY)" := LocalGLAccount."Additional-Currency Net Change";
+        EXRTrialBalanceBuffer."Net Change (Debit) (ACY)" := LocalGLAccount."Add.-Currency Debit Amount";
+        EXRTrialBalanceBuffer."Net Change (Credit) (ACY)" := LocalGLAccount."Add.-Currency Credit Amount";
+        EXRTrialBalanceBuffer."Balance (ACY)" := LocalGLAccount."Add.-Currency Balance at Date";
+        EXRTrialBalanceBuffer."Balance (Debit) (ACY)" := LocalGLAccountBalance."Add.-Currency Debit Amount";
+        EXRTrialBalanceBuffer."Balance (Credit) (ACY)" := LocalGLAccountBalance."Add.-Currency Credit Amount";
+        EXRTrialBalanceBuffer."Last Period Net (ACY)" := LocalGLAccountLastPeriod."Additional-Currency Net Change";
+        EXRTrialBalanceBuffer."Last Period Net (Debit) (ACY)" := LocalGLAccountLastPeriod."Add.-Currency Debit Amount";
+        EXRTrialBalanceBuffer."Last Period Net (Credit) (ACY)" := LocalGLAccountLastPeriod."Add.-Currency Credit Amount";
+        EXRTrialBalanceBuffer."Last Period Bal. (ACY)" := LocalGLAccountLastPeriod."Add.-Currency Balance at Date";
+        EXRTrialBalanceBuffer."Last Period Bal. (Debit) (ACY)" := LocalGLAccountLastPeriodBalance."Add.-Currency Debit Amount";
+        EXRTrialBalanceBuffer."Last Period Bal. (Cred.) (ACY)" := LocalGLAccountLastPeriodBalance."Add.-Currency Credit Amount";
         EXRTrialBalanceBuffer.CalculateVariances();
         EXRTrialBalanceBuffer.Insert(true);
     end;

--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalance.Query.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalance.Query.al
@@ -32,7 +32,23 @@ query 4405 "EXR Trial Balance"
                 {
                     Method = sum;
                 }
+                column(DebitAmount; "Debit Amount")
+                {
+                    Method = sum;
+                }
+                column(CreditAmount; "Credit Amount")
+                {
+                    Method = sum;
+                }
                 column(ACYAmount; "Additional-Currency Amount")
+                {
+                    Method = sum;
+                }
+                column(ACYDebitAmount; "Add.-Currency Debit Amount")
+                {
+                    Method = sum;
+                }
+                column(ACYCreditAmount; "Add.-Currency Credit Amount")
                 {
                     Method = sum;
                 }

--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalanceBU.Query.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalanceBU.Query.al
@@ -32,7 +32,23 @@ query 4407 "EXR Trial Balance BU"
                 {
                     Method = sum;
                 }
+                column(DebitAmount; "Debit Amount")
+                {
+                    Method = sum;
+                }
+                column(CreditAmount; "Credit Amount")
+                {
+                    Method = sum;
+                }
                 column(ACYAmount; "Additional-Currency Amount")
+                {
+                    Method = sum;
+                }
+                column(ACYDebitAmount; "Add.-Currency Debit Amount")
+                {
+                    Method = sum;
+                }
+                column(ACYCreditAmount; "Add.-Currency Credit Amount")
                 {
                     Method = sum;
                 }

--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalanceBuffer.Table.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalanceBuffer.Table.al
@@ -45,18 +45,6 @@ table 4402 "EXR Trial Balance Buffer"
             Caption = 'Net Change';
             AutoFormatType = 1;
             AutoFormatExpression = '';
-
-            trigger OnValidate()
-            begin
-                if ("Net Change" > 0) then begin
-                    Validate("Net Change (Debit)", "Net Change");
-                    Validate("Net Change (Credit)", 0);
-                end
-                else begin
-                    Validate("Net Change (Credit)", -"Net Change");
-                    Validate("Net Change (Debit)", 0);
-                end;
-            end;
         }
         field(11; "Net Change (Debit)"; Decimal)
         {
@@ -75,18 +63,6 @@ table 4402 "EXR Trial Balance Buffer"
             Caption = 'Balance';
             AutoFormatType = 1;
             AutoFormatExpression = '';
-
-            trigger OnValidate()
-            begin
-                if ("Balance" > 0) then begin
-                    Validate("Balance (Debit)", "Balance");
-                    Validate("Balance (Credit)", 0);
-                end
-                else begin
-                    Validate("Balance (Credit)", -"Balance");
-                    Validate("Balance (Debit)", 0);
-                end;
-            end;
         }
         field(14; "Balance (Debit)"; Decimal)
         {
@@ -105,18 +81,6 @@ table 4402 "EXR Trial Balance Buffer"
             Caption = 'Starting Balance';
             AutoFormatType = 1;
             AutoFormatExpression = '';
-
-            trigger OnValidate()
-            begin
-                if ("Starting Balance" > 0) then begin
-                    Validate("Starting Balance (Debit)", "Starting Balance");
-                    Validate("Starting Balance (Credit)", 0);
-                end
-                else begin
-                    Validate("Starting Balance (Credit)", -"Starting Balance");
-                    Validate("Starting Balance (Debit)", 0);
-                end;
-            end;
         }
         field(17; "Starting Balance (Debit)"; Decimal)
         {
@@ -157,18 +121,6 @@ table 4402 "EXR Trial Balance Buffer"
             Caption = 'Last Period Net';
             AutoFormatType = 1;
             AutoFormatExpression = '';
-
-            trigger OnValidate()
-            begin
-                if ("Last Period Net" > 0) then begin
-                    Validate("Last Period Net (Debit)", "Last Period Net");
-                    Validate("Last Period Net (Credit)", 0);
-                end
-                else begin
-                    Validate("Last Period Net (Credit)", -"Last Period Net");
-                    Validate("Last Period Net (Debit)", 0);
-                end;
-            end;
         }
         field(51; "Last Period Net (Debit)"; Decimal)
         {
@@ -187,18 +139,6 @@ table 4402 "EXR Trial Balance Buffer"
             Caption = 'Last Period Bal.';
             AutoFormatType = 1;
             AutoFormatExpression = '';
-
-            trigger OnValidate()
-            begin
-                if ("Last Period Bal." > 0) then begin
-                    Validate("Last Period Bal. (Debit)", "Last Period Bal.");
-                    Validate("Last Period Bal. (Credit)", 0);
-                end
-                else begin
-                    Validate("Last Period Bal. (Credit)", -"Last Period Bal.");
-                    Validate("Last Period Bal. (Debit)", 0);
-                end;
-            end;
         }
         field(61; "Last Period Bal. (Debit)"; Decimal)
         {
@@ -239,18 +179,6 @@ table 4402 "EXR Trial Balance Buffer"
             AutoFormatType = 1;
             AutoFormatExpression = GetAdditionalReportingCurrencyCode();
             Caption = 'Net Change';
-
-            trigger OnValidate()
-            begin
-                if ("Net Change (ACY)" > 0) then begin
-                    Validate("Net Change (Debit) (ACY)", "Net Change (ACY)");
-                    Validate("Net Change (Credit) (ACY)", 0);
-                end
-                else begin
-                    Validate("Net Change (Credit) (ACY)", -"Net Change (ACY)");
-                    Validate("Net Change (Debit) (ACY)", 0);
-                end;
-            end;
         }
         field(111; "Net Change (Debit) (ACY)"; Decimal)
         {
@@ -269,18 +197,6 @@ table 4402 "EXR Trial Balance Buffer"
             Caption = 'Balance';
             AutoFormatType = 1;
             AutoFormatExpression = GetAdditionalReportingCurrencyCode();
-
-            trigger OnValidate()
-            begin
-                if ("Balance (ACY)" > 0) then begin
-                    Validate("Balance (Debit) (ACY)", "Balance (ACY)");
-                    Validate("Balance (Credit) (ACY)", 0);
-                end
-                else begin
-                    Validate("Balance (Credit) (ACY)", -"Balance (ACY)");
-                    Validate("Balance (Debit) (ACY)", 0);
-                end;
-            end;
         }
         field(114; "Balance (Debit) (ACY)"; Decimal)
         {
@@ -299,18 +215,6 @@ table 4402 "EXR Trial Balance Buffer"
             Caption = 'Starting Balance';
             AutoFormatType = 1;
             AutoFormatExpression = GetAdditionalReportingCurrencyCode();
-
-            trigger OnValidate()
-            begin
-                if ("Starting Balance (ACY)" > 0) then begin
-                    Validate("Starting Balance (Debit) (ACY)", "Starting Balance (ACY)");
-                    Validate("Starting Balance (Credit)(ACY)", 0);
-                end
-                else begin
-                    Validate("Starting Balance (Credit)(ACY)", -"Starting Balance (ACY)");
-                    Validate("Starting Balance (Debit) (ACY)", 0);
-                end;
-            end;
         }
         field(117; "Starting Balance (Debit) (ACY)"; Decimal)
         {
@@ -329,18 +233,6 @@ table 4402 "EXR Trial Balance Buffer"
             Caption = 'Last Period Net';
             AutoFormatType = 1;
             AutoFormatExpression = GetAdditionalReportingCurrencyCode();
-
-            trigger OnValidate()
-            begin
-                if ("Last Period Net (ACY)" > 0) then begin
-                    Validate("Last Period Net (Debit) (ACY)", "Last Period Net (ACY)");
-                    Validate("Last Period Net (Credit) (ACY)", 0);
-                end
-                else begin
-                    Validate("Last Period Net (Credit) (ACY)", -"Last Period Net (ACY)");
-                    Validate("Last Period Net (Debit) (ACY)", 0);
-                end;
-            end;
         }
         field(151; "Last Period Net (Debit) (ACY)"; Decimal)
         {
@@ -359,18 +251,6 @@ table 4402 "EXR Trial Balance Buffer"
             Caption = 'Last Period Bal.';
             AutoFormatType = 1;
             AutoFormatExpression = GetAdditionalReportingCurrencyCode();
-
-            trigger OnValidate()
-            begin
-                if ("Last Period Bal. (ACY)" > 0) then begin
-                    Validate("Last Period Bal. (Debit) (ACY)", "Last Period Bal. (ACY)");
-                    Validate("Last Period Bal. (Cred.) (ACY)", 0);
-                end
-                else begin
-                    Validate("Last Period Bal. (Cred.) (ACY)", -"Last Period Bal. (ACY)");
-                    Validate("Last Period Bal. (Debit) (ACY)", 0);
-                end;
-            end;
         }
         field(161; "Last Period Bal. (Debit) (ACY)"; Decimal)
         {

--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalbyPeriodExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalbyPeriodExcel.Report.al
@@ -206,20 +206,30 @@ report 4408 "EXR Trial Bal by Period Excel"
     local procedure AddGLToDataset(var GLAccount: Record "G/L Account"; PeriodStartDate: Date; PeriodEndDate: Date; Dimension1Code: Code[20]; Dimension2Code: Code[20])
     var
         LocalGLAccount: Record "G/L Account";
+        LocalGLAccountBalance: Record "G/L Account";
     begin
         LocalGLAccount.Copy(GLAccount);
         LocalGLAccount.SetFilter("Global Dimension 1 Filter", Dimension1Code);
         LocalGLAccount.SetFilter("Global Dimension 2 Filter", Dimension2Code);
 
-        LocalGLAccount.CalcFields("Net Change", "Balance at Date");
+        LocalGLAccount.CalcFields("Net Change", "Balance at Date", "Debit Amount", "Credit Amount");
+        // Cumulative debit/credit for balance requires date filter ..EndDate
+        LocalGLAccountBalance.Copy(LocalGLAccount);
+        LocalGLAccountBalance.SetFilter("Date Filter", '..%1', PeriodEndDate);
+        LocalGLAccountBalance.CalcFields("Debit Amount", "Credit Amount");
+
         Clear(EXRTrialBalanceBuffer);
         EXRTrialBalanceBuffer."G/L Account No." := LocalGLAccount."No.";
         EXRTrialBalanceBuffer."Period Start" := PeriodStartDate;
         EXRTrialBalanceBuffer."Period End" := PeriodEndDate;
         EXRTrialBalanceBuffer."Dimension 1 Code" := Dimension1Code;
         EXRTrialBalanceBuffer."Dimension 2 Code" := Dimension2Code;
-        EXRTrialBalanceBuffer.Validate("Net Change", LocalGLAccount."Net Change");
-        EXRTrialBalanceBuffer.Validate("Balance", LocalGLAccount."Balance at Date");
+        EXRTrialBalanceBuffer."Net Change" := LocalGLAccount."Net Change";
+        EXRTrialBalanceBuffer."Net Change (Debit)" := LocalGLAccount."Debit Amount";
+        EXRTrialBalanceBuffer."Net Change (Credit)" := LocalGLAccount."Credit Amount";
+        EXRTrialBalanceBuffer.Balance := LocalGLAccount."Balance at Date";
+        EXRTrialBalanceBuffer."Balance (Debit)" := LocalGLAccountBalance."Debit Amount";
+        EXRTrialBalanceBuffer."Balance (Credit)" := LocalGLAccountBalance."Credit Amount";
         EXRTrialBalanceBuffer.Insert(true);
     end;
 }

--- a/src/Apps/W1/ExcelReports/App/src/Financials/TrialBalance.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/TrialBalance.Codeunit.al
@@ -151,19 +151,31 @@ codeunit 4410 "Trial Balance"
         if GLAccount.GetFilter("Date Filter") <> '' then begin
             GLAccount2.Copy(GLAccount);
             GLAccount2.SetFilter("Date Filter", '..%1', ClosingDate(GLAccount2.GetRangeMin("Date Filter") - 1));
-            GLAccount2.CalcFields("Balance at Date", "Add.-Currency Balance at Date");
-            TrialBalanceData.Validate("Starting Balance", GLAccount2."Balance at Date");
-            TrialBalanceData.Validate("Starting Balance (ACY)", GLAccount2."Add.-Currency Balance at Date");
+            GLAccount2.CalcFields("Balance at Date", "Add.-Currency Balance at Date", "Debit Amount", "Credit Amount", "Add.-Currency Debit Amount", "Add.-Currency Credit Amount");
+            TrialBalanceData."Starting Balance" := GLAccount2."Balance at Date";
+            TrialBalanceData."Starting Balance (Debit)" := GLAccount2."Debit Amount";
+            TrialBalanceData."Starting Balance (Credit)" := GLAccount2."Credit Amount";
+            TrialBalanceData."Starting Balance (ACY)" := GLAccount2."Add.-Currency Balance at Date";
+            TrialBalanceData."Starting Balance (Debit) (ACY)" := GLAccount2."Add.-Currency Debit Amount";
+            TrialBalanceData."Starting Balance (Credit)(ACY)" := GLAccount2."Add.-Currency Credit Amount";
         end;
-        GlAccount.CalcFields("Net Change", "Balance at Date", "Additional-Currency Net Change", "Add.-Currency Balance at Date", "Budgeted Amount", "Budget at Date");
+        GlAccount.CalcFields("Net Change", "Balance at Date", "Additional-Currency Net Change", "Add.-Currency Balance at Date", "Budgeted Amount", "Budget at Date", "Debit Amount", "Credit Amount", "Add.-Currency Debit Amount", "Add.-Currency Credit Amount");
         TrialBalanceData."G/L Account No." := GlAccount."No.";
         TrialBalanceData."Dimension 1 Code" := Dimension1ValueCode;
         TrialBalanceData."Dimension 2 Code" := Dimension2ValueCode;
         TrialBalanceData."Business Unit Code" := BusinessUnitCode;
-        TrialBalanceData.Validate("Net Change", GLAccount."Net Change");
-        TrialBalanceData.Validate(Balance, GLAccount."Balance at Date");
-        TrialBalanceData.Validate("Net Change (ACY)", GLAccount."Additional-Currency Net Change");
-        TrialBalanceData.Validate("Balance (ACY)", GLAccount."Add.-Currency Balance at Date");
+        TrialBalanceData."Net Change" := GLAccount."Net Change";
+        TrialBalanceData."Net Change (Debit)" := GLAccount."Debit Amount";
+        TrialBalanceData."Net Change (Credit)" := GLAccount."Credit Amount";
+        TrialBalanceData.Balance := GLAccount."Balance at Date";
+        TrialBalanceData."Balance (Debit)" := TrialBalanceData."Starting Balance (Debit)" + TrialBalanceData."Net Change (Debit)";
+        TrialBalanceData."Balance (Credit)" := TrialBalanceData."Starting Balance (Credit)" + TrialBalanceData."Net Change (Credit)";
+        TrialBalanceData."Net Change (ACY)" := GLAccount."Additional-Currency Net Change";
+        TrialBalanceData."Net Change (Debit) (ACY)" := GLAccount."Add.-Currency Debit Amount";
+        TrialBalanceData."Net Change (Credit) (ACY)" := GLAccount."Add.-Currency Credit Amount";
+        TrialBalanceData."Balance (ACY)" := GLAccount."Add.-Currency Balance at Date";
+        TrialBalanceData."Balance (Debit) (ACY)" := TrialBalanceData."Starting Balance (Debit) (ACY)" + TrialBalanceData."Net Change (Debit) (ACY)";
+        TrialBalanceData."Balance (Credit) (ACY)" := TrialBalanceData."Starting Balance (Credit)(ACY)" + TrialBalanceData."Net Change (Credit) (ACY)";
         TrialBalanceData.Validate("Budget (Net)", GLAccount."Budgeted Amount");
         TrialBalanceData.Validate("Budget (Bal. at Date)", GLAccount."Budget at Date");
         TrialBalanceData.CalculateBudgetComparisons();
@@ -224,11 +236,20 @@ codeunit 4410 "Trial Balance"
             TrialBalanceData."Dimension 1 Code" := EXRTrialBalanceQuery.DimensionValue1Code;
             TrialBalanceData."Dimension 2 Code" := EXRTrialBalanceQuery.DimensionValue2Code;
             // The balances at the ending date are filled in from the values returned in this query
-            TrialBalanceData.Validate(Balance, EXRTrialBalanceQuery.Amount);
-            TrialBalanceData.Validate("Balance (ACY)", EXRTrialBalanceQuery.ACYAmount);
-            // And also in Net Change (which will have later the value at the starting date subtracted)
-            TrialBalanceData.Validate("Net Change", EXRTrialBalanceQuery.Amount);
-            TrialBalanceData.Validate("Net Change (ACY)", EXRTrialBalanceQuery.ACYAmount);
+            TrialBalanceData.Balance := EXRTrialBalanceQuery.Amount;
+            TrialBalanceData."Balance (Debit)" := EXRTrialBalanceQuery.DebitAmount;
+            TrialBalanceData."Balance (Credit)" := EXRTrialBalanceQuery.CreditAmount;
+            TrialBalanceData."Balance (ACY)" := EXRTrialBalanceQuery.ACYAmount;
+            TrialBalanceData."Balance (Debit) (ACY)" := EXRTrialBalanceQuery.ACYDebitAmount;
+            TrialBalanceData."Balance (Credit) (ACY)" := EXRTrialBalanceQuery.ACYCreditAmount;
+            // Net Change fields temporarily hold cumulative values up to the ending date,
+            // the starting date values will be subtracted in the second query
+            TrialBalanceData."Net Change" := EXRTrialBalanceQuery.Amount;
+            TrialBalanceData."Net Change (Debit)" := EXRTrialBalanceQuery.DebitAmount;
+            TrialBalanceData."Net Change (Credit)" := EXRTrialBalanceQuery.CreditAmount;
+            TrialBalanceData."Net Change (ACY)" := EXRTrialBalanceQuery.ACYAmount;
+            TrialBalanceData."Net Change (Debit) (ACY)" := EXRTrialBalanceQuery.ACYDebitAmount;
+            TrialBalanceData."Net Change (Credit) (ACY)" := EXRTrialBalanceQuery.ACYCreditAmount;
             TrialBalanceData.CheckAllZero();
             if not TrialBalanceData."All Zero" then begin
                 TrialBalanceData.Insert(true);
@@ -252,11 +273,19 @@ codeunit 4410 "Trial Balance"
                 TrialBalanceData.Insert(true);
             end;
             // The balances at starting date are filled in from the values returned in this query
-            TrialBalanceData.Validate("Starting Balance", EXRTrialBalanceQuery.Amount);
-            TrialBalanceData.Validate("Starting Balance (ACY)", EXRTrialBalanceQuery.ACYAmount);
-            // The "Net Change" will be modified from what it had (balance at ending date) to the subtraction with the starting balance
-            TrialBalanceData.Validate("Net Change", TrialBalanceData."Net Change" - EXRTrialBalanceQuery.Amount);
-            TrialBalanceData.Validate("Net Change (ACY)", TrialBalanceData."Net Change (ACY)" - EXRTrialBalanceQuery.ACYAmount);
+            TrialBalanceData."Starting Balance" := EXRTrialBalanceQuery.Amount;
+            TrialBalanceData."Starting Balance (Debit)" := EXRTrialBalanceQuery.DebitAmount;
+            TrialBalanceData."Starting Balance (Credit)" := EXRTrialBalanceQuery.CreditAmount;
+            TrialBalanceData."Starting Balance (ACY)" := EXRTrialBalanceQuery.ACYAmount;
+            TrialBalanceData."Starting Balance (Debit) (ACY)" := EXRTrialBalanceQuery.ACYDebitAmount;
+            TrialBalanceData."Starting Balance (Credit)(ACY)" := EXRTrialBalanceQuery.ACYCreditAmount;
+            // Subtract cumulative values at the starting date to get the period net change (gross debit and credit)
+            TrialBalanceData."Net Change" := TrialBalanceData."Net Change" - EXRTrialBalanceQuery.Amount;
+            TrialBalanceData."Net Change (Debit)" := TrialBalanceData."Net Change (Debit)" - EXRTrialBalanceQuery.DebitAmount;
+            TrialBalanceData."Net Change (Credit)" := TrialBalanceData."Net Change (Credit)" - EXRTrialBalanceQuery.CreditAmount;
+            TrialBalanceData."Net Change (ACY)" := TrialBalanceData."Net Change (ACY)" - EXRTrialBalanceQuery.ACYAmount;
+            TrialBalanceData."Net Change (Debit) (ACY)" := TrialBalanceData."Net Change (Debit) (ACY)" - EXRTrialBalanceQuery.ACYDebitAmount;
+            TrialBalanceData."Net Change (Credit) (ACY)" := TrialBalanceData."Net Change (Credit) (ACY)" - EXRTrialBalanceQuery.ACYCreditAmount;
             TrialBalanceData.Modify();
             InsertUsedDimensionValue(1, TrialBalanceData."Dimension 1 Code", Dimension1Values);
             InsertUsedDimensionValue(2, TrialBalanceData."Dimension 2 Code", Dimension2Values);
@@ -277,10 +306,18 @@ codeunit 4410 "Trial Balance"
             TrialBalanceData."Dimension 1 Code" := EXRTrialBalanceBUQuery.DimensionValue1Code;
             TrialBalanceData."Dimension 2 Code" := EXRTrialBalanceBUQuery.DimensionValue2Code;
             TrialBalanceData."Business Unit Code" := EXRTrialBalanceBUQuery.BusinessUnitCode;
-            TrialBalanceData.Validate(Balance, EXRTrialBalanceBUQuery.Amount);
-            TrialBalanceData.Validate("Balance (ACY)", EXRTrialBalanceBUQuery.ACYAmount);
-            TrialBalanceData.Validate("Net Change", EXRTrialBalanceBUQuery.Amount);
-            TrialBalanceData.Validate("Net Change (ACY)", EXRTrialBalanceBUQuery.ACYAmount);
+            TrialBalanceData.Balance := EXRTrialBalanceBUQuery.Amount;
+            TrialBalanceData."Balance (Debit)" := EXRTrialBalanceBUQuery.DebitAmount;
+            TrialBalanceData."Balance (Credit)" := EXRTrialBalanceBUQuery.CreditAmount;
+            TrialBalanceData."Balance (ACY)" := EXRTrialBalanceBUQuery.ACYAmount;
+            TrialBalanceData."Balance (Debit) (ACY)" := EXRTrialBalanceBUQuery.ACYDebitAmount;
+            TrialBalanceData."Balance (Credit) (ACY)" := EXRTrialBalanceBUQuery.ACYCreditAmount;
+            TrialBalanceData."Net Change" := EXRTrialBalanceBUQuery.Amount;
+            TrialBalanceData."Net Change (Debit)" := EXRTrialBalanceBUQuery.DebitAmount;
+            TrialBalanceData."Net Change (Credit)" := EXRTrialBalanceBUQuery.CreditAmount;
+            TrialBalanceData."Net Change (ACY)" := EXRTrialBalanceBUQuery.ACYAmount;
+            TrialBalanceData."Net Change (Debit) (ACY)" := EXRTrialBalanceBUQuery.ACYDebitAmount;
+            TrialBalanceData."Net Change (Credit) (ACY)" := EXRTrialBalanceBUQuery.ACYCreditAmount;
             TrialBalanceData.CheckAllZero();
             if not TrialBalanceData."All Zero" then begin
                 TrialBalanceData.Insert(true);
@@ -305,10 +342,18 @@ codeunit 4410 "Trial Balance"
                 TrialBalanceData."Business Unit Code" := EXRTrialBalanceBUQuery.BusinessUnitCode;
                 TrialBalanceData.Insert(true);
             end;
-            TrialBalanceData.Validate("Starting Balance", EXRTrialBalanceBUQuery.Amount);
-            TrialBalanceData.Validate("Starting Balance (ACY)", EXRTrialBalanceBUQuery.ACYAmount);
-            TrialBalanceData.Validate("Net Change", TrialBalanceData."Net Change" - EXRTrialBalanceBUQuery.Amount);
-            TrialBalanceData.Validate("Net Change (ACY)", TrialBalanceData."Net Change (ACY)" - EXRTrialBalanceBUQuery.ACYAmount);
+            TrialBalanceData."Starting Balance" := EXRTrialBalanceBUQuery.Amount;
+            TrialBalanceData."Starting Balance (Debit)" := EXRTrialBalanceBUQuery.DebitAmount;
+            TrialBalanceData."Starting Balance (Credit)" := EXRTrialBalanceBUQuery.CreditAmount;
+            TrialBalanceData."Starting Balance (ACY)" := EXRTrialBalanceBUQuery.ACYAmount;
+            TrialBalanceData."Starting Balance (Debit) (ACY)" := EXRTrialBalanceBUQuery.ACYDebitAmount;
+            TrialBalanceData."Starting Balance (Credit)(ACY)" := EXRTrialBalanceBUQuery.ACYCreditAmount;
+            TrialBalanceData."Net Change" := TrialBalanceData."Net Change" - EXRTrialBalanceBUQuery.Amount;
+            TrialBalanceData."Net Change (Debit)" := TrialBalanceData."Net Change (Debit)" - EXRTrialBalanceBUQuery.DebitAmount;
+            TrialBalanceData."Net Change (Credit)" := TrialBalanceData."Net Change (Credit)" - EXRTrialBalanceBUQuery.CreditAmount;
+            TrialBalanceData."Net Change (ACY)" := TrialBalanceData."Net Change (ACY)" - EXRTrialBalanceBUQuery.ACYAmount;
+            TrialBalanceData."Net Change (Debit) (ACY)" := TrialBalanceData."Net Change (Debit) (ACY)" - EXRTrialBalanceBUQuery.ACYDebitAmount;
+            TrialBalanceData."Net Change (Credit) (ACY)" := TrialBalanceData."Net Change (Credit) (ACY)" - EXRTrialBalanceBUQuery.ACYCreditAmount;
             TrialBalanceData.Modify();
             InsertUsedDimensionValue(1, TrialBalanceData."Dimension 1 Code", Dimension1Values);
             InsertUsedDimensionValue(2, TrialBalanceData."Dimension 2 Code", Dimension2Values);

--- a/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
@@ -346,7 +346,7 @@ codeunit 139544 "Trial Balance Excel Reports"
     var
         GLAccount: Record "G/L Account";
         TempDimensionValue: Record "Dimension Value" temporary;
-        TempTrialBalanceData: Record "EXR Trial Balance Buffer";
+        TrialBalanceData: Record "EXR Trial Balance Buffer";
         TrialBalance: Codeunit "Trial Balance";
         PostingAccount: Code[20];
         DebitAmount: Decimal;
@@ -366,14 +366,14 @@ codeunit 139544 "Trial Balance Excel Reports"
         GLAccount.SetRange("No.", PostingAccount);
         GLAccount.SetRange("Date Filter", DMY2Date(1, 1, Date2DMY(WorkDate(), 3)), DMY2Date(31, 12, Date2DMY(WorkDate(), 3)));
         TrialBalance.ConfigureTrialBalance(false, false);
-        TrialBalance.InsertTrialBalanceReportData(GLAccount, TempDimensionValue, TempDimensionValue, TempTrialBalanceData);
+        TrialBalance.InsertTrialBalanceReportData(GLAccount, TempDimensionValue, TempDimensionValue, TrialBalanceData);
 
         // [THEN] The buffer has gross debit and credit amounts, not netted
-        TempTrialBalanceData.SetRange("G/L Account No.", PostingAccount);
-        Assert.IsTrue(TempTrialBalanceData.FindFirst(), 'Buffer record should exist for the posting account');
-        Assert.AreEqual(DebitAmount + CreditAmount, TempTrialBalanceData."Net Change", 'Net Change should be the algebraic sum');
-        Assert.AreEqual(DebitAmount, TempTrialBalanceData."Net Change (Debit)", 'Net Change (Debit) should be the gross debit amount');
-        Assert.AreEqual(-CreditAmount, TempTrialBalanceData."Net Change (Credit)", 'Net Change (Credit) should be the gross credit amount');
+        TrialBalanceData.SetRange("G/L Account No.", PostingAccount);
+        Assert.IsTrue(TrialBalanceData.FindFirst(), 'Buffer record should exist for the posting account');
+        Assert.AreEqual(DebitAmount + CreditAmount, TrialBalanceData."Net Change", 'Net Change should be the algebraic sum');
+        Assert.AreEqual(DebitAmount, TrialBalanceData."Net Change (Debit)", 'Net Change (Debit) should be the gross debit amount');
+        Assert.AreEqual(-CreditAmount, TrialBalanceData."Net Change (Credit)", 'Net Change (Credit) should be the gross credit amount');
     end;
 
     [Test]

--- a/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
@@ -307,68 +307,6 @@ codeunit 139544 "Trial Balance Excel Reports"
     end;
 
     [Test]
-    procedure TrialBalanceBufferNetChangeSplitsIntoDebitAndCreditWhenCalledSeveralTimes()
-    var
-        EXRTrialBalanceBuffer: Record "EXR Trial Balance Buffer";
-        ValuesToSplitInCreditAndDebit: array[3] of Decimal;
-    begin
-        // [SCENARIO 547558] Trial Balance Buffer data split into Debit and Credit correctly, even if called multiple times.
-        // [GIVEN] Trial Balance Buffer filled with positive Balance/Net Change
-        ValuesToSplitInCreditAndDebit[1] := 837;
-        // [GIVEN] Trial Balance Buffer filled with negative Balance/Net Change
-        ValuesToSplitInCreditAndDebit[2] := -110;
-        // [GIVEN] Trial Balance Buffer filled with positive Balance/Net Change
-        ValuesToSplitInCreditAndDebit[3] := 998;
-        // [WHEN] Trial Balance Buffer entries are inserted
-        EXRTrialBalanceBuffer."G/L Account No." := 'A';
-        EXRTrialBalanceBuffer.Validate("Starting Balance", ValuesToSplitInCreditAndDebit[1]);
-        EXRTrialBalanceBuffer.Validate("Net Change", ValuesToSplitInCreditAndDebit[1]);
-        EXRTrialBalanceBuffer.Validate(Balance, ValuesToSplitInCreditAndDebit[1]);
-        EXRTrialBalanceBuffer.Validate("Starting Balance (ACY)", ValuesToSplitInCreditAndDebit[1]);
-        EXRTrialBalanceBuffer.Validate("Net Change (ACY)", ValuesToSplitInCreditAndDebit[1]);
-        EXRTrialBalanceBuffer.Validate("Balance (ACY)", ValuesToSplitInCreditAndDebit[1]);
-        EXRTrialBalanceBuffer.Insert();
-        EXRTrialBalanceBuffer."G/L Account No." := 'B';
-        EXRTrialBalanceBuffer.Validate("Starting Balance", ValuesToSplitInCreditAndDebit[2]);
-        EXRTrialBalanceBuffer.Validate("Net Change", ValuesToSplitInCreditAndDebit[2]);
-        EXRTrialBalanceBuffer.Validate(Balance, ValuesToSplitInCreditAndDebit[2]);
-        EXRTrialBalanceBuffer.Validate("Starting Balance (ACY)", ValuesToSplitInCreditAndDebit[2]);
-        EXRTrialBalanceBuffer.Validate("Net Change (ACY)", ValuesToSplitInCreditAndDebit[2]);
-        EXRTrialBalanceBuffer.Validate("Balance (ACY)", ValuesToSplitInCreditAndDebit[2]);
-        EXRTrialBalanceBuffer.Insert();
-        EXRTrialBalanceBuffer."G/L Account No." := 'C';
-        EXRTrialBalanceBuffer.Validate("Starting Balance", ValuesToSplitInCreditAndDebit[3]);
-        EXRTrialBalanceBuffer.Validate("Net Change", ValuesToSplitInCreditAndDebit[3]);
-        EXRTrialBalanceBuffer.Validate(Balance, ValuesToSplitInCreditAndDebit[3]);
-        EXRTrialBalanceBuffer.Validate("Starting Balance (ACY)", ValuesToSplitInCreditAndDebit[3]);
-        EXRTrialBalanceBuffer.Validate("Net Change (ACY)", ValuesToSplitInCreditAndDebit[3]);
-        EXRTrialBalanceBuffer.Validate("Balance (ACY)", ValuesToSplitInCreditAndDebit[3]);
-        EXRTrialBalanceBuffer.Insert();
-        // [THEN] All Entries have the right split in Credit and Debit
-        EXRTrialBalanceBuffer.FindSet();
-        Assert.AreEqual(ValuesToSplitInCreditAndDebit[1], Abs(EXRTrialBalanceBuffer."Starting Balance (Debit)" + EXRTrialBalanceBuffer."Starting Balance (Credit)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(ValuesToSplitInCreditAndDebit[1], Abs(EXRTrialBalanceBuffer."Net Change (Debit)" + EXRTrialBalanceBuffer."Net Change (Credit)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(ValuesToSplitInCreditAndDebit[1], Abs(EXRTrialBalanceBuffer."Balance (Debit)" + EXRTrialBalanceBuffer."Balance (Credit)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(ValuesToSplitInCreditAndDebit[1], Abs(EXRTrialBalanceBuffer."Starting Balance (Debit) (ACY)" + EXRTrialBalanceBuffer."Starting Balance (Credit)(ACY)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(ValuesToSplitInCreditAndDebit[1], Abs(EXRTrialBalanceBuffer."Net Change (Debit) (ACY)" + EXRTrialBalanceBuffer."Net Change (Credit) (ACY)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(ValuesToSplitInCreditAndDebit[1], Abs(EXRTrialBalanceBuffer."Balance (Debit) (ACY)" + EXRTrialBalanceBuffer."Balance (Credit) (ACY)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        EXRTrialBalanceBuffer.Next();
-        Assert.AreEqual(-ValuesToSplitInCreditAndDebit[2], Abs(EXRTrialBalanceBuffer."Starting Balance (Debit)" + EXRTrialBalanceBuffer."Starting Balance (Credit)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(-ValuesToSplitInCreditAndDebit[2], Abs(EXRTrialBalanceBuffer."Net Change (Debit)" + EXRTrialBalanceBuffer."Net Change (Credit)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(-ValuesToSplitInCreditAndDebit[2], Abs(EXRTrialBalanceBuffer."Balance (Debit)" + EXRTrialBalanceBuffer."Balance (Credit)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(-ValuesToSplitInCreditAndDebit[2], Abs(EXRTrialBalanceBuffer."Starting Balance (Debit) (ACY)" + EXRTrialBalanceBuffer."Starting Balance (Credit)(ACY)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(-ValuesToSplitInCreditAndDebit[2], Abs(EXRTrialBalanceBuffer."Net Change (Debit) (ACY)" + EXRTrialBalanceBuffer."Net Change (Credit) (ACY)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(-ValuesToSplitInCreditAndDebit[2], Abs(EXRTrialBalanceBuffer."Balance (Debit) (ACY)" + EXRTrialBalanceBuffer."Balance (Credit) (ACY)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        EXRTrialBalanceBuffer.Next();
-        Assert.AreEqual(ValuesToSplitInCreditAndDebit[3], Abs(EXRTrialBalanceBuffer."Starting Balance (Debit)" + EXRTrialBalanceBuffer."Starting Balance (Credit)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(ValuesToSplitInCreditAndDebit[3], Abs(EXRTrialBalanceBuffer."Net Change (Debit)" + EXRTrialBalanceBuffer."Net Change (Credit)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(ValuesToSplitInCreditAndDebit[3], Abs(EXRTrialBalanceBuffer."Balance (Debit)" + EXRTrialBalanceBuffer."Balance (Credit)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(ValuesToSplitInCreditAndDebit[3], Abs(EXRTrialBalanceBuffer."Starting Balance (Debit) (ACY)" + EXRTrialBalanceBuffer."Starting Balance (Credit)(ACY)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(ValuesToSplitInCreditAndDebit[3], Abs(EXRTrialBalanceBuffer."Net Change (Debit) (ACY)" + EXRTrialBalanceBuffer."Net Change (Credit) (ACY)"), 'Split in line in credit and debit should be the same as the inserted value.');
-        Assert.AreEqual(ValuesToSplitInCreditAndDebit[3], Abs(EXRTrialBalanceBuffer."Balance (Debit) (ACY)" + EXRTrialBalanceBuffer."Balance (Credit) (ACY)"), 'Split in line in credit and debit should be the same as the inserted value.');
-    end;
-
-    [Test]
     procedure QueryPathProducesCorrectAmounts()
     var
         GLAccount: Record "G/L Account";
@@ -401,6 +339,41 @@ codeunit 139544 "Trial Balance Excel Reports"
         Assert.AreEqual(BeforePeriodAmount, TrialBalanceData."Starting Balance", 'Starting Balance should equal the entry before the period');
         Assert.AreEqual(InPeriodAmount, TrialBalanceData."Net Change", 'Net Change should equal the entry within the period');
         Assert.AreEqual(BeforePeriodAmount + InPeriodAmount, TrialBalanceData.Balance, 'Balance should equal Starting Balance + Net Change');
+    end;
+
+    [Test]
+    procedure GrossDebitAndCreditTurnoverReportedForEachAccount()
+    var
+        GLAccount: Record "G/L Account";
+        TempDimensionValue: Record "Dimension Value" temporary;
+        TempTrialBalanceData: Record "EXR Trial Balance Buffer";
+        TrialBalance: Codeunit "Trial Balance";
+        PostingAccount: Code[20];
+        DebitAmount: Decimal;
+        CreditAmount: Decimal;
+    begin
+        // [SCENARIO] The query path produces gross debit and credit turnover, not netted amounts.
+        // [GIVEN] A posting account with both debit and credit entries in the same period
+        Initialize();
+        CreateGLAccount(GLAccount);
+        PostingAccount := GLAccount."No.";
+        DebitAmount := 5000;
+        CreditAmount := -8000;
+        CreateGLEntryWithAmount(PostingAccount, '', '', '', DMY2Date(1, 3, Date2DMY(WorkDate(), 3)), DebitAmount);
+        CreateGLEntryWithAmount(PostingAccount, '', '', '', DMY2Date(15, 3, Date2DMY(WorkDate(), 3)), CreditAmount);
+
+        // [WHEN] Running the query-based trial balance for the current year
+        GLAccount.SetRange("No.", PostingAccount);
+        GLAccount.SetRange("Date Filter", DMY2Date(1, 1, Date2DMY(WorkDate(), 3)), DMY2Date(31, 12, Date2DMY(WorkDate(), 3)));
+        TrialBalance.ConfigureTrialBalance(false, false);
+        TrialBalance.InsertTrialBalanceReportData(GLAccount, TempDimensionValue, TempDimensionValue, TempTrialBalanceData);
+
+        // [THEN] The buffer has gross debit and credit amounts, not netted
+        TempTrialBalanceData.SetRange("G/L Account No.", PostingAccount);
+        Assert.IsTrue(TempTrialBalanceData.FindFirst(), 'Buffer record should exist for the posting account');
+        Assert.AreEqual(DebitAmount + CreditAmount, TempTrialBalanceData."Net Change", 'Net Change should be the algebraic sum');
+        Assert.AreEqual(DebitAmount, TempTrialBalanceData."Net Change (Debit)", 'Net Change (Debit) should be the gross debit amount');
+        Assert.AreEqual(-CreditAmount, TempTrialBalanceData."Net Change (Credit)", 'Net Change (Credit) should be the gross credit amount');
     end;
 
     [Test]
@@ -771,10 +744,13 @@ codeunit 139544 "Trial Balance Excel Reports"
         GLEntry."Business Unit Code" := BusinessUnitCode;
         GLEntry.Amount := Amount;
         GLEntry."Additional-Currency Amount" := Amount;
-        if Amount > 0 then
-            GLEntry."Debit Amount" := Amount
-        else
+        if Amount > 0 then begin
+            GLEntry."Debit Amount" := Amount;
+            GLEntry."Add.-Currency Debit Amount" := Amount;
+        end else begin
             GLEntry."Credit Amount" := -Amount;
+            GLEntry."Add.-Currency Credit Amount" := -Amount;
+        end;
         GLEntry."Posting Date" := PostingDate;
         GLEntry.Insert();
     end;


### PR DESCRIPTION
## Summary
- Backport of #7572 to 28.x
- Debit/Credit columns for turnover, balance, and starting balance were showing netted amounts instead of gross.
- Now all debit/credit columns use gross amounts from G/L Entry's Debit Amount / Credit Amount fields.

Fixes [AB#630268](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630268)


