### PR TITLE
[releases/27.5][Shopify] Sync tax registration ID from Shopify company to BC customer

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Companies/Codeunits/ShpfyTaxRegistrationNo.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Companies/Codeunits/ShpfyTaxRegistrationNo.Codeunit.al
@@ -23,4 +23,10 @@ codeunit 30367 "Shpfy Tax Registration No." implements "Shpfy Tax Registration I
     begin
         Customer.SetRange("Registration Number", CompanyLocation."Tax Registration Id");
     end;
+
+    procedure UpdateTaxRegistrationId(var Customer: Record Customer; NewTaxRegistrationId: Text[150])
+    begin
+        Customer.Validate("Registration Number", CopyStr(NewTaxRegistrationId, 1, MaxStrLen(Customer."Registration Number")));
+        Customer.Modify(true);
+    end;
 }

--- a/src/Apps/W1/Shopify/App/src/Companies/Codeunits/ShpfyVATRegistrationNo.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Companies/Codeunits/ShpfyVATRegistrationNo.Codeunit.al
@@ -23,4 +23,10 @@ codeunit 30368 "Shpfy VAT Registration No." implements "Shpfy Tax Registration I
     begin
         Customer.SetRange("VAT Registration No.", CompanyLocation."Tax Registration Id");
     end;
+
+    procedure UpdateTaxRegistrationId(var Customer: Record Customer; NewTaxRegistrationId: Text[150])
+    begin
+        Customer.Validate("VAT Registration No.", CopyStr(NewTaxRegistrationId, 1, MaxStrLen(Customer."VAT Registration No.")));
+        Customer.Modify(true);
+    end;
 }

--- a/src/Apps/W1/Shopify/App/src/Companies/Interfaces/ShpfyTaxRegistrationIdMapping.Interface.al
+++ b/src/Apps/W1/Shopify/App/src/Companies/Interfaces/ShpfyTaxRegistrationIdMapping.Interface.al
@@ -25,4 +25,13 @@ interface "Shpfy Tax Registration Id Mapping"
     /// <param name="Customer">Customer record</param>
     /// <param name="CompanyLocation">Company location record</param>
     procedure SetMappingFiltersForCustomers(var Customer: Record Customer; CompanyLocation: Record "Shpfy Company Location");
+
+#pragma warning disable AS0066
+    /// <summary>
+    /// Updates the tax registration id for the customer.
+    /// </summary>
+    /// <param name="Customer">Customer record</param>
+    /// <param name="NewTaxRegistrationId">New tax registration id</param>
+    procedure UpdateTaxRegistrationId(var Customer: Record Customer; NewTaxRegistrationId: Text[150]);
+#pragma warning restore AS0066
 }

--- a/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCreateCustomer.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCreateCustomer.Codeunit.al
@@ -122,6 +122,7 @@ codeunit 30110 "Shpfy Create Customer"
         CustomerTemplMgt: Codeunit "Customer Templ. Mgt.";
         UpdateCustomer: Codeunit "Shpfy Update Customer";
         ICounty: Interface "Shpfy ICounty";
+        ITaxRegistrationIdMapping: Interface "Shpfy Tax Registration Id Mapping";
         CountryCode: Code[20];
         CurrentTemplateCode: Code[20];
         IsHandled: Boolean;
@@ -169,6 +170,9 @@ codeunit 30110 "Shpfy Create Customer"
 
         if CompanyLocation."Shpfy Payment Terms Id" <> 0 then
             Customer.Validate("Payment Terms Code", UpdateCustomer.GetPaymentTermsCodeFromShopifyPaymentTermsId(CompanyLocation."Shpfy Payment Terms Id"));
+
+        ITaxRegistrationIdMapping := Shop."Shpfy Comp. Tax Id Mapping";
+        ITaxRegistrationIdMapping.UpdateTaxRegistrationId(Customer, CompanyLocation."Tax Registration Id");
 
         Customer.Modify();
 

--- a/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyUpdateCustomer.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyUpdateCustomer.Codeunit.al
@@ -134,6 +134,7 @@ codeunit 30124 "Shpfy Update Customer"
         CompanyLocation: Record "Shpfy Company Location";
         ShopifyTaxArea: Record "Shpfy Tax Area";
         ICounty: Interface "Shpfy ICounty";
+        ITaxRegistrationIdMapping: Interface "Shpfy Tax Registration Id Mapping";
     begin
         if not Customer.GetBySystemId(ShopifyCompany."Customer SystemId") then
             exit;
@@ -172,6 +173,9 @@ codeunit 30124 "Shpfy Update Customer"
 
         if CompanyLocation."Shpfy Payment Terms Id" <> 0 then
             Customer.Validate("Payment Terms Code", GetPaymentTermsCodeFromShopifyPaymentTermsId(CompanyLocation."Shpfy Payment Terms Id"));
+
+        ITaxRegistrationIdMapping := Shop."Shpfy Comp. Tax Id Mapping";
+        ITaxRegistrationIdMapping.UpdateTaxRegistrationId(Customer, CompanyLocation."Tax Registration Id");
 
         Customer.Modify();
     end;

--- a/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyImportTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyImportTest.Codeunit.al
@@ -5,10 +5,11 @@
 
 namespace Microsoft.Integration.Shopify.Test;
 
-using Microsoft.Integration.Shopify;
-using System.TestLibraries.Utilities;
-using Microsoft.Sales.Customer;
+using Microsoft.Foundation.Company;
 using Microsoft.Foundation.PaymentTerms;
+using Microsoft.Integration.Shopify;
+using Microsoft.Sales.Customer;
+using System.TestLibraries.Utilities;
 
 codeunit 139647 "Shpfy Company Import Test"
 {
@@ -19,6 +20,7 @@ codeunit 139647 "Shpfy Company Import Test"
     var
         Shop: Record "Shpfy Shop";
         LibraryAssert: Codeunit "Library Assert";
+        LibraryERM: Codeunit "Library - ERM";
         Any: Codeunit Any;
         InitializeTest: Codeunit "Shpfy Initialize Test";
         IsInitialized: Boolean;
@@ -146,6 +148,80 @@ codeunit 139647 "Shpfy Company Import Test"
         LibraryAssert.AreEqual(Customer."Payment Terms Code", PaymentTermsCode, 'Payment Terms Code');
     end;
 
+    [Test]
+    procedure UnitTestCreateCustomerFromCompanyWithRegistrationNo()
+    var
+        Customer: Record Customer;
+        TempShopifyCustomer: Record "Shpfy Customer" temporary;
+        ShopifyCompany: Record "Shpfy Company";
+        CompanyLocation: Record "Shpfy Company Location";
+        CreateCustomer: Codeunit "Shpfy Create Customer";
+        TaxRegistrationId: Text[150];
+        EmptyGuid: Guid;
+    begin
+        // [SCENARIO] Create a customer from a company with location with Tax Registration Id using Registration No. mapping.
+        Initialize();
+
+        // [GIVEN] Tax Registration Id
+        TaxRegistrationId := CopyStr(Any.AlphanumericText(20), 1, MaxStrLen(TaxRegistrationId));
+        // [GIVEN] Shop with Tax Id Mapping set to "Registration No."
+        Shop."Shpfy Comp. Tax Id Mapping" := Enum::"Shpfy Comp. Tax Id Mapping"::"Registration No.";
+        Shop.Modify(false);
+        // [GIVEN] Shopify Company
+        CreateCompany(ShopifyCompany, EmptyGuid);
+        // [GIVEN] Company Location with Tax Registration Id
+        CreateCompanyLocationWithTaxId(CompanyLocation, ShopifyCompany, TaxRegistrationId);
+        // [GIVEN] TempShopifyCustomer
+        CreateTempShopifyCustomer(TempShopifyCustomer);
+
+        // [WHEN] Invoke CreateCustomerFromCompany
+        CreateCustomer.SetShop(Shop);
+        CreateCustomer.SetTemplateCode(Shop."Customer Templ. Code");
+        CreateCustomer.CreateCustomerFromCompany(ShopifyCompany, TempShopifyCustomer);
+
+        // [THEN] Customer record is created with the correct Registration Number.
+        Customer.GetBySystemId(ShopifyCompany."Customer SystemId");
+        LibraryAssert.AreEqual(TaxRegistrationId, Customer."Registration Number", 'Registration Number');
+    end;
+
+    [Test]
+    procedure UnitTestCreateCustomerFromCompanyWithVATRegistrationNo()
+    var
+        CompanyInformation: Record "Company Information";
+        Customer: Record Customer;
+        TempShopifyCustomer: Record "Shpfy Customer" temporary;
+        ShopifyCompany: Record "Shpfy Company";
+        CompanyLocation: Record "Shpfy Company Location";
+        CreateCustomer: Codeunit "Shpfy Create Customer";
+        TaxRegistrationId: Text[150];
+        EmptyGuid: Guid;
+    begin
+        // [SCENARIO] Create a customer from a company with location with Tax Registration Id using VAT Registration No. mapping.
+        Initialize();
+
+        // [GIVEN] Tax Registration Id
+        CompanyInformation.Get();
+        TaxRegistrationId := LibraryERM.GenerateVATRegistrationNo(CompanyInformation."Country/Region Code");
+        // [GIVEN] Shop with Tax Id Mapping set to "VAT Registration No."
+        Shop."Shpfy Comp. Tax Id Mapping" := Enum::"Shpfy Comp. Tax Id Mapping"::"VAT Registration No.";
+        Shop.Modify(false);
+        // [GIVEN] Shopify Company
+        CreateCompany(ShopifyCompany, EmptyGuid);
+        // [GIVEN] Company Location with Tax Registration Id
+        CreateCompanyLocationWithTaxId(CompanyLocation, ShopifyCompany, TaxRegistrationId);
+        // [GIVEN] TempShopifyCustomer
+        CreateTempShopifyCustomer(TempShopifyCustomer);
+
+        // [WHEN] Invoke CreateCustomerFromCompany
+        CreateCustomer.SetShop(Shop);
+        CreateCustomer.SetTemplateCode(Shop."Customer Templ. Code");
+        CreateCustomer.CreateCustomerFromCompany(ShopifyCompany, TempShopifyCustomer);
+
+        // [THEN] Customer record is created with the correct VAT Registration No.
+        Customer.GetBySystemId(ShopifyCompany."Customer SystemId");
+        LibraryAssert.AreEqual(TaxRegistrationId, Customer."VAT Registration No.", 'VAT Registration No.');
+    end;
+
     local procedure Initialize()
     begin
         Any.SetDefaultSeed();
@@ -201,6 +277,18 @@ codeunit 139647 "Shpfy Company Import Test"
         CompanyLocation."Company SystemId" := ShopifyCompany.SystemId;
         CompanyLocation.Id := Any.IntegerInRange(10000, 99999);
         CompanyLocation."Shpfy Payment Terms Id" := PaymentTermsId;
+        CompanyLocation.Insert(false);
+
+        ShopifyCompany."Location Id" := CompanyLocation.Id;
+        ShopifyCompany.Modify(false);
+    end;
+
+    local procedure CreateCompanyLocationWithTaxId(var CompanyLocation: Record "Shpfy Company Location"; var ShopifyCompany: Record "Shpfy Company"; TaxRegistrationId: Text[150])
+    begin
+        CompanyLocation.Init();
+        CompanyLocation."Company SystemId" := ShopifyCompany.SystemId;
+        CompanyLocation.Id := Any.IntegerInRange(10000, 99999);
+        CompanyLocation."Tax Registration Id" := TaxRegistrationId;
         CompanyLocation.Insert(false);
 
         ShopifyCompany."Location Id" := CompanyLocation.Id;

--- a/src/Apps/W1/Shopify/Test/Companies/ShpfyTaxIdMappingTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Companies/ShpfyTaxIdMappingTest.Codeunit.al
@@ -5,6 +5,7 @@
 
 namespace Microsoft.Integration.Shopify.Test;
 
+using Microsoft.Foundation.Company;
 using Microsoft.Integration.Shopify;
 using System.TestLibraries.Utilities;
 using Microsoft.Sales.Customer;
@@ -17,6 +18,7 @@ codeunit 134246 "Shpfy Tax Id Mapping Test"
     var
         Any: Codeunit Any;
         LibraryAssert: Codeunit "Library Assert";
+        LibraryERM: Codeunit "Library - ERM";
         IsInitialized: Boolean;
 
     trigger OnRun()
@@ -128,6 +130,57 @@ codeunit 134246 "Shpfy Tax Id Mapping Test"
         LibraryAssert.AreEqual(VATRegistrationNo, Customer.GetFilter("VAT Registration No."), 'VAT Registration No. filter is not set correctly.');
     end;
 
+    [Test]
+    procedure UnitTestUpdateTaxRegistrationIdForRegistrationNo()
+    var
+        Customer: Record Customer;
+        TaxRegistrationIdMapping: Interface "Shpfy Tax Registration Id Mapping";
+        NewTaxRegistrationId: Text[150];
+    begin
+        // [SCENARIO] UpdateTaxRegistrationId for Registration No. implementation of mapping
+        Initialize();
+
+        // [GIVEN] New Tax Registration Id
+        NewTaxRegistrationId := CopyStr(Any.AlphanumericText(20), 1, MaxStrLen(NewTaxRegistrationId));
+        // [GIVEN] Customer with empty Registration Number
+        CreateCustomerWithRegistrationNo(Customer, '');
+        // [GIVEN] TaxRegistrationIdMapping interface is "Registration No."
+        TaxRegistrationIdMapping := Enum::"Shpfy Comp. Tax Id Mapping"::"Registration No.";
+
+        // [WHEN] UpdateTaxRegistrationId is called
+        TaxRegistrationIdMapping.UpdateTaxRegistrationId(Customer, NewTaxRegistrationId);
+
+        // [THEN] The Registration Number field of the Customer record is updated
+        Customer.Get(Customer."No.");
+        LibraryAssert.AreEqual(NewTaxRegistrationId, Customer."Registration Number", 'Registration Number should be updated.');
+    end;
+
+    [Test]
+    procedure UnitTestUpdateTaxRegistrationIdForVATRegistrationNo()
+    var
+        CompanyInformation: Record "Company Information";
+        Customer: Record Customer;
+        TaxRegistrationIdMapping: Interface "Shpfy Tax Registration Id Mapping";
+        NewTaxRegistrationId: Text[150];
+    begin
+        // [SCENARIO] UpdateTaxRegistrationId for VAT Registration No. implementation of mapping
+        Initialize();
+
+        // [GIVEN] New Tax Registration Id
+        CompanyInformation.Get();
+        NewTaxRegistrationId := LibraryERM.GenerateVATRegistrationNo(CompanyInformation."Country/Region Code");
+        // [GIVEN] Customer with empty VAT Registration No.
+        CreateCustomerWithVATRegNo(Customer, '');
+        // [GIVEN] TaxRegistrationIdMapping interface is "VAT Registration No."
+        TaxRegistrationIdMapping := Enum::"Shpfy Comp. Tax Id Mapping"::"VAT Registration No.";
+
+        // [WHEN] UpdateTaxRegistrationId is called
+        TaxRegistrationIdMapping.UpdateTaxRegistrationId(Customer, NewTaxRegistrationId);
+
+        // [THEN] The VAT Registration No. field of the Customer record is updated
+        Customer.Get(Customer."No.");
+        LibraryAssert.AreEqual(NewTaxRegistrationId, Customer."VAT Registration No.", 'VAT Registration No. should be updated.');
+    end;
 
     local procedure Initialize()
     begin


### PR DESCRIPTION
Backport of #5966 to `releases/27.5`.

### Summary
When creating or updating a BC Customer from a Shopify Company, the Tax Registration ID from the Company Location is now automatically synced to the Customer record based on the shop's tax ID mapping configuration.

### Changes

#### Feature Implementation
- **Interface**: Added `UpdateTaxRegistrationId` method to `Shpfy Tax Registration Id Mapping` interface
- **Registration No. mapping**: Updates `Customer."Registration Number"` field
- **VAT Registration No. mapping**: Updates `Customer."VAT Registration No."` field (with automatic truncation to field max length)

#### Integration Points
- `Shpfy Create Customer`: Now calls `UpdateTaxRegistrationId` when creating a customer from a company
- `Shpfy Update Customer`: Now calls `UpdateTaxRegistrationId` when updating a customer from a company

#### Work Item(s)
Fixes [AB#631801](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/631801)

