### PR TITLE
[Subcontracting] Change Capacity Ledger Entries page action to Show Document

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/SubcCapLEntries.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/SubcCapLEntries.PageExt.al
@@ -82,9 +82,10 @@ pageextension 99001502 "Subc. CapLEntries" extends "Capacity Ledger Entries"
 		exit;
             end;
         // No document found
-        Message(NoDocumentFoundMsg);        
+        Message(NoDocumentFoundMsg);
     end;
     
     var
-    NoDocumentFoundMsg: Label 'No related document could be found for this entry.';
+    var
+        NoDocumentFoundMsg: Label 'No related document could be found for this entry.';
 }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/SubcCapLEntries.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/SubcCapLEntries.PageExt.al
@@ -70,7 +70,14 @@ pageextension 99001502 "Subc. CapLEntries" extends "Capacity Ledger Entries"
                 PageManagement.PageRun(PurchRcptHeader);
                 exit;
             end;
-            PurchInvHeader.SetRange("No.", CapacityLedgerEntry."Document No.");
+        end;
+
+        // No document found
+        Message(NoDocumentFoundMsg);
+    end;
+
+var
+    NoDocumentFoundMsg: Label 'No related document could be found for this entry.';
             if PurchInvHeader.FindFirst() then begin
                 PageManagement.PageRun(PurchInvHeader);
                 exit;

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/SubcCapLEntries.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/SubcCapLEntries.PageExt.al
@@ -65,23 +65,19 @@ pageextension 99001502 "Subc. CapLEntries" extends "Capacity Ledger Entries"
         PageManagement: Codeunit "Page Management";
     begin
         if CapacityLedgerEntry."Document No." <> '' then begin
-            PurchRcptHeader.SetRange("No.", CapacityLedgerEntry."Document No.");
-            if PurchRcptHeader.FindFirst() then begin
+            if PurchRcptHeader.Get(CapacityLedgerEntry."Document No.") then begin
                 PageManagement.PageRun(PurchRcptHeader);
                 exit;
             end;
-            PurchInvHeader.SetRange("No.", CapacityLedgerEntry."Document No.");
-            if PurchInvHeader.FindFirst() then begin
+
+            if PurchInvHeader.Get(CapacityLedgerEntry."Document No.") then begin
                 PageManagement.PageRun(PurchInvHeader);
                 exit;
             end;
         end;
 
-        if CapacityLedgerEntry."Subc. Purch. Order No." <> '' then begin
-            PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
-            PurchaseHeader.SetRange("No.", CapacityLedgerEntry."Subc. Purch. Order No.");
-            if PurchaseHeader.FindFirst() then
+        if CapacityLedgerEntry."Subc. Purch. Order No." <> '' then
+            if PurchaseHeader.Get(PurchaseHeader."Document Type"::Order, CapacityLedgerEntry."Subc. Purch. Order No.") then
                 PageManagement.PageRun(PurchaseHeader);
-        end;
     end;
 }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/SubcCapLEntries.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/SubcCapLEntries.PageExt.al
@@ -4,7 +4,10 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
+using Microsoft.Foundation.Navigate;
 using Microsoft.Manufacturing.Capacity;
+using Microsoft.Purchases.Document;
+using Microsoft.Purchases.History;
 
 pageextension 99001502 "Subc. CapLEntries" extends "Capacity Ledger Entries"
 {
@@ -40,24 +43,45 @@ pageextension 99001502 "Subc. CapLEntries" extends "Capacity Ledger Entries"
             {
                 Caption = 'Production';
 
-                action("Purchase Order")
+                action(ShowDocument)
                 {
                     ApplicationArea = Manufacturing;
-                    Caption = 'Subcontracting Purchase Order';
-                    Image = Order;
-                    ToolTip = 'View the related subcontracting purchase order.';
+                    Caption = 'Show Document';
+                    Image = Document;
+                    ToolTip = 'View the document related to this capacity ledger entry. Shows the posted purchase receipt or invoice if available, otherwise shows the purchase order.';
                     trigger OnAction()
                     begin
-                        ShowPurchaseOrder(Rec);
+                        ShowRelatedDocument(Rec);
                     end;
                 }
             }
         }
     }
-    local procedure ShowPurchaseOrder(RecRelatedVariant: Variant)
+    local procedure ShowRelatedDocument(CapacityLedgerEntry: Record "Capacity Ledger Entry")
     var
-        SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
+        PurchRcptHeader: Record "Purch. Rcpt. Header";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeader: Record "Purchase Header";
+        PageManagement: Codeunit "Page Management";
     begin
-        SubcPurchFactboxMgmt.ShowPurchaseOrder(RecRelatedVariant);
+        if CapacityLedgerEntry."Document No." <> '' then begin
+            PurchRcptHeader.SetRange("No.", CapacityLedgerEntry."Document No.");
+            if PurchRcptHeader.FindFirst() then begin
+                PageManagement.PageRun(PurchRcptHeader);
+                exit;
+            end;
+            PurchInvHeader.SetRange("No.", CapacityLedgerEntry."Document No.");
+            if PurchInvHeader.FindFirst() then begin
+                PageManagement.PageRun(PurchInvHeader);
+                exit;
+            end;
+        end;
+
+        if CapacityLedgerEntry."Subc. Purch. Order No." <> '' then begin
+            PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
+            PurchaseHeader.SetRange("No.", CapacityLedgerEntry."Subc. Purch. Order No.");
+            if PurchaseHeader.FindFirst() then
+                PageManagement.PageRun(PurchaseHeader);
+        end;
     end;
 }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/SubcCapLEntries.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/SubcCapLEntries.PageExt.al
@@ -4,10 +4,10 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
-using Microsoft.Foundation.Navigate;
 using Microsoft.Manufacturing.Capacity;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
+using Microsoft.Utilities;
 
 pageextension 99001502 "Subc. CapLEntries" extends "Capacity Ledger Entries"
 {

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingUITest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingUITest.Codeunit.al
@@ -6,10 +6,12 @@ namespace Microsoft.Manufacturing.Subcontracting.Test;
 
 using Microsoft.Inventory.Planning;
 using Microsoft.Inventory.Requisition;
+using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Document;
+using Microsoft.Purchases.History;
 using Microsoft.Purchases.Vendor;
 using System.Reflection;
 
@@ -452,6 +454,143 @@ codeunit 139990 "Subc. Subcontracting UI Test"
         // [THEN] Subcontractor Prices action is enabled
         Assert.IsTrue(WorkCenterList."Subcontractor Prices".Enabled(), SubcontractingActionsNotEnabledErr);
         WorkCenterList.Close();
+    end;
+
+    [Test]
+    [HandlerFunctions('HandlePostedPurchaseReceiptPage')]
+    procedure CapLedgerEntriesShowDocumentOpensPostedReceipt()
+    var
+        CapacityLedgerEntry: Record "Capacity Ledger Entry";
+        PurchRcptHeader: Record "Purch. Rcpt. Header";
+        CapacityLedgerEntries: TestPage "Capacity Ledger Entries";
+    begin
+        // [SCENARIO 620656] Show Document action opens Posted Purchase Receipt when Document No. matches a receipt
+        Initialize();
+
+        // [GIVEN] A Posted Purchase Receipt
+        PurchRcptHeader.Init();
+        PurchRcptHeader."No." := 'TEST-RCPT-001';
+        if not PurchRcptHeader.Insert() then
+            PurchRcptHeader.Modify();
+
+        // [GIVEN] A Capacity Ledger Entry with Document No. pointing to the receipt
+        CapacityLedgerEntry.Init();
+        CapacityLedgerEntry."Entry No." := GetNextCapLedgerEntryNo();
+        CapacityLedgerEntry."Document No." := PurchRcptHeader."No.";
+        CapacityLedgerEntry.Insert();
+
+        // [WHEN] The Show Document action is invoked
+        CapacityLedgerEntries.OpenView();
+        CapacityLedgerEntries.GoToRecord(CapacityLedgerEntry);
+        CapacityLedgerEntries.ShowDocument.Invoke();
+
+        // [THEN] The Posted Purchase Receipt page is opened (verified by PageHandler)
+        CapacityLedgerEntries.Close();
+
+        // Cleanup
+        CapacityLedgerEntry.Delete();
+        PurchRcptHeader.Delete();
+    end;
+
+    [Test]
+    [HandlerFunctions('HandlePostedPurchaseInvoicePage')]
+    procedure CapLedgerEntriesShowDocumentOpensPostedInvoice()
+    var
+        CapacityLedgerEntry: Record "Capacity Ledger Entry";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        CapacityLedgerEntries: TestPage "Capacity Ledger Entries";
+    begin
+        // [SCENARIO 620656] Show Document action opens Posted Purchase Invoice when Document No. matches an invoice
+        Initialize();
+
+        // [GIVEN] A Posted Purchase Invoice (no matching receipt)
+        PurchInvHeader.Init();
+        PurchInvHeader."No." := 'TEST-INV-001';
+        if not PurchInvHeader.Insert() then
+            PurchInvHeader.Modify();
+
+        // [GIVEN] A Capacity Ledger Entry with Document No. pointing to the invoice
+        CapacityLedgerEntry.Init();
+        CapacityLedgerEntry."Entry No." := GetNextCapLedgerEntryNo();
+        CapacityLedgerEntry."Document No." := PurchInvHeader."No.";
+        CapacityLedgerEntry.Insert();
+
+        // [WHEN] The Show Document action is invoked
+        CapacityLedgerEntries.OpenView();
+        CapacityLedgerEntries.GoToRecord(CapacityLedgerEntry);
+        CapacityLedgerEntries.ShowDocument.Invoke();
+
+        // [THEN] The Posted Purchase Invoice page is opened (verified by PageHandler)
+        CapacityLedgerEntries.Close();
+
+        // Cleanup
+        CapacityLedgerEntry.Delete();
+        PurchInvHeader.Delete();
+    end;
+
+    [Test]
+    [HandlerFunctions('HandlePurchaseOrderPage')]
+    procedure CapLedgerEntriesShowDocumentOpensPurchaseOrder()
+    var
+        CapacityLedgerEntry: Record "Capacity Ledger Entry";
+        PurchaseHeader: Record "Purchase Header";
+        CapacityLedgerEntries: TestPage "Capacity Ledger Entries";
+    begin
+        // [SCENARIO 620656] Show Document action opens Purchase Order when no posted document exists
+        Initialize();
+
+        // [GIVEN] A Purchase Order
+        PurchaseHeader.Init();
+        PurchaseHeader."Document Type" := PurchaseHeader."Document Type"::Order;
+        PurchaseHeader."No." := 'TEST-PO-001';
+        if not PurchaseHeader.Insert() then
+            PurchaseHeader.Modify();
+
+        // [GIVEN] A Capacity Ledger Entry with Subc. Purch. Order No. but no matching posted document
+        CapacityLedgerEntry.Init();
+        CapacityLedgerEntry."Entry No." := GetNextCapLedgerEntryNo();
+        CapacityLedgerEntry."Document No." := '';
+        CapacityLedgerEntry."Subc. Purch. Order No." := PurchaseHeader."No.";
+        CapacityLedgerEntry.Insert();
+
+        // [WHEN] The Show Document action is invoked
+        CapacityLedgerEntries.OpenView();
+        CapacityLedgerEntries.GoToRecord(CapacityLedgerEntry);
+        CapacityLedgerEntries.ShowDocument.Invoke();
+
+        // [THEN] The Purchase Order page is opened (verified by PageHandler)
+        CapacityLedgerEntries.Close();
+
+        // Cleanup
+        CapacityLedgerEntry.Delete();
+        PurchaseHeader.Delete();
+    end;
+
+    local procedure GetNextCapLedgerEntryNo(): Integer
+    var
+        CapacityLedgerEntry: Record "Capacity Ledger Entry";
+    begin
+        if CapacityLedgerEntry.FindLast() then
+            exit(CapacityLedgerEntry."Entry No." + 1);
+        exit(1);
+    end;
+
+    [PageHandler]
+    procedure HandlePostedPurchaseReceiptPage(var PostedPurchaseReceipt: TestPage "Posted Purchase Receipt")
+    begin
+        PostedPurchaseReceipt.Close();
+    end;
+
+    [PageHandler]
+    procedure HandlePostedPurchaseInvoicePage(var PostedPurchaseInvoice: TestPage "Posted Purchase Invoice")
+    begin
+        PostedPurchaseInvoice.Close();
+    end;
+
+    [PageHandler]
+    procedure HandlePurchaseOrderPage(var PurchaseOrder: TestPage "Purchase Order")
+    begin
+        PurchaseOrder.Close();
     end;
 
     var


### PR DESCRIPTION
## Summary

Fixes [AB#620656](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620656)

Merges the separate 'Show Document' and 'Subcontracting Purchase Order' actions on the Capacity Ledger Entries page extension into a single unified **Show Document** action.

## Changes

### SubcCapLEntries.PageExt.al
- Replaced two separate actions with a single 'Show Document' action
- New logic navigates to the appropriate document based on posting status:
  1. **Posted Purchase Receipt** — if \Document No.\ matches a receipt
  2. **Posted Purchase Invoice** — if \Document No.\ matches an invoice
  3. **Purchase Order** — fallback using \Subc. Purch. Order No.\ if no posted document is found

### SubcSubcontractingUITest.Codeunit.al
- Added 3 tests verifying each navigation scenario:
  - \CapLedgerEntriesShowDocumentOpensPostedReceipt\
  - \CapLedgerEntriesShowDocumentOpensPostedInvoice\
  - \CapLedgerEntriesShowDocumentOpensPurchaseOrder\






