### PR TITLE
Update CODEOWNERS to remove app code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,9 +5,6 @@
 # Default owners
 * @microsoft/dynamics-365-business-central
 
-# Default owners for all app code
-/src @microsoft/d365-bc-app-required
-
 # App Rulesets
 /src/rulesets/ @microsoft/d365-bc-app-rulesets
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Removed default owners for all app code in CODEOWNERS. The default should no longer be the app team, but rather the D365BC team.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#634194](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634194)


