### PR TITLE
[E-Document] Expose E-Document Purchase Header / Line for country-app consumers

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseHeader.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseHeader.Table.al
@@ -14,7 +14,6 @@ using System.Telemetry;
 
 table 6100 "E-Document Purchase Header"
 {
-    Access = Internal;
     ReplicateData = false;
     InherentEntitlements = RIMDX;
     InherentPermissions = RIMDX;

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseLine.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseLine.Table.al
@@ -27,7 +27,6 @@ using System.Utilities;
 
 table 6101 "E-Document Purchase Line"
 {
-    Access = Internal;
     DataClassification = CustomerContent;
     ReplicateData = false;
     InherentEntitlements = RIMDX;
@@ -310,7 +309,7 @@ table 6101 "E-Document Purchase Line"
         EDocPOMatching.RemoveAllMatchesForEDocumentLine(Rec);
     end;
 
-    internal procedure GetNextLineNo(EDocumentEntryNo: Integer): Integer
+    procedure GetNextLineNo(EDocumentEntryNo: Integer): Integer
     var
         EDocumentPurchaseLine: Record "E-Document Purchase Line";
     begin


### PR DESCRIPTION
## Summary

- Removes `Access = Internal` from tables `6100 "E-Document Purchase Header"` and `6101 "E-Document Purchase Line"`.
- Promotes `EDocumentPurchaseLine.GetNextLineNo` from `internal procedure` to public.

## Why

Country-specific E-Document format apps need to populate draft purchase headers and lines from their own `IStructuredFormatReader` implementations. Today they can only do that by adding the country app to W1 E-Document Core's `internalsVisibleTo`, which is undesirable as a long-term pattern (every new country format = another `internalsVisibleTo` entry into a core W1 app).

Concrete driver: the upcoming DE XRechnung structured-format reader ([ALAppExtensions #29097](https://github.com/microsoft/ALAppExtensions/pull/29097) / NAV PR 247053). Promoting these two staging tables to public API removes that coupling for DE and any future country format apps.

## Scope

- Tables stay structurally unchanged. No fields added, removed, or renamed.
- Other internal procedures on these tables remain internal -- only `GetNextLineNo` is exposed (called from country handlers when appending lines).

## Test plan

- [x] BCApps build passes.
- [x] Existing tests under W1 EDocument continue to pass unchanged.
- [x] Downstream consumer (DE XRechnung handler) compiles against these promoted symbols without `internalsVisibleTo`.

[AB#637440](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637440)



