### PR TITLE
28.1: Render per-row Currency Code in Aged Accounts Receivable/Payable Excel

### DIFF
--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccPayableExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccPayableExcel.Report.al
@@ -84,8 +84,9 @@ report 4403 "EXR Aged Acc Payable Excel"
                 {
                     IncludeCaption = true;
                 }
-                column(CurrencyCode; CurrencyCodeDisplayCode)
+                column(CurrencyCode; "Currency Code")
                 {
+                    IncludeCaption = true;
                 }
                 column(PostingDate; "Posting Date")
                 {
@@ -126,11 +127,7 @@ report 4403 "EXR Aged Acc Payable Excel"
                 Clear(AgingData);
                 AgingData.DeleteAll();
                 InsertAgingData(VendorAgingData);
-
-                if AgingData."Currency Code" = '' then
-                    CurrencyCodeDisplayCode := GeneralLedgerSetup.GetCurrencyCode('')
-                else
-                    CurrencyCodeDisplayCode := AgingData."Currency Code";
+                CurrencyCodeDisplayCode := AgingData."Currency Code";
             end;
         }
 
@@ -271,7 +268,6 @@ report 4403 "EXR Aged Acc Payable Excel"
         DueByCurrencies = 'Due by Currencies', MaxLength = 31, Comment = 'Excel worksheet name.';
         OpenByFCY = 'Open by (FCY)';
         DataRetrieved = 'Data retrieved:';
-        CurrencyCodeDisplay = 'Currency Code';
         AgedAsOf = 'Aged as of:';
         AgedAccountsPayable = 'Aged Accounts Payable';
         AgedAccountsPayablePrint = 'Aged Accounts Payable (Print)', MaxLength = 31, Comment = 'Excel worksheet name.';
@@ -322,6 +318,9 @@ report 4403 "EXR Aged Acc Payable Excel"
         if PeriodCount = 0 then
             PeriodCount := 5;
 
+        if not GeneralLedgerSetup.Get() then
+            Clear(GeneralLedgerSetup);
+
         WorkingEndDate := EndingDate;
         WorkingStartDate := CalcDate(PeriodLength, WorkingEndDate);
         repeat
@@ -366,7 +365,10 @@ report 4403 "EXR Aged Acc Payable Excel"
         AgingData."Document Type" := VendorLedgerEntry."Document Type";
         AgingData."Dimension 1 Code" := VendorLedgerEntry."Global Dimension 1 Code";
         AgingData."Dimension 2 Code" := VendorLedgerEntry."Global Dimension 2 Code";
-        AgingData."Currency Code" := VendorLedgerEntry."Currency Code";
+        if VendorLedgerEntry."Currency Code" = '' then
+            AgingData."Currency Code" := GeneralLedgerSetup.GetCurrencyCode('')
+        else
+            AgingData."Currency Code" := VendorLedgerEntry."Currency Code";
         AgingData."Posting Date" := VendorLedgerEntry."Posting Date";
         AgingData."Document Date" := VendorLedgerEntry."Document Date";
         AgingData."Due Date" := VendorLedgerEntry."Due Date";

--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccountsRecExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccountsRecExcel.Report.al
@@ -83,8 +83,9 @@ report 4402 "EXR Aged Accounts Rec Excel"
                 {
                     IncludeCaption = true;
                 }
-                column(CurrencyCode; CurrencyCodeDisplayCode)
+                column(CurrencyCode; "Currency Code")
                 {
+                    IncludeCaption = true;
                 }
                 column(PostingDate; "Posting Date")
                 {
@@ -125,11 +126,7 @@ report 4402 "EXR Aged Accounts Rec Excel"
                 Clear(AgingData);
                 AgingData.DeleteAll();
                 InsertAgingData(CustomerAgingData);
-
-                if AgingData."Currency Code" = '' then
-                    CurrencyCodeDisplayCode := GeneralLedgerSetup.GetCurrencyCode('')
-                else
-                    CurrencyCodeDisplayCode := AgingData."Currency Code";
+                CurrencyCodeDisplayCode := AgingData."Currency Code";
             end;
         }
 
@@ -270,7 +267,6 @@ report 4402 "EXR Aged Accounts Rec Excel"
         DueByCurrencies = 'Due by Currencies', MaxLength = 31, Comment = 'Excel worksheet name.';
         OpenByFCY = 'Open by (FCY)';
         DataRetrieved = 'Data retrieved:';
-        CurrencyCodeDisplay = 'Currency Code';
         AgedAsOf = 'Aged as of:';
         AgedAccountsReceivable = 'Aged Accounts Receivable';
         AgedAccountsReceivablePrint = 'Aged Accounts Rec. (Print)', MaxLength = 31, Comment = 'Excel worksheet name.';
@@ -321,6 +317,9 @@ report 4402 "EXR Aged Accounts Rec Excel"
         if PeriodCount = 0 then
             PeriodCount := 5;
 
+        if not GeneralLedgerSetup.Get() then
+            Clear(GeneralLedgerSetup);
+
         WorkingEndDate := EndingDate;
         WorkingStartDate := CalcDate(PeriodLength, WorkingEndDate);
         repeat
@@ -365,7 +364,10 @@ report 4402 "EXR Aged Accounts Rec Excel"
         AgingData."Document Type" := CustLedgerEntry."Document Type";
         AgingData."Dimension 1 Code" := CustLedgerEntry."Global Dimension 1 Code";
         AgingData."Dimension 2 Code" := CustLedgerEntry."Global Dimension 2 Code";
-        AgingData."Currency Code" := CustLedgerEntry."Currency Code";
+        if CustLedgerEntry."Currency Code" = '' then
+            AgingData."Currency Code" := GeneralLedgerSetup.GetCurrencyCode('')
+        else
+            AgingData."Currency Code" := CustLedgerEntry."Currency Code";
         AgingData."Posting Date" := CustLedgerEntry."Posting Date";
         AgingData."Document Date" := CustLedgerEntry."Document Date";
         AgingData."Due Date" := CustLedgerEntry."Due Date";


### PR DESCRIPTION
Backport of #8423. Fixes [AB#637447](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637447). Cherry-pick conflict in TrialBalanceExcelReports.Codeunit.al resolved by accepting the deletion of the moved-out tests/handlers (mirror of main).






