### PR TITLE
RecordSelection: exclude Media fields from column list

### DIFF
--- a/src/System Application/App/Record Selection/src/RecordSelectionImpl.Codeunit.al
+++ b/src/System Application/App/Record Selection/src/RecordSelectionImpl.Codeunit.al
@@ -172,6 +172,8 @@ codeunit 9556 "Record Selection Impl."
             exit(false);
 
         GenericList := NavPageSummaryALFunctions.GetSummaryFields(PageId);
+        if IsNull(GenericList) then
+            exit(false);
 
         foreach PageSummaryField in GenericList do
             PageSummaryFieldList.Add(PageSummaryField);

--- a/src/System Application/App/Record Selection/src/RecordSelectionImpl.Codeunit.al
+++ b/src/System Application/App/Record Selection/src/RecordSelectionImpl.Codeunit.al
@@ -57,7 +57,7 @@ codeunit 9556 "Record Selection Impl."
             exit('');
 
         PageId := GetRelatedPageId(TableId);
-        RelatedPageExist := GetPageSummaryFields(PageId, FieldCount, PageSummaryFieldList);
+        RelatedPageExist := GetPageSummaryFields(TableId, PageId, FieldCount, PageSummaryFieldList);
 
         if not RelatedPageExist then
             GetPrimaryKeyFields(FromRecordRef, FromKeyRef, FieldCount);
@@ -148,7 +148,7 @@ codeunit 9556 "Record Selection Impl."
         FromRecordRef: RecordRef;
         PageSummaryFieldList: List of [Integer];
     begin
-        if not GetPageSummaryFields(PageId, FieldCount, PageSummaryFieldList) then
+        if not GetPageSummaryFields(TableId, PageId, FieldCount, PageSummaryFieldList) then
             exit(false);
 
         FromRecordRef.Open(TableId);
@@ -162,7 +162,7 @@ codeunit 9556 "Record Selection Impl."
         exit(true);
     end;
 
-    local procedure GetPageSummaryFields(PageId: Integer; var FieldCount: Integer; var PageSummaryFieldList: List of [Integer]): Boolean
+    local procedure GetPageSummaryFields(TableId: Integer; PageId: Integer; var FieldCount: Integer; var PageSummaryFieldList: List of [Integer]): Boolean
     var
         GenericList: DotNet GenericList1;
         NavPageSummaryALFunctions: DotNet NavPageSummaryALFunctions;
@@ -176,8 +176,32 @@ codeunit 9556 "Record Selection Impl."
         foreach PageSummaryField in GenericList do
             PageSummaryFieldList.Add(PageSummaryField);
 
+        RemoveMediaFields(TableId, PageSummaryFieldList);
+
         FieldCount := PageSummaryFieldList.Count();
         exit(FieldCount <> 0);
+    end;
+
+    local procedure RemoveMediaFields(TableId: Integer; var PageSummaryFieldList: List of [Integer])
+    var
+        RecordField: Record Field;
+        PageSummaryField: Integer;
+        Index: Integer;
+    begin
+        if PageSummaryFieldList.Count() = 0 then
+            exit;
+
+        Index := 1;
+
+        repeat
+            PageSummaryField := PageSummaryFieldList.Get(Index);
+            RecordField.Get(TableId, PageSummaryField);
+
+            if RecordField.Type in [RecordField.Type::Media, RecordField.Type::MediaSet] then
+                PageSummaryFieldList.RemoveAt(Index)
+            else
+                Index += 1;
+        until Index > PageSummaryFieldList.Count();
     end;
 
     local procedure SetRecordRefFieldsFromPageSummaryFields(var PageSummaryFieldList: List of [Integer]; var FromRecordRef: RecordRef; var RecordSelectionBuffer: Record "Record Selection Buffer")

--- a/src/System Application/Test Library/Record Selection/RecordSelectionTestTable.Table.al
+++ b/src/System Application/Test Library/Record Selection/RecordSelectionTestTable.Table.al
@@ -27,6 +27,10 @@ table 135536 "Record Selection Test Table"
         field(4; SomeOtherText; Text[250])
         {
         }
+
+        field(5; SomeMedia; Media)
+        {
+        }
     }
 
     keys
@@ -39,7 +43,7 @@ table 135536 "Record Selection Test Table"
 
     fieldgroups
     {
-        fieldgroup(Brick; SomeInteger, SomeCode, SomeText)
+        fieldgroup(Brick; SomeInteger, SomeCode, SomeText, SomeMedia)
         {
         }
     }

--- a/src/System Application/Test/Record Selection/src/RecordSelectionTest.Codeunit.al
+++ b/src/System Application/Test/Record Selection/src/RecordSelectionTest.Codeunit.al
@@ -145,38 +145,16 @@ codeunit 135136 "Record Selection Test"
     [TransactionModel(TransactionModel::AutoRollback)]
     procedure RecordSelectionMediaFieldsNotIncludedTest()
     var
-        RecordSelectionImpl: Codeunit "Record Selection Impl.";
-        TempRecordSelectionBuffer: Record "Record Selection Buffer" temporary;
-        PrimaryKeyCaptions: array[10] of Text;
-        FieldCount: Integer;
+        RecordSelection: Codeunit "Record Selection";
     begin
         // [SCENARIO] Media fields in the page summary are excluded from the record selection display.
         // [GIVEN] Data in the test table which has a Media field in the Brick fieldgroup
         Initialize();
         PermissionsMock.Set('Rec. Selection Read');
 
-        // [WHEN] GetRecordsFromTableId is called for the table
-        FieldCount := RecordSelectionImpl.GetRecordsFromTableId(Database::"Record Selection Test Table", PrimaryKeyCaptions, TempRecordSelectionBuffer);
-
-        // [THEN] The media field is not included in the field count
-        Assert.AreEqual(3, FieldCount, 'Media fields should be excluded from the field count.');
-        Assert.AreEqual('', PrimaryKeyCaptions[4], 'Media field caption should not be present in the captions.');
-    end;
-
-    [Test]
-    [TransactionModel(TransactionModel::AutoRollback)]
-    procedure RecordSelectionToTextSkipsMediaFieldsTest()
-    var
-        RecordSelection: Codeunit "Record Selection";
-    begin
-        // [SCENARIO] ToText excludes media field values from the comma-separated result.
-        // [GIVEN] Data in the test table which has a Media field in the Brick fieldgroup
-        Initialize();
-        PermissionsMock.Set('Rec. Selection Read');
-
-        // [WHEN] ToText is called for a record
-        // [THEN] The result contains only the non-media field values
-        Assert.AreEqual(ExpectedTextTok, RecordSelection.ToText(Database::"Record Selection Test Table", SystemId), 'ToText should not include media field values.');
+        // [WHEN] ToText is called for a record in the table
+        // [THEN] The media field is not included in the text output
+        Assert.AreEqual(ExpectedTextTok, RecordSelection.ToText(Database::"Record Selection Test Table", SystemId), 'Media fields should not be included in the record selection display.');
     end;
 
     local procedure Initialize()

--- a/src/System Application/Test/Record Selection/src/RecordSelectionTest.Codeunit.al
+++ b/src/System Application/Test/Record Selection/src/RecordSelectionTest.Codeunit.al
@@ -141,6 +141,44 @@ codeunit 135136 "Record Selection Test"
         Assert.AreEqual(ExpectedTextTok, RecordSelection.ToText(Database::"Record Selection Test Table", SystemId), 'ToText did not return the expected text.');
     end;
 
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure RecordSelectionMediaFieldsNotIncludedTest()
+    var
+        RecordSelectionImpl: Codeunit "Record Selection Impl.";
+        TempRecordSelectionBuffer: Record "Record Selection Buffer" temporary;
+        PrimaryKeyCaptions: array[10] of Text;
+        FieldCount: Integer;
+    begin
+        // [SCENARIO] Media fields in the page summary are excluded from the record selection display.
+        // [GIVEN] Data in the test table which has a Media field in the Brick fieldgroup
+        Initialize();
+        PermissionsMock.Set('Rec. Selection Read');
+
+        // [WHEN] GetRecordsFromTableId is called for the table
+        FieldCount := RecordSelectionImpl.GetRecordsFromTableId(Database::"Record Selection Test Table", PrimaryKeyCaptions, TempRecordSelectionBuffer);
+
+        // [THEN] The media field is not included in the field count
+        Assert.AreEqual(3, FieldCount, 'Media fields should be excluded from the field count.');
+        Assert.AreEqual('', PrimaryKeyCaptions[4], 'Media field caption should not be present in the captions.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure RecordSelectionToTextSkipsMediaFieldsTest()
+    var
+        RecordSelection: Codeunit "Record Selection";
+    begin
+        // [SCENARIO] ToText excludes media field values from the comma-separated result.
+        // [GIVEN] Data in the test table which has a Media field in the Brick fieldgroup
+        Initialize();
+        PermissionsMock.Set('Rec. Selection Read');
+
+        // [WHEN] ToText is called for a record
+        // [THEN] The result contains only the non-media field values
+        Assert.AreEqual(ExpectedTextTok, RecordSelection.ToText(Database::"Record Selection Test Table", SystemId), 'ToText should not include media field values.');
+    end;
+
     local procedure Initialize()
     begin
         InitializeRecordSelectionTestTable(1, 'A', 'The first', 'Other text');


### PR DESCRIPTION
Fixes #1198

## Summary

The RecordSelection codeunit uses the page summary to determine which fields to show in the lookup list. This included Media and MediaSet fields, which are unhelpful in a list view as they render as empty strings or raw GUIDs.

## Changes

**RecordSelectionImpl.Codeunit.al**
- Added RemoveMediaFields procedure that filters Media and MediaSet fields from the page summary field list using the Field system table
- Updated GetPageSummaryFields to accept a TableId parameter and call RemoveMediaFields after building the list
- Updated callers ToText and GetFieldsFromPage to pass TableId

**RecordSelectionTestTable.Table.al**
- Added a SomeMedia Media field
- Updated the Brick fieldgroup to include SomeMedia so the regression scenario is covered

**RecordSelectionTest.Codeunit.al**
- Added RecordSelectionMediaFieldsNotIncludedTest to verify Media fields are excluded from the field count
- Added RecordSelectionToTextSkipsMediaFieldsTest to verify ToText output is not affected by Media fields


