### PR TITLE
Feature 629862: Only run triage agent upon issue creation and when (re-)tagged with AI-Triage

### DIFF
--- a/.github/workflows/ai-triage-dispatch.yml
+++ b/.github/workflows/ai-triage-dispatch.yml
@@ -2,7 +2,7 @@ name: Dispatch AI Triage
 
 on:
   issues:
-    types: [opened, edited, labeled]
+    types: [opened, labeled]
 
 permissions: {}
 
@@ -11,7 +11,6 @@ jobs:
     if: >-
       github.event.issue.state == 'open' && (
         github.event.action == 'opened' ||
-        github.event.action == 'edited' ||
         github.event.label.name == 'ai-triage'
       )
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Only run triage agent upon issue creation and when (re-)tagged with AI-Triage.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#629862](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/629862)



