### PR TITLE
[Quality Management] Fix promoted-result matrix column visibility in pages

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultConditionMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultConditionMgmt.Codeunit.al
@@ -555,30 +555,36 @@ codeunit 20409 "Qlty. Result Condition Mgmt."
         QltyIResultConditConf.SetRange("Result Visibility", QltyIResultConditConf."Result Visibility"::Promoted);
         QltyIResultConditConf.SetCurrentKey("Condition Type", "Result Visibility", Priority, "Target Code", "Target Re-inspection No.", "Target Line No.");
         QltyIResultConditConf.Ascending(false);
-        if QltyIResultConditConf.FindSet() then
+
+        // Drive iteration by Qlty. Inspection Result using the same ordering and filters as
+        // GetDefaultPromotedResults so that a given "Result Code" always maps to the same Iterator slot.
+        QltyInspectionResult.SetRange("Result Visibility", QltyInspectionResult."Result Visibility"::Promoted);
+        QltyInspectionResult.SetCurrentKey("Result Visibility", "Evaluation Sequence");
+        QltyInspectionResult.Ascending(false);
+        if QltyInspectionResult.FindSet() then begin
+            Iterator := 0;
             repeat
-                if QltyInspectionResult.Get(QltyIResultConditConf."Result Code") then begin
-                    Iterator += 1;
-                    if Iterator <= GetMaxResultConditions() then begin
-                        MatrixVisibleStateToSet[Iterator] := true;
-                        if QltyInspectionResult.Description <> '' then
-                            MatrixArrayToSetCaptionSet[Iterator] := QltyInspectionResult.Description
-                        else
-                            MatrixArrayToSetCaptionSet[Iterator] := QltyInspectionResult.Code;
-                        MatrixArrayToSetConditionCellData[Iterator] := QltyIResultConditConf.Condition;
-                        MatrixArrayToSetConditionDescriptionCellData[Iterator] := QltyIResultConditConf."Condition Description";
-                        if MatrixArrayToSetConditionDescriptionCellData[Iterator] = '' then
-                            MatrixArrayToSetConditionDescriptionCellData[Iterator] := MatrixArrayToSetConditionCellData[Iterator];
+                Iterator += 1;
+                QltyIResultConditConf.SetRange("Result Code", QltyInspectionResult.Code);
+                if QltyIResultConditConf.FindFirst() then begin
+                    MatrixVisibleStateToSet[Iterator] := true;
+                    if QltyInspectionResult.Description <> '' then
+                        MatrixArrayToSetCaptionSet[Iterator] := QltyInspectionResult.Description
+                    else
+                        MatrixArrayToSetCaptionSet[Iterator] := QltyInspectionResult.Code;
+                    MatrixArrayToSetConditionCellData[Iterator] := QltyIResultConditConf.Condition;
+                    MatrixArrayToSetConditionDescriptionCellData[Iterator] := QltyIResultConditConf."Condition Description";
+                    if MatrixArrayToSetConditionDescriptionCellData[Iterator] = '' then
+                        MatrixArrayToSetConditionDescriptionCellData[Iterator] := MatrixArrayToSetConditionCellData[Iterator];
 
-                        if (not OptionalQltyInspectionHeader.IsTemporary()) and (OptionalQltyInspectionHeader."No." <> '') then
-                            if MatrixArrayToSetConditionDescriptionCellData[Iterator].Contains('[') then
-                                MatrixArrayToSetConditionDescriptionCellData[Iterator] := QltyExpressionMgmt.EvaluateTextExpression(MatrixArrayToSetConditionDescriptionCellData[Iterator], OptionalQltyInspectionHeader, OptionalQltyInspectionLine);
+                    if (not OptionalQltyInspectionHeader.IsTemporary()) and (OptionalQltyInspectionHeader."No." <> '') then
+                        if MatrixArrayToSetConditionDescriptionCellData[Iterator].Contains('[') then
+                            MatrixArrayToSetConditionDescriptionCellData[Iterator] := QltyExpressionMgmt.EvaluateTextExpression(MatrixArrayToSetConditionDescriptionCellData[Iterator], OptionalQltyInspectionHeader, OptionalQltyInspectionLine);
 
-                        MatrixSourceRecordId[Iterator] := QltyIResultConditConf.RecordId();
-                    end else
-                        break;
+                    MatrixSourceRecordId[Iterator] := QltyIResultConditConf.RecordId();
                 end;
-            until (QltyIResultConditConf.Next() = 0) or (Iterator >= MaxResultConditions);
+            until (QltyInspectionResult.Next() = 0) or (Iterator >= MaxResultConditions);
+        end;
     end;
 
     local procedure GetMaxResultConditions(): Integer

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateLine.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateLine.Table.al
@@ -131,7 +131,6 @@ table 20403 "Qlty. Inspection Template Line"
             exit;
 
         InitLineNoIfNeeded();
-        EnsureResultsExist(true);
         Rec.CalcFields("Test Value Type");
     end;
 
@@ -139,13 +138,14 @@ table 20403 "Qlty. Inspection Template Line"
     var
         ExistingsQltyInspectionTemplateLine: Record "Qlty. Inspection Template Line";
     begin
-        if Rec."Line No." = 0 then begin
-            ExistingsQltyInspectionTemplateLine.SetRange("Template Code", Rec."Template Code");
-            ExistingsQltyInspectionTemplateLine.SetCurrentKey("Template Code", "Line No.");
-            ExistingsQltyInspectionTemplateLine.Ascending(false);
-            if ExistingsQltyInspectionTemplateLine.FindFirst() then;
-            Rec."Line No." := ExistingsQltyInspectionTemplateLine."Line No." + 10000;
-        end;
+        if Rec."Line No." <> 0 then
+            exit;
+
+        ExistingsQltyInspectionTemplateLine.SetRange("Template Code", Rec."Template Code");
+        ExistingsQltyInspectionTemplateLine.SetCurrentKey("Template Code", "Line No.");
+        ExistingsQltyInspectionTemplateLine.Ascending(true);
+        if ExistingsQltyInspectionTemplateLine.FindLast() then;
+        Rec."Line No." := ExistingsQltyInspectionTemplateLine."Line No." + 10000;
     end;
 
     trigger OnModify()

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateSubf.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateSubf.Page.al
@@ -74,7 +74,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[1]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 1';
                     Visible = Visible1;
-                    Editable = Visible1;
+                    Editable = Editable1;
 
                     trigger OnValidate()
                     begin
@@ -83,6 +83,8 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable1 then
+                            exit;
                         AssistEditCondition(1);
                     end;
                 }
@@ -91,7 +93,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[1]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 1';
                     Visible = Visible1;
-                    Editable = Visible1;
+                    Editable = Editable1;
 
                     trigger OnValidate()
                     begin
@@ -100,6 +102,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable1 then
+                            exit;
+
                         AssistEditConditionDescription(1);
                     end;
                 }
@@ -108,7 +113,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[2]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 2';
                     Visible = Visible2;
-                    Editable = Visible2;
+                    Editable = Editable2;
 
                     trigger OnValidate()
                     begin
@@ -117,6 +122,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable2 then
+                            exit;
+
                         AssistEditCondition(2);
                     end;
                 }
@@ -125,7 +133,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[2]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 2';
                     Visible = Visible2;
-                    Editable = Visible2;
+                    Editable = Editable2;
 
                     trigger OnValidate()
                     begin
@@ -134,6 +142,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable2 then
+                            exit;
+
                         AssistEditConditionDescription(2);
                     end;
                 }
@@ -142,7 +153,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[3]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 3';
                     Visible = Visible3;
-                    Editable = Visible3;
+                    Editable = Editable3;
 
                     trigger OnValidate()
                     begin
@@ -151,6 +162,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable3 then
+                            exit;
+
                         AssistEditCondition(3);
                     end;
                 }
@@ -159,7 +173,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[3]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 3';
                     Visible = Visible3;
-                    Editable = Visible3;
+                    Editable = Editable3;
 
                     trigger OnValidate()
                     begin
@@ -168,6 +182,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable3 then
+                            exit;
+
                         AssistEditConditionDescription(3);
                     end;
                 }
@@ -176,7 +193,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[4]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4';
                     Visible = Visible4;
-                    Editable = Visible4;
+                    Editable = Editable4;
 
                     trigger OnValidate()
                     begin
@@ -185,6 +202,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable4 then
+                            exit;
+
                         AssistEditCondition(4);
                     end;
                 }
@@ -193,7 +213,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[4]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4';
                     Visible = Visible4;
-                    Editable = Visible4;
+                    Editable = Editable4;
 
                     trigger OnValidate()
                     begin
@@ -202,6 +222,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable4 then
+                            exit;
+
                         AssistEditConditionDescription(4);
                     end;
                 }
@@ -210,7 +233,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[5]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5';
                     Visible = Visible5;
-                    Editable = Visible5;
+                    Editable = Editable5;
 
                     trigger OnValidate()
                     begin
@@ -219,6 +242,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable5 then
+                            exit;
+
                         AssistEditCondition(5);
                     end;
                 }
@@ -227,7 +253,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[5]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5';
                     Visible = Visible5;
-                    Editable = Visible5;
+                    Editable = Editable5;
 
                     trigger OnValidate()
                     begin
@@ -236,6 +262,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable5 then
+                            exit;
+
                         AssistEditConditionDescription(5);
                     end;
                 }
@@ -244,7 +273,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[6]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6';
                     Visible = Visible6;
-                    Editable = Visible6;
+                    Editable = Editable6;
 
                     trigger OnValidate()
                     begin
@@ -253,6 +282,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable6 then
+                            exit;
+
                         AssistEditCondition(6);
                     end;
                 }
@@ -261,7 +293,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[6]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6';
                     Visible = Visible6;
-                    Editable = Visible6;
+                    Editable = Editable6;
 
                     trigger OnValidate()
                     begin
@@ -270,6 +302,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable6 then
+                            exit;
+
                         AssistEditConditionDescription(6);
                     end;
                 }
@@ -278,7 +313,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[7]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7';
                     Visible = Visible7;
-                    Editable = Visible7;
+                    Editable = Editable7;
 
                     trigger OnValidate()
                     begin
@@ -287,6 +322,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable7 then
+                            exit;
+
                         AssistEditCondition(7);
                     end;
                 }
@@ -295,7 +333,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[7]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7';
                     Visible = Visible7;
-                    Editable = Visible7;
+                    Editable = Editable7;
 
                     trigger OnValidate()
                     begin
@@ -304,6 +342,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable7 then
+                            exit;
+
                         AssistEditConditionDescription(7);
                     end;
                 }
@@ -312,7 +353,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[8]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8';
                     Visible = Visible8;
-                    Editable = Visible8;
+                    Editable = Editable8;
 
                     trigger OnValidate()
                     begin
@@ -321,6 +362,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable8 then
+                            exit;
+
                         AssistEditCondition(8);
                     end;
                 }
@@ -329,7 +373,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[8]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8';
                     Visible = Visible8;
-                    Editable = Visible8;
+                    Editable = Editable8;
 
                     trigger OnValidate()
                     begin
@@ -338,6 +382,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable8 then
+                            exit;
+
                         AssistEditConditionDescription(8);
                     end;
                 }
@@ -346,7 +393,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[9]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9';
                     Visible = Visible9;
-                    Editable = Visible9;
+                    Editable = Editable9;
 
                     trigger OnValidate()
                     begin
@@ -355,6 +402,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable9 then
+                            exit;
+
                         AssistEditCondition(9);
                     end;
                 }
@@ -363,7 +413,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[9]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9';
                     Visible = Visible9;
-                    Editable = Visible9;
+                    Editable = Editable9;
 
                     trigger OnValidate()
                     begin
@@ -372,6 +422,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable9 then
+                            exit;
+
                         AssistEditConditionDescription(9);
                     end;
                 }
@@ -380,7 +433,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[10]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10';
                     Visible = Visible10;
-                    Editable = Visible10;
+                    Editable = Editable10;
 
                     trigger OnValidate()
                     begin
@@ -389,6 +442,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable10 then
+                            exit;
+
                         AssistEditCondition(10);
                     end;
                 }
@@ -397,7 +453,7 @@ page 20403 "Qlty. Inspection Template Subf"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[10]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10';
                     Visible = Visible10;
-                    Editable = Visible10;
+                    Editable = Editable10;
 
                     trigger OnValidate()
                     begin
@@ -406,6 +462,9 @@ page 20403 "Qlty. Inspection Template Subf"
 
                     trigger OnAssistEdit()
                     begin
+                        if not Editable10 then
+                            exit;
+
                         AssistEditConditionDescription(10);
                     end;
                 }
@@ -414,7 +473,6 @@ page 20403 "Qlty. Inspection Template Subf"
     }
 
     var
-        CachedQltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
         QltyResultConditionMgmt: Codeunit "Qlty. Result Condition Mgmt.";
         MatrixSourceRecordId: array[10] of RecordId;
         RowStyle: Option None,Standard,StandardAccent,Strong,StrongAccent,Attention,AttentionAccent,Favorable,Unfavorable,Ambiguous,Subordinate;
@@ -422,64 +480,17 @@ page 20403 "Qlty. Inspection Template Subf"
         MatrixArrayConditionCellData: array[10] of Text;
         MatrixArrayConditionDescriptionCellData: array[10] of Text;
         MatrixArrayCaptionSet: array[10] of Text;
-        MatrixVisibleState: array[10] of Boolean;
-        Visible1: Boolean;
-        Visible2: Boolean;
-        Visible3: Boolean;
-        Visible4: Boolean;
-        Visible5: Boolean;
-        Visible6: Boolean;
-        Visible7: Boolean;
-        Visible8: Boolean;
-        Visible9: Boolean;
-        Visible10: Boolean;
+        Visible1, Visible2, Visible3, Visible4, Visible5, Visible6, Visible7, Visible8, Visible9, Visible10 : Boolean;
+        Editable1, Editable2, Editable3, Editable4, Editable5, Editable6, Editable7, Editable8, Editable9, Editable10 : Boolean;
         DescriptionLbl: Label '%1 Description', Comment = '%1 = Matrix field caption';
         ConditionLbl: Label '%1 Condition', Comment = '%1 = Matrix field caption';
 
-    trigger OnNewRecord(BelowxRec: Boolean)
-    begin
-        if Rec."Template Code" <> CachedQltyInspectionTemplateHdr.Code then begin
-            Clear(CachedQltyInspectionTemplateHdr);
-            if Rec."Template Code" <> '' then
-                if CachedQltyInspectionTemplateHdr.Get(Rec."Template Code") then;
-        end;
-        Rec.EnsureResultsExist(false);
-    end;
-
-    trigger OnFindRecord(Which: Text): Boolean
-    begin
-        Clear(CachedQltyInspectionTemplateHdr);
-        exit(Rec.Find(Which));
-    end;
-
-    trigger OnAfterGetRecord()
+    trigger OnOpenPage()
     var
-        DuplicateTestCheckQltyInspectionTemplateLine: Record "Qlty. Inspection Template Line";
+        MatrixVisibleState: array[10] of Boolean;
     begin
-        UpdateRowData();
-        RowStyle := RowStyle::None;
-        DuplicateTestCheckQltyInspectionTemplateLine.SetRange("Template Code", Rec."Template Code");
-        DuplicateTestCheckQltyInspectionTemplateLine.SetRange("Test Code", Rec."Test Code");
-        DuplicateTestCheckQltyInspectionTemplateLine.SetFilter("Line No.", '<>%1', Rec."Line No.");
-        if not DuplicateTestCheckQltyInspectionTemplateLine.IsEmpty() then
-            RowStyle := RowStyle::Unfavorable;
-
-        RowStyleText := Format(RowStyle);
-    end;
-
-    trigger OnAfterGetCurrRecord()
-    begin
-        UpdateRowData();
-    end;
-
-    local procedure UpdateRowData()
-    begin
-        Rec.CalcFields("Test Value Type");
-
-        if (CachedQltyInspectionTemplateHdr.Code <> Rec."Template Code") and (Rec."Template Code" <> '') then
-            if CachedQltyInspectionTemplateHdr.Get(Rec."Template Code") then;
-
-        QltyResultConditionMgmt.GetPromotedResultsForTemplateLine(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
+        // Column visibility and captions are page-wide and driven by the global set of promoted results, so they only need to be computed once when the page opens.
+        QltyResultConditionMgmt.GetDefaultPromotedResults(true, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
         Visible1 := MatrixVisibleState[1];
         Visible2 := MatrixVisibleState[2];
         Visible3 := MatrixVisibleState[3];
@@ -490,6 +501,56 @@ page 20403 "Qlty. Inspection Template Subf"
         Visible8 := MatrixVisibleState[8];
         Visible9 := MatrixVisibleState[9];
         Visible10 := MatrixVisibleState[10];
+    end;
+
+    trigger OnFindRecord(Which: Text): Boolean
+    begin
+        exit(Rec.Find(Which));
+    end;
+
+    trigger OnAfterGetRecord()
+    var
+        DuplicateTestCheckQltyInspectionTemplateLine: Record "Qlty. Inspection Template Line";
+    begin
+        UpdateRowData();
+
+        RowStyle := RowStyle::None;
+        DuplicateTestCheckQltyInspectionTemplateLine.SetRange("Template Code", Rec."Template Code");
+        DuplicateTestCheckQltyInspectionTemplateLine.SetRange("Test Code", Rec."Test Code");
+        DuplicateTestCheckQltyInspectionTemplateLine.SetFilter("Line No.", '<>%1', Rec."Line No.");
+        if not DuplicateTestCheckQltyInspectionTemplateLine.IsEmpty() then
+            RowStyle := RowStyle::Unfavorable;
+
+        RowStyleText := Format(RowStyle);
+    end;
+
+    local procedure UpdateRowData()
+    var
+        DummyMatrixVisibleState: array[10] of Boolean;
+        RowIsLabel: Boolean;
+    begin
+        Rec.CalcFields("Test Value Type");
+        RowIsLabel := Rec."Test Value Type" = Rec."Test Value Type"::"Value Type Label";
+
+        // Label rows never have promoted result condition records, so just blank the per-row cell data instead.
+        if RowIsLabel then begin
+            Clear(MatrixSourceRecordId);
+            Clear(MatrixArrayConditionCellData);
+            Clear(MatrixArrayConditionDescriptionCellData);
+        end else
+            // Refresh the per-row condition values and source RecordIds so OnValidate/OnAssistEdit on each cell operates on the correct underlying configuration record.
+            QltyResultConditionMgmt.GetPromotedResultsForTemplateLine(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, DummyMatrixVisibleState);
+
+        Editable1 := Visible1 and not RowIsLabel;
+        Editable2 := Visible2 and not RowIsLabel;
+        Editable3 := Visible3 and not RowIsLabel;
+        Editable4 := Visible4 and not RowIsLabel;
+        Editable5 := Visible5 and not RowIsLabel;
+        Editable6 := Visible6 and not RowIsLabel;
+        Editable7 := Visible7 and not RowIsLabel;
+        Editable8 := Visible8 and not RowIsLabel;
+        Editable9 := Visible9 and not RowIsLabel;
+        Editable10 := Visible10 and not RowIsLabel;
     end;
 
     local procedure UpdateMatrixDataCondition(Matrix: Integer)

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateSubf.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateSubf.Page.al
@@ -72,7 +72,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field1; MatrixArrayConditionCellData[1])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[1]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 1';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 1.';
                     Visible = Visible1;
                     Editable = Editable1;
 
@@ -91,7 +91,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field1_Desc; MatrixArrayConditionDescriptionCellData[1])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[1]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 1';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 1.';
                     Visible = Visible1;
                     Editable = Editable1;
 
@@ -111,7 +111,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field2; MatrixArrayConditionCellData[2])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[2]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 2';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 2.';
                     Visible = Visible2;
                     Editable = Editable2;
 
@@ -131,7 +131,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field2_Desc; MatrixArrayConditionDescriptionCellData[2])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[2]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 2';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 2.';
                     Visible = Visible2;
                     Editable = Editable2;
 
@@ -151,7 +151,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field3; MatrixArrayConditionCellData[3])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[3]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 3';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 3.';
                     Visible = Visible3;
                     Editable = Editable3;
 
@@ -171,7 +171,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field3_Desc; MatrixArrayConditionDescriptionCellData[3])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[3]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 3';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 3.';
                     Visible = Visible3;
                     Editable = Editable3;
 
@@ -191,7 +191,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field4; MatrixArrayConditionCellData[4])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[4]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4.';
                     Visible = Visible4;
                     Editable = Editable4;
 
@@ -211,7 +211,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field4_Desc; MatrixArrayConditionDescriptionCellData[4])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[4]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4.';
                     Visible = Visible4;
                     Editable = Editable4;
 
@@ -231,7 +231,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field5; MatrixArrayConditionCellData[5])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[5]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5.';
                     Visible = Visible5;
                     Editable = Editable5;
 
@@ -251,7 +251,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field5_Desc; MatrixArrayConditionDescriptionCellData[5])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[5]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5.';
                     Visible = Visible5;
                     Editable = Editable5;
 
@@ -271,7 +271,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field6; MatrixArrayConditionCellData[6])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[6]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6.';
                     Visible = Visible6;
                     Editable = Editable6;
 
@@ -291,7 +291,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field6_Desc; MatrixArrayConditionDescriptionCellData[6])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[6]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6.';
                     Visible = Visible6;
                     Editable = Editable6;
 
@@ -311,7 +311,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field7; MatrixArrayConditionCellData[7])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[7]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7.';
                     Visible = Visible7;
                     Editable = Editable7;
 
@@ -331,7 +331,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field7_Desc; MatrixArrayConditionDescriptionCellData[7])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[7]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7.';
                     Visible = Visible7;
                     Editable = Editable7;
 
@@ -351,7 +351,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field8; MatrixArrayConditionCellData[8])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[8]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8.';
                     Visible = Visible8;
                     Editable = Editable8;
 
@@ -371,7 +371,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field8_Desc; MatrixArrayConditionDescriptionCellData[8])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[8]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8.';
                     Visible = Visible8;
                     Editable = Editable8;
 
@@ -391,7 +391,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field9; MatrixArrayConditionCellData[9])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[9]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9.';
                     Visible = Visible9;
                     Editable = Editable9;
 
@@ -411,7 +411,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field9_Desc; MatrixArrayConditionDescriptionCellData[9])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[9]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9.';
                     Visible = Visible9;
                     Editable = Editable9;
 
@@ -431,7 +431,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field10; MatrixArrayConditionCellData[10])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[10]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10.';
                     Visible = Visible10;
                     Editable = Editable10;
 
@@ -451,7 +451,7 @@ page 20403 "Qlty. Inspection Template Subf"
                 field(Field10_Desc; MatrixArrayConditionDescriptionCellData[10])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[10]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10.';
                     Visible = Visible10;
                     Editable = Editable10;
 

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateSubf.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateSubf.Page.al
@@ -526,6 +526,7 @@ page 20403 "Qlty. Inspection Template Subf"
 
     local procedure UpdateRowData()
     var
+        DummyMatrixArrayCaptionSet: array[10] of Text;
         DummyMatrixVisibleState: array[10] of Boolean;
         RowIsLabel: Boolean;
     begin
@@ -539,7 +540,7 @@ page 20403 "Qlty. Inspection Template Subf"
             Clear(MatrixArrayConditionDescriptionCellData);
         end else
             // Refresh the per-row condition values and source RecordIds so OnValidate/OnAssistEdit on each cell operates on the correct underlying configuration record.
-            QltyResultConditionMgmt.GetPromotedResultsForTemplateLine(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, DummyMatrixVisibleState);
+            QltyResultConditionMgmt.GetPromotedResultsForTemplateLine(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, DummyMatrixArrayCaptionSet, DummyMatrixVisibleState);
 
         Editable1 := Visible1 and not RowIsLabel;
         Editable2 := Visible2 and not RowIsLabel;

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
@@ -588,7 +588,6 @@ page 20479 "Qlty. Test Card"
         MatrixArrayConditionCellData: array[10] of Text;
         MatrixArrayConditionDescriptionCellData: array[10] of Text;
         MatrixArrayCaptionSet: array[10] of Text;
-        MatrixVisibleState: array[10] of Boolean;
         Visible1, Visible2, Visible3, Visible4, Visible5, Visible6, Visible7, Visible8, Visible9, Visible10 : Boolean;
         EditableResult: Boolean;
         IsAllowableValuesEditable: Boolean;
@@ -599,8 +598,20 @@ page 20479 "Qlty. Test Card"
         NotEditableLbl: Label 'The %1 field is not editable for the selected %2.', Comment = '%1 = Expression Formula, %2 = Test Value Type';
 
     trigger OnOpenPage()
+    var
+        MatrixVisibleState: array[10] of Boolean;
     begin
-        UpdateRowData();
+        QltyResultConditionMgmt.GetDefaultPromotedResults(true, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
+        Visible1 := MatrixVisibleState[1];
+        Visible2 := MatrixVisibleState[2];
+        Visible3 := MatrixVisibleState[3];
+        Visible4 := MatrixVisibleState[4];
+        Visible5 := MatrixVisibleState[5];
+        Visible6 := MatrixVisibleState[6];
+        Visible7 := MatrixVisibleState[7];
+        Visible8 := MatrixVisibleState[8];
+        Visible9 := MatrixVisibleState[9];
+        Visible10 := MatrixVisibleState[10];
     end;
 
     trigger OnAfterGetRecord()
@@ -627,28 +638,17 @@ page 20479 "Qlty. Test Card"
     end;
 
     local procedure UpdateRowData()
+    var
+        DummyMatrixArrayCaptionSet: array[10] of Text;
+        DummyMatrixVisibleState: array[10] of Boolean;
     begin
         IsAllowableValuesEditable := not (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Table Lookup"]);
         IsLookupField := (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Table Lookup"]);
 
         if Rec.Code = '' then
-            QltyResultConditionMgmt.GetDefaultPromotedResults(false, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState)
-        else begin
-            QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
-            if not MatrixVisibleState[1] then
-                QltyResultConditionMgmt.GetDefaultPromotedResults(false, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
-        end;
-
-        Visible1 := MatrixVisibleState[1];
-        Visible2 := MatrixVisibleState[2];
-        Visible3 := MatrixVisibleState[3];
-        Visible4 := MatrixVisibleState[4];
-        Visible5 := MatrixVisibleState[5];
-        Visible6 := MatrixVisibleState[6];
-        Visible7 := MatrixVisibleState[7];
-        Visible8 := MatrixVisibleState[8];
-        Visible9 := MatrixVisibleState[9];
-        Visible10 := MatrixVisibleState[10];
+            QltyResultConditionMgmt.GetDefaultPromotedResults(false, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, DummyMatrixArrayCaptionSet, DummyMatrixVisibleState)
+        else
+            QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, DummyMatrixArrayCaptionSet, DummyMatrixVisibleState);
 
         EditableResult := (Rec.Code <> '') and (CurrPage.Editable) and (Visible1) and (MatrixArrayCaptionSet[1] <> '');
 

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
@@ -588,17 +588,7 @@ page 20479 "Qlty. Test Card"
         MatrixArrayConditionCellData: array[10] of Text;
         MatrixArrayConditionDescriptionCellData: array[10] of Text;
         MatrixArrayCaptionSet: array[10] of Text;
-        MatrixVisibleState: array[10] of Boolean;
-        Visible1: Boolean;
-        Visible2: Boolean;
-        Visible3: Boolean;
-        Visible4: Boolean;
-        Visible5: Boolean;
-        Visible6: Boolean;
-        Visible7: Boolean;
-        Visible8: Boolean;
-        Visible9: Boolean;
-        Visible10: Boolean;
+        Visible1, Visible2, Visible3, Visible4, Visible5, Visible6, Visible7, Visible8, Visible9, Visible10 : Boolean;
         EditableResult: Boolean;
         IsAllowableValuesEditable: Boolean;
         IsLookupField: Boolean;
@@ -608,21 +598,23 @@ page 20479 "Qlty. Test Card"
         NotEditableLbl: Label 'The %1 field is not editable for the selected %2.', Comment = '%1 = Expression Formula, %2 = Test Value Type';
 
     trigger OnOpenPage()
+    var
+        MatrixVisibleState: array[10] of Boolean;
     begin
-        UpdateRowData();
+        QltyResultConditionMgmt.GetDefaultPromotedResults(true, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
+        Visible1 := MatrixVisibleState[1];
+        Visible2 := MatrixVisibleState[2];
+        Visible3 := MatrixVisibleState[3];
+        Visible4 := MatrixVisibleState[4];
+        Visible5 := MatrixVisibleState[5];
+        Visible6 := MatrixVisibleState[6];
+        Visible7 := MatrixVisibleState[7];
+        Visible8 := MatrixVisibleState[8];
+        Visible9 := MatrixVisibleState[9];
+        Visible10 := MatrixVisibleState[10];
     end;
 
     trigger OnAfterGetRecord()
-    begin
-        UpdateRowData();
-    end;
-
-    trigger OnAfterGetCurrRecord()
-    begin
-        UpdateRowData();
-    end;
-
-    trigger OnInsertRecord(BelowxRec: Boolean): Boolean
     begin
         UpdateRowData();
     end;
@@ -636,28 +628,14 @@ page 20479 "Qlty. Test Card"
     end;
 
     local procedure UpdateRowData()
+    var
+        MatrixVisibleState: array[10] of Boolean;
     begin
         IsAllowableValuesEditable := not (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Table Lookup"]);
         IsLookupField := (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Table Lookup"]);
 
-        if Rec.Code = '' then
-            QltyResultConditionMgmt.GetDefaultPromotedResults(false, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState)
-        else begin
+        if Rec.Code <> '' then
             QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
-            if not MatrixVisibleState[1] then
-                QltyResultConditionMgmt.GetDefaultPromotedResults(false, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
-        end;
-
-        Visible1 := MatrixVisibleState[1];
-        Visible2 := MatrixVisibleState[2];
-        Visible3 := MatrixVisibleState[3];
-        Visible4 := MatrixVisibleState[4];
-        Visible5 := MatrixVisibleState[5];
-        Visible6 := MatrixVisibleState[6];
-        Visible7 := MatrixVisibleState[7];
-        Visible8 := MatrixVisibleState[8];
-        Visible9 := MatrixVisibleState[9];
-        Visible10 := MatrixVisibleState[10];
 
         EditableResult := (Rec.Code <> '') and (CurrPage.Editable) and (Visible1) and (MatrixArrayCaptionSet[1] <> '');
 

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
@@ -619,6 +619,11 @@ page 20479 "Qlty. Test Card"
         UpdateRowData();
     end;
 
+    trigger OnAfterGetCurrRecord()
+    begin
+        UpdateRowData();
+    end;
+
     trigger OnQueryClosePage(CloseAction: Action): Boolean
     begin
         if CloseAction in [Action::OK, Action::LookupOK] then
@@ -635,7 +640,12 @@ page 20479 "Qlty. Test Card"
         IsLookupField := (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Table Lookup"]);
 
         if Rec.Code <> '' then
-            QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
+            QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState)
+        else begin
+            Clear(MatrixSourceRecordId);
+            Clear(MatrixArrayConditionCellData);
+            Clear(MatrixArrayConditionDescriptionCellData);
+        end;
 
         EditableResult := (Rec.Code <> '') and (CurrPage.Editable) and (Visible1) and (MatrixArrayCaptionSet[1] <> '');
 

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
@@ -588,6 +588,7 @@ page 20479 "Qlty. Test Card"
         MatrixArrayConditionCellData: array[10] of Text;
         MatrixArrayConditionDescriptionCellData: array[10] of Text;
         MatrixArrayCaptionSet: array[10] of Text;
+        MatrixVisibleState: array[10] of Boolean;
         Visible1, Visible2, Visible3, Visible4, Visible5, Visible6, Visible7, Visible8, Visible9, Visible10 : Boolean;
         EditableResult: Boolean;
         IsAllowableValuesEditable: Boolean;
@@ -598,20 +599,8 @@ page 20479 "Qlty. Test Card"
         NotEditableLbl: Label 'The %1 field is not editable for the selected %2.', Comment = '%1 = Expression Formula, %2 = Test Value Type';
 
     trigger OnOpenPage()
-    var
-        MatrixVisibleState: array[10] of Boolean;
     begin
-        QltyResultConditionMgmt.GetDefaultPromotedResults(true, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
-        Visible1 := MatrixVisibleState[1];
-        Visible2 := MatrixVisibleState[2];
-        Visible3 := MatrixVisibleState[3];
-        Visible4 := MatrixVisibleState[4];
-        Visible5 := MatrixVisibleState[5];
-        Visible6 := MatrixVisibleState[6];
-        Visible7 := MatrixVisibleState[7];
-        Visible8 := MatrixVisibleState[8];
-        Visible9 := MatrixVisibleState[9];
-        Visible10 := MatrixVisibleState[10];
+        UpdateRowData();
     end;
 
     trigger OnAfterGetRecord()
@@ -620,6 +609,11 @@ page 20479 "Qlty. Test Card"
     end;
 
     trigger OnAfterGetCurrRecord()
+    begin
+        UpdateRowData();
+    end;
+
+    trigger OnInsertRecord(BelowxRec: Boolean): Boolean
     begin
         UpdateRowData();
     end;
@@ -633,19 +627,28 @@ page 20479 "Qlty. Test Card"
     end;
 
     local procedure UpdateRowData()
-    var
-        MatrixVisibleState: array[10] of Boolean;
     begin
         IsAllowableValuesEditable := not (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Table Lookup"]);
         IsLookupField := (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Table Lookup"]);
 
-        if Rec.Code <> '' then
-            QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState)
+        if Rec.Code = '' then
+            QltyResultConditionMgmt.GetDefaultPromotedResults(false, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState)
         else begin
-            Clear(MatrixSourceRecordId);
-            Clear(MatrixArrayConditionCellData);
-            Clear(MatrixArrayConditionDescriptionCellData);
+            QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
+            if not MatrixVisibleState[1] then
+                QltyResultConditionMgmt.GetDefaultPromotedResults(false, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
         end;
+
+        Visible1 := MatrixVisibleState[1];
+        Visible2 := MatrixVisibleState[2];
+        Visible3 := MatrixVisibleState[3];
+        Visible4 := MatrixVisibleState[4];
+        Visible5 := MatrixVisibleState[5];
+        Visible6 := MatrixVisibleState[6];
+        Visible7 := MatrixVisibleState[7];
+        Visible8 := MatrixVisibleState[8];
+        Visible9 := MatrixVisibleState[9];
+        Visible10 := MatrixVisibleState[10];
 
         EditableResult := (Rec.Code <> '') and (CurrPage.Editable) and (Visible1) and (MatrixArrayCaptionSet[1] <> '');
 

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
@@ -220,7 +220,7 @@ page 20479 "Qlty. Test Card"
                     field(Field4; MatrixArrayConditionCellData[4])
                     {
                         CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[4]);
-                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4';
+                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4.';
                         Visible = Visible4;
                         Editable = EditableResult;
 
@@ -238,7 +238,7 @@ page 20479 "Qlty. Test Card"
                     field(Field4_Desc; MatrixArrayConditionDescriptionCellData[4])
                     {
                         CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[4]);
-                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4';
+                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4.';
                         Visible = Visible4;
                         Editable = EditableResult;
 
@@ -260,7 +260,7 @@ page 20479 "Qlty. Test Card"
                     field(Field5; MatrixArrayConditionCellData[5])
                     {
                         CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[5]);
-                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5';
+                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5.';
                         Visible = Visible5;
                         Editable = EditableResult;
 
@@ -277,7 +277,7 @@ page 20479 "Qlty. Test Card"
                     field(Field5_Desc; MatrixArrayConditionDescriptionCellData[5])
                     {
                         CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[5]);
-                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5';
+                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5.';
                         Visible = Visible5;
                         Editable = EditableResult;
 
@@ -299,7 +299,7 @@ page 20479 "Qlty. Test Card"
                     field(Field6; MatrixArrayConditionCellData[6])
                     {
                         CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[6]);
-                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6';
+                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6.';
                         Visible = Visible6;
                         Editable = EditableResult;
 
@@ -316,7 +316,7 @@ page 20479 "Qlty. Test Card"
                     field(Field6_Desc; MatrixArrayConditionDescriptionCellData[6])
                     {
                         CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[6]);
-                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6';
+                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6.';
                         Visible = Visible6;
                         Editable = EditableResult;
 
@@ -338,7 +338,7 @@ page 20479 "Qlty. Test Card"
                     field(Field7; MatrixArrayConditionCellData[7])
                     {
                         CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[7]);
-                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7';
+                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7.';
                         Visible = Visible7;
                         Editable = EditableResult;
 
@@ -355,7 +355,7 @@ page 20479 "Qlty. Test Card"
                     field(Field7_Desc; MatrixArrayConditionDescriptionCellData[7])
                     {
                         CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[7]);
-                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7';
+                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7.';
                         Visible = Visible7;
                         Editable = EditableResult;
 
@@ -377,7 +377,7 @@ page 20479 "Qlty. Test Card"
                     field(Field8; MatrixArrayConditionCellData[8])
                     {
                         CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[8]);
-                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8';
+                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8.';
                         Visible = Visible8;
                         Editable = EditableResult;
 
@@ -394,7 +394,7 @@ page 20479 "Qlty. Test Card"
                     field(Field8_Desc; MatrixArrayConditionDescriptionCellData[8])
                     {
                         CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[8]);
-                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8';
+                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8.';
                         Visible = Visible8;
                         Editable = EditableResult;
 
@@ -416,7 +416,7 @@ page 20479 "Qlty. Test Card"
                     field(Field9; MatrixArrayConditionCellData[9])
                     {
                         CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[9]);
-                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9';
+                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9.';
                         Visible = Visible9;
                         Editable = EditableResult;
 
@@ -433,7 +433,7 @@ page 20479 "Qlty. Test Card"
                     field(Field9_Desc; MatrixArrayConditionDescriptionCellData[9])
                     {
                         CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[9]);
-                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9';
+                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9.';
                         Visible = Visible9;
                         Editable = EditableResult;
 
@@ -455,7 +455,7 @@ page 20479 "Qlty. Test Card"
                     field(Field10; MatrixArrayConditionCellData[10])
                     {
                         CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[10]);
-                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10';
+                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10.';
                         Visible = Visible10;
                         Editable = EditableResult;
 
@@ -472,7 +472,7 @@ page 20479 "Qlty. Test Card"
                     field(Field10_Desc; MatrixArrayConditionDescriptionCellData[10])
                     {
                         CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[10]);
-                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10';
+                        ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10.';
                         Visible = Visible10;
                         Editable = EditableResult;
 

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestLookup.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestLookup.Page.al
@@ -420,21 +420,22 @@ page 20445 "Qlty. Test Lookup"
 
     local procedure UpdateRowData()
     var
-        MatrixVisibleState: array[10] of Boolean;
+        DummyMatrixArrayCaptionSet: array[10] of Text;
+        DummyMatrixVisibleState: array[10] of Boolean;
     begin
         IsAllowableValuesEditable := not (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Table Lookup"]);
 
-        QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
-        Editable1 := Visible1 and MatrixVisibleState[1];
-        Editable2 := Visible2 and MatrixVisibleState[2];
-        Editable3 := Visible3 and MatrixVisibleState[3];
-        Editable4 := Visible4 and MatrixVisibleState[4];
-        Editable5 := Visible5 and MatrixVisibleState[5];
-        Editable6 := Visible6 and MatrixVisibleState[6];
-        Editable7 := Visible7 and MatrixVisibleState[7];
-        Editable8 := Visible8 and MatrixVisibleState[8];
-        Editable9 := Visible9 and MatrixVisibleState[9];
-        Editable10 := Visible10 and MatrixVisibleState[10];
+        QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, DummyMatrixArrayCaptionSet, DummyMatrixVisibleState);
+        Editable1 := Visible1 and DummyMatrixVisibleState[1];
+        Editable2 := Visible2 and DummyMatrixVisibleState[2];
+        Editable3 := Visible3 and DummyMatrixVisibleState[3];
+        Editable4 := Visible4 and DummyMatrixVisibleState[4];
+        Editable5 := Visible5 and DummyMatrixVisibleState[5];
+        Editable6 := Visible6 and DummyMatrixVisibleState[6];
+        Editable7 := Visible7 and DummyMatrixVisibleState[7];
+        Editable8 := Visible8 and DummyMatrixVisibleState[8];
+        Editable9 := Visible9 and DummyMatrixVisibleState[9];
+        Editable10 := Visible10 and DummyMatrixVisibleState[10];
     end;
 
     local procedure UpdateMatrixDataCondition(MatrixField: Integer)

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestLookup.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestLookup.Page.al
@@ -43,6 +43,11 @@ page 20445 "Qlty. Test Lookup"
                 {
                     AboutTitle = 'Test Value Type';
                     AboutText = 'Specifies the data type of the values you can enter or select for this test. Use Decimal for numerical measurements. Use Choice to give a list of options to choose from. If you want to choose options from an existing table, use Table Lookup.';
+
+                    trigger OnValidate()
+                    begin
+                        UpdateRowData();
+                    end;
                 }
                 field("Allowable Values"; Rec."Allowable Values")
                 {

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestLookup.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestLookup.Page.al
@@ -160,7 +160,7 @@ page 20445 "Qlty. Test Lookup"
                 field(Field4; MatrixArrayConditionCellData[4])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[4]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4.';
                     Visible = Visible4;
                     Editable = Editable4;
 
@@ -172,7 +172,7 @@ page 20445 "Qlty. Test Lookup"
                 field(Field4_Desc; MatrixArrayConditionDescriptionCellData[4])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[4]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4.';
                     Visible = Visible4;
                     Editable = Editable4;
 
@@ -184,7 +184,7 @@ page 20445 "Qlty. Test Lookup"
                 field(Field5; MatrixArrayConditionCellData[5])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[5]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5.';
                     Visible = Visible5;
                     Editable = Editable5;
 
@@ -196,7 +196,7 @@ page 20445 "Qlty. Test Lookup"
                 field(Field5_Desc; MatrixArrayConditionDescriptionCellData[5])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[5]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5.';
                     Visible = Visible5;
                     Editable = Editable5;
 
@@ -208,7 +208,7 @@ page 20445 "Qlty. Test Lookup"
                 field(Field6; MatrixArrayConditionCellData[6])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[6]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6.';
                     Visible = Visible6;
                     Editable = Editable6;
 
@@ -220,7 +220,7 @@ page 20445 "Qlty. Test Lookup"
                 field(Field6_Desc; MatrixArrayConditionDescriptionCellData[6])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[6]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6.';
                     Visible = Visible6;
                     Editable = Editable6;
 
@@ -232,7 +232,7 @@ page 20445 "Qlty. Test Lookup"
                 field(Field7; MatrixArrayConditionCellData[7])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[7]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7.';
                     Visible = Visible7;
                     Editable = Editable7;
 
@@ -244,7 +244,7 @@ page 20445 "Qlty. Test Lookup"
                 field(Field7_Desc; MatrixArrayConditionDescriptionCellData[7])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[7]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7.';
                     Visible = Visible7;
                     Editable = Editable7;
 
@@ -256,7 +256,7 @@ page 20445 "Qlty. Test Lookup"
                 field(Field8; MatrixArrayConditionCellData[8])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[8]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8.';
                     Visible = Visible8;
                     Editable = Editable8;
 
@@ -268,7 +268,7 @@ page 20445 "Qlty. Test Lookup"
                 field(Field8_Desc; MatrixArrayConditionDescriptionCellData[8])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[8]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8.';
                     Visible = Visible8;
                     Editable = Editable8;
 
@@ -280,7 +280,7 @@ page 20445 "Qlty. Test Lookup"
                 field(Field9; MatrixArrayConditionCellData[9])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[9]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9.';
                     Visible = Visible9;
                     Editable = Editable9;
 
@@ -292,7 +292,7 @@ page 20445 "Qlty. Test Lookup"
                 field(Field9_Desc; MatrixArrayConditionDescriptionCellData[9])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[9]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9.';
                     Visible = Visible9;
                     Editable = Editable9;
 
@@ -304,7 +304,7 @@ page 20445 "Qlty. Test Lookup"
                 field(Field10; MatrixArrayConditionCellData[10])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[10]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10.';
                     Visible = Visible10;
                     Editable = Editable10;
 
@@ -316,7 +316,7 @@ page 20445 "Qlty. Test Lookup"
                 field(Field10_Desc; MatrixArrayConditionDescriptionCellData[10])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[10]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10.';
                     Visible = Visible10;
                     Editable = Editable10;
 

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestLookup.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestLookup.Page.al
@@ -75,7 +75,7 @@ page 20445 "Qlty. Test Lookup"
                     AboutTitle = 'Result Condition Expression';
                     AboutText = 'The passing condition for this result. If you had a result of Pass being 80 to 100, you would then configure 80..100 here.';
                     Visible = Visible1;
-                    Editable = Visible1;
+                    Editable = Editable1;
 
                     trigger OnValidate()
                     begin
@@ -89,7 +89,7 @@ page 20445 "Qlty. Test Lookup"
                     AboutTitle = 'Result Condition Description';
                     AboutText = 'A description for people of this result condition. If you had a result of Pass being 80 to 100, you would put in text describing this. This text will be visible when recording inspections and will show up on the Certificate of Analysis.';
                     Visible = Visible1;
-                    Editable = Visible1;
+                    Editable = Editable1;
 
                     trigger OnValidate()
                     begin
@@ -103,7 +103,7 @@ page 20445 "Qlty. Test Lookup"
                     AboutTitle = 'Result Condition Expression';
                     AboutText = 'The passing condition for this result. If you had a result of Pass being 80 to 100, you would then configure 80..100 here.';
                     Visible = Visible2;
-                    Editable = Visible2;
+                    Editable = Editable2;
 
                     trigger OnValidate()
                     begin
@@ -117,7 +117,7 @@ page 20445 "Qlty. Test Lookup"
                     AboutTitle = 'Result Condition Description';
                     AboutText = 'A description for people of this result condition. If you had a result of Pass being 80 to 100, you would put in text describing this. This text will be visible when recording inspections and will show up on the Certificate of Analysis.';
                     Visible = Visible2;
-                    Editable = Visible2;
+                    Editable = Editable2;
 
                     trigger OnValidate()
                     begin
@@ -131,7 +131,7 @@ page 20445 "Qlty. Test Lookup"
                     AboutTitle = 'Result Condition Expression';
                     AboutText = 'The passing condition for this result. If you had a result of Pass being 80 to 100, you would then configure 80..100 here.';
                     Visible = Visible3;
-                    Editable = Visible3;
+                    Editable = Editable3;
 
                     trigger OnValidate()
                     begin
@@ -141,11 +141,11 @@ page 20445 "Qlty. Test Lookup"
                 field(Field3_Desc; MatrixArrayConditionDescriptionCellData[3])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[3]);
-                    Editable = true;
                     ToolTip = 'Specifies a description for people of this result condition. If you had a result of Pass being 80 to 100, you would put in text describing this. This text will be visible when recording inspections and will show up on the Certificate of Analysis.';
                     AboutTitle = 'Result Condition Description';
                     AboutText = 'A description for people of this result condition. If you had a result of Pass being 80 to 100, you would put in text describing this. This text will be visible when recording inspections and will show up on the Certificate of Analysis.';
                     Visible = Visible3;
+                    Editable = Editable3;
 
                     trigger OnValidate()
                     begin
@@ -157,7 +157,7 @@ page 20445 "Qlty. Test Lookup"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[4]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4';
                     Visible = Visible4;
-                    Editable = Visible4;
+                    Editable = Editable4;
 
                     trigger OnValidate()
                     begin
@@ -169,7 +169,7 @@ page 20445 "Qlty. Test Lookup"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[4]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4';
                     Visible = Visible4;
-                    Editable = Visible4;
+                    Editable = Editable4;
 
                     trigger OnValidate()
                     begin
@@ -181,7 +181,7 @@ page 20445 "Qlty. Test Lookup"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[5]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5';
                     Visible = Visible5;
-                    Editable = Visible5;
+                    Editable = Editable5;
 
                     trigger OnValidate()
                     begin
@@ -193,7 +193,7 @@ page 20445 "Qlty. Test Lookup"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[5]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5';
                     Visible = Visible5;
-                    Editable = Visible5;
+                    Editable = Editable5;
 
                     trigger OnValidate()
                     begin
@@ -205,7 +205,7 @@ page 20445 "Qlty. Test Lookup"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[6]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6';
                     Visible = Visible6;
-                    Editable = Visible6;
+                    Editable = Editable6;
 
                     trigger OnValidate()
                     begin
@@ -217,7 +217,7 @@ page 20445 "Qlty. Test Lookup"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[6]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6';
                     Visible = Visible6;
-                    Editable = Visible6;
+                    Editable = Editable6;
 
                     trigger OnValidate()
                     begin
@@ -229,7 +229,7 @@ page 20445 "Qlty. Test Lookup"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[7]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7';
                     Visible = Visible7;
-                    Editable = Visible7;
+                    Editable = Editable7;
 
                     trigger OnValidate()
                     begin
@@ -241,7 +241,7 @@ page 20445 "Qlty. Test Lookup"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[7]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7';
                     Visible = Visible7;
-                    Editable = Visible7;
+                    Editable = Editable7;
 
                     trigger OnValidate()
                     begin
@@ -253,7 +253,7 @@ page 20445 "Qlty. Test Lookup"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[8]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8';
                     Visible = Visible8;
-                    Editable = Visible8;
+                    Editable = Editable8;
 
                     trigger OnValidate()
                     begin
@@ -265,7 +265,7 @@ page 20445 "Qlty. Test Lookup"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[8]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8';
                     Visible = Visible8;
-                    Editable = Visible8;
+                    Editable = Editable8;
 
                     trigger OnValidate()
                     begin
@@ -277,7 +277,7 @@ page 20445 "Qlty. Test Lookup"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[9]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9';
                     Visible = Visible9;
-                    Editable = Visible9;
+                    Editable = Editable9;
 
                     trigger OnValidate()
                     begin
@@ -289,7 +289,7 @@ page 20445 "Qlty. Test Lookup"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[9]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9';
                     Visible = Visible9;
-                    Editable = Visible9;
+                    Editable = Editable9;
 
                     trigger OnValidate()
                     begin
@@ -301,7 +301,7 @@ page 20445 "Qlty. Test Lookup"
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[10]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10';
                     Visible = Visible10;
-                    Editable = Visible10;
+                    Editable = Editable10;
 
                     trigger OnValidate()
                     begin
@@ -313,7 +313,7 @@ page 20445 "Qlty. Test Lookup"
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[10]);
                     ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10';
                     Visible = Visible10;
-                    Editable = Visible10;
+                    Editable = Editable10;
 
                     trigger OnValidate()
                     begin
@@ -385,36 +385,17 @@ page 20445 "Qlty. Test Lookup"
         MatrixArrayConditionCellData: array[10] of Text;
         MatrixArrayConditionDescriptionCellData: array[10] of Text;
         MatrixArrayCaptionSet: array[10] of Text;
-        MatrixVisibleState: array[10] of Boolean;
-        Visible1: Boolean;
-        Visible2: Boolean;
-        Visible3: Boolean;
-        Visible4: Boolean;
-        Visible5: Boolean;
-        Visible6: Boolean;
-        Visible7: Boolean;
-        Visible8: Boolean;
-        Visible9: Boolean;
-        Visible10: Boolean;
+        Visible1, Visible2, Visible3, Visible4, Visible5, Visible6, Visible7, Visible8, Visible9, Visible10 : Boolean;
+        Editable1, Editable2, Editable3, Editable4, Editable5, Editable6, Editable7, Editable8, Editable9, Editable10 : Boolean;
         IsAllowableValuesEditable: Boolean;
         DescriptionLbl: Label '%1 Description', Comment = '%1 = Matrix field caption';
         ConditionLbl: Label '%1 Condition', Comment = '%1 = Matrix field caption';
 
-    trigger OnAfterGetRecord()
+    trigger OnOpenPage()
+    var
+        MatrixVisibleState: array[10] of Boolean;
     begin
-        UpdateRowData();
-    end;
-
-    trigger OnAfterGetCurrRecord()
-    begin
-        UpdateRowData();
-    end;
-
-    local procedure UpdateRowData()
-    begin
-        IsAllowableValuesEditable := not (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Table Lookup"]);
-
-        QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
+        QltyResultConditionMgmt.GetDefaultPromotedResults(true, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
         Visible1 := MatrixVisibleState[1];
         Visible2 := MatrixVisibleState[2];
         Visible3 := MatrixVisibleState[3];
@@ -425,6 +406,30 @@ page 20445 "Qlty. Test Lookup"
         Visible8 := MatrixVisibleState[8];
         Visible9 := MatrixVisibleState[9];
         Visible10 := MatrixVisibleState[10];
+    end;
+
+    trigger OnAfterGetRecord()
+    begin
+        UpdateRowData();
+    end;
+
+    local procedure UpdateRowData()
+    var
+        MatrixVisibleState: array[10] of Boolean;
+    begin
+        IsAllowableValuesEditable := not (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Table Lookup"]);
+
+        QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
+        Editable1 := Visible1 and MatrixVisibleState[1];
+        Editable2 := Visible2 and MatrixVisibleState[2];
+        Editable3 := Visible3 and MatrixVisibleState[3];
+        Editable4 := Visible4 and MatrixVisibleState[4];
+        Editable5 := Visible5 and MatrixVisibleState[5];
+        Editable6 := Visible6 and MatrixVisibleState[6];
+        Editable7 := Visible7 and MatrixVisibleState[7];
+        Editable8 := Visible8 and MatrixVisibleState[8];
+        Editable9 := Visible9 and MatrixVisibleState[9];
+        Editable10 := Visible10 and MatrixVisibleState[10];
     end;
 
     local procedure UpdateMatrixDataCondition(MatrixField: Integer)

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTests.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTests.Page.al
@@ -263,37 +263,15 @@ page 20401 "Qlty. Tests"
         MatrixArrayConditionCellData: array[10] of Text;
         MatrixArrayConditionDescriptionCellData: array[10] of Text;
         MatrixArrayCaptionSet: array[10] of Text;
-        MatrixVisibleState: array[10] of Boolean;
-        Visible1: Boolean;
-        Visible2: Boolean;
-        Visible3: Boolean;
-        Visible4: Boolean;
-        Visible5: Boolean;
-        Visible6: Boolean;
-        Visible7: Boolean;
-        Visible8: Boolean;
-        Visible9: Boolean;
-        Visible10: Boolean;
+        Visible1, Visible2, Visible3, Visible4, Visible5, Visible6, Visible7, Visible8, Visible9, Visible10 : Boolean;
         DescriptionLbl: Label '%1 Description', Comment = '%1 = Matrix field caption';
         ConditionLbl: Label '%1 Condition', Comment = '%1 = Matrix field caption';
 
     trigger OnOpenPage()
+    var
+        MatrixVisibleState: array[10] of Boolean;
     begin
-    end;
-
-    trigger OnAfterGetRecord()
-    begin
-        UpdateRowData();
-    end;
-
-    trigger OnAfterGetCurrRecord()
-    begin
-        UpdateRowData();
-    end;
-
-    local procedure UpdateRowData()
-    begin
-        QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
+        QltyResultConditionMgmt.GetDefaultPromotedResults(true, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
         Visible1 := MatrixVisibleState[1];
         Visible2 := MatrixVisibleState[2];
         Visible3 := MatrixVisibleState[3];
@@ -304,6 +282,18 @@ page 20401 "Qlty. Tests"
         Visible8 := MatrixVisibleState[8];
         Visible9 := MatrixVisibleState[9];
         Visible10 := MatrixVisibleState[10];
+    end;
+
+    trigger OnAfterGetRecord()
+    begin
+        UpdateRowData();
+    end;
+
+    local procedure UpdateRowData()
+    var
+        MatrixVisibleState: array[10] of Boolean;
+    begin
+        QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
     end;
 
     local procedure UpdateMatrixDataCondition(Matrix: Integer)

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTests.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTests.Page.al
@@ -291,9 +291,10 @@ page 20401 "Qlty. Tests"
 
     local procedure UpdateRowData()
     var
-        MatrixVisibleState: array[10] of Boolean;
+        DummyMatrixArrayCaptionSet: array[10] of Text;
+        DummyMatrixVisibleState: array[10] of Boolean;
     begin
-        QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
+        QltyResultConditionMgmt.GetPromotedResultsForTest(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, DummyMatrixArrayCaptionSet, DummyMatrixVisibleState);
     end;
 
     local procedure UpdateMatrixDataCondition(Matrix: Integer)

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTests.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTests.Page.al
@@ -100,85 +100,85 @@ page 20401 "Qlty. Tests"
                 field(Field4; MatrixArrayConditionCellData[4])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[4]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4.';
                     Visible = Visible4;
                 }
                 field(Field4_Desc; MatrixArrayConditionDescriptionCellData[4])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[4]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4.';
                     Visible = Visible4;
                 }
                 field(Field5; MatrixArrayConditionCellData[5])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[5]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5.';
                     Visible = Visible5;
                 }
                 field(Field5_Desc; MatrixArrayConditionDescriptionCellData[5])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[5]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5.';
                     Visible = Visible5;
                 }
                 field(Field6; MatrixArrayConditionCellData[6])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[6]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6.';
                     Visible = Visible6;
                 }
                 field(Field6_Desc; MatrixArrayConditionDescriptionCellData[6])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[6]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6.';
                     Visible = Visible6;
                 }
                 field(Field7; MatrixArrayConditionCellData[7])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[7]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7.';
                     Visible = Visible7;
                 }
                 field(Field7_Desc; MatrixArrayConditionDescriptionCellData[7])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[7]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7.';
                     Visible = Visible7;
                 }
                 field(Field8; MatrixArrayConditionCellData[8])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[8]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8.';
                     Visible = Visible8;
                 }
                 field(Field8_Desc; MatrixArrayConditionDescriptionCellData[8])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[8]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8.';
                     Visible = Visible8;
                 }
                 field(Field9; MatrixArrayConditionCellData[9])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[9]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9.';
                     Visible = Visible9;
                 }
                 field(Field9_Desc; MatrixArrayConditionDescriptionCellData[9])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[9]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9.';
                     Visible = Visible9;
                 }
                 field(Field10; MatrixArrayConditionCellData[10])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[10]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10.';
                     Visible = Visible10;
                 }
                 field(Field10_Desc; MatrixArrayConditionDescriptionCellData[10])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[10]);
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10.';
                     Visible = Visible10;
                 }
                 field("Lookup Table No."; Rec."Lookup Table No.")

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionSubform.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionSubform.Page.al
@@ -91,14 +91,14 @@ page 20407 "Qlty. Inspection Subform"
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[1]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 1';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 1.';
                     Visible = false;
                 }
                 field(Field1_Desc; MatrixArrayConditionDescriptionCellData[1])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[1]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 1';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 1.';
                     Visible = Visible1;
                 }
 
@@ -106,126 +106,126 @@ page 20407 "Qlty. Inspection Subform"
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[2]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 2';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 2.';
                     Visible = false;
                 }
                 field(Field2_Desc; MatrixArrayConditionDescriptionCellData[2])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[2]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 2';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 2.';
                     Visible = Visible2;
                 }
                 field(Field3; MatrixArrayConditionCellData[3])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[3]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 3';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 3.';
                     Visible = false;
                 }
                 field(Field3_Desc; MatrixArrayConditionDescriptionCellData[3])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[3]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 3';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 3.';
                     Visible = Visible3;
                 }
                 field(Field4; MatrixArrayConditionCellData[4])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[4]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4.';
                     Visible = false;
                 }
                 field(Field4_Desc; MatrixArrayConditionDescriptionCellData[4])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[4]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 4.';
                     Visible = Visible4;
                 }
                 field(Field5; MatrixArrayConditionCellData[5])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[5]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5.';
                     Visible = false;
                 }
                 field(Field5_Desc; MatrixArrayConditionDescriptionCellData[5])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[5]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 5.';
                     Visible = Visible5;
                 }
                 field(Field6; MatrixArrayConditionCellData[6])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[6]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6.';
                     Visible = false;
                 }
                 field(Field6_Desc; MatrixArrayConditionDescriptionCellData[6])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[6]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 6.';
                     Visible = Visible6;
                 }
                 field(Field7; MatrixArrayConditionCellData[7])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[7]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7.';
                     Visible = false;
                 }
                 field(Field7_Desc; MatrixArrayConditionDescriptionCellData[7])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[7]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 7.';
                     Visible = Visible7;
                 }
                 field(Field8; MatrixArrayConditionCellData[8])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[8]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8.';
                     Visible = false;
                 }
                 field(Field8_Desc; MatrixArrayConditionDescriptionCellData[8])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[8]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 8.';
                     Visible = Visible8;
                 }
                 field(Field9; MatrixArrayConditionCellData[9])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[9]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9.';
                     Visible = false;
                 }
                 field(Field9_Desc; MatrixArrayConditionDescriptionCellData[9])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[9]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 9.';
                     Visible = Visible9;
                 }
                 field(Field10; MatrixArrayConditionCellData[10])
                 {
                     CaptionClass = '3,' + StrSubstNo(ConditionLbl, MatrixArrayCaptionSet[10]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10.';
                     Visible = false;
                 }
                 field(Field10_Desc; MatrixArrayConditionDescriptionCellData[10])
                 {
                     CaptionClass = '3,' + StrSubstNo(DescriptionLbl, MatrixArrayCaptionSet[10]);
                     Editable = false;
-                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10';
+                    ToolTip = 'Specifies a test condition for a promoted result. This is dynamic based on the promoted results, this is result condition 10.';
                     Visible = Visible10;
                 }
                 field("Result Code"; Rec."Result Code")

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionSubform.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionSubform.Page.al
@@ -343,7 +343,8 @@ page 20407 "Qlty. Inspection Subform"
 
     local procedure UpdateRowData()
     var
-        MatrixVisibleState: array[10] of Boolean;
+        DummyMatrixArrayCaptionSet: array[10] of Text;
+        DummyMatrixVisibleState: array[10] of Boolean;
         Index: Integer;
     begin
         MeasurementNote := Rec.GetMeasurementNote();
@@ -361,7 +362,7 @@ page 20407 "Qlty. Inspection Subform"
             exit;
         end;
 
-        QltyResultConditionMgmt.GetPromotedResultsForInspectionLine(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
+        QltyResultConditionMgmt.GetPromotedResultsForInspectionLine(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, DummyMatrixArrayCaptionSet, DummyMatrixVisibleState);
     end;
 
     local procedure GetCanEditTestValue() Result: Boolean

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionSubform.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionSubform.Page.al
@@ -272,25 +272,14 @@ page 20407 "Qlty. Inspection Subform"
     }
 
     var
-        CachedReadOnlyQltyInspectionHeader: Record "Qlty. Inspection Header";
         QltyResultConditionMgmt: Codeunit "Qlty. Result Condition Mgmt.";
         QltyPermissionMgmt: Codeunit "Qlty. Permission Mgmt.";
         MatrixSourceRecordId: array[10] of RecordId;
         MatrixArrayConditionCellData: array[10] of Text;
         MatrixArrayConditionDescriptionCellData: array[10] of Text;
         MatrixArrayCaptionSet: array[10] of Text;
-        MatrixVisibleState: array[10] of Boolean;
         CanEditTestValue: Boolean;
-        Visible1: Boolean;
-        Visible2: Boolean;
-        Visible3: Boolean;
-        Visible4: Boolean;
-        Visible5: Boolean;
-        Visible6: Boolean;
-        Visible7: Boolean;
-        Visible8: Boolean;
-        Visible9: Boolean;
-        Visible10: Boolean;
+        Visible1, Visible2, Visible3, Visible4, Visible5, Visible6, Visible7, Visible8, Visible9, Visible10 : Boolean;
         CanEditLineNotes: Boolean;
         ShowUnitOfMeasure: Boolean;
         ResultStyleExpr: Text;
@@ -302,8 +291,22 @@ page 20407 "Qlty. Inspection Subform"
         ConditionLbl: Label '%1 Condition', Comment = '%1 = Matrix field caption';
 
     trigger OnOpenPage()
+    var
+        MatrixVisibleState: array[10] of Boolean;
     begin
         CanEditLineNotes := QltyPermissionMgmt.CanEditLineComments() and CurrPage.Editable();
+
+        QltyResultConditionMgmt.GetDefaultPromotedResults(true, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
+        Visible1 := MatrixVisibleState[1];
+        Visible2 := MatrixVisibleState[2];
+        Visible3 := MatrixVisibleState[3];
+        Visible4 := MatrixVisibleState[4];
+        Visible5 := MatrixVisibleState[5];
+        Visible6 := MatrixVisibleState[6];
+        Visible7 := MatrixVisibleState[7];
+        Visible8 := MatrixVisibleState[8];
+        Visible9 := MatrixVisibleState[9];
+        Visible10 := MatrixVisibleState[10];
     end;
 
     trigger OnFindRecord(Which: Text): Boolean
@@ -336,33 +339,29 @@ page 20407 "Qlty. Inspection Subform"
         QltySessionHelper: Codeunit "Qlty. Session Helper";
     begin
         QltySessionHelper.SetSessionValue(CurrentSelectedInspectionLineTok, Format(Rec.RecordId()));
-        UpdateRowData();
     end;
 
     local procedure UpdateRowData()
+    var
+        MatrixVisibleState: array[10] of Boolean;
+        Index: Integer;
     begin
         MeasurementNote := Rec.GetMeasurementNote();
-
-        if (CachedReadOnlyQltyInspectionHeader."No." <> Rec."Inspection No.") or (CachedReadOnlyQltyInspectionHeader."Re-inspection No." <> CachedReadOnlyQltyInspectionHeader."Re-inspection No.") then begin
-            CachedReadOnlyQltyInspectionHeader.ReadIsolation(IsolationLevel::ReadUncommitted);
-            if CachedReadOnlyQltyInspectionHeader.Get(Rec."Inspection No.", Rec."Re-inspection No.") then;
-        end;
 
         Rec.CalcFields("Test Value Type");
         CanEditTestValue := GetCanEditTestValue();
 
-        QltyResultConditionMgmt.GetPromotedResultsForInspectionLine(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
+        if Rec."Test Value Type" = Rec."Test Value Type"::"Value Type Label" then begin
+            // Preserve page-wide captions; only clear per-row data for label rows.
+            for Index := 1 to ArrayLen(MatrixArrayConditionCellData) do begin
+                Clear(MatrixSourceRecordId[Index]);
+                Clear(MatrixArrayConditionCellData[Index]);
+                Clear(MatrixArrayConditionDescriptionCellData[Index]);
+            end;
+            exit;
+        end;
 
-        Visible1 := MatrixVisibleState[1];
-        Visible2 := MatrixVisibleState[2];
-        Visible3 := MatrixVisibleState[3];
-        Visible4 := MatrixVisibleState[4];
-        Visible5 := MatrixVisibleState[5];
-        Visible6 := MatrixVisibleState[6];
-        Visible7 := MatrixVisibleState[7];
-        Visible8 := MatrixVisibleState[8];
-        Visible9 := MatrixVisibleState[9];
-        Visible10 := MatrixVisibleState[10];
+        QltyResultConditionMgmt.GetPromotedResultsForInspectionLine(Rec, MatrixSourceRecordId, MatrixArrayConditionCellData, MatrixArrayConditionDescriptionCellData, MatrixArrayCaptionSet, MatrixVisibleState);
     end;
 
     local procedure GetCanEditTestValue() Result: Boolean

--- a/src/Apps/W1/Quality Management/app/src/Integration/Manufacturing/QltyProdGenRuleSGuide.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Manufacturing/QltyProdGenRuleSGuide.Page.al
@@ -597,7 +597,6 @@ page 20462 "Qlty. Prod. Gen. Rule S. Guide"
     end;
 
     local procedure NextAction();
-
     begin
         CurrPage.Update(true);
         ChangeToStep(CurrentStepCounter + 1);


### PR DESCRIPTION
## What & why
Fixes issue "Conditions disappears from the template once user selected new test of type Label" and related issues of UI inconsistency.

Fixes:
 - For list pages, set visibility and captions in OnOpenPage
 - Remove cached records that were not used
 - Remove redundant calls, like repeated calls in OnAfterGetCurrRecord
 - Improve condition visibility consistency after changing promoted Results

## Linked work

Fixes [AB#622771](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622771)
Fixes [AB#622770](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622770)






