### PR TITLE
Bug 634704: Add page views to standard list pages for subcontracting

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Purchase/SubcPurchOrderList.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Purchase/SubcPurchOrderList.PageExt.al
@@ -19,17 +19,6 @@ pageextension 99001525 "Subc. PurchOrderList" extends "Purchase Order List"
             }
         }
     }
-    views
-    {
-        addlast
-        {
-            view(SubcontractingOrders)
-            {
-                Caption = 'Subcontracting Orders';
-                Filters = where("Subc. Order" = const(true));
-            }
-        }
-    }
     actions
     {
         addafter("Create Inventor&y Put-away/Pick")
@@ -81,6 +70,17 @@ pageextension 99001525 "Subc. PurchOrderList" extends "Purchase Order List"
                     PurchaseHeader.SetRecFilter();
                     Report.Run(Report::"Subc. Dispatching List", true, false, PurchaseHeader);
                 end;
+            }
+        }
+    }
+    views
+    {
+        addlast
+        {
+            view(SubcontractingOrders)
+            {
+                Caption = 'Subcontracting Orders';
+                Filters = where("Subc. Order" = const(true));
             }
         }
     }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Purchase/SubcPurchOrderList.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Purchase/SubcPurchOrderList.PageExt.al
@@ -19,6 +19,17 @@ pageextension 99001525 "Subc. PurchOrderList" extends "Purchase Order List"
             }
         }
     }
+    views
+    {
+        addlast
+        {
+            view(SubcontractingOrders)
+            {
+                Caption = 'Subcontracting Orders';
+                Filters = where("Subc. Order" = const(true));
+            }
+        }
+    }
     actions
     {
         addafter("Create Inventor&y Put-away/Pick")

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Purchase/SubcPurchOrderList.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Purchase/SubcPurchOrderList.PageExt.al
@@ -85,3 +85,4 @@ pageextension 99001525 "Subc. PurchOrderList" extends "Purchase Order List"
         }
     }
 }
+}

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Purchase/SubcPurchOrderList.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Purchase/SubcPurchOrderList.PageExt.al
@@ -85,4 +85,3 @@ pageextension 99001525 "Subc. PurchOrderList" extends "Purchase Order List"
         }
     }
 }
-}

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Transfer/SubcPstdDirectTransfers.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Transfer/SubcPstdDirectTransfers.PageExt.al
@@ -1,0 +1,22 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Manufacturing.Subcontracting;
+
+using Microsoft.Inventory.Transfer;
+
+pageextension 99001554 "Subc. Pstd. Direct Transfers" extends "Posted Direct Transfers"
+{
+    views
+    {
+        addlast
+        {
+            view(SubcontractingDirectTransfers)
+            {
+                Caption = 'Subcontracting Direct Transfers';
+                Filters = where("Source Type" = const(Subcontracting));
+            }
+        }
+    }
+}

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Transfer/SubcPstdTransferRcpts.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Transfer/SubcPstdTransferRcpts.PageExt.al
@@ -1,0 +1,22 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Manufacturing.Subcontracting;
+
+using Microsoft.Inventory.Transfer;
+
+pageextension 99001553 "Subc. Pstd. Transfer Rcpts." extends "Posted Transfer Receipts"
+{
+    views
+    {
+        addlast
+        {
+            view(SubcontractingReceipts)
+            {
+                Caption = 'Subcontracting Receipts';
+                Filters = where("Subc. Source Type" = const(Subcontracting));
+            }
+        }
+    }
+}

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Transfer/SubcPstdTransferShpts.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Transfer/SubcPstdTransferShpts.PageExt.al
@@ -1,0 +1,22 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Manufacturing.Subcontracting;
+
+using Microsoft.Inventory.Transfer;
+
+pageextension 99001552 "Subc. Pstd. Transfer Shpts." extends "Posted Transfer Shipments"
+{
+    views
+    {
+        addlast
+        {
+            view(SubcontractingShipments)
+            {
+                Caption = 'Subcontracting Shipments';
+                Filters = where("Subc. Source Type" = const(Subcontracting));
+            }
+        }
+    }
+}

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Transfer/SubcTransferOrders.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Transfer/SubcTransferOrders.PageExt.al
@@ -1,0 +1,27 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Manufacturing.Subcontracting;
+
+using Microsoft.Inventory.Transfer;
+
+pageextension 99001551 "Subc. Transfer Orders" extends "Transfer Orders"
+{
+    views
+    {
+        addlast
+        {
+            view(SubcontractingOutbound)
+            {
+                Caption = 'To Subcontractor';
+                Filters = where("Subc. Source Type" = const(Subcontracting), "Subc. Return Order" = const(false));
+            }
+            view(SubcontractingReturns)
+            {
+                Caption = 'Returns from Subcontractor';
+                Filters = where("Subc. Source Type" = const(Subcontracting), "Subc. Return Order" = const(true));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
The Subcontracting app extends standard Purchase Order List and Transfer Orders pages with fields, factboxes, and actions — but does not add page views for filtering to subcontracting-specific records. This PR adds the missing page views as replacement for the obsoleted Italian localization pages (12152–12155, 35490, 35491).

## Root Cause
The Italian localization created dedicated pages that filtered for subcontracting records. These pages are now obsoleted with the comment 'Preparation for replacement by Subcontracting app' — but the Subcontracting app never provided the replacement filtering UX.

## Fix
Added page views via pageextension to allow users to quickly filter to subcontracting records:

| Page | View | Filter |
|---|---|---|
| Purchase Order List (9307) | Subcontracting Orders | \\\Subc. Order = true\\\ |
| Transfer Orders (5742) | To Subcontractor | \\\Subc. Source Type = Subcontracting, Subc. Return Order = false\\\ |
| Transfer Orders (5742) | Returns from Subcontractor | \\\Subc. Source Type = Subcontracting, Subc. Return Order = true\\\ |
| Posted Transfer Shipments (5752) | Subcontracting Shipments | \\\Subc. Source Type = Subcontracting\\\ |
| Posted Transfer Receipts (5753) | Subcontracting Receipts | \\\Subc. Source Type = Subcontracting\\\ |
| Posted Direct Transfers (6783) | Subcontracting Direct Transfers | \\\Source Type = Subcontracting\\\ |

## Test
No automated test added — these are declarative page views (UI metadata). Syntax and field resolution are validated by the AL compiler during CI.

Fixes [AB#634704](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634704)

🤖 Generated with GitHub Copilot




