### PR TITLE
Revert temporary suppression during default interface methods uptake

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Integration/EDocumentNoIntegration.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Integration/EDocumentNoIntegration.Codeunit.al
@@ -20,7 +20,6 @@ codeunit 6128 "E-Document No Integration" implements IDocumentSender, IDocumentR
 {
 
 #if not CLEAN26
-#pragma warning disable AL0432 // TODO(#632280) - new compiler validation needs to be relaxed
     procedure Send(var EDocument: Record "E-Document"; var TempBlob: Codeunit "Temp Blob"; var IsAsync: Boolean; var HttpRequest: HttpRequestMessage; var http: HttpResponseMessage)
     begin
         IsAsync := false;
@@ -56,7 +55,6 @@ codeunit 6128 "E-Document No Integration" implements IDocumentSender, IDocumentR
         SetupPage := 0;
         SetupTable := 0;
     end;
-#pragma warning restore AL0432 // TODO(#632280) - new compiler validation needs to be relaxed
 #endif
 
     #region IDocumentSender

--- a/src/Apps/W1/EDocument/Test/src/Mock/EDocIntegrationMock.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Mock/EDocIntegrationMock.Codeunit.al
@@ -15,7 +15,7 @@ codeunit 139619 "E-Doc. Integration Mock" implements "E-Document Integration"
     ObsoleteState = Pending;
     ObsoleteReason = 'Obsolete in 26.0';
 #pragma warning restore AL0432
-#pragma warning disable AL0432 // TODO(#632280) - new compiler validation needs to be relaxed
+
     procedure Send(var EDocument: Record "E-Document"; var TempBlob: Codeunit "Temp Blob"; var IsAsync: Boolean; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage);
     begin
         OnSend(EDocument, TempBlob, IsAsync, HttpRequest, HttpResponse);
@@ -68,7 +68,6 @@ codeunit 139619 "E-Doc. Integration Mock" implements "E-Document Integration"
     begin
 
     end;
-#pragma warning restore AL0432 // TODO(#632280) - new compiler validation needs to be relaxed
 
     [IntegrationEvent(false, false)]
     local procedure OnSend(var EDocument: Record "E-Document"; var TempBlob: Codeunit "Temp Blob"; var IsAsync: Boolean; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage)


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->
A compiler regression caused the need to pragma suppress some diagnostics to unblock the compiler uptake.
Reverting these changes now that the compiler issue has been addressed.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#633114](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633114)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*
The build system will validate that it builds. No functionality impact.

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->
None


