### PR TITLE
Rerun unstable failures for CI/CD workflow

### DIFF
--- a/.github/workflows/RerunUnstableFailures.yaml
+++ b/.github/workflows/RerunUnstableFailures.yaml
@@ -1,7 +1,7 @@
 name: Rerun Unstable Failures
 on:
   workflow_run:
-    workflows: ['Pull Request Build']
+    workflows: ['Pull Request Build', ' CI/CD']
     types: [completed]
 
 permissions: read-all


### PR DESCRIPTION
Extends the `RerunUnstableFailures` workflow to also trigger on completed runs of the ` CI/CD` workflow (in addition to `Pull Request Build`).CI/CD builds occasionally hit the same kinds of flaky infrastructure failures as PR builds, so they benefit equally from automatic rerun-on-failure. The existing safeguards (`MAX_FAILED_JOBS=3`, `MIN_TOTAL_JOBS=10`, `MAX_ATTEMPTS=1`) apply unchanged, and `build/scripts/RerunUnstableFailures.ps1` is already workflow-agnostic so no script changes are needed.

Fixes [AB#636157](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636157)

