### PR TITLE
Fix Bug 626576: AI Development Toolkit silently fails to install with…

### DIFF
--- a/src/System Application/App/Extension Management/src/ExtensionInstallationImpl.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionInstallationImpl.Codeunit.al
@@ -18,6 +18,8 @@ codeunit 2500 "Extension Installation Impl"
     SingleInstance = false;
 
     var
+        DotNetALNavAppOperationInvoker: DotNet ALNavAppOperationInvoker;
+        OperationInvokerHasBeenCreated: Boolean;
         DotNetNavAppALInstaller: DotNet NavAppALInstaller;
         InstallerHasBeenCreated: Boolean;
         InstalledTxt: Label 'Installed';
@@ -173,6 +175,15 @@ codeunit 2500 "Extension Installation Impl"
             DotNetNavAppALInstaller := DotNetNavAppALInstaller.NavAppALInstaller();
             InstallerHasBeenCreated := true;
         end;
+    end;
+
+    procedure CreatePreDeployedTargetReference(AppId: Guid; Lcid: Integer)
+    begin
+        if not OperationInvokerHasBeenCreated then begin
+            DotNetALNavAppOperationInvoker := DotNetALNavAppOperationInvoker.ALNavAppOperationInvoker();
+            OperationInvokerHasBeenCreated := true;
+        end;
+        DotNetALNavAppOperationInvoker.CreatePreDeployedTargetReference(AppId, Format(Lcid));
     end;
 
     procedure CheckPermissions()

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
@@ -380,7 +380,10 @@ codeunit 2501 "Extension Marketplace"
     end;
 
     local procedure InstallApp(PackageId: Guid; AppId: Guid; ResponseURL: Text; lcid: Integer)
+    var
+        ExtensionInstallationImpl: Codeunit "Extension Installation Impl";
     begin
+        ExtensionInstallationImpl.CreatePreDeployedTargetReference(AppId, lcid);
         if not InstallApp(PackageId, ResponseURL, lcid) then
             exit;
 


### PR DESCRIPTION

#### Summary
Fixes [Bug 626576]: AI Development Toolkit silently fails to install with no error message provided


Root Cause
The install of the pre-published Microsoft Apps "AI Development Toolkit" fails silently, and leaves no error entry in the installation status page because the original installation status entry that would be added during the publish flow is not there for pre-publish scenarios.

Fix
Add the initial entry for installation status when installing a  pre-published first party app via app source marketplace by calling the newly added `DotNetALNavAppOperationInvoker.CreatePreDeployedTargetReference()`.

Fixes [AB#626576](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/626576)




