### PR TITLE
[Subcontracting] Code issue in the procedure DeleteEnhancedDocumentsByChangeOfVendorNo

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcSynchronizeManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcSynchronizeManagement.Codeunit.al
@@ -148,7 +148,7 @@ codeunit 99001511 "Subc. Synchronize Management"
                                     PurchaseLine2.DeleteAll(true);
 
                                 TransferHeader.SetCurrentKey("Source ID", "Subc. Source Type", "Source Subtype");
-                                TransferHeader.SetRange("Source ID", PurchaseHeader."Buy-from Vendor No.");
+                                TransferHeader.SetRange("Source ID", xPurchaseHeader."Buy-from Vendor No.");
                                 TransferHeader.SetRange("Subc. Source Type", "Transfer Source Type"::Subcontracting);
                                 TransferHeader.SetRange("Source Subtype", TransferHeader."Source Subtype"::"2");
                                 TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
@@ -156,7 +156,7 @@ codeunit 99001511 "Subc. Synchronize Management"
                                     TransferHeader.FindFirst();
                                     ItemLedgerEntry2.SetRange("Order Type", "Inventory Order Type"::Production);
                                     ItemLedgerEntry2.SetRange("Order No.", ProductionOrder."No.");
-                                    if ItemLedgerEntry.IsEmpty() then
+                                    if ItemLedgerEntry2.IsEmpty() then
                                         TransferHeader.Delete(true);
                                 end;
                                 ProductionOrder.Delete();

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingSyncTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingSyncTest.Codeunit.al
@@ -8,8 +8,10 @@ using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.NoSeries;
 using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Ledger;
 using Microsoft.Inventory.Location;
 using Microsoft.Inventory.Requisition;
+using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.MachineCenter;
@@ -108,6 +110,150 @@ codeunit 139992 "Subc. Subcontracting Sync Test"
         MakeSubconPurchOrder(ProductionOrder."No.", WorkCenter[2]."No.");
 
         Assert.AreNotEqual(0, ProductionOrder.Quantity, 'Prod. order Qty. must not be zero after calculation of subcontracting in work sheet.');
+    end;
+
+    [Test]
+    [HandlerFunctions('DoConfirmCreateProdOrderForSubcontractingProcess,HandleTransferOrder')]
+    procedure ChangeVendorKeepsTransferOrderWhenItemLedgerEntryExistsForProductionOrder()
+    var
+        Item: Record Item;
+        ItemLedgerEntry: Record "Item Ledger Entry";
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        TransferHeader: Record "Transfer Header";
+        Vendor: Record Vendor;
+        WorkCenter: array[2] of Record "Work Center";
+        ProductionLocation: Record Location;
+        InitialTransferOrderNo: Code[20];
+    begin
+        // [SCENARIO 623643] When an Item Ledger Entry exists for Production Order "P", changing vendor on Subcontracting PO must NOT delete Transfer Order "T"
+        Initialize();
+
+        // [GIVEN] Subcontracting setup with Transfer-type Production Order "P" for item "I", Subcontracting PO for vendor "V1", Transfer Order "T"
+        SubcontractingMgmtLibrary.UpdateManufacturingSetupWithSubcontractingLocation();
+        SubcontractingMgmtLibrary.SetupInventorySetup();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateProdBomWithSubcontractingType(Item, "Subcontracting Type"::Transfer);
+        UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(ProductionLocation);
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+        ProductionOrder.Get(ProductionOrder.Status, ProductionOrder."No.");
+        ProductionOrder."Created from Purch. Order" := true;
+        ProductionOrder.Modify();
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+        SetAllProdOrderTransferComponentLocations(ProductionOrder."No.", ProductionLocation.Code);
+        SubcontractingMgmtLibrary.CreateTransferRoute(WorkCenter[2], ProductionOrder);
+
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+
+        PurchaseLine.Validate("Location Code", ProductionLocation.Code);
+        PurchaseLine.Modify(true);
+
+        CreateTransferOrderForSubcontractingPO(PurchaseHeader);
+        TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
+        TransferHeader.FindFirst();
+        InitialTransferOrderNo := TransferHeader."No.";
+
+        // [GIVEN] Item Ledger Entry of "Order Type" = Production and "Order No." = "P"
+        CreateItemLedgerEntryForProductionOrder(ItemLedgerEntry, ProductionOrder, Item);
+
+        // [GIVEN] Second subcontracting Vendor "V2"
+        CreateSecondSubcontractingVendor(Vendor, WorkCenter[2]);
+
+        // [WHEN] Validate "Buy-from Vendor No." on Subcontracting PO to "V2"
+        PurchaseHeader.Get(PurchaseHeader."Document Type", PurchaseHeader."No.");
+        PurchaseHeader.Validate("Buy-from Vendor No.", Vendor."No.");
+        PurchaseHeader.Modify(true);
+
+        // [THEN] Transfer Order "T" still exists
+        Assert.IsTrue(TransferHeader.Get(InitialTransferOrderNo), 'Transfer Order must still exist when Item Ledger Entry exists for Production Order');
+    end;
+
+    [Test]
+    [HandlerFunctions('DoConfirmCreateProdOrderForSubcontractingProcess,HandleTransferOrder')]
+    procedure ChangeVendorDeletesTransferOrderWhenNoItemLedgerEntryExistsForProductionOrder()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        TransferHeader: Record "Transfer Header";
+        Vendor: Record Vendor;
+        WorkCenter: array[2] of Record "Work Center";
+        ProductionLocation: Record Location;
+        InitialTransferOrderNo: Code[20];
+    begin
+        // [SCENARIO 623643] When NO Item Ledger Entry exists for Production Order "P", changing vendor on Subcontracting PO must delete Transfer Order "T"
+        Initialize();
+
+        // [GIVEN] Subcontracting setup with Transfer-type Production Order "P", Subcontracting PO for vendor "V1", Transfer Order "T"
+        SubcontractingMgmtLibrary.UpdateManufacturingSetupWithSubcontractingLocation();
+        SubcontractingMgmtLibrary.SetupInventorySetup();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateProdBomWithSubcontractingType(Item, "Subcontracting Type"::Transfer);
+        UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(ProductionLocation);
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", 1);  // Use quantity 1
+        ProductionOrder.Get(ProductionOrder.Status, ProductionOrder."No.");
+        ProductionOrder."Created from Purch. Order" := true;
+        ProductionOrder.Modify();
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+        SetAllProdOrderTransferComponentLocations(ProductionOrder."No.", ProductionLocation.Code);
+        SubcontractingMgmtLibrary.CreateTransferRoute(WorkCenter[2], ProductionOrder);
+
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+
+        PurchaseLine.Validate("Location Code", ProductionLocation.Code);
+        PurchaseLine.Modify(true);
+
+        CreateTransferOrderForSubcontractingPO(PurchaseHeader);
+        TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
+        TransferHeader.FindFirst();
+        InitialTransferOrderNo := TransferHeader."No.";
+
+        // [GIVEN] No Item Ledger Entry exists with "Order Type" = Production and "Order No." = "P"
+
+        // [GIVEN] Second subcontracting Vendor "V2"
+        CreateSecondSubcontractingVendor(Vendor, WorkCenter[2]);
+
+        // [WHEN] Validate "Buy-from Vendor No." on Subcontracting PO to "V2"
+        // Pre-clear all blocking relationships to allow Production Order deletion to succeed
+        PrepareProdOrderForDeletion(ProductionOrder."No.", PurchaseHeader."No.");
+
+        // Change vendor - triggers deletion logic with ItemLedgerEntry2.IsEmpty() check
+        PurchaseHeader.Get(PurchaseHeader."Document Type", PurchaseHeader."No.");
+        PurchaseHeader.Validate("Buy-from Vendor No.", Vendor."No.");
+        PurchaseHeader.Modify(true);
+
+        // [THEN] Transfer Order "T" no longer exists
+        Assert.IsFalse(TransferHeader.Get(InitialTransferOrderNo), 'Transfer Order must be deleted when no Item Ledger Entry exists for Production Order');
     end;
 
     local procedure MakeSubconPurchOrder(ProductionOrderNo: Code[20]; WorkCenterNo: Code[20])
@@ -294,6 +440,59 @@ codeunit 139992 "Subc. Subcontracting Sync Test"
         Item.Modify(true);
     end;
 
+    local procedure CreateTransferOrderForSubcontractingPO(var PurchaseHeader: Record "Purchase Header")
+    var
+        PurchaseHeaderPage: TestPage "Purchase Order";
+    begin
+        PurchaseHeaderPage.OpenView();
+        PurchaseHeaderPage.GoToRecord(PurchaseHeader);
+        PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+        PurchaseHeaderPage.Close();
+    end;
+
+    local procedure CreateItemLedgerEntryForProductionOrder(var ItemLedgerEntry: Record "Item Ledger Entry"; ProductionOrder: Record "Production Order"; Item: Record Item)
+    begin
+        ItemLedgerEntry.Init();
+        if ItemLedgerEntry.FindLast() then;
+        ItemLedgerEntry."Entry No." += 1;
+        ItemLedgerEntry."Item No." := Item."No.";
+        ItemLedgerEntry."Order Type" := ItemLedgerEntry."Order Type"::Production;
+        ItemLedgerEntry."Order No." := ProductionOrder."No.";
+        ItemLedgerEntry."Entry Type" := ItemLedgerEntry."Entry Type"::Output;
+        ItemLedgerEntry.Quantity := 1;
+        ItemLedgerEntry.Insert();
+    end;
+
+    local procedure CreateSecondSubcontractingVendor(var Vendor: Record Vendor; WorkCenter: Record "Work Center")
+    var
+        Location: Record Location;
+        GenProductPostingGroup: Record "Gen. Product Posting Group";
+        VATPostingSetup: Record "VAT Posting Setup";
+    begin
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(Location);
+        LibraryERM.FindVATPostingSetup(VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Normal VAT");
+        GenProductPostingGroup.Get(WorkCenter."Gen. Prod. Posting Group");
+        LibraryMfgManagement.CreateSubcontractorWithCurrency('');
+        Vendor.FindLast();
+        Vendor."Subc. Location Code" := Location.Code;
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(Location);
+        Vendor."Location Code" := Location.Code;
+        Vendor.Modify();
+    end;
+
+    local procedure SetAllProdOrderTransferComponentLocations(ProdOrderNo: Code[20]; LocationCode: Code[10])
+    var
+        ProdOrderComp: Record "Prod. Order Component";
+    begin
+        ProdOrderComp.SetRange("Prod. Order No.", ProdOrderNo);
+        ProdOrderComp.SetRange("Subcontracting Type", ProdOrderComp."Subcontracting Type"::Transfer);
+        if ProdOrderComp.FindSet() then
+            repeat
+                ProdOrderComp."Location Code" := LocationCode;
+                ProdOrderComp.Modify();
+            until ProdOrderComp.Next() = 0;
+    end;
+
     local procedure Initialize()
     begin
         LibraryTestInitialize.OnTestInitialize(Codeunit::"Subc. Subcontracting Sync Test");
@@ -350,6 +549,43 @@ codeunit 139992 "Subc. Subcontracting Sync Test"
         ReleasedProdOrderRtng.CreateSubcontracting.Invoke();
     end;
 
+    local procedure PrepareProdOrderForDeletion(ProdOrderNo: Code[20]; PurchDocNo: Code[20])
+    var
+        ProdOrderLine: Record "Prod. Order Line";
+        ProdOrderComp: Record "Prod. Order Component";
+        ProdOrderRtngLine: Record "Prod. Order Routing Line";
+        PurchaseLine: Record "Purchase Line";
+    begin
+        // Keep main Purchase Line with Prod. Order No. so deletion logic runs,
+        // but clear Line No. and routing fields to prevent blocking
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Document No.", PurchDocNo);
+        PurchaseLine.SetRange("Prod. Order No.", ProdOrderNo);
+        if PurchaseLine.FindFirst() then begin
+            PurchaseLine."Prod. Order Line No." := 0;
+            PurchaseLine."Operation No." := '';
+            PurchaseLine."Routing No." := '';
+            PurchaseLine."Routing Reference No." := 0;
+            PurchaseLine."Qty. Received (Base)" := 0;
+            PurchaseLine.Modify();
+        end;
+
+        // Delete subcontracting Purchase Lines
+        PurchaseLine.Reset();
+        PurchaseLine.SetRange("Subc. Prod. Order No.", ProdOrderNo);
+        PurchaseLine.DeleteAll(true);
+
+        // Delete Production Order parts to allow DeleteProdOrderRelations() to succeed
+        ProdOrderComp.SetRange("Prod. Order No.", ProdOrderNo);
+        ProdOrderComp.DeleteAll(true);
+
+        ProdOrderRtngLine.SetRange("Prod. Order No.", ProdOrderNo);
+        ProdOrderRtngLine.DeleteAll(true);
+
+        ProdOrderLine.SetRange("Prod. Order No.", ProdOrderNo);
+        ProdOrderLine.DeleteAll(true);
+    end;
+
     [ConfirmHandler]
     procedure DoConfirmCreateProdOrderForSubcontractingProcess(Question: Text[1024]; var Reply: Boolean)
     begin
@@ -359,6 +595,11 @@ codeunit 139992 "Subc. Subcontracting Sync Test"
             else
                 Reply := false;
         end;
+    end;
+
+    [PageHandler]
+    procedure HandleTransferOrder(var TransfOrderPage: TestPage "Transfer Order")
+    begin
     end;
 
     var


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#623643](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/623643)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

