### PR TITLE
[Subcontracting] Manufacturing Setup: Refactor Subcontracting Fields

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Install/SubcontractingCompInit.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Install/SubcontractingCompInit.Codeunit.al
@@ -26,7 +26,6 @@ codeunit 99001503 "Subcontracting Comp. Init."
         if not CreateSubcontractingReqWkshTemplateAndNameAndUpdateSetup(ManufacturingSetup) then
             exit;
 
-        ManufacturingSetup."Direct Transfer" := true;
         ManufacturingSetup."Create Prod. Order Info Line" := true;
         Evaluate(ManufacturingSetup."Subc. Inb. Whse. Handling Time", GetDefaultInboundWhseHandlingTime());
         ManufacturingSetup.Modify(true);

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcontractingManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcontractingManagement.Codeunit.al
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
@@ -522,19 +522,19 @@ codeunit 99001505 "Subcontracting Management"
     end;
 
     /// <summary>
-    /// Gets the transfer-from location code based on the setup field "Subc. Comp. at Location".
+    /// Gets the location code for production order components based on the setup field "Subc. Default Comp. Location".
     /// The location code is retrieved from the purchase line, company information, or manufacturing setup.
     /// </summary>
-    /// <returns>The transfer-from location code.</returns>
+    /// <returns>The components location code.</returns>
     procedure GetComponentsLocationCode(PurchaseLine: Record "Purchase Line"): Code[10]
     var
         CompanyInformation: Record "Company Information";
         ComponentsLocationCode: Code[10];
     begin
         GetManufacturingSetup();
-        ManufacturingSetup.TestField("Subc. Comp. at Location");
+        ManufacturingSetup.TestField("Subc. Default Comp. Location");
 
-        case ManufacturingSetup."Subc. Comp. at Location" of
+        case ManufacturingSetup."Subc. Default Comp. Location" of
             "Components at Location"::Purchase:
                 begin
                     PurchaseLine.TestField("Location Code");

--- a/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Codeunits/SubcCreateProdOrdOpt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Prod Order Creation Wizard/Codeunits/SubcCreateProdOrdOpt.Codeunit.al
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
@@ -636,7 +636,7 @@ codeunit 99001556 "Subc. Create Prod. Ord. Opt."
     begin
         GetManufacturingSetupCached();
         ManufacturingSetup.TestField("Rtng. Link Code Purch. Prov.");
-        ManufacturingSetup.TestField("Subc. Comp. at Location");
+        ManufacturingSetup.TestField("Subc. Default Comp. Location");
 
         ManufacturingSetup.TestField("Released Order Nos.");
         ManufacturingSetup.TestField("Production BOM Nos.");

--- a/src/Apps/W1/Subcontracting/App/src/Setup/Pages/ManufacturingSetupSubc.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Setup/Pages/ManufacturingSetupSubc.PageExt.al
@@ -12,7 +12,7 @@ pageextension 99001542 "Manufacturing Setup Subc." extends "Manufacturing Setup"
     {
         addlast(Content)
         {
-            group(Subcontracting)
+            group(SubcontractingSetup)
             {
                 Caption = 'Subcontracting';
 
@@ -29,48 +29,39 @@ pageextension 99001542 "Manufacturing Setup Subc." extends "Manufacturing Setup"
                         ApplicationArea = Manufacturing;
                         ToolTip = 'Specifies the time to calculate the Receipt Date in Transfer Line. The calculation will be Due Date from Prod. Order Component minus the entered date formula.';
                     }
-                    group(SubcSubcontracting)
+                    field("Subcontracting Template Name"; Rec."Subcontracting Template Name")
                     {
-                        Caption = 'Subcontracting';
-                        field("Subcontracting Template Name"; Rec."Subcontracting Template Name")
-                        {
-                            ApplicationArea = Manufacturing;
-                            ToolTip = 'Specifies the name of the subcontracting journal template to be used for the direct creation of subcontracting orders from a released routing.';
-                        }
-                        field("Subcontracting Batch Name"; Rec."Subcontracting Batch Name")
-                        {
-                            ApplicationArea = Manufacturing;
-                            ToolTip = 'Specifies the name of the subcontracting journal batch to be used for the direct creation of subcontracting orders from a released routing.';
-                        }
-                        field("Component Direct Unit Cost"; Rec."Component Direct Unit Cost")
-                        {
-                            ApplicationArea = Manufacturing;
-                            ToolTip = 'Specifies which Direct Unit Cost of a Prod. Order Component is to be used in the subcontracting purchase order. Standard: Standard pricing is used when procuring the component. Prod. Order Component: The calculated Direct Unit Cost of the Prod. Order Component Line is transferred to the subcontracting purchase order.';
-                        }
-                        field(RefItemChargeToRcptSubLines; Rec.RefItemChargeToRcptSubLines)
-                        {
-                            ApplicationArea = Manufacturing;
-                            ToolTip = 'Specifies whether to enable the item charge assignment to purchase receipt lines with subcontracting. When enabled, the item charge is posted as a new value entry of type "Direct Cost", when it is assigned to a purchase receipt line with referenced production order line. This created value entry is automatically assigned to a capacity entry of the prod order.';
-                        }
+                        ApplicationArea = Manufacturing;
+                        ToolTip = 'Specifies the name of the subcontracting journal template to be used for the direct creation of subcontracting orders from a released routing.';
                     }
-                    group(SubcProvision)
+                    field("Subcontracting Batch Name"; Rec."Subcontracting Batch Name")
                     {
-                        Caption = 'Purchase Provision';
-                        field("Rtng. Link Code Purch. Prov."; Rec."Rtng. Link Code Purch. Prov.")
-                        {
-                            ApplicationArea = Manufacturing;
-                            ToolTip = 'Specifies the value of the Routing Link Code for purchase provision.';
-                        }
-                        field("Direct Transfer"; Rec."Direct Transfer")
-                        {
-                            ApplicationArea = Manufacturing;
-                            ToolTip = 'Specifies that the transfer for subcontracting components does not use an in-transit location. When you transfer directly, the Qty. to Receive field will be locked with the same value as the quantity to ship.';
-                        }
-                        field("Subc. Comp. at Location"; Rec."Subc. Comp. at Location")
-                        {
-                            ApplicationArea = Manufacturing;
-                            ToolTip = 'Specifies which location code is to be used as the transfer-from location when creating a transfer order of external production components (provision).';
-                        }
+                        ApplicationArea = Manufacturing;
+                        ToolTip = 'Specifies the name of the subcontracting journal batch to be used for the direct creation of subcontracting orders from a released routing.';
+                    }
+                    field("Component Direct Unit Cost"; Rec."Component Direct Unit Cost")
+                    {
+                        ApplicationArea = Manufacturing;
+                        ToolTip = 'Specifies which Direct Unit Cost of a Prod. Order Component is to be used in the subcontracting purchase order. Standard: Standard pricing is used when procuring the component. Prod. Order Component: The calculated Direct Unit Cost of the Prod. Order Component Line is transferred to the subcontracting purchase order.';
+                    }
+                    field(RefItemChargeToRcptSubLines; Rec.RefItemChargeToRcptSubLines)
+                    {
+                        ApplicationArea = Manufacturing;
+                        ToolTip = 'Specifies whether to enable the item charge assignment to purchase receipt lines with subcontracting. When enabled, the item charge is posted as a new value entry of type "Direct Cost", when it is assigned to a purchase receipt line with referenced production order line. This created value entry is automatically assigned to a capacity entry of the prod order.';
+                    }
+                }
+                group(SubcPurchaseProvision)
+                {
+                    Caption = 'Purchase Provision';
+                    field("Rtng. Link Code Purch. Prov."; Rec."Rtng. Link Code Purch. Prov.")
+                    {
+                        ApplicationArea = Manufacturing;
+                        ToolTip = 'Specifies the value of the Routing Link Code for purchase provision.';
+                    }
+                    field("Subc. Default Comp. Location"; Rec."Subc. Default Comp. Location")
+                    {
+                        ApplicationArea = Manufacturing;
+                        ToolTip = 'Specifies the source used to determine the default location code for production order components in purchase provision. Purchase: the location code from the purchase order line is used. Company: the location code from the company information is used. Manufacturing: the location code from the manufacturing setup is used.';
                     }
                 }
             }

--- a/src/Apps/W1/Subcontracting/App/src/Setup/Pages/SubcManufacturingSetup.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Setup/Pages/SubcManufacturingSetup.PageExt.al
@@ -6,7 +6,7 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Setup;
 
-pageextension 99001542 "Manufacturing Setup Subc." extends "Manufacturing Setup"
+pageextension 99001542 "Subc. Manufacturing Setup" extends "Manufacturing Setup"
 {
     layout
     {

--- a/src/Apps/W1/Subcontracting/App/src/Setup/Tables/SubcManufacturingSetup.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Setup/Tables/SubcManufacturingSetup.TableExt.al
@@ -39,11 +39,6 @@ tableextension 99001501 "Subc. Manufacturing Setup" extends "Manufacturing Setup
 #pragma warning restore AL0432
 #pragma warning restore AL0520
         }
-        field(99001503; "Direct Transfer"; Boolean)
-        {
-            Caption = 'Direct Transfer for Subcontracting';
-            DataClassification = CustomerContent;
-        }
         field(99001504; "Component Direct Unit Cost"; Option)
         {
             Caption = 'Component Direct Unit Cost';
@@ -62,9 +57,9 @@ tableextension 99001501 "Subc. Manufacturing Setup" extends "Manufacturing Setup
             DataClassification = CustomerContent;
             TableRelation = "Routing Link";
         }
-        field(99001509; "Subc. Comp. at Location"; Enum "Components at Location")
+        field(99001509; "Subc. Default Comp. Location"; Enum "Components at Location")
         {
-            Caption = 'Component at Location';
+            Caption = 'Default Component Location Source';
             DataClassification = CustomerContent;
 
             trigger OnValidate()
@@ -72,13 +67,13 @@ tableextension 99001501 "Subc. Manufacturing Setup" extends "Manufacturing Setup
                 CompanyInformation: Record "Company Information";
                 ManufacturingSetup: Record "Manufacturing Setup";
             begin
-                case "Subc. Comp. at Location" of
-                    "Subc. Comp. at Location"::Company:
+                case "Subc. Default Comp. Location" of
+                    "Subc. Default Comp. Location"::Company:
                         begin
                             CompanyInformation.Get();
                             CompanyInformation.TestField("Location Code");
                         end;
-                    "Subc. Comp. at Location"::Manufacturing:
+                    "Subc. Default Comp. Location"::Manufacturing:
                         begin
                             ManufacturingSetup.Get();
                             ManufacturingSetup.TestField("Components at Location");

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Libraries/SubcSetupLibrary.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Libraries/SubcSetupLibrary.Codeunit.al
@@ -59,7 +59,7 @@ codeunit 139988 "Subc. Setup Library"
         end;
 
         ManufacturingSetup."Rtng. Link Code Purch. Prov." := RoutingLink."Code";
-        ManufacturingSetup."Subc. Comp. at Location" := ManufacturingSetup."Subc. Comp. at Location"::Purchase;
+        ManufacturingSetup."Subc. Default Comp. Location" := ManufacturingSetup."Subc. Default Comp. Location"::Purchase;
         ManufacturingSetup.Modify();
     end;
 

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcLocationHandlerTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcLocationHandlerTest.Codeunit.al
@@ -82,7 +82,7 @@ codeunit 139981 "Subc. Location Handler Test"
         // [SCENARIO] GetComponentsLocationCode returns Purchase Line Location when Setup is Purchase
         Initialize();
 
-        // [GIVEN] Sub Management Setup "Subc. Comp. at Location" is Purchase
+        // [GIVEN] Sub Management Setup "Subc. Default Comp. Location" is Purchase
         UpdateSubManagementSetup("Components at Location"::Purchase);
 
         // [GIVEN] A Purchase Line with a Location
@@ -110,7 +110,7 @@ codeunit 139981 "Subc. Location Handler Test"
         // [SCENARIO] GetComponentsLocationCode returns Company Location when Setup is Company
         Initialize();
 
-        // [GIVEN] Sub Management Setup "Subc. Comp. at Location" is Company
+        // [GIVEN] Sub Management Setup "Subc. Default Comp. Location" is Company
         UpdateSubManagementSetup("Components at Location"::Company);
 
         // [GIVEN] Company Information has a Location
@@ -135,7 +135,7 @@ codeunit 139981 "Subc. Location Handler Test"
         // [SCENARIO] GetComponentsLocationCode returns Manufacturing Location when Setup is Manufacturing
         Initialize();
 
-        // [GIVEN] Sub Management Setup "Subc. Comp. at Location" is Manufacturing
+        // [GIVEN] Sub Management Setup "Subc. Default Comp. Location" is Manufacturing
         UpdateSubManagementSetup("Components at Location"::Manufacturing);
 
         // [GIVEN] Manufacturing Setup has a Location
@@ -295,7 +295,7 @@ codeunit 139981 "Subc. Location Handler Test"
         // [GIVEN] proper setup configuration with Manufacturing location
         Initialize();
 
-        // [GIVEN] Sub Management Setup "Subc. Comp. at Location" is Manufacturing
+        // [GIVEN] Sub Management Setup "Subc. Default Comp. Location" is Manufacturing
         UpdateSubManagementSetup("Components at Location"::Manufacturing);
 
         // [GIVEN] Manufacturing Setup with a specific Location Code
@@ -437,7 +437,7 @@ codeunit 139981 "Subc. Location Handler Test"
             ManufacturingSetup.Init();
             ManufacturingSetup.Insert();
         end;
-        ManufacturingSetup."Subc. Comp. at Location" := ComponentAtLocation;
+        ManufacturingSetup."Subc. Default Comp. Location" := ComponentAtLocation;
         ManufacturingSetup.Modify();
     end;
 

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingSyncTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingSyncTest.Codeunit.al
@@ -440,7 +440,7 @@ codeunit 139992 "Subc. Subcontracting Sync Test"
         ManufacturingSetup: Record "Manufacturing Setup";
     begin
         ManufacturingSetup.Get();
-        ManufacturingSetup."Subc. Comp. at Location" := CompAtLocation;
+        ManufacturingSetup."Subc. Default Comp. Location" := CompAtLocation;
         ManufacturingSetup.Modify();
     end;
 

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2935,7 +2935,7 @@ Comment = '|%1 = Transfer Order No.';
 
         LibraryInventory.NoSeriesSetup(InventorySetup);
         InventorySetup."Inventory Put-away Nos." := LibraryUtility.GetGlobalNoSeriesCode();
-        // InventorySetup."Direct Transfer Posting Type" := InventorySetup."Direct Transfer Posting Type"::"Direct Transfer";
+        InventorySetup."Direct Transfer Posting Type" := InventorySetup."Direct Transfer Posting Type"::"Direct Transfer";
         InventorySetup.Modify();
         LibraryInventory.UpdateInventoryPostingSetup(Location);
     end;

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2895,7 +2895,7 @@ Comment = '|%1 = Transfer Order No.';
         ManufacturingSetup: Record "Manufacturing Setup";
     begin
         ManufacturingSetup.Get();
-        ManufacturingSetup."Subc. Comp. at Location" := CompAtLocation;
+        ManufacturingSetup."Subc. Default Comp. Location" := CompAtLocation;
         ManufacturingSetup.Modify();
     end;
 
@@ -2935,7 +2935,7 @@ Comment = '|%1 = Transfer Order No.';
 
         LibraryInventory.NoSeriesSetup(InventorySetup);
         InventorySetup."Inventory Put-away Nos." := LibraryUtility.GetGlobalNoSeriesCode();
-        InventorySetup."Direct Transfer Posting Type" := InventorySetup."Direct Transfer Posting Type"::"Direct Transfer";
+        // InventorySetup."Direct Transfer Posting Type" := InventorySetup."Direct Transfer Posting Type"::"Direct Transfer";
         InventorySetup.Modify();
         LibraryInventory.UpdateInventoryPostingSetup(Location);
     end;


### PR DESCRIPTION
This pull request refactors the configuration for default component location handling in the Subcontracting module. It replaces the field `Subc. Comp. at Location` with `Subc. Default Comp. Location` throughout the codebase, updates related page layouts and tooltips for clarity, and removes the obsolete `Direct Transfer` field. The changes also update tests and documentation to align with the new field name and logic.

**Manufacturing Setup Field Refactoring**

* The field `Subc. Comp. at Location` is replaced by `Subc. Default Comp. Location` in the manufacturing setup table, with corresponding updates to the caption, validation logic, and all code references. [[1]](diffhunk://#diff-03caf9a45b2a85a9af236d3504bcbb99c07b38f26f41018d9f4b29c84e6ab960L65-R76) [[2]](diffhunk://#diff-4fd8c93dd6a53103e5d9e50edb9fc297ce8c735677088dcb86028b698722e724L525-R537) [[3]](diffhunk://#diff-a3bdb7392b518403cbdd3b21f8bdffcd9478beea1c0a6131fa7b80fde2a1cfc5L639-R639) [[4]](diffhunk://#diff-d7ddb2715c07a323f9cd8c4db4019b5a503bdf4c05b5f3f92aed4bcb6ab43729L62-R62) [[5]](diffhunk://#diff-5deb06093aa676cb7741ec4fa2e7bfdebb015872953f928f1dde6e87a5b4d7d1L440-R440) [[6]](diffhunk://#diff-5a1cb401b229a35a2a6c46b70422f236e6a4eb348b823fd9c539d76cdf118e16L443-R443) [[7]](diffhunk://#diff-472647a27bccfc70f7beb69a4a14e39eea2c0671189498afa0bea4a31fcc8e97L2898-R2898)
* The obsolete field `Direct Transfer` is removed from the manufacturing setup table, related initialization code, and page layouts. [[1]](diffhunk://#diff-03caf9a45b2a85a9af236d3504bcbb99c07b38f26f41018d9f4b29c84e6ab960L42-L46) [[2]](diffhunk://#diff-f036ca78b2a6473af8e638b2a4708f7abdcffc1dae34dc17388ea64864fb871eL29) [[3]](diffhunk://#diff-d0e73680d036c43bd1b2ed31c62f6bfec2d2264d90a78e5261cc1436030e352eL56-R64)

**Page and UI Improvements**

* The manufacturing setup page extension is updated to use the new field name, group names are clarified, and tooltips are improved to better explain the default component location logic. [[1]](diffhunk://#diff-d0e73680d036c43bd1b2ed31c62f6bfec2d2264d90a78e5261cc1436030e352eL15-R15) [[2]](diffhunk://#diff-d0e73680d036c43bd1b2ed31c62f6bfec2d2264d90a78e5261cc1436030e352eL32-L34) [[3]](diffhunk://#diff-d0e73680d036c43bd1b2ed31c62f6bfec2d2264d90a78e5261cc1436030e352eL56-R64)

**Business Logic Updates**

* The logic in `GetComponentsLocationCode` and related procedures is updated to reference `Subc. Default Comp. Location` and use the new naming in all code and documentation. [[1]](diffhunk://#diff-4fd8c93dd6a53103e5d9e50edb9fc297ce8c735677088dcb86028b698722e724L525-R537) [[2]](diffhunk://#diff-a3bdb7392b518403cbdd3b21f8bdffcd9478beea1c0a6131fa7b80fde2a1cfc5L639-R639)

**Test Suite Updates**

* All tests are updated to use `Subc. Default Comp. Location` instead of the old field, ensuring consistency and correctness. [[1]](diffhunk://#diff-5deb06093aa676cb7741ec4fa2e7bfdebb015872953f928f1dde6e87a5b4d7d1L85-R85) [[2]](diffhunk://#diff-5deb06093aa676cb7741ec4fa2e7bfdebb015872953f928f1dde6e87a5b4d7d1L113-R113) [[3]](diffhunk://#diff-5deb06093aa676cb7741ec4fa2e7bfdebb015872953f928f1dde6e87a5b4d7d1L138-R138) [[4]](diffhunk://#diff-5deb06093aa676cb7741ec4fa2e7bfdebb015872953f928f1dde6e87a5b4d7d1L298-R298) [[5]](diffhunk://#diff-5deb06093aa676cb7741ec4fa2e7bfdebb015872953f928f1dde6e87a5b4d7d1L440-R440) [[6]](diffhunk://#diff-5a1cb401b229a35a2a6c46b70422f236e6a4eb348b823fd9c539d76cdf118e16L443-R443) [[7]](diffhunk://#diff-472647a27bccfc70f7beb69a4a14e39eea2c0671189498afa0bea4a31fcc8e97L2898-R2898)

**Minor Cleanups**

* Unused or commented-out references to direct transfer posting types are removed for clarity.
* File headers are normalized. [[1]](diffhunk://#diff-4fd8c93dd6a53103e5d9e50edb9fc297ce8c735677088dcb86028b698722e724L1-R1) [[2]](diffhunk://#diff-a3bdb7392b518403cbdd3b21f8bdffcd9478beea1c0a6131fa7b80fde2a1cfc5L1-R1)
Fixes [AB#618366](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/618366)



