### PR TITLE
Surface errors from failed M365 user-sync updates in the wizard

### DIFF
--- a/src/System Application/App/Azure AD User Management/src/User sync/AzureADUserSyncImpl.Codeunit.al
+++ b/src/System Application/App/Azure AD User Management/src/User sync/AzureADUserSyncImpl.Codeunit.al
@@ -37,6 +37,7 @@ codeunit 9029 "Azure AD User Sync Impl."
         FetchingUpdatesForDeviceGroupTxt: Label 'Fetching updates for device group.', Locked = true;
         ApplyingUserUpdateTxt: Label 'Applying update for user security ID [%1] with authentication object ID [%2]. Blank Guids indicate users not present in BC.', Comment = '%1 = user security ID (guid) and %2 = authentication object ID (guid)', Locked = true;
         FailedToUpdateUserTxt: Label 'Failed to update user record. Error details: [%1]', Comment = '%1 = ErrorCallStack', Locked = true;
+        UnknownUpdateErrorTxt: Label 'An unknown error occurred while applying the update.';
         UserCreatedTxt: Label 'A new user with authentication object ID [%1] and security ID [%2] has been created.', Comment = '%1 = authentication object ID (guid); %2 = user security ID (guid)', Locked = true;
         ApplyingEntityUpdateTxt: Label 'Updating %1 for user [%2]', Comment = '%1 = the update entity e.g. Full name, Plan etc.; %2 = user security ID (guid)', Locked = true;
         NewUserChangesTxt: Label 'A new user with authentication object ID [%1] received property [%2] from Graph.', Comment = '%1 = authentication object ID (guid); %2 = the update entity e.g. Full name, Plan etc.; %3 = new value of entity; %4 = original value of entity from Graph', Locked = true;
@@ -487,6 +488,7 @@ codeunit 9029 "Azure AD User Sync Impl."
     var
         User: Record User;
         UpdatedSuccessfully: Boolean;
+        ErrorText: Text;
     begin
         Session.LogMessage('0000BHN', StrSubstNo(ApplyingUserUpdateTxt, AzureADUserUpdate."User Security ID", AzureADUserUpdate."Authentication Object ID"), Verbosity::Normal, DataClassification::EndUserPseudonymousIdentifiers, TelemetryScope::ExtensionPublisher, 'Category', UserSetupCategoryTxt);
 
@@ -495,8 +497,14 @@ codeunit 9029 "Azure AD User Sync Impl."
             OnApplyUpdateFromAzureGraph(AzureADUserUpdate, User, UpdatedSuccessfully);
             if UpdatedSuccessfully then
                 NumberOfSuccessfulUpdates += 1
-            else
+            else begin
+                ErrorText := GetLastErrorText();
                 Session.LogMessage('0000BPA', StrSubstNo(FailedToUpdateUserTxt, GetLastErrorCallStack), Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', UserSetupCategoryTxt);
+                if ErrorText = '' then
+                    ErrorText := UnknownUpdateErrorTxt;
+                AzureADUserUpdate."Error Message" := CopyStr(ErrorText, 1, MaxStrLen(AzureADUserUpdate."Error Message"));
+                AzureADUserUpdate.Modify();
+            end;
         until AzureADUserUpdate.Next() = 0;
         Commit();
     end;

--- a/src/System Application/App/Azure AD User Management/src/User sync/AzureADUserUpdateBuffer.Table.al
+++ b/src/System Application/App/Azure AD User Management/src/User sync/AzureADUserUpdateBuffer.Table.al
@@ -109,6 +109,12 @@ table 9010 "Azure AD User Update Buffer"
             Editable = false;
             DataClassification = EndUserIdentifiableInformation;
         }
+        field(10; "Error Message"; Text[2048])
+        {
+            Caption = 'Error Message';
+            Editable = false;
+            DataClassification = EndUserIdentifiableInformation;
+        }
     }
 
     keys

--- a/src/System Application/App/Azure AD User Management/src/User sync/AzureADUserUpdateWizard.Page.al
+++ b/src/System Application/App/Azure AD User Management/src/User sync/AzureADUserUpdateWizard.Page.al
@@ -162,6 +162,34 @@ page 9515 "Azure AD User Update Wizard"
                         ShowCaption = false;
                     }
                 }
+                group(FailedUpdatesGroup)
+                {
+                    Visible = HasFailures;
+                    Caption = 'Failed updates';
+                    InstructionalText = 'The following changes could not be applied. Resolve the issues and run this guide again to retry.';
+                    repeater(Failures)
+                    {
+                        Editable = false;
+                        field(FailedDisplayName; Rec."Display Name")
+                        {
+                            Caption = 'User';
+                            ToolTip = 'Specifies the display name of the user that failed to update.';
+                            ApplicationArea = All;
+                        }
+                        field(FailedEntity; Rec."Update Entity")
+                        {
+                            Caption = 'Information';
+                            ToolTip = 'Specifies the user information that failed to update.';
+                            ApplicationArea = All;
+                        }
+                        field(FailedError; Rec."Error Message")
+                        {
+                            Caption = 'Error';
+                            ToolTip = 'Specifies the error returned when applying the update.';
+                            ApplicationArea = All;
+                        }
+                    }
+                }
             }
         }
     }
@@ -289,12 +317,22 @@ page 9515 "Azure AD User Update Wizard"
                     AzureADUserSyncImpl: Codeunit "Azure AD User Sync Impl.";
                     GuidedExperience: Codeunit "Guided Experience";
                     SuccessCount: Integer;
+                    TotalCount: Integer;
                     UpdateUsersfromMicrosoft365RunLbl: Label 'Update users from Microsoft 365 wizard has been run by the UserSecurityId %1.', Locked = true;
                 begin
                     Rec.Reset();
+                    TotalCount := Rec.Count();
                     SuccessCount := AzureADUserSyncImpl.ApplyUpdatesFromAzureGraph(Rec);
-                    NumberOfUpdatesApplied := StrSubstNo(NumberOfUpdatesAppliedTxt, SuccessCount, Rec.Count());
+                    HasFailures := SuccessCount < TotalCount;
+                    if HasFailures then
+                        NumberOfUpdatesApplied := StrSubstNo(SomeUpdatesFailedTxt, SuccessCount, TotalCount)
+                    else
+                        NumberOfUpdatesApplied := StrSubstNo(NumberOfUpdatesAppliedTxt, SuccessCount, TotalCount);
+
+                    // Keep failed records so the user can see them; drop the successful ones.
+                    Rec.SetRange("Error Message", '');
                     Rec.DeleteAll();
+                    Rec.SetRange("Error Message");
 
                     GuidedExperience.CompleteAssistedSetup(ObjectType::Page, Page::"Azure AD User Update Wizard");
                     Session.LogAuditMessage(StrSubstNo(UpdateUsersfromMicrosoft365RunLbl, UserSecurityId()), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 2, 0);
@@ -343,9 +381,12 @@ page 9515 "Azure AD User Update Wizard"
         CountOfManagedPermissionUpdates: Integer;
         CountOfApplicableUpdates: Integer;
 
+        HasFailures: Boolean;
+
         ConfirmCancelQst: Label 'Are you sure you wish to cancel the updates?';
         NumberOfUpdatesApplied: Text;
         NumberOfUpdatesAppliedTxt: Label '%1 out of %2 updates have been applied in Business Central. You can close this guide.', Comment = '%1 = An integer count of total updates applied; %2 = total count of updates';
+        SomeUpdatesFailedTxt: Label '%1 out of %2 updates have been applied in Business Central. Review the details of the failed updates below and try again.', Comment = '%1 = An integer count of total updates applied; %2 = total count of updates';
 
         NoAvailableUpdatesVisible: Boolean;
 

--- a/src/System Application/Test/Azure AD User Management/src/AzureADUserSyncTest.Codeunit.al
+++ b/src/System Application/Test/Azure AD User Management/src/AzureADUserSyncTest.Codeunit.al
@@ -856,6 +856,41 @@ codeunit 132928 "Azure AD User Sync Test"
         TearDown();
     end;
 
+    [Test]
+    procedure TestFailedUpdateRecordsErrorMessageOnBuffer()
+    var
+        TempAzureADUserUpdateBuffer: Record "Azure AD User Update Buffer" temporary;
+        AzureADUserSyncImpl: Codeunit "Azure AD User Sync Impl.";
+        BogusUserSecurityId: Guid;
+        SuccessCount: Integer;
+    begin
+        // Can't have TransactionModel::AutoRollback + CommitBehavior::Ignore, because isolated events only work
+        // if at the moment of raising we are not in the write transaction (which is achieved by calling Commit())
+        Initialize();
+        BogusUserSecurityId := CreateGuid();
+
+        // [GIVEN] A pending Change update referencing a user that does not exist in BC, so the subscriber errors on User.Get
+        TempAzureADUserUpdateBuffer."Authentication Object ID" := 'ghost-auth-id';
+        TempAzureADUserUpdateBuffer."Update Entity" := TempAzureADUserUpdateBuffer."Update Entity"::"Full Name";
+        TempAzureADUserUpdateBuffer."Update Type" := TempAzureADUserUpdateBuffer."Update Type"::Change;
+        TempAzureADUserUpdateBuffer."User Security ID" := BogusUserSecurityId;
+        TempAzureADUserUpdateBuffer."Display Name" := 'Ghost User';
+        TempAzureADUserUpdateBuffer."New Value" := 'New Name';
+        TempAzureADUserUpdateBuffer.Insert();
+
+        // [WHEN] The updates are applied
+        SuccessCount := AzureADUserSyncImpl.ApplyUpdatesFromAzureGraph(TempAzureADUserUpdateBuffer);
+
+        // [THEN] The success count reflects the failure
+        LibraryAssert.AreEqual(0, SuccessCount, 'Expected no successful updates.');
+
+        // [THEN] The buffer record is updated with the error text so the wizard can surface it
+        LibraryAssert.IsTrue(TempAzureADUserUpdateBuffer.FindFirst(), 'Buffer record should still be present after a failed apply.');
+        LibraryAssert.AreNotEqual('', TempAzureADUserUpdateBuffer."Error Message", 'Error Message should be populated on the failed update.');
+
+        TearDown();
+    end;
+
     local procedure CreateUsers(AzureAdOnly: Boolean)
     begin
         CreateUsers(AzureAdOnly, '');


### PR DESCRIPTION
Fixes [AB#624888](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/624888) — *Fix UI to show proper errors when failing to sync users from M365* (ICM 21000000009259).

## Problem

When the **Update users from Microsoft 365** wizard hit per-update failures, the Finish page only displayed `0 out of 8 updates have been applied in Business Central. You can close this guide.` — with no indication of which updates failed or why.

The isolated event `OnApplyUpdateFromAzureGraph` in `Azure AD User Sync Impl.` swallowed errors from subscribers; only the call stack made it to telemetry. The wizard never received the error text, so administrators had no actionable signal.

## Fix

- **`Azure AD User Update Buffer`** — new field `Error Message` (`Text[2048]`, `EndUserIdentifiableInformation`) that holds the per-update failure reason.
- **`Azure AD User Sync Impl.`** — in `ProcessAllUpdatesForUser`, after the isolated event returns with `UpdatedSuccessfully = false`, capture `GetLastErrorText()` (with an "unknown error" fallback) and write it onto the buffer record. Telemetry continues to record the call stack as before.
- **`Azure AD User Update Wizard`** — on the **Good work!** page, render a `Failed updates` group containing a repeater (User / Information / Error) when any update failed, and switch the summary line to mention that failures are listed below. Only the successful records are deleted, so the failed ones remain visible to the admin.
- **`Azure AD User Sync Test`** — new test `TestFailedUpdateRecordsErrorMessageOnBuffer` builds a Change update for a user that doesn't exist in BC, forces the subscriber's `User.Get` to error, and asserts the buffer's `Error Message` is populated and `SuccessCount = 0`.

## Test plan

- [x] Unit test `TestFailedUpdateRecordsErrorMessageOnBuffer` added and runs against the impl.
- [x] Manual: open the wizard with a mix of pass/fail updates → verify the Failed updates list shows the user, the field, and the error text.
- [x] Manual: all updates succeed → summary keeps the original wording, no Failed updates group.
- [x] Manual: all updates fail → summary says "0 out of N applied", every row listed.



