### PR TITLE
fix: reset TempOrderLine between iterations in SetAndInsertOrderLines to prevent Tip flag from persisting across order lines

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
@@ -636,11 +636,13 @@ codeunit 30161 "Shpfy Import Order"
     var
         JOrderLine: JsonToken;
     begin
-        foreach JOrderLine in JOrderLines do
+        foreach JOrderLine in JOrderLines do begin
+            TempOrderLine.Init();
             if SetOrderLineValuesFromJson(JOrderLine, OrderId, TempOrderLine) then begin
                 TempOrderLine.Insert();
                 DataCaptureDict.Add(TempOrderLine."Line Id", JOrderLine);
             end;
+        end;
     end;
 
     internal procedure TranslateCurrencyCode(ShopifyCurrencyCode: Text): Code[10]

--- a/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrdersAPITest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrdersAPITest.Codeunit.al
@@ -1486,6 +1486,56 @@ codeunit 139608 "Shpfy Orders API Test"
         LibraryAssert.AreEqual(OrderHeader."Shopify Order No.", SalesHeader."No.", 'Sales Invoice number should equal Shopify Order No.');
     end;
 
+    [Test]
+    procedure UnitTestTipFlagNotPropagatedToSubsequentOrderLines()
+    var
+        OrderLine: Record "Shpfy Order Line";
+        ImportOrder: Codeunit "Shpfy Import Order";
+        JOrderLines: JsonArray;
+        JEmptyArray: JsonArray;
+        JTipLine: JsonObject;
+        JRegularLine: JsonObject;
+        JNull: JsonValue;
+        GidLbl: Label 'gid://shopify/LineItem/%1', Locked = true, Comment = '%1 = Line Id';
+        OrderId: BigInteger;
+        TipLineId: BigInteger;
+        RegularLineId: BigInteger;
+    begin
+        // [SCENARIO] When an order contains a Tip line followed by a regular line, the Tip flag must not carry over to the regular line.
+        Initialize();
+
+        OrderId := LibraryRandom.RandIntInRange(100000, 999999);
+        TipLineId := LibraryRandom.RandIntInRange(10000, 49999);
+        RegularLineId := LibraryRandom.RandIntInRange(50000, 99999);
+
+        // [GIVEN] A Tip order line in JSON form
+        JNull.SetValueToNull();
+        JTipLine.Add('id', StrSubstNo(GidLbl, TipLineId));
+        JTipLine.Add('name', 'Tip');
+        JTipLine.Add('product', JNull);
+        JTipLine.Add('discountAllocations', JEmptyArray);
+
+        // [GIVEN] A regular order line in JSON form that follows the Tip line
+        JRegularLine.Add('id', StrSubstNo(GidLbl, RegularLineId));
+        JRegularLine.Add('name', 'Product');
+        JRegularLine.Add('discountAllocations', JEmptyArray);
+
+        JOrderLines.Add(JTipLine);
+        JOrderLines.Add(JRegularLine);
+
+        // [WHEN] Order lines are imported from the JSON array
+        ImportOrder.ImportCreateAndUpdateOrderLinesFromMock(OrderId, JOrderLines);
+        Commit();
+
+        // [THEN] The Tip line has the Tip flag set to true
+        LibraryAssert.IsTrue(OrderLine.Get(OrderId, TipLineId), 'Tip order line must exist');
+        LibraryAssert.IsTrue(OrderLine.Tip, 'Tip flag must be set on the Tip order line');
+
+        // [THEN] The regular line does not have the Tip flag carried over from the previous Tip line
+        LibraryAssert.IsTrue(OrderLine.Get(OrderId, RegularLineId), 'Regular order line must exist');
+        LibraryAssert.IsFalse(OrderLine.Tip, 'Tip flag must not be propagated to the subsequent regular order line');
+    end;
+
     local procedure CreateTaxArea(var TaxArea: Record "Tax Area"; var ShopifyTaxArea: Record "Shpfy Tax Area"; ShopParam: Record "Shpfy Shop")
     var
         ShopifyCustomerTemplate: Record "Shpfy Customer Template";


### PR DESCRIPTION
Fixes #6811

## Problem

In codeunit 30161 Shpfy Import Order, the procedure SetAndInsertOrderLines iterates over a JsonArray of order lines and passes TempOrderLine by reference to SetOrderLineValuesFromJson. When a line named Tip with a null product is encountered, the Tip field is set to true on the record. Because TempOrderLine is never re-initialized between iterations, the next line in the loop inherits all field values including Tip = true from the previous iteration. This causes every order line that follows a Tip line to be incorrectly classified as a Tip, even standard item lines.

The stale-value problem only manifests for new lines. When LocalOrderLine.Get succeeds (the line already exists in the database), OrderLine.Copy(LocalOrderLine) overwrites all fields. For brand-new lines, no such reset occurs, so the previous iteration's values persist.

## Solution

Add TempOrderLine.Init() at the start of the foreach loop body in SetAndInsertOrderLines. This resets all fields to their default values before SetOrderLineValuesFromJson populates them from the JSON token, ensuring each iteration starts from a clean state.

## Changes

- ShpfyImportOrder.Codeunit.al: Wrapped the foreach body in a begin...end block and added TempOrderLine.Init() before calling SetOrderLineValuesFromJson.
- ShpfyOrdersAPITest.Codeunit.al: Added UnitTestTipFlagNotPropagatedToSubsequentOrderLines, which imports a Tip line followed by a regular line using ImportCreateAndUpdateOrderLinesFromMock and asserts that only the Tip line has Tip = true.

## How to Test

1. In a Business Central environment with the Shopify connector, create a Shopify order containing a Tip item followed by one or more regular items.
2. Sync the order to Business Central.
3. Open the imported Shopify Order and inspect the order lines.
4. Expected: only the Tip line has the Tip indicator set. Subsequent lines do not inherit the Tip flag.

Alternatively, run the automated test UnitTestTipFlagNotPropagatedToSubsequentOrderLines in codeunit 139608 Shpfy Orders API Test. The test fails without the fix and passes with it.

Fixes [AB#632856](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632856)

