### PR TITLE
Bug 634126: [Subcontracting] Move Labels to global scope and remove underscores from procedure names

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Install/SubcBusinessSetupExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Install/SubcBusinessSetupExt.Codeunit.al
@@ -9,13 +9,15 @@ using System.Environment.Configuration;
 
 codeunit 99001502 "Subc. Business Setup Ext."
 {
+    var
+        SubcontractingDescriptionLbl: Label 'Make manual Subcontracting Setup';
+        SubcontractingKeyWordsLbl: Label 'Subcontracting, Management';
+        SubcontractingLbl: Label 'Subcontracting App';
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Guided Experience", OnRegisterManualSetup, '', false, false)]
     local procedure OnRegisterManualSetup(sender: Codeunit "Guided Experience")
     var
         ManualSetupCategory: Enum "Manual Setup Category";
-        SubcontractingDescriptionLbl: Label 'Make manual Subcontracting Setup';
-        SubcontractingKeyWordsLbl: Label 'Subcontracting, Management';
-        SubcontractingLbl: Label 'Subcontracting App';
     begin
         sender.InsertManualSetup(SubcontractingLbl, SubcontractingLbl, SubcontractingDescriptionLbl, 0, ObjectType::Page, Page::"Subc. Management Setup", ManualSetupCategory::Uncategorized, SubcontractingKeyWordsLbl);
     end;

--- a/src/Apps/W1/Subcontracting/App/src/Install/SubcontractingCompInit.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Install/SubcontractingCompInit.Codeunit.al
@@ -8,6 +8,13 @@ using Microsoft.Inventory.Requisition;
 
 codeunit 99001503 "Subcontracting Comp. Init."
 {
+    var
+        ReqWkshTempDescLbl: Label 'Subcontracting', MaxLength = 80;
+        ReqWkshTempNameLbl: Label 'SUBCONTR', MaxLength = 10;
+        ReqWkshDescLbl: Label 'Subcontracting', MaxLength = 100;
+        ReqWkshNameLbl: Label 'SUBCONTR', MaxLength = 10;
+        DefaultInboundWhseHandlingTimeLbl: Label '<1D>', Locked = true;
+
     procedure CreateBasicSubcontractingMgtSetup()
     begin
         CreateSubcontractingManagementSetup();
@@ -38,9 +45,6 @@ codeunit 99001503 "Subcontracting Comp. Init."
     end;
 
     procedure CreateReqWkshTemplate(var ReqWkshTemplate: Record "Req. Wksh. Template"; Recurring: Boolean)
-    var
-        ReqWkshTempDescLbl: Label 'Subcontracting', MaxLength = 80;
-        ReqWkshTempNameLbl: Label 'SUBCONTR', MaxLength = 10;
     begin
         ReqWkshTemplate.SetRange(Type, ReqWkshTemplate.Type::Subcontracting);
         if ReqWkshTemplate.FindFirst() then
@@ -56,9 +60,6 @@ codeunit 99001503 "Subcontracting Comp. Init."
     end;
 
     procedure CreateRequisitionWkshName(var RequisitionWkshName: Record "Requisition Wksh. Name"; WorksheetTemplateName: Text)
-    var
-        ReqWkshDescLbl: Label 'Subcontracting', MaxLength = 100;
-        ReqWkshNameLbl: Label 'SUBCONTR', MaxLength = 10;
     begin
         RequisitionWkshName.SetRange("Worksheet Template Name", WorksheetTemplateName);
         if RequisitionWkshName.FindFirst() then
@@ -72,8 +73,6 @@ codeunit 99001503 "Subcontracting Comp. Init."
     end;
 
     local procedure GetDefaultInboundWhseHandlingTime(): Text
-    var
-        DefaultInboundWhseHandlingTimeLbl: Label '<1D>', Locked = true;
     begin
         exit(DefaultInboundWhseHandlingTimeLbl);
     end;

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcPlanningCompExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcPlanningCompExt.Codeunit.al
@@ -62,7 +62,7 @@ codeunit 99001522 "Subc. Planning Comp. Ext."
             PlanningRoutingLine.SetRange(Type, PlanningRoutingLine.Type::"Work Center");
             if PlanningRoutingLine.FindFirst() then
                 if SubcontractingManagement.GetSubcontractor(PlanningRoutingLine."No.", Vendor) then
-                    SubcontractingManagement.ChangeLocation_OnPlanningComponent(PlanningComponent, Vendor."Subcontr. Location Code", PlanningComponent."Orig. Location Code", PlanningComponent."Orig. Bin Code");
+                    SubcontractingManagement.ChangeLocationOnPlanningComponent(PlanningComponent, Vendor."Subcontr. Location Code", PlanningComponent."Orig. Location Code", PlanningComponent."Orig. Bin Code");
         end else
             if xPlanningComponent."Routing Link Code" <> '' then
                 if PlanningComponent."Orig. Location Code" <> '' then begin

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcProdOrderCompExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcProdOrderCompExt.Codeunit.al
@@ -15,6 +15,12 @@ using System.Utilities;
 
 codeunit 99001524 "Subc. Prod. Order Comp. Ext."
 {
+    var
+        ExistingPostedTransferLineQst: Label 'The component has already been assigned to the posted subcontracting transfer order %1.\\Do you want to continue?', Comment = '%1=Transfer Order No';
+        ExistingPurchLineErr: Label 'You cannot change this field because the component is already assigned to subcontracting purchase order %1.\\Updating the quantity is only allowed through the purchase order.', Comment = '%1=Document No';
+        ExistingTransferLineQst: Label 'The component has already been assigned to the subcontracting transfer order %1.\\The quantity may only be updated via the purchase order and processing of the stock transfer.', Comment = '%1=Transfer Order No';
+        ExistingTransferLineErr: Label 'You cannot open Tracking Specification because this component is already specified in Transfer Order %1.', Comment = '%1=Document No.';
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Prod. Order Comp.-Reserve", OnAfterInitFromProdOrderComp, '', false, false)]
     local procedure OnAfterInitFromProdOrderComp(ProdOrderComponent: Record "Prod. Order Component")
     begin
@@ -65,7 +71,6 @@ codeunit 99001524 "Subc. Prod. Order Comp. Ext."
     var
         TransferShipmentLine: Record "Transfer Shipment Line";
         ConfirmManagement: Codeunit "Confirm Management";
-        ExistingTransferLineQst: Label 'The component has already been assigned to the posted subcontracting transfer order %1.\\Do you want to continue?', Comment = '%1=Transfer Order No';
     begin
         if ProdOrderComponent."Subcontracting Type" <> "Subcontracting Type"::Transfer then
             exit;
@@ -77,7 +82,7 @@ codeunit 99001524 "Subc. Prod. Order Comp. Ext."
         if not TransferShipmentLine.IsEmpty() then begin
             TransferShipmentLine.SetLoadFields(SystemId);
             TransferShipmentLine.FindFirst();
-            if not ConfirmManagement.GetResponse(StrSubstNo(ExistingTransferLineQst, TransferShipmentLine."Document No.")) then
+            if not ConfirmManagement.GetResponse(StrSubstNo(ExistingPostedTransferLineQst, TransferShipmentLine."Document No.")) then
                 Error('');
         end;
     end;
@@ -101,7 +106,6 @@ codeunit 99001524 "Subc. Prod. Order Comp. Ext."
     var
         PurchaseLine: Record "Purchase Line";
         TempPurchaseLine: Record "Purchase Line" temporary;
-        ExistingPurchLineErr: Label 'You cannot change this field because the component is already assigned to subcontracting purchase order %1.\\Updating the quantity is only allowed through the purchase order.', Comment = '%1=Document No';
     begin
         if ProdOrderComponent."Subcontracting Type" <> ProdOrderComponent."Subcontracting Type"::Purchase then
             exit;
@@ -132,7 +136,6 @@ codeunit 99001524 "Subc. Prod. Order Comp. Ext."
     local procedure CheckExistingSubcontractingTransferOrder(var ProdOrderComponent: Record "Prod. Order Component"; var xProdOrderComponent: Record "Prod. Order Component"; CurrFieldNo: Integer)
     var
         TransferLine: Record "Transfer Line";
-        ExistingTransferLineQst: Label 'The component has already been assigned to the subcontracting transfer order %1.\\The quantity may only be updated via the purchase order and processing of the stock transfer.', Comment = '%1=Transfer Order No';
     begin
         if CurrFieldNo = 0 then
             exit;
@@ -233,7 +236,6 @@ codeunit 99001524 "Subc. Prod. Order Comp. Ext."
     local procedure ValidateSubcontractingReservationConstraints(var ProdOrderComponent: Record "Prod. Order Component")
     var
         TransferLine: Record "Transfer Line";
-        ExistingTransferLineErr: Label 'You cannot open Tracking Specification because this component is already specified in Transfer Order %1.', Comment = '%1=Document No.';
     begin
         if not CheckIfProdOrderCompIsInSubcontractingOrder(ProdOrderComponent) then
             exit;

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcProdOrderCompExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcProdOrderCompExt.Codeunit.al
@@ -274,7 +274,7 @@ codeunit 99001524 "Subc. Prod. Order Comp. Ext."
                 ProdOrderComponent."Due Time" := ProdOrderRoutingLine."Starting Time";
                 if (ProdOrderRoutingLine.Type = ProdOrderRoutingLine.Type::"Work Center") then
                     if SubcontractingManagement.GetSubcontractor(ProdOrderRoutingLine."No.", Vendor) then
-                        SubcontractingManagement.ChangeLocation_OnProdOrderComponent(ProdOrderComponent, Vendor."Subcontr. Location Code", ProdOrderComponent."Orig. Location Code", ProdOrderComponent."Orig. Bin Code");
+                        SubcontractingManagement.ChangeLocationOnProdOrderComponent(ProdOrderComponent, Vendor."Subcontr. Location Code", ProdOrderComponent."Orig. Location Code", ProdOrderComponent."Orig. Bin Code");
             end;
         end else
             if xProdOrderComponent."Routing Link Code" <> '' then

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubcPurchaseHeaderExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubcPurchaseHeaderExt.Codeunit.al
@@ -19,7 +19,7 @@ codeunit 99001533 "Subc. Purchase Header Ext"
     end;
 
     [EventSubscriber(ObjectType::Table, Database::"Purchase Header", OnAfterValidateEvent, "Buy-from Vendor No.", false, false)]
-    local procedure OnAfterValidateEvent_BuyFromVendorNo(var Rec: Record "Purchase Header"; var xRec: Record "Purchase Header")
+    local procedure OnAfterValidateEventBuyFromVendorNo(var Rec: Record "Purchase Header"; var xRec: Record "Purchase Header")
     begin
         SubcSynchronizeManagement.DeleteEnhancedDocumentsByChangeOfVendorNo(Rec, xRec);
     end;

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubcPurchaseLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubcPurchaseLineExt.Codeunit.al
@@ -20,6 +20,10 @@ codeunit 99001534 "Subc. Purchase Line Ext"
         Comment = '%1 = PurchaseLine Outstanding Qty, %2 = Tablecaption PurchaseLine, %3 = ProdOrderLine Remaining Qty, %4 = Tablecaption ProdOrderLine, %5 = Current ProdOrderLine Qty, %6 = New PurchaseLine Qty';
         NotLastOperationLineErr: Label 'Item tracking lines can only be viewed for subcontracting purchase lines which are linked to a routing line which is the last operation.';
         CannotOpenProductionOrderErr: Label 'Cannot open Production Order %1.', Comment = '%1=Production Order No.';
+        ChangeVariantNoNotAllowedErr: Label 'You cannot change %1 because the order line is associated with production order %2.', Comment = '%1=Field Caption, %2=Production Order No.';
+        ShowProductionOrderActionLbl: Label 'Show Prod. Order';
+        AdjustQtyActionLbl: Label 'Adjust Quantity';
+        OpenItemTrackingAnywayActionLbl: Label 'Open anyway';
 
     [EventSubscriber(ObjectType::Table, Database::"Purchase Line", OnAfterDeleteEvent, '', false, false)]
     local procedure OnAfterDeleteEvent(var Rec: Record "Purchase Line"; RunTrigger: Boolean)
@@ -77,8 +81,6 @@ codeunit 99001534 "Subc. Purchase Line Ext"
 
     [EventSubscriber(ObjectType::Table, Database::"Purchase Line", OnValidateVariantCodeOnBeforeDropShipmentError, '', false, false)]
     local procedure OnValidateVariantCodeOnBeforeDropShipmentError(PurchaseLine: Record "Purchase Line"; var IsHandled: Boolean)
-    var
-        ChangeVariantNoNotAllowedErr: Label 'You cannot change %1 because the order line is associated with production order %2.', Comment = '%1=Field Caption, %2=Production Order No.';
     begin
         if PurchaseLine."Prod. Order No." <> '' then
             Error(ChangeVariantNoNotAllowedErr, PurchaseLine.FieldCaption(PurchaseLine."Variant Code"), PurchaseLine."Prod. Order No.");
@@ -114,9 +116,6 @@ codeunit 99001534 "Subc. Purchase Line Ext"
 
     local procedure CheckOverDeliveryQty(PurchaseLine: Record "Purchase Line"; ProdOrderLine: Record "Prod. Order Line")
     var
-        ShowProductionOrderActionLbl: Label 'Show Prod. Order';
-        AdjustQtyActionLbl: Label 'Adjust Quantity';
-        OpenItemTrackingAnywayActionLbl: Label 'Open anyway';
         CannotInvoiceErrorInfo: ErrorInfo;
     begin
         if PurchaseLine.Quantity > ProdOrderLine.Quantity then begin

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcCrPurchSubconYesNo.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcCrPurchSubconYesNo.Codeunit.al
@@ -11,10 +11,13 @@ codeunit 99001509 "Subc. CrPurchSubcon(Yes/No)"
 {
     TableNo = "Purchase Line";
 
+    var
+        NothingToCreateErr: Label 'There is nothing to create.';
+        PostConfirmQst: Label 'Do you want to create a production order from %1, %2 line no. %3?', Comment = '%1=Document Type, %2=Document No., %3=Line No.';
+
     trigger OnRun()
     var
         PurchaseLine: Record "Purchase Line";
-        NothingToCreateErr: Label 'There is nothing to create.';
     begin
         if not Rec.Find() then
             Error(NothingToCreateErr);
@@ -53,7 +56,6 @@ codeunit 99001509 "Subc. CrPurchSubcon(Yes/No)"
     local procedure ConfirmCreateProductionOrder(var PurchaseLine: Record "Purchase Line"): Boolean
     var
         ConfirmManagement: Codeunit "Confirm Management";
-        PostConfirmQst: Label 'Do you want to create a production order from %1, %2 line no. %3?', Comment = '%1=Document Type, %2=Document No., %3=Line No.';
     begin
         if not ConfirmManagement.GetResponse(StrSubstNo(PostConfirmQst, Format(PurchaseLine."Document Type"), PurchaseLine."Document No.", PurchaseLine."Line No."), true) then
             exit(false);

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcNotificationMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcNotificationMgmt.Codeunit.al
@@ -8,6 +8,12 @@ using System.Environment.Configuration;
 
 codeunit 99001506 "Subc. Notification Mgmt."
 {
+    var
+        ProdOrdNotificationDescriptionTxt: Label 'Show a notification if Production Orders were created for Subcontracting.';
+        ProdOrdNotificationNameLbl: Label 'Show Created Production Orders';
+        SubcOrdNotificationDescriptionTxt: Label 'Show a notification if Subcontracting Orders were created for Subcontracting.';
+        SubcOrdNotificationNameLbl: Label 'Show Created Subcontracting Orders';
+
     procedure ShowCreatedProductionOrderConfirmationMessageCode(): Code[50]
     begin
         exit(UpperCase(GetShowCreatedProductionOrderCode()));
@@ -38,19 +44,15 @@ codeunit 99001506 "Subc. Notification Mgmt."
     local procedure RegisterSubcontrProductionOrderCreatedNotification()
     var
         MyNotifications: Record "My Notifications";
-        MyNotificationsDescriptionTxt: Label 'Show a notification if Production Orders were created for Subcontracting.';
-        MyNotificationsNameLbl: Label 'Show Created Production Orders';
     begin
-        MyNotifications.InsertDefault(GetGuidProductionOrderCreatedNotification(), MyNotificationsNameLbl, MyNotificationsDescriptionTxt, true);
+        MyNotifications.InsertDefault(GetGuidProductionOrderCreatedNotification(), ProdOrdNotificationNameLbl, ProdOrdNotificationDescriptionTxt, true);
     end;
 
     local procedure RegisterSubcontrPurchOrderCreatedNotification()
     var
         MyNotifications: Record "My Notifications";
-        MyNotificationsDescriptionTxt: Label 'Show a notification if Subcontracting Orders were created for Subcontracting.';
-        MyNotificationsNameLbl: Label 'Show Created Subcontracting Orders';
     begin
-        MyNotifications.InsertDefault(GetGuidSubcontractingPOCreatedNotification(), MyNotificationsNameLbl, MyNotificationsDescriptionTxt, true);
+        MyNotifications.InsertDefault(GetGuidSubcontractingPOCreatedNotification(), SubcOrdNotificationNameLbl, SubcOrdNotificationDescriptionTxt, true);
     end;
 
     procedure DisableNotification(var NotificationVar: Notification)

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchFactboxMgmt.Codeunit.al
@@ -15,6 +15,10 @@ using System.Reflection;
 
 codeunit 99001560 "Subc. Purch. Factbox Mgmt."
 {
+    var
+        MultipleLbl: Label 'Multiple', MaxLength = 20;
+        NoTransferExistsMsg: Label 'No transfer order exists for this purchase order.';
+
     /// <summary>
     /// Opens the Purchase Order page for the subcontracting purchase order linked to the given variant record.
     /// </summary>
@@ -65,7 +69,6 @@ codeunit 99001560 "Subc. Purch. Factbox Mgmt."
         PurchOrderNo: Code[20];
         NoOfTransferOrders: Integer;
         PurchOrderLineNo: Integer;
-        MultipleLbl: Label 'Multiple', MaxLength = 20;
     begin
         if not GetPurchaseOrderNoByVariant(RecRelatedVariant, PurchOrderNo, PurchOrderLineNo) then
             exit('');
@@ -228,7 +231,6 @@ codeunit 99001560 "Subc. Purch. Factbox Mgmt."
         TransferLine: Record "Transfer Line";
         DataTypeManagement: Codeunit "Data Type Management";
         RecRef: RecordRef;
-        NoTransferExistsMsg: Label 'No transfer order exists for this purchase order.';
     begin
         if not RecRelatedVariant.IsRecord() then
             exit;

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcontractingManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcontractingManagement.Codeunit.al
@@ -46,7 +46,7 @@ codeunit 99001505 "Subcontracting Management"
         exit(ReceiptDate);
     end;
 
-    procedure ChangeLocation_OnProdOrderComponent(var ProdOrderComponent: Record "Prod. Order Component"; VendorSubcontrLocation: Code[10]; OriginalLocationCode: Code[10]; OriginalBinCode: Code[20])
+    procedure ChangeLocationOnProdOrderComponent(var ProdOrderComponent: Record "Prod. Order Component"; VendorSubcontrLocation: Code[10]; OriginalLocationCode: Code[10]; OriginalBinCode: Code[20])
     begin
         case ProdOrderComponent."Subcontracting Type" of
             "Subcontracting Type"::InventoryByVendor,
@@ -69,7 +69,7 @@ codeunit 99001505 "Subcontracting Management"
         end;
     end;
 
-    procedure ChangeLocation_OnPlanningComponent(var PlanningComponent: Record "Planning Component"; VendorSubcontrLocation: Code[10]; OriginalLocationCode: Code[10]; OriginalBinCode: Code[20])
+    procedure ChangeLocationOnPlanningComponent(var PlanningComponent: Record "Planning Component"; VendorSubcontrLocation: Code[10]; OriginalLocationCode: Code[10]; OriginalBinCode: Code[20])
     begin
         case PlanningComponent."Subcontracting Type" of
             "Subcontracting Type"::InventoryByVendor,
@@ -377,7 +377,7 @@ codeunit 99001505 "Subcontracting Management"
     begin
         if ProdOrderComponent.Get("Production Order Status"::Released, TransferLine."Prod. Order No.", TransferLine."Prod. Order Line No.", TransferLine."Prod. Order Comp. Line No.") then
             if ProdOrderComponent."Orig. Location Code" <> '' then begin
-                ChangeLocation_OnProdOrderComponent(ProdOrderComponent, '', ProdOrderComponent."Orig. Location Code", ProdOrderComponent."Orig. Bin Code");
+                ChangeLocationOnProdOrderComponent(ProdOrderComponent, '', ProdOrderComponent."Orig. Location Code", ProdOrderComponent."Orig. Bin Code");
                 ProdOrderComponent."Orig. Location Code" := '';
                 ProdOrderComponent."Orig. Bin Code" := '';
 
@@ -411,7 +411,7 @@ codeunit 99001505 "Subcontracting Management"
             OrigLocationCode := PlanningComponent."Orig. Location Code";
             OrigBinCode := PlanningComponent."Orig. Bin Code";
 
-            ChangeLocation_OnPlanningComponent(PlanningComponent, VendorSubcontractingLocationCode, OrigLocationCode, OrigBinCode);
+            ChangeLocationOnPlanningComponent(PlanningComponent, VendorSubcontractingLocationCode, OrigLocationCode, OrigBinCode);
 
             PlanningComponent.Modify();
         end;
@@ -469,7 +469,7 @@ codeunit 99001505 "Subcontracting Management"
                 OrigLocationCode := ProdOrderComponent."Orig. Location Code";
                 OrigBinCode := ProdOrderComponent."Orig. Bin Code";
 
-                ChangeLocation_OnProdOrderComponent(ProdOrderComponent, VendorSubcontractingLocationCode, OrigLocationCode, OrigBinCode);
+                ChangeLocationOnProdOrderComponent(ProdOrderComponent, VendorSubcontractingLocationCode, OrigLocationCode, OrigBinCode);
 
                 ProdOrderComponent.Modify();
             end;
@@ -504,7 +504,7 @@ codeunit 99001505 "Subcontracting Management"
                     OrigLocationCode := ProdOrderComponent."Orig. Location Code";
                     OrigBinCode := ProdOrderComponent."Orig. Bin Code";
 
-                    ChangeLocation_OnProdOrderComponent(ProdOrderComponent, VendorSubcontractingLocationCode, OrigLocationCode, OrigBinCode);
+                    ChangeLocationOnProdOrderComponent(ProdOrderComponent, VendorSubcontractingLocationCode, OrigLocationCode, OrigBinCode);
 
                     ProdOrderComponent.Modify();
                 until ProdOrderComponent.Next() = 0;

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcontractingManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcontractingManagement.Codeunit.al
@@ -28,6 +28,12 @@ codeunit 99001505 "Subcontracting Management"
         SubcManagementSetup: Record "Subc. Management Setup";
         TempGlobalReservationEntry: Record "Reservation Entry" temporary;
         HasSubManagementSetup: Boolean;
+        RoutingLinkUpdConfQst: Label 'If you change the Work Center, you will also change the default location for components with Routing Link Code=%1.\Do you want to continue anyway?', Comment = '%1=Routing Link Code';
+        SuccessfullyUpdatedMsg: Label 'Successfully updated.';
+        UpdateIsCancelledErr: Label 'Update cancelled.';
+        UpdateIsCanceledErr: Label 'The update is canceled.';
+        WorkCenterVendorDoesntExistErr: Label 'Subcontractor %1 on Work Center %2 does not exist.', Comment = 'Parameter %1 - subcontractor/vendor number, %2 - work center number.';
+        PurchOrderExistErr: Label 'The currently selected component %1 is already used in Purchase Order %2. Therefore, it is not permitted to change the %3 field.', Comment = '%1=Item No, %2=Purchase Order No, %3=Field Caption';
 
     procedure CalcReceiptDateFromProdCompDueDateWithInbWhseHandlingTime(ProdOrderComponent: Record "Prod. Order Component") ReceiptDate: Date
     begin
@@ -131,9 +137,6 @@ codeunit 99001505 "Subcontracting Management"
         StockkeepingUnit: Record "Stockkeeping Unit";
         ConfirmManagement: Codeunit "Confirm Management";
         PlanningGetParameters: Codeunit "Planning-Get Parameters";
-        RoutingLinkUpdConfQst: Label 'If you change the Work Center, you will also change the default location for components with Routing Link Code=%1.\Do you want to continue anyway?', Comment = '%1=Routing Link Code';
-        SuccessfullyUpdatedMsg: Label 'Successfully updated.';
-        UpdateIsCancelledErr: Label 'Update cancelled.';
     begin
 
         ProdOrderComponent.SetRange(Status, ProdOrderRoutingLine.Status);
@@ -172,8 +175,6 @@ codeunit 99001505 "Subcontracting Management"
     var
         WorkCenter: Record "Work Center";
         HasSubcontractor, IsHandled : Boolean;
-        WorkCenterVendorDoesntExistErr: Label 'Subcontractor %1 on Work Center %2 does not exist.',
-            Comment = 'Parameter %1 - subcontractor/vendor number, %2 - work center number.';
     begin
         OnBeforeGetSubcontractor(WorkCenterNo, Vendor, HasSubcontractor, IsHandled);//DO NOT DELETE
         if IsHandled then
@@ -427,7 +428,6 @@ codeunit 99001505 "Subcontracting Management"
         OrigLocationCode, VendorSubcontractingLocationCode : Code[10];
         OrigBinCode: Code[20];
         PurchOrderNo: Code[20];
-        PurchOrderExistErr: Label 'The currently selected component %1 is already used in Purchase Order %2. Therefore, it is not permitted to change the %3 field.', Comment = '%1=Item No, %2=Purchase Order No, %3=Field Caption';
     begin
         if ProdOrderComponent."Routing Link Code" = '' then
             exit;
@@ -484,9 +484,6 @@ codeunit 99001505 "Subcontracting Management"
         Subcontracting: Boolean;
         OrigLocationCode, VendorSubcontractingLocationCode : Code[10];
         OrigBinCode: Code[20];
-        RoutingLinkUpdConfQst: Label 'If you change the Work Center, you will also change the default location for components with Routing Link Code=%1.\Do you want to continue anyway?', Comment = '%1=Routing Link Code';
-        SuccessfullyUpdatedMsg: Label 'Successfully updated.';
-        UpdateIsCancelledErr: Label 'The update is canceled.';
     begin
         ProdOrderComponent.SetRange(Status, ProdOrderRoutingLine.Status);
         ProdOrderComponent.SetRange("Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
@@ -500,7 +497,7 @@ codeunit 99001505 "Subcontracting Management"
                 VendorSubcontractingLocationCode := Vendor."Subcontr. Location Code";
                 if ShowMsg then
                     if not ConfirmManagement.GetResponseOrDefault(StrSubstNo(RoutingLinkUpdConfQst, ProdOrderRoutingLine."Routing Link Code"), true) then
-                        Error(UpdateIsCancelledErr);
+                        Error(UpdateIsCanceledErr);
                 repeat
                     if not (ProdOrderComponent."Subcontracting Type" in ["Subcontracting Type"::InventoryByVendor, "Subcontracting Type"::Purchase]) then
                         Clear(VendorSubcontractingLocationCode);

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcProdOrderRtng.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcProdOrderRtng.PageExt.al
@@ -55,7 +55,6 @@ pageextension 99001503 "Subc. Prod. Order Rtng." extends "Prod. Order Routing"
                     PurchaseLine: Record "Purchase Line";
                     SubcPurchaseOrderCreator: Codeunit "Subc. Purchase Order Creator";
                     NoOfCreatedPurchOrder: Integer;
-                    NoPurchOrderCreatedMsg: Label 'No subcontracting order was created for the selected operations in production order %1. Please check whether the operation or operations have already been completed.', Comment = '%1=Production Order No.';
                 begin
                     CurrPage.SetSelectionFilter(ProdOrderRoutingLine);
                     ProdOrderRoutingLine.FindSet();
@@ -83,4 +82,7 @@ pageextension 99001503 "Subc. Prod. Order Rtng." extends "Prod. Order Routing"
             }
         }
     }
+
+    var
+        NoPurchOrderCreatedMsg: Label 'No subcontracting order was created for the selected operations in production order %1. Please check whether the operation or operations have already been completed.', Comment = '%1=Production Order No.';
 }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Purchase/SubcPOSubform.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Purchase/SubcPOSubform.PageExt.al
@@ -91,9 +91,11 @@ pageextension 99001524 "Subc. PO Subform" extends "Purchase Order Subform"
             }
         }
     }
+
     var
         SubcProdOrderFactboxMgmt: Codeunit "Subc. ProdO. Factbox Mgmt.";
         SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
+        OpenCreatedTransferOrderQst: Label 'The production order %1 was created from the current purchase order.\\Would you like to open the production order?', Comment = '%1=Production Order No.';
 
     local procedure CreateProductionOrder(CreatingCodeunitID: Integer; ShowCreatedDocument: Boolean)
     var
@@ -125,7 +127,6 @@ pageextension 99001524 "Subc. PO Subform" extends "Purchase Order Subform"
         InstructionMgt: Codeunit "Instruction Mgt.";
         PageManagement: Codeunit "Page Management";
         SubcNotificationMgmt: Codeunit "Subc. Notification Mgmt.";
-        OpenCreatedTransferOrderQst: Label 'The production order %1 was created from the current purchase order.\\Would you like to open the production order?', Comment = '%1=Production Order No.';
     begin
         ProductionOrder.SetRange(Status, "Production Order Status"::Released);
         ProductionOrder.SetRange("No.", Rec."Prod. Order No.");

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pages/SubcontractorPrices.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pages/SubcontractorPrices.Page.al
@@ -253,6 +253,7 @@ page 99001500 "Subcontractor Prices"
         MultipleWorkCenterSelectedErr: Label 'More than one work center uses these subcontractor prices. To copy prices, the Vendor No. Filter field must contain one vendor only.';
         NoDataWithinFilterErr: Label 'There is no %1 within the filter %2.',
             Comment = '@@@=%1: Field(Code), %2: GetFilter(Code)';
+        PlaceholderLbl: Label '%1 %2 %3 %4 ', Locked = true;
         ItemNoFilter: Text;
         StandardTaskCodeFilter: Text;
         StartingDateFilter: Text;
@@ -308,7 +309,6 @@ page 99001500 "Subcontractor Prices"
     local procedure GetCaption(): Text
     var
         ObjectTranslation: Record "Object Translation";
-        PlaceholderLbl: Label '%1 %2 %3 %4 ', Locked = true;
         Description: Text[100];
         SourceTableName: Text[250];
     begin

--- a/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Codeunits/SubcTempDataInitializer.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Codeunits/SubcTempDataInitializer.Codeunit.al
@@ -32,6 +32,13 @@ codeunit 99001552 "Subc. Temp Data Initializer"
         SubcVersionMgmt: Codeunit "Subc. Version Mgmt.";
         HasSubManagementSetup: Boolean;
         SubcRtngBOMSourceType: Enum "Subc. RtngBOMSourceType";
+        TempProdOrderNoLbl: Label 'TEMP-%1', Locked = true, MaxLength = 20;
+        BOMForLbl: Label 'BOM for %1', Comment = '%1 = Item description';
+        TempBOMNoLbl: Label 'TEMP-BOM-%1', Locked = true, MaxLength = 20;
+        RoutingForLbl: Label 'Routing for %1', Comment = '%1 = Item description';
+        TempRoutingNoLbl: Label 'TEMP-RTNG-%1', Locked = true, MaxLength = 20;
+        PutAwayOperationLbl: Label 'Put-Away Operation';
+        SubcontractingOperationLbl: Label 'Subcontracting Operation';
 
     /// <summary>
     /// Initializes the temporary structure for production order processing based on a purchase line.
@@ -58,8 +65,6 @@ codeunit 99001552 "Subc. Temp Data Initializer"
     end;
 
     local procedure CreateTemporaryProductionOrder()
-    var
-        TempProdOrderNoLbl: Label 'TEMP-%1', Locked = true, MaxLength = 20;
     begin
         TempGlobalProductionBOMLine.Reset();
         TempGlobalProductionBOMLine.DeleteAll();
@@ -141,8 +146,6 @@ codeunit 99001552 "Subc. Temp Data Initializer"
     local procedure InitializeTemporaryBOMHeaderFromSetup(Item: Record Item): Code[20]
     var
         BOMNo: Code[20];
-        BOMForLbl: Label 'BOM for %1', Comment = '%1 = Item description';
-        TempBOMNoLbl: Label 'TEMP-BOM-%1', Locked = true, MaxLength = 20;
     begin
         TempGlobalProductionBOMHeader.Init();
         BOMNo := StrSubstNo(TempBOMNoLbl, CopyStr(Format(CreateGuid()), 2, 10));
@@ -197,8 +200,6 @@ codeunit 99001552 "Subc. Temp Data Initializer"
     local procedure InitializeTemporaryRoutingHeaderFromSetup(Item: Record Item): Code[20]
     var
         RoutingNo: Code[20];
-        RoutingForLbl: Label 'Routing for %1', Comment = '%1 = Item description';
-        TempRoutingNoLbl: Label 'TEMP-RTNG-%1', Locked = true, MaxLength = 20;
     begin
         TempGlobalRoutingHeader.Init();
         RoutingNo := StrSubstNo(TempRoutingNoLbl, CopyStr(Format(CreateGuid()), 2, 10));
@@ -227,8 +228,6 @@ codeunit 99001552 "Subc. Temp Data Initializer"
     local procedure InitializeTemporaryRoutingLinesFromSetup(RoutingNo: Code[20]; WorkCenterNo: Code[20])
     var
         Location: Record Location;
-        PutAwayOperationLbl: Label 'Put-Away Operation';
-        SubcontractingOperationLbl: Label 'Subcontracting Operation';
     begin
         TempGlobalRoutingLine.Init();
         TempGlobalRoutingLine."Routing No." := RoutingNo;

--- a/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Pages/SubcPurchProvisionWizard.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Pages/SubcPurchProvisionWizard.Page.al
@@ -103,8 +103,6 @@ page 99001505 "Subc. PurchProvisionWizard"
                             Editable = SaveBOMRouting;
                             ToolTip = 'Specifies where to apply the BOM and Routing changes.';
                             trigger OnValidate()
-                            var
-                                SaveBOMRtngSourceNotEmptyErr: Label 'Please select a valid source for saving BOM and Routing changes.';
                             begin
                                 if SaveBOMRouting and (SaveBomRtngToSource = SaveBomRtngToSource::Empty) then
                                     Error(SaveBOMRtngSourceNotEmptyErr);
@@ -394,6 +392,8 @@ page 99001505 "Subc. PurchProvisionWizard"
         BomRtngFromSource: Enum "Subc. RtngBOMSourceType";
         BomRtngFromSourceTxt: Text;
         NewVersionIntroductionLbl: Label 'To edit lines directly, activate "Create New Version". This generates a temporary version code (replaced by a number series upon saving). Without this, existing master data is used, and editing is not available for this step.';
+        SaveBOMRtngSourceNotEmptyErr: Label 'Please select a valid source for saving BOM and Routing changes.';
+        SetupSourceLbl: Label 'Subcontracting Management Setup';
 
     trigger OnInit()
     begin
@@ -690,8 +690,6 @@ page 99001505 "Subc. PurchProvisionWizard"
     end;
 
     local procedure InitBomRoutingSource()
-    var
-        SetupSourceLbl: Label 'Subcontracting Management Setup';
     begin
         BomRtngFromSource := SubcTempDataInitializer.GetRtngBOMSourceType();
         case BomRtngFromSource of

--- a/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcCreateProdRouting.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcCreateProdRouting.Report.al
@@ -39,8 +39,6 @@ report 99001503 "Subc. Create Prod. Routing"
 
             trigger OnPostDataItem()
             var
-                StatusProdBOMLbl: Label 'Status Production BOM:';
-                StatusRoutingLbl: Label 'Status Routing';
                 StatusTxt: Text;
                 SumStatusTxt: Text;
             begin
@@ -68,11 +66,6 @@ report 99001503 "Subc. Create Prod. Routing"
             trigger OnPreDataItem()
             var
                 ConfirmManagement: Codeunit "Confirm Management";
-                ConfirmBOMQst: Label 'Do you really want to create BOMs for %1 items?', Comment = '%1=Number of Items';
-                ConfirmBothQst: Label 'Do you really want to create routings and BOMs for %1 items?', Comment = '%1=Number of Items';
-                ConfirmRoutingQst: Label 'Do you really want to create routings for %1 items?', Comment = '%1=Number of Items';
-                WindowFromLbl: Label '##1#########\', Locked = true;
-                WindowToLbl: Label '##2#########\', Locked = true;
             begin
                 ManufacturingSetup.Get();
                 if GuiAllowed() and not HideDialogWindows then begin
@@ -130,6 +123,19 @@ report 99001503 "Subc. Create Prod. Routing"
         ItemCount: Integer;
         StatusProdBOMList: List of [Text];
         StatusRoutingList: List of [Text];
+        StatusProdBOMLbl: Label 'Status Production BOM:';
+        StatusRoutingLbl: Label 'Status Routing';
+        ConfirmBOMQst: Label 'Do you really want to create BOMs for %1 items?', Comment = '%1=Number of Items';
+        ConfirmBothQst: Label 'Do you really want to create routings and BOMs for %1 items?', Comment = '%1=Number of Items';
+        ConfirmRoutingQst: Label 'Do you really want to create routings for %1 items?', Comment = '%1=Number of Items';
+        WindowFromLbl: Label '##1#########\', Locked = true;
+        WindowToLbl: Label '##2#########\', Locked = true;
+        CreateBOMLbl: Label 'Create Production BOM.';
+        ProdBOMCreatedMsg: Label 'Production BOM %1 was created for item %2.', Comment = '%1=Production BOM No., %2=Item No.';
+        ProdBOMExistsMsg: Label 'Production BOM %1 already exists.', Comment = '%1=Production BOM No.';
+        CreateRoutingLbl: Label 'Create Routing.';
+        RoutingCreatedMsg: Label 'Routing %1 was created for item %2.', Comment = '%1=Routing No., %2=Item No.';
+        RoutingExistsMsg: Label 'Routing %1 already exists.', Comment = '%1=Routing No.';
 
     trigger OnInitReport()
     begin
@@ -159,9 +165,6 @@ report 99001503 "Subc. Create Prod. Routing"
     local procedure HandleProductionBOM(var CurrentItem: Record Item)
     var
         ProductionBOMHeader: Record "Production BOM Header";
-        CreateBOMLbl: Label 'Create Production BOM.';
-        ProdBOMCreatedMsg: Label 'Production BOM %1 was created for item %2.', Comment = '%1=Production BOM No., %2=Item No.';
-        ProdBOMExistsMsg: Label 'Production BOM %1 already exists.', Comment = '%1=Production BOM No.';
         NextNoType: Option ProdBOM,Routing;
     begin
         if GuiAllowed() and not HideDialogWindows then
@@ -187,9 +190,6 @@ report 99001503 "Subc. Create Prod. Routing"
     local procedure HandleRouting(var CurrentItem: Record Item)
     var
         RoutingHeader: Record "Routing Header";
-        CreateRoutingLbl: Label 'Create Routing.';
-        RoutingCreatedMsg: Label 'Routing %1 was created for item %2.', Comment = '%1=Routing No., %2=Item No.';
-        RoutingExistsMsg: Label 'Routing %1 already exists.', Comment = '%1=Routing No.';
         NextNoType: Option ProdBOM,Routing;
     begin
         if GuiAllowed() and not HideDialogWindows then

--- a/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcDispatchingList.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcDispatchingList.Report.al
@@ -1823,6 +1823,9 @@ report 99001504 "Subc. Dispatching List"
         VendorIDCaptionLbl: Label 'Vendor ID';
         VendorInvoiceNoLbl: Label 'Vendor Invoice No.';
         VendorOrderNoLbl: Label 'Vendor Order No.';
+        LineDiscountPctPlaceholderLbl: Label '%1%', Locked = true;
+        InvDiscAmtCapLbl: Label 'Invoice Discount Amount %1', Comment = '%1=Currency Code';
+        TotalTxt: Label 'Net Amount %1', Comment = '%1=Currency Code';
         CustomGiroLbl, CustomGiroTxt, LegalOfficeLbl, LegalOfficeTxt : Text;
         FormattedDirectUnitCost: Text;
         FormattedLineAmount: Text;
@@ -1915,9 +1918,6 @@ report 99001504 "Subc. Dispatching List"
     end;
 
     local procedure BlankZero(PurchaseLine: Record "Purchase Line")
-    var
-        LineDiscountPctPlaceholderLbl: Label '%1%',
-            Locked = true;
     begin
         if PurchaseLine."Line Discount %" = 0 then
             LineDiscountPctText := ''
@@ -1970,7 +1970,6 @@ report 99001504 "Subc. Dispatching List"
     local procedure SetInvDisAmountLbl(CurrencyCode: Code[10]; var SubInvDiscAmtCaptionLbl: Text[50])
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
-        InvDiscAmtCapLbl: Label 'Invoice Discount Amount %1', Comment = '%1=Currency Code';
     begin
         if CurrencyCode = '' then begin
             GeneralLedgerSetup.Get();
@@ -1983,7 +1982,6 @@ report 99001504 "Subc. Dispatching List"
     local procedure SetTotalLabels(CurrencyCode: Code[10]; var TotalAsText: Text[50])
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
-        TotalTxt: Label 'Net Amount %1', Comment = '%1=Currency Code';
     begin
         if CurrencyCode = '' then begin
             GeneralLedgerSetup.Get();

--- a/src/Apps/W1/Subcontracting/App/src/Process/Tables/SubcontractorPrice.Table.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Tables/SubcontractorPrice.Table.al
@@ -68,8 +68,6 @@ table 99001500 "Subcontractor Price"
         {
             Caption = 'Starting Date';
             trigger OnValidate()
-            var
-                InvalidStartingDateErr: Label '%1 cannot be after %2', Comment = '%1=Field Caption for starting date, %2=Field Caption for ending date';
             begin
                 if ("Starting Date" > "Ending Date") and ("Ending Date" <> 0D) then
                     Error(InvalidStartingDateErr, FieldCaption("Starting Date"), FieldCaption("Ending Date"));
@@ -154,6 +152,9 @@ table 99001500 "Subcontractor Price"
         TestField("Vendor No.");
         TestField("Item No.");
     end;
+
+    var
+        InvalidStartingDateErr: Label '%1 cannot be after %2', Comment = '%1=Field Caption for starting date, %2=Field Caption for ending date';
 
     procedure CopySubcontractorPriceToVendorsSubcontractorPrice(var SubcontractorPrice: Record "Subcontractor Price"; VendNo: Code[20]; WorkCenterNo: Code[20])
     var

--- a/src/Apps/W1/Subcontracting/Test/DisabledTests/SubcontractingTests.json
+++ b/src/Apps/W1/Subcontracting/Test/DisabledTests/SubcontractingTests.json
@@ -3,6 +3,6 @@
         "bug": "617432",
         "codeunitId": 139989,
         "codeunitName": "Subc. Subcontracting Test",
-        "method": "TestPostItemChargeAssignedToSubcontractingLing_ValueEntryWithCapacityRelation"
+        "method": "TestPostItemChargeAssignedToSubcontractingLingValueEntryWithCapacityRelation"
     }
 ]

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -50,6 +50,7 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         ErrorMessageDescriptionList: List of [Text];
         ItemTrackingWasOpened: Boolean;
         UnitCostCalculation: Option Time,Units;
+        NotSupportedErr: Label 'Drop Shipment must be equal to', Locked = true;
 
     [Test]
     [HandlerFunctions('DoConfirmCreateProdOrderForSubcontractingProcess')]
@@ -225,7 +226,6 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         RoutingLink: Record "Routing Link";
         Vendor: Record Vendor;
         WorkCenter: Record "Work Center";
-        NotSupportedErr: Label 'Drop Shipment must be equal to', Locked = true;
         PurchOrder: TestPage "Purchase Order";
     begin
         // [SCENARIO] Create Production Order from Purchase Order from scratch

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingSyncTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingSyncTest.Codeunit.al
@@ -405,7 +405,7 @@ codeunit 139992 "Subc. Subcontracting Sync Test"
         LibrarySetupStorage.Restore();
 
         SubcontractingMgmtLibrary.Initialize();
-        UpdateSubMgmtSetup_ComponentAtLocation("Components at Location"::Purchase);
+        UpdateSubMgmtSetupComponentAtLocation("Components at Location"::Purchase);
         LibraryMfgManagement.Initialize();
 
         if IsInitialized then
@@ -433,7 +433,7 @@ codeunit 139992 "Subc. Subcontracting Sync Test"
         LibraryMfgManagement.CreateLaborReqWkshTemplateAndNameAndUpdateSetup();
     end;
 
-    local procedure UpdateSubMgmtSetup_ComponentAtLocation(CompAtLocation: Enum "Components at Location")
+    local procedure UpdateSubMgmtSetupComponentAtLocation(CompAtLocation: Enum "Components at Location")
     var
         EsMgmtSetup: Record "Subc. Management Setup";
     begin

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -1389,8 +1389,6 @@ codeunit 139989 "Subc. Subcontracting Test"
         PurchaseLine: Record "Purchase Line";
         TransferLine: Record "Transfer Line";
         WorkCenter: array[2] of Record "Work Center";
-        AlreadySpecifiedErr: Label 'You cannot open Tracking Specification because this component is already specified in Transfer Order %1.',
-Comment = '|%1 = Transfer Order No.';
         ProdOrderCompPage: TestPage "Prod. Order Components";
         PurchaseHeaderPage: TestPage "Purchase Order";
         ExpectedErrorMsg: Text;
@@ -2831,5 +2829,6 @@ Comment = '|%1 = Transfer Order No.';
         Subcontracting: Boolean;
         UnitCostCalculation: Option Time,Units;
         ConfirmDialogCalledCount: Integer;
+        AlreadySpecifiedErr: Label 'You cannot open Tracking Specification because this component is already specified in Transfer Order %1.', Comment = '|%1 = Transfer Order No.';
 
 }

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -111,7 +111,7 @@ codeunit 139989 "Subc. Subcontracting Test"
     end;
 
     [Test]
-    procedure CreateSubcOrderFromRtngLine_EmptyDefVATProdPostGrp()
+    procedure CreateSubcOrderFromRtngLineEmptyDefVATProdPostGrp()
     var
         GenProductPostingGroup: Record "Gen. Product Posting Group";
         Item: Record Item;
@@ -1696,7 +1696,7 @@ codeunit 139989 "Subc. Subcontracting Test"
     end;
 
     [Test]
-    procedure TestPostItemChargeAssignedToSubcontractingLing_ValueEntryWithCapacityRelation()
+    procedure TestPostItemChargeAssignedToSubcontractingLingValueEntryWithCapacityRelation()
     var
         ItemCharge: Record "Item Charge";
         ItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)";
@@ -2028,7 +2028,7 @@ codeunit 139989 "Subc. Subcontracting Test"
 
     [Test]
     [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
-    procedure CreateReturnTransferOrder_AfterPartialShipOfOutbound()
+    procedure CreateReturnTransferOrderAfterPartialShipOfOutbound()
     var
         Bin: Record Bin;
         Item: Record Item;
@@ -2128,7 +2128,7 @@ codeunit 139989 "Subc. Subcontracting Test"
 
     [Test]
     [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
-    procedure CreateReturnTransferOrder_AfterPartialShipOfOutbound_DirectTransfer()
+    procedure CreateReturnTransferOrderAfterPartialShipOfOutboundDirectTransfer()
     var
         Bin: Record Bin;
         Item: Record Item;
@@ -2621,7 +2621,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         LibrarySetupStorage.Restore();
 
         SubcontractingMgmtLibrary.Initialize();
-        UpdateSubMgmtSetup_ComponentAtLocation("Components at Location"::Purchase);
+        UpdateSubMgmtSetupComponentAtLocation("Components at Location"::Purchase);
         LibraryMfgManagement.Initialize();
 
         if IsInitialized then
@@ -2659,7 +2659,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         EsMgmtSetup.Modify();
     end;
 
-    local procedure UpdateSubMgmtSetup_ComponentAtLocation(CompAtLocation: Enum "Components at Location")
+    local procedure UpdateSubMgmtSetupComponentAtLocation(CompAtLocation: Enum "Components at Location")
     var
         EsMgmtSetup: Record "Subc. Management Setup";
     begin
@@ -2750,7 +2750,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         ManufacturingSetup.Get();
         ManufacturingSetup."Components at Location" := Location.Code;
         ManufacturingSetup.Modify();
-        UpdateSubMgmtSetup_ComponentAtLocation("Components at Location"::Manufacturing);
+        UpdateSubMgmtSetupComponentAtLocation("Components at Location"::Manufacturing);
     end;
 
     procedure CreateInventory(Item: Record Item; Location: Record Location; Bin: Record Bin; Quantity: Decimal)

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcWizSourceTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcWizSourceTest.Codeunit.al
@@ -33,6 +33,7 @@ codeunit 139997 "Subc. Wiz. Source Test"
         WizardFinishedSuccessfully: Boolean;
         WizardWasOpened: Boolean;
         ExpectedSourceType: Enum "Subc. RtngBOMSourceType";
+        SubManSetupLbl: Label 'Subcontracting Management Setup', Locked = true;
 
     // ==================== SCENARIO G: Source Data Validation ====================
 
@@ -291,8 +292,6 @@ codeunit 139997 "Subc. Wiz. Source Test"
 
     [ModalPageHandler]
     procedure HandlePurchProvisionWizardVerifySetupSource(var PurchProvisionWizard: TestPage "Subc. PurchProvisionWizard")
-    var
-        SubManSetupLbl: Label 'Subcontracting Management Setup', Locked = true;
     begin
         // [SCENARIO G5] Verify that BomRtngFromSource reflects new setup
         WizardWasOpened := true;
@@ -311,8 +310,6 @@ codeunit 139997 "Subc. Wiz. Source Test"
 
     [ModalPageHandler]
     procedure HandlePurchProvisionWizardVerifyEmptySource(var PurchProvisionWizard: TestPage "Subc. PurchProvisionWizard")
-    var
-        SubManSetupLbl: Label 'Subcontracting Management Setup', Locked = true;
     begin
         // [SCENARIO G4] Verify that BomRtngFromSource shows Empty when no setup exists
         WizardWasOpened := true;
@@ -331,8 +328,6 @@ codeunit 139997 "Subc. Wiz. Source Test"
 
     [ModalPageHandler]
     procedure HandlePurchProvisionWizardVerifyNewSetupSource(var PurchProvisionWizard: TestPage "Subc. PurchProvisionWizard")
-    var
-        SubManSetupLbl: Label 'Subcontracting Management Setup', Locked = true;
     begin
         // [SCENARIO G5] Verify that BomRtngFromSource reflects new setup
         WizardWasOpened := true;


### PR DESCRIPTION
## Summary
Two related code-style refactors in the W1 Subcontracting app — no functional changes.

### 1. Move `Label` declarations to global scope
All `Label` declarations that were declared inside method/trigger `var` sections were promoted to the object's global `var` section across the App and Test apps. This aligns with the BC convention that labels live at the object scope so they are translatable and discoverable.

A few labels shared the same name across methods but with different values; they were renamed and call sites were updated:
- `ExistingTransferLineQst` → `ExistingPostedTransferLineQst` (posted-transfer variant) in `SubcProdOrderCompExt`
- `UpdateIsCancelledErr` → `UpdateIsCanceledErr` (different message) in `SubcontractingManagement`
- `MyNotificationsNameLbl`/`DescriptionTxt` split into `ProdOrd*` and `SubcOrd*` in `SubcNotificationMgmt`

### 2. Remove underscores from procedure names
BC naming conventions disallow underscores in identifiers. The following 8 procedures were renamed and all callers (plus the DisabledTests entry) updated:

App:
- `ChangeLocation_OnProdOrderComponent` → `ChangeLocationOnProdOrderComponent`
- `ChangeLocation_OnPlanningComponent` → `ChangeLocationOnPlanningComponent`
- `OnAfterValidateEvent_BuyFromVendorNo` → `OnAfterValidateEventBuyFromVendorNo`

Test:
- `CreateSubcOrderFromRtngLine_EmptyDefVATProdPostGrp` → `CreateSubcOrderFromRtngLineEmptyDefVATProdPostGrp`
- `TestPostItemChargeAssignedToSubcontractingLing_ValueEntryWithCapacityRelation` → `TestPostItemChargeAssignedToSubcontractingLingValueEntryWithCapacityRelation`
- `CreateReturnTransferOrder_AfterPartialShipOfOutbound` → `CreateReturnTransferOrderAfterPartialShipOfOutbound`
- `CreateReturnTransferOrder_AfterPartialShipOfOutbound_DirectTransfer` → `CreateReturnTransferOrderAfterPartialShipOfOutboundDirectTransfer`
- `UpdateSubMgmtSetup_ComponentAtLocation` → `UpdateSubMgmtSetupComponentAtLocation`

### Verification
- App and Test apps both compile and publish successfully.
- No functional changes — only label scope moves and identifier renames.

Fixes [AB#634126](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634126)



