### PR TITLE
[Shopify] Move Order No. field to correct transactions page

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Transactions/Pages/ShpfyOrderTransactions.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Transactions/Pages/ShpfyOrderTransactions.Page.al
@@ -42,6 +42,7 @@ page 30131 "Shpfy Order Transactions"
                 field(ShpfyOrderNo; Rec."Shpfy Order No.")
                 {
                     ApplicationArea = All;
+                    Visible = false;
                     ToolTip = 'Specifies the order number from Shopify.';
                 }
                 field(Type; Rec.Type)

--- a/src/Apps/W1/Shopify/App/src/Transactions/Pages/ShpfyTransactions.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Transactions/Pages/ShpfyTransactions.Page.al
@@ -122,6 +122,11 @@ page 30134 "Shpfy Transactions"
                     ApplicationArea = All;
                     ToolTip = 'Specifies the standardized error code, independent of the payment provider. Valid values are: incorrect_number, invalid_number, invalid_expiry_date, invalid_cvc, expired_card, incorrect_cvc, incorrect_zip, incorrect_address, card_declined, processing_error, call_issuer, pick_up_card.';
                 }
+                field(ShpfyOrderNo; Rec."Shpfy Order No.")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the order number from Shopify.';
+                }
                 field(ShopifyOrderId; Rec."Shopify Order Id")
                 {
                     ApplicationArea = All;


### PR DESCRIPTION
## Summary
- Hide `Shpfy Order No.` field on page 30131 (Order Transactions sub-page) where it's redundant in the context of a specific order
- Add `Shpfy Order No.` field to page 30134 (standalone Transactions list) where users need it to identify which order a transaction belongs to

Fixes [AB#629705](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/629705)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
