### PR TITLE
Add Truncateall into EAP

### DIFF
--- a/src/System Application/App/Resources/Files/EarlyAccessPreviewFeatures.json
+++ b/src/System Application/App/Resources/Files/EarlyAccessPreviewFeatures.json
@@ -1,8 +1,8 @@
 [
     {
-        "FeatureName": "No features listed yet for the 2026 wave 2 release",
-        "Description": "Check back here in a couple of weeks to see and provide feedback on features coming in the upcoming release.",
-        "Category": "Other",
+        "FeatureName": "Faster cleanup of retention policy logs and large system tables",
+        "Description": "Retention policies now use Truncate All for a limited set of supported tables: Change Log Entry, Integration Synch. Job Errors, Error Message, and Error Message Register. Truncate All clears the entire table, making cleanup much faster than row-by-row deletion. ",
+        "Category": "Administration",
         "HelpURL": "",
         "VideoURL": ""
     }

--- a/src/System Application/App/Resources/Files/EarlyAccessPreviewFeatures.json
+++ b/src/System Application/App/Resources/Files/EarlyAccessPreviewFeatures.json
@@ -1,7 +1,7 @@
 [
     {
-        "FeatureName": "Faster cleanup of retention policy logs and large system tables",
-        "Description": "Retention policies now use Truncate All for a limited set of supported tables: Change Log Entry, Integration Synch. Job Errors, Error Message, and Error Message Register. Truncate All clears the entire table, making cleanup much faster than row-by-row deletion. ",
+        "FeatureName": "Fast cleanup of large tables in retention policy",
+        "Description": "A limited set of supported tables in Retention Policy now support TruncateAll: Change Log Entry, Integration Synch. Job Errors, Error Message, and Error Message Register. Truncate All clears the entire table, making cleanup much faster than row-by-row deletion. ",
         "Category": "Administration",
         "HelpURL": "",
         "VideoURL": ""


### PR DESCRIPTION
**Early Access Preview Features update:**

* Replaced the placeholder entry with a new feature: "Faster cleanup of retention policy logs and large system tables", which describes the use of "Truncate All" for certain tables to speed up cleanup operations.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#546970](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/546970)


