### PR TITLE
[Shopify] Refresh cached plan before order sync

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
@@ -41,7 +41,9 @@ codeunit 30161 "Shpfy Import Order"
         OrderHeader.Get(OrderHeader."Shopify Order Id");
         if ShopToRefresh.Get(OrderHeader."Shop Code") then begin
             ShopToRefresh.GetShopSettings();
+#pragma warning disable AA0214
             ShopToRefresh.Modify();
+#pragma warning restore AA0214
         end;
         ImportOrderAndCreateOrUpdate(OrderHeader."Shop Code", OrderHeader."Shopify Order Id");
         OrderHeader.Get(OrderHeader."Shopify Order Id");

--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
@@ -35,9 +35,14 @@ codeunit 30161 "Shpfy Import Order"
 
     internal procedure ReimportExistingOrderConfirmIfConflicting(OrderHeader: Record "Shpfy Order Header")
     var
+        ShopToRefresh: Record "Shpfy Shop";
         OrderMapping: Codeunit "Shpfy Order Mapping";
     begin
         OrderHeader.Get(OrderHeader."Shopify Order Id");
+        if ShopToRefresh.Get(OrderHeader."Shop Code") then begin
+            ShopToRefresh.GetShopSettings();
+            ShopToRefresh.Modify();
+        end;
         ImportOrderAndCreateOrUpdate(OrderHeader."Shop Code", OrderHeader."Shopify Order Id");
         OrderHeader.Get(OrderHeader."Shopify Order Id");
         if OrderMapping.DoMapping(OrderHeader) then;

--- a/src/Apps/W1/Shopify/App/src/Order handling/Reports/ShpfySyncOrdersfromShopify.Report.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Reports/ShpfySyncOrdersfromShopify.Report.al
@@ -90,6 +90,8 @@ report 30104 "Shpfy Sync Orders from Shopify"
 
             trigger OnAfterGetRecord()
             begin
+                Shop.GetShopSettings();
+                Shop.Modify();
                 Clear(OrdersAPI);
                 OrdersAPI.GetOrdersToImport(Shop);
             end;

--- a/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrdersAPITest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrdersAPITest.Codeunit.al
@@ -1558,7 +1558,6 @@ codeunit 139608 "Shpfy Orders API Test"
 
         // [GIVEN] The HTTP handler is primed to return a downgraded-plan response
         PlanRefreshExpected := true;
-        PlanRefreshCallCount := 0;
 
         // [WHEN] GetShopSettings is called
         LocalShop.GetShopSettings();
@@ -1566,8 +1565,6 @@ codeunit 139608 "Shpfy Orders API Test"
         // [THEN] The Advanced Shopify Plan flag is cleared based on the live response
         LibraryAssert.IsFalse(LocalShop."Advanced Shopify Plan", 'Stale Advanced Shopify Plan flag should be refreshed to false after plan downgrade.');
         LibraryAssert.AreEqual(1, PlanRefreshCallCount, 'GetShopSettings should issue exactly one plan-refresh query.');
-
-        PlanRefreshExpected := false;
     end;
 
     [Test]
@@ -1597,7 +1594,6 @@ codeunit 139608 "Shpfy Orders API Test"
 
         // [GIVEN] The HTTP handler is primed to return a downgraded-plan response
         PlanRefreshExpected := true;
-        PlanRefreshCallCount := 0;
 
         // [WHEN] The "Sync Orders from Shopify" report runs against this shop
         ShopFilter.SetRange(Code, Shop.Code);
@@ -1609,8 +1605,6 @@ codeunit 139608 "Shpfy Orders API Test"
         Shop.Get(Shop.Code);
         LibraryAssert.IsFalse(Shop."Advanced Shopify Plan", 'Bulk sync report should refresh Advanced Shopify Plan flag before importing orders.');
         LibraryAssert.IsTrue(PlanRefreshCallCount >= 1, 'Bulk sync report should issue a plan-refresh query.');
-
-        PlanRefreshExpected := false;
     end;
 
     local procedure CreateTaxArea(var TaxArea: Record "Tax Area"; var ShopifyTaxArea: Record "Shpfy Tax Area"; ShopParam: Record "Shpfy Shop")
@@ -1714,6 +1708,11 @@ codeunit 139608 "Shpfy Orders API Test"
         CommunicationMgt: Codeunit "Shpfy Communication Mgt.";
         AccessToken: SecretText;
     begin
+        // Reset per-test mock state so a previous test's assertion failure cannot leak
+        // the plan-refresh flag into the next test and corrupt unrelated HTTP calls.
+        PlanRefreshExpected := false;
+        PlanRefreshCallCount := 0;
+
         if IsInitialized then
             exit;
 

--- a/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrdersAPITest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrdersAPITest.Codeunit.al
@@ -1604,9 +1604,9 @@ codeunit 139608 "Shpfy Orders API Test"
         // [THEN] The Advanced Shopify Plan flag is refreshed on the persisted Shop record
         Shop.Get(Shop.Code);
         LibraryAssert.IsFalse(Shop."Advanced Shopify Plan", 'Bulk sync report should refresh Advanced Shopify Plan flag before importing orders.');
-        LibraryAssert.IsTrue(PlanRefreshCallCount >= 1, 'Bulk sync report should issue a plan-refresh query.');
+        LibraryAssert.AreEqual(1, PlanRefreshCallCount, 'Bulk sync report should issue exactly one plan-refresh query.');
     end;
-LibraryAssert.AreEqual(1, PlanRefreshCallCount, 'Bulk sync report should issue exactly one plan-refresh query.');
+
     local procedure CreateTaxArea(var TaxArea: Record "Tax Area"; var ShopifyTaxArea: Record "Shpfy Tax Area"; ShopParam: Record "Shpfy Shop")
     var
         ShopifyCustomerTemplate: Record "Shpfy Customer Template";

--- a/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrdersAPITest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrdersAPITest.Codeunit.al
@@ -1606,7 +1606,7 @@ codeunit 139608 "Shpfy Orders API Test"
         LibraryAssert.IsFalse(Shop."Advanced Shopify Plan", 'Bulk sync report should refresh Advanced Shopify Plan flag before importing orders.');
         LibraryAssert.IsTrue(PlanRefreshCallCount >= 1, 'Bulk sync report should issue a plan-refresh query.');
     end;
-
+LibraryAssert.AreEqual(1, PlanRefreshCallCount, 'Bulk sync report should issue exactly one plan-refresh query.');
     local procedure CreateTaxArea(var TaxArea: Record "Tax Area"; var ShopifyTaxArea: Record "Shpfy Tax Area"; ShopParam: Record "Shpfy Shop")
     var
         ShopifyCustomerTemplate: Record "Shpfy Customer Template";

--- a/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrdersAPITest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrdersAPITest.Codeunit.al
@@ -32,10 +32,13 @@ codeunit 139608 "Shpfy Orders API Test"
         Any: Codeunit Any;
         CompanyLocationId: BigInteger;
         IsInitialized: Boolean;
+        PlanRefreshExpected: Boolean;
+        PlanRefreshCallCount: Integer;
         OrdersToImportChannelLiableMismatchTxt: Label 'Orders to import Channel Liable Taxes mismatch when %1.', Locked = true;
         OrderLevelTaxLineExpectedTxt: Label 'An order-level tax line should exist when %1.', Locked = true;
         ChannelLiableFlagMismatchTxt: Label 'Channel Liable flag mismatch when %1.', Locked = true;
         OrderHeaderChannelLiableMismatchTxt: Label 'Order header Channel Liable Taxes mismatch when %1.', Locked = true;
+        DowngradedPlanShopResponseTok: Label '{"data":{"shop":{"name":"Test","plan":{"publicDisplayName":"Basic Shopify","partnerDevelopment":false,"shopifyPlus":false},"weightUnit":"KILOGRAMS"}},"extensions":{"cost":{"requestedQueryCost":1,"actualQueryCost":1,"throttleStatus":{"maximumAvailable":2000.0,"currentlyAvailable":1999,"restoreRate":100.0}}}}', Locked = true;
 
     [Test]
     procedure UnitTestExtractShopifyOrdersToImport()
@@ -1536,6 +1539,80 @@ codeunit 139608 "Shpfy Orders API Test"
         LibraryAssert.IsFalse(OrderLine.Tip, 'Tip flag must not be propagated to the subsequent regular order line');
     end;
 
+    [Test]
+    [HandlerFunctions('OrdersAPIHttpHandler')]
+    procedure TestGetShopSettingsClearsStaleAdvancedShopifyPlanFlag()
+    var
+        LocalShop: Record "Shpfy Shop";
+    begin
+        // [SCENARIO] Bug 635878: when the merchant downgrades from a Plus/Advanced plan to a
+        // standard plan, Shop.GetShopSettings() must clear the cached "Advanced Shopify Plan"
+        // flag based on the live response from Shopify so the order GraphQL query stops
+        // requesting the staffMember field (which would otherwise fail with ACCESS_DENIED).
+        Initialize();
+
+        // [GIVEN] Shop has a stale "Advanced Shopify Plan" flag set to true
+        LocalShop.Get(Shop.Code);
+        LocalShop."Advanced Shopify Plan" := true;
+        LocalShop.Modify(false);
+
+        // [GIVEN] The HTTP handler is primed to return a downgraded-plan response
+        PlanRefreshExpected := true;
+        PlanRefreshCallCount := 0;
+
+        // [WHEN] GetShopSettings is called
+        LocalShop.GetShopSettings();
+
+        // [THEN] The Advanced Shopify Plan flag is cleared based on the live response
+        LibraryAssert.IsFalse(LocalShop."Advanced Shopify Plan", 'Stale Advanced Shopify Plan flag should be refreshed to false after plan downgrade.');
+        LibraryAssert.AreEqual(1, PlanRefreshCallCount, 'GetShopSettings should issue exactly one plan-refresh query.');
+
+        PlanRefreshExpected := false;
+    end;
+
+    [Test]
+    [HandlerFunctions('OrdersAPIHttpHandler')]
+    procedure TestSyncOrdersFromShopifyReportRefreshesAdvancedShopifyPlanFlag()
+    var
+        ShopFilter: Record "Shpfy Shop";
+        OrdersToImport: Record "Shpfy Orders to Import";
+        SyncOrdersFromShopify: Report "Shpfy Sync Orders from Shopify";
+    begin
+        // [SCENARIO] Bug 635878: the bulk "Sync Orders from Shopify" report must refresh
+        // the cached "Advanced Shopify Plan" flag before importing orders, so a plan
+        // downgrade does not leave the connector requesting the staffMember field that
+        // the new plan can no longer grant access to.
+        Initialize();
+
+        // [GIVEN] Shop has a stale "Advanced Shopify Plan" flag set to true
+        Shop.Get(Shop.Code);
+        Shop."Advanced Shopify Plan" := true;
+        Shop."Auto Create Orders" := false;
+        Shop.Modify(false);
+        Commit();
+
+        // [GIVEN] No orders are queued so the report only exercises the Shop dataitem trigger
+        OrdersToImport.SetRange("Shop Code", Shop.Code);
+        OrdersToImport.DeleteAll(false);
+
+        // [GIVEN] The HTTP handler is primed to return a downgraded-plan response
+        PlanRefreshExpected := true;
+        PlanRefreshCallCount := 0;
+
+        // [WHEN] The "Sync Orders from Shopify" report runs against this shop
+        ShopFilter.SetRange(Code, Shop.Code);
+        SyncOrdersFromShopify.SetTableView(ShopFilter);
+        SyncOrdersFromShopify.UseRequestPage(false);
+        SyncOrdersFromShopify.Run();
+
+        // [THEN] The Advanced Shopify Plan flag is refreshed on the persisted Shop record
+        Shop.Get(Shop.Code);
+        LibraryAssert.IsFalse(Shop."Advanced Shopify Plan", 'Bulk sync report should refresh Advanced Shopify Plan flag before importing orders.');
+        LibraryAssert.IsTrue(PlanRefreshCallCount >= 1, 'Bulk sync report should issue a plan-refresh query.');
+
+        PlanRefreshExpected := false;
+    end;
+
     local procedure CreateTaxArea(var TaxArea: Record "Tax Area"; var ShopifyTaxArea: Record "Shpfy Tax Area"; ShopParam: Record "Shpfy Shop")
     var
         ShopifyCustomerTemplate: Record "Shpfy Customer Template";
@@ -1656,6 +1733,12 @@ codeunit 139608 "Shpfy Orders API Test"
     begin
         if not InitializeTest.VerifyRequestUrl(Request.Path, Shop."Shopify URL") then
             exit(true);
+
+        if PlanRefreshExpected and (PlanRefreshCallCount = 0) then begin
+            PlanRefreshCallCount += 1;
+            Response.Content.WriteFrom(DowngradedPlanShopResponseTok);
+            exit(false);
+        end;
 
         if CompanyLocationId <> 0 then begin
             Body := NavApp.GetResourceAsText('Order Handling/CompanyLocationResult.txt', TextEncoding::UTF8);


### PR DESCRIPTION
## Summary

Bug 635878: When a merchant downgrades their Shopify plan from Plus / Advanced to a standard plan, the connector keeps requesting the `staffMember { id }` field in the order GraphQL query. The lower plan does not grant `read_users` scope, so Shopify returns `ACCESS_DENIED` and order sync is fully broken until the user manually toggles the **Enabled** field off and on again on the Shop Card.

`Shop."Advanced Shopify Plan"` (field 207) is the cached flag that gates the staff member field. It was only refreshed when the user toggled Enabled or when a scope change was detected on Shop Card open — never before an order sync.

## Fix

Auto-refresh the cached plan via the existing `Shop.GetShopSettings()` helper (one cheap GraphQL query for `shop { plan { ... } weightUnit }`) before both order-import entry points:

1. **Bulk sync** — Report `30104 Shpfy Sync Orders from Shopify` (also the scheduled auto-sync path). One refresh call per shop per batch run.
2. **Single-order reimport** — `ShpfyImportOrder.ReimportExistingOrderConfirmIfConflicting` (manual reimport action on the Order Header page).

The refresh is deliberately not placed in `ShpfyImportOrder.SetShop()` because that runs per order; for a 100-order batch it would mean 100 extra GraphQL round-trips.

## Tests

Two regression tests added to the existing `ShpfyOrdersAPITest.Codeunit.al` (139608):

- `TestGetShopSettingsClearsStaleAdvancedShopifyPlanFlag` — sets stale `"Advanced Shopify Plan" = true`, calls `GetShopSettings`, asserts the flag becomes `false`.
- `TestSyncOrdersFromShopifyReportRefreshesAdvancedShopifyPlanFlag` — sets stale flag, runs Report 30104, asserts the persisted Shop record has the flag refreshed to `false`.

Existing `OrdersAPIHttpHandler` extended with a one-shot `PlanRefreshExpected` flag returning a downgraded-plan JSON for the first request, then falling through to the prior empty-data behavior.

Both tests verified locally.

Fixes [AB#635878](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/635878)






