### PR TITLE
[28.X] [Quality Management] Now Open status is bold + green for all of the quality inspections created by item tracking l

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
@@ -1585,6 +1585,18 @@ table 20405 "Qlty. Inspection Header"
         end;
     end;
 
+    procedure GetStatusStyleExpression(): Text
+    begin
+        case Rec.Status of
+            Rec.Status::Open:
+                exit('Favorable');
+            Rec.Status::Finished:
+                exit('Strong');
+            else
+                exit('None');
+        end;
+    end;
+
     /// <summary>
     /// Gets the preferred result style to use.
     /// </summary>

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
@@ -63,6 +63,7 @@ page 20408 "Qlty. Inspection List"
                 {
                     AboutTitle = 'Inspection status at a glance';
                     AboutText = '**Status** shows whether the inspection is still in progress or finished. Finished inspections are locked and can''t be changed.';
+                    StyleExpr = StatusStyleExpr;
                 }
                 field("Result Code"; Rec."Result Code")
                 {
@@ -701,10 +702,12 @@ page 20408 "Qlty. Inspection List"
         CanFinish: Boolean;
         CanReopen: Boolean;
         RowActionsAreEnabled: Boolean;
+        StatusStyleExpr: Text;
 
     trigger OnAfterGetRecord()
     begin
         ResultStyleExpr := Rec.GetResultStyle();
+        StatusStyleExpr := Rec.GetStatusStyleExpression();
     end;
 
     trigger OnAfterGetCurrRecord()


### PR DESCRIPTION
Fixes [AB#626971](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/626971)

Backported from https://github.com/microsoft/BCApps/pull/7648
Also added the Style function that was missing.






