### PR TITLE
[SOA] Enhance attachment handling in agent task messages with ignored…

### DIFF
--- a/src/System Application/App/Agent/Interaction/AgentTaskMessageBuilder.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/AgentTaskMessageBuilder.Codeunit.al
@@ -204,6 +204,24 @@ codeunit 4316 "Agent Task Message Builder"
     /// The file will be attached when the message is created.
     /// It is possible to attach multiple files to the message.
     /// </summary>
+    /// <param name="FileName">The name of the file to attach.</param>
+    /// <param name="FileMIMEType">The MIME type of the file to attach.</param>
+    /// <param name="InStream">The stream of the file to attach.</param>
+    /// <param name="Ignored">Specifies if the attachment should be marked as ignored, so that it is not processed by agent.</param>
+    /// <param name="IgnoredReason">Specifies why the attachment was ignored.</param>
+    /// <returns>This instance of the Agent Task Message Builder.</returns>
+    procedure AddAttachment(FileName: Text[250]; FileMIMEType: Text[100]; InStream: InStream; Ignored: Boolean; IgnoredReason: Text[250]): codeunit "Agent Task Message Builder"
+    begin
+        FeatureAccessManagement.AgentTaskManagementPreviewEnabled(true);
+        AgentTaskMsgBuilderImpl.AddAttachment(FileName, FileMIMEType, InStream, Ignored, IgnoredReason);
+        exit(this);
+    end;
+
+    /// <summary>
+    /// Attach a file to the task message.
+    /// The file will be attached when the message is created.
+    /// It is possible to attach multiple files to the message.
+    /// </summary>
     /// <param name="AgentTaskFile">The file to attach.</param>
     /// <returns>This instance of the Agent Task Message Builder.</returns>
 #if not CLEAN28

--- a/src/System Application/App/Agent/Interaction/Internal/AgentMessageImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentMessageImpl.Codeunit.al
@@ -96,7 +96,7 @@ codeunit 4308 "Agent Message Impl."
         GlobalIgnoreAttachment := IgnoreAttachment;
     end;
 
-    procedure AddAttachment(var AgentTaskMessage: Record "Agent Task Message"; var TempAgentTaskFile: Record "Agent Task File" temporary)
+    procedure AddAttachment(var AgentTaskMessage: Record "Agent Task Message"; var TempAgentTaskFile: Record "Agent Task File" temporary; IgnoredReason: Text[250])
     var
         AgentTaskImpl: Codeunit "Agent Task Impl.";
         FileInstream: InStream;
@@ -106,10 +106,15 @@ codeunit 4308 "Agent Message Impl."
             exit;
 
         TempAgentTaskFile.Content.CreateInStream(FileInstream, AgentTaskImpl.GetDefaultEncoding());
-        AddAttachment(AgentTaskMessage, TempAgentTaskFile."File Name", TempAgentTaskFile."File MIME Type", FileInstream);
+        AddAttachment(AgentTaskMessage, TempAgentTaskFile."File Name", TempAgentTaskFile."File MIME Type", FileInstream, IgnoredReason);
     end;
 
     procedure AddAttachment(var AgentTaskMessage: Record "Agent Task Message"; FileName: Text[250]; FileMIMEType: Text[100]; InStream: InStream)
+    begin
+        AddAttachment(AgentTaskMessage, FileName, FileMIMEType, InStream, '');
+    end;
+
+    procedure AddAttachment(var AgentTaskMessage: Record "Agent Task Message"; FileName: Text[250]; FileMIMEType: Text[100]; InStream: InStream; IgnoredReason: Text[250])
     var
         AgentTaskFile: Record "Agent Task File";
         AgentTaskMessageAttachment: Record "Agent Task Message Attachment";
@@ -129,6 +134,7 @@ codeunit 4308 "Agent Message Impl."
         AgentTaskMessageAttachment."Message ID" := AgentTaskMessage.ID;
         AgentTaskMessageAttachment."File ID" := AgentTaskFile.ID;
         AgentTaskMessageAttachment.Ignored := GlobalIgnoreAttachment;
+        AgentTaskMessageAttachment."Ignored Reason" := CopyStr(IgnoredReason, 1, MaxStrLen(AgentTaskMessageAttachment."Ignored Reason"));
         AgentTaskMessageAttachment.Insert();
     end;
 

--- a/src/System Application/App/Agent/Interaction/Internal/AgentTaskMsgBuilderImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentTaskMsgBuilderImpl.Codeunit.al
@@ -18,6 +18,7 @@ codeunit 4311 "Agent Task Msg. Builder Impl."
         GlobalAgentTask: Record "Agent Task";
         GlobalAgentTaskMessage: Record "Agent Task Message";
         GlobalIgnoreAttachmentsList: Dictionary of [BigInteger, Boolean];
+        GlobalIgnoredReasonByFileId: Dictionary of [BigInteger, Text[250]];
         GlobalFrom: Text[250];
         GlobalMessageExternalID: Text[2048];
         GlobalMessageText: Text;
@@ -95,6 +96,7 @@ codeunit 4311 "Agent Task Msg. Builder Impl."
         AgentTaskImpl: Codeunit "Agent Task Impl.";
         AgentMessageImpl: Codeunit "Agent Message Impl.";
         IgnoreAttachment: Boolean;
+        IgnoredReason: Text[250];
         MessageText: Text;
     begin
         VerifyMandatoryFieldsSet();
@@ -108,8 +110,11 @@ codeunit 4311 "Agent Task Msg. Builder Impl."
                 IgnoreAttachment := false;
                 if GlobalIgnoreAttachmentsList.ContainsKey(TempAgentTaskFileToAttach.ID) then
                     IgnoreAttachment := GlobalIgnoreAttachmentsList.Get(TempAgentTaskFileToAttach.ID);
+                IgnoredReason := '';
+                if GlobalIgnoredReasonByFileId.ContainsKey(TempAgentTaskFileToAttach.ID) then
+                    IgnoredReason := GlobalIgnoredReasonByFileId.Get(TempAgentTaskFileToAttach.ID);
                 AgentMessageImpl.SetIgnoreAttachment(GlobalIgnoreAttachment or IgnoreAttachment);
-                AgentMessageImpl.AddAttachment(GlobalAgentTaskMessage, TempAgentTaskFileToAttach);
+                AgentMessageImpl.AddAttachment(GlobalAgentTaskMessage, TempAgentTaskFileToAttach, IgnoredReason);
             until TempAgentTaskFileToAttach.Next() = 0;
 
         if SetTaskStatusToReady then
@@ -127,12 +132,19 @@ codeunit 4311 "Agent Task Msg. Builder Impl."
     [Scope('OnPrem')]
     procedure AddAttachment(FileName: Text[250]; FileMIMEType: Text[100]; InStream: InStream): codeunit "Agent Task Msg. Builder Impl."
     begin
-        AddAttachment(FileName, FileMIMEType, InStream, false);
+        AddAttachment(FileName, FileMIMEType, InStream, false, '');
         exit(this);
     end;
 
     [Scope('OnPrem')]
     procedure AddAttachment(FileName: Text[250]; FileMIMEType: Text[100]; InStream: InStream; Ignored: Boolean): codeunit "Agent Task Msg. Builder Impl."
+    begin
+        AddAttachment(FileName, FileMIMEType, InStream, Ignored, '');
+        exit(this);
+    end;
+
+    [Scope('OnPrem')]
+    procedure AddAttachment(FileName: Text[250]; FileMIMEType: Text[100]; InStream: InStream; Ignored: Boolean; IgnoredReason: Text[250]): codeunit "Agent Task Msg. Builder Impl."
     var
         FileOutStream: OutStream;
     begin
@@ -146,6 +158,8 @@ codeunit 4311 "Agent Task Msg. Builder Impl."
         TempAgentTaskFileToAttach.Modify();
 
         GlobalIgnoreAttachmentsList.Add(TempAgentTaskFileToAttach.ID, Ignored);
+        if Ignored then
+            GlobalIgnoredReasonByFileId.Add(TempAgentTaskFileToAttach.ID, IgnoredReason);
         exit(this);
     end;
 


### PR DESCRIPTION
[SOA][Backport 28.x] Enhance attachment handling in agent task messages with ignored reason support (https://github.com/microsoft/BCApps/pull/7786)
<!-- Thank you for submitting a Pull Request. If you're new to
contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This PR adds support for tracking and populating the ignored reason when
handling attachments in agent task messages.

**Changes:**
- Modified `AgentTaskMessageBuilder.Codeunit.al `to expose ignored
reason functionality
- Updated `AgentMessageImpl.Codeunit.al` to handle ignored reason in
attachment processing
- Enhanced `AgentTaskMsgBuilderImpl.Codeunit.al` to populate ignored
reason for attachments

#### Work Item(s) <!-- Add the issue number here after the #. The issue
needs to be open and approved. Submitting PRs with no linked issues or
unapproved issues is highly discouraged. -->
Fixes
[[AB#635833](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/635833)]

