### PR TITLE
[Quality Management] Now Open status is bold + green for all of the quality inspections created by item tracking lines

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
@@ -715,6 +715,7 @@ page 20408 "Qlty. Inspection List"
     trigger OnAfterGetRecord()
     begin
         ResultStyleExpr := Rec.GetResultStyle();
+        StatusStyleExpr := Rec.GetStatusStyleExpression();
     end;
 
     trigger OnAfterGetCurrRecord()


### PR DESCRIPTION
Fixes [AB#630612](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630612)





