### PR TITLE
[Quality Management] Fix init values in the test conditions if there are two or more promoted quality results

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultConditionMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultConditionMgmt.Codeunit.al
@@ -347,7 +347,7 @@ codeunit 20409 "Qlty. Result Condition Mgmt."
                     ToTestQltyIResultConditConf."Condition Description" := CopyStr(Condition, 1, MaxStrLen(ToTestQltyIResultConditConf."Condition Description"));
                     ToTestQltyIResultConditConf.Insert();
                 end else
-                    if AlwaysUpdateExistingCondition or (OnlyOverwriteIfADefaultCondition and (ToTestQltyIResultConditConf.Condition in [QltyInspectionResult."Default Boolean Condition", QltyInspectionResult."Default Number Condition", QltyInspectionResult."Default Text Condition"])) then begin
+                    if AlwaysUpdateExistingCondition or (OnlyOverwriteIfADefaultCondition and (ToTestQltyIResultConditConf.Condition in ['', QltyInspectionResult."Default Boolean Condition", QltyInspectionResult."Default Number Condition", QltyInspectionResult."Default Text Condition"])) then begin
                         ToTestQltyIResultConditConf.Validate(Condition, CopyStr(Condition, 1, MaxStrLen(ToTestQltyIResultConditConf.Condition)));
                         ToTestQltyIResultConditConf."Condition Description" := CopyStr(Condition, 1, MaxStrLen(ToTestQltyIResultConditConf."Condition Description"));
                         ToTestQltyIResultConditConf.Priority := QltyInspectionResult."Evaluation Sequence";

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultConditionMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultConditionMgmt.Codeunit.al
@@ -347,7 +347,14 @@ codeunit 20409 "Qlty. Result Condition Mgmt."
                     ToTestQltyIResultConditConf."Condition Description" := CopyStr(Condition, 1, MaxStrLen(ToTestQltyIResultConditConf."Condition Description"));
                     ToTestQltyIResultConditConf.Insert();
                 end else
-                    if AlwaysUpdateExistingCondition or (OnlyOverwriteIfADefaultCondition and (ToTestQltyIResultConditConf.Condition in ['', QltyInspectionResult."Default Boolean Condition", QltyInspectionResult."Default Number Condition", QltyInspectionResult."Default Text Condition"])) then begin
+                    if AlwaysUpdateExistingCondition or
+                       (OnlyOverwriteIfADefaultCondition and
+                            (ToTestQltyIResultConditConf.Condition in
+                                ['', // '' treated as uninitialized; safe to overwrite just like named defaults
+                                QltyInspectionResult."Default Boolean Condition",
+                                QltyInspectionResult."Default Number Condition",
+                                QltyInspectionResult."Default Text Condition"]))
+                    then begin
                         ToTestQltyIResultConditConf.Validate(Condition, CopyStr(Condition, 1, MaxStrLen(ToTestQltyIResultConditConf.Condition)));
                         ToTestQltyIResultConditConf."Condition Description" := CopyStr(Condition, 1, MaxStrLen(ToTestQltyIResultConditConf."Condition Description"));
                         ToTestQltyIResultConditConf.Priority := QltyInspectionResult."Evaluation Sequence";


### PR DESCRIPTION
## What & why

Handle default condition in Test for blank value

## Linked work

Fixes [AB#622769](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622769)
