### PR TITLE
E-Document Import Helper: return vendor when matched by name but not address

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Helpers/EDocumentImportHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Helpers/EDocumentImportHelper.Codeunit.al
@@ -568,7 +568,6 @@ codeunit 6109 "E-Document Import Helper"
         EDocumentNotification: Codeunit "E-Document Notification";
         NameNearness: Integer;
         AddressNearness: Integer;
-        MatchedByAddress: Boolean;
     begin
         Vendor.SetCurrentKey(Blocked);
         Vendor.SetLoadFields(Name, Address);
@@ -580,11 +579,11 @@ codeunit 6109 "E-Document Import Helper"
                 else
                     AddressNearness := RecordMatchMgt.CalculateStringNearness(VendorAddress, Vendor.Address, MatchThreshold(), NormalizingFactor());
                 if NameNearness >= RequiredNearness() then begin
-                    MatchedByAddress := AddressNearness >= RequiredNearness();
-                    if MatchedByAddress then
+                    if AddressNearness >= RequiredNearness() then
                         exit(Vendor."No.");
                     if EDocEntryNoForNotification <> 0 then
                         EDocumentNotification.AddVendorMatchedByNameNotAddressNotification(EDocEntryNoForNotification);
+                    exit(Vendor."No.");
                 end;
             until Vendor.Next() = 0;
     end;

--- a/src/Apps/W1/EDocument/Test/src/Receive/EDocHelperTest.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Receive/EDocHelperTest.Codeunit.al
@@ -9,6 +9,7 @@ using Microsoft.eServices.EDocument.Integration;
 using Microsoft.eServices.EDocument.Service.Participant;
 using Microsoft.Foundation.Company;
 using Microsoft.Purchases.Document;
+using Microsoft.Purchases.Vendor;
 
 codeunit 139799 "E-Doc. Helper Test"
 {
@@ -20,6 +21,7 @@ codeunit 139799 "E-Doc. Helper Test"
         Assert: Codeunit "Assert";
         LibraryEDoc: Codeunit "Library - E-Document";
         LibraryLowerPermission: Codeunit "Library - Lower Permissions";
+        LibraryPurchase: Codeunit "Library - Purchase";
 
     trigger OnRun()
     begin
@@ -131,5 +133,61 @@ codeunit 139799 "E-Doc. Helper Test"
 
         // Cleanup
         EDocument.Delete();
+    end;
+
+    [Test]
+    procedure FindVendorByNameAndAddressReturnsVendorWhenNameMatchesAddressDoesNot()
+    var
+        Vendor: Record Vendor;
+        EDocumentImportHelper: Codeunit "E-Document Import Helper";
+        VendorNo: Code[20];
+    begin
+        // [SCENARIO] FindVendorByNameAndAddress returns the vendor when name matches but address does not
+        // [GIVEN] A vendor with a known name and address
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor.Name := 'Contoso Software Solutions AB';
+        Vendor.Address := '100 Main Street';
+        Vendor.Modify();
+
+        // [WHEN] FindVendorByNameAndAddress is called with the matching name and a non-matching address
+        VendorNo := EDocumentImportHelper.FindVendorByNameAndAddress('Contoso Software Solutions AB', 'Completely Different Road');
+
+        // [THEN] The vendor number is returned even though the address did not match
+        Assert.AreEqual(Vendor."No.", VendorNo, 'Vendor should be found by name even when address does not match');
+    end;
+
+    [Test]
+    procedure FindVendorByNameAndAddressReturnsVendorWhenBothNameAndAddressMatch()
+    var
+        Vendor: Record Vendor;
+        EDocumentImportHelper: Codeunit "E-Document Import Helper";
+        VendorNo: Code[20];
+    begin
+        // [SCENARIO] FindVendorByNameAndAddress returns the vendor when both name and address match
+        // [GIVEN] A vendor with a known name and address
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor.Name := 'Fabrikam Supplies International';
+        Vendor.Address := '200 Commerce Avenue';
+        Vendor.Modify();
+
+        // [WHEN] FindVendorByNameAndAddress is called with matching name and matching address
+        VendorNo := EDocumentImportHelper.FindVendorByNameAndAddress('Fabrikam Supplies International', '200 Commerce Avenue');
+
+        // [THEN] The vendor number is returned
+        Assert.AreEqual(Vendor."No.", VendorNo, 'Vendor should be found when both name and address match');
+    end;
+
+    [Test]
+    procedure FindVendorByNameAndAddressReturnsEmptyWhenNoNameMatches()
+    var
+        EDocumentImportHelper: Codeunit "E-Document Import Helper";
+        VendorNo: Code[20];
+    begin
+        // [SCENARIO] FindVendorByNameAndAddress returns empty when no vendor name is similar enough
+        // [WHEN] FindVendorByNameAndAddress is called with a name that does not match any vendor
+        VendorNo := EDocumentImportHelper.FindVendorByNameAndAddress('ZZZ-NoSuchVendorExistsInDatabase-XYZ', '');
+
+        // [THEN] An empty vendor number is returned
+        Assert.AreEqual('', VendorNo, 'Vendor No. should be empty when no name matches');
     end;
 }


### PR DESCRIPTION
## Summary

`FindVendorByNameAndAddressWithNotification` in codeunit 6109 "E-Document Import Helper" iterates vendors looking for a name-and-address match. When a vendor's name meets the required nearness threshold but its address does not, the procedure logged a notification and then continued the loop without returning the vendor. At the end of the loop, the function fell through and returned an empty `Code[20]`.

Fixes #7419

## Root Cause

The `if NameNearness >= RequiredNearness()` branch handled the address-match case with an `exit`, but there was no `exit` after the name-only notification path:

```al
if NameNearness >= RequiredNearness() then begin
    MatchedByAddress := AddressNearness >= RequiredNearness();
    if MatchedByAddress then
        exit(Vendor."No.");           // address match: exits correctly
    if EDocEntryNoForNotification <> 0 then
        EDocumentNotification.AddVendorMatchedByNameNotAddressNotification(EDocEntryNoForNotification);
    // BUG: no exit here -- falls through and continues the loop
end;
```

## Fix

Add `exit(Vendor."No.")` after the notification call. The now-redundant `MatchedByAddress` local variable is also removed.

```al
if NameNearness >= RequiredNearness() then begin
    if AddressNearness >= RequiredNearness() then
        exit(Vendor."No.");
    if EDocEntryNoForNotification <> 0 then
        EDocumentNotification.AddVendorMatchedByNameNotAddressNotification(EDocEntryNoForNotification);
    exit(Vendor."No.");  // fixed: return the name-matched vendor
end;
```

## Tests

Three new tests are added to `EDocHelperTest` (codeunit 139799):

| Test | Scenario |
|---|---|
| `FindVendorByNameAndAddressReturnsVendorWhenNameMatchesAddressDoesNot` | Reproduces the reported bug: vendor is returned when name matches but address does not |
| `FindVendorByNameAndAddressReturnsVendorWhenBothNameAndAddressMatch` | Confirms the existing happy path (name + address both match) still works |
| `FindVendorByNameAndAddressReturnsEmptyWhenNoNameMatches` | Confirms an empty result is returned when no vendor name is similar enough |



