### PR TITLE
Change codeunit ID 139898 to 139790 to avoid conflict with NAV repo

### DIFF
--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocPurchOrderExpTest.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocPurchOrderExpTest.Codeunit.al
@@ -11,7 +11,7 @@ using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 using Microsoft.Sales.Customer;
 
-codeunit 139898 "E-Doc. Purch. Order Exp. Test"
+codeunit 139790 "E-Doc. Purch. Order Exp. Test"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Codeunit 139898 `E-Doc. Purch. Order Exp. Test` collides with `Sust. Copilot Brand Tests` defined in the NAV repo (`App/Internal/Apps/SustainabilityCopilotBrandTests`), whose idRange is 139897-139898.

Changing the BCApps codeunit ID to 139790 (free, within the EDocument test idRange 139500-139899) resolves the duplicate-object-id failure surfaced by CCMerger/AlSourceReader when the NAV PR builds.

[AB#637527](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637527)



