### PR TITLE
[Shopify] Fix duplicate Sync Prices on B2B Catalogs and GraphQL quote escaping

### DIFF
--- a/src/Apps/W1/Shopify/App/.resources/graphql/Catalogs/GetCatalogs.graphql
+++ b/src/Apps/W1/Shopify/App/.resources/graphql/Catalogs/GetCatalogs.graphql
@@ -1,2 +1,2 @@
 # cost: 14
-{"query": "{catalogs(first:25, query: \"company_id:''{{CompanyId}}'' status:ACTIVE\"){ pageInfo{hasNextPage} edges{cursor node{ id title priceList { currency }}}}}"}
+{"query": "{catalogs(first:25, query: \"company_id:'{{CompanyId}}' status:ACTIVE\"){ pageInfo{hasNextPage} edges{cursor node{ id title priceList { currency }}}}}"}

--- a/src/Apps/W1/Shopify/App/.resources/graphql/Catalogs/GetNextCatalogs.graphql
+++ b/src/Apps/W1/Shopify/App/.resources/graphql/Catalogs/GetNextCatalogs.graphql
@@ -1,2 +1,2 @@
 # cost: 14
-{"query": "{catalogs(first:25, after:\"{{After}}\", query: \"company_id:''{{CompanyId}}'' status:ACTIVE\"){ pageInfo{hasNextPage} edges{cursor node{ id title priceList { currency }}}}}"}
+{"query": "{catalogs(first:25, after:\"{{After}}\", query: \"company_id:'{{CompanyId}}' status:ACTIVE\"){ pageInfo{hasNextPage} edges{cursor node{ id title priceList { currency }}}}}"}

--- a/src/Apps/W1/Shopify/App/.resources/graphql/Fulfillments/HasFulfillmentService.graphql
+++ b/src/Apps/W1/Shopify/App/.resources/graphql/Fulfillments/HasFulfillmentService.graphql
@@ -1,2 +1,2 @@
 # cost: 6
-{"query":"{ locations(first: 1, includeLegacy: true, query: \"name:''{{Name}}''\") { nodes { name }}}"}
+{"query":"{ locations(first: 1, includeLegacy: true, query: \"name:'{{Name}}'\") { nodes { name }}}"}

--- a/src/Apps/W1/Shopify/App/src/Catalogs/Tables/ShpfyCatalog.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Catalogs/Tables/ShpfyCatalog.Table.al
@@ -131,6 +131,12 @@ table 30152 "Shpfy Catalog"
             Caption = 'Sync Prices';
             DataClassification = CustomerContent;
             ToolTip = 'Specifies if the prices are synced to Shopify.';
+
+            trigger OnValidate()
+            begin
+                if "Sync Prices" then
+                    CheckDuplicateSyncPrices();
+            end;
         }
         field(17; "Customer No."; Code[20])
         {
@@ -171,5 +177,43 @@ table 30152 "Shpfy Catalog"
     begin
         MarketCatalogRelation.SetRange("Catalog Id", Id);
         MarketCatalogRelation.DeleteAll(true);
+    end;
+
+    local procedure CheckDuplicateSyncPrices()
+    var
+        OtherCatalog: Record "Shpfy Catalog";
+        DisableSyncPricesOnOtherLinesQst: Label 'Catalog "%1" already has Sync Prices enabled for company(s) %2. Only one pricing configuration per catalog is used during sync.\Do you want to disable Sync Prices on the other line(s) and enable it on the current one?\Consider using Market Catalogs if you want to link the same catalog to multiple B2B companies.', Comment = '%1 = Catalog Name, %2 = Company Name(s)';
+    begin
+        if not GuiAllowed then
+            exit;
+
+        OtherCatalog.SetRange(Id, Id);
+        OtherCatalog.SetRange("Sync Prices", true);
+        OtherCatalog.SetFilter("Company SystemId", '<>%1', "Company SystemId");
+        if OtherCatalog.IsEmpty() then
+            exit;
+
+        if not Confirm(DisableSyncPricesOnOtherLinesQst, false, Name, GetCompanyNamesForCatalogs(OtherCatalog)) then begin
+            "Sync Prices" := false;
+            exit;
+        end;
+
+        OtherCatalog.ModifyAll("Sync Prices", false);
+    end;
+
+    local procedure GetCompanyNamesForCatalogs(var CatalogFilter: Record "Shpfy Catalog"): Text
+    var
+        Names: TextBuilder;
+        Separator: Text;
+    begin
+        Separator := '';
+        if CatalogFilter.FindSet() then
+            repeat
+                CatalogFilter.CalcFields("Company Name");
+                Names.Append(Separator);
+                Names.Append(CatalogFilter."Company Name");
+                Separator := ', ';
+            until CatalogFilter.Next() = 0;
+        exit(Names.ToText());
     end;
 }

--- a/src/Apps/W1/Shopify/Test/Catalogs/ShpfyCatalogPricesTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Catalogs/ShpfyCatalogPricesTest.Codeunit.al
@@ -473,9 +473,166 @@ codeunit 139646 "Shpfy Catalog Prices Test"
         LibraryAssert.AreNearlyEqual(InitPrice * (1 - InitDiscountPerc / 100), Price, 0.01, 'Accurate calculation of discounted price should be verified.');
     end;
 
+    [Test]
+    [HandlerFunctions('ActivateConfirmHandler')]
+    procedure SyncPricesConfirmDisablesOtherLine()
+    var
+        Shop: Record "Shpfy Shop";
+        Catalog1: Record "Shpfy Catalog";
+        Catalog2: Record "Shpfy Catalog";
+        ShopifyCompany1: Record "Shpfy Company";
+        ShopifyCompany2: Record "Shpfy Company";
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+        CatalogId: BigInteger;
+    begin
+        // [SCENARIO] When enabling Sync Prices on a catalog line where another line for the same
+        // catalog ID already has Sync Prices enabled, the user confirms to disable the other line.
+
+        // [GIVEN] Two companies sharing the same catalog ID, first has Sync Prices = true
+        Shop := InitializeTest.CreateShop();
+        ShopifyCompany1.DeleteAll();
+        CatalogId := Any.IntegerInRange(100000, 999999);
+
+        ShopifyCompany1.Init();
+        ShopifyCompany1.Id := Any.IntegerInRange(1000, 99999);
+        ShopifyCompany1.Name := 'Company A';
+        ShopifyCompany1.Insert();
+
+        ShopifyCompany2.Init();
+        ShopifyCompany2.Id := Any.IntegerInRange(1000, 99999);
+        ShopifyCompany2.Name := 'Company B';
+        ShopifyCompany2.Insert();
+
+        Catalog1.Init();
+        Catalog1.Id := CatalogId;
+        Catalog1."Company SystemId" := ShopifyCompany1.SystemId;
+        Catalog1.Name := 'Test Catalog';
+        Catalog1."Shop Code" := Shop.Code;
+        Catalog1."Catalog Type" := "Shpfy Catalog Type"::Company;
+        Catalog1."Sync Prices" := true;
+        Catalog1.Insert();
+
+        Catalog2.Init();
+        Catalog2.Id := CatalogId;
+        Catalog2."Company SystemId" := ShopifyCompany2.SystemId;
+        Catalog2.Name := 'Test Catalog';
+        Catalog2."Shop Code" := Shop.Code;
+        Catalog2."Catalog Type" := "Shpfy Catalog Type"::Company;
+        Catalog2.Insert();
+
+        // [WHEN] User enables Sync Prices on Catalog2 (confirm handler replies true)
+        Catalog2.Validate("Sync Prices", true);
+        Catalog2.Modify(true);
+
+        // [THEN] Catalog2 has Sync Prices = true
+        LibraryAssert.IsTrue(Catalog2."Sync Prices", 'Catalog2 should have Sync Prices enabled');
+
+        // [THEN] Catalog1 has Sync Prices = false (disabled by the confirmation logic)
+        Catalog1.Get(CatalogId, ShopifyCompany1.SystemId);
+        LibraryAssert.IsFalse(Catalog1."Sync Prices", 'Catalog1 should have Sync Prices disabled');
+    end;
+
+    [Test]
+    [HandlerFunctions('CancelConfirmHandler')]
+    procedure SyncPricesCancelKeepsBothUnchanged()
+    var
+        Shop: Record "Shpfy Shop";
+        Catalog1: Record "Shpfy Catalog";
+        Catalog2: Record "Shpfy Catalog";
+        ShopifyCompany1: Record "Shpfy Company";
+        ShopifyCompany2: Record "Shpfy Company";
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+        CatalogId: BigInteger;
+    begin
+        // [SCENARIO] When enabling Sync Prices on a catalog line where another line for the same
+        // catalog ID already has Sync Prices enabled, the user cancels.
+
+        // [GIVEN] Two companies sharing the same catalog ID, first has Sync Prices = true
+        Shop := InitializeTest.CreateShop();
+        ShopifyCompany1.DeleteAll();
+        CatalogId := Any.IntegerInRange(100000, 999999);
+
+        ShopifyCompany1.Init();
+        ShopifyCompany1.Id := Any.IntegerInRange(1000, 99999);
+        ShopifyCompany1.Name := 'Company A';
+        ShopifyCompany1.Insert();
+
+        ShopifyCompany2.Init();
+        ShopifyCompany2.Id := Any.IntegerInRange(1000, 99999);
+        ShopifyCompany2.Name := 'Company B';
+        ShopifyCompany2.Insert();
+
+        Catalog1.Init();
+        Catalog1.Id := CatalogId;
+        Catalog1."Company SystemId" := ShopifyCompany1.SystemId;
+        Catalog1.Name := 'Test Catalog';
+        Catalog1."Shop Code" := Shop.Code;
+        Catalog1."Catalog Type" := "Shpfy Catalog Type"::Company;
+        Catalog1."Sync Prices" := true;
+        Catalog1.Insert();
+
+        Catalog2.Init();
+        Catalog2.Id := CatalogId;
+        Catalog2."Company SystemId" := ShopifyCompany2.SystemId;
+        Catalog2.Name := 'Test Catalog';
+        Catalog2."Shop Code" := Shop.Code;
+        Catalog2."Catalog Type" := "Shpfy Catalog Type"::Company;
+        Catalog2.Insert();
+
+        // [WHEN] User enables Sync Prices on Catalog2 (confirm handler replies false)
+        Catalog2.Validate("Sync Prices", true);
+
+        // [THEN] Catalog2 has Sync Prices = false (reverted by cancel)
+        LibraryAssert.IsFalse(Catalog2."Sync Prices", 'Catalog2 should remain with Sync Prices disabled');
+
+        // [THEN] Catalog1 still has Sync Prices = true (unchanged)
+        Catalog1.Get(CatalogId, ShopifyCompany1.SystemId);
+        LibraryAssert.IsTrue(Catalog1."Sync Prices", 'Catalog1 should remain with Sync Prices enabled');
+    end;
+
+    [Test]
+    procedure SyncPricesNoConfirmWhenNoDuplicate()
+    var
+        Shop: Record "Shpfy Shop";
+        Catalog: Record "Shpfy Catalog";
+        ShopifyCompany: Record "Shpfy Company";
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+    begin
+        // [SCENARIO] No confirmation when there's no other line with the same catalog ID
+        // having Sync Prices enabled.
+
+        // [GIVEN] A single catalog record with Sync Prices = false
+        Shop := InitializeTest.CreateShop();
+
+        ShopifyCompany.Init();
+        ShopifyCompany.Id := Any.IntegerInRange(1000, 99999);
+        ShopifyCompany.Name := 'Company A';
+        ShopifyCompany.Insert();
+
+        Catalog.Init();
+        Catalog.Id := Any.IntegerInRange(100000, 999999);
+        Catalog."Company SystemId" := ShopifyCompany.SystemId;
+        Catalog.Name := 'Test Catalog';
+        Catalog."Shop Code" := Shop.Code;
+        Catalog."Catalog Type" := "Shpfy Catalog Type"::Company;
+        Catalog.Insert();
+
+        // [WHEN] User enables Sync Prices (no other line exists with same catalog ID)
+        Catalog.Validate("Sync Prices", true);
+
+        // [THEN] Sync Prices = true, no confirmation dialog appeared
+        LibraryAssert.IsTrue(Catalog."Sync Prices", 'Sync Prices should be enabled');
+    end;
+
     [ConfirmHandler]
     procedure ActivateConfirmHandler(Question: Text[1024]; var Reply: Boolean)
     begin
         Reply := true;
+    end;
+
+    [ConfirmHandler]
+    procedure CancelConfirmHandler(Question: Text[1024]; var Reply: Boolean)
+    begin
+        Reply := false;
     end;
 }


### PR DESCRIPTION
## Summary
- Add confirmation dialog on the **Sync Prices** field validation in B2B Catalogs. When enabling Sync Prices on a catalog that already has it enabled for another company (same catalog ID, different company), the user is prompted to disable it on the other line(s). This prevents conflicting pricing configurations that are silently ignored during sync.
- Fix doubled single quotes (`''` → `'`) in 3 GraphQL resource files (`GetCatalogs`, `GetNextCatalogs`, `HasFulfillmentService`) introduced during the PR #7198 migration from AL codeunits to `.graphql` resource files. In AL string literals `''` is an escape for `'`, but in plain-text resource files it's literal, causing Shopify to reject the query parameters.

## Test plan
- [x] `SyncPricesConfirmDisablesOtherLine` — user confirms, other catalog line gets Sync Prices disabled
- [x] `SyncPricesCancelKeepsBothUnchanged` — user cancels, no changes
- [x] `SyncPricesNoConfirmWhenNoDuplicate` — no duplicate, no dialog, field enables normally

Fixes [AB#630273](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630273)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



