### PR TITLE
[28.x] Deprecate SFTP connector

### DIFF
--- a/src/Apps/W1/External File Storage - SFTP Connector/App/Entitlements/ExtSFTPConnector.Entitlement.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/Entitlements/ExtSFTPConnector.Entitlement.al
@@ -5,10 +5,10 @@
 
 namespace System.ExternalFileStorage;
 
-#pragma warning disable AL0432
+#pragma warning disable AL0432, AS0105
 entitlement "Ext. SFTP Connector"
 {
     ObjectEntitlements = "Ext. SFTP - Edit";
     Type = Implicit;
 }
-#pragma warning restore AL0432
+#pragma warning restore AL0432, AS0105

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/Entitlements/ExtSFTPConnector.Entitlement.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/Entitlements/ExtSFTPConnector.Entitlement.al
@@ -5,9 +5,10 @@
 
 namespace System.ExternalFileStorage;
 
+#pragma warning disable AL0432
 entitlement "Ext. SFTP Connector"
 {
-
     ObjectEntitlements = "Ext. SFTP - Edit";
     Type = Implicit;
 }
+#pragma warning restore AL0432

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/ExtSFTPEdit.PermissionSet.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/ExtSFTPEdit.PermissionSet.al
@@ -5,6 +5,7 @@
 
 namespace System.ExternalFileStorage;
 
+#pragma warning disable AL0432, AS0105
 permissionset 4621 "Ext. SFTP - Edit"
 {
     Access = Public;
@@ -18,3 +19,4 @@ permissionset 4621 "Ext. SFTP - Edit"
     Permissions =
         tabledata "Ext. SFTP Account" = imd;
 }
+#pragma warning restore AL0432, AS0105

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/ExtSFTPEdit.PermissionSet.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/ExtSFTPEdit.PermissionSet.al
@@ -10,6 +10,9 @@ permissionset 4621 "Ext. SFTP - Edit"
     Access = Public;
     Assignable = false;
     Caption = 'SFTP - Edit';
+    ObsoleteReason = 'The SFTP connector is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
     IncludedPermissionSets = "Ext. SFTP - Read";
 
     Permissions =

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/ExtSFTPObjects.PermissionSet.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/ExtSFTPObjects.PermissionSet.al
@@ -5,6 +5,7 @@
 
 namespace System.ExternalFileStorage;
 
+#pragma warning disable AL0432, AS0105
 permissionset 4622 "Ext. SFTP - Objects"
 {
     Access = Public;
@@ -18,3 +19,4 @@ permissionset 4622 "Ext. SFTP - Objects"
         page "Ext. SFTP Account Wizard" = X,
         page "Ext. SFTP Account" = X;
 }
+#pragma warning restore AL0432, AS0105

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/ExtSFTPObjects.PermissionSet.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/ExtSFTPObjects.PermissionSet.al
@@ -10,6 +10,9 @@ permissionset 4622 "Ext. SFTP - Objects"
     Access = Public;
     Assignable = false;
     Caption = 'SFTP - Objects';
+    ObsoleteReason = 'The SFTP connector is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
     Permissions =
         table "Ext. SFTP Account" = X,
         page "Ext. SFTP Account Wizard" = X,

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/ExtSFTPRead.PermissionSet.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/ExtSFTPRead.PermissionSet.al
@@ -10,6 +10,9 @@ permissionset 4623 "Ext. SFTP - Read"
     Access = Public;
     Assignable = false;
     Caption = 'SFTP - Read';
+    ObsoleteReason = 'The SFTP connector is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
     IncludedPermissionSets = "Ext. SFTP - Objects";
 
     Permissions =

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/ExtSFTPRead.PermissionSet.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/ExtSFTPRead.PermissionSet.al
@@ -5,6 +5,7 @@
 
 namespace System.ExternalFileStorage;
 
+#pragma warning disable AL0432, AS0105
 permissionset 4623 "Ext. SFTP - Read"
 {
     Access = Public;
@@ -18,3 +19,4 @@ permissionset 4623 "Ext. SFTP - Read"
     Permissions =
         tabledata "Ext. SFTP Account" = r;
 }
+#pragma warning restore AL0432, AS0105

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/FileStorageAdminExtSFTP.PermissionSetExt.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/FileStorageAdminExtSFTP.PermissionSetExt.al
@@ -5,7 +5,9 @@
 
 namespace System.ExternalFileStorage;
 
+#pragma warning disable AL0432
 permissionsetextension 4621 "File Storage - Admin - Ext. SFTP" extends "File Storage - Admin"
 {
     IncludedPermissionSets = "Ext. SFTP - Edit";
 }
+#pragma warning restore AL0432

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/FileStorageAdminExtSFTP.PermissionSetExt.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/FileStorageAdminExtSFTP.PermissionSetExt.al
@@ -5,9 +5,9 @@
 
 namespace System.ExternalFileStorage;
 
-#pragma warning disable AL0432
+#pragma warning disable AL0432, AS0105
 permissionsetextension 4621 "File Storage - Admin - Ext. SFTP" extends "File Storage - Admin"
 {
     IncludedPermissionSets = "Ext. SFTP - Edit";
 }
-#pragma warning restore AL0432
+#pragma warning restore AL0432, AS0105

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/FileStorageEditExtSFTP.PermissionSetExt.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/FileStorageEditExtSFTP.PermissionSetExt.al
@@ -5,9 +5,9 @@
 
 namespace System.ExternalFileStorage;
 
-#pragma warning disable AL0432
+#pragma warning disable AL0432, AS0105
 permissionsetextension 4622 "File Storage - Edit - Ext. SFTP" extends "File Storage - Edit"
 {
     IncludedPermissionSets = "Ext. SFTP - Read";
 }
-#pragma warning restore AL0432
+#pragma warning restore AL0432, AS0105

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/FileStorageEditExtSFTP.PermissionSetExt.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/permissions/FileStorageEditExtSFTP.PermissionSetExt.al
@@ -5,7 +5,9 @@
 
 namespace System.ExternalFileStorage;
 
+#pragma warning disable AL0432
 permissionsetextension 4622 "File Storage - Edit - Ext. SFTP" extends "File Storage - Edit"
 {
     IncludedPermissionSets = "Ext. SFTP - Read";
 }
+#pragma warning restore AL0432

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAccount.Page.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAccount.Page.al
@@ -19,6 +19,9 @@ page 4621 "Ext. SFTP Account"
     Permissions = tabledata "Ext. SFTP Account" = rimd;
     SourceTable = "Ext. SFTP Account";
     UsageCategory = None;
+    ObsoleteReason = 'The SFTP connector is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
 
     layout
     {

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAccount.Page.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAccount.Page.al
@@ -8,6 +8,7 @@ namespace System.ExternalFileStorage;
 /// <summary>
 /// Displays an account that was registered via the SFTP connector.
 /// </summary>
+#pragma warning disable AL0432, AS0105
 page 4621 "Ext. SFTP Account"
 {
     ApplicationArea = All;
@@ -162,3 +163,4 @@ page 4621 "Ext. SFTP Account"
             CertificateStatusText := CertificateUploadedLbl;
     end;
 }
+#pragma warning restore AL0432, AS0105

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAccount.Table.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAccount.Table.al
@@ -11,6 +11,7 @@ using System.Utilities;
 /// <summary>
 /// Holds the information for all file accounts that are registered via the SFTP connector
 /// </summary>
+#pragma warning disable AL0432, AS0105
 table 4621 "Ext. SFTP Account"
 {
     Caption = 'SFTP Account';
@@ -240,3 +241,4 @@ table 4621 "Ext. SFTP Account"
         exit(CertificateBase64);
     end;
 }
+#pragma warning restore AL0432, AS0105

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAccount.Table.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAccount.Table.al
@@ -15,6 +15,9 @@ table 4621 "Ext. SFTP Account"
 {
     Caption = 'SFTP Account';
     DataClassification = CustomerContent;
+    ObsoleteReason = 'The SFTP connector is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
 
     fields
     {

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAccountWizard.Page.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAccountWizard.Page.al
@@ -20,6 +20,9 @@ page 4622 "Ext. SFTP Account Wizard"
     Permissions = tabledata "Ext. SFTP Account" = rimd;
     SourceTable = "Ext. SFTP Account";
     SourceTableTemporary = true;
+    ObsoleteReason = 'The SFTP connector is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
 
     layout
     {

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAccountWizard.Page.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAccountWizard.Page.al
@@ -10,6 +10,7 @@ using System.Environment;
 /// <summary>
 /// Displays an account that is being registered via the SFTP connector.
 /// </summary>
+#pragma warning disable AL0432, AS0105
 page 4622 "Ext. SFTP Account Wizard"
 {
     ApplicationArea = All;
@@ -244,3 +245,4 @@ page 4622 "Ext. SFTP Account Wizard"
             CertificateStatusText := CertificateUploadedLbl;
     end;
 }
+#pragma warning restore AL0432, AS0105

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAuthType.Enum.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAuthType.Enum.al
@@ -12,6 +12,9 @@ enum 4621 "Ext. SFTP Auth Type"
 {
     Extensible = false;
     Access = Public;
+    ObsoleteReason = 'The SFTP connector is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
 
     /// <summary>
     /// Authenticate using password.

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnector.EnumExt.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnector.EnumExt.al
@@ -8,6 +8,7 @@ namespace System.ExternalFileStorage;
 /// <summary>
 /// Enum extension to register the SFTP connector.
 /// </summary>
+#pragma warning disable AL0432, AS0105
 enumextension 4621 "Ext. SFTP Connector" extends "Ext. File Storage Connector"
 {
     /// <summary>
@@ -22,3 +23,4 @@ enumextension 4621 "Ext. SFTP Connector" extends "Ext. File Storage Connector"
         ObsoleteTag = '29.0';
     }
 }
+#pragma warning restore AL0432, AS0105

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnector.EnumExt.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnector.EnumExt.al
@@ -17,5 +17,8 @@ enumextension 4621 "Ext. SFTP Connector" extends "Ext. File Storage Connector"
     {
         Caption = 'SFTP';
         Implementation = "External File Storage Connector" = "Ext. SFTP Connector Impl";
+        ObsoleteReason = 'The SFTP connector is deprecated because platform hardening will prevent support for SFTP connections.';
+        ObsoleteState = Pending;
+        ObsoleteTag = '29.0';
     }
 }

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnectorImpl.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnectorImpl.Codeunit.al
@@ -10,6 +10,7 @@ using System.SFTPClient;
 using System.Text;
 using System.Utilities;
 
+#pragma warning disable AL0432, AS0105
 codeunit 4621 "Ext. SFTP Connector Impl" implements "External File Storage Connector"
 {
     Access = Internal;
@@ -498,3 +499,4 @@ codeunit 4621 "Ext. SFTP Connector Impl" implements "External File Storage Conne
         Account.ModifyAll(Disabled, true);
     end;
 }
+#pragma warning restore AL0432, AS0105

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnectorImpl.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnectorImpl.Codeunit.al
@@ -15,6 +15,9 @@ codeunit 4621 "Ext. SFTP Connector Impl" implements "External File Storage Conne
     Access = Internal;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteReason = 'The SFTP connector is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
     Permissions = tabledata "Ext. SFTP Account" = rimd;
 
     var

--- a/src/Apps/W1/External File Storage - SFTP Connector/Test/src/ExtSFTPConnectorTest.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/Test/src/ExtSFTPConnectorTest.Codeunit.al
@@ -9,6 +9,7 @@ using System.Environment;
 using System.ExternalFileStorage;
 using System.TestLibraries.Utilities;
 
+#pragma warning disable AL0432, AS0105
 codeunit 144591 "Ext. SFTP Connector Test"
 {
     Subtype = Test;
@@ -160,3 +161,4 @@ codeunit 144591 "Ext. SFTP Connector Test"
         Assert: Codeunit "Library Assert";
         FileAccountMock: Codeunit "Ext. SFTP Account Mock";
 }
+#pragma warning restore AL0432, AS0105

--- a/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
+++ b/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
@@ -16,6 +16,7 @@ using System.MCP;
 using System.Privacy;
 using System.SFTPClient;
 
+#pragma warning disable AL0432
 permissionset 154 "System Application - Admin"
 {
     Access = Internal;
@@ -42,3 +43,4 @@ permissionset 154 "System Application - Admin"
                              "TROUBLESHOOT TOOLS",
                              "VSC Intgr. - Admin";
 }
+#pragma warning restore AL0432

--- a/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
+++ b/src/System Application/App/Permissions/SystemApplicationAdmin.PermissionSet.al
@@ -16,7 +16,7 @@ using System.MCP;
 using System.Privacy;
 using System.SFTPClient;
 
-#pragma warning disable AL0432
+#pragma warning disable AL0432, AS0105
 permissionset 154 "System Application - Admin"
 {
     Access = Internal;
@@ -43,4 +43,4 @@ permissionset 154 "System Application - Admin"
                              "TROUBLESHOOT TOOLS",
                              "VSC Intgr. - Admin";
 }
-#pragma warning restore AL0432
+#pragma warning restore AL0432, AS0105

--- a/src/System Application/App/SFTP Client/src/DotnetSFTPClient.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/DotnetSFTPClient.Codeunit.al
@@ -7,7 +7,7 @@ namespace System.SFTPClient;
 
 using System;
 
-#pragma warning disable AL0432
+#pragma warning disable AL0432, AS0105
 codeunit 9760 "Dotnet SFTP Client" implements "ISFTP Client"
 {
     Access = Internal;
@@ -264,4 +264,4 @@ codeunit 9760 "Dotnet SFTP Client" implements "ISFTP Client"
         FingerprintsMD5 := Fingerprints;
     end;
 }
-#pragma warning restore AL0432
+#pragma warning restore AL0432, AS0105

--- a/src/System Application/App/SFTP Client/src/DotnetSFTPClient.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/DotnetSFTPClient.Codeunit.al
@@ -7,11 +7,15 @@ namespace System.SFTPClient;
 
 using System;
 
+#pragma warning disable AL0432
 codeunit 9760 "Dotnet SFTP Client" implements "ISFTP Client"
 {
     Access = Internal;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteReason = 'The SFTP module is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
 
     var
         [WithEvents]
@@ -260,3 +264,4 @@ codeunit 9760 "Dotnet SFTP Client" implements "ISFTP Client"
         FingerprintsMD5 := Fingerprints;
     end;
 }
+#pragma warning restore AL0432

--- a/src/System Application/App/SFTP Client/src/DotnetSFTPFile.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/DotnetSFTPFile.Codeunit.al
@@ -7,11 +7,15 @@ namespace System.SFTPClient;
 
 using System;
 
+#pragma warning disable AL0432
 codeunit 9761 "Dotnet SFTP File" implements "ISFTP File"
 {
     Access = Internal;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteReason = 'The SFTP module is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
 
     var
         RenciSFTPFile: DotNet RenciISftpFile;
@@ -59,3 +63,4 @@ codeunit 9761 "Dotnet SFTP File" implements "ISFTP File"
         RenciSFTPFile := NewFile;
     end;
 }
+#pragma warning restore AL0432

--- a/src/System Application/App/SFTP Client/src/DotnetSFTPFile.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/DotnetSFTPFile.Codeunit.al
@@ -7,7 +7,7 @@ namespace System.SFTPClient;
 
 using System;
 
-#pragma warning disable AL0432
+#pragma warning disable AL0432, AS0105
 codeunit 9761 "Dotnet SFTP File" implements "ISFTP File"
 {
     Access = Internal;
@@ -63,4 +63,4 @@ codeunit 9761 "Dotnet SFTP File" implements "ISFTP File"
         RenciSFTPFile := NewFile;
     end;
 }
-#pragma warning restore AL0432
+#pragma warning restore AL0432, AS0105

--- a/src/System Application/App/SFTP Client/src/ISFTPClient.Interface.al
+++ b/src/System Application/App/SFTP Client/src/ISFTPClient.Interface.al
@@ -7,7 +7,7 @@ namespace System.SFTPClient;
 
 using System;
 
-#pragma warning disable AL0432
+#pragma warning disable AL0432, AS0105
 interface "ISFTP Client"
 {
     Access = Internal;
@@ -33,4 +33,4 @@ interface "ISFTP Client"
     procedure SetSHA256Fingerprints(FingerPrints: List of [Text])
     procedure SetMD5Fingerprints(FingerPrints: List of [Text])
 }
-#pragma warning restore AL0432
+#pragma warning restore AL0432, AS0105

--- a/src/System Application/App/SFTP Client/src/ISFTPClient.Interface.al
+++ b/src/System Application/App/SFTP Client/src/ISFTPClient.Interface.al
@@ -7,9 +7,14 @@ namespace System.SFTPClient;
 
 using System;
 
+#pragma warning disable AL0432
 interface "ISFTP Client"
 {
     Access = Internal;
+    ObsoleteReason = 'The SFTP module is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
+
     procedure SftpClient(Host: Text; Port: Integer; UserName: Text; Password: SecretText): Boolean
     procedure SftpClient(Host: Text; Port: Integer; UserName: Text; PrivateKey: InStream): Boolean
     procedure SftpClient(HostName: Text; Port: Integer; Username: Text; PrivateKey: InStream; Passphrase: SecretText): Boolean
@@ -28,3 +33,4 @@ interface "ISFTP Client"
     procedure SetSHA256Fingerprints(FingerPrints: List of [Text])
     procedure SetMD5Fingerprints(FingerPrints: List of [Text])
 }
+#pragma warning restore AL0432

--- a/src/System Application/App/SFTP Client/src/ISFTPFile.Interface.al
+++ b/src/System Application/App/SFTP Client/src/ISFTPFile.Interface.al
@@ -8,6 +8,10 @@ namespace System.SFTPClient;
 interface "ISFTP File"
 {
     Access = Public;
+    ObsoleteReason = 'The SFTP module is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
+
     procedure MoveTo(Destination: Text): Boolean
     procedure Name(): Text
     procedure FullName(): Text

--- a/src/System Application/App/SFTP Client/src/PermissionSets/SFTPAdmin.PermissionSet.al
+++ b/src/System Application/App/SFTP Client/src/PermissionSets/SFTPAdmin.PermissionSet.al
@@ -9,6 +9,9 @@ permissionset 9762 "SFTP - Admin"
     Access = Public;
     Assignable = true;
     Caption = 'SFTP - Admin';
+    ObsoleteReason = 'The SFTP module is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
 
     Permissions =
         page "SFTP Folder Content" = X;

--- a/src/System Application/App/SFTP Client/src/PermissionSets/SFTPAdmin.PermissionSet.al
+++ b/src/System Application/App/SFTP Client/src/PermissionSets/SFTPAdmin.PermissionSet.al
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------------------------------------------
 namespace System.SFTPClient;
 
+#pragma warning disable AL0432, AS0105
 permissionset 9762 "SFTP - Admin"
 {
     Access = Public;
@@ -16,3 +17,4 @@ permissionset 9762 "SFTP - Admin"
     Permissions =
         page "SFTP Folder Content" = X;
 }
+#pragma warning restore AL0432, AS0105

--- a/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
@@ -10,6 +10,9 @@ codeunit 9762 "SFTP Client"
     Access = Public;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteReason = 'The SFTP module is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
 
     /// <summary>
     /// Adds a SHA256 fingerprint to the list of accepted host key fingerprints.

--- a/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
@@ -5,6 +5,7 @@
 
 namespace System.SFTPClient;
 
+#pragma warning disable AL0432, AS0105
 codeunit 9762 "SFTP Client"
 {
     Access = Public;
@@ -206,3 +207,4 @@ codeunit 9762 "SFTP Client"
     var
         SFTPClientImplementation: Codeunit "SFTP Client Implementation";
 }
+#pragma warning restore AL0432, AS0105

--- a/src/System Application/App/SFTP Client/src/SFTPClientImplementation.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClientImplementation.Codeunit.al
@@ -8,6 +8,7 @@ namespace System.SFTPClient;
 using System;
 using System.Utilities;
 
+#pragma warning disable AL0432, AS0105
 codeunit 9763 "SFTP Client Implementation"
 {
     Access = Internal;
@@ -213,3 +214,4 @@ codeunit 9763 "SFTP Client Implementation"
         HostkeyFingerprintsMD5: List of [Text];
         ISFTPClientSet: Boolean;
 }
+#pragma warning restore AL0432, AS0105

--- a/src/System Application/App/SFTP Client/src/SFTPClientImplementation.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClientImplementation.Codeunit.al
@@ -13,6 +13,9 @@ codeunit 9763 "SFTP Client Implementation"
     Access = Internal;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteReason = 'The SFTP module is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
 
     procedure Initialize(Host: Text; Port: Integer; UserName: Text; Password: SecretText): Codeunit "SFTP Operation Response"
     begin

--- a/src/System Application/App/SFTP Client/src/SFTPExceptionType.Enum.al
+++ b/src/System Application/App/SFTP Client/src/SFTPExceptionType.Enum.al
@@ -9,6 +9,9 @@ enum 9760 "SFTP Exception Type"
 {
     Extensible = false;
     Access = Public;
+    ObsoleteReason = 'The SFTP module is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
 
     value(0; None)
     {

--- a/src/System Application/App/SFTP Client/src/SFTPFolderContent.Page.al
+++ b/src/System Application/App/SFTP Client/src/SFTPFolderContent.Page.al
@@ -16,6 +16,9 @@ page 9761 "SFTP Folder Content"
     DeleteAllowed = false;
     Editable = false;
     Extensible = false;
+    ObsoleteReason = 'The SFTP module is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
 
     layout
     {

--- a/src/System Application/App/SFTP Client/src/SFTPFolderContent.Page.al
+++ b/src/System Application/App/SFTP Client/src/SFTPFolderContent.Page.al
@@ -5,6 +5,7 @@
 
 namespace System.SFTPClient;
 
+#pragma warning disable AL0432, AS0105
 page 9761 "SFTP Folder Content"
 {
     Caption = 'SFTP Folder Content';
@@ -56,3 +57,4 @@ page 9761 "SFTP Folder Content"
         }
     }
 }
+#pragma warning restore AL0432, AS0105

--- a/src/System Application/App/SFTP Client/src/SFTPFolderContent.Table.al
+++ b/src/System Application/App/SFTP Client/src/SFTPFolderContent.Table.al
@@ -14,6 +14,9 @@ table 9760 "SFTP Folder Content"
     Extensible = false;
     Caption = 'SFTP Folder Content';
     TableType = Temporary;
+    ObsoleteReason = 'The SFTP module is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
 
     fields
     {

--- a/src/System Application/App/SFTP Client/src/SFTPOperationResponse.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPOperationResponse.Codeunit.al
@@ -7,6 +7,7 @@ namespace System.SFTPClient;
 
 using System.Utilities;
 
+#pragma warning disable AL0432, AS0105
 codeunit 9764 "SFTP Operation Response"
 {
     Access = Public;
@@ -73,3 +74,4 @@ codeunit 9764 "SFTP Operation Response"
         ErrorType: Enum "SFTP Exception Type";
         ErrorMsg: Text;
 }
+#pragma warning restore AL0432, AS0105

--- a/src/System Application/App/SFTP Client/src/SFTPOperationResponse.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPOperationResponse.Codeunit.al
@@ -12,6 +12,9 @@ codeunit 9764 "SFTP Operation Response"
     Access = Public;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteReason = 'The SFTP module is deprecated because platform hardening will prevent support for SFTP connections.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '29.0';
 
     internal procedure GetResponseStream(var ResultInstream: InStream)
     begin

--- a/src/System Application/App/app.json
+++ b/src/System Application/App/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides a standard set of capabilities that serve as a foundation for developing business apps.",
   "description": "Contains an expansive set of open source modules that make it easier to build, maintain, and easily upgrade on-premises and online apps. These modules let you focus on the business logic, and the needs of your users or customers.",
-  "version": "28.1.0.1",
+  "version": "28.1.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/app.json
+++ b/src/System Application/App/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides a standard set of capabilities that serve as a foundation for developing business apps.",
   "description": "Contains an expansive set of open source modules that make it easier to build, maintain, and easily upgrade on-premises and online apps. These modules let you focus on the business logic, and the needs of your users or customers.",
-  "version": "28.1.0.0",
+  "version": "28.1.0.1",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/Test/SFTP Client/src/MockSFTPClient.Codeunit.al
+++ b/src/System Application/Test/SFTP Client/src/MockSFTPClient.Codeunit.al
@@ -8,6 +8,7 @@ namespace System.Test.SFTPClient;
 using System;
 using System.SFTPClient;
 
+#pragma warning disable AL0432, AS0105
 codeunit 139075 "Mock SFTP Client" implements "ISFTP Client"
 {
     Access = Internal;
@@ -293,3 +294,4 @@ codeunit 139075 "Mock SFTP Client" implements "ISFTP Client"
         exit(true);
     end;
 }
+#pragma warning restore AL0432, AS0105

--- a/src/System Application/Test/SFTP Client/src/MockSFTPFile.Codeunit.al
+++ b/src/System Application/Test/SFTP Client/src/MockSFTPFile.Codeunit.al
@@ -7,6 +7,7 @@ namespace System.Test.SFTPClient;
 
 using System.SFTPClient;
 
+#pragma warning disable AL0432, AS0105
 codeunit 139076 "Mock SFTP File" implements "ISFTP File"
 {
     Access = Internal;
@@ -61,3 +62,4 @@ codeunit 139076 "Mock SFTP File" implements "ISFTP File"
         exit(LastWriteTimeVar);
     end;
 }
+#pragma warning restore AL0432, AS0105

--- a/src/System Application/Test/SFTP Client/src/SFTPClientTest.Codeunit.al
+++ b/src/System Application/Test/SFTP Client/src/SFTPClientTest.Codeunit.al
@@ -9,6 +9,7 @@ using System.SFTPClient;
 using System.TestLibraries.Utilities;
 using System.Utilities;
 
+#pragma warning disable AL0432, AS0105
 codeunit 139077 "SFTP Client Test"
 {
     Subtype = Test;
@@ -410,3 +411,4 @@ codeunit 139077 "SFTP Client Test"
         Assert.AreEqual(Enum::"SFTP Exception Type"::"Untrusted Server Exception", Response.GetErrorType(), 'Incorrect error type');
     end;
 }
+#pragma warning restore AL0432, AS0105


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
From version 29.0, we won't be able to support SFTP connections as introduced with #3697. The module and the connector are hence deprecated again.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#632775](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632775)





