### PR TITLE
Fix Agent Tasks Executed count broken by locale thousands separator (ADO 633444)

### DIFF
--- a/src/Tools/AI Test Toolkit/src/Agent/AgentTestContextImpl.Codeunit.al
+++ b/src/Tools/AI Test Toolkit/src/Agent/AgentTestContextImpl.Codeunit.al
@@ -194,7 +194,10 @@ codeunit 149049 "Agent Test Context Impl."
             repeat
                 if not TaskIDList.Contains(AgentTestTaskLog."Agent Task ID") then begin
                     TaskIDList.Add(AgentTestTaskLog."Agent Task ID");
-                    TaskIDTextList.Add(Format(AgentTestTaskLog."Agent Task ID"));
+                    // Format using XML/invariant culture (format 9) to avoid locale thousands
+                    // separators that would otherwise be split as extra IDs by the comma-based
+                    // serialization used in GetAgentTaskCount and ConvertCommaSeparatedToFilter.
+                    TaskIDTextList.Add(Format(AgentTestTaskLog."Agent Task ID", 0, 9));
                 end;
             until AgentTestTaskLog.Next() = 0;
 


### PR DESCRIPTION
## Summary

Fix the `Agent Tasks Executed` counter (and the drill-down filter) on the AI Test Toolkit pages, which over-counts by a factor of ~2-3 on locales that render thousands separators (en-US default).

Repro from ADO 633444: running the full `RT-ACCUR` suite (184 distinct Agent Tasks) shows **`Agent Tasks Executed = 369`** on the AIT Test Suite page. After this fix, the counter shows `184`.

Resolves [AB#633444](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633444)

## Root cause

`Codeunit 149049 "Agent Test Context Impl."` aggregates the Agent Task IDs touched during a test run via a comma-separated text round-trip:

1. **Producer** — `GetCommaSeparatedAgentTaskIDs` formats each `BigInteger` ID into text and joins with `", "`:
   ```al
   TaskIDTextList.Add(Format(AgentTestTaskLog."Agent Task ID"));     // <-- offender
   ...
   exit(ConcatenateList(TaskIDTextList, ', '));
   ```
2. **Consumer #1** — `GetAgentTaskCount` counts elements after `Split(',')`:
   ```al
   TaskIDList := CommaSeparatedTaskIDs.Split(',');
   exit(TaskIDList.Count);
   ```
3. **Consumer #2** — `ConvertCommaSeparatedToFilter` turns the text into a `SetFilter` expression by replacing `,` with `|`.

The default overload `Format(BigInteger)` honors the current culture. On en-US (the runtime locale for these tests, per `AgentRuntimeTests`' `.resources`), a 6-digit Agent Task ID such as `1234567` renders as `"1,234,567"` — three fragments after `Split(',')`.

So for `N` distinct Agent Task IDs with `c` average internal commas, the counter returns roughly `N × (c + 1)` instead of `N`. With BC's current Agent Task IDs in the 6-7 digit range, `c ≈ 1`, giving the observed `~2 × N + 1 = 369` for `N = 184`.

The drill-down filter built by `ConvertCommaSeparatedToFilter` (used to navigate from the counter to the Agent Task List) was silently broken in the same way: `1,234,567` became the filter `1|234|567`, three unrelated IDs.

## Scope of impact (all fixed transitively by the one-line change)

| Surface | Field | Source |
|---|---|---|
| AIT Test Suite | `Agent Tasks Executed` (totals row) | `AgentTestSuite.PageExt.al` calls `GetAgentTaskCount` |
| AIT Run History — by Version | `Agent Tasks Executed` | `AgentRunHistory.PageExt.al` |
| AIT Run History — by Tag | `Agent Tasks Executed` | `AgentRunHistory.PageExt.al` |
| AIT Test Method Lines | `Agent Tasks Executed` per line | `AgentTestMethodLines.PageExt.al` |
| AITLogEntry API page | `agentTasksExecuted` | API field |
| Agent Task List drill-down | filter values | `ConvertCommaSeparatedToFilter` |

## Fix

`Format(value, 0, 9)` — Format type `9` is the XML / invariant culture format and emits the integer as a plain digit run with no group separators. This is the canonical "give me machine-parseable text for a number" pattern in BC AL and is already used elsewhere in the same submodule (e.g. `LibraryAgentImpl.Codeunit.al`).

The change is one line plus a code comment explaining why the locale-sensitive overload must not be reintroduced here:

```diff
-                    TaskIDTextList.Add(Format(AgentTestTaskLog."Agent Task ID"));
+                    // Format using XML/invariant culture (format 9) to avoid locale thousands
+                    // separators that would otherwise be split as extra IDs by the comma-based
+                    // serialization used in GetAgentTaskCount and ConvertCommaSeparatedToFilter.
+                    TaskIDTextList.Add(Format(AgentTestTaskLog."Agent Task ID", 0, 9));
```

No other producers were found — `rg -n "Format\(.*Agent Task ID.*\)"` over `src/Tools/AI Test Toolkit` returns exactly one hit. Fixing the producer fixes all consumers.

## Why not change the delimiter instead?

You could also defend against this by switching from `","` to a delimiter that can't appear in a culture-formatted number (e.g. `";"` or `"|"`), but that would require touching the producer **and** both consumers and would change a string the AIT API page surfaces. The locale-safe `Format(value, 0, 9)` at the single producer is strictly smaller, strictly safer, and brings the toolkit in line with the BC convention for round-tripping numeric IDs through text.

## Math check

Observed: 184 distinct Agent Tasks → counter shows 369.
After fix: counter shows 184.
Pre-fix arithmetic for 6-digit IDs (`1,234,567` → 3 fragments per ID, plus the inter-ID separator): `184 × 2 + 1 = 369`. ✅

## Test notes

No new unit test is added in this change. The existing AIT regression run (`RT-ACCUR`) is the repro — its `Agent Tasks Executed` totals now equal the number of distinct rows in the underlying `Agent Task Log` cursor.

If desired, a targeted regression test for `GetCommaSeparatedAgentTaskIDs` could be added that seeds Agent Task IDs `>= 1000` and asserts both `GetAgentTaskCount` and `ConvertCommaSeparatedToFilter` produce the expected values regardless of `GLOBALLANGUAGE`. Happy to add this in a follow-up if maintainers want it in-tree.


