### PR TITLE
[Bug]: E-Documents: Basic info from purchase credit memo: Order No. i…

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Format/EDocImportPEPPOLBIS30.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Format/EDocImportPEPPOLBIS30.Codeunit.al
@@ -104,6 +104,8 @@ codeunit 6166 "EDoc Import PEPPOL BIS 3.0"
         Evaluate(EDocument."Amount Excl. VAT", GetNodeByPath(TempXMLBuffer, RootPath + '/cac:LegalMonetaryTotal/cbc:TaxExclusiveAmount'), 9);
         Evaluate(EDocument."Amount Incl. VAT", GetNodeByPath(TempXMLBuffer, RootPath + '/cac:LegalMonetaryTotal/cbc:PayableAmount'), 9);
 
+        EDocument."Order No." := CopyStr(GetNodeByPath(TempXMLBuffer, RootPath + '/cac:OrderReference/cbc:ID'), 1, MaxStrLen(EDocument."Order No."));
+
         Currency := CopyStr(GetNodeByPath(TempXMLBuffer, RootPath + '/cbc:DocumentCurrencyCode'), 1, MaxStrLen(EDocument."Currency Code"));
         if LCYCode <> Currency then
             EDocument."Currency Code" := Currency;


### PR DESCRIPTION
In E-documents, when importing an purchase invoice the field"Order No. is filled with the tag "/Invoice/cac:OrderReference/cbc:ID".
When importing a purchase credit memo, this field stays empty.
See the procedures "ParseInvoiceBasicInfo" and "ParseCreditMemoBasicInfo" in codeunit "EDoc Import PEPPOL BIS 3.0" in E-Document Core.

Fixes #7746
Fixes [AB#631976](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/631976)