### PR TITLE
Fix AA0137: Remove unused variables in multi-var declarations

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Document/Inbound/InboundEDocFactbox.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Document/Inbound/InboundEDocFactbox.Page.al
@@ -137,7 +137,7 @@ page 6108 "Inbound E-Doc. Factbox"
 #endif
 
     var
-        ImportProcessingStatusVisible, Visible : Boolean;
+        ImportProcessingStatusVisible: Boolean;
         EDocSystemCreatedAt: DateTime;
         EDocSystemCreatedBy: Text;
 

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseDraft.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseDraft.Page.al
@@ -773,7 +773,7 @@ page 6181 "E-Document Purchase Draft"
         EDocumentProcessing: Codeunit "E-Document Processing";
         FeatureTelemetry: Codeunit "Feature Telemetry";
         GlobalEDocumentHelper: Codeunit "E-Document Helper";
-        RecordLinkTxt, StyleStatusTxt, DataCaption: Text;
+        RecordLinkTxt, StyleStatusTxt, DataCaption : Text;
         HasErrorsOrWarnings, HasErrors : Boolean;
         ShowFinalizeDraftAction: Boolean;
         ShowAnalyzeDocumentAction: Boolean;

--- a/src/Apps/W1/EDocument/Test/src/Mock/EDocImplState.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Mock/EDocImplState.Codeunit.al
@@ -21,7 +21,7 @@ codeunit 139630 "E-Doc. Impl. State"
         PurchDocTestBuffer: Codeunit "E-Doc. Test Buffer";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         EnableOnCheck, DisableOnCreateOutput, DisableOnCreateBatch, IsAsync2, EnableHttpData, ThrowIntegrationRuntimeError, ThrowIntegrationLoggedError : Boolean;
-        ThrowRuntimeError, ThrowLoggedError, ThrowBasicInfoError, ThrowCompleteInfoError, OnGetResponseSuccess, OnGetApprovalSuccess, ActionHasUpdate : Boolean;
+        ThrowRuntimeError, ThrowLoggedError, ThrowBasicInfoError, ThrowCompleteInfoError, OnGetResponseSuccess, ActionHasUpdate : Boolean;
         LocalHttpResponse: HttpResponseMessage;
         ActionStatus: Enum "E-Document Service Status";
 

--- a/src/Apps/W1/EDocument/Test/src/Mock/EDocImplState.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Mock/EDocImplState.Codeunit.al
@@ -22,6 +22,9 @@ codeunit 139630 "E-Doc. Impl. State"
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         EnableOnCheck, DisableOnCreateOutput, DisableOnCreateBatch, IsAsync2, EnableHttpData, ThrowIntegrationRuntimeError, ThrowIntegrationLoggedError : Boolean;
         ThrowRuntimeError, ThrowLoggedError, ThrowBasicInfoError, ThrowCompleteInfoError, OnGetResponseSuccess, ActionHasUpdate : Boolean;
+#if not CLEAN26
+        OnGetApprovalSuccess: Boolean;
+#endif
         LocalHttpResponse: HttpResponseMessage;
         ActionStatus: Enum "E-Document Service Status";
 


### PR DESCRIPTION
#### Summary 
The AL compiler bug fix (BC-DeveloperExperience PR #7928) now correctly triggers AA0137 for individual unused variables in comma-separated multi-line declarations. Since NAV treats warnings as errors, these previously-undetected unused variables now break builds.


Fixes [AB#629344](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/629344)






