### PR TITLE
Add configurable default posting date for e-document purchase invoices

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchDefPostingDate.Enum.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchDefPostingDate.Enum.al
@@ -1,0 +1,20 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument;
+
+enum 6162 "E-Doc. Purch.Def. Posting Date"
+{
+    Extensible = false;
+    Caption = 'Purchase Invoice Posting Date (E-Docs)';
+
+    value(0; "Work Date")
+    {
+        Caption = 'Work Date';
+    }
+    value(1; "Document Date")
+    {
+        Caption = 'Document Date';
+    }
+}

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchPayablesSetup.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchPayablesSetup.PageExt.al
@@ -21,6 +21,11 @@ pageextension 6162 "E-Doc. Purch. Payables Setup" extends "Purchases & Payables 
                 ApplicationArea = All;
                 ToolTip = 'Specifies whether Copilot E-Document line matchings are learned by default (Item References and Text To Account Mappings). This can be overwritten on the matching page.';
             }
+            field("E-Doc. Def. Posting Date"; Rec."E-Doc. Def. Posting Date")
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies how the posting date is set on purchase invoices created from e-documents. Work Date uses the current work date. Document Date uses the document date from the e-document.';
+            }
         }
     }
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchPayablesSetup.TableExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchPayablesSetup.TableExt.al
@@ -21,5 +21,10 @@ tableextension 6162 "E-Doc. Purch. Payables Setup" extends "Purchases & Payables
             Caption = 'E-Document Learn Copilot Matchings';
             DataClassification = SystemMetadata;
         }
+        field(6102; "E-Doc. Def. Posting Date"; Enum "E-Doc. Purch.Def. Posting Date")
+        {
+            Caption = 'E-Document Default Posting Date';
+            DataClassification = CustomerContent;
+        }
     }
 }

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
@@ -150,6 +150,7 @@ codeunit 6117 "E-Doc. Create Purchase Invoice" implements IEDocumentFinishDraft,
         PurchaseHeader.Insert(true);
 
         PurchaseHeader."Invoice Received Date" := PurchaseHeader."Document Date";
+        EDocPurchaseDocumentHelper.ApplyDefaultPostingDateFromSetup(PurchaseHeader, EDocumentPurchaseHeader);
         PurchaseHeader.Modify();
 
         // Validate of currency has to happen after insert.

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocPurchDocHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocPurchDocHelper.Codeunit.al
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.eServices.EDocument.Processing.Import;
 
+using Microsoft.EServices.EDocument.Processing.Import.Purchase;
 using Microsoft.Purchases.Document;
+using Microsoft.Purchases.Setup;
 
 /// <summary>
 /// Shared logic for creating BC purchase documents (invoices and credit memos) from e-document draft data.
@@ -35,5 +37,17 @@ codeunit 6402 "E-Doc. Purch. Doc. Helper"
         EDocImportErrorContext.OnValidateFieldWithContext(FldRef.Caption());
         FldRef.Validate(Value);
         RecRef.SetTable(RecVariant);
+    end;
+
+    procedure ApplyDefaultPostingDateFromSetup(var PurchaseHeader: Record "Purchase Header"; EDocumentPurchaseHeader: Record "E-Document Purchase Header")
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
+    begin
+        PurchasesPayablesSetup.GetRecordOnce();
+        if (PurchasesPayablesSetup."E-Doc. Def. Posting Date" <> PurchasesPayablesSetup."E-Doc. Def. Posting Date"::"Document Date") then
+            exit;
+        if EDocumentPurchaseHeader."Document Date" = 0D then
+            exit;
+        PurchaseHeader.Validate("Posting Date", EDocumentPurchaseHeader."Document Date");
     end;
 }


### PR DESCRIPTION
## Why

When purchase invoices are created from e-documents, the posting date defaults to the work date. Users need the ability to use the document date from the e-document as the posting date instead, so the resulting purchase invoice aligns with the original document's date.

## Summary

- **Added** new enum `E-Doc. Purch.Def. Posting Date` with options "Work Date" (default) and "Document Date"
- **Added** field "E-Doc. Def. Posting Date" to the Purchases & Payables Setup table and page extensions
- **Added** procedure `ApplyDefaultPostingDateFromSetup` in `E-Doc. Purch. Doc. Helper` to apply the configured posting date when creating purchase invoices from e-document drafts

[AB#635747](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/635747)
