### PR TITLE
[MCP] Toggle Default via field on MCP Configuration pages

### DIFF
--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
@@ -63,7 +63,19 @@ page 8351 "MCP Config Card"
                     {
                         Caption = 'Default';
                         ToolTip = 'Specifies whether this configuration is the default. The default configuration is used when no configuration is specified by a connection.';
-                        Editable = false;
+                        Editable = not IsDefault;
+
+                        trigger OnValidate()
+                        begin
+                            if Rec.Default = xRec.Default then
+                                exit;
+
+                            if Rec.Default then
+                                MCPConfigImplementation.SetAsDefaultConfiguration(Rec.SystemId)
+                            else
+                                MCPConfigImplementation.ClearDefaultConfiguration();
+                            CurrPage.Update(false);
+                        end;
                     }
                     field(EnableDynamicToolMode; Rec.EnableDynamicToolMode)
                     {
@@ -176,43 +188,11 @@ page 8351 "MCP Config Card"
                     end;
                 }
             }
-            action(SetAsDefault)
-            {
-                Caption = 'Set as Default';
-                ToolTip = 'Set this configuration as the default. It will be used when no configuration is specified by a connection.';
-                Image = Approve;
-                AccessByPermission = tabledata "MCP Configuration" = M;
-                Visible = not IsDefault;
-                Enabled = not Rec.Default;
-
-                trigger OnAction()
-                begin
-                    MCPConfigImplementation.SetAsDefaultConfiguration(Rec.SystemId);
-                    CurrPage.Update(false);
-                end;
-            }
-            action(ClearDefault)
-            {
-                Caption = 'Clear Default';
-                ToolTip = 'Remove the default designation from this configuration. The system will revert to built-in default settings.';
-                Image = Undo;
-                AccessByPermission = tabledata "MCP Configuration" = M;
-                Visible = not IsDefault;
-                Enabled = Rec.Default;
-
-                trigger OnAction()
-                begin
-                    MCPConfigImplementation.ClearDefaultConfiguration();
-                    CurrPage.Update(false);
-                end;
-            }
         }
         area(Promoted)
         {
             actionref(Promoted_Copy; Copy) { }
             actionref(Promoted_Validate; Validate) { }
-            actionref(Promoted_SetAsDefault; SetAsDefault) { }
-            actionref(Promoted_ClearDefault; ClearDefault) { }
             group(Promoted_Advanced)
             {
                 Caption = 'Advanced';

--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
@@ -62,7 +62,7 @@ page 8351 "MCP Config Card"
                     field(Default; Rec.Default)
                     {
                         Caption = 'Default';
-                        ToolTip = 'Specifies whether this configuration is the default. The default configuration is used when no configuration is specified by a connection. Clear this field to remove the default designation, in which case the system reverts to built-in default settings.';
+                        ToolTip = 'Specifies whether this configuration is the default. The default configuration is used when no configuration is specified by a connection. Clear this field to remove the default designation, in which case the system reverts to built-in default configuration.';
                         Editable = not IsDefault;
 
                         trigger OnValidate()

--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
@@ -74,7 +74,6 @@ page 8351 "MCP Config Card"
                                 MCPConfigImplementation.SetAsDefaultConfiguration(Rec.SystemId)
                             else
                                 MCPConfigImplementation.ClearDefaultConfiguration();
-                            CurrPage.Update(false);
                         end;
                     }
                     field(EnableDynamicToolMode; Rec.EnableDynamicToolMode)

--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
@@ -62,7 +62,7 @@ page 8351 "MCP Config Card"
                     field(Default; Rec.Default)
                     {
                         Caption = 'Default';
-                        ToolTip = 'Specifies whether this configuration is the default. The default configuration is used when no configuration is specified by a connection.';
+                        ToolTip = 'Specifies whether this configuration is the default. The default configuration is used when no configuration is specified by a connection. Clear this field to remove the default designation, in which case the system reverts to built-in default settings.';
                         Editable = not IsDefault;
 
                         trigger OnValidate()

--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigList.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigList.Page.al
@@ -42,7 +42,7 @@ page 8350 "MCP Config List"
                 }
                 field(Default; Rec.Default)
                 {
-                    ToolTip = 'Specifies whether this configuration is the default. The default configuration is used when no configuration is specified by a connection.';
+                    ToolTip = 'Specifies whether this configuration is the default. The default configuration is used when no configuration is specified by a connection. Clear this field to remove the default designation, in which case the system reverts to built-in default settings.';
                     Editable = false;
                 }
                 field(EnableDynamicToolMode; Rec.EnableDynamicToolMode)

--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigList.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigList.Page.al
@@ -42,7 +42,7 @@ page 8350 "MCP Config List"
                 }
                 field(Default; Rec.Default)
                 {
-                    ToolTip = 'Specifies whether this configuration is the default. The default configuration is used when no configuration is specified by a connection. Clear this field to remove the default designation, in which case the system reverts to built-in default settings.';
+                    ToolTip = 'Specifies whether this configuration is the default. The default configuration is used when no configuration is specified by a connection. Clear this field to remove the default designation, in which case the system reverts to built-in default configuration.';
                     Editable = false;
                 }
                 field(EnableDynamicToolMode; Rec.EnableDynamicToolMode)

--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigList.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigList.Page.al
@@ -137,47 +137,11 @@ page 8350 "MCP Config List"
                         CurrPage.Update(false);
                     end;
                 }
-                action(SetAsDefault)
-                {
-                    Caption = 'Set as Default';
-                    ToolTip = 'Set this configuration as the default. It will be used when no configuration is specified by a connection.';
-                    Image = Approve;
-                    AccessByPermission = tabledata "MCP Configuration" = M;
-                    Scope = Repeater;
-                    Enabled = not Rec.Default;
-
-                    trigger OnAction()
-                    var
-                        MCPConfigImplementation: Codeunit "MCP Config Implementation";
-                    begin
-                        MCPConfigImplementation.SetAsDefaultConfiguration(Rec.SystemId);
-                        CurrPage.Update(false);
-                    end;
-                }
-                action(ClearDefault)
-                {
-                    Caption = 'Clear Default';
-                    ToolTip = 'Remove the default designation from this configuration. The system will revert to built-in default settings.';
-                    Image = Undo;
-                    AccessByPermission = tabledata "MCP Configuration" = M;
-                    Scope = Repeater;
-                    Enabled = Rec.Default;
-
-                    trigger OnAction()
-                    var
-                        MCPConfigImplementation: Codeunit "MCP Config Implementation";
-                    begin
-                        MCPConfigImplementation.ClearDefaultConfiguration();
-                        CurrPage.Update(false);
-                    end;
-                }
             }
         }
         area(Promoted)
         {
             actionref(Promoted_Copy; Copy) { }
-            actionref(Promoted_SetAsDefault; SetAsDefault) { }
-            actionref(Promoted_ClearDefault; ClearDefault) { }
             actionref(Promoted_GiveFeedback; GiveFeedback) { }
             group(Promoted_Advanced)
             {


### PR DESCRIPTION
## Summary
Replaces the **Set as Default** / **Clear Default** actions on the MCP Configuration Card and List pages with an editable **Default** field. The new field's `OnValidate` trigger toggles the designation directly via the existing `MCPConfigImplementation.SetAsDefaultConfiguration` / `ClearDefaultConfiguration` helpers, so behaviour is unchanged - just exposed through the field instead of two separate actions.

## Changes
- `MCP Config Card` (page 8351): made `Default` field editable when the row is not the built-in default; added `OnValidate` trigger; removed `SetAsDefault` and `ClearDefault` actions and their promoted refs.
- `MCP Config List` (page 8350): removed `SetAsDefault` and `ClearDefault` repeater actions and their promoted refs (the column's `Default` field already toggles the designation now).

Fixes [AB#612699](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612699)




