### PR TITLE
Fix ambiguous FromMilliseconds overload

### DIFF
--- a/src/System Application/App/Regex/src/RegexImpl.Codeunit.al
+++ b/src/System Application/App/Regex/src/RegexImpl.Codeunit.al
@@ -327,7 +327,7 @@ codeunit 3961 "Regex Impl."
     procedure Regex(Pattern: Text; var RegexOptions: Record "Regex Options")
     var
         TimeoutDuration: DotNet TimeSpan;
-        MatchTimeoutInMs: Decimal;
+        MatchTimeoutInMs: BigInteger;
     begin
         DotNetRegexOptions := RegexOptions.GetRegexOptions();
         MatchTimeoutInMs := RegexOptions.MatchTimeoutInMs;
@@ -336,7 +336,7 @@ codeunit 3961 "Regex Impl."
         if MatchTimeoutInMs > 10000 then
             Error(TimeoutTooHighErr);
 
-        DotNetRegex := DotNetRegex.Regex(Pattern, DotNetRegexOptions, TimeoutDuration.FromMilliseconds(MatchTimeoutInMs));
+        DotNetRegex := DotNetRegex.Regex(Pattern, DotNetRegexOptions, TimeoutDuration.FromTicks(MatchTimeoutInMs * 10000));
     end;
 
     local procedure CheckIfInstantiated()


### PR DESCRIPTION
#### Summary
The .NET overload resolution cannot figure out if it should pick up the Int64 or the Double overload in .NET 10. Use the ticks overload to ensure no ambiguity.

#### Work Item(s) 
Fixes [AB#630657](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630657)


