### PR TITLE
[Shopify] Rename Italian Sardinian provinces (Olbia-Tempio, Carbonia-Iglesias)

### DIFF
--- a/src/Apps/W1/Shopify/App/.resources/data/provinces.yml
+++ b/src/Apps/W1/Shopify/App/.resources/data/provinces.yml
@@ -825,7 +825,7 @@ countries:
     code: CL
   - name: Campobasso
     code: CB
-  - name: Carbonia-Iglesias
+  - name: Sulcis Iglesiente
     code: CI
   - name: Caserta
     code: CE
@@ -911,7 +911,7 @@ countries:
     code: NU
   - name: Ogliastra
     code: OG
-  - name: Olbia-Tempio
+  - name: Gallura Nord-Est Sardegna
     code: OT
   - name: Oristano
     code: OR

--- a/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyUpgradeMgt.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyUpgradeMgt.Codeunit.al
@@ -21,7 +21,7 @@ codeunit 30106 "Shpfy Upgrade Mgt."
     Access = Internal;
     Subtype = Upgrade;
     Permissions = tabledata "Shpfy Shop" = RM,
-                  tabledata "Shpfy Tax Area" = rmd,
+                  tabledata "Shpfy Tax Area" = rimd,
                   tabledata "Webhook Subscription" = rimd;
 
     trigger OnUpgradePerDatabase()
@@ -636,11 +636,14 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         if not OldShpfyTaxArea.Get(CountryRegionCode, OldName) then
             exit;
 
-        if NewShpfyTaxArea.Get(CountryRegionCode, NewName) then begin
-            // New name already exists (e.g. manually re-seeded); drop the old row.
-            OldShpfyTaxArea.Delete();
+        // If the new name already exists (e.g. a tenant manually pre-seeded it before this
+        // upgrade ran), leave both rows in place: the new row carries the user's intended
+        // configuration, and the old row is harmless because Shopify no longer sends the
+        // pre-2026-05-14 name -- no lookup will match it. Admins can clean up the stale row
+        // from the Shopify Tax Areas page if desired. Auto-deleting would risk discarding
+        // user-configured Tax Area Code / VAT Bus. Posting Group values on the old row.
+        if NewShpfyTaxArea.Get(CountryRegionCode, NewName) then
             exit;
-        end;
 
         OldShpfyTaxArea.Rename(CountryRegionCode, NewName);
     end;

--- a/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyUpgradeMgt.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyUpgradeMgt.Codeunit.al
@@ -21,6 +21,7 @@ codeunit 30106 "Shpfy Upgrade Mgt."
     Access = Internal;
     Subtype = Upgrade;
     Permissions = tabledata "Shpfy Shop" = RM,
+                  tabledata "Shpfy Tax Area" = rmd,
                   tabledata "Webhook Subscription" = rimd;
 
     trigger OnUpgradePerDatabase()
@@ -43,6 +44,7 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         CreateInvoicesFromOrdersUpgrade();
         OrderTransactionShopCodeUpgrade();
         HasAdvancedShopifyPlanUpgrade();
+        ItalianSardinianProvinceRenameUpgrade();
     end;
 
     internal procedure UpgradeTemplatesData()
@@ -613,6 +615,41 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         exit('MS-630316-HasAdvancedShopifyPlanUpgrade-20260408');
     end;
 
+    local procedure ItalianSardinianProvinceRenameUpgrade()
+    var
+        UpgradeTag: Codeunit "Upgrade Tag";
+    begin
+        if UpgradeTag.HasUpgradeTag(GetItalianSardinianProvinceRenameUpgradeTag()) then
+            exit;
+
+        RenameItalianProvince('IT', 'Olbia-Tempio', 'Gallura Nord-Est Sardegna');
+        RenameItalianProvince('IT', 'Carbonia-Iglesias', 'Sulcis Iglesiente');
+
+        UpgradeTag.SetUpgradeTag(GetItalianSardinianProvinceRenameUpgradeTag());
+    end;
+
+    local procedure RenameItalianProvince(CountryRegionCode: Code[20]; OldName: Text[50]; NewName: Text[50])
+    var
+        OldShpfyTaxArea: Record "Shpfy Tax Area";
+        NewShpfyTaxArea: Record "Shpfy Tax Area";
+    begin
+        if not OldShpfyTaxArea.Get(CountryRegionCode, OldName) then
+            exit;
+
+        if NewShpfyTaxArea.Get(CountryRegionCode, NewName) then begin
+            // New name already exists (e.g. manually re-seeded); drop the old row.
+            OldShpfyTaxArea.Delete();
+            exit;
+        end;
+
+        OldShpfyTaxArea.Rename(CountryRegionCode, NewName);
+    end;
+
+    local procedure GetItalianSardinianProvinceRenameUpgradeTag(): Code[250]
+    begin
+        exit('MS-638035-ItalianSardinianProvinceRenameUpgrade-20260609');
+    end;
+
     local procedure GetDateBeforeFeature(): DateTime
     begin
         exit(CreateDateTime(DMY2Date(1, 8, 2022), 0T));
@@ -633,5 +670,6 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         PerCompanyUpgradeTags.Add(GetCreateInvoicesFromOrdersUpgradeTag());
         PerCompanyUpgradeTags.Add(GetOrderTransactionShopCodeUpgradeTag());
         PerCompanyUpgradeTags.Add(GetHasAdvancedShopifyPlanUpgradeTag());
+        PerCompanyUpgradeTags.Add(GetItalianSardinianProvinceRenameUpgradeTag());
     end;
 }


### PR DESCRIPTION
Fixes [AB#638035](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638035)

### Background
On 2026-05-14 [Shopify renamed two Sardinian provinces](https://changelog.shopify.com/posts/italy-s-sardinian-province-definitions-updated) in their platform data:

| Code | Old name | New name |
|---|---|---|
| OT | Olbia-Tempio | Gallura Nord-Est Sardegna |
| CI | Carbonia-Iglesias | Sulcis Iglesiente |

Verified against the upstream source at [`Shopify/worldwide/data/regions/IT.yml`](https://github.com/Shopify/worldwide/blob/main/data/regions/IT.yml) -- both entries list the old name as a `name_alternates` value. The other Sardinian entries already present in our YAML (`Medio Campidano`/VS, `Ogliastra`/OG) are unchanged on Shopify's side, so they are left as-is here.

### Impact
`provinces.yml` seeds `Shpfy Tax Area` (insert-only, keyed on Country/Region Code + County **name**) via `Shpfy Sync Countries`. The Tax Area lookups in `ShpfyUpdateCustomer`, `ShpfyCreateCustomer` and `ShpfyOrderMgt` all call `.Get(CountryCode, ProvinceName)`. Without the rename, addresses Shopify sends with the new names fail to resolve to a Tax Area on import.

### Changes
- `.resources/data/provinces.yml` -- rename the two Italian entries. Codes (OT, CI) are unchanged.
- `ShpfyUpgradeMgt.Codeunit.al` -- new per-company upgrade step `ItalianSardinianProvinceRenameUpgrade` that `Rename`s existing `Shpfy Tax Area` rows so user-configured `Tax Area Code`, `VAT Bus. Posting Group`, `Tax Liable` and `County Code` are preserved. If the new-name row already exists (e.g. manual re-seed after Shopify started sending the new name), the old row is dropped to avoid PK conflicts. Guarded by tag `MS-638035-ItalianSardinianProvinceRenameUpgrade-20260609`.
- Adds `tabledata "Shpfy Tax Area" = rmd` to the codeunit Permissions.


