### PR TITLE
Enable Copilot customizations discovery from repo root in DevEnv

### DIFF
--- a/build/scripts/DevEnv/DefaultSettings.json
+++ b/build/scripts/DevEnv/DefaultSettings.json
@@ -1,4 +1,5 @@
 {
+    "chat.useCustomizationsInParentRepositories":  true,
     "al.codeAnalyzers":  [
         "${CodeCop}",
         "${AppSourceCop}",


### PR DESCRIPTION
## Summary
- Adds `"chat.useCustomizationsInParentRepositories": true` to the default VS Code settings for the dev environment
- This ensures that when developers open a subfolder of the BCApps repository (e.g., a specific app), VS Code still discovers AI customization files (like `copilot-instructions.md`, `AGENTS.md`, `CLAUDE.md`, prompt files, custom agents, and hooks) from the repository root
- Without this setting (disabled by default), developers working in subfolders of the monorepo miss repo-level Copilot/AI guidance and tools

## Why
BCApps is a monorepo. When a developer opens a subfolder rather than the repo root, VS Code by default only looks for AI customization files within that subfolder. Enabling this setting makes VS Code walk up the folder hierarchy to the `.git` root, collecting all customizations along the way. This ensures consistent AI-assisted development experience regardless of which folder is opened.

Fixes [AB#631256](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/631256)


