### PR TITLE
(Bug 620431): [Subcontracting] PurchLine.Get() called repeatedly in UI action triggers - SubWhseRcptSubformExt.PageExt.al

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Warehouse/SubcWhseRcptLinesExt.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Warehouse/SubcWhseRcptLinesExt.PageExt.al
@@ -24,9 +24,8 @@ pageextension 99001534 "Subc. Whse Rcpt Lines Ext." extends "Whse. Receipt Lines
                     ToolTip = 'View the related production order.';
                     trigger OnAction()
                     begin
-                        if Rec."Source Type" = Database::"Purchase Line" then
-                            if PurchaseLine.Get(Rec."Source Subtype", Rec."Source No.", Rec."Source Line No.") then
-                                ShowProductionOrder(PurchaseLine);
+                        if GetSourcePurchaseLine() then
+                            ShowProductionOrder(PurchaseLine);
                     end;
                 }
                 action("Production Order Routing")
@@ -37,9 +36,8 @@ pageextension 99001534 "Subc. Whse Rcpt Lines Ext." extends "Whse. Receipt Lines
                     ToolTip = 'View the related production order routing.';
                     trigger OnAction()
                     begin
-                        if Rec."Source Type" = Database::"Purchase Line" then
-                            if PurchaseLine.Get(Rec."Source Subtype", Rec."Source No.", Rec."Source Line No.") then
-                                ShowProductionOrderRouting(PurchaseLine);
+                        if GetSourcePurchaseLine() then
+                            ShowProductionOrderRouting(PurchaseLine);
                     end;
                 }
                 action("Production Order Components")
@@ -50,9 +48,8 @@ pageextension 99001534 "Subc. Whse Rcpt Lines Ext." extends "Whse. Receipt Lines
                     ToolTip = 'View the related production order components.';
                     trigger OnAction()
                     begin
-                        if Rec."Source Type" = Database::"Purchase Line" then
-                            if PurchaseLine.Get(Rec."Source Subtype", Rec."Source No.", Rec."Source Line No.") then
-                                ShowProductionOrderComponents(PurchaseLine);
+                        if GetSourcePurchaseLine() then
+                            ShowProductionOrderComponents(PurchaseLine);
                     end;
                 }
                 action("Transfer Order")
@@ -63,9 +60,8 @@ pageextension 99001534 "Subc. Whse Rcpt Lines Ext." extends "Whse. Receipt Lines
                     ToolTip = 'View the related transfer order.';
                     trigger OnAction()
                     begin
-                        if Rec."Source Type" = Database::"Purchase Line" then
-                            if PurchaseLine.Get(Rec."Source Subtype", Rec."Source No.", Rec."Source Line No.") then
-                                SubcPurchFactboxMgmt.ShowTransferOrdersAndReturnOrder(Rec, true, false);
+                        if GetSourcePurchaseLine() then
+                            SubcPurchFactboxMgmt.ShowTransferOrdersAndReturnOrder(PurchaseLine, true, false);
                     end;
                 }
                 action("Return Transfer Order")
@@ -76,9 +72,8 @@ pageextension 99001534 "Subc. Whse Rcpt Lines Ext." extends "Whse. Receipt Lines
                     ToolTip = 'View the related return transfer order.';
                     trigger OnAction()
                     begin
-                        if Rec."Source Type" = Database::"Purchase Line" then
-                            if PurchaseLine.Get(Rec."Source Subtype", Rec."Source No.", Rec."Source Line No.") then
-                                SubcPurchFactboxMgmt.ShowTransferOrdersAndReturnOrder(Rec, true, true);
+                        if GetSourcePurchaseLine() then
+                            SubcPurchFactboxMgmt.ShowTransferOrdersAndReturnOrder(PurchaseLine, true, true);
                     end;
                 }
             }
@@ -88,6 +83,18 @@ pageextension 99001534 "Subc. Whse Rcpt Lines Ext." extends "Whse. Receipt Lines
         PurchaseLine: Record "Purchase Line";
         SubcProdOrderFactboxMgmt: Codeunit "Subc. ProdO. Factbox Mgmt.";
         SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
+
+    local procedure GetSourcePurchaseLine(): Boolean
+    begin
+        if Rec."Source Type" <> Database::"Purchase Line" then
+            exit(false);
+        if (PurchaseLine."Document Type".AsInteger() = Rec."Source Subtype") and
+           (PurchaseLine."Document No." = Rec."Source No.") and
+           (PurchaseLine."Line No." = Rec."Source Line No.")
+        then
+            exit(true);
+        exit(PurchaseLine.Get(Rec."Source Subtype", Rec."Source No.", Rec."Source Line No."));
+    end;
 
     local procedure ShowProductionOrder(RecRelatedVariant: Variant)
     begin

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Warehouse/SubcWhseRcptSubformExt.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Warehouse/SubcWhseRcptSubformExt.PageExt.al
@@ -24,9 +24,8 @@ pageextension 99001533 "Subc. Whse Rcpt Subform Ext." extends "Whse. Receipt Sub
                     ToolTip = 'View the related production order.';
                     trigger OnAction()
                     begin
-                        if Rec."Source Type" = Database::"Purchase Line" then
-                            if PurchaseLine.Get(Rec."Source Subtype", Rec."Source No.", Rec."Source Line No.") then
-                                ShowProductionOrder(PurchaseLine);
+                        if GetSourcePurchaseLine() then
+                            ShowProductionOrder(PurchaseLine);
                     end;
                 }
                 action("Production Order Routing")
@@ -37,9 +36,8 @@ pageextension 99001533 "Subc. Whse Rcpt Subform Ext." extends "Whse. Receipt Sub
                     ToolTip = 'View the related production order routing.';
                     trigger OnAction()
                     begin
-                        if Rec."Source Type" = Database::"Purchase Line" then
-                            if PurchaseLine.Get(Rec."Source Subtype", Rec."Source No.", Rec."Source Line No.") then
-                                ShowProductionOrderRouting(PurchaseLine);
+                        if GetSourcePurchaseLine() then
+                            ShowProductionOrderRouting(PurchaseLine);
                     end;
                 }
                 action("Production Order Components")
@@ -50,9 +48,8 @@ pageextension 99001533 "Subc. Whse Rcpt Subform Ext." extends "Whse. Receipt Sub
                     ToolTip = 'View the related production order components.';
                     trigger OnAction()
                     begin
-                        if Rec."Source Type" = Database::"Purchase Line" then
-                            if PurchaseLine.Get(Rec."Source Subtype", Rec."Source No.", Rec."Source Line No.") then
-                                ShowProductionOrderComponents(PurchaseLine);
+                        if GetSourcePurchaseLine() then
+                            ShowProductionOrderComponents(PurchaseLine);
                     end;
                 }
                 action("Transfer Order")
@@ -63,9 +60,8 @@ pageextension 99001533 "Subc. Whse Rcpt Subform Ext." extends "Whse. Receipt Sub
                     ToolTip = 'View the related transfer order.';
                     trigger OnAction()
                     begin
-                        if Rec."Source Type" = Database::"Purchase Line" then
-                            if PurchaseLine.Get(Rec."Source Subtype", Rec."Source No.", Rec."Source Line No.") then
-                                SubcPurchFactboxMgmt.ShowTransferOrdersAndReturnOrder(Rec, true, false);
+                        if GetSourcePurchaseLine() then
+                            SubcPurchFactboxMgmt.ShowTransferOrdersAndReturnOrder(PurchaseLine, true, false);
                     end;
                 }
                 action("Return Transfer Order")
@@ -76,9 +72,8 @@ pageextension 99001533 "Subc. Whse Rcpt Subform Ext." extends "Whse. Receipt Sub
                     ToolTip = 'View the related return transfer order.';
                     trigger OnAction()
                     begin
-                        if Rec."Source Type" = Database::"Purchase Line" then
-                            if PurchaseLine.Get(Rec."Source Subtype", Rec."Source No.", Rec."Source Line No.") then
-                                SubcPurchFactboxMgmt.ShowTransferOrdersAndReturnOrder(Rec, true, true);
+                        if GetSourcePurchaseLine() then
+                            SubcPurchFactboxMgmt.ShowTransferOrdersAndReturnOrder(PurchaseLine, true, true);
                     end;
                 }
             }
@@ -88,6 +83,17 @@ pageextension 99001533 "Subc. Whse Rcpt Subform Ext." extends "Whse. Receipt Sub
         PurchaseLine: Record "Purchase Line";
         SubcProdOrderFactboxMgmt: Codeunit "Subc. ProdO. Factbox Mgmt.";
         SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
+
+    local procedure GetSourcePurchaseLine(): Boolean
+    begin
+        if Rec."Source Type" <> Database::"Purchase Line" then
+            exit(false);
+        if (PurchaseLine."Document Type".AsInteger() = Rec."Source Subtype") and
+           (PurchaseLine."Document No." = Rec."Source No.") and
+           (PurchaseLine."Line No." = Rec."Source Line No.") then
+            exit(true);
+        exit(PurchaseLine.Get(Rec."Source Subtype", Rec."Source No.", Rec."Source Line No."));
+    end;
 
     local procedure ShowProductionOrder(RecRelatedVariant: Variant)
     begin


### PR DESCRIPTION
### Summary

Refactored the production / transfer order action triggers on the Warehouse Receipt pages so they no longer re-read the same `Purchase Line` from the database on every click, and fixed two actions that were silently doing nothing.

### Problem

Each of the five actions (`Production Order`, `Production Order Routing`, `Production Order Components`, `Transfer Order`, `Return Transfer Order`) duplicated this body:

```al
if Rec."Source Type" = Database::"Purchase Line" then
    if PurchaseLine.Get(Rec."Source Subtype", Rec."Source No.", Rec."Source Line No.") then
        Show...(PurchaseLine);
```

Two issues:

1. **Redundant DB round-trips.** The page-level `PurchaseLine` global is preserved across action invocations on the same row, but each click re-issued an identical `PurchaseLine.Get`.
2. **Silent no-op on `Transfer Order` / `Return Transfer Order`.** They called `SubcPurchFactboxMgmt.ShowTransferOrdersAndReturnOrder(Rec, …)` passing `Rec` (a `Whse. Receipt Line`). That codeunit only handles `Prod. Order Component`, `Purchase Line`, and `Prod. Order Routing Line` — anything else hits the `else exit;` and the action quietly does nothing. (Same shape as the recently-fixed bug 633292 on Item Ledger Entries.)

### Fix

- Extracted a single helper `GetSourcePurchaseLine(): Boolean` that:
  - Returns `false` when the receipt line's source isn't a Purchase Line.
  - Reuses the existing global `PurchaseLine` if its primary key already matches `Rec`'s source key (cache hit → no DB call).
  - Otherwise issues exactly one `PurchaseLine.Get` and refreshes the cache.
- Replaced the duplicated guard/Get in all five actions with `if GetSourcePurchaseLine() then …`.
- Fixed the `Transfer Order` / `Return Transfer Order` actions to pass `PurchaseLine` (not `Rec`) to `ShowTransferOrdersAndReturnOrder`, so the call now resolves to the `Database::"Purchase Line"` branch instead of silently exiting.

### Result

- At most **one** `PurchaseLine.Get` per warehouse receipt line, regardless of how many of the five actions the user clicks; navigating to a different row invalidates the cache via the source-key mismatch.
- Removes ten copies of the source-type guard and Get from the source.
- The two previously broken actions now actually open the related transfer / return transfer order.

### Scope check

Scanned the rest of the Subcontracting app for the same shape (multiple action triggers in one file `Get`-ing the same record). No other instances found — other page extensions either pass `Rec` straight to a `Variant`-handling helper or `Get` at most once.

Fixes [AB#620431](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620431)

