### PR TITLE
[releases/28.x] [MCP] Loosen API page restriction beyond APIV2

### DIFF
--- a/src/System Application/App/MCP/src/Configuration/Codeunits/MCPConfigImplementation.Codeunit.al
+++ b/src/System Application/App/MCP/src/Configuration/Codeunits/MCPConfigImplementation.Codeunit.al
@@ -26,7 +26,7 @@ codeunit 8351 "MCP Config Implementation"
         ToolsCannotBeAddedToDefaultConfigErr: Label 'Tools cannot be added to the default configuration.';
         PageNotFoundErr: Label 'Page not found.';
         InvalidPageTypeErr: Label 'Only API pages are supported.';
-        InvalidAPIVersionErr: Label 'Only API v2.0 pages are supported.';
+        APIToolNotSupportedErr: Label 'This API page is not available for MCP configuration.';
         DefaultMCPConfigurationDescriptionLbl: Label 'Default MCP configuration';
         DynamicToolModeRequiredErr: Label 'Dynamic tool mode needs to be enabled to discover read-only objects.';
         VersionNotValidErr: Label 'The API version is not valid for the selected tool.';
@@ -470,8 +470,8 @@ codeunit 8351 "MCP Config Implementation"
         MCPAPIConfigToolLookup: Page "MCP API Config Tool Lookup";
     begin
         PageMetadata.SetRange(PageType, PageMetadata.PageType::API);
-        PageMetadata.SetFilter(APIPublisher, '<>%1', 'microsoft');
         PageMetadata.SetFilter("AL Namespace", '<>%1', 'Microsoft.API.V1');
+        PageMetadata.SetFilter(APIVersion, '<>%1', 'beta');
 
         MCPAPIConfigToolLookup.LookupMode := true;
         MCPAPIConfigToolLookup.SetTableView(PageMetadata);
@@ -488,7 +488,10 @@ codeunit 8351 "MCP Config Implementation"
     begin
         PageMetadata.SetLoadFields(PageType, APIPublisher, APIGroup);
         PageMetadata.SetRange(PageType, PageMetadata.PageType::API);
-        PageMetadata.SetFilter(APIPublisher, '<>%1&<>%2', '', 'microsoft');
+        PageMetadata.SetFilter(APIPublisher, '<>%1', '');
+        PageMetadata.SetFilter("AL Namespace", '<>%1', 'Microsoft.API.V1');
+        PageMetadata.SetFilter(APIVersion, '<>%1', 'beta');
+
         if not PageMetadata.FindSet() then
             exit;
 
@@ -532,11 +535,11 @@ codeunit 8351 "MCP Config Implementation"
         if not ValidateAPIPublisher then
             exit(PageMetadata);
 
-        if PageMetadata.APIPublisher = 'microsoft' then
-            Error(InvalidAPIVersionErr);
-
         if PageMetadata."AL Namespace" = 'Microsoft.API.V1' then
-            Error(InvalidAPIVersionErr);
+            Error(APIToolNotSupportedErr);
+
+        if PageMetadata.APIVersion = 'beta' then
+            Error(APIToolNotSupportedErr);
 
         exit(PageMetadata);
     end;
@@ -558,12 +561,12 @@ codeunit 8351 "MCP Config Implementation"
         if (APIGroup = '') or (APIPublisher = '') then
             exit;
 
-        if APIPublisher = 'microsoft' then
-            exit;
-
         PageMetadata.SetRange(PageType, PageMetadata.PageType::API);
         PageMetadata.SetFilter(APIPublisher, APIPublisher);
         PageMetadata.SetFilter(APIGroup, APIGroup);
+        PageMetadata.SetFilter("AL Namespace", '<>%1', 'Microsoft.API.V1');
+        PageMetadata.SetFilter(APIVersion, '<>%1', 'beta');
+
         if not PageMetadata.FindSet() then
             exit;
 


### PR DESCRIPTION
## Summary
Backport of bug #631961 to releases/28.x.

Fixes [AB#636235](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636235)

Original PR: #7726

