### PR TITLE
EDocument: scope PEPPOL BIS 3.0 .xml file extension to correct document format

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Format/EDocImportPEPPOLBIS30.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Format/EDocImportPEPPOLBIS30.Codeunit.al
@@ -611,7 +611,13 @@ codeunit 6166 "EDoc Import PEPPOL BIS 3.0"
 
     [EventSubscriber(ObjectType::Table, Database::"E-Document Log", 'OnBeforeExportDataStorage', '', false, false)]
     local procedure SetFileExt(EDocumentLog: Record "E-Document Log"; var FileName: Text)
+    var
+        FileManagement: Codeunit "File Management";
     begin
+        if EDocumentLog."Document Format" <> Enum::"E-Document Format"::"PEPPOL BIS 3.0" then
+            exit;
+        if FileManagement.GetExtension(FileName) <> '' then
+            exit;
         FileName += '.xml';
     end;
 


### PR DESCRIPTION
## Summary

Closes #7200

The SetFileExt event subscriber in EDocImportPEPPOLBIS30.Codeunit.al (codeunit 6166) was unconditionally appending '.xml' to every E-Document Log export, regardless of the Document Format on the E-Document Service. This caused third-party integrations using non-PEPPOL formats (e.g., json, csv) to receive exported files with an incorrect .xml extension.

## Root cause

The subscriber appended '.xml' for all Document Formats, not only PEPPOL BIS 3.0.

## Change

The subscriber now guards with two conditions before appending '.xml':

1. The E-Document Log entry's Document Format is PEPPOL BIS 3.0 (the only format this codeunit is responsible for)
2. The FileName does not already have a file extension, allowing other subscribers or implementations to set their own extension first

## No breaking changes

- PEPPOL BIS 3.0 log exports continue to receive '.xml' when no extension is already set
- Other format log exports (Data Exchange, custom) are no longer overridden with '.xml'
- The 'using System.IO;' namespace for 'File Management' is already declared in this codeunit

Fixes [AB#634372](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634372)



