### PR TITLE
Bug 634238: [Subcontracting] Subcontracting false 'already created' warning when prod order has multiple lines sharing routing/operation

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchaseOrderCreator.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchaseOrderCreator.Codeunit.al
@@ -31,6 +31,7 @@ codeunit 99001557 "Subc. Purchase Order Creator"
         HasSubManagementSetup: Boolean;
         HasManufacturingSetup: Boolean;
         OperationNo: Code[10];
+        RoutingReferenceNo: Integer;
         PurchOrderCreatedTxt: Label '%1 Purchase Order(s) created.\\Do you want to view them?', Comment = '%1 = No of Purchase Order(s) created.';
         PurchOrderAlreadyCreatedQst: Label 'Purchase order(s) have already been created.\\Do you want to view them?';
         CreationOfSubcontractingOrderIsNotAllowedErr: Label 'You cannot create Subcontracting Order, because the Production Order %1 is not released.', Comment = '%1=Production Order No.';
@@ -193,6 +194,8 @@ codeunit 99001557 "Subc. Purchase Order Creator"
                     PurchaseLine.SetLoadFields(SystemId);
                     if (NoOfCreatedPurchOrder = 1) and (OperationNo <> '') then
                         PurchaseLine.SetRange("Operation No.", OperationNo);
+                    if (NoOfCreatedPurchOrder = 1) and (RoutingReferenceNo <> 0) then
+                        PurchaseLine.SetRange("Routing Reference No.", RoutingReferenceNo);
                     PurchaseLine.FindFirst();
                     PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
                     PageManagement.PageRun(PurchaseHeader);
@@ -208,6 +211,16 @@ codeunit 99001557 "Subc. Purchase Order Creator"
     internal procedure ClearOperationNoForCreatedPurchaseOrder()
     begin
         Clear(OperationNo);
+    end;
+
+    internal procedure SetRoutingReferenceNoForCreatedPurchaseOrder(RoutingReferenceNoToSet: Integer)
+    begin
+        RoutingReferenceNo := RoutingReferenceNoToSet;
+    end;
+
+    internal procedure ClearRoutingReferenceNoForCreatedPurchaseOrder()
+    begin
+        Clear(RoutingReferenceNo);
     end;
 
     local procedure CheckProdOrderRtngLine(ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var ProdOrderLine: Record "Prod. Order Line")
@@ -249,6 +262,7 @@ codeunit 99001557 "Subc. Purchase Order Creator"
             PurchaseLine.SetRange(Type, "Purchase Line Type"::Item);
             PurchaseLine.SetRange("Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
             PurchaseLine.SetRange("Routing No.", ProdOrderRoutingLine."Routing No.");
+            PurchaseLine.SetRange("Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
             PurchaseLine.SetRange("Operation No.", ProdOrderRoutingLine."Operation No.");
             if not PurchaseLine.IsEmpty() then
                 ExistingPOFound := true;

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcProdOrderRtng.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcProdOrderRtng.PageExt.al
@@ -76,6 +76,8 @@ pageextension 99001503 "Subc. Prod. Order Rtng." extends "Prod. Order Routing"
                         if NoOfCreatedPurchOrder = 1 then begin
                             SubcPurchaseOrderCreator.ClearOperationNoForCreatedPurchaseOrder();
                             SubcPurchaseOrderCreator.SetOperationNoForCreatedPurchaseOrder(Rec."Operation No.");
+                            SubcPurchaseOrderCreator.ClearRoutingReferenceNoForCreatedPurchaseOrder();
+                            SubcPurchaseOrderCreator.SetRoutingReferenceNoForCreatedPurchaseOrder(Rec."Routing Reference No.");
                         end;
                         SubcPurchaseOrderCreator.ShowCreatedPurchaseOrder(Rec."Prod. Order No.", NoOfCreatedPurchOrder);
                     end;

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcProdOrderRtng.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcProdOrderRtng.PageExt.al
@@ -69,6 +69,7 @@ pageextension 99001503 "Subc. Prod. Order Rtng." extends "Prod. Order Routing"
                         PurchaseLine.SetRange(Type, PurchaseLine.Type::Item);
                         PurchaseLine.SetRange("Prod. Order No.", Rec."Prod. Order No.");
                         PurchaseLine.SetRange("Routing No.", Rec."Routing No.");
+                        PurchaseLine.SetRange("Routing Reference No.", Rec."Routing Reference No.");
                         PurchaseLine.SetRange("Operation No.", Rec."Operation No.");
                         if PurchaseLine.IsEmpty() then
                             Message(NoPurchOrderCreatedMsg, ProdOrderRoutingLine."Prod. Order No.")

--- a/src/Apps/W1/Subcontracting/Test/app.json
+++ b/src/Apps/W1/Subcontracting/Test/app.json
@@ -24,6 +24,12 @@
       "name": "Tests-TestLibraries",
       "publisher": "Microsoft",
       "version": "29.0.0.0"
+    },
+    {
+      "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
+      "publisher": "Microsoft",
+      "name": "Library Variable Storage",
+      "version": "$(app_minimumVersion)"
     }
   ],
   "platform": "29.0.0.0",

--- a/src/Apps/W1/Subcontracting/Test/app.json
+++ b/src/Apps/W1/Subcontracting/Test/app.json
@@ -29,7 +29,7 @@
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "publisher": "Microsoft",
       "name": "Library Variable Storage",
-      "version": "$(app_minimumVersion)"
+      "version": "29.0.0.0"
     }
   ],
   "platform": "29.0.0.0",

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -472,7 +472,7 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
             ProductionOrder."Source Type"::Item, FinishedItem."No.", Qty, HomeLocation.Code);
 
         // [GIVEN] Requisition worksheet template for subcontracting
-        LibraryMfgManagement.CreateLaborReqWkshTemplateAndNameAndUpdateSetup();
+        LibraryMfgManagement.CreateSubcontractingReqWkshTemplateAndNameAndUpdateSetup();
 
         // [WHEN] Create subcontracting purchase order from Prod. Order Routing
         ProdOrderRtngLine.SetRange("Routing No.", RoutingHeader."No.");

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2402,7 +2402,7 @@ codeunit 139989 "Subc. Subcontracting Test"
 Assert.AreEqual(0, ProdOrderLine.Count(), 'Expected no production order lines to exist at this point');
         ProdOrderLine.SetRange(Status, ProdOrderLine.Status::Released);
         ProdOrderLine.SetRange("Prod. Order No.", ProductionOrder."No.");
-        Assert.AreEqual(0, ProdOrderLine.Count(), 'Expected only one production order line initially');
+Assert.AreEqual(0, ProdOrderLine.Count(), 'Expected no production order lines to exist before manually creating them');
 
         // [GIVEN] Create two production order lines for the same item but different locations
         LibraryWarehouse.CreateLocationWithInventoryPostingSetup(ProductionLocation[1]);

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2412,7 +2412,19 @@ Assert.AreEqual(0, ProdOrderLine.Count(), 'Expected no production order lines to
         LibraryManufacturing.CreateProdOrderLine(ProdOrderLine, ProductionOrder.Status, ProductionOrder."No.", Item."No.", '', ProductionLocation[2].Code, LibraryRandom.RandInt(10) + 2);
         ProdOrderLineNo[2] := ProdOrderLine."Line No.";
         Assert.AreNotEqual(ProdOrderLineNo[1], ProdOrderLineNo[2], 'Expected two distinct production order lines');
+        // [WHEN] Creating a Subcontracting Purchase Order for each Prod. Order routing line
+        for I := 1 to 2 do begin
+            ProdOrderRoutingLine.Reset();
+            // ... routing line filters ...
+            ProdOrderRtng.OpenView();
+            ProdOrderRtng.GoToRecord(ProdOrderRoutingLine);
+            ProdOrderRtng.CreateSubcontracting.Invoke();
+            ProdOrderRtng.Close();
 
+            // [THEN] A new Purchase Order is created (not the false 'already created' warning)
+            Assert.AreEqual('1 Purchase Order(s) created.\\Do you want to view them?', LibraryVariableStorage.DequeueText(), 'Expected "created" confirmation for each prod order line');
+            LibraryVariableStorage.AssertEmpty();
+        end;
         // [GIVEN] Refresh the production order to update the routing and component lines
         LibraryManufacturing.RefreshProdOrder(ProductionOrder, false, false, true, true, false);
 

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -36,6 +36,7 @@ using Microsoft.Sales.Document;
 using Microsoft.Utilities;
 using Microsoft.Warehouse.Document;
 using Microsoft.Warehouse.Structure;
+using System.TestLibraries.Utilities;
 
 codeunit 139989 "Subc. Subcontracting Test"
 {
@@ -2367,6 +2368,76 @@ codeunit 139989 "Subc. Subcontracting Test"
     end;
 
     [Test]
+    [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting')]
+    procedure CreateSubcontractingPOForEachProdOrderLineWhenLinesShareRoutingAndOperation()
+    var
+        Item: Record Item;
+        ProductionLocation: array[2] of Record Location;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProdOrderLine: Record "Prod. Order Line";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        ProductionOrder: Record "Production Order";
+        WorkCenter: array[2] of Record "Work Center";
+        ProdOrderRtng: TestPage "Prod. Order Routing";
+        I: Integer;
+        ProdOrderLineNo: array[2] of Integer;
+    begin
+        // [SCENARIO 634238] When a Released Production Order has multiple Prod. Order lines sharing the same
+        // Routing/Operation, creating a Subcontracting Order for the second line must not raise the false
+        // "Purchase order(s) have already been created" warning, and must create/show its own Purchase Order.
+
+        // [GIVEN] Subcontracting setup with direct transfer (no in-transit route)
+        Initialize();
+        UpdateManufacturingSetupWithSubcontractingLocation();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+
+        // [GIVEN] One released production order created directly from item
+        LibraryManufacturing.CreateProductionOrder(ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", 0);
+
+        // [GIVEN] Add second production order line to the same production order
+        ProdOrderLine.SetRange(Status, ProdOrderLine.Status::Released);
+        ProdOrderLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        Assert.AreEqual(0, ProdOrderLine.Count(), 'Expected only one production order line initially');
+
+        // [GIVEN] Create two production order lines for the same item but different locations
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(ProductionLocation[1]);
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(ProductionLocation[2]);
+        LibraryManufacturing.CreateProdOrderLine(ProdOrderLine, ProductionOrder.Status, ProductionOrder."No.", Item."No.", '', ProductionLocation[1].Code, LibraryRandom.RandInt(10) + 2);
+        ProdOrderLineNo[1] := ProdOrderLine."Line No.";
+        LibraryManufacturing.CreateProdOrderLine(ProdOrderLine, ProductionOrder.Status, ProductionOrder."No.", Item."No.", '', ProductionLocation[2].Code, LibraryRandom.RandInt(10) + 2);
+        ProdOrderLineNo[2] := ProdOrderLine."Line No.";
+        Assert.AreNotEqual(ProdOrderLineNo[1], ProdOrderLineNo[2], 'Expected two distinct production order lines');
+
+        // [GIVEN] Refresh the production order to update the routing and component lines
+        LibraryManufacturing.RefreshProdOrder(ProductionOrder, false, false, true, true, false);
+
+        // [GIVEN] The two production-order lines have transfer components on different locations
+        for I := 1 to 2 do begin
+            ProdOrderRoutingLine.Reset();
+            ProdOrderRoutingLine.SetRange(Status, ProdOrderRoutingLine.Status::Released);
+            ProdOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+            ProdOrderRoutingLine.SetRange("Routing Reference No.", ProdOrderLineNo[I]);
+            ProdOrderRoutingLine.SetRange("Work Center No.", WorkCenter[2]."No.");
+            Assert.RecordCount(ProdOrderRoutingLine, 1);
+
+            ProdOrderRoutingLine.FindFirst();
+
+            ProdOrderRtng.OpenView();
+            ProdOrderRtng.GoToRecord(ProdOrderRoutingLine);
+            ProdOrderRtng.CreateSubcontracting.Invoke();
+            ProdOrderRtng.Close();
+
+            Assert.AreEqual('1 Purchase Order(s) created.\\Do you want to view them?', LibraryVariableStorage.DequeueText(), 'Expected "created" confirmation for each prod order line, not the false "already created" warning');
+            LibraryVariableStorage.AssertEmpty();
+        end;
+    end;
+
+    [Test]
     [HandlerFunctions('ConfirmYesShowSubcontractingPurchOrders,HandlePurchaseOrderPage,HandlePurchaseLinesPage')]
     procedure ShowExistingPurchOrdersOpensListWhenAlreadyCreated()
     var
@@ -2462,6 +2533,7 @@ codeunit 139989 "Subc. Subcontracting Test"
     [ConfirmHandler]
     procedure DoNotConfirmShowCreatedPurchOrderForSubcontracting(Question: Text[1024]; var Reply: Boolean)
     begin
+        LibraryVariableStorage.Enqueue(Question);
         Reply := false;
     end;
 
@@ -2908,6 +2980,9 @@ codeunit 139989 "Subc. Subcontracting Test"
 
         SubcontractingMgmtLibrary.Initialize();
         UpdateSubMgmtSetupComponentAtLocation("Components at Location"::Purchase);
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+        LibraryVariableStorage.Clear();
+
         LibraryMfgManagement.Initialize();
 
         if IsInitialized then
@@ -3110,6 +3185,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         LibraryWarehouse: Codeunit "Library - Warehouse";
         LibraryMfgManagement: Codeunit "Subc. Library Mfg. Management";
         SubcontractingMgmtLibrary: Codeunit "Subc. Management Library";
+        LibraryVariableStorage: Codeunit "Library - Variable Storage";
         SubSetupLibrary: Codeunit "Subc. Setup Library";
         IsInitialized: Boolean;
         Subcontracting: Boolean;

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2616,7 +2616,7 @@ codeunit 139989 "Subc. Subcontracting Test"
             PurchaseLine.SetRange(Type, PurchaseLine.Type::Item);
             PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
             PurchaseLine.SetRange("Routing Reference No.", ProdOrderLineNo[I]);
-            Assert.IsFalse(PurchaseLine.IsEmpty(), StrSubstNo('Opened Purchase Order %1 should contain a line tied to Routing Reference No. %2', OpenedPurchaseOrderNo, ProdOrderLineNo[I]));
+            Assert.IsFalse(PurchaseLine.IsEmpty(), StrSubstNo(PurchOrderRoutingErr, OpenedPurchaseOrderNo, ProdOrderLineNo[I]));
             LibraryVariableStorage.AssertEmpty();
         end;
     end;
@@ -3407,5 +3407,6 @@ codeunit 139989 "Subc. Subcontracting Test"
         UnitCostCalculation: Option Time,Units;
         ConfirmDialogCalledCount: Integer;
         AlreadySpecifiedErr: Label 'You cannot open Tracking Specification because this component is already specified in Transfer Order %1.', Comment = '|%1 = Transfer Order No.';
+        PurchOrderRoutingErr: Label 'Purchase Order %1 should contain a line tied to Routing Reference No. %2', Comment = '%1 = Purchase Order No., %2 = Routing Reference No.';
 
 }

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2396,7 +2396,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
         UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
 
-        // [GIVEN] One released production order created directly from item
+        // [GIVEN] Verify no production order lines exist before manual creation
         LibraryManufacturing.CreateProductionOrder(ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", 0);
 
         // [GIVEN] Add second production order line to the same production order

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2396,15 +2396,15 @@ codeunit 139989 "Subc. Subcontracting Test"
         CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
         UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
 
-        // [GIVEN] Verify no production order lines exist before manual creation
+        // [GIVEN] One released production order created directly from item
         LibraryManufacturing.CreateProductionOrder(ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", 0);
 
-Assert.AreEqual(0, ProdOrderLine.Count(), 'Expected no production order lines to exist at this point');
+        // [GIVEN] No production order lines exist yet for this order
         ProdOrderLine.SetRange(Status, ProdOrderLine.Status::Released);
         ProdOrderLine.SetRange("Prod. Order No.", ProductionOrder."No.");
-Assert.AreEqual(0, ProdOrderLine.Count(), 'Expected no production order lines to exist before manually creating them');
+        Assert.AreEqual(0, ProdOrderLine.Count(), 'Expected no production order lines to exist before manually creating them');
 
-        // [GIVEN] Create two production order lines for the same item but different locations
+        // [GIVEN] Two production order lines on the same production order, on different locations
         LibraryWarehouse.CreateLocationWithInventoryPostingSetup(ProductionLocation[1]);
         LibraryWarehouse.CreateLocationWithInventoryPostingSetup(ProductionLocation[2]);
         LibraryManufacturing.CreateProdOrderLine(ProdOrderLine, ProductionOrder.Status, ProductionOrder."No.", Item."No.", '', ProductionLocation[1].Code, LibraryRandom.RandInt(10) + 2);
@@ -2412,19 +2412,7 @@ Assert.AreEqual(0, ProdOrderLine.Count(), 'Expected no production order lines to
         LibraryManufacturing.CreateProdOrderLine(ProdOrderLine, ProductionOrder.Status, ProductionOrder."No.", Item."No.", '', ProductionLocation[2].Code, LibraryRandom.RandInt(10) + 2);
         ProdOrderLineNo[2] := ProdOrderLine."Line No.";
         Assert.AreNotEqual(ProdOrderLineNo[1], ProdOrderLineNo[2], 'Expected two distinct production order lines');
-        // [WHEN] Creating a Subcontracting Purchase Order for each Prod. Order routing line
-        for I := 1 to 2 do begin
-            ProdOrderRoutingLine.Reset();
-            // ... routing line filters ...
-            ProdOrderRtng.OpenView();
-            ProdOrderRtng.GoToRecord(ProdOrderRoutingLine);
-            ProdOrderRtng.CreateSubcontracting.Invoke();
-            ProdOrderRtng.Close();
 
-            // [THEN] A new Purchase Order is created (not the false 'already created' warning)
-            Assert.AreEqual('1 Purchase Order(s) created.\\Do you want to view them?', LibraryVariableStorage.DequeueText(), 'Expected "created" confirmation for each prod order line');
-            LibraryVariableStorage.AssertEmpty();
-        end;
         // [GIVEN] Refresh the production order to update the routing and component lines
         LibraryManufacturing.RefreshProdOrder(ProductionOrder, false, false, true, true, false);
 
@@ -2450,6 +2438,75 @@ Assert.AreEqual(0, ProdOrderLine.Count(), 'Expected no production order lines to
     end;
 
     [Test]
+    [HandlerFunctions('ConfirmYesShowSubcontractingPurchOrders,CapturePurchaseOrderPageNo')]
+    procedure CreateSubcontractingPONavigatesToOwnPOWhenLinesShareRoutingAndOperation()
+    var
+        Item: Record Item;
+        ProductionLocation: array[2] of Record Location;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProdOrderLine: Record "Prod. Order Line";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        ProductionOrder: Record "Production Order";
+        PurchaseLine: Record "Purchase Line";
+        WorkCenter: array[2] of Record "Work Center";
+        ProdOrderRtng: TestPage "Prod. Order Routing";
+        I: Integer;
+        ProdOrderLineNo: array[2] of Integer;
+        OpenedPurchaseOrderNo: Code[20];
+    begin
+        // [SCENARIO 634238] When a Released Production Order has multiple Prod. Order lines sharing routing/operation,
+        // confirming "view them" on the just-created Subcontracting Order must open the PO tied to the invoked
+        // routing line, not the unrelated PO of a sibling line.
+
+        // [GIVEN] Subcontracting setup with two prod order lines sharing routing/operation but different Routing Reference No.
+        Initialize();
+        UpdateManufacturingSetupWithSubcontractingLocation();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+
+        LibraryManufacturing.CreateProductionOrder(ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", 0);
+
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(ProductionLocation[1]);
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(ProductionLocation[2]);
+        LibraryManufacturing.CreateProdOrderLine(ProdOrderLine, ProductionOrder.Status, ProductionOrder."No.", Item."No.", '', ProductionLocation[1].Code, LibraryRandom.RandInt(10) + 2);
+        ProdOrderLineNo[1] := ProdOrderLine."Line No.";
+        LibraryManufacturing.CreateProdOrderLine(ProdOrderLine, ProductionOrder.Status, ProductionOrder."No.", Item."No.", '', ProductionLocation[2].Code, LibraryRandom.RandInt(10) + 2);
+        ProdOrderLineNo[2] := ProdOrderLine."Line No.";
+
+        LibraryManufacturing.RefreshProdOrder(ProductionOrder, false, false, true, true, false);
+
+        // [WHEN] Creating a Subcontracting Order from each routing line and confirming "view them"
+        for I := 1 to 2 do begin
+            ProdOrderRoutingLine.Reset();
+            ProdOrderRoutingLine.SetRange(Status, ProdOrderRoutingLine.Status::Released);
+            ProdOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+            ProdOrderRoutingLine.SetRange("Routing Reference No.", ProdOrderLineNo[I]);
+            ProdOrderRoutingLine.SetRange("Work Center No.", WorkCenter[2]."No.");
+            ProdOrderRoutingLine.FindFirst();
+
+            ProdOrderRtng.OpenView();
+            ProdOrderRtng.GoToRecord(ProdOrderRoutingLine);
+            ProdOrderRtng.CreateSubcontracting.Invoke();
+            ProdOrderRtng.Close();
+
+            // [THEN] The page handler opens the Purchase Order whose line carries this routing line's Routing Reference No.
+            OpenedPurchaseOrderNo := CopyStr(LibraryVariableStorage.DequeueText(), 1, MaxStrLen(OpenedPurchaseOrderNo));
+            PurchaseLine.Reset();
+            PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+            PurchaseLine.SetRange("Document No.", OpenedPurchaseOrderNo);
+            PurchaseLine.SetRange(Type, PurchaseLine.Type::Item);
+            PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+            PurchaseLine.SetRange("Routing Reference No.", ProdOrderLineNo[I]);
+            Assert.IsFalse(PurchaseLine.IsEmpty(), StrSubstNo('Opened Purchase Order %1 should contain a line tied to Routing Reference No. %2', OpenedPurchaseOrderNo, ProdOrderLineNo[I]));
+            LibraryVariableStorage.AssertEmpty();
+        end;
+    end;
+
+    [Test]
     [HandlerFunctions('ConfirmYesShowSubcontractingPurchOrders,HandlePurchaseOrderPage,HandlePurchaseLinesPage')]
     procedure ShowExistingPurchOrdersOpensListWhenAlreadyCreated()
     var
@@ -2469,7 +2526,6 @@ Assert.AreEqual(0, ProdOrderLine.Count(), 'Expected no production order lines to
         CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
         CreateAndRefreshProductionOrder(
             ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
-        UpdateSubMgmtSetupWithReqWkshTemplate();
 
         // [WHEN] Create Subcontracting Order from the routing line for the first time
         PurchaseOrderPageOpened := false;
@@ -2511,6 +2567,13 @@ Assert.AreEqual(0, ProdOrderLine.Count(), 'Expected no production order lines to
     procedure HandlePurchaseOrderPage(var PurchaseOrderPage: TestPage "Purchase Order")
     begin
         PurchaseOrderPageOpened := true;
+        PurchaseOrderPage.Close();
+    end;
+
+    [PageHandler]
+    procedure CapturePurchaseOrderPageNo(var PurchaseOrderPage: TestPage "Purchase Order")
+    begin
+        LibraryVariableStorage.Enqueue(PurchaseOrderPage."No.".Value);
         PurchaseOrderPage.Close();
     end;
 

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2399,7 +2399,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         // [GIVEN] Verify no production order lines exist before manual creation
         LibraryManufacturing.CreateProductionOrder(ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", 0);
 
-        // [GIVEN] Add second production order line to the same production order
+Assert.AreEqual(0, ProdOrderLine.Count(), 'Expected no production order lines to exist at this point');
         ProdOrderLine.SetRange(Status, ProdOrderLine.Status::Released);
         ProdOrderLine.SetRange("Prod. Order No.", ProductionOrder."No.");
         Assert.AreEqual(0, ProdOrderLine.Count(), 'Expected only one production order line initially');

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2548,7 +2548,7 @@ codeunit 139989 "Subc. Subcontracting Test"
 
         // [GIVEN] Subcontracting setup with direct transfer (no in-transit route)
         Initialize();
-        UpdateManufacturingSetupWithSubcontractingLocation();
+        SubcontractingMgmtLibrary.UpdateManufacturingSetupWithSubcontractingLocation();
         Subcontracting := true;
         UnitCostCalculation := UnitCostCalculation::Units;
         CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
@@ -2620,7 +2620,7 @@ codeunit 139989 "Subc. Subcontracting Test"
 
         // [GIVEN] Subcontracting setup with two prod order lines sharing routing/operation but different Routing Reference No.
         Initialize();
-        UpdateManufacturingSetupWithSubcontractingLocation();
+        SubcontractingMgmtLibrary.UpdateManufacturingSetupWithSubcontractingLocation();
         Subcontracting := true;
         UnitCostCalculation := UnitCostCalculation::Units;
         CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);


### PR DESCRIPTION
## Bug

[AB#634238](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634238) — When a Released Production Order has multiple Prod. Order lines that share the same Routing/Operation but differ by `Routing Reference No.`, creating a Subcontracting Order from the routing of a second line:

- **Symptom 1:** Falsely raises *"Purchase order(s) have already been created. Do you want to view them?"* — even though the second line never had a PO.
- **Symptom 2:** Confirming "view them" opens the unrelated PO of the **first** line, not the newly-created PO of the second line.

## Root cause

Three filter sites identified Prod. Order lines by `Prod. Order No.` + `Routing No.` + `Operation No.` only, missing `Routing Reference No.` — the field that disambiguates Prod. Order lines sharing the same routing/operation:

- `Subc. Purchase Order Creator` (codeunit `99001557`)
  - `ShowExistingPurchaseOrdersForRoutingLines` — drives the *"already created"* prompt.
  - `ShowCreatedPurchaseOrder` (single-PO navigation branch) — drives which PO opens.
- `SubcProdOrderRtng.PageExt.al` — the *Create Subcontracting Order* action's `if NoOfCreatedPurchOrder = 0` fallback that decides whether to show the *"No subcontracting order was created"* message.

The static `RunPageLink` on the *Subcontracting Purchase Order Lines* action in `SubcProdOrderRtng.PageExt.al` already includes `Routing Reference No.` as a filter — confirming this is the canonical filter pattern the programmatic checks should follow.

## Fix

1. **`SubcPurchaseOrderCreator.Codeunit.al`**
   - `ShowExistingPurchaseOrdersForRoutingLines`: add `PurchaseLine.SetRange("Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.")` to the existence check.
   - `ShowCreatedPurchaseOrder`: add a `RoutingReferenceNo` global with `Set/Clear` accessors (mirroring the existing `OperationNo` pattern) and apply it in the single-PO navigation branch.

2. **`SubcProdOrderRtng.PageExt.al`**
   - The *Create Subcontracting Order* action now calls `ClearRoutingReferenceNoForCreatedPurchaseOrder()` + `SetRoutingReferenceNoForCreatedPurchaseOrder(Rec."Routing Reference No.")` before invoking `ShowCreatedPurchaseOrder`.
   - The `if NoOfCreatedPurchOrder = 0` fallback also filters by `"Routing Reference No." = Rec."Routing Reference No."`, so the *"No subcontracting order was created"* message is no longer wrongly suppressed when a sibling Prod. Order line already has an unrelated PO.

The change is minimal and targeted — no broader refactoring.

## Tests

Two tests added to codeunit `139989 "Subc. Subcontracting Test"`. Both build a single Released Production Order with two Prod. Order lines for the same item on different locations (so they share routing/operation but have different `Routing Reference No.`) and invoke *Create Subcontracting Order* on each line's routing entry.

1. **`CreateSubcontractingPOForEachProdOrderLineWhenLinesShareRoutingAndOperation`** — covers **Symptom 1**. Captures the confirm-handler question text and asserts each invocation ends with the *"1 Purchase Order(s) created"* confirmation — i.e. neither raises the false *"already created"* warning.
2. **`CreateSubcontractingPONavigatesToOwnPOWhenLinesShareRoutingAndOperation`** — covers **Symptom 2**. Confirms *"view them"* with `Yes` and captures the opened Purchase Order's `No.` via a page handler, then asserts the opened PO contains a `Purchase Line` carrying the invoked routing line's `Routing Reference No.` — proving the single-PO navigation branch routes to the correct PO.

Both tests fail on the unfixed code and pass after the fix.

The test app gains a dependency on `Library - Variable Storage` so the confirm/page handlers can enqueue captured values for assertion.

## Work item

[AB#634238](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634238)






