### PR TITLE
[Shopify] Use ISO country code when filtering Shpfy Tax Area on customer/company export

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
@@ -123,6 +123,7 @@ codeunit 30284 "Shpfy Company Export"
         TaxRegistrationIdMapping: Interface "Shpfy Tax Registration Id Mapping";
         CountyCodeTooLongErr: Text;
         PaymentTermsId: BigInteger;
+        ISOCountryCode: Code[2];
     begin
         TempCompanyLocation := CompanyLocation;
 
@@ -133,8 +134,20 @@ codeunit 30284 "Shpfy Company Export"
         CompanyLocation.City := Customer.City;
         CompanyLocation.Recipient := Customer.Name;
 
+        if (Customer."Country/Region Code" = '') and CompanyInformation.Get() then
+            Customer."Country/Region Code" := CompanyInformation."Country/Region Code";
+
+        // Shpfy Tax Area is keyed by Shopify's ISO 3166-1 alpha-2 codes (e.g. "GR")
+        // which can differ from BC's Country/Region Code (e.g. "EL" used for EU/VIES).
+        // Resolve once and reuse for both Tax Area filtering and the Shopify-side location.
+        if CountryRegion.Get(Customer."Country/Region Code") then begin
+            CountryRegion.TestField("ISO Code");
+            ISOCountryCode := CountryRegion."ISO Code";
+            CompanyLocation."Country/Region Code" := ISOCountryCode;
+        end;
+
         if Customer.County <> '' then begin
-            TaxArea.SetRange("Country/Region Code", Customer."Country/Region Code");
+            TaxArea.SetRange("Country/Region Code", ISOCountryCode);
             if not TaxArea.IsEmpty() then
                 case Shop."County Source" of
                     Shop."County Source"::Code:
@@ -143,7 +156,7 @@ codeunit 30284 "Shpfy Company Export"
                                 CountyCodeTooLongErr := StrSubstNo(CountyCodeTooLongLbl, Customer."No.", Customer.Name, StrLen(Customer.County), MaxStrLen(TaxArea."County Code"), Customer.County, Customer.FieldCaption(County));
                                 Error(CountyCodeTooLongErr);
                             end;
-                            TaxArea.SetRange("Country/Region Code", Customer."Country/Region Code");
+                            TaxArea.SetRange("Country/Region Code", ISOCountryCode);
                             TaxArea.SetRange("County Code", Customer.County);
                             if TaxArea.FindFirst() then begin
                                 CompanyLocation."Province Code" := TaxArea."County Code";
@@ -152,7 +165,7 @@ codeunit 30284 "Shpfy Company Export"
                         end;
                     Shop."County Source"::Name:
                         begin
-                            TaxArea.SetRange("Country/Region Code", Customer."Country/Region Code");
+                            TaxArea.SetRange("Country/Region Code", ISOCountryCode);
                             TaxArea.SetRange(County, Customer.County);
                             if TaxArea.FindFirst() then begin
                                 CompanyLocation."Province Code" := TaxArea."County Code";
@@ -166,14 +179,6 @@ codeunit 30284 "Shpfy Company Export"
                             end;
                         end;
                 end;
-        end;
-
-        if (Customer."Country/Region Code" = '') and CompanyInformation.Get() then
-            Customer."Country/Region Code" := CompanyInformation."Country/Region Code";
-
-        if CountryRegion.Get(Customer."Country/Region Code") then begin
-            CountryRegion.TestField("ISO Code");
-            CompanyLocation."Country/Region Code" := CountryRegion."ISO Code";
         end;
 
         CompanyLocation."Phone No." := Customer."Phone No.";

--- a/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCustomerExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCustomerExport.Codeunit.al
@@ -109,6 +109,7 @@ codeunit 30116 "Shpfy Customer Export"
 #pragma warning restore AA0073
         TaxArea: Record "Shpfy Tax Area";
         CountyCodeTooLongErr: Text;
+        ISOCountryCode: Code[2];
     begin
         xShopifyCustomer := ShopifyCustomer;
         xCustomerAddress := CustomerAddress;
@@ -147,8 +148,17 @@ codeunit 30116 "Shpfy Customer Export"
         if (Customer."Country/Region Code" = '') and CompanyInformation.Get() then
             Customer."Country/Region Code" := CompanyInformation."Country/Region Code";
 
+        // Shpfy Tax Area is keyed by Shopify's ISO 3166-1 alpha-2 codes (e.g. "GR")
+        // which can differ from BC's Country/Region Code (e.g. "EL" used for EU/VIES).
+        // Resolve once and reuse for both Tax Area filtering and the Shopify-side address.
+        if CountryRegion.Get(Customer."Country/Region Code") then begin
+            CountryRegion.TestField("ISO Code");
+            ISOCountryCode := CountryRegion."ISO Code";
+            CustomerAddress."Country/Region Code" := ISOCountryCode;
+        end;
+
         if Customer.County <> '' then begin
-            TaxArea.SetRange("Country/Region Code", Customer."Country/Region Code");
+            TaxArea.SetRange("Country/Region Code", ISOCountryCode);
             if not TaxArea.IsEmpty() then
                 case Shop."County Source" of
                     Shop."County Source"::Code:
@@ -157,7 +167,7 @@ codeunit 30116 "Shpfy Customer Export"
                                 CountyCodeTooLongErr := StrSubstNo(CountyCodeTooLongLbl, Customer."No.", Customer.Name, StrLen(Customer.County), MaxStrLen(TaxArea."County Code"), Customer.County, Customer.FieldCaption(County));
                                 Error(CountyCodeTooLongErr);
                             end;
-                            TaxArea.SetRange("Country/Region Code", Customer."Country/Region Code");
+                            TaxArea.SetRange("Country/Region Code", ISOCountryCode);
                             TaxArea.SetRange("County Code", Customer.County);
                             if TaxArea.FindFirst() then begin
                                 CustomerAddress."Province Code" := TaxArea."County Code";
@@ -166,7 +176,7 @@ codeunit 30116 "Shpfy Customer Export"
                         end;
                     Shop."County Source"::Name:
                         begin
-                            TaxArea.SetRange("Country/Region Code", Customer."Country/Region Code");
+                            TaxArea.SetRange("Country/Region Code", ISOCountryCode);
                             TaxArea.SetRange(County, Customer.County);
                             if TaxArea.FindFirst() then begin
                                 CustomerAddress."Province Code" := TaxArea."County Code";
@@ -180,11 +190,6 @@ codeunit 30116 "Shpfy Customer Export"
                             end;
                         end;
                 end;
-        end;
-
-        if CountryRegion.Get(Customer."Country/Region Code") then begin
-            CountryRegion.TestField("ISO Code");
-            CustomerAddress."Country/Region Code" := CountryRegion."ISO Code";
         end;
 
         CustomerAddress.Phone := Customer."Phone No.";

--- a/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyExportTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyExportTest.Codeunit.al
@@ -5,6 +5,7 @@
 
 namespace Microsoft.Integration.Shopify.Test;
 
+using Microsoft.Foundation.Address;
 using Microsoft.Foundation.PaymentTerms;
 using Microsoft.Integration.Shopify;
 using Microsoft.Sales.Customer;
@@ -154,6 +155,65 @@ codeunit 139636 "Shpfy Company Export Test"
         LibraryAssert.IsTrue(Result, 'Result');
         LibraryAssert.IsTrue(CompanyLocation."Province Code" = '', 'Province Code');
         LibraryAssert.IsTrue(CompanyLocation."Province Name" = '', 'Province Name');
+    end;
+
+    [Test]
+    procedure UnitTestFillInShopifyCompanyLocationISOCountryCodeMapping()
+    var
+        Customer: Record Customer;
+        CountryRegion: Record "Country/Region";
+        CompanyLocation: Record "Shpfy Company Location";
+        ShopifyShop: Record "Shpfy Shop";
+        TaxArea: Record "Shpfy Tax Area";
+        Result: Boolean;
+    begin
+        // [SCENARIO] When BC's Country/Region Code differs from its ISO Code (e.g. "EL" vs "GR" for Greece),
+        // the Shopify company location export uses the ISO code for both Tax Area lookups and the Shopify-side location.
+
+        // [GIVEN] A Country/Region with mismatched BC code and ISO code (Greece: BC = "EL", ISO = "GR")
+        if not CountryRegion.Get('EL') then begin
+            CountryRegion.Init();
+            CountryRegion.Code := 'EL';
+            CountryRegion."ISO Code" := 'GR';
+            CountryRegion.Insert();
+        end else
+            if CountryRegion."ISO Code" <> 'GR' then begin
+                CountryRegion."ISO Code" := 'GR';
+                CountryRegion.Modify();
+            end;
+
+        // [GIVEN] A Customer in that country with a county set
+        Customer.FindFirst();
+        Customer."Country/Region Code" := 'EL';
+        Customer.County := 'ATT';
+        Customer.Modify();
+
+        // [GIVEN] A Shpfy Tax Area keyed by the Shopify-side ISO code, not BC's local code
+        TaxArea."Country/Region Code" := 'GR';
+        TaxArea.County := 'Attica';
+        TaxArea."County Code" := 'ATT';
+        TaxArea.Insert();
+
+        ShopifyShop := InitializeTest.CreateShop();
+        ShopifyShop."Name Source" := Enum::"Shpfy Name Source"::CompanyName;
+        ShopifyShop."Name 2 Source" := Enum::"Shpfy Name Source"::None;
+        ShopifyShop."Contact Source" := Enum::"Shpfy Name Source"::None;
+        ShopifyShop."County Source" := Enum::"Shpfy County Source"::Code;
+        CompanyLocation.Init();
+
+        // [GIVEN] Shop
+        CompanyExport.SetShop(ShopifyShop);
+
+        // [WHEN] Filling in Shopify company location data
+        Result := CompanyExport.FillInShopifyCompanyLocation(Customer, CompanyLocation);
+
+        // [THEN] CompanyLocation."Country/Region Code" is the ISO code, not BC's local code
+        LibraryAssert.IsTrue(Result, 'Result');
+        LibraryAssert.AreEqual('GR', CompanyLocation."Country/Region Code", 'Country/Region Code should be ISO');
+
+        // [THEN] Province lookup against the ISO-keyed Shpfy Tax Area succeeded
+        LibraryAssert.AreEqual('ATT', CompanyLocation."Province Code", 'Province Code');
+        LibraryAssert.AreEqual('Attica', CompanyLocation."Province Name", 'Province Name');
     end;
 
 

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerExportTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerExportTest.Codeunit.al
@@ -5,6 +5,7 @@
 
 namespace Microsoft.Integration.Shopify.Test;
 
+using Microsoft.Foundation.Address;
 using Microsoft.Integration.Shopify;
 using Microsoft.Sales.Customer;
 using System.TestLibraries.Utilities;
@@ -145,5 +146,67 @@ codeunit 139568 "Shpfy Customer Export Test"
         LibraryAssert.IsTrue(Result, 'Result');
         LibraryAssert.IsTrue(CustomerAddress."Province Code" = '', 'Province Code');
         LibraryAssert.IsTrue(CustomerAddress."Province Name" = '', 'Province Name');
+    end;
+
+    [Test]
+    procedure UnitTestFillInShopifyCustomerDataISOCountryCodeMapping()
+    var
+        Customer: Record Customer;
+        CountryRegion: Record "Country/Region";
+        ShopifyCustomer: Record "Shpfy Customer";
+        CustomerAddress: Record "Shpfy Customer Address";
+        Shop: Record "Shpfy Shop";
+        TaxArea: Record "Shpfy Tax Area";
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+        Result: Boolean;
+    begin
+        // [SCENARIO] When BC's Country/Region Code differs from its ISO Code (e.g. "EL" vs "GR" for Greece),
+        // the Shopify export uses the ISO code for both Tax Area lookups and the Shopify-side address.
+
+        // [GIVEN] A Country/Region with mismatched BC code and ISO code (Greece: BC = "EL", ISO = "GR")
+        if not CountryRegion.Get('EL') then begin
+            CountryRegion.Init();
+            CountryRegion.Code := 'EL';
+            CountryRegion."ISO Code" := 'GR';
+            CountryRegion.Insert();
+        end else
+            if CountryRegion."ISO Code" <> 'GR' then begin
+                CountryRegion."ISO Code" := 'GR';
+                CountryRegion.Modify();
+            end;
+
+        // [GIVEN] A Customer in that country with a county set
+        Customer.FindFirst();
+        Customer."Country/Region Code" := 'EL';
+        Customer.County := 'ATT';
+        Customer.Modify();
+
+        // [GIVEN] A Shpfy Tax Area keyed by the Shopify-side ISO code, not BC's local code
+        TaxArea."Country/Region Code" := 'GR';
+        TaxArea.County := 'Attica';
+        TaxArea."County Code" := 'ATT';
+        TaxArea.Insert();
+
+        Shop := InitializeTest.CreateShop();
+        Shop."Name Source" := Enum::"Shpfy Name Source"::CompanyName;
+        Shop."Name 2 Source" := Enum::"Shpfy Name Source"::None;
+        Shop."Contact Source" := Enum::"Shpfy Name Source"::None;
+        Shop."County Source" := Enum::"Shpfy County Source"::Code;
+        ShopifyCustomer.Init();
+        CustomerAddress.Init();
+
+        // [GIVEN] Shop
+        CustomerExport.SetShop(Shop);
+
+        // [WHEN] Filling in Shopify customer data
+        Result := CustomerExport.FillInShopifyCustomerData(Customer, ShopifyCustomer, CustomerAddress);
+
+        // [THEN] CustomerAddress."Country/Region Code" is the ISO code, not BC's local code
+        LibraryAssert.IsTrue(Result, 'Result');
+        LibraryAssert.AreEqual('GR', CustomerAddress."Country/Region Code", 'Country/Region Code should be ISO');
+
+        // [THEN] Province lookup against the ISO-keyed Shpfy Tax Area succeeded
+        LibraryAssert.AreEqual('ATT', CustomerAddress."Province Code", 'Province Code');
+        LibraryAssert.AreEqual('Attica', CustomerAddress."Province Name", 'Province Name');
     end;
 }


### PR DESCRIPTION
## What & why

`Shpfy Tax Area` is populated from Shopify's `shipsToCountries` GraphQL enum (and the bundled `provinces.yml`) and stores ISO 3166-1 alpha-2 codes (e.g. `GR`). The customer and company export procedures filtered it using BC's local `Country/Region Code` (e.g. `EL` for Greece per EU/VIES). For any country whose BC code differs from its ISO code, the Tax Area filter never matched and Province Code / Province Name silently failed to populate on the Shopify-side address.

This PR resolves the ISO code once via `Country/Region.Get` + `TestField("ISO Code")` and reuses it for both Tax Area filtering and the Shopify-side address assignment. The local ISO variable is declared as `Code[2]`, matching `Country/Region."ISO Code"` and the destination `Shpfy Customer Address."Country/Region Code"` / `Shpfy Company Location."Country/Region Code"` fields, which avoids the AA0139 overflow that blocked the previous attempt in PR #6130.

I also harmonized the order of operations in `Shpfy Company Export.FillInShopifyCompanyLocation` so the Company Information fallback runs before the county lookup, matching `Shpfy Customer Export.FillInShopifyCustomerData`. Today the company-side flow runs the county lookup with a possibly-empty `Customer."Country/Region Code"`, so a customer with no country falls through with blank province even when the company has a country configured.

## Linked work

Fixes #6129

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Added two regression tests, `UnitTestFillInShopifyCustomerDataISOCountryCodeMapping` in `Shpfy Customer Export Test` and `UnitTestFillInShopifyCompanyLocationISOCountryCodeMapping` in `Shpfy Company Export Test`. Each creates a `Country/Region` fixture with `Code = 'EL'` and `"ISO Code" = 'GR'`, sets up a `Shpfy Tax Area` keyed by `'GR'`, and asserts the Shopify-side address `"Country/Region Code"` resolves to `'GR'` and Province Code / Name populate from the Tax Area.
- Existing `UnitTestFillInShopifyCustomerDataCounty` and `UnitTestFillInShopifyCustomerData` (and the company equivalents) are unaffected because the BC demo data they rely on (`'US'`) has matching BC code and ISO code.
- I did not run a clean local compile: the Shopify app's `.alpackages` is empty (AL-Go for PTE pattern) so it would require fetching symbols out of band. I rely on CI for the build. PR #6130's CI failure on AA0139 was the specific signal I designed the `Code[2]` local around to avoid.

## Risk & compatibility

- Behavioral change in `Shpfy Company Export`: when `Customer."Country/Region Code"` is blank and `Company Information` has a country, the county lookup now resolves against that fallback country. Today the company-side county block runs with an empty `Customer.Country` and finds nothing. This brings the company flow in line with the existing order in `Shpfy Customer Export`.
- The procedures preserve the existing "skip the address country assignment when `Country/Region` is missing" behavior, so a customer whose BC country code does not exist in `Country/Region` continues to leave the Shopify-side country blank rather than being assigned the raw BC code. This is intentionally different from PR #6130, which silently fell back to the BC code.
- No breaking changes, no permissions / upgrade / telemetry impact.
- Builds on the approach validated by @onbuyuka and @JesperSchulz before PR #6130 was closed for inactivity.


Fixes [AB#636783](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636783)


