### PR TITLE
Fix blank Schedule Description on Performance Profiles list

### DIFF
--- a/src/System Application/App/Performance Profiler/src/PerformanceProfileList.Page.al
+++ b/src/System Application/App/Performance Profiler/src/PerformanceProfileList.Page.al
@@ -244,6 +244,7 @@ page 1931 "Performance Profile List"
     var
     begin
         this.MapClientTypeToActivityType();
+        ScheduleDescription := ScheduleDisplayName();
         PlatformCallDuration := this.ComputePlatformCallDuration();
     end;
 


### PR DESCRIPTION
## Summary

On page 1931 `Performance Profile List` the `Schedule Description` column was populated only inside `OnAfterGetCurrRecord`. That trigger fires only for the currently selected row, so every other row in the list showed the column as blank until the user clicked it.

This fix sets `ScheduleDescription` in `OnAfterGetRecord` as well, which fires per row as the list is rendered. This mirrors the pattern already used in `Perf. Profiler Schedules List` for `UserName` and `Activity`.

## Repro

1. Open **Performance Profiles** (page 1931) with profile data for an active schedule.
2. Before the fix, the **Schedule Description** column is empty for every row except the currently selected row.
3. After the fix, every row shows the description of its associated schedule.

Fixes [AB#637898](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637898)


