### PR TITLE
Update CODEOWNERS to remove permissions entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,10 +24,6 @@
 dotnet.al @microsoft/d365-bc-app-security
 
 # App Permissions
-/src/**/Permissions/ @microsoft/d365-bc-app-permissions
-/src/**/permissions/ @microsoft/d365-bc-app-permissions
-*.Permissionset.al @microsoft/d365-bc-app-permissions
-*.Permissionsetext.al @microsoft/d365-bc-app-permissions
 *.Entitlement.al @microsoft/d365-bc-app-permissions
 
 # app.json files are owned by Engineering Systems to control the versions and BC app team to control the other metadata


### PR DESCRIPTION
Removed permissions-related ownership entries from CODEOWNERS.

[AB#632234](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632234)



