### PR TITLE
[Security] Mark all procedures in Http Authentication Basic as [NonDebuggable]

### DIFF
--- a/src/System Application/App/Rest Client/src/Authentication/HttpAuthenticationBasic.Codeunit.al
+++ b/src/System Application/App/Rest Client/src/Authentication/HttpAuthenticationBasic.Codeunit.al
@@ -54,13 +54,12 @@ codeunit 2359 "Http Authentication Basic" implements "Http Authentication"
         Header.Add('Authorization', SecretStrSubstNo('Basic %1', ToBase64(SecretStrSubstNo('%1:%2', GlobalUsername, GlobalPassword))));
     end;
 
+    [NonDebuggable]
     local procedure ToBase64(String: SecretText) Base64String: SecretText
     var
         Convert: DotNet Convert;
         Encoding: DotNet Encoding;
     begin
-#pragma warning disable AL0796
         Base64String := Convert.ToBase64String(Encoding.UTF8().GetBytes(String.Unwrap()));
-#pragma warning restore AL0796
     end;
 }

--- a/src/System Application/App/Rest Client/src/Authentication/HttpAuthenticationBasic.Codeunit.al
+++ b/src/System Application/App/Rest Client/src/Authentication/HttpAuthenticationBasic.Codeunit.al
@@ -21,6 +21,7 @@ codeunit 2359 "Http Authentication Basic" implements "Http Authentication"
     /// <summary>Initializes the authentication object with the given username and password</summary>
     /// <param name="Username">The username to use for authentication</param>
     /// <param name="Password">The password to use for authentication</param>
+    [NonDebuggable]
     procedure Initialize(Username: Text; Password: SecretText)
     begin
         Initialize(Username, '', Password);
@@ -30,6 +31,7 @@ codeunit 2359 "Http Authentication Basic" implements "Http Authentication"
     /// <param name="Username">The username to use for authentication</param>
     /// <param name="Domain">The domain to use for authentication</param>
     /// <param name="Password">The password to use for authentication</param>
+    [NonDebuggable]
     procedure Initialize(Username: Text; Domain: Text; Password: SecretText)
     begin
         if Domain = '' then
@@ -42,6 +44,7 @@ codeunit 2359 "Http Authentication Basic" implements "Http Authentication"
 
     /// <summary>Checks if authentication is required for the request</summary>
     /// <returns>Returns true because authentication is required</returns>
+    [NonDebuggable]
     procedure IsAuthenticationRequired(): Boolean;
     begin
         exit(true);
@@ -49,6 +52,7 @@ codeunit 2359 "Http Authentication Basic" implements "Http Authentication"
 
     /// <summary>Gets the authorization headers for the request</summary>
     /// <returns>Returns a dictionary of headers that need to be added to the request</returns>
+    [NonDebuggable]
     procedure GetAuthorizationHeaders() Header: Dictionary of [Text, SecretText];
     begin
         Header.Add('Authorization', SecretStrSubstNo('Basic %1', ToBase64(SecretStrSubstNo('%1:%2', GlobalUsername, GlobalPassword))));


### PR DESCRIPTION
## Summary

- Mark **every procedure** in the `Http Authentication Basic` codeunit (Rest Client app, codeunit 2359) as `[NonDebuggable]` — `Initialize` (both overloads), `IsAuthenticationRequired`, `GetAuthorizationHeaders`, and `ToBase64`. AL does not support `[NonDebuggable]` at the codeunit object level, so decorating every procedure is the equivalent of "the whole codeunit is non-debuggable."
- The credential-handling chain in this codeunit takes a `SecretText` password through `Initialize` -> stores it in `GlobalPassword` -> composes the basic-auth header in `GetAuthorizationHeaders` -> base64-encodes it via `ToBase64` (which calls `SecretText.Unwrap()`). Marking every entry point `[NonDebuggable]` is a structural defense-in-depth: it protects the codepath regardless of how the body of any procedure evolves, and it prevents any future refactor that introduces a debugger-visible local from silently exposing the credential.
- Aligns with the existing convention in `Base64ConvertImpl.Codeunit.al` (System Application Base64 Convert), where the equivalent `ToBase64(SecretString: SecretText): SecretText` overload is already `[NonDebuggable]`.
- The `#pragma warning disable AL0796` / `restore AL0796` block is removed: AL0796 fires on `Unwrap()` calls in debuggable contexts, so once `ToBase64` is `[NonDebuggable]` the warning no longer applies and the suppression becomes dead noise.

## Scope

- All procedures in codeunit 2359 are decorated with `[NonDebuggable]`. The interface contract (`Http Authentication`) is unaffected — the attribute is independent of the interface signature, and the sibling implementation `Http Authentication Anonymous` (codeunit 2358) handles no secrets and is unchanged.
- Behavior is unchanged. The existing `TestBasicAuthentication` test in `HttpAuthenticationTests.Codeunit.al` is itself `[NonDebuggable]` and still exercises the full `GetAuthorizationHeaders` -> `ToBase64` chain.

Fixes [AB#631826](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/631826)


