### PR TITLE
(Bug 634464): [Subcontracting] Purchase Order creation confirmation uses non-standard "Order(s)" pluralization

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchaseOrderCreator.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchaseOrderCreator.Codeunit.al
@@ -30,8 +30,9 @@ codeunit 99001557 "Subc. Purchase Order Creator"
         HasManufacturingSetup: Boolean;
         OperationNo: Code[10];
         RoutingReferenceNo: Integer;
-        PurchOrderCreatedTxt: Label '%1 Purchase Order(s) created.\\Do you want to view them?', Comment = '%1 = No of Purchase Order(s) created.';
-        PurchOrderAlreadyCreatedQst: Label 'Purchase order(s) have already been created.\\Do you want to view them?';
+        PurchOrderCreatedSingularTxt: Label 'A purchase order was created.\\Do you want to view it?';
+        PurchOrderCreatedPluralTxt: Label '%1 purchase orders were created.\\Do you want to view them?', Comment = '%1 = number of purchase orders created';
+        PurchOrderAlreadyCreatedQst: Label 'Purchase orders have already been created.\\Do you want to view them?';
         CreationOfSubcontractingOrderIsNotAllowedErr: Label 'You cannot create Subcontracting Order, because the Production Order %1 is not released.', Comment = '%1=Production Order No.';
         NoProdOrderLineWithRemQtyErr: Label 'No Prod. Order Line with Remaining Quantity.';
         BlankLocationConfirmQst: Label 'One or more Prod. Order Components with Subcontracting Type Transfer have a blank Location Code. Without a Location Code, you will not be able to create a transfer order to send the components to the subcontractor.\\Do you want to create the Subcontracting Order anyway?';
@@ -179,7 +180,7 @@ codeunit 99001557 "Subc. Purchase Order Creator"
         if NoOfCreatedPurchOrder = 0 then
             exit;
         if InstructionMgt.IsEnabled(SubcNotificationMgmt.GetShowCreatedSubContPurchOrderCode()) then
-            if InstructionMgt.ShowConfirm(StrSubstNo(PurchOrderCreatedTxt, NoOfCreatedPurchOrder), SubcNotificationMgmt.GetShowCreatedSubContPurchOrderCode()) and
+            if InstructionMgt.ShowConfirm(GetPurchOrderCreatedMessage(NoOfCreatedPurchOrder), SubcNotificationMgmt.GetShowCreatedSubContPurchOrderCode()) and
                 GuiAllowed()
             then begin
                 PurchaseLine.SetCurrentKey("Document Type", Type, "Prod. Order No.");
@@ -199,6 +200,13 @@ codeunit 99001557 "Subc. Purchase Order Creator"
                     PageManagement.PageRun(PurchaseHeader);
                 end;
             end;
+    end;
+
+    local procedure GetPurchOrderCreatedMessage(NoOfCreatedPurchOrder: Integer): Text
+    begin
+        if NoOfCreatedPurchOrder > 1 then
+            exit(StrSubstNo(PurchOrderCreatedPluralTxt, NoOfCreatedPurchOrder));
+        exit(PurchOrderCreatedSingularTxt);
     end;
 
     internal procedure SetOperationNoForCreatedPurchaseOrder(OperationNoToSet: Code[10])

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2451,7 +2451,7 @@ codeunit 139989 "Subc. Subcontracting Test"
     begin
         // [SCENARIO 634238] When a Released Production Order has multiple Prod. Order lines sharing the same
         // Routing/Operation, creating a Subcontracting Order for the second line must not raise the false
-        // "Purchase order(s) have already been created" warning, and must create/show its own Purchase Order.
+        // "Purchase orders have already been created" warning, and must create/show its own Purchase Order.
 
         // [GIVEN] Subcontracting setup with direct transfer (no in-transit route)
         Initialize();
@@ -2499,7 +2499,7 @@ codeunit 139989 "Subc. Subcontracting Test"
             ProdOrderRtng.CreateSubcontracting.Invoke();
             ProdOrderRtng.Close();
 
-            Assert.AreEqual('1 Purchase Order(s) created.\\Do you want to view them?', LibraryVariableStorage.DequeueText(), 'Expected "created" confirmation for each prod order line, not the false "already created" warning');
+            Assert.AreEqual('A purchase order was created.\\Do you want to view it?', LibraryVariableStorage.DequeueText(), 'Expected "created" confirmation for each prod order line, not the false "already created" warning');
             LibraryVariableStorage.AssertEmpty();
         end;
     end;


### PR DESCRIPTION
## Summary
Fixes [AB#634464](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634464)

## Changes
**`SubcPurchaseOrderCreator.Codeunit.al`**
- Replaced `PurchOrderCreatedTxt` (`'%1 Purchase Order(s) created.\\Do you want to view them?'`) with two count-aware labels following the BaseApp `CreateContractServiceOrders.Report.al` pattern:
  - `PurchOrderCreatedSingularTxt`: `'A purchase order was created.\\Do you want to view it?'`
  - `PurchOrderCreatedPluralTxt`: `'%1 purchase orders were created.\\Do you want to view them?'`
- Reworded `PurchOrderAlreadyCreatedQst` to always-plural sentence case: `'Purchase orders have already been created.\\Do you want to view them?'` (no count parameter — by the time this fires, one or more POs already exist).
- Added a local `GetPurchOrderCreatedMessage` helper that picks the right label based on `NoOfCreatedPurchOrder` and is used at the existing call site.

**`SubcSubcontractingTest.Codeunit.al`**
- Updated the exact-text assertion in `CreateSubcontractingPONavigatesToOwnPOWhenLinesShareRoutingAndOperation` to expect the new singular wording (the test creates exactly one PO per iteration).
- Updated an inline scenario comment to drop the `(s)` form.

## Why this wording
- `(s)` pluralization is not used anywhere else in BaseApp — the established idioms are either count-aware singular/plural labels (e.g. `CreateContractServiceOrders.Report.al:202-203`) or always-plural wording.
- Sentence case matches BC dialog-text conventions; the old labels were inconsistent (`Purchase Order(s)` title case vs. `Purchase order(s)` sentence case on adjacent lines).
- Picked the count-aware variant because the singular case ("1 purchase orders were created.") would otherwise read awkwardly; chose the `'A purchase order was created.'` form (no `%1`) for the singular because the count is always 1 there.
