### PR TITLE
Add dispatch workflow for AI triage

### DIFF
--- a/.github/workflows/ai-triage-dispatch.yml
+++ b/.github/workflows/ai-triage-dispatch.yml
@@ -1,0 +1,20 @@
+name: Dispatch AI Triage
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  dispatch:
+    if: github.event.label.name == 'ai-triage' && github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger triage on BCAppsTriage
+        env:
+          TOKEN: ${{ secrets.TRIAGE_DISPATCH_TOKEN }}
+        run: |
+          curl -s -X POST \
+            -H "Authorization: token $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/microsoft/BCAppsTriage/dispatches \
+            -d '{"event_type":"issue-triage","client_payload":{"issue_number":${{ github.event.issue.number }}}}'

--- a/.github/workflows/ai-triage-dispatch.yml
+++ b/.github/workflows/ai-triage-dispatch.yml
@@ -4,6 +4,8 @@ on:
   issues:
     types: [labeled]
 
+permissions: {}
+
 jobs:
   dispatch:
     if: github.event.label.name == 'ai-triage' && github.event.issue.state == 'open'

--- a/.github/workflows/ai-triage-dispatch.yml
+++ b/.github/workflows/ai-triage-dispatch.yml
@@ -2,13 +2,18 @@ name: Dispatch AI Triage
 
 on:
   issues:
-    types: [labeled]
+    types: [opened, edited, labeled]
 
 permissions: {}
 
 jobs:
   dispatch:
-    if: github.event.label.name == 'ai-triage' && github.event.issue.state == 'open'
+    if: >-
+      github.event.issue.state == 'open' && (
+        github.event.action == 'opened' ||
+        github.event.action == 'edited' ||
+        github.event.label.name == 'ai-triage'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Trigger triage on BCAppsTriage


### PR DESCRIPTION
## Summary
- Adds a lightweight workflow that fires a `repository_dispatch` to `microsoft/BCAppsTriage` when the `ai-triage` label is added to an issue
- The full triage agent runs on BCAppsTriage and posts results back here

## Required setup
- **Secret**: `TRIAGE_DISPATCH_TOKEN` — a PAT with `repo` scope on `microsoft/BCAppsTriage` (to trigger dispatches)

## Test plan
- [ ] Configure `TRIAGE_DISPATCH_TOKEN` secret on BCApps
- [ ] Add `ai-triage` label to a test issue
- [ ] Verify dispatch workflow runs (BCApps Actions tab)
- [ ] Verify triage workflow triggers on BCAppsTriage (requires companion PR: microsoft/BCAppsTriage#3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes: [AB#629862](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/629862)


