### PR TITLE
Bug 618368: [Subcontracting] Move "Create Prod. BOM/Routing" action to Functions group and rename

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/MasterData/SubcItemCard.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/MasterData/SubcItemCard.PageExt.al
@@ -22,12 +22,15 @@ pageextension 99001518 "Subc. Item Card" extends "Item Card"
                 RunPageView = sorting("Vendor No.", "Item No.", "Standard Task Code", "Work Center No.", "Variant Code", "Starting Date", "Unit of Measure Code", "Minimum Quantity", "Currency Code");
                 ToolTip = 'Set up different prices for the item in subcontracting.';
             }
+        }
+        addlast(Functions)
+        {
             action(CreatePurchProvProdBOMRtng)
             {
                 ApplicationArea = Manufacturing;
-                Caption = 'Create purchase provision Prod. BOM/Routing';
+                Caption = 'Create Prod. BOM/Routing';
                 Image = CreateForm;
-                ToolTip = 'Create Production BOM and/or Routing BOM with purchase provision options.';
+                ToolTip = 'Create Production BOM and/or Routing with purchase provision options.';
                 trigger OnAction()
                 var
                     SubcCreateProdRtngExt: Codeunit "Subc. Create Prod. Rtng. Ext.";

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/MasterData/SubcItemCard.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/MasterData/SubcItemCard.PageExt.al
@@ -30,7 +30,7 @@ pageextension 99001518 "Subc. Item Card" extends "Item Card"
                 ApplicationArea = Manufacturing;
                 Caption = 'Create Prod. BOM/Routing';
                 Image = CreateForm;
-                ToolTip = 'Create Production BOM and/or Routing with purchase provision options.';
+                ToolTip = 'Create a Production BOM and/or Routing for the item.';
                 trigger OnAction()
                 var
                     SubcCreateProdRtngExt: Codeunit "Subc. Create Prod. Rtng. Ext.";

--- a/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcCreateProdRouting.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcCreateProdRouting.Report.al
@@ -14,7 +14,7 @@ using System.Utilities;
 report 99001503 "Subc. Create Prod. Routing"
 {
     ApplicationArea = Manufacturing;
-    Caption = 'Create Production BOM, Routing BOM';
+    Caption = 'Create Production BOM, Routing';
     ProcessingOnly = true;
     UsageCategory = Tasks;
 


### PR DESCRIPTION
## Summary

- Moves the `CreatePurchProvProdBOMRtng` action on the **Item Card** page extension from the **Purchase Prices and Discounts** group (`addafter(PurchPriceLists)`) to the **Functions** group (`addlast(Functions)`)
- Renames the action caption from `'Create purchase provision Prod. BOM/Routing'` to `'Create Prod. BOM/Routing'`
- Updates the tooltip to remove the now-inconsistent "purchase provision" phrasing
- Cleans up the related report caption from `'Create Production BOM, Routing BOM'` to `'Create Production BOM, Routing'` (removes the redundant "BOM" suffix)

Fixes [AB#618368](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/618368)

## Test plan

- [x] Open the Item Card for a manufacturing item in a Subcontracting-enabled environment
- [x] Verify the action no longer appears under **Purchase Prices and Discounts**
- [x] Verify the action appears under **Functions** with caption **Create Prod. BOM/Routing**
- [x] Trigger the action and confirm the Create Production BOM/Routing report runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)





