### PR TITLE
[releases/28.1] Adding a check if the task ID is zero

### DIFF
--- a/src/System Application/App/Agent/Monetization/AgentConsumptionOverview.Codeunit.al
+++ b/src/System Application/App/Agent/Monetization/AgentConsumptionOverview.Codeunit.al
@@ -22,6 +22,9 @@ codeunit 4333 "Agent Consumption Overview"
     var
         UserAIConsumptionData: Record "User AI Consumption Data";
     begin
+        if TaskId = 0 then
+            exit(0);
+
         UserAIConsumptionData.SetRange("Agent Task Id", TaskId);
         UserAIConsumptionData.CalcSums("Copilot Credits");
         exit(UserAIConsumptionData."Copilot Credits");


### PR DESCRIPTION
Cherry-pick of b43a24bb6e5f8ffdc649d68e7c9af17dc3f8c9c0 to `releases/28.1`.

Adds a guard so `Agent Consumption Overview.GetCopilotCreditsConsumed` returns `0` when `TaskId = 0` instead of querying with an invalid task ID.

**Conflict resolution:** On `releases/28.1` this procedure has a different body — it queries `User AI Consumption Data` directly rather than delegating to `Agent Utilities`. Kept the 28.1 body and added the `if TaskId = 0 then exit(0)` guard at the top of the procedure.

Fixes [AB#635846](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/635846)

