### PR TITLE
Shopify: preserve Customer filters during customer mapping

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCustomerMapping.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCustomerMapping.Codeunit.al
@@ -108,6 +108,7 @@ codeunit 30118 "Shpfy Customer Mapping"
         case Direction of
             Direction::ShopifyToBC:
                 begin
+                    FindCustomer.CopyFilters(Customer);
                     if ShopifyCustomer.Email <> '' then begin
                         FindCustomer.SetFilter("E-Mail", '@' + ShopifyCustomer.Email);
                         if FindCustomer.FindFirst() then begin
@@ -119,6 +120,7 @@ codeunit 30118 "Shpfy Customer Mapping"
                         PhoneFilter := CreatePhoneFilter(ShopifyCustomer."Phone No.");
                         if PhoneFilter <> '' then begin
                             Clear(FindCustomer);
+                            FindCustomer.CopyFilters(Customer);
                             FindCustomer.SetFilter("Phone No.", PhoneFilter);
                             if FindCustomer.FindFirst() then begin
                                 Customer := FindCustomer;

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCustMappingFilterSub.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCustMappingFilterSub.Codeunit.al
@@ -26,7 +26,7 @@ codeunit 139700 "Shpfy Cust. Mapping Filter Sub"
         CustomerNoFilter := CustomerNo;
     end;
 
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Customer Events", 'OnBeforeFindMapping', '', false, false)]
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Customer Events", 'OnBeforeFindMapping', '', true, false)]
     local procedure OnBeforeFindMapping(Direction: Enum "Shpfy Mapping Direction"; var ShopifyCustomer: Record "Shpfy Customer"; var Customer: Record Customer; var Handled: Boolean)
     begin
         if CustomerNoFilter <> '' then

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCustMappingFilterSub.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCustMappingFilterSub.Codeunit.al
@@ -1,0 +1,35 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify.Test;
+
+using Microsoft.Integration.Shopify;
+using Microsoft.Sales.Customer;
+
+/// <summary>
+/// Codeunit Shpfy Cust. Mapping Filter Sub. (ID 139700).
+/// Helper subscriber used by Shpfy Customer Mapping Test to verify that
+/// filters set on the Customer record via OnBeforeFindMapping are respected.
+/// </summary>
+codeunit 139700 "Shpfy Cust. Mapping Filter Sub"
+{
+    SingleInstance = true;
+    EventSubscriberInstance = Manual;
+
+    var
+        CustomerNoFilter: Code[20];
+
+    internal procedure SetCustomerNoFilter(CustomerNo: Code[20])
+    begin
+        CustomerNoFilter := CustomerNo;
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Customer Events", 'OnBeforeFindMapping', '', false, false)]
+    local procedure OnBeforeFindMapping(Direction: Enum "Shpfy Mapping Direction"; var ShopifyCustomer: Record "Shpfy Customer"; var Customer: Record Customer; var Handled: Boolean)
+    begin
+        if CustomerNoFilter <> '' then
+            Customer.SetRange("No.", CustomerNoFilter);
+    end;
+}

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerMappingTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerMappingTest.Codeunit.al
@@ -71,6 +71,101 @@ codeunit 139569 "Shpfy Customer Mapping Test"
         LibraryAssert.AreEqual(Customer."No.", ResultCode, 'Mapping By Bill-to Info');
     end;
 
+    [Test]
+    procedure TestFindMappingRespectsCustomerFilters()
+    var
+        Customer1: Record Customer;
+        Customer2: Record Customer;
+        ShopifyCustomer: Record "Shpfy Customer";
+        CustomerMapping: Codeunit "Shpfy Customer Mapping";
+        FilterSub: Codeunit "Shpfy Cust. Mapping Filter Sub";
+        SharedEmail: Text[80];
+    begin
+        // [SCENARIO] FindMapping respects Customer filters applied via OnBeforeFindMapping
+        Init(Customer1);
+        SharedEmail := 'filtertest@domain.com';
+
+        // [GIVEN] Two customers sharing the same email address
+        Customer1.Init();
+        Customer1."No." := 'SHPFY-F-01';
+        Customer1."E-Mail" := SharedEmail;
+        Customer1.Insert(false);
+
+        Customer2.Init();
+        Customer2."No." := 'SHPFY-F-02';
+        Customer2."E-Mail" := SharedEmail;
+        Customer2.Insert(false);
+
+        // [GIVEN] A Shopify customer whose email matches both BC customers
+        ShopifyCustomer.DeleteAll();
+        ShopifyCustomer.Init();
+        ShopifyCustomer.Id := 99700;
+        ShopifyCustomer.Email := SharedEmail;
+        ShopifyCustomer.Insert();
+
+        // [GIVEN] A subscriber that restricts the Customer view to Customer2 only
+        FilterSub.SetCustomerNoFilter(Customer2."No.");
+        BindSubscription(FilterSub);
+
+        // [WHEN] FindMapping is executed
+        CustomerMapping.FindMapping(ShopifyCustomer);
+
+        // [THEN] The Shopify customer is mapped to Customer2, not Customer1
+        LibraryAssert.AreEqual(
+            Customer2.SystemId,
+            ShopifyCustomer."Customer SystemId",
+            'FindMapping must honour the Customer filters set via OnBeforeFindMapping.');
+
+        UnbindSubscription(FilterSub);
+    end;
+
+    [Test]
+    procedure TestFindMappingRespectsPhoneFilter()
+    var
+        Customer1: Record Customer;
+        Customer2: Record Customer;
+        ShopifyCustomer: Record "Shpfy Customer";
+        CustomerMapping: Codeunit "Shpfy Customer Mapping";
+        FilterSub: Codeunit "Shpfy Cust. Mapping Filter Sub";
+    begin
+        // [SCENARIO] FindMapping phone-number path also respects Customer filters
+        Init(Customer1);
+
+        // [GIVEN] Two customers sharing the same phone number
+        Customer1.Init();
+        Customer1."No." := 'SHPFY-P-01';
+        Customer1."Phone No." := '123456789';
+        Customer1.Insert(false);
+
+        Customer2.Init();
+        Customer2."No." := 'SHPFY-P-02';
+        Customer2."Phone No." := '123456789';
+        Customer2.Insert(false);
+
+        // [GIVEN] A Shopify customer whose phone matches both BC customers (no email)
+        ShopifyCustomer.DeleteAll();
+        ShopifyCustomer.Init();
+        ShopifyCustomer.Id := 99701;
+        ShopifyCustomer."Phone No." := '+1 234 56789';
+        ShopifyCustomer.Insert();
+
+        // [GIVEN] A subscriber that restricts the Customer view to Customer2 only
+        FilterSub.SetCustomerNoFilter(Customer2."No.");
+        BindSubscription(FilterSub);
+
+        // [WHEN] FindMapping is executed
+        CustomerMapping.FindMapping(ShopifyCustomer);
+
+        // [THEN] The Shopify customer is mapped to Customer2, not Customer1
+        LibraryAssert.AreEqual(
+            Customer2.SystemId,
+            ShopifyCustomer."Customer SystemId",
+            'FindMapping phone path must honour the Customer filters set via OnBeforeFindMapping.');
+
+        UnbindSubscription(FilterSub);
+    end;
+
+
     local procedure CreateShopifyCustomerAddress(var Customer: Record Customer; var ShopifyCustomer: Record "Shpfy Customer")
     var
         CustomerAddress: Record "Shpfy Customer Address";

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerMappingTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerMappingTest.Codeunit.al
@@ -109,14 +109,13 @@ codeunit 139569 "Shpfy Customer Mapping Test"
 
         // [WHEN] FindMapping is executed
         CustomerMapping.FindMapping(ShopifyCustomer);
+        UnbindSubscription(FilterSub);
 
         // [THEN] The Shopify customer is mapped to Customer2, not Customer1
         LibraryAssert.AreEqual(
             Customer2.SystemId,
             ShopifyCustomer."Customer SystemId",
             'FindMapping must honour the Customer filters set via OnBeforeFindMapping.');
-
-        UnbindSubscription(FilterSub);
     end;
 
     [Test]
@@ -155,14 +154,13 @@ codeunit 139569 "Shpfy Customer Mapping Test"
 
         // [WHEN] FindMapping is executed
         CustomerMapping.FindMapping(ShopifyCustomer);
+        UnbindSubscription(FilterSub);
 
         // [THEN] The Shopify customer is mapped to Customer2, not Customer1
         LibraryAssert.AreEqual(
             Customer2.SystemId,
             ShopifyCustomer."Customer SystemId",
             'FindMapping phone path must honour the Customer filters set via OnBeforeFindMapping.');
-
-        UnbindSubscription(FilterSub);
     end;
 
 


### PR DESCRIPTION
Fixes #4436

## Problem

In ShpfyCustomerMapping.Codeunit.al, the DoFindMapping local procedure declares its own FindCustomer: Record Customer variable for the ShopifyToBC direction. This variable starts with no filters, so any filters that subscribers set on the Customer parameter via OnBeforeFindMapping are silently discarded. In scenarios such as B2B/B2C where multiple customers share the same email or phone number, the caller has no reliable way to restrict which customer is matched.

## Root Cause

FindCustomer is a fresh local variable so caller filters applied via OnBeforeFindMapping are never inherited before the email or phone lookup.

## Fix

Call FindCustomer.CopyFilters(Customer) before each lookup, and again after Clear(FindCustomer) (which resets all filters) in the phone-number path.

## Tests

Two new integration tests in ShpfyCustomerMappingTest (codeunit 139569):

- TestFindMappingRespectsCustomerFilters: two BC customers share the same email; a manual event subscriber restricts the Customer view to the second customer via SetRange; asserts FindMapping maps the Shopify customer to the filtered customer only.
- TestFindMappingRespectsPhoneFilter: same pattern exercising the phone-number lookup path.

A new subscriber codeunit Shpfy Cust. Mapping Filter Sub (ID 139700) follows the EventSubscriberInstance = Manual pattern with BindSubscription/UnbindSubscription established across the Shopify test suite.


