### PR TITLE
Add .gitattributes for consistent line-ending handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+* text=auto
+
+*.app binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.ttf binary
+*.woff binary
+*.woff2 binary
+*.eot binary
+*.pdf binary
+*.zip binary
+*.dll binary
+*.exe binary
+*.snk binary


### PR DESCRIPTION
Without .gitattributes, line endings depend on each contributors local `core.autocrlf` setting (defaults to `true` on Windows, `false` on Linux). On cross-platform checkouts — e.g. a Windows enlistment mounted into a Linux container or WSL — every text file appears modified because the working tree has CRLF while blobs are LF.

Adds a minimal `.gitattributes` at the repo root with `* text=auto` to normalize text files consistently across platforms, plus binary markers so common binary file types are not normalized.

The parent NAV repo uses a similar approach and does not exhibit this issue.

### Repro
1. On Windows with default Git-for-Windows install (`core.autocrlf=true` globally), clone BCApps. Git writes CRLF to the working tree; blobs in `.git/` are LF.
2. From WSL or a Linux container with a bind mount, access the same checkout.
3. `git status --porcelain` inside WSL/container lists hundreds of tracked files as modified.
4. `git diff <any-file>` shows only CRLF/LF differences; `git diff --ignore-cr-at-eol` is empty.

[AB#631442](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/631442)

