### PR TITLE
Revert "[System Application] Add 'Is Excluding From Billing' column to page ' Agent Consumption Overview'"

### DIFF
--- a/src/System Application/App/Agent/Monetization/AgentConsumptionOverview.Page.al
+++ b/src/System Application/App/Agent/Monetization/AgentConsumptionOverview.Page.al
@@ -109,11 +109,6 @@ page 4333 "Agent Consumption Overview"
                         DrillDownToAgentTaskConsumption();
                     end;
                 }
-
-                field("Is Excluded From Billing"; Rec."Is Excluded From Billing")
-                {
-                    Caption = 'Non-billable';
-                }
             }
             group(TotalsFooterOuterGroup)
             {


### PR DESCRIPTION
Reverts microsoft/BCApps#8010

We have decided that this will not work because it will not show all types of trial/non-billable consumption.

Fixes [AB#634025](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634025).


