### PR TITLE
Suppress AL0432 obsolete warnings for AllObj."Object Name" field

### DIFF
--- a/src/System Application/App/Permission Sets/src/PermissionImpl.Codeunit.al
+++ b/src/System Application/App/Permission Sets/src/PermissionImpl.Codeunit.al
@@ -213,7 +213,9 @@ codeunit 9864 "Permission Impl."
             ObjectCaption := TenantPermission."Object Name";
             ObjectName := '';
             if AllObj.Get(TenantPermission."Object Type", TenantPermission."Object ID") then
+                #pragma warning disable AL0432
                 ObjectName := AllObj."Object Name";
+                #pragma warning restore AL0432
         end else begin
             ObjectName := CopyStr(StrSubstNo(AllObjTxt, TenantPermission."Object Type"), 1, MaxStrLen(TenantPermission."Object Name"));
             ObjectCaption := ObjectName;
@@ -229,7 +231,9 @@ codeunit 9864 "Permission Impl."
             ObjectCaption := MetadataPermission."Object Name";
             ObjectName := '';
             if AllObj.Get(MetadataPermission."Object Type", MetadataPermission."Object ID") then
+                #pragma warning disable AL0432
                 ObjectName := AllObj."Object Name";
+                #pragma warning restore AL0432
         end else begin
             ObjectName := CopyStr(StrSubstNo(AllObjTxt, MetadataPermission."Object Type"), 1, MaxStrLen(MetadataPermission."Object Name"));
             ObjectCaption := ObjectName;
@@ -245,7 +249,9 @@ codeunit 9864 "Permission Impl."
             ObjectCaption := ExpandedPermission."Object Name";
             ObjectName := '';
             if AllObj.Get(ExpandedPermission."Object Type", ExpandedPermission."Object ID") then
+                #pragma warning disable AL0432
                 ObjectName := AllObj."Object Name";
+                #pragma warning restore AL0432
         end else begin
             ObjectName := CopyStr(StrSubstNo(AllObjExceptTxt, ExpandedPermission."Object Type"), 1, MaxStrLen(ExpandedPermission."Object Name"));
             ObjectCaption := ObjectName;

--- a/src/System Application/App/Retention Policy/src/Retention Policy Allowed Tables/RetenPolAllowedTblImpl.Codeunit.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Allowed Tables/RetenPolAllowedTblImpl.Codeunit.al
@@ -83,9 +83,11 @@ codeunit 3906 "Reten. Pol. Allowed Tbl. Impl."
             UnbindSubscription(RetenPolAllowedTblImpl);
 
             if TableAllowed then
+                #pragma warning disable AL0432
                 RetentionPolicyLog.LogInfo(LogCategory(), StrSubstNo(AllowedTablesModifiedLbl, RetentionPolicyAllowedTable."Table Id", AllObj."Object Name", RetentionPolicyAllowedTable."Default Date Field No."))
             else
                 RetentionPolicyLog.LogError(LogCategory(), StrSubstNo(FailedModifyingTableLbl, RetentionPolicyAllowedTable."Table Id", AllObj."Object Name"), false);
+                #pragma warning restore AL0432
 
             exit(TableAllowed);
         end;
@@ -95,9 +97,11 @@ codeunit 3906 "Reten. Pol. Allowed Tbl. Impl."
         UnbindSubscription(RetenPolAllowedTblImpl);
 
         if TableAllowed then
+            #pragma warning disable AL0432
             RetentionPolicyLog.LogInfo(LogCategory(), StrSubstNo(AddTableToAllowedTablesLbl, RetentionPolicyAllowedTable."Table Id", AllObj."Object Name", RetentionPolicyAllowedTable."Default Date Field No."))
         else
             RetentionPolicyLog.LogError(LogCategory(), StrSubstNo(FailedAddingTableLbl, RetentionPolicyAllowedTable."Table Id", AllObj."Object Name"), false);
+            #pragma warning restore AL0432
 
         exit(TableAllowed)
     end;
@@ -121,7 +125,9 @@ codeunit 3906 "Reten. Pol. Allowed Tbl. Impl."
         PublishedApplication.SetRange("Version Revision", CallerModuleInfo.AppVersion.Revision);
         PublishedApplication.SetFilter("Tenant ID", '%1|%2', '', TenantInformation.GetTenantId());
         if not PublishedApplication.FindFirst() then begin
+            #pragma warning disable AL0432
             RetentionPolicyLog.LogWarning(LogCategory(), StrSubstNo(ModuleDoesNotExistLbl, TableId, AllObj."Object Name", CallerModuleInfo.Id));
+            #pragma warning restore AL0432
             exit(false);
         end;
 
@@ -129,7 +135,9 @@ codeunit 3906 "Reten. Pol. Allowed Tbl. Impl."
             exit(true);
 
         if AllObj."App Runtime Package ID" <> PublishedApplication."Runtime Package ID" then begin
+            #pragma warning disable AL0432
             RetentionPolicyLog.LogWarning(LogCategory(), StrSubstNo(WrongModuleOwnerLbl, TableId, AllObj."Object Name", CallerModuleInfo.Id));
+            #pragma warning restore AL0432
             exit(false);
         end;
 

--- a/src/System Application/App/Web Service Management/src/WebServiceManagementImpl.Codeunit.al
+++ b/src/System Application/App/Web Service Management/src/WebServiceManagementImpl.Codeunit.al
@@ -54,7 +54,9 @@ codeunit 9751 "Web Service Management Impl."
         WebServiceName: Text;
     begin
         AllObj.Get(ObjectType, ObjectId);
+        #pragma warning disable AL0432
         WebServiceName := GetWebServiceName(ObjectName, AllObj."Object Name");
+        #pragma warning restore AL0432
 
         if WebService.Get(ObjectType, WebServiceName) then begin
             ModifyWebService(WebService, AllObj, WebServiceName, Published);
@@ -73,7 +75,9 @@ codeunit 9751 "Web Service Management Impl."
         WebServiceName: Text;
     begin
         AllObj.Get(ObjectType, ObjectId);
+        #pragma warning disable AL0432
         WebServiceName := GetWebServiceName(ObjectName, AllObj."Object Name");
+        #pragma warning restore AL0432
 
         if TenantWebService.Get(ObjectType, WebServiceName) then begin
             ModifyTenantWebService(TenantWebService, AllObj, WebServiceName, Published);

--- a/src/Tools/Test Framework/Test Runner/src/TestSuiteMgt.Codeunit.al
+++ b/src/Tools/Test Framework/Test Runner/src/TestSuiteMgt.Codeunit.al
@@ -171,7 +171,9 @@ codeunit 130456 "Test Suite Mgt."
         AllObj.SetRange("Object ID", CodeunitTestMethodLine."Test Codeunit");
         AllObj.SetRange("Object Type", AllObj."Object Type"::Codeunit);
         if AllObj.FindFirst() then begin
+            #pragma warning disable AL0432
             CodeunitResultJson.Add('codeunitName', AllObj."Object Name");
+            #pragma warning restore AL0432
             NavInstalledApp.SetRange("Package ID", AllObj."App Package ID");
             if NavInstalledApp.FindFirst() then begin
                 CodeunitResultJson.Add('applicationID', NavInstalledApp."App ID");


### PR DESCRIPTION
## Summary
Suppresses AL0432 compiler warnings introduced by platform PR 246852, which marks AllObj."Object Name" as ObsoleteState = Pending.

Applied #pragma warning disable/restore AL0432\ around all references in 4 codeunits:
- PermissionImpl.Codeunit.al
- RetenPolAllowedTblImpl.Codeunit.al
- WebServiceManagementImpl.Codeunit.al
- TestSuiteMgt.Codeunit.al

## Related
- Work item: [AB#485120](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/485120)
- Platform PR: 246852
- Companion NAV repo PR: pending (depends on this PR being merged first)








