### PR TITLE
[Shopify] Add Company drilldown on B2B Catalogs page (30159)

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Catalogs/Pages/ShpfyCatalogs.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Catalogs/Pages/ShpfyCatalogs.Page.al
@@ -31,6 +31,19 @@ page 30159 "Shpfy Catalogs"
                 {
                     Caption = 'Company';
                     Editable = false;
+                    DrillDown = true;
+
+                    trigger OnDrillDown()
+                    var
+                        ShopifyCompany: Record "Shpfy Company";
+                        CompanyCard: Page "Shpfy Company Card";
+                    begin
+                        if ShopifyCompany.GetBySystemId(Rec."Company SystemId") then begin
+                            ShopifyCompany.SetRecFilter();
+                            CompanyCard.SetTableView(ShopifyCompany);
+                            CompanyCard.Run();
+                        end;
+                    end;
                 }
                 field(SyncPrices; Rec."Sync Prices") { }
                 field("Currency Code"; Rec."Currency Code")

--- a/src/Apps/W1/Shopify/App/src/Catalogs/Pages/ShpfyCatalogs.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Catalogs/Pages/ShpfyCatalogs.Page.al
@@ -35,14 +35,10 @@ page 30159 "Shpfy Catalogs"
 
                     trigger OnDrillDown()
                     var
-                        ShopifyCompany: Record "Shpfy Company";
-                        CompanyCard: Page "Shpfy Company Card";
+                        Company: Record "Shpfy Company";
                     begin
-                        if ShopifyCompany.GetBySystemId(Rec."Company SystemId") then begin
-                            ShopifyCompany.SetRecFilter();
-                            CompanyCard.SetTableView(ShopifyCompany);
-                            CompanyCard.Run();
-                        end;
+                        if Company.GetBySystemId(Rec."Company SystemId") then
+                            Page.Run(Page::"Shpfy Company Card", Company);
                     end;
                 }
                 field(SyncPrices; Rec."Sync Prices") { }


### PR DESCRIPTION
## Summary
On the **Shopify B2B Catalogs** page (`page 30159 "Shpfy Catalogs"`), clicking the **Company** column returned the generic *"Something went wrong. An error has occurred"* page instead of opening the related Shopify Company. Reproduces deterministically across environments; no customer extension involved.

## Root cause
The **Company** column is bound to the `Shpfy Catalog."Company Name"` FlowField, which is a `lookup` keyed on the **Guid** `"Company SystemId"`. The field declared no explicit `OnDrillDown`, so the platform's implicit drilldown into `Shpfy Company` (via its `DrillDownPageId`) throws an unhandled exception that surfaces as the generic application-error page. The connector already uses the explicit-`OnDrillDown` workaround for the *Customer No.* column in `ShpfyCompanies.Page.al` for the same reason.

## Fix
Add an explicit `OnDrillDown` on the Company field of page 30159 that opens the **Shpfy Company Card** (page 30157) via `GetBySystemId`, mirroring the existing `ShpfyCompanies.Page.al` idiom (`GetBySystemId` → `SetRecFilter` → `SetTableView` → `Run`).

## Impact / risk
- Purely additive, low risk. The previous behavior was a hard error; the new behavior opens the company card, or is a no-op when the catalog has no linked company.
- Cosmetic/navigation fix — no data, sync, or functional impact.

## Backport candidates
Land in `main`; backport candidates **28.x**, **28.2.x**, **28.1.x** (code is identical across these). A follow-up sweep for other Shpfy pages using the same `lookup ... where SystemId = field("... SystemId")` FlowField pattern is advisable.

Linked work item: [AB#637615](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637615) (ICM 51000001047725)

🤖 Generated with [Claude Code](https://claude.com/claude-code)






