### PR TITLE
RSA: add PEM import and export to RSA and RSACryptoServiceProvider

### DIFF
--- a/src/System Application/App/Cryptography Management/src/RSA.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/RSA.Codeunit.al
@@ -27,6 +27,61 @@ codeunit 1475 "RSA"
     end;
 
     /// <summary>
+    /// Imports the public or private RSA key from a PEM-encoded string into the current RSA instance.
+    /// Supported PEM labels: RSA PRIVATE KEY, PRIVATE KEY, ENCRYPTED PRIVATE KEY, RSA PUBLIC KEY, PUBLIC KEY.
+    /// </summary>
+    /// <param name="PemKey">The PEM-encoded RSA key to import.</param>
+    procedure ImportFromPem(PemKey: SecretText)
+    begin
+        RSAImpl.ImportFromPem(PemKey);
+    end;
+
+    /// <summary>
+    /// Exports the public key of the current RSA instance in PKCS#1 PEM format.
+    /// </summary>
+    /// <returns>The RSA public key as a PEM-encoded string.</returns>
+    procedure ExportRSAPublicKeyPem(): Text
+    begin
+        exit(RSAImpl.ExportRSAPublicKeyPem());
+    end;
+
+    /// <summary>
+    /// Exports the private key of the current RSA instance in PKCS#1 PEM format.
+    /// </summary>
+    /// <returns>The RSA private key as a PEM-encoded string.</returns>
+    procedure ExportRSAPrivateKeyPem(): SecretText
+    begin
+        exit(RSAImpl.ExportRSAPrivateKeyPem());
+    end;
+
+    /// <summary>
+    /// Computes the hash value of the specified data and signs it using the loaded RSA key.
+    /// Call ImportFromPem or InitializeRSA before using this overload.
+    /// </summary>
+    /// <param name="DataInStream">The input stream to hash and sign.</param>
+    /// <param name="HashAlgorithm">The hash algorithm to use to create the hash value.</param>
+    /// <param name="RSASignaturePadding">The padding mode to use for the RSA signature.</param>
+    /// <param name="SignatureOutStream">The RSA signature stream for the specified data.</param>
+    procedure SignData(DataInStream: InStream; HashAlgorithm: Enum "Hash Algorithm"; RSASignaturePadding: Enum "RSA Signature Padding"; SignatureOutStream: OutStream)
+    begin
+        RSAImpl.SignData(DataInStream, HashAlgorithm, RSASignaturePadding, SignatureOutStream);
+    end;
+
+    /// <summary>
+    /// Verifies that a digital signature is valid using the loaded RSA key.
+    /// Call ImportFromPem or InitializeRSA before using this overload.
+    /// </summary>
+    /// <param name="DataInStream">The input stream of data that was signed.</param>
+    /// <param name="HashAlgorithm">The name of the hash algorithm used to create the hash value of the data.</param>
+    /// <param name="RSASignaturePadding">The padding mode to use for the RSA signature.</param>
+    /// <param name="SignatureInStream">The stream of signature data to be verified.</param>
+    /// <returns>True if the signature is valid; otherwise, false.</returns>
+    procedure VerifyData(DataInStream: InStream; HashAlgorithm: Enum "Hash Algorithm"; RSASignaturePadding: Enum "RSA Signature Padding"; SignatureInStream: InStream): Boolean
+    begin
+        exit(RSAImpl.VerifyData(DataInStream, HashAlgorithm, RSASignaturePadding, SignatureInStream));
+    end;
+
+    /// <summary>
     /// Creates a RSA object with private key and returns the XML string.
     /// </summary>
     /// <param name="PrivateKey">private key as text</param>

--- a/src/System Application/App/Cryptography Management/src/RSACryptoServiceProvider.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/RSACryptoServiceProvider.Codeunit.al
@@ -107,4 +107,14 @@ codeunit 1445 RSACryptoServiceProvider
     begin
         RSACryptoServiceProviderImpl.CreateRSAKeyPair(PublicKeyInXml, PrivateKeyInXml);
     end;
+
+    /// <summary>
+    /// Imports the public or private RSA key from a PEM-encoded string into the current RSACryptoServiceProvider instance.
+    /// Supported PEM labels: RSA PRIVATE KEY, PRIVATE KEY, ENCRYPTED PRIVATE KEY, RSA PUBLIC KEY, PUBLIC KEY.
+    /// </summary>
+    /// <param name="PemKey">The PEM-encoded RSA key to import.</param>
+    procedure ImportFromPem(PemKey: SecretText)
+    begin
+        RSACryptoServiceProviderImpl.ImportFromPem(PemKey);
+    end;
 }

--- a/src/System Application/App/Cryptography Management/src/RSACryptoServiceProviderImpl.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/RSACryptoServiceProviderImpl.Codeunit.al
@@ -158,19 +158,19 @@ codeunit 1446 "RSACryptoServiceProvider Impl." implements "Signature Algorithm v
     var
         DotNetRSA: DotNet RSA;
         RSAEncryptionHelper: DotNet RSAEncryptionHelper;
-        XmlString: Text;
+        XmlString: SecretText;
     begin
         RSACryptoServiceProvider();
         DotNetRSA := DotNetRSACryptoServiceProvider.Create();
         RSAEncryptionHelper.ImportFromPem(DotNetRSA, PemKey.Unwrap());
         if not TryExportPrivateXml(DotNetRSA, XmlString) then
             XmlString := DotNetRSA.ToXmlString(false);
-        DotNetRSACryptoServiceProvider.FromXmlString(XmlString);
+        FromSecretXmlString(XmlString);
     end;
 
     [TryFunction]
     [NonDebuggable]
-    local procedure TryExportPrivateXml(DotNetRSA: DotNet RSA; var XmlString: Text)
+    local procedure TryExportPrivateXml(DotNetRSA: DotNet RSA; var XmlString: SecretText)
     begin
         XmlString := DotNetRSA.ToXmlString(true);
     end;

--- a/src/System Application/App/Cryptography Management/src/RSACryptoServiceProviderImpl.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/RSACryptoServiceProviderImpl.Codeunit.al
@@ -152,6 +152,28 @@ codeunit 1446 "RSACryptoServiceProvider Impl." implements "Signature Algorithm v
         RSACryptoServiceProvider();
         DotNetRSACryptoServiceProvider.FromXmlString(XmlString.Unwrap());
     end;
+
+    [NonDebuggable]
+    procedure ImportFromPem(PemKey: SecretText)
+    var
+        DotNetRSA: DotNet RSA;
+        RSAEncryptionHelper: DotNet RSAEncryptionHelper;
+        XmlString: Text;
+    begin
+        RSACryptoServiceProvider();
+        DotNetRSA := DotNetRSACryptoServiceProvider.Create();
+        RSAEncryptionHelper.ImportFromPem(DotNetRSA, PemKey.Unwrap());
+        if not TryExportPrivateXml(DotNetRSA, XmlString) then
+            XmlString := DotNetRSA.ToXmlString(false);
+        DotNetRSACryptoServiceProvider.FromXmlString(XmlString);
+    end;
+
+    [TryFunction]
+    [NonDebuggable]
+    local procedure TryExportPrivateXml(DotNetRSA: DotNet RSA; var XmlString: Text)
+    begin
+        XmlString := DotNetRSA.ToXmlString(true);
+    end;
     #endregion
 
     local procedure RSACryptoServiceProvider()

--- a/src/System Application/App/Cryptography Management/src/RSAImpl.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/RSAImpl.Codeunit.al
@@ -163,6 +163,22 @@ codeunit 1476 "RSA Impl." implements "Signature Algorithm v2"
     #endregion
 
 
+    #region PEM
+    [NonDebuggable]
+    procedure ImportFromPem(PemKey: SecretText)
+    var
+        RSAEncryptionHelper: DotNet RSAEncryptionHelper;
+    begin
+        RSA();
+        RSAEncryptionHelper.ImportFromPem(DotNetRSA, PemKey.Unwrap());
+    end;
+
+    procedure ExportRSAPublicKeyPem(): Text
+    begin
+        exit(DotNetRSA.ExportRSAPublicKeyPem());
+    end;
+    #endregion
+
     #region XmlString
     [NonDebuggable]
     procedure ToSecretXmlString(PrivateKey: SecretText; IncludePrivateParameters: Boolean): SecretText

--- a/src/System Application/Test/Cryptography Management/src/RSACryptoServiceProviderTests.Codeunit.al
+++ b/src/System Application/Test/Cryptography Management/src/RSACryptoServiceProviderTests.Codeunit.al
@@ -205,6 +205,46 @@ codeunit 132613 RSACryptoServiceProviderTests
         LibraryAssert.ExpectedError('A call to System.Security.Cryptography.RSACryptoServiceProvider.Decrypt failed with this message:');
     end;
 
+    [Test]
+    procedure ImportFromPemAndSignData()
+    var
+        RSA: Codeunit RSA;
+        EncryptingTempBlob: Codeunit "Temp Blob";
+        SignatureTempBlob: Codeunit "Temp Blob";
+        EncryptingOutStream: OutStream;
+        SignatureOutStream: OutStream;
+        EncryptingInStream: InStream;
+        SignatureInStream: InStream;
+        PemPrivateKey: SecretText;
+        PublicKeyXmlText: Text;
+        PublicKeyXmlSecret: SecretText;
+    begin
+        // [SCENARIO] A PEM-encoded private key imported into RSACryptoServiceProvider can be used to sign data.
+
+        // [GIVEN] A PEM private key and its matching XML public key generated via the RSA codeunit
+        RSA.InitializeRSA(2048);
+        PemPrivateKey := RSA.ExportRSAPrivateKeyPem();
+        PublicKeyXmlText := GetXmlString(RSA.ToSecretXmlString(false));
+        PublicKeyXmlSecret := PublicKeyXmlText;
+
+        // [GIVEN] Random data to sign
+        EncryptingTempBlob.CreateOutStream(EncryptingOutStream);
+        SaveRandomTextToOutStream(EncryptingOutStream);
+        EncryptingTempBlob.CreateInStream(EncryptingInStream);
+
+        // [WHEN] The PEM key is imported into RSACryptoServiceProvider and the data is signed
+        RSACryptoServiceProvider.ImportFromPem(PemPrivateKey);
+        SignatureTempBlob.CreateOutStream(SignatureOutStream);
+        RSACryptoServiceProvider.SignData(RSACryptoServiceProvider.ToSecretXmlString(true), EncryptingInStream, Enum::"Hash Algorithm"::SHA256, SignatureOutStream);
+
+        EncryptingTempBlob.CreateInStream(EncryptingInStream);
+        SignatureTempBlob.CreateInStream(SignatureInStream);
+
+        // [THEN] The signature is valid when verified against the matching public key
+        LibraryAssert.IsTrue(RSACryptoServiceProvider.VerifyData(PublicKeyXmlSecret, EncryptingInStream, Enum::"Hash Algorithm"::SHA256, SignatureInStream),
+            'Signature must be valid after ImportFromPem with a private key.');
+    end;
+
     local procedure SaveRandomTextToOutStream(OutStream: OutStream) PlainText: Text
     begin
         PlainText := Any.AlphanumericText(Any.IntegerInRange(80));

--- a/src/System Application/Test/Cryptography Management/src/RSATest.Codeunit.al
+++ b/src/System Application/Test/Cryptography Management/src/RSATest.Codeunit.al
@@ -339,7 +339,7 @@ codeunit 132617 "RSA Test"
         TempBlobData.CreateInStream(DataInStream);
         TempBlobSignature.CreateInStream(SignatureInStream);
 
-        // [THEN] The signature can be verified using the first instance's stateful verify (same key loaded)
+        // [THEN] The signature can be verified using the instance that imported the PEM private key
         LibraryAssert.IsTrue(RSA2.VerifyData(DataInStream, Enum::"Hash Algorithm"::SHA256, Enum::"RSA Signature Padding"::Pkcs1, SignatureInStream),
             'Signature must be valid after ImportFromPem with a private key.');
     end;
@@ -423,10 +423,10 @@ codeunit 132617 "RSA Test"
         // [WHEN] The public key is exported as PEM
         PublicKeyPem := RSA1.ExportRSAPublicKeyPem();
 
-        // [THEN] The result contains a valid PEM header and footer
-        LibraryAssert.IsTrue(PublicKeyPem.Contains('-----BEGIN RSA PUBLIC KEY-----'),
+        // [THEN] The result has valid PEM header and footer in the correct positions
+        LibraryAssert.IsTrue(PublicKeyPem.StartsWith('-----BEGIN RSA PUBLIC KEY-----'),
             'PEM public key must start with RSA PUBLIC KEY header.');
-        LibraryAssert.IsTrue(PublicKeyPem.Contains('-----END RSA PUBLIC KEY-----'),
+        LibraryAssert.IsTrue(PublicKeyPem.TrimEnd().EndsWith('-----END RSA PUBLIC KEY-----'),
             'PEM public key must end with RSA PUBLIC KEY footer.');
     end;
 

--- a/src/System Application/Test/Cryptography Management/src/RSATest.Codeunit.al
+++ b/src/System Application/Test/Cryptography Management/src/RSATest.Codeunit.al
@@ -307,6 +307,129 @@ codeunit 132617 "RSA Test"
         RSA.Decrypt(XmlString, EncryptedInStream, false, DecryptedOutStream);
     end;
 
+    [Test]
+    procedure ImportFromPemPrivateKeyAndSignData()
+    var
+        RSA1: Codeunit RSA;
+        RSA2: Codeunit RSA;
+        TempBlobData: Codeunit "Temp Blob";
+        TempBlobSignature: Codeunit "Temp Blob";
+        DataOutStream: OutStream;
+        SignatureOutStream: OutStream;
+        DataInStream: InStream;
+        SignatureInStream: InStream;
+        PemPrivateKey: SecretText;
+    begin
+        // [SCENARIO] A private RSA key exported as PEM can be imported and used to sign data that is verifiable with the matching public key.
+
+        // [GIVEN] An RSA instance with a generated key pair and its private key in PEM format
+        RSA1.InitializeRSA(2048);
+        PemPrivateKey := RSA1.ExportRSAPrivateKeyPem();
+
+        // [GIVEN] Random data to sign
+        TempBlobData.CreateOutStream(DataOutStream);
+        SaveRandomTextToOutStream(DataOutStream);
+        TempBlobData.CreateInStream(DataInStream);
+
+        // [WHEN] A new RSA instance imports the PEM private key and signs the data
+        RSA2.ImportFromPem(PemPrivateKey);
+        TempBlobSignature.CreateOutStream(SignatureOutStream);
+        RSA2.SignData(DataInStream, Enum::"Hash Algorithm"::SHA256, Enum::"RSA Signature Padding"::Pkcs1, SignatureOutStream);
+
+        TempBlobData.CreateInStream(DataInStream);
+        TempBlobSignature.CreateInStream(SignatureInStream);
+
+        // [THEN] The signature can be verified using the first instance's stateful verify (same key loaded)
+        LibraryAssert.IsTrue(RSA2.VerifyData(DataInStream, Enum::"Hash Algorithm"::SHA256, Enum::"RSA Signature Padding"::Pkcs1, SignatureInStream),
+            'Signature must be valid after ImportFromPem with a private key.');
+    end;
+
+    [Test]
+    procedure ImportFromPemPublicKeyAndVerifyData()
+    var
+        RSA1: Codeunit RSA;
+        RSA2: Codeunit RSA;
+        RSA3: Codeunit RSA;
+        TempBlobData: Codeunit "Temp Blob";
+        TempBlobSignature: Codeunit "Temp Blob";
+        DataOutStream: OutStream;
+        SignatureOutStream: OutStream;
+        DataInStream: InStream;
+        SignatureInStream: InStream;
+        PemPublicKey: Text;
+        PrivateXmlKey: SecretText;
+    begin
+        // [SCENARIO] A public RSA key exported as PEM can be imported and used to verify a signature.
+
+        // [GIVEN] An RSA key pair with its public key in PEM and private key in XML
+        RSA1.InitializeRSA(2048);
+        PemPublicKey := RSA1.ExportRSAPublicKeyPem();
+        PrivateXmlKey := RSA1.ToSecretXmlString(true);
+
+        // [GIVEN] Data signed using the private key (XML-based)
+        TempBlobData.CreateOutStream(DataOutStream);
+        SaveRandomTextToOutStream(DataOutStream);
+        TempBlobData.CreateInStream(DataInStream);
+        TempBlobSignature.CreateOutStream(SignatureOutStream);
+        RSA2.SignData(PrivateXmlKey, DataInStream, Enum::"Hash Algorithm"::SHA256, Enum::"RSA Signature Padding"::Pkcs1, SignatureOutStream);
+
+        TempBlobData.CreateInStream(DataInStream);
+        TempBlobSignature.CreateInStream(SignatureInStream);
+
+        // [WHEN] A new RSA instance imports the PEM public key and verifies the signature
+        RSA3.ImportFromPem(PemPublicKey);
+
+        // [THEN] Verification succeeds
+        LibraryAssert.IsTrue(RSA3.VerifyData(DataInStream, Enum::"Hash Algorithm"::SHA256, Enum::"RSA Signature Padding"::Pkcs1, SignatureInStream),
+            'Signature must be verifiable after ImportFromPem with a public key.');
+    end;
+
+    [Test]
+    procedure ExportAndImportRSAPrivateKeyPem()
+    var
+        RSA1: Codeunit RSA;
+        RSA2: Codeunit RSA;
+        PemPrivateKey: SecretText;
+        XmlFromOriginal: SecretText;
+        XmlFromImported: SecretText;
+    begin
+        // [SCENARIO] A private key roundtrips losslessly through ExportRSAPrivateKeyPem and ImportFromPem.
+
+        // [GIVEN] An RSA instance with a generated private key
+        RSA1.InitializeRSA(2048);
+        XmlFromOriginal := RSA1.ToSecretXmlString(false);
+
+        // [WHEN] The private key is exported to PEM and imported into a new instance
+        PemPrivateKey := RSA1.ExportRSAPrivateKeyPem();
+        RSA2.ImportFromPem(PemPrivateKey);
+
+        // [THEN] The public key XML exported from the new instance matches the original
+        XmlFromImported := RSA2.ToSecretXmlString(false);
+        LibraryAssert.AreEqual(GetXmlString(XmlFromOriginal), GetXmlString(XmlFromImported),
+            'Public key XML must be identical after PEM roundtrip.');
+    end;
+
+    [Test]
+    procedure ExportRSAPublicKeyPemContainsPemHeader()
+    var
+        RSA1: Codeunit RSA;
+        PublicKeyPem: Text;
+    begin
+        // [SCENARIO] ExportRSAPublicKeyPem returns a well-formed PEM string with the correct header.
+
+        // [GIVEN] An initialized RSA instance
+        RSA1.InitializeRSA(2048);
+
+        // [WHEN] The public key is exported as PEM
+        PublicKeyPem := RSA1.ExportRSAPublicKeyPem();
+
+        // [THEN] The result contains a valid PEM header and footer
+        LibraryAssert.IsTrue(PublicKeyPem.Contains('-----BEGIN RSA PUBLIC KEY-----'),
+            'PEM public key must start with RSA PUBLIC KEY header.');
+        LibraryAssert.IsTrue(PublicKeyPem.Contains('-----END RSA PUBLIC KEY-----'),
+            'PEM public key must end with RSA PUBLIC KEY footer.');
+    end;
+
     local procedure SaveRandomTextToOutStream(OutStream: OutStream) PlainText: Text
     begin
         PlainText := Any.AlphanumericText(Any.IntegerInRange(80));


### PR DESCRIPTION
## Summary

Closes #5053

The RSA-related codeunits in the System Application had no way to import a key in PEM format. Developers working with third-party APIs that distribute keys as PEM files had to manually convert to XML before using the AL RSA codeunits. This PR adds \ImportFromPem\ to both \RSA\ (codeunit 1475) and \RSACryptoServiceProvider\ (codeunit 1445), along with the symmetric export procedures and stateful Sign/Verify overloads that make the PEM workflow complete.

## Changes

### \RSAImpl.Codeunit.al\ (1476)
- Added \ImportFromPem(PemKey: SecretText)\ using the existing \RSAEncryptionHelper.ImportFromPem\ helper (same helper already used internally in \ToSecretXmlString(PrivateKey, ...)\). Loads the key directly into the \DotNetRSA\ field, so all subsequent stateful calls use it.
- Added \ExportRSAPublicKeyPem(): Text\ exposing \DotNet RSA.ExportRSAPublicKeyPem()\.

### \RSA.Codeunit.al\ (1475)
- Exposed \ImportFromPem(PemKey: SecretText)\ publicly with XML doc.
- Exposed \ExportRSAPublicKeyPem(): Text\ publicly with XML doc.
- Exposed \ExportRSAPrivateKeyPem(): SecretText\ publicly (was already \internal\ in RSAImpl).
- Added stateful \SignData(DataInStream, HashAlgorithm, RSASignaturePadding, SignatureOutStream)\ overload (no XmlString parameter) delegating to the existing impl procedure.
- Added stateful \VerifyData(DataInStream, HashAlgorithm, RSASignaturePadding, SignatureInStream): Boolean\ overload (no XmlString parameter) delegating to the existing impl procedure.

### \RSACryptoServiceProviderImpl.Codeunit.al\ (1446)
- Added \ImportFromPem(PemKey: SecretText)\ using \RSAEncryptionHelper.ImportFromPem\ on a temporary \DotNet RSA\ instance, then round-tripping through XML into the \DotNetRSACryptoServiceProvider\ field (same XML round-trip pattern already used in \CreateRSAKeyPair\).
- Added local \TryExportPrivateXml\ to gracefully handle public-only PEM keys (falls back to public-key XML when no private parameters are present).

### \RSACryptoServiceProvider.Codeunit.al\ (1445)
- Exposed \ImportFromPem(PemKey: SecretText)\ publicly with XML doc.

### \RSATest.Codeunit.al\ (132617)
- \ImportFromPemPrivateKeyAndSignData\: exports private key as PEM, imports into a new RSA instance, signs data, verifies with stateful VerifyData.
- \ImportFromPemPublicKeyAndVerifyData\: exports public key as PEM, imports into a new RSA instance, verifies a signature produced by a separate instance holding the private key.
- \ExportAndImportRSAPrivateKeyPem\: round-trips private key through PEM and asserts the public key XML is preserved.
- \ExportRSAPublicKeyPemContainsPemHeader\: asserts the PEM string starts and ends with the correct PKCS#1 public key header/footer.

### \RSACryptoServiceProviderTests.Codeunit.al\ (132613)
- \ImportFromPemAndSignData\: imports a PEM private key into RSACryptoServiceProvider, signs data, verifies the signature using the corresponding XML public key.

## How to Test

1. Open the **System Application Test** app in a BC sandbox.
2. Run codeunit **132617 RSA Test** and verify the four new tests pass.
3. Run codeunit **132613 RSACryptoServiceProviderTests** and verify \ImportFromPemAndSignData\ passes alongside existing tests.

## Expected Behavior

| Scenario | Expected |
|---|---|
| Import private PEM, sign data, verify statefully | Signature verified |
| Import public PEM, verify signature from another instance | Verification succeeds |
| Export private PEM, import back, compare public XML | XML is identical |
| Export public PEM | Begins with \-----BEGIN RSA PUBLIC KEY-----\ |
| Import PEM into RSACryptoServiceProvider, export to XML, sign, verify | Signature verified |




Fixes [AB#640919](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640919)

