### PR TITLE
[Shopify] Persist current B2B Catalog row before disabling Sync Prices on other lines

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Catalogs/Tables/ShpfyCatalog.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Catalogs/Tables/ShpfyCatalog.Table.al
@@ -199,6 +199,8 @@ table 30152 "Shpfy Catalog"
             exit;
         end;
 
+        Modify();
+
         OtherCatalog.ModifyAll("Sync Prices", false);
     end;
 

--- a/src/Apps/W1/Shopify/Test/Catalogs/ShpfyCatalogPricesTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Catalogs/ShpfyCatalogPricesTest.Codeunit.al
@@ -524,7 +524,8 @@ codeunit 139646 "Shpfy Catalog Prices Test"
         Catalog2.Validate("Sync Prices", true);
         Catalog2.Modify(true);
 
-        // [THEN] Catalog2 has Sync Prices = true
+        // [THEN] Catalog2 persists Sync Prices = true in the database
+        Catalog2.Get(CatalogId, ShopifyCompany2.SystemId);
         LibraryAssert.IsTrue(Catalog2."Sync Prices", 'Catalog2 should have Sync Prices enabled');
 
         // [THEN] Catalog1 has Sync Prices = false (disabled by the confirmation logic)


### PR DESCRIPTION
## Summary
Reactivation of bug 630273. PR #7585 introduced a confirmation dialog for the `Sync Prices` toggle on B2B Catalog rows that share a catalog ID across multiple companies. PM testing showed that when the user clicked **Yes** on the dialog, the toggle was lost on the current row too — not just the other line — so nothing ended up with Sync Prices enabled.

## Root cause
`"Sync Prices"` OnValidate called `OtherCatalog.ModifyAll("Sync Prices", false)` while the user's change `Rec."Sync Prices" := true` was still only in memory. The client refresh that follows the `ModifyAll` re-read the current row from the database (still `false`), clobbering the in-memory `true`.

The existing `SyncPricesConfirmDisablesOtherLine` test asserted the in-memory value of the current row after `Validate` + `Modify(true)`, so it passed even though the persisted state was wrong.

## Fix
Persist the current row with `Modify()` **before** the `ModifyAll` on other rows. This way the database already reflects the user's intent if the page refreshes.

## Test plan
- [x] Strengthen `SyncPricesConfirmDisablesOtherLine` to re-read Catalog2 from the database (mirroring the existing pattern used for Catalog1 in the same test) so the regression would be caught next time.
- [x] `SyncPricesCancelKeepsBothUnchanged` — unchanged, still passes.
- [x] `SyncPricesNoConfirmWhenNoDuplicate` — unchanged, still passes.
- All three tests pass locally against the published App with this fix.

Fixes [AB#630273](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/630273)

