### PR TITLE
Bug 634720: [Subcontracting] Production Routing factbox count must match drill-down operation filter

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcProdOFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcProdOFactboxMgmt.Codeunit.al
@@ -80,6 +80,8 @@ codeunit 99001559 "Subc. ProdO. Factbox Mgmt."
         ProdOrderRoutingLine.SetRange(Status, ProdOrderRoutingLine.Status::Released);
         ProdOrderRoutingLine.SetRange("Prod. Order No.", ProdOrderNo);
         ProdOrderRoutingLine.SetRange("Routing Reference No.", ProdOrderLineNo);
+        ProdOrderRoutingLine.SetRange("Routing No.", RoutingNo);
+        ProdOrderRoutingLine.SetRange("Operation No.", OperationNo);
         exit(ProdOrderRoutingLine.Count());
     end;
 

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -472,7 +472,7 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
             ProductionOrder."Source Type"::Item, FinishedItem."No.", Qty, HomeLocation.Code);
 
         // [GIVEN] Requisition worksheet template for subcontracting
-        LibraryMfgManagement.CreateLaborReqWkshTemplateAndNameAndUpdateSetup();
+        LibraryMfgManagement.CreateSubcontractingReqWkshTemplateAndNameAndUpdateSetup();
 
         // [WHEN] Create subcontracting purchase order from Prod. Order Routing
         ProdOrderRtngLine.SetRange("Routing No.", RoutingHeader."No.");

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2030,6 +2030,54 @@ codeunit 139989 "Subc. Subcontracting Test"
 
     [Test]
     [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting')]
+    procedure CalcNoOfProductionOrderRoutingsReturnsOneForSubcontractingPurchaseLine()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        ProductionOrder: Record "Production Order";
+        PurchaseLine: Record "Purchase Line";
+        WorkCenter: array[2] of Record "Work Center";
+        SubcProdOFactboxMgmt: Codeunit "Subc. ProdO. Factbox Mgmt.";
+    begin
+        // [SCENARIO 634720] CalcNoOfProductionOrderRoutings must filter by Routing No. and Operation No. so the factbox count matches the drill-down (which is always a single routing line for a subcontracting purchase line).
+
+        // [GIVEN] Manufacturing setup with a routing of multiple operations where only the second work center is subcontracting
+        Initialize();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+
+        // [GIVEN] A Released Production Order whose routing has more than one operation
+        CreateAndRefreshProductionOrder(
+          ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+
+        ProdOrderRoutingLine.SetRange(Status, ProdOrderRoutingLine.Status::Released);
+        ProdOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        Assert.IsTrue(ProdOrderRoutingLine.Count() > 1, 'Test precondition: routing must have more than one operation to detect the bug.');
+
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+
+        // [GIVEN] A Subcontracting Purchase Order created from the routing line of the subcontracting work center
+        CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+#pragma warning disable AA0210
+        PurchaseLine.SetRange("Work Center No.", WorkCenter[2]."No.");
+#pragma warning restore AA0210
+        PurchaseLine.FindFirst();
+
+        // [WHEN] CalcNoOfProductionOrderRoutings is called with the purchase line
+        // [THEN] It returns 1, matching the single routing line shown by the drill-down (not the total operations of the prod order line)
+        Assert.AreEqual(
+          1, SubcProdOFactboxMgmt.CalcNoOfProductionOrderRoutings(PurchaseLine),
+          'CalcNoOfProductionOrderRoutings must equal the number of routing lines opened by the drill-down (exactly one for a subcontracting purchase line).');
+    end;
+
+    [Test]
+    [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting')]
     procedure Description2CopiedFromProdOrderComponentToPurchaseLine()
     var
         Item: Record Item;

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2268,7 +2268,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
 
         // [GIVEN] A Released Production Order whose routing has more than one operation
-        CreateAndRefreshProductionOrder(
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
           ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
 
         ProdOrderRoutingLine.SetRange(Status, ProdOrderRoutingLine.Status::Released);
@@ -2278,7 +2278,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         UpdateSubMgmtSetupWithReqWkshTemplate();
 
         // [GIVEN] A Subcontracting Purchase Order created from the routing line of the subcontracting work center
-        CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
         PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
         PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
 #pragma warning disable AA0210


### PR DESCRIPTION
## Summary
- In the Subcontracting Details factbox on a Purchase Order, the **Production Routing** field showed a count (e.g. `4`) that didn't match the single routing line opened by its drill-down. Same issue on the Transfer Order factbox.
- **Root cause:** `CalcNoOfProductionOrderRoutings` in codeunit 99001559 `Subc. ProdO. Factbox Mgmt.` filtered the `Prod. Order Routing Line` table by `Status` + `Prod. Order No.` + `Routing Reference No.` only, while its drill-down counterpart `ShowProductionOrderRouting` additionally filters by `Routing No.` and `Operation No.`. The count therefore returned all operations of the production order line; the drill-down always returns the single linked routing operation.
- **Fix:** Add the two missing filters in `CalcNoOfProductionOrderRoutings` so both methods apply the same filter set. Single-point fix shared by both `Subc. Purchase Line Factbox` and `Subc. Transfer Line Factbox`.

## Test
Added `CalcNoOfProductionOrderRoutingsReturnsOneForSubcontractingPurchaseLine` (`[SCENARIO 634720]`) in codeunit 139989 `Subc. Subcontracting Test` (`src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al`). The test:
1. Creates a production order whose routing has multiple operations (asserts `Count() > 1` as a precondition to detect the bug),
2. Creates a subcontracting purchase order for the subcontracting work center, and
3. Asserts `CalcNoOfProductionOrderRoutings(PurchaseLine) = 1`, matching the drill-down.

Without the fix, the assertion would observe the total number of routing operations of the prod-order line (e.g. `4`).

Fixes [AB#634720](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634720)

🤖 Generated with [Claude Code](https://claude.com/claude-code)






