### PR TITLE
EDocument: rename Data Exchange format caption to PEPPOL Data Exchange

### DIFF
--- a/src/Apps/W1/EDocument/App/src/DataExchange/EDocDataExchangeImpl.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/DataExchange/EDocDataExchangeImpl.Codeunit.al
@@ -29,7 +29,12 @@ codeunit 6152 "E-Doc. Data Exchange Impl." implements "E-Document"
         ServiceCrMemoHeader: Record "Service Cr.Memo Header";
         PEPPOLValidation: Codeunit "PEPPOL Validation";
         PEPPOLServiceValidation: Codeunit "PEPPOL Service Validation";
+        IsHandled: Boolean;
     begin
+        OnBeforeCheck(SourceDocumentHeader, EDocumentService, EDocumentProcessingPhase, IsHandled);
+        if IsHandled then
+            exit;
+
         case SourceDocumentHeader.Number of
             Database::"Sales Header":
                 begin
@@ -550,6 +555,11 @@ codeunit 6152 "E-Doc. Data Exchange Impl." implements "E-Document"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeDataExchangeExport(var DataExch: Record "Data Exch."; EDocumentFormat: Record "E-Document Service"; var EDocument: Record "E-Document"; var SourceDocumentHeader: RecordRef; var SourceDocumentLines: RecordRef);
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheck(var SourceDocumentHeader: RecordRef; EDocumentService: Record "E-Document Service"; EDocumentProcessingPhase: Enum "E-Document Processing Phase"; var IsHandled: Boolean);
     begin
     end;
 

--- a/src/Apps/W1/EDocument/App/src/Document/EDocumentFormat.Enum.al
+++ b/src/Apps/W1/EDocument/App/src/Document/EDocumentFormat.Enum.al
@@ -11,7 +11,7 @@ enum 6101 "E-Document Format" implements "E-Document"
     Extensible = true;
     value(0; "Data Exchange")
     {
-        Caption = 'Data Exchange';
+        Caption = 'PEPPOL Data Exchange';
         Implementation = "E-Document" = "E-Doc. Data Exchange Impl.";
     }
     value(1; "PEPPOL BIS 3.0")


### PR DESCRIPTION
## Summary

Closes #7304

The **Data Exchange** E-Document Format had a misleading caption. Its implementation (codeunit 6152 \E-Doc. Data Exchange Impl.\) always runs \PEPPOL Validation\ and \PEPPOL Service Validation\ in its \Check()\ procedure, making it strictly PEPPOL-specific despite the generic-sounding name **Data Exchange**.

Users who selected **Data Exchange** for a custom, non-PEPPOL data exchange definition unexpectedly received PEPPOL validation errors (e.g. \Your Reference must not be blank\) that had no apparent connection to their setup.

## Changes

### EDocumentFormat.Enum.al
- Caption of enum value \
