### PR TITLE
Expose tenant Azure EUDB via Server Setting

### DIFF
--- a/src/System Application/App/Server Settings/src/ServerSetting.Codeunit.al
+++ b/src/System Application/App/Server Settings/src/ServerSetting.Codeunit.al
@@ -112,5 +112,14 @@ codeunit 6723 "Server Setting"
     begin
         exit(ServerSettingImpl.GetEnableMembershipEntitlement());
     end;
+
+    /// <summary>Returns whether the tenant's hosting Azure geography is within the Microsoft EU Data Boundary.</summary>
+    /// <returns>True if the tenant is in the EU Data Boundary; otherwise false.</returns>
+    /// <remarks>Backed by ServerUserSettings.AzureGeography on the BC platform. This is independent from the Copilot/CAPI-level EUDB check and may legitimately differ from it.</remarks>
+    [Scope('OnPrem')]
+    procedure GetIsTenantInEUDB(): Boolean
+    begin
+        exit(ServerSettingImpl.GetIsTenantInEUDB());
+    end;
 }
 

--- a/src/System Application/App/Server Settings/src/ServerSettingImpl.Codeunit.al
+++ b/src/System Application/App/Server Settings/src/ServerSettingImpl.Codeunit.al
@@ -98,5 +98,11 @@ codeunit 3703 "Server Setting Impl."
         InitializeConfigSettings();
         exit(ALConfigSettings.IsSaaS());
     end;
+
+    procedure GetIsTenantInEUDB(): Boolean
+    begin
+        InitializeConfigSettings();
+        exit(ALConfigSettings.IsTenantInEUDB());
+    end;
 }
 


### PR DESCRIPTION
Adds GetIsTenantInEUDB() to the public Server Setting (6723) codeunit and its Server Setting Impl. (3703) backing, wrapping the new ALConfigSettings.IsTenantInEUDB() platform method.

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

