### PR TITLE
[Extensibility][SubscriptionBilling]: Add PostingDate parameter to OnBeforeReleaseCustomerContractDeferral and OnBeforeReleaseVendorContractDeferral integration events

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Deferrals/Reports/ContractDeferralsRelease.Report.al
+++ b/src/Apps/W1/Subscription Billing/App/Deferrals/Reports/ContractDeferralsRelease.Report.al
@@ -145,7 +145,7 @@ report 8051 "Contract Deferrals Release"
         PostingAmount: Decimal;
     begin
         ShouldRelease := true;
-        OnBeforeReleaseCustomerContractDeferral(CustomerContractDeferral, ShouldRelease);
+        OnBeforeReleaseCustomerContractDeferral(CustomerContractDeferral, ShouldRelease, PostingDate);
         if not ShouldRelease then begin
             UpdateWindow(CustomerContractDeferral."Subscription Contract No.");
             exit;
@@ -200,7 +200,7 @@ report 8051 "Contract Deferrals Release"
         PostingAmount: Decimal;
     begin
         ShouldRelease := true;
-        OnBeforeReleaseVendorContractDeferral(VendorContractDeferral, ShouldRelease);
+        OnBeforeReleaseVendorContractDeferral(VendorContractDeferral, ShouldRelease, PostingDate);
         if not ShouldRelease then begin
             UpdateWindow(VendorContractDeferral."Subscription Contract No.");
             exit;
@@ -414,12 +414,12 @@ report 8051 "Contract Deferrals Release"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeReleaseCustomerContractDeferral(var CustomerContractDeferral: Record "Cust. Sub. Contract Deferral"; var ShouldReleaseDeferral: Boolean)
+    local procedure OnBeforeReleaseCustomerContractDeferral(var CustomerContractDeferral: Record "Cust. Sub. Contract Deferral"; var ShouldReleaseDeferral: Boolean; PostingDate: Date)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeReleaseVendorContractDeferral(var VendorContractDeferral: Record "Vend. Sub. Contract Deferral"; var ShouldReleaseDeferral: Boolean)
+    local procedure OnBeforeReleaseVendorContractDeferral(var VendorContractDeferral: Record "Vend. Sub. Contract Deferral"; var ShouldReleaseDeferral: Boolean; PostingDate: Date)
     begin
     end;
 }


### PR DESCRIPTION
Fixes #7980

## Summary

Added `PostingDate` as a parameter to the `OnBeforeReleaseCustomerContractDeferral` and `OnBeforeReleaseVendorContractDeferral` integration events in `ContractDeferralsRelease.Report.al`.

Previously, subscribers had no way to access the posting date at the time these events were raised. The `PostingDate` is now exposed as a read-only parameter, allowing subscribers to act on or conditionally respond to the posting date as part of their event handling logic.

### Changed
- `OnBeforeReleaseCustomerContractDeferral(var CustomerContractDeferral, var ShouldReleaseDeferral)` ΓåÆ `(..., PostingDate: Date)`
- `OnBeforeReleaseVendorContractDeferral(var VendorContractDeferral, var ShouldReleaseDeferral)` ΓåÆ `(..., PostingDate: Date)`
Fixes [AB#634371](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634371)


