### PR TITLE
Bug 634267: [Subcontracting] Transfer Order Reopen not persisting from factbox drill-down (Bug 634267)

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchFactboxMgmt.Codeunit.al
@@ -314,6 +314,8 @@ codeunit 99001560 "Subc. Purch. Factbox Mgmt."
                     end;
                 NoOfTransferHeaders > 1:
                     begin
+                        // As we do not expect more than a handful tranfer orders linked to the purchase order, there is no need to 
+                        // add extra processing if the number of records linked are more than allowed.
                         TransferHeaderToOpen.SetFilter("No.", SelectionFilterMgt.GetSelectionFilterForTransferHeader(TransferHeader));
                         PageManagement.PageRunList(TransferHeaderToOpen);
                     end;

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchFactboxMgmt.Codeunit.al
@@ -12,6 +12,7 @@ using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
 using Microsoft.Utilities;
 using System.Reflection;
+using System.Text;
 
 codeunit 99001560 "Subc. Purch. Factbox Mgmt."
 {
@@ -229,9 +230,11 @@ codeunit 99001560 "Subc. Purch. Factbox Mgmt."
         ProductionOrder: Record "Production Order";
         PurchaseLine: Record "Purchase Line";
         TransferHeader: Record "Transfer Header";
+        TransferHeaderToOpen: Record "Transfer Header";
         TransferLine: Record "Transfer Line";
         DataTypeManagement: Codeunit "Data Type Management";
         PageManagement: Codeunit "Page Management";
+        SelectionFilterMgt: Codeunit SelectionFilterManagement;
         RecRef: RecordRef;
         NoOfTransferHeaders: Integer;
     begin
@@ -305,10 +308,15 @@ codeunit 99001560 "Subc. Purch. Factbox Mgmt."
                 NoOfTransferHeaders = 0:
                     Message(NoTransferExistsMsg);
                 NoOfTransferHeaders = 1:
-                    if TransferHeader.FindFirst() then
-                        PageManagement.PageRun(TransferHeader);
+                    if TransferHeader.FindFirst() then begin
+                        TransferHeaderToOpen.Get(TransferHeader."No.");
+                        PageManagement.PageRun(TransferHeaderToOpen);
+                    end;
                 NoOfTransferHeaders > 1:
-                    PageManagement.PageRunList(TransferHeader);
+                    begin
+                        TransferHeaderToOpen.SetFilter("No.", SelectionFilterMgt.GetSelectionFilterForTransferHeader(TransferHeader));
+                        PageManagement.PageRunList(TransferHeaderToOpen);
+                    end;
             end;
         end;
     end;

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2098,7 +2098,6 @@ codeunit 139989 "Subc. Subcontracting Test"
         // [GIVEN] Subcontracting setup with transfer components and a released transfer order
         Initialize();
         SubcontractingMgmtLibrary.UpdateManufacturingSetupWithSubcontractingLocation();
-        SubcontractingMgmtLibrary.SetupInventorySetup();
         Subcontracting := true;
         UnitCostCalculation := UnitCostCalculation::Units;
 

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2074,6 +2074,82 @@ codeunit 139989 "Subc. Subcontracting Test"
     end;
 
     [Test]
+    [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrderReopen')]
+    procedure FactboxDrilldownTransferOrderReopenPersists()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        TransferHeader: Record "Transfer Header";
+        WorkCenter: array[2] of Record "Work Center";
+        ProductionLocation: Record Location;
+        SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
+        ReleaseTransferDocument: Codeunit "Release Transfer Document";
+        PurchaseHeaderPage: TestPage "Purchase Order";
+        ReleasedProdOrderRtng: TestPage "Prod. Order Routing";
+    begin
+        // [SCENARIO] Bug 634267 - Reopen Transfer Order does not persist when opened from Subcontracting Details Factbox.
+        // ShowTransferOrdersAndReturnOrder must open the page on a real database record, so actions like
+        // Reopen that modify Rec directly persist after the page closes.
+
+        // [GIVEN] Subcontracting setup with transfer components and a released transfer order
+        Initialize();
+        SubcontractingMgmtLibrary.UpdateManufacturingSetupWithSubcontractingLocation();
+        SubcontractingMgmtLibrary.SetupInventorySetup();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateProdBomWithSubcontractingType(Item, "Subcontracting Type"::Transfer);
+        UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(ProductionLocation);
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+        SetAllProdOrderTransferComponentLocations(ProductionOrder."No.", ProductionLocation.Code);
+        SubcontractingMgmtLibrary.CreateTransferRoute(WorkCenter[2], ProductionOrder);
+
+        ProdOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderRoutingLine.SetRange("Work Center No.", WorkCenter[2]."No.");
+        ProdOrderRoutingLine.FindFirst();
+        ReleasedProdOrderRtng.OpenView();
+        ReleasedProdOrderRtng.GoToRecord(ProdOrderRoutingLine);
+        ReleasedProdOrderRtng.CreateSubcontracting.Invoke();
+        ReleasedProdOrderRtng.Close();
+
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+
+        PurchaseHeaderPage.OpenView();
+        PurchaseHeaderPage.GoToRecord(PurchaseHeader);
+        PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+        PurchaseHeaderPage.Close();
+
+        TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
+        TransferHeader.FindFirst();
+        ReleaseTransferDocument.Release(TransferHeader);
+        Assert.AreEqual(TransferHeader.Status::Released, TransferHeader.Status, 'Transfer order should be Released before the test.');
+
+        // [WHEN] Opening the transfer order from the factbox drill-down and performing Reopen
+        // The page handler HandleTransferOrderReopen will reopen the transfer order
+        PurchaseLine.FindFirst();
+        SubcPurchFactboxMgmt.ShowTransferOrdersAndReturnOrder(PurchaseLine, true, false);
+
+        // [THEN] The transfer order status must be Open after closing the page
+        TransferHeader.Get(TransferHeader."No.");
+        Assert.AreEqual(TransferHeader.Status::Open, TransferHeader.Status,
+            'Transfer order status should be Open after Reopen from factbox drill-down. Before the fix, the Reopen modified a marked record and the change was lost.');
+    end;
+
+    [Test]
     [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting')]
     procedure Description2CopiedFromProdOrderComponentToPurchaseLine()
     var
@@ -2576,6 +2652,13 @@ codeunit 139989 "Subc. Subcontracting Test"
     procedure HandleTransferOrder(var TransfOrderPage: TestPage "Transfer Order")
     begin
         OpenedTransferOrderNo := CopyStr(TransfOrderPage."No.".Value(), 1, MaxStrLen(OpenedTransferOrderNo));
+        TransfOrderPage.OK().Invoke();
+    end;
+
+    [PageHandler]
+    procedure HandleTransferOrderReopen(var TransfOrderPage: TestPage "Transfer Order")
+    begin
+        TransfOrderPage."Reo&pen".Invoke();
         TransfOrderPage.OK().Invoke();
     end;
 


### PR DESCRIPTION
## Problem

When a Transfer Order is opened from the **Subcontracting Details Factbox** (e.g. clicking *No. of Transfer Orders* on a Purchase Order), actions like **Reopen** that modify `Rec` directly appear to succeed on screen but the change is silently lost when the page closes.

### Root Cause

`ShowTransferOrdersAndReturnOrder` in `SubcPurchFactboxMgmt` collected Transfer Headers using `Mark`/`MarkedOnly` and passed that marked record directly to `PageManagement.PageRun`/`PageRunList`. When the Transfer Order page opened bound to a marked record, operations that modify `Rec` (e.g. Reopen → `Rec.Validate(Status, Open); Rec.Modify()`) wrote to the marked record set in memory rather than the real database table. The change was discarded when the page closed.

Actions like **Post** were unaffected because they call `TransferHeader.Get()` internally on a separate variable, bypassing `Rec`.

## Fix

Introduced a separate `TransferHeaderToOpen` record variable that is populated from the real database:

- **Single record**: `TransferHeaderToOpen.Get(TransferHeader.\"No.\")` fetches the real DB record, then `PageManagement.PageRun(TransferHeaderToOpen)`.
- **Multiple records**: Uses `SelectionFilterManagement.GetSelectionFilterForTransferHeader` to build a \"No.\" filter from the marked set, applies it to `TransferHeaderToOpen`, then `PageManagement.PageRunList(TransferHeaderToOpen)`.

## Test

Added `FactboxDrilldownTransferOrderReopenPersists`:
1. Sets up subcontracting with transfer components
2. Creates and releases a Transfer Order
3. Opens it via `ShowTransferOrdersAndReturnOrder` (the factbox drill-down path)
4. Page handler invokes Reopen
5. Asserts the Transfer Order status persists as **Open** after the page closes

[AB#634267](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634267)


