### PR TITLE
Add ExcludeFromBilling overload to LogAgentUserAIConsumption

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotQuota.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotQuota.Codeunit.al
@@ -49,7 +49,28 @@ codeunit 7785 "Copilot Quota"
         CallerModuleInfo: ModuleInfo;
     begin
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
-        CopilotQuotaImpl.LogAgentUserAIConsumption(CopilotCapability, Usage, CopilotQuotaUsageType, CallerModuleInfo, AgentTaskID, ActionsCharged, Description, UniqueID);
+        CopilotQuotaImpl.LogAgentUserAIConsumption(CopilotCapability, Usage, CopilotQuotaUsageType, CallerModuleInfo, AgentTaskID, ActionsCharged, Description, UniqueID, false);
+    end;
+
+    /// <summary>
+    /// Log usage of Agent functionality. This function is only available for Microsoft Agents.
+    /// Function will call the platform to log the usage of the agents. Charging will be handled by the platform afterwards.
+    /// </summary>
+    /// <param name="CopilotCapability">The Copilot Capability to log usage for.</param>
+    /// <param name="Usage">The usage to log.</param>
+    /// <param name="CopilotQuotaUsageType">The type of Copilot Quota to log.</param>
+    /// <param name="AgentTaskID">The unique identifier of the Agent task.</param>
+    /// <param name="ActionsCharged">The actions that were charged for this usage. This should be a short text, for example Quote Operation, Processed E-Document and etc...</param>
+    /// <param name="Description">A description of the usage. This text is providing the additional information to ActionsCharged, for example specifying which operation was done on which quote or which e-document was processed.</param>
+    /// <param name="UniqueID">A unique identifier for this log entry. Parameter is mandatory. This value is used to avoid double charging. Platform will check if we have the entry already logged and will not double charge. If you want to charge always use CreateGuid() or a strategy that will always issue a charge.</param>
+    /// <param name="ExcludeFromBilling">If true, the usage will be logged but excluded from billing.</param>
+    [Scope('OnPrem')]
+    procedure LogAgentUserAIConsumption(CopilotCapability: Enum "Copilot Capability"; Usage: Integer; CopilotQuotaUsageType: Enum "Copilot Quota Usage Type"; AgentTaskID: BigInteger; ActionsCharged: Text[1024]; Description: Text; UniqueID: Text[1024]; ExcludeFromBilling: Boolean)
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        CopilotQuotaImpl.LogAgentUserAIConsumption(CopilotCapability, Usage, CopilotQuotaUsageType, CallerModuleInfo, AgentTaskID, ActionsCharged, Description, UniqueID, ExcludeFromBilling);
     end;
 
     /// <summary>

--- a/src/System Application/App/AI/src/Copilot/CopilotQuotaImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotQuotaImpl.Codeunit.al
@@ -16,7 +16,7 @@ codeunit 7786 "Copilot Quota Impl."
         CopilotCapabilityImpl: Codeunit "Copilot Capability Impl";
         InvalidUsageTypeErr: Label 'The value "%1" is not a valid Copilot Quota Usage Type.', Comment = '%1=a value such as "AI response" or "5"';
         CapabilityNotRegisteredTelemetryMsg: Label 'Capability "%1" is not registered in the system but is logging usage.', Locked = true;
-        LoggingUsageTelemetryMsg: Label 'Capability "%1" is logging %2 usage of type %3.', Locked = true;
+        LoggingUsageTelemetryMsg: Label 'Capability "%1" is logging %2 usage of type %3, excluded from billing: %4.', Locked = true;
 
     trigger OnRun()
     var
@@ -64,7 +64,7 @@ codeunit 7786 "Copilot Quota Impl."
         if not CopilotCapabilityImpl.IsCapabilityRegistered(CopilotCapability, CallerModuleInfo) then
             Session.LogMessage('0000OSL', StrSubstNo(CapabilityNotRegisteredTelemetryMsg, CopilotCapability), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CopilotCapabilityImpl.GetCopilotCategory());
 
-        Session.LogMessage('0000OSM', StrSubstNo(LoggingUsageTelemetryMsg, CopilotCapability, Usage, CopilotQuotaUsageType), Verbosity::Verbose, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CopilotCapabilityImpl.GetCopilotCategory());
+        Session.LogMessage('0000OSM', StrSubstNo(LoggingUsageTelemetryMsg, CopilotCapability, Usage, CopilotQuotaUsageType, false), Verbosity::Verbose, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CopilotCapabilityImpl.GetCopilotCategory());
 
         ALCopilotCapability := ALCopilotCapability.ALCopilotCapability(
             CallerModuleInfo.Publisher(), CallerModuleInfo.Id(), Format(CallerModuleInfo.AppVersion()), CopilotCapabilityImpl.CapabilityToEnumName(CopilotCapability));
@@ -74,7 +74,7 @@ codeunit 7786 "Copilot Quota Impl."
         ALCopilotFunctions.LogCopilotQuotaUsage(AlCopilotCapability, Usage, AlCopilotUsageType);
     end;
 
-    procedure LogAgentUserAIConsumption(CopilotCapability: Enum "Copilot Capability"; Usage: Integer; CopilotQuotaUsageType: Enum "Copilot Quota Usage Type"; CallerModuleInfo: ModuleInfo; AgentTaskID: BigInteger; ActionsCharged: Text[1024]; Description: Text; UniqueID: Text[1024])
+    procedure LogAgentUserAIConsumption(CopilotCapability: Enum "Copilot Capability"; Usage: Integer; CopilotQuotaUsageType: Enum "Copilot Quota Usage Type"; CallerModuleInfo: ModuleInfo; AgentTaskID: BigInteger; ActionsCharged: Text[1024]; Description: Text; UniqueID: Text[1024]; ExcludeFromBilling: Boolean)
     var
         AlCopilotCapability: DotNet ALCopilotCapability;
         ALCopilotFunctions: DotNet ALCopilotFunctions;
@@ -83,7 +83,7 @@ codeunit 7786 "Copilot Quota Impl."
         if not CopilotCapabilityImpl.IsCapabilityRegistered(CopilotCapability, CallerModuleInfo) then
             Session.LogMessage('0000QIY', StrSubstNo(CapabilityNotRegisteredTelemetryMsg, CopilotCapability), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CopilotCapabilityImpl.GetCopilotCategory());
 
-        Session.LogMessage('0000QIZ', StrSubstNo(LoggingUsageTelemetryMsg, CopilotCapability, Usage, CopilotQuotaUsageType), Verbosity::Verbose, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CopilotCapabilityImpl.GetCopilotCategory());
+        Session.LogMessage('0000QIZ', StrSubstNo(LoggingUsageTelemetryMsg, CopilotCapability, Usage, CopilotQuotaUsageType, ExcludeFromBilling), Verbosity::Verbose, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CopilotCapabilityImpl.GetCopilotCategory());
 
         ALCopilotCapability := ALCopilotCapability.ALCopilotCapability(
                  CallerModuleInfo.Publisher(), CallerModuleInfo.Id(), Format(CallerModuleInfo.AppVersion()), CopilotCapabilityImpl.CapabilityToEnumName(CopilotCapability));
@@ -97,7 +97,8 @@ codeunit 7786 "Copilot Quota Impl."
             Description,
             AlCopilotUsageType,
             Usage,
-            UniqueID
+            UniqueID,
+            ExcludeFromBilling
         );
     end;
 


### PR DESCRIPTION
## Summary
- Add new overload of `LogAgentUserAIConsumption` in `Copilot Quota` and `Copilot Quota Impl.` codeunits that accepts an `ExcludeFromBilling: Boolean` parameter
- Update `LoggingUsageTelemetryMsg` to include the `ExcludeFromBilling` value (`%4`)
- Existing callers pass `false` for backward compatibility
- The dotnet `ALCopilotFunctions.LogAgentUserAIConsumptionAsync` call will be updated in a follow-up to pass `ExcludeFromBilling` through to the platform

[AB#620754](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620754)
[AB#631081](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/631081)




