### PR TITLE
[28.0][Agent] Enable regular users to create agents

### DIFF
--- a/src/System Application/App/Agent/AgentInstall.Codeunit.al
+++ b/src/System Application/App/Agent/AgentInstall.Codeunit.al
@@ -1,0 +1,20 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace System.Agents;
+
+codeunit 4331 "Agent Install"
+{
+    Access = Internal;
+    Subtype = Install;
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    trigger OnInstallAppPerDatabase()
+    var
+        AgentUpgrade: Codeunit "Agent Upgrade";
+    begin
+        AgentUpgrade.InsertDefaultPermissionIfEmpty();
+    end;
+}

--- a/src/System Application/App/Agent/AgentUpgrade.Codeunit.al
+++ b/src/System Application/App/Agent/AgentUpgrade.Codeunit.al
@@ -1,0 +1,57 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace System.Agents;
+
+using System.Upgrade;
+
+codeunit 4326 "Agent Upgrade"
+{
+    Access = Internal;
+    Subtype = Upgrade;
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    trigger OnUpgradePerDatabase()
+    begin
+        InsertDefaultPermissionIfEmpty();
+    end;
+
+    procedure InsertDefaultPermissionIfEmpty()
+    var
+        AgentCreationControl: Record "Agent Creation Control";
+        UpgradeTag: Codeunit "Upgrade Tag";
+        DefaultPermissionDescriptionLbl: Label 'Default: Allow all users with required permissions to create agents';
+        EmptyGuid: Guid;
+    begin
+        if UpgradeTag.HasDatabaseUpgradeTag(GetDefaultAgentCreationControlUpgradeTag()) then
+            exit;
+
+        // If the table already has data, just set the upgrade tag.
+        if not AgentCreationControl.IsEmpty() then begin
+            UpgradeTag.SetDatabaseUpgradeTag(GetDefaultAgentCreationControlUpgradeTag());
+            exit;
+        end;
+
+        // Insert default rule.
+        AgentCreationControl."User Security ID" := EmptyGuid;
+        AgentCreationControl."Agent Metadata Provider" := -1;
+        AgentCreationControl."Company Name" := '';
+        AgentCreationControl.Description := DefaultPermissionDescriptionLbl;
+        AgentCreationControl.Insert();
+
+        UpgradeTag.SetDatabaseUpgradeTag(GetDefaultAgentCreationControlUpgradeTag());
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Upgrade Tag", OnGetPerDatabaseUpgradeTags, '', false, false)]
+    local procedure OnGetPerDatabaseUpgradeTags(var PerDatabaseUpgradeTags: List of [Code[250]])
+    begin
+        PerDatabaseUpgradeTags.Add(GetDefaultAgentCreationControlUpgradeTag());
+    end;
+
+    local procedure GetDefaultAgentCreationControlUpgradeTag(): Code[250]
+    begin
+        exit('MS-AgentDesigner-InsertDefaultCreationPermission-20260310');
+    end;
+}

--- a/src/System Application/App/Agent/Permissions/AgentSystemPermissions.Codeunit.al
+++ b/src/System Application/App/Agent/Permissions/AgentSystemPermissions.Codeunit.al
@@ -16,7 +16,7 @@ codeunit 4317 "Agent System Permissions"
     /// <returns>True if the user has permissions to manage all agents, false otherwise.</returns>
     procedure CurrentUserHasCanManageAllAgentsPermission(): Boolean
     begin
-        exit("Agent System Permissions Impl.".CurrentUserHasCanManageAllAgentsPermission());
+        exit(AgentSystemPermissionsImpl.CurrentUserHasCanManageAllAgentsPermission());
     end;
 
     /// <summary>
@@ -26,7 +26,7 @@ codeunit 4317 "Agent System Permissions"
     [Scope('OnPrem')]
     procedure CurrentUserHasTroubleshootAllAgents(): Boolean
     begin
-        exit("Agent System Permissions Impl.".CurrentUserHasTroubleshootAllAgents());
+        exit(AgentSystemPermissionsImpl.CurrentUserHasTroubleshootAllAgents());
     end;
 
     /// <summary>
@@ -36,9 +36,20 @@ codeunit 4317 "Agent System Permissions"
     [Scope('OnPrem')]
     procedure CurrentUserHasCanCreateCustomAgent(): Boolean
     begin
-        exit("Agent System Permissions Impl.".CurrentUserHasCanCreateCustomAgent());
+        exit(AgentSystemPermissionsImpl.CurrentUserHasCanCreateCustomAgent());
+    end;
+
+    /// <summary>
+    /// Gets whether the current user has permissions to manage a specific agent.
+    /// </summary>
+    /// <param name="AgentUserSecurityId">The user security id associated with the agent.</param>
+    /// <returns>True if the user has manage permissions for the specified agent, false otherwise.</returns>
+    [Scope('OnPrem')]
+    procedure CurrentUserCanManageAgent(AgentUserSecurityId: Guid): Boolean
+    begin
+        exit(AgentSystemPermissionsImpl.CurrentUserCanManageAgent(AgentUserSecurityId));
     end;
 
     var
-        "Agent System Permissions Impl.": Codeunit "Agent System Permissions Impl.";
+        AgentSystemPermissionsImpl: Codeunit "Agent System Permissions Impl.";
 }

--- a/src/System Application/App/Agent/Permissions/Internal/AgentSystemPermissionsImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Permissions/Internal/AgentSystemPermissionsImpl.Codeunit.al
@@ -30,6 +30,20 @@ codeunit 4318 "Agent System Permissions Impl."
         exit(false);
     end;
 
+    procedure CurrentUserCanManageAgent(AgentUserSecurityId: Guid): Boolean
+    var
+        Agent: Record Agent;
+    begin
+        if (CurrentUserHasCanManageAllAgentsPermission()) then
+            exit(true);
+
+        if Agent.Get(AgentUserSecurityId) then
+            if Agent."Can Curr. User Configure Agent" then
+                exit(true);
+
+        exit(false);
+    end;
+
     local procedure CurrentUserHasExecuteSystemPermission(PermissionId: Integer): Boolean
     var
         TempPermission: Record "Expanded Permission" temporary;

--- a/src/System Application/App/Agent/Setup/AgentCard.Page.al
+++ b/src/System Application/App/Agent/Setup/AgentCard.Page.al
@@ -200,7 +200,7 @@ page 4315 "Agent Card"
     begin
         AgentUtilities.BlockPageFromBeingOpenedByAgent();
 
-        if not AgentSystemPermissions.CurrentUserHasCanManageAllAgentsPermission() then
+        if not AgentSystemPermissions.CurrentUserCanManageAgent(Rec."User Security ID") then
             Error(YouDoNotHavePermissionToModifyThisAgentErr);
     end;
 

--- a/src/System Application/App/Agent/Setup/AgentCreationControls/AgentCreationControl.Page.al
+++ b/src/System Application/App/Agent/Setup/AgentCreationControls/AgentCreationControl.Page.al
@@ -1,0 +1,36 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Agents;
+
+page 4326 "Agent Creation Control"
+{
+    AboutTitle = 'About agent configuration rights';
+    AboutText = 'Use this page to control which users can create agents. If no rules exist, only agent administrators can create agents.';
+    AdditionalSearchTerms = 'agent creation control,allow agent creation,block agent creation';
+    ApplicationArea = All;
+    Caption = 'Agent Configuration Rights';
+    DataCaptionExpression = '';
+    InherentEntitlements = X;
+    PageType = ListPlus;
+    InsertAllowed = false;
+    DeleteAllowed = false;
+    UsageCategory = Administration;
+    DelayedInsert = true;
+
+    layout
+    {
+        area(Content)
+        {
+            label(Info)
+            {
+                Caption = 'Grant agent creation capability to non-administrator users. Users must also have the required permissions for the agent type.';
+            }
+            part(AgentCreationControlPart; "Agent Creation Control Part")
+            {
+            }
+        }
+    }
+}

--- a/src/System Application/App/Agent/Setup/AgentCreationControls/AgentCreationControlLookup.Page.al
+++ b/src/System Application/App/Agent/Setup/AgentCreationControls/AgentCreationControlLookup.Page.al
@@ -1,0 +1,70 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Agents;
+
+page 4331 "Agent Creation Control Lookup"
+{
+    ApplicationArea = All;
+    Caption = 'Agent Creation Control Lookup';
+    Editable = false;
+    PageType = List;
+    InherentEntitlements = X;
+    InherentPermissions = X;
+    SourceTable = "Agent Creation Control Lookup";
+    SourceTableTemporary = true;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Repeater)
+            {
+                ShowCaption = false;
+                field(Value; Rec.Value)
+                {
+                    ShowCaption = false;
+                }
+            }
+        }
+    }
+
+    trigger OnOpenPage()
+    begin
+        if HasSelectedKey then begin
+            Rec.SetRange("Key", SelectedKey);
+            if Rec.FindFirst() then;
+            Rec.SetRange("Key");
+        end else
+            if Rec.FindFirst() then;
+    end;
+
+    procedure Initialize(PageCaption: Text; SelectedEntryKey: Text[250])
+    begin
+        CurrPage.Caption := PageCaption;
+        SelectedKey := SelectedEntryKey;
+        HasSelectedKey := true;
+    end;
+
+    procedure AddEntry(EntryKey: Text[250]; EntryValue: Text[2048])
+    var
+        NextID: Integer;
+    begin
+        if Rec.FindLast() then
+            NextID := Rec.ID + 1
+        else
+            NextID := 1;
+
+        Clear(Rec);
+        Rec.ID := NextID;
+        Rec."Key" := EntryKey;
+        Rec.Value := EntryValue;
+        Rec.Insert();
+    end;
+
+    var
+        SelectedKey: Text[250];
+        HasSelectedKey: Boolean;
+}

--- a/src/System Application/App/Agent/Setup/AgentCreationControls/AgentCreationControlLookup.Table.al
+++ b/src/System Application/App/Agent/Setup/AgentCreationControls/AgentCreationControlLookup.Table.al
@@ -1,0 +1,53 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace System.Agents;
+
+table 4331 "Agent Creation Control Lookup"
+{
+    Access = Internal;
+    Caption = 'Agent Creation Control Lookup';
+    DataClassification = CustomerContent;
+    InherentEntitlements = RIMDX;
+    InherentPermissions = RIMDX;
+    TableType = Temporary;
+
+    fields
+    {
+        field(1; ID; Integer)
+        {
+            AutoIncrement = true;
+            Caption = 'ID';
+        }
+        field(2; "Key"; Text[250])
+        {
+            Caption = 'Key';
+            ToolTip = 'Specifies the key.';
+        }
+        field(3; Value; Text[2048])
+        {
+            Caption = 'Value';
+            ToolTip = 'Specifies the value.';
+        }
+    }
+
+    keys
+    {
+        key(Key1; ID)
+        {
+            Clustered = true;
+        }
+    }
+
+    fieldgroups
+    {
+        fieldgroup(DropDown; "Key")
+        {
+        }
+        fieldgroup(Brick; "Key", Value)
+        {
+        }
+    }
+}
+

--- a/src/System Application/App/Agent/Setup/AgentCreationControls/AgentCreationControlPart.Page.al
+++ b/src/System Application/App/Agent/Setup/AgentCreationControls/AgentCreationControlPart.Page.al
@@ -1,0 +1,231 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Agents;
+
+using System.Environment;
+using System.Security.AccessControl;
+
+page 4332 "Agent Creation Control Part"
+{
+    ApplicationArea = All;
+    Caption = 'Agent configuration rights';
+    DataCaptionExpression = '';
+    InherentEntitlements = X;
+    MultipleNewLines = false;
+    PageType = ListPart;
+    SourceTable = "Agent Creation Control";
+    DelayedInsert = true;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Repeater)
+            {
+                field(CompanyField; CompanyDisplayText)
+                {
+                    Caption = 'Company';
+                    ToolTip = 'Specifies the company where this permission applies. Select "(All Companies)" to apply everywhere.';
+                    Editable = false;
+
+                    trigger OnAssistEdit()
+                    begin
+                        OnCompanyAssistEdit();
+                    end;
+                }
+                field(AgentTypeField; AgentMetadataProviderDisplayText)
+                {
+                    Caption = 'Agent Type';
+                    ToolTip = 'Specifies the agent type allowed to be created. Select "(All Agent Types)" to apply to all types.';
+                    Editable = false;
+
+                    trigger OnAssistEdit()
+                    begin
+                        OnAgentTypeAssistEdit();
+                    end;
+                }
+                field(UserField; UserDisplayText)
+                {
+                    Caption = 'User';
+                    ToolTip = 'Specifies the user allowed to create agents. Select "(All Users)" to apply to everyone.';
+                    Editable = false;
+
+                    trigger OnAssistEdit()
+                    begin
+                        OnUserAssistEdit();
+                    end;
+                }
+                field(Description; Rec.Description)
+                {
+                    ShowMandatory = true;
+                }
+            }
+        }
+    }
+
+    trigger OnAfterGetRecord()
+    begin
+        UpdateDisplayTexts();
+    end;
+
+    trigger OnNewRecord(BelowxRec: Boolean)
+    begin
+        Rec."Agent Metadata Provider" := -1;
+        ClearDisplayTexts();
+    end;
+
+    local procedure OnCompanyAssistEdit()
+    var
+        Company: Record Company;
+        TempAgentCreationControlLookup: Record "Agent Creation Control Lookup" temporary;
+        CreationControlLookup: Page "Agent Creation Control Lookup";
+        SelectCompanyLbl: Label 'Select company';
+        CompanyDisplayName: Text[250];
+        AllCompaniesKeyTok: Label '', Locked = true;
+    begin
+        // Add "(All Companies)" as first option.
+        CreationControlLookup.AddEntry(AllCompaniesKeyTok, AllCompaniesLbl);
+
+        // Add all companies.
+        if Company.FindSet() then
+            repeat
+                CompanyDisplayName := Company."Display Name" <> '' ? Company."Display Name" : Company.Name;
+                CreationControlLookup.AddEntry(Company.Name, CompanyDisplayName);
+            until Company.Next() = 0;
+
+        // Run the lookup.
+        CreationControlLookup.Initialize(SelectCompanyLbl, Rec.IsAllCompanies() ? AllCompaniesKeyTok : Rec."Company Name");
+        CreationControlLookup.LookupMode := true;
+        if CreationControlLookup.RunModal() = Action::LookupOK then begin
+            CreationControlLookup.GetRecord(TempAgentCreationControlLookup);
+            Rec.Validate(Rec."Company Name", CopyStr(TempAgentCreationControlLookup."Key", 1, MaxStrLen(Rec."Company Name")));
+            UpdateDisplayTexts();
+        end;
+    end;
+
+    local procedure OnAgentTypeAssistEdit()
+    var
+        TempAgentCreationControlLookup: Record "Agent Creation Control Lookup" temporary;
+        AgentUtilities: Codeunit "Agent Utilities";
+        CreationControlLookup: Page "Agent Creation Control Lookup";
+        AgentMetadataProvider: Enum "Agent Metadata Provider";
+        EnumIndex: Integer;
+        AgentValue: Text[2048];
+        AppPublisher, AppName : Text[250];
+        AppId: Guid;
+        AgentByPublisherLbl: Label '%1 from ''%2'' by ''%3''', Comment = '%1 = the agent type; %2 = the app name; %3 = the app publisher';
+        SelectAgentTypeLbl: Label 'Select agent type';
+        AllAgentsEntryKeyTok: Label '', Locked = true;
+    begin
+        // Add "(All Agent Types)" as first option.
+        CreationControlLookup.AddEntry(AllAgentsEntryKeyTok, AllAgentMetadataProvidersLbl);
+
+        // Add all agent types.
+        foreach EnumIndex in Enum::"Agent Metadata Provider".Ordinals() do begin
+            AgentMetadataProvider := Enum::"Agent Metadata Provider".FromInteger(EnumIndex);
+            if AgentUtilities.TryGetAgentAppInfo(AgentMetadataProvider, AppPublisher, AppName, AppId) then begin
+                AgentValue := StrSubstNo(AgentByPublisherLbl, Format(AgentMetadataProvider), AppName, AppPublisher);
+                CreationControlLookup.AddEntry(Format(EnumIndex), AgentValue);
+            end;
+        end;
+
+        // Run the lookup.
+        CreationControlLookup.Initialize(SelectAgentTypeLbl, Rec.IsAllAgentTypes() ? AllAgentsEntryKeyTok : Format(Rec."Agent Metadata Provider"));
+        CreationControlLookup.LookupMode := true;
+        if CreationControlLookup.RunModal() = Action::LookupOK then begin
+            CreationControlLookup.GetRecord(TempAgentCreationControlLookup);
+            if TempAgentCreationControlLookup."Key" = '' then
+                Rec.Validate(Rec."Agent Metadata Provider", -1)
+            else begin
+                Evaluate(EnumIndex, TempAgentCreationControlLookup."Key");
+                Rec.Validate(Rec."Agent Metadata Provider", EnumIndex);
+            end;
+            UpdateDisplayTexts();
+        end;
+    end;
+
+    local procedure OnUserAssistEdit()
+    var
+        User: Record User;
+        TempAgentCreationControlLookup: Record "Agent Creation Control Lookup" temporary;
+        CreationControlLookup: Page "Agent Creation Control Lookup";
+        SelectUserLbl: Label 'Select user';
+        EmptyGuid, UserSecurityId : Guid;
+        AllUsersEntryKeyTok: Label '', Locked = true;
+    begin
+        // Add "(All Users)" as first option
+        CreationControlLookup.AddEntry(AllUsersEntryKeyTok, AllUsersLbl);
+
+        // Add all users
+        if User.FindSet() then
+            repeat
+                if not (User."License Type" in [User."License Type"::Application, User."License Type"::"Windows Group", User."License Type"::Agent]) then
+                    CreationControlLookup.AddEntry(User."User Security ID", User."User Name");
+            until User.Next() = 0;
+
+        // Run the lookup.
+        CreationControlLookup.Initialize(SelectUserLbl, Rec.IsAllUsers() ? AllUsersEntryKeyTok : Rec."User Security ID");
+        CreationControlLookup.LookupMode := true;
+        if CreationControlLookup.RunModal() = Action::LookupOK then begin
+            CreationControlLookup.GetRecord(TempAgentCreationControlLookup);
+            if TempAgentCreationControlLookup."Key" = '' then
+                Rec.Validate(Rec."User Security ID", EmptyGuid)
+            else begin
+                Evaluate(UserSecurityId, TempAgentCreationControlLookup."Key");
+                Rec.Validate(Rec."User Security ID", UserSecurityId);
+            end;
+            UpdateDisplayTexts();
+        end;
+    end;
+
+    local procedure ClearDisplayTexts()
+    begin
+        Clear(CompanyDisplayText);
+        Clear(AgentMetadataProviderDisplayText);
+        Clear(UserDisplayText);
+    end;
+
+    local procedure UpdateDisplayTexts()
+    begin
+        UserDisplayText := GetUserDisplayText();
+        AgentMetadataProviderDisplayText := GetAgentMetadataProviderDisplayText();
+        CompanyDisplayText := GetCompanyDisplayText();
+    end;
+
+    local procedure GetUserDisplayText(): Text
+    begin
+        if Rec.IsAllUsers() then
+            exit(AllUsersLbl);
+
+        Rec.CalcFields("User Name");
+        if Rec."User Name" <> '' then
+            exit(Rec."User Name");
+
+        exit(Format(Rec."User Security ID"));
+    end;
+
+    local procedure GetCompanyDisplayText(): Text
+    begin
+        if Rec.IsAllCompanies() then
+            exit(AllCompaniesLbl);
+
+        exit(Rec."Company Name");
+    end;
+
+    local procedure GetAgentMetadataProviderDisplayText(): Text
+    begin
+        if Rec.IsAllAgentTypes() then
+            exit(AllAgentMetadataProvidersLbl);
+
+        exit(Format(Enum::"Agent Metadata Provider".FromInteger(Rec."Agent Metadata Provider")));
+    end;
+
+    var
+        UserDisplayText, AgentMetadataProviderDisplayText, CompanyDisplayText : Text;
+        AllUsersLbl: Label 'All users', MaxLength = 2048;
+        AllCompaniesLbl: Label 'All companies', MaxLength = 2048;
+        AllAgentMetadataProvidersLbl: Label 'All agent types', MaxLength = 2048;
+}

--- a/src/System Application/App/Agent/Setup/AgentList.Page.al
+++ b/src/System Application/App/Agent/Setup/AgentList.Page.al
@@ -110,6 +110,17 @@ page 4316 "Agent List"
                 end;
             }
         }
+        area(Navigation)
+        {
+            action(AgentConfigurationRights)
+            {
+                ApplicationArea = All;
+                Caption = 'View agent configuration rights';
+                ToolTip = 'View who can create new agents';
+                Image = Permission;
+                RunObject = Page "Agent Creation Control";
+            }
+        }
         area(Promoted)
         {
             group(Category_Process)

--- a/src/System Application/App/Agent/app.json
+++ b/src/System Application/App/Agent/app.json
@@ -86,6 +86,12 @@
       "name": "AI SDK",
       "publisher": "Microsoft",
       "version": "28.0.0.0"
+    },
+    {
+      "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
+      "name": "Upgrade Tags",
+      "publisher": "Microsoft",
+      "version": "28.0.0.0"
     }
   ],
   "propagateDependencies": true,


### PR DESCRIPTION
#### Summary
Backport of #7436 to `releases/28.0`.

Original commit: e7ea880e580f1f1306598ce041e84cb0605caa47

Cherry-pick had one conflict in `src/System Application/App/Agent/app.json`. On 28.x the AI SDK dependency was bumped to `28.1.0.0` and an `Upgrade Tags` dependency at `28.1.0.0` was added. Resolved by keeping all dependency versions at `28.0.0.0` for the 28.0 branch and adding `Upgrade Tags` at `28.0.0.0`.

#### Work Item(s)
[AB#623405](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/623405)
