### PR TITLE
Clarify separation between generation rule management and source configuration traversal

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspecGenRuleMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspecGenRuleMgmt.Codeunit.al
@@ -11,7 +11,14 @@ using Microsoft.QualityManagement.Document;
 using Microsoft.QualityManagement.Utilities;
 
 /// <summary>
-/// Methods to assist with quality inspection generation rule management.
+/// Manages the selection and evaluation of Quality Inspection generation rules.
+/// This codeunit is responsible for business rule matching: given a source record, it determines
+/// which generation rule applies based on source table, condition filters, item filters,
+/// item attribute filters, sort order, and activation trigger.
+/// Source configuration graph traversal is intentionally delegated to "Qlty. Traversal", which
+/// this codeunit uses as a navigation service to discover reachable inspection targets before
+/// evaluating rule criteria. Developers adding generation rule logic should work here; developers
+/// adding new record navigation or relationship lookups should work in "Qlty. Traversal".
 /// </summary>
 codeunit 20405 "Qlty. Inspec. Gen. Rule Mgmt."
 {
@@ -170,19 +177,23 @@ codeunit 20405 "Qlty. Inspec. Gen. Rule Mgmt."
     end;
 
     /// <summary>
-    /// Finds the first matching generation rule and record.
-    /// Note that TempQltyInspectionGenRule can be used to supply optional input filters, however it will be replaced upon output.
+    /// Finds the first matching generation rule and source record by walking the pre-computed source configuration traversal set.
+    /// The procedure evaluates generation rules at the current record level first, then recurses upward through parent
+    /// records using "Qlty. Traversal" to navigate to the linked source record for each unvisited configuration path.
+    /// Rule candidates are ordered by Sort Order ascending; the first match across condition filter, item filter,
+    /// and item attribute filter is returned. TempQltyInspectionGenRule can supply optional input filters but will
+    /// be overwritten with the matched rule on output.
     /// </summary>
-    /// <param name="CurrentRecursionDepth"></param>
-    /// <param name="UseActivationFilter"></param>
-    /// <param name="IsManualCreation"></param>
-    /// <param name="TargetRecordRef"></param>
-    /// <param name="OptionalItem"></param>
-    /// <param name="TempAvailableQltyInspectSourceConfig"></param>
-    /// <param name="TempAlreadySearchedsQltyInspectSourceConfig"></param>
-    /// <param name="OptionalSpecificTemplate"></param>
-    /// <param name="TempQltyInspectionGenRule">Filters are copied from the input, but will be replaced on output.</param>
-    /// <returns></returns>
+    /// <param name="CurrentRecursionDepth">Remaining recursion budget; decremented on each call to prevent infinite loops in circular configurations</param>
+    /// <param name="UseActivationFilter">When true, restricts rule matching to the activation trigger determined by IsManualCreation</param>
+    /// <param name="IsManualCreation">When UseActivationFilter is true, selects Manual-only or Automatic-only activation trigger filter</param>
+    /// <param name="TargetRecordRef">The source record to evaluate rules against; updated to the matched parent record on output when recursion finds the rule at a higher level</param>
+    /// <param name="OptionalItem">Optional Item used to evaluate Item Filter and Item Attribute Filter on generation rule candidates</param>
+    /// <param name="TempAvailableQltyInspectSourceConfig">Traversal set pre-populated by QltyTraversal.FindPossibleTargetsBasedOnConfigRecursive; filtered internally by To Table No. during recursive descent</param>
+    /// <param name="TempAlreadySearchedsQltyInspectSourceConfig">Visited set that prevents re-processing the same source configuration path across recursive calls</param>
+    /// <param name="OptionalSpecificTemplate">When non-empty, restricts rule matching to this template code</param>
+    /// <param name="TempQltyInspectionGenRule">Input: optional filters applied to the rule search. Output: the first matched generation rule record</param>
+    /// <returns>True if a matching generation rule was found at this level or any reachable parent level; False otherwise</returns>
     local procedure FindFirstGenerationRuleAndRecordBasedOnRecursive(CurrentRecursionDepth: Integer; UseActivationFilter: Boolean; IsManualCreation: Boolean; var TargetRecordRef: RecordRef; var OptionalItem: Record Item; var TempAvailableQltyInspectSourceConfig: Record "Qlty. Inspect. Source Config." temporary; var TempAlreadySearchedsQltyInspectSourceConfig: Record "Qlty. Inspect. Source Config." temporary; OptionalSpecificTemplate: Code[20]; var TempQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary) Found: Boolean
     var
         QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";

--- a/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyTraversal.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyTraversal.Codeunit.al
@@ -15,7 +15,18 @@ using Microsoft.Sales.Customer;
 using System.Reflection;
 
 /// <summary>
-/// Methods to assist with traversing records, connecting one record to another.
+/// Provides navigation and traversal services for the Quality Management source configuration graph.
+/// This codeunit is a shared infrastructure component used across Quality Management to navigate
+/// configured table relationships without applying business rule logic.
+/// Responsibilities include:
+/// - Traversing source configuration relationships to discover all reachable inspection targets
+/// - Navigating record hierarchies by following configured table field mappings in both directions
+/// - Applying source field values from originating documents to Quality Inspection Header records
+/// - Resolving dynamic control captions and visibility for the Inspection Header page
+/// - Locating related entities (Item, Vendor, Customer, Routing, BOM) from any source record variant
+/// This codeunit is intentionally separate from generation rule evaluation, which is handled in
+/// "Qlty. Inspec. Gen. Rule Mgmt." and other callers that consume this codeunit as a navigation service.
+/// If traversal is needed from a new context, add a call to this codeunit rather than duplicating logic.
 /// </summary>
 codeunit 20408 "Qlty. Traversal"
 {


### PR DESCRIPTION
Qlty. Traversal is a shared navigation service used in six different callers across Quality Management. The previous codeunit summaries did not communicate what each codeunit owned or why they are separate, leaving developers without guidance on which one to modify or call.

**QltyTraversal.Codeunit.al**

Replaced the one-line summary with an enumerated description of responsibilities: graph traversal to discover reachable inspection targets, bidirectional record navigation via configured field mappings, source field application to inspection headers, dynamic control caption and visibility resolution, and related entity lookup for Item, Vendor, Customer, Routing, and BOM. The summary states this codeunit is the navigation layer and is intentionally separate from business rule evaluation.

**QltyInspecGenRuleMgmt.Codeunit.al**

Updated the codeunit summary to state that generation rule evaluation is its responsibility and that source configuration graph traversal is delegated to Qlty. Traversal. Added developer guidance directing rule logic changes here and navigation or relationship changes to Qlty. Traversal.

Filled in all empty param and returns documentation on FindFirstGenerationRuleAndRecordBasedOnRecursive to document the two-phase contract: the caller pre-populates TempAvailableQltyInspectSourceConfig using QltyTraversal.FindPossibleTargetsBasedOnConfigRecursive, and this procedure then walks that set evaluating rule criteria at each level.

Closes #6555
