### PR TITLE
[releases/28.x] Adding a check if the task ID is zero

### DIFF
--- a/src/System Application/App/Agent/Monetization/AgentConsumptionOverview.Codeunit.al
+++ b/src/System Application/App/Agent/Monetization/AgentConsumptionOverview.Codeunit.al
@@ -20,6 +20,9 @@ codeunit 4333 "Agent Consumption Overview"
     var
         AgentUtilities: Codeunit "Agent Utilities";
     begin
+        if TaskId = 0 then
+            exit(0);
+
         exit(AgentUtilities.GetConsumedCopilotCredits(TaskId));
     end;
 


### PR DESCRIPTION
Cherry-pick of b43a24bb6e5f8ffdc649d68e7c9af17dc3f8c9c0 to `releases/28.x`.

Adds a guard so `Agent Consumption Overview.GetCopilotCreditsConsumed` returns `0` when `TaskId = 0` instead of querying with an invalid task ID.

Clean cherry-pick (no conflicts).

Fixes [AB#635847](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/635847)

