### PR TITLE
[Master]-Fix aging test failures in country localizations

### DIFF
--- a/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
@@ -26,10 +26,8 @@ codeunit 139544 "Trial Balance Excel Reports"
 
     var
         LibraryERM: Codeunit "Library - ERM";
-        LibraryPurchase: Codeunit "Library - Purchase";
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportDataset: Codeunit "Library - Report Dataset";
-        LibrarySales: Codeunit "Library - Sales";
         Assert: Codeunit Assert;
         DocumentTypeShouldBeInvoiceErr: Label 'Document Type should be Invoice';
         DocumentNoShouldMatchErr: Label 'Document No should match the ledger entry';
@@ -712,7 +710,8 @@ codeunit 139544 "Trial Balance Excel Reports"
         InitializeAgingData();
 
         // [GIVEN] Vendor "V" with an open vendor ledger entry of type Invoice
-        LibraryPurchase.CreateVendor(Vendor);
+        // Create vendor directly to avoid VAT posting setup requirements in some localizations
+        CreateMinimalVendor(Vendor);
         CreateVendorLedgerEntry(VendorLedgerEntry, Vendor."No.", "Gen. Journal Document Type"::Invoice);
         Commit();
 
@@ -748,7 +747,8 @@ codeunit 139544 "Trial Balance Excel Reports"
         InitializeAgingData();
 
         // [GIVEN] Customer "C" with an open customer ledger entry of type Invoice
-        LibrarySales.CreateCustomer(Customer);
+        // Create customer directly to avoid VAT posting setup requirements in some localizations
+        CreateMinimalCustomer(Customer);
         CreateCustLedgerEntry(CustLedgerEntry, Customer."No.", "Gen. Journal Document Type"::Invoice);
         Commit();
 
@@ -903,6 +903,22 @@ codeunit 139544 "Trial Balance Excel Reports"
         CustLedgerEntry.DeleteAll();
         Vendor.DeleteAll();
         Customer.DeleteAll();
+    end;
+
+    local procedure CreateMinimalVendor(var Vendor: Record Vendor)
+    begin
+        Vendor.Init();
+        Vendor."No." := CopyStr(Format(CreateGuid()), 1, MaxStrLen(Vendor."No."));
+        Vendor.Name := Vendor."No.";
+        Vendor.Insert();
+    end;
+
+    local procedure CreateMinimalCustomer(var Customer: Record Customer)
+    begin
+        Customer.Init();
+        Customer."No." := CopyStr(Format(CreateGuid()), 1, MaxStrLen(Customer."No."));
+        Customer.Name := Customer."No.";
+        Customer.Insert();
     end;
 
     local procedure CreateVendorLedgerEntry(var VendorLedgerEntry: Record "Vendor Ledger Entry"; VendorNo: Code[20]; DocumentType: Enum "Gen. Journal Document Type")


### PR DESCRIPTION
The tests AgedAccountsPayableExportsDocumentTypeAndNo and AgedAccountsRecExportsDocumentTypeAndNo were failing in IT/DE/DK/FR localizations with 'The VAT Business Posting Group table is empty' error.

Root cause: LibraryPurchase.CreateVendor and LibrarySales.CreateCustomer have internal dependencies on VAT posting setup that don't exist in some localization databases.

Fix: Since these tests only need a vendor/customer record to exist (not full VAT functionality), create minimal records directly using Init/Insert, which works in all localizations.

Fixes Bug 630306

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#630306](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630306)


