### PR TITLE
AOAIChatCompletionParams: add ReasoningEffort parameter for reasoning models

### DIFF
--- a/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIChatComplParamsImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIChatComplParamsImpl.Codeunit.al
@@ -12,6 +12,7 @@ codeunit 7762 "AOAI Chat Compl Params Impl"
 
     var
         AOAIPolicyParams: Codeunit "AOAI Policy Params";
+        ReasoningEffort: Enum "AOAI Reasoning Effort";
         Initialized: Boolean;
         Temperature: Decimal;
         MaxTokens: Integer;
@@ -70,6 +71,14 @@ codeunit 7762 "AOAI Chat Compl Params Impl"
             InitializeDefaults();
 
         exit(FrequencyPenalty);
+    end;
+
+    procedure GetReasoningEffort(): Enum "AOAI Reasoning Effort"
+    begin
+        if not Initialized then
+            InitializeDefaults();
+
+        exit(ReasoningEffort);
     end;
 
     procedure GetAOAIPolicyParams(): Codeunit "AOAI Policy Params"
@@ -146,18 +155,38 @@ codeunit 7762 "AOAI Chat Compl Params Impl"
         FrequencyPenalty := NewFrequencyPenalty;
     end;
 
+    procedure SetReasoningEffort(NewReasoningEffort: Enum "AOAI Reasoning Effort")
+    begin
+        if not Initialized then
+            InitializeDefaults();
+
+        ReasoningEffort := NewReasoningEffort;
+    end;
+
     [NonDebuggable]
     procedure AddChatCompletionsParametersToPayload(var Payload: JsonObject)
     begin
         if GetMaxTokens() > 0 then
-            Payload.Add('max_tokens', GetMaxTokens());
+            if HasReasoningEffort() then
+                Payload.Add('max_completion_tokens', GetMaxTokens())
+            else
+                Payload.Add('max_tokens', GetMaxTokens());
 
-        Payload.Add('temperature', GetTemperature());
-        Payload.Add('presence_penalty', GetPresencePenalty());
-        Payload.Add('frequency_penalty', GetFrequencyPenalty());
+        if HasReasoningEffort() then
+            Payload.Add('reasoning_effort', Format(GetReasoningEffort()))
+        else begin
+            Payload.Add('temperature', GetTemperature());
+            Payload.Add('presence_penalty', GetPresencePenalty());
+            Payload.Add('frequency_penalty', GetFrequencyPenalty());
+        end;
 
         if IsJsonMode() then
             Payload.Add('response_format', GetJsonResponseFormat());
+    end;
+
+    local procedure HasReasoningEffort(): Boolean
+    begin
+        exit(GetReasoningEffort().AsInteger() > 0);
     end;
 
     local procedure GetJsonResponseFormat() ResponseFormat: JsonObject

--- a/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIChatCompletionParams.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIChatCompletionParams.Codeunit.al
@@ -146,6 +146,26 @@ codeunit 7761 "AOAI Chat Completion Params"
     end;
 
     /// <summary>
+    /// Gets the reasoning effort setting for reasoning models.
+    /// </summary>
+    /// <returns>The reasoning effort setting. Returns the default enum value (ordinal 0) if not configured.</returns>
+    procedure GetReasoningEffort(): Enum "AOAI Reasoning Effort"
+    begin
+        exit(AOAIChatComplParamsImpl.GetReasoningEffort());
+    end;
+
+    /// <summary>
+    /// Sets the reasoning effort for Azure OpenAI reasoning models (e.g. o1, o3, o4-mini).
+    /// When set, reasoning model semantics apply: max_completion_tokens replaces max_tokens in the request,
+    /// and temperature, presence_penalty, and frequency_penalty are omitted.
+    /// </summary>
+    /// <param name="NewReasoningEffort">The reasoning effort level to use: Low, Medium, or High.</param>
+    procedure SetReasoningEffort(NewReasoningEffort: Enum "AOAI Reasoning Effort")
+    begin
+        AOAIChatComplParamsImpl.SetReasoningEffort(NewReasoningEffort);
+    end;
+
+    /// <summary>
     /// Adds the Chat Completion parameters to the payload.
     /// </summary>
     /// <param name="Payload">JsonObject to add parameters to.</param>

--- a/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIReasoningEffort.Enum.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIReasoningEffort.Enum.al
@@ -1,0 +1,38 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace System.AI;
+
+/// <summary>
+/// Specifies the reasoning effort for Azure OpenAI reasoning models.
+/// Controls how much internal reasoning the model performs before generating a response.
+/// </summary>
+enum 7780 "AOAI Reasoning Effort"
+{
+    Extensible = false;
+
+    /// <summary>
+    /// Low reasoning effort. Fastest response with less in-depth reasoning.
+    /// </summary>
+    value(1; Low)
+    {
+        Caption = 'low', Locked = true;
+    }
+
+    /// <summary>
+    /// Medium reasoning effort. Balances response speed and reasoning depth.
+    /// </summary>
+    value(2; Medium)
+    {
+        Caption = 'medium', Locked = true;
+    }
+
+    /// <summary>
+    /// High reasoning effort. Slowest response with the most in-depth reasoning.
+    /// </summary>
+    value(3; High)
+    {
+        Caption = 'high', Locked = true;
+    }
+}

--- a/src/System Application/Test/AI/src/AzureOpenAIToolsTest.Codeunit.al
+++ b/src/System Application/Test/AI/src/AzureOpenAIToolsTest.Codeunit.al
@@ -137,4 +137,157 @@ codeunit 132686 "Azure OpenAI Tools Test"
     begin
         exit('{"type": "function","function": {"name": "test_function_1"}');
     end;
+    [Test]
+    procedure TestChatCompletionParamsDefaultPayloadHasStandardFields()
+    var
+        AzureOpenAITestLibrary: Codeunit "Azure OpenAI Test Library";
+        AOAIChatCompletionParams: Codeunit "AOAI Chat Completion Params";
+        Payload: JsonObject;
+        Token: JsonToken;
+    begin
+        // [SCENARIO] Default chat completion params produce a standard (non-reasoning) payload
+
+        // [GIVEN] Default AOAIChatCompletionParams (no reasoning effort set)
+        // [WHEN] Parameters are added to the payload
+        AzureOpenAITestLibrary.GetAOAIChatCompletionParametersPayload(AOAIChatCompletionParams, Payload);
+
+        // [THEN] Standard parameters are present
+        LibraryAssert.IsTrue(Payload.Get('temperature', Token), 'Payload should contain temperature.');
+        LibraryAssert.IsTrue(Payload.Get('presence_penalty', Token), 'Payload should contain presence_penalty.');
+        LibraryAssert.IsTrue(Payload.Get('frequency_penalty', Token), 'Payload should contain frequency_penalty.');
+
+        // [THEN] Reasoning model parameters are absent
+        LibraryAssert.IsFalse(Payload.Get('reasoning_effort', Token), 'Payload should not contain reasoning_effort.');
+        LibraryAssert.IsFalse(Payload.Get('max_completion_tokens', Token), 'Payload should not contain max_completion_tokens.');
+    end;
+
+    [Test]
+    procedure TestChatCompletionParamsReasoningEffortLowPayload()
+    var
+        AzureOpenAITestLibrary: Codeunit "Azure OpenAI Test Library";
+        AOAIChatCompletionParams: Codeunit "AOAI Chat Completion Params";
+        Payload: JsonObject;
+        Token: JsonToken;
+    begin
+        // [SCENARIO] Setting reasoning effort Low produces a reasoning model payload
+
+        // [GIVEN] ReasoningEffort set to Low
+        AOAIChatCompletionParams.SetReasoningEffort(Enum::"AOAI Reasoning Effort"::Low);
+
+        // [WHEN] Parameters are added to the payload
+        AzureOpenAITestLibrary.GetAOAIChatCompletionParametersPayload(AOAIChatCompletionParams, Payload);
+
+        // [THEN] reasoning_effort is 'low'
+        LibraryAssert.IsTrue(Payload.Get('reasoning_effort', Token), 'Payload should contain reasoning_effort.');
+        LibraryAssert.AreEqual('low', Token.AsValue().AsText(), 'reasoning_effort should be low.');
+
+        // [THEN] Standard non-reasoning parameters are absent
+        LibraryAssert.IsFalse(Payload.Get('temperature', Token), 'Payload should not contain temperature for reasoning models.');
+        LibraryAssert.IsFalse(Payload.Get('presence_penalty', Token), 'Payload should not contain presence_penalty for reasoning models.');
+        LibraryAssert.IsFalse(Payload.Get('frequency_penalty', Token), 'Payload should not contain frequency_penalty for reasoning models.');
+    end;
+
+    [Test]
+    procedure TestChatCompletionParamsReasoningEffortMediumPayload()
+    var
+        AzureOpenAITestLibrary: Codeunit "Azure OpenAI Test Library";
+        AOAIChatCompletionParams: Codeunit "AOAI Chat Completion Params";
+        Payload: JsonObject;
+        Token: JsonToken;
+    begin
+        // [SCENARIO] Setting reasoning effort Medium produces correct payload value
+
+        // [GIVEN] ReasoningEffort set to Medium
+        AOAIChatCompletionParams.SetReasoningEffort(Enum::"AOAI Reasoning Effort"::Medium);
+
+        // [WHEN] Parameters are added to the payload
+        AzureOpenAITestLibrary.GetAOAIChatCompletionParametersPayload(AOAIChatCompletionParams, Payload);
+
+        // [THEN] reasoning_effort is 'medium'
+        LibraryAssert.IsTrue(Payload.Get('reasoning_effort', Token), 'Payload should contain reasoning_effort.');
+        LibraryAssert.AreEqual('medium', Token.AsValue().AsText(), 'reasoning_effort should be medium.');
+    end;
+
+    [Test]
+    procedure TestChatCompletionParamsReasoningEffortHighPayload()
+    var
+        AzureOpenAITestLibrary: Codeunit "Azure OpenAI Test Library";
+        AOAIChatCompletionParams: Codeunit "AOAI Chat Completion Params";
+        Payload: JsonObject;
+        Token: JsonToken;
+    begin
+        // [SCENARIO] Setting reasoning effort High produces correct payload value
+
+        // [GIVEN] ReasoningEffort set to High
+        AOAIChatCompletionParams.SetReasoningEffort(Enum::"AOAI Reasoning Effort"::High);
+
+        // [WHEN] Parameters are added to the payload
+        AzureOpenAITestLibrary.GetAOAIChatCompletionParametersPayload(AOAIChatCompletionParams, Payload);
+
+        // [THEN] reasoning_effort is 'high'
+        LibraryAssert.IsTrue(Payload.Get('reasoning_effort', Token), 'Payload should contain reasoning_effort.');
+        LibraryAssert.AreEqual('high', Token.AsValue().AsText(), 'reasoning_effort should be high.');
+    end;
+
+    [Test]
+    procedure TestChatCompletionParamsReasoningEffortUsesMaxCompletionTokens()
+    var
+        AzureOpenAITestLibrary: Codeunit "Azure OpenAI Test Library";
+        AOAIChatCompletionParams: Codeunit "AOAI Chat Completion Params";
+        Payload: JsonObject;
+        Token: JsonToken;
+    begin
+        // [SCENARIO] Reasoning models use max_completion_tokens instead of max_tokens
+
+        // [GIVEN] ReasoningEffort set and MaxTokens configured
+        AOAIChatCompletionParams.SetReasoningEffort(Enum::"AOAI Reasoning Effort"::Medium);
+        AOAIChatCompletionParams.SetMaxTokens(1000);
+
+        // [WHEN] Parameters are added to the payload
+        AzureOpenAITestLibrary.GetAOAIChatCompletionParametersPayload(AOAIChatCompletionParams, Payload);
+
+        // [THEN] max_completion_tokens is used, not max_tokens
+        LibraryAssert.IsTrue(Payload.Get('max_completion_tokens', Token), 'Payload should contain max_completion_tokens for reasoning models.');
+        LibraryAssert.AreEqual(1000, Token.AsValue().AsInteger(), 'max_completion_tokens should be 1000.');
+        LibraryAssert.IsFalse(Payload.Get('max_tokens', Token), 'Payload should not contain max_tokens for reasoning models.');
+    end;
+
+    [Test]
+    procedure TestChatCompletionParamsStandardModelUsesMaxTokens()
+    var
+        AzureOpenAITestLibrary: Codeunit "Azure OpenAI Test Library";
+        AOAIChatCompletionParams: Codeunit "AOAI Chat Completion Params";
+        Payload: JsonObject;
+        Token: JsonToken;
+    begin
+        // [SCENARIO] Standard models use max_tokens
+
+        // [GIVEN] No reasoning effort, MaxTokens configured
+        AOAIChatCompletionParams.SetMaxTokens(500);
+
+        // [WHEN] Parameters are added to the payload
+        AzureOpenAITestLibrary.GetAOAIChatCompletionParametersPayload(AOAIChatCompletionParams, Payload);
+
+        // [THEN] max_tokens is used, not max_completion_tokens
+        LibraryAssert.IsTrue(Payload.Get('max_tokens', Token), 'Payload should contain max_tokens for standard models.');
+        LibraryAssert.AreEqual(500, Token.AsValue().AsInteger(), 'max_tokens should be 500.');
+        LibraryAssert.IsFalse(Payload.Get('max_completion_tokens', Token), 'Payload should not contain max_completion_tokens for standard models.');
+    end;
+
+    [Test]
+    procedure TestChatCompletionParamsGetSetReasoningEffort()
+    var
+        AOAIChatCompletionParams: Codeunit "AOAI Chat Completion Params";
+    begin
+        // [SCENARIO] GetReasoningEffort returns what was set
+
+        // [GIVEN] Default params - reasoning effort not set (ordinal 0)
+        LibraryAssert.AreEqual(0, AOAIChatCompletionParams.GetReasoningEffort().AsInteger(), 'Default reasoning effort should be unset (ordinal 0).');
+
+        // [WHEN] ReasoningEffort is set to High
+        AOAIChatCompletionParams.SetReasoningEffort(Enum::"AOAI Reasoning Effort"::High);
+
+        // [THEN] GetReasoningEffort returns High
+        LibraryAssert.AreEqual(Enum::"AOAI Reasoning Effort"::High, AOAIChatCompletionParams.GetReasoningEffort(), 'GetReasoningEffort should return High.');
+    end;
 }


### PR DESCRIPTION
## Summary

Azure OpenAI reasoning models (o1, o3, o4-mini, gpt-5.x) require a `reasoning_effort` parameter that controls how much internal reasoning the model performs before generating a response. This parameter was not previously supported in `AOAIChatCompletionParams`.

Reasoning models also have different API constraints:
- They use `max_completion_tokens` instead of `max_tokens`
- They do not accept `temperature`, `presence_penalty`, or `frequency_penalty`

## Changes

### New: `enum 7780 "AOAI Reasoning Effort"`
Defines the three effort levels accepted by the Azure OpenAI API:
- `Low` (caption: `'low'`) - fastest, least reasoning
- `Medium` (caption: `'medium'`) - balanced
- `High` (caption: `'high'`) - slowest, deepest reasoning

Captions are lowercase and locked to match the exact string values required by the API.

### Modified: `AOAIChatCompletionParams` (codeunit 7761)
Added public procedures:
- `GetReasoningEffort(): Enum "AOAI Reasoning Effort"`
- `SetReasoningEffort(NewReasoningEffort: Enum "AOAI Reasoning Effort")`

### Modified: `AOAIChatComplParamsImpl` (codeunit 7762)
- Added `ReasoningEffort` field and corresponding get/set procedures
- Added `local procedure HasReasoningEffort(): Boolean` for internal branching
- Modified `AddChatCompletionsParametersToPayload()`:
  - When reasoning effort is set: emits `reasoning_effort` and `max_completion_tokens`; omits `temperature`, `presence_penalty`, `frequency_penalty`
  - When not set: existing behavior is unchanged

### Modified: `AzureOpenAIToolsTest` (codeunit 132686)
Added 7 test procedures covering:
- Default (non-reasoning) payload includes standard parameters
- Each effort level (Low, Medium, High) produces the correct `reasoning_effort` string
- Reasoning models use `max_completion_tokens` instead of `max_tokens`
- Standard models still use `max_tokens`
- GetReasoningEffort round-trips correctly

## Closes

Closes #6020
