### PR TITLE
[Shopify] Remove B2B Plus-only plan restriction

### DIFF
--- a/src/Apps/W1/Shopify/App/.docs-updated
+++ b/src/Apps/W1/Shopify/App/.docs-updated
@@ -1,4 +1,4 @@
 # Documentation last updated
-commit: 40f9d4ce5f71b412b5dbfa8d17fd5150a13532ea
-date: 2026-03-24
+commit: 343aa21d1e5737d250aabf05cd9233d15c411cdc
+date: 2026-04-08
 scope: full

--- a/src/Apps/W1/Shopify/App/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/CLAUDE.md
@@ -9,7 +9,11 @@ The Shopify Connector bridges Shopify e-commerce with Business Central ERP, bi-d
 
 ## How it works
 
-The Shop table (`ShpfyShop.Table.al`, ID 30102) is the god object. Nearly every configuration setting lives there: sync directions for items/customers/companies, mapping strategies, customer/item template codes, G/L account mappings for shipping/tips/gift cards/refunds, B2B flags, currency handling, webhook settings, and fulfillment service configuration. A single BC company can connect to multiple Shopify shops (each with its own Shop Code), and each shop gets its own set of configuration.
+The Shop table (`ShpfyShop.Table.al`, ID 30102) is the god object. Nearly every configuration setting lives there: sync directions for items/customers/companies, mapping strategies, customer/item template codes, G/L account mappings for shipping/tips/gift cards/refunds, plan-based feature flags, currency handling, webhook settings, and fulfillment service configuration. A single BC company can connect to multiple Shopify shops (each with its own Shop Code), and each shop gets its own set of configuration.
+
+The `"Advanced Shopify Plan"` boolean field (207) on the Shop table gates features that require Plus, Plus Trial, Development, or Advanced plans. `GetShopSettings()` reads the Shopify plan and sets this flag automatically. B2B features (companies, catalogs, company sync) are now unconditionally available on all Shopify plans -- the old `"B2B Enabled"` field (117) has been obsoleted (CLEAN29/CLEANSCHEMA32 guards).
+
+*Updated: 2026-04-08 -- B2B Enabled obsoleted, Advanced Shopify Plan added*
 
 All Shopify API communication goes through GraphQL. The `ShpfyCommunicationMgt.Codeunit.al` is the single entry point for API calls. It constructs URLs using a versioned API path (currently `2026-01`), handles authentication, rate limiting, and retry logic. GraphQL queries are stored as `.graphql` resource files under `.resources/graphql/{Area}/`, loaded at runtime via `NavApp.GetResourceAsText()`. The `ShpfyGraphQLType` enum maps each query to its resource file using `{Area}_{QueryName}` naming, and the dispatcher loads the corresponding file instead of calling interface methods. The `ShpfyGraphQLRateLimit` codeunit (singleton) tracks Shopify's cost-based throttle -- it reads `restoreRate` and `currentlyAvailable` from responses and sleeps before issuing requests that would exceed the budget.
 
@@ -56,7 +60,7 @@ Records link to BC entities via SystemId (GUID), not Code/No. For example, `Shpf
 
 ## Things to know
 
-- The Shop table is the god object -- nearly every configuration setting lives there, with over 100 fields controlling sync directions, mapping strategies, account mappings, B2B flags, webhook config, and more.
+- The Shop table is the god object -- nearly every configuration setting lives there, with over 100 fields controlling sync directions, mapping strategies, account mappings, plan-based feature flags, webhook config, and more. The `"Advanced Shopify Plan"` field gates features requiring Plus/Advanced plans (currently staff members). B2B features are now unconditionally available on all plans.
 - All API calls go through GraphQL, never REST. Queries are `.graphql` resource files in `.resources/graphql/{Area}/`, loaded via `NavApp.GetResourceAsText()` and dispatched through the `ShpfyGraphQLType` enum.
 - Products use hash-based change detection (`"Image Hash"`, `"Tags Hash"`, `"Description Html Hash"`) via a custom hash algorithm to skip unnecessary API calls when nothing has changed.
 - Records link to BC entities via SystemId (GUID), not Code/No. -- FlowFields like `"Item No."` display the human-readable values via CalcFormula lookup. Renumbering BC items does not break Shopify links.

--- a/src/Apps/W1/Shopify/App/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/docs/business-logic.md
@@ -12,7 +12,9 @@ The export flow is driven by `ShpfyProductExport.Codeunit.al`. It iterates all S
 
 The update flow relies heavily on hash-based change detection. Before making any API call, the codeunit computes the current hash of the product's tags, HTML description, and images, then compares them against the stored hashes on the Product record. Only fields that have actually changed result in API calls. This is critical because Shopify's GraphQL API has per-store rate limits, and a full product catalog update without change detection would quickly exhaust the budget.
 
-Price sync can run independently of the full product sync via the `OnlyUpdatePrice` flag. When enabled, prices are batched into a bulk mutation (`ShpfyBulkUpdateProductPrice.Codeunit.al`) for efficiency. If the bulk operation fails, it falls back to individual variant price updates, reverting variant changes on failure.
+Price sync can run independently of the full product sync via the `OnlyUpdatePrice` flag. When enabled, prices are batched into a bulk mutation (`ShpfyBulkUpdateProductPrice.Codeunit.al`) for efficiency. If the bulk operation fails, it falls back to individual variant price updates, reverting variant changes on failure. Item price sync is skipped when the item's unit of measure is invalid, preventing errors from propagating into Shopify pricing data.
+
+*Updated: 2026-04-08 -- Price sync skipped for invalid unit of measure*
 
 The product body HTML is assembled from BC data by `CreateProductBody()` in the export codeunit -- it concatenates extended text, marketing text, and item attributes into an HTML structure. Events fire before and after this assembly (`OnBeforeCreateProductBodyHtml`, `OnAfterCreateProductBodyHtml`), allowing extensions to customize the output.
 
@@ -52,7 +54,9 @@ Order processing is the most complex flow in the connector. It spans multiple co
 
 ### Import
 
-`ShpfyImportOrder.Codeunit.al` takes an order from the staging table and creates the full Order Header and Order Lines. It parses the GraphQL response to populate all address blocks, financial fields (in both currencies), customer IDs, discount codes, attributes, tax lines, and risk assessments. The `OnAfterImportShopifyOrderHeader` and `OnAfterCreateShopifyOrderAndLines` events fire after import.
+`ShpfyImportOrder.Codeunit.al` takes an order from the staging table and creates the full Order Header and Order Lines. It parses the GraphQL response to populate all address blocks, financial fields (in both currencies), customer IDs, discount codes, attributes, tax lines, and risk assessments. Staff member handling during order import is gated by the Shop's `"Advanced Shopify Plan"` flag (true for Plus, Plus Trial, Development, and Advanced plans). The `OnAfterImportShopifyOrderHeader` and `OnAfterCreateShopifyOrderAndLines` events fire after import.
+
+*Updated: 2026-04-08 -- Staff member gating moved from B2B Enabled to Advanced Shopify Plan*
 
 ### Mapping
 
@@ -90,6 +94,10 @@ The header creation in `CreateHeaderFromShopifyOrder()` is notably manual -- it 
 The `"Create Invoices From Orders"` setting causes fully-fulfilled orders to be created as Sales Invoices instead of Sales Orders. The `"Use Shopify Order No."` setting uses the Shopify order number (e.g., "#1001") as the BC document number, which requires the number series to have Manual Nos. enabled.
 
 Special line types require attention: gift card purchases map to the `"Sold Gift Card Account"` G/L account, tips map to `"Tip Account"`, and shipping charges map to `"Shipping Charges Account"`. These are all configured on the Shop record.
+
+The Shopify Order page includes contact lookup and validation, allowing users to verify and resolve customer contact information directly from the order.
+
+*Updated: 2026-04-08 -- Contact lookup/validation added to Shopify Order page*
 
 ## Fulfillment
 
@@ -136,3 +144,9 @@ Export to Shopify is handled by `ShpfyCustomerExport.Codeunit.al`. It creates or
 Company sync follows the same pattern but with `ShpfyCompanyImport.Codeunit.al` and `ShpfyCompanyExport.Codeunit.al`. Company mapping uses `ICompanyMapping` with strategies including By Email/Phone, By Tax ID, and Default Company. The B2B chain is: Company -> Company Location -> Customer (the location's main contact becomes the BC customer).
 
 When a B2B order arrives, the customer resolution differs from D2C: the connector looks up the company's main contact customer ID and the company location to determine the sell-to and ship-to customer numbers. This can result in different BC customers for different company locations of the same Shopify company.
+
+## Test infrastructure
+
+Test mocking uses the HttpClientHandler pattern rather than `IsTestInProgress` checks. Test codeunits inject a mock HTTP handler that intercepts Shopify API calls and returns canned responses, avoiding conditional test logic scattered through production code.
+
+*Updated: 2026-04-08 -- Test mocking migrated from IsTestInProgress to HttpClientHandler*

--- a/src/Apps/W1/Shopify/App/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/docs/data-model.md
@@ -8,6 +8,10 @@ The Shop table is the center of the configuration universe. Every sync operation
 
 Synchronization Info stores the last sync timestamp per shop and sync type (products, customers, orders, inventory, etc.). It is keyed on Shop Code + Synchronization Type. For order sync specifically, the key is the Shop's integer hash (`"Shop Id"`) rather than the Shop Code -- this allows multiple BC companies connected to the same Shopify store to share one order sync cursor without re-importing the same orders.
 
+The Shop table includes plan-based feature flags. The `"Advanced Shopify Plan"` field (207) is set to true for Plus, Plus Trial, Development, and Advanced plans, and currently gates staff member features. The old `"B2B Enabled"` field (117) has been obsoleted (CLEAN29/CLEANSCHEMA32 guards) -- B2B features are now unconditionally available on all plans.
+
+*Updated: 2026-04-08 -- B2B Enabled obsoleted, Advanced Shopify Plan added*
+
 Shop Location maps Shopify fulfillment locations to BC warehouse locations. Each mapping includes a stock calculation enum that determines how to compute available stock for that pairing.
 
 ```mermaid
@@ -131,11 +135,15 @@ erDiagram
     COMPANY }o--|| SHOP : belongs_to
 ```
 
-The B2B order flow differs from D2C: when an order has a `"Company Id"`, the connector uses the company mapping strategy instead of the customer mapping strategy, and it looks up the company location to determine the bill-to/ship-to customer.
+The B2B order flow differs from D2C: when an order has a `"Company Id"`, the connector uses the company mapping strategy instead of the customer mapping strategy, and it looks up the company location to determine the bill-to/ship-to customer. B2B features (companies, catalogs, company sync) are available on all Shopify plans -- they are no longer gated by a plan-specific flag.
+
+*Updated: 2026-04-08 -- B2B no longer gated by plan*
 
 ## Payments and transactions
 
-Order Transactions record the individual payment events on an order (authorization, capture, refund). They are imported from Shopify and store amounts, gateway names, and status.
+Order Transactions record the individual payment events on an order (authorization, capture, refund). They are imported from Shopify and store amounts, gateway names, and status. A `"Shop"` field links each transaction to its Shop record (populated via upgrade DataTransfer from Order Header).
+
+*Updated: 2026-04-08 -- Shop field added to OrderTransaction*
 
 Gift Cards have their own table because they serve dual roles: as a line item when purchased and as a payment instrument when redeemed.
 

--- a/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyUpgradeMgt.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyUpgradeMgt.Codeunit.al
@@ -42,6 +42,7 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         SetShopifyCatalogsType();
         CreateInvoicesFromOrdersUpgrade();
         OrderTransactionShopCodeUpgrade();
+        StaffMembersEnabledUpgrade();
     end;
 
     internal procedure UpgradeTemplatesData()
@@ -496,6 +497,24 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         UpgradeTag.SetUpgradeTag(GetOrderTransactionShopCodeUpgradeTag());
     end;
 
+    local procedure StaffMembersEnabledUpgrade()
+    var
+        Shop: Record "Shpfy Shop";
+        UpgradeTag: Codeunit "Upgrade Tag";
+        ShopDataTransfer: DataTransfer;
+    begin
+        if UpgradeTag.HasUpgradeTag(GetStaffMembersEnabledUpgradeTag()) then
+            exit;
+
+        ShopDataTransfer.SetTables(Database::"Shpfy Shop", Database::"Shpfy Shop");
+        ShopDataTransfer.AddSourceFilter(Shop.FieldNo("B2B Enabled"), '=%1', true);
+        ShopDataTransfer.AddConstantValue(true, Shop.FieldNo("Staff Members Enabled"));
+        ShopDataTransfer.UpdateAuditFields := false;
+        ShopDataTransfer.CopyFields();
+
+        UpgradeTag.SetUpgradeTag(GetStaffMembersEnabledUpgradeTag());
+    end;
+
     internal procedure GetAllowOutgoingRequestseUpgradeTag(): Code[250]
     begin
         exit('MS-445989-AllowOutgoingRequestseUpgradeTag-20220816');
@@ -571,6 +590,11 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         exit('MS-610671-OrderTransactionShopCodeUpgrade-20251022');
     end;
 
+    local procedure GetStaffMembersEnabledUpgradeTag(): Code[250]
+    begin
+        exit('MS-630316-StaffMembersEnabledUpgrade-20260408');
+    end;
+
     local procedure GetDateBeforeFeature(): DateTime
     begin
         exit(CreateDateTime(DMY2Date(1, 8, 2022), 0T));
@@ -590,5 +614,6 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         PerCompanyUpgradeTags.Add(GetShopifyCatalogsTypeUpgradeTag());
         PerCompanyUpgradeTags.Add(GetCreateInvoicesFromOrdersUpgradeTag());
         PerCompanyUpgradeTags.Add(GetOrderTransactionShopCodeUpgradeTag());
+        PerCompanyUpgradeTags.Add(GetStaffMembersEnabledUpgradeTag());
     end;
 }

--- a/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyUpgradeMgt.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyUpgradeMgt.Codeunit.al
@@ -508,7 +508,7 @@ codeunit 30106 "Shpfy Upgrade Mgt."
 
         ShopDataTransfer.SetTables(Database::"Shpfy Shop", Database::"Shpfy Shop");
         ShopDataTransfer.AddSourceFilter(Shop.FieldNo("B2B Enabled"), '=%1', true);
-        ShopDataTransfer.AddConstantValue(true, Shop.FieldNo("Has Advanced Shopify Plan"));
+        ShopDataTransfer.AddConstantValue(true, Shop.FieldNo("Advanced Shopify Plan"));
         ShopDataTransfer.UpdateAuditFields := false;
         ShopDataTransfer.CopyFields();
 

--- a/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyUpgradeMgt.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyUpgradeMgt.Codeunit.al
@@ -42,7 +42,7 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         SetShopifyCatalogsType();
         CreateInvoicesFromOrdersUpgrade();
         OrderTransactionShopCodeUpgrade();
-        StaffMembersEnabledUpgrade();
+        HasAdvancedShopifyPlanUpgrade();
     end;
 
     internal procedure UpgradeTemplatesData()
@@ -497,22 +497,22 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         UpgradeTag.SetUpgradeTag(GetOrderTransactionShopCodeUpgradeTag());
     end;
 
-    local procedure StaffMembersEnabledUpgrade()
+    local procedure HasAdvancedShopifyPlanUpgrade()
     var
         Shop: Record "Shpfy Shop";
         UpgradeTag: Codeunit "Upgrade Tag";
         ShopDataTransfer: DataTransfer;
     begin
-        if UpgradeTag.HasUpgradeTag(GetStaffMembersEnabledUpgradeTag()) then
+        if UpgradeTag.HasUpgradeTag(GetHasAdvancedShopifyPlanUpgradeTag()) then
             exit;
 
         ShopDataTransfer.SetTables(Database::"Shpfy Shop", Database::"Shpfy Shop");
         ShopDataTransfer.AddSourceFilter(Shop.FieldNo("B2B Enabled"), '=%1', true);
-        ShopDataTransfer.AddConstantValue(true, Shop.FieldNo("Staff Members Enabled"));
+        ShopDataTransfer.AddConstantValue(true, Shop.FieldNo("Has Advanced Shopify Plan"));
         ShopDataTransfer.UpdateAuditFields := false;
         ShopDataTransfer.CopyFields();
 
-        UpgradeTag.SetUpgradeTag(GetStaffMembersEnabledUpgradeTag());
+        UpgradeTag.SetUpgradeTag(GetHasAdvancedShopifyPlanUpgradeTag());
     end;
 
     internal procedure GetAllowOutgoingRequestseUpgradeTag(): Code[250]
@@ -590,9 +590,9 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         exit('MS-610671-OrderTransactionShopCodeUpgrade-20251022');
     end;
 
-    local procedure GetStaffMembersEnabledUpgradeTag(): Code[250]
+    local procedure GetHasAdvancedShopifyPlanUpgradeTag(): Code[250]
     begin
-        exit('MS-630316-StaffMembersEnabledUpgrade-20260408');
+        exit('MS-630316-HasAdvancedShopifyPlanUpgrade-20260408');
     end;
 
     local procedure GetDateBeforeFeature(): DateTime
@@ -614,6 +614,6 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         PerCompanyUpgradeTags.Add(GetShopifyCatalogsTypeUpgradeTag());
         PerCompanyUpgradeTags.Add(GetCreateInvoicesFromOrdersUpgradeTag());
         PerCompanyUpgradeTags.Add(GetOrderTransactionShopCodeUpgradeTag());
-        PerCompanyUpgradeTags.Add(GetStaffMembersEnabledUpgradeTag());
+        PerCompanyUpgradeTags.Add(GetHasAdvancedShopifyPlanUpgradeTag());
     end;
 }

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyActivities.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyActivities.Page.al
@@ -38,7 +38,6 @@ page 30100 "Shpfy Activities"
                     ApplicationArea = All;
                     DrillDownPageId = "Shpfy Companies";
                     ToolTip = 'Specifies the number of imported companoes that aren''t mapped.';
-                    Visible = B2BEnabled;
                 }
                 field(UnmappedProducts; Rec."Unmapped Products")
                 {
@@ -154,10 +153,6 @@ page 30100 "Shpfy Activities"
                 Commit();
             end;
 
-        Shop.SetRange("B2B Enabled", true);
-        B2BEnabled := not Shop.IsEmpty();
-
-        Shop.Reset();
         Shop.SetRange(Enabled, true);
         if Shop.FindFirst() then begin
             ApiVersion := CommunicationMgt.GetApiVersion();
@@ -166,6 +161,4 @@ page 30100 "Shpfy Activities"
         end;
     end;
 
-    var
-        B2BEnabled: Boolean;
 }

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -352,7 +352,6 @@ page 30101 "Shpfy Shop Card"
             }
             group("B2B Company Synchronization")
             {
-                Visible = Rec."B2B Enabled";
                 field("Company Import From Shopify"; Rec."Company Import From Shopify")
                 {
                     ApplicationArea = All;
@@ -745,7 +744,6 @@ page 30101 "Shpfy Shop Card"
                 RunObject = Page "Shpfy Companies";
                 RunPageLink = "Shop Id" = field("Shop Id");
                 ToolTip = 'Add, view or edit detailed information for the companies.';
-                Visible = Rec."B2B Enabled";
             }
             action(Catalogs)
             {
@@ -759,7 +757,6 @@ page 30101 "Shpfy Shop Card"
                 RunObject = Page "Shpfy Catalogs";
                 RunPageLink = "Shop Code" = field(Code);
                 ToolTip = 'View a list of Shopify B2B catalogs for the shop.';
-                Visible = Rec."B2B Enabled";
             }
             action(MarketCatalogs)
             {
@@ -773,7 +770,6 @@ page 30101 "Shpfy Shop Card"
                 RunObject = Page "Shpfy Market Catalogs";
                 RunPageLink = "Shop Code" = field(Code);
                 ToolTip = 'View a list of Shopify market catalogs for the shop.';
-                Visible = Rec."B2B Enabled";
             }
             action(Languages)
             {
@@ -839,7 +835,7 @@ page 30101 "Shpfy Shop Card"
                 RunObject = Page "Shpfy Staff Mapping";
                 RunPageLink = "Shop Code" = field(Code);
                 ToolTip = 'View a list of Shopify Staff Members for the shop.';
-                Visible = Rec."B2B Enabled";
+                Visible = Rec."Staff Members Enabled";
             }
         }
         area(Processing)
@@ -1009,7 +1005,6 @@ page 30101 "Shpfy Shop Card"
                     PromotedCategory = Category5;
                     PromotedOnly = true;
                     ToolTip = 'Synchronize the companies with Shopify. The way companies are synchronized depends on the B2B settings in the Shopify Shop Card.';
-                    Visible = Rec."B2B Enabled";
 
                     trigger OnAction()
                     var
@@ -1126,10 +1121,8 @@ page 30101 "Shpfy Shop Card"
                         BackgroundSyncs.InventorySync(Rec);
                         BackgroundSyncs.ProductImagesSync(Rec, '');
                         BackgroundSyncs.ProductPricesSync(Rec);
-                        if Rec."B2B Enabled" then begin
-                            BackgroundSyncs.CompanySync(Rec);
-                            BackgroundSyncs.CatalogPricesSync(Rec, '', "Shpfy Catalog Type"::" ");
-                        end;
+                        BackgroundSyncs.CompanySync(Rec);
+                        BackgroundSyncs.CatalogPricesSync(Rec, '', "Shpfy Catalog Type"::" ");
                     end;
                 }
             }

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -388,6 +388,7 @@ page 30101 "Shpfy Shop Card"
                 field("Auto Create Catalog"; Rec."Auto Create Catalog")
                 {
                     ApplicationArea = All;
+                    Visible = Rec."Advanced Shopify Plan";
                 }
                 field("Company Metafields To Shopify"; Rec."Company Metafields To Shopify")
                 {

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -835,7 +835,7 @@ page 30101 "Shpfy Shop Card"
                 RunObject = Page "Shpfy Staff Mapping";
                 RunPageLink = "Shop Code" = field(Code);
                 ToolTip = 'View a list of Shopify Staff Members for the shop.';
-                Visible = Rec."Staff Members Enabled";
+                Visible = Rec."Has Advanced Shopify Plan";
             }
         }
         area(Processing)

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -757,6 +757,7 @@ page 30101 "Shpfy Shop Card"
                 RunObject = Page "Shpfy Catalogs";
                 RunPageLink = "Shop Code" = field(Code);
                 ToolTip = 'View a list of Shopify B2B catalogs for the shop.';
+                Visible = Rec."Advanced Shopify Plan";
             }
             action(MarketCatalogs)
             {
@@ -1122,7 +1123,8 @@ page 30101 "Shpfy Shop Card"
                         BackgroundSyncs.ProductImagesSync(Rec, '');
                         BackgroundSyncs.ProductPricesSync(Rec);
                         BackgroundSyncs.CompanySync(Rec);
-                        BackgroundSyncs.CatalogPricesSync(Rec, '', "Shpfy Catalog Type"::" ");
+                        if Rec."Advanced Shopify Plan" then
+                            BackgroundSyncs.CatalogPricesSync(Rec, '', "Shpfy Catalog Type"::" ");
                     end;
                 }
             }

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -1124,8 +1124,7 @@ page 30101 "Shpfy Shop Card"
                         BackgroundSyncs.ProductImagesSync(Rec, '');
                         BackgroundSyncs.ProductPricesSync(Rec);
                         BackgroundSyncs.CompanySync(Rec);
-                        if Rec."Advanced Shopify Plan" then
-                            BackgroundSyncs.CatalogPricesSync(Rec, '', "Shpfy Catalog Type"::" ");
+                        BackgroundSyncs.CatalogPricesSync(Rec, '', "Shpfy Catalog Type"::" ");
                     end;
                 }
             }

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -835,7 +835,7 @@ page 30101 "Shpfy Shop Card"
                 RunObject = Page "Shpfy Staff Mapping";
                 RunPageLink = "Shop Code" = field(Code);
                 ToolTip = 'View a list of Shopify Staff Members for the shop.';
-                Visible = Rec."Has Advanced Shopify Plan";
+                Visible = Rec."Advanced Shopify Plan";
             }
         }
         area(Processing)

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -937,9 +937,9 @@ table 30102 "Shpfy Shop"
 #endif
         }
 #endif
-        field(207; "Has Advanced Shopify Plan"; Boolean)
+        field(207; "Advanced Shopify Plan"; Boolean)
         {
-            Caption = 'Has Advanced Shopify Plan';
+            Caption = 'Advanced Shopify Plan';
             DataClassification = SystemMetadata;
         }
     }
@@ -1146,7 +1146,7 @@ table 30102 "Shpfy Shop"
         JResponse := CommunicationMgt.ExecuteGraphQL('{"query":"query { shop { name plan { publicDisplayName partnerDevelopment shopifyPlus } weightUnit } }"}');
         if JResponse.SelectToken('$.data.shop.plan', JItem) then
             if JItem.IsObject then
-                Rec."Has Advanced Shopify Plan" := JsonHelper.GetValueAsBoolean(JItem, 'shopifyPlus') or
+                Rec."Advanced Shopify Plan" := JsonHelper.GetValueAsBoolean(JItem, 'shopifyPlus') or
                                                 (JsonHelper.GetValueAsText(JItem, 'publicDisplayName') in ['Plus Trial', 'Development', 'Advanced']);
         Rec."Weight Unit" := ConvertToWeightUnit(JsonHelper.GetValueAsText(JResponse, 'data.shop.weightUnit'));
     end;

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -937,9 +937,9 @@ table 30102 "Shpfy Shop"
 #endif
         }
 #endif
-        field(207; "Staff Members Enabled"; Boolean)
+        field(207; "Has Advanced Shopify Plan"; Boolean)
         {
-            Caption = 'Staff Members Enabled';
+            Caption = 'Has Advanced Shopify Plan';
             DataClassification = SystemMetadata;
         }
     }
@@ -1146,7 +1146,7 @@ table 30102 "Shpfy Shop"
         JResponse := CommunicationMgt.ExecuteGraphQL('{"query":"query { shop { name plan { publicDisplayName partnerDevelopment shopifyPlus } weightUnit } }"}');
         if JResponse.SelectToken('$.data.shop.plan', JItem) then
             if JItem.IsObject then
-                Rec."Staff Members Enabled" := JsonHelper.GetValueAsBoolean(JItem, 'shopifyPlus') or
+                Rec."Has Advanced Shopify Plan" := JsonHelper.GetValueAsBoolean(JItem, 'shopifyPlus') or
                                                 (JsonHelper.GetValueAsText(JItem, 'publicDisplayName') in ['Plus Trial', 'Development', 'Advanced']);
         Rec."Weight Unit" := ConvertToWeightUnit(JsonHelper.GetValueAsText(JResponse, 'data.shop.weightUnit'));
     end;

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -716,11 +716,21 @@ table 30102 "Shpfy Shop"
             DataClassification = SystemMetadata;
             InitValue = true;
         }
+#if not CLEANSCHEMA32
         field(117; "B2B Enabled"; Boolean)
         {
             Caption = 'B2B Enabled';
             DataClassification = SystemMetadata;
+            ObsoleteReason = 'B2B features are now available on all Shopify plans.';
+#if CLEAN29
+            ObsoleteState = Removed;
+            ObsoleteTag = '32.0';
+#else
+            ObsoleteState = Pending;
+            ObsoleteTag = '29.0';
+#endif
         }
+#endif
         field(118; "Can Update Shopify Companies"; Boolean)
         {
             Caption = 'Can Update Shopify Companies';
@@ -927,6 +937,11 @@ table 30102 "Shpfy Shop"
 #endif
         }
 #endif
+        field(207; "Staff Members Enabled"; Boolean)
+        {
+            Caption = 'Staff Members Enabled';
+            DataClassification = SystemMetadata;
+        }
     }
 
     keys
@@ -1131,8 +1146,8 @@ table 30102 "Shpfy Shop"
         JResponse := CommunicationMgt.ExecuteGraphQL('{"query":"query { shop { name plan { publicDisplayName partnerDevelopment shopifyPlus } weightUnit } }"}');
         if JResponse.SelectToken('$.data.shop.plan', JItem) then
             if JItem.IsObject then
-                Rec."B2B Enabled" := JsonHelper.GetValueAsBoolean(JItem, 'shopifyPlus') or
-                                        (JsonHelper.GetValueAsText(JItem, 'publicDisplayName') in ['Plus Trial', 'Development']);
+                Rec."Staff Members Enabled" := JsonHelper.GetValueAsBoolean(JItem, 'shopifyPlus') or
+                                                (JsonHelper.GetValueAsText(JItem, 'publicDisplayName') in ['Plus Trial', 'Development', 'Advanced']);
         Rec."Weight Unit" := ConvertToWeightUnit(JsonHelper.GetValueAsText(JResponse, 'data.shop.weightUnit'));
     end;
 

--- a/src/Apps/W1/Shopify/App/src/Base/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Base/docs/CLAUDE.md
@@ -27,6 +27,35 @@ splitting between background-allowed and foreground-only shops.
 `Shpfy Installer` sets up retention policies and Cue thresholds on
 install, and disables all shops on company copy or environment cleanup.
 
+## B2B Enabled → Advanced Shopify Plan migration
+
+The `B2B Enabled` field (117) on the Shop table is obsoleted with
+`CLEAN29`/`CLEANSCHEMA32` guards. It is replaced by a new field
+`Advanced Shopify Plan` (207), which is set to true for Plus, Plus Trial,
+Development, and Advanced plans.
+
+*Updated: 2026-04-08 -- B2B Enabled obsoleted, replaced by Advanced Shopify Plan*
+
+`GetShopSettings()` still queries the Shopify plan info but now sets
+`Advanced Shopify Plan` instead of `B2B Enabled`. The plan name check
+includes "Advanced" in addition to the previous Plus/Development values.
+
+`ShpfyUpgradeMgt` has a new `HasAdvancedShopifyPlanUpgrade()` procedure
+that uses DataTransfer to copy `B2B Enabled` → `Advanced Shopify Plan`
+(with a source filter on true and a constant value).
+
+## Activities page and Shop Card visibility changes
+
+`ShpfyActivities` page: the `B2BEnabled` variable and B2B shop filter
+have been removed -- the Unmapped Companies cue is now always visible.
+
+*Updated: 2026-04-08 -- B2B visibility gates removed from Activities and Shop Card*
+
+`ShpfyShopCard` page: six `Visible = Rec."B2B Enabled"` gates on B2B
+groups/actions have been removed. The StaffMembers action is now gated on
+`Advanced Shopify Plan` instead. The "Sync All" action now unconditionally
+syncs companies and catalog prices regardless of plan.
+
 ## Things to know
 
 - The `Shpfy Cue` table uses FlowFields for role center counts: unmapped

--- a/src/Apps/W1/Shopify/App/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
@@ -59,6 +59,7 @@ codeunit 30284 "Shpfy Company Export"
             exit;
         end;
 
+        ShopifyCompany.SetRange("Shop Code", Shop.Code);
         ShopifyCompany.SetRange("External Id", Customer."No.");
         if not ShopifyCompany.IsEmpty() then begin
             SkippedRecord.LogSkippedRecord(Customer.RecordId, StrSubstNo(CompanyWithExternalIdExistsLbl, Customer."No."), Shop);

--- a/src/Apps/W1/Shopify/App/src/Companies/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Companies/docs/CLAUDE.md
@@ -4,7 +4,10 @@ B2B company management -- separate from D2C customer sync.
 
 ## What it does
 
-Imports Shopify companies (a Shopify Plus feature) and maps them to BC Customers.
+Imports Shopify companies and maps them to BC Customers. B2B features
+(companies, catalogs) are now available on all Shopify plans, not just Plus.
+
+*Updated: 2026-04-08 -- B2B features no longer restricted to Shopify Plus*
 Each company has locations with billing addresses, tax registration IDs, and
 payment terms. The company's main contact is a Shopify Customer used for email
 and phone-based matching.
@@ -20,13 +23,18 @@ company's location data (address, phone, tax ID, payment terms).
 
 ## Things to know
 
-- Requires Shopify Plus. Without it, the companies API is unavailable.
+- B2B features (companies, catalogs) are available on all Shopify plans.
+  The old Shopify Plus restriction has been removed.
 - The relationship chain is Company -> Location -> Customer. A company has
   locations (physical addresses), and each company has a main contact who is a
   Shopify Customer record. The `Main Contact Customer Id` on the Company
   links to `Shpfy Customer`.
 - `Customer SystemId` on Company links to the BC Customer, same pattern as
   Customers and Products.
+- `ShpfyCompanyExport` now includes a `Shop Code` filter when checking for
+  an existing company by External Id. Previously, a company exported from
+  shop A could falsely block export from shop B.
+  *Updated: 2026-04-08 -- Shop Code filter added to company export lookup*
 - Company Locations can override the default customer mapping for order
   processing via `Sell-to Customer No.` and `Bill-to Customer No.` fields.
 - Three mapping strategies exist: By Email/Phone (matches main contact's

--- a/src/Apps/W1/Shopify/App/src/Order Fulfillments/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Fulfillments/docs/CLAUDE.md
@@ -8,13 +8,17 @@ When an order is imported, `ShpfyFulfillmentOrdersAPI.GetShopifyFulfillmentOrder
 
 Fulfillments (actual shipments) are tracked in `Shpfy Order Fulfillment` and `Shpfy Fulfillment Line`. The `ShpfyOrderFulfillments` codeunit imports fulfillment data from Shopify, including tracking info (numbers, URLs, companies) and line-level quantities. It handles pagination for fulfillments with many line items and detects gift card fulfillments to trigger gift card retrieval.
 
-The module also manages BC's fulfillment service registration. On first outgoing request, it registers a fulfillment service with Shopify (`CreateFulfillmentService`), which allows BC to appear as a fulfillment location. Assigned fulfillment orders (where Shopify has routed work to BC's service) are tracked via `GetAssignedFulfillmentOrders` and must be accepted before they can be fulfilled.
+The module also manages BC's fulfillment service registration. On first outgoing request, it registers a fulfillment service with Shopify (`CreateFulfillmentService`), which allows BC to appear as a fulfillment location. Before fetching assigned fulfillment orders, `GetAssignedFulfillmentOrders` validates that the fulfillment service still exists in Shopify via `HasFulfillmentService` -- if the service was deleted from Shopify, it automatically deactivates the `Fulfillment Service Activated` flag on the shop and exits early. Assigned fulfillment orders (where Shopify has routed work to BC's service) must be accepted via `AcceptFulfillmentRequest` before they can be fulfilled; this sends a GraphQL mutation and updates the request status to ACCEPTED on success.
+
+*Updated: 2026-04-08 -- HasFulfillmentService validation and AcceptFulfillmentRequest details*
 
 ## Things to know
 
+- Fulfillment order headers store `Shop Id` and `Shop Code` directly (populated from the shop record during extraction), enabling direct shop-level filtering without joining through the order.
 - Fulfillment Orders are Shopify's concept -- they represent "what needs to ship from where." Fulfillments are the actual shipment records.
 - The `Request Status` enum (SUBMITTED, ACCEPTED, etc.) tracks the fulfillment service handshake -- BC must accept assigned requests before creating fulfillments.
 - Fulfillment order lines carry `Remaining Quantity` and `Quantity to Fulfill` -- the Shipping module uses these to match BC shipment lines to Shopify fulfillment order lines.
 - `Delivery Method Type` distinguishes shipping, pickup, local delivery, and other methods.
 - The fulfillment service is auto-registered on first outgoing sync if `Allow Outgoing Requests` is enabled.
 - Multiple tracking numbers per fulfillment are supported -- they are stored as comma-separated values.
+- Fulfillment line items are paginated -- `ImportFulfillment` in `ShpfyOrderFulfillments` follows `hasNextPage`/`endCursor` to fetch all lines when a fulfillment has many items.

--- a/src/Apps/W1/Shopify/App/src/Order Refunds/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/docs/CLAUDE.md
@@ -10,6 +10,10 @@ Refund lines are linked back to order lines via `Order Line Id` and carry a `Res
 
 If the refund is associated with a return, the module collects return locations from the Returns API to populate the `Location Id` on refund lines, since Shopify does not always include location data directly on the refund.
 
+The refund header stores `Shop Code` directly (populated from the communication manager's current shop during import), enabling shop-level filtering without joining through the order header. Currency codes (`Currency Code` and `Presentment Currency Code`) are also stored on the header and translated via `ImportOrder.TranslateCurrencyCode`. Error tracking fields (`Has Processing Error`, `Last Error Description`, `Last Error Call Stack`) support retry/debugging workflows. The `CheckCanCreateDocument` method prevents duplicate processing by checking whether a `Shpfy Doc. Link To Doc.` already exists for the refund.
+
+*Updated: 2026-04-08 -- Shop Code, currency codes, error tracking, and CheckCanCreateDocument on refund header*
+
 ## Things to know
 
 - A refund can exist without a return -- for example, an appeasement refund or a partial amount adjustment.

--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
@@ -314,7 +314,7 @@ codeunit 30161 "Shpfy Import Order"
         JResponse: JsonToken;
     begin
         Parameters.Add('OrderId', Format(OrderId));
-        if Shop."B2B Enabled" then
+        if Shop."Staff Members Enabled" then
             Parameters.Add('StaffMember', 'staffMember { id }')
         else
             Parameters.Add('StaffMember', '');
@@ -388,7 +388,7 @@ codeunit 30161 "Shpfy Import Order"
         JsonHelper.GetValueIntoField(JOrder, 'presentmentCurrencyCode', OrderHeaderRecordRef, OrderHeader.FieldNo("Presentment Currency Code"));
         JsonHelper.GetValueIntoField(JOrder, 'test', OrderHeaderRecordRef, OrderHeader.FieldNo(Test));
         JsonHelper.GetValueIntoField(JOrder, 'edited', OrderHeaderRecordRef, OrderHeader.FieldNo(Edited));
-        if Shop."B2B Enabled" then begin
+        if Shop."Staff Members Enabled" then begin
             StaffMemberId := CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JOrder, 'staffMember.id'));
             SetSalespersonOnOrderHeader(OrderHeader."Shop Code", StaffMemberId, OrderHeaderRecordRef);
         end;

--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
@@ -314,7 +314,7 @@ codeunit 30161 "Shpfy Import Order"
         JResponse: JsonToken;
     begin
         Parameters.Add('OrderId', Format(OrderId));
-        if Shop."Has Advanced Shopify Plan" then
+        if Shop."Advanced Shopify Plan" then
             Parameters.Add('StaffMember', 'staffMember { id }')
         else
             Parameters.Add('StaffMember', '');
@@ -388,7 +388,7 @@ codeunit 30161 "Shpfy Import Order"
         JsonHelper.GetValueIntoField(JOrder, 'presentmentCurrencyCode', OrderHeaderRecordRef, OrderHeader.FieldNo("Presentment Currency Code"));
         JsonHelper.GetValueIntoField(JOrder, 'test', OrderHeaderRecordRef, OrderHeader.FieldNo(Test));
         JsonHelper.GetValueIntoField(JOrder, 'edited', OrderHeaderRecordRef, OrderHeader.FieldNo(Edited));
-        if Shop."Has Advanced Shopify Plan" then begin
+        if Shop."Advanced Shopify Plan" then begin
             StaffMemberId := CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JOrder, 'staffMember.id'));
             SetSalespersonOnOrderHeader(OrderHeader."Shop Code", StaffMemberId, OrderHeaderRecordRef);
         end;

--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
@@ -314,7 +314,7 @@ codeunit 30161 "Shpfy Import Order"
         JResponse: JsonToken;
     begin
         Parameters.Add('OrderId', Format(OrderId));
-        if Shop."Staff Members Enabled" then
+        if Shop."Has Advanced Shopify Plan" then
             Parameters.Add('StaffMember', 'staffMember { id }')
         else
             Parameters.Add('StaffMember', '');
@@ -388,7 +388,7 @@ codeunit 30161 "Shpfy Import Order"
         JsonHelper.GetValueIntoField(JOrder, 'presentmentCurrencyCode', OrderHeaderRecordRef, OrderHeader.FieldNo("Presentment Currency Code"));
         JsonHelper.GetValueIntoField(JOrder, 'test', OrderHeaderRecordRef, OrderHeader.FieldNo(Test));
         JsonHelper.GetValueIntoField(JOrder, 'edited', OrderHeaderRecordRef, OrderHeader.FieldNo(Edited));
-        if Shop."Staff Members Enabled" then begin
+        if Shop."Has Advanced Shopify Plan" then begin
             StaffMemberId := CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JOrder, 'staffMember.id'));
             SetSalespersonOnOrderHeader(OrderHeader."Shop Code", StaffMemberId, OrderHeaderRecordRef);
         end;

--- a/src/Apps/W1/Shopify/App/src/Order handling/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Order handling/docs/CLAUDE.md
@@ -8,7 +8,9 @@ The pipeline has three stages.
 
 - **Discovery**: `ShpfyOrdersAPI` queries the Shopify GraphQL API for orders updated since the last sync. It writes lightweight rows into the `Orders to Import` queue table, not full order data. The query distinguishes first-time sync (open orders only) from incremental sync (all orders by updated-at).
 
-- **Import**: `ShpfyImportOrder` fetches the full order JSON for each queued entry, populates `Order Header` and `Order Line` records, and pulls in related data (tax lines, attributes, risks, shipping charges, transactions, fulfillment orders, returns, refunds). It detects conflicts when a previously processed order is edited in Shopify and flags them with `Has Order State Error`.
+- **Import**: `ShpfyImportOrder` fetches the full order JSON for each queued entry, populates `Order Header` and `Order Line` records, and pulls in related data (tax lines, attributes, risks, shipping charges, transactions, fulfillment orders, returns, refunds). It detects conflicts when a previously processed order is edited in Shopify and flags them with `Has Order State Error`. Staff member retrieval in the GraphQL query and salesperson assignment during header population are conditional on `Shop."Advanced Shopify Plan"` (requires Plus/Advanced plans).
+
+*Updated: 2026-04-08 -- staff member gating changed from B2B Enabled to Advanced Shopify Plan*
 
 - **Processing**: `ShpfyProcessOrder` runs mapping then document creation. `ShpfyOrderMapping.DoMapping` resolves Shopify customers to BC customer numbers (with B2B company mapping as a separate path) and maps each order line's variant to an item/variant/UoM. `ShpfyProcessOrder.CreateHeaderFromShopifyOrder` builds a Sales Header with all three address contexts (sell-to, ship-to, bill-to), then `CreateLinesFromShopifyOrder` adds item lines, tip lines (G/L), gift card lines (G/L), shipping charge lines, and a cash rounding line. Global discounts that were not allocated to individual lines are applied as invoice discount. If the shop has "Auto Release Sales Orders" enabled, the document is released immediately.
 
@@ -18,6 +20,10 @@ The pipeline has three stages.
 - `Orders to Import` is a queue, not a mirror. It is populated during discovery and consumed during import. It carries summary data and error tracking (`Has Error`, blob `Error Message` and `Error Call Stack`).
 - The `Processed` flag on `Order Header` prevents re-processing. `IsProcessed()` also checks `Doc. Link To Doc.` so that orders linked to BC documents through any path are considered processed.
 - `Document Date` has a validation trigger that calls `TestField("Sales Order No.", '')`, which prevents changes after a sales order has been created.
+- The Shopify Order page (`ShpfyOrder.Page.al`) exposes contact lookup fields (`Sell-to Contact No.`, `Ship-to Contact No.`, `Bill-to Contact No.`) with `OnLookup` triggers that call `LookupContactForCustomer` to filter contacts by the related customer's company contact. The `OnValidate` triggers on these fields call `CheckContactRelatedToCustomer` to ensure the selected contact belongs to the correct customer. These fields are hidden by default (`Visible = false`).
+
+*Updated: 2026-04-08 -- contact lookup/validation added to Shopify Order page (PR #7525)*
+
 - Fulfilled orders become invoices instead of sales orders when `Create Invoices From Orders` is enabled on the shop.
 - `ShpfyProcessOrders` (plural) is the batch entry point. After processing orders it also processes refunds if the shop uses the "Auto Create Credit Memo" strategy.
 - `ShpfyOrders` (public API codeunit) exposes `MarkAsPaid` and `CancelOrder` for external callers.

--- a/src/Apps/W1/Shopify/App/src/Order handling/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/src/Order handling/docs/business-logic.md
@@ -27,6 +27,10 @@ flowchart TD
 
 `ShpfyImportOrder.ImportOrderAndCreateOrUpdate` does the heavy lifting. It fetches the full order JSON via a second GraphQL call (`GetOrderHeader`), retrieves order lines in a paginated loop (`GetOrderLines` / `GetNextOrderLines`), and populates the staging tables.
 
+`RetrieveOrderHeaderJson` conditionally includes the `staffMember { id }` field in the GraphQL query parameters based on `Shop."Advanced Shopify Plan"`. When the shop is not on an Advanced/Plus plan, the `StaffMember` parameter is sent as an empty string, omitting staff data from the query. `SetNewOrderHeaderValuesFromJson` (which populates the order header from the JSON response) similarly gates the staff member processing -- it only extracts the staff member ID and calls `SetSalespersonOnOrderHeader` when `Shop."Advanced Shopify Plan"` is true.
+
+*Updated: 2026-04-08 -- staff member handling gated by Advanced Shopify Plan instead of B2B Enabled*
+
 For already-processed orders, it runs conflict detection. A conflict is flagged if the current total items quantity increased, the line item composition changed (checked via a hash of line IDs), or the shipping charges amount changed. Conflicting orders get `Has Order State Error = true`.
 
 After populating the header and lines, the import calls into related modules: fulfillment orders, shipping charges, transactions, returns (if the return/refund process requires import), and refunds. It then adjusts order line quantities and header amounts by subtracting refund line quantities and amounts. Zero-quantity lines are deleted. If the order is fully fulfilled and paid, and `Archive Processed Orders` is enabled, it closes the order in Shopify via the `CloseOrder` GraphQL mutation.
@@ -67,3 +71,17 @@ A final cash rounding line is created if the order has a non-zero `Payment Round
 ## Error handling
 
 `ShpfyProcessOrders.ProcessShopifyOrder` wraps `ShpfyProcessOrder.Run` in a `if not ... Run` pattern. On failure it captures the error text into the order header's `Error Message`, clears the sales document number, and calls `CleanUpLastCreatedDocument` to delete the partially created sales document. On success it sets `Processed = true` and records the `Processed Currency Handling` so refund processing later knows which currency was used.
+
+## Contact lookup on the order page
+
+The Shopify Order page exposes contact number fields for all three address contexts (sell-to, ship-to, bill-to). These fields are hidden by default and provide lookup and validation behavior.
+
+- **Automatic resolution during mapping**: `ShpfyOrderMapping.FindContactNo` resolves a contact name to a contact number by finding a person-type contact whose name matches and whose company contact matches the customer's contact business relation. This runs during `DoMapping` for both standard and B2B paths, populating `Sell-to Contact No.`, `Ship-to Contact No.`, and `Bill-to Contact No.`.
+
+- **Manual lookup on the page**: Each contact field's `OnLookup` trigger calls `OrderHeader.LookupContactForCustomer`, which filters the Contact list to contacts belonging to the customer's company contact. The user selects a contact, and `Validate` is called to store the selection.
+
+- **Validation**: The `OnValidate` triggers on the contact number fields call `CheckContactRelatedToCustomer`, which verifies the selected contact is related to the corresponding customer via `Contact Business Relation`. If the contact is neither the company contact itself nor a person under that company, an error is raised.
+
+- **Customer number changes**: When `Sell-to Customer No.` is validated on the order header, it automatically re-resolves `Sell-to Contact No.` and `Ship-to Contact No.` via `FindContactNo`. Similarly, validating `Bill-to Customer No.` re-resolves `Bill-to Contact No.`.
+
+*Updated: 2026-04-08 -- contact lookup/validation added (PR #7525)*

--- a/src/Apps/W1/Shopify/App/src/Order handling/docs/data-model.md
+++ b/src/Apps/W1/Shopify/App/src/Order handling/docs/data-model.md
@@ -42,6 +42,20 @@ Every amount field on both header and line exists in two versions: shop currency
 
 `Shpfy Sales Header` (tableextension 30101) adds `Shpfy Order Id`, `Shpfy Order No.`, and `Shpfy Refund Id` to the Sales Header. `Shpfy Sales Line` (tableextension 30104) adds `Shpfy Order Line Id`, `Shpfy Order No.`, `Shpfy Refund Id`, `Shpfy Refund Line Id`, and `Shpfy Refund Shipping Line Id` to the Sales Line. These fields link the BC sales documents back to their Shopify source records.
 
+## Contact fields
+
+The Order Header carries contact name and contact number fields for all three address contexts:
+
+- `Sell-to Contact Name` (1014), `Sell-to Contact No.` (1017)
+- `Bill-to Contact Name` (1015), `Bill-to Contact No.` (1018)
+- `Ship-to Contact Name` (1016), `Ship-to Contact No.` (1019)
+
+Contact names are populated during import from the Shopify order's address data. Contact numbers are resolved during mapping by `ShpfyOrderMapping.FindContactNo`, which matches the contact name against person-type contacts under the customer's company contact. The contact number fields have `OnValidate` triggers that call `CheckContactRelatedToCustomer` to enforce that the contact belongs to the associated customer. `LookupContactForCustomer` provides filtered lookup behavior for the Order page.
+
+When `Sell-to Customer No.` is validated, it automatically re-resolves both `Sell-to Contact No.` and `Ship-to Contact No.`. When `Bill-to Customer No.` is validated, it re-resolves `Bill-to Contact No.`.
+
+*Updated: 2026-04-08 -- contact name/number fields documented (PR #7525)*
+
 ## B2B fields
 
 The Order Header has a cluster of B2B fields: `Company Id`, `Company Main Contact Id`, `Company Main Contact Email`, `Company Main Contact Phone No.`, `Company Main Contact Cust. Id`, `Company Location Id`, `B2B` (boolean), and `PO Number`. When `B2B` is true, mapping takes a different path through `MapB2BHeaderFields` in `ShpfyOrderMapping`.

--- a/src/Apps/W1/Shopify/App/src/Products/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Products/docs/CLAUDE.md
@@ -40,6 +40,7 @@ or Vendor Item No. Unmatched products can auto-create Items via
 - `ICreateProductStatusValue` determines whether newly created products start
   as Active or Draft.
 - Max 2048 variants per product -- enforced in `ShpfyCreateProduct`.
+- Price sync silently skips items whose unit of measure is invalid (not in `Unit of Measure` table or not in `Item Unit of Measure` for that item). A `Shpfy Skipped Record` entry is logged instead of raising an error.
 - Item attributes marked "As Option" can drive Shopify product options instead
   of the default Variant/UoM scheme, with validation for uniqueness and
   completeness.

--- a/src/Apps/W1/Shopify/App/src/Products/docs/business-logic.md
+++ b/src/Apps/W1/Shopify/App/src/Products/docs/business-logic.md
@@ -60,6 +60,17 @@ calculated `Unit Price`, `Line Amount`, and `Unit Cost`. If ComparePrice is less
 than or equal to Price after calculation, ComparePrice is zeroed out. Events fire
 before and after to allow overrides.
 
+Before any price calculation, `CalcPrice` validates the unit of measure via
+`IsValidUoM`. This checks that the UoM code exists in the `Unit of Measure`
+table and is a valid `Item Unit of Measure` for the given item. If validation
+fails, the entire price sync for that item/variant/UoM combination is skipped
+and a `Shpfy Skipped Record` entry is logged with a descriptive message
+("Item price is not synchronized because the unit of measure %1 is not valid for
+item %2"). This prevents errors when an item's Sales Unit of Measure has been
+deleted or is otherwise misconfigured.
+
+*Updated: 2026-04-08 -- CalcPrice now validates UoM before calculating and skips invalid combinations (PR #7498)*
+
 ### Image sync
 
 `ShpfySyncProductImage` supports both directions. Export iterates products,

--- a/src/Apps/W1/Shopify/App/src/Staff/Codeunits/ShpfyStaffMemberAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Staff/Codeunits/ShpfyStaffMemberAPI.Codeunit.al
@@ -28,7 +28,7 @@ codeunit 30105 "Shpfy Staff Member API"
         Cursor: Text;
     begin
         Shop.Get(ShopCode);
-        if not Shop."B2B Enabled" then
+        if not Shop."Staff Members Enabled" then
             exit;
 
         CommunicationMgt.SetShop(Shop.Code);

--- a/src/Apps/W1/Shopify/App/src/Staff/Codeunits/ShpfyStaffMemberAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Staff/Codeunits/ShpfyStaffMemberAPI.Codeunit.al
@@ -28,7 +28,7 @@ codeunit 30105 "Shpfy Staff Member API"
         Cursor: Text;
     begin
         Shop.Get(ShopCode);
-        if not Shop."Has Advanced Shopify Plan" then
+        if not Shop."Advanced Shopify Plan" then
             exit;
 
         CommunicationMgt.SetShop(Shop.Code);

--- a/src/Apps/W1/Shopify/App/src/Staff/Codeunits/ShpfyStaffMemberAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Staff/Codeunits/ShpfyStaffMemberAPI.Codeunit.al
@@ -28,7 +28,7 @@ codeunit 30105 "Shpfy Staff Member API"
         Cursor: Text;
     begin
         Shop.Get(ShopCode);
-        if not Shop."Staff Members Enabled" then
+        if not Shop."Has Advanced Shopify Plan" then
             exit;
 
         CommunicationMgt.SetShop(Shop.Code);

--- a/src/Apps/W1/Shopify/App/src/Transactions/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/App/src/Transactions/docs/CLAUDE.md
@@ -12,9 +12,13 @@ The `Shpfy Payment Method Mapping` table is the central configuration point -- u
 
 ## Things to know
 
+- The `Shop` field (108) is a direct Code[20] field with TableRelation to `Shpfy Shop`, populated via an upgrade DataTransfer from the order header's `Shop Code`. This replaces the old `Shop Code` FlowField (103), which is now obsoleted (CLEAN28/CLEANSCHEMA31). The `Payment Method` FlowField uses the `Shop` field for its lookup key.
+- The `Shpfy Order No.` FlowField (109) provides a quick lookup to the Shopify order number from the order header.
 - The `Parent Id` field on `Shpfy Order Transaction` links refund transactions back to their original charge, enabling refund-to-charge tracing.
 - Payment method mapping is keyed on shop + gateway + credit card company -- the same gateway can map to different BC payment methods depending on the card brand.
 - The `Gift Card Id` is extracted from the transaction's receipt JSON, not from a direct GraphQL field.
 - Transaction amounts include both shop money and presentment money, plus separate rounding amounts for each currency.
 - The `Manual Payment Gateway` boolean distinguishes manual payment methods (like COD or bank transfer) from automated gateways.
-- FlowFields on the transaction table provide quick lookups to Sales Document No. and Posted Invoice No. for the related order.
+- FlowFields on the transaction table provide quick lookups to Sales Document No., Posted Invoice No., and Shopify Order No. for the related order.
+
+*Updated: 2026-04-08 -- New Shop field (direct, via DataTransfer upgrade) replaces obsoleted Shop Code FlowField; Shpfy Order No. FlowField added*

--- a/src/Apps/W1/Shopify/Test/.docs-updated
+++ b/src/Apps/W1/Shopify/Test/.docs-updated
@@ -1,4 +1,4 @@
 # Documentation last updated
-commit: 212fc4094e48b78995eff6108b5a1bafd4955087
-date: 2026-03-30
+commit: 343aa21d1e5737d250aabf05cd9233d15c411cdc
+date: 2026-04-08
 scope: full

--- a/src/Apps/W1/Shopify/Test/CLAUDE.md
+++ b/src/Apps/W1/Shopify/Test/CLAUDE.md
@@ -11,13 +11,15 @@ This app is the test suite for the Shopify Connector. It verifies the connector'
 
 The central piece of infrastructure is `ShpfyInitializeTest` (codeunit 139561). It creates a fully configured Shpfy Shop record with randomized codes -- posting groups, VAT setup, customer and item templates, GL accounts, number series, and a dummy customer and item. The shop is cached in a temporary record so subsequent calls in the same session return the same shop instead of creating duplicates. Every domain-specific test codeunit calls `Initialize()` which runs this codeunit exactly once via the `isInitialized` boolean flag pattern.
 
-HTTP mocking uses two complementary mechanisms. The newer approach is `[HttpClientHandler]` -- test codeunits declare a handler procedure that intercepts outbound HTTP requests at the platform level. The handler inspects the request URL (via `InitializeTest.VerifyRequestUrl`), decides what mock response to return, and writes it into `TestHttpResponseMessage`. Mock response payloads come from two sources: JSON built programmatically in helper codeunits (like `ShpfyOrderHandlingHelper.CreateShopifyOrderAsJson`) or loaded from `.resources/` files via `NavApp.GetResource()`. The `.resources/` folder mirrors the test folder structure (e.g., `.resources/Bulk Operations/`, `.resources/Products/`). For testing interface contracts, the app uses enum extensions -- `ShpfyStockCalculationExt` adds a "Return Const" value that maps to `ShpfyConstToReturn`, a trivial implementation that returns a configurable decimal. Similarly, `ShpfyBulkOperationType` is extended with `AddProduct` backed by `ShpfyMockBulkProductCreate`.
+HTTP mocking uses `[HttpClientHandler]` exclusively -- test codeunits declare a handler procedure that intercepts outbound HTTP requests at the platform level. The handler inspects the request URL (via `InitializeTest.VerifyRequestUrl`), decides what mock response to return, and writes it into `TestHttpResponseMessage`. Mock response payloads come from two sources: JSON built programmatically in helper codeunits (like `ShpfyOrderHandlingHelper.CreateShopifyOrderAsJson`) or loaded from `.resources/` files via `NavApp.GetResource()`. The `.resources/` folder mirrors the test folder structure (e.g., `.resources/Bulk Operations/`, `.resources/Products/`). The earlier `IsTestInProgress` pattern for mocking has been fully replaced by `[HttpClientHandler]` (PR #7204); the only remaining `IsTestInProgress` usage is in the webhooks test, where it serves a different purpose (suppressing task scheduling). For testing interface contracts, the app uses enum extensions -- `ShpfyStockCalculationExt` adds a "Return Const" value that maps to `ShpfyConstToReturn`, a trivial implementation that returns a configurable decimal. Similarly, `ShpfyBulkOperationType` is extended with `AddProduct` backed by `ShpfyMockBulkProductCreate`.
+
+*Updated: 2026-04-08 -- IsTestInProgress mocking fully replaced by HttpClientHandler (PR #7204)*
 
 The app does not test the Shopify admin UI, webhooks delivery, or actual GraphQL network round-trips. It tests the AL-side logic: data transformation, record creation, field mapping, GraphQL query generation, retry/idempotency handling, and error flows. The boundary is always at the HTTP layer.
 
 ## Structure
 
-- **Base/** -- Shop initialization (`ShpfyInitializeTest`), core smoke tests (`ShpfyTestShopify`), filter management tests, checklist and connector guide tests
+- **Base/** -- Shop initialization (`ShpfyInitializeTest`), core smoke tests (`ShpfyTestShopify` -- currently commented out), filter management tests, checklist and connector guide tests
 - **Products/** -- Largest area (14 files). Item creation, product mapping, price calculation, variant handling, collections, sales channels, image sync. Has its own init codeunit `ShpfyProductInitTest`. See [Products/docs/CLAUDE.md](Products/docs/CLAUDE.md)
 - **Companies/** -- B2B company sync: import, export, mapping, locations, tax ID. Init in `ShpfyCompanyInitialize`. See [Companies/docs/CLAUDE.md](Companies/docs/CLAUDE.md)
 - **Customers/** -- Customer mapping, export, API query generation, name resolution. Init in `ShpfyCustomerInitTest`
@@ -51,6 +53,10 @@ The app does not test the Shopify admin UI, webhooks delivery, or actual GraphQL
 - Disabled tests are tracked in `DisabledTests/*.json` files with the structure `{ bug, codeunitId, CodeunitName, Method }`. The test runner reads these to skip known-failing methods. Currently 3 methods are disabled across 2 files, all linked to bug 621557 (price calculation).
 
 - The `.resources/` folder is declared in `app.json` under `resourceFolders` and accessed via `NavApp.GetResource()`. If you add a new mock response file, it must go under `.resources/` to be included in the compiled app.
+
+- B2B features (companies, catalogs) are now unconditionally available on all Shopify plans -- the old `"B2B Enabled"` field has been obsoleted. Tests no longer set `Shop."B2B Enabled" := true`. Staff member visibility testing now uses `Shop."Advanced Shopify Plan"` to gate the Staff Members action on the Shop Card page.
+
+*Updated: 2026-04-08 -- B2B Enabled removed from tests; staff tests use Advanced Shopify Plan*
 
 - `ShpfyOrderHandlingHelper` is the most complex helper -- it builds complete order JSON structures including nested customer, address, tax, line item, and B2B company data. It also creates real BC records (items, shop locations, Shopify products/variants) as side effects of building the JSON.
 

--- a/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyExportTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyExportTest.Codeunit.al
@@ -48,7 +48,6 @@ codeunit 139636 "Shpfy Company Export Test"
         ShopifyShop."Name 2 Source" := Enum::"Shpfy Name Source"::None;
         ShopifyShop."Contact Source" := Enum::"Shpfy Name Source"::None;
         ShopifyShop."County Source" := Enum::"Shpfy County Source"::Name;
-        ShopifyShop."B2B Enabled" := true;
         ShopifyCompany.Init();
         CompanyLocation.Init();
         ShopifyPaymentTermsId := 0;
@@ -131,7 +130,6 @@ codeunit 139636 "Shpfy Company Export Test"
         ShopifyShop."Name 2 Source" := Enum::"Shpfy Name Source"::None;
         ShopifyShop."Contact Source" := Enum::"Shpfy Name Source"::None;
         ShopifyShop."County Source" := Enum::"Shpfy County Source"::Name;
-        ShopifyShop."B2B Enabled" := true;
         CompanyLocation.Init();
 
         // [GIVEN] Shop

--- a/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyImportTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyImportTest.Codeunit.al
@@ -41,7 +41,6 @@ codeunit 139647 "Shpfy Company Import Test"
         // [SCENARIO] Importing a company record that is already mapped to a customer record via email.
         Initialize();
         ShopifyShop := InitializeTest.CreateShop();
-        ShopifyShop."B2B Enabled" := true;
 
         // [GIVEN] Shop, Shopify company and Shopify customer
         CompanyMapping.SetShop(ShopifyShop);

--- a/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyLocationsTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyLocationsTest.Codeunit.al
@@ -169,8 +169,6 @@ codeunit 139539 "Shpfy Company Locations Test"
         Commit();
 
         Shop := InitializeTest.CreateShop();
-        Shop."B2B Enabled" := true;
-        Shop.Modify();
 
         CompanyLocation := CompanyInitialize.CreateShopifyCompanyLocation();
         ShopifyCompany.GetBySystemId(CompanyLocation."Company SystemId");

--- a/src/Apps/W1/Shopify/Test/Companies/docs/CLAUDE.md
+++ b/src/Apps/W1/Shopify/Test/Companies/docs/CLAUDE.md
@@ -18,7 +18,9 @@ ShpfyCompanyLocationsTest tests creating company locations from customers, inclu
 
 ## Things to know
 
-- The B2B tests require `Shop."B2B Enabled" := true` -- several tests set this explicitly on the shop record.
+- B2B features are now unconditionally available on all Shopify plans. The old `Shop."B2B Enabled" := true` assignments have been removed from `ShpfyCompanyExportTest`, `ShpfyCompanyImportTest`, and `ShpfyCompanyLocationsTest`. Tests no longer need to set any plan-gating flag for B2B functionality.
+
+*Updated: 2026-04-08 -- B2B Enabled removed from company tests; B2B features now unconditional*
 - ShpfyCompanyInitialize.ModifyFields uses RecordRef/FieldRef reflection to generically modify all text fields, so tests can detect whether update queries include changed fields without manually setting each one.
 - ShpfyTaxIdMappingTest uses manual event subscriber binding (BindSubscription) on `OnBeforeValidateVATRegistrationNo` to bypass localization-specific VAT validation that would otherwise reject test data.
 - Company mapping tests exercise two distinct code paths: FindMapping (inbound -- does this Shopify company match a BC customer?) and DoMapping (outbound -- which customer should this company sync to?).

--- a/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
@@ -39,7 +39,7 @@ codeunit 139551 "Shpfy Staff Test"
         Initialize();
 
         // [When] Set store as not having staff members enabled and check action is not visible
-        Shop."Has Advanced Shopify Plan" := false;
+        Shop."Advanced Shopify Plan" := false;
         Shop.Modify(false);
         ShpfyShopCard.OpenView();
         ShpfyShopCard.GoToRecord(Shop);
@@ -49,7 +49,7 @@ codeunit 139551 "Shpfy Staff Test"
         ShpfyShopCard.Close();
 
         // [When] Set store as having staff members enabled and check action is visible
-        Shop."Has Advanced Shopify Plan" := true;
+        Shop."Advanced Shopify Plan" := true;
         Shop.Modify(false);
         ShpfyShopCard.OpenView();
         ShpfyShopCard.GoToRecord(Shop);
@@ -247,7 +247,7 @@ codeunit 139551 "Shpfy Staff Test"
 
         // Creating Shopify Shop
         Shop := InitializeTest.CreateShop();
-        Shop."Has Advanced Shopify Plan" := true;
+        Shop."Advanced Shopify Plan" := true;
         Shop.Modify();
 
         //Register Shopify Access Token

--- a/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
@@ -39,7 +39,7 @@ codeunit 139551 "Shpfy Staff Test"
         Initialize();
 
         // [When] Set store as not having staff members enabled and check action is not visible
-        Shop."Staff Members Enabled" := false;
+        Shop."Has Advanced Shopify Plan" := false;
         Shop.Modify(false);
         ShpfyShopCard.OpenView();
         ShpfyShopCard.GoToRecord(Shop);
@@ -49,7 +49,7 @@ codeunit 139551 "Shpfy Staff Test"
         ShpfyShopCard.Close();
 
         // [When] Set store as having staff members enabled and check action is visible
-        Shop."Staff Members Enabled" := true;
+        Shop."Has Advanced Shopify Plan" := true;
         Shop.Modify(false);
         ShpfyShopCard.OpenView();
         ShpfyShopCard.GoToRecord(Shop);
@@ -247,7 +247,7 @@ codeunit 139551 "Shpfy Staff Test"
 
         // Creating Shopify Shop
         Shop := InitializeTest.CreateShop();
-        Shop."Staff Members Enabled" := true;
+        Shop."Has Advanced Shopify Plan" := true;
         Shop.Modify();
 
         //Register Shopify Access Token

--- a/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
@@ -30,7 +30,7 @@ codeunit 139551 "Shpfy Staff Test"
     end;
 
     [Test]
-    procedure TestStaffMembersActionVisibleOnlyForB2BStore()
+    procedure TestStaffMembersActionVisibleOnlyForSupportedPlans()
     var
         LibraryAssert: Codeunit "Library Assert";
         ShpfyShopCard: TestPage "Shpfy Shop Card";
@@ -38,24 +38,24 @@ codeunit 139551 "Shpfy Staff Test"
         // [Given] Shop exists
         Initialize();
 
-        // [When] Set store as not B2B and check action is not visible
-        Shop."B2B Enabled" := false;
+        // [When] Set store as not having staff members enabled and check action is not visible
+        Shop."Staff Members Enabled" := false;
         Shop.Modify(false);
         ShpfyShopCard.OpenView();
         ShpfyShopCard.GoToRecord(Shop);
 
         // [Then] The action should not be visible
-        LibraryAssert.IsFalse(ShpfyShopCard.StaffMembers.Visible(), 'Staff Members action should not be visible for non-B2B store');
+        LibraryAssert.IsFalse(ShpfyShopCard.StaffMembers.Visible(), 'Staff Members action should not be visible for unsupported plan');
         ShpfyShopCard.Close();
 
-        // [When] Set store as B2B and check action is visible
-        Shop."B2B Enabled" := true;
+        // [When] Set store as having staff members enabled and check action is visible
+        Shop."Staff Members Enabled" := true;
         Shop.Modify(false);
         ShpfyShopCard.OpenView();
         ShpfyShopCard.GoToRecord(Shop);
 
         // [Then] The action should be visible
-        LibraryAssert.IsTrue(ShpfyShopCard.StaffMembers.Visible(), 'Staff Members action should be visible for B2B store');
+        LibraryAssert.IsTrue(ShpfyShopCard.StaffMembers.Visible(), 'Staff Members action should be visible for supported plan');
         ShpfyShopCard.Close();
     end;
 
@@ -247,7 +247,7 @@ codeunit 139551 "Shpfy Staff Test"
 
         // Creating Shopify Shop
         Shop := InitializeTest.CreateShop();
-        Shop."B2B Enabled" := true;
+        Shop."Staff Members Enabled" := true;
         Shop.Modify();
 
         //Register Shopify Access Token


### PR DESCRIPTION
## Summary

Shopify [expanded B2B features](https://changelog.shopify.com/posts/key-b2b-features-now-available-on-non-plus-plans) to all plans (Basic, Grow, Advanced, Plus), not just Plus. The connector currently restricts B2B to Plus plans only via the `B2B Enabled` field on the Shop table.

This PR:
- **Obsoletes the `B2B Enabled` field** (117) with `CLEAN29`/`CLEANSCHEMA32` guards — B2B features (companies, catalogs, company sync, B2B orders) are now unconditionally available on all plans
- **Introduces `Staff Members Enabled` field** (207) — staff member GraphQL queries still require Plus, Plus Trial, Development, or Advanced plans, so this new field gates only staff-member-specific functionality
- **Adds upgrade code** using `DataTransfer` to migrate existing `B2B Enabled = true` shops to `Staff Members Enabled = true`
- **Removes all consumer code** that checked `B2B Enabled` for B2B features (ShopCard page visibility, Activities page filter, ImportOrder/StaffMemberAPI guards)
- **Updates tests** to remove `B2B Enabled` assignments and update staff visibility test

Fixes [AB#630316](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630316)

## Changes by file

| File | Change |
|------|--------|
| `ShpfyShop.Table.al` | Obsolete field 117, add field 207, update `GetShopSettings()` plan check (adds `Advanced`) |
| `ShpfyShopCard.Page.al` | Remove 6x `Visible = Rec."B2B Enabled"`, unconditional company/catalog sync, gate StaffMembers on new field |
| `ShpfyActivities.Page.al` | Remove `B2BEnabled` variable and B2B shop filter |
| `ShpfyImportOrder.Codeunit.al` | Gate `StaffMember` query parameter on `Staff Members Enabled` instead of `B2B Enabled` |
| `ShpfyStaffMemberAPI.Codeunit.al` | Gate early exit on `Staff Members Enabled` instead of `B2B Enabled` |
| `ShpfyUpgradeMgt.Codeunit.al` | Add `StaffMembersEnabledUpgrade()` with `DataTransfer` (source filter + constant value) |
| 4 test files | Remove `B2B Enabled := true` setup, update staff visibility test |

## How to review

1. **ShpfyShop.Table.al** — verify the obsolete field follows the `CLEAN29`/`CLEANSCHEMA32` dual-state pattern (compare with field 206). Verify `GetShopSettings()` now sets `Staff Members Enabled` for Plus, Plus Trial, Development, and Advanced plans.
2. **ShpfyShopCard.Page.al** — verify all B2B visibility gates are removed (companies, catalogs, market catalogs, sync companies, B2B company sync group). Verify `StaffMembers` action is now gated on the new `Staff Members Enabled` field. Verify the "Sync All" action now always syncs companies and catalog prices.
3. **ShpfyUpgradeMgt.Codeunit.al** — verify upgrade uses `AddSourceFilter` on `B2B Enabled = true` + `AddConstantValue(true)` to `Staff Members Enabled`. Verify tag is registered in `RegisterPerCompanyTags`.
4. **ShpfyImportOrder.Codeunit.al** / **ShpfyStaffMemberAPI.Codeunit.al** — verify staff member gating now uses `Staff Members Enabled` instead of `B2B Enabled`.
5. **Test files** — verify `B2B Enabled` assignments are removed and staff test uses `Staff Members Enabled`.

## Testing scenarios

- Connect a Basic/Grow plan shop → B2B sections (companies, catalogs) should be visible and functional
- Connect a Plus/Advanced plan shop → Staff Members action should be visible, staff member import should work
- Connect a Basic plan shop → Staff Members action should NOT be visible
- Upgrade from previous version → shops that had `B2B Enabled = true` should now have `Staff Members Enabled = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)






