### PR TITLE
Problem purchase header security filters bug

### DIFF
--- a/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
@@ -750,6 +750,10 @@ codeunit 8900 "Email Impl"
         repeat
             if AllObj.Get(AllObj."Object Type"::Table, EmailRelatedRecord."Table Id") then begin
                 SourceRecordRef.Open(EmailRelatedRecord."Table Id");
+                // If at least one security filter is applied to the “Purchase Header” table, 
+                // the user will have a problem when push ‘Add file from source document’ action on the “Email Attachments” 
+                // subpage. Message: "Did not find any attachments related to this email"
+                SourceRecordRef.SecurityFiltering(SecurityFilter::Ignored);
                 if SourceRecordRef.ReadPermission() then
                     if SourceRecordRef.GetBySystemId(EmailRelatedRecord."System Id") then
                         EmailRelatedRecord.Mark(true);


### PR DESCRIPTION
If at least one security filter is applied to the “Purchase Header” table, the user will have a problem when push ‘Add file from source document’ action on the “Email Attachments” subpage. Message: "Did not find any attachments related to this email"

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #
