### PR TITLE
Reintroduce direct historical line matching for E-Document drafts

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/AI/Tools/EDocHistoricalMatching.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/AI/Tools/EDocHistoricalMatching.Codeunit.al
@@ -51,6 +51,9 @@ codeunit 6177 "E-Doc. Historical Matching" implements "AOAI Function", IEDocAISy
         HistoricalMatchingExperimentTok: Label 'EDocHistoricalMatchingExperiment', Locked = true;
         HistoricalMatchingConfig: Text;
     begin
+        if DirectHistoricalMatch(Rec) then
+            exit;
+
         // Get experiment configuration
         HistoricalMatchingConfig := FeatureConfiguration.GetConfiguration(HistoricalMatchingExperimentTok);
 
@@ -88,6 +91,44 @@ codeunit 6177 "E-Doc. Historical Matching" implements "AOAI Function", IEDocAISy
         TelemetryDimensions.Add('Matched lines', Format(MatchedCount));
         TelemetryDimensions.Add('Processing mistakes', Format(MistakesCount));
         FeatureTelemetry.LogUsage('0000PUP', EDocumentAIProcessor.GetEDocumentMatchingAssistanceName(), GetFeatureName(), TelemetryDimensions);
+    end;
+
+    local procedure DirectHistoricalMatch(var SourceEDocumentPurchaseLine: Record "E-Document Purchase Line"): Boolean
+    var
+        EDocumentPurchaseLine: Record "E-Document Purchase Line";
+        EDocumentPurchaseHeader: Record "E-Document Purchase Header";
+        EDocPurchaseLineHistory: Record "E-Doc. Purchase Line History";
+        PurchInvLine: Record "Purch. Inv. Line";
+        EDocPurchaseHistMapping: Codeunit "E-Doc. Purchase Hist. Mapping";
+        EDocImpSessionTelemetry: Codeunit "E-Doc. Imp. Session Telemetry";
+        VendorNo: Code[20];
+        DirectHistoricalMatchEventTok: Label 'Direct Historical Match', Locked = true;
+    begin
+        EDocumentPurchaseLine.Copy(SourceEDocumentPurchaseLine);
+        if not EDocumentPurchaseLine.FindFirst() then
+            exit(false);
+
+        EDocumentPurchaseHeader.SetRange("E-Document Entry No.", EDocumentPurchaseLine."E-Document Entry No.");
+        if EDocumentPurchaseHeader.FindFirst() then
+            VendorNo := EDocumentPurchaseHeader."[BC] Vendor No.";
+        if VendorNo = '' then
+            exit(false);
+
+        if EDocumentPurchaseLine.FindSet() then
+            repeat
+                if EDocumentPurchaseLine."[BC] Purchase Type No." = '' then
+                    if EDocPurchaseHistMapping.FindRelatedPurchaseLineInHistory(VendorNo, EDocumentPurchaseLine, EDocPurchaseLineHistory) then
+                        if PurchInvLine.GetBySystemId(EDocPurchaseLineHistory."Purch. Inv. Line SystemId") then begin
+                            EDocPurchaseHistMapping.UpdateMissingLineValuesFromHistory(PurchInvLine, EDocumentPurchaseLine, '', 'High');
+                            EDocumentPurchaseLine."E-Doc. Purch. Line History Id" := EDocPurchaseLineHistory."Entry No.";
+                            EDocumentPurchaseLine.Modify(true);
+                            EDocImpSessionTelemetry.SetLineBool(EDocumentPurchaseLine.SystemId, DirectHistoricalMatchEventTok, true);
+                        end;
+            until EDocumentPurchaseLine.Next() = 0;
+
+        // If no unmatched lines remain, all lines were resolved directly
+        EDocumentPurchaseLine.SetRange("[BC] Purchase Type No.", '');
+        exit(EDocumentPurchaseLine.IsEmpty());
     end;
 
     local procedure GetConfidenceScore(ExperimentConfig: Text): Text

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/History/EDocPurchaseHistMapping.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/History/EDocPurchaseHistMapping.Codeunit.al
@@ -159,7 +159,7 @@ codeunit 6120 "E-Doc. Purchase Hist. Mapping"
             if UnitOfMeasure.Get(PurchInvLine."Unit of Measure") then // we only assign if it's a valid unit of measure
                 EDocumentPurchaseLine."[BC] Unit of Measure" := CopyStr(PurchInvLine."Unit of Measure", 1, MaxStrLen(EDocumentPurchaseLine."[BC] Unit of Measure"));
 
-        if (EDocumentPurchaseLine."[BC] Purchase Line Type" = "Purchase Line Type"::" ") and (EDocumentPurchaseLine."[BC] Purchase Type No." = '') then begin
+        if EDocumentPurchaseLine."[BC] Purchase Type No." = '' then begin
             // We first check if the purchase invoice line came from an allocation account line
             // If so, we set the account type and number explictly since the type and number of the line has changed
             if not IsNullGuid(PurchInvLine."Alloc. Purch. Line SystemId") then begin


### PR DESCRIPTION
## Summary
- Wire up `FindRelatedPurchaseLineInHistory` (previously dead code) as a direct matching step before the AI pipeline in `E-Doc. Historical Matching`
- Sets `E-Doc. Purch. Line History Id` on matched lines, enabling the source invoice link and additional fields features
- If all lines resolve via direct history, the AI pipeline is skipped entirely

Fixes [AB#630431](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630431)


