### PR TITLE
Fix data-driven AI tests failing when TestPermissions is not Disabled

### DIFF
--- a/src/Tools/AI Test Toolkit/src/AITTestRunInputHandler.Codeunit.al
+++ b/src/Tools/AI Test Toolkit/src/AITTestRunInputHandler.Codeunit.al
@@ -33,10 +33,17 @@ codeunit 149045 "AIT Test Run Input Handler"
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"AIT Test Run Iteration", 'OnBeforeRunTestMethodLine', '', false, false)]
     local procedure OnBeforeRunTestMethodLine(var TestMethodLine: Record "Test Method Line")
+    var
+        TestInput: Codeunit "Test Input";
     begin
         TestMethodLine.SetRange("Data Input Group Code", TestInputGroupCode);
         TestMethodLine.SetRange("Data Input", TestInputCode);
         TestMethodLine.SetRange("Line Type", TestMethodLine."Line Type"::Function);
+
+        // Load the test input now, while still running under full permissions. The data-driven test framework
+        // otherwise reads it from inside the test method's TestPermissions scope, which fails for any test that
+        // declares a TestPermissions value other than Disabled (bug 636024).
+        TestInput.PreloadTestInput(TestInputGroupCode, TestInputCode);
     end;
 
 }

--- a/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInput.Codeunit.al
+++ b/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInput.Codeunit.al
@@ -24,13 +24,29 @@ codeunit 130460 "Test Input"
 
     internal procedure InitializeTestInputsBeforeTestMethodRun(CodeunitID: Integer; CodeunitName: Text[30]; FunctionName: Text[128]; FunctionTestPermissions: TestPermissions; var CurrentTestMethodLine: Record "Test Method Line")
     begin
-        if CurrentTestMethodLine."Data Input" = '' then
+        LoadTestInput(CurrentTestMethodLine."Data Input Group Code", CurrentTestMethodLine."Data Input");
+    end;
+
+    // Pre-loads the test input into the (single instance) globals before the test method runs. The data-driven
+    // test framework reads the "Test Input" table from a subscriber to OnBeforeTestMethodRun, which the platform
+    // raises inside the test method's TestPermissions scope. When a test declares a TestPermissions value other
+    // than Disabled, the platform overrides the effective permissions and the IndirectRead on the "Test Input"
+    // table fails. Calling this from a context that still runs under full permissions (before the test runner is
+    // invoked) caches the input so the later read inside the restricted scope is a no-op.
+    procedure PreloadTestInput(TestInputGroupCode: Code[100]; TestInputCode: Code[100])
+    begin
+        LoadTestInput(TestInputGroupCode, TestInputCode);
+    end;
+
+    local procedure LoadTestInput(TestInputGroupCode: Code[100]; TestInputCode: Code[100])
+    begin
+        if TestInputCode = '' then
             exit;
 
-        if (CurrentTestMethodLine."Data Input" = DataPerTest.Code) and (CurrentTestMethodLine."Data Input Group Code" = DataPerTest."Test Input Group Code") then
+        if (TestInputCode = DataPerTest.Code) and (TestInputGroupCode = DataPerTest."Test Input Group Code") then
             exit;
 
-        DataPerTest.Get(CurrentTestMethodLine."Data Input Group Code", CurrentTestMethodLine."Data Input");
+        DataPerTest.Get(TestInputGroupCode, TestInputCode);
 
         DataPerTestTestInput.Initialize(DataPerTest.GetInput(DataPerTest));
     end;

--- a/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInput.Codeunit.al
+++ b/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInput.Codeunit.al
@@ -37,7 +37,7 @@ codeunit 130460 "Test Input"
     /// which the platform raises inside the test method's TestPermissions scope. When a test declares a
     /// TestPermissions value other than Disabled, the platform overrides the effective permissions and the
     /// IndirectRead on the "Test Input" table fails. Calling this from a context that still runs under full
-    /// permissions before the test runner is invoked caches the input so the later read inside the restricted
+    /// permissions (before the test runner is invoked) caches the input so the later read inside the restricted
     /// scope is a no-op.
     /// </remarks>
     procedure PreloadTestInput(TestInputGroupCode: Code[100]; TestInputCode: Code[100])

--- a/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInput.Codeunit.al
+++ b/src/Tools/Test Framework/Test Runner/src/DataDrivenTest/DataInputs/TestInput.Codeunit.al
@@ -27,12 +27,19 @@ codeunit 130460 "Test Input"
         LoadTestInput(CurrentTestMethodLine."Data Input Group Code", CurrentTestMethodLine."Data Input");
     end;
 
-    // Pre-loads the test input into the (single instance) globals before the test method runs. The data-driven
-    // test framework reads the "Test Input" table from a subscriber to OnBeforeTestMethodRun, which the platform
-    // raises inside the test method's TestPermissions scope. When a test declares a TestPermissions value other
-    // than Disabled, the platform overrides the effective permissions and the IndirectRead on the "Test Input"
-    // table fails. Calling this from a context that still runs under full permissions (before the test runner is
-    // invoked) caches the input so the later read inside the restricted scope is a no-op.
+    /// <summary>
+    /// Pre-loads the test input into the single-instance globals before the test method runs.
+    /// </summary>
+    /// <param name="TestInputGroupCode">The test input group code to load.</param>
+    /// <param name="TestInputCode">The test input code to load.</param>
+    /// <remarks>
+    /// The data-driven test framework reads the "Test Input" table from a subscriber to OnBeforeTestMethodRun,
+    /// which the platform raises inside the test method's TestPermissions scope. When a test declares a
+    /// TestPermissions value other than Disabled, the platform overrides the effective permissions and the
+    /// IndirectRead on the "Test Input" table fails. Calling this from a context that still runs under full
+    /// permissions before the test runner is invoked caches the input so the later read inside the restricted
+    /// scope is a no-op.
+    /// </remarks>
     procedure PreloadTestInput(TestInputGroupCode: Code[100]; TestInputCode: Code[100])
     begin
         LoadTestInput(TestInputGroupCode, TestInputCode);


### PR DESCRIPTION
#### Summary

Data-driven tests run by the AI Test Suite Runner fail when the test method declares a `TestPermissions` value other than `Disabled`.

The data-driven test framework reads the `Test Input` table from a subscriber to `OnBeforeTestMethodRun` (codeunit 130460 `Test Input`). The platform raises that event **inside** the test method's `TestPermissions` scope, so the effective permissions are overridden and the `IndirectRead` on table `Test Input` fails:

```
Sorry, the current permissions prevented the action.
(TableData 130452 Test Input IndirectRead: Test Runner)
The user permissions have been overridden by the TestPermissions property.
```

Because the permission execution context is overridden by `TestPermissions`, the codeunit's own `Permissions` property is not honored in that window, so the read cannot succeed there.

#### Work Item(s)

Fixes [AB#636024](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636024)

#### Fix

Load the test input earlier, while still running under full permissions. The AI Test Toolkit input handler already has a pre-permission hook (`OnBeforeRunTestMethodLine`, raised before the test runner codeunit is invoked). It now pre-loads the input into the single-instance `Test Input` globals via a new `PreloadTestInput` method, so the later read inside the restricted `TestPermissions` scope becomes a no-op (the existing early-exit guard returns before the `Get`).

- `Test Input` (130460): extracted the load logic into a shared `LoadTestInput` helper and exposed `PreloadTestInput(GroupCode, InputCode)`.
- `AIT Test Run Input Handler` (149045): calls `PreloadTestInput` from its existing `OnBeforeRunTestMethodLine` subscriber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



