### PR TITLE
[28.0][Agent] Expose CurrentUserHasCanManageAllAgentsPermission

### DIFF
--- a/src/System Application/App/Agent/Permissions/AgentSystemPermissions.Codeunit.al
+++ b/src/System Application/App/Agent/Permissions/AgentSystemPermissions.Codeunit.al
@@ -14,7 +14,6 @@ codeunit 4317 "Agent System Permissions"
     /// Gets whether the current user has permissions to manage all agents.
     /// </summary>
     /// <returns>True if the user has permissions to manage all agents, false otherwise.</returns>
-    [Scope('OnPrem')]
     procedure CurrentUserHasCanManageAllAgentsPermission(): Boolean
     begin
         exit("Agent System Permissions Impl.".CurrentUserHasCanManageAllAgentsPermission());


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Expose method to allow AL devs to easily see if a user is an agent admin or not.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#631411](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/631411)


