### PR TITLE
Use correct overload for FromMilliseconds in RegexImpl

### DIFF
--- a/src/System Application/App/Regex/src/RegexImpl.Codeunit.al
+++ b/src/System Application/App/Regex/src/RegexImpl.Codeunit.al
@@ -327,13 +327,16 @@ codeunit 3961 "Regex Impl."
     procedure Regex(Pattern: Text; var RegexOptions: Record "Regex Options")
     var
         TimeoutDuration: DotNet TimeSpan;
+        MatchTimeoutInMs: BigInteger;
     begin
         DotNetRegexOptions := RegexOptions.GetRegexOptions();
-        if RegexOptions.MatchTimeoutInMs < 1000 then
+        MatchTimeoutInMs := RegexOptions.MatchTimeoutInMs;
+        if MatchTimeoutInMs < 1000 then
             Error(TimeoutTooLowErr);
-        if RegexOptions.MatchTimeoutInMs > 10000 then
+        if MatchTimeoutInMs > 10000 then
             Error(TimeoutTooHighErr);
-        DotNetRegex := DotNetRegex.Regex(Pattern, DotNetRegexOptions, TimeoutDuration.FromMilliseconds(RegexOptions.MatchTimeoutInMs));
+
+        DotNetRegex := DotNetRegex.Regex(Pattern, DotNetRegexOptions, TimeoutDuration.FromMilliseconds(MatchTimeoutInMs));
     end;
 
     local procedure CheckIfInstantiated()

--- a/src/System Application/App/Regex/src/RegexImpl.Codeunit.al
+++ b/src/System Application/App/Regex/src/RegexImpl.Codeunit.al
@@ -327,7 +327,7 @@ codeunit 3961 "Regex Impl."
     procedure Regex(Pattern: Text; var RegexOptions: Record "Regex Options")
     var
         TimeoutDuration: DotNet TimeSpan;
-        MatchTimeoutInMs: BigInteger;
+        MatchTimeoutInMs: Decimal;
     begin
         DotNetRegexOptions := RegexOptions.GetRegexOptions();
         MatchTimeoutInMs := RegexOptions.MatchTimeoutInMs;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
.NET 10 adds a new overload for FromMilliseconds which takes Int64, leading to ambiguous overload resolution. Force the double overload by using Decimal in AL, as it exists in both .NET 8 and .NET 10.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#630657](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630657)



