### PR TITLE
Smoke test: insecure AL codeunit for Copilot review

### DIFF
--- a/.github/copilot-smoke/BadCodeunit.al
+++ b/.github/copilot-smoke/BadCodeunit.al
@@ -1,0 +1,23 @@
+codeunit 80990 "Copilot Smoke Test"
+{
+    procedure SendCustomerData(CustomerNo: Code[20])
+    var
+        Client: HttpClient;
+        RequestHeaders: HttpHeaders;
+        Content: HttpContent;
+        Response: HttpResponseMessage;
+        Token: Text;
+        Endpoint: Text;
+        BodyText: Text;
+    begin
+        Token := 'ghp_1234567890abcdefghijklmnopqrstuv';
+        Endpoint := 'http://api.contoso.internal/customers';
+        BodyText := '{"customerNo":"' + CustomerNo + '"}';
+
+        Content.WriteFrom(BodyText);
+        Content.GetHeaders(RequestHeaders);
+        RequestHeaders.Add('Authorization', Token);
+
+        Client.Post(Endpoint, Content, Response);
+    end;
+}

--- a/.github/copilot-smoke/BadCodeunit2.al
+++ b/.github/copilot-smoke/BadCodeunit2.al
@@ -1,0 +1,23 @@
+codeunit 80991 "Copilot Smoke Test 2"
+{
+    procedure NotifyWebhook(UserEmail: Text)
+    var
+        Client: HttpClient;
+        Headers: HttpHeaders;
+        Content: HttpContent;
+        Response: HttpResponseMessage;
+        ApiKey: Text;
+        WebhookUrl: Text;
+        Payload: Text;
+    begin
+        ApiKey := 'HardcodedApiKey123!';
+        WebhookUrl := 'http://webhook.contoso.local/notify';
+
+        Payload := '{"email":"' + UserEmail + '","source":"bcapps-smoke"}';
+        Content.WriteFrom(Payload);
+        Content.GetHeaders(Headers);
+        Headers.Add('x-api-key', ApiKey);
+
+        Client.Post(WebhookUrl, Content, Response);
+    end;
+}


### PR DESCRIPTION
Test PR to validate Copilot PR review findings on AL code.

Contains intentionally insecure patterns for review detection:
- Hardcoded token-like secret
- Plain HTTP endpoint
- Outbound HTTP post with authorization header

File added:
- .github/copilot-smoke/BadCodeunit.al

