### PR TITLE
[Shopify] Fix bulk variant price update sending compareAtPrice as "0"

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Bulk Operations/Codeunits/ShpfyBulkUpdateProductPrice.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Bulk Operations/Codeunits/ShpfyBulkUpdateProductPrice.Codeunit.al
@@ -21,7 +21,10 @@ codeunit 30281 "Shpfy Bulk UpdateProductPrice" implements "Shpfy IBulk Operation
 
     procedure GetInput(): Text
     begin
-        exit('{ "productId": "gid://shopify/Product/%1", "variants": [{ "id": "gid://shopify/ProductVariant/%2", "price": "%3", "compareAtPrice": "%4", "inventoryItem": { "cost": "%5" }}]}');
+        // %4 carries the entire optional ', "compareAtPrice": <value>' fragment (or empty
+        // string to omit the field, in which case Shopify preserves the existing value).
+        // It must include the leading comma and field name when present.
+        exit('{ "productId": "gid://shopify/Product/%1", "variants": [{ "id": "gid://shopify/ProductVariant/%2", "price": "%3"%4, "inventoryItem": { "cost": "%5" }}]}');
     end;
 
     procedure GetName(): Text[250]

--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyVariantAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyVariantAPI.Codeunit.al
@@ -698,11 +698,11 @@ codeunit 30189 "Shpfy Variant API"
                 GraphQuery.Append(Format(ShopifyVariant."Compare at Price", 0, 9));
                 GraphQuery.Append('\"');
                 if IsBulkOperationEnabled then
-                    CompareAtPrice := Format(ShopifyVariant."Compare at Price", 0, 9);
+                    CompareAtPrice := ', "compareAtPrice": "' + Format(ShopifyVariant."Compare at Price", 0, 9) + '"';
             end else begin
                 HasChange := true;
                 GraphQuery.Append(', compareAtPrice: null');
-                CompareAtPrice := '0';
+                CompareAtPrice := ', "compareAtPrice": null';
             end;
         if ShopifyVariant."Unit Cost" <> xShopifyVariant."Unit Cost" then begin
             HasChange := true;
@@ -720,8 +720,6 @@ codeunit 30189 "Shpfy Variant API"
                 IBulkOperation := BulkOperationType::UpdateProductPrice;
                 if Price = '' then
                     Price := Format(ShopifyVariant.Price, 0, 9);
-                if CompareAtPrice = '' then
-                    CompareAtPrice := Format(ShopifyVariant."Compare at Price", 0, 9);
                 if UnitCost = '' then
                     UnitCost := Format(ShopifyVariant."Unit Cost", 0, 9);
 

--- a/src/Apps/W1/Shopify/Test/Bulk Operations/Codeunits/ShpfyBulkOperationsTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Bulk Operations/Codeunits/ShpfyBulkOperationsTest.Codeunit.al
@@ -314,6 +314,154 @@ codeunit 139633 "Shpfy Bulk Operations Test"
         ClearSetup();
     end;
 
+    [Test]
+    procedure TestBulkUpdateProductPriceClearsCompareAtPriceAsNull()
+    var
+        ShopifyVariant: Record "Shpfy Variant";
+        xShopifyVariant: Record "Shpfy Variant";
+        VariantApi: Codeunit "Shpfy Variant API";
+        BulkOperationInput: TextBuilder;
+        GraphQueryList: Dictionary of [BigInteger, TextBuilder];
+        JRequestData: JsonArray;
+        Jsonl: Text;
+    begin
+        // [SCENARIO] Bug fix for ICM 21000001004461: when Compare at Price is cleared (set to 0)
+        // on the bulk path, the JSONL must contain "compareAtPrice": null, not "compareAtPrice": "0".
+        Initialize();
+        ClearSetup();
+
+        // [GIVEN] A Shopify variant whose Compare at Price has just been cleared (200 -> 0)
+        ShopifyVariant.Init();
+        ShopifyVariant."Product Id" := Any.IntegerInRange(100000, 555555);
+        ShopifyVariant.Id := Any.IntegerInRange(100000, 555555);
+        ShopifyVariant.Price := 100;
+        ShopifyVariant."Compare at Price" := 0;
+        ShopifyVariant."Unit Cost" := 50;
+        ShopifyVariant.Insert();
+        xShopifyVariant := ShopifyVariant;
+        xShopifyVariant."Compare at Price" := 200;
+
+        // [WHEN] UpdateProductPrice runs on the bulk path (RecordCount >= 100)
+        VariantApi.UpdateProductPrice(ShopifyVariant, xShopifyVariant, BulkOperationInput, GraphQueryList, 100, JRequestData);
+
+        // [THEN] The JSONL line clears Compare at Price with the literal token null, not the string "0"
+        Jsonl := BulkOperationInput.ToText();
+        LibraryAssert.IsTrue(Jsonl.Contains('"compareAtPrice": null'), 'JSONL must clear Compare at Price with null. Was: ' + Jsonl);
+        LibraryAssert.IsFalse(Jsonl.Contains('"compareAtPrice": "0"'), 'JSONL must not send Compare at Price as the string "0". Was: ' + Jsonl);
+        LibraryAssert.IsFalse(Jsonl.Contains('"compareAtPrice": "null"'), 'JSONL must not quote the null token. Was: ' + Jsonl);
+        ClearSetup();
+    end;
+
+    [Test]
+    procedure TestBulkUpdateProductPriceOmitsUnchangedCompareAtPrice()
+    var
+        ShopifyVariant: Record "Shpfy Variant";
+        xShopifyVariant: Record "Shpfy Variant";
+        VariantApi: Codeunit "Shpfy Variant API";
+        BulkOperationInput: TextBuilder;
+        GraphQueryList: Dictionary of [BigInteger, TextBuilder];
+        JRequestData: JsonArray;
+        Jsonl: Text;
+    begin
+        // [SCENARIO] Bug fix for ICM 21000001004461: when only Price changes and Compare at Price
+        // is unchanged in BC, the bulk path must omit compareAtPrice from the JSONL so that
+        // Shopify preserves whatever value is currently set on the variant.
+        Initialize();
+        ClearSetup();
+
+        // [GIVEN] A Shopify variant with Compare at Price = 0 (unchanged), Price changing 80 -> 100
+        ShopifyVariant.Init();
+        ShopifyVariant."Product Id" := Any.IntegerInRange(100000, 555555);
+        ShopifyVariant.Id := Any.IntegerInRange(100000, 555555);
+        ShopifyVariant.Price := 100;
+        ShopifyVariant."Compare at Price" := 0;
+        ShopifyVariant."Unit Cost" := 50;
+        ShopifyVariant.Insert();
+        xShopifyVariant := ShopifyVariant;
+        xShopifyVariant.Price := 80;
+
+        // [WHEN] UpdateProductPrice runs on the bulk path
+        VariantApi.UpdateProductPrice(ShopifyVariant, xShopifyVariant, BulkOperationInput, GraphQueryList, 100, JRequestData);
+
+        // [THEN] compareAtPrice is not in the JSONL at all - Shopify preserves its existing value
+        Jsonl := BulkOperationInput.ToText();
+        LibraryAssert.IsFalse(Jsonl.Contains('compareAtPrice'), 'JSONL must omit compareAtPrice when unchanged in BC. Was: ' + Jsonl);
+        ClearSetup();
+    end;
+
+    [Test]
+    procedure TestBulkUpdateProductPriceSendsValidCompareAtPriceAsQuoted()
+    var
+        ShopifyVariant: Record "Shpfy Variant";
+        xShopifyVariant: Record "Shpfy Variant";
+        VariantApi: Codeunit "Shpfy Variant API";
+        BulkOperationInput: TextBuilder;
+        GraphQueryList: Dictionary of [BigInteger, TextBuilder];
+        JRequestData: JsonArray;
+        Jsonl: Text;
+    begin
+        // [SCENARIO] When Compare at Price is set above Price (a valid sale price), the bulk path
+        // must send the value as a quoted decimal string, matching the non-bulk GraphQL path.
+        Initialize();
+        ClearSetup();
+
+        // [GIVEN] Variant going on sale: Price 100, Compare at Price changing 0 -> 200
+        ShopifyVariant.Init();
+        ShopifyVariant."Product Id" := Any.IntegerInRange(100000, 555555);
+        ShopifyVariant.Id := Any.IntegerInRange(100000, 555555);
+        ShopifyVariant.Price := 100;
+        ShopifyVariant."Compare at Price" := 200;
+        ShopifyVariant."Unit Cost" := 50;
+        ShopifyVariant.Insert();
+        xShopifyVariant := ShopifyVariant;
+        xShopifyVariant."Compare at Price" := 0;
+
+        // [WHEN] UpdateProductPrice runs on the bulk path
+        VariantApi.UpdateProductPrice(ShopifyVariant, xShopifyVariant, BulkOperationInput, GraphQueryList, 100, JRequestData);
+
+        // [THEN] Compare at Price is sent as a quoted decimal string
+        Jsonl := BulkOperationInput.ToText();
+        LibraryAssert.IsTrue(Jsonl.Contains('"compareAtPrice": "200'), 'JSONL must send positive Compare at Price as a quoted decimal. Was: ' + Jsonl);
+        LibraryAssert.IsFalse(Jsonl.Contains('"compareAtPrice": null'), 'JSONL must not null out a valid Compare at Price. Was: ' + Jsonl);
+        ClearSetup();
+    end;
+
+    [Test]
+    procedure TestBulkUpdateProductPriceOmitsUnchangedPositiveCompareAtPrice()
+    var
+        ShopifyVariant: Record "Shpfy Variant";
+        xShopifyVariant: Record "Shpfy Variant";
+        VariantApi: Codeunit "Shpfy Variant API";
+        BulkOperationInput: TextBuilder;
+        GraphQueryList: Dictionary of [BigInteger, TextBuilder];
+        JRequestData: JsonArray;
+        Jsonl: Text;
+    begin
+        // [SCENARIO] When only Unit Cost changes and Compare at Price is unchanged (even if
+        // currently > Price), the bulk path must omit compareAtPrice so Shopify preserves it.
+        Initialize();
+        ClearSetup();
+
+        // [GIVEN] Variant with valid sale (Compare 200 > Price 100); only Unit Cost changes
+        ShopifyVariant.Init();
+        ShopifyVariant."Product Id" := Any.IntegerInRange(100000, 555555);
+        ShopifyVariant.Id := Any.IntegerInRange(100000, 555555);
+        ShopifyVariant.Price := 100;
+        ShopifyVariant."Compare at Price" := 200;
+        ShopifyVariant."Unit Cost" := 75;
+        ShopifyVariant.Insert();
+        xShopifyVariant := ShopifyVariant;
+        xShopifyVariant."Unit Cost" := 50;
+
+        // [WHEN] UpdateProductPrice runs on the bulk path
+        VariantApi.UpdateProductPrice(ShopifyVariant, xShopifyVariant, BulkOperationInput, GraphQueryList, 100, JRequestData);
+
+        // [THEN] compareAtPrice is omitted entirely - Shopify keeps its current value
+        Jsonl := BulkOperationInput.ToText();
+        LibraryAssert.IsFalse(Jsonl.Contains('compareAtPrice'), 'JSONL must omit unchanged compareAtPrice. Was: ' + Jsonl);
+        ClearSetup();
+    end;
+
     local procedure CreateBulkOperation(BulkOperationId: BigInteger; BulkOperationType: Enum "Shpfy Bulk Operation Type"; ShopCode: Code[20]; BulkOpUrl: Text; RequestData: JsonArray): Record "Shpfy Bulk Operation"
     var
         BulkOperation: Record "Shpfy Bulk Operation";


### PR DESCRIPTION
## Summary
The bulk variant price update path (`productVariantsBulkUpdate` via Shopify's bulk operations API, used when RecordCount >= 100 in a single price sync) was emitting `"compareAtPrice": "0"` instead of `null` or omitting the field. Shopify stores `"0"` as a real `.00` compare-at price, which on themes that surface compare-at prices appears as a "was " sale, and corrupts the field for storefront feeds (Google Shopping, Facebook, Shop app), analytics, and merchants who set Compare at price manually in admin.

## Repro (code-side, `ShpfyVariantAPI.UpdateProductPrice`)
Two bulk-only paths produced `"0"`:

1. **Clearing**: when Compare at Price changed to 0 in BC, the inline GraphQL emitted `compareAtPrice: null` correctly, but the bulk JSONL fragment hard-coded `CompareAtPrice := '0'`.
2. **Defaulting**: when Compare at Price was unchanged but Price/Unit Cost moved, the bulk JSONL defaulted to `Format(ShopifyVariant."Compare at Price", 0, 9)`, which is `"0"` for the (very common) no-sale case - silently overwriting any compare-at price set in Shopify admin on every BC price sync.

The single-variant GraphQL path was fine; it never hit the bulk template.

## Fix
- `%4` in the bulk JSONL template (`ShpfyBulkUpdateProductPrice.GetInput`) now carries the entire optional `, "compareAtPrice": <value>` fragment (including the leading comma) or an empty string.
- `ShpfyVariantAPI.UpdateProductPrice` builds the fragment as:
  - `, "compareAtPrice": "<value>"` when Price < Compare at Price (a valid sale),
  - `, "compareAtPrice": null` when Compare at Price changed and is at/below Price (clear it on Shopify),
  - empty string when Compare at Price did not change in BC (omit the field, Shopify preserves its current value).
- The defaulting block that emitted `"0"` is removed.

This mirrors the non-bulk GraphQL path's semantics for `compareAtPrice`.

## Tests
Added regression tests in `ShpfyBulkOperationsTest.Codeunit.al` that call `UpdateProductPrice` directly on the bulk path (RecordCount = 100) and assert on the JSONL produced:

- `TestBulkUpdateProductPriceClearsCompareAtPriceAsNull` - covers defect 1 (must emit `null`, never `"0"`).
- `TestBulkUpdateProductPriceOmitsUnchangedCompareAtPrice` - covers defect 2 (BC Compare = 0 unchanged, only Price moved → omit, do not send `"0"`).
- `TestBulkUpdateProductPriceSendsValidCompareAtPriceAsQuoted` - guards against over-correction; valid sale price still sends as quoted decimal.
- `TestBulkUpdateProductPriceOmitsUnchangedPositiveCompareAtPrice` - guards against accidentally clearing a valid sale price during unrelated updates.

Fixes [AB#633535](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633535)



