### PR TITLE
(Bug 635870): [Subcontracting] Rename "Subcontracting Inbound Whse. Handling Time" to "Subcontracting Component Transfer Lead Time"

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Install/SubcontractingCompInit.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Install/SubcontractingCompInit.Codeunit.al
@@ -14,7 +14,7 @@ codeunit 99001503 "Subcontracting Comp. Init."
         ReqWkshTempNameLbl: Label 'SUBCONTR', MaxLength = 10;
         ReqWkshDescLbl: Label 'Subcontracting', MaxLength = 100;
         ReqWkshNameLbl: Label 'SUBCONTR', MaxLength = 10;
-        DefaultInboundWhseHandlingTimeLbl: Label '<1D>', Locked = true;
+        DefaultCompTransferLeadTimeLbl: Label '<1D>', Locked = true;
 
     procedure CreateBasicSubcontractingMgtSetup()
     begin
@@ -34,7 +34,7 @@ codeunit 99001503 "Subcontracting Comp. Init."
             exit;
 
         ManufacturingSetup."Create Prod. Order Info Line" := true;
-        Evaluate(ManufacturingSetup."Subc. Inb. Whse. Handling Time", GetDefaultInboundWhseHandlingTime());
+        Evaluate(ManufacturingSetup."Subc. Comp. Transfer Lead Time", GetDefaultCompTransferLeadTime());
         ManufacturingSetup.Modify(true);
     end;
 
@@ -81,8 +81,8 @@ codeunit 99001503 "Subcontracting Comp. Init."
         RequisitionWkshName.Insert(true);
     end;
 
-    local procedure GetDefaultInboundWhseHandlingTime(): Text
+    local procedure GetDefaultCompTransferLeadTime(): Text
     begin
-        exit(DefaultInboundWhseHandlingTimeLbl);
+        exit(DefaultCompTransferLeadTimeLbl);
     end;
 }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcontractingManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcontractingManagement.Codeunit.al
@@ -34,13 +34,13 @@ codeunit 99001505 "Subcontracting Management"
         PurchOrderExistErr: Label 'The currently selected component %1 is already used in Purchase Order %2. Therefore, it is not permitted to change the %3 field.', Comment = '%1=Item No, %2=Purchase Order No, %3=Field Caption';
         HasManufacturingSetup: Boolean;
 
-    procedure CalcReceiptDateFromProdCompDueDateWithInbWhseHandlingTime(ProdOrderComponent: Record "Prod. Order Component") ReceiptDate: Date
+    procedure CalcReceiptDateFromProdCompDueDateWithCompTransferLeadTime(ProdOrderComponent: Record "Prod. Order Component") ReceiptDate: Date
     begin
         GetManufacturingSetup();
-        if not HasManufacturingSetup or (Format(ManufacturingSetup."Subc. Inb. Whse. Handling Time") = '') then
+        if not HasManufacturingSetup or (Format(ManufacturingSetup."Subc. Comp. Transfer Lead Time") = '') then
             exit(ProdOrderComponent."Due Date");
 
-        ReceiptDate := CalcDate('-' + Format(ManufacturingSetup."Subc. Inb. Whse. Handling Time"), ProdOrderComponent."Due Date");
+        ReceiptDate := CalcDate('-' + Format(ManufacturingSetup."Subc. Comp. Transfer Lead Time"), ProdOrderComponent."Due Date");
 
         exit(ReceiptDate);
     end;

--- a/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcCreateTransfOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcCreateTransfOrder.Report.al
@@ -211,7 +211,7 @@ report 99001501 "Subc. Create Transf. Order"
                         TransferLine.Validate(Quantity, Round(QtyToPost / ProdOrderComponent."Qty. per Unit of Measure", Item."Rounding Precision", '>'));
 
                         if ProdOrderComponent."Due Date" <> 0D then
-                            TransferLine.Validate("Receipt Date", SubcontractingManagement.CalcReceiptDateFromProdCompDueDateWithInbWhseHandlingTime(ProdOrderComponent));
+                            TransferLine.Validate("Receipt Date", SubcontractingManagement.CalcReceiptDateFromProdCompDueDateWithCompTransferLeadTime(ProdOrderComponent));
 
                         TransferLine."Subc. Purch. Order No." := PurchaseLine."Document No.";
                         TransferLine."Subc. Purch. Order Line No." := PurchaseLine."Line No.";

--- a/src/Apps/W1/Subcontracting/App/src/Setup/Pages/SubcManufacturingSetup.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Setup/Pages/SubcManufacturingSetup.PageExt.al
@@ -24,10 +24,10 @@ pageextension 99001542 "Subc. Manufacturing Setup" extends "Manufacturing Setup"
                         ApplicationArea = Manufacturing;
                         ToolTip = 'Specifies whether an additional Information Line of the Production Order Line will be created in a Subcontracting Purchase Order.';
                     }
-                    field("Subc. Inb. Whse. Handling Time"; Rec."Subc. Inb. Whse. Handling Time")
+                    field("Subc. Comp. Transfer Lead Time"; Rec."Subc. Comp. Transfer Lead Time")
                     {
                         ApplicationArea = Manufacturing;
-                        ToolTip = 'Specifies the time to calculate the Receipt Date in Transfer Line. The calculation will be Due Date from Prod. Order Component minus the entered date formula.';
+                        ToolTip = 'Specifies the lead time for transferring components to the subcontractor. This time is subtracted from the production component due date to calculate the transfer order receipt date.';
                     }
                     field("Subcontracting Template Name"; Rec."Subcontracting Template Name")
                     {

--- a/src/Apps/W1/Subcontracting/App/src/Setup/Tables/SubcManufacturingSetup.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Setup/Tables/SubcManufacturingSetup.TableExt.al
@@ -45,9 +45,9 @@ tableextension 99001501 "Subc. Manufacturing Setup" extends "Manufacturing Setup
             OptionCaption = 'Standard,Prod. Order Component';
             OptionMembers = Standard,"Prod. Order Component";
         }
-        field(99001505; "Subc. Inb. Whse. Handling Time"; DateFormula)
+        field(99001505; "Subc. Comp. Transfer Lead Time"; DateFormula)
         {
-            Caption = 'Subcontracting Inbound Whse. Handling Time';
+            Caption = 'Subcontracting Component Transfer Lead Time';
             DataClassification = CustomerContent;
         }
         field(99001509; "Subc. Default Comp. Location"; Enum "Components at Location")

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -1273,7 +1273,7 @@ codeunit 139989 "Subc. Subcontracting Test"
 
         ManufacturingSetup.Get();
 
-        ExpectedDate := CalcDate(ManufacturingSetup."Subc. Inb. Whse. Handling Time", TransferLine."Receipt Date");
+        ExpectedDate := CalcDate(ManufacturingSetup."Subc. Comp. Transfer Lead Time", TransferLine."Receipt Date");
 
         Assert.AreEqual(ExpectedDate, ProdOrderComp."Due Date", '');
 
@@ -3311,7 +3311,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         ManufacturingSetup: Record "Manufacturing Setup";
     begin
         ManufacturingSetup.Get();
-        Evaluate(ManufacturingSetup."Subc. Inb. Whse. Handling Time", '<1D>');
+        Evaluate(ManufacturingSetup."Subc. Comp. Transfer Lead Time", '<1D>');
         ManufacturingSetup.Modify();
     end;
 


### PR DESCRIPTION
Fixes [AB#635870](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/635870)

## Summary
Renames Manufacturing Setup field `99001505` (owned by the Subcontracting app) to remove misleading terminology borrowed from the base Location Card field "Inbound Whse. Handling Time". The Subcontracting field has fundamentally different semantics — it is a **backward**-calculated planning lead time subtracted from the prod-order component due date to schedule transfer-order arrival at the subcontractor, not a forward-calculated put-away time.

## Why the old name was wrong
- **False cognate** with the base-app Location Card field, which is forward-calculated.
- **"Inbound" is the wrong direction** from the user''s perspective — components travel outbound from the company''s warehouse to the subcontractor.
- **"Whse. Handling Time"** implies put-away/processing, but the value is a planning buffer.

## Changes
Manufacturing Setup field 99001505:

| | Before | After |
|---|---|---|
| Identifier | `"Subc. Inb. Whse. Handling Time"` | `"Subc. Comp. Transfer Lead Time"` (30 chars) |
| Caption | `Subcontracting Inbound Whse. Handling Time` | `Subcontracting Component Transfer Lead Time` |
| ToolTip | "Specifies the time to calculate the Receipt Date in Transfer Line…" | "Specifies the lead time for transferring components to the subcontractor. This time is subtracted from the production component due date to calculate the transfer order receipt date." |

Public API in `codeunit 99001505 "Subcontracting Management"`:
- `CalcReceiptDateFromProdCompDueDateWithInbWhseHandlingTime` → `CalcReceiptDateFromProdCompDueDateWithCompTransferLeadTime`

Internal helpers in `codeunit "Subcontracting Comp. Init."` renamed for consistency:
- `DefaultInboundWhseHandlingTimeLbl` → `DefaultCompTransferLeadTimeLbl`
- `GetDefaultInboundWhseHandlingTime` → `GetDefaultCompTransferLeadTime`

## Files touched
- `App/src/Setup/Tables/SubcManufacturingSetup.TableExt.al`
- `App/src/Setup/Pages/SubcManufacturingSetup.PageExt.al`
- `App/src/Process/Codeunits/SubcontractingManagement.Codeunit.al`
- `App/src/Process/Reports/SubcCreateTransfOrder.Report.al`
- `App/src/Install/SubcontractingCompInit.Codeunit.al`
- `Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al`

## Compatibility
Breaking change for any extension binding to the old field identifier or the renamed public procedure. Acceptable because the Subcontracting app is a not-yet-released feature.

## Related
Part of the broader Subcontracting terminology cleanup alongside bug 633674 (Subcontracting Type → Component Supply Method, Transfer → Transfer to Vendor).



