### PR TITLE
[Agent] Skip agent task model tests when copilot service is not deployed

### DIFF
--- a/src/System Application/Test/Agent/src/SDK/AgentTaskTest.codeunit.al
+++ b/src/System Application/Test/Agent/src/SDK/AgentTaskTest.codeunit.al
@@ -802,6 +802,7 @@ codeunit 133960 "Agent Task Test"
     procedure CreateTaskWithModelIdAndVerify()
     var
         AgentRecord: Record Agent;
+        AgentModel: Record "Agent Model";
         AgentTaskRecord: Record "Agent Task";
         AgentTaskBuilder: Codeunit "Agent Task Builder";
         Any: Codeunit Any;
@@ -823,7 +824,14 @@ codeunit 133960 "Agent Task Test"
             CopyStr(Any.AlphanumericText(2048), 1, 2048));
 
         TaskTitle := CopyStr(Any.AlphanumericText(MaxStrLen(TaskTitle)), 1, MaxStrLen(TaskTitle));
-        ModelId := CopyStr(Any.AlphanumericText(MaxStrLen(ModelId)), 1, MaxStrLen(ModelId));
+
+        if AgentModel.IsEmpty() then
+            // Copilot Service is not running and not populating the Agent Model table.
+            exit;
+
+        AgentModel.SetRange("Is Default", true);
+        Assert.IsTrue(AgentModel.FindFirst(), 'There should be a default model in the Agent Model table');
+        ModelId := AgentModel."Model ID";
 
         // [WHEN] A task is created with a model ID
         AgentTaskBuilder
@@ -839,7 +847,7 @@ codeunit 133960 "Agent Task Test"
 
         // [THEN] GetModelName returns empty since the model ID does not exist in the Agent Model table
         RetrievedModelName := AgentTask.GetModelName(AgentTaskRecord.ID);
-        Assert.AreEqual('', RetrievedModelName, 'Model name should be empty for a non-existent model');
+        Assert.AreEqual(AgentModel."Model Name", RetrievedModelName, 'Model name should be empty for a non-existent model');
     end;
 
     [Test]
@@ -874,6 +882,10 @@ codeunit 133960 "Agent Task Test"
             .SetExternalId(ExternalIdTok);
 
         AgentTaskRecord := AgentTaskBuilder.Create(true, false);
+
+        if AgentModel.IsEmpty() then
+            // Copilot Service is not running and not populating the Agent Model table.
+            exit;
 
         AgentModel.SetRange("Is Default", true);
         Assert.IsTrue(AgentModel.FindFirst(), 'There should be a default model in the Agent Model table');
@@ -933,6 +945,10 @@ codeunit 133960 "Agent Task Test"
 
         TaskTitle := CopyStr(Any.AlphanumericText(MaxStrLen(TaskTitle)), 1, MaxStrLen(TaskTitle));
 
+        if AgentModel.IsEmpty() then
+            // Copilot Service is not running and not populating the Agent Model table.
+            exit;
+
         AgentModel.SetRange("Is Default", true);
         Assert.IsTrue(AgentModel.FindFirst(), 'There should be a default model in the Agent Model table');
 
@@ -946,29 +962,27 @@ codeunit 133960 "Agent Task Test"
 
         // [THEN] GetModelId returns the default model
         RetrievedModelId := AgentTask.GetModelId(AgentTaskRecord.ID);
-        Assert.AreEqual(AgentModel."Model ID", RetrievedModelId, 'Model ID should be empty when not set');
+        Assert.AreEqual(AgentModel."Model ID", RetrievedModelId, 'Model ID should be the default model when not set');
 
         // [THEN] GetModelName returns the default model
         RetrievedModelName := AgentTask.GetModelName(AgentTaskRecord.ID);
-        Assert.AreEqual(AgentModel."Model Name", RetrievedModelName, 'Model name should be empty when model ID is not set');
+        Assert.AreEqual(AgentModel."Model Name", RetrievedModelName, 'Model name should be the default model name when model ID is not set');
     end;
 
     [Test]
     procedure CreateMultipleTasksWithDifferentModelIds()
     var
         AgentRecord: Record Agent;
+        AgentModel: Record "Agent Model";
         AgentTaskRecord1: Record "Agent Task";
         AgentTaskRecord2: Record "Agent Task";
-        AgentTaskRecord3: Record "Agent Task";
         AgentTaskBuilder: Codeunit "Agent Task Builder";
         Any: Codeunit Any;
         AgentUserId: Guid;
         ModelId1: Code[30];
         ModelId2: Code[30];
-        ModelId3: Code[30];
         ExternalId1Tok: Label 'EXT-TASK-MODEL-005-A', Locked = true;
         ExternalId2Tok: Label 'EXT-TASK-MODEL-005-B', Locked = true;
-        ExternalId3Tok: Label 'EXT-TASK-MODEL-005-C', Locked = true;
     begin
         // [SCENARIO] Multiple tasks with different model IDs retain their own model ID
         Initialize();
@@ -980,9 +994,14 @@ codeunit 133960 "Agent Task Test"
             CopyStr(Any.AlphanumericText(80), 1, 80),
             CopyStr(Any.AlphanumericText(2048), 1, 2048));
 
-        ModelId1 := CopyStr(Any.AlphanumericText(MaxStrLen(ModelId1)), 1, MaxStrLen(ModelId1));
-        ModelId2 := CopyStr(Any.AlphanumericText(MaxStrLen(ModelId2)), 1, MaxStrLen(ModelId2));
-        ModelId3 := CopyStr(Any.AlphanumericText(MaxStrLen(ModelId3)), 1, MaxStrLen(ModelId3));
+        if AgentModel.IsEmpty() then
+            // Copilot Service is not running and not populating the Agent Model table.
+            exit;
+
+        Assert.IsTrue(AgentModel.FindSet(), 'There should be a first model in the Agent Model table');
+        ModelId1 := AgentModel."Model ID";
+        Assert.IsTrue(AgentModel.Next() <> 0, 'There should be a second model in the Agent Model table');
+        ModelId2 := AgentModel."Model ID";
 
         // [WHEN] Multiple tasks are created with different model IDs
         Clear(AgentTaskBuilder);
@@ -1000,21 +1019,13 @@ codeunit 133960 "Agent Task Test"
         AgentTaskRecord2 := AgentTaskBuilder.Create(true, false);
 
         Clear(AgentTaskBuilder);
-        AgentTaskBuilder
-            .Initialize(AgentUserId, 'Task Model 3')
-            .SetExternalId(ExternalId3Tok)
-            .SetModelId(ModelId3);
-        AgentTaskRecord3 := AgentTaskBuilder.Create(true, false);
 
         // [THEN] Each task should have its own model ID
         Assert.AreEqual(ModelId1, AgentTask.GetModelId(AgentTaskRecord1.ID), 'First task model ID should match');
         Assert.AreEqual(ModelId2, AgentTask.GetModelId(AgentTaskRecord2.ID), 'Second task model ID should match');
-        Assert.AreEqual(ModelId3, AgentTask.GetModelId(AgentTaskRecord3.ID), 'Third task model ID should match');
 
         // [THEN] All model IDs should be different from each other
         Assert.AreNotEqual(ModelId1, ModelId2, 'Model IDs should be different');
-        Assert.AreNotEqual(ModelId1, ModelId3, 'Model IDs should be different');
-        Assert.AreNotEqual(ModelId2, ModelId3, 'Model IDs should be different');
     end;
 
     [Test]
@@ -1040,6 +1051,10 @@ codeunit 133960 "Agent Task Test"
             CopyStr(Any.AlphanumericText(MaxStrLen(AgentRecord."User Name")), 1, MaxStrLen(AgentRecord."User Name")),
             CopyStr(Any.AlphanumericText(80), 1, 80),
             CopyStr(Any.AlphanumericText(2048), 1, 2048));
+
+        if AgentModel.IsEmpty() then
+            // Copilot Service is not running and not populating the Agent Model table.
+            exit;
 
         AgentModel.SetRange("Is Default", true);
         Assert.IsTrue(AgentModel.FindFirst(), 'A default agent model should exist');

--- a/src/System Application/Test/Agent/src/SDK/AgentTest.Codeunit.al
+++ b/src/System Application/Test/Agent/src/SDK/AgentTest.Codeunit.al
@@ -346,6 +346,10 @@ codeunit 133961 "Agent Test"
             CopyStr(Any.AlphanumericText(80), 1, 80),
             CopyStr(Any.AlphanumericText(2048), 1, 2048));
 
+        if AgentModel.IsEmpty() then
+            // Copilot Service is not running and not populating the Agent Model table.
+            exit;
+
         AgentModel.SetRange("Is Default", true);
         Assert.IsTrue(AgentModel.FindFirst(), 'A default agent model should exist');
 


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->
Copilot service is not deployed in BCApps so the Agent Model is not populated with models causing the tests to fail.
Skipping the execution in such a case, we have a lot of coverage locally and in the platform already.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#634925](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634925)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->


