### PR TITLE
Fix Routing Lines page layout - move WIP fields after Description

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcRoutingLines.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcRoutingLines.PageExt.al
@@ -24,7 +24,7 @@ pageextension 99001508 "Subc. Routing Lines" extends "Routing Lines"
                 UpdateWIPEnabled();
             end;
         }
-        addafter("Routing Link Code")
+        addafter(Description)
         {
             field("Transfer WIP Item"; Rec."Transfer WIP Item")
             {


### PR DESCRIPTION
## Summary
The Subcontracting page extension added Transfer WIP Item, Transfer Description, and Transfer Description 2 fields after \Routing Link Code\, pushing the Description column far away from the No. field.

## Fix
Move the anchor from \^Gddafter("Routing Link Code")\ to \^Gddafter(Description)\ so Description stays adjacent to No. for better readability.

## Fixes
[AB#636810](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636810)
