### PR TITLE
[Shopify] Auto Create Catalog: always visible, validate plan on enable

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -395,7 +395,6 @@ page 30101 "Shpfy Shop Card"
                 field("Auto Create Catalog"; Rec."Auto Create Catalog")
                 {
                     ApplicationArea = All;
-                    Visible = Rec."Advanced Shopify Plan";
                 }
                 field("Company Metafields To Shopify"; Rec."Company Metafields To Shopify")
                 {

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -951,10 +951,8 @@ table 30102 "Shpfy Shop"
 
             trigger OnValidate()
             begin
-                if (not Rec."Advanced Shopify Plan") and Rec."Auto Create Catalog" then begin
+                if (not Rec."Advanced Shopify Plan") and Rec."Auto Create Catalog" then
                     Rec.Validate("Auto Create Catalog", false);
-                    Message(AutoCreateCatalogDisabledMsg);
-                end;
             end;
         }
         field(208; "Find Mapping by Barcode"; Boolean)
@@ -996,7 +994,6 @@ table 30102 "Shpfy Shop"
         CurrencyExchangeRateNotDefinedErr: Label 'The specified currency must have exchange rates configured. If your online shop uses the same currency as Business Central then leave the field empty.';
         AutoCreateErrorMsg: Label 'You cannot turn "%1" off if "%2" is set to the value of "%3".', Comment = '%1 = Field Caption of "Auto Create Orders", %2 = Field Caption of "Return and Refund Process", %3 = Field Value of "Return and Refund Process"';
         AutoCreateCatalogPlanErr: Label '%1 can only be enabled for Shopify Plus, Plus Trial, Development, or Advanced plans.', Comment = '%1 = Field Caption of "Auto Create Catalog"';
-        AutoCreateCatalogDisabledMsg: Label 'Auto Create Catalog has been disabled because the Shopify plan no longer supports B2B catalog creation.';
         ExpirationNotificationTxt: Label 'Shopify API version 30 days before expiry notification sent.', Locked = true;
         BlockedNotificationTxt: Label 'Shopify API version expired notification sent.', Locked = true;
         CategoryTok: Label 'Shopify Integration', Locked = true;

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -757,6 +757,19 @@ table 30102 "Shpfy Shop"
             Caption = 'Auto Create Catalog';
             ToolTip = 'Specifies whether a catalog is automatically created for new companies.';
             DataClassification = CustomerContent;
+
+            trigger OnValidate()
+            var
+                ErrorInfo: ErrorInfo;
+            begin
+                if Rec."Auto Create Catalog" and not Rec."Advanced Shopify Plan" then begin
+                    ErrorInfo.FieldNo(Rec.FieldNo("Auto Create Catalog"));
+                    ErrorInfo.ErrorType := ErrorType::Client;
+                    ErrorInfo.RecordId := Rec.RecordId;
+                    ErrorInfo.Message := StrSubstNo(AutoCreateCatalogPlanErr, Rec.FieldCaption("Auto Create Catalog"));
+                    Error(ErrorInfo);
+                end;
+            end;
         }
         field(121; "Company Import From Shopify"; Enum "Shpfy Company Import Range")
         {
@@ -981,6 +994,7 @@ table 30102 "Shpfy Shop"
     var
         CurrencyExchangeRateNotDefinedErr: Label 'The specified currency must have exchange rates configured. If your online shop uses the same currency as Business Central then leave the field empty.';
         AutoCreateErrorMsg: Label 'You cannot turn "%1" off if "%2" is set to the value of "%3".', Comment = '%1 = Field Caption of "Auto Create Orders", %2 = Field Caption of "Return and Refund Process", %3 = Field Value of "Return and Refund Process"';
+        AutoCreateCatalogPlanErr: Label '%1 can only be enabled for Shopify Plus, Plus Trial, Development, or Advanced plans.', Comment = '%1 = Field Caption of "Auto Create Catalog"';
         ExpirationNotificationTxt: Label 'Shopify API version 30 days before expiry notification sent.', Locked = true;
         BlockedNotificationTxt: Label 'Shopify API version expired notification sent.', Locked = true;
         CategoryTok: Label 'Shopify Integration', Locked = true;

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -759,16 +759,9 @@ table 30102 "Shpfy Shop"
             DataClassification = CustomerContent;
 
             trigger OnValidate()
-            var
-                ErrorInfo: ErrorInfo;
             begin
-                if Rec."Auto Create Catalog" and not Rec."Advanced Shopify Plan" then begin
-                    ErrorInfo.FieldNo(Rec.FieldNo("Auto Create Catalog"));
-                    ErrorInfo.ErrorType := ErrorType::Client;
-                    ErrorInfo.RecordId := Rec.RecordId;
-                    ErrorInfo.Message := StrSubstNo(AutoCreateCatalogPlanErr, Rec.FieldCaption("Auto Create Catalog"));
-                    Error(ErrorInfo);
-                end;
+                if Rec."Auto Create Catalog" and not Rec."Advanced Shopify Plan" then
+                    Error(AutoCreateCatalogPlanErr, Rec.FieldCaption("Auto Create Catalog"));
             end;
         }
         field(121; "Company Import From Shopify"; Enum "Shpfy Company Import Range")
@@ -955,6 +948,14 @@ table 30102 "Shpfy Shop"
         {
             Caption = 'Advanced Shopify Plan';
             DataClassification = SystemMetadata;
+
+            trigger OnValidate()
+            begin
+                if (not Rec."Advanced Shopify Plan") and Rec."Auto Create Catalog" then begin
+                    Rec.Validate("Auto Create Catalog", false);
+                    Message(AutoCreateCatalogDisabledMsg);
+                end;
+            end;
         }
         field(208; "Find Mapping by Barcode"; Boolean)
         {
@@ -995,6 +996,7 @@ table 30102 "Shpfy Shop"
         CurrencyExchangeRateNotDefinedErr: Label 'The specified currency must have exchange rates configured. If your online shop uses the same currency as Business Central then leave the field empty.';
         AutoCreateErrorMsg: Label 'You cannot turn "%1" off if "%2" is set to the value of "%3".', Comment = '%1 = Field Caption of "Auto Create Orders", %2 = Field Caption of "Return and Refund Process", %3 = Field Value of "Return and Refund Process"';
         AutoCreateCatalogPlanErr: Label '%1 can only be enabled for Shopify Plus, Plus Trial, Development, or Advanced plans.', Comment = '%1 = Field Caption of "Auto Create Catalog"';
+        AutoCreateCatalogDisabledMsg: Label 'Auto Create Catalog has been disabled because the Shopify plan no longer supports B2B catalog creation.';
         ExpirationNotificationTxt: Label 'Shopify API version 30 days before expiry notification sent.', Locked = true;
         BlockedNotificationTxt: Label 'Shopify API version expired notification sent.', Locked = true;
         CategoryTok: Label 'Shopify Integration', Locked = true;
@@ -1157,8 +1159,8 @@ table 30102 "Shpfy Shop"
         JResponse := CommunicationMgt.ExecuteGraphQL('{"query":"query { shop { name plan { publicDisplayName partnerDevelopment shopifyPlus } weightUnit } }"}');
         if JResponse.SelectToken('$.data.shop.plan', JItem) then
             if JItem.IsObject then
-                Rec."Advanced Shopify Plan" := JsonHelper.GetValueAsBoolean(JItem, 'shopifyPlus') or
-                                                (JsonHelper.GetValueAsText(JItem, 'publicDisplayName') in ['Plus Trial', 'Development', 'Advanced']);
+                Rec.Validate("Advanced Shopify Plan", JsonHelper.GetValueAsBoolean(JItem, 'shopifyPlus') or
+                                                (JsonHelper.GetValueAsText(JItem, 'publicDisplayName') in ['Plus Trial', 'Development', 'Advanced']));
         Rec."Weight Unit" := ConvertToWeightUnit(JsonHelper.GetValueAsText(JResponse, 'data.shop.weightUnit'));
     end;
 

--- a/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
@@ -87,7 +87,6 @@ codeunit 139551 "Shpfy Staff Test"
     end;
 
     [Test]
-    [HandlerFunctions('AutoCreateCatalogDisabledMessageHandler')]
     procedure TestAdvancedPlanDowngradeDisablesAutoCreateCatalog()
     var
         LibraryAssert: Codeunit "Library Assert";
@@ -101,7 +100,7 @@ codeunit 139551 "Shpfy Staff Test"
         // [When] The shop's plan is downgraded (as happens during a plan sync from Shopify)
         Shop.Validate("Advanced Shopify Plan", false);
 
-        // [Then] Auto Create Catalog is automatically disabled and the user is notified via the message handler
+        // [Then] Auto Create Catalog is silently disabled
         LibraryAssert.IsFalse(Shop."Auto Create Catalog", 'Auto Create Catalog should be disabled after the plan is downgraded.');
     end;
 
@@ -311,11 +310,6 @@ codeunit 139551 "Shpfy Staff Test"
 
         MakeResponse(Response);
         exit(false); // Prevents actual HTTP call
-    end;
-
-    [MessageHandler]
-    internal procedure AutoCreateCatalogDisabledMessageHandler(Message: Text[1024])
-    begin
     end;
 
     local procedure MakeResponse(var HttpResponseMessage: TestHttpResponseMessage): Boolean

--- a/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
@@ -60,6 +60,33 @@ codeunit 139551 "Shpfy Staff Test"
     end;
 
     [Test]
+    procedure TestAutoCreateCatalogRequiresAdvancedPlan()
+    var
+        LibraryAssert: Codeunit "Library Assert";
+    begin
+        // [Given] A shop on a plan that does not support B2B catalogs
+        Initialize();
+        Shop."Advanced Shopify Plan" := false;
+        Shop."Auto Create Catalog" := false;
+        Shop.Modify(false);
+
+        // [When] The user tries to enable Auto Create Catalog
+        // [Then] A field error is raised mentioning the field
+        asserterror Shop.Validate("Auto Create Catalog", true);
+        LibraryAssert.ExpectedError('Auto Create Catalog');
+
+        // [Given] The shop is upgraded to a plan that supports B2B catalogs
+        Shop."Advanced Shopify Plan" := true;
+        Shop.Modify(false);
+
+        // [When] The user enables Auto Create Catalog
+        Shop.Validate("Auto Create Catalog", true);
+
+        // [Then] The field is enabled successfully
+        LibraryAssert.IsTrue(Shop."Auto Create Catalog", 'Auto Create Catalog should be enabled on an Advanced plan.');
+    end;
+
+    [Test]
     [HandlerFunctions('HttpSubmitHandler')]
     procedure TestImportStaff()
     var

--- a/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
@@ -87,6 +87,25 @@ codeunit 139551 "Shpfy Staff Test"
     end;
 
     [Test]
+    [HandlerFunctions('AutoCreateCatalogDisabledMessageHandler')]
+    procedure TestAdvancedPlanDowngradeDisablesAutoCreateCatalog()
+    var
+        LibraryAssert: Codeunit "Library Assert";
+    begin
+        // [Given] A shop on an Advanced plan with Auto Create Catalog enabled
+        Initialize();
+        Shop."Advanced Shopify Plan" := true;
+        Shop."Auto Create Catalog" := true;
+        Shop.Modify(false);
+
+        // [When] The shop's plan is downgraded (as happens during a plan sync from Shopify)
+        Shop.Validate("Advanced Shopify Plan", false);
+
+        // [Then] Auto Create Catalog is automatically disabled and the user is notified via the message handler
+        LibraryAssert.IsFalse(Shop."Auto Create Catalog", 'Auto Create Catalog should be disabled after the plan is downgraded.');
+    end;
+
+    [Test]
     [HandlerFunctions('HttpSubmitHandler')]
     procedure TestImportStaff()
     var
@@ -292,6 +311,11 @@ codeunit 139551 "Shpfy Staff Test"
 
         MakeResponse(Response);
         exit(false); // Prevents actual HTTP call
+    end;
+
+    [MessageHandler]
+    internal procedure AutoCreateCatalogDisabledMessageHandler(Message: Text[1024])
+    begin
     end;
 
     local procedure MakeResponse(var HttpResponseMessage: TestHttpResponseMessage): Boolean


### PR DESCRIPTION
## Summary

Re-fix for **bug 630316** after PM verification of [PR #7605](https://github.com/microsoft/BCApps/pull/7605).

PR #7605 made B2B features unconditional on all Shopify plans, but the `Auto Create Catalog` toggle on the **Customers and Companies** group of the Shop Card stayed hidden for non-Advanced shops because its `Visible = Rec."Advanced Shopify Plan"` binding is not re-evaluated after `GetShopSettings()` flips the flag at runtime.

Per PM Andrei Pankos guidance:
- Drop the dynamic visibility on the `Auto Create Catalog` field so its always visible in the Companies group.
- Gate the field at the table layer instead: an `OnValidate` trigger raises a field error if the user tries to enable `Auto Create Catalog` on a shop whose plan does not support B2B catalogs (Plus, Plus Trial, Development, or Advanced).

The error uses the existing `ErrorInfo` / `FieldNo` pattern already used elsewhere in `ShpfyShop.Table.al` (e.g. field 21 `Auto Create Orders`).

## What is NOT changed

- `action(Catalogs)` (B2B Catalogs action) and `action(StaffMembers)` visibility on the Shop Card  PM only flagged the field control.
- The runtime `Shop."Auto Create Catalog"` checks in `ShpfyCompanyAPI.Codeunit.al` / `ShpfyCompanyExport.Codeunit.al`  the table guard prevents the boolean from being set to `true` on an unsupported plan, so no runtime check is needed.
- The `B2B Enabled` obsoletion and upgrade code from PR #7605  already accepted by PM.
- `app.json` versions  intentionally untouched.

## Test

Adds `TestAutoCreateCatalogRequiresAdvancedPlan` to `ShpfyStaffTest` (codeunit 139551, which is already the home for `Advanced Shopify Plan`-gated tests). Verified both passes locally:

```
PASS TestStaffMembersActionVisibleOnlyForSupportedPlans (513ms)
PASS TestAutoCreateCatalogRequiresAdvancedPlan (23ms)
```

Fixes [AB#630316](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630316)



