### PR TITLE
[E-Document] Fix historical matching and capability registration

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/AI/EDocAIToolProcessor.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/AI/EDocAIToolProcessor.Codeunit.al
@@ -5,6 +5,7 @@
 namespace Microsoft.eServices.EDocument.Processing.AI;
 
 using System.AI;
+using System.Environment;
 using System.Environment.Configuration;
 using System.Globalization;
 using System.Telemetry;
@@ -39,6 +40,8 @@ codeunit 6195 "E-Doc. AI Tool Processor"
         CopilotCapability: Codeunit "Copilot Capability";
     begin
         Clear(TelemetryDimensions);
+
+        RegisterCapabilityIfNeeded();
 
         if not CopilotCapability.IsCapabilityRegistered(Enum::"Copilot Capability"::"E-Document Matching Assistance") then
             exit(false);
@@ -209,6 +212,18 @@ codeunit 6195 "E-Doc. AI Tool Processor"
     local procedure LogError(EventName: Text; ErrorMessage: Text)
     begin
         FeatureTelemetry.LogError('0000PUI', AISystem.GetFeatureName(), EventName, ErrorMessage, '', TelemetryDimensions);
+    end;
+
+    local procedure RegisterCapabilityIfNeeded()
+    var
+        CopilotCapability: Codeunit "Copilot Capability";
+        EnvironmentInformation: Codeunit "Environment Information";
+        LearnMoreUrlTxt: Label 'https://go.microsoft.com/fwlink/?linkid=2262630', Locked = true;
+    begin
+        if not EnvironmentInformation.IsSaaSInfrastructure() then
+            exit;
+        if not CopilotCapability.IsCapabilityRegistered(Enum::"Copilot Capability"::"E-Document Matching Assistance") then
+            CopilotCapability.RegisterCapability(Enum::"Copilot Capability"::"E-Document Matching Assistance", LearnMoreUrlTxt);
     end;
 
     local procedure GetDefaultMaxInputTokens(): Integer

--- a/src/Apps/W1/EDocument/App/src/Processing/AI/Tools/EDocHistoricalMatching.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/AI/Tools/EDocHistoricalMatching.Codeunit.al
@@ -220,6 +220,7 @@ codeunit 6177 "E-Doc. Historical Matching" implements "AOAI Function", IEDocAISy
     var
         PurchInvLine: Record "Purch. Inv. Line";
         AllocationAccount: Record "Allocation Account";
+        EDocPurchaseLineHistory: Record "E-Doc. Purchase Line History";
         FeatureTelemetry: Codeunit "Feature Telemetry";
         OneYearAgoDate: Date;
         RecordCount: Integer;
@@ -252,6 +253,18 @@ codeunit 6177 "E-Doc. Historical Matching" implements "AOAI Function", IEDocAISy
                 RecordCount += 1;
             until (PurchInvLine.Next() = 0) or (RecordCount >= MaxHistoricalRecords);
         end;
+
+        // Enrich temp records with product codes from e-document history
+        EDocPurchaseLineHistory.SetCurrentKey("Vendor No.", "Product Code");
+        EDocPurchaseLineHistory.SetRange("Vendor No.", VendorNo);
+        EDocPurchaseLineHistory.SetFilter("Product Code", '<>%1', '');
+        if EDocPurchaseLineHistory.FindSet() then
+            repeat
+                if TempPurchInvLine.GetBySystemId(EDocPurchaseLineHistory."Purch. Inv. Line SystemId") then begin
+                    TempPurchInvLine."Vendor Item No." := CopyStr(EDocPurchaseLineHistory."Product Code", 1, MaxStrLen(TempPurchInvLine."Vendor Item No."));
+                    TempPurchInvLine.Modify();
+                end;
+            until EDocPurchaseLineHistory.Next() = 0;
 
         ElapsedTime := CurrentDateTime() - StartTime;
         TelemetryDimensions.Add('Records loaded', Format(RecordCount));
@@ -320,7 +333,7 @@ codeunit 6177 "E-Doc. Historical Matching" implements "AOAI Function", IEDocAISy
         TempPurchInvLine.Reset();
         case MatchType of
             ProductCodeTok:
-                TempPurchInvLine.SetRange("No.", SearchValue);
+                TempPurchInvLine.SetRange("Vendor Item No.", CopyStr(SearchValue, 1, MaxStrLen(TempPurchInvLine."Vendor Item No.")));
             DescriptionTok:
                 TempPurchInvLine.SetRange(Description, SearchValue);
             'Similar Description':

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/PrepareDraft/EDocPreparePurchDraft.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/PrepareDraft/EDocPreparePurchDraft.Codeunit.al
@@ -142,7 +142,7 @@ codeunit 6406 "EDoc Prepare Purch. Draft"
     var
         EDocumentPurchaseLine: Record "E-Document Purchase Line";
     begin
-        EDocumentPurchaseLine.SetLoadFields("E-Document Entry No.", "[BC] Purchase Type No.", "[BC] Deferral Code");
+        EDocumentPurchaseLine.SetLoadFields("E-Document Entry No.", "[BC] Purchase Type No.", "[BC] Deferral Code", Description, "Product Code", Quantity, "Unit of Measure", "Unit Price");
         EDocumentPurchaseLine.ReadIsolation(IsolationLevel::ReadCommitted);
 
         EDocumentPurchaseLine.SetRange("E-Document Entry No.", EDocumentEntryNo);


### PR DESCRIPTION
Bug 631283: Fix three issues in e-document AI matching:

1. Register Copilot capability on-demand in SaaS if not already registered, preventing matching from silently failing.

2. Add missing fields to SetLoadFields in CopilotLineMatching (Description, Product Code, Quantity, Unit of Measure, Unit Price) so historical matching receives the data it needs.

3. Fix Product Code search in historical matching — was searching Purch. Inv. Line "No." (G/L Account) instead of the vendor's product code. Now enriches temp table with product codes from E-Doc. Purchase Line History during loading and searches "Vendor Item No." for the ProductCode match type.

Fixes [AB#631283](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/631283)



