### PR TITLE
Bug 636016: Expose codeunit 9224 "Dynamics 2D QR-Code Encoder"

### DIFF
--- a/src/System Application/App/Barcode/src/Dynamics Barcode Provider/Encoders/Dynamics2DQRCodeEncoder.Codeunit.al
+++ b/src/System Application/App/Barcode/src/Dynamics Barcode Provider/Encoders/Dynamics2DQRCodeEncoder.Codeunit.al
@@ -10,7 +10,6 @@ using System.Utilities;
 
 codeunit 9224 "Dynamics 2D QR-Code Encoder" implements "Barcode Image Encoder 2D"
 {
-    Access = Internal;
     InherentEntitlements = X;
     InherentPermissions = X;
 


### PR DESCRIPTION
## Summary

Remove `Access = Internal;` from codeunit 9224 `"Dynamics 2D QR-Code Encoder"` so extensions can use the encoder directly.

Without this, partners are forced to "abuse" `"Swiss QR Code Helper"` (with its centered logo) to generate QR codes without a web service round-trip.

## Work Item(s)

Fixes [AB#636016](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/636016)

Source ALAppExtensions request: microsoft/ALAppExtensions#30095

## Test plan

- [x] System Application Test build passes
- [x] Codeunit 9224 is reachable from a test extension (verifies non-internal access)


