### PR TITLE
[Subcontracting] Bug 631232: Change position of "purchase with service" lines with "suctontracting…

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcReqWkshMakeOrd.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcReqWkshMakeOrd.Codeunit.al
@@ -12,14 +12,24 @@ codeunit 99001516 "Subc. Req. Wksh. Make Ord."
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Req. Wksh.-Make Order", OnAfterInsertPurchOrderLine, '', false, false)]
     local procedure OnAfterInsertPurchOrderLine(var PurchOrderLine: Record "Purchase Line"; var NextLineNo: Integer; var RequisitionLine: Record "Requisition Line")
     begin
-        HandleSubcontractingAfterPurchOrderLineInsert(PurchOrderLine, NextLineNo, RequisitionLine);
+        HandleSubcontractingAfterPurchOrderLineInsert(PurchOrderLine, RequisitionLine);
     end;
 
-    local procedure HandleSubcontractingAfterPurchOrderLineInsert(var PurchaseLine: Record "Purchase Line"; var NextLineNo: Integer; var RequisitionLine: Record "Requisition Line")
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Req. Wksh.-Make Order", OnInsertPurchOrderLineOnAfterCheckInsertFinalizePurchaseOrderHeader, '', false, false)]
+    local procedure OnInsertPurchOrderLineOnAfterCheckInsertFinalizePurchaseOrderHeader(var RequisitionLine: Record "Requisition Line"; var PurchaseHeader: Record "Purchase Header"; var NextLineNo: Integer)
+    var
+        AdditionallyPurchaseLine: Record "Purchase Line";
+        SubcPurchaseOrderCreator: Codeunit "Subc. Purchase Order Creator";
+    begin
+        AdditionallyPurchaseLine."Document Type" := PurchaseHeader."Document Type";
+        AdditionallyPurchaseLine."Document No." := PurchaseHeader."No.";
+        SubcPurchaseOrderCreator.TransferSubcontractingProdOrderComp(AdditionallyPurchaseLine, RequisitionLine, NextLineNo);
+    end;
+
+    local procedure HandleSubcontractingAfterPurchOrderLineInsert(var PurchaseLine: Record "Purchase Line"; var RequisitionLine: Record "Requisition Line")
     var
         SubcPurchaseOrderCreator: Codeunit "Subc. Purchase Order Creator";
     begin
         SubcPurchaseOrderCreator.InsertProdDescriptionOnAfterInsertPurchOrderLine(PurchaseLine, RequisitionLine);
-        SubcPurchaseOrderCreator.TransferSubcontractingProdOrderComp(PurchaseLine, RequisitionLine, NextLineNo);
     end;
 }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcReqWkshMakeOrd.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcReqWkshMakeOrd.Codeunit.al
@@ -18,12 +18,14 @@ codeunit 99001516 "Subc. Req. Wksh. Make Ord."
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Req. Wksh.-Make Order", OnInsertPurchOrderLineOnAfterCheckInsertFinalizePurchaseOrderHeader, '', false, false)]
     local procedure OnInsertPurchOrderLineOnAfterCheckInsertFinalizePurchaseOrderHeader(var RequisitionLine: Record "Requisition Line"; var PurchaseHeader: Record "Purchase Header"; var NextLineNo: Integer)
     var
-        AdditionallyPurchaseLine: Record "Purchase Line";
+        PurchaseLineWithService: Record "Purchase Line";
         SubcPurchaseOrderCreator: Codeunit "Subc. Purchase Order Creator";
     begin
-        AdditionallyPurchaseLine."Document Type" := PurchaseHeader."Document Type";
-        AdditionallyPurchaseLine."Document No." := PurchaseHeader."No.";
-        SubcPurchaseOrderCreator.TransferSubcontractingProdOrderComp(AdditionallyPurchaseLine, RequisitionLine, NextLineNo);
+        if RequisitionLine."Prod. Order No." = '' then
+            exit;
+        PurchaseLineWithService."Document Type" := PurchaseHeader."Document Type";
+        PurchaseLineWithService."Document No." := PurchaseHeader."No.";
+        SubcPurchaseOrderCreator.TransferSubcontractingProdOrderComp(PurchaseLineWithService, RequisitionLine, NextLineNo);
     end;
 
     local procedure HandleSubcontractingAfterPurchOrderLineInsert(var PurchaseLine: Record "Purchase Line"; var RequisitionLine: Record "Requisition Line")

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -378,7 +378,7 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         LibraryManufacturing.CreateProductionBOMLine(
             ProductionBOMHeader, ProductionBOMLine, '', ProductionBOMLine.Type::Item, ComponentItem."No.", 1);
         ProductionBOMLine.Validate("Routing Link Code", RoutingLink.Code);
-        ProductionBOMLine."Subcontracting Type" := "Subcontracting Type"::Purchase;
+        ProductionBOMLine.Validate("Subcontracting Type", "Subcontracting Type"::Purchase);
         ProductionBOMLine.Modify(true);
         ProductionBOMHeader.Validate(Status, ProductionBOMHeader.Status::Certified);
         ProductionBOMHeader.Modify(true);
@@ -436,12 +436,16 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         ItemLedgerEntry.SetRange("Item No.", ComponentItem."No.");
         ItemLedgerEntry.SetRange("Entry Type", ItemLedgerEntry."Entry Type"::Purchase);
         Assert.RecordIsNotEmpty(ItemLedgerEntry);
+        ItemLedgerEntry.FindFirst();
+        ItemLedgerEntry.TestField(Quantity, Qty);
 
         // [THEN] Component has a negative consumption ILE (backward flushing)
         ItemLedgerEntry.Reset();
         ItemLedgerEntry.SetRange("Item No.", ComponentItem."No.");
         ItemLedgerEntry.SetRange("Entry Type", ItemLedgerEntry."Entry Type"::Consumption);
         Assert.RecordIsNotEmpty(ItemLedgerEntry);
+        ItemLedgerEntry.FindFirst();
+        ItemLedgerEntry.TestField(Quantity, -Qty);
 
         // [THEN] Net inventory of component is zero (received and consumed via backward flushing)
         ComponentItem.CalcFields(Inventory);

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -7,10 +7,12 @@ namespace Microsoft.Manufacturing.Subcontracting.Test;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Setup;
 using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Ledger;
 using Microsoft.Inventory.Location;
 using Microsoft.Inventory.Tracking;
 using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
+using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.Setup;
 using Microsoft.Manufacturing.Subcontracting;
@@ -44,6 +46,7 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         LibraryWarehouse: Codeunit "Library - Warehouse";
         LibraryMfgManagement: Codeunit "Subc. Library Mfg. Management";
         SubcontractingMgmtLibrary: Codeunit "Subc. Management Library";
+        SubcWarehouseLibrary: Codeunit "Subc. Warehouse Library";
         SubSetupLibrary: Codeunit "Subc. Setup Library";
         IsInitialized: Boolean;
         ErrorCounter: Integer;
@@ -308,6 +311,143 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
             'Item tracking lines page must open for a non-subcontracting purchase line');
     end;
 
+    [Test]
+    [HandlerFunctions('DoConfirmCreateProdOrderForSubcontractingProcess')]
+    procedure PostSubcontPurchOrder_PurchWithService_BackwardFlush()
+    var
+        ComponentItem: Record Item;
+        FinishedItem: Record Item;
+        ItemLedgerEntry: Record "Item Ledger Entry";
+        Location, HomeLocation : Record Location;
+        ProdOrderRtngLine: Record "Prod. Order Routing Line";
+        ProductionBOMHeader: Record "Production BOM Header";
+        ProductionBOMLine: Record "Production BOM Line";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        RoutingLink: Record "Routing Link";
+        Vendor: Record Vendor;
+        WorkCenter: Record "Work Center";
+        ReleasedProdOrderRtng: TestPage "Prod. Order Routing";
+        Qty: Decimal;
+    begin
+        // [SCENARIO] When posting a subcontracting purchase order where the BOM has a component
+        // with Subcontracting Type = "Purchase with Service" and Flushing Method = Backward,
+        // the component is consumed via backward flushing when the output is posted.
+        // BOM: 1 component item (Subcontracting Type = Purchase with Service, linked to Routing Line 100).
+        // Routing: 1 subcontracting line (Operation 100).
+        // Purchase order has 2 lines: Finished Good (output) + Component (Purchase with Service).
+        // After posting the purchase order:
+        // - Finished good gets positive output ILE.
+        // - Component gets positive purchase receipt ILE AND negative consumption ILE (backward flushing).
+        // - Net component inventory = 0.
+        Initialize();
+
+        // [GIVEN] A subcontracting work center with vendor and location
+        CreateAndCalculateNeededWorkCenter(WorkCenter, true);
+        Vendor.Get(WorkCenter."Subcontractor No.");
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(Location);
+        Vendor."Subcontr. Location Code" := Location.Code;
+        Vendor.Modify();
+
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(HomeLocation);
+
+        // [GIVEN] A routing with a single subcontracting line (Operation 100)
+        LibraryManufacturing.CreateRoutingHeader(RoutingHeader, RoutingHeader.Type::Serial);
+        LibraryManufacturing.CreateRoutingLineSetup(
+            RoutingLine, RoutingHeader, WorkCenter."No.", '100',
+            LibraryRandom.RandInt(5), LibraryRandom.RandInt(5));
+
+        // [GIVEN] A routing link connecting BOM component to routing line
+        LibraryManufacturing.CreateRoutingLink(RoutingLink);
+        RoutingLine.Validate("Routing Link Code", RoutingLink.Code);
+        RoutingLine.Modify(true);
+
+        RoutingHeader.Validate(Status, RoutingHeader.Status::Certified);
+        RoutingHeader.Modify(true);
+
+        // [GIVEN] A component item with Flushing Method = Backward
+        LibraryManufacturing.CreateItemManufacturing(
+            ComponentItem, "Costing Method"::FIFO, LibraryRandom.RandInt(10),
+            "Reordering Policy"::"Lot-for-Lot", "Flushing Method"::Backward, '', '');
+
+        // [GIVEN] A production BOM with one component, Subcontracting Type = Purchase with Service
+        LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, ComponentItem."Base Unit of Measure");
+        LibraryManufacturing.CreateProductionBOMLine(
+            ProductionBOMHeader, ProductionBOMLine, '', ProductionBOMLine.Type::Item, ComponentItem."No.", 1);
+        ProductionBOMLine.Validate("Routing Link Code", RoutingLink.Code);
+        ProductionBOMLine."Subcontracting Type" := "Subcontracting Type"::Purchase;
+        ProductionBOMLine.Modify(true);
+        ProductionBOMHeader.Validate(Status, ProductionBOMHeader.Status::Certified);
+        ProductionBOMHeader.Modify(true);
+
+        // [GIVEN] A finished good item with the routing and production BOM
+        LibraryManufacturing.CreateItemManufacturing(
+            FinishedItem, "Costing Method"::FIFO, LibraryRandom.RandInt(10),
+            "Reordering Policy"::"Lot-for-Lot", "Flushing Method"::"Pick + Manual",
+            RoutingHeader."No.", ProductionBOMHeader."No.");
+
+        // [GIVEN] A released production order
+        Qty := LibraryRandom.RandInt(10) + 5;
+        SubcWarehouseLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released,
+            ProductionOrder."Source Type"::Item, FinishedItem."No.", Qty, HomeLocation.Code);
+
+        // [GIVEN] Requisition worksheet template for subcontracting
+        LibraryMfgManagement.CreateLaborReqWkshTemplateAndNameAndUpdateSetup();
+
+        // [WHEN] Create subcontracting purchase order from Prod. Order Routing
+        ProdOrderRtngLine.SetRange("Routing No.", RoutingHeader."No.");
+        ProdOrderRtngLine.SetRange("Work Center No.", WorkCenter."No.");
+        ProdOrderRtngLine.FindFirst();
+
+        ReleasedProdOrderRtng.OpenView();
+        ReleasedProdOrderRtng.GoToRecord(ProdOrderRtngLine);
+        ReleasedProdOrderRtng.CreateSubcontracting.Invoke();
+
+        // [WHEN] Post the purchase order (receive)
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+
+        PurchaseLine.Reset();
+        PurchaseLine.SetRange("Document Type", PurchaseHeader."Document Type");
+        PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
+        PurchaseLine.SetRange(Type, PurchaseLine.Type::Item);
+        if PurchaseLine.FindSet() then
+            repeat
+                EnsureGeneralPostingSetupIsValid(PurchaseLine."Gen. Bus. Posting Group", PurchaseLine."Gen. Prod. Posting Group");
+            until PurchaseLine.Next() = 0;
+
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+
+        // [THEN] Finished good has a positive output ILE
+        ItemLedgerEntry.SetRange("Item No.", FinishedItem."No.");
+        ItemLedgerEntry.SetRange("Entry Type", ItemLedgerEntry."Entry Type"::Output);
+        Assert.RecordIsNotEmpty(ItemLedgerEntry);
+        ItemLedgerEntry.FindFirst();
+        ItemLedgerEntry.TestField(Quantity, Qty);
+
+        // [THEN] Component has a positive purchase receipt ILE
+        ItemLedgerEntry.Reset();
+        ItemLedgerEntry.SetRange("Item No.", ComponentItem."No.");
+        ItemLedgerEntry.SetRange("Entry Type", ItemLedgerEntry."Entry Type"::Purchase);
+        Assert.RecordIsNotEmpty(ItemLedgerEntry);
+
+        // [THEN] Component has a negative consumption ILE (backward flushing)
+        ItemLedgerEntry.Reset();
+        ItemLedgerEntry.SetRange("Item No.", ComponentItem."No.");
+        ItemLedgerEntry.SetRange("Entry Type", ItemLedgerEntry."Entry Type"::Consumption);
+        Assert.RecordIsNotEmpty(ItemLedgerEntry);
+
+        // [THEN] Net inventory of component is zero (received and consumed via backward flushing)
+        ComponentItem.CalcFields(Inventory);
+        Assert.AreEqual(0, ComponentItem.Inventory, 'Component inventory should be zero after backward flushing.');
+    end;
+
     [ModalPageHandler]
     procedure ItemTrackingLinesSimpleHandler(var ItemTrackingLines: TestPage "Item Tracking Lines")
     begin
@@ -422,5 +562,24 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         EsMgmtSetup.Get();
         EsMgmtSetup."Rtng. Link Code Purch. Prov." := RtngLink;
         EsMgmtSetup.Modify();
+    end;
+
+    local procedure EnsureGeneralPostingSetupIsValid(GenBusPostingGroup: Code[20]; GenProdPostingGroup: Code[20])
+    var
+        GeneralPostingSetup: Record "General Posting Setup";
+    begin
+        if GeneralPostingSetup.Get(GenBusPostingGroup, GenProdPostingGroup) then begin
+            if GeneralPostingSetup.Blocked then begin
+                GeneralPostingSetup.Blocked := false;
+                GeneralPostingSetup.Modify();
+            end;
+            exit;
+        end;
+
+        GeneralPostingSetup.Init();
+        GeneralPostingSetup."Gen. Bus. Posting Group" := GenBusPostingGroup;
+        GeneralPostingSetup."Gen. Prod. Posting Group" := GenProdPostingGroup;
+        GeneralPostingSetup.Insert();
+        GeneralPostingSetup.SuggestSetupAccounts();
     end;
 }


### PR DESCRIPTION
* <!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This pull request introduces a new automated test for subcontracting purchase orders with backward flushing and includes related utility improvements and minor refactoring in the manufacturing and subcontracting modules.

### New test scenario for backward flushing in subcontracting

* Added the `PostSubcontPurchOrder_PurchWithService_BackwardFlush` test to `SubcPurchSubcontTest.Codeunit.al`, which verifies that when posting a subcontracting purchase order for a BOM component with Subcontracting Type "Purchase with Service" and Flushing Method "Backward," the component is both received and consumed correctly, resulting in zero net inventory.

* Introduced the `EnsureGeneralPostingSetupIsValid` local procedure to ensure that the required general posting setup exists and is unblocked before posting purchase documents in tests.

### Refactoring and event handling

* Refactored the handling of subcontracting purchase order line insertion in `SubcReqWkshMakeOrd.Codeunit.al` by removing the `NextLineNo` parameter from `HandleSubcontractingAfterPurchOrderLineInsert` and adding a new event subscriber for `OnInsertPurchOrderLineOnAfterCheckInsertFinalizePurchaseOrderHeader` to ensure proper transfer of subcontracting production order components.
* 
#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#631232](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/631232)






