### PR TITLE
[Bug][SubscriptionBilling]: "Learn more" link in Subscription Billing Role Center uses long URL instead of short aka.ms link

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Base/Pages/SubBillingHeadlineRC.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Base/Pages/SubBillingHeadlineRC.Page.al
@@ -62,5 +62,5 @@ page 8086 "Sub. Billing Headline RC"
         RCHeadlinesPageCommon: Codeunit "RC Headlines Page Common";
         DefaultFieldsVisible: Boolean;
         UserGreetingVisible: Boolean;
-        DocumentationUrlTxt: Label 'https://learn.microsoft.com/en-us/dynamics365/business-central/srb/welcome';
+        DocumentationUrlTxt: Label 'https://aka.ms/bcsubscriptionbilling', Locked = true;
 }


### PR DESCRIPTION
fix: use aka.ms short link for Subscription Billing Role Center learn more URL

Replace the hardcoded full documentation URL with the canonical short redirect link (https://aka.ms/bcsubscriptionbilling) and lock the label to prevent accidental modification.

Using the aka.ms redirect is preferable as it is centrally managed - if the target documentation URL changes, only the redirect needs updating without requiring a code change.

Fixes #7977

Fixes [AB#634402](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634402)


