### PR TITLE
[Agent] Use AgentManagementAllowed instead of AgentTaskManagementPreviewEnabled

### DIFF
--- a/src/System Application/App/Agent/Interaction/AgentMessage.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/AgentMessage.Codeunit.al
@@ -24,7 +24,7 @@ codeunit 4307 "Agent Message"
     var
         AgentMessageImpl: Codeunit "Agent Message Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentMessageImpl.GetText(AgentTaskMessage));
     end;
 
@@ -37,7 +37,7 @@ codeunit 4307 "Agent Message"
     var
         AgentMessageImpl: Codeunit "Agent Message Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentMessageImpl.UpdateText(AgentTaskMessage, NewMessageText);
     end;
 
@@ -50,7 +50,7 @@ codeunit 4307 "Agent Message"
     var
         AgentMessageImpl: Codeunit "Agent Message Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentMessageImpl.IsEditable(AgentTaskMessage));
     end;
 
@@ -62,7 +62,7 @@ codeunit 4307 "Agent Message"
     var
         AgentMessageImpl: Codeunit "Agent Message Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentMessageImpl.SetStatusToSent(AgentTaskMessage);
     end;
 
@@ -90,7 +90,7 @@ codeunit 4307 "Agent Message"
     var
         AgentMessageImpl: Codeunit "Agent Message Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentMessageImpl.SetIgnoreAttachment(IgnoreAttachment);
     end;
 
@@ -102,7 +102,7 @@ codeunit 4307 "Agent Message"
     var
         AgentMessageImpl: Codeunit "Agent Message Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentMessageImpl.DownloadAttachments(AgentTaskMessage);
     end;
 
@@ -115,7 +115,7 @@ codeunit 4307 "Agent Message"
     var
         AgentMessageImpl: Codeunit "Agent Message Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentMessageImpl.ShowOrDownloadAttachment(TaskId, FileID, false);
     end;
 
@@ -127,7 +127,7 @@ codeunit 4307 "Agent Message"
     var
         AgentMessageImpl: Codeunit "Agent Message Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentMessageImpl.ShowOrDownloadAttachment(AgentTaskFile, false);
     end;
 
@@ -141,7 +141,7 @@ codeunit 4307 "Agent Message"
     var
         AgentMessageImpl: Codeunit "Agent Message Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentMessageImpl.GetAttachments(TaskID, MessageID, TempAgentTaskFile);
     end;
 
@@ -154,7 +154,7 @@ codeunit 4307 "Agent Message"
     var
         AgentMessageImpl: Codeunit "Agent Message Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentMessageImpl.GetFileSizeDisplayText(SizeInBytes));
     end;
 }

--- a/src/System Application/App/Agent/Interaction/AgentTask.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/AgentTask.Codeunit.al
@@ -22,7 +22,7 @@ codeunit 4303 "Agent Task"
     var
         AgentTaskImpl: Codeunit "Agent Task Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskImpl.TaskExists(AgentUserSecurityId, ExternalId));
     end;
 
@@ -36,7 +36,7 @@ codeunit 4303 "Agent Task"
     var
         AgentTask: Record "Agent Task";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTask.SetRange("Agent User Security ID", AgentUserSecurityId);
         AgentTask.SetRange("External ID", ExternalId);
         AgentTask.FindFirst();
@@ -53,7 +53,7 @@ codeunit 4303 "Agent Task"
     var
         AgentTaskImpl: Codeunit "Agent Task Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskImpl.SetTaskStatusToReadyIfPossible(AgentTask);
     end;
 
@@ -66,7 +66,7 @@ codeunit 4303 "Agent Task"
     var
         AgentTaskImpl: Codeunit "Agent Task Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskImpl.CanAgentTaskBeSetToReady(AgentTask));
     end;
 
@@ -80,7 +80,7 @@ codeunit 4303 "Agent Task"
         AgentTaskImpl: Codeunit "Agent Task Impl.";
         TaskStatus: Enum "Agent Task Status";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskImpl.StopTask(AgentTask, TaskStatus::"Stopped by User", UserConfirm);
     end;
 
@@ -93,7 +93,7 @@ codeunit 4303 "Agent Task"
     var
         AgentTaskImpl: Codeunit "Agent Task Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskImpl.RestartTask(AgentTask, UserConfirm);
     end;
 
@@ -106,7 +106,7 @@ codeunit 4303 "Agent Task"
     var
         AgentTaskImpl: Codeunit "Agent Task Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskImpl.IsTaskRunning(AgentTask));
     end;
 
@@ -119,7 +119,7 @@ codeunit 4303 "Agent Task"
     var
         AgentTaskImpl: Codeunit "Agent Task Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskImpl.IsTaskCompleted(AgentTask));
     end;
 
@@ -132,7 +132,7 @@ codeunit 4303 "Agent Task"
     var
         AgentTaskImpl: Codeunit "Agent Task Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskImpl.IsTaskStopped(AgentTask));
     end;
 

--- a/src/System Application/App/Agent/Interaction/AgentTaskBuilder.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/AgentTaskBuilder.Codeunit.al
@@ -27,7 +27,7 @@ codeunit 4315 "Agent Task Builder"
     /// <returns>This instance of the Agent Task Builder.</returns>
     procedure Initialize(NewAgentUserSecurityId: Guid; NewTaskTitle: Text[150]): codeunit "Agent Task Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskBuilderImpl.Initialize(NewAgentUserSecurityId, NewTaskTitle);
         exit(this);
     end;
@@ -39,7 +39,7 @@ codeunit 4315 "Agent Task Builder"
     /// <remarks>The builder keeps the state, do not reuse the same instance of the builder to create multiple tasks.</remarks>
     procedure Create(): Record "Agent Task"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskBuilderImpl.Create(true, true));
     end;
 
@@ -51,7 +51,7 @@ codeunit 4315 "Agent Task Builder"
     /// <remarks>The builder keeps the state, do not reuse the same instance of the builder to create multiple tasks.</remarks>
     procedure Create(SetTaskStatusToReady: Boolean): Record "Agent Task"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskBuilderImpl.Create(SetTaskStatusToReady, true));
     end;
 
@@ -65,7 +65,7 @@ codeunit 4315 "Agent Task Builder"
     [Scope('OnPrem')]
     procedure Create(SetTaskStatusToReady: Boolean; RequiresMessage: Boolean): Record "Agent Task"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskBuilderImpl.Create(SetTaskStatusToReady, RequiresMessage));
     end;
 
@@ -77,7 +77,7 @@ codeunit 4315 "Agent Task Builder"
     /// </returns>
     procedure GetAgentTaskMessageCreated(): Record "Agent Task Message"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskBuilderImpl.GetAgentTaskMessageCreated());
     end;
 
@@ -88,7 +88,7 @@ codeunit 4315 "Agent Task Builder"
     /// <returns>This instance of the Agent Task Builder.</returns>
     procedure SetExternalId(ExternalId: Text[2048]): codeunit "Agent Task Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskBuilderImpl.SetExternalId(ExternalId);
         exit(this);
     end;
@@ -102,7 +102,7 @@ codeunit 4315 "Agent Task Builder"
     /// <returns>This instance of the Agent Task Builder.</returns>
     procedure AddTaskMessage(From: Text[250]; MessageText: Text): codeunit "Agent Task Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskBuilderImpl.AddTaskMessage(From, MessageText);
         exit(this);
     end;
@@ -115,7 +115,7 @@ codeunit 4315 "Agent Task Builder"
     /// <returns>This instance of the Agent Task Builder.</returns>
     procedure AddTaskMessage(var AgentTaskMessageBuilder: Codeunit "Agent Task Message Builder"): codeunit "Agent Task Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskBuilderImpl.AddTaskMessage(AgentTaskMessageBuilder);
         exit(this);
     end;
@@ -126,7 +126,7 @@ codeunit 4315 "Agent Task Builder"
     /// <returns>The agent task message builder.</returns>
     procedure GetTaskMessageBuilder(): Codeunit "Agent Task Message Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskBuilderImpl.GetTaskMessageBuilder());
     end;
 
@@ -140,7 +140,7 @@ codeunit 4315 "Agent Task Builder"
     var
         AgentTaskImpl: Codeunit "Agent Task Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskImpl.TaskExists(AgentUserSecurityId, ConversationId));
     end;
 }

--- a/src/System Application/App/Agent/Interaction/AgentTaskMessageBuilder.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/AgentTaskMessageBuilder.Codeunit.al
@@ -27,7 +27,7 @@ codeunit 4316 "Agent Task Message Builder"
     /// <returns>This instance of the Agent Task Message Builder.</returns>
     procedure Initialize(MessageText: Text): codeunit "Agent Task Message Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskMsgBuilderImpl.Initialize(MessageText);
         exit(this);
     end;
@@ -40,7 +40,7 @@ codeunit 4316 "Agent Task Message Builder"
     /// <returns>This instance of the Agent Task Message Builder.</returns>
     procedure Initialize(From: Text[250]; MessageText: Text): codeunit "Agent Task Message Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskMsgBuilderImpl.Initialize(From, MessageText);
         exit(this);
     end;
@@ -64,7 +64,7 @@ codeunit 4316 "Agent Task Message Builder"
     /// <param name="IgnoreAttachment">Specifies if attachments should be ignored.</param>
     procedure SetIgnoreAttachment(IgnoreAttachment: Boolean): codeunit "Agent Task Message Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskMsgBuilderImpl.SetIgnoreAttachment(IgnoreAttachment);
         exit(this);
     end;
@@ -79,7 +79,7 @@ codeunit 4316 "Agent Task Message Builder"
     [Scope('OnPrem')]
     procedure SetSkipMessageSanitization(SkipSanitizeMessage: Boolean): codeunit "Agent Task Message Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskMsgBuilderImpl.SetSkipMessageSanitization(SkipSanitizeMessage);
         exit(this);
     end;
@@ -91,7 +91,7 @@ codeunit 4316 "Agent Task Message Builder"
     /// <returns>This instance of the Agent Task Message Builder.</returns>
     procedure SetMessageExternalID(ExternalId: Text[2048]): codeunit "Agent Task Message Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskMsgBuilderImpl.SetMessageExternalID(ExternalId);
         exit(this);
     end;
@@ -103,7 +103,7 @@ codeunit 4316 "Agent Task Message Builder"
     /// <returns>This instance of the Agent Task Message Builder.</returns>
     procedure SetAgentTask(ParentAgentTask: Record "Agent Task"): codeunit "Agent Task Message Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskMsgBuilderImpl.SetAgentTask(ParentAgentTask);
         exit(this);
     end;
@@ -115,7 +115,7 @@ codeunit 4316 "Agent Task Message Builder"
     /// <returns>This instance of the Agent Task Message Builder.</returns>
     procedure SetAgentTask(ParentAgentTaskID: BigInteger): codeunit "Agent Task Message Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskMsgBuilderImpl.SetAgentTask(ParentAgentTaskID);
         exit(this);
     end;
@@ -132,7 +132,7 @@ codeunit 4316 "Agent Task Message Builder"
     /// </remarks>
     procedure Create(): Record "Agent Task Message"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskMsgBuilderImpl.Create());
     end;
 
@@ -150,7 +150,7 @@ codeunit 4316 "Agent Task Message Builder"
     /// </remarks>
     procedure Create(SetTaskStatusToReady: Boolean): Record "Agent Task Message"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskMsgBuilderImpl.Create(SetTaskStatusToReady));
     end;
 
@@ -162,7 +162,7 @@ codeunit 4316 "Agent Task Message Builder"
     /// </returns>
     procedure GetAgentTaskMessage(): Record "Agent Task Message"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskMsgBuilderImpl.GetAgentTaskMessage());
     end;
 
@@ -177,7 +177,7 @@ codeunit 4316 "Agent Task Message Builder"
     /// <returns>This instance of the Agent Task Message Builder.</returns>
     procedure AddAttachment(FileName: Text[250]; FileMIMEType: Text[100]; InStream: InStream): codeunit "Agent Task Message Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskMsgBuilderImpl.AddAttachment(FileName, FileMIMEType, InStream);
         exit(this);
     end;
@@ -194,7 +194,7 @@ codeunit 4316 "Agent Task Message Builder"
     /// <returns>This instance of the Agent Task Message Builder.</returns>
     procedure AddAttachment(FileName: Text[250]; FileMIMEType: Text[100]; InStream: InStream; Ignored: Boolean): codeunit "Agent Task Message Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskMsgBuilderImpl.AddAttachment(FileName, FileMIMEType, InStream, Ignored);
         exit(this);
     end;
@@ -211,7 +211,7 @@ codeunit 4316 "Agent Task Message Builder"
 #endif
     procedure AddAttachment(var AgentTaskFile: Record "Agent Task File"): codeunit "Agent Task Message Builder"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentTaskMsgBuilderImpl.AddAttachment(AgentTaskFile);
         exit(this);
     end;
@@ -226,7 +226,7 @@ codeunit 4316 "Agent Task Message Builder"
     /// <returns>True if the attachment was uploaded, false otherwise.</returns>
     procedure UploadAttachment(): Boolean
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskMsgBuilderImpl.UploadAttachment());
     end;
 
@@ -238,7 +238,7 @@ codeunit 4316 "Agent Task Message Builder"
     /// </returns>
     procedure GetLastAttachment(): Record "Agent Task File"
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskMsgBuilderImpl.GetLastAttachment());
     end;
 
@@ -250,7 +250,7 @@ codeunit 4316 "Agent Task Message Builder"
     /// </returns>
     procedure GetAttachments(var TempAttachments: Record "Agent Task File" temporary): Boolean
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentTaskMsgBuilderImpl.GetAttachments(TempAttachments));
     end;
 }

--- a/src/System Application/App/Agent/Setup/Agent.Codeunit.al
+++ b/src/System Application/App/Agent/Setup/Agent.Codeunit.al
@@ -29,7 +29,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentImpl.CreateAgent(AgentMetadataProvider, UserName, UserDisplayName, TempAgentAccessControl));
     end;
 
@@ -41,7 +41,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentImpl.Activate(AgentUserSecurityID);
     end;
 
@@ -53,7 +53,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentImpl.Deactivate(AgentUserSecurityID);
     end;
 
@@ -65,7 +65,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentImpl.GetDisplayName(AgentUserSecurityID));
     end;
 
@@ -77,7 +77,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentImpl.GetUserName(AgentUserSecurityID));
     end;
 
@@ -90,7 +90,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentImpl.SetDisplayName(AgentUserSecurityID, DisplayName);
     end;
 
@@ -103,7 +103,7 @@ codeunit 4321 Agent
     var
         AgentUtilities: Codeunit "Agent Utilities";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentUtilities.SetInstructions(AgentUserSecurityID, Instructions);
     end;
 
@@ -116,7 +116,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentImpl.IsActive(AgentUserSecurityID));
     end;
 
@@ -130,7 +130,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentImpl.PopulateProfileTempRecord(ProfileID, ProfileAppID, TempAllProfile);
     end;
 
@@ -145,7 +145,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentImpl.SetProfile(AgentUserSecurityID, ProfileID, ProfileAppID);
     end;
 
@@ -160,7 +160,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentImpl.UpdateLocalizationSettings(AgentUserSecurityID, LanguageID, LocaleID, TimeZone);
     end;
 
@@ -173,7 +173,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentImpl.GetUserSettings(AgentUserSecurityID, UserSettingsRec);
     end;
 
@@ -187,7 +187,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentImpl.AssignPermissionSets(AgentUserSecurityID, TempAccessControlBuffer);
     end;
 
@@ -200,7 +200,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentImpl.GetPermissionSets(AgentUserSecurityID, TempAccessControlBuffer);
     end;
 
@@ -213,7 +213,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentImpl.GetUserAccess(AgentUserSecurityID, TempAgentAccessControl);
     end;
 
@@ -226,7 +226,7 @@ codeunit 4321 Agent
     var
         AgentImpl: Codeunit "Agent Impl.";
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentImpl.UpdateAgentAccessControl(AgentUserSecurityID, TempAgentAccessControl);
     end;
 

--- a/src/System Application/App/Agent/Setup/SetupPart/AgentSetup.Codeunit.al
+++ b/src/System Application/App/Agent/Setup/SetupPart/AgentSetup.Codeunit.al
@@ -27,7 +27,7 @@ codeunit 4324 "Agent Setup"
     /// <param name="AgentSummary">Summary information about the agent</param>
     procedure GetSetupRecord(var AgentSetupBuffer: Record "Agent Setup Buffer"; UserSecurityID: Guid; AgentMetadataProvider: Enum "Agent Metadata Provider"; DefaultUserName: Code[50]; DefaultDisplayName: Text[80]; AgentSummary: Text)
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentSetupImpl.GetSetupRecord(AgentSetupBuffer, UserSecurityID, AgentMetadataProvider, DefaultUserName, DefaultDisplayName, AgentSummary);
     end;
 
@@ -38,7 +38,7 @@ codeunit 4324 "Agent Setup"
     /// <param name="Source"><see cref="AgentSetupBuffer"/> that contains the setup data to be copied.</param>
     procedure CopySetupRecord(var Target: Record "Agent Setup Buffer"; var Source: Record "Agent Setup Buffer")
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentSetupImpl.CopySetupRecord(Target, Source);
     end;
 
@@ -49,7 +49,7 @@ codeunit 4324 "Agent Setup"
     /// <returns>Agent User ID of the created or updated agent.</returns>
     procedure SaveChanges(var AgentSetupBuffer: Record "Agent Setup Buffer") "Agent User ID": Guid
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentSetupImpl.SaveChanges(AgentSetupBuffer));
     end;
 
@@ -60,7 +60,7 @@ codeunit 4324 "Agent Setup"
     /// <returns>True if there are changes made, false otherwise.</returns>
     procedure GetChangesMade(var AgentSetupBuffer: Record "Agent Setup Buffer"): Boolean
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentSetupImpl.GetChangesMade(AgentSetupBuffer));
     end;
 
@@ -71,7 +71,7 @@ codeunit 4324 "Agent Setup"
     /// <returns>True if the language and region settings were updated, false otherwise.</returns>
     procedure OpenLanguageAndRegionPage(var AgentSetupBuffer: Record "Agent Setup Buffer"): Boolean
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentSetupImpl.OpenLanguageAndRegionPage(AgentSetupBuffer));
     end;
 
@@ -82,7 +82,7 @@ codeunit 4324 "Agent Setup"
     /// <returns>Summary information about the agent.</returns>
     procedure GetAgentSummary(var AgentSetupBuffer: Record "Agent Setup Buffer"): Text
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentSetupImpl.GetAgentSummary(AgentSetupBuffer));
     end;
 
@@ -93,7 +93,7 @@ codeunit 4324 "Agent Setup"
     /// <returns>True if the user access control settings were updated, false otherwise.</returns>
     procedure OpenAgentAccessControlPage(var AgentSetupBuffer: Record "Agent Setup Buffer"): Boolean
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentSetupImpl.OpenAgentAccessControlSetup(AgentSetupBuffer));
     end;
 
@@ -104,7 +104,7 @@ codeunit 4324 "Agent Setup"
     /// <param name="UserSettingsRec">User settings to update with the new profile</param>
     procedure OpenProfileLookup(var UserSettingsRec: Record "User Settings"): Boolean
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentSetupImpl.OpenProfileLookup(UserSettingsRec));
     end;
 
@@ -114,7 +114,7 @@ codeunit 4324 "Agent Setup"
     /// <returns>The security ID of the selected agent or the empty guid if none selected.</returns>
     procedure OpenAgentLookup(var AgentUserSecurityId: Guid): Boolean
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentSetupImpl.OpenAgentLookup(AgentUserSecurityId));
     end;
 
@@ -126,7 +126,7 @@ codeunit 4324 "Agent Setup"
     /// <returns>True if an agent with the provided user name is found, false otherwise.</returns>
     procedure FindAgentByUserName(AgentUserName: Text; var AgentUserSecurityId: Guid): Boolean
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentSetupImpl.FindAgentByUserName(AgentUserName, AgentUserSecurityId));
     end;
 
@@ -137,7 +137,7 @@ codeunit 4324 "Agent Setup"
     /// <returns>The security ID of the selected agent or the empty guid if none selected.</returns>
     procedure OpenAgentLookup(AgentType: Enum "Agent Metadata Provider"; var AgentUserSecurityId: Guid): Boolean
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentSetupImpl.OpenAgentLookup(AgentType, AgentUserSecurityId));
     end;
 
@@ -147,7 +147,7 @@ codeunit 4324 "Agent Setup"
     /// <param name="AgentSetupBuffer">A record that should point to the agent.</param>
     procedure OpenSetupPage(var AgentSetupBuffer: Record "Agent Setup Buffer")
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentSetupImpl.OpenSetupPage(AgentSetupBuffer."User Security ID");
     end;
 
@@ -157,7 +157,7 @@ codeunit 4324 "Agent Setup"
     /// <param name="AgentUserSecurityId">The user security ID of the agent.</param>
     procedure OpenSetupPage(AgentUserSecurityId: Guid)
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         AgentSetupImpl.OpenSetupPage(AgentUserSecurityId);
     end;
 
@@ -169,7 +169,7 @@ codeunit 4324 "Agent Setup"
     [Scope('OnPrem')]
     procedure UpdateUserAccessControl(var AgentSetupBuffer: Record "Agent Setup Buffer"): Boolean
     begin
-        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        FeatureAccessManagement.AgentManagementAllowed(true);
         exit(AgentSetupImpl.OpenAgentAccessControlSetup(AgentSetupBuffer));
     end;
 


### PR DESCRIPTION
…iewEnabled

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Use new utility as AgentTaskManagementPreviewEnabled should be removed.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#621141](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/621141)



