### PR TITLE
[28x] [Quality Management] Install Demo Data app Action on the Setup Page +…

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Permissions/QltyMgmtObjects.PermissionSet.al
+++ b/src/Apps/W1/Quality Management/app/src/Permissions/QltyMgmtObjects.PermissionSet.al
@@ -91,6 +91,7 @@ permissionset 20406 "QltyMgmt - Objects"
         codeunit "Qlty. Assembly Integration" = X,
         codeunit "Qlty. Batch Notif. Helper" = X,
         codeunit "Qlty. Demo Data Mgmt." = X,
+        codeunit "Qlty. Demo Data Runner" = X,
         codeunit "Qlty. Receiving Integration" = X,
         codeunit "Qlty. Report Mgmt." = X,
         codeunit "Qlty. Session Helper" = X,
@@ -111,7 +112,11 @@ permissionset 20406 "QltyMgmt - Objects"
         page "Qlty. Test Lookup Values" = X,
         page "Qlty. Manager Role Center" = X,
         page "Qlty. Management Setup Guide" = X,
+#if not CLEAN29
+#pragma warning disable AL0432
         page "Qlty. Demo Data Launcher" = X,
+#pragma warning restore AL0432
+#endif
         page "Qlty. Management Setup" = X,
         page "Qlty. Most Recent Picture" = X,
         page "Qlty. Prod. Gen. Rule S. Guide" = X,

--- a/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Page.al
@@ -11,6 +11,7 @@ using Microsoft.QualityManagement.Configuration.SourceConfiguration;
 using Microsoft.QualityManagement.Configuration.Template;
 using Microsoft.QualityManagement.Configuration.Template.Test;
 using Microsoft.QualityManagement.Setup.ApplicationAreas;
+using System.Environment;
 using System.Telemetry;
 
 page 20400 "Qlty. Management Setup"
@@ -273,15 +274,38 @@ page 20400 "Qlty. Management Setup"
                 }
             }
         }
+        area(Processing)
+        {
+            action(InstallDemoData)
+            {
+                ApplicationArea = QualityManagement;
+                Caption = 'Install Demo Data';
+                ToolTip = 'Install the Quality Management Contoso Coffee Demo Dataset app to explore Quality Management with sample data.';
+                Image = Database;
+                Visible = IsSaaS;
+
+                trigger OnAction()
+                var
+                    QltyDemoDataMgmt: Codeunit "Qlty. Demo Data Mgmt.";
+                begin
+                    QltyDemoDataMgmt.InstallOrOpenDemoData();
+                end;
+            }
+        }
     }
 
     var
         QltyAutoConfigure: Codeunit "Qlty. Auto Configure";
         FeatureTelemetry: Codeunit "Feature Telemetry";
         QualityManagementTok: Label 'Quality Management', Locked = true;
+        IsSaaS: Boolean;
 
     trigger OnOpenPage()
+    var
+        EnvironmentInformation: Codeunit "Environment Information";
     begin
+        IsSaaS := EnvironmentInformation.IsSaaS();
+
         FeatureTelemetry.LogUptake('0000QID', QualityManagementTok, Enum::"Feature Uptake Status"::Discovered);
         if not Rec.Get() then begin
             QltyAutoConfigure.EnsureBasicSetupExists(false);

--- a/src/Apps/W1/Quality Management/app/src/Setup/SetupGuide/QltyDemoDataLauncher.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/SetupGuide/QltyDemoDataLauncher.Page.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -16,6 +17,9 @@ page 20422 "Qlty. Demo Data Launcher"
     DeleteAllowed = false;
     InsertAllowed = false;
     ModifyAllowed = false;
+    ObsoleteReason = 'Unused. Use the "Install Demo Data" action on the Quality Management Setup page instead.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
 
     layout
     {
@@ -34,3 +38,4 @@ page 20422 "Qlty. Demo Data Launcher"
         CurrPage.Close();
     end;
 }
+#endif

--- a/src/Apps/W1/Quality Management/app/src/Setup/SetupGuide/QltyDemoDataMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/SetupGuide/QltyDemoDataMgmt.Codeunit.al
@@ -7,11 +7,24 @@ namespace Microsoft.QualityManagement.Setup;
 using System.Apps;
 
 /// <summary>
-/// Handles launching Contoso Demo Tool or showing installation message.
+/// Handles launching Contoso Demo Tool or installing it from the marketplace.
 /// </summary>
 codeunit 20422 "Qlty. Demo Data Mgmt."
 {
     Access = Internal;
+
+    /// <summary>
+    /// Installs the QM demo data app if not installed, otherwise opens the Contoso Demo Tool.
+    /// </summary>
+    procedure InstallOrOpenDemoData()
+    var
+        ExtensionManagement: Codeunit "Extension Management";
+    begin
+        if IsContosoDemoToolInstalled() then
+            OpenContosoDemoTool()
+        else
+            ExtensionManagement.InstallMarketplaceExtension(GetContosoAppId());
+    end;
 
     /// <summary>
     /// Launches the Contoso Demo Tool if installed, otherwise shows installation message.
@@ -31,11 +44,16 @@ codeunit 20422 "Qlty. Demo Data Mgmt."
     procedure IsContosoDemoToolInstalled(): Boolean
     var
         ExtensionManagement: Codeunit "Extension Management";
-        ContosoAppId: Guid;
     begin
-        // Quality Management Contoso Coffee Demo Dataset App ID
-        ContosoAppId := '40bf2bab-2a57-4c34-9002-c11d23fcbff6';
-        exit(ExtensionManagement.IsInstalledByAppId(ContosoAppId));
+        exit(ExtensionManagement.IsInstalledByAppId(GetContosoAppId()));
+    end;
+
+    /// <summary>
+    /// Returns the App ID of the Quality Management Contoso Coffee Demo Dataset app.
+    /// </summary>
+    local procedure GetContosoAppId(): Guid
+    begin
+        exit('40bf2bab-2a57-4c34-9002-c11d23fcbff6');
     end;
 
     local procedure OpenContosoDemoTool()

--- a/src/Apps/W1/Quality Management/app/src/Setup/SetupGuide/QltyDemoDataRunner.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/SetupGuide/QltyDemoDataRunner.Codeunit.al
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.QualityManagement.Setup;
+
+/// <summary>
+/// Public codeunit used by the Guided Experience checklist to install or open demo data.
+/// </summary>
+codeunit 20457 "Qlty. Demo Data Runner"
+{
+    Access = Public;
+    TableNo = "Qlty. Management Setup";
+
+    trigger OnRun()
+    var
+        QltyDemoDataMgmt: Codeunit "Qlty. Demo Data Mgmt.";
+    begin
+        QltyDemoDataMgmt.InstallOrOpenDemoData();
+    end;
+}

--- a/src/Apps/W1/Quality Management/app/src/Setup/SetupGuide/QltyGuidedExperience.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/SetupGuide/QltyGuidedExperience.Codeunit.al
@@ -25,7 +25,7 @@ codeunit 20419 "Qlty. Guided Experience"
         QualityManagerRoleCenterTourDescriptionTxt: Label 'The Quality Manager home page offers metrics and activities that help run a business. We`ll also show you how to explore all Business Central features.';
         DemoDataShortTitleTxt: Label 'Demo data';
         DemoDataTitleTxt: Label 'Explore with demo data';
-        DemoDataDescriptionTxt: Label 'Use Contoso demo data to explore Quality Management with sample quality tests, templates, generation rules, and inspections. This lets you learn how quality checks work without setting up your own data.';
+        DemoDataDescriptionTxt: Label 'Install or explore Contoso demo data for Quality Management with sample quality tests, templates, generation rules, and inspections. This lets you learn how quality checks work without setting up your own data.';
         QualityResultsShortTitleTxt: Label 'Inspection results';
         QualityResultsTitleTxt: Label 'Set up quality inspection results';
         QualityResultsDescriptionTxt: Label 'Define possible outcomes for quality inspections, like Pass, Fail, or In Progress. Create custom results and set priorities to match your organization''s standards. These results control how inspections are evaluated and how items are blocked or released.';
@@ -90,7 +90,7 @@ codeunit 20419 "Qlty. Guided Experience"
 
         // Register checklist items only once
         if not QltyManagementSetup."Checklist Items Registered" then begin
-            InitializeChecklist(SetupExists);
+            InitializeChecklist();
             QltyManagementSetup."Checklist Items Registered" := true;
             QltyManagementSetup.Modify();
         end;
@@ -141,9 +141,8 @@ codeunit 20419 "Qlty. Guided Experience"
         GuidedExperience.InsertTour(QualityManagerRoleCenterTourTitleTxt, QualityManagerRoleCenterTourShortTitleTxt,
             QualityManagerRoleCenterTourDescriptionTxt, 2, Page::"Qlty. Manager Role Center");
 
-        // Always register demo data item - it will check if Contoso is installed when opened
-        GuidedExperience.InsertApplicationFeature(DemoDataTitleTxt, DemoDataShortTitleTxt, DemoDataDescriptionTxt, 3, ObjectType::Page,
-            Page::"Qlty. Demo Data Launcher");
+        GuidedExperience.InsertApplicationFeature(DemoDataTitleTxt, DemoDataShortTitleTxt, DemoDataDescriptionTxt, 3, ObjectType::Codeunit,
+            Codeunit::"Qlty. Demo Data Runner");
         GuidedExperience.InsertApplicationFeature(QualityResultsTitleTxt, QualityResultsShortTitleTxt, QualityResultsDescriptionTxt, 4, ObjectType::Page,
             Page::"Qlty. Inspection Result List");
         GuidedExperience.InsertApplicationFeature(QualityTestsTitleTxt, QualityTestsShortTitleTxt, QualityTestsDescriptionTxt, 3, ObjectType::Page,
@@ -160,15 +159,14 @@ codeunit 20419 "Qlty. Guided Experience"
         GuidedExperience.InsertLearnLink(MicrosoftLearnTitleTxt, MicrosoftLearnShortTitleTxt, MicrosoftLearnDescriptionTxt, 5, MicrosoftLearnLinkTxt);
     end;
 
-    local procedure InitializeChecklist(SetupExists: Boolean)
+    local procedure InitializeChecklist()
     var
         TempAllProfileQualityManager: Record "All Profile" temporary;
         Checklist: Codeunit Checklist;
     begin
         GetQualityManagerRole(TempAllProfileQualityManager);
 
-        if SetupExists then
-            Checklist.Insert("Guided Experience Type"::"Application Feature", ObjectType::Page, Page::"Qlty. Demo Data Launcher", 1000, TempAllProfileQualityManager, true);
+        Checklist.Insert("Guided Experience Type"::"Application Feature", ObjectType::Codeunit, Codeunit::"Qlty. Demo Data Runner", 1000, TempAllProfileQualityManager, true);
         Checklist.Insert("Guided Experience Type"::"Application Feature", ObjectType::Page, Page::"Qlty. Inspection Result List", 2000, TempAllProfileQualityManager, true);
         Checklist.Insert("Guided Experience Type"::"Application Feature", ObjectType::Page, Page::"Qlty. Tests", 3000, TempAllProfileQualityManager, true);
         Checklist.Insert("Guided Experience Type"::"Application Feature", ObjectType::Page, Page::"Qlty. Inspection Template List", 4000, TempAllProfileQualityManager, true);
@@ -200,4 +198,6 @@ codeunit 20419 "Qlty. Guided Experience"
             TempAllProfile.Insert();
         end;
     end;
+
+
 }


### PR DESCRIPTION
Backport

… Updated Guided Tour on the Role Center (#7679)

- Obsolete Qlty. Demo Data Launcher page
- New action on the Qlty. Management Setup page to open the Contoso Demo Tool page, or install the QM demo data app if needed
- **Updated Qlty Guided Experience** (tour guide on QM RC): the Demo Data checklist item runs the same action as mentioned above

<img width="918" height="432" alt="image"
src="https://github.com/user-attachments/assets/1b051dac-7fbb-4a6a-a65c-ac9b835de51d" />

<img width="1144" height="907" alt="image"
src="https://github.com/user-attachments/assets/8d398c0d-bcf5-4870-ae81-389b9c0511e8" />

Fixes [AB#630960](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630960)




