### PR TITLE
[28.x] Add Query procedure to Activity Log Builder

### DIFF
--- a/src/System Application/App/ActivityLog/src/ActivityLogBuilder.Codeunit.al
+++ b/src/System Application/App/ActivityLog/src/ActivityLogBuilder.Codeunit.al
@@ -99,4 +99,13 @@ codeunit 3111 "Activity Log Builder"
         ActivityLogBuilderImpl.Log();
     end;
 
+    /// <summary>
+    /// Retrieves the activity log entries for the specified table and system identifier as a JSON string.
+    /// </summary>
+    [Scope('OnPrem')]
+    procedure Query(TableNo: Integer; RecSystemId: Guid): Text
+    begin
+        exit(ActivityLogBuilderImpl.Query(TableNo, RecSystemId));
+    end;
+
 }

--- a/src/System Application/App/ActivityLog/src/ActivityLogBuilderImpl.Codeunit.al
+++ b/src/System Application/App/ActivityLog/src/ActivityLogBuilderImpl.Codeunit.al
@@ -76,4 +76,11 @@ codeunit 3112 "Activity Log Builder Impl."
         LogEntry.Log();
     end;
 
+    procedure Query(TableNo: Integer; RecSystemId: Guid): Text
+    var
+        QueryEntry: DotNet ActivityLogEntry;
+    begin
+        exit(QueryEntry.Query(TableNo, RecSystemId));
+    end;
+
 }


### PR DESCRIPTION
Backport of #8266 to `releases/28.x`.

## Summary

- Surfaces `ALActivityLogEntry.Query(tableId, systemId)` through the AL DotNet interop layer
- Adds `Query(TableNo: Integer; RecSystemId: Guid): Text` to `Activity Log Builder` (codeunit 3111) and `Activity Log Builder Impl.` (codeunit 3112)
- Delegates to the existing static .NET method via `DotNet ActivityLogEntry`, matching the pattern already used by `Create`

Fixes Bug [AB#636240](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636240)

[AB#636240](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636240)

