### PR TITLE
Port PEPPOL price-incl-VAT line amount fix to PEPPOL app

### DIFF
--- a/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Impl.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Impl.Codeunit.al
@@ -798,6 +798,8 @@ codeunit 37201 "PEPPOL30 Impl."
         InvoiceLineNote := DelChr(Format(SalesLine.Type), '<>');
         InvoicedQuantity := Format(SalesLine.Quantity, 0, 9);
         SalesLineLineAmount := SalesLine."Line Amount";
+        if SalesHeader."Prices Including VAT" and (SalesLine."VAT %" <> 0) then
+            SalesLineLineAmount := Round(SalesLineLineAmount / (1 + SalesLine."VAT %" / 100), 0.01);
         InvoiceLineExtensionAmount := Format(SalesLineLineAmount, 0, 9);
         LineExtensionAmountCurrencyID := GetSalesDocCurrencyCode(SalesHeader);
         InvoiceLineAccountingCost := '';
@@ -869,7 +871,10 @@ codeunit 37201 "PEPPOL30 Impl."
 
         InvLnAllowanceChargeIndicator := 'false';
         InvLnAllowanceChargeReason := LineDisAmtTxt;
-        InvLnAllowanceChargeAmount := Format(SalesLine."Line Discount Amount", 0, 9);
+        if SalesHeader."Prices Including VAT" and (SalesLine."VAT %" <> 0) then
+            InvLnAllowanceChargeAmount := Format(Round(SalesLine."Line Discount Amount" / (1 + SalesLine."VAT %" / 100), 0.01), 0, 9)
+        else
+            InvLnAllowanceChargeAmount := Format(SalesLine."Line Discount Amount", 0, 9);
         InvLnAllowanceChargeAmtCurrID := GetSalesDocCurrencyCode(SalesHeader);
     end;
 

--- a/src/Apps/W1/PEPPOL/Test/src/PEPPOL30ManagementTests.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/Test/src/PEPPOL30ManagementTests.Codeunit.al
@@ -3349,6 +3349,68 @@ codeunit 139235 "PEPPOL30 Management Tests"
         Assert.AreEqual('', CustTaxSchemeID, 'Tax Scheme ID should be empty for Tax Category O.');
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure LineAmountsConsistentWhenPricesInclVATNoDiscount()
+    var
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Customer: Record Customer;
+        Item: Record Item;
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        SalesInvoiceLine: Record "Sales Invoice Line";
+        PEPPOLLineInfoProvider: Interface "PEPPOL Line Info Provider";
+        InvoiceLineID: Text;
+        InvoiceLineNote: Text;
+        InvoicedQuantity: Text;
+        InvoiceLineExtensionAmount: Text;
+        LineExtensionAmountCurrencyID: Text;
+        InvoiceLineAccountingCost: Text;
+        InvoiceLinePriceAmount: Text;
+        InvLinePriceAmountCurrencyID: Text;
+        BaseQuantity: Text;
+        UnitCode: Text;
+        PriceAmount: Decimal;
+        LineExtensionAmt: Decimal;
+        SalesInvoiceNo: Code[20];
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 630795] PEPPOL LineExtensionAmount equals PriceAmount times Quantity when Prices Including VAT is used
+        Initialize();
+
+        // [GIVEN] Customer "C" with PEPPOL identifier
+        LibrarySales.CreateCustomer(Customer);
+        AddCustPEPPOLIdentifier(Customer."No.");
+
+        // [GIVEN] Sales Invoice for "C" with "Prices Including VAT" = TRUE and Quantity = 7
+        CreateItemWithPrice(Item, 139);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, Customer."No.");
+        SalesHeader.Validate("Prices Including VAT", true);
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, Item."No.", 7);
+
+        // [WHEN] Post the Sales Invoice and retrieve PEPPOL line amounts
+        SalesInvoiceNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        SalesInvoiceHeader.Get(SalesInvoiceNo);
+        SalesHeader.TransferFields(SalesInvoiceHeader);
+        FindSalesInvoiceLine(SalesInvoiceLine, SalesInvoiceNo);
+        SalesLine.TransferFields(SalesInvoiceLine);
+
+        PEPPOLLineInfoProvider := GetFormat();
+        PEPPOLLineInfoProvider.GetLineGeneralInfo(
+          SalesLine, SalesHeader, InvoiceLineID, InvoiceLineNote, InvoicedQuantity,
+          InvoiceLineExtensionAmount, LineExtensionAmountCurrencyID, InvoiceLineAccountingCost);
+        PEPPOLLineInfoProvider.GetLinePriceInfo(
+          SalesLine, SalesHeader, InvoiceLinePriceAmount, InvLinePriceAmountCurrencyID,
+          BaseQuantity, UnitCode);
+
+        // [THEN] LineExtensionAmount equals PriceAmount times Quantity per PEPPOL BIS 3.0
+        Evaluate(PriceAmount, InvoiceLinePriceAmount, 9);
+        Evaluate(LineExtensionAmt, InvoiceLineExtensionAmount, 9);
+        Assert.AreEqual(PriceAmount * SalesInvoiceLine.Quantity, LineExtensionAmt,
+          'LineExtensionAmount must equal PriceAmount * Quantity per PEPPOL BIS 3.0');
+    end;
+
     var
     local procedure Initialize()
     var
@@ -3993,6 +4055,8 @@ codeunit 139235 "PEPPOL30 Management Tests"
         Assert.AreEqual(UnitOfMeasure."International Standard Code", unitCode, '');
         Assert.AreEqual('UNECERec20', unitCodeListID, '');
         SalesInvoiceLineLineAmount := SalesInvoiceLine."Line Amount";
+        if SalesHeader."Prices Including VAT" and (SalesLine."VAT %" <> 0) then
+            SalesInvoiceLineLineAmount := Round(SalesInvoiceLineLineAmount / (1 + SalesLine."VAT %" / 100), 0.01);
         Assert.AreEqual(Format(SalesInvoiceLineLineAmount, 0, 9), InvoiceLineExtensionAmount, '');
         Assert.AreEqual(SalesHeader."Currency Code", LineExtensionAmountCurrencyID, '');
         Assert.AreEqual('', InvoiceLineAccountingCost, '');


### PR DESCRIPTION
## Summary
Mirrors BaseApp commit 7999d10 (ADO PR 244837 / work item [AB#630795](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630795)) into the standalone PEPPOL app. PEPPOL BIS 3.0 requires line amounts and discount amounts to be VAT-exclusive; the BaseApp `PEPPOL Management` codeunit was fixed but the equivalent code in `PEPPOL30 Impl.` was never updated, so e-invoices generated through the PEPPOL app still failed validation when `Prices Including VAT` was used on a sales document.

- `PEPPOL30Impl.GetLineGeneralInfo`: divide `Line Amount` by `(1 + VAT%/100)` when `Prices Including VAT` is true
- `PEPPOL30Impl.GetLineAllowanceChargeInfo`: same VAT adjustment for `Line Discount Amount`
- `PEPPOL30ManagementTests.VerifyGetLineGeneralInfo`: updated to apply the same adjustment in assertions
- New test `LineAmountsConsistentWhenPricesInclVATNoDiscount` asserts `LineExtensionAmount = PriceAmount * Quantity` per PEPPOL BIS 3.0





