### PR TITLE
Clean up orphaned data notification in Extension Management page

### DIFF
--- a/src/System Application/App/Extension Management/src/ExtensionManagement.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionManagement.Page.al
@@ -387,24 +387,21 @@ page 2500 "Extension Management"
 
     local procedure ShowUninstalledExtensionsNotification()
     var
-        Uninstalled: Record "Extension Database Snapshot";
-        Notif: Notification;
+        ExtensionDatabaseSnapshot: Record "Extension Database Snapshot";
+        OrphanedDataNotification: Notification;
     begin
-        if not Uninstalled.ReadPermission() then
-            exit;
+        OrphanedDataNotification.Id := OrphanedDataNotificationIdTok;
+        OrphanedDataNotification.Scope := NotificationScope::LocalScope;
 
-        Notif.Id := OrphanedDataNotificationIdTok;
-        Notif.Scope := NotificationScope::LocalScope;
+        OrphanedDataNotification.Recall();
 
-        Notif.Recall();
-
-        Uninstalled.SetFilter(Status, '<>%1', Uninstalled.Status::Installed);
-        Uninstalled.SetFilter("Is Reviewed", '%1', false);
-        if not Uninstalled.IsEmpty() then begin
-            Notif.Message(UninstalledExtensionsMsg);
-            Notif.AddAction(ShowOrphanedDataLbl, Codeunit::"Extension Operation Impl", 'HandleOrphanedDataNotification');
-            Notif.AddAction(MarkAllAsReviewedLbl, Codeunit::"Extension Operation Impl", 'MarkOrphanedDataAsReviewed');
-            Notif.Send();
+        ExtensionDatabaseSnapshot.SetFilter(Status, '<>%1', ExtensionDatabaseSnapshot.Status::Installed);
+        ExtensionDatabaseSnapshot.SetFilter("Is Reviewed", '%1', false);
+        if not ExtensionDatabaseSnapshot.IsEmpty() then begin
+            OrphanedDataNotification.Message(UninstalledExtensionsMsg);
+            OrphanedDataNotification.AddAction(ShowOrphanedDataLbl, Codeunit::"Extension Operation Impl", 'HandleOrphanedDataNotification');
+            OrphanedDataNotification.AddAction(MarkAllAsReviewedLbl, Codeunit::"Extension Operation Impl", 'MarkOrphanedDataAsReviewed');
+            OrphanedDataNotification.Send();
         end;
     end;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Follow-up to #7350. Cleans up the orphaned extension data notification code:
- Remove redundant `ReadPermission()` guard
- Rename variables to follow AL conventions: `Uninstalled` → `ExtensionDatabaseSnapshot`, `Notif` → `OrphanedDataNotification`

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#616423](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/616423)




