### PR TITLE
Fix insert of metadata permissions

### DIFF
--- a/src/System Application/App/Permission Sets/src/xmlports/ImportPermissionSets.xmlport.al
+++ b/src/System Application/App/Permission Sets/src/xmlports/ImportPermissionSets.xmlport.al
@@ -223,18 +223,18 @@ xmlport 9864 "Import Permission Sets"
 
                 trigger OnBeforeInsertRecord()
                 var
-                    MetadataPermission: Record "Metadata Permission";
-                    MetadataPermissionSetRel: Record "Metadata Permission Set Rel.";
+                    TenantPermission: Record "Tenant Permission";
+                    TenantPermissionSetRel: Record "Tenant Permission Set Rel.";
                 begin
                     if TempMetadataPermissionSet.Get(TempMetadataPermissionSet."App ID", TempMetadataPermissionSet."Role ID") then
                         currXMLport.Skip();
                     if not UpdatePermissions then begin
-                        MetadataPermissionSetRel.SetFilter("App ID", TempMetadataPermissionSet."App ID");
-                        MetadataPermissionSetRel.SetFilter("Role ID", TempMetadataPermissionSet."Role ID");
-                        MetadataPermissionSetRel.DeleteAll();
-                        MetadataPermission.SetFilter("App ID", TempMetadataPermissionSet."App ID");
-                        MetadataPermission.SetFilter("Role ID", TempTenantPermissionSet."Role ID");
-                        MetadataPermission.DeleteAll();
+                        TenantPermissionSetRel.SetRange("App ID", TempMetadataPermissionSet."App ID");
+                        TenantPermissionSetRel.SetRange("Role ID", TempMetadataPermissionSet."Role ID");
+                        TenantPermissionSetRel.DeleteAll();
+                        TenantPermission.SetRange("App ID", TempMetadataPermissionSet."App ID");
+                        TenantPermission.SetRange("Role ID", TempMetadataPermissionSet."Role ID");
+                        TenantPermission.DeleteAll();
                     end;
                 end;
             }


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why
Fix import of tenant permission sets
<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#631431](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/631431)

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [X] I built the affected app(s) locally with no new analyzer warnings.
- [X] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->


