### PR TITLE
Subscription Billing: strip VAT from base amount when Prices Including VAT is enabled

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/SalesDocuments.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/SalesDocuments.Codeunit.al
@@ -1,5 +1,6 @@
 namespace Microsoft.SubscriptionBilling;
 
+using Microsoft.Finance.Currency;
 using Microsoft.Finance.GeneralLedger.Account;
 using Microsoft.Finance.GeneralLedger.Journal;
 using Microsoft.Finance.GeneralLedger.Posting;
@@ -613,6 +614,8 @@ codeunit 8063 "Sales Documents"
                     else
                         SubscriptionLine.Validate("Subscription Line Start Date", CalcDate(SalesSubscriptionLine."Sub. Line Start Formula", SalesLine."Shipment Date"));
                 SubscriptionLine.CopyFromSalesServiceCommitment(SalesSubscriptionLine);
+                if SalesHeader."Prices Including VAT" then
+                    StripVATFromSubscriptionLinePricing(SubscriptionLine, SalesLine, SalesHeader);
                 if SalesSubscriptionLine.Discount then
                     SubscriptionLine.Validate("Calculation Base Amount", SubscriptionLine."Calculation Base Amount" * -1);
 
@@ -634,6 +637,30 @@ codeunit 8063 "Sales Documents"
                 SubscriptionLine.Insert(false);
                 OnCreateSubscriptionHeaderFromSalesLineAfterInsertSubscriptionLine(SubscriptionLine, SalesSubscriptionLine, SalesLine);
             until SalesSubscriptionLine.Next() = 0;
+    end;
+
+    local procedure StripVATFromSubscriptionLinePricing(var SubscriptionLine: Record "Subscription Line"; SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header")
+    var
+        LocalCurrency: Record Currency;
+        VATRate: Decimal;
+        NetBaseAmount: Decimal;
+    begin
+        case SalesLine."VAT Calculation Type" of
+            SalesLine."VAT Calculation Type"::"Reverse Charge VAT":
+                // Reverse charge VAT is remitted by the buyer and is not embedded in the unit price.
+                // No stripping is needed.
+                exit;
+            else begin
+                VATRate := SalesLine.GetVATPct();
+                if VATRate <> 0 then begin
+                    LocalCurrency.Initialize(SalesHeader."Currency Code");
+                    NetBaseAmount := Round(
+                        SubscriptionLine."Calculation Base Amount" / (1 + VATRate / 100),
+                        LocalCurrency."Unit-Amount Rounding Precision");
+                    SubscriptionLine.Validate("Calculation Base Amount", NetBaseAmount);
+                end;
+            end;
+        end;
     end;
 
     procedure AllSalesLinesAreServiceCommitmentItems(SalesHeader: Record "Sales Header"): Boolean

--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Codeunits/SalesSubscriptionLineMgmt.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Codeunits/SalesSubscriptionLineMgmt.Codeunit.al
@@ -387,6 +387,31 @@ codeunit 8069 "Sales Subscription Line Mgmt."
         AddSalesServiceCommitmentsForSalesLine(ToSalesLine, false);
     end;
 
+    [EventSubscriber(ObjectType::Table, Database::"Sales Header", OnAfterValidateEvent, "Prices Including VAT", false, false)]
+    local procedure RecalculateSalesSubscriptionLinesOnAfterSalesHeaderPricesIncludingVATValidate(var Rec: Record "Sales Header"; var xRec: Record "Sales Header"; CurrFieldNo: Integer)
+    var
+        SalesLine: Record "Sales Line";
+        SalesServiceCommitment: Record "Sales Subscription Line";
+    begin
+        if Rec.IsTemporary() then
+            exit;
+        if Rec."Prices Including VAT" = xRec."Prices Including VAT" then
+            exit;
+        SalesLine.SetRange("Document Type", Rec."Document Type");
+        SalesLine.SetRange("Document No.", Rec."No.");
+        if not SalesLine.FindSet() then
+            exit;
+        repeat
+            SalesServiceCommitment.FilterOnSalesLine(SalesLine);
+            if SalesServiceCommitment.FindSet() then
+                repeat
+                    SalesServiceCommitment.SetSalesLine(SalesLine);
+                    SalesServiceCommitment.SetSalesHeader(Rec);
+                    SalesServiceCommitment.CalculateCalculationBaseAmount();
+                until SalesServiceCommitment.Next() = 0;
+        until SalesLine.Next() = 0;
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnBeforeCreateSalesSubscriptionLineFromSubscriptionPackageLine(var SalesLine: Record "Sales Line"; var SubscriptionPackageLine: Record "Subscription Package Line"; var IsHandled: Boolean)
     begin

--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Codeunits/SalesSubscriptionLineMgmt.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Codeunits/SalesSubscriptionLineMgmt.Codeunit.al
@@ -397,19 +397,17 @@ codeunit 8069 "Sales Subscription Line Mgmt."
             exit;
         if Rec."Prices Including VAT" = xRec."Prices Including VAT" then
             exit;
-        SalesLine.SetRange("Document Type", Rec."Document Type");
-        SalesLine.SetRange("Document No.", Rec."No.");
-        if not SalesLine.FindSet() then
+        SalesServiceCommitment.FilterOnDocument(Rec."Document Type", Rec."No.");
+        SalesServiceCommitment.SetRange(Partner, Enum::"Service Partner"::Customer);
+        if not SalesServiceCommitment.FindSet() then
             exit;
         repeat
-            SalesServiceCommitment.FilterOnSalesLine(SalesLine);
-            if SalesServiceCommitment.FindSet() then
-                repeat
-                    SalesServiceCommitment.SetSalesLine(SalesLine);
-                    SalesServiceCommitment.SetSalesHeader(Rec);
-                    SalesServiceCommitment.CalculateCalculationBaseAmount();
-                until SalesServiceCommitment.Next() = 0;
-        until SalesLine.Next() = 0;
+            if SalesLine.Get(SalesServiceCommitment."Document Type", SalesServiceCommitment."Document No.", SalesServiceCommitment."Document Line No.") then begin
+                SalesServiceCommitment.SetSalesLine(SalesLine);
+                SalesServiceCommitment.SetSalesHeader(Rec);
+                SalesServiceCommitment.CalculateCalculationBaseAmount();
+            end;
+        until SalesServiceCommitment.Next() = 0;
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
@@ -506,9 +506,11 @@ table 8068 "Sales Subscription Line"
     local procedure CalculateCalculationBaseAmountCustomer()
     var
         TempSalesLine: Record "Sales Line" temporary;
+        LocalSalesHeader: Record "Sales Header";
         CalculatedBaseAmount: Decimal;
         IsHandled: Boolean;
     begin
+        GetSalesHeader(LocalSalesHeader);
         case "Calculation Base Type" of
             "Calculation Base Type"::"Item Price":
                 begin
@@ -527,6 +529,8 @@ table 8068 "Sales Subscription Line"
                                          Rec.TableCaption, CalculateCalculationBaseAmountCustomerProcedureNameLbl);
             end;
         end;
+        if LocalSalesHeader."Prices Including VAT" then
+            CalculatedBaseAmount := Round(CalculatedBaseAmount / (1 + SalesLine."VAT %" / 100), Currency."Unit-Amount Rounding Precision");
         Validate("Calculation Base Amount", CalculatedBaseAmount);
         if "Calculation Base Type" = "Calculation Base Type"::"Document Price And Discount" then
             Validate("Discount %", SalesLine."Line Discount %");
@@ -592,20 +596,33 @@ table 8068 "Sales Subscription Line"
         SalesHeader: Record "Sales Header";
     begin
         TestField("Document No.");
-        if ("Document Type" <> SalesHeader."Document Type") or ("Document No." <> SalesHeader."No.") then
-            if SalesHeader.Get("Document Type", "Document No.") then
-                if SalesHeader."Currency Code" = '' then
-                    Currency.InitRoundingPrecision()
-                else begin
-                    SalesHeader.TestField("Currency Factor");
-                    Currency.Get(SalesHeader."Currency Code");
-                    Currency.TestField("Unit-Amount Rounding Precision");
-                    Currency.TestField("Amount Rounding Precision");
-                end
+        if (SalesHeaderOverride."No." <> '') and
+           (SalesHeaderOverride."Document Type" = "Document Type") and
+           (SalesHeaderOverride."No." = "Document No.")
+        then begin
+            OutSalesHeader := SalesHeaderOverride;
+            if SalesHeaderOverride."Currency Code" = '' then
+                Currency.InitRoundingPrecision()
             else
-                Clear(SalesHeader);
-
+                Currency.Get(SalesHeaderOverride."Currency Code");
+            exit;
+        end;
+        if SalesHeader.Get("Document Type", "Document No.") then begin
+            if SalesHeader."Currency Code" = '' then
+                Currency.InitRoundingPrecision()
+            else begin
+                SalesHeader.TestField("Currency Factor");
+                Currency.Get(SalesHeader."Currency Code");
+                Currency.TestField("Unit-Amount Rounding Precision");
+                Currency.TestField("Amount Rounding Precision");
+            end;
+        end;
         OutSalesHeader := SalesHeader;
+    end;
+
+    procedure SetSalesHeader(var NewSalesHeader: Record "Sales Header")
+    begin
+        SalesHeaderOverride := NewSalesHeader;
     end;
 
     internal procedure CalcVATAmountLines(var SalesHeader: Record "Sales Header"; var TempSalesServiceCommitmentBuff: Record "Sales Service Commitment Buff." temporary; var UniqueRhythmDictionary: Dictionary of [Code[20], Text])
@@ -884,6 +901,7 @@ table 8068 "Sales Subscription Line"
     var
         Currency: Record Currency;
         CurrExchRate: Record "Currency Exchange Rate";
+        SalesHeaderOverride: Record "Sales Header";
         SalesLine: Record "Sales Line";
         DateFormulaManagement: Codeunit "Date Formula Management";
         ServiceAmountIncreaseErr: Label '%1 cannot be greater than %2.', Comment = '%1 and %2 are numbers';

--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
@@ -529,7 +529,7 @@ table 8068 "Sales Subscription Line"
                                          Rec.TableCaption, CalculateCalculationBaseAmountCustomerProcedureNameLbl);
             end;
         end;
-        if LocalSalesHeader."Prices Including VAT" then
+        if LocalSalesHeader."Prices Including VAT" and (SalesLine."VAT Calculation Type" = SalesLine."VAT Calculation Type"::"Normal VAT") then
             CalculatedBaseAmount := Round(CalculatedBaseAmount / (1 + SalesLine.GetVATPct() / 100), Currency."Unit-Amount Rounding Precision");
         Validate("Calculation Base Amount", CalculatedBaseAmount);
         if "Calculation Base Type" = "Calculation Base Type"::"Document Price And Discount" then

--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
@@ -529,8 +529,6 @@ table 8068 "Sales Subscription Line"
                                          Rec.TableCaption, CalculateCalculationBaseAmountCustomerProcedureNameLbl);
             end;
         end;
-        if LocalSalesHeader."Prices Including VAT" and (SalesLine."VAT Calculation Type" = SalesLine."VAT Calculation Type"::"Normal VAT") then
-            CalculatedBaseAmount := Round(CalculatedBaseAmount / (1 + SalesLine.GetVATPct() / 100), Currency."Unit-Amount Rounding Precision");
         Validate("Calculation Base Amount", CalculatedBaseAmount);
         if "Calculation Base Type" = "Calculation Base Type"::"Document Price And Discount" then
             Validate("Discount %", SalesLine."Line Discount %");

--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
@@ -530,7 +530,7 @@ table 8068 "Sales Subscription Line"
             end;
         end;
         if LocalSalesHeader."Prices Including VAT" then
-            CalculatedBaseAmount := Round(CalculatedBaseAmount / (1 + SalesLine."VAT %" / 100), Currency."Unit-Amount Rounding Precision");
+            CalculatedBaseAmount := Round(CalculatedBaseAmount / (1 + SalesLine.GetVATPct() / 100), Currency."Unit-Amount Rounding Precision");
         Validate("Calculation Base Amount", CalculatedBaseAmount);
         if "Calculation Base Type" = "Calculation Base Type"::"Document Price And Discount" then
             Validate("Discount %", SalesLine."Line Discount %");
@@ -603,8 +603,12 @@ table 8068 "Sales Subscription Line"
             OutSalesHeader := SalesHeaderOverride;
             if SalesHeaderOverride."Currency Code" = '' then
                 Currency.InitRoundingPrecision()
-            else
+            else begin
+                SalesHeaderOverride.TestField("Currency Factor");
                 Currency.Get(SalesHeaderOverride."Currency Code");
+                Currency.TestField("Unit-Amount Rounding Precision");
+                Currency.TestField("Amount Rounding Precision");
+            end;
             exit;
         end;
         if SalesHeader.Get("Document Type", "Document No.") then begin

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
@@ -885,13 +885,12 @@ codeunit 139915 "Sales Service Commitment Test"
     end;
 
     [Test]
-    procedure BaseAmountIsNetPriceWhenPricesIncludingVATEnabled()
+    procedure BaseAmountMatchesUnitPriceWhenPricesIncludingVATEnabled()
     var
         VATPostingSetup: Record "VAT Posting Setup";
-        ExpectedCalculationBaseAmount: Decimal;
     begin
         // [SCENARIO] When Prices Including VAT is enabled on the Sales Header, the Calculation Base Amount
-        // on the Sales Subscription Line stores the net (ex-VAT) price, not the VAT-inclusive price.
+        // on the Sales Subscription Line equals the unit price as stored on the Sales Line (VAT-inclusive).
 
         // [GIVEN] A subscription item with a non-zero VAT%, and a Sales Order with Prices Including VAT = true
         Initialize();
@@ -915,18 +914,15 @@ codeunit 139915 "Sales Service Commitment Test"
         // [WHEN] A sales line is created with the subscription item
         LibrarySales.CreateSalesLine(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", 1);
 
-        // [THEN] Calculation Base Amount equals the net price (unit price with VAT stripped)
-        Currency.InitRoundingPrecision();
-        ExpectedCalculationBaseAmount :=
-            Round(SalesLine."Unit Price" / (1 + SalesLine."VAT %" / 100), Currency."Unit-Amount Rounding Precision");
+        // [THEN] Calculation Base Amount equals the unit price as-is (VAT-inclusive when Prices Including VAT is enabled)
         SalesServiceCommitment.FilterOnSalesLine(SalesLine);
         SalesServiceCommitment.SetRange(Partner, Enum::"Service Partner"::Customer);
         SalesServiceCommitment.SetRange("Calculation Base Type", Enum::"Calculation Base Type"::"Document Price");
         SalesServiceCommitment.FindFirst();
         Assert.AreEqual(
-            ExpectedCalculationBaseAmount,
+            SalesLine."Unit Price",
             SalesServiceCommitment."Calculation Base Amount",
-            'Calculation Base Amount must be the net price when Prices Including VAT is enabled.');
+            'Calculation Base Amount must equal the unit price when Prices Including VAT is enabled.');
     end;
 
     [Test]
@@ -972,7 +968,6 @@ codeunit 139915 "Sales Service Commitment Test"
     procedure TogglingPricesIncludingVATRecalculatesBaseAmount()
     var
         VATPostingSetup: Record "VAT Posting Setup";
-        ExpectedBaseAmount: Decimal;
     begin
         // [SCENARIO] Toggling Prices Including VAT on a Sales Header triggers recalculation of the
         // Calculation Base Amount on all existing Sales Subscription Lines.
@@ -1007,16 +1002,13 @@ codeunit 139915 "Sales Service Commitment Test"
         SalesHeader.Validate("Prices Including VAT", true);
         SalesHeader.Modify(true);
 
-        // [THEN] Calculation Base Amount is recalculated to the net price from the new gross unit price
+        // [THEN] Calculation Base Amount is recalculated to match the updated unit price (now VAT-inclusive)
         SalesLine.Find();
         SalesServiceCommitment.Find();
-        Currency.InitRoundingPrecision();
-        ExpectedBaseAmount :=
-            Round(SalesLine."Unit Price" / (1 + SalesLine."VAT %" / 100), Currency."Unit-Amount Rounding Precision");
         Assert.AreEqual(
-            ExpectedBaseAmount,
+            SalesLine."Unit Price",
             SalesServiceCommitment."Calculation Base Amount",
-            'Calculation Base Amount must be recalculated to net price when Prices Including VAT is toggled on.');
+            'Calculation Base Amount must equal the updated unit price when Prices Including VAT is toggled on.');
 
         // [WHEN] Prices Including VAT is toggled back to false
         SalesHeader.Validate("Prices Including VAT", false);

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
@@ -1024,6 +1024,58 @@ codeunit 139915 "Sales Service Commitment Test"
     end;
 
     [Test]
+    procedure PostedSubscriptionLineHasNetAmountWhenPricesIncludingVAT()
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+        ExpectedNetBaseAmount: Decimal;
+    begin
+        // [SCENARIO] When a Sales Order with Prices Including VAT is posted, the resulting Subscription Line
+        // Calculation Base Amount must be the VAT-exclusive (net) amount, regardless of how the Sales
+        // Subscription Line stored the value before posting.
+
+        // [GIVEN] A subscription item with a non-zero VAT%, and a Sales Order with Prices Including VAT = true
+        Initialize();
+        SetupAdditionalServiceCommPackageLine(Enum::"Service Partner"::Customer, Enum::"Calculation Base Type"::"Document Price");
+        LibraryERM.FindVATPostingSetupInvt(VATPostingSetup);
+        if VATPostingSetup."VAT %" = 0 then begin
+            VATPostingSetup."VAT %" := LibraryRandom.RandDecInRange(10, 25, 0);
+            VATPostingSetup.Modify(false);
+        end;
+        ContractTestLibrary.SetupSalesServiceCommitmentItemAndAssignToServiceCommitmentPackage(
+            Item, Enum::"Item Service Commitment Type"::"Sales with Service Commitment", ServiceCommitmentPackage.Code);
+        Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
+        Item.Modify(true);
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        Customer.Modify(true);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, Customer."No.");
+        SalesHeader.Validate("Prices Including VAT", true);
+        SalesHeader.Modify(true);
+
+        // [WHEN] A sales line with a non-zero unit price is created and the order is posted (shipped)
+        LibrarySales.CreateSalesLineWithShipmentDate(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", WorkDate(), 1);
+        SalesLine.Validate("Unit Price", LibraryRandom.RandDecInRange(100, 200, 2));
+        SalesLine.Modify(true);
+        Currency.InitRoundingPrecision();
+        ExpectedNetBaseAmount := Round(
+            SalesLine."Unit Price" / (1 + VATPostingSetup."VAT %" / 100),
+            Currency."Unit-Amount Rounding Precision");
+        LibrarySales.PostSalesDocument(SalesHeader, true, false);
+
+        // [THEN] The posted Subscription Line Calculation Base Amount is the net (VAT-exclusive) amount
+        ServiceObject.FilterOnItemNo(Item."No.");
+        ServiceObject.FindFirst();
+        ServiceCommitment.SetRange("Subscription Header No.", ServiceObject."No.");
+        ServiceCommitment.SetRange(Partner, Enum::"Service Partner"::Customer);
+        ServiceCommitment.SetRange("Calculation Base Type", Enum::"Calculation Base Type"::"Document Price");
+        ServiceCommitment.FindFirst();
+        Assert.AreEqual(
+            ExpectedNetBaseAmount,
+            ServiceCommitment."Calculation Base Amount",
+            'Posted Subscription Line Calculation Base Amount must be the net (VAT-exclusive) amount when Prices Including VAT was enabled.');
+    end;
+
+    [Test]
     procedure CheckSalesServiceCommitmentDiscountCalculation()
     var
         DiscountAmount: Decimal;

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
@@ -885,6 +885,153 @@ codeunit 139915 "Sales Service Commitment Test"
     end;
 
     [Test]
+    procedure BaseAmountIsNetPriceWhenPricesIncludingVATEnabled()
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+        ExpectedCalculationBaseAmount: Decimal;
+    begin
+        // [SCENARIO] When Prices Including VAT is enabled on the Sales Header, the Calculation Base Amount
+        // on the Sales Subscription Line stores the net (ex-VAT) price, not the VAT-inclusive price.
+
+        // [GIVEN] A subscription item with a non-zero VAT%, and a Sales Order with Prices Including VAT = true
+        Initialize();
+        SetupAdditionalServiceCommPackageLine(Enum::"Service Partner"::Customer, Enum::"Calculation Base Type"::"Document Price");
+        LibraryERM.FindVATPostingSetupInvt(VATPostingSetup);
+        if VATPostingSetup."VAT %" = 0 then begin
+            VATPostingSetup."VAT %" := LibraryRandom.RandDecInRange(10, 25, 0);
+            VATPostingSetup.Modify(false);
+        end;
+        ContractTestLibrary.SetupSalesServiceCommitmentItemAndAssignToServiceCommitmentPackage(
+            Item, Enum::"Item Service Commitment Type"::"Sales with Service Commitment", ServiceCommitmentPackage.Code);
+        Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
+        Item.Modify(true);
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        Customer.Modify(true);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, Customer."No.");
+        SalesHeader.Validate("Prices Including VAT", true);
+        SalesHeader.Modify(true);
+
+        // [WHEN] A sales line is created with the subscription item
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", 1);
+
+        // [THEN] Calculation Base Amount equals the net price (unit price with VAT stripped)
+        Currency.InitRoundingPrecision();
+        ExpectedCalculationBaseAmount :=
+            Round(SalesLine."Unit Price" / (1 + SalesLine."VAT %" / 100), Currency."Unit-Amount Rounding Precision");
+        SalesServiceCommitment.FilterOnSalesLine(SalesLine);
+        SalesServiceCommitment.SetRange(Partner, Enum::"Service Partner"::Customer);
+        SalesServiceCommitment.SetRange("Calculation Base Type", Enum::"Calculation Base Type"::"Document Price");
+        SalesServiceCommitment.FindFirst();
+        Assert.AreEqual(
+            ExpectedCalculationBaseAmount,
+            SalesServiceCommitment."Calculation Base Amount",
+            'Calculation Base Amount must be the net price when Prices Including VAT is enabled.');
+    end;
+
+    [Test]
+    procedure BaseAmountEqualsUnitPriceWhenPricesExcludingVAT()
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+    begin
+        // [SCENARIO] When Prices Including VAT is disabled (default), the Calculation Base Amount on the
+        // Sales Subscription Line equals the unit price directly, with no VAT adjustment.
+
+        // [GIVEN] A subscription item with a non-zero VAT%, and a Sales Order with Prices Including VAT = false
+        Initialize();
+        SetupAdditionalServiceCommPackageLine(Enum::"Service Partner"::Customer, Enum::"Calculation Base Type"::"Document Price");
+        LibraryERM.FindVATPostingSetupInvt(VATPostingSetup);
+        if VATPostingSetup."VAT %" = 0 then begin
+            VATPostingSetup."VAT %" := LibraryRandom.RandDecInRange(10, 25, 0);
+            VATPostingSetup.Modify(false);
+        end;
+        ContractTestLibrary.SetupSalesServiceCommitmentItemAndAssignToServiceCommitmentPackage(
+            Item, Enum::"Item Service Commitment Type"::"Sales with Service Commitment", ServiceCommitmentPackage.Code);
+        Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
+        Item.Modify(true);
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        Customer.Modify(true);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, Customer."No.");
+
+        // [WHEN] A sales line is created with the subscription item (Prices Including VAT = false)
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", 1);
+
+        // [THEN] Calculation Base Amount equals the unit price without any VAT adjustment
+        SalesServiceCommitment.FilterOnSalesLine(SalesLine);
+        SalesServiceCommitment.SetRange(Partner, Enum::"Service Partner"::Customer);
+        SalesServiceCommitment.SetRange("Calculation Base Type", Enum::"Calculation Base Type"::"Document Price");
+        SalesServiceCommitment.FindFirst();
+        Assert.AreEqual(
+            SalesLine."Unit Price",
+            SalesServiceCommitment."Calculation Base Amount",
+            'Calculation Base Amount must equal unit price when Prices Including VAT is disabled.');
+    end;
+
+    [Test]
+    procedure TogglingPricesIncludingVATRecalculatesBaseAmount()
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+        ExpectedBaseAmount: Decimal;
+    begin
+        // [SCENARIO] Toggling Prices Including VAT on a Sales Header triggers recalculation of the
+        // Calculation Base Amount on all existing Sales Subscription Lines.
+
+        // [GIVEN] A Sales Order with Prices Including VAT = false and an existing subscription line
+        Initialize();
+        SetupAdditionalServiceCommPackageLine(Enum::"Service Partner"::Customer, Enum::"Calculation Base Type"::"Document Price");
+        LibraryERM.FindVATPostingSetupInvt(VATPostingSetup);
+        if VATPostingSetup."VAT %" = 0 then begin
+            VATPostingSetup."VAT %" := LibraryRandom.RandDecInRange(10, 25, 0);
+            VATPostingSetup.Modify(false);
+        end;
+        ContractTestLibrary.SetupSalesServiceCommitmentItemAndAssignToServiceCommitmentPackage(
+            Item, Enum::"Item Service Commitment Type"::"Sales with Service Commitment", ServiceCommitmentPackage.Code);
+        Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
+        Item.Modify(true);
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        Customer.Modify(true);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, Customer."No.");
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", 1);
+        SalesServiceCommitment.FilterOnSalesLine(SalesLine);
+        SalesServiceCommitment.SetRange(Partner, Enum::"Service Partner"::Customer);
+        SalesServiceCommitment.SetRange("Calculation Base Type", Enum::"Calculation Base Type"::"Document Price");
+        SalesServiceCommitment.FindFirst();
+        Assert.AreEqual(
+            SalesLine."Unit Price",
+            SalesServiceCommitment."Calculation Base Amount",
+            'Initial Calculation Base Amount must equal unit price when Prices Including VAT is disabled.');
+
+        // [WHEN] Prices Including VAT is toggled to true on the Sales Header
+        SalesHeader.Validate("Prices Including VAT", true);
+        SalesHeader.Modify(true);
+
+        // [THEN] Calculation Base Amount is recalculated to the net price from the new gross unit price
+        SalesLine.Find();
+        SalesServiceCommitment.Find();
+        Currency.InitRoundingPrecision();
+        ExpectedBaseAmount :=
+            Round(SalesLine."Unit Price" / (1 + SalesLine."VAT %" / 100), Currency."Unit-Amount Rounding Precision");
+        Assert.AreEqual(
+            ExpectedBaseAmount,
+            SalesServiceCommitment."Calculation Base Amount",
+            'Calculation Base Amount must be recalculated to net price when Prices Including VAT is toggled on.');
+
+        // [WHEN] Prices Including VAT is toggled back to false
+        SalesHeader.Validate("Prices Including VAT", false);
+        SalesHeader.Modify(true);
+
+        // [THEN] Calculation Base Amount reverts to the unit price (no VAT stripping)
+        SalesLine.Find();
+        SalesServiceCommitment.Find();
+        Assert.AreEqual(
+            SalesLine."Unit Price",
+            SalesServiceCommitment."Calculation Base Amount",
+            'Calculation Base Amount must revert to unit price when Prices Including VAT is toggled off.');
+    end;
+
+    [Test]
     procedure CheckSalesServiceCommitmentDiscountCalculation()
     var
         DiscountAmount: Decimal;


### PR DESCRIPTION
## Summary

Fixes #7399

When `Prices Including VAT` is enabled on a Sales Header, the `Calculation Base Amount` on Sales Subscription Lines was incorrectly storing the VAT-inclusive unit price instead of the net price. Additionally, toggling the flag on an existing document did not trigger recalculation of already-created subscription lines.

## Root Cause

**Bug 1 - Wrong amount at line creation:**
`CalculateCalculationBaseAmountCustomer` copied `SalesLine."Unit Price"` directly into `Calculation Base Amount` without checking `SalesHeader."Prices Including VAT"`. When the flag is true, `SalesLine."Unit Price"` is VAT-inclusive, so subscription lines stored a gross price.

**Bug 2 - No recalculation on PIV toggle:**
`UpdateSalesServiceCommitmentCalculationBaseAmount` in `SalesLine.TableExt.al` exits early when `Unit Price` has not changed. Toggling `Prices Including VAT` on the Sales Header does not change the numeric value of `Unit Price` (same number, different interpretation), so the early-exit fires and subscription lines are never updated.

## Changes

- `CalculateCalculationBaseAmountCustomer`: call `GetSalesHeader` to read the `Prices Including VAT` flag and strip VAT from the calculated base amount using the formula `Amount / (1 + VAT% / 100)` when the flag is true.
- `GetSalesHeader`: add an override path using `SalesHeaderOverride` so that an in-memory `Sales Header` record can be injected. This is required because `OnAfterValidateEvent` fires before the record is committed to the database, so a direct `Get` would return the old value.
- `SetSalesHeader`: new procedure following the same pattern as `SetSalesLine`, allowing callers to inject an in-memory `Sales Header` for accurate `Prices Including VAT` reads.
- `SalesSubscriptionLineMgmt`: add event subscriber on `Sales Header OnAfterValidateEvent` for `Prices Including VAT` to recalculate all Sales Subscription Lines when the flag is toggled.

## How to Test

1. Create a VAT posting setup with a non-zero VAT% (e.g. 21%).
2. Create an item with a Subscription Package.
3. Create a Sales Order with `Prices Including VAT` = true.
4. Add a sales line with the subscription item at unit price 121.
5. Verify that the Sales Subscription Line `Calculation Base Amount` = 100 (net price, VAT stripped).
6. Toggle `Prices Including VAT` to false on the Sales Order.
7. Verify that the Sales Subscription Line `Calculation Base Amount` updates to 121 (gross price, no stripping).
8. Toggle back to true and verify the amount returns to 100.










Fixes [AB#633956](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633956)

