### PR TITLE
Add workflow to label PRs awaiting workflow approval

### DIFF
--- a/.github/actions/LabelPRsAwaitingApproval/action.ps1
+++ b/.github/actions/LabelPRsAwaitingApproval/action.ps1
@@ -57,38 +57,32 @@ function Ensure-Label {
 
 function Get-AwaitingApprovalPRs {
     Write-Host ""
-    Write-Host "Fetching workflow runs with status=action_required from $repo..."
+    Write-Host "Fetching open PRs in $repo (for head-SHA mapping)..."
+    $prsJson = Invoke-GhApi -Arguments @('--paginate', "repos/$repo/pulls?state=open&per_page=100", '--jq', '[.[] | {number: .number, sha: .head.sha}]')
+    $openPRs = @()
+    if ($prsJson) { $openPRs = @($prsJson | ConvertFrom-Json) }
+    Write-Host "Found $($openPRs.Count) open PR(s)"
+
+    # Map of current PR head SHA -> PR number. We match action_required runs
+    # against the *current* head only, so PRs with stale action_required runs
+    # from older commits (whose newer commits have been approved) are not
+    # falsely flagged.
+    $headShaToPR = @{}
+    foreach ($pr in $openPRs) {
+        if ($pr.sha) { $headShaToPR[$pr.sha] = [int]$pr.number }
+    }
+
+    Write-Host ""
+    Write-Host "Fetching workflow runs with status=action_required..."
     $runsJson = Invoke-GhApi -Arguments @("repos/$repo/actions/runs?status=action_required&per_page=100", '--jq', '.workflow_runs')
     $runs = @()
     if ($runsJson) { $runs = @($runsJson | ConvertFrom-Json) }
     Write-Host "Found $($runs.Count) action_required workflow run(s)"
 
     $awaiting = [System.Collections.Generic.HashSet[int]]::new()
-    $shaCache = @{}
-
     foreach ($run in $runs) {
-        $prNumbers = @()
-        $hasPRs = ($run.PSObject.Properties.Name -contains 'pull_requests') -and $run.pull_requests
-        if ($hasPRs -and $run.pull_requests.Count -gt 0) {
-            $prNumbers = @($run.pull_requests | ForEach-Object { [int]$_.number })
-        }
-        elseif ($run.PSObject.Properties.Name -contains 'head_sha' -and $run.head_sha) {
-            $sha = $run.head_sha
-            if (-not $shaCache.ContainsKey($sha)) {
-                try {
-                    $byShaJson = Invoke-GhApi -Arguments @("repos/$repo/commits/$sha/pulls", '--jq', '[.[] | select(.state=="open") | .number]')
-                    $shaCache[$sha] = @($byShaJson | ConvertFrom-Json)
-                }
-                catch {
-                    Write-Host "  ! Failed to resolve PRs for run $($run.id) (sha $sha): $_"
-                    $shaCache[$sha] = @()
-                }
-            }
-            $prNumbers = $shaCache[$sha]
-        }
-
-        foreach ($n in $prNumbers) {
-            [void]$awaiting.Add([int]$n)
+        if (($run.PSObject.Properties.Name -contains 'head_sha') -and $run.head_sha -and $headShaToPR.ContainsKey($run.head_sha)) {
+            [void]$awaiting.Add($headShaToPR[$run.head_sha])
         }
     }
 

--- a/.github/actions/LabelPRsAwaitingApproval/action.ps1
+++ b/.github/actions/LabelPRsAwaitingApproval/action.ps1
@@ -24,14 +24,27 @@ function Invoke-GhApi {
         [int] $MaxRetries = 3
     )
     for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        $stderrFile = [System.IO.Path]::GetTempFileName()
         try {
-            $result = & gh api @Arguments 2>&1
-            if ($LASTEXITCODE -eq 0) { return $result }
-            throw "gh api failed (exit $LASTEXITCODE): $result"
+            # Redirect stderr to a temp file so deprecation notices / warnings
+            # don't get prepended to stdout and break ConvertFrom-Json.
+            $stdout = & gh api @Arguments 2>$stderrFile
+            if ($LASTEXITCODE -eq 0) {
+                $stderrText = Get-Content -Path $stderrFile -Raw -ErrorAction SilentlyContinue
+                if ($stderrText -and $stderrText.Trim()) {
+                    Write-Host "  gh api stderr: $($stderrText.Trim())"
+                }
+                return $stdout
+            }
+            $stderrText = Get-Content -Path $stderrFile -Raw -ErrorAction SilentlyContinue
+            throw "gh api failed (exit $LASTEXITCODE): $stderrText"
         }
         catch {
             if ($attempt -eq $MaxRetries) { throw }
             Start-Sleep -Seconds ([Math]::Pow(2, $attempt))
+        }
+        finally {
+            Remove-Item -Path $stderrFile -ErrorAction SilentlyContinue
         }
     }
 }
@@ -58,9 +71,13 @@ function Ensure-Label {
 function Get-AwaitingApprovalPRs {
     Write-Host ""
     Write-Host "Fetching open PRs in $repo (for head-SHA mapping)..."
-    $prsJson = Invoke-GhApi -Arguments @('--paginate', "repos/$repo/pulls?state=open&per_page=100", '--jq', '[.[] | {number: .number, sha: .head.sha}]')
-    $openPRs = @()
-    if ($prsJson) { $openPRs = @($prsJson | ConvertFrom-Json) }
+    # With --paginate, gh runs the --jq filter against each page and emits the
+    # results concatenated. We use a filter that emits one JSON object per
+    # line, and parse them individually below (NDJSON style) - this avoids
+    # the "multiple JSON arrays concatenated" problem that breaks
+    # ConvertFrom-Json.
+    $prsJson = Invoke-GhApi -Arguments @('--paginate', "repos/$repo/pulls?state=open&per_page=100", '--jq', '.[] | {number: .number, sha: .head.sha}')
+    $openPRs = @($prsJson | Where-Object { $_ -and $_.ToString().Trim() } | ForEach-Object { $_ | ConvertFrom-Json })
     Write-Host "Found $($openPRs.Count) open PR(s)"
 
     # Map of current PR head SHA -> PR number. We match action_required runs
@@ -74,9 +91,8 @@ function Get-AwaitingApprovalPRs {
 
     Write-Host ""
     Write-Host "Fetching workflow runs with status=action_required..."
-    $runsJson = Invoke-GhApi -Arguments @("repos/$repo/actions/runs?status=action_required&per_page=100", '--jq', '.workflow_runs')
-    $runs = @()
-    if ($runsJson) { $runs = @($runsJson | ConvertFrom-Json) }
+    $runsJson = Invoke-GhApi -Arguments @('--paginate', "repos/$repo/actions/runs?status=action_required&per_page=100", '--jq', '.workflow_runs[]')
+    $runs = @($runsJson | Where-Object { $_ -and $_.ToString().Trim() } | ForEach-Object { $_ | ConvertFrom-Json })
     Write-Host "Found $($runs.Count) action_required workflow run(s)"
 
     $awaiting = [System.Collections.Generic.HashSet[int]]::new()
@@ -96,10 +112,10 @@ function Get-LabeledPRs {
     Write-Host ""
     Write-Host "Fetching open PRs currently labelled '$LabelName'..."
     $encoded = [Uri]::EscapeDataString($LabelName)
-    $json = Invoke-GhApi -Arguments @('--paginate', "repos/$repo/issues?state=open&labels=$encoded&per_page=100", '--jq', '[.[] | select(.pull_request) | .number]')
+    $json = Invoke-GhApi -Arguments @('--paginate', "repos/$repo/issues?state=open&labels=$encoded&per_page=100", '--jq', '.[] | select(.pull_request) | .number')
     $set = [System.Collections.Generic.HashSet[int]]::new()
-    if ($json) {
-        foreach ($n in @($json | ConvertFrom-Json)) { [void]$set.Add([int]$n) }
+    foreach ($n in @($json | Where-Object { $_ -and $_.ToString().Trim() -match '^\d+$' })) {
+        [void]$set.Add([int]$n)
     }
     Write-Host "Found $($set.Count) PR(s) with label '$LabelName'"
     return ,$set

--- a/.github/actions/LabelPRsAwaitingApproval/action.ps1
+++ b/.github/actions/LabelPRsAwaitingApproval/action.ps1
@@ -51,11 +51,20 @@ function Invoke-GhApi {
 
 function Ensure-Label {
     param ([string] $Name)
+    $stderrFile = [System.IO.Path]::GetTempFileName()
     try {
-        Invoke-GhApi -Arguments @("repos/$repo/labels/$([Uri]::EscapeDataString($Name))") | Out-Null
-        Write-Host "Label '$Name' exists"
-    }
-    catch {
+        & gh api "repos/$repo/labels/$([Uri]::EscapeDataString($Name))" 2>$stderrFile | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "Label '$Name' exists"
+            return
+        }
+        $errText = Get-Content -Path $stderrFile -Raw -ErrorAction SilentlyContinue
+        # Only treat genuine "not found" responses as a signal to create the
+        # label. Other failures (rate limiting, 5xx, network) should bubble
+        # up so they're not masked as a missing-label condition.
+        if ($errText -notmatch 'HTTP 404|Not Found') {
+            throw "Unexpected error checking label '$Name' (exit $LASTEXITCODE): $errText"
+        }
         Write-Host "Label '$Name' not found - creating it"
         if ($WhatIf) {
             Write-Host "  [WhatIf] Would create label '$Name'"
@@ -65,6 +74,9 @@ function Ensure-Label {
         if ($LASTEXITCODE -ne 0) {
             throw "Failed to create label '$Name'"
         }
+    }
+    finally {
+        Remove-Item -Path $stderrFile -ErrorAction SilentlyContinue
     }
 }
 
@@ -80,13 +92,20 @@ function Get-AwaitingApprovalPRs {
     $openPRs = @($prsJson | Where-Object { $_ -and $_.ToString().Trim() } | ForEach-Object { $_ | ConvertFrom-Json })
     Write-Host "Found $($openPRs.Count) open PR(s)"
 
-    # Map of current PR head SHA -> PR number. We match action_required runs
-    # against the *current* head only, so PRs with stale action_required runs
-    # from older commits (whose newer commits have been approved) are not
-    # falsely flagged.
-    $headShaToPR = @{}
+    # Map of current PR head SHA -> list of PR numbers. We match action_required
+    # runs against the *current* head only, so PRs with stale action_required
+    # runs from older commits (whose newer commits have been approved) are not
+    # falsely flagged. A list (rather than a single PR) handles the edge case
+    # where multiple open PRs share the same head SHA (e.g. one PR per base
+    # branch from a single commit).
+    $headShaToPRs = @{}
     foreach ($pr in $openPRs) {
-        if ($pr.sha) { $headShaToPR[$pr.sha] = [int]$pr.number }
+        if ($pr.sha) {
+            if (-not $headShaToPRs.ContainsKey($pr.sha)) {
+                $headShaToPRs[$pr.sha] = [System.Collections.Generic.List[int]]::new()
+            }
+            $headShaToPRs[$pr.sha].Add([int]$pr.number)
+        }
     }
 
     Write-Host ""
@@ -97,8 +116,10 @@ function Get-AwaitingApprovalPRs {
 
     $awaiting = [System.Collections.Generic.HashSet[int]]::new()
     foreach ($run in $runs) {
-        if (($run.PSObject.Properties.Name -contains 'head_sha') -and $run.head_sha -and $headShaToPR.ContainsKey($run.head_sha)) {
-            [void]$awaiting.Add($headShaToPR[$run.head_sha])
+        if (($run.PSObject.Properties.Name -contains 'head_sha') -and $run.head_sha -and $headShaToPRs.ContainsKey($run.head_sha)) {
+            foreach ($prNum in $headShaToPRs[$run.head_sha]) {
+                [void]$awaiting.Add($prNum)
+            }
         }
     }
 

--- a/.github/actions/LabelPRsAwaitingApproval/action.ps1
+++ b/.github/actions/LabelPRsAwaitingApproval/action.ps1
@@ -1,0 +1,185 @@
+param (
+    [Parameter(Mandatory = $false, HelpMessage = "Label to manage on PRs awaiting workflow approval")]
+    [string] $Label = 'needs-approval',
+    [Parameter(Mandatory = $false, HelpMessage = "Dry-run mode - log changes without applying them")]
+    [switch] $WhatIf
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+Set-StrictMode -Version 2.0
+
+$repo = $env:GITHUB_REPOSITORY
+if (-not $repo) {
+    throw "GITHUB_REPOSITORY environment variable is not set"
+}
+
+if ($WhatIf) {
+    Write-Host "::notice::Running in WhatIf mode - no label changes will be applied"
+}
+
+function Invoke-GhApi {
+    param (
+        [Parameter(Mandatory = $true)] [string[]] $Arguments,
+        [int] $MaxRetries = 3
+    )
+    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        try {
+            $result = & gh api @Arguments 2>&1
+            if ($LASTEXITCODE -eq 0) { return $result }
+            throw "gh api failed (exit $LASTEXITCODE): $result"
+        }
+        catch {
+            if ($attempt -eq $MaxRetries) { throw }
+            Start-Sleep -Seconds ([Math]::Pow(2, $attempt))
+        }
+    }
+}
+
+function Ensure-Label {
+    param ([string] $Name)
+    try {
+        Invoke-GhApi -Arguments @("repos/$repo/labels/$([Uri]::EscapeDataString($Name))") | Out-Null
+        Write-Host "Label '$Name' exists"
+    }
+    catch {
+        Write-Host "Label '$Name' not found - creating it"
+        if ($WhatIf) {
+            Write-Host "  [WhatIf] Would create label '$Name'"
+            return
+        }
+        & gh label create $Name --repo $repo --color 'FBCA04' --description 'Workflow runs require maintainer approval to start' 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to create label '$Name'"
+        }
+    }
+}
+
+function Get-AwaitingApprovalPRs {
+    Write-Host ""
+    Write-Host "Fetching workflow runs with status=action_required from $repo..."
+    $runsJson = Invoke-GhApi -Arguments @("repos/$repo/actions/runs?status=action_required&per_page=100", '--jq', '.workflow_runs')
+    $runs = @()
+    if ($runsJson) { $runs = @($runsJson | ConvertFrom-Json) }
+    Write-Host "Found $($runs.Count) action_required workflow run(s)"
+
+    $awaiting = [System.Collections.Generic.HashSet[int]]::new()
+    $shaCache = @{}
+
+    foreach ($run in $runs) {
+        $prNumbers = @()
+        $hasPRs = ($run.PSObject.Properties.Name -contains 'pull_requests') -and $run.pull_requests
+        if ($hasPRs -and $run.pull_requests.Count -gt 0) {
+            $prNumbers = @($run.pull_requests | ForEach-Object { [int]$_.number })
+        }
+        elseif ($run.PSObject.Properties.Name -contains 'head_sha' -and $run.head_sha) {
+            $sha = $run.head_sha
+            if (-not $shaCache.ContainsKey($sha)) {
+                try {
+                    $byShaJson = Invoke-GhApi -Arguments @("repos/$repo/commits/$sha/pulls", '--jq', '[.[] | select(.state=="open") | .number]')
+                    $shaCache[$sha] = @($byShaJson | ConvertFrom-Json)
+                }
+                catch {
+                    Write-Host "  ! Failed to resolve PRs for run $($run.id) (sha $sha): $_"
+                    $shaCache[$sha] = @()
+                }
+            }
+            $prNumbers = $shaCache[$sha]
+        }
+
+        foreach ($n in $prNumbers) {
+            [void]$awaiting.Add([int]$n)
+        }
+    }
+
+    # Comma prevents PowerShell from unrolling the HashSet (which would
+    # turn an empty set into $null at the call site).
+    return ,$awaiting
+}
+
+function Get-LabeledPRs {
+    param ([string] $LabelName)
+    Write-Host ""
+    Write-Host "Fetching open PRs currently labelled '$LabelName'..."
+    $encoded = [Uri]::EscapeDataString($LabelName)
+    $json = Invoke-GhApi -Arguments @('--paginate', "repos/$repo/issues?state=open&labels=$encoded&per_page=100", '--jq', '[.[] | select(.pull_request) | .number]')
+    $set = [System.Collections.Generic.HashSet[int]]::new()
+    if ($json) {
+        foreach ($n in @($json | ConvertFrom-Json)) { [void]$set.Add([int]$n) }
+    }
+    Write-Host "Found $($set.Count) PR(s) with label '$LabelName'"
+    return ,$set
+}
+
+# --- Main ---
+
+Ensure-Label -Name $Label
+$awaitingPRs = Get-AwaitingApprovalPRs
+$labeledPRs  = Get-LabeledPRs -LabelName $Label
+
+if ($awaitingPRs.Count -gt 0) {
+    Write-Host ""
+    Write-Host "PRs awaiting approval:"
+    $awaitingPRs | Sort-Object | ForEach-Object { Write-Host "  - #$_" }
+}
+
+$toAdd    = @($awaitingPRs | Where-Object { -not $labeledPRs.Contains($_) } | Sort-Object)
+$toRemove = @($labeledPRs  | Where-Object { -not $awaitingPRs.Contains($_) } | Sort-Object)
+
+Write-Host ""
+Write-Host "Plan: add '$Label' to $($toAdd.Count) PR(s), remove from $($toRemove.Count) PR(s)"
+
+$added = 0; $removed = 0; $failed = 0
+
+foreach ($pr in $toAdd) {
+    Write-Host "  + Add '$Label' to PR #$pr"
+    if ($WhatIf) { $added++; continue }
+    try {
+        & gh pr edit $pr --repo $repo --add-label $Label 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "gh pr edit exited with $LASTEXITCODE" }
+        $added++
+    }
+    catch {
+        Write-Host "    ::warning::Failed to add label to PR #${pr}: $_"
+        $failed++
+    }
+}
+
+foreach ($pr in $toRemove) {
+    Write-Host "  - Remove '$Label' from PR #$pr"
+    if ($WhatIf) { $removed++; continue }
+    try {
+        & gh pr edit $pr --repo $repo --remove-label $Label 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "gh pr edit exited with $LASTEXITCODE" }
+        $removed++
+    }
+    catch {
+        Write-Host "    ::warning::Failed to remove label from PR #${pr}: $_"
+        $failed++
+    }
+}
+
+Write-Host ""
+Write-Host "Summary:"
+Write-Host "  PRs awaiting approval: $($awaitingPRs.Count)"
+Write-Host "  Labels added:          $added"
+Write-Host "  Labels removed:        $removed"
+Write-Host "  Failures:              $failed"
+
+if ($env:GITHUB_STEP_SUMMARY) {
+    $title = if ($WhatIf) { "## PRs Awaiting Approval - Label Sync (WhatIf)" } else { "## PRs Awaiting Approval - Label Sync" }
+    Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $title
+    Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ""
+    Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Label: ``$Label``"
+    Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- PRs awaiting approval: **$($awaitingPRs.Count)**"
+    Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Labels added: **$added**"
+    Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Labels removed: **$removed**"
+    if ($failed -gt 0) {
+        Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Failures: **$failed**"
+    }
+}
+
+if ($failed -gt 0 -and -not $WhatIf) {
+    Write-Host "::error::Encountered $failed label operation failure(s)"
+    exit 1
+}

--- a/.github/actions/LabelPRsAwaitingApproval/action.yaml
+++ b/.github/actions/LabelPRsAwaitingApproval/action.yaml
@@ -22,10 +22,13 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
         GITHUB_REPOSITORY: ${{ github.repository }}
+        ACTION_LABEL: ${{ inputs.label }}
+        ACTION_WHATIF: ${{ inputs.whatIf }}
+        ACTION_PATH: ${{ github.action_path }}
       run: |
         $whatIfSwitch = @{}
-        if ('${{ inputs.whatIf }}' -eq 'true') { $whatIfSwitch['WhatIf'] = $true }
-        & ${{ github.action_path }}/action.ps1 -Label '${{ inputs.label }}' @whatIfSwitch
+        if ($env:ACTION_WHATIF -eq 'true') { $whatIfSwitch['WhatIf'] = $true }
+        & "$env:ACTION_PATH/action.ps1" -Label $env:ACTION_LABEL @whatIfSwitch
 branding:
   icon: tag
   color: yellow

--- a/.github/actions/LabelPRsAwaitingApproval/action.yaml
+++ b/.github/actions/LabelPRsAwaitingApproval/action.yaml
@@ -1,0 +1,31 @@
+name: Label PRs Awaiting Workflow Approval
+author: Microsoft Corporation
+description: Adds or removes a label on open PRs based on whether they have workflow runs in the 'action_required' state (waiting for maintainer approval).
+inputs:
+  token:
+    description: The GitHub token running the action
+    required: false
+    default: ${{ github.token }}
+  label:
+    description: The label to add to PRs that have workflow runs awaiting approval
+    required: false
+    default: 'needs-approval'
+  whatIf:
+    description: If 'true', logs intended changes without applying them
+    required: false
+    default: 'false'
+runs:
+  using: composite
+  steps:
+    - name: Sync 'needs-approval' label
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+      run: |
+        $whatIfSwitch = @{}
+        if ('${{ inputs.whatIf }}' -eq 'true') { $whatIfSwitch['WhatIf'] = $true }
+        & ${{ github.action_path }}/action.ps1 -Label '${{ inputs.label }}' @whatIfSwitch
+branding:
+  icon: tag
+  color: yellow

--- a/.github/workflows/LabelPRsAwaitingApproval.yaml
+++ b/.github/workflows/LabelPRsAwaitingApproval.yaml
@@ -1,0 +1,42 @@
+name: 'Label PRs Awaiting Workflow Approval'
+
+on:
+  schedule:
+    - cron: '*/15 * * * *' # Every 15 minutes
+  workflow_dispatch:
+    inputs:
+      whatIf:
+        description: 'Dry-run mode - log changes without applying them'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+defaults:
+  run:
+    shell: pwsh
+
+concurrency:
+  group: label-prs-awaiting-approval
+  cancel-in-progress: false
+
+jobs:
+  SyncLabel:
+    runs-on: ubuntu-latest
+    name: Sync 'needs-approval' label
+    if: github.repository_owner == 'microsoft'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Sync 'needs-approval' label
+        uses: ./.github/actions/LabelPRsAwaitingApproval
+        with:
+          token: ${{ github.token }}
+          label: 'needs-approval'
+          whatIf: ${{ inputs.whatIf == true }}

--- a/.github/workflows/LabelPRsAwaitingApproval.yaml
+++ b/.github/workflows/LabelPRsAwaitingApproval.yaml
@@ -28,6 +28,7 @@ concurrency:
 jobs:
   SyncLabel:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: Sync 'needs-approval' label
     if: github.repository_owner == 'microsoft'
     steps:


### PR DESCRIPTION
## Summary

Adds a scheduled workflow that automatically labels open PRs whose GitHub Actions workflow runs are in the `action_required` state — i.e. waiting for a maintainer with write access to click *Approve and run*.

This lets us easily find PRs that need a manual approval click via:

```
is:pr is:open label:needs-approval
```

…or:

```
gh pr list --repo microsoft/BCApps --label needs-approval
```

## How it works

- **Trigger**: `cron: '*/15 * * * *'` + `workflow_dispatch` (with optional `whatIf` dry-run input). Mirrors the pattern in `CleanUpStalePRChecks.yaml`.
- **Reconciliation** is idempotent on every run:
  1. Ensures the `needs-approval` label exists (creates it if missing, color `#FBCA04`).
  2. Fetches workflow runs with `status=action_required` from the Actions API.
  3. Resolves each run to a PR number (with a fork-PR fallback via `commits/{sha}/pulls` since fork-PR workflow runs have an empty `pull_requests` array).
  4. Computes the diff against PRs currently carrying the label.
  5. Adds the label to new awaiters, removes it from PRs no longer awaiting (approved, or PR closed).
- Guarded by `if: github.repository_owner == 'microsoft'` so forks don't run it.
- Follows existing repo conventions: pwsh, SHA-pinned `actions/checkout`, composite action under `.github/actions/`, GitHub step summary.

## Files

- `.github/workflows/LabelPRsAwaitingApproval.yaml` — workflow (schedule + manual)
- `.github/actions/LabelPRsAwaitingApproval/action.yaml` — composite action wrapper
- `.github/actions/LabelPRsAwaitingApproval/action.ps1` — reconciliation logic

## Validation

Dry-run against `microsoft/BCApps` (using `-WhatIf`) successfully:
- Detected 100 `action_required` workflow runs
- Deduped to 5 unique open PRs awaiting approval (#7410, #7699, #7843, #8165, #8313)
- Correctly computed: would add label to 5 PRs, remove from 0

## Permissions

The workflow requests minimum required scopes:
- `actions: read` — list action_required runs
- `contents: read` — checkout the composite action
- `issues: write` + `pull-requests: write` — manage the label

Uses `github.token` — no additional secrets needed.

## Caveats / future enhancements

- Page size is 100 with no pagination. Given BCApps' volume of currently-awaiting runs, this is well within bounds; can be paginated later if needed.
- Latency is up to 15 minutes. A future enhancement could add `workflow_run: types: [completed]` for near-instant labelling.


[AB#637233](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637233)


