### PR TITLE
[Quality Management] [28.x] Add Quality Inspection Result card and Multi-select test action in templates

### DIFF
--- a/src/Apps/W1/Quality Management/Test Library/src/QltyInspectionUtility.Codeunit.al
+++ b/src/Apps/W1/Quality Management/Test Library/src/QltyInspectionUtility.Codeunit.al
@@ -3451,4 +3451,19 @@ codeunit 139940 "Qlty. Inspection Utility"
     end;
 
     #endregion Qlty. Misc Helpers Wrappers
+
+    /// <summary>
+    /// Wrapper for Qlty. Inspection Template Line.AddSelectedTests()
+    /// Adds the tests matching the provided selection filter to the given template, bypassing the Qlty. Tests lookup page.
+    /// Intended for unit tests of the "Add multiple tests" feature where TestPage cannot multi-select rows.
+    /// </summary>
+    /// <param name="QltyInspectionTemplateHdr">The template into which the selected tests will be inserted.</param>
+    /// <param name="SelectionFilter">A filter string (e.g. 'CODE1|CODE2') matching Qlty. Test codes to add.</param>
+    internal procedure AddSelectedTestsToTemplate(QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr."; SelectionFilter: Text)
+    var
+        QltyInspectionTemplateLine: Record "Qlty. Inspection Template Line";
+    begin
+        QltyInspectionTemplateLine."Template Code" := QltyInspectionTemplateHdr.Code;
+        QltyInspectionTemplateLine.AddSelectedTests(QltyInspectionTemplateLine."Template Code", SelectionFilter);
+    end;
 }

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResult.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResult.Table.al
@@ -214,6 +214,7 @@ table 20411 "Qlty. Inspection Result"
         PromptFirstExistingInspectionQst: Label 'This result, although not set on an inspection, is available to previous inspections. Are you sure you want to remove this result? This cannot be undone.';
         PromptFirstExistingTemplateQst: Label 'This result is currently defined on some Quality Inspection Templates. Are you sure you want to remove this result? This cannot be undone.';
         PromptFirstExistingTestQst: Label 'This result is currently defined on some tests. Are you sure you want to remove this result? This cannot be undone.';
+        EvaluationSequencePriorityMustBeUniqueErr: Label 'Evaluation Sequence priority must be unique, you cannot have two results with the same evaluation sequence. Result %1 %2 already has the same evaluation sequence %3.', Comment = '%1=Result Code, %2=Result description, %3=Evaluation Sequence';
         DefaultResultInProgressCodeLbl: Label 'INPROGRESS', Locked = true, MaxLength = 20;
         ResultCodePassLbl: Label 'PASS', MaxLength = 20;
         ResultCodeGoodLbl: Label 'GOOD', MaxLength = 20;
@@ -357,20 +358,19 @@ table 20411 "Qlty. Inspection Result"
     internal procedure ValidateEvaluationSequenceNotUsedElsewhere()
     var
         ExistingQltyInspectionResult: Record "Qlty. Inspection Result";
-        MustChangePriorityErr: Label 'Evaluation Sequence must be unique, you cannot have two results with the same evaluation sequence. Result [%1/%2] already has the same evaluation sequence.', Comment = '%1=The result code, %2=the result condition';
     begin
         ExistingQltyInspectionResult.SetFilter(Code, '<>%1', Rec.Code);
         ExistingQltyInspectionResult.SetRange("Evaluation Sequence", Rec."Evaluation Sequence");
         ExistingQltyInspectionResult.SetLoadFields(Description);
         if ExistingQltyInspectionResult.FindFirst() then
-            Error(MustChangePriorityErr, ExistingQltyInspectionResult.Code, ExistingQltyInspectionResult.Description);
+            Error(EvaluationSequencePriorityMustBeUniqueErr, ExistingQltyInspectionResult.Code, ExistingQltyInspectionResult.Description, Rec."Evaluation Sequence");
     end;
 
     /// <summary>
     /// Updates tests, templates, and inspections with result changes.
     /// Adds newly created results to existing quality tests and templates, adjusts evaluation sequences, and updates promoted results.
     /// </summary>
-    procedure UpdateTestsTemplatesAndInspections()
+    internal procedure UpdateTestsTemplatesAndInspections()
     var
         QltyResultConditionMgmt2: Codeunit "Qlty. Result Condition Mgmt.";
     begin

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResult.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResult.Table.al
@@ -335,4 +335,45 @@ table 20411 "Qlty. Inspection Result"
                 exit(Format(RowStyle::None));
         end;
     end;
+
+    /// <summary>
+    /// Sets the default evaluation sequence for a new record.
+    /// </summary>
+    internal procedure SetDefaultEvaluationSequence()
+    var
+        ExistingQltyInspectionResult: Record "Qlty. Inspection Result";
+    begin
+        ExistingQltyInspectionResult.SetCurrentKey("Evaluation Sequence");
+        ExistingQltyInspectionResult.Ascending(false);
+        if not ExistingQltyInspectionResult.FindFirst() then
+            Rec."Evaluation Sequence" := 0
+        else
+            Rec."Evaluation Sequence" := ExistingQltyInspectionResult."Evaluation Sequence" + 1;
+    end;
+
+    /// <summary>
+    /// Validates that the evaluation sequence is not used by another result.
+    /// </summary>
+    internal procedure ValidateEvaluationSequenceNotUsedElsewhere()
+    var
+        ExistingQltyInspectionResult: Record "Qlty. Inspection Result";
+        MustChangePriorityErr: Label 'Evaluation Sequence must be unique, you cannot have two results with the same evaluation sequence. Result [%1/%2] already has the same evaluation sequence.', Comment = '%1=The result code, %2=the result condition';
+    begin
+        ExistingQltyInspectionResult.SetFilter(Code, '<>%1', Rec.Code);
+        ExistingQltyInspectionResult.SetRange("Evaluation Sequence", Rec."Evaluation Sequence");
+        ExistingQltyInspectionResult.SetLoadFields(Description);
+        if ExistingQltyInspectionResult.FindFirst() then
+            Error(MustChangePriorityErr, ExistingQltyInspectionResult.Code, ExistingQltyInspectionResult.Description);
+    end;
+
+    /// <summary>
+    /// Updates tests, templates, and inspections with result changes.
+    /// Adds newly created results to existing quality tests and templates, adjusts evaluation sequences, and updates promoted results.
+    /// </summary>
+    procedure UpdateTestsTemplatesAndInspections()
+    var
+        QltyResultConditionMgmt2: Codeunit "Qlty. Result Condition Mgmt.";
+    begin
+        QltyResultConditionMgmt2.CopyGradeConditionsFromDefaultToAllTemplates();
+    end;
 }

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResultCard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResultCard.Page.al
@@ -9,7 +9,7 @@ namespace Microsoft.QualityManagement.Configuration.Result;
 /// </summary>
 page 20417 "Qlty. Inspection Result Card"
 {
-    Caption = 'Quality Inspection Result Card';
+    Caption = 'Quality Inspection Result';
     AboutTitle = 'About Inspection Result details';
     AboutText = 'Inspection result shows the outcome of an inspection, such as *In progress, Fail*, or *Pass*. Use this page to set up custom grades to match your process.';
     SourceTable = "Qlty. Inspection Result";

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResultCard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResultCard.Page.al
@@ -1,0 +1,212 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.QualityManagement.Configuration.Result;
+
+/// <summary>
+/// Card page for Quality Inspection Result.
+/// </summary>
+page 20417 "Qlty. Inspection Result Card"
+{
+    Caption = 'Quality Inspection Result Card';
+    AboutTitle = 'About Inspection Result details';
+    AboutText = 'Inspection result shows the outcome of an inspection, such as *In progress, Fail*, or *Pass*. Use this page to set up custom grades to match your process.';
+    SourceTable = "Qlty. Inspection Result";
+    PageType = Card;
+    ApplicationArea = QualityManagement;
+    UsageCategory = None;
+
+    layout
+    {
+        area(Content)
+        {
+            group(General)
+            {
+                Caption = 'General';
+
+                field(Code; Rec.Code)
+                {
+                    ShowMandatory = true;
+                }
+                field(Description; Rec.Description)
+                {
+                    ShowMandatory = true;
+                }
+                field("Evaluation Sequence"; Rec."Evaluation Sequence")
+                {
+                    AboutTitle = 'Evaluation Sequence';
+                    AboutText = 'The evaluation sequence sets the priority order for checking results. Inspection results with lower numbers are checked first, so *Fail* or *In progress* conditions are usually prioritized before *Pass*.';
+
+                    trigger OnValidate()
+                    begin
+                        Rec.ValidateEvaluationSequenceNotUsedElsewhere();
+                    end;
+                }
+                field("Copy Behavior"; Rec."Copy Behavior")
+                {
+                }
+                field("Result Visibility"; Rec."Result Visibility")
+                {
+                    AboutTitle = 'Result Visibility';
+                    AboutText = '*Promote* important results, typically pass conditions, so they will show on pages and reports, such as Quality Tests, Quality Inspections and Certificate of Analysis.';
+                }
+                field("Result Category"; Rec."Result Category")
+                {
+                }
+                field("Finish Allowed"; Rec."Finish Allowed")
+                {
+                }
+            }
+            group("Default Conditions")
+            {
+                Caption = 'Default Conditions';
+
+                field("Default Number Condition"; Rec."Default Number Condition")
+                {
+                }
+                field("Default Text Condition"; Rec."Default Text Condition")
+                {
+                }
+                field("Default Boolean Condition"; Rec."Default Boolean Condition")
+                {
+                }
+            }
+            group("Item Tracking Restrictions")
+            {
+                Caption = 'Item Tracking Restrictions';
+                AboutTitle = 'Allow or block specific transactions';
+                AboutText = 'For items with lot, serial, or package tracking, you can specify how quality inspection results affect specific document transactions. For example, you can block purchase documents while inspections are in progress and block sales documents for failed inspections.';
+
+                group(Basic)
+                {
+                    Caption = 'Basic';
+                    ShowCaption = true;
+
+                    field("Item Tracking Allow Sales"; Rec."Item Tracking Allow Sales")
+                    {
+                        Caption = 'Sales';
+                    }
+                    field("Item Tracking Allow Purchase"; Rec."Item Tracking Allow Purchase")
+                    {
+                        Caption = 'Purchase';
+                    }
+                    field("Item Tracking Allow Transfer"; Rec."Item Tracking Allow Transfer")
+                    {
+                        Caption = 'Transfer';
+                    }
+                }
+                group(Manufacturing)
+                {
+                    Caption = 'Manufacturing';
+                    ShowCaption = true;
+
+                    field("Item Tracking Allow Consump."; Rec."Item Tracking Allow Consump.")
+                    {
+                        Caption = 'Consumption';
+                        ApplicationArea = Manufacturing;
+                    }
+                    field("Item Tracking Allow Output"; Rec."Item Tracking Allow Output")
+                    {
+                        Caption = 'Output';
+                        ApplicationArea = Manufacturing;
+                    }
+                }
+                group(Assembly)
+                {
+                    Caption = 'Assembly';
+                    ShowCaption = true;
+
+                    field("Item Tracking Allow Asm. Cons."; Rec."Item Tracking Allow Asm. Cons.")
+                    {
+                        Caption = 'Assembly Consumption';
+                        ApplicationArea = Assembly;
+                    }
+                    field("Item Tracking Allow Asm. Out."; Rec."Item Tracking Allow Asm. Out.")
+                    {
+                        Caption = 'Assembly Output';
+                        ApplicationArea = Assembly;
+                    }
+                }
+                group(Warehouse)
+                {
+                    Caption = 'Warehouse';
+                    ShowCaption = true;
+
+                    field("Item Tracking Allow Invt. Mov."; Rec."Item Tracking Allow Invt. Mov.")
+                    {
+                        Caption = 'Inventory Movement';
+                    }
+                    field("Item Tracking Allow Invt. Pick"; Rec."Item Tracking Allow Invt. Pick")
+                    {
+                        Caption = 'Inventory Pick';
+                    }
+                    field("Item Tracking Allow Invt. PA"; Rec."Item Tracking Allow Invt. PA")
+                    {
+                        Caption = 'Inventory Put-Away';
+                    }
+                    field("Item Tracking Allow Movement"; Rec."Item Tracking Allow Movement")
+                    {
+                        Caption = 'Movement';
+                    }
+                    field("Item Tracking Allow Pick"; Rec."Item Tracking Allow Pick")
+                    {
+                        Caption = 'Pick';
+                    }
+                    field("Item Tracking Allow Put-Away"; Rec."Item Tracking Allow Put-Away")
+                    {
+                        Caption = 'Put-Away';
+                    }
+                }
+            }
+            group(Appearance)
+            {
+                Caption = 'Appearance';
+
+                field("Override Style"; Rec."Override Style")
+                {
+                    Editable = false;
+
+                    trigger OnAssistEdit()
+                    begin
+                        Rec.AssistEditResultStyle();
+                    end;
+                }
+            }
+        }
+    }
+
+    actions
+    {
+        area(Processing)
+        {
+            action(CopyResultsToAllTemplates)
+            {
+                ApplicationArea = QualityManagement;
+                Caption = 'Update Tests, Templates, and Inspections';
+                ToolTip = 'Adds newly created results to existing quality tests and templates, adjusts evaluation sequences, and updates promoted results. Inspections based on these templates are also updated.';
+                Image = CopyToTask;
+
+                trigger OnAction()
+                begin
+                    Rec.UpdateTestsTemplatesAndInspections();
+                end;
+            }
+        }
+    }
+
+    trigger OnNewRecord(BelowxRec: Boolean)
+    begin
+        Rec.SetDefaultEvaluationSequence();
+    end;
+
+    trigger OnInsertRecord(BelowxRec: Boolean): Boolean
+    begin
+        Rec.ValidateEvaluationSequenceNotUsedElsewhere();
+    end;
+
+    trigger OnModifyRecord(): Boolean
+    begin
+        Rec.ValidateEvaluationSequenceNotUsedElsewhere();
+    end;
+}

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResultList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResultList.Page.al
@@ -15,6 +15,7 @@ page 20416 "Qlty. Inspection Result List"
     Caption = 'Quality Inspection Results';
     SourceTable = "Qlty. Inspection Result";
     SourceTableView = sorting("Evaluation Sequence");
+    CardPageId = "Qlty. Inspection Result Card";
     PageType = List;
     ApplicationArea = QualityManagement;
     UsageCategory = Lists;
@@ -42,7 +43,7 @@ page 20416 "Qlty. Inspection Result List"
 
                     trigger OnValidate()
                     begin
-                        ValidateEvaluationSequenceNotUsedElsewhere();
+                        Rec.ValidateEvaluationSequenceNotUsedElsewhere();
                     end;
                 }
                 field("Copy Behavior"; Rec."Copy Behavior")
@@ -141,17 +142,12 @@ page 20416 "Qlty. Inspection Result List"
                 Image = CopyToTask;
 
                 trigger OnAction()
-                var
-                    QltyResultConditionMgmt: Codeunit "Qlty. Result Condition Mgmt.";
                 begin
-                    QltyResultConditionMgmt.CopyGradeConditionsFromDefaultToAllTemplates();
+                    Rec.UpdateTestsTemplatesAndInspections();
                 end;
             }
         }
     }
-
-    var
-        MustChangePriorityErr: Label 'Evaluation Sequence must be unique, you cannot have two results with the same evaluation sequence. Result [%1/%2] already has the same evaluation sequence.', Comment = '%1=The result code, %2=the result condition';
 
     trigger OnOpenPage()
     var
@@ -162,35 +158,17 @@ page 20416 "Qlty. Inspection Result List"
     end;
 
     trigger OnNewRecord(BelowxRec: Boolean)
-    var
-        ExistingQltyInspectionResult: Record "Qlty. Inspection Result";
     begin
-        ExistingQltyInspectionResult.SetCurrentKey("Evaluation Sequence");
-        ExistingQltyInspectionResult.Ascending(false);
-        if not ExistingQltyInspectionResult.FindFirst() then
-            Rec."Evaluation Sequence" := 0
-        else
-            Rec."Evaluation Sequence" := ExistingQltyInspectionResult."Evaluation Sequence" + 1;
+        Rec.SetDefaultEvaluationSequence();
     end;
 
     trigger OnInsertRecord(BelowxRec: Boolean): Boolean
     begin
-        ValidateEvaluationSequenceNotUsedElsewhere();
+        Rec.ValidateEvaluationSequenceNotUsedElsewhere();
     end;
 
     trigger OnModifyRecord(): Boolean
     begin
-        ValidateEvaluationSequenceNotUsedElsewhere();
-    end;
-
-    local procedure ValidateEvaluationSequenceNotUsedElsewhere()
-    var
-        ExistingQltyInspectionResult: Record "Qlty. Inspection Result";
-    begin
-        ExistingQltyInspectionResult.SetFilter(Code, '<>%1', Rec.Code);
-        ExistingQltyInspectionResult.SetRange("Evaluation Sequence", Rec."Evaluation Sequence");
-        ExistingQltyInspectionResult.SetLoadFields(Description);
-        if ExistingQltyInspectionResult.FindFirst() then
-            Error(MustChangePriorityErr, ExistingQltyInspectionResult.Code, ExistingQltyInspectionResult.Description);
+        Rec.ValidateEvaluationSequenceNotUsedElsewhere();
     end;
 }

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateLine.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateLine.Table.al
@@ -177,6 +177,62 @@ table 20403 "Qlty. Inspection Template Line"
         OnValidateExpressionFormula(Rec);
     end;
 
+    #region Add multiple tests to template
+    internal procedure SelectMultipleTests(TemplateCode: Code[20])
+    var
+        SelectionFilter: Text;
+    begin
+        if TemplateCode = '' then
+            exit;
+
+        SelectionFilter := SelectInQltyTests();
+
+        if SelectionFilter <> '' then
+            AddSelectedTests(TemplateCode, SelectionFilter);
+    end;
+
+    local procedure SelectInQltyTests(): Text
+    var
+        QltyTests: Page "Qlty. Tests";
+    begin
+        QltyTests.LookupMode(true);
+        if QltyTests.RunModal() = Action::LookupOK then
+            exit(QltyTests.GetSelectionFilter());
+    end;
+
+    internal procedure AddSelectedTests(TemplateCode: Code[20]; SelectionFilter: Text)
+    var
+        QltyTest: Record "Qlty. Test";
+    begin
+        if (TemplateCode = '') or (SelectionFilter = '') then
+            exit;
+
+        QltyTest.SetFilter(Code, SelectionFilter);
+        if QltyTest.FindSet() then
+            repeat
+                AddTestToTemplateLine(TemplateCode, QltyTest.Code);
+            until QltyTest.Next() = 0;
+    end;
+
+    local procedure AddTestToTemplateLine(TemplateCode: Code[20]; QltyTestCode: Code[20])
+    var
+        ExistingQltyInspectionTemplateLine, NewQltyInspectionTemplateLine : Record "Qlty. Inspection Template Line";
+    begin
+        ExistingQltyInspectionTemplateLine.SetRange("Template Code", TemplateCode);
+        ExistingQltyInspectionTemplateLine.SetRange("Test Code", QltyTestCode);
+        if not ExistingQltyInspectionTemplateLine.IsEmpty() then
+            exit;
+
+        NewQltyInspectionTemplateLine.Init();
+        NewQltyInspectionTemplateLine."Template Code" := TemplateCode;
+        NewQltyInspectionTemplateLine.InitLineNoIfNeeded();
+        NewQltyInspectionTemplateLine.Validate("Test Code", QltyTestCode);
+        NewQltyInspectionTemplateLine.Insert(true);
+        NewQltyInspectionTemplateLine.EnsureResultsExist(true);
+        NewQltyInspectionTemplateLine.Modify();
+    end;
+    #endregion Add multiple tests to template
+
     /// <summary>
     /// Validates the expression formula.
     /// </summary>

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateSubf.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateSubf.Page.al
@@ -472,6 +472,27 @@ page 20403 "Qlty. Inspection Template Subf"
         }
     }
 
+    actions
+    {
+        area(Processing)
+        {
+            action(AddMultipleTests)
+            {
+                AccessByPermission = tabledata "Qlty. Inspection Template Line" = I;
+                Caption = 'Select tests';
+                ToolTip = 'Add two or more tests to this template, by selecting from the full list of quality tests. Tests that already exist in the template are skipped.';
+                Ellipsis = true;
+                Image = SelectMore;
+                Enabled = Rec."Template Code" <> '';
+
+                trigger OnAction()
+                begin
+                    Rec.SelectMultipleTests(Rec."Template Code");
+                end;
+            }
+        }
+    }
+
     var
         QltyResultConditionMgmt: Codeunit "Qlty. Result Condition Mgmt.";
         MatrixSourceRecordId: array[10] of RecordId;

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTests.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTests.Page.al
@@ -8,6 +8,7 @@ using Microsoft.QualityManagement.Configuration.Result;
 using Microsoft.QualityManagement.Configuration.Template;
 using Microsoft.QualityManagement.Document;
 using Microsoft.QualityManagement.Telemetry;
+using System.Text;
 
 /// <summary>
 /// This page lets you define data points, questions, measurements, and entries with their allowable values and default passing thresholds. You can later use these tests in Quality Inspection Templates
@@ -346,4 +347,23 @@ page 20401 "Qlty. Tests"
             UpdateMatrixDataConditionDescription(Matrix);
         end;
     end;
+
+    #region Add multiple tests to template
+    internal procedure GetSelectionFilter(): Text
+    var
+        QltyTest: Record "Qlty. Test";
+    begin
+        CurrPage.SetSelectionFilter(QltyTest);
+        exit(GetSelectionFilterForTest(QltyTest));
+    end;
+
+    local procedure GetSelectionFilterForTest(var QltyTest: Record "Qlty. Test"): Text
+    var
+        SelectionFilterManagement: Codeunit SelectionFilterManagement;
+        RecRef: RecordRef;
+    begin
+        RecRef.GetTable(QltyTest);
+        exit(SelectionFilterManagement.GetSelectionFilter(RecRef, QltyTest.FieldNo(Code)));
+    end;
+    #endregion Add multiple tests to template
 }

--- a/src/Apps/W1/Quality Management/app/src/Permissions/QltyMgmtObjects.PermissionSet.al
+++ b/src/Apps/W1/Quality Management/app/src/Permissions/QltyMgmtObjects.PermissionSet.al
@@ -109,6 +109,7 @@ permissionset 20406 "QltyMgmt - Objects"
         page "Qlty. Tests" = X,
         page "Qlty. Inspection Gen. Rules" = X,
         page "Qlty. Inspection Result List" = X,
+        page "Qlty. Inspection Result Card" = X,
         page "Qlty. Test Lookup Values" = X,
         page "Qlty. Manager Role Center" = X,
         page "Qlty. Management Setup Guide" = X,

--- a/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Table.al
@@ -43,7 +43,7 @@ table 20400 "Qlty. Management Setup"
         field(4; "Inspection Creation Option"; Enum "Qlty. Inspect. Creation Option")
         {
             Caption = 'Inspection Creation Option';
-            ToolTip = 'Specifies how the system handles inspection creation when existing inspections exist.';
+            ToolTip = 'Specifies handling of inspection creation when existing inspections are found.';
             InitValue = "Use existing open inspection if available";
         }
         field(5; "Inspection Search Criteria"; Enum "Qlty. Inspect. Search Criteria")

--- a/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Table.al
@@ -43,7 +43,7 @@ table 20400 "Qlty. Management Setup"
         field(4; "Inspection Creation Option"; Enum "Qlty. Inspect. Creation Option")
         {
             Caption = 'Inspection Creation Option';
-            ToolTip = 'Specifies whether and how a new quality inspection is created if existing inspections are found.';
+            ToolTip = 'Specifies how the system handles inspection creation when existing inspections exist.';
             InitValue = "Use existing open inspection if available";
         }
         field(5; "Inspection Search Criteria"; Enum "Qlty. Inspect. Search Criteria")

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsTestTable.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsTestTable.Codeunit.al
@@ -91,6 +91,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         ResultCode1Tok: Label '><{}.@!`~''';
         ResultCode2Tok: Label '"|\/?&*()';
         CannotBeRemovedExistingInspectionErr: Label 'This result cannot be removed because it is being used actively on at least one existing Quality Inspection. If you no longer want to use this result consider changing the description, or consider changing the visibility not to be promoted. You can also change the "Copy" setting on the result.';
+        TestAddedExactlyOnceErr: Label 'Test %1 should be added exactly once.', Comment = '%1 = quality test code';
         IsInitialized: Boolean;
 
     [Test]
@@ -4570,56 +4571,95 @@ codeunit 139967 "Qlty. Tests - Test Table"
     end;
 
     [Test]
-    procedure TemplateTable_AddTestToTemplate()
+    procedure AddMultipleTestsToTemplate()
     var
-        ToLoadQltyInspectionResult: Record "Qlty. Inspection Result";
-        ConfigurationToLoadQltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
-        ConfigurationToLoadQltyInspectionTemplateLine: Record "Qlty. Inspection Template Line";
-        TestToLoadQltyIResultConditConf: Record "Qlty. I. Result Condit. Conf.";
-        DurationTemplateToLoadQltyIResultConditConf: Record "Qlty. I. Result Condit. Conf.";
-        ToLoadQltyTest: Record "Qlty. Test";
+        QltyInspectionResult: Record "Qlty. Inspection Result";
+        QltyTest: array[5] of Record "Qlty. Test";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionTemplateLine: Record "Qlty. Inspection Template Line";
+        TestQltyIResultConditConf, ForTemplateQltyIResultConditConf : Record "Qlty. I. Result Condit. Conf.";
         ResultCode: Text;
+        Index: Integer;
     begin
-        // [SCENARIO] Add test to template creates template line and copies result conditions
+        // [SCENARIO 618886] Selecting multiple tests through adds all selected tests as new template lines, with copied result conditions.
+        // [SCENARIO 618886] When the selection includes a test that is already on the template, that test is skipped and only the missing tests are inserted.
+        // [SCENARIO 618886] When every selected test already exists on the template, no new lines are created.
         Initialize();
 
         // [GIVEN] A result is created
         QltyInspectionUtility.GenerateRandomCharacters(20, ResultCode);
-        ToLoadQltyInspectionResult.Code := CopyStr(ResultCode, 1, MaxStrLen(ToLoadQltyInspectionResult.Code));
-        ToLoadQltyInspectionResult."Result Category" := ToLoadQltyInspectionResult."Result Category"::Acceptable;
-        ToLoadQltyInspectionResult.Insert();
+        QltyInspectionResult.Code := CopyStr(ResultCode, 1, MaxStrLen(QltyInspectionResult.Code));
+        QltyInspectionResult."Result Category" := QltyInspectionResult."Result Category"::Acceptable;
+        QltyInspectionResult.Insert();
 
-        // [GIVEN] A test is created
-        ToLoadQltyTest.Code := CopyStr(ResultCode, 1, MaxStrLen(ToLoadQltyTest.Code));
-        ToLoadQltyTest."Test Value Type" := ToLoadQltyTest."Test Value Type"::"Value Type Integer";
-        ToLoadQltyTest.Insert();
-
-        // [GIVEN] A result condition is created for the test
-        TestToLoadQltyIResultConditConf."Condition Type" := TestToLoadQltyIResultConditConf."Condition Type"::Test;
-        TestToLoadQltyIResultConditConf."Target Code" := ToLoadQltyTest.Code;
-        TestToLoadQltyIResultConditConf."Test Code" := ToLoadQltyTest.Code;
-        TestToLoadQltyIResultConditConf."Result Code" := ToLoadQltyInspectionResult.Code;
-        TestToLoadQltyIResultConditConf.Insert();
+        // [GIVEN] Five quality tests created
+        for Index := 1 to ArrayLen(QltyTest) do
+            QltyInspectionUtility.CreateTest(QltyTest[Index], "Qlty. Test Value Type"::"Value Type Integer");
 
         // [GIVEN] An empty template is created
-        QltyInspectionUtility.CreateTemplate(ConfigurationToLoadQltyInspectionTemplateHdr, 0);
+        QltyInspectionUtility.CreateTemplate(QltyInspectionTemplateHdr, 0);
 
-        // [WHEN] Adding test to template
-        LibraryAssert.IsTrue(ConfigurationToLoadQltyInspectionTemplateHdr.AddTestToTemplate(ToLoadQltyTest.Code), 'Should add template line for test');
+        // [GIVEN] Mock that three tests (1|2|5) are passed as the selection filter
+        // [WHEN] Add multiple tests is invoked for the template
+        QltyInspectionUtility.AddSelectedTestsToTemplate(QltyInspectionTemplateHdr, StrSubstNo('%1|%2|%3', QltyTest[1].Code, QltyTest[2].Code, QltyTest[5].Code));
 
-        // [THEN] Template line is created with correct test code
-        ConfigurationToLoadQltyInspectionTemplateLine.SetRange("Template Code", ConfigurationToLoadQltyInspectionTemplateHdr.Code);
-        ConfigurationToLoadQltyInspectionTemplateLine.FindFirst();
-        LibraryAssert.AreEqual(ToLoadQltyTest.Code, ConfigurationToLoadQltyInspectionTemplateLine."Test Code", 'Should be correct test code.');
+        // [THEN] Three new template lines exist
+        QltyInspectionTemplateLine.SetRange("Template Code", QltyInspectionTemplateHdr.Code);
+        LibraryAssert.AreEqual(3, QltyInspectionTemplateLine.Count(), 'All selected tests should be added to the template.');
 
-        // [THEN] Result condition is copied to template
-        DurationTemplateToLoadQltyIResultConditConf.SetRange("Condition Type", DurationTemplateToLoadQltyIResultConditConf."Condition Type"::Template);
-        DurationTemplateToLoadQltyIResultConditConf.SetRange("Target Code", ConfigurationToLoadQltyInspectionTemplateHdr.Code);
-        DurationTemplateToLoadQltyIResultConditConf.FindFirst();
+        for Index := 1 to ArrayLen(QltyTest) do begin
+            // Tests 3 and 4 were not selected in the lookup, so skip the per-test assertions for them
+            if Index in [3, 4] then
+                continue;
 
-        // [THEN] Template result condition has correct test and result codes
-        LibraryAssert.AreEqual(ToLoadQltyTest.Code, DurationTemplateToLoadQltyIResultConditConf."Test Code", 'Should be correct test code.');
-        LibraryAssert.AreEqual(ToLoadQltyInspectionResult.Code, DurationTemplateToLoadQltyIResultConditConf."Result Code", 'Should be correct result code.');
+            QltyInspectionTemplateLine.SetRange("Test Code", QltyTest[Index].Code);
+
+            // [THEN] Each selected test is represented on the template exactly once
+            LibraryAssert.AreEqual(1, QltyInspectionTemplateLine.Count(), StrSubstNo(TestAddedExactlyOnceErr, QltyTest[Index].Code));
+
+            // [THEN] Result condition is copied to template for each test
+            TestQltyIResultConditConf.SetRange("Condition Type", TestQltyIResultConditConf."Condition Type"::Test);
+            TestQltyIResultConditConf.SetRange("Target Code", QltyTest[Index].Code);
+            if TestQltyIResultConditConf.FindSet() then
+                repeat
+                    ForTemplateQltyIResultConditConf.SetRange("Condition Type", ForTemplateQltyIResultConditConf."Condition Type"::Template);
+                    ForTemplateQltyIResultConditConf.SetRange("Target Code", QltyInspectionTemplateHdr.Code);
+                    ForTemplateQltyIResultConditConf.SetRange("Test Code", QltyTest[Index].Code);
+                    ForTemplateQltyIResultConditConf.SetRange("Result Code", TestQltyIResultConditConf."Result Code");
+                    LibraryAssert.IsTrue(ForTemplateQltyIResultConditConf.FindFirst(), 'A result condition should have been created for the template.');
+                    LibraryAssert.AreEqual(TestQltyIResultConditConf.Condition, ForTemplateQltyIResultConditConf.Condition, 'Condition should be the same.');
+                    LibraryAssert.AreEqual(TestQltyIResultConditConf."Condition Description", ForTemplateQltyIResultConditConf."Condition Description", 'Condition Description should be the same.');
+                    LibraryAssert.AreEqual(TestQltyIResultConditConf.Priority, ForTemplateQltyIResultConditConf.Priority, 'Priority should be the same.');
+                until TestQltyIResultConditConf.Next() = 0;
+        end;
+
+
+        // [GIVEN] Mock that two tests (2|4) are passed as the selection filter. Note that test 2 is already on the template from the previous selection, so only test 4 should be added this time.
+        // [WHEN] Add multiple tests is invoked for the template
+        QltyInspectionUtility.AddSelectedTestsToTemplate(QltyInspectionTemplateHdr, StrSubstNo('%1|%2', QltyTest[2].Code, QltyTest[4].Code));
+
+        // [THEN] The template contains exactly 4 lines (the original plus the one new test)
+        QltyInspectionTemplateLine.Reset();
+        QltyInspectionTemplateLine.SetRange("Template Code", QltyInspectionTemplateHdr.Code);
+        LibraryAssert.AreEqual(4, QltyInspectionTemplateLine.Count(), 'All selected tests should be added to the template.');
+
+        // [THEN] The pre-existing line for test 2 was not duplicated on the template
+        QltyInspectionTemplateLine.SetRange("Test Code", QltyTest[2].Code);
+        LibraryAssert.AreEqual(1, QltyInspectionTemplateLine.Count(), 'The existing test should appear only once.');
+
+        // [THEN] Test 4 is added to the template
+        QltyInspectionTemplateLine.SetRange("Test Code", QltyTest[4].Code);
+        LibraryAssert.AreEqual(1, QltyInspectionTemplateLine.Count(), 'The new test should be added to the template.');
+
+
+        // [GIVEN] Mock that two tests (1|4) are passed as the selection filter. Note that both tests are already on the template, so no changes should be made to the template this time.
+        // [WHEN] Add multiple tests is invoked for the template
+        QltyInspectionUtility.AddSelectedTestsToTemplate(QltyInspectionTemplateHdr, StrSubstNo('%1|%2', QltyTest[1].Code, QltyTest[4].Code));
+
+        // [THEN] No new lines are inserted
+        QltyInspectionTemplateLine.Reset();
+        QltyInspectionTemplateLine.SetRange("Template Code", QltyInspectionTemplateHdr.Code);
+        LibraryAssert.AreEqual(4, QltyInspectionTemplateLine.Count(), 'No new template lines should be created when all selected tests are already present.');
     end;
 
     local procedure Initialize()


### PR DESCRIPTION
## What & why

Backport improvements:
1. Add card page to make it easier to show all settings.
<img width="1213" height="1202" alt="image" src="https://github.com/user-attachments/assets/95fb8785-ebd9-4bde-a112-d41af6d06ff9" />

2. Add multi-select test action in templates
<img width="1537" height="297" alt="image" src="https://github.com/user-attachments/assets/45792817-03ac-4972-b2c2-3ef387822f94" />

## Linked work
Fixes [AB#637741](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637741)
Fixes [AB#637838](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637838)


