### PR TITLE
(Bug 635844): [Subcontracting] SubcTransferLine "Work Center No." OnValidate overwrites Gen. Prod. Posting Group — dead code that is potentially dangerous

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Tableextensions/Transfer/SubcTransferLine.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Tableextensions/Transfer/SubcTransferLine.TableExt.al
@@ -74,16 +74,6 @@ tableextension 99001517 "Subc. Transfer Line" extends "Transfer Line"
             DataClassification = CustomerContent;
             TableRelation = "Work Center";
             ToolTip = 'Specifies the number of the related production work center.';
-            trigger OnValidate()
-            var
-                WorkCenter: Record "Work Center";
-            begin
-                if "Subc. Work Center No." = '' then
-                    exit;
-
-                WorkCenter.Get("Subc. Work Center No.");
-                "Gen. Prod. Posting Group" := WorkCenter."Gen. Prod. Posting Group";
-            end;
         }
         field(99001538; "Subc. Operation No."; Code[10])
         {


### PR DESCRIPTION
## Summary

Removes a dormant `OnValidate` trigger on `"Subc. Work Center No."` (field 99001537) in `SubcTransferLine.TableExt.al` that would silently overwrite the transfer line's `"Gen. Prod. Posting Group"` with the Work Center's posting group if ever invoked via `Validate(...)`.

## Problem

The trigger:

```al
trigger OnValidate()
var
    WorkCenter: Record "Work Center";
begin
    if "Subc. Work Center No." = '' then
        exit;
    WorkCenter.Get("Subc. Work Center No.");
    "Gen. Prod. Posting Group" := WorkCenter."Gen. Prod. Posting Group";
end;
```

- Is **dead code today** — every caller in the codebase assigns the field with `:=`, never `Validate(...)`, and the page field is `Editable = false`/`Visible = false`.
- Is **a latent footgun** — on a standard transfer flow `"Gen. Prod. Posting Group"` is correctly populated from the **Item card** via `Validate("Item No.")` in BaseApp's `TransferLine`. The first caller who writes `Validate("Subc. Work Center No.", ...)` would silently replace the Item's posting group with the Work Center's, producing wrong G/L entries on transfer posting with no error.

`"Subc. Work Center No."` on the transfer line is purely informational/traceability — it is propagated as-is into posted shipment/receipt/direct-transfer lines and into `SubcontractorWIPLedgerEntry`, but never participates in calculations, filtering on transfer lines, or G/L posting logic.

## Fix

Delete the body of the `OnValidate` trigger. The field definition (caption, table relation, tooltip) is unchanged.

## Verification

- Searched all references to `"Subc. Work Center No."` across `App/` and `Test/`: every write uses `:=`; no `Validate("Subc. Work Center No.", ...)` exists anywhere.
- Page field on `SubcTransOrderSub.PageExt.al` is `Editable = false` and `Visible = false` — no UI trigger path.
- No existing test exercised the trigger, so no test regressions are expected.

## Risk

Minimal. The trigger never executes today, so behavior on existing flows is unchanged. The change eliminates a future correctness risk for G/L posting.

Fixes [AB#635844](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/635844)
