### PR TITLE
[Shopify] Add OCV user feedback actions to Shopify pages

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyShopMgt.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyShopMgt.Codeunit.al
@@ -6,6 +6,7 @@
 namespace Microsoft.Integration.Shopify;
 
 using System.Environment.Configuration;
+using System.Feedback;
 
 codeunit 30211 "Shpfy Shop Mgt."
 {
@@ -90,6 +91,13 @@ codeunit 30211 "Shpfy Shop Mgt."
         if MyNotifications.WritePermission() then
             if not MyNotifications.Disable(GetBlockedNotificationId()) then
                 MyNotifications.InsertDefault(GetBlockedNotificationId(), BlockedNotificationNameTok, BlockedNotificationDescTok, false);
+    end;
+
+    internal procedure RequestFeedback()
+    var
+        Feedback: Codeunit "Microsoft User Feedback";
+    begin
+        Feedback.RequestFeedback('Shopify Connector', 'ShopifyConnector', 'Shopify Connector');
     end;
 
     procedure DisableNoItemNotification(Notification: Notification)

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -10,6 +10,7 @@ using Microsoft.Foundation.NoSeries;
 using Microsoft.Sales.Setup;
 using System.DateTime;
 using System.Environment;
+using System.Feedback;
 using System.Telemetry;
 
 /// <summary>
@@ -1200,6 +1201,20 @@ page 30101 "Shpfy Shop Card"
                     FullfillmentOrdersAPI: Codeunit "Shpfy Fulfillment Orders API";
                 begin
                     FullfillmentOrdersAPI.RegisterFulfillmentService(Rec);
+                end;
+            }
+            action(ProvideFeedback)
+            {
+                ApplicationArea = All;
+                Caption = 'Provide Feedback';
+                ToolTip = 'Provide feedback on Shopify Connector.';
+                Image = Comment;
+
+                trigger OnAction()
+                var
+                    Feedback: Codeunit "Microsoft User Feedback";
+                begin
+                    Feedback.RequestFeedback('Shopify Connector', 'ShopifyConnector', 'Shopify Connector');
                 end;
             }
         }

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -10,7 +10,6 @@ using Microsoft.Foundation.NoSeries;
 using Microsoft.Sales.Setup;
 using System.DateTime;
 using System.Environment;
-using System.Feedback;
 using System.Telemetry;
 
 /// <summary>
@@ -1212,9 +1211,9 @@ page 30101 "Shpfy Shop Card"
 
                 trigger OnAction()
                 var
-                    Feedback: Codeunit "Microsoft User Feedback";
+                    ShopMgt: Codeunit "Shpfy Shop Mgt.";
                 begin
-                    Feedback.RequestFeedback('Shopify Connector', 'ShopifyConnector', 'Shopify Connector');
+                    ShopMgt.RequestFeedback();
                 end;
             }
         }

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShops.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShops.Page.al
@@ -5,6 +5,8 @@
 
 namespace Microsoft.Integration.Shopify;
 
+using System.Feedback;
+
 /// <summary>
 /// Page Shpfy Shops (ID 30102).
 /// </summary>
@@ -44,6 +46,33 @@ page 30102 "Shpfy Shops"
                     ApplicationArea = All;
                     ToolTip = 'Specifies the language of the Shopify Shop.';
                 }
+            }
+        }
+    }
+
+    actions
+    {
+        area(Processing)
+        {
+            action(ProvideFeedback)
+            {
+                ApplicationArea = All;
+                Caption = 'Provide Feedback';
+                ToolTip = 'Provide feedback on Shopify Connector.';
+                Image = Comment;
+
+                trigger OnAction()
+                var
+                    Feedback: Codeunit "Microsoft User Feedback";
+                begin
+                    Feedback.RequestFeedback('Shopify Connector', 'ShopifyConnector', 'Shopify Connector');
+                end;
+            }
+        }
+        area(Promoted)
+        {
+            actionref(ProvideFeedback_Promoted; ProvideFeedback)
+            {
             }
         }
     }

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShops.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShops.Page.al
@@ -5,8 +5,6 @@
 
 namespace Microsoft.Integration.Shopify;
 
-using System.Feedback;
-
 /// <summary>
 /// Page Shpfy Shops (ID 30102).
 /// </summary>
@@ -63,9 +61,9 @@ page 30102 "Shpfy Shops"
 
                 trigger OnAction()
                 var
-                    Feedback: Codeunit "Microsoft User Feedback";
+                    ShopMgt: Codeunit "Shpfy Shop Mgt.";
                 begin
-                    Feedback.RequestFeedback('Shopify Connector', 'ShopifyConnector', 'Shopify Connector');
+                    ShopMgt.RequestFeedback();
                 end;
             }
         }

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
@@ -10,6 +10,7 @@ using Microsoft.Inventory.Item;
 using Microsoft.Sales.Customer;
 using Microsoft.Sales.Document;
 using Microsoft.Warehouse.Setup;
+using System.Feedback;
 
 /// <summary>
 /// Page Shpfy Order (ID 30113).
@@ -847,6 +848,20 @@ page 30113 "Shpfy Order"
                         ImportOrder.ReimportExistingOrderConfirmIfConflicting(Rec);
                     end;
                 }
+            }
+            action(ProvideFeedback)
+            {
+                ApplicationArea = All;
+                Caption = 'Provide Feedback';
+                ToolTip = 'Provide feedback on Shopify Connector.';
+                Image = Comment;
+
+                trigger OnAction()
+                var
+                    Feedback: Codeunit "Microsoft User Feedback";
+                begin
+                    Feedback.RequestFeedback('Shopify Connector', 'ShopifyConnector', 'Shopify Connector');
+                end;
             }
         }
         area(navigation)

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
@@ -10,7 +10,6 @@ using Microsoft.Inventory.Item;
 using Microsoft.Sales.Customer;
 using Microsoft.Sales.Document;
 using Microsoft.Warehouse.Setup;
-using System.Feedback;
 
 /// <summary>
 /// Page Shpfy Order (ID 30113).
@@ -858,9 +857,9 @@ page 30113 "Shpfy Order"
 
                 trigger OnAction()
                 var
-                    Feedback: Codeunit "Microsoft User Feedback";
+                    ShopMgt: Codeunit "Shpfy Shop Mgt.";
                 begin
-                    Feedback.RequestFeedback('Shopify Connector', 'ShopifyConnector', 'Shopify Connector');
+                    ShopMgt.RequestFeedback();
                 end;
             }
         }

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrders.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrders.Page.al
@@ -7,7 +7,6 @@ namespace Microsoft.Integration.Shopify;
 
 using Microsoft.Sales.Customer;
 using Microsoft.Sales.Document;
-using System.Feedback;
 
 /// <summary>
 /// Page Shpfy Orders (ID 30115).
@@ -351,9 +350,9 @@ page 30115 "Shpfy Orders"
 
                 trigger OnAction()
                 var
-                    Feedback: Codeunit "Microsoft User Feedback";
+                    ShopMgt: Codeunit "Shpfy Shop Mgt.";
                 begin
-                    Feedback.RequestFeedback('Shopify Connector', 'ShopifyConnector', 'Shopify Connector');
+                    ShopMgt.RequestFeedback();
                 end;
             }
         }

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrders.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrders.Page.al
@@ -7,6 +7,7 @@ namespace Microsoft.Integration.Shopify;
 
 using Microsoft.Sales.Customer;
 using Microsoft.Sales.Document;
+using System.Feedback;
 
 /// <summary>
 /// Page Shpfy Orders (ID 30115).
@@ -339,6 +340,20 @@ page 30115 "Shpfy Orders"
                 begin
                     ImportOrder.MarkOrderConflictAsResolved(Rec);
                     Rec.Modify();
+                end;
+            }
+            action(ProvideFeedback)
+            {
+                ApplicationArea = All;
+                Caption = 'Provide Feedback';
+                ToolTip = 'Provide feedback on Shopify Connector.';
+                Image = Comment;
+
+                trigger OnAction()
+                var
+                    Feedback: Codeunit "Microsoft User Feedback";
+                begin
+                    Feedback.RequestFeedback('Shopify Connector', 'ShopifyConnector', 'Shopify Connector');
                 end;
             }
         }

--- a/src/Apps/W1/Shopify/App/src/Products/Pages/ShpfyProducts.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Pages/ShpfyProducts.Page.al
@@ -7,6 +7,7 @@ namespace Microsoft.Integration.Shopify;
 
 using Microsoft.Inventory.Item;
 using System.Environment.Configuration;
+using System.Feedback;
 
 /// <summary>
 /// Page Shpfy Products (ID 30126).
@@ -450,6 +451,20 @@ page 30126 "Shpfy Products"
                             BackgroundSyncs.InventorySync(CopyStr(Rec.GetFilter("Shop Code"), 1, MaxStrLen(Rec."Shop Code")));
                     end;
                 }
+            }
+            action(ProvideFeedback)
+            {
+                ApplicationArea = All;
+                Caption = 'Provide Feedback';
+                ToolTip = 'Provide feedback on Shopify Connector.';
+                Image = Comment;
+
+                trigger OnAction()
+                var
+                    Feedback: Codeunit "Microsoft User Feedback";
+                begin
+                    Feedback.RequestFeedback('Shopify Connector', 'ShopifyConnector', 'Shopify Connector');
+                end;
             }
         }
     }

--- a/src/Apps/W1/Shopify/App/src/Products/Pages/ShpfyProducts.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Pages/ShpfyProducts.Page.al
@@ -7,7 +7,6 @@ namespace Microsoft.Integration.Shopify;
 
 using Microsoft.Inventory.Item;
 using System.Environment.Configuration;
-using System.Feedback;
 
 /// <summary>
 /// Page Shpfy Products (ID 30126).
@@ -461,9 +460,9 @@ page 30126 "Shpfy Products"
 
                 trigger OnAction()
                 var
-                    Feedback: Codeunit "Microsoft User Feedback";
+                    ShopMgt: Codeunit "Shpfy Shop Mgt.";
                 begin
-                    Feedback.RequestFeedback('Shopify Connector', 'ShopifyConnector', 'Shopify Connector');
+                    ShopMgt.RequestFeedback();
                 end;
             }
         }


### PR DESCRIPTION
## Summary
- Add "Provide Feedback" actions to 5 Shopify pages (Shops, Shop Card, Orders, Order, Products) using `Codeunit "Microsoft User Feedback"` with `ShopifyConnector` feature area for OCV filtering
- Promoted only on the Shops list page; normal action on all other pages
- Follows the same pattern as MCP Server feedback implementation

Fixes [AB#630259](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630259)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



