### PR TITLE
Bug 626972: [Quality Management] Scheduled Inspection for Positive ILE (but with 0 remaining qty) created unexpectedly

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/JobQueue/QltyScheduleInspection.Report.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/JobQueue/QltyScheduleInspection.Report.al
@@ -5,6 +5,7 @@
 namespace Microsoft.QualityManagement.Configuration.GenerationRule.JobQueue;
 
 using Microsoft.QualityManagement.Configuration.GenerationRule;
+using Microsoft.QualityManagement.Configuration.SourceConfiguration;
 using Microsoft.QualityManagement.Document;
 using Microsoft.QualityManagement.Setup;
 
@@ -72,6 +73,7 @@ report 20412 "Qlty. Schedule Inspection"
         CreatedQltyInspectionIds: List of [Code[20]];
         ZeroInspectionsCreatedMsg: Label 'No inspections were created.';
         SomeInspectionsWereCreatedQst: Label '%1 inspections were created. Do you want to see them?', Comment = '%1=the count of inspections that were created.';
+        NoSourceConfigForScheduleErr: Label 'Cannot schedule inspections because no enabled source configuration with a table filter exists for source table %1. Navigate to the Quality Inspection Source Configuration page and ensure at least one enabled configuration exists for this table with a From Table Filter defined.', Comment = '%1=the source table number';
 
     trigger OnInitReport()
     begin
@@ -103,22 +105,42 @@ report 20412 "Qlty. Schedule Inspection"
     procedure CreateInspectionsThatMatchRule(QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule")
     var
         QltyJobQueueManagement: Codeunit "Qlty. Job Queue Management";
-        SourceRecordRef: RecordRef;
     begin
         if QltyInspectionGenRule."Activation Trigger" = QltyInspectionGenRule."Activation Trigger"::Disabled then
             exit;
 
         QltyJobQueueManagement.CheckIfGenerationRuleCanBeScheduled(QltyInspectionGenRule);
 
-        SourceRecordRef.Open(QltyInspectionGenRule."Source Table No.");
-        if QltyInspectionGenRule."Condition Filter" <> '' then
-            SourceRecordRef.SetView(QltyInspectionGenRule."Condition Filter");
-
         QltyInspectionGenRule.SetRecFilter();
         if QltyInspectionGenRule."Schedule Group" <> '' then
             QltyInspectionGenRule.SetRange("Schedule Group", QltyInspectionGenRule."Schedule Group");
         QltyInspectionGenRule.SetRange("Template Code", QltyInspectionGenRule."Template Code");
-        if SourceRecordRef.FindSet() then
-            QltyInspectionCreate.CreateMultipleInspectionsWithoutDisplaying(SourceRecordRef, GuiAllowed(), QltyInspectionGenRule, CreatedQltyInspectionIds);
+
+        CreateInspectionsPerSourceConfigFilter(QltyInspectionGenRule);
+    end;
+
+    local procedure CreateInspectionsPerSourceConfigFilter(var QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule")
+    var
+        QltyInspectSourceConfig: Record "Qlty. Inspect. Source Config.";
+        SourceRecordRef: RecordRef;
+    begin
+        QltyInspectSourceConfig.SetRange("From Table No.", QltyInspectionGenRule."Source Table No.");
+        QltyInspectSourceConfig.SetRange("To Type", QltyInspectSourceConfig."To Type"::Inspection);
+        QltyInspectSourceConfig.SetRange(Enabled, true);
+        QltyInspectSourceConfig.SetFilter("From Table Filter", '<>%1', '');
+        if not QltyInspectSourceConfig.FindSet() then
+            Error(NoSourceConfigForScheduleErr, QltyInspectionGenRule."Source Table No.");
+
+        repeat
+            Clear(SourceRecordRef);
+            SourceRecordRef.Open(QltyInspectionGenRule."Source Table No.");
+            if QltyInspectionGenRule."Condition Filter" <> '' then
+                SourceRecordRef.SetView(QltyInspectionGenRule."Condition Filter");
+            SourceRecordRef.FilterGroup(20);
+            SourceRecordRef.SetView(QltyInspectSourceConfig."From Table Filter");
+            SourceRecordRef.FilterGroup(0);
+            if SourceRecordRef.FindSet() then
+                QltyInspectionCreate.CreateMultipleInspectionsWithoutDisplaying(SourceRecordRef, GuiAllowed(), QltyInspectionGenRule, CreatedQltyInspectionIds);
+        until QltyInspectSourceConfig.Next() = 0;
     end;
 }

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
@@ -2151,9 +2151,9 @@ codeunit 139965 "Qlty. Tests - More Tests"
         QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
         QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
         QltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyScheduleInspection: Report "Qlty. Schedule Inspection";
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryItemTracking: Codeunit "Library - Item Tracking";
-        QltyScheduleInspection: Report "Qlty. Schedule Inspection";
         LotNo: Code[50];
         ConditionFilter: Text;
     begin
@@ -2218,9 +2218,9 @@ codeunit 139965 "Qlty. Tests - More Tests"
         QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
         QltyInspectionHeader: Record "Qlty. Inspection Header";
         QltyInspectSourceConfig: Record "Qlty. Inspect. Source Config.";
+        QltyScheduleInspection: Report "Qlty. Schedule Inspection";
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryItemTracking: Codeunit "Library - Item Tracking";
-        QltyScheduleInspection: Report "Qlty. Schedule Inspection";
         LotNo: Code[50];
         ConditionFilter: Text;
     begin
@@ -2260,7 +2260,7 @@ codeunit 139965 "Qlty. Tests - More Tests"
         QltyInspectSourceConfig.SetRange("From Table No.", Database::"Item Ledger Entry");
         QltyInspectSourceConfig.SetRange("To Type", QltyInspectSourceConfig."To Type"::Inspection);
         QltyInspectSourceConfig.SetRange(Enabled, true);
-        LibraryAssert.IsTrue(QltyInspectSourceConfig.FindFirst(), 'Source config for ILE→Inspection should exist.');
+        LibraryAssert.RecordIsNotEmpty(QltyInspectSourceConfig);
 
         // [WHEN] Schedule Inspection report calls CreateInspectionsThatMatchRule directly
         QltyScheduleInspection.CreateInspectionsThatMatchRule(QltyInspectionGenRule);

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
@@ -11,6 +11,7 @@ using Microsoft.Inventory.Item.Attribute;
 using Microsoft.Inventory.Journal;
 using Microsoft.Inventory.Ledger;
 using Microsoft.Inventory.Location;
+using Microsoft.Inventory.Tracking;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
@@ -77,6 +78,7 @@ codeunit 139965 "Qlty. Tests - More Tests"
         ExpressionFormulaTestCodeTok: Label '[%1]', Comment = '%1=The first test code', Locked = true;
         TargetErr: Label 'When the target of the source configuration is an inspection, then all target fields must also refer to the inspection. Note that you can chain tables in another source configuration and still target inspection values. For example if you would like to ensure that a field from the Customer is included for a source configuration that is not directly related to a Customer then create another source configuration that links Customer to your record.';
         CanOnlyBeSetWhenToTypeIsInspectionErr: Label 'This is only used when the To Type is an inspection';
+        ILEConditionFilterItemNoTok: Label 'WHERE(Item No.=FILTER(%1))', Comment = '%1 = Item No.', Locked = true;
         OrderTypeProductionConditionFilterTok: Label 'WHERE(Order Type=FILTER(Production))', Locked = true;
         EntryTypeOutputConditionFilterTok: Label 'WHERE(Entry Type=FILTER(Output))', Locked = true;
         PassFailQuantityInvalidErr: Label 'The %1 and %2 cannot exceed the %3. The %3 is currently exceeded by %4.', Comment = '%1=the passed quantity caption, %2=the failed quantity caption, %3=the source quantity caption, %4=the quantity exceeded';
@@ -2137,6 +2139,138 @@ codeunit 139965 "Qlty. Tests - More Tests"
         // [WHEN] Checking if Quality Management application area is enabled
         // [THEN] The application area is enabled
         LibraryAssert.AreEqual(true, QltyInspectionUtility.IsQualityManagementApplicationAreaEnabled(), 'Should be enabled.');
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler')]
+    procedure ScheduleInspection_ClosedILE_ShouldNotCreateInspection()
+    var
+        Item: Record Item;
+        PosAdjItemJournalLine, NegAdjItemJournalLine : Record "Item Journal Line";
+        ReservationEntry: Record "Reservation Entry";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        LibraryInventory: Codeunit "Library - Inventory";
+        LibraryItemTracking: Codeunit "Library - Item Tracking";
+        QltyScheduleInspection: Report "Qlty. Schedule Inspection";
+        LotNo: Code[50];
+        ConditionFilter: Text;
+    begin
+        // [SCENARIO] Schedule Inspection should not create inspections for Item Ledger Entries with 0 remaining quantity (Open=false)
+        Initialize();
+
+        // [GIVEN] Quality Management setup exists
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] A lot-tracked item
+        QltyInspectionUtility.CreateLotTrackedItem(Item);
+
+        // [GIVEN] Item journal batch for posting
+        // QltyInspectionUtility.CreateItemJournalTemplateAndBatch(PosAdjItemJournalLine."Entry Type"::"Positive Adjmt.", ItemJournalBatch);
+
+        // [GIVEN] A positive adjustment of 10 units with lot tracking
+        LotNo := LibraryUtility.GenerateGUID();
+        LibraryInventory.CreateItemJournalLineInItemTemplate(PosAdjItemJournalLine, Item."No.", '', '', 10);
+        LibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, PosAdjItemJournalLine, '', LotNo, PosAdjItemJournalLine.Quantity);
+        LibraryInventory.PostItemJournalLine(PosAdjItemJournalLine."Journal Template Name", PosAdjItemJournalLine."Journal Batch Name");
+
+        // [GIVEN] A negative adjustment of 10 units for the same lot (fully consuming inventory)
+        LibraryInventory.CreateItemJournalLineInItemTemplate(NegAdjItemJournalLine, Item."No.", '', '', -10);
+        LibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, NegAdjItemJournalLine, '', LotNo, NegAdjItemJournalLine.Quantity);
+        LibraryInventory.PostItemJournalLine(NegAdjItemJournalLine."Journal Template Name", NegAdjItemJournalLine."Journal Batch Name");
+
+        // [GIVEN] A template with a test line
+        QltyInspectionUtility.CreateTemplate(QltyInspectionTemplateHdr, 1);
+
+        // [GIVEN] A generation rule for Item Ledger Entry filtered to this specific item
+        ConditionFilter := StrSubstNo(ILEConditionFilterItemNoTok, Item."No.");
+        QltyInspectionGenRule.Init();
+        QltyInspectionGenRule."Template Code" := QltyInspectionTemplateHdr.Code;
+        QltyInspectionGenRule."Source Table No." := Database::"Item Ledger Entry";
+        QltyInspectionGenRule."Condition Filter" := CopyStr(ConditionFilter, 1, MaxStrLen(QltyInspectionGenRule."Condition Filter"));
+        QltyInspectionGenRule."Activation Trigger" := QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic";
+        QltyInspectionGenRule.Insert(true);
+
+        // [GIVEN] No inspections exist for this item before running
+        QltyInspectionHeader.SetRange("Source Item No.", Item."No.");
+        LibraryAssert.AreEqual(0, QltyInspectionHeader.Count(), 'No inspections should exist before running the report.');
+
+        // [WHEN] Schedule Inspection report is run for the generation rule
+        QltyInspectionGenRule.SetRecFilter();
+        QltyScheduleInspection.SetTableView(QltyInspectionGenRule);
+        QltyScheduleInspection.UseRequestPage(false);
+        QltyScheduleInspection.Run();
+
+        // [THEN] No inspections should be created since all ILEs for this item are closed
+        QltyInspectionHeader.Reset();
+        QltyInspectionHeader.SetRange("Source Item No.", Item."No.");
+        LibraryAssert.AreEqual(0, QltyInspectionHeader.Count(), 'No inspections should be created for items with 0 remaining quantity.');
+    end;
+
+    [Test]
+    procedure ScheduleInspection_OpenILE_ShouldCreateInspection()
+    var
+        Item: Record Item;
+        PosAdjItemJournalLine, NegAdjItemJournalLine : Record "Item Journal Line";
+        ReservationEntry: Record "Reservation Entry";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyInspectSourceConfig: Record "Qlty. Inspect. Source Config.";
+        LibraryInventory: Codeunit "Library - Inventory";
+        LibraryItemTracking: Codeunit "Library - Item Tracking";
+        QltyScheduleInspection: Report "Qlty. Schedule Inspection";
+        LotNo: Code[50];
+        ConditionFilter: Text;
+    begin
+        // [SCENARIO] Schedule Inspection should create an inspection for Item Ledger Entries with remaining quantity > 0 (Open=true)
+        Initialize();
+
+        // [GIVEN] Quality Management setup exists
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] A lot-tracked item
+        QltyInspectionUtility.CreateLotTrackedItem(Item);
+
+        // [GIVEN] A positive adjustment of 10 units with lot tracking
+        LotNo := LibraryUtility.GenerateGUID();
+        LibraryInventory.CreateItemJournalLineInItemTemplate(PosAdjItemJournalLine, Item."No.", '', '', 10);
+        LibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, PosAdjItemJournalLine, '', LotNo, PosAdjItemJournalLine.Quantity);
+        LibraryInventory.PostItemJournalLine(PosAdjItemJournalLine."Journal Template Name", PosAdjItemJournalLine."Journal Batch Name");
+
+        // [GIVEN] A negative adjustment of 9 units for the same lot (leaving 1 remaining)
+        LibraryInventory.CreateItemJournalLineInItemTemplate(NegAdjItemJournalLine, Item."No.", '', '', -9);
+        LibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, NegAdjItemJournalLine, '', LotNo, NegAdjItemJournalLine.Quantity);
+        LibraryInventory.PostItemJournalLine(NegAdjItemJournalLine."Journal Template Name", NegAdjItemJournalLine."Journal Batch Name");
+
+        // [GIVEN] A template with a test line
+        QltyInspectionUtility.CreateTemplate(QltyInspectionTemplateHdr, 1);
+
+        // [GIVEN] A generation rule for Item Ledger Entry filtered to this specific item
+        ConditionFilter := StrSubstNo(ILEConditionFilterItemNoTok, Item."No.");
+        QltyInspectionGenRule.Init();
+        QltyInspectionGenRule."Template Code" := QltyInspectionTemplateHdr.Code;
+        QltyInspectionGenRule."Source Table No." := Database::"Item Ledger Entry";
+        QltyInspectionGenRule."Condition Filter" := CopyStr(ConditionFilter, 1, MaxStrLen(QltyInspectionGenRule."Condition Filter"));
+        QltyInspectionGenRule."Activation Trigger" := QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic";
+        QltyInspectionGenRule.Insert(true);
+
+        // [GIVEN] Verify the source config for ILE→Inspection exists
+        QltyInspectSourceConfig.SetRange("From Table No.", Database::"Item Ledger Entry");
+        QltyInspectSourceConfig.SetRange("To Type", QltyInspectSourceConfig."To Type"::Inspection);
+        QltyInspectSourceConfig.SetRange(Enabled, true);
+        LibraryAssert.IsTrue(QltyInspectSourceConfig.FindFirst(), 'Source config for ILE→Inspection should exist.');
+
+        // [WHEN] Schedule Inspection report calls CreateInspectionsThatMatchRule directly
+        QltyScheduleInspection.CreateInspectionsThatMatchRule(QltyInspectionGenRule);
+
+        // [THEN] Exactly one inspection should be created for the open ILE with remaining quantity 1
+        QltyInspectionHeader.SetRange("Source Item No.", Item."No.");
+        LibraryAssert.AreEqual(1, QltyInspectionHeader.Count(), 'Exactly one inspection should be created for the item with remaining quantity.');
+        QltyInspectionHeader.FindFirst();
+        LibraryAssert.AreEqual(1, QltyInspectionHeader."Source Quantity (Base)", 'Inspection should have source quantity of 1 (remaining quantity).');
+        LibraryAssert.AreEqual(LotNo, QltyInspectionHeader."Source Lot No.", 'Inspection should have the correct lot number.');
     end;
 
     local procedure Initialize()


### PR DESCRIPTION
## Fix scheduled inspection generation for Item Ledger Entries with zero remaining quantity

### Summary
- Scheduled inspections now respect source configuration filters (`From Table Filter`) when iterating source records, preventing inspections from being created for Item Ledger Entries with zero remaining quantity
- Each source configuration filter runs as a separate database query (OR semantics), so records matching any enabled source config are processed
- If no enabled source configuration with a `From Table Filter` exists for the source table, the scheduler raises an error instead of silently creating incomplete inspections

### Details

**Bug:** The Schedule Inspection report (20412) iterated all Item Ledger Entries matching the generation rule's Condition Filter, ignoring the `WHERE(Open=CONST(true))` filter defined on the `ITEMLDGROPENINSPECT` source configuration. This caused inspections to be created for fully consumed ILEs (Remaining Quantity = 0), resulting in inspections with empty Item No., Lot No., and Qty = 0.

**Root cause:** The `From Table Filter` on source configurations was only applied during the field mapping step (`ApplySourceRecursive` in the traversal), where it prevented field population but did not prevent inspection creation. The scheduler never applied these filters when selecting which records to iterate.

**Fix:** Refactored `CreateInspectionsThatMatchRule` to iterate source records per source configuration. For each enabled source config with a `From Table Filter`, a separate filtered query is executed with the config's filter applied in FilterGroup 20 alongside the generation rule's Condition Filter in FilterGroup 0. This ensures the database does the filtering efficiently rather than iterating all records in the application.

### Files changed
- `app/src/Configuration/GenerationRule/JobQueue/QltyScheduleInspection.Report.al` — Refactored `CreateInspectionsThatMatchRule` into two procedures; added `CreateInspectionsPerSourceConfigFilter` that iterates per source config filter; added error for missing source config
- `test/src/QltyTestsMoreTests.Codeunit.al` — Added two tests: `ScheduleInspection_ClosedILE_ShouldNotCreateInspection` (verifies zero-qty ILEs are excluded) and `ScheduleInspection_OpenILE_ShouldCreateInspection` (verifies open ILEs generate inspections with correct quantity)

### Test plan
- [ ] Run `ScheduleInspection_ClosedILE_ShouldNotCreateInspection` — should pass (no inspections for closed ILEs)
- [ ] Run `ScheduleInspection_OpenILE_ShouldCreateInspection` — should pass (1 inspection with correct qty/lot)
- [ ] Run existing `GenerationRule_ValidateScheduleGroup_*` and `GenerationRule_*JobQueue*` tests — should still pass
- [ ] Manual: Create ILE generation rule, post +10/-10 for item, run Schedule Inspection — verify no inspection created
- [ ] Manual: Create ILE generation rule, post +10/-6 for item, run Schedule Inspection — verify inspection created with qty 4

Fixes [AB#626972](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/626972)



