### PR TITLE
Bug 633221: [Subcontracting] Reword awkward confirm message in Create Subcontracting Order

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchaseOrderCreator.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchaseOrderCreator.Codeunit.al
@@ -205,7 +205,7 @@ codeunit 99001557 "Subc. Purchase Order Creator"
         ConfirmManagement: Codeunit "Confirm Management";
         CreationOfSubcontractingOrderIsNotAllowedErr: Label 'You cannot create Subcontracting Order, because the Production Order %1 is not released.', Comment = '%1=Production Order No.';
         NoProdOrderLineWithRemQtyErr: Label 'No Prod. Order Line with Remaining Quantity.';
-        PurchOrderCreatedTxt: Label 'Already Purchase Order(s) created.\\Do you want to view them?';
+        PurchOrderCreatedTxt: Label 'Purchase order(s) have already been created.\\Do you want to view them?';
     begin
         if ProdOrderRoutingLine.Status <> "Production Order Status"::Released then
             Error(CreationOfSubcontractingOrderIsNotAllowedErr, ProdOrderRoutingLine."Prod. Order No.");


### PR DESCRIPTION
## Summary
- When a subcontracting purchase order already exists for a routing line, the system showed the confirm message: **'Already Purchase Order(s) created. Do you want to view them?'** — grammatically awkward and unnatural.
- Root cause: The label text in `CheckProdOrderRtngLine` (`SubcPurchaseOrderCreator.Codeunit.al`) used incorrect word order.
- Fix: Changed label to **'Purchase order(s) have already been created. Do you want to view them?'** for natural English phrasing.

Fixes [AB#633221](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633221)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)


