### PR TITLE
[Subcontracting] Check negative quantities and arbitrary values on WIP Adjustment

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/WIP Item/SubcWIPAdjustment.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/WIP Item/SubcWIPAdjustment.Page.al
@@ -385,8 +385,8 @@ page 99001561 "Subc. WIP Adjustment"
         if NewQty < 0 then
             Error(NewQuantityMustNotBeNegativeErr);
         ProdOrderLine.SetLoadFields("Quantity (Base)");
-        if ProdOrderLine.Get(Rec."Prod. Order Status", Rec."Prod. Order No.", Rec."Prod. Order Line No.") then
-            if NewQty > ProdOrderLine."Quantity (Base)" then
-                Error(NewQuantityExceedsProdOrderQtyErr, ProdOrderLine."Quantity (Base)");
+        ProdOrderLine.Get(Rec."Prod. Order Status", Rec."Prod. Order No.", Rec."Prod. Order Line No.");
+        if NewQty > ProdOrderLine."Quantity (Base)" then
+            Error(NewQuantityExceedsProdOrderQtyErr, ProdOrderLine."Quantity (Base)");
     end;
 }

--- a/src/Apps/W1/Subcontracting/App/src/Process/WIP Item/SubcWIPAdjustment.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/WIP Item/SubcWIPAdjustment.Page.al
@@ -5,6 +5,7 @@
 namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Item;
+using Microsoft.Manufacturing.Document;
 
 page 99001561 "Subc. WIP Adjustment"
 {
@@ -112,6 +113,7 @@ page 99001561 "Subc. WIP Adjustment"
 
                     trigger OnValidate()
                     begin
+                        ValidateNewQuantity(NewQuantityBase);
                         NewQuantities.Set(Rec."Entry No.", NewQuantityBase);
                         UpdateQuantityStyle();
                     end;
@@ -202,6 +204,7 @@ page 99001561 "Subc. WIP Adjustment"
 
                     trigger OnValidate()
                     begin
+                        ValidateNewQuantity(NewQuantityBase);
                         NewQuantities.Set(Rec."Entry No.", NewQuantityBase);
                         UpdateQuantityStyle();
                     end;
@@ -258,6 +261,8 @@ page 99001561 "Subc. WIP Adjustment"
         LineCount: Integer;
         CaptionLbl: Label 'Production Order %1 %2', Comment = '%1=Prod. Order Status,%2=Prod. Order Number';
         NothingToAdjustErr: Label 'There are no WIP quantities to adjust, because there are no existing ledger entries for the specified source.';
+        NewQuantityMustNotBeNegativeErr: Label 'New Quantity (Base) must not be negative.';
+        NewQuantityExceedsProdOrderQtyErr: Label 'New Quantity (Base) must not exceed the production order line quantity of %1.', Comment = '%1=Production order line quantity (base)';
 
     /// <summary>
     /// Populates the page source table with one row per (Routing Reference No., Operation No., Location Code)
@@ -371,5 +376,17 @@ page 99001561 "Subc. WIP Adjustment"
         if ItemNo <> Item."No." then
             Item.Get(ItemNo);
         exit(Item."Base Unit of Measure");
+    end;
+
+    local procedure ValidateNewQuantity(NewQty: Decimal)
+    var
+        ProdOrderLine: Record "Prod. Order Line";
+    begin
+        if NewQty < 0 then
+            Error(NewQuantityMustNotBeNegativeErr);
+        ProdOrderLine.SetLoadFields("Quantity (Base)");
+        if ProdOrderLine.Get(Rec."Prod. Order Status", Rec."Prod. Order No.", Rec."Prod. Order Line No.") then
+            if NewQty > ProdOrderLine."Quantity (Base)" then
+                Error(NewQuantityExceedsProdOrderQtyErr, ProdOrderLine."Quantity (Base)");
     end;
 }

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcWIPAdjustmentTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcWIPAdjustmentTest.Codeunit.al
@@ -127,6 +127,56 @@ codeunit 149914 "Subc. WIP Adjustment Test"
             'ADJ-003', 'Aggregation Test', '');
     end;
 
+    [Test]
+    [HandlerFunctions('WIPAdjustmentPageHandler')]
+    procedure WIPAdjustment_NegativeQuantity_RaisesError()
+    var
+        WIPLedgerEntry: Record "Subcontractor WIP Ledger Entry";
+        WIPAdjustmentPage: Page "Subc. WIP Adjustment";
+        ProdOrderNo: Code[20];
+    begin
+        // [SCENARIO] Entering a negative new quantity on the WIP Adjustment page raises an error
+        Initialize();
+
+        // [GIVEN] A WIP ledger entry exists for a production order with an initial quantity of 10
+        CreateTestWIPSetup(WIPLedgerEntry, 10, ProdOrderNo);
+
+        // [GIVEN] The WIP Adjustment page handler will attempt to set the new quantity to -50
+        SetHandlerValues(-50, '', '', '');
+
+        // [WHEN] The WIP Adjustment page is opened and a negative quantity is entered
+        WIPAdjustmentPage.SetWIPLedgerEntry(WIPLedgerEntry);
+
+        // [THEN] An error is raised indicating that the new quantity must not be negative
+        asserterror WIPAdjustmentPage.RunModal();
+        Assert.ExpectedError('must not be negative');
+    end;
+
+    [Test]
+    [HandlerFunctions('WIPAdjustmentPageHandler')]
+    procedure WIPAdjustment_QuantityExceedsProdOrderQty_RaisesError()
+    var
+        WIPLedgerEntry: Record "Subcontractor WIP Ledger Entry";
+        WIPAdjustmentPage: Page "Subc. WIP Adjustment";
+        ProdOrderNo: Code[20];
+    begin
+        // [SCENARIO] Entering a new quantity exceeding the production order line quantity raises an error
+        Initialize();
+
+        // [GIVEN] A production order line with quantity 10 and a WIP ledger entry with initial quantity 5
+        CreateTestWIPSetupWithProdOrderQty(WIPLedgerEntry, 5, 10, ProdOrderNo);
+
+        // [GIVEN] The WIP Adjustment page handler will attempt to set the new quantity to 15 (exceeds prod order qty of 10)
+        SetHandlerValues(15, '', '', '');
+
+        // [WHEN] The WIP Adjustment page is opened and a quantity exceeding the production order is entered
+        WIPAdjustmentPage.SetWIPLedgerEntry(WIPLedgerEntry);
+
+        // [THEN] An error is raised indicating that the new quantity must not exceed the production order line quantity
+        asserterror WIPAdjustmentPage.RunModal();
+        Assert.ExpectedError('must not exceed the production order line quantity');
+    end;
+
     [ModalPageHandler]
     procedure WIPAdjustmentPageHandler(var WIPAdjustmentPage: TestPage "Subc. WIP Adjustment")
     begin
@@ -239,6 +289,46 @@ codeunit 149914 "Subc. WIP Adjustment Test"
             WIPLedgerEntry, Item."No.", Location.Code,
             ProductionOrder, ProdOrderLine, ProdOrderRoutingLine,
             'WC-001', Quantity2, false);
+
+        ProdOrderNo := ProductionOrder."No.";
+        WIPLedgerEntry.SetRange("Prod. Order No.", ProdOrderNo);
+    end;
+
+    /// <summary>
+    /// Creates a WIP ledger entry linked to a real Prod. Order Line with the specified quantity.
+    /// The Prod. Order Line is inserted without running triggers to allow testing the
+    /// exceeding-quantity validation without requiring a full production order setup.
+    /// </summary>
+    local procedure CreateTestWIPSetupWithProdOrderQty(var WIPLedgerEntry: Record "Subcontractor WIP Ledger Entry"; WIPQuantityBase: Decimal; ProdOrderQty: Decimal; var ProdOrderNo: Code[20])
+    var
+        Item: Record Item;
+        Location: Record Location;
+        ProductionOrder: Record "Production Order";
+        ProdOrderLine: Record "Prod. Order Line";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+    begin
+        LibraryInventory.CreateItem(Item);
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(Location);
+
+        ProductionOrder."No." := CopyStr(
+            LibraryUtility.GenerateRandomCode(ProductionOrder.FieldNo("No."), Database::"Production Order"),
+            1, MaxStrLen(ProductionOrder."No."));
+
+        ProdOrderLine.Status := "Production Order Status"::Released;
+        ProdOrderLine."Prod. Order No." := ProductionOrder."No.";
+        ProdOrderLine."Line No." := 10000;
+        ProdOrderLine."Quantity (Base)" := ProdOrderQty;
+        ProdOrderLine."Unit of Measure Code" := Item."Base Unit of Measure";
+        ProdOrderLine.Insert(false);
+
+        ProdOrderRoutingLine."Routing No." := 'RTNG-001';
+        ProdOrderRoutingLine."Routing Reference No." := 10000;
+        ProdOrderRoutingLine."Operation No." := '10';
+
+        SubcontractingMgmtLibrary.CreateWIPLedgerEntry(
+            WIPLedgerEntry, Item."No.", Location.Code,
+            ProductionOrder, ProdOrderLine, ProdOrderRoutingLine,
+            'WC-001', WIPQuantityBase, false);
 
         ProdOrderNo := ProductionOrder."No.";
         WIPLedgerEntry.SetRange("Prod. Order No.", ProdOrderNo);

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcWIPAdjustmentTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcWIPAdjustmentTest.Codeunit.al
@@ -177,6 +177,69 @@ codeunit 149914 "Subc. WIP Adjustment Test"
         Assert.ExpectedError('must not exceed the production order line quantity');
     end;
 
+    [Test]
+    [HandlerFunctions('WIPAdjustmentPageHandler')]
+    procedure WIPAdjustment_ZeroNewQuantity_Succeeds()
+    var
+        WIPLedgerEntry: Record "Subcontractor WIP Ledger Entry";
+        WIPAdjustmentPage: Page "Subc. WIP Adjustment";
+        ProdOrderNo: Code[20];
+        InitialQty: Decimal;
+    begin
+        // [SCENARIO] Entering zero as the new quantity succeeds (lower boundary: 0 is allowed, < 0 is not)
+        Initialize();
+
+        // [GIVEN] A WIP ledger entry with initial quantity 5 and a prod. order line quantity of 10
+        InitialQty := 5;
+        CreateTestWIPSetupWithProdOrderQty(WIPLedgerEntry, InitialQty, 10, ProdOrderNo);
+
+        // [GIVEN] The WIP Adjustment page handler will set the new quantity to 0 (lower boundary)
+        SetHandlerValues(0, 'ADJ-ZRO', 'Zero Qty Test', '');
+
+        // [WHEN] The WIP Adjustment page is opened and a zero quantity is confirmed
+        WIPAdjustmentPage.SetWIPLedgerEntry(WIPLedgerEntry);
+        WIPAdjustmentPage.RunModal();
+
+        // [THEN] A negative adjustment entry is created reducing the WIP quantity to zero
+        AssertWIPQuantitySum(ProdOrderNo, 0);
+        AssertAdjustmentEntry(
+            ProdOrderNo, -InitialQty,
+            "WIP Ledger Entry Type"::"Negative Adjustment",
+            'ADJ-ZRO', 'Zero Qty Test', '');
+    end;
+
+    [Test]
+    [HandlerFunctions('WIPAdjustmentPageHandler')]
+    procedure WIPAdjustment_ExactProdOrderQuantity_Succeeds()
+    var
+        WIPLedgerEntry: Record "Subcontractor WIP Ledger Entry";
+        WIPAdjustmentPage: Page "Subc. WIP Adjustment";
+        ProdOrderNo: Code[20];
+        InitialQty, ProdOrderQty : Decimal;
+    begin
+        // [SCENARIO] Entering exactly the production order line quantity succeeds (upper boundary: = is allowed, > is not)
+        Initialize();
+
+        // [GIVEN] A WIP ledger entry with initial quantity 3 and a prod. order line quantity of 10
+        InitialQty := 3;
+        ProdOrderQty := 10;
+        CreateTestWIPSetupWithProdOrderQty(WIPLedgerEntry, InitialQty, ProdOrderQty, ProdOrderNo);
+
+        // [GIVEN] The WIP Adjustment page handler will set the new quantity exactly equal to the prod. order line quantity
+        SetHandlerValues(ProdOrderQty, 'ADJ-MAX', 'Exact Prod Order Qty Test', '');
+
+        // [WHEN] The WIP Adjustment page is opened and the production order line quantity is confirmed
+        WIPAdjustmentPage.SetWIPLedgerEntry(WIPLedgerEntry);
+        WIPAdjustmentPage.RunModal();
+
+        // [THEN] A positive adjustment entry is created raising the WIP quantity to the production order line quantity
+        AssertWIPQuantitySum(ProdOrderNo, ProdOrderQty);
+        AssertAdjustmentEntry(
+            ProdOrderNo, ProdOrderQty - InitialQty,
+            "WIP Ledger Entry Type"::"Positive Adjustment",
+            'ADJ-MAX', 'Exact Prod Order Qty Test', '');
+    end;
+
     [ModalPageHandler]
     procedure WIPAdjustmentPageHandler(var WIPAdjustmentPage: TestPage "Subc. WIP Adjustment")
     begin
@@ -241,8 +304,12 @@ codeunit 149914 "Subc. WIP Adjustment Test"
         ProductionOrder."No." := CopyStr(
             LibraryUtility.GenerateRandomCode(ProductionOrder.FieldNo("No."), Database::"Production Order"),
             1, MaxStrLen(ProductionOrder."No."));
+        ProdOrderLine.Status := "Production Order Status"::Released;
+        ProdOrderLine."Prod. Order No." := ProductionOrder."No.";
         ProdOrderLine."Line No." := 10000;
+        ProdOrderLine."Quantity (Base)" := QuantityBase + 100;
         ProdOrderLine."Unit of Measure Code" := Item."Base Unit of Measure";
+        ProdOrderLine.Insert(false);
         ProdOrderRoutingLine."Routing No." := 'RTNG-001';
         ProdOrderRoutingLine."Routing Reference No." := 10000;
         ProdOrderRoutingLine."Operation No." := '10';
@@ -275,8 +342,12 @@ codeunit 149914 "Subc. WIP Adjustment Test"
         ProductionOrder."No." := CopyStr(
             LibraryUtility.GenerateRandomCode(ProductionOrder.FieldNo("No."), Database::"Production Order"),
             1, MaxStrLen(ProductionOrder."No."));
+        ProdOrderLine.Status := "Production Order Status"::Released;
+        ProdOrderLine."Prod. Order No." := ProductionOrder."No.";
         ProdOrderLine."Line No." := 10000;
+        ProdOrderLine."Quantity (Base)" := Quantity1 + Quantity2 + 100;
         ProdOrderLine."Unit of Measure Code" := Item."Base Unit of Measure";
+        ProdOrderLine.Insert(false);
         ProdOrderRoutingLine."Routing No." := 'RTNG-001';
         ProdOrderRoutingLine."Routing Reference No." := 10000;
         ProdOrderRoutingLine."Operation No." := '10';


### PR DESCRIPTION
## What & why

- Implement validation to prevent negative new quantities.
- Ensure new quantity does not exceed production order line quantity.
- Add corresponding test cases to verify error handling.

## Linked work

Fixes [AB#636826](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636826)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

- Ran the new Test Functions

