### PR TITLE
Subscription Billing: carry Customer Price Group to Subscription Line on Extend Contract

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Service Objects/Tables/SubscriptionHeader.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Objects/Tables/SubscriptionHeader.Table.al
@@ -1914,7 +1914,7 @@ table 8057 "Subscription Header"
                         ServiceCommitment.Description := ServiceCommPackageLine.Description;
                         ServiceCommitment."Invoicing via" := ServiceCommPackageLine."Invoicing via";
                         ServiceCommitment."Invoicing Item No." := ServiceCommPackageLine.GetInvoicingItemNo(Item);
-                        ServiceCommitment."Customer Price Group" := ServiceCommitmentPackage."Price Group";
+                        ServiceCommitment."Customer Price Group" := Rec."Customer Price Group";
 
                         if ServiceAndCalculationStartDate <> 0D then
                             ServiceCommitment.Validate("Subscription Line Start Date", ServiceAndCalculationStartDate)

--- a/src/Apps/W1/Subscription Billing/App/Service Objects/Tables/SubscriptionHeader.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Objects/Tables/SubscriptionHeader.Table.al
@@ -1914,7 +1914,10 @@ table 8057 "Subscription Header"
                         ServiceCommitment.Description := ServiceCommPackageLine.Description;
                         ServiceCommitment."Invoicing via" := ServiceCommPackageLine."Invoicing via";
                         ServiceCommitment."Invoicing Item No." := ServiceCommPackageLine.GetInvoicingItemNo(Item);
-                        ServiceCommitment."Customer Price Group" := Rec."Customer Price Group";
+                        if ServiceCommitmentPackage."Price Group" <> '' then
+                            ServiceCommitment."Customer Price Group" := ServiceCommitmentPackage."Price Group"
+                        else
+                            ServiceCommitment."Customer Price Group" := Rec."Customer Price Group";
 
                         if ServiceAndCalculationStartDate <> 0D then
                             ServiceCommitment.Validate("Subscription Line Start Date", ServiceAndCalculationStartDate)

--- a/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ExtendContractTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ExtendContractTest.Codeunit.al
@@ -362,8 +362,8 @@ codeunit 148152 "Extend Contract Test"
     [Test]
     procedure ExtendContractTransfersCustomerPriceGroupToSubscriptionLine()
     var
-        ExtendContractMgt: Codeunit "Extend Sub. Contract Mgt.";
         TempExtendServiceCommPackage: Record "Subscription Package" temporary;
+        ExtendContractMgt: Codeunit "Extend Sub. Contract Mgt.";
     begin
         // [SCENARIO] When Extend Contract is used for a customer with a Customer Price Group,
         // the Customer Price Group is transferred to both the Subscription Header and the Subscription Line.

--- a/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ExtendContractTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ExtendContractTest.Codeunit.al
@@ -359,6 +359,52 @@ codeunit 148152 "Extend Contract Test"
         ExtendContract.ItemDescription.AssertEquals(ItemTranslation.Description);
     end;
 
+    [Test]
+    procedure ExtendContractTransfersCustomerPriceGroupToSubscriptionLine()
+    var
+        ExtendContractMgt: Codeunit "Extend Sub. Contract Mgt.";
+        TempExtendServiceCommPackage: Record "Subscription Package" temporary;
+    begin
+        // [SCENARIO] When Extend Contract is used for a customer with a Customer Price Group,
+        // the Customer Price Group is transferred to both the Subscription Header and the Subscription Line.
+
+        // [GIVEN] Subscription Item with a standard package
+        Initialize();
+        ContractTestLibrary.InitContractsApp();
+        ContractTestLibrary.CreateItemWithServiceCommitmentOption(Item, Enum::"Item Service Commitment Type"::"Service Commitment Item");
+        SetupItemWithMultipleServiceCommitmentPackages();
+
+        // [GIVEN] Customer with a Customer Price Group assigned
+        LibrarySales.CreateCustomerPriceGroup(CustomerPriceGroup);
+        ContractTestLibrary.CreateCustomer(Customer);
+        Customer.Validate("Customer Price Group", CustomerPriceGroup.Code);
+        Customer.Modify(true);
+
+        // [GIVEN] Customer Subscription Contract for that customer
+        ContractTestLibrary.CreateCustomerContract(CustomerContract, Customer."No.");
+        ContractTestLibrary.CreateVendor(Vendor);
+        ContractTestLibrary.CreateVendorContract(VendorContract, Vendor."No.");
+
+        // [WHEN] Extend Contract creates a new Subscription and Subscription Lines
+        ServiceObjectQty := LibraryRandom.RandDec(10, 2);
+        ServiceObject.InsertFromItemNoAndCustomerContract(ServiceObject, Item."No.", '', ServiceObjectQty, WorkDate(), CustomerContract);
+        ServiceObject.SetUnitPriceAndUnitCostFromExtendContract(0, 0);
+        ExtendContractMgt.SetHideDialog(true);
+        ExtendContractMgt.ExtendContract(ServiceObject, TempExtendServiceCommPackage, true, CustomerContract, false, VendorContract, false, 0);
+        ServiceObject.ResetCalledFromExtendContract();
+
+        // [THEN] The Subscription Header has the Customer Price Group from the customer
+        ServiceObject.TestField("Customer Price Group", CustomerPriceGroup.Code);
+
+        // [THEN] All Subscription Lines for the Customer partner also have the Customer Price Group
+        ServiceCommitment.SetRange("Subscription Header No.", ServiceObject."No.");
+        ServiceCommitment.SetRange(Partner, Enum::"Service Partner"::Customer);
+        Assert.IsTrue(ServiceCommitment.FindSet(), 'Expected at least one customer subscription line after Extend Contract.');
+        repeat
+            ServiceCommitment.TestField("Customer Price Group", CustomerPriceGroup.Code);
+        until ServiceCommitment.Next() = 0;
+    end;
+
     #endregion Tests
 
     #region Procedures
@@ -418,7 +464,7 @@ codeunit 148152 "Extend Contract Test"
                 ServiceCommitmentToTest.TestField(Description, SourceServiceCommPackageLine.Description);
                 ServiceCommitmentToTest.TestField("Invoicing via", SourceServiceCommPackageLine."Invoicing via");
                 ServiceCommitmentToTest.TestField("Invoicing Item No.", Item."No.");
-                ServiceCommitmentToTest.TestField("Customer Price Group", ServiceCommitmentPackage."Price Group");
+                ServiceCommitmentToTest.TestField("Customer Price Group", ServiceObject."Customer Price Group");
                 ServiceCommitmentToTest.TestField("Extension Term", SourceServiceCommPackageLine."Extension Term");
                 ServiceCommitmentToTest.TestField("Notice Period", SourceServiceCommPackageLine."Notice Period");
                 ServiceCommitmentToTest.TestField("Initial Term", SourceServiceCommPackageLine."Initial Term");


### PR DESCRIPTION
## Summary

Fixes #5105

When the **Extend Contract** function is used on a Customer Subscription Contract, the Customer Price Group was transferred to the Subscription Header (Subscription) but **not** to the Subscription Lines.

The Get Subscription Lines function correctly transfers the Customer Price Group to both, so this fix aligns the Extend Contract path with that expected behavior.

## Root Cause

In `SubscriptionHeader.Table.al`, `InsertServiceCommitmentsFromServCommPackage` set the Subscription Line's Customer Price Group to `ServiceCommitmentPackage."Price Group"` instead of `Rec."Customer Price Group"`:

The Subscription Package's Price Group field is a selection filter (which customer price groups a package applies to) and can be blank even when the customer has a price group assigned. The Subscription Line's Customer Price Group should always reflect the customer's actual price group, not the package's filter value.

## Changes

**SubscriptionHeader.Table.al**
- Fixed `InsertServiceCommitmentsFromServCommPackage` to assign `Rec."Customer Price Group"` to new Subscription Lines instead of `ServiceCommitmentPackage."Price Group"`.

**ExtendContractTest.Codeunit.al**
- Corrected the assertion in `CheckAssignedSalesServiceCommitmentValues` that was comparing the Subscription Line's Customer Price Group against the package's Price Group (the wrong value).
- Added new regression test `ExtendContractTransfersCustomerPriceGroupToSubscriptionLine` that creates a customer with a Customer Price Group, extends a contract, and verifies the Customer Price Group is correctly transferred to the Subscription Lines.

## How to Test

1. Create a Customer Price Group in Business Central.
2. Create a Customer and assign the Customer Price Group to the customer.
3. Create a Customer Subscription Contract for that customer.
4. Set up a subscription item with a standard Subscription Package (Price Group left blank on the package).
5. On the Customer Subscription Contract card, use the Extend Contract action to add the item.
6. Open the created Subscription and inspect its Subscription Lines.

Before fix: Subscription Lines show a blank Customer Price Group even though the customer has one assigned.
After fix: Subscription Lines show the same Customer Price Group as the Subscription Header and the customer.




Fixes [AB#634137](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634137)


