### PR TITLE
[Bug][SubscriptionBilling]: "Learn more" link in Subscription Billing Role Center points to wrong page

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Base/Pages/SubBillingHeadlineRC.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Base/Pages/SubBillingHeadlineRC.Page.al
@@ -35,7 +35,7 @@ page 8086 "Sub. Billing Headline RC"
 
                     trigger OnDrillDown()
                     begin
-                        HyperLink(RCHeadlinesPageCommon.DocumentationUrlTxt());
+                        HyperLink(DocumentationUrlTxt);
                     end;
                 }
             }
@@ -62,4 +62,5 @@ page 8086 "Sub. Billing Headline RC"
         RCHeadlinesPageCommon: Codeunit "RC Headlines Page Common";
         DefaultFieldsVisible: Boolean;
         UserGreetingVisible: Boolean;
+        DocumentationUrlTxt: Label 'https://learn.microsoft.com/en-us/dynamics365/business-central/srb/welcome';
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
fix: Update "Learn more" link in Subscription Billing Role Center to point to correct documentation

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #6975


Fixes [AB#630831](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630831)
