### PR TITLE
Bug 631975: [EDocument][28.x] Copilot capability registration + historical matching fixes

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/AI/EDocAIToolProcessor.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/AI/EDocAIToolProcessor.Codeunit.al
@@ -5,6 +5,7 @@
 namespace Microsoft.eServices.EDocument.Processing.AI;
 
 using System.AI;
+using System.Environment;
 using System.Environment.Configuration;
 using System.Globalization;
 using System.Telemetry;
@@ -39,6 +40,8 @@ codeunit 6195 "E-Doc. AI Tool Processor"
         CopilotCapability: Codeunit "Copilot Capability";
     begin
         Clear(TelemetryDimensions);
+
+        RegisterCapabilityIfNeeded();
 
         if not CopilotCapability.IsCapabilityRegistered(Enum::"Copilot Capability"::"E-Document Matching Assistance") then
             exit(false);
@@ -204,6 +207,18 @@ codeunit 6195 "E-Doc. AI Tool Processor"
             FeatureTelemetry.LogUsage('0000PUL', AISystem.GetFeatureName(), 'AI Processing Success', TelemetryDimensions)
         else
             FeatureTelemetry.LogError('0000PUH', AISystem.GetFeatureName(), 'AI Processing Failed', 'Processing failed', '', TelemetryDimensions);
+    end;
+
+    local procedure RegisterCapabilityIfNeeded()
+    var
+        CopilotCapability: Codeunit "Copilot Capability";
+        EnvironmentInformation: Codeunit "Environment Information";
+        LearnMoreUrlTxt: Label 'https://go.microsoft.com/fwlink/?linkid=2262630', Locked = true;
+    begin
+        if not EnvironmentInformation.IsSaaSInfrastructure() then
+            exit;
+        if not CopilotCapability.IsCapabilityRegistered(Enum::"Copilot Capability"::"E-Document Matching Assistance") then
+            CopilotCapability.RegisterCapability(Enum::"Copilot Capability"::"E-Document Matching Assistance", LearnMoreUrlTxt);
     end;
 
     local procedure LogError(EventName: Text; ErrorMessage: Text)

--- a/src/Apps/W1/EDocument/App/src/Processing/AI/Tools/EDocHistoricalMatching.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/AI/Tools/EDocHistoricalMatching.Codeunit.al
@@ -219,6 +219,7 @@ codeunit 6177 "E-Doc. Historical Matching" implements "AOAI Function", IEDocAISy
     local procedure LoadHistoricalDataIntoTempTable(var TempPurchInvLine: Record "Purch. Inv. Line" temporary; VendorNo: Code[20]; HistoricalMatchingConfig: Text)
     var
         PurchInvLine: Record "Purch. Inv. Line";
+        EDocPurchaseLineHistory: Record "E-Doc. Purchase Line History";
         AllocationAccount: Record "Allocation Account";
         FeatureTelemetry: Codeunit "Feature Telemetry";
         OneYearAgoDate: Date;
@@ -252,6 +253,18 @@ codeunit 6177 "E-Doc. Historical Matching" implements "AOAI Function", IEDocAISy
                 RecordCount += 1;
             until (PurchInvLine.Next() = 0) or (RecordCount >= MaxHistoricalRecords);
         end;
+
+        // Enrich temp records with product codes from e-document history
+        EDocPurchaseLineHistory.SetCurrentKey("Vendor No.", "Product Code");
+        EDocPurchaseLineHistory.SetRange("Vendor No.", VendorNo);
+        EDocPurchaseLineHistory.SetFilter("Product Code", '<>%1', '');
+        if EDocPurchaseLineHistory.FindSet() then
+            repeat
+                if TempPurchInvLine.GetBySystemId(EDocPurchaseLineHistory."Purch. Inv. Line SystemId") then begin
+                    TempPurchInvLine."Vendor Item No." := CopyStr(EDocPurchaseLineHistory."Product Code", 1, MaxStrLen(TempPurchInvLine."Vendor Item No."));
+                    TempPurchInvLine.Modify();
+                end;
+            until EDocPurchaseLineHistory.Next() = 0;
 
         ElapsedTime := CurrentDateTime() - StartTime;
         TelemetryDimensions.Add('Records loaded', Format(RecordCount));
@@ -320,7 +333,7 @@ codeunit 6177 "E-Doc. Historical Matching" implements "AOAI Function", IEDocAISy
         TempPurchInvLine.Reset();
         case MatchType of
             ProductCodeTok:
-                TempPurchInvLine.SetRange("No.", SearchValue);
+                TempPurchInvLine.SetRange("Vendor Item No.", CopyStr(SearchValue, 1, MaxStrLen(TempPurchInvLine."Vendor Item No.")));
             DescriptionTok:
                 TempPurchInvLine.SetRange(Description, SearchValue);
             'Similar Description':

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/PrepareDraft/PreparePurchaseEDocDraft.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/PrepareDraft/PreparePurchaseEDocDraft.Codeunit.al
@@ -116,7 +116,7 @@ codeunit 6125 "Prepare Purchase E-Doc. Draft" implements IProcessStructuredData
     var
         EDocumentPurchaseLine: Record "E-Document Purchase Line";
     begin
-        EDocumentPurchaseLine.SetLoadFields("E-Document Entry No.", "[BC] Purchase Type No.", "[BC] Deferral Code");
+        EDocumentPurchaseLine.SetLoadFields("E-Document Entry No.", "[BC] Purchase Type No.", "[BC] Deferral Code", Description, "Product Code", Quantity, "Unit of Measure", "Unit Price");
         EDocumentPurchaseLine.ReadIsolation(IsolationLevel::ReadCommitted);
 
         // Step 1: Apply historical pattern matching


### PR DESCRIPTION
- Add self-healing RegisterCapabilityIfNeeded in AI Tool Processor Setup
- Expand SetLoadFields to include all fields needed by historical matching
- Enrich temp table with product codes from E-Doc Purchase Line History
- Fix ProductCode search to use Vendor Item No instead of G/L Account No

Fixes [AB#631975](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/631975)

