### PR TITLE
[28.x][Agent] Expose setting/getting model on Agent Task level

### DIFF
--- a/src/System Application/App/Agent/Interaction/AgentTask.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/AgentTask.Codeunit.al
@@ -272,6 +272,32 @@ codeunit 4303 "Agent Task"
         exit(AgentTaskImpl.GetDetailsForAgentTaskLogEntry(AgentTaskLogEntry));
     end;
 
+    /// <summary>
+    /// Gets the model ID of the agent task.
+    /// </summary>
+    /// <param name="AgentTaskID">The ID of the agent task.</param>
+    /// <returns>The model ID of the agent task. Must be valid value from Agent Model table.</returns>
+    procedure GetModelId(AgentTaskID: BigInteger): Code[30]
+    var
+        AgentTaskImpl: Codeunit "Agent Task Impl.";
+    begin
+        FeatureAccessManagement.AgentManagementAllowed(true);
+        exit(AgentTaskImpl.GetModelId(AgentTaskID));
+    end;
+
+    /// <summary>
+    /// Gets the model name of the agent task.
+    /// </summary>
+    /// <param name="AgentTaskID">The ID of the agent task.</param>
+    /// <returns>The model name of the agent task.</returns>
+    procedure GetModelName(AgentTaskID: BigInteger): Text[70]
+    var
+        AgentTaskImpl: Codeunit "Agent Task Impl.";
+    begin
+        FeatureAccessManagement.AgentManagementAllowed(true);
+        exit(AgentTaskImpl.GetModelName(AgentTaskID));
+    end;
+
     var
         FeatureAccessManagement: Codeunit "Feature Access Management";
 

--- a/src/System Application/App/Agent/Interaction/AgentTaskBuilder.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/AgentTaskBuilder.Codeunit.al
@@ -62,7 +62,6 @@ codeunit 4315 "Agent Task Builder"
     /// <param name="RequiresMessage">Specifies whether a message is required, default is true.</param>
     /// <returns>Agent task that was created.</returns>
     /// <remarks>The builder keeps the state, do not reuse the same instance of the builder to create multiple tasks.</remarks>
-    [Scope('OnPrem')]
     procedure Create(SetTaskStatusToReady: Boolean; RequiresMessage: Boolean): Record "Agent Task"
     begin
         FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
@@ -79,6 +78,20 @@ codeunit 4315 "Agent Task Builder"
     begin
         FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
         exit(AgentTaskBuilderImpl.GetAgentTaskMessageCreated());
+    end;
+
+    /// <summary>
+    /// Set the model ID that will be used to process the task.
+    /// If the model ID is not set, the model from the agent will be used, if any.
+    /// If the agent does not have a model, the default model will be used.
+    /// </summary>
+    /// <param name="ModelId">The model ID of the task. This field is used to connect to external systems, like Message ID for emails.</param>
+    /// <returns>This instance of the Agent Task Builder.</returns>
+    procedure SetModelId(ModelId: Code[30]): codeunit "Agent Task Builder"
+    begin
+        FeatureAccessManagement.AgentManagementAllowed(true);
+        AgentTaskBuilderImpl.SetModelId(ModelId);
+        exit(this);
     end;
 
     /// <summary>

--- a/src/System Application/App/Agent/Interaction/Internal/AgentTaskBuilderImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentTaskBuilderImpl.Codeunit.al
@@ -20,6 +20,7 @@ codeunit 4310 "Agent Task Builder Impl."
         GlobalAgentUserSecurityId: Guid;
         GlobalTaskTitle: Text[150];
         GlobalExternalID: Text[2048];
+        GlobalModelId: Code[30];
         GlobalBillingContext: Enum "Agent Task Billing Context";
 
     [Scope('OnPrem')]
@@ -40,7 +41,7 @@ codeunit 4310 "Agent Task Builder Impl."
         VerifyMandatoryFieldsSet();
         VerifyTaskCanBeCreated(RequiresMessage);
 
-        AgentTaskImpl.CreateTask(GlobalAgentUserSecurityId, GlobalTaskTitle, GlobalExternalID, GlobalBillingContext, AgentTaskRecord);
+        AgentTaskImpl.CreateTask(GlobalAgentUserSecurityId, GlobalTaskTitle, GlobalExternalID, GlobalBillingContext, GlobalModelId, AgentTaskRecord);
         if MessageSet then begin
             GlobalAgentTaskMessageBuilder.SetAgentTask(AgentTaskRecord);
             GlobalAgentTaskMessageBuilder.Create(false);
@@ -62,6 +63,13 @@ codeunit 4310 "Agent Task Builder Impl."
     procedure SetExternalId(ExternalId: Text[2048]): codeunit "Agent Task Builder Impl."
     begin
         GlobalExternalID := ExternalId;
+        exit(this);
+    end;
+
+    [Scope('OnPrem')]
+    procedure SetModelId(ModelId: Code[30]): codeunit "Agent Task Builder Impl."
+    begin
+        GlobalModelId := ModelId;
         exit(this);
     end;
 

--- a/src/System Application/App/Agent/Interaction/Internal/AgentTaskImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentTaskImpl.Codeunit.al
@@ -43,7 +43,7 @@ codeunit 4300 "Agent Task Impl."
         Page.Run(Page::"Agent Task Log Entry List", AgentTaskLogEntry);
     end;
 
-    procedure CreateTask(AgentUserSecurityID: Guid; TaskTitle: Text[150]; ExternalID: Text[2048]; BillingContext: Enum "Agent Task Billing Context"; var NewAgentTask: Record "Agent Task")
+    procedure CreateTask(AgentUserSecurityID: Guid; TaskTitle: Text[150]; ExternalID: Text[2048]; BillingContext: Enum "Agent Task Billing Context"; ModelId: Code[30]; var NewAgentTask: Record "Agent Task")
     begin
         NewAgentTask."Agent User Security ID" := AgentUserSecurityID;
         NewAgentTask."Created By" := UserSecurityId();
@@ -51,6 +51,7 @@ codeunit 4300 "Agent Task Impl."
         NewAgentTask."Needs Attention" := false;
         NewAgentTask.Status := NewAgentTask.Status::Paused;
         NewAgentTask."External ID" := ExternalID;
+        NewAgentTask."Model ID" := ModelId;
         NewAgentTask."Billing Context" := BillingContext;
         NewAgentTask.Insert();
     end;
@@ -226,6 +227,24 @@ codeunit 4300 "Agent Task Impl."
 
         exit(false);
     end;
+
+    procedure GetModelId(TaskId: BigInteger): Code[30]
+    var
+        AgentTaskRecord: Record "Agent Task";
+    begin
+        AgentTaskRecord.Get(TaskId);
+        exit(AgentTaskRecord."Model ID")
+    end;
+
+    procedure GetModelName(TaskId: BigInteger): Text[70]
+    var
+        AgentTaskRecord: Record "Agent Task";
+    begin
+        AgentTaskRecord.Get(TaskId);
+        AgentTaskRecord.CalcFields("Model Name");
+        exit(AgentTaskRecord."Model Name");
+    end;
+
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"System Action Triggers", GetAgentTaskMessagePageId, '', true, true)]
     local procedure OnGetAgentTaskMessagePageId(var PageId: Integer)


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->
Enabling developers using the agent SDK to set the model to use on agent tasks.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#620625](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620625)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->
None




