### PR TITLE
[Extensibility][SubscriptionBilling]: Add PostingDate parameter to OnBeforeReleaseCustomerContractDeferral and OnBeforeReleaseVendorContractDeferral integration event for 28.x

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Deferrals/Reports/ContractDeferralsRelease.Report.al
+++ b/src/Apps/W1/Subscription Billing/App/Deferrals/Reports/ContractDeferralsRelease.Report.al
@@ -144,7 +144,7 @@ report 8051 "Contract Deferrals Release"
         PostingAmount: Decimal;
     begin
         ShouldRelease := true;
-        OnBeforeReleaseCustomerContractDeferral(CustomerContractDeferral, ShouldRelease);
+        OnBeforeReleaseCustomerContractDeferral(CustomerContractDeferral, ShouldRelease, PostingDate);
         if not ShouldRelease then begin
             UpdateWindow(CustomerContractDeferral."Subscription Contract No.");
             exit;
@@ -199,7 +199,7 @@ report 8051 "Contract Deferrals Release"
         PostingAmount: Decimal;
     begin
         ShouldRelease := true;
-        OnBeforeReleaseVendorContractDeferral(VendorContractDeferral, ShouldRelease);
+        OnBeforeReleaseVendorContractDeferral(VendorContractDeferral, ShouldRelease, PostingDate);
         if not ShouldRelease then begin
             UpdateWindow(VendorContractDeferral."Subscription Contract No.");
             exit;
@@ -413,12 +413,12 @@ report 8051 "Contract Deferrals Release"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeReleaseCustomerContractDeferral(var CustomerContractDeferral: Record "Cust. Sub. Contract Deferral"; var ShouldReleaseDeferral: Boolean)
+    local procedure OnBeforeReleaseCustomerContractDeferral(var CustomerContractDeferral: Record "Cust. Sub. Contract Deferral"; var ShouldReleaseDeferral: Boolean; PostingDate: Date)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeReleaseVendorContractDeferral(var VendorContractDeferral: Record "Vend. Sub. Contract Deferral"; var ShouldReleaseDeferral: Boolean)
+    local procedure OnBeforeReleaseVendorContractDeferral(var VendorContractDeferral: Record "Vend. Sub. Contract Deferral"; var ShouldReleaseDeferral: Boolean; PostingDate: Date)
     begin
     end;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

This is a backport of https://github.com/microsoft/BCApps/pull/7981
Added `PostingDate` as a parameter to the `OnBeforeReleaseCustomerContractDeferral` and `OnBeforeReleaseVendorContractDeferral` integration events in `ContractDeferralsRelease.Report.al`.

Previously, subscribers had no way to access the posting date at the time these events were raised. The `PostingDate` is now exposed as a read-only parameter, allowing subscribers to act on or conditionally respond to the posting date as part of their event handling logic.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #7980
Fixes [AB#635032](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/635032)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.


<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->
     
This is a backport, no risks observed.

