### PR TITLE
[Shopify] Fix Item Card showing 'Add to Shopify' for variant-mapped items

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfySyncProducts.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfySyncProducts.Codeunit.al
@@ -183,6 +183,7 @@ codeunit 30185 "Shpfy Sync Products"
     internal procedure ConfirmAddItemToShopify(Item: Record Item; var ShopifyShop: Record "Shpfy Shop"): Boolean
     var
         ShopifyProduct: Record "Shpfy Product";
+        ShopifyVariant: Record "Shpfy Variant";
         ShopSelection: Page "Shpfy Shop Selection";
         AddItemConfirm: Page "Shpfy Add Item Confirm";
         MappedShopsFilter: Text;
@@ -196,11 +197,17 @@ codeunit 30185 "Shpfy Sync Products"
             if AddItemConfirm.RunModal() = Action::OK then
                 exit(true);
         end else begin
-            ShopifyProduct.SetRange("Item SystemId", Item.systemId);
-            if ShopifyProduct.FindSet() then begin
+            ShopifyProduct.SetRange("Item SystemId", Item.SystemId);
+            if ShopifyProduct.FindSet() then
                 repeat
                     MappedShopsFilter += '<>' + ShopifyProduct."Shop Code" + '&';
                 until ShopifyProduct.Next() = 0;
+            ShopifyVariant.SetRange("Item SystemId", Item.SystemId);
+            if ShopifyVariant.FindSet() then
+                repeat
+                    MappedShopsFilter += '<>' + ShopifyVariant."Shop Code" + '&';
+                until ShopifyVariant.Next() = 0;
+            if MappedShopsFilter <> '' then begin
                 MappedShopsFilter := MappedShopsFilter.TrimEnd('&');
                 ShopifyShop.SetFilter(Code, MappedShopsFilter);
             end;

--- a/src/Apps/W1/Shopify/App/src/Products/Page Extensions/ShpfyItemCard.PageExt.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Page Extensions/ShpfyItemCard.PageExt.al
@@ -113,6 +113,7 @@ pageextension 30119 "Shpfy Item Card" extends "Item Card"
     var
         Shop: Record "Shpfy Shop";
         ShopifyProduct: Record "Shpfy Product";
+        ShopifyVariant: Record "Shpfy Variant";
     begin
         IsProductMapped := false;
         ShopifyProduct.SetLoadFields("Item SystemId", "Shop Code");
@@ -125,12 +126,26 @@ pageextension 30119 "Shpfy Item Card" extends "Item Card"
                         exit;
                     end;
             until ShopifyProduct.Next() = 0;
+
+        if not IsProductMapped then begin
+            ShopifyVariant.SetLoadFields("Item SystemId", "Shop Code");
+            ShopifyVariant.SetRange("Item SystemId", Rec.SystemId);
+            if ShopifyVariant.FindSet() then
+                repeat
+                    if Shop.Get(ShopifyVariant."Shop Code") then
+                        if Shop.Enabled then begin
+                            IsProductMapped := true;
+                            exit;
+                        end;
+                until ShopifyVariant.Next() = 0;
+        end;
     end;
 
     local procedure SetAvailableStoresToMap()
     var
         Shop: Record "Shpfy Shop";
         ShopifyProduct: Record "Shpfy Product";
+        ShopifyVariant: Record "Shpfy Variant";
     begin
         AvailableStoresToMap := false;
         Shop.SetRange(Enabled, true);
@@ -139,8 +154,12 @@ pageextension 30119 "Shpfy Item Card" extends "Item Card"
                 ShopifyProduct.SetRange("Item SystemId", Rec.SystemId);
                 ShopifyProduct.SetRange("Shop Code", Shop.Code);
                 if ShopifyProduct.IsEmpty() then begin
-                    AvailableStoresToMap := true;
-                    exit;
+                    ShopifyVariant.SetRange("Item SystemId", Rec.SystemId);
+                    ShopifyVariant.SetRange("Shop Code", Shop.Code);
+                    if ShopifyVariant.IsEmpty() then begin
+                        AvailableStoresToMap := true;
+                        exit;
+                    end;
                 end;
             until Shop.Next() = 0;
     end;

--- a/src/Apps/W1/Shopify/App/src/Products/Page Extensions/ShpfyItemList.PageExt.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Page Extensions/ShpfyItemList.PageExt.al
@@ -63,6 +63,7 @@ pageextension 30120 "Shpfy Item List" extends "Item List"
     var
         Shop: Record "Shpfy Shop";
         ShopifyProduct: Record "Shpfy Product";
+        ShopifyVariant: Record "Shpfy Variant";
     begin
         IsProductMapped := false;
         ShopifyProduct.SetLoadFields("Item SystemId", "Shop Code");
@@ -75,5 +76,18 @@ pageextension 30120 "Shpfy Item List" extends "Item List"
                         exit;
                     end;
             until ShopifyProduct.Next() = 0;
+
+        if not IsProductMapped then begin
+            ShopifyVariant.SetLoadFields("Item SystemId", "Shop Code");
+            ShopifyVariant.SetRange("Item SystemId", Rec.SystemId);
+            if ShopifyVariant.FindSet() then
+                repeat
+                    if Shop.Get(ShopifyVariant."Shop Code") then
+                        if Shop.Enabled then begin
+                            IsProductMapped := true;
+                            exit;
+                        end;
+                until ShopifyVariant.Next() = 0;
+        end;
     end;
 }


### PR DESCRIPTION
## Summary
- `SetIsProductMapped()` on the Item Card and Item List page extensions now also checks the `Shpfy Variant` table, so items linked to Shopify as variants (not standalone products) correctly show **Show Product in Shopify** instead of **Add to Shopify**
- `SetAvailableStoresToMap()` on the Item Card now excludes shops where the item already exists as a variant, preventing the **Add to Shopify** action from being enabled for those shops
- `ConfirmAddItemToShopify()` shop exclusion filter now also filters out shops where the item is already a variant, preventing duplicate product creation in multi-shop scenarios

Fixes [AB#631019](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/631019)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

