### PR TITLE
[27.x][Agent] Backport billing changes (#7680, #7697) (#7779)

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotQuota.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotQuota.Codeunit.al
@@ -49,7 +49,28 @@ codeunit 7785 "Copilot Quota"
         CallerModuleInfo: ModuleInfo;
     begin
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
-        CopilotQuotaImpl.LogAgentUserAIConsumption(CopilotCapability, Usage, CopilotQuotaUsageType, CallerModuleInfo, AgentTaskID, ActionsCharged, Description, UniqueID);
+        CopilotQuotaImpl.LogAgentUserAIConsumption(CopilotCapability, Usage, CopilotQuotaUsageType, CallerModuleInfo, AgentTaskID, ActionsCharged, Description, UniqueID, false);
+    end;
+
+    /// <summary>
+    /// Log usage of Agent functionality. This function is only available for Microsoft Agents.
+    /// Function will call the platform to log the usage of the agents. Charging will be handled by the platform afterwards.
+    /// </summary>
+    /// <param name="CopilotCapability">The Copilot Capability to log usage for.</param>
+    /// <param name="Usage">The usage to log.</param>
+    /// <param name="CopilotQuotaUsageType">The type of Copilot Quota to log.</param>
+    /// <param name="AgentTaskID">The unique identifier of the Agent task.</param>
+    /// <param name="ActionsCharged">The actions that were charged for this usage. This should be a short text, for example Quote Operation, Processed E-Document and etc...</param>
+    /// <param name="Description">A description of the usage. This text is providing the additional information to ActionsCharged, for example specifying which operation was done on which quote or which e-document was processed.</param>
+    /// <param name="UniqueID">A unique identifier for this log entry. Parameter is mandatory. This value is used to avoid double charging. Platform will check if we have the entry already logged and will not double charge. If you want to charge always use CreateGuid() or a strategy that will always issue a charge.</param>
+    /// <param name="ExcludeFromBilling">If true, the usage will be logged but excluded from billing.</param>
+    [Scope('OnPrem')]
+    procedure LogAgentUserAIConsumption(CopilotCapability: Enum "Copilot Capability"; Usage: Integer; CopilotQuotaUsageType: Enum "Copilot Quota Usage Type"; AgentTaskID: BigInteger; ActionsCharged: Text[1024]; Description: Text; UniqueID: Text[1024]; ExcludeFromBilling: Boolean)
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        CopilotQuotaImpl.LogAgentUserAIConsumption(CopilotCapability, Usage, CopilotQuotaUsageType, CallerModuleInfo, AgentTaskID, ActionsCharged, Description, UniqueID, ExcludeFromBilling);
     end;
 
     /// <summary>

--- a/src/System Application/App/AI/src/Copilot/CopilotQuotaImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotQuotaImpl.Codeunit.al
@@ -16,7 +16,7 @@ codeunit 7786 "Copilot Quota Impl."
         CopilotCapabilityImpl: Codeunit "Copilot Capability Impl";
         InvalidUsageTypeErr: Label 'The value "%1" is not a valid Copilot Quota Usage Type.', Comment = '%1=a value such as "AI response" or "5"';
         CapabilityNotRegisteredTelemetryMsg: Label 'Capability "%1" is not registered in the system but is logging usage.', Locked = true;
-        LoggingUsageTelemetryMsg: Label 'Capability "%1" is logging %2 usage of type %3.', Locked = true;
+        LoggingUsageTelemetryMsg: Label 'Capability "%1" is logging %2 usage of type %3, excluded from billing: %4.', Locked = true;
 
     trigger OnRun()
     var
@@ -64,7 +64,7 @@ codeunit 7786 "Copilot Quota Impl."
         if not CopilotCapabilityImpl.IsCapabilityRegistered(CopilotCapability, CallerModuleInfo) then
             Session.LogMessage('0000OSL', StrSubstNo(CapabilityNotRegisteredTelemetryMsg, CopilotCapability), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CopilotCapabilityImpl.GetCopilotCategory());
 
-        Session.LogMessage('0000OSM', StrSubstNo(LoggingUsageTelemetryMsg, CopilotCapability, Usage, CopilotQuotaUsageType), Verbosity::Verbose, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CopilotCapabilityImpl.GetCopilotCategory());
+        Session.LogMessage('0000OSM', StrSubstNo(LoggingUsageTelemetryMsg, CopilotCapability, Usage, CopilotQuotaUsageType, false), Verbosity::Verbose, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CopilotCapabilityImpl.GetCopilotCategory());
 
         ALCopilotCapability := ALCopilotCapability.ALCopilotCapability(
             CallerModuleInfo.Publisher(), CallerModuleInfo.Id(), Format(CallerModuleInfo.AppVersion()), CopilotCapabilityImpl.CapabilityToEnumName(CopilotCapability));
@@ -74,7 +74,7 @@ codeunit 7786 "Copilot Quota Impl."
         ALCopilotFunctions.LogCopilotQuotaUsage(AlCopilotCapability, Usage, AlCopilotUsageType);
     end;
 
-    procedure LogAgentUserAIConsumption(CopilotCapability: Enum "Copilot Capability"; Usage: Integer; CopilotQuotaUsageType: Enum "Copilot Quota Usage Type"; CallerModuleInfo: ModuleInfo; AgentTaskID: BigInteger; ActionsCharged: Text[1024]; Description: Text; UniqueID: Text[1024])
+    procedure LogAgentUserAIConsumption(CopilotCapability: Enum "Copilot Capability"; Usage: Integer; CopilotQuotaUsageType: Enum "Copilot Quota Usage Type"; CallerModuleInfo: ModuleInfo; AgentTaskID: BigInteger; ActionsCharged: Text[1024]; Description: Text; UniqueID: Text[1024]; ExcludeFromBilling: Boolean)
     var
         AlCopilotCapability: DotNet ALCopilotCapability;
         ALCopilotFunctions: DotNet ALCopilotFunctions;
@@ -83,7 +83,7 @@ codeunit 7786 "Copilot Quota Impl."
         if not CopilotCapabilityImpl.IsCapabilityRegistered(CopilotCapability, CallerModuleInfo) then
             Session.LogMessage('0000QIY', StrSubstNo(CapabilityNotRegisteredTelemetryMsg, CopilotCapability), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CopilotCapabilityImpl.GetCopilotCategory());
 
-        Session.LogMessage('0000QIZ', StrSubstNo(LoggingUsageTelemetryMsg, CopilotCapability, Usage, CopilotQuotaUsageType), Verbosity::Verbose, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CopilotCapabilityImpl.GetCopilotCategory());
+        Session.LogMessage('0000QIZ', StrSubstNo(LoggingUsageTelemetryMsg, CopilotCapability, Usage, CopilotQuotaUsageType, ExcludeFromBilling), Verbosity::Verbose, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CopilotCapabilityImpl.GetCopilotCategory());
 
         ALCopilotCapability := ALCopilotCapability.ALCopilotCapability(
                  CallerModuleInfo.Publisher(), CallerModuleInfo.Id(), Format(CallerModuleInfo.AppVersion()), CopilotCapabilityImpl.CapabilityToEnumName(CopilotCapability));
@@ -97,7 +97,8 @@ codeunit 7786 "Copilot Quota Impl."
             Description,
             AlCopilotUsageType,
             Usage,
-            UniqueID
+            UniqueID,
+            ExcludeFromBilling
         );
     end;
 

--- a/src/System Application/App/Agent/Interaction/AgentTaskBuilder.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/AgentTaskBuilder.Codeunit.al
@@ -94,6 +94,19 @@ codeunit 4315 "Agent Task Builder"
     end;
 
     /// <summary>
+    /// Set the billing context for the task.
+    /// </summary>
+    /// <param name="BillingContext">The billing context to set on the task.</param>
+    /// <returns>This instance of the Agent Task Builder.</returns>
+    [Scope('OnPrem')]
+    procedure SetBillingContext(BillingContext: Enum "Agent Task Billing Context"): codeunit "Agent Task Builder"
+    begin
+        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        AgentTaskBuilderImpl.SetBillingContext(BillingContext);
+        exit(this);
+    end;
+
+    /// <summary>
     /// Add a task message to the task.
     /// Only a single message can be added to the task.
     /// </summary>

--- a/src/System Application/App/Agent/Interaction/Internal/AgentTaskBuilderImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentTaskBuilderImpl.Codeunit.al
@@ -20,12 +20,14 @@ codeunit 4310 "Agent Task Builder Impl."
         GlobalAgentUserSecurityId: Guid;
         GlobalTaskTitle: Text[150];
         GlobalExternalID: Text[2048];
+        GlobalBillingContext: Enum "Agent Task Billing Context";
 
     [Scope('OnPrem')]
     procedure Initialize(NewAgentUserSecurityId: Guid; NewTaskTitle: Text[150]): codeunit "Agent Task Builder Impl."
     begin
         GlobalAgentUserSecurityId := NewAgentUserSecurityId;
         GlobalTaskTitle := NewTaskTitle;
+        GlobalBillingContext := Enum::"Agent Task Billing Context"::Default;
         exit(this);
     end;
 
@@ -38,7 +40,7 @@ codeunit 4310 "Agent Task Builder Impl."
         VerifyMandatoryFieldsSet();
         VerifyTaskCanBeCreated(RequiresMessage);
 
-        AgentTaskImpl.CreateTask(GlobalAgentUserSecurityId, GlobalTaskTitle, GlobalExternalID, AgentTaskRecord);
+        AgentTaskImpl.CreateTask(GlobalAgentUserSecurityId, GlobalTaskTitle, GlobalExternalID, GlobalBillingContext, AgentTaskRecord);
         if MessageSet then begin
             GlobalAgentTaskMessageBuilder.SetAgentTask(AgentTaskRecord);
             GlobalAgentTaskMessageBuilder.Create(false);
@@ -60,6 +62,13 @@ codeunit 4310 "Agent Task Builder Impl."
     procedure SetExternalId(ExternalId: Text[2048]): codeunit "Agent Task Builder Impl."
     begin
         GlobalExternalID := ExternalId;
+        exit(this);
+    end;
+
+    [Scope('OnPrem')]
+    procedure SetBillingContext(BillingContext: Enum "Agent Task Billing Context"): codeunit "Agent Task Builder Impl."
+    begin
+        GlobalBillingContext := BillingContext;
         exit(this);
     end;
 

--- a/src/System Application/App/Agent/Interaction/Internal/AgentTaskImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentTaskImpl.Codeunit.al
@@ -53,7 +53,7 @@ codeunit 4300 "Agent Task Impl."
         Page.Run(Page::"Agent Task Log Entry List", AgentTaskLogEntry);
     end;
 
-    procedure CreateTask(AgentUserSecurityID: Guid; TaskTitle: Text[150]; ExternalID: Text[2048]; var NewAgentTask: Record "Agent Task")
+    procedure CreateTask(AgentUserSecurityID: Guid; TaskTitle: Text[150]; ExternalID: Text[2048]; BillingContext: Enum "Agent Task Billing Context"; var NewAgentTask: Record "Agent Task")
     begin
         NewAgentTask."Agent User Security ID" := AgentUserSecurityID;
         NewAgentTask."Created By" := UserSecurityId();
@@ -61,6 +61,7 @@ codeunit 4300 "Agent Task Impl."
         NewAgentTask."Needs Attention" := false;
         NewAgentTask.Status := NewAgentTask.Status::Paused;
         NewAgentTask."External ID" := ExternalID;
+        NewAgentTask."Billing Context" := BillingContext;
         NewAgentTask.Insert();
     end;
 


### PR DESCRIPTION
## Summary
Backport of #7779 to `releases/27.x` (BCApps consumer side of Platform-Core PR 245447).

Includes:
- **#7680** — Add `ExcludeFromBilling` overload to `LogAgentUserAIConsumption`
- **#7697** — Add `SetBillingType` to Agent Task Builder

Clean cherry-pick of `760e14e87c` (which was itself the 28.x backport `6a18b94555`).

[AB#620754](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620754)
[AB#631081](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/631081)

## Test plan
- [ ] CI green
