### PR TITLE
[releases/28.x] [MCP] Add feedback button and fix OCV ID

### DIFF
--- a/src/System Application/App/MCP/app.json
+++ b/src/System Application/App/MCP/app.json
@@ -40,6 +40,12 @@
       "name": "Upgrade Tags",
       "publisher": "Microsoft",
       "version": "28.1.0.0"
+    },
+    {
+      "id": "f7964d32-7685-400f-8297-4bc17d0aab0e",
+      "name": "Microsoft User Feedback",
+      "publisher": "Microsoft",
+      "version": "28.1.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/MCP/src/Configuration/Codeunits/MCPConfigImplementation.Codeunit.al
+++ b/src/System Application/App/MCP/src/Configuration/Codeunits/MCPConfigImplementation.Codeunit.al
@@ -1051,7 +1051,7 @@ codeunit 8351 "MCP Config Implementation"
             exit;
 
         Feedback.WithCustomQuestion(MCPServerFeedbackQst, MCPServerFeedbackQst).WithCustomQuestionType(Enum::FeedbackQuestionType::Text);
-        Feedback.RequestDislikeFeedback('MCP Server', 'Configuration', 'Model Context Protocol (MCP) Server');
+        Feedback.RequestDislikeFeedback('MCP Server', 'MCPServer', 'Model Context Protocol (MCP) Server');
 
         Session.LogMessage('0000RTR', NoActiveConfigsFeedbackTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', GetTelemetryCategory());
     end;
@@ -1060,7 +1060,7 @@ codeunit 8351 "MCP Config Implementation"
     var
         Feedback: Codeunit "Microsoft User Feedback";
     begin
-        Feedback.RequestFeedback('MCP Server', 'Configuration', 'Model Context Protocol (MCP) Server');
+        Feedback.RequestFeedback('MCP Server', 'MCPServer', 'Model Context Protocol (MCP) Server');
 
         Session.LogMessage('0000RTS', GeneralFeedbackTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', GetTelemetryCategory());
     end;

--- a/src/System Application/App/MCP/src/Configuration/Codeunits/MCPConfigImplementation.Codeunit.al
+++ b/src/System Application/App/MCP/src/Configuration/Codeunits/MCPConfigImplementation.Codeunit.al
@@ -7,6 +7,7 @@ namespace System.MCP;
 
 using System.Azure.Identity;
 using System.Environment;
+using System.Feedback;
 using System.Reflection;
 using System.Utilities;
 
@@ -54,6 +55,10 @@ codeunit 8351 "MCP Config Implementation"
         JsonFilterTxt: Label 'JSON Files (*.json)|*.json';
         InvalidJsonErr: Label 'The selected file is not a valid configuration file.';
         ConfigNameExistsMsg: Label 'A configuration with the name ''%1'' already exists. Please provide a different name.', Comment = '%1 = configuration name';
+        MCPServerFeedbackConfirmQst: Label 'We noticed you no longer have any active configurations. Could you share what made you decide to stop using the MCP server? Your feedback helps us improve the experience.';
+        MCPServerFeedbackQst: Label 'What could we do to improve the MCP server experience?';
+        NoActiveConfigsFeedbackTxt: Label 'No active configs feedback triggered', Locked = true;
+        GeneralFeedbackTxt: Label 'General MCP feedback triggered', Locked = true;
 
     #region Configurations
     internal procedure GetConfigurationIdByName(Name: Text[100]): Guid
@@ -1037,6 +1042,40 @@ codeunit 8351 "MCP Config Implementation"
     end;
     #endregion
 
+    #region Feedback
+    internal procedure TriggerNoActiveConfigsFeedback()
+    var
+        Feedback: Codeunit "Microsoft User Feedback";
+    begin
+        if not Confirm(MCPServerFeedbackConfirmQst, true) then
+            exit;
+
+        Feedback.WithCustomQuestion(MCPServerFeedbackQst, MCPServerFeedbackQst).WithCustomQuestionType(Enum::FeedbackQuestionType::Text);
+        Feedback.RequestDislikeFeedback('MCP Server', 'Configuration', 'Model Context Protocol (MCP) Server');
+
+        Session.LogMessage('0000RTR', NoActiveConfigsFeedbackTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', GetTelemetryCategory());
+    end;
+
+    internal procedure TriggerGeneralFeedback()
+    var
+        Feedback: Codeunit "Microsoft User Feedback";
+    begin
+        Feedback.RequestFeedback('MCP Server', 'Configuration', 'Model Context Protocol (MCP) Server');
+
+        Session.LogMessage('0000RTS', GeneralFeedbackTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', GetTelemetryCategory());
+    end;
+
+    internal procedure HasNoActiveConfigurations(): Boolean
+    var
+        MCPConfiguration: Record "MCP Configuration";
+    begin
+        MCPConfiguration.SetRange(Active, true);
+        MCPConfiguration.SetFilter(Name, '<>%1', '');
+        exit(MCPConfiguration.IsEmpty());
+    end;
+    #endregion Feedback
+
+    #region Telemetry
     local procedure GetDimensions(MCPConfiguration: Record "MCP Configuration") Dimensions: Dictionary of [Text, Text]
     begin
         Dimensions.Add('Category', GetTelemetryCategory());
@@ -1089,4 +1128,5 @@ codeunit 8351 "MCP Config Implementation"
         Session.LogMessage('0000QEB', MCPConfigurationDeletedLbl, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, GetDimensions(MCPConfiguration));
         Session.LogAuditMessage(StrSubstNo(MCPConfigurationAuditDeletedLbl, MCPConfiguration.Name, UserSecurityId(), CompanyName()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 3, 0);
     end;
+    #endregion
 }

--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigList.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigList.Page.al
@@ -65,8 +65,6 @@ page 8350 "MCP Config List"
                 Scope = Repeater;
 
                 trigger OnAction()
-                var
-                    MCPConfigImplementation: Codeunit "MCP Config Implementation";
                 begin
                     MCPConfigImplementation.CopyConfiguration(Rec.SystemId);
                 end;
@@ -74,6 +72,17 @@ page 8350 "MCP Config List"
         }
         area(Processing)
         {
+            action(GiveFeedback)
+            {
+                Caption = 'Give Feedback';
+                ToolTip = 'Share your feedback about the MCP server experience.';
+                Image = Questionaire;
+
+                trigger OnAction()
+                begin
+                    MCPConfigImplementation.TriggerGeneralFeedback();
+                end;
+            }
             group(Advanced)
             {
                 Caption = 'Advanced';
@@ -87,8 +96,6 @@ page 8350 "MCP Config List"
                     Scope = Repeater;
 
                     trigger OnAction()
-                    var
-                        MCPConfigImplementation: Codeunit "MCP Config Implementation";
                     begin
                         MCPConfigImplementation.ShowConnectionString(Rec.Name);
                     end;
@@ -108,8 +115,6 @@ page 8350 "MCP Config List"
                     Scope = Repeater;
 
                     trigger OnAction()
-                    var
-                        MCPConfigImplementation: Codeunit "MCP Config Implementation";
                     begin
                         MCPConfigImplementation.ExportConfigurationToFile(Rec.SystemId, Rec.Name);
                     end;
@@ -122,8 +127,6 @@ page 8350 "MCP Config List"
                     AccessByPermission = tabledata "MCP Configuration" = IM;
 
                     trigger OnAction()
-                    var
-                        MCPConfigImplementation: Codeunit "MCP Config Implementation";
                     begin
                         MCPConfigImplementation.ImportConfigurationFromFile();
                         CurrPage.Update(false);
@@ -134,6 +137,7 @@ page 8350 "MCP Config List"
         area(Promoted)
         {
             actionref(Promoted_Copy; Copy) { }
+            actionref(Promoted_GiveFeedback; GiveFeedback) { }
             group(Promoted_Advanced)
             {
                 Caption = 'Advanced';
@@ -154,4 +158,23 @@ page 8350 "MCP Config List"
             Filters = where(Active = const(true));
         }
     }
+
+    trigger OnOpenPage()
+    begin
+        HadActiveConfigsOnOpen := not MCPConfigImplementation.HasNoActiveConfigurations();
+    end;
+
+    trigger OnQueryClosePage(CloseAction: Action): Boolean
+    begin
+        if not HadActiveConfigsOnOpen then
+            exit;
+
+        if MCPConfigImplementation.HasNoActiveConfigurations() then
+            MCPConfigImplementation.TriggerNoActiveConfigsFeedback();
+    end;
+
+    var
+        MCPConfigImplementation: Codeunit "MCP Config Implementation";
+        HadActiveConfigsOnOpen: Boolean;
+
 }


### PR DESCRIPTION
## Summary
- Backport of [MCP] Add feedback feature for MCP configuration (#6817) and [MCP] Fix feedback feature area OCV ID (#7570) to `releases/28.x`
- Adds user feedback collection when all MCP configurations are deactivated/deleted and a "Give Feedback" action on the MCP Config List page
- Fixes OCV feature area ID from `'Configuration'` to `'MCPServer'`

Fixes [AB#622892](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622892)
Fixes [AB#630240](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630240)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



