### PR TITLE
[AI Test Toolkit] Refresh Run History when changing View By

### DIFF
--- a/src/Tools/AI Test Toolkit/src/Logs/AITRunHistory.Codeunit.al
+++ b/src/Tools/AI Test Toolkit/src/Logs/AITRunHistory.Codeunit.al
@@ -41,5 +41,7 @@ codeunit 149036 "AIT Run History"
 
         if (LineNo <> 0) then
             TempAITRunHistory.SetRange("Line No. Filter", LineNo)
+        else
+            TempAITRunHistory.SetRange("Line No. Filter");
     end;
 }

--- a/src/Tools/AI Test Toolkit/src/Logs/AITRunHistory.Page.al
+++ b/src/Tools/AI Test Toolkit/src/Logs/AITRunHistory.Page.al
@@ -245,6 +245,6 @@ page 149032 "AIT Run History"
             LineNo := 0;
 
         AITRunHistory.GetHistory(TestSuiteCode, LineNo, ViewBy, Rec);
-        CurrPage.Update();
+        CurrPage.Update(false);
     end;
 }


### PR DESCRIPTION
## Summary
On the **AI Eval Suite Run History** page (`page 149032 "AIT Run History"`), changing the **View By** control (Version/Tag) — or toggling **Apply Filter** — did not update the displayed data.

## Root cause
Two compounding defects in the refresh path:

1. **Repaint.** `UpdateRunHistory()` rebuilds the temporary source table (`DeleteAll` + re-`Insert` inside `codeunit 149036 "AIT Run History".GetHistory`) and then calls the **parameterless** `CurrPage.Update()`, which defaults to `Update(true)`. That tries to *save* the (just-deleted) current record rather than redraw. The canonical pattern after repopulating a temporary page source is `CurrPage.Update(false)`.

2. **Stale FlowFilter.** `GetHistory` set the `"Line No. Filter"` FlowFilter only when `LineNo <> 0` and never cleared it. Since `DeleteAll` does not clear filters, unchecking **Apply Filter** (`LineNo -> 0`) left the previous line filter on the FlowFields, so the columns recomputed against the wrong line and showed zeros/old data.

## Fix
- `AITRunHistory.Page.al` — `CurrPage.Update(false)` after rebuilding the temp records.
- `AITRunHistory.Codeunit.al` — clear the `"Line No. Filter"` FlowFilter when `LineNo = 0` (add an `else SetRange("Line No. Filter")`).

## Impact / risk
Low — internal AI Test Toolkit tooling page, read-only temporary source. Both changes are the standard idioms for this scenario.

## Verification
- Statically traced: `View By` OnValidate → `UpdateRunHistory` → `GetHistory` (sole data builder) → `CurrPage.Update`. FlowField columns key on `"Line No. Filter"`.
- ⚠️ Not runtime-verified on an NST (AL does not run locally here) — relying on PR CI for compile + tests; manual repro on the Run History page recommended before merge.

Linked work item: [AB#622420](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622420)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



