### PR TITLE
Delete linked Error Message with E-Document

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Document/EDocument.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Document/EDocument.Table.al
@@ -420,11 +420,14 @@ table 6121 "E-Document"
 #if not CLEAN27
         PurchaseHeader: Record "Purchase Header";
 #endif
+        EDocumentErrorHelper: Codeunit "E-Document Error Helper";
         IProcessStructuredData: Interface IProcessStructuredData;
 #if not CLEAN27
         NullGuid: Guid;
 #endif
     begin
+        EDocumentErrorHelper.ClearErrorMessages(Rec);
+
         EDocumentLog.SetRange("E-Doc. Entry No", Rec."Entry No");
         if not EDocumentLog.IsEmpty() then
             EDocumentLog.DeleteAll(true);


### PR DESCRIPTION
## What & why

This change fixes the issue of linked **Error Messages** not being deleted from the database along with the **E-Document**.

## Linked work

Fixes #8208 

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Manually ran the case described in the issue:
1. Manually uploaded an E-Document that generated an error.
2. Manually deleted the E-Document.
3. Verified that linked entries were also deleted from the Error Message table.

## Risk & compatibility

None.

Fixes [AB#636339](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636339)
