### PR TITLE
[Quality Management] [28.0] Workflow responses are marked as default for any event

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Workflow/QltyWorkflowSetup.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Workflow/QltyWorkflowSetup.Codeunit.al
@@ -397,12 +397,8 @@ codeunit 20423 "Qlty. Workflow Setup"
         OptionalSuffix: Text;
     begin
         WorkflowResponse.SetFilter("Function Name", QltyPrefixTok + '*');
-        if WorkflowResponse.FindSet() then
-            repeat
-                WorkflowResponse.MakeDependentOnAllEvents();
-            until WorkflowResponse.Next() = 0;
-
         WorkflowResponse.DeleteAll(false);
+
         WorkflowResponse.Reset();
         WorkflowResponse.SetRange(Description, QMWorkflowResponseDescriptionCreateAQltyInspectionLbl);
         if not WorkflowResponse.IsEmpty() then

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsWorkflows.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsWorkflows.Codeunit.al
@@ -53,7 +53,41 @@ codeunit 139969 "Qlty. Tests - Workflows"
         EventFilterTok: Label 'Where("Result Code"=Filter(%1))', Comment = '%1=result code.';
         DefaultResult1FailCodeTok: Label 'FAIL', Locked = true;
         DefaultResult2PassCodeTok: Label 'PASS', Locked = true;
+        QMResponseNotPredecessorOfNonQMEventErr: Label 'QM response %1 should not be a predecessor of non-QM event %2.', Comment = '%1=response function name, %2=predecessor function name.';
         IsInitialized: Boolean;
+
+    [Test]
+    procedure QltyResponsesAreNotPredecessorsOfNonQltyEvents()
+    var
+        WFEventResponseCombination: Record "WF Event/Response Combination";
+        WorkflowEventHandling: Codeunit "Workflow Event Handling";
+        WorkflowResponseHandling: Codeunit "Workflow Response Handling";
+        QltyPrefix: Text;
+    begin
+        // [SCENARIO] QM workflow responses should only be predecessors of QM events, not of any unrelated event
+        Initialize();
+
+        // [GIVEN] The workflow events and responses libraries are initialized
+        WorkflowEventHandling.CreateEventsLibrary();
+        WorkflowResponseHandling.CreateResponsesLibrary();
+
+        // [WHEN] We look at all event/response combinations where the response is a QM response
+        QltyPrefix := 'QLTY-*';
+        WFEventResponseCombination.SetFilter("Function Name", QltyPrefix);
+        WFEventResponseCombination.FindSet();
+
+        // [THEN] Every linked predecessor event must also be a QM event
+        repeat
+            LibraryAssert.IsTrue(
+                WFEventResponseCombination."Predecessor Type" = WFEventResponseCombination."Predecessor Type"::"Event",
+                'Expected predecessor type to be Event.');
+            LibraryAssert.IsTrue(
+                CopyStr(WFEventResponseCombination."Predecessor Function Name", 1, 5) = 'QLTY-',
+                StrSubstNo(QMResponseNotPredecessorOfNonQMEventErr,
+                    WFEventResponseCombination."Function Name",
+                    WFEventResponseCombination."Predecessor Function Name"));
+        until WFEventResponseCombination.Next() = 0;
+    end;
 
     [Test]
     procedure PurchaseReturnWorkflow_OnInspectionFinished()


### PR DESCRIPTION
## What & why

Quality Management responses are nominally valid only for Quality Management events.

## Linked work

Fixes [AB#637722](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637722)
