### PR TITLE
[releases/27.5][Shopify] Backport BE test fix for UnitTestUpdateTaxRegistrationIdForVATRegistrationNo

### DIFF
--- a/src/Apps/W1/Shopify/Test/Companies/ShpfyTaxIdMappingTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Companies/ShpfyTaxIdMappingTest.Codeunit.al
@@ -171,6 +171,11 @@ codeunit 134246 "Shpfy Tax Id Mapping Test"
         NewTaxRegistrationId := LibraryERM.GenerateVATRegistrationNo(CompanyInformation."Country/Region Code");
         // [GIVEN] Customer with empty VAT Registration No.
         CreateCustomerWithVATRegNo(Customer, '');
+        if CompanyInformation."Country/Region Code" = 'BE' then begin
+            Customer."Country/Region Code" := 'DE'; // VAT Reg No. not allowed for BE Customers
+            Customer.Modify();
+            NewTaxRegistrationId := LibraryERM.GenerateVATRegistrationNo(Customer."Country/Region Code");
+        end;
         // [GIVEN] TaxRegistrationIdMapping interface is "VAT Registration No."
         TaxRegistrationIdMapping := Enum::"Shpfy Comp. Tax Id Mapping"::"VAT Registration No.";
 

--- a/src/Apps/W1/Shopify/Test/Companies/ShpfyTaxIdMappingTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Companies/ShpfyTaxIdMappingTest.Codeunit.al
@@ -5,20 +5,19 @@
 
 namespace Microsoft.Integration.Shopify.Test;
 
-using Microsoft.Foundation.Company;
 using Microsoft.Integration.Shopify;
-using System.TestLibraries.Utilities;
 using Microsoft.Sales.Customer;
+using System.TestLibraries.Utilities;
 
 codeunit 134246 "Shpfy Tax Id Mapping Test"
 {
     Subtype = Test;
     TestPermissions = Disabled;
+    EventSubscriberInstance = Manual;
 
     var
         Any: Codeunit Any;
         LibraryAssert: Codeunit "Library Assert";
-        LibraryERM: Codeunit "Library - ERM";
         IsInitialized: Boolean;
 
     trigger OnRun()
@@ -158,8 +157,8 @@ codeunit 134246 "Shpfy Tax Id Mapping Test"
     [Test]
     procedure UnitTestUpdateTaxRegistrationIdForVATRegistrationNo()
     var
-        CompanyInformation: Record "Company Information";
         Customer: Record Customer;
+        ShpfyTaxIdMappingTest: Codeunit "Shpfy Tax Id Mapping Test";
         TaxRegistrationIdMapping: Interface "Shpfy Tax Registration Id Mapping";
         NewTaxRegistrationId: Text[150];
     begin
@@ -167,20 +166,17 @@ codeunit 134246 "Shpfy Tax Id Mapping Test"
         Initialize();
 
         // [GIVEN] New Tax Registration Id
-        CompanyInformation.Get();
-        NewTaxRegistrationId := LibraryERM.GenerateVATRegistrationNo(CompanyInformation."Country/Region Code");
+        NewTaxRegistrationId := CopyStr(Any.AlphanumericText(20), 1, MaxStrLen(Customer."VAT Registration No."));
         // [GIVEN] Customer with empty VAT Registration No.
         CreateCustomerWithVATRegNo(Customer, '');
-        if CompanyInformation."Country/Region Code" = 'BE' then begin
-            Customer."Country/Region Code" := 'DE'; // VAT Reg No. not allowed for BE Customers
-            Customer.Modify();
-            NewTaxRegistrationId := LibraryERM.GenerateVATRegistrationNo(Customer."Country/Region Code");
-        end;
         // [GIVEN] TaxRegistrationIdMapping interface is "VAT Registration No."
         TaxRegistrationIdMapping := Enum::"Shpfy Comp. Tax Id Mapping"::"VAT Registration No.";
 
         // [WHEN] UpdateTaxRegistrationId is called
+        // Bypass localization-specific VAT Registration No. validation (e.g. BE requires Enterprise No. instead)
+        BindSubscription(ShpfyTaxIdMappingTest);
         TaxRegistrationIdMapping.UpdateTaxRegistrationId(Customer, NewTaxRegistrationId);
+        UnbindSubscription(ShpfyTaxIdMappingTest);
 
         // [THEN] The VAT Registration No. field of the Customer record is updated
         Customer.Get(Customer."No.");
@@ -221,5 +217,11 @@ codeunit 134246 "Shpfy Tax Id Mapping Test"
         CompanyLocation.Id := Any.IntegerInRange(10000, 99999);
         CompanyLocation."Tax Registration Id" := RegistrationNo;
         CompanyLocation.Insert(false);
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::Customer, 'OnBeforeValidateVATRegistrationNo', '', false, false)]
+    local procedure HandleOnBeforeValidateVATRegistrationNo(var Customer: Record Customer; xCustomer: Record Customer; FieldNumber: Integer; var IsHandled: Boolean)
+    begin
+        IsHandled := true;
     end;
 }


### PR DESCRIPTION
## Summary
Backports the BE test fix for `UnitTestUpdateTaxRegistrationIdForVATRegistrationNo` from `main` to `releases/27.5`. The original Shopify tax registration ID feature (PR #7750 / cherry-picked as `8d5f0f3c`) was backported, but the follow-up test fixes that make the test pass on the BE gate were not.

The `RunALUnitTests_BE_Extensions` task is currently failing on `releases/27.5` BCApps validation as a result.

## Cherry-picked commits
- `1d87928` — [Shopify] Test failure in UnitTestUpdateTaxRegistrationIdForVATRegistrationNo for Belgian customers (#6400)
- `bfdac91` — [Shopify] Fix VAT Registration No. test for BE gate (#6606)

#6606 supersedes #6400 (replaces the country-code check with an `EventSubscriber` on `OnBeforeValidateVATRegistrationNo` to handle the Empty Company case used by the BE gate). Both are cherry-picked here so the resulting test code matches `main`.

Fixes [AB#632783](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632783)


