### PR TITLE
[Edit in Excel] Expose ExternalizeODataObjectName and add Page Control Field publisher

### DIFF
--- a/src/System Application/App/Edit in Excel/src/EditInExcel.Codeunit.al
+++ b/src/System Application/App/Edit in Excel/src/EditInExcel.Codeunit.al
@@ -6,6 +6,7 @@
 namespace System.Integration.Excel;
 
 using System.Integration;
+using System.Reflection;
 
 /// <summary>
 /// This codeunit provides an interface to running Edit in Excel for a specific page.
@@ -81,6 +82,18 @@ codeunit 1481 "Edit in Excel"
         EditInExcelImpl.GetEndPointAndCreateWorkbookWStructuredFilter(TenantWebService."Service Name", EditinExcelFilters, '');
     end;
 
+    /// <summary>
+    /// Converts a name (e.g. a field name or service name) to its OData externalized form. Mimics the conversion the Edit in Excel runtime applies to field and service names when generating the workbook payload, so that other apps can derive the same external names without duplicating the conversion logic.
+    /// </summary>
+    /// <param name="Name">The name to convert.</param>
+    /// <returns>The OData-externalized name.</returns>
+    procedure ExternalizeODataObjectName(Name: Text): Text
+    var
+        EditInExcelImpl: Codeunit "Edit in Excel Impl.";
+    begin
+        exit(EditInExcelImpl.ExternalizeODataObjectName(Name));
+    end;
+
 
     /// <summary>
     /// This event is called when Edit in Excel is invoked, handling JSON structured filters. It also allows overriding the Edit in Excel functionality.
@@ -106,6 +119,16 @@ codeunit 1481 "Edit in Excel"
     //  <param name="Handled">Specifies whether the event has been handled and no further execution should occur.</param>
     [IntegrationEvent(false, false)]
     internal procedure OnEditInExcelWithFilters(ServiceName: Text[240]; var EditinExcelFilters: Codeunit "Edit in Excel Filters"; SearchFilter: Text; var Handled: Boolean)
+    begin
+    end;
+
+    /// <summary>
+    /// This event is raised inside SetupFieldColumnBindings before iterating the Page Control Field record set, after the procedure has applied the PageNo filter and Sequence sort order. Subscribers can add further filters or change the sort order to control which page fields are exported to Excel (for example, to honor user personalization).
+    /// </summary>
+    /// <param name="PageControlField">The Page Control Field record, already filtered by PageNo and sorted by Sequence. Subscribers may add further filters.</param>
+    /// <param name="PageId">The ID of the page being exported.</param>
+    [IntegrationEvent(false, false)]
+    internal procedure OnPageControlFieldFilterBeforeFindSetInSetupFieldColumnBindings(var PageControlField: Record "Page Control Field"; PageId: Integer)
     begin
     end;
 }

--- a/src/System Application/App/Edit in Excel/src/EditInExcel.Codeunit.al
+++ b/src/System Application/App/Edit in Excel/src/EditInExcel.Codeunit.al
@@ -123,12 +123,12 @@ codeunit 1481 "Edit in Excel"
     end;
 
     /// <summary>
-    /// This event is raised inside SetupFieldColumnBindings before iterating the Page Control Field record set, after the procedure has applied the PageNo filter and Sequence sort order. Subscribers can add further filters or change the sort order to control which page fields are exported to Excel (for example, to honor user personalization).
+    /// This event is raised before iterating the Page Control Field record set used to build the Edit in Excel workbook column bindings. Subscribers can add further filters or change the sort order to control which page fields are exported to Excel (for example, to honor user personalization).
     /// </summary>
-    /// <param name="PageControlField">The Page Control Field record, already filtered by PageNo and sorted by Sequence. Subscribers may add further filters.</param>
+    /// <param name="PageControlField">The Page Control Field record with relevant filters and sorting already applied. Subscribers can add further filters.</param>
     /// <param name="PageId">The ID of the page being exported.</param>
     [IntegrationEvent(false, false)]
-    internal procedure OnPageControlFieldFilterBeforeFindSetInSetupFieldColumnBindings(var PageControlField: Record "Page Control Field"; PageId: Integer)
+    internal procedure OnBeforePageControlFieldFindSet(var PageControlField: Record "Page Control Field"; PageId: Integer)
     begin
     end;
 }

--- a/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
+++ b/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
@@ -84,6 +84,7 @@ codeunit 1482 "Edit in Excel Impl."
         PageControlField.SetRange(PageNo, PageNo);
         PageControlField.SetCurrentKey(Sequence);
         PageControlField.SetAscending(Sequence, true);
+        EditinExcel.OnPageControlFieldFilterBeforeFindSetInSetupFieldColumnBindings(PageControlField, PageNo);
         if PageControlField.FindSet() then
             repeat
                 if FieldsTable.Get(PageControlField.TableNo, PageControlField.FieldNo) then

--- a/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
+++ b/src/System Application/App/Edit in Excel/src/EditinExcelImpl.Codeunit.al
@@ -84,7 +84,7 @@ codeunit 1482 "Edit in Excel Impl."
         PageControlField.SetRange(PageNo, PageNo);
         PageControlField.SetCurrentKey(Sequence);
         PageControlField.SetAscending(Sequence, true);
-        EditinExcel.OnPageControlFieldFilterBeforeFindSetInSetupFieldColumnBindings(PageControlField, PageNo);
+        EditinExcel.OnBeforePageControlFieldFindSet(PageControlField, PageNo);
         if PageControlField.FindSet() then
             repeat
                 if FieldsTable.Get(PageControlField.TableNo, PageControlField.FieldNo) then

--- a/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
+++ b/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
@@ -9,6 +9,7 @@ using System;
 using System.Integration;
 using System.Integration.Excel;
 using System.TestLibraries.Integration.Excel;
+using System.Reflection;
 using System.TestLibraries.Utilities;
 codeunit 132525 "Edit in Excel Test"
 {
@@ -21,6 +22,8 @@ codeunit 132525 "Edit in Excel Test"
         EditInExcel: Codeunit "Edit in Excel";
         IsInitialized: Boolean;
         EventServiceName: Text[240];
+        EventPageControlFieldFilterPageId: Integer;
+        EventPageControlFieldFilterFired: Boolean;
 
     [Test]
     procedure TestEditInExcelCreatesWebService()
@@ -398,5 +401,74 @@ codeunit 132525 "Edit in Excel Test"
 
         LibraryAssert.AreEqual(ExpectedNumberFilter, NumberFieldFilter.ToString(), 'The actual and expected filters are not equal');
         LibraryAssert.AreEqual(ExpectedCountryRegionCodeFilter, CountryRegionCodeFieldFilter.ToString(), 'The actual and expected filters are not equal');
+    end;
+
+    [Test]
+    procedure TestExternalizeODataObjectNamePublicWrapper()
+    var
+        EditinExcelTestLibrary: Codeunit "Edit in Excel Test Library";
+        Input: Text;
+        PublicResult: Text;
+        ImplResult: Text;
+    begin
+        // [SCENARIO] The public ExternalizeODataObjectName procedure on codeunit "Edit in Excel" exposes the same conversion as the internal implementation, so other apps can match Edit in Excel OData externalized names without duplicating the conversion logic.
+        Init();
+
+        // [GIVEN] A name that triggers OData escaping (digit prefix, en dash, space)
+        Input := '3 lager – reklassfication field';
+
+        // [WHEN] The public wrapper and the internal implementation are called with the same input
+        PublicResult := EditInExcel.ExternalizeODataObjectName(Input);
+        ImplResult := EditinExcelTestLibrary.ExternalizeODataObjectName(Input);
+
+        // [THEN] Both produce the same OData externalized name
+        LibraryAssert.AreEqual(ImplResult, PublicResult, 'Public ExternalizeODataObjectName wrapper should return the same value as the internal implementation');
+    end;
+
+    [Test]
+    procedure TestOnPageControlFieldFilterBeforeFindSetEventFires()
+    var
+        TenantWebService: Record "Tenant Web Service";
+        EditinExcelFilters: Codeunit "Edit in Excel Filters";
+        EditInExcelList: Page "Edit in Excel List";
+    begin
+        // [SCENARIO] When EditPageInExcel runs, the new OnPageControlFieldFilterBeforeFindSetInSetupFieldColumnBindings event is raised with the page ID being exported, so subscribers can apply additional filters to the Page Control Field record.
+        Init();
+
+        // [GIVEN] No tenant web service for the page and no captured event state
+        TenantWebService.SetRange("Object Type", TenantWebService."Object Type"::Page);
+        TenantWebService.SetRange("Object ID", Page::"Edit in Excel List");
+        TenantWebService.DeleteAll();
+        EditInExcelTest.ResetCapturedPageControlFieldFilter();
+
+        // [WHEN] EditPageInExcel runs the export flow that calls SetupFieldColumnBindings
+        EditInExcel.EditPageInExcel(CopyStr(EditInExcelList.Caption, 1, 240), Page::"Edit in Excel List", EditinExcelFilters);
+
+        // [THEN] The subscriber was invoked with the page that is being exported
+        LibraryAssert.IsTrue(EditInExcelTest.GetCapturedPageControlFieldFilterFired(), 'OnPageControlFieldFilterBeforeFindSetInSetupFieldColumnBindings event should have fired');
+        LibraryAssert.AreEqual(Page::"Edit in Excel List", EditInExcelTest.GetCapturedPageControlFieldFilterPageId(), 'OnPageControlFieldFilterBeforeFindSetInSetupFieldColumnBindings event should pass the exported page ID');
+    end;
+
+    procedure GetCapturedPageControlFieldFilterFired(): Boolean
+    begin
+        exit(EventPageControlFieldFilterFired);
+    end;
+
+    procedure GetCapturedPageControlFieldFilterPageId(): Integer
+    begin
+        exit(EventPageControlFieldFilterPageId);
+    end;
+
+    procedure ResetCapturedPageControlFieldFilter()
+    begin
+        EventPageControlFieldFilterPageId := 0;
+        EventPageControlFieldFilterFired := false;
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Edit in Excel", 'OnPageControlFieldFilterBeforeFindSetInSetupFieldColumnBindings', '', false, false)]
+    local procedure CapturePageControlFieldFilterBeforeFindSet(var PageControlField: Record "Page Control Field"; PageId: Integer)
+    begin
+        EventPageControlFieldFilterPageId := PageId;
+        EventPageControlFieldFilterFired := true;
     end;
 }

--- a/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
+++ b/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
@@ -111,6 +111,9 @@ codeunit 132525 "Edit in Excel Test"
         ForwardSlashesFieldName: Text;
         ManyForwardSlashesFieldName: Text;
         ForwardSlashesEmDashesAndUnderscoresFieldName: Text;
+        ArabicFieldName: Text;
+        JapaneseFieldName: Text;
+        AccentedLatinFieldName: Text;
     begin
         Init();
         FieldNameStartingWDigit := EditinExcelTestLibrary.ExternalizeODataObjectName('3field');
@@ -142,6 +145,11 @@ codeunit 132525 "Edit in Excel Test"
         // when converting from a special symbol to underscore(unless that special character is translated to a byte value).
         ForwardSlashesEmDashesAndUnderscoresFieldName := EditinExcelTestLibrary.ExternalizeODataObjectName('lager/_/-reklassfication field');
 
+        // Arabic, Japanese, and accented Latin BMP characters do not match any of the conversion rules so they pass through unchanged.
+        ArabicFieldName := EditinExcelTestLibrary.ExternalizeODataObjectName('مرحبا');
+        JapaneseFieldName := EditinExcelTestLibrary.ExternalizeODataObjectName('こんにちは');
+        AccentedLatinFieldName := EditinExcelTestLibrary.ExternalizeODataObjectName('café');
+
         LibraryAssert.AreEqual('field', RegularFieldName, 'Conversion alters name that does not begin with a string');
         LibraryAssert.AreEqual('_x0033_field', FieldNameStartingWDigit, 'Did not convert the name with number correctly');
         LibraryAssert.AreEqual('new_vendor_x0027_s_name', ApostropheFieldName, 'Did not convert the name with an apostrophe correctly');
@@ -153,6 +161,9 @@ codeunit 132525 "Edit in Excel Test"
         LibraryAssert.AreEqual('lager_reklassfication_field', ForwardSlashesFieldName, 'Did not convert the name with 2 forward slashes correctly');
         LibraryAssert.AreEqual('lager_reklassfication_field', ManyForwardSlashesFieldName, 'Did not convert the name with many forward slashes correctly');
         LibraryAssert.AreEqual('lager__reklassfication_field', ForwardSlashesEmDashesAndUnderscoresFieldName, 'Did not convert the name with forward slashes, em dash and underscores correctly');
+        LibraryAssert.AreEqual('مرحبا', ArabicFieldName, 'Arabic BMP characters should pass through unchanged');
+        LibraryAssert.AreEqual('こんにちは', JapaneseFieldName, 'Japanese hiragana BMP characters should pass through unchanged');
+        LibraryAssert.AreEqual('café', AccentedLatinFieldName, 'Accented Latin BMP characters should pass through unchanged');
     end;
 
     [Test]
@@ -406,29 +417,26 @@ codeunit 132525 "Edit in Excel Test"
 
     [Test]
     procedure TestExternalizeODataObjectNamePublicWrapper()
+    var
+        EditinExcelTestLibrary: Codeunit "Edit in Excel Test Library";
     begin
-        // [SCENARIO] The public ExternalizeODataObjectName procedure on codeunit "Edit in Excel" produces the OData externalized name that the Edit in Excel runtime applies to field and service names, so other apps can derive the same external names without duplicating the conversion logic.
+        // [SCENARIO] The public ExternalizeODataObjectName procedure on codeunit "Edit in Excel" delegates to the same internal implementation that the Edit in Excel test library wraps. This test guards against refactor drift between the two wrappers, so that if either of them is ever changed (extra parameter, fast-path optimization, pre-processing step, inlined copy of the impl), the divergence shows up here.
         Init();
 
-        // [GIVEN] A clean ASCII name
-        // [THEN] The wrapper passes it through unchanged
-        LibraryAssert.AreEqual('CustomerNumber', EditInExcel.ExternalizeODataObjectName('CustomerNumber'), 'A clean ASCII name should pass through unchanged');
+        // [THEN] The public wrapper and the test library wrapper agree on a clean ASCII name
+        LibraryAssert.AreEqual(EditinExcelTestLibrary.ExternalizeODataObjectName('CustomerNumber'), EditInExcel.ExternalizeODataObjectName('CustomerNumber'), 'Public wrapper should match the test library wrapper for a clean ASCII name');
 
-        // [GIVEN] An ASCII name with a single space
-        // [THEN] The wrapper converts the space to an underscore
-        LibraryAssert.AreEqual('Posting_Date', EditInExcel.ExternalizeODataObjectName('Posting Date'), 'A single space should convert to an underscore');
+        // [THEN] They agree on an ASCII name with a single space
+        LibraryAssert.AreEqual(EditinExcelTestLibrary.ExternalizeODataObjectName('Posting Date'), EditInExcel.ExternalizeODataObjectName('Posting Date'), 'Public wrapper should match the test library wrapper for an ASCII name with a space');
 
-        // [GIVEN] A name made of Arabic BMP characters
-        // [THEN] The wrapper passes the Arabic characters through unchanged (they do not match any of the conversion rules)
-        LibraryAssert.AreEqual('مرحبا', EditInExcel.ExternalizeODataObjectName('مرحبا'), 'Arabic BMP characters should pass through unchanged');
+        // [THEN] They agree on Arabic BMP characters
+        LibraryAssert.AreEqual(EditinExcelTestLibrary.ExternalizeODataObjectName('مرحبا'), EditInExcel.ExternalizeODataObjectName('مرحبا'), 'Public wrapper should match the test library wrapper for Arabic BMP characters');
 
-        // [GIVEN] A name made of Japanese hiragana BMP characters
-        // [THEN] The wrapper passes the Japanese characters through unchanged
-        LibraryAssert.AreEqual('こんにちは', EditInExcel.ExternalizeODataObjectName('こんにちは'), 'Japanese hiragana BMP characters should pass through unchanged');
+        // [THEN] They agree on Japanese hiragana BMP characters
+        LibraryAssert.AreEqual(EditinExcelTestLibrary.ExternalizeODataObjectName('こんにちは'), EditInExcel.ExternalizeODataObjectName('こんにちは'), 'Public wrapper should match the test library wrapper for Japanese hiragana BMP characters');
 
-        // [GIVEN] A name with an accented Latin character
-        // [THEN] The wrapper passes the accented character through unchanged
-        LibraryAssert.AreEqual('café', EditInExcel.ExternalizeODataObjectName('café'), 'Accented Latin BMP characters should pass through unchanged');
+        // [THEN] They agree on accented Latin BMP characters
+        LibraryAssert.AreEqual(EditinExcelTestLibrary.ExternalizeODataObjectName('café'), EditInExcel.ExternalizeODataObjectName('café'), 'Public wrapper should match the test library wrapper for accented Latin BMP characters');
     end;
 
     [Test]

--- a/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
+++ b/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
@@ -8,9 +8,10 @@ namespace System.Test.Integration.Excel;
 using System;
 using System.Integration;
 using System.Integration.Excel;
-using System.TestLibraries.Integration.Excel;
 using System.Reflection;
+using System.TestLibraries.Integration.Excel;
 using System.TestLibraries.Utilities;
+
 codeunit 132525 "Edit in Excel Test"
 {
     Subtype = Test;

--- a/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
+++ b/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
@@ -23,8 +23,8 @@ codeunit 132525 "Edit in Excel Test"
         EditInExcel: Codeunit "Edit in Excel";
         IsInitialized: Boolean;
         EventServiceName: Text[240];
-        EventPageControlFieldFilterPageId: Integer;
-        EventPageControlFieldFilterFired: Boolean;
+        EventBeforePageControlFieldFindSetPageId: Integer;
+        EventBeforePageControlFieldFindSetFireCount: Integer;
 
     [Test]
     procedure TestEditInExcelCreatesWebService()
@@ -406,70 +406,75 @@ codeunit 132525 "Edit in Excel Test"
 
     [Test]
     procedure TestExternalizeODataObjectNamePublicWrapper()
-    var
-        EditinExcelTestLibrary: Codeunit "Edit in Excel Test Library";
-        Input: Text;
-        PublicResult: Text;
-        ImplResult: Text;
     begin
-        // [SCENARIO] The public ExternalizeODataObjectName procedure on codeunit "Edit in Excel" exposes the same conversion as the internal implementation, so other apps can match Edit in Excel OData externalized names without duplicating the conversion logic.
+        // [SCENARIO] The public ExternalizeODataObjectName procedure on codeunit "Edit in Excel" produces the OData externalized name that the Edit in Excel runtime applies to field and service names, so other apps can derive the same external names without duplicating the conversion logic.
         Init();
 
-        // [GIVEN] A name that triggers OData escaping (digit prefix, en dash, space)
-        Input := '3 lager – reklassfication field';
+        // [GIVEN] A clean ASCII name
+        // [THEN] The wrapper passes it through unchanged
+        LibraryAssert.AreEqual('CustomerNumber', EditInExcel.ExternalizeODataObjectName('CustomerNumber'), 'A clean ASCII name should pass through unchanged');
 
-        // [WHEN] The public wrapper and the internal implementation are called with the same input
-        PublicResult := EditInExcel.ExternalizeODataObjectName(Input);
-        ImplResult := EditinExcelTestLibrary.ExternalizeODataObjectName(Input);
+        // [GIVEN] An ASCII name with a single space
+        // [THEN] The wrapper converts the space to an underscore
+        LibraryAssert.AreEqual('Posting_Date', EditInExcel.ExternalizeODataObjectName('Posting Date'), 'A single space should convert to an underscore');
 
-        // [THEN] Both produce the same OData externalized name
-        LibraryAssert.AreEqual(ImplResult, PublicResult, 'Public ExternalizeODataObjectName wrapper should return the same value as the internal implementation');
+        // [GIVEN] A name made of Arabic BMP characters
+        // [THEN] The wrapper passes the Arabic characters through unchanged (they do not match any of the conversion rules)
+        LibraryAssert.AreEqual('مرحبا', EditInExcel.ExternalizeODataObjectName('مرحبا'), 'Arabic BMP characters should pass through unchanged');
+
+        // [GIVEN] A name made of Japanese hiragana BMP characters
+        // [THEN] The wrapper passes the Japanese characters through unchanged
+        LibraryAssert.AreEqual('こんにちは', EditInExcel.ExternalizeODataObjectName('こんにちは'), 'Japanese hiragana BMP characters should pass through unchanged');
+
+        // [GIVEN] A name with an accented Latin character
+        // [THEN] The wrapper passes the accented character through unchanged
+        LibraryAssert.AreEqual('café', EditInExcel.ExternalizeODataObjectName('café'), 'Accented Latin BMP characters should pass through unchanged');
     end;
 
     [Test]
-    procedure TestOnPageControlFieldFilterBeforeFindSetEventFires()
+    procedure TestOnBeforePageControlFieldFindSetEventFires()
     var
         TenantWebService: Record "Tenant Web Service";
         EditinExcelFilters: Codeunit "Edit in Excel Filters";
         EditInExcelList: Page "Edit in Excel List";
     begin
-        // [SCENARIO] When EditPageInExcel runs, the new OnPageControlFieldFilterBeforeFindSetInSetupFieldColumnBindings event is raised with the page ID being exported, so subscribers can apply additional filters to the Page Control Field record.
+        // [SCENARIO] When EditPageInExcel runs, the new OnBeforePageControlFieldFindSet event is raised once with the page ID being exported, so subscribers can apply additional filters to the Page Control Field record.
         Init();
 
         // [GIVEN] No tenant web service for the page and no captured event state
         TenantWebService.SetRange("Object Type", TenantWebService."Object Type"::Page);
         TenantWebService.SetRange("Object ID", Page::"Edit in Excel List");
         TenantWebService.DeleteAll();
-        EditInExcelTest.ResetCapturedPageControlFieldFilter();
+        EditInExcelTest.ResetCapturedBeforePageControlFieldFindSet();
 
-        // [WHEN] EditPageInExcel runs the export flow that calls SetupFieldColumnBindings
+        // [WHEN] EditPageInExcel runs the export flow that iterates the Page Control Field record set
         EditInExcel.EditPageInExcel(CopyStr(EditInExcelList.Caption, 1, 240), Page::"Edit in Excel List", EditinExcelFilters);
 
-        // [THEN] The subscriber was invoked with the page that is being exported
-        LibraryAssert.IsTrue(EditInExcelTest.GetCapturedPageControlFieldFilterFired(), 'OnPageControlFieldFilterBeforeFindSetInSetupFieldColumnBindings event should have fired');
-        LibraryAssert.AreEqual(Page::"Edit in Excel List", EditInExcelTest.GetCapturedPageControlFieldFilterPageId(), 'OnPageControlFieldFilterBeforeFindSetInSetupFieldColumnBindings event should pass the exported page ID');
+        // [THEN] The subscriber was invoked exactly once with the page that is being exported
+        LibraryAssert.AreEqual(1, EditInExcelTest.GetCapturedBeforePageControlFieldFindSetFireCount(), 'OnBeforePageControlFieldFindSet event should fire exactly once per EditPageInExcel call');
+        LibraryAssert.AreEqual(Page::"Edit in Excel List", EditInExcelTest.GetCapturedBeforePageControlFieldFindSetPageId(), 'OnBeforePageControlFieldFindSet event should pass the exported page ID');
     end;
 
-    procedure GetCapturedPageControlFieldFilterFired(): Boolean
+    procedure GetCapturedBeforePageControlFieldFindSetFireCount(): Integer
     begin
-        exit(EventPageControlFieldFilterFired);
+        exit(EventBeforePageControlFieldFindSetFireCount);
     end;
 
-    procedure GetCapturedPageControlFieldFilterPageId(): Integer
+    procedure GetCapturedBeforePageControlFieldFindSetPageId(): Integer
     begin
-        exit(EventPageControlFieldFilterPageId);
+        exit(EventBeforePageControlFieldFindSetPageId);
     end;
 
-    procedure ResetCapturedPageControlFieldFilter()
+    procedure ResetCapturedBeforePageControlFieldFindSet()
     begin
-        EventPageControlFieldFilterPageId := 0;
-        EventPageControlFieldFilterFired := false;
+        EventBeforePageControlFieldFindSetPageId := 0;
+        EventBeforePageControlFieldFindSetFireCount := 0;
     end;
 
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Edit in Excel", 'OnPageControlFieldFilterBeforeFindSetInSetupFieldColumnBindings', '', false, false)]
-    local procedure CapturePageControlFieldFilterBeforeFindSet(var PageControlField: Record "Page Control Field"; PageId: Integer)
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Edit in Excel", 'OnBeforePageControlFieldFindSet', '', false, false)]
+    local procedure CaptureBeforePageControlFieldFindSet(var PageControlField: Record "Page Control Field"; PageId: Integer)
     begin
-        EventPageControlFieldFilterPageId := PageId;
-        EventPageControlFieldFilterFired := true;
+        EventBeforePageControlFieldFindSetPageId := PageId;
+        EventBeforePageControlFieldFindSetFireCount += 1;
     end;
 }

--- a/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
+++ b/src/System Application/Test/Edit in Excel/src/EditInExcelTest.Codeunit.al
@@ -437,6 +437,9 @@ codeunit 132525 "Edit in Excel Test"
 
         // [THEN] They agree on accented Latin BMP characters
         LibraryAssert.AreEqual(EditinExcelTestLibrary.ExternalizeODataObjectName('café'), EditInExcel.ExternalizeODataObjectName('café'), 'Public wrapper should match the test library wrapper for accented Latin BMP characters');
+
+        // [THEN] They agree on a name that exercises the digit prefix, en-dash, and space rules together
+        LibraryAssert.AreEqual(EditinExcelTestLibrary.ExternalizeODataObjectName('3 lager – reklassfication field'), EditInExcel.ExternalizeODataObjectName('3 lager – reklassfication field'), 'Public wrapper should match the test library wrapper for a name with digit prefix, en-dash, and spaces');
     end;
 
     [Test]


### PR DESCRIPTION
#### Summary

Adds two extension points to the public Edit in Excel codeunit so other apps can integrate with Edit in Excel without duplicating internal conversion logic and without forking the Page Control Field selection.

- Exposes `ExternalizeODataObjectName` as a public procedure on codeunit 1481 "Edit in Excel". The conversion already exists on the internal codeunit 1482 "Edit in Excel Impl." but was not reachable from other apps. Callers can now derive the same OData externalized field and service names that Edit in Excel uses when generating the workbook payload.

- Adds `OnPageControlFieldFilterBeforeFindSetInSetupFieldColumnBindings` on codeunit 1481, raised inside `SetupFieldColumnBindings` after PageNo and Sequence have been applied but before `FindSet`. Subscribers receive the `Page Control Field` record by reference and can add filters or change the sort order to control which fields end up in the workbook (for example, to honor user personalization).

Tests added for the public wrapper round-trip and for event invocation with the correct PageId.

#### Work Item(s)
Fixes #5390

Fixes [AB#325948](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/325948)









