### PR TITLE
(Bug 633224): [Subcontracting] View purchase orders prompt opens card pages instead of list when orders already exist

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchaseOrderCreator.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchaseOrderCreator.Codeunit.al
@@ -209,10 +209,7 @@ codeunit 99001557 "Subc. Purchase Order Creator"
 
     local procedure CheckProdOrderRtngLine(ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var ProdOrderLine: Record "Prod. Order Line")
     var
-        PurchaseHeader: Record "Purchase Header";
-        PurchaseLine: Record "Purchase Line";
         WorkCenter: Record "Work Center";
-        ConfirmManagement: Codeunit "Confirm Management";
     begin
         if ProdOrderRoutingLine.Status <> "Production Order Status"::Released then
             Error(CreationOfSubcontractingOrderIsNotAllowedErr, ProdOrderRoutingLine."Prod. Order No.");
@@ -230,23 +227,42 @@ codeunit 99001557 "Subc. Purchase Order Creator"
         WorkCenter.Get(ProdOrderRoutingLine."Work Center No.");
         WorkCenter.TestField("Subcontractor No.");
         WorkCenter.TestField("Gen. Prod. Posting Group");
+    end;
 
-        ProdOrderLine.FindFirst();
+    internal procedure ShowExistingPurchaseOrdersForRoutingLines(var ProdOrderRoutingLine: Record "Prod. Order Routing Line")
+    var
+        PurchaseLine: Record "Purchase Line";
+        ConfirmManagement: Codeunit "Confirm Management";
+        ExistingPOFound: Boolean;
+        ProdOrderNo: Code[20];
+    begin
+        if not ProdOrderRoutingLine.FindSet() then
+            exit;
+
+        ProdOrderNo := ProdOrderRoutingLine."Prod. Order No.";
+        repeat
+            PurchaseLine.SetCurrentKey("Document Type", Type, "Prod. Order No.");
+            PurchaseLine.SetRange("Document Type", "Purchase Document Type"::Order);
+            PurchaseLine.SetRange(Type, "Purchase Line Type"::Item);
+            PurchaseLine.SetRange("Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+            PurchaseLine.SetRange("Routing No.", ProdOrderRoutingLine."Routing No.");
+            PurchaseLine.SetRange("Operation No.", ProdOrderRoutingLine."Operation No.");
+            if not PurchaseLine.IsEmpty() then
+                ExistingPOFound := true;
+        until (ProdOrderRoutingLine.Next() = 0) or ExistingPOFound;
+
+        if not ExistingPOFound then
+            exit;
+
+        if not ConfirmManagement.GetResponseOrDefault(PurchOrderAlreadyCreatedQst, false) then
+            exit;
+
+        PurchaseLine.Reset();
         PurchaseLine.SetCurrentKey("Document Type", Type, "Prod. Order No.");
         PurchaseLine.SetRange("Document Type", "Purchase Document Type"::Order);
         PurchaseLine.SetRange(Type, "Purchase Line Type"::Item);
-        PurchaseLine.SetRange("Prod. Order No.", ProdOrderLine."Prod. Order No.");
-        PurchaseLine.SetRange("Routing No.", ProdOrderRoutingLine."Routing No.");
-        PurchaseLine.SetRange("Operation No.", ProdOrderRoutingLine."Operation No.");
-        if not PurchaseLine.IsEmpty() then
-            if ConfirmManagement.GetResponseOrDefault(PurchOrderAlreadyCreatedQst, false) then
-                if PurchaseLine.Count() > 1 then
-                    Page.Run(Page::"Purchase Lines", PurchaseLine)
-                else begin
-                    PurchaseLine.FindFirst();
-                    PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
-                    PageManagement.PageRun(PurchaseHeader);
-                end;
+        PurchaseLine.SetRange("Prod. Order No.", ProdOrderNo);
+        PageManagement.PageRun(PurchaseLine);
     end;
 
     local procedure CheckProdOrderComponentLines(ProdOrderRoutingLine: Record "Prod. Order Routing Line"): Boolean

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcProdOrderRtng.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcProdOrderRtng.PageExt.al
@@ -58,6 +58,7 @@ pageextension 99001503 "Subc. Prod. Order Rtng." extends "Prod. Order Routing"
                     NoPurchOrderCreatedMsg: Label 'No subcontracting order was created for the selected operations in production order %1. Please check whether the operation or operations have already been completed.', Comment = '%1=Production Order No.';
                 begin
                     CurrPage.SetSelectionFilter(ProdOrderRoutingLine);
+                    SubcPurchaseOrderCreator.ShowExistingPurchaseOrdersForRoutingLines(ProdOrderRoutingLine);
                     ProdOrderRoutingLine.FindSet();
                     repeat
                         NoOfCreatedPurchOrder += SubcPurchaseOrderCreator.CreateSubcontractingPurchaseOrderFromRoutingLine(ProdOrderRoutingLine);

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2227,10 +2227,76 @@ Comment = '|%1 = Transfer Order No.';
         Assert.ExpectedError('Return from Subcontractor has already been created');
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmYesShowSubcontractingPurchOrders,HandlePurchaseOrderPage,HandlePurchaseLinesPage')]
+    procedure ShowExistingPurchOrdersOpensListWhenAlreadyCreated()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        PurchaseLine: Record "Purchase Line";
+        WorkCenter: array[2] of Record "Work Center";
+    begin
+        // [SCENARIO 633224] First Create Subcontracting Order opens the Purchase Order; running the action again on the same routing line opens the Purchase Lines list.
+
+        // [GIVEN] Manufacturing setup with subcontracting work center, item with routing/BOM, released production order
+        Initialize();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+
+        // [WHEN] Create Subcontracting Order from the routing line for the first time
+        PurchaseOrderPageOpened := false;
+        PurchaseLinesPageOpened := false;
+        CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+
+        // [THEN] The Purchase Order card is shown
+        Assert.IsTrue(PurchaseOrderPageOpened, 'Purchase Order should open after first creation.');
+        Assert.IsFalse(PurchaseLinesPageOpened, 'Purchase Lines list should not open on first creation.');
+
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.SetRange("Work Center No.", WorkCenter[2]."No.");
+        Assert.IsFalse(PurchaseLine.IsEmpty(), 'Purchase line should exist for the production order.');
+
+        // [WHEN] Create Subcontracting Order from the same routing line again
+        PurchaseOrderPageOpened := false;
+        PurchaseLinesPageOpened := false;
+        CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+
+        // [THEN] The Purchase Lines list is shown instead of individual Purchase Order cards
+        Assert.IsTrue(PurchaseLinesPageOpened, 'Purchase Lines list should open when purchase orders already exist.');
+        Assert.IsFalse(PurchaseOrderPageOpened, 'Purchase Order card should not open when purchase orders already exist.');
+    end;
+
     [PageHandler]
     procedure HandleTransferOrder(var TransfOrderPage: TestPage "Transfer Order")
     begin
         TransfOrderPage.OK().Invoke();
+    end;
+
+    [ConfirmHandler]
+    procedure ConfirmYesShowSubcontractingPurchOrders(Question: Text[1024]; var Reply: Boolean)
+    begin
+        Reply := true;
+    end;
+
+    [PageHandler]
+    procedure HandlePurchaseOrderPage(var PurchaseOrderPage: TestPage "Purchase Order")
+    begin
+        PurchaseOrderPageOpened := true;
+        PurchaseOrderPage.Close();
+    end;
+
+    [PageHandler]
+    procedure HandlePurchaseLinesPage(var PurchaseLinesPage: TestPage "Purchase Lines")
+    begin
+        PurchaseLinesPageOpened := true;
+        PurchaseLinesPage.Close();
     end;
 
     [PageHandler]
@@ -2829,6 +2895,8 @@ Comment = '|%1 = Transfer Order No.';
         SubSetupLibrary: Codeunit "Subc. Setup Library";
         IsInitialized: Boolean;
         Subcontracting: Boolean;
+        PurchaseOrderPageOpened: Boolean;
+        PurchaseLinesPageOpened: Boolean;
         UnitCostCalculation: Option Time,Units;
         ConfirmDialogCalledCount: Integer;
 


### PR DESCRIPTION
### Problem

When **Create Subcontracting Order** is invoked from a Prod. Order Routing for which purchase orders already exist, the system prompts *"Purchase order(s) have already been created. Do you want to view them?"* and — on **Yes** — opens an individual **Purchase Order** card per existing PO. With multiple selected routing lines or multiple existing POs, the user gets a stack of card windows instead of a single consolidated list. The first-time path (no existing POs) correctly opens a list view via `ShowCreatedPurchaseOrder`, so the two paths were inconsistent.

Root cause: `Subc. Purchase Order Creator.CheckProdOrderRtngLine` runs once **per routing line** and each invocation independently prompted and opened its own page, with the per-line branch always falling through to `PageManagement.PageRun(PurchaseHeader)` (the card).

### Fix

- Stripped the existing-PO prompt and per-line page-opening out of `CheckProdOrderRtngLine` — it now only does validation (status, prod-order-line existence, work-center fields).
- Added `ShowExistingPurchaseOrdersForRoutingLines(var ProdOrderRoutingLine)` which iterates the selection, prompts **once** if any matching `Purchase Line` exists, and on Yes calls `PageManagement.PageRun(PurchaseLine)` filtered by `Document Type=Order`, `Type=Item`, `Prod. Order No.` — the same call/filter as `ShowCreatedPurchaseOrder`'s multi-PO branch, so both Scenario A (newly created) and Scenario B (already exists) now route through identical page-dispatch logic.
- The new method is invoked from `Subc. Prod. Order Rtng.` page extension's `Create Subcontracting Order` action, after `SetSelectionFilter` and before the create loop.

Fixes [AB#633224](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633224)

