### PR TITLE
Skip Copilot PR review for business-central-bot PRs

### DIFF
--- a/.github/workflows/CopilotPRReview.yaml
+++ b/.github/workflows/CopilotPRReview.yaml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   intake:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'business-central-bot[bot]'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary
- skip Copilot PR review intake when PR author is business-central-bot[bot]
- prevent downstream review runner from triggering for bot-authored PRs

## Validation
- verified workflow file parses without errors
Fixes [AB#636195](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636195)
