### PR TITLE
[Shopify] Default Allow Line Disc. to true and move upgrade procedure

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyUpgradeMgt.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyUpgradeMgt.Codeunit.al
@@ -248,11 +248,29 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         Shop.SetRange("Customer Posting Group", '');
         if Shop.FindSet(true) then
             repeat
-                Shop.CopyPriceCalculationFieldsFromCustomerTempl(Shop."Customer Templ. Code");
-                Shop.Modify();
+                CopyPriceCalculationFieldsFromCustomerTempl(Shop, Shop."Customer Templ. Code");
             until Shop.Next() = 0;
 
         UpgradeTag.SetUpgradeTag(GetPriceCalculationUpgradeTag());
+    end;
+
+    local procedure CopyPriceCalculationFieldsFromCustomerTempl(var Shop: Record "Shpfy Shop"; TemplateCode: Code[20])
+    var
+        CustomerTempl: Record "Customer Templ.";
+    begin
+        if TemplateCode = '' then
+            exit;
+        if not CustomerTempl.Get(TemplateCode) then
+            exit;
+        Shop."Gen. Bus. Posting Group" := CustomerTempl."Gen. Bus. Posting Group";
+        Shop."VAT Bus. Posting Group" := CustomerTempl."VAT Bus. Posting Group";
+        Shop."Tax Area Code" := CustomerTempl."Tax Area Code";
+        Shop."Tax Liable" := CustomerTempl."Tax Liable";
+        Shop."VAT Country/Region Code" := CustomerTempl."Country/Region Code";
+        Shop."Customer Posting Group" := CustomerTempl."Customer Posting Group";
+        Shop."Prices Including VAT" := CustomerTempl."Prices Including VAT";
+        Shop."Allow Line Disc." := CustomerTempl."Allow Line Disc.";
+        Shop.Modify();
     end;
 
     local procedure LoggingModeUpgrade()

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -527,6 +527,7 @@ table 30102 "Shpfy Shop"
             Caption = 'Allow Line Disc.';
             ToolTip = 'Specifies if line discount is allowed while calculating prices for Shopify.';
             DataClassification = CustomerContent;
+            InitValue = true;
         }
         field(62; "Customer Templ. Code"; Code[20])
         {
@@ -1080,24 +1081,6 @@ table 30102 "Shpfy Shop"
         GLAccount.TestField(Blocked, false);
     end;
 
-    internal procedure CopyPriceCalculationFieldsFromCustomerTempl(TemplateCode: Code[20])
-    var
-        CustomerTempl: Record "Customer Templ.";
-    begin
-        if TemplateCode = '' then
-            exit;
-        if not CustomerTempl.Get(TemplateCode) then
-            exit;
-        Rec."Gen. Bus. Posting Group" := CustomerTempl."Gen. Bus. Posting Group";
-        Rec."VAT Bus. Posting Group" := CustomerTempl."VAT Bus. Posting Group";
-        Rec."Tax Area Code" := CustomerTempl."Tax Area Code";
-        Rec."Tax Liable" := CustomerTempl."Tax Liable";
-        Rec."VAT Country/Region Code" := CustomerTempl."Country/Region Code";
-        Rec."Customer Posting Group" := CustomerTempl."Customer Posting Group";
-        Rec."Prices Including VAT" := CustomerTempl."Prices Including VAT";
-        Rec."Allow Line Disc." := CustomerTempl."Allow Line Disc.";
-        Rec.Modify();
-    end;
 
     local procedure EnableShopifyLogRetentionPolicySetup()
     var

--- a/src/Apps/W1/Shopify/App/src/Catalogs/Tables/ShpfyCatalog.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Catalogs/Tables/ShpfyCatalog.Table.al
@@ -125,6 +125,7 @@ table 30152 "Shpfy Catalog"
             Caption = 'Allow Line Disc.';
             DataClassification = CustomerContent;
             ToolTip = 'Specifies if line discount is allowed while calculating prices for the catalog.';
+            InitValue = true;
         }
         field(16; "Sync Prices"; Boolean)
         {


### PR DESCRIPTION
## Summary
- Set `InitValue = true` on the `"Allow Line Disc."` field in both `Shpfy Shop` (field 61) and `Shpfy Catalog` (field 15) tables so line discounts from BC price lists are no longer silently suppressed
- Move `CopyPriceCalculationFieldsFromCustomerTempl` from `ShpfyShop.Table.al` to `ShpfyUpgradeMgt.Codeunit.al` as a local procedure, since it is only called from the upgrade codeunit

Fixes [AB#630270](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630270)
Fixes [AB#630269](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630269)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


