### PR TITLE
Subscription Billing: add integration events to Contract Deferrals Release

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Deferrals/Reports/ContractDeferralsRelease.Report.al
+++ b/src/Apps/W1/Subscription Billing/App/Deferrals/Reports/ContractDeferralsRelease.Report.al
@@ -169,7 +169,8 @@ report 8051 "Contract Deferrals Release"
                 GenPostingSetup."Cust. Sub. Contr. Def Account",
                 CustomerContractDeferral."Gen. Bus. Posting Group",
                 CustomerContractDeferral."Gen. Prod. Posting Group",
-                PostingAmount);
+                PostingAmount,
+                Enum::"Service Partner"::Customer);
 
         if LineDiscountPosting and (CustomerContractDeferral."Discount Amount" <> 0) then
             InsertTempGenJournalLine(
@@ -181,7 +182,8 @@ report 8051 "Contract Deferrals Release"
                 GenPostingSetup."Cust. Sub. Contr. Def Account",
                 CustomerContractDeferral."Gen. Bus. Posting Group",
                 CustomerContractDeferral."Gen. Prod. Posting Group",
-                -CustomerContractDeferral."Discount Amount");
+                -CustomerContractDeferral."Discount Amount",
+                Enum::"Service Partner"::Customer);
     end;
 
     local procedure ReleaseAllVendorContractDeferralsAndInsertTempGenJournalLines()
@@ -224,7 +226,8 @@ report 8051 "Contract Deferrals Release"
                 GenPostingSetup."Vend. Sub. Contr. Def. Account",
                 VendorContractDeferral."Gen. Bus. Posting Group",
                 VendorContractDeferral."Gen. Prod. Posting Group",
-                PostingAmount);
+                PostingAmount,
+                Enum::"Service Partner"::Vendor);
 
         if LineDiscountPosting and (VendorContractDeferral."Discount Amount" <> 0) then
             InsertTempGenJournalLine(
@@ -236,7 +239,8 @@ report 8051 "Contract Deferrals Release"
                 GenPostingSetup."Vend. Sub. Contr. Def. Account",
                 VendorContractDeferral."Gen. Bus. Posting Group",
                 VendorContractDeferral."Gen. Prod. Posting Group",
-                -VendorContractDeferral."Discount Amount");
+                -VendorContractDeferral."Discount Amount",
+                Enum::"Service Partner"::Vendor);
     end;
 
     local procedure GetLineDiscountPostingSetup(Partner: Enum "Service Partner")
@@ -284,13 +288,13 @@ report 8051 "Contract Deferrals Release"
             exit(Amount);
     end;
 
-    local procedure InsertTempGenJournalLine(DocumentNo: Code[20]; ContractNo: Code[20]; DeferralEntryNo: Integer; DimSetID: Integer; AccountNo: Code[20]; BalAccountNo: Code[20]; GenBusPostingGroup: Code[20]; GenProdPostingGroup: Code[20]; PostingAmount: Decimal)
+    local procedure InsertTempGenJournalLine(DocumentNo: Code[20]; ContractNo: Code[20]; DeferralEntryNo: Integer; DimSetID: Integer; AccountNo: Code[20]; BalAccountNo: Code[20]; GenBusPostingGroup: Code[20]; GenProdPostingGroup: Code[20]; PostingAmount: Decimal; Partner: Enum "Service Partner")
     begin
         UpdateWindow(ContractNo);
-        InsertTempGenJournalLine(DocumentNo, ContractNo, DeferralEntryNo, DimSetID, AccountNo, BalAccountNo, PostingAmount, GenBusPostingGroup, GenProdPostingGroup);
+        InsertTempGenJournalLine(DocumentNo, ContractNo, DeferralEntryNo, DimSetID, AccountNo, BalAccountNo, PostingAmount, GenBusPostingGroup, GenProdPostingGroup, Partner);
     end;
 
-    local procedure InsertTempGenJournalLine(DocumentNo: Code[20]; ContractNo: Code[20]; DeferralEntryNo: Integer; DimSetID: Integer; AccountNo: Code[20]; BalAccountNo: Code[20]; PostingAmount: Decimal; GenBusPostingGroup: Code[20]; GenProdPostingGroup: Code[20])
+    local procedure InsertTempGenJournalLine(DocumentNo: Code[20]; ContractNo: Code[20]; DeferralEntryNo: Integer; DimSetID: Integer; AccountNo: Code[20]; BalAccountNo: Code[20]; PostingAmount: Decimal; GenBusPostingGroup: Code[20]; GenProdPostingGroup: Code[20]; Partner: Enum "Service Partner")
     begin
         LineNo += 1;
         TempGenJournalLine."Account No." := AccountNo;
@@ -303,6 +307,7 @@ report 8051 "Contract Deferrals Release"
         TempGenJournalLine.Amount := PostingAmount;
         TempGenJournalLine."Line No." := LineNo;
         TempGenJournalLine."Deferral Line No." := DeferralEntryNo;
+        OnBeforeInsertTempGenJournalLine(TempGenJournalLine, Partner);
         TempGenJournalLine.Insert(false);
     end;
 
@@ -388,6 +393,7 @@ report 8051 "Contract Deferrals Release"
         GenJnlLine."Gen. Prod. Posting Group" := '';
         GenJnlLine."VAT Bus. Posting Group" := '';
         GenJnlLine."VAT Prod. Posting Group" := '';
+        OnBeforePostGenJnlLine(InputTempGenJournalLine, GenJnlLine);
         GenJnlPostLine.RunWithCheck(GenJnlLine);
 
         GenJnlLine.Validate("Account No.", InputTempGenJournalLine."Bal. Account No.");
@@ -399,6 +405,7 @@ report 8051 "Contract Deferrals Release"
         GenJnlLine."VAT Bus. Posting Group" := '';
         GenJnlLine."VAT Prod. Posting Group" := '';
         GenJnlLine.Description := StrSubstNo(ReleasingOfContractNoTxt, Format(GenJnlLine."Posting Date", 0, '<Month Text> <Year4>'));
+        OnBeforePostGenJnlLine(InputTempGenJournalLine, GenJnlLine);
         GenJnlPostLine.RunWithCheck(GenJnlLine);
     end;
 
@@ -420,6 +427,16 @@ report 8051 "Contract Deferrals Release"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeReleaseVendorContractDeferral(var VendorContractDeferral: Record "Vend. Sub. Contract Deferral"; var ShouldReleaseDeferral: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeInsertTempGenJournalLine(var TempGenJournalLine: Record "Gen. Journal Line"; Partner: Enum "Service Partner")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforePostGenJnlLine(TempGenJournalLine: Record "Gen. Journal Line"; var GenJnlLine: Record "Gen. Journal Line")
     begin
     end;
 }


### PR DESCRIPTION
Resolves #7896

## Summary

Adds the Service Partner parameter and two new integration events to report 8051 Contract Deferrals Release, enabling extensions to intercept the release posting and document G/L entries with additional partner-specific data.

## Changes

### InsertTempGenJournalLine - Partner parameter added

Both local overloads of InsertTempGenJournalLine now accept Partner: Enum Service Partner as the final parameter. The outer overload (which calls UpdateWindow) threads the value through to the inner one. All four call sites are updated to pass the corresponding value:

- ReleaseCustomerContractDeferralAndInsertTempGenJournalLine: passes Enum::Service Partner::Customer
- ReleaseVendorContractDeferralsAndInsertTempGenJournalLines: passes Enum::Service Partner::Vendor

### OnBeforeInsertTempGenJournalLine (new integration event)

Raised in the inner InsertTempGenJournalLine, after all fields are assigned but before TempGenJournalLine.Insert(). Signature:

local procedure OnBeforeInsertTempGenJournalLine(var TempGenJournalLine: Record Gen. Journal Line; Partner: Enum Service Partner)

### OnBeforePostGenJnlLine (new integration event)

Raised twice inside PostGenJnlLine, once before each GenJnlPostLine.RunWithCheck(GenJnlLine) call (main account leg and balancing account leg). Signature:

local procedure OnBeforePostGenJnlLine(TempGenJournalLine: Record Gen. Journal Line; var GenJnlLine: Record Gen. Journal Line)

TempGenJournalLine is passed by value (read-only source context); GenJnlLine is passed by reference so subscribers can modify fields before posting.

Fixes [AB#633954](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633954)


