### PR TITLE
[Retention Policy] Keep record marks for indirect-permission subset deletes

### DIFF
--- a/src/System Application/App/Retention Policy/src/Apply Retention Policy/ApplyRetentionPolicyImpl.Codeunit.al
+++ b/src/System Application/App/Retention Policy/src/Apply Retention Policy/ApplyRetentionPolicyImpl.Codeunit.al
@@ -243,13 +243,18 @@ codeunit 3904 "Apply Retention Policy Impl."
         RetenPolDeleting.DeleteRecords(RecordRef, TempRetenPolDeletingParam);
 
         if not TempRetenPolDeletingParam."Skip Event Indirect Perm. Req." then begin
-            ApplyRetentionPolicyFacade.OnApplyRetentionPolicyIndirectPermissionRequired(RecordRefDuplicate, Handled);
+            // Indirect-permission path: RecordRef is still open and retains its record marks.
+            // RecordRef.Duplicate() copies filters and the MarkedOnly flag but NOT the marks, so the
+            // subscriber must receive the original marked RecordRef - otherwise subset (marked) deletes
+            // would delete nothing. Count the remaining marked records, then close the original ref.
+            ApplyRetentionPolicyFacade.OnApplyRetentionPolicyIndirectPermissionRequired(RecordRef, Handled);
             if not Handled then
-                RetentionPolicyLog.LogError(LogCategory(), StrSubstNo(IndirectPermissionsRequiredErr, RecordRefDuplicate.Number, RecordRefDuplicate.Caption));
+                RetentionPolicyLog.LogError(LogCategory(), StrSubstNo(IndirectPermissionsRequiredErr, RecordRef.Number, RecordRef.Caption));
             Handled := false;
-        end;
-
-        RecordCountAfter := Count(RecordRefDuplicate);
+            RecordCountAfter := Count(RecordRef);
+            RecordRef.Close();
+        end else
+            RecordCountAfter := Count(RecordRefDuplicate);
         NumberOfRecordsDeleted := RecordCountBefore - RecordCountAfter;
         TotalNumberOfRecordsDeleted += NumberOfRecordsDeleted;
 

--- a/src/System Application/App/Retention Policy/src/Apply Retention Policy/RetenPolDeleteImpl.Codeunit.al
+++ b/src/System Application/App/Retention Policy/src/Apply Retention Policy/RetenPolDeleteImpl.Codeunit.al
@@ -41,10 +41,14 @@ codeunit 3916 "Reten. Pol. Delete. Impl." implements "Reten. Pol. Deleting"
                     LimitRecordsToBeDeleted(RecordRef, RecordReferenceIndirectPermission, RetenPolDeletingParam."Skip Event Rec. Limit Exceeded", RetenPolDeletingParam."Max. Number of Rec. To Delete", RetenPolDeletingParam."Total Max. Nr. of Rec. to Del.");
                 end;
 
-        if not RetenPolDeletingParam."Indirect Permission Required" then
+        if not RetenPolDeletingParam."Indirect Permission Required" then begin
             RecordReferenceIndirectPermission.DeleteAll(RecordRef, true);
+            // Direct-permission path: close here. For the indirect-permission path the caller needs
+            // the still-open RecordRef (with its record marks intact) to raise
+            // OnApplyRetentionPolicyIndirectPermissionRequired, and closes it afterwards.
+            RecordRef.Close();
+        end;
         RetenPolDeletingParam."Skip Event Indirect Perm. Req." := not RetenPolDeletingParam."Indirect Permission Required";
-        RecordRef.Close();
     end;
 
     local procedure LimitRecordsToBeDeleted(var RecordRef: RecordRef; RecordReferenceIndirectPermission: Interface "Record Reference"; var SkipOnApplyRetentionPolicyRecordLimitExceeded: Boolean; MaxNumberOfRecordsToDelete: Integer; TotalMaxNumberOfRecordsToDelete: Integer)


### PR DESCRIPTION
## Summary
Retention-policy **subset** deletion (specific marked records — i.e. a policy that is *not* "apply to all records") **deleted nothing** for tables that require **indirect delete permission** (Email Logs, Retention Policy Logs, Performance Profiler, Shopify Logs). IcM 21000000010094.

## Root cause
In `"Apply Retention Policy Impl.".DeleteExpiredRecords`:

```al
RecordRefDuplicate := RecordRef.Duplicate();        // (1) copies filters + MarkedOnly flag, NOT the marks
...
RetenPolDeleting.DeleteRecords(RecordRef, ...);      // (2) for indirect tables this Close()s RecordRef
...
OnApplyRetentionPolicyIndirectPermissionRequired(RecordRefDuplicate, Handled);  // (3) markless duplicate
```

`RecordRef.Duplicate()` copies the filters and the `MarkedOnly` flag but **not** the individual record marks. So the subscriber received a *marked-only view with zero marks*, and its `DeleteAll(true)` deleted nothing (the subscribers gate on `MarkedOnly()`/filters). Meanwhile `"Reten. Pol. Delete. Impl.".DeleteRecords` had already `Close()`d the original `RecordRef` — which still held the marks — *before* the event ran.

## Fix
- **`RetenPolDeleteImpl.DeleteRecords`** — `Close()` the `RecordRef` only on the **direct**-permission path (where this codeunit does the `DeleteAll` itself). On the **indirect** path leave it open so the marks survive for the caller.
- **`ApplyRetentionPolicyImpl.DeleteExpiredRecords`** — pass the **original marked `RecordRef`** to the event, compute `RecordCountAfter` from it (remaining marked records), then `Close()` it. The **direct path is unchanged** (still counts via the duplicate; the duplicate is still used for telemetry caption/name/number in both paths).

### Counting note
On the indirect path, `RecordCountAfter` now counts the original ref *after* the subscriber's `DeleteAll`, i.e. the marked records still remaining (0 when all were deleted) → `NumberOfRecordsDeleted = RecordCountBefore`. The previous code counted the markless duplicate (always 0), which combined with deleting nothing under-deleted while still *logging* `RecordCountBefore` deleted — a misleading count this fix also corrects.

## Subscriber safety
All four subscribers of `OnApplyRetentionPolicyIndirectPermissionRequired` use the same template (`MarkedOnly()`/`GetFilters()` check → `RecRef.DeleteAll(true)` → set `Handled`) and **none of them close the ref**, so passing the original ref is safe for every consumer.

## Provenance / status
The previously-attempted ADO PR 243754 (submodule-pointer bump) was **abandoned**; this implements the fix directly in BCApps. Posting as **draft**.

## Verification ⚠️
- Statically traced end-to-end across `DeleteExpiredRecords`, `DeleteRecords`, all four subscribers, and the `Reten. Pol. Filtering` mark logic.
- **Not runtime-verified** — AL does not run locally here, and this is sensitive data-deletion code. **Please validate on an NST before merging.** Recommended regression test: register a test table requiring *indirect* delete permission, configure a subset (not "apply to all") policy, mark a multi-record expired set, run apply, and assert (a) all marked records are deleted and (b) the logged deleted-count matches.

Linked work item: [AB#626315](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/626315)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

