### PR TITLE
Quality Management actions for Warehouse Receipt subform

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Integration/Receiving/Document/QltyWhseReceiptSubform.PageExt.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Receiving/Document/QltyWhseReceiptSubform.PageExt.al
@@ -1,0 +1,85 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.QualityManagement.Integration.Receiving.Document;
+
+using Microsoft.Warehouse.Document;
+using Microsoft.QualityManagement.Document;
+
+pageextension 20434 "Qlty. Whse. Receipt Subform" extends "Whse. Receipt Subform"
+{
+    actions
+    {
+        addlast("&Line")
+        {
+            group(Qlty_QualityManagement)
+            {
+                Caption = 'Quality Management';
+
+                action(Qlty_CreateQualityInspection)
+                {
+                    ApplicationArea = QualityManagement;
+                    AccessByPermission = tabledata "Qlty. Inspection Header" = I;
+                    Image = BulletList;
+                    Caption = 'Create Quality Inspection';
+                    ToolTip = 'Creates a quality inspection for this warehouse receipt line.';
+                    AboutTitle = 'Create Quality Inspection';
+                    AboutText = 'Create a quality inspection for this warehouse receipt line.';
+
+                    trigger OnAction()
+                    var
+                        QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
+                    begin
+                        if CanBeProcessed() then
+                            QltyInspectionCreate.CreateInspectionWithVariant(Rec, true);
+                    end;
+                }
+                action(Qlty_ShowQualityInspectionsForItemAndDocument)
+                {
+                    ApplicationArea = QualityManagement;
+                    AccessByPermission = tabledata "Qlty. Inspection Header" = R;
+                    Image = CheckList;
+                    Caption = 'Show Quality Inspections for Item and Document';
+                    ToolTip = 'Shows quality inspections for this item and document.';
+                    AboutTitle = 'Show Quality Inspections';
+                    AboutText = 'Shows quality inspections for this item and document.';
+
+                    trigger OnAction()
+                    var
+                        QltyInspectionList: Page "Qlty. Inspection List";
+                    begin
+                        if CanBeProcessed() then
+                            QltyInspectionList.RunModalSourceItemAndSourceDocumentFilterWithRecord(Rec);
+                    end;
+                }
+                action(Qlty_ShowQualityInspectionsForItem)
+                {
+                    ApplicationArea = QualityManagement;
+                    AccessByPermission = tabledata "Qlty. Inspection Header" = R;
+                    Image = CheckList;
+                    Caption = 'Show Quality Inspections for Item';
+                    ToolTip = 'Shows Quality Inspections for Item';
+                    AboutTitle = 'Show Quality Inspections';
+                    AboutText = 'Shows quality inspections for this item.';
+
+                    trigger OnAction()
+                    var
+                        QltyInspectionList: Page "Qlty. Inspection List";
+                    begin
+                        if CanBeProcessed() then
+                            QltyInspectionList.RunModalSourceItemFilterWithRecord(Rec);
+                    end;
+                }
+            }
+        }
+    }
+
+    local procedure CanBeProcessed(): Boolean
+    begin
+        if IsNullGuid(Rec.SystemId) then
+            exit(false);
+
+        exit(Rec."Item No." <> '');
+    end;
+}


### PR DESCRIPTION
## Summary

The Warehouse Receipt subform (page 5769) had no Quality Management actions, making it impossible for warehouse users to manually create quality inspections or view existing ones from that page.

The receiving integration codeunit (QltyReceivingIntegration) already handles automatic inspection creation when receipt lines are created or posted. This change adds the missing manual UI surface by introducing a page extension for the Whse. Receipt Subform.

## Changes

Added QltyWhseReceiptSubform.PageExt.al (pageextension 20434) under Integration/Receiving/Document/ following the established pattern from QltyPurchaseOrderSubform.PageExt.al and QltySalesOrderSubform.PageExt.al.

Three actions are added inside the existing Line group:

- **Create Quality Inspection** - creates an inspection for the selected receipt line (requires Insert permission on Qlty. Inspection Header)
- **Show Quality Inspections for Item and Document** - opens the inspection list filtered by item and source document
- **Show Quality Inspections for Item** - opens the inspection list filtered by item only

CanBeProcessed() guards all three actions: it returns false if the record has no SystemId (unsaved) or no Item No.

## Testing

1. Enable the Quality Management extension and configure a generation rule for Warehouse Receipt Line as the source table.
2. Create a warehouse receipt with at least one item line.
3. Open the Whse. Receipt Subform.
4. In the Line menu, verify the Quality Management group is present with the three actions.
5. Select a receipt line and choose Create Quality Inspection. Confirm an inspection header is created.
6. Choose Show Quality Inspections for Item and Document. Confirm the list is filtered to that item and document.
7. Choose Show Quality Inspections for Item. Confirm the list is filtered to that item across all documents.
8. Verify that the actions are not visible or are disabled for lines with no Item No.

Closes #6678
