### PR TITLE
Downgrade AW0017 to warning

### DIFF
--- a/src/rulesets/UICop.ruleset.json
+++ b/src/rulesets/UICop.ruleset.json
@@ -69,7 +69,8 @@
                   },
                   {
                       "id":  "AW0017",
-                      "action":  "Error"
+                      "action":  "Warning",
+                      "justification": "MaskType is not yet implemented for repeater controls, but it does not break the UI. It is informational that the value will not be visible in the repeater."
                   },
                   {
                       "id":  "AW0018",


### PR DESCRIPTION
Fixes [AB#637738](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637738)

### Problem
AW0017 UI rule was by default treated as an error. The rule is blocking defining `MaskedType=Concealed` on repeaters  because this is not implemented in our UI at the moment. This is currently blocking this PR: https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_git/NAV/pullrequest/248522 

### Fix
We downgrade AW0017 from error to warning. Our UI simply won't display it and this property will be ignored.




