### PR TITLE
Add the ability in the Email Module to store Message Headers

### DIFF
--- a/src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al
+++ b/src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al
@@ -67,6 +67,10 @@ table 8885 "Email Retrieval Filters"
             InitValue = "Include";
             Caption = 'Category Filter Type';
         }
+        field(11; "Load Headers"; Boolean)
+        {
+            Caption = 'Load Headers';
+        }
     }
 
     keys

--- a/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
@@ -236,9 +236,9 @@ codeunit 8904 "Email Message"
     /// <returns><c>true</c> when a value was found.</returns>
     /// <remarks>Reads include any unflushed mutations issued via <see cref="AddHeader"/> or
     /// <see cref="SetHeader"/> on this codeunit instance.</remarks>
-    procedure TryGetHeader(HeaderName: Text; var Value: Text): Boolean
+    procedure GetHeader(HeaderName: Text; var Value: Text): Boolean
     begin
-        exit(EmailMessageImpl.TryGetHeader(HeaderName, Value));
+        exit(EmailMessageImpl.GetHeader(HeaderName, Value));
     end;
 
     /// <summary>

--- a/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
@@ -198,21 +198,36 @@ codeunit 8904 "Email Message"
     end;
 
     /// <summary>
-    /// Writes the supplied headers as JSON into the currently loaded message.
+    /// Adds a header to the currently loaded message. If a header with the same name is already
+    /// present, the new value is appended after a line feed (#10) so the full sequence is
+    /// preserved -- useful for headers that legitimately repeat (e.g. <c>Received</c>).
     /// </summary>
-    /// <param name="HeadersJson">Headers as a JSON object. Callers should lowercase header names and
-    /// concatenate multi-value headers with a line feed (#10) for consistency across connectors.
-    /// An empty object clears the stored headers.</param>
+    /// <param name="HeaderName">Header name. Lookups are case-insensitive; the stored name is
+    /// normalized to lowercase by the module.</param>
+    /// <param name="HeaderValue">Header value to append.</param>
     /// <remarks>Intended for connectors that retrieve RFC822-style headers from their provider
     /// (e.g. the Outlook REST API connector reading <c>internetMessageHeaders</c> from Graph).</remarks>
-    procedure SetHeaders(HeadersJson: JsonObject)
+    procedure AddHeader(HeaderName: Text; HeaderValue: Text)
     begin
-        EmailMessageImpl.SetHeaders(HeadersJson);
+        EmailMessageImpl.AddHeader(HeaderName, HeaderValue);
+    end;
+
+    /// <summary>
+    /// Sets a header on the currently loaded message, replacing any existing value for the same
+    /// name. Use <see cref="AddHeader"/> when repeated headers should accumulate.
+    /// </summary>
+    /// <param name="HeaderName">Header name. Lookups are case-insensitive; the stored name is
+    /// normalized to lowercase by the module.</param>
+    /// <param name="HeaderValue">Header value to store.</param>
+    procedure SetHeader(HeaderName: Text; HeaderValue: Text)
+    begin
+        EmailMessageImpl.SetHeader(HeaderName, HeaderValue);
     end;
 
     /// <summary>
     /// Reads a single header value from the currently loaded message. Lookups are case-insensitive
-    /// on the header name.
+    /// on the header name. Repeated headers are returned as one string with values joined by #10
+    /// in the order they were added.
     /// </summary>
     /// <param name="HeaderName">Header name to look up (case-insensitive, whitespace-trimmed).</param>
     /// <param name="Value">Returned value when the header is present; empty otherwise.</param>

--- a/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
@@ -199,7 +199,7 @@ codeunit 8904 "Email Message"
 
     /// <summary>
     /// Adds a header to the currently loaded message. If a header with the same name is already
-    /// present, the new value is appended after a line feed (#10) so the full sequence is
+    /// present, the new value is appended after a line feed character so the full sequence is
     /// preserved -- useful for headers that legitimately repeat (e.g. <c>Received</c>).
     /// </summary>
     /// <param name="HeaderName">Header name. Lookups are case-insensitive; the stored name is
@@ -226,8 +226,8 @@ codeunit 8904 "Email Message"
 
     /// <summary>
     /// Reads a single header value from the currently loaded message. Lookups are case-insensitive
-    /// on the header name. Repeated headers are returned as one string with values joined by #10
-    /// in the order they were added.
+    /// on the header name. Repeated headers are returned as one string with values joined by a
+    /// line feed character in the order they were added.
     /// </summary>
     /// <param name="HeaderName">Header name to look up (case-insensitive, whitespace-trimmed).</param>
     /// <param name="Value">Returned value when the header is present; empty otherwise.</param>

--- a/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
@@ -202,11 +202,11 @@ codeunit 8904 "Email Message"
     /// present, the new value is appended after a line feed character so the full sequence is
     /// preserved -- useful for headers that legitimately repeat (e.g. <c>Received</c>).
     /// </summary>
-    /// <param name="HeaderName">Header name. Lookups are case-insensitive; the stored name is
-    /// normalized to lowercase by the module.</param>
+    /// <param name="HeaderName">Header name (case-insensitive).</param>
     /// <param name="HeaderValue">Header value to append.</param>
-    /// <remarks>Intended for connectors that retrieve RFC822-style headers from their provider
-    /// (e.g. the Outlook REST API connector reading <c>internetMessageHeaders</c> from Graph).</remarks>
+    /// <remarks>Mutations are buffered in memory. Call <see cref="FlushHeaders"/> to persist them
+    /// before the codeunit instance goes out of scope or before navigating to another message via
+    /// <c>Get</c>; unflushed changes are discarded otherwise.</remarks>
     procedure AddHeader(HeaderName: Text; HeaderValue: Text)
     begin
         EmailMessageImpl.AddHeader(HeaderName, HeaderValue);
@@ -216,9 +216,11 @@ codeunit 8904 "Email Message"
     /// Sets a header on the currently loaded message, replacing any existing value for the same
     /// name. Use <see cref="AddHeader"/> when repeated headers should accumulate.
     /// </summary>
-    /// <param name="HeaderName">Header name. Lookups are case-insensitive; the stored name is
-    /// normalized to lowercase by the module.</param>
+    /// <param name="HeaderName">Header name (case-insensitive).</param>
     /// <param name="HeaderValue">Header value to store.</param>
+    /// <remarks>Mutations are buffered in memory. Call <see cref="FlushHeaders"/> to persist them
+    /// before the codeunit instance goes out of scope or before navigating to another message via
+    /// <c>Get</c>; unflushed changes are discarded otherwise.</remarks>
     procedure SetHeader(HeaderName: Text; HeaderValue: Text)
     begin
         EmailMessageImpl.SetHeader(HeaderName, HeaderValue);
@@ -232,9 +234,22 @@ codeunit 8904 "Email Message"
     /// <param name="HeaderName">Header name to look up (case-insensitive, whitespace-trimmed).</param>
     /// <param name="Value">Returned value when the header is present; empty otherwise.</param>
     /// <returns><c>true</c> when a value was found.</returns>
+    /// <remarks>Reads include any unflushed mutations issued via <see cref="AddHeader"/> or
+    /// <see cref="SetHeader"/> on this codeunit instance.</remarks>
     procedure TryGetHeader(HeaderName: Text; var Value: Text): Boolean
     begin
         exit(EmailMessageImpl.TryGetHeader(HeaderName, Value));
+    end;
+
+    /// <summary>
+    /// Persists any pending header mutations to the database in a single write. Safe to call when
+    /// nothing is pending. Call this after any sequence of <see cref="AddHeader"/> /
+    /// <see cref="SetHeader"/> calls so the changes survive the codeunit instance going out of
+    /// scope or a subsequent navigation to another message.
+    /// </summary>
+    procedure FlushHeaders()
+    begin
+        EmailMessageImpl.FlushHeaders();
     end;
 
     procedure GetExternalId(): Text[2048]

--- a/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
@@ -197,6 +197,31 @@ codeunit 8904 "Email Message"
         EmailMessageImpl.AppendToBody(Value);
     end;
 
+    /// <summary>
+    /// Writes the supplied headers as JSON into the currently loaded message.
+    /// </summary>
+    /// <param name="HeadersJson">Headers as a JSON object. Callers should lowercase header names and
+    /// concatenate multi-value headers with a line feed (#10) for consistency across connectors.
+    /// An empty object clears the stored headers.</param>
+    /// <remarks>Intended for connectors that retrieve RFC822-style headers from their provider
+    /// (e.g. the Outlook REST API connector reading <c>internetMessageHeaders</c> from Graph).</remarks>
+    procedure SetHeaders(HeadersJson: JsonObject)
+    begin
+        EmailMessageImpl.SetHeaders(HeadersJson);
+    end;
+
+    /// <summary>
+    /// Reads a single header value from the currently loaded message. Lookups are case-insensitive
+    /// on the header name.
+    /// </summary>
+    /// <param name="HeaderName">Header name to look up (case-insensitive, whitespace-trimmed).</param>
+    /// <param name="Value">Returned value when the header is present; empty otherwise.</param>
+    /// <returns><c>true</c> when a value was found.</returns>
+    procedure TryGetHeader(HeaderName: Text; var Value: Text): Boolean
+    begin
+        exit(EmailMessageImpl.TryGetHeader(HeaderName, Value));
+    end;
+
     procedure GetExternalId(): Text[2048]
     begin
         exit(EmailMessageImpl.GetExternalId());

--- a/src/System Application/App/Email/src/Message/EmailMessage.Table.al
+++ b/src/System Application/App/Email/src/Message/EmailMessage.Table.al
@@ -52,6 +52,11 @@ table 8900 "Email Message"
             Access = Internal;
             DataClassification = CustomerContent;
         }
+        field(8; "Message Headers"; Blob)
+        {
+            Access = Internal;
+            DataClassification = CustomerContent;
+        }
     }
 
     keys

--- a/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -223,7 +223,83 @@ codeunit 8905 "Email Message Impl."
         Modify();
     end;
 
-    procedure SetHeaders(HeadersJson: JsonObject)
+    procedure AddHeader(HeaderName: Text; HeaderValue: Text)
+    var
+        HeadersJson: JsonObject;
+        ExistingToken: JsonToken;
+        NormalizedName: Text;
+        ExistingValue: Text;
+    begin
+        NormalizedName := NormalizeHeaderName(HeaderName);
+        if NormalizedName = '' then
+            exit;
+        LoadHeadersJson(HeadersJson);
+        if HeadersJson.Get(NormalizedName, ExistingToken) then begin
+            ExistingValue := ExistingToken.AsValue().AsText();
+            HeadersJson.Replace(NormalizedName, ExistingValue + #10 + HeaderValue);
+        end else
+            HeadersJson.Add(NormalizedName, HeaderValue);
+        WriteHeadersJson(HeadersJson);
+    end;
+
+    procedure SetHeader(HeaderName: Text; HeaderValue: Text)
+    var
+        HeadersJson: JsonObject;
+        NormalizedName: Text;
+    begin
+        NormalizedName := NormalizeHeaderName(HeaderName);
+        if NormalizedName = '' then
+            exit;
+        LoadHeadersJson(HeadersJson);
+        if HeadersJson.Contains(NormalizedName) then
+            HeadersJson.Replace(NormalizedName, HeaderValue)
+        else
+            HeadersJson.Add(NormalizedName, HeaderValue);
+        WriteHeadersJson(HeadersJson);
+    end;
+
+    procedure TryGetHeader(HeaderName: Text; var Value: Text): Boolean
+    var
+        HeadersJson: JsonObject;
+        HeaderToken: JsonToken;
+        NormalizedName: Text;
+    begin
+        Value := '';
+        NormalizedName := NormalizeHeaderName(HeaderName);
+        if NormalizedName = '' then
+            exit(false);
+        LoadHeadersJson(HeadersJson);
+        if not HeadersJson.Get(NormalizedName, HeaderToken) then
+            exit(false);
+        if not HeaderToken.IsValue() then
+            exit(false);
+        Value := HeaderToken.AsValue().AsText();
+        exit(true);
+    end;
+
+    local procedure NormalizeHeaderName(HeaderName: Text): Text
+    begin
+        exit(LowerCase(DelChr(HeaderName, '<>', ' ')));
+    end;
+
+    local procedure LoadHeadersJson(var HeadersJson: JsonObject)
+    var
+        HeadersInStream: InStream;
+        HeadersText: Text;
+    begin
+        Clear(HeadersJson);
+        GlobalEmailMessage.CalcFields("Message Headers");
+        if not GlobalEmailMessage."Message Headers".HasValue() then
+            exit;
+        GlobalEmailMessage."Message Headers".CreateInStream(HeadersInStream, TextEncoding::UTF8);
+        HeadersInStream.ReadText(HeadersText);
+        if HeadersText = '' then
+            exit;
+        if not HeadersJson.ReadFrom(HeadersText) then
+            Clear(HeadersJson);
+    end;
+
+    local procedure WriteHeadersJson(HeadersJson: JsonObject)
     var
         HeadersOutStream: OutStream;
         HeadersText: Text;
@@ -237,31 +313,6 @@ codeunit 8905 "Email Message Impl."
         GlobalEmailMessage."Message Headers".CreateOutStream(HeadersOutStream, TextEncoding::UTF8);
         HeadersOutStream.WriteText(HeadersText);
         Modify();
-    end;
-
-    procedure TryGetHeader(HeaderName: Text; var Value: Text): Boolean
-    var
-        HeadersInStream: InStream;
-        HeadersJson: JsonObject;
-        HeaderToken: JsonToken;
-        HeadersText: Text;
-    begin
-        Value := '';
-        GlobalEmailMessage.CalcFields("Message Headers");
-        if not GlobalEmailMessage."Message Headers".HasValue() then
-            exit(false);
-        GlobalEmailMessage."Message Headers".CreateInStream(HeadersInStream, TextEncoding::UTF8);
-        HeadersInStream.ReadText(HeadersText);
-        if HeadersText = '' then
-            exit(false);
-        if not HeadersJson.ReadFrom(HeadersText) then
-            exit(false);
-        if not HeadersJson.Get(LowerCase(DelChr(HeaderName, '<>', ' ')), HeaderToken) then
-            exit(false);
-        if not HeaderToken.IsValue() then
-            exit(false);
-        Value := HeaderToken.AsValue().AsText();
-        exit(true);
     end;
 
     procedure IsRead(): Boolean

--- a/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -223,6 +223,47 @@ codeunit 8905 "Email Message Impl."
         Modify();
     end;
 
+    procedure SetHeaders(HeadersJson: JsonObject)
+    var
+        HeadersOutStream: OutStream;
+        HeadersText: Text;
+    begin
+        Clear(GlobalEmailMessage."Message Headers");
+        if HeadersJson.Keys().Count() = 0 then begin
+            Modify();
+            exit;
+        end;
+        HeadersJson.WriteTo(HeadersText);
+        GlobalEmailMessage."Message Headers".CreateOutStream(HeadersOutStream, TextEncoding::UTF8);
+        HeadersOutStream.WriteText(HeadersText);
+        Modify();
+    end;
+
+    procedure TryGetHeader(HeaderName: Text; var Value: Text): Boolean
+    var
+        HeadersInStream: InStream;
+        HeadersJson: JsonObject;
+        HeaderToken: JsonToken;
+        HeadersText: Text;
+    begin
+        Value := '';
+        GlobalEmailMessage.CalcFields("Message Headers");
+        if not GlobalEmailMessage."Message Headers".HasValue() then
+            exit(false);
+        GlobalEmailMessage."Message Headers".CreateInStream(HeadersInStream, TextEncoding::UTF8);
+        HeadersInStream.ReadText(HeadersText);
+        if HeadersText = '' then
+            exit(false);
+        if not HeadersJson.ReadFrom(HeadersText) then
+            exit(false);
+        if not HeadersJson.Get(LowerCase(DelChr(HeaderName, '<>', ' ')), HeaderToken) then
+            exit(false);
+        if not HeaderToken.IsValue() then
+            exit(false);
+        Value := HeaderToken.AsValue().AsText();
+        exit(true);
+    end;
+
     procedure IsRead(): Boolean
     begin
         exit(not GlobalEmailMessage.Editable);

--- a/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -103,6 +103,7 @@ codeunit 8905 "Email Message Impl."
     begin
         Clear(GlobalEmailMessageAttachment);
         Clear(GlobalEmailMessage);
+        InvalidateHeadersCache();
 
         GlobalEmailMessage.Id := CreateGuid();
         GlobalEmailMessage.Insert();
@@ -224,45 +225,17 @@ codeunit 8905 "Email Message Impl."
     end;
 
     procedure AddHeader(HeaderName: Text; HeaderValue: Text)
-    var
-        HeadersJson: JsonObject;
-        ExistingToken: JsonToken;
-        NormalizedName: Text;
-        ExistingValue: Text;
-        LineFeed: Text[1];
     begin
-        NormalizedName := NormalizeHeaderName(HeaderName);
-        if NormalizedName = '' then
-            exit;
-        LoadHeadersJson(HeadersJson);
-        if HeadersJson.Get(NormalizedName, ExistingToken) then begin
-            ExistingValue := ExistingToken.AsValue().AsText();
-            LineFeed[1] := 10;
-            HeadersJson.Replace(NormalizedName, ExistingValue + LineFeed + HeaderValue);
-        end else
-            HeadersJson.Add(NormalizedName, HeaderValue);
-        WriteHeadersJson(HeadersJson);
+        StoreHeader(HeaderName, HeaderValue, true);
     end;
 
     procedure SetHeader(HeaderName: Text; HeaderValue: Text)
-    var
-        HeadersJson: JsonObject;
-        NormalizedName: Text;
     begin
-        NormalizedName := NormalizeHeaderName(HeaderName);
-        if NormalizedName = '' then
-            exit;
-        LoadHeadersJson(HeadersJson);
-        if HeadersJson.Contains(NormalizedName) then
-            HeadersJson.Replace(NormalizedName, HeaderValue)
-        else
-            HeadersJson.Add(NormalizedName, HeaderValue);
-        WriteHeadersJson(HeadersJson);
+        StoreHeader(HeaderName, HeaderValue, false);
     end;
 
     procedure TryGetHeader(HeaderName: Text; var Value: Text): Boolean
     var
-        HeadersJson: JsonObject;
         HeaderToken: JsonToken;
         NormalizedName: Text;
     begin
@@ -270,8 +243,8 @@ codeunit 8905 "Email Message Impl."
         NormalizedName := NormalizeHeaderName(HeaderName);
         if NormalizedName = '' then
             exit(false);
-        LoadHeadersJson(HeadersJson);
-        if not HeadersJson.Get(NormalizedName, HeaderToken) then
+        EnsureHeadersLoaded();
+        if not GlobalHeadersJson.Get(NormalizedName, HeaderToken) then
             exit(false);
         if not HeaderToken.IsValue() then
             exit(false);
@@ -279,42 +252,73 @@ codeunit 8905 "Email Message Impl."
         exit(true);
     end;
 
+    procedure FlushHeaders()
+    var
+        HeadersOutStream: OutStream;
+        HeadersText: Text;
+    begin
+        if not GlobalHeadersDirty then
+            exit;
+        Clear(GlobalEmailMessage."Message Headers");
+        if GlobalHeadersJson.Keys().Count() > 0 then begin
+            GlobalHeadersJson.WriteTo(HeadersText);
+            GlobalEmailMessage."Message Headers".CreateOutStream(HeadersOutStream, TextEncoding::UTF8);
+            HeadersOutStream.WriteText(HeadersText);
+        end;
+        Modify();
+        GlobalHeadersDirty := false;
+    end;
+
+    local procedure StoreHeader(HeaderName: Text; HeaderValue: Text; AppendIfPresent: Boolean)
+    var
+        ExistingToken: JsonToken;
+        NormalizedName: Text;
+        LineFeed: Text[1];
+    begin
+        NormalizedName := NormalizeHeaderName(HeaderName);
+        if NormalizedName = '' then
+            exit;
+        EnsureHeadersLoaded();
+        if GlobalHeadersJson.Get(NormalizedName, ExistingToken) then
+            if AppendIfPresent then begin
+                LineFeed[1] := 10;
+                GlobalHeadersJson.Replace(NormalizedName, ExistingToken.AsValue().AsText() + LineFeed + HeaderValue);
+            end else
+                GlobalHeadersJson.Replace(NormalizedName, HeaderValue)
+        else
+            GlobalHeadersJson.Add(NormalizedName, HeaderValue);
+        GlobalHeadersDirty := true;
+    end;
+
     local procedure NormalizeHeaderName(HeaderName: Text): Text
     begin
         exit(LowerCase(DelChr(HeaderName, '<>', ' ')));
     end;
 
-    local procedure LoadHeadersJson(var HeadersJson: JsonObject)
+    local procedure EnsureHeadersLoaded()
     var
         HeadersInStream: InStream;
         HeadersText: Text;
     begin
-        Clear(HeadersJson);
+        if GlobalHeadersLoaded then
+            exit;
+        Clear(GlobalHeadersJson);
         GlobalEmailMessage.CalcFields("Message Headers");
-        if not GlobalEmailMessage."Message Headers".HasValue() then
-            exit;
-        GlobalEmailMessage."Message Headers".CreateInStream(HeadersInStream, TextEncoding::UTF8);
-        HeadersInStream.ReadText(HeadersText);
-        if HeadersText = '' then
-            exit;
-        if not HeadersJson.ReadFrom(HeadersText) then
-            Clear(HeadersJson);
+        if GlobalEmailMessage."Message Headers".HasValue() then begin
+            GlobalEmailMessage."Message Headers".CreateInStream(HeadersInStream, TextEncoding::UTF8);
+            HeadersInStream.ReadText(HeadersText);
+            if HeadersText <> '' then
+                if not GlobalHeadersJson.ReadFrom(HeadersText) then
+                    Clear(GlobalHeadersJson);
+        end;
+        GlobalHeadersLoaded := true;
     end;
 
-    local procedure WriteHeadersJson(HeadersJson: JsonObject)
-    var
-        HeadersOutStream: OutStream;
-        HeadersText: Text;
+    local procedure InvalidateHeadersCache()
     begin
-        Clear(GlobalEmailMessage."Message Headers");
-        if HeadersJson.Keys().Count() = 0 then begin
-            Modify();
-            exit;
-        end;
-        HeadersJson.WriteTo(HeadersText);
-        GlobalEmailMessage."Message Headers".CreateOutStream(HeadersOutStream, TextEncoding::UTF8);
-        HeadersOutStream.WriteText(HeadersText);
-        Modify();
+        Clear(GlobalHeadersJson);
+        GlobalHeadersLoaded := false;
+        GlobalHeadersDirty := false;
     end;
 
     procedure IsRead(): Boolean
@@ -742,6 +746,7 @@ codeunit 8905 "Email Message Impl."
     procedure Get(MessageId: Guid): Boolean
     begin
         Clear(GlobalEmailMessageAttachment);
+        InvalidateHeadersCache();
 
         exit(GlobalEmailMessage.Get(MessageId));
     end;
@@ -1100,6 +1105,9 @@ codeunit 8905 "Email Message Impl."
         GlobalEmailMessageAttachment: Record "Email Message Attachment";
         TenantMedia: Record "Tenant Media";
         Telemetry: Codeunit Telemetry;
+        GlobalHeadersJson: JsonObject;
+        GlobalHeadersLoaded: Boolean;
+        GlobalHeadersDirty: Boolean;
         EmailCategoryLbl: Label 'Email', Locked = true;
         EmailMessageQueuedCannotModifyErr: Label 'Cannot edit the email because it has been queued to be sent.';
         EmailMessageSentCannotModifyErr: Label 'Cannot edit the message because it has already been sent.';

--- a/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -229,6 +229,7 @@ codeunit 8905 "Email Message Impl."
         ExistingToken: JsonToken;
         NormalizedName: Text;
         ExistingValue: Text;
+        LineFeed: Text[1];
     begin
         NormalizedName := NormalizeHeaderName(HeaderName);
         if NormalizedName = '' then
@@ -236,7 +237,8 @@ codeunit 8905 "Email Message Impl."
         LoadHeadersJson(HeadersJson);
         if HeadersJson.Get(NormalizedName, ExistingToken) then begin
             ExistingValue := ExistingToken.AsValue().AsText();
-            HeadersJson.Replace(NormalizedName, ExistingValue + #10 + HeaderValue);
+            LineFeed[1] := 10;
+            HeadersJson.Replace(NormalizedName, ExistingValue + LineFeed + HeaderValue);
         end else
             HeadersJson.Add(NormalizedName, HeaderValue);
         WriteHeadersJson(HeadersJson);

--- a/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -234,7 +234,7 @@ codeunit 8905 "Email Message Impl."
         StoreHeader(HeaderName, HeaderValue, false);
     end;
 
-    procedure TryGetHeader(HeaderName: Text; var Value: Text): Boolean
+    procedure GetHeader(HeaderName: Text; var Value: Text): Boolean
     var
         HeaderToken: JsonToken;
         NormalizedName: Text;

--- a/src/System Application/Test/Email/app.json
+++ b/src/System Application/Test/Email/app.json
@@ -117,7 +117,7 @@
     },
     {
       "from": 134705,
-      "to": 134706
+      "to": 134707
     }
   ],
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2134520",

--- a/src/System Application/Test/Email/src/EmailMessageHeadersTest.Codeunit.al
+++ b/src/System Application/Test/Email/src/EmailMessageHeadersTest.Codeunit.al
@@ -20,7 +20,7 @@ codeunit 134707 "Email Message Headers Test"
 
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
-    procedure AddHeaderRoundTripsCaseInsensitively()
+    procedure AddHeaderRoundTripsCaseInsensitivelyAfterFlush()
     var
         Message: Codeunit "Email Message";
         Value: Text;
@@ -30,6 +30,7 @@ codeunit 134707 "Email Message Headers Test"
         Message.Create('to@test.com', 'subject', 'body');
         Message.AddHeader('Authentication-Results', 'spf=pass');
         Message.AddHeader('X-MS-Exchange-Organization-AuthAs', 'Internal');
+        Message.FlushHeaders();
 
         Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
         Assert.IsTrue(Message.TryGetHeader('authentication-results', Value), 'Header lookup should succeed case-insensitively');
@@ -67,6 +68,7 @@ codeunit 134707 "Email Message Headers Test"
         Message.Create('to@test.com', 'subject', 'body');
         Message.AddHeader('Received', 'from hop1');
         Message.AddHeader('Received', 'from hop2');
+        Message.FlushHeaders();
 
         Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
         Assert.IsTrue(Message.TryGetHeader('Received', Value), 'Repeated header lookup should succeed');
@@ -86,9 +88,29 @@ codeunit 134707 "Email Message Headers Test"
         Message.AddHeader('Received', 'from hop1');
         Message.AddHeader('Received', 'from hop2');
         Message.SetHeader('Received', 'canonical');
+        Message.FlushHeaders();
 
         Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
         Assert.IsTrue(Message.TryGetHeader('Received', Value), 'Header lookup after SetHeader should succeed');
         Assert.AreEqual('canonical', Value, 'SetHeader should replace any previously joined values');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure UnflushedMutationsAreDiscardedOnGet()
+    var
+        Message: Codeunit "Email Message";
+        Value: Text;
+        MessageId: Guid;
+    begin
+        PermissionsMock.Set('Email Edit');
+
+        Message.Create('to@test.com', 'subject', 'body');
+        MessageId := Message.GetId();
+        Message.AddHeader('Authentication-Results', 'spf=pass');
+        // Intentionally no FlushHeaders -- pending mutations should be lost when we re-Get the message.
+
+        Assert.IsTrue(Message.Get(MessageId), 'Message not found after reload');
+        Assert.IsFalse(Message.TryGetHeader('Authentication-Results', Value), 'Unflushed mutations should not survive a Get');
     end;
 }

--- a/src/System Application/Test/Email/src/EmailMessageHeadersTest.Codeunit.al
+++ b/src/System Application/Test/Email/src/EmailMessageHeadersTest.Codeunit.al
@@ -20,29 +20,27 @@ codeunit 134707 "Email Message Headers Test"
 
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
-    procedure RoundTripsHeadersJson()
+    procedure AddHeaderRoundTripsCaseInsensitively()
     var
         Message: Codeunit "Email Message";
-        HeadersJson: JsonObject;
         Value: Text;
     begin
         PermissionsMock.Set('Email Edit');
 
         Message.Create('to@test.com', 'subject', 'body');
-        HeadersJson.Add('authentication-results', 'spf=pass');
-        HeadersJson.Add('x-ms-exchange-organization-authas', 'Internal');
-        Message.SetHeaders(HeadersJson);
+        Message.AddHeader('Authentication-Results', 'spf=pass');
+        Message.AddHeader('X-MS-Exchange-Organization-AuthAs', 'Internal');
 
         Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
-        Assert.IsTrue(Message.TryGetHeader('Authentication-Results', Value), 'Header lookup should succeed case-insensitively');
+        Assert.IsTrue(Message.TryGetHeader('authentication-results', Value), 'Header lookup should succeed case-insensitively');
         Assert.AreEqual('spf=pass', Value, 'Authentication-Results header value mismatch');
-        Assert.IsTrue(Message.TryGetHeader('X-MS-Exchange-Organization-AuthAs', Value), 'AuthAs header lookup should succeed');
+        Assert.IsTrue(Message.TryGetHeader('X-MS-EXCHANGE-ORGANIZATION-AUTHAS', Value), 'AuthAs header lookup should succeed case-insensitively');
         Assert.AreEqual('Internal', Value, 'AuthAs header value mismatch');
     end;
 
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
-    procedure TryGetHeaderReturnsFalseOnEmptyBlob()
+    procedure TryGetHeaderReturnsFalseWhenNoHeadersStored()
     var
         Message: Codeunit "Email Message";
         Value: Text;
@@ -51,47 +49,44 @@ codeunit 134707 "Email Message Headers Test"
 
         Message.Create('to@test.com', 'subject', 'body');
 
-        Assert.IsFalse(Message.TryGetHeader('any-header', Value), 'Empty blob should return false');
+        Assert.IsFalse(Message.TryGetHeader('any-header', Value), 'Lookup on a message with no headers should return false');
         Assert.AreEqual('', Value, 'Value should be empty when no headers stored');
     end;
 
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
-    procedure SetHeadersWithEmptyJsonClearsBlob()
+    procedure AddHeaderJoinsRepeatedValuesWithLineFeed()
     var
         Message: Codeunit "Email Message";
-        HeadersJson: JsonObject;
-        EmptyHeadersJson: JsonObject;
         Value: Text;
     begin
         PermissionsMock.Set('Email Edit');
 
         Message.Create('to@test.com', 'subject', 'body');
-        HeadersJson.Add('authentication-results', 'spf=pass');
-        Message.SetHeaders(HeadersJson);
-
-        Message.SetHeaders(EmptyHeadersJson);
+        Message.AddHeader('Received', 'from hop1');
+        Message.AddHeader('Received', 'from hop2');
 
         Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
-        Assert.IsFalse(Message.TryGetHeader('Authentication-Results', Value), 'Headers should be cleared after empty SetHeaders');
+        Assert.IsTrue(Message.TryGetHeader('Received', Value), 'Repeated header lookup should succeed');
+        Assert.AreEqual('from hop1' + #10 + 'from hop2', Value, 'Repeated AddHeader calls should join values with line feed in insertion order');
     end;
 
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
-    procedure MultiValueHeaderRetainsAllValuesJoinedWithLineFeed()
+    procedure SetHeaderReplacesExistingValue()
     var
         Message: Codeunit "Email Message";
-        HeadersJson: JsonObject;
         Value: Text;
     begin
         PermissionsMock.Set('Email Edit');
 
         Message.Create('to@test.com', 'subject', 'body');
-        HeadersJson.Add('received', 'from hop1' + #10 + 'from hop2');
-        Message.SetHeaders(HeadersJson);
+        Message.AddHeader('Received', 'from hop1');
+        Message.AddHeader('Received', 'from hop2');
+        Message.SetHeader('Received', 'canonical');
 
         Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
-        Assert.IsTrue(Message.TryGetHeader('Received', Value), 'Multi-value header lookup should succeed');
-        Assert.AreEqual('from hop1' + #10 + 'from hop2', Value, 'Multi-value header should preserve line-feed joiner');
+        Assert.IsTrue(Message.TryGetHeader('Received', Value), 'Header lookup after SetHeader should succeed');
+        Assert.AreEqual('canonical', Value, 'SetHeader should replace any previously joined values');
     end;
 }

--- a/src/System Application/Test/Email/src/EmailMessageHeadersTest.Codeunit.al
+++ b/src/System Application/Test/Email/src/EmailMessageHeadersTest.Codeunit.al
@@ -33,15 +33,15 @@ codeunit 134707 "Email Message Headers Test"
         Message.FlushHeaders();
 
         Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
-        Assert.IsTrue(Message.TryGetHeader('authentication-results', Value), 'Header lookup should succeed case-insensitively');
+        Assert.IsTrue(Message.GetHeader('authentication-results', Value), 'Header lookup should succeed case-insensitively');
         Assert.AreEqual('spf=pass', Value, 'Authentication-Results header value mismatch');
-        Assert.IsTrue(Message.TryGetHeader('X-MS-EXCHANGE-ORGANIZATION-AUTHAS', Value), 'AuthAs header lookup should succeed case-insensitively');
+        Assert.IsTrue(Message.GetHeader('X-MS-EXCHANGE-ORGANIZATION-AUTHAS', Value), 'AuthAs header lookup should succeed case-insensitively');
         Assert.AreEqual('Internal', Value, 'AuthAs header value mismatch');
     end;
 
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
-    procedure TryGetHeaderReturnsFalseWhenNoHeadersStored()
+    procedure GetHeaderReturnsFalseWhenNoHeadersStored()
     var
         Message: Codeunit "Email Message";
         Value: Text;
@@ -50,7 +50,7 @@ codeunit 134707 "Email Message Headers Test"
 
         Message.Create('to@test.com', 'subject', 'body');
 
-        Assert.IsFalse(Message.TryGetHeader('any-header', Value), 'Lookup on a message with no headers should return false');
+        Assert.IsFalse(Message.GetHeader('any-header', Value), 'Lookup on a message with no headers should return false');
         Assert.AreEqual('', Value, 'Value should be empty when no headers stored');
     end;
 
@@ -71,7 +71,7 @@ codeunit 134707 "Email Message Headers Test"
         Message.FlushHeaders();
 
         Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
-        Assert.IsTrue(Message.TryGetHeader('Received', Value), 'Repeated header lookup should succeed');
+        Assert.IsTrue(Message.GetHeader('Received', Value), 'Repeated header lookup should succeed');
         Assert.AreEqual('from hop1' + LineFeed + 'from hop2', Value, 'Repeated AddHeader calls should join values with line feed in insertion order');
     end;
 
@@ -91,7 +91,7 @@ codeunit 134707 "Email Message Headers Test"
         Message.FlushHeaders();
 
         Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
-        Assert.IsTrue(Message.TryGetHeader('Received', Value), 'Header lookup after SetHeader should succeed');
+        Assert.IsTrue(Message.GetHeader('Received', Value), 'Header lookup after SetHeader should succeed');
         Assert.AreEqual('canonical', Value, 'SetHeader should replace any previously joined values');
     end;
 
@@ -111,6 +111,6 @@ codeunit 134707 "Email Message Headers Test"
         // Intentionally no FlushHeaders -- pending mutations should be lost when we re-Get the message.
 
         Assert.IsTrue(Message.Get(MessageId), 'Message not found after reload');
-        Assert.IsFalse(Message.TryGetHeader('Authentication-Results', Value), 'Unflushed mutations should not survive a Get');
+        Assert.IsFalse(Message.GetHeader('Authentication-Results', Value), 'Unflushed mutations should not survive a Get');
     end;
 }

--- a/src/System Application/Test/Email/src/EmailMessageHeadersTest.Codeunit.al
+++ b/src/System Application/Test/Email/src/EmailMessageHeadersTest.Codeunit.al
@@ -59,8 +59,10 @@ codeunit 134707 "Email Message Headers Test"
     var
         Message: Codeunit "Email Message";
         Value: Text;
+        LineFeed: Text[1];
     begin
         PermissionsMock.Set('Email Edit');
+        LineFeed[1] := 10;
 
         Message.Create('to@test.com', 'subject', 'body');
         Message.AddHeader('Received', 'from hop1');
@@ -68,7 +70,7 @@ codeunit 134707 "Email Message Headers Test"
 
         Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
         Assert.IsTrue(Message.TryGetHeader('Received', Value), 'Repeated header lookup should succeed');
-        Assert.AreEqual('from hop1' + #10 + 'from hop2', Value, 'Repeated AddHeader calls should join values with line feed in insertion order');
+        Assert.AreEqual('from hop1' + LineFeed + 'from hop2', Value, 'Repeated AddHeader calls should join values with line feed in insertion order');
     end;
 
     [Test]

--- a/src/System Application/Test/Email/src/EmailMessageHeadersTest.Codeunit.al
+++ b/src/System Application/Test/Email/src/EmailMessageHeadersTest.Codeunit.al
@@ -1,0 +1,97 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Test.Email;
+
+using System.Email;
+using System.TestLibraries.Security.AccessControl;
+using System.TestLibraries.Utilities;
+
+codeunit 134707 "Email Message Headers Test"
+{
+    Subtype = Test;
+    Permissions = tabledata "Email Message" = rm;
+
+    var
+        Assert: Codeunit "Library Assert";
+        PermissionsMock: Codeunit "Permissions Mock";
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure RoundTripsHeadersJson()
+    var
+        Message: Codeunit "Email Message";
+        HeadersJson: JsonObject;
+        Value: Text;
+    begin
+        PermissionsMock.Set('Email Edit');
+
+        Message.Create('to@test.com', 'subject', 'body');
+        HeadersJson.Add('authentication-results', 'spf=pass');
+        HeadersJson.Add('x-ms-exchange-organization-authas', 'Internal');
+        Message.SetHeaders(HeadersJson);
+
+        Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
+        Assert.IsTrue(Message.TryGetHeader('Authentication-Results', Value), 'Header lookup should succeed case-insensitively');
+        Assert.AreEqual('spf=pass', Value, 'Authentication-Results header value mismatch');
+        Assert.IsTrue(Message.TryGetHeader('X-MS-Exchange-Organization-AuthAs', Value), 'AuthAs header lookup should succeed');
+        Assert.AreEqual('Internal', Value, 'AuthAs header value mismatch');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TryGetHeaderReturnsFalseOnEmptyBlob()
+    var
+        Message: Codeunit "Email Message";
+        Value: Text;
+    begin
+        PermissionsMock.Set('Email Edit');
+
+        Message.Create('to@test.com', 'subject', 'body');
+
+        Assert.IsFalse(Message.TryGetHeader('any-header', Value), 'Empty blob should return false');
+        Assert.AreEqual('', Value, 'Value should be empty when no headers stored');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure SetHeadersWithEmptyJsonClearsBlob()
+    var
+        Message: Codeunit "Email Message";
+        HeadersJson: JsonObject;
+        EmptyHeadersJson: JsonObject;
+        Value: Text;
+    begin
+        PermissionsMock.Set('Email Edit');
+
+        Message.Create('to@test.com', 'subject', 'body');
+        HeadersJson.Add('authentication-results', 'spf=pass');
+        Message.SetHeaders(HeadersJson);
+
+        Message.SetHeaders(EmptyHeadersJson);
+
+        Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
+        Assert.IsFalse(Message.TryGetHeader('Authentication-Results', Value), 'Headers should be cleared after empty SetHeaders');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure MultiValueHeaderRetainsAllValuesJoinedWithLineFeed()
+    var
+        Message: Codeunit "Email Message";
+        HeadersJson: JsonObject;
+        Value: Text;
+    begin
+        PermissionsMock.Set('Email Edit');
+
+        Message.Create('to@test.com', 'subject', 'body');
+        HeadersJson.Add('received', 'from hop1' + #10 + 'from hop2');
+        Message.SetHeaders(HeadersJson);
+
+        Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
+        Assert.IsTrue(Message.TryGetHeader('Received', Value), 'Multi-value header lookup should succeed');
+        Assert.AreEqual('from hop1' + #10 + 'from hop2', Value, 'Multi-value header should preserve line-feed joiner');
+    end;
+}


### PR DESCRIPTION
Addresses [AB#625413](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625413)

## What

Adding the ability in the Email Module to pass filters to be used at email retrieval for populating `Message Headers`, as well as primitives in the `Email Message` to manage them.

## Why

Part of the "skip review for trusted senders" slice. The headers will be used for determining authentication properties of the received email.

## Summary of the changes

- Adds a new BLOB field "Message Headers" that won't be populated by default.
- Adds a new field to the temporary "Filters" table to use as parameter in the email retrieval
- Exposes a surface for connectors to store the headers. It's up to connector to honor the contract on the parameter. Such surface is:
    - AddHeader: Sets (appending) the header specified
    - SetHeader: Sets (replacing) the header specified
    - TryGetHeader: From the stored JSON, retrieves the header value requested.
    - FlushHeaders: Instead of full round-trips persisting for each header on every call to `AddHeader`, the updates are done on the instance of the EmailMessage. Persistance happens when flushing. 

### Other technical considerations

- Maintaining a cache of the headers JSON
- Only persisted when required (filters that default to false). Preliminar "smoke-analysis" reveals an increase of around 50% on DB size on emails if we were to store all the headers for all the emails.
<img width="873" height="1455" alt="image" src="https://github.com/user-attachments/assets/9eb787c5-8ae6-42e0-930b-2d34225b7636" />

## PTE for testing

[OutlookHeadersTester.zip](https://github.com/user-attachments/files/28313134/OutlookHeadersTester.zip)

Requires the changes in the [M365 API app](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_git/NAV/pullrequest/247802)

Scenarios behave as expected:
- Retrieving email without the "Load headers" filter don't store anything in the headers blob:
<img width="3645" height="1638" alt="image" src="https://github.com/user-attachments/assets/32ff25a1-b95b-42eb-bd3a-7ed745d78b21" />

- Retrieving them with the "Load headers" filter, stores them, and the proposed API allows retrieving them

<img width="3651" height="1620" alt="image" src="https://github.com/user-attachments/assets/788c2a7a-98f9-4c55-9333-ee5539800311" />






