### PR TITLE
[QM] [28.X] Creating a re-inspection does not show a notification but opens a new inspection

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
@@ -479,13 +479,13 @@ page 20406 "Qlty. Inspection"
 
                 trigger OnAction()
                 var
-                    CreatedReinspectionHeader: Record "Qlty. Inspection Header";
+                    ReinspectionQltyInspectionHeader: Record "Qlty. Inspection Header";
                 begin
-                    Rec.CreateReinspection(CreatedReinspectionHeader);
+                    Rec.CreateReinspection(ReinspectionQltyInspectionHeader);
                     CurrPage.Update(false);
-                    if not IsNullGuid(CreatedReinspectionHeader.SystemId) then begin
+                    if not IsNullGuid(ReinspectionQltyInspectionHeader.SystemId) then begin
                         Commit();
-                        Page.Run(Page::"Qlty. Inspection", CreatedReinspectionHeader);
+                        Page.Run(Page::"Qlty. Inspection", ReinspectionQltyInspectionHeader);
                     end;
                 end;
             }

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
@@ -478,9 +478,15 @@ page 20406 "Qlty. Inspection"
                 ToolTip = 'Create a new re-inspection based on this inspection. If the inspection is still open, it will be finished first. Finishing may be blocked if the current result does not allow it.';
 
                 trigger OnAction()
+                var
+                    CreatedReinspectionHeader: Record "Qlty. Inspection Header";
                 begin
-                    Rec.CreateReinspection();
+                    Rec.CreateReinspection(CreatedReinspectionHeader);
                     CurrPage.Update(false);
+                    if not IsNullGuid(CreatedReinspectionHeader.SystemId) then begin
+                        Commit();
+                        Page.Run(Page::"Qlty. Inspection", CreatedReinspectionHeader);
+                    end;
                 end;
             }
             action(ChangeStatusFinish)

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionCreate.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionCreate.Codeunit.al
@@ -709,7 +709,6 @@ codeunit 20404 "Qlty. Inspection - Create"
     internal procedure CreateReinspection(FromThisQltyInspectionHeader: Record "Qlty. Inspection Header"; var CreatedReinspectionQltyInspectionHeader: Record "Qlty. Inspection Header")
     var
         PrecedingQltyInspectionHeader: Record "Qlty. Inspection Header";
-        QltyNotificationMgmt: Codeunit "Qlty. Notification Mgmt.";
         IsHandled: Boolean;
     begin
         QltyManagementSetup.Get();
@@ -732,9 +731,6 @@ codeunit 20404 "Qlty. Inspection - Create"
         CreateQualityInspectionResultLinesFromTemplate(CreatedReinspectionQltyInspectionHeader);
 
         LastCreatedQltyInspectionHeader := CreatedReinspectionQltyInspectionHeader;
-
-        if GuiAllowed() then
-            QltyNotificationMgmt.NotifyInspectionCreated(CreatedReinspectionQltyInspectionHeader);
 
         OnAfterCreateReinspection(FromThisQltyInspectionHeader, CreatedReinspectionQltyInspectionHeader);
     end;

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
@@ -991,6 +991,16 @@ table 20405 "Qlty. Inspection Header"
     procedure CreateReinspection()
     var
         NewlyCreatedReQltyInspectionHeader: Record "Qlty. Inspection Header";
+    begin
+        CreateReinspection(NewlyCreatedReQltyInspectionHeader);
+    end;
+
+    /// <summary>
+    /// Creates a Re-inspection and returns the created record.
+    /// </summary>
+    /// <param name="CreatedReinspectionHeader">The newly created re-inspection header.</param>
+    procedure CreateReinspection(var CreatedReinspectionHeader: Record "Qlty. Inspection Header")
+    var
         QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
         Proceed: Boolean;
     begin
@@ -1007,7 +1017,7 @@ table 20405 "Qlty. Inspection Header"
         else
             Proceed := true;
         if Proceed then
-            QltyInspectionCreate.CreateReinspection(Rec, NewlyCreatedReQltyInspectionHeader);
+            QltyInspectionCreate.CreateReinspection(Rec, CreatedReinspectionHeader);
     end;
 
     /// <summary>

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
@@ -998,8 +998,8 @@ table 20405 "Qlty. Inspection Header"
     /// <summary>
     /// Creates a Re-inspection and returns the created record.
     /// </summary>
-    /// <param name="CreatedReinspectionHeader">The newly created re-inspection header.</param>
-    procedure CreateReinspection(var CreatedReinspectionHeader: Record "Qlty. Inspection Header")
+    /// <param name="ReinspectionQltyInspectionHeader">The newly created re-inspection header.</param>
+    procedure CreateReinspection(var ReinspectionQltyInspectionHeader: Record "Qlty. Inspection Header")
     var
         QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
         Proceed: Boolean;
@@ -1017,7 +1017,7 @@ table 20405 "Qlty. Inspection Header"
         else
             Proceed := true;
         if Proceed then
-            QltyInspectionCreate.CreateReinspection(Rec, CreatedReinspectionHeader);
+            QltyInspectionCreate.CreateReinspection(Rec, ReinspectionQltyInspectionHeader);
     end;
 
     /// <summary>

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
@@ -223,13 +223,13 @@ page 20408 "Qlty. Inspection List"
 
                 trigger OnAction()
                 var
-                    CreatedReinspectionHeader: Record "Qlty. Inspection Header";
+                    ReinspectionQltyInspectionHeader: Record "Qlty. Inspection Header";
                 begin
-                    Rec.CreateReinspection(CreatedReinspectionHeader);
+                    Rec.CreateReinspection(ReinspectionQltyInspectionHeader);
                     CurrPage.Update(false);
-                    if not IsNullGuid(CreatedReinspectionHeader.SystemId) then begin
+                    if not IsNullGuid(ReinspectionQltyInspectionHeader.SystemId) then begin
                         Commit();
-                        Page.Run(Page::"Qlty. Inspection", CreatedReinspectionHeader);
+                        Page.Run(Page::"Qlty. Inspection", ReinspectionQltyInspectionHeader);
                     end;
                 end;
             }

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
@@ -222,9 +222,15 @@ page 20408 "Qlty. Inspection List"
                 Enabled = CanCreateReinspection;
 
                 trigger OnAction()
+                var
+                    CreatedReinspectionHeader: Record "Qlty. Inspection Header";
                 begin
-                    Rec.CreateReinspection();
+                    Rec.CreateReinspection(CreatedReinspectionHeader);
                     CurrPage.Update(false);
+                    if not IsNullGuid(CreatedReinspectionHeader.SystemId) then begin
+                        Commit();
+                        Page.Run(Page::"Qlty. Inspection", CreatedReinspectionHeader);
+                    end;
                 end;
             }
             action(TakePicture)


### PR DESCRIPTION
Fixes [AB#630607](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630607)

Backport to 28.X of [AB#624744](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624744)


