### PR TITLE
Update E-Document AI tools to GPT-5.3 chat latest

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/AI/EDocAIToolProcessor.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/AI/EDocAIToolProcessor.Codeunit.al
@@ -245,7 +245,7 @@ codeunit 6195 "E-Doc. AI Tool Processor"
     var
         AOAIDeployments: Codeunit "AOAI Deployments";
     begin
-        exit(AOAIDeployments.GetGPT41Latest());
+        exit(AOAIDeployments.GetGPT53ChatLatest());
     end;
 
     procedure GetEDocumentMatchingAssistanceName(): Text

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentMLLMHandler.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentMLLMHandler.Codeunit.al
@@ -93,7 +93,7 @@ codeunit 6231 "E-Document MLLM Handler" implements IStructureReceivedEDocument, 
         Base64Data := Base64Convert.ToBase64(InStream);
 
         // Build AOAI call
-        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT41MiniPreview());
+        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT53ChatLatest());
         AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"E-Document MLLM Analysis");
 
         AOAIChatCompletionParams.SetTemperature(0);

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOCopilotMatching.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOCopilotMatching.Codeunit.al
@@ -110,7 +110,7 @@ codeunit 6163 "E-Doc. PO Copilot Matching"
         Session.LogMessage('0000MOT', AttempToUseCopilotMsg, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', FeatureName());
 
         // Generate OpenAI Completion
-        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT41Latest());
+        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT53ChatLatest());
         AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"E-Document Matching Assistance");
 
         AOAIChatCompletionParams.SetMaxTokens(MaxTokens());

--- a/src/Apps/W1/EDocument/App/src/Processing/docs/CLAUDE.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/docs/CLAUDE.md
@@ -10,7 +10,7 @@ The Processing module orchestrates what happens to E-Documents between creation 
 
 **Order matching.** For incoming purchase orders, `EDocLineMatching.Codeunit.al` matches imported e-document lines to existing purchase order lines. Automatic matching filters on UOM, unit cost, and discount, then uses `CalculateStringNearness()` above 80% for description matching, plus Item Reference and Text-to-Account Mapping lookups. The Copilot subfolder adds AI-assisted matching via Azure OpenAI when automatic matching leaves unmatched lines.
 
-**AI tools.** `EDocAIToolProcessor.Codeunit.al` is a generic Copilot orchestrator that configures Azure OpenAI (GPT-4.1), registers AI tools as function calls, and processes responses. The `Tools/` subfolder provides implementations for historical matching, G/L account matching, deferral matching, and similar-description lookups.
+**AI tools.** `EDocAIToolProcessor.Codeunit.al` is a generic Copilot orchestrator that configures Azure OpenAI (GPT-5.3 chat), registers AI tools as function calls, and processes responses. The `Tools/` subfolder provides implementations for historical matching, G/L account matching, deferral matching, and similar-description lookups.
 
 ## Things to know
 
@@ -22,7 +22,7 @@ The Processing module orchestrates what happens to E-Documents between creation 
 
 - Order matching only applies to incoming purchase orders (`"Document Type" = "Purchase Order"`, `Direction = Incoming`, `Status = "Order Linked"`). The matching page lets users match manually, run automatic matching, or invoke Copilot. Accepted matches persist to the `"E-Doc. Order Match"` table and update `"Qty. to Invoice"` on purchase lines.
 
-- The Copilot PO matching (`EDocPOCopilotMatching.Codeunit.al`) builds a user prompt from imported line and PO line descriptions, sends it to GPT-4.1 with function-calling tools, and grounds the result by verifying cost/quantity thresholds before surfacing proposals.
+- The Copilot PO matching (`EDocPOCopilotMatching.Codeunit.al`) builds a user prompt from imported line and PO line descriptions, sends it to GPT-5.3 chat with function-calling tools, and grounds the result by verifying cost/quantity thresholds before surfacing proposals.
 
 - `EDocumentBackgroundJobs` manages three job types: the one-shot "created flow" trigger, the recurring 5-minute `GetResponse` poller, and the recurrent batch send/import jobs with configurable frequency.
 

--- a/src/Apps/W1/EDocument/App/src/Processing/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/docs/business-logic.md
@@ -85,7 +85,7 @@ If you are working on the V2.0 import pipeline (Prepare Draft / Finish Draft sta
 
 ## Copilot PO matching
 
-When automatic matching (V1 interactive system) leaves unmatched lines, users can invoke Copilot from the matching page. `EDocPOCopilotMatching.MatchWithCopilot()` builds a prompt containing imported line and PO line descriptions, sends it to Azure OpenAI (GPT-4.1 via the `"E-Document Matching Assistance"` Copilot capability), and interprets the response through function-calling tools.
+When automatic matching (V1 interactive system) leaves unmatched lines, users can invoke Copilot from the matching page. `EDocPOCopilotMatching.MatchWithCopilot()` builds a prompt containing imported line and PO line descriptions, sends it to Azure OpenAI (GPT-5.3 chat via the `"E-Document Matching Assistance"` Copilot capability), and interprets the response through function-calling tools.
 
 The Copilot result is **grounded** before being shown: the framework verifies that proposed matches respect the cost difference threshold configured in `"Purchases & Payables Setup"."E-Document Matching Difference"`. Proposals that exceed the threshold are discarded. Accepted proposals are surfaced on a proposal page where the user reviews and confirms.
 


### PR DESCRIPTION
## Summary

Switches every AI-tool caller in the **E-Document** app from the GPT-4.1 deployments to `GetGPT53ChatLatest()`:

- `E-Doc. AI Tool Processor` (LLM tool processor)
- `E-Doc. Multi-Modal LLM Handler` (structured document import)
- `E-Doc. PO Copilot Matching` (Copilot PO line matching)

Docs under `src/Apps/W1/EDocument/App/src/Processing/docs` updated to match.

## Notes

- The `GetGPT4TokenCount` call in `EDocAIToolProcessor` is an AOAI token-counter API, not a model selector, so it stays.
- The 22K prompt-size threshold comment in `EDocPOCopilotMatching` is left as-is; revisit if a different cap is desired for the new model.