### PR TITLE
Bug 633225: [Subcontracting] Fix Copy Document incorrectly copying Subcontracting Location Code

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubcPurchaseHeaderExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubcPurchaseHeaderExt.Codeunit.al
@@ -6,6 +6,7 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
+using Microsoft.Utilities;
 
 codeunit 99001533 "Subc. Purchase Header Ext"
 {
@@ -22,5 +23,11 @@ codeunit 99001533 "Subc. Purchase Header Ext"
     local procedure OnAfterValidateEvent_BuyFromVendorNo(var Rec: Record "Purchase Header"; var xRec: Record "Purchase Header")
     begin
         SubcSynchronizeManagement.DeleteEnhancedDocumentsByChangeOfVendorNo(Rec, xRec);
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Copy Document Mgt.", OnAfterCopyPurchHeaderDone, '', false, false)]
+    local procedure ClearSubcLocationCodeOnAfterCopyPurchHeaderDone(var ToPurchaseHeader: Record "Purchase Header")
+    begin
+        ToPurchaseHeader."Subc. Location Code" := '';
     end;
 }

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -26,12 +26,14 @@ using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.Setup;
 using Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Manufacturing.WorkCenter;
+using Microsoft.Purchases.Archive;
 using Microsoft.Purchases.Comment;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
 using Microsoft.Purchases.Vendor;
 using Microsoft.Sales.Customer;
 using Microsoft.Sales.Document;
+using Microsoft.Utilities;
 using Microsoft.Warehouse.Document;
 using Microsoft.Warehouse.Structure;
 
@@ -2085,6 +2087,12 @@ Comment = '|%1 = Transfer Order No.';
         Reply := true;
     end;
 
+    [ConfirmHandler]
+    procedure ConfirmArchiveOrderHandler(Question: Text[1024]; var Reply: Boolean)
+    begin
+        Reply := true;
+    end;
+
     local procedure RemoveSubcontractingManagementSetupRecord()
     var
         SubcontractingManagementSetup: Record "Subc. Management Setup";
@@ -2416,6 +2424,79 @@ Comment = '|%1 = Transfer Order No.';
         Item.Validate("Overhead Rate", LibraryRandom.RandDec(5, 2));
         Item.Validate("Indirect Cost %", LibraryRandom.RandDec(5, 2));
         Item.Modify(true);
+    end;
+
+    [Test]
+    procedure CopyDocumentDoesNotCopySubcLocationCode()
+    var
+        FromPurchaseHeader: Record "Purchase Header";
+        ToPurchaseHeader: Record "Purchase Header";
+        Location: Record Location;
+        CopyPurchDoc: Report "Copy Purchase Document";
+    begin
+        // [SCENARIO 633225] Copy Document should not copy the Subcontracting Location Code to the new purchase order
+        Initialize();
+
+        // [GIVEN] A purchase order with Subcontracting Location Code set
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(Location);
+        LibraryPurchase.CreatePurchaseOrder(FromPurchaseHeader);
+        FromPurchaseHeader."Subc. Location Code" := Location.Code;
+        FromPurchaseHeader.Modify();
+
+        // [GIVEN] A new target purchase order for the same vendor
+        LibraryPurchase.CreatePurchHeader(ToPurchaseHeader, ToPurchaseHeader."Document Type"::Order, FromPurchaseHeader."Buy-from Vendor No.");
+
+        // [WHEN] Copy Document is used to copy the source order (IncludeHeader = true)
+        Clear(CopyPurchDoc);
+        CopyPurchDoc.SetParameters("Purchase Document Type From"::Order, FromPurchaseHeader."No.", true, false);
+        CopyPurchDoc.SetPurchHeader(ToPurchaseHeader);
+        CopyPurchDoc.UseRequestPage(false);
+        CopyPurchDoc.RunModal();
+
+        // [THEN] Subcontracting Location Code is not copied to the new purchase order
+        ToPurchaseHeader.Get(ToPurchaseHeader."Document Type", ToPurchaseHeader."No.");
+        Assert.AreEqual('', ToPurchaseHeader."Subc. Location Code", 'Subc. Location Code should not be copied by Copy Document');
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmArchiveOrderHandler,MessageHandler')]
+    procedure CopyDocumentFromArchiveDoesNotCopySubcLocationCode()
+    var
+        FromPurchaseHeader: Record "Purchase Header";
+        ToPurchaseHeader: Record "Purchase Header";
+        PurchaseHeaderArchive: Record "Purchase Header Archive";
+        Location: Record Location;
+        ArchiveManagement: Codeunit ArchiveManagement;
+        CopyDocumentMgt: Codeunit "Copy Document Mgt.";
+        FromDocNo: Code[20];
+    begin
+        // [SCENARIO 633225] Copy Document from archive should not copy the Subcontracting Location Code to the new purchase order
+        Initialize();
+
+        // [GIVEN] A purchase order with Subcontracting Location Code set
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(Location);
+        LibraryPurchase.CreatePurchaseOrder(FromPurchaseHeader);
+        FromPurchaseHeader."Subc. Location Code" := Location.Code;
+        FromPurchaseHeader.Modify();
+        FromDocNo := FromPurchaseHeader."No.";
+
+        // [GIVEN] The purchase order is archived
+        ArchiveManagement.ArchivePurchDocument(FromPurchaseHeader);
+
+        // [GIVEN] A new target purchase order for the same vendor
+        LibraryPurchase.CreatePurchHeader(ToPurchaseHeader, ToPurchaseHeader."Document Type"::Order, FromPurchaseHeader."Buy-from Vendor No.");
+
+        // [WHEN] Copy Document is used to copy from the archived order (IncludeHeader = true)
+        PurchaseHeaderArchive.SetRange("Document Type", FromPurchaseHeader."Document Type");
+        PurchaseHeaderArchive.SetRange("No.", FromDocNo);
+        PurchaseHeaderArchive.FindFirst();
+        CopyDocumentMgt.SetProperties(true, false, false, false, false, false, false);
+        CopyDocumentMgt.SetArchDocVal(PurchaseHeaderArchive."Doc. No. Occurrence", PurchaseHeaderArchive."Version No.");
+        CopyDocumentMgt.CopyPurchDoc("Purchase Document Type From"::"Arch. Order", FromDocNo, ToPurchaseHeader);
+
+        // [THEN] Subcontracting Location Code is not copied to the new purchase order
+        ToPurchaseHeader.Get(ToPurchaseHeader."Document Type", ToPurchaseHeader."No.");
+        Assert.AreEqual('', ToPurchaseHeader."Subc. Location Code", 'Subc. Location Code should not be copied from archive by Copy Document');
     end;
 
     local procedure Initialize()


### PR DESCRIPTION
## Summary
- When using **Copy Document** on a subcontracting purchase order, the `Subc. Location Code` field was incorrectly copied to the new purchase order.
- Root cause: `CopyDocumentMgt.CopyPurchHeaderFromPurchHeader` calls `TransferFields(FromPurchHeader, false)`, which copies **all** fields including extension fields like `Subc. Location Code`.
- Fix: Subscribe to `OnAfterCopyPurchHeaderDone` (fires after all header-copy paths in `Copy Document Mgt.`) and clear `ToPurchaseHeader."Subc. Location Code"` on the target document.

## Test plan
- [x] `CopyDocumentDoesNotCopySubcLocationCode` — copies a live purchase order with `Subc. Location Code` set; asserts field is blank on target (codeunit 139989)
- [x] `CopyDocumentFromArchiveDoesNotCopySubcLocationCode` — archives a purchase order with `Subc. Location Code` set, then copies from archive; asserts field is blank on target (codeunit 139989)
- [x] Both tests pass on W1

Fixes [AB#633225](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633225)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



