### PR TITLE
[Bug 620643] Fix deletion of Subcontractor Prices when Work Center or Item is deleted

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcWorkCenterExtension.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcWorkCenterExtension.Codeunit.al
@@ -19,9 +19,6 @@ codeunit 99001519 "Subc. Work Center Extension"
         if not RunTrigger then
             exit;
 
-        SubcontractorPrice.SetCurrentKey("Work Center No.");
-        SubcontractorPrice.SetRange("Work Center No.", Rec."No.");
-        if not SubcontractorPrice.IsEmpty() then
-            SubcontractorPrice.DeleteAll(true);
+        SubcontractorPrice.DeletePricesForWorkCenter(Rec."No.");
     end;
 }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/MasterData/SubcItemExtension.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/MasterData/SubcItemExtension.Codeunit.al
@@ -10,6 +10,8 @@ codeunit 99001532 "Subc. Item Extension"
 {
     [EventSubscriber(ObjectType::Table, Database::Item, OnAfterDeleteEvent, '', false, false)]
     local procedure OnAfterDeleteItem(var Rec: Record Item; RunTrigger: Boolean)
+    var
+        SubcontractorPrice: Record "Subcontractor Price";
     begin
         if Rec.IsTemporary() then
             exit;
@@ -17,16 +19,6 @@ codeunit 99001532 "Subc. Item Extension"
         if not RunTrigger then
             exit;
 
-        DeleteRelatedSubcontractorPrices(Rec);
-    end;
-
-    local procedure DeleteRelatedSubcontractorPrices(var Item: Record Item)
-    var
-        SubcontractorPrice: Record "Subcontractor Price";
-    begin
-        SubcontractorPrice.SetCurrentKey("Item No.");
-        SubcontractorPrice.SetRange("Item No.", Item."No.");
-        if not SubcontractorPrice.IsEmpty() then
-            SubcontractorPrice.DeleteAll(true);
+        SubcontractorPrice.DeletePricesForItem(Rec."No.");
     end;
 }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/MasterData/SubcVendorExtension.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/MasterData/SubcVendorExtension.Codeunit.al
@@ -19,9 +19,6 @@ codeunit 99001531 "Subc. Vendor Extension"
         if not RunTrigger then
             exit;
 
-        SubcontractorPrice.SetCurrentKey("Vendor No.");
-        SubcontractorPrice.SetRange("Vendor No.", Rec."No.");
-        if not SubcontractorPrice.IsEmpty() then
-            SubcontractorPrice.DeleteAll(true);
+        SubcontractorPrice.DeletePricesForVendor(Rec."No.");
     end;
 }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Tables/SubcontractorPrice.Table.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Tables/SubcontractorPrice.Table.al
@@ -168,4 +168,28 @@ table 99001500 "Subcontractor Price"
             until SubcontractorPrice.Next() = 0;
     end;
 
+    procedure DeletePricesForVendor(VendorNo: Code[20])
+    begin
+        SetCurrentKey("Vendor No.");
+        SetRange("Vendor No.", VendorNo);
+        if not IsEmpty() then
+            DeleteAll(true);
+    end;
+
+    procedure DeletePricesForWorkCenter(WorkCenterNo: Code[20])
+    begin
+        SetCurrentKey("Work Center No.");
+        SetRange("Work Center No.", WorkCenterNo);
+        if not IsEmpty() then
+            DeleteAll(true);
+    end;
+
+    procedure DeletePricesForItem(ItemNo: Code[20])
+    begin
+        SetCurrentKey("Item No.");
+        SetRange("Item No.", ItemNo);
+        if not IsEmpty() then
+            DeleteAll(true);
+    end;
+
 }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Tables/SubcontractorPrice.Table.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Tables/SubcontractorPrice.Table.al
@@ -127,6 +127,12 @@ table 99001500 "Subcontractor Price"
         key(Key02; "Vendor No.", "Item No.", "Work Center No.", "Variant Code", "Unit of Measure Code", "Currency Code")
         {
         }
+        key(Key03; "Work Center No.")
+        {
+        }
+        key(Key04; "Item No.")
+        {
+        }
     }
     fieldgroups
     {

--- a/src/Apps/W1/Subcontracting/App/src/Process/Tables/SubcontractorPrice.Table.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Tables/SubcontractorPrice.Table.al
@@ -168,7 +168,7 @@ table 99001500 "Subcontractor Price"
             until SubcontractorPrice.Next() = 0;
     end;
 
-    procedure DeletePricesForVendor(VendorNo: Code[20])
+    internal procedure DeletePricesForVendor(VendorNo: Code[20])
     begin
         SetCurrentKey("Vendor No.");
         SetRange("Vendor No.", VendorNo);
@@ -176,7 +176,7 @@ table 99001500 "Subcontractor Price"
             DeleteAll(true);
     end;
 
-    procedure DeletePricesForWorkCenter(WorkCenterNo: Code[20])
+    internal procedure DeletePricesForWorkCenter(WorkCenterNo: Code[20])
     begin
         SetCurrentKey("Work Center No.");
         SetRange("Work Center No.", WorkCenterNo);
@@ -184,7 +184,7 @@ table 99001500 "Subcontractor Price"
             DeleteAll(true);
     end;
 
-    procedure DeletePricesForItem(ItemNo: Code[20])
+    internal procedure DeletePricesForItem(ItemNo: Code[20])
     begin
         SetCurrentKey("Item No.");
         SetRange("Item No.", ItemNo);

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -1538,6 +1538,64 @@ Comment = '|%1 = Transfer Order No.';
     end;
 
     [Test]
+    [Scope('OnPrem')]
+    procedure DeleteWorkCenterWithPricesDeletesRelatedPrices()
+    var
+        Item: Record Item;
+        SubcontractorPrice: Record "Subcontractor Price";
+        WorkCenter: Record "Work Center";
+        WorkCenterNo: Code[20];
+    begin
+        // [SCENARIO 620643] Deleting a Work Center deletes all associated Subcontractor Prices
+
+        // [GIVEN] A work center with a subcontractor and multiple Subcontractor Prices
+        Initialize();
+        LibraryMfgManagement.CreateWorkCenterWithCalendar(WorkCenter, 0);
+        WorkCenter.Validate("Subcontractor No.", LibraryMfgManagement.CreateSubcontractorWithCurrency(''));
+        WorkCenter.Modify(true);
+        LibraryInventory.CreateItem(Item);
+        WorkCenterNo := WorkCenter."No.";
+        SubcontractingMgmtLibrary.CreateSubContractingPrice(SubcontractorPrice, WorkCenterNo, WorkCenter."Subcontractor No.", Item."No.", '', '', WorkDate(), '', 0, '');
+        SubcontractingMgmtLibrary.CreateSubContractingPrice(SubcontractorPrice, WorkCenterNo, WorkCenter."Subcontractor No.", Item."No.", '', '', WorkDate(), '', 10, '');
+
+        // [WHEN] The work center is deleted
+        WorkCenter.Delete(true);
+
+        // [THEN] All Subcontractor Prices for the work center are deleted
+        SubcontractorPrice.SetRange("Work Center No.", WorkCenterNo);
+        Assert.IsTrue(SubcontractorPrice.IsEmpty(), 'Subcontractor prices must be deleted when work center is deleted');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DeleteItemWithPricesDeletesRelatedPrices()
+    var
+        Item: Record Item;
+        SubcontractorPrice: Record "Subcontractor Price";
+        WorkCenter: Record "Work Center";
+        ItemNo: Code[20];
+    begin
+        // [SCENARIO 620643] Deleting an Item deletes all associated Subcontractor Prices
+
+        // [GIVEN] An item with multiple Subcontractor Prices
+        Initialize();
+        LibraryMfgManagement.CreateWorkCenterWithCalendar(WorkCenter, 0);
+        WorkCenter.Validate("Subcontractor No.", LibraryMfgManagement.CreateSubcontractorWithCurrency(''));
+        WorkCenter.Modify(true);
+        LibraryInventory.CreateItem(Item);
+        ItemNo := Item."No.";
+        SubcontractingMgmtLibrary.CreateSubContractingPrice(SubcontractorPrice, WorkCenter."No.", WorkCenter."Subcontractor No.", ItemNo, '', '', WorkDate(), '', 0, '');
+        SubcontractingMgmtLibrary.CreateSubContractingPrice(SubcontractorPrice, WorkCenter."No.", WorkCenter."Subcontractor No.", ItemNo, '', '', WorkDate(), '', 10, '');
+
+        // [WHEN] The item is deleted
+        Item.Delete(true);
+
+        // [THEN] All Subcontractor Prices for the item are deleted
+        SubcontractorPrice.SetRange("Item No.", ItemNo);
+        Assert.IsTrue(SubcontractorPrice.IsEmpty(), 'Subcontractor prices must be deleted when item is deleted');
+    end;
+
+    [Test]
     [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,SubcontrDispatchingListDefaultRequestPageHandler')]
     procedure TestSubcontrDispatchingList()
     var


### PR DESCRIPTION
## Summary

- `SetCurrentKey("Work Center No.")` in `SubcWorkCenterExtension.Codeunit.al` and `SetCurrentKey("Item No.")` in `SubcItemExtension.Codeunit.al` failed at runtime because neither field was the first field of any existing key on the `SubcontractorPrice` table.
- This caused a runtime error whenever a Work Center or Item with associated Subcontractor Prices was deleted, preventing the deletion from completing.
- Added secondary keys `Key03 ("Work Center No.")` and `Key04 ("Item No.")` to `SubcontractorPrice.Table.al` so the `SetCurrentKey` calls resolve correctly and cascaded deletion works as intended.

## Root cause

The `SubcVendorExtension` correctly calls `SetCurrentKey("Vendor No.")` because `"Vendor No."` is the first field of the clustered PK. The other two extensions used fields that are not the first field of any key:

| Codeunit | SetCurrentKey call | Was valid? |
|---|---|---|
| SubcVendorExtension | `"Vendor No."` | ✅ First field of PK |
| SubcWorkCenterExtension | `"Work Center No."` | ❌ No key starts with this field |
| SubcItemExtension | `"Item No."` | ❌ No key starts with this field |

## Fix

Added two secondary keys to `SubcontractorPrice.Table.al`:
- `key(Key03; "Work Center No.")`
- `key(Key04; "Item No.")`

## Tests added

- `DeleteWorkCenterWithPricesDeletesRelatedPrices` (codeunit 139989) — creates a work center with multiple subcontractor prices, deletes the work center, asserts all prices are deleted
- `DeleteItemWithPricesDeletesRelatedPrices` (codeunit 139989) — creates an item with multiple subcontractor prices, deletes the item, asserts all prices are deleted

Fixes [AB#620643](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620643)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



