### PR TITLE
Bug 620556: [Subcontracting] Align Subcontracting app with changes to the "Description 2" on various tables

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchaseOrderCreator.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchaseOrderCreator.Codeunit.al
@@ -351,7 +351,7 @@ codeunit 99001557 "Subc. Purchase Order Creator"
     begin
         GetSubmanagementSetup();
 
-        Item.SetLoadFields("Item Category Code", "Description 2");
+        Item.SetLoadFields("Item Category Code");
         Item.Get(ProdOrderComponent."Item No.");
 
         PurchaseLine.Init();

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchaseOrderCreator.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchaseOrderCreator.Codeunit.al
@@ -385,7 +385,7 @@ codeunit 99001557 "Subc. Purchase Order Creator"
         end;
 
         PurchaseLine.Description := ProdOrderComponent.Description;
-        PurchaseLine."Description 2" := Item."Description 2";
+        PurchaseLine."Description 2" := ProdOrderComponent."Description 2";
 
         PurchaseLine."Sales Order No." := RequisitionLine."Sales Order No.";
         PurchaseLine."Sales Order Line No." := RequisitionLine."Sales Order Line No.";
@@ -471,7 +471,7 @@ codeunit 99001557 "Subc. Purchase Order Creator"
         RequisitionLine.Validate("Vendor No.", WorkCenter."Subcontractor No.");
 
         RequisitionLine.Description := ProdOrderRoutingLine.Description;
-        RequisitionLine."Description 2" := '';
+        RequisitionLine."Description 2" := ProdOrderRoutingLine."Description 2";
         SetVendorItemNo(RequisitionLine);
 
         if PurchLineExists(PurchaseLine, ProdOrderLine, ProdOrderRoutingLine) then begin

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pages/SubcProdOrderComponents.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pages/SubcProdOrderComponents.Page.al
@@ -39,6 +39,11 @@ page 99001503 "Subc. Prod. Order Components"
                 {
                     ToolTip = 'Specifies a description of the item on the line.';
                 }
+                field("Description 2"; Rec."Description 2")
+                {
+                    ToolTip = 'Specifies a second description of the item on the line.';
+                    Visible = false;
+                }
                 field("Location Code"; Rec."Location Code")
                 {
                     ToolTip = 'Specifies the location where the component is stored. Copies the location code from the corresponding field on the production order line.';

--- a/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Codeunits/SubcCreateProdOrdOpt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Codeunits/SubcCreateProdOrdOpt.Codeunit.al
@@ -479,7 +479,7 @@ codeunit 99001556 "Subc. Create Prod. Ord. Opt."
     /// </summary>
     local procedure FindRoutingLinesForProdOrderLine(var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var ProdOrderLine: Record "Prod. Order Line"): Boolean
     begin
-        ProdOrderRoutingLine.SetLoadFields("Work Center No.", "Operation No.", Description, "Routing No.", "Routing Reference No.");
+        ProdOrderRoutingLine.SetLoadFields("Work Center No.", "Operation No.", Description, "Description 2", "Routing No.", "Routing Reference No.");
         ProdOrderRoutingLine.SetRange(Status, ProdOrderLine.Status);
         ProdOrderRoutingLine.SetRange("Prod. Order No.", ProdOrderLine."Prod. Order No.");
         ProdOrderRoutingLine.SetRange("Routing No.", ProdOrderLine."Routing No.");
@@ -525,6 +525,7 @@ codeunit 99001556 "Subc. Create Prod. Ord. Opt."
         SubcPriceManagement: Codeunit "Subc. Price Management";
     begin
         PurchaseLine.Description := ProdOrderRoutingLine.Description;
+        PurchaseLine."Description 2" := ProdOrderRoutingLine."Description 2";
         PurchaseLine."Routing No." := ProdOrderRoutingLine."Routing No.";
         PurchaseLine."Routing Reference No." := ProdOrderRoutingLine."Routing Reference No.";
         PurchaseLine."Operation No." := ProdOrderRoutingLine."Operation No.";
@@ -817,6 +818,7 @@ codeunit 99001556 "Subc. Create Prod. Ord. Opt."
         ProductionBOMHeader.Init();
         ProductionBOMHeader."No." := BOMNo;
         ProductionBOMHeader.Description := TempProductionBOMHeader.Description;
+        ProductionBOMHeader."Description 2" := TempProductionBOMHeader."Description 2";
         ProductionBOMHeader.Validate("Unit of Measure Code", TempProductionBOMHeader."Unit of Measure Code");
         ProductionBOMHeader.Insert(true);
         BOMCreated := true;
@@ -871,6 +873,7 @@ codeunit 99001556 "Subc. Create Prod. Ord. Opt."
         RoutingHeader.Init();
         RoutingHeader."No." := RoutingNo;
         RoutingHeader.Description := TempRoutingHeader.Description;
+        RoutingHeader."Description 2" := TempRoutingHeader."Description 2";
         RoutingHeader.Insert(true);
         RoutingCreated := true;
 
@@ -1154,6 +1157,7 @@ codeunit 99001556 "Subc. Create Prod. Ord. Opt."
         ProdOrderComponent.Validate("Item No.", TempProdOrderComponent."Item No.");
         ProdOrderComponent.Validate("Variant Code", TempProdOrderComponent."Variant Code");
         ProdOrderComponent.Description := TempProdOrderComponent.Description;
+        ProdOrderComponent."Description 2" := TempProdOrderComponent."Description 2";
         ProdOrderComponent.Validate("Quantity per", TempProdOrderComponent."Quantity per");
         ProdOrderComponent.Validate("Unit of Measure Code", TempProdOrderComponent."Unit of Measure Code");
         ProdOrderComponent.Validate("Location Code", TempProdOrderComponent."Location Code");
@@ -1185,6 +1189,7 @@ codeunit 99001556 "Subc. Create Prod. Ord. Opt."
         ProdOrderRoutingLine.Validate(Type, TempProdOrderRoutingLine.Type);
         ProdOrderRoutingLine.Validate("No.", TempProdOrderRoutingLine."No.");
         ProdOrderRoutingLine.Description := TempProdOrderRoutingLine.Description;
+        ProdOrderRoutingLine."Description 2" := TempProdOrderRoutingLine."Description 2";
         ProdOrderRoutingLine."Setup Time" := TempProdOrderRoutingLine."Setup Time";
         ProdOrderRoutingLine."Run Time" := TempProdOrderRoutingLine."Run Time";
         ProdOrderRoutingLine."Wait Time" := TempProdOrderRoutingLine."Wait Time";

--- a/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Codeunits/SubcTempDataInitializer.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Codeunits/SubcTempDataInitializer.Codeunit.al
@@ -320,6 +320,7 @@ codeunit 99001552 "Subc. Temp Data Initializer"
                     TempGlobalProdOrderComponent."Qty. per Unit of Measure" := 1;
                     TempGlobalProdOrderComponent.Validate("Item No.", ProductionBOMLine."No.");
                     TempGlobalProdOrderComponent.Description := ProductionBOMLine.Description;
+                    TempGlobalProdOrderComponent."Description 2" := ProductionBOMLine."Description 2";
                     TempGlobalProdOrderComponent.Validate("Quantity per", ProductionBOMLine."Quantity per" * BOMQuantity);
                     if ProductionBOMLine."Unit of Measure Code" <> '' then
                         TempGlobalProdOrderComponent.Validate("Unit of Measure Code", ProductionBOMLine."Unit of Measure Code");
@@ -361,6 +362,7 @@ codeunit 99001552 "Subc. Temp Data Initializer"
         TempGlobalProdOrderRoutingLine.Validate("No.", RoutingLine."No.");
         TempGlobalProdOrderRoutingLine.Validate("Work Center No.", RoutingLine."Work Center No.");
         TempGlobalProdOrderRoutingLine.Description := RoutingLine.Description;
+        TempGlobalProdOrderRoutingLine."Description 2" := RoutingLine."Description 2";
         TempGlobalProdOrderRoutingLine.Validate("Setup Time", RoutingLine."Setup Time");
         TempGlobalProdOrderRoutingLine.Validate("Run Time", RoutingLine."Run Time");
         TempGlobalProdOrderRoutingLine.Validate("Wait Time", RoutingLine."Wait Time");

--- a/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Pages/SubcPurchProvisionWizard.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Pages/SubcPurchProvisionWizard.Page.al
@@ -66,6 +66,13 @@ page 99001505 "Subc. PurchProvisionWizard"
                         Editable = false;
                         ToolTip = 'Specifies the description of the item for which the purchase provision is being set up.';
                     }
+                    field("Description 2"; Rec."Description 2")
+                    {
+                        Caption = 'Description 2';
+                        Editable = false;
+                        ToolTip = 'Specifies additional description of the item for which the purchase provision is being set up.';
+                        Visible = false;
+                    }
                     group(BomRoutingTransfer)
                     {
                         Caption = 'BOM/Routing Transfer';

--- a/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Pages/SubcTempBOMLines.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Pages/SubcTempBOMLines.Page.al
@@ -41,6 +41,12 @@ page 99001506 "Subc. Temp BOM Lines"
                 {
                     ToolTip = 'Specifies a description of the item or resource.';
                 }
+                field("Description 2"; Rec."Description 2")
+                {
+                    ApplicationArea = Manufacturing;
+                    ToolTip = 'Specifies additional description of the item or resource.';
+                    Visible = false;
+                }
                 field("Quantity per"; Rec."Quantity per")
                 {
                     AutoFormatType = 0;

--- a/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Pages/SubcTempProdOrdRtngLines.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Pages/SubcTempProdOrdRtngLines.Page.al
@@ -39,6 +39,12 @@ page 99001509 "Subc. TempProdOrdRtngLines"
                 {
                     ToolTip = 'Specifies a description of the operation.';
                 }
+                field("Description 2"; Rec."Description 2")
+                {
+                    ApplicationArea = Manufacturing;
+                    ToolTip = 'Specifies additional description of the operation.';
+                    Visible = false;
+                }
                 field("Setup Time"; Rec."Setup Time")
                 {
                     AutoFormatType = 0;

--- a/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Pages/SubcTempProdOrderComp.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Pages/SubcTempProdOrderComp.Page.al
@@ -44,6 +44,12 @@ page 99001508 "Subc. Temp Prod Order Comp"
                 {
                     ToolTip = 'Specifies a description of the item on the line.';
                 }
+                field("Description 2"; Rec."Description 2")
+                {
+                    ApplicationArea = Manufacturing;
+                    ToolTip = 'Specifies additional description of the item on the line.';
+                    Visible = false;
+                }
                 field("Location Code"; Rec."Location Code")
                 {
                     ToolTip = 'Specifies the location where the component is stored.';

--- a/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Pages/SubcTempRoutingLines.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Pages/SubcTempRoutingLines.Page.al
@@ -39,6 +39,12 @@ page 99001507 "Subc. Temp Routing Lines"
                 {
                     ToolTip = 'Specifies a description of the operation.';
                 }
+                field("Description 2"; Rec."Description 2")
+                {
+                    ApplicationArea = Manufacturing;
+                    ToolTip = 'Specifies additional description of the operation.';
+                    Visible = false;
+                }
                 field("Setup Time"; Rec."Setup Time")
                 {
                     AutoFormatType = 0;

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Libraries/SubcCreateProdOrdWizLibrary.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Libraries/SubcCreateProdOrdWizLibrary.Codeunit.al
@@ -291,7 +291,7 @@ codeunit 139986 "Subc. CreateProdOrdWizLibrary"
         LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, ComponentItem."Base Unit of Measure");
         LibraryManufacturing.CreateProductionBOMLine(
             ProductionBOMHeader, ProductionBOMLine, '', ProductionBOMLine.Type::Item, ComponentItem."No.", 1);
-        BOMLineDescription2 := CopyStr('BOMDesc2_' + Format(LibraryRandom.RandIntInRange(1000, 9999)), 1, MaxStrLen(ProductionBOMLine."Description 2"));
+        BOMLineDescription2 := CopyStr(StrSubstNo('BOMDesc2_%1', LibraryRandom.RandIntInRange(1000, 9999)), 1, MaxStrLen(ProductionBOMLine."Description 2"));
         ProductionBOMLine."Description 2" := BOMLineDescription2;
         ProductionBOMLine.Modify();
         ProductionBOMHeader.Validate("Version Nos.", LibraryERM.CreateNoSeriesCode());
@@ -324,7 +324,7 @@ codeunit 139986 "Subc. CreateProdOrdWizLibrary"
             RoutingHeader, RoutingLine, '', '20', RoutingLine.Type::"Work Center", WorkCenter2."No.");
         RoutingLine.Validate("Setup Time", 15);
         RoutingLine.Validate("Run Time", 8);
-        RoutingLineDescription2 := CopyStr('RtgDesc2_' + Format(LibraryRandom.RandIntInRange(1000, 9999)), 1, MaxStrLen(RoutingLine."Description 2"));
+        RoutingLineDescription2 := CopyStr(StrSubstNo('RtgDesc2_%1', LibraryRandom.RandIntInRange(1000, 9999)), 1, MaxStrLen(RoutingLine."Description 2"));
         RoutingLine."Description 2" := RoutingLineDescription2;
         RoutingLine.Modify(true);
 

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Libraries/SubcCreateProdOrdWizLibrary.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Libraries/SubcCreateProdOrdWizLibrary.Codeunit.al
@@ -279,4 +279,59 @@ codeunit 139986 "Subc. CreateProdOrdWizLibrary"
         RoutingVersion.Validate(Status, RoutingVersion.Status::Certified);
         RoutingVersion.Modify(true);
     end;
+
+    procedure CreateBOMWithDescription2(var BOMLineDescription2: Text[50]): Code[20]
+    var
+        ComponentItem: Record Item;
+        ProductionBOMHeader: Record "Production BOM Header";
+        ProductionBOMLine: Record "Production BOM Line";
+    begin
+        // Create a BOM with a single line that has Description 2 set
+        LibraryInventory.CreateItem(ComponentItem);
+        LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, ComponentItem."Base Unit of Measure");
+        LibraryManufacturing.CreateProductionBOMLine(
+            ProductionBOMHeader, ProductionBOMLine, '', ProductionBOMLine.Type::Item, ComponentItem."No.", 1);
+        BOMLineDescription2 := CopyStr('BOMDesc2_' + Format(LibraryRandom.RandIntInRange(1000, 9999)), 1, MaxStrLen(ProductionBOMLine."Description 2"));
+        ProductionBOMLine."Description 2" := BOMLineDescription2;
+        ProductionBOMLine.Modify();
+        ProductionBOMHeader.Validate("Version Nos.", LibraryERM.CreateNoSeriesCode());
+        ProductionBOMHeader.Validate(Status, ProductionBOMHeader.Status::Certified);
+        ProductionBOMHeader.Modify(true);
+        exit(ProductionBOMHeader."No.");
+    end;
+
+    procedure CreateRoutingWithSubcWorkCenterAndDescription2(var SubcWorkCenterNo: Code[20]; var RoutingLineDescription2: Text[50]): Code[20]
+    var
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        WorkCenter1: Record "Work Center";
+        WorkCenter2: Record "Work Center";
+    begin
+        // Create a routing with two lines; the second work center is subcontracting and has Description 2 set
+        CreateAndCalculateNeededWorkCenter(WorkCenter1, false);
+        CreateAndCalculateNeededWorkCenter(WorkCenter2, true);
+        SubcWorkCenterNo := WorkCenter2."No.";
+
+        LibraryManufacturing.CreateRoutingHeader(RoutingHeader, RoutingHeader.Type::Serial);
+
+        LibraryManufacturing.CreateRoutingLine(
+            RoutingHeader, RoutingLine, '', '10', RoutingLine.Type::"Work Center", WorkCenter1."No.");
+        RoutingLine.Validate("Setup Time", 10);
+        RoutingLine.Validate("Run Time", 5);
+        RoutingLine.Modify(true);
+
+        LibraryManufacturing.CreateRoutingLine(
+            RoutingHeader, RoutingLine, '', '20', RoutingLine.Type::"Work Center", WorkCenter2."No.");
+        RoutingLine.Validate("Setup Time", 15);
+        RoutingLine.Validate("Run Time", 8);
+        RoutingLineDescription2 := CopyStr('RtgDesc2_' + Format(LibraryRandom.RandIntInRange(1000, 9999)), 1, MaxStrLen(RoutingLine."Description 2"));
+        RoutingLine."Description 2" := RoutingLineDescription2;
+        RoutingLine.Modify(true);
+
+        RoutingHeader.Validate("Version Nos.", LibraryERM.CreateNoSeriesCode());
+        RoutingHeader.Validate(Status, RoutingHeader.Status::Certified);
+        RoutingHeader.Modify(true);
+
+        exit(RoutingHeader."No.");
+    end;
 }

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Libraries/SubcCreateProdOrdWizLibrary.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Libraries/SubcCreateProdOrdWizLibrary.Codeunit.al
@@ -291,7 +291,7 @@ codeunit 139986 "Subc. CreateProdOrdWizLibrary"
         LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, ComponentItem."Base Unit of Measure");
         LibraryManufacturing.CreateProductionBOMLine(
             ProductionBOMHeader, ProductionBOMLine, '', ProductionBOMLine.Type::Item, ComponentItem."No.", 1);
-        BOMLineDescription2 := CopyStr(StrSubstNo('BOMDesc2_%1', LibraryRandom.RandIntInRange(1000, 9999)), 1, MaxStrLen(ProductionBOMLine."Description 2"));
+        BOMLineDescription2 := CopyStr(LibraryRandom.RandText(MaxStrLen(ProductionBOMLine."Description 2")), 1, MaxStrLen(ProductionBOMLine."Description 2"));
         ProductionBOMLine."Description 2" := BOMLineDescription2;
         ProductionBOMLine.Modify();
         ProductionBOMHeader.Validate("Version Nos.", LibraryERM.CreateNoSeriesCode());
@@ -324,7 +324,7 @@ codeunit 139986 "Subc. CreateProdOrdWizLibrary"
             RoutingHeader, RoutingLine, '', '20', RoutingLine.Type::"Work Center", WorkCenter2."No.");
         RoutingLine.Validate("Setup Time", 15);
         RoutingLine.Validate("Run Time", 8);
-        RoutingLineDescription2 := CopyStr(StrSubstNo('RtgDesc2_%1', LibraryRandom.RandIntInRange(1000, 9999)), 1, MaxStrLen(RoutingLine."Description 2"));
+        RoutingLineDescription2 := CopyStr(LibraryRandom.RandText(MaxStrLen(RoutingLine."Description 2")), 1, MaxStrLen(RoutingLine."Description 2"));
         RoutingLine."Description 2" := RoutingLineDescription2;
         RoutingLine.Modify(true);
 

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Libraries/SubcProdOrderCheckLib.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Libraries/SubcProdOrderCheckLib.Codeunit.al
@@ -19,6 +19,8 @@ codeunit 139987 "Subc. ProdOrderCheckLib"
     var
         Assert: Codeunit Assert;
         ProdOrderRefreshed: Boolean;
+        Description2MismatchOnLineLbl: Label 'Description 2 mismatch on Line %1. Expected: %2, Actual: %3', Locked = true;
+        Description2MismatchOnOperationLbl: Label 'Description 2 mismatch on Operation %1. Expected: %2, Actual: %3', Locked = true;
         DescriptionMismatchOnOperationLbl: Label 'Description mismatch on Operation %1. Expected: %2, Actual: %3', Locked = true;
         DirectUnitCostMismatchOnOperationLbl: Label 'Direct Unit Cost mismatch on Operation %1. Expected: %2, Actual: %3', Locked = true;
         DueDateMismatchOnLineLbl: Label 'Due Date mismatch on Line %1. Expected: %2, Actual: %3', Locked = true;
@@ -184,6 +186,12 @@ codeunit 139987 "Subc. ProdOrderCheckLib"
             Assert.AreEqual(TempComponent."Due Date", ActualComponent."Due Date",
                 StrSubstNo(DueDateMismatchOnLineLbl,
                     TempComponent."Line No.", TempComponent."Due Date", ActualComponent."Due Date"));
+
+        // Verify Description 2 if set in temporary record
+        if TempComponent."Description 2" <> '' then
+            Assert.AreEqual(TempComponent."Description 2", ActualComponent."Description 2",
+                StrSubstNo(Description2MismatchOnLineLbl,
+                    TempComponent."Line No.", TempComponent."Description 2", ActualComponent."Description 2"));
     end;
 
     procedure VerifyProdOrderRoutingLinesMatchTempRecords(ProdOrder: Record "Production Order"; var TempProdOrderRoutingLine: Record "Prod. Order Routing Line" temporary)
@@ -284,6 +292,12 @@ codeunit 139987 "Subc. ProdOrderCheckLib"
             Assert.AreEqual(TempRoutingLine.Description, ActualRoutingLine.Description,
                 StrSubstNo(DescriptionMismatchOnOperationLbl,
                     TempRoutingLine."Operation No.", TempRoutingLine.Description, ActualRoutingLine.Description));
+
+        // Verify Description 2 if set in temporary record
+        if TempRoutingLine."Description 2" <> '' then
+            Assert.AreEqual(TempRoutingLine."Description 2", ActualRoutingLine."Description 2",
+                StrSubstNo(Description2MismatchOnOperationLbl,
+                    TempRoutingLine."Operation No.", TempRoutingLine."Description 2", ActualRoutingLine."Description 2"));
     end;
 
     procedure CreateTempProdOrderComponentFromBOM(var TempProdOrderComponent: Record "Prod. Order Component" temporary; BOMNo: Code[20]; PurchLine: Record "Purchase Line")
@@ -314,6 +328,7 @@ codeunit 139987 "Subc. ProdOrderCheckLib"
                 TempProdOrderComponent."Quantity per" := ProductionBOMLine."Quantity per";
                 TempProdOrderComponent."Unit of Measure Code" := ProductionBOMLine."Unit of Measure Code";
                 TempProdOrderComponent."Routing Link Code" := ProductionBOMLine."Routing Link Code";
+                TempProdOrderComponent."Description 2" := ProductionBOMLine."Description 2";
                 if ProductionBOMLine."Subcontracting Type" in [ProductionBOMLine."Subcontracting Type"::"Purchase", ProductionBOMLine."Subcontracting Type"::InventoryByVendor] then
                     TempProdOrderComponent."Location Code" := GetVendorSubcontractingLocation(PurchLine."Buy-from Vendor No.")
                 else
@@ -374,6 +389,7 @@ codeunit 139987 "Subc. ProdOrderCheckLib"
                 TempProdOrderRoutingLine.Type := RoutingLine.Type;
                 TempProdOrderRoutingLine."No." := RoutingLine."No.";
                 TempProdOrderRoutingLine.Description := RoutingLine.Description;
+                TempProdOrderRoutingLine."Description 2" := RoutingLine."Description 2";
                 TempProdOrderRoutingLine."Setup Time" := RoutingLine."Setup Time";
                 TempProdOrderRoutingLine."Run Time" := RoutingLine."Run Time";
                 TempProdOrderRoutingLine."Wait Time" := RoutingLine."Wait Time";

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -1707,6 +1707,133 @@ Comment = '|%1 = Transfer Order No.';
         Assert.AreEqual(0, ValueEntry."Invoiced Quantity", 'Invoiced Quantity must be zero on value entry.');
     end;
 
+    [Test]
+    [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting')]
+    procedure Description2CopiedFromProdOrderComponentToPurchaseLine()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProdOrderComp: Record "Prod. Order Component";
+        ProductionOrder: Record "Production Order";
+        PurchaseLine: Record "Purchase Line";
+        WorkCenter: array[2] of Record "Work Center";
+        ExpectedDescription2: Text[50];
+    begin
+        // [SCENARIO] Description 2 from Prod. Order Component is propagated to Purchase Line
+        // [FEATURE] Bug 620556 - Subcontracting Description 2 alignment
+
+        // [GIVEN] Complete Setup of Manufacturing
+        Initialize();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        UpdateProdBomWithSubcontractingType(Item, "Subcontracting Type"::Purchase);
+        UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+
+        // [GIVEN] A Description 2 value is set on the Prod. Order Component with Subcontracting Type = Purchase
+        ProdOrderComp.SetRange(Status, ProdOrderComp.Status::Released);
+        ProdOrderComp.SetRange("Prod. Order No.", ProductionOrder."No.");
+#pragma warning disable AA0210
+        ProdOrderComp.SetRange("Subcontracting Type", ProdOrderComp."Subcontracting Type"::Purchase);
+#pragma warning restore AA0210
+        ProdOrderComp.FindFirst();
+        ExpectedDescription2 := 'TestDescription2_Comp';
+        ProdOrderComp."Description 2" := ExpectedDescription2;
+        ProdOrderComp.Modify();
+
+        // [WHEN] Create Subcontracting Purchase Order from Prod. Order Routing
+        CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+
+        // [THEN] Description 2 from Prod. Order Component is propagated to the component Purchase Line
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange(Type, PurchaseLine.Type::Item);
+        PurchaseLine.SetRange("No.", ProdOrderComp."Item No.");
+        PurchaseLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+        Assert.AreEqual(
+            ExpectedDescription2, PurchaseLine."Description 2",
+            'Description 2 must be propagated from Prod. Order Component to Purchase Line');
+    end;
+
+    [Test]
+    procedure Description2PopulatedOnRequisitionLineFromCalculateSubcontracts()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        ReqWkshTemplate: Record "Req. Wksh. Template";
+        RequisitionLine: Record "Requisition Line";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
+        WorkCenter: array[2] of Record "Work Center";
+        SubcCalculateSubContract: Report "Subc. Calculate Subcontracts";
+        LibraryUtility: Codeunit "Library - Utility";
+        ExpectedDescription2: Text[50];
+    begin
+        // [SCENARIO] Description 2 from Prod. Order Routing Line is populated on Requisition Line
+        // via Calculate Subcontracts report
+        // [FEATURE] Bug 620556 - Subcontracting Description 2 alignment
+
+        // [GIVEN] Complete Setup of Manufacturing
+        Initialize();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+
+        // [GIVEN] Description 2 is set on the subcontracting Work Center Name 2
+        // (SubcCalcSubcontractsExt copies WorkCenter."Name 2" → RequisitionLine."Description 2")
+        ExpectedDescription2 := 'TestDesc2_WC';
+        WorkCenter[2].Get(WorkCenter[2]."No.");
+        WorkCenter[2].Validate("Name 2", ExpectedDescription2);
+        WorkCenter[2].Modify(true);
+
+        // [GIVEN] Create requisition worksheet
+        ReqWkshTemplate.DeleteAll(true);
+        ReqWkshTemplate.Name := SelectRequisitionTemplateName();
+        RequisitionWkshName.Init();
+        RequisitionWkshName.Validate("Worksheet Template Name", ReqWkshTemplate.Name);
+        RequisitionWkshName.Validate(
+            Name,
+            CopyStr(
+                LibraryUtility.GenerateRandomCode(RequisitionWkshName.FieldNo(Name), Database::"Requisition Wksh. Name"),
+                1, LibraryUtility.GetFieldLength(Database::"Requisition Wksh. Name", RequisitionWkshName.FieldNo(Name))));
+        RequisitionWkshName.Insert(true);
+
+        RequisitionLine."Worksheet Template Name" := RequisitionWkshName."Worksheet Template Name";
+        RequisitionLine."Journal Batch Name" := RequisitionWkshName.Name;
+
+        // [WHEN] Calculate Subcontracts
+        SubcCalculateSubContract.SetWkShLine(RequisitionLine);
+        SubcCalculateSubContract.UseRequestPage(false);
+        SubcCalculateSubContract.RunModal();
+
+        // [THEN] Description 2 on the Requisition Line is populated
+        RequisitionLine.SetRange("Worksheet Template Name", RequisitionWkshName."Worksheet Template Name");
+        RequisitionLine.SetRange("Journal Batch Name", RequisitionWkshName.Name);
+#pragma warning disable AA0210
+        RequisitionLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+#pragma warning restore AA0210
+        RequisitionLine.FindFirst();
+        Assert.AreEqual(
+            ExpectedDescription2, RequisitionLine."Description 2",
+            'Description 2 must be populated on the Requisition Line from the subcontracting Work Center');
+    end;
+
     [PageHandler]
     procedure HandleTransferOrder(var TransfOrderPage: TestPage "Transfer Order")
     begin

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -1756,7 +1756,9 @@ Comment = '|%1 = Transfer Order No.';
         PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
         PurchaseLine.SetRange(Type, PurchaseLine.Type::Item);
         PurchaseLine.SetRange("No.", ProdOrderComp."Item No.");
+#pragma warning disable AA0210
         PurchaseLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+#pragma warning restore AA0210
         PurchaseLine.FindFirst();
         Assert.AreEqual(
             ExpectedDescription2, PurchaseLine."Description 2",

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcWizGeneralTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcWizGeneralTest.Codeunit.al
@@ -231,6 +231,72 @@ codeunit 139993 "Subc. Wiz. General Test"
         ProdOrderCheckLib.VerifyProdOrderRoutingLinesMatchTempRecords(ProdOrder, TempProdOrderRoutingLine);
     end;
 
+    [Test]
+    [HandlerFunctions('HandlePurchProvisionWizard')]
+    procedure TestWizardPreservesDescription2ThroughBOMAndRoutingLines()
+    var
+        ProdOrder: Record "Production Order";
+        ProdOrderComponent: Record "Prod. Order Component";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        PurchLine: Record "Purchase Line";
+        CreateProdOrdOpt: Codeunit "Subc. Create Prod. Ord. Opt.";
+        BOMNo: Code[20];
+        ItemNo: Code[20];
+        RoutingNo: Code[20];
+        SubcWorkCenterNo: Code[20];
+        BOMLineDescription2: Text[50];
+        RoutingLineDescription2: Text[50];
+    begin
+        // [SCENARIO] Description 2 from BOM line and Routing line is preserved end-to-end through
+        // the Production Order Creation Wizard to Prod. Order Components and Routing Lines
+        // [FEATURE] Bug 620556 - Subcontracting Description 2 alignment
+
+        // [GIVEN] Proper setup configuration
+        Initialize();
+
+        // [GIVEN] A BOM with a line that has Description 2 set
+        BOMNo := SubCreateProdOrdWizLibrary.CreateBOMWithDescription2(BOMLineDescription2);
+
+        // [GIVEN] A Routing with a subcontracting work center line that has Description 2 set
+        RoutingNo := SubCreateProdOrdWizLibrary.CreateRoutingWithSubcWorkCenterAndDescription2(SubcWorkCenterNo, RoutingLineDescription2);
+
+        // [GIVEN] An item with the BOM and Routing above
+        ItemNo := SubCreateProdOrdWizLibrary.CreateItemWithBOMAndRouting(BOMNo, RoutingNo);
+
+        // [GIVEN] A purchase line with a subcontracting vendor
+        SubCreateProdOrdWizLibrary.CreatePurchaseLineWithSubcontractingVendor(PurchLine, ItemNo);
+
+        // [WHEN] Run the Production Order Creation Wizard
+        WizardFinishedSuccessfully := false;
+        Commit();
+        CreateProdOrdOpt.Run(PurchLine);
+
+        // [THEN] Wizard completed successfully
+        Assert.IsTrue(WizardFinishedSuccessfully, 'Wizard should have finished successfully');
+
+        // [THEN] Production Order was created
+        PurchLine.Get(PurchLine."Document Type", PurchLine."Document No.", PurchLine."Line No.");
+        Assert.AreNotEqual('', PurchLine."Prod. Order No.", 'Production Order No. should be set on Purchase Line');
+        ProdOrder.Get("Production Order Status"::Released, PurchLine."Prod. Order No.");
+
+        // [THEN] Description 2 from the BOM line is preserved on the Prod. Order Component
+        ProdOrderComponent.SetRange(Status, ProdOrder.Status);
+        ProdOrderComponent.SetRange("Prod. Order No.", ProdOrder."No.");
+        Assert.IsTrue(ProdOrderComponent.FindFirst(), 'Prod. Order Component must exist');
+        Assert.AreEqual(
+            BOMLineDescription2, ProdOrderComponent."Description 2",
+            'Description 2 from the Production BOM Line must be preserved on the Prod. Order Component');
+
+        // [THEN] Description 2 from the Routing line is preserved on the Prod. Order Routing Line
+        ProdOrderRoutingLine.SetRange(Status, ProdOrder.Status);
+        ProdOrderRoutingLine.SetRange("Prod. Order No.", ProdOrder."No.");
+        ProdOrderRoutingLine.SetRange("Work Center No.", SubcWorkCenterNo);
+        Assert.IsTrue(ProdOrderRoutingLine.FindFirst(), 'Prod. Order Routing Line must exist for subcontracting work center');
+        Assert.AreEqual(
+            RoutingLineDescription2, ProdOrderRoutingLine."Description 2",
+            'Description 2 from the Routing Line must be preserved on the Prod. Order Routing Line');
+    end;
+
     [ModalPageHandler]
     procedure HandlePurchProvisionWizard(var PurchProvisionWizard: TestPage "Subc. PurchProvisionWizard")
     begin


### PR DESCRIPTION
## Summary

- **SubcPurchaseOrderCreator**: copy `Description 2` from `ProdOrderComponent` (not `Item`) to `PurchaseLine`; copy from `ProdOrderRoutingLine` (not blank) to `RequisitionLine`
- **SubcTempDataInitializer**: propagate `Description 2` from `RoutingLine` → temp `ProdOrderRoutingLine` and from `ProductionBOMLine` → temp `ProdOrderComponent`
- **SubcCreateProdOrdOpt**: include `Description 2` in `SetLoadFields`; propagate it to `PurchaseLine`, `ProductionBOMHeader`, `RoutingHeader`, `ProdOrderComponent`, and `ProdOrderRoutingLine` when committing wizard data
- **Pages**: surface `Description 2` (hidden) on `SubcProdOrderComponents`, `SubcPurchProvisionWizard`, and all four wizard list part pages

## Root cause

Bug 617366 added the `Description 2` field to manufacturing tables in the base app. The Subcontracting app was not updated to propagate that field through its wizard pipeline or purchase order creation flow, causing the field to be lost or blanked.

Fixes [AB#620556](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620556)

🤖 Generated with [Claude Code](https://claude.com/claude-code)




