### PR TITLE
Rest Client: use ContainsSecret when removing default request headers

### DIFF
--- a/src/System Application/App/Rest Client/src/RestClientImpl.Codeunit.al
+++ b/src/System Application/App/Rest Client/src/RestClientImpl.Codeunit.al
@@ -77,7 +77,7 @@ codeunit 2351 "Rest Client Impl."
     procedure SetDefaultRequestHeader(Name: Text; Value: Text)
     begin
         CheckInitialized();
-        if CurrHttpClientInstance.DefaultRequestHeaders.Contains(Name) then
+        if CurrHttpClientInstance.DefaultRequestHeaders.Contains(Name) or CurrHttpClientInstance.DefaultRequestHeaders.ContainsSecret(Name) then
             CurrHttpClientInstance.DefaultRequestHeaders.Remove(Name);
         CurrHttpClientInstance.DefaultRequestHeaders.Add(Name, Value);
     end;
@@ -85,7 +85,7 @@ codeunit 2351 "Rest Client Impl."
     procedure SetDefaultRequestHeader(Name: Text; Value: SecretText)
     begin
         CheckInitialized();
-        if CurrHttpClientInstance.DefaultRequestHeaders.Contains(Name) then
+        if CurrHttpClientInstance.DefaultRequestHeaders.Contains(Name) or CurrHttpClientInstance.DefaultRequestHeaders.ContainsSecret(Name) then
             CurrHttpClientInstance.DefaultRequestHeaders.Remove(Name);
         CurrHttpClientInstance.DefaultRequestHeaders.Add(Name, Value);
     end;

--- a/src/System Application/Test/Rest Client/src/RestClientTests.Codeunit.al
+++ b/src/System Application/Test/Rest Client/src/RestClientTests.Codeunit.al
@@ -490,6 +490,56 @@ codeunit 134971 "Rest Client Tests"
         Assert.AreEqual(MockRestClientService.GetGetUrl(), GetJsonToken(JsonObject, 'url').AsValue().AsText(), 'The response should contain the expected url');
     end;
 
+    [Test]
+    procedure TestSetAuthorizationHeaderTwice()
+    var
+        RestClient: Codeunit "Rest Client";
+    begin
+        // [SCENARIO] Calling SetAuthorizationHeader twice on the same instance must not throw an error
+
+        // [GIVEN] An initialized Rest Client
+        RestClient.Initialize();
+
+        // [WHEN] SetAuthorizationHeader is called a first time
+        RestClient.SetAuthorizationHeader(SecretStrSubstNo('Bearer %1', 'first-token'));
+
+        // [THEN] Calling SetAuthorizationHeader a second time replaces the header without error
+        RestClient.SetAuthorizationHeader(SecretStrSubstNo('Bearer %1', 'second-token'));
+    end;
+
+    [Test]
+    procedure TestSetDefaultRequestHeaderSecretTwice()
+    var
+        RestClient: Codeunit "Rest Client";
+    begin
+        // [SCENARIO] Calling SetDefaultRequestHeader with a SecretText value twice must not throw an error
+
+        // [GIVEN] An initialized Rest Client
+        RestClient.Initialize();
+
+        // [WHEN] A secret default request header is set a first time
+        RestClient.SetDefaultRequestHeader('X-Api-Key', SecretStrSubstNo('%1', 'key1'));
+
+        // [THEN] Setting the same header a second time replaces the value without error
+        RestClient.SetDefaultRequestHeader('X-Api-Key', SecretStrSubstNo('%1', 'key2'));
+    end;
+
+    [Test]
+    procedure TestSetDefaultRequestHeaderReplaceSecretWithText()
+    var
+        RestClient: Codeunit "Rest Client";
+    begin
+        // [SCENARIO] Replacing a secret default request header with a plain-text value must not throw an error
+
+        // [GIVEN] An initialized Rest Client with a secret header
+        RestClient.Initialize();
+        RestClient.SetDefaultRequestHeader('X-Custom', SecretStrSubstNo('%1', 'secret-value'));
+
+        // [WHEN] The same header is overwritten with a plain-text value
+        // [THEN] No error is thrown
+        RestClient.SetDefaultRequestHeader('X-Custom', 'plain-value');
+    end;
+
     local procedure GetResponseData(Url: Text; BodyJsonObject: JsonObject): Text
     var
         ResponseBodyText: Text;


### PR DESCRIPTION
Fixes #7581

## Summary

Calling `SetAuthorizationHeader` (or `SetDefaultRequestHeader`) twice on the same `Rest Client` instance throws `Invalid HTTP header. Please, make sure the format of the header is correct.` The root cause is that the `SecretText` overload of `SetDefaultRequestHeader` in codeunit 2351 "Rest Client Impl." uses `Contains()` to check for an existing header before removing it. `Contains()` only finds plain-text headers. When a header was previously stored as a `SecretText` value, `Contains()` returns false, the `Remove()` is skipped, and the subsequent `Add()` fails with a collision.

## Root Cause

`HttpHeaders.Contains(Name)` and `HttpHeaders.ContainsSecret(Name)` are separate checks. A header added with a `SecretText` value is invisible to `Contains()` and must be queried with `ContainsSecret()`.

The sibling codeunit `HttpRequestMessageImpl` (2349) in the same module already uses the correct combined check:

```al
if RequestHttpHeaders.Contains(HeaderName) or RequestHttpHeaders.ContainsSecret(HeaderName) then
    RequestHttpHeaders.Remove(HeaderName);
```

`SetDefaultRequestHeader` in `RestClientImpl` used only `Contains()`, missing the secret-header case.

## Fix

Apply the same `Contains(Name) or ContainsSecret(Name)` pattern to both overloads of `SetDefaultRequestHeader` in `RestClientImpl.Codeunit.al`.

The `Text` overload is also updated so that a secret header can be cleanly replaced by a plain-text header (symmetric fix).

## Files Changed

- `src/System Application/App/Rest Client/src/RestClientImpl.Codeunit.al` -- add `ContainsSecret` check to both overloads of `SetDefaultRequestHeader`
- `src/System Application/Test/Rest Client/src/RestClientTests.Codeunit.al` -- add three regression tests

## How to Test

**Reproduce the bug (before fix):**
```al
trigger OnAction()
var
    RestClient: Codeunit "Rest Client";
begin
    RestClient.Initialize();
    RestClient.SetAuthorizationHeader(SecretStrSubstNo('Bearer test'));
    RestClient.SetAuthorizationHeader(SecretStrSubstNo('Bearer test')); // throws before fix
end;
```

**After fix:** the code above completes without error.

The three new test procedures in `RestClientTests.Codeunit.al` cover:
1. `TestSetAuthorizationHeaderTwice` -- exact reproduction from the issue
2. `TestSetDefaultRequestHeaderSecretTwice` -- general `SecretText` overload called twice
3. `TestSetDefaultRequestHeaderReplaceSecretWithText` -- secret header replaced by plain-text header


