### PR TITLE
[Bug][SubscriptionBilling]: "Learn more" link in Subscription Billing Role Center uses long URL instead of short aka.ms link for 28.x

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Base/Pages/SubBillingHeadlineRC.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Base/Pages/SubBillingHeadlineRC.Page.al
@@ -35,7 +35,7 @@ page 8086 "Sub. Billing Headline RC"
 
                     trigger OnDrillDown()
                     begin
-                        HyperLink(RCHeadlinesPageCommon.DocumentationUrlTxt());
+                        HyperLink(DocumentationUrlTxt);
                     end;
                 }
             }
@@ -62,4 +62,5 @@ page 8086 "Sub. Billing Headline RC"
         RCHeadlinesPageCommon: Codeunit "RC Headlines Page Common";
         DefaultFieldsVisible: Boolean;
         UserGreetingVisible: Boolean;
+        DocumentationUrlTxt: Label 'https://aka.ms/bcsubscriptionbilling', Locked = true;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

this is a backport of https://github.com/microsoft/BCApps/pull/7978
fix: use aka.ms short link for Subscription Billing Role Center learn more URL

Replace the hardcoded full documentation URL with the canonical short redirect link (https://aka.ms/bcsubscriptionbilling) and lock the label to prevent accidental modification.

Using the aka.ms redirect is preferable as it is centrally managed - if the target documentation URL changes, only the redirect needs updating without requiring a code change.

## Linked work

Fixes [AB#636178](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636178)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.


<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->
No risk as this is a simple backport



