### PR TITLE
Email: expose FindEmailSourceEntities and GetPrimarySourceEntity

### DIFF
--- a/src/System Application/App/Email/src/Email/Email.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/Email.Codeunit.al
@@ -629,6 +629,29 @@ codeunit 8901 Email
     end;
 
     /// <summary>
+    /// Finds all source entities related to an email message and returns them as a dictionary of table IDs to pipe-separated system IDs.
+    /// </summary>
+    /// <param name="EmailMessage">The email message for which to find source entities.</param>
+    /// <param name="Dict">A dictionary mapping each table ID to a pipe-separated list of system IDs of the related records.</param>
+    /// <returns>True if at least one source entity was found, otherwise false.</returns>
+    procedure FindEmailSourceEntities(EmailMessage: Codeunit "Email Message"; var Dict: Dictionary of [Integer, Text]): Boolean
+    begin
+        exit(EmailImpl.FindEmailSourceEntities(EmailMessage.GetId(), Dict));
+    end;
+
+    /// <summary>
+    /// Gets the primary source entity among the related entities of an email message.
+    /// </summary>
+    /// <param name="PrimarySource">Out parameter that receives the table ID of the primary source entity.</param>
+    /// <param name="EmailMessage">The email message for which to find the primary source entity.</param>
+    /// <param name="RelatedIds">The list of table IDs of the candidate related entities.</param>
+    /// <returns>True if a primary source entity was found, otherwise false.</returns>
+    procedure GetPrimarySourceEntity(var PrimarySource: Integer; EmailMessage: Codeunit "Email Message"; RelatedIds: List of [Integer]): Boolean
+    begin
+        exit(EmailImpl.GetPrimarySourceEntity(PrimarySource, EmailMessage.GetId(), RelatedIds));
+    end;
+
+    /// <summary>
     /// Adds the default attachments of a scenario to the email message.
     /// </summary>
     /// <param name="EmailMessage">The email message for which to add the attachments.</param>

--- a/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
@@ -746,9 +746,11 @@ codeunit 8900 "Email Impl"
     var
         EmailRelatedRecord: Record "Email Related Record";
         SystemIdFilter: Text;
+        Found: Boolean;
     begin
         EmailRelatedRecord.SetRange("Email Message Id", EmailMessageId);
-        if EmailRelatedRecord.FindSet() then
+        Found := EmailRelatedRecord.FindSet();
+        if Found then
             repeat
                 if Dict.Get(EmailRelatedRecord."Table Id", SystemIdFilter) then
                     Dict.Set(EmailRelatedRecord."Table Id", SystemIdFilter + '|' + Format(EmailRelatedRecord."System Id"))
@@ -756,7 +758,7 @@ codeunit 8900 "Email Impl"
                     Dict.Add(EmailRelatedRecord."Table Id", Format(EmailRelatedRecord."System Id"));
             until EmailRelatedRecord.Next() <= 0;
 
-        exit(EmailRelatedRecord.Count() > 0);
+        exit(Found);
     end;
 
     procedure GetPrimarySourceEntity(var PrimarySource: Integer; EmailMessageId: Guid; RelatedIds: List of [Integer]): Boolean
@@ -772,7 +774,7 @@ codeunit 8900 "Email Impl"
 
         EmailRelatedRecord.SetRange("Email Message Id", EmailMessageId);
         foreach RelatedId in RelatedIds do begin
-            EmailRelatedRecord.SetFilter("Table Id", Format(RelatedId));
+            EmailRelatedRecord.SetRange("Table Id", RelatedId);
 
             if EmailRelatedRecord.FindSet() then
                 repeat

--- a/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
@@ -742,6 +742,50 @@ codeunit 8900 "Email Impl"
         exit(not EmailRelatedRecord.IsEmpty());
     end;
 
+    procedure FindEmailSourceEntities(EmailMessageId: Guid; var Dict: Dictionary of [Integer, Text]): Boolean
+    var
+        EmailRelatedRecord: Record "Email Related Record";
+        SystemIdFilter: Text;
+    begin
+        EmailRelatedRecord.SetRange("Email Message Id", EmailMessageId);
+        if EmailRelatedRecord.FindSet() then
+            repeat
+                if Dict.Get(EmailRelatedRecord."Table Id", SystemIdFilter) then
+                    Dict.Set(EmailRelatedRecord."Table Id", SystemIdFilter + '|' + Format(EmailRelatedRecord."System Id"))
+                else
+                    Dict.Add(EmailRelatedRecord."Table Id", Format(EmailRelatedRecord."System Id"));
+            until EmailRelatedRecord.Next() <= 0;
+
+        exit(EmailRelatedRecord.Count() > 0);
+    end;
+
+    procedure GetPrimarySourceEntity(var PrimarySource: Integer; EmailMessageId: Guid; RelatedIds: List of [Integer]): Boolean
+    var
+        EmailRelatedRecord: Record "Email Related Record";
+        RelatedId: Integer;
+    begin
+        // If there is only one key in the dict, then there is no need to use DB resources.
+        if RelatedIds.Count = 1 then begin
+            PrimarySource := RelatedIds.Get(1);
+            exit(true);
+        end;
+
+        EmailRelatedRecord.SetRange("Email Message Id", EmailMessageId);
+        foreach RelatedId in RelatedIds do begin
+            EmailRelatedRecord.SetFilter("Table Id", Format(RelatedId));
+
+            if EmailRelatedRecord.FindSet() then
+                repeat
+                    if EmailRelatedRecord."Relation Type" = EmailRelatedRecord."Relation Type"::"Primary Source" then begin
+                        PrimarySource := RelatedId;
+                        exit(true);
+                    end;
+                until EmailRelatedRecord.Next() = 0;
+        end;
+
+        exit(false);
+    end;
+
     procedure FilterRemovedSourceRecords(var EmailRelatedRecord: Record "Email Related Record")
     var
         AllObj: Record AllObj;

--- a/src/System Application/App/Email/src/Email/Outbox/EmailEditor.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/Outbox/EmailEditor.Codeunit.al
@@ -297,60 +297,17 @@ codeunit 8906 "Email Editor"
             until TempEmailRelatedAttachment.Next() = 0;
     end;
 
-    local procedure GetPrimarySourceEntity(var PrimarySource: Integer; EmailMessageID: Guid; RelatedIds: List of [Integer]): Boolean
-    var
-        EmailRelatedRecord: Record "Email Related Record";
-        RelatedId: Integer;
-    begin
-        // If there is only one key in the dict, then there is no need to use DB resources.
-        if RelatedIds.Count = 1 then begin
-            PrimarySource := RelatedIds.Get(1);
-            exit(true);
-        end;
-
-        EmailRelatedRecord.SetRange("Email Message Id", EmailMessageID);
-        foreach RelatedId in RelatedIds do begin
-            EmailRelatedRecord.SetFilter("Table Id", Format(RelatedId));
-
-            if EmailRelatedRecord.FindSet() then
-                repeat
-                    if EmailRelatedRecord."Relation Type" = EmailRelatedRecord."Relation Type"::"Primary Source" then begin
-                        PrimarySource := RelatedId;
-                        exit(true);
-                    end;
-                until EmailRelatedRecord.Next() = 0;
-        end;
-
-        exit(false);
-    end;
-
-    local procedure FindEmailSourceEntities(EmailMessageID: Guid; var Dict: Dictionary of [Integer, Text]): Boolean
-    var
-        EmailRelatedRecord: Record "Email Related Record";
-        SystemIdFilter: Text;
-    begin
-        EmailRelatedRecord.SetRange("Email Message Id", EmailMessageID);
-        if EmailRelatedRecord.FindSet() then
-            repeat
-                if Dict.Get(EmailRelatedRecord."Table Id", SystemIdFilter) then
-                    Dict.Set(EmailRelatedRecord."Table Id", SystemIdFilter + '|' + Format(EmailRelatedRecord."System Id"))
-                else
-                    Dict.Add(EmailRelatedRecord."Table Id", Format(EmailRelatedRecord."System Id"));
-            until EmailRelatedRecord.Next() <= 0;
-
-        exit(EmailRelatedRecord.Count() > 0);
-    end;
-
     procedure LoadWordTemplate(EmailMessageImpl: Codeunit "Email Message Impl."; EmailMessageID: Guid)
     var
         WordTemplateRecord: Record "Word Template";
         WordTemplateToTextWizard: Page "Word Template To Text Wizard";
+        EmailImpl: Codeunit "Email Impl";
         TemplateSize: Integer;
         Dict: Dictionary of [Integer, Text];
         PrimarySource: Integer;
     begin
-        if FindEmailSourceEntities(EmailMessageID, Dict) then begin
-            if not GetPrimarySourceEntity(PrimarySource, EmailMessageID, Dict.Keys) then
+        if EmailImpl.FindEmailSourceEntities(EmailMessageID, Dict) then begin
+            if not EmailImpl.GetPrimarySourceEntity(PrimarySource, EmailMessageID, Dict.Keys) then
                 Error(NoPrimarySourceOnEmailErr);
 
             WordTemplateToTextWizard.SetData(Dict, PrimarySource);
@@ -378,13 +335,14 @@ codeunit 8906 "Email Editor"
     var
         WordTemplateRecord: Record "Word Template";
         WordTemplateSelectionWizard: Page "Word Template Selection Wizard";
+        EmailImpl: Codeunit "Email Impl";
         InStream: InStream;
         Filename: Text;
         FileSize: Integer;
         ContentType: Text[250];
         Dict: Dictionary of [Integer, Text];
     begin
-        if FindEmailSourceEntities(EmailMessageID, Dict) then begin
+        if EmailImpl.FindEmailSourceEntities(EmailMessageID, Dict) then begin
             WordTemplateSelectionWizard.SetData(Dict);
             WordTemplateSelectionWizard.SaveAsDocumentStream();
             WordTemplateSelectionWizard.RunModal();

--- a/src/System Application/App/Email/src/Email/Outbox/EmailEditor.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/Outbox/EmailEditor.Codeunit.al
@@ -300,8 +300,8 @@ codeunit 8906 "Email Editor"
     procedure LoadWordTemplate(EmailMessageImpl: Codeunit "Email Message Impl."; EmailMessageID: Guid)
     var
         WordTemplateRecord: Record "Word Template";
-        WordTemplateToTextWizard: Page "Word Template To Text Wizard";
         EmailImpl: Codeunit "Email Impl";
+        WordTemplateToTextWizard: Page "Word Template To Text Wizard";
         TemplateSize: Integer;
         Dict: Dictionary of [Integer, Text];
         PrimarySource: Integer;
@@ -334,8 +334,8 @@ codeunit 8906 "Email Editor"
     procedure AttachFromWordTemplate(EmailMessageImpl: Codeunit "Email Message Impl."; EmailMessageID: Guid)
     var
         WordTemplateRecord: Record "Word Template";
-        WordTemplateSelectionWizard: Page "Word Template Selection Wizard";
         EmailImpl: Codeunit "Email Impl";
+        WordTemplateSelectionWizard: Page "Word Template Selection Wizard";
         InStream: InStream;
         Filename: Text;
         FileSize: Integer;

--- a/src/System Application/Test/Email/src/EmailTest.Codeunit.al
+++ b/src/System Application/Test/Email/src/EmailTest.Codeunit.al
@@ -1458,6 +1458,9 @@ codeunit 134685 "Email Test"
         // [Then] The primary source is the table marked as primary source, not the related entity
         Assert.AreEqual(PrimaryTableId, PrimarySource, 'GetPrimarySourceEntity should return the table ID of the primary source record');
     end;
+
+    [Test]
+    procedure GetSentEmailsForRecordByVariant()
     var
         SentEmail: Record "Sent Email";
         TempSentEmail: Record "Sent Email" temporary;

--- a/src/System Application/Test/Email/src/EmailTest.Codeunit.al
+++ b/src/System Application/Test/Email/src/EmailTest.Codeunit.al
@@ -1344,7 +1344,120 @@ codeunit 134685 "Email Test"
     end;
 
     [Test]
-    procedure GetSentEmailsForRecordByVariant()
+    [Scope('OnPrem')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure FindEmailSourceEntitiesWithRelatedRecord()
+    var
+        EmailOutbox: Record "Email Outbox";
+        EmailMessage: Codeunit "Email Message";
+        Any: Codeunit Any;
+        Dict: Dictionary of [Integer, Text];
+        TableId: Integer;
+        SystemId: Guid;
+    begin
+        // [Scenario] FindEmailSourceEntities returns the related source entities for an email.
+        PermissionsMock.Set('Email Edit');
+
+        // [Given] An email created with a primary source relation
+        TableId := Any.IntegerInRange(1, 10000);
+        SystemId := Any.GuidValue();
+        CreateEmailWithSource(EmailMessage, TableId, SystemId);
+        Email.SaveAsDraft(EmailMessage, EmailOutbox);
+
+        // [When] FindEmailSourceEntities is called
+        // [Then] The dict is populated with the table ID and system ID of the source
+        Assert.IsTrue(Email.FindEmailSourceEntities(EmailMessage, Dict), 'FindEmailSourceEntities should return true when source entities exist');
+        Assert.IsTrue(Dict.ContainsKey(TableId), 'The dict should contain the source table ID');
+        Assert.IsTrue(Dict.Get(TableId).Contains(Format(SystemId)), 'The dict should contain the system ID of the source');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure FindEmailSourceEntitiesWithNoRelatedRecord()
+    var
+        EmailOutbox: Record "Email Outbox";
+        EmailMessage: Codeunit "Email Message";
+        Dict: Dictionary of [Integer, Text];
+    begin
+        // [Scenario] FindEmailSourceEntities returns false when the email has no source entities.
+        PermissionsMock.Set('Email Edit');
+
+        // [Given] An email with no relations
+        CreateEmail(EmailMessage);
+        Email.SaveAsDraft(EmailMessage, EmailOutbox);
+
+        // [When] FindEmailSourceEntities is called
+        // [Then] The function returns false and the dict remains empty
+        Assert.IsFalse(Email.FindEmailSourceEntities(EmailMessage, Dict), 'FindEmailSourceEntities should return false when no source entities exist');
+        Assert.AreEqual(0, Dict.Count(), 'The dict should be empty when there are no source entities');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure GetPrimarySourceEntityWithSingleSource()
+    var
+        EmailOutbox: Record "Email Outbox";
+        EmailMessage: Codeunit "Email Message";
+        Any: Codeunit Any;
+        Dict: Dictionary of [Integer, Text];
+        PrimarySource: Integer;
+        TableId: Integer;
+        SystemId: Guid;
+    begin
+        // [Scenario] GetPrimarySourceEntity returns the single source when there is exactly one.
+        PermissionsMock.Set('Email Edit');
+
+        // [Given] An email with a single primary source relation
+        TableId := Any.IntegerInRange(1, 10000);
+        SystemId := Any.GuidValue();
+        CreateEmailWithSource(EmailMessage, TableId, SystemId);
+        Email.SaveAsDraft(EmailMessage, EmailOutbox);
+
+        // [When] FindEmailSourceEntities and GetPrimarySourceEntity are called
+        Assert.IsTrue(Email.FindEmailSourceEntities(EmailMessage, Dict), 'FindEmailSourceEntities should return true');
+        Assert.IsTrue(Email.GetPrimarySourceEntity(PrimarySource, EmailMessage, Dict.Keys), 'GetPrimarySourceEntity should return true for a single source');
+
+        // [Then] The primary source is the table ID of the only relation
+        Assert.AreEqual(TableId, PrimarySource, 'GetPrimarySourceEntity should return the table ID of the single source');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure GetPrimarySourceEntityWithMultipleSources()
+    var
+        EmailOutbox: Record "Email Outbox";
+        EmailMessageRecord: Record "Email Message";
+        EmailMessage: Codeunit "Email Message";
+        Any: Codeunit Any;
+        Dict: Dictionary of [Integer, Text];
+        PrimarySource: Integer;
+        PrimaryTableId: Integer;
+        RelatedTableId: Integer;
+    begin
+        // [Scenario] GetPrimarySourceEntity returns the record marked as primary source when there are multiple sources.
+        PermissionsMock.Set('Email Edit');
+
+        // [Given] An email with two related records, one marked as primary source and one as related entity
+        PrimaryTableId := Database::"Email Outbox";
+        CreateEmail(EmailMessage);
+        Email.SaveAsDraft(EmailMessage, EmailOutbox);
+
+        EmailMessageRecord.Get(EmailMessage.GetId());
+        RelatedTableId := Database::"Email Message";
+
+        Email.AddRelation(EmailMessage, PrimaryTableId, EmailOutbox.SystemId, Enum::"Email Relation Type"::"Primary Source", Enum::"Email Relation Origin"::"Compose Context");
+        Email.AddRelation(EmailMessage, RelatedTableId, EmailMessageRecord.SystemId, Enum::"Email Relation Type"::"Related Entity", Enum::"Email Relation Origin"::"Compose Context");
+
+        // [When] FindEmailSourceEntities and GetPrimarySourceEntity are called
+        Assert.IsTrue(Email.FindEmailSourceEntities(EmailMessage, Dict), 'FindEmailSourceEntities should return true');
+        Assert.IsTrue(Email.GetPrimarySourceEntity(PrimarySource, EmailMessage, Dict.Keys), 'GetPrimarySourceEntity should return true when a primary source exists');
+
+        // [Then] The primary source is the table marked as primary source, not the related entity
+        Assert.AreEqual(PrimaryTableId, PrimarySource, 'GetPrimarySourceEntity should return the table ID of the primary source record');
+    end;
     var
         SentEmail: Record "Sent Email";
         TempSentEmail: Record "Sent Email" temporary;


### PR DESCRIPTION
Fixes #4540

## Summary

The procedures GetPrimarySourceEntity and FindEmailSourceEntities were previously local to EmailEditor (codeunit 8906), making them inaccessible to scenarios that send emails programmatically without opening the editor (e.g. Word template emails sent via email flows, referenced in ALAppExtensions issues #29062 and #29061).

## Changes

### EmailImpl.Codeunit.al (codeunit 8900)
Added two internal procedures following the existing delegation pattern used by HasSourceRecord, AddRelation and RemoveRelation:
- FindEmailSourceEntities(EmailMessageId: Guid; var Dict: Dictionary of [Integer, Text]): Boolean
- GetPrimarySourceEntity(var PrimarySource: Integer; EmailMessageId: Guid; RelatedIds: List of [Integer]): Boolean

### Email.Codeunit.al (codeunit 8901)
Exposed both procedures publicly with XML documentation, using EmailMessage: Codeunit parameters consistent with the existing public API (AddRelation, RemoveRelation, HasRelations):
- FindEmailSourceEntities(EmailMessage: Codeunit "Email Message"; var Dict: Dictionary of [Integer, Text]): Boolean
- GetPrimarySourceEntity(var PrimarySource: Integer; EmailMessage: Codeunit "Email Message"; RelatedIds: List of [Integer]): Boolean

### EmailEditor.Codeunit.al (codeunit 8906)
Removed the two local procedure copies and refactored LoadWordTemplate and AttachFromWordTemplate to delegate to EmailImpl, keeping behaviour identical.

### EmailTest.Codeunit.al
Added 4 automated tests:
- FindEmailSourceEntitiesWithRelatedRecord - verifies source entities are returned correctly
- FindEmailSourceEntitiesWithNoRelatedRecord - verifies false is returned when no entities exist
- GetPrimarySourceEntityWithSingleSource - verifies single-source shortcut path
- GetPrimarySourceEntityWithMultipleSources - verifies correct primary is identified among multiple relations




