### PR TITLE
Fixes #8156

### DIFF
--- a/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
@@ -748,7 +748,7 @@ codeunit 8900 "Email Impl"
         SourceRecordRef: RecordRef;
         Handled: Boolean;
     begin
-        OnBeforeFilterRemovedSourceRecords(EmailRelatedRecord,Handled);
+OnBeforeFilterRemovedSourceRecords(EmailRelatedRecord, Handled);
         if Handled then
             exit;
         repeat

--- a/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
@@ -746,7 +746,11 @@ codeunit 8900 "Email Impl"
     var
         AllObj: Record AllObj;
         SourceRecordRef: RecordRef;
+        Handled: Boolean;
     begin
+        OnBeforeFilterRemovedSourceRecords(EmailRelatedRecord,Handled);
+        if Handled then
+            exit;
         repeat
             if AllObj.Get(AllObj."Object Type"::Table, EmailRelatedRecord."Table Id") then begin
                 SourceRecordRef.Open(EmailRelatedRecord."Table Id");
@@ -1111,6 +1115,11 @@ codeunit 8900 "Email Impl"
         TelemetryDimensions.Add('ViewPolicy', Format(EmailViewPolicy."Email View Policy"));
 
         GlobalLanguage(CurrentLanguage);
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeFilterRemovedSourceRecords(var EmailRelatedRecord: Record "Email Related Record";var Handled:Boolean)
+    begin
     end;
     #endregion
 }

--- a/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
@@ -1118,7 +1118,7 @@ OnBeforeFilterRemovedSourceRecords(EmailRelatedRecord, Handled);
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeFilterRemovedSourceRecords(var EmailRelatedRecord: Record "Email Related Record";var Handled:Boolean)
+    local procedure OnBeforeFilterRemovedSourceRecords(var EmailRelatedRecord: Record "Email Related Record"; var Handled: Boolean)
     begin
     end;
     #endregion


### PR DESCRIPTION
Hi,
If at least one security filter is applied to the “Purchase Header” table, the user will have a problem when push ‘Add file from source document’ action on the “Email Attachments” subpage. Message: "Did not find any attachments related to this email"

With this event, we will be able to add the following condition: SourceRecordRef.SecurityFiltering(SecurityFilter::Ignored); before reading permissions.

Thx in advance,
Frank Neeckx

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #8156 

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->
