### PR TITLE
Bug 637527: Set DataClassification = SystemMetadata on PEPPOL 3.0 Setup table

### DIFF
--- a/src/Apps/W1/PEPPOL/App/src/Setup/PEPPOL30Setup.Table.al
+++ b/src/Apps/W1/PEPPOL/App/src/Setup/PEPPOL30Setup.Table.al
@@ -15,14 +15,13 @@ table 37202 "PEPPOL 3.0 Setup"
     Caption = 'PEPPOL 3.0 Setup';
     InherentEntitlements = RIMX;
     InherentPermissions = RMX;
-    DataClassification = CustomerContent;
+    DataClassification = SystemMetadata;
 
     fields
     {
         field(1; "Primary Key"; Code[10])
         {
             Caption = 'Primary Key';
-            DataClassification = SystemMetadata;
         }
         field(2; "PEPPOL 3.0 Sales Format"; Enum "PEPPOL 3.0 Format")
         {


### PR DESCRIPTION
## Summary

Move `DataClassification` to the table level (`SystemMetadata`) on table 37202 `PEPPOL 3.0 Setup`. All fields on this table are system metadata (the primary key and two enum format selectors), so the table-level classification is the correct semantic and removes the need for per-field overrides.

## Why

`Data Classification Eval. Data.CreateEvaluationData` only creates `Data Sensitivity` entries for fields classified as `CustomerContent`, `EndUserIdentifiableInformation`, or `EndUserPseudonymousIdentifiers`. With the previous `CustomerContent` table-level default inherited by fields 2 and 3, entries were created as `Unclassified`, causing `Data Classs Demo Data Tests.TestDataSensitivities` to fail with:

```
Field 2 of Table 37202 has Data Sensitivity Unclassified
```

With `SystemMetadata` at the table level, no entries are created for these fields and the test passes.

## Work item

[AB#637527](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637527)

