### PR TITLE
(Bug 633223): [Subcontracting] Inserting a routing line after creating a subcontracting PO leaves the production order in a broken state

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcProdOrderRtngExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcProdOrderRtngExt.Codeunit.al
@@ -99,9 +99,10 @@ codeunit 99001520 "Subc. Prod. Order Rtng. Ext."
     begin
         if ProdOrderRoutingLine.Status = ProdOrderRoutingLine.Status::Released then
             if ProdOrderRoutingLine.Type = ProdOrderRoutingLine.Type::"Work Center" then begin
-                WorkCenter.Get(ProdOrderRoutingLine."No.");
-                if (ProdOrderRoutingLine."Routing Link Code" <> '') and (WorkCenter."Subcontractor No." <> '') then
-                    SubcontractingManagement.DelLocationLinkedComponents(ProdOrderRoutingLine, false);
+                WorkCenter.SetLoadFields("Subcontractor No.");
+                if WorkCenter.Get(ProdOrderRoutingLine."No.") then
+                    if (ProdOrderRoutingLine."Routing Link Code" <> '') and (WorkCenter."Subcontractor No." <> '') then
+                        SubcontractingManagement.DelLocationLinkedComponents(ProdOrderRoutingLine, false);
             end;
     end;
 }


### PR DESCRIPTION
## Summary
Guard the `Work Center` lookup in `Subc. Prod. Order Rtng. Ext.HandleSubcontractingAfterRoutingLineDelete` so the `OnAfterDelete` subscriber no longer errors when the deleted routing line has an empty `No.`.

Fixes [AB#633223](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633223)
