### PR TITLE
[28.0] Mark AOAI user message AddTextPart/AddFilePart as OnPrem and GenerateChatCompletion impl overload as NonDebuggable

### DIFF
--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -263,6 +263,7 @@ codeunit 7772 "Azure OpenAI Impl" implements "AI Service Name"
         GenerateChatCompletion(ChatMessages, AOAIChatCompletionParams, AOAIOperationResponse, CallerModuleInfo);
     end;
 
+    [NonDebuggable]
     procedure GenerateChatCompletion(var ChatMessages: Codeunit "AOAI Chat Messages"; AOAIChatCompletionParams: Codeunit "AOAI Chat Completion Params"; var AOAIOperationResponse: Codeunit "AOAI Operation Response"; CallerModuleInfo: ModuleInfo)
     var
         AOAIPolicyParams: Codeunit "AOAI Policy Params";

--- a/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIUserMessage.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIUserMessage.Codeunit.al
@@ -22,7 +22,9 @@ codeunit 7783 "AOAI User Message"
     /// </summary>
     /// <param name="TextContent">The text content to add.</param>
     [Scope('OnPrem')]
+#pragma warning disable AS0022
     procedure AddTextPart(TextContent: Text)
+#pragma warning restore AS0022
     begin
         AOAIUserMessageImpl.AddTextPart(TextContent);
     end;
@@ -32,7 +34,9 @@ codeunit 7783 "AOAI User Message"
     /// </summary>
     /// <param name="FileData">The file data to add (e.g. base64-encoded content).</param>
     [Scope('OnPrem')]
+#pragma warning disable AS0022
     procedure AddFilePart(FileData: Text)
+#pragma warning restore AS0022
     begin
         AOAIUserMessageImpl.AddFilePart(FileData);
     end;

--- a/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIUserMessage.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIUserMessage.Codeunit.al
@@ -21,6 +21,7 @@ codeunit 7783 "AOAI User Message"
     /// Adds a text content part to the user message.
     /// </summary>
     /// <param name="TextContent">The text content to add.</param>
+    [Scope('OnPrem')]
     procedure AddTextPart(TextContent: Text)
     begin
         AOAIUserMessageImpl.AddTextPart(TextContent);
@@ -30,6 +31,7 @@ codeunit 7783 "AOAI User Message"
     /// Adds a file content part to the user message.
     /// </summary>
     /// <param name="FileData">The file data to add (e.g. base64-encoded content).</param>
+    [Scope('OnPrem')]
     procedure AddFilePart(FileData: Text)
     begin
         AOAIUserMessageImpl.AddFilePart(FileData);

--- a/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIUserMessage.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIUserMessage.Codeunit.al
@@ -16,6 +16,8 @@ codeunit 7783 "AOAI User Message"
 
     var
         AOAIUserMessageImpl: Codeunit "AOAI User Message Impl";
+        CopilotCapabilityImpl: Codeunit "Copilot Capability Impl";
+        NotMicrosoftPublisherErr: Label 'This functionality is only available to Microsoft published apps.';
 
     /// <summary>
     /// Adds a text content part to the user message.
@@ -25,7 +27,12 @@ codeunit 7783 "AOAI User Message"
 #pragma warning disable AS0022
     procedure AddTextPart(TextContent: Text)
 #pragma warning restore AS0022
+    var
+        CallerModuleInfo: ModuleInfo;
     begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        if not CopilotCapabilityImpl.IsPublisherMicrosoft(CallerModuleInfo) then
+            Error(NotMicrosoftPublisherErr);
         AOAIUserMessageImpl.AddTextPart(TextContent);
     end;
 
@@ -37,7 +44,12 @@ codeunit 7783 "AOAI User Message"
 #pragma warning disable AS0022
     procedure AddFilePart(FileData: Text)
 #pragma warning restore AS0022
+    var
+        CallerModuleInfo: ModuleInfo;
     begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        if not CopilotCapabilityImpl.IsPublisherMicrosoft(CallerModuleInfo) then
+            Error(NotMicrosoftPublisherErr);
         AOAIUserMessageImpl.AddFilePart(FileData);
     end;
 

--- a/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIUserMessage.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIUserMessage.Codeunit.al
@@ -16,8 +16,6 @@ codeunit 7783 "AOAI User Message"
 
     var
         AOAIUserMessageImpl: Codeunit "AOAI User Message Impl";
-        CopilotCapabilityImpl: Codeunit "Copilot Capability Impl";
-        NotMicrosoftPublisherErr: Label 'This functionality is only available to Microsoft published apps.';
 
     /// <summary>
     /// Adds a text content part to the user message.
@@ -31,9 +29,7 @@ codeunit 7783 "AOAI User Message"
         CallerModuleInfo: ModuleInfo;
     begin
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
-        if not CopilotCapabilityImpl.IsPublisherMicrosoft(CallerModuleInfo) then
-            Error(NotMicrosoftPublisherErr);
-        AOAIUserMessageImpl.AddTextPart(TextContent);
+        AOAIUserMessageImpl.AddTextPart(TextContent, CallerModuleInfo);
     end;
 
     /// <summary>
@@ -48,9 +44,7 @@ codeunit 7783 "AOAI User Message"
         CallerModuleInfo: ModuleInfo;
     begin
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
-        if not CopilotCapabilityImpl.IsPublisherMicrosoft(CallerModuleInfo) then
-            Error(NotMicrosoftPublisherErr);
-        AOAIUserMessageImpl.AddFilePart(FileData);
+        AOAIUserMessageImpl.AddFilePart(FileData, CallerModuleInfo);
     end;
 
     /// <summary>

--- a/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIUserMessageImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIUserMessageImpl.Codeunit.al
@@ -11,15 +11,19 @@ codeunit 7784 "AOAI User Message Impl"
     InherentPermissions = X;
 
     var
+        CopilotCapabilityImpl: Codeunit "Copilot Capability Impl";
         [NonDebuggable]
         ContentParts: JsonArray;
         HasFileContent, HasTextContent : Boolean;
+        NotMicrosoftPublisherErr: Label 'This functionality is only available to Microsoft published apps.';
 
     [NonDebuggable]
-    procedure AddTextPart(TextContent: Text)
+    procedure AddTextPart(TextContent: Text; CallerModuleInfo: ModuleInfo)
     var
         TextPartObject: JsonObject;
     begin
+        if not CopilotCapabilityImpl.IsPublisherMicrosoft(CallerModuleInfo) then
+            Error(NotMicrosoftPublisherErr);
         TextPartObject.Add('type', 'text');
         TextPartObject.Add('text', TextContent);
         ContentParts.Add(TextPartObject);
@@ -27,11 +31,13 @@ codeunit 7784 "AOAI User Message Impl"
     end;
 
     [NonDebuggable]
-    procedure AddFilePart(FileData: Text)
+    procedure AddFilePart(FileData: Text; CallerModuleInfo: ModuleInfo)
     var
         FilePartObject: JsonObject;
         FileDataObject: JsonObject;
     begin
+        if not CopilotCapabilityImpl.IsPublisherMicrosoft(CallerModuleInfo) then
+            Error(NotMicrosoftPublisherErr);
         FileDataObject.Add('file_data', FileData);
         FilePartObject.Add('type', 'file');
         FilePartObject.Add('file', FileDataObject);


### PR DESCRIPTION
Backport of #8186 to releases/28.0.

## Summary
- Add `[Scope('OnPrem')]` to `AddTextPart` and `AddFilePart` on the `AOAI User Message` codeunit.
- Add `[NonDebuggable]` to the second `GenerateChatCompletion` overload in `Azure OpenAI Impl`.

Fixes [AB#635891](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/635891)




