### PR TITLE
[Shopify] Tolerate legacy bulk-operation request data missing unitCost key

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Bulk Operations/Codeunits/ShpfyBulkUpdateProductPrice.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Bulk Operations/Codeunits/ShpfyBulkUpdateProductPrice.Codeunit.al
@@ -88,7 +88,8 @@ codeunit 30281 "Shpfy Bulk UpdateProductPrice" implements "Shpfy IBulk Operation
                     ShopifyVariant.Price := JVariant.GetDecimal('price');
                     ShopifyVariant."Compare at Price" := JVariant.GetDecimal('compareAtPrice');
                     ShopifyVariant."Updated At" := JVariant.GetDateTime('updatedAt');
-                    ShopifyVariant."Unit Cost" := JVariant.GetDecimal('unitCost');
+                    if JVariant.Contains('unitCost') then
+                        ShopifyVariant."Unit Cost" := JVariant.GetDecimal('unitCost');
                     ShopifyVariant.Modify();
                 end;
         end;

--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductExport.Codeunit.al
@@ -894,7 +894,8 @@ codeunit 30178 "Shpfy Product Export"
                     ShopifyVariant.Price := JVariant.GetDecimal('price');
                     ShopifyVariant."Compare at Price" := JVariant.GetDecimal('compareAtPrice');
                     ShopifyVariant."Updated At" := JVariant.GetDateTime('updatedAt');
-                    ShopifyVariant."Unit Cost" := JVariant.GetDecimal('unitCost');
+                    if JVariant.Contains('unitCost') then
+                        ShopifyVariant."Unit Cost" := JVariant.GetDecimal('unitCost');
                     ShopifyVariant.Modify();
                 end;
                 exit;

--- a/src/Apps/W1/Shopify/Test/Bulk Operations/Codeunits/ShpfyBulkOperationsTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Bulk Operations/Codeunits/ShpfyBulkOperationsTest.Codeunit.al
@@ -315,6 +315,70 @@ codeunit 139633 "Shpfy Bulk Operations Test"
     end;
 
     [Test]
+    [HandlerFunctions('BulkOperationHttpHandler')]
+    procedure TestBulkOperationRevertFailedWithLegacyRequestDataMissingUnitCost()
+    var
+        ShopifyVariant: Record "Shpfy Variant";
+        BulkOperation: Record "Shpfy Bulk Operation";
+        BulkOperationType: Enum "Shpfy Bulk Operation Type";
+        ProductId: BigInteger;
+        VariantId: BigInteger;
+        VariantIds: List of [BigInteger];
+        Index: Integer;
+    begin
+        // [SCENARIO] A bulk operation persisted before the unitCost key was added still
+        // completes its revert without throwing, leaving Unit Cost untouched.
+        // Regression for bug 637250.
+
+        // [GIVEN] A bulk operation whose request data was written by the pre-unitCost code
+        // (i.e. the JSON objects only contain id/price/compareAtPrice/updatedAt) and four variants
+        Initialize();
+        for Index := 1 to 4 do begin
+            ProductId := Any.IntegerInRange(100000, 555555);
+            VariantId := Any.IntegerInRange(100000, 555555);
+            VariantIds.Add(VariantId);
+            ShopifyVariant."Product Id" := ProductId;
+            ShopifyVariant.Id := VariantId;
+            ShopifyVariant.Price := 200;
+            ShopifyVariant."Compare at Price" := 250;
+            ShopifyVariant."Unit Cost" := 75;
+            ShopifyVariant.Insert();
+        end;
+        BulkOperationUrl := 'https://storage.googleapis.com/shopify-bulk-result/' + Any.AlphabeticText(20);
+        BulkOperation := CreateBulkOperation(BulkOperationId1, BulkOperationType::UpdateProductPrice, Shop.Code, BulkOperationUrl, GenerateLegacyRequestDataWithoutUnitCost(VariantIds, 100, 150));
+
+        // [WHEN] Bulk operation is completed
+        BulkOperationIdCurrent := BulkOperationId1;
+        VariantId1 := VariantIds.Get(1);
+        VariantId2 := VariantIds.Get(4);
+        BulkOperation.Status := BulkOperation.Status::Completed;
+        BulkOperation.Modify(true);
+
+        // [THEN] The bulk operation is processed without throwing on the missing unitCost key,
+        // failed variants have their Price/Compare at Price reverted, and Unit Cost is left
+        // untouched on every variant (since the legacy blob doesn't know the pre-update value).
+        BulkOperation.Get(BulkOperationId1, Shop.Code, BulkOperation.Type::mutation);
+        LibraryAssert.IsTrue(BulkOperation.Processed, 'Bulk operation should be processed.');
+        ShopifyVariant.Get(VariantIds.Get(1));
+        LibraryAssert.AreEqual(200, ShopifyVariant.Price, 'Variant price should not be reverted.');
+        LibraryAssert.AreEqual(250, ShopifyVariant."Compare at Price", 'Variant compare at price should not be reverted.');
+        LibraryAssert.AreEqual(75, ShopifyVariant."Unit Cost", 'Variant unit cost should be left untouched when legacy blob lacks unitCost.');
+        ShopifyVariant.Get(VariantIds.Get(2));
+        LibraryAssert.AreEqual(100, ShopifyVariant.Price, 'Variant price should be reverted.');
+        LibraryAssert.AreEqual(150, ShopifyVariant."Compare at Price", 'Variant compare at price should be reverted.');
+        LibraryAssert.AreEqual(75, ShopifyVariant."Unit Cost", 'Variant unit cost should be left untouched when legacy blob lacks unitCost.');
+        ShopifyVariant.Get(VariantIds.Get(3));
+        LibraryAssert.AreEqual(100, ShopifyVariant.Price, 'Variant price should be reverted.');
+        LibraryAssert.AreEqual(150, ShopifyVariant."Compare at Price", 'Variant compare at price should be reverted.');
+        LibraryAssert.AreEqual(75, ShopifyVariant."Unit Cost", 'Variant unit cost should be left untouched when legacy blob lacks unitCost.');
+        ShopifyVariant.Get(VariantIds.Get(4));
+        LibraryAssert.AreEqual(200, ShopifyVariant.Price, 'Variant price should not be reverted.');
+        LibraryAssert.AreEqual(250, ShopifyVariant."Compare at Price", 'Variant compare at price should not be reverted.');
+        LibraryAssert.AreEqual(75, ShopifyVariant."Unit Cost", 'Variant unit cost should be left untouched when legacy blob lacks unitCost.');
+        ClearSetup();
+    end;
+
+    [Test]
     procedure TestBulkUpdateProductPriceClearsCompareAtPriceAsNull()
     var
         ShopifyVariant: Record "Shpfy Variant";
@@ -489,6 +553,26 @@ codeunit 139633 "Shpfy Bulk Operations Test"
             Data.Add('price', Price);
             Data.Add('compareAtPrice', CompareAtPrice);
             Data.Add('unitCost', UnitCost);
+            Data.Add('updatedAt', '2025-02-25T13:40:15.6530000Z');
+            RequestData.Add(Data);
+        end;
+        exit(RequestData);
+    end;
+
+    local procedure GenerateLegacyRequestDataWithoutUnitCost(VariantIds: List of [BigInteger]; Price: Decimal; CompareAtPrice: Decimal): JsonArray
+    var
+        RequestData: JsonArray;
+        VariantId: BigInteger;
+        Data: JsonObject;
+    begin
+        // Simulates the request-data layout written by the connector before the unitCost key
+        // was added to the bulk-operation rollback bookkeeping. Used to test that the revert
+        // tolerates legacy blobs persisted before the upgrade.
+        foreach VariantId in VariantIds do begin
+            Clear(Data);
+            Data.Add('id', VariantId);
+            Data.Add('price', Price);
+            Data.Add('compareAtPrice', CompareAtPrice);
             Data.Add('updatedAt', '2025-02-25T13:40:15.6530000Z');
             RequestData.Add(Data);
         end;


### PR DESCRIPTION
## Summary
Bulk variant price updates persist a JSON `Request Data` blob on `Shpfy Bulk Operation` so the rollback path can restore the previous Price / Compare-at-Price / Updated At / Unit Cost values when Shopify's async callback reports failure.

PR #6155 added a new `unitCost` key to that blob and a matching reader on the rollback path, but the reader uses `JsonObject.GetDecimal` which throws if the key is missing. Any bulk operation queued **before** the upgrade (no `unitCost` in the blob) and reverted **after** the upgrade crashes with:

> There are no properties with the key 'unitCost' on the JSON object

The same stale rows can keep retrying, so the error surfaces repeatedly even though the upgrade happened once.

The Shopify API payload itself is unaffected — it still correctly sends `inventoryItem.cost`. The crash is purely on the BC-side rollback reader.

## Changes

**Production code**
- `ShpfyBulkUpdateProductPrice.RevertRequests` and `ShpfyProductExport.RevertVariantChanges`: guard the `unitCost` read with `JsonObject.Contains('unitCost')`. If absent (legacy blob), Unit Cost is left untouched, matching the pre-PR-#6155 behaviour.

**Test code**
- `TestBulkOperationRevertFailedWithLegacyRequestDataMissingUnitCost`: new regression test that builds a request-data blob without the `unitCost` key (via a `GenerateLegacyRequestDataWithoutUnitCost` helper) and asserts that the rollback completes without throwing, reverts Price / Compare-at-Price correctly, and leaves Unit Cost untouched.

## Why only `unitCost` is gated, not every field
The other keys (`id`, `price`, `compareAtPrice`, `updatedAt`) have been written by `ShpfyVariantAPI.UpdateProductPrice` since the connector was first migrated to BCApps — there is no version that ever persisted a `Request Data` blob without them. A missing `price`/`compareAtPrice`/`updatedAt`/`id` is therefore not a legitimate "legacy blob" scenario; it would be a real upstream bug (regressed writer, corrupted blob, forgotten `JRequest.Add`). `GetDecimal`'s throw is the correct behaviour there — surfacing the bug loudly is better than silently skipping a rollback (which would leave variants showing the wrong price in BC, or no-op the revert with zero diagnostic).

`unitCost` is the one and only key that was added later, so it's the one key where a key-missing scenario has both a legitimate root cause (legacy persisted blob) and a safe fallback (leave the field untouched).

## Customer mitigation (no patch required)
Customers hitting this on the current BC28 build can self-mitigate by opening the **Shopify Bulk Operations** page and running **Delete Entries Older Than 7 Days**. The deletion bypasses the rollback trigger, removing the stale pre-upgrade rows without re-throwing. Bulk operations queued after the upgrade are written in the new layout and are unaffected.

## Scope
Main only — rare upgrade-window race condition with a self-service mitigation available. Not backported.

#### Work Item(s)
Fixes [AB#637250](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637250)





