### PR TITLE
[Shopify] Fix wrong dictionary used for pagination cursor in ReturnsAPI

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order Returns/Codeunits/ShpfyReturnsAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Returns/Codeunits/ShpfyReturnsAPI.Codeunit.al
@@ -119,10 +119,10 @@ codeunit 30250 "Shpfy Returns API"
 
             GraphQLType := "Shpfy GraphQL Type"::Returns_GetNextReverseFulfillmentOrders;
             JOrders := JsonHelper.GetJsonArray(JResponse, 'data.return.reverseFulfillmentOrders.nodes');
-            if Parameters.ContainsKey('After') then
-                Parameters.Set('After', JsonHelper.GetValueAsText(JResponse, 'data.return.reverseFulfillmentOrders.pageInfo.endCursor'))
+            if LineParameters.ContainsKey('After') then
+                LineParameters.Set('After', JsonHelper.GetValueAsText(JResponse, 'data.return.reverseFulfillmentOrders.pageInfo.endCursor'))
             else
-                Parameters.Add('After', JsonHelper.GetValueAsText(JResponse, 'data.return.reverseFulfillmentOrders.pageInfo.endCursor'));
+                LineParameters.Add('After', JsonHelper.GetValueAsText(JResponse, 'data.return.reverseFulfillmentOrders.pageInfo.endCursor'));
 
             foreach JOrder in JOrders do
                 GetReturnLocationsFromReturnFulfillOrder(JsonHelper.GetValueAsText(JOrder, 'id'), ReturnLocations);
@@ -144,10 +144,10 @@ codeunit 30250 "Shpfy Returns API"
 
             GraphQLType := "Shpfy GraphQL Type"::Returns_GetNextReverseFulfillmentOrderLines;
             JLines := JsonHelper.GetJsonArray(JResponse, 'data.reverseFulfillmentOrder.lineItems.nodes');
-            if Parameters.ContainsKey('After') then
-                Parameters.Set('After', JsonHelper.GetValueAsText(JResponse, 'data.reverseFulfillmentOrder.lineItems.pageInfo.endCursor'))
+            if LineParameters.ContainsKey('After') then
+                LineParameters.Set('After', JsonHelper.GetValueAsText(JResponse, 'data.reverseFulfillmentOrder.lineItems.pageInfo.endCursor'))
             else
-                Parameters.Add('After', JsonHelper.GetValueAsText(JResponse, 'data.reverseFulfillmentOrder.lineItems.pageInfo.endCursor'));
+                LineParameters.Add('After', JsonHelper.GetValueAsText(JResponse, 'data.reverseFulfillmentOrder.lineItems.pageInfo.endCursor'));
 
             foreach JLine in JLines do
                 CollectLocationsFromLineDispositions(JLine, ReturnLocations);


### PR DESCRIPTION
## What this changes

In Shpfy Returns API (codeunit 30250), procedures GetReturnLocations (lines 107–130) and GetReturnLocationsFromReturnFulfillOrder (lines 132–155) both declare a local `LineParameters: Dictionary of [text, Text]` and pass that dictionary to `CommunicationMgt.ExecuteGraphQL` — but they were writing the `After` cursor into the **module-level** `Parameters` dictionary instead.

As a result the `{{After}}` placeholder in `GetNextReverseFulfillmentOrders.graphql` and `GetNextReverseFulfillmentOrderLines.graphql` (both substituted from `LineParameters`) was never populated, breaking pagination beyond the first 10 reverse-fulfillment-orders for a return, or the first 10 line items of a reverse fulfillment order.

The user-visible symptom is **Shpfy Return Lines with missing Location IDs**, and credit memos that consequently lose the restock-to-location information for the affected lines. The intermittence depends on whether a return reaches the >10 reverse-fulfillment-orders or >10 lines-per-RFO thresholds.

This PR replaces the three `Parameters` references in each procedure with `LineParameters` — the dictionary that is actually passed to `ExecuteGraphQL`. Six lines changed total.

## Why no test

There is no existing unit-test coverage for `GetReturnLocations` / `GetReturnLocationsFromReturnFulfillOrder` in `src/Apps/W1/Shopify/Test`. A pagination test would need new mock-GraphQL fixtures that simulate the `pageInfo.hasNextPage` contract for the `reverseFulfillmentOrders` connection and a multi-page disposition response. That harness work is out of scope for this surgical fix; a follow-up to add coverage is welcome.

Fixes [AB#636657](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636657)

