### PR TITLE
Make SetSecret and GetSecret procedures internal in Blob and File Share connectors

### DIFF
--- a/src/Apps/W1/External File Storage - Azure Blob Service Connector/App/src/ExtBlobStorageAccount.Table.al
+++ b/src/Apps/W1/External File Storage - Azure Blob Service Connector/App/src/ExtBlobStorageAccount.Table.al
@@ -75,7 +75,9 @@ table 4560 "Ext. Blob Storage Account"
                 IsolatedStorage.Delete(Rec."Secret Key", DataScope::Company);
     end;
 
-    procedure SetSecret(Secret: SecretText)
+#pragma warning disable AS0022
+    internal procedure SetSecret(Secret: SecretText)
+#pragma warning restore AS0022
     begin
         if IsNullGuid(Rec."Secret Key") then
             Rec."Secret Key" := CreateGuid();
@@ -84,7 +86,9 @@ table 4560 "Ext. Blob Storage Account"
             Error(UnableToSetSecretMsg);
     end;
 
-    procedure GetSecret(SecretKey: Guid) Secret: SecretText
+#pragma warning disable AS0022
+    internal procedure GetSecret(SecretKey: Guid) Secret: SecretText
+#pragma warning restore AS0022
     begin
         if not IsolatedStorage.Get(Format(SecretKey), DataScope::Company, Secret) then
             Error(UnableToGetSecretMsg);

--- a/src/Apps/W1/External File Storage - Azure File Service Connector/App/src/ExtFileShareAccount.Table.al
+++ b/src/Apps/W1/External File Storage - Azure File Service Connector/App/src/ExtFileShareAccount.Table.al
@@ -73,7 +73,9 @@ table 4570 "Ext. File Share Account"
                 IsolatedStorage.Delete(Rec."Secret Key", DataScope::Company);
     end;
 
-    procedure SetSecret(Secret: SecretText)
+#pragma warning disable AS0022
+    internal procedure SetSecret(Secret: SecretText)
+#pragma warning restore AS0022
     begin
         if IsNullGuid(Rec."Secret Key") then
             Rec."Secret Key" := CreateGuid();
@@ -82,7 +84,9 @@ table 4570 "Ext. File Share Account"
             Error(UnableToSetSecretMsg);
     end;
 
-    procedure GetSecret(SecretKey: Guid) Secret: SecretText
+#pragma warning disable AS0022
+    internal procedure GetSecret(SecretKey: Guid) Secret: SecretText
+#pragma warning restore AS0022
     begin
         if not IsolatedStorage.Get(Format(SecretKey), DataScope::Company, Secret) then
             Error(UnableToGetSecretMsg);


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why
This pull request updates the visibility of the `SetSecret` and `GetSecret` procedures in both the `Ext. Blob Storage Account` and `Ext. File Share Account` tables, making them `internal` instead of `public`. Compiler warnings for rule AS0022 are explicitly disabled and re-enabled around these changes to allow the use of `internal` procedures.

**Procedure visibility updates:**

* Changed the `SetSecret` and `GetSecret` procedures from `public` to `internal` in `ExtBlobStorageAccount.Table.al` to restrict their access within the module. (`src/Apps/W1/External File Storage - Azure Blob Service Connector/App/src/ExtBlobStorageAccount.Table.al`) [[1]](diffhunk://#diff-48f6a76a50dec8c9f6546d45c1ce7d72e364df0451413c5ebc0807ff4938655dL78-R80) [[2]](diffhunk://#diff-48f6a76a50dec8c9f6546d45c1ce7d72e364df0451413c5ebc0807ff4938655dL87-R91)
* Changed the `SetSecret` and `GetSecret` procedures from `public` to `internal` in `ExtFileShareAccount.Table.al` to restrict their access within the module. (`src/Apps/W1/External File Storage - Azure File Service Connector/App/src/ExtFileShareAccount.Table.al`) [[1]](diffhunk://#diff-ca9ceb8e59992b736e2debee3342cb1dc7b3a4a576c6c4b6236ffcec380670a9L76-R78) [[2]](diffhunk://#diff-ca9ceb8e59992b736e2debee3342cb1dc7b3a4a576c6c4b6236ffcec380670a9L85-R89)

**Compiler warning handling:**

* Disabled and restored warning AS0022 around the `internal` procedure declarations to suppress related compiler warnings. [[1]](diffhunk://#diff-48f6a76a50dec8c9f6546d45c1ce7d72e364df0451413c5ebc0807ff4938655dL78-R80) [[2]](diffhunk://#diff-48f6a76a50dec8c9f6546d45c1ce7d72e364df0451413c5ebc0807ff4938655dL87-R91) [[3]](diffhunk://#diff-ca9ceb8e59992b736e2debee3342cb1dc7b3a4a576c6c4b6236ffcec380670a9L76-R78) [[4]](diffhunk://#diff-ca9ceb8e59992b736e2debee3342cb1dc7b3a4a576c6c4b6236ffcec380670a9L85-R89)

## Linked work
Fixes [AB#632366](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632366)

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [X] I built the affected app(s) locally with no new analyzer warnings.
- [X] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility
The breaking change is accepted in order to harden security,
<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

