### PR TITLE
Bug 636814: Rename WIP Ledger Entries to Subcontracting WIP Entries

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcFinishedProdOrder.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcFinishedProdOrder.PageExt.al
@@ -15,11 +15,11 @@ pageextension 99001548 "Subc. Finished Prod. Order" extends "Finished Production
             action("WIP Ledger Entries")
             {
                 ApplicationArea = Manufacturing;
-                Caption = 'WIP Ledger Entries';
+                Caption = 'Subcontracting WIP Entries';
                 Image = LedgerEntries;
                 RunObject = page "Subc. WIP Ledger Entries";
                 RunPageLink = "Prod. Order Status" = field(Status), "Prod. Order No." = field("No.");
-                ToolTip = 'View the Subcontractor WIP Ledger Entries for this production order.';
+                ToolTip = 'View the Subcontracting WIP Entries for this production order.';
             }
         }
         addlast(Category_Entries)

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcFinishedProdOrders.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcFinishedProdOrders.PageExt.al
@@ -15,11 +15,11 @@ pageextension 99001543 "Subc. Finished Prod. Orders" extends "Finished Productio
             action("WIP Ledger Entries")
             {
                 ApplicationArea = Manufacturing;
-                Caption = 'WIP Ledger Entries';
+                Caption = 'Subcontracting WIP Entries';
                 Image = LedgerEntries;
                 RunObject = page "Subc. WIP Ledger Entries";
                 RunPageLink = "Prod. Order Status" = field(Status), "Prod. Order No." = field("No.");
-                ToolTip = 'View the Subcontractor WIP Ledger Entries for this production order.';
+                ToolTip = 'View the Subcontracting WIP Entries for this production order.';
             }
         }
     }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcProdOrderRtng.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcProdOrderRtng.PageExt.al
@@ -83,7 +83,7 @@ pageextension 99001503 "Subc. Prod. Order Rtng." extends "Prod. Order Routing"
             action("WIP Ledger Entries")
             {
                 ApplicationArea = Manufacturing;
-                Caption = 'WIP Ledger Entries';
+                Caption = 'Subcontracting WIP Entries';
                 Image = LedgerEntries;
                 RunObject = page "Subc. WIP Ledger Entries";
                 RunPageLink = "Prod. Order Status" = field(Status),
@@ -91,7 +91,7 @@ pageextension 99001503 "Subc. Prod. Order Rtng." extends "Prod. Order Routing"
                               "Routing Reference No." = field("Routing Reference No."),
                               "Routing No." = field("Routing No."),
                               "Operation No." = field("Operation No.");
-                ToolTip = 'View the Subcontractor WIP Ledger Entries for this routing line.';
+                ToolTip = 'View the Subcontracting WIP Entries for this routing line.';
             }
         }
         addlast("F&unctions")

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcRelProdOrder.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcRelProdOrder.PageExt.al
@@ -39,11 +39,11 @@ pageextension 99001504 "Subc. Rel. Prod. Order" extends "Released Production Ord
             action("WIP Ledger Entries")
             {
                 ApplicationArea = Manufacturing;
-                Caption = 'WIP Ledger Entries';
+                Caption = 'Subcontracting WIP Entries';
                 Image = LedgerEntries;
                 RunObject = page "Subc. WIP Ledger Entries";
                 RunPageLink = "Prod. Order Status" = field(Status), "Prod. Order No." = field("No.");
-                ToolTip = 'View the Subcontractor WIP Ledger Entries for this production order.';
+                ToolTip = 'View the Subcontracting WIP Entries for this production order.';
             }
         }
         addlast("F&unctions")

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcRelProdOrders.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcRelProdOrders.PageExt.al
@@ -27,11 +27,11 @@ pageextension 99001505 "Subc. Rel. Prod. Orders" extends "Released Production Or
             action("WIP Ledger Entries")
             {
                 ApplicationArea = Manufacturing;
-                Caption = 'WIP Ledger Entries';
+                Caption = 'Subcontracting WIP Entries';
                 Image = LedgerEntries;
                 RunObject = page "Subc. WIP Ledger Entries";
                 RunPageLink = "Prod. Order Status" = field(Status), "Prod. Order No." = field("No.");
-                ToolTip = 'View the Subcontractor WIP Ledger Entries for this production order.';
+                ToolTip = 'View the Subcontracting WIP Entries for this production order.';
             }
         }
     }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcWorkCenterCard.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcWorkCenterCard.PageExt.al
@@ -35,11 +35,11 @@ pageextension 99001506 "Subc. Work Center Card" extends "Work Center Card"
             action("WIP Ledger Entries")
             {
                 ApplicationArea = Manufacturing;
-                Caption = 'WIP Ledger Entries';
+                Caption = 'Subcontracting WIP Entries';
                 Image = LedgerEntries;
                 RunObject = page "Subc. WIP Ledger Entries";
                 RunPageLink = "Work Center No." = field("No.");
-                ToolTip = 'View the Subcontractor WIP Ledger Entries that track work-in-progress quantities at this work center''s subcontracting location.';
+                ToolTip = 'View the Subcontracting WIP Entries that track work-in-progress quantities at this work center''s subcontracting location.';
             }
         }
         modify("Subcontractor - Dispatch List")

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcWorkCenterList.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcWorkCenterList.PageExt.al
@@ -36,11 +36,11 @@ pageextension 99001507 "Subc. Work Center List" extends "Work Center List"
                 action("WIP Ledger Entries")
                 {
                     ApplicationArea = Manufacturing;
-                    Caption = 'WIP Ledger Entries';
+                    Caption = 'Subcontracting WIP Entries';
                     Image = LedgerEntries;
                     RunObject = page "Subc. WIP Ledger Entries";
                     RunPageLink = "Work Center No." = field("No.");
-                    ToolTip = 'View the Subcontractor WIP Ledger Entries that track work-in-progress quantities at this work center''s subcontracting location.';
+                    ToolTip = 'View the Subcontracting WIP Entries that track work-in-progress quantities at this work center''s subcontracting location.';
                 }
             }
         }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/MasterData/SubcItemList.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/MasterData/SubcItemList.PageExt.al
@@ -28,11 +28,11 @@ pageextension 99001519 "Subc. Item List" extends "Item List"
             action("WIP Ledger Entries")
             {
                 ApplicationArea = Manufacturing;
-                Caption = 'WIP Ledger Entries';
+                Caption = 'Subcontracting WIP Entries';
                 Image = LedgerEntries;
                 RunObject = page "Subc. WIP Ledger Entries";
                 RunPageLink = "Item No." = field("No.");
-                ToolTip = 'View the Subcontractor WIP Ledger Entries that track work-in-progress quantities for this item across subcontracting locations.';
+                ToolTip = 'View the Subcontracting WIP Entries that track work-in-progress quantities for this item across subcontracting locations.';
             }
         }
     }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Tableextensions/Manufacturing/SubcProdOrderRtngLineExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Tableextensions/Manufacturing/SubcProdOrderRtngLineExt.TableExt.al
@@ -110,7 +110,7 @@ tableextension 99001506 "Subc. ProdOrderRtngLine Ext." extends "Prod. Order Rout
             DecimalPlaces = 0 : 5;
             Editable = false;
             FieldClass = FlowField;
-            ToolTip = 'Specifies the total work-in-progress quantity (base) of the production order parent item currently held at the subcontractor location for this operation, as tracked by Subcontractor WIP Ledger Entries.';
+            ToolTip = 'Specifies the total work-in-progress quantity (base) of the production order parent item currently held at the subcontractor location for this operation, as tracked by Subcontracting WIP Entries.';
         }
         field(99001564; "WIP Qty. (Base) in Transit"; Decimal)
         {

--- a/src/Apps/W1/Subcontracting/App/src/Process/WIP Item/SubcWIPLedgerEntries.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/WIP Item/SubcWIPLedgerEntries.Page.al
@@ -7,7 +7,7 @@ namespace Microsoft.Manufacturing.Subcontracting;
 page 99001560 "Subc. WIP Ledger Entries"
 {
     ApplicationArea = Manufacturing;
-    Caption = 'WIP Ledger Entries';
+    Caption = 'Subcontracting WIP Entries';
     Editable = false;
     PageType = List;
     SourceTable = "Subcontractor WIP Ledger Entry";


### PR DESCRIPTION
## Summary
- The Subcontracting WIP page and all navigation actions were titled **WIP Ledger Entries**, making it unclear they belong to the Subcontracting module.
- Renamed all user-facing captions and tooltips to **Subcontracting WIP Entries** for clarity and discoverability.

## Root Cause
The page caption and action captions used a generic name ("WIP Ledger Entries") that didn't identify the Subcontracting scope.

## Fix
- Updated `Caption` property on page 99001560 "Subc. WIP Ledger Entries"
- Updated `Caption` and `ToolTip` on 8 page extension actions across production order, work center, and item list pages
- Updated `ToolTip` on table extension field referencing the old name

## Test
No automated test — this is a UI caption/tooltip-only change with no logic impact.

Fixes [AB#636814](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636814)

:robot: Generated with GitHub Copilot


