### PR TITLE
Fix AA0137: Remove unused variables in multi-var declarations

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/EDocumentCreateJnlLine.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocumentCreateJnlLine.Codeunit.al
@@ -203,7 +203,7 @@ codeunit 6137 "E-Document Create Jnl. Line"
         SourceEDocumentService: Record "E-Document Service";
         NoSeriesBatch: Codeunit "No. Series - Batch";
         EDocumentErrorHelper: Codeunit "E-Document Error Helper";
-        SourceDocumentHeader, CreatedJnlLine : RecordRef;
+        CreatedJnlLine: RecordRef;
         NoBalanceAccountMappingErr: Label 'Could not fill the Bal. Account No. field for vendor ''''%1''''. Choose the Map Text to Account button to map ''''%1'''' to the relevant G/L account.', Comment = '%1 - vendor name';
         NoDebitAccountMappingErr: Label 'Could not fill the %1 field for vendor ''''%2''''. Choose the Map Text to Account button to map ''''%2'''' to the relevant G/L account.', Comment = '%1 - Debit Acc. No. or Credit Acc. No. field caption, %2 - vendor name';
         VatAmountMismatchErr: Label 'VAT amount %1 on the general journal line does not match VAT amount %2 in the electroinc document.', Comment = '%1 - General Journal Line VAT amount, %2 - Electronic Document VAT amount';

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseDraft.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseDraft.Page.al
@@ -773,7 +773,7 @@ page 6181 "E-Document Purchase Draft"
         EDocumentProcessing: Codeunit "E-Document Processing";
         FeatureTelemetry: Codeunit "Feature Telemetry";
         GlobalEDocumentHelper: Codeunit "E-Document Helper";
-        RecordLinkTxt, StyleStatusTxt, ServiceStatusStyleTxt, VendorName, DataCaption : Text;
+        RecordLinkTxt, StyleStatusTxt, DataCaption: Text;
         HasErrorsOrWarnings, HasErrors : Boolean;
         ShowFinalizeDraftAction: Boolean;
         ShowAnalyzeDocumentAction: Boolean;

--- a/src/Apps/W1/PEPPOL/App/src/Sales/XmlPorts/SalesInvoicePEPPOL30.XmlPort.al
+++ b/src/Apps/W1/PEPPOL/App/src/Sales/XmlPorts/SalesInvoicePEPPOL30.XmlPort.al
@@ -2247,7 +2247,7 @@ xmlport 37201 "Sales Invoice - PEPPOL30"
         PostedHeaderIterator, PostedLineIterator : Interface "PEPPOL Posted Document Iterator";
         PEPPOL30Format: Enum "PEPPOL 3.0 Format";
         DummyVar: Text;
-        IsFormatSet, IsFormatInitialized : Boolean;
+        IsFormatSet: Boolean;
         GeneratePDF: Boolean;
 
 

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
@@ -1122,7 +1122,6 @@ page 30113 "Shpfy Order"
         OrderCancelFailedErr: Label 'Specifies the order could not be cancelled. You can see the error message from Shopify Log Entries.';
         LogEntriesLbl: Label 'Log Entries';
         WorkDescription: Text;
-
         PresentmentVisible: Boolean;
 
     trigger OnAfterGetRecord()

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
@@ -1122,7 +1122,7 @@ page 30113 "Shpfy Order"
         OrderCancelFailedErr: Label 'Specifies the order could not be cancelled. You can see the error message from Shopify Log Entries.';
         LogEntriesLbl: Label 'Log Entries';
         WorkDescription: Text;
-        TotalAmount, SubtotalAmount : Decimal;
+
         PresentmentVisible: Boolean;
 
     trigger OnAfterGetRecord()


### PR DESCRIPTION
#### Summary
The AL compiler bug fix (BC-DeveloperExperience PR #7928) now correctly triggers AA0137 for individual unused variables in comma-separated multi-line declarations. Since NAV treats warnings as errors, these previously-undetected unused variables now break builds.

Removed 6 unused variables across 4 files:
- EDocumentCreateJnlLine.Codeunit.al: SourceDocumentHeader
- EDocumentPurchaseDraft.Page.al: ServiceStatusStyleTxt, VendorName
- SalesInvoicePEPPOL30.XmlPort.al: IsFormatInitialized
- ShpfyOrder.Page.al: TotalAmount, SubtotalAmount (entire line deleted)

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->

Fixes [AB#629344](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/629344)



