### PR TITLE
[Subcontracting] Component quantities on Purchase Order not updated when Production Order quantity changes

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcReqWkshMakeOrd.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcReqWkshMakeOrd.Codeunit.al
@@ -29,6 +29,12 @@ codeunit 99001516 "Subc. Req. Wksh. Make Ord."
         SubcPurchaseOrderCreator.TransferSubcontractingProdOrderComp(PurchaseLineWithService, RequisitionLine, NextLineNo);
     end;
 
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Carry Out Action", OnPurchOrderChgAndResheduleOnAfterGetPurchHeader, '', false, false)]
+    local procedure OnPurchOrderChgAndResheduleOnAfterGetPurchHeader(var PurchaseHeader: Record "Purchase Header"; var PurchaseLine: Record "Purchase Line"; var RequisitionLine: Record "Requisition Line")
+    begin
+        UpdateSubcontractingComponentPurchLines(PurchaseLine, RequisitionLine);
+    end;
+
     local procedure HandleSubcontractingAfterPurchOrderLineInsert(var PurchaseLine: Record "Purchase Line"; var RequisitionLine: Record "Requisition Line")
     var
         ProdOrderRoutingLine: Record "Prod. Order Routing Line";
@@ -48,5 +54,45 @@ codeunit 99001516 "Subc. Req. Wksh. Make Ord."
                 PurchaseLine.Modify();
             end;
         end;
+    end;
+
+    local procedure UpdateSubcontractingComponentPurchLines(PurchaseLine: Record "Purchase Line"; RequisitionLine: Record "Requisition Line")
+    var
+        ProdOrderComponent: Record "Prod. Order Component";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        PurchaseLineComp: Record "Purchase Line";
+    begin
+        if RequisitionLine."Prod. Order No." = '' then
+            exit;
+        if RequisitionLine."Operation No." = '' then
+            exit;
+
+        ProdOrderRoutingLine.SetLoadFields("Routing Link Code");
+        if not ProdOrderRoutingLine.Get(
+                "Production Order Status"::Released, RequisitionLine."Prod. Order No.",
+                RequisitionLine."Routing Reference No.", RequisitionLine."Routing No.", RequisitionLine."Operation No.")
+        then
+            exit;
+
+        ProdOrderComponent.SetRange(Status, "Production Order Status"::Released);
+        ProdOrderComponent.SetRange("Prod. Order No.", RequisitionLine."Prod. Order No.");
+        ProdOrderComponent.SetRange("Prod. Order Line No.", RequisitionLine."Prod. Order Line No.");
+        ProdOrderComponent.SetRange("Routing Link Code", ProdOrderRoutingLine."Routing Link Code");
+        ProdOrderComponent.SetRange("Component Supply Method", "Component Supply Method"::"Vendor-Supplied");
+        if ProdOrderComponent.FindSet() then
+            repeat
+                PurchaseLineComp.SetRange("Document Type", PurchaseLine."Document Type");
+                PurchaseLineComp.SetRange("Document No.", PurchaseLine."Document No.");
+                PurchaseLineComp.SetRange(Type, "Purchase Line Type"::Item);
+                PurchaseLineComp.SetRange("No.", ProdOrderComponent."Item No.");
+                PurchaseLineComp.SetRange("Variant Code", ProdOrderComponent."Variant Code");
+                PurchaseLineComp.SetRange("Subc. Prod. Order No.", ProdOrderComponent."Prod. Order No.");
+                PurchaseLineComp.SetRange("Subc. Operation No.", RequisitionLine."Operation No.");
+                if PurchaseLineComp.FindFirst() then
+                    if PurchaseLineComp.Quantity <> ProdOrderComponent."Remaining Quantity" then begin
+                        PurchaseLineComp.Validate(Quantity, ProdOrderComponent."Remaining Quantity");
+                        PurchaseLineComp.Modify(true);
+                    end;
+            until ProdOrderComponent.Next() = 0;
     end;
 }

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -3527,6 +3527,139 @@ codeunit 139989 "Subc. Subcontracting Test"
             'GetSubcPriceForReqLine must pick the price row matching the line''s Unit of Measure when FixedUOM is empty.');
     end;
 
+    [Test]
+    procedure VendorSuppliedCompQtyUpdatedOnPurchOrderReschedule()
+    var
+        Item: Record Item;
+        ComponentItem: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionBOMLine: Record "Production BOM Line";
+        ProductionOrder: Record "Production Order";
+        ProdOrderLine: Record "Prod. Order Line";
+        ProdOrderComponent: Record "Prod. Order Component";
+        PurchaseLine: Record "Purchase Line";
+        PurchaseLineComp: Record "Purchase Line";
+        ReqWkshTemplate: Record "Req. Wksh. Template";
+        RequisitionLine: Record "Requisition Line";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
+        WorkCenter: array[2] of Record "Work Center";
+        InitialQty: Decimal;
+        NewQty: Decimal;
+    begin
+        // [SCENARIO 637496] When a production order quantity changes and the subcontracting purchase order
+        // is rescheduled via the requisition worksheet, the Vendor-Supplied component purchase lines
+        // should be updated to reflect the new quantity.
+
+        // [GIVEN] A subcontracting setup with a Vendor-Supplied component
+        Initialize();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateProdBomWithComponentSupplyMethod(Item, "Component Supply Method"::"Vendor-Supplied");
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        // [GIVEN] A released production order
+        InitialQty := LibraryRandom.RandIntInRange(5, 10);
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", InitialQty);
+
+        // [GIVEN] A subcontracting purchase order created via the requisition worksheet
+        SubcontractingMgmtLibrary.CreateReqWkshTemplateAndName(ReqWkshTemplate, RequisitionWkshName);
+        CalculateSubcontractsAndFindReqLine(RequisitionWkshName, ProductionOrder."No.", RequisitionLine);
+        CarryOutSubcontractingAction(RequisitionLine);
+
+        // [GIVEN] The vendor-supplied component purchase line exists
+        ProductionBOMLine.SetRange("Production BOM No.", Item."Production BOM No.");
+        ProductionBOMLine.SetRange("Component Supply Method", "Component Supply Method"::"Vendor-Supplied");
+        ProductionBOMLine.FindFirst();
+        ComponentItem.Get(ProductionBOMLine."No.");
+
+        FindSubcPurchLineForProdOrder(PurchaseLine, Item."No.", ProductionOrder."No.");
+        FindComponentPurchLine(PurchaseLineComp, PurchaseLine."Document No.", ComponentItem."No.");
+        Assert.IsTrue(PurchaseLineComp.FindFirst(), 'Vendor-Supplied component purchase line should exist after initial PO creation.');
+
+        // [WHEN] The production order quantity is increased and refreshed
+        NewQty := InitialQty + LibraryRandom.RandIntInRange(3, 7);
+        ProdOrderLine.SetRange(Status, "Production Order Status"::Released);
+        ProdOrderLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderLine.FindFirst();
+        ProdOrderLine.Validate(Quantity, NewQty);
+        ProdOrderLine.Modify(true);
+
+        // [WHEN] CalculateSubcontracts is run again and carried out (reschedule path)
+        CalculateSubcontractsAndFindReqLine(RequisitionWkshName, ProductionOrder."No.", RequisitionLine);
+
+        Assert.IsTrue(
+            RequisitionLine."Action Message" in
+                [RequisitionLine."Action Message"::"Change Qty.",
+                 RequisitionLine."Action Message"::"Resched. & Chg. Qty."],
+            'Requisition line should have a Change Qty or Reschedule action message.');
+
+        CarryOutSubcontractingAction(RequisitionLine);
+
+        // [THEN] The component purchase line quantity matches the updated component remaining quantity
+        ProdOrderComponent.SetRange(Status, "Production Order Status"::Released);
+        ProdOrderComponent.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderComponent.SetRange("Item No.", ComponentItem."No.");
+        ProdOrderComponent.SetRange("Component Supply Method", "Component Supply Method"::"Vendor-Supplied");
+        ProdOrderComponent.FindFirst();
+
+        PurchaseLineComp.FindFirst();
+        Assert.AreEqual(
+            ProdOrderComponent."Remaining Quantity",
+            PurchaseLineComp.Quantity,
+            'Vendor-Supplied component purchase line quantity should match the updated production order component remaining quantity.');
+    end;
+
+    local procedure CalculateSubcontractsAndFindReqLine(RequisitionWkshName: Record "Requisition Wksh. Name"; ProdOrderNo: Code[20]; var RequisitionLine: Record "Requisition Line")
+    var
+        SubcCalculateSubContract: Report "Subc. Calculate Subcontracts";
+    begin
+        Clear(RequisitionLine);
+        RequisitionLine."Worksheet Template Name" := RequisitionWkshName."Worksheet Template Name";
+        RequisitionLine."Journal Batch Name" := RequisitionWkshName.Name;
+
+        SubcCalculateSubContract.SetWkShLine(RequisitionLine);
+        SubcCalculateSubContract.UseRequestPage(false);
+        SubcCalculateSubContract.RunModal();
+
+        RequisitionLine.SetRange("Worksheet Template Name", RequisitionWkshName."Worksheet Template Name");
+        RequisitionLine.SetRange("Journal Batch Name", RequisitionWkshName.Name);
+#pragma warning disable AA0210
+        RequisitionLine.SetRange("Prod. Order No.", ProdOrderNo);
+#pragma warning restore AA0210
+        RequisitionLine.FindFirst();
+    end;
+
+    local procedure CarryOutSubcontractingAction(var RequisitionLine: Record "Requisition Line")
+    var
+        CarryOutActionMsgReq: Report "Carry Out Action Msg. - Req.";
+    begin
+        CarryOutActionMsgReq.SetReqWkshLine(RequisitionLine);
+        CarryOutActionMsgReq.UseRequestPage(false);
+        CarryOutActionMsgReq.RunModal();
+    end;
+
+    local procedure FindSubcPurchLineForProdOrder(var PurchaseLine: Record "Purchase Line"; ItemNo: Code[20]; ProdOrderNo: Code[20])
+    begin
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange(Type, "Purchase Line Type"::Item);
+        PurchaseLine.SetRange("No.", ItemNo);
+        PurchaseLine.SetRange("Prod. Order No.", ProdOrderNo);
+        PurchaseLine.FindFirst();
+    end;
+
+    local procedure FindComponentPurchLine(var PurchaseLineComp: Record "Purchase Line"; DocumentNo: Code[20]; ComponentItemNo: Code[20])
+    begin
+        PurchaseLineComp.SetRange("Document Type", PurchaseLineComp."Document Type"::Order);
+        PurchaseLineComp.SetRange("Document No.", DocumentNo);
+        PurchaseLineComp.SetRange(Type, "Purchase Line Type"::Item);
+        PurchaseLineComp.SetRange("No.", ComponentItemNo);
+    end;
+
     local procedure CreateUOMCodeSortingAfter(BaseUOMCode: Code[10]): Code[10]
     var
         UnitOfMeasure: Record "Unit of Measure";

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -3573,7 +3573,9 @@ codeunit 139989 "Subc. Subcontracting Test"
 
         // [GIVEN] The vendor-supplied component purchase line exists
         ProductionBOMLine.SetRange("Production BOM No.", Item."Production BOM No.");
+#pragma warning disable AA0210        
         ProductionBOMLine.SetRange("Component Supply Method", "Component Supply Method"::"Vendor-Supplied");
+#pragma warning restore AA0210
         ProductionBOMLine.FindFirst();
         ComponentItem.Get(ProductionBOMLine."No.");
 
@@ -3604,7 +3606,9 @@ codeunit 139989 "Subc. Subcontracting Test"
         ProdOrderComponent.SetRange(Status, "Production Order Status"::Released);
         ProdOrderComponent.SetRange("Prod. Order No.", ProductionOrder."No.");
         ProdOrderComponent.SetRange("Item No.", ComponentItem."No.");
+#pragma warning disable AA0210        
         ProdOrderComponent.SetRange("Component Supply Method", "Component Supply Method"::"Vendor-Supplied");
+#pragma warning restore AA0210
         ProdOrderComponent.FindFirst();
 
         PurchaseLineComp.FindFirst();


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

In SubcPurchaseOrderCreator.Codeunit.al, when PurchLineExists() finds an existing PO line, the Requisition Line is created with Action Message = "Change Qty." This routes through BaseApp's PurchOrderChgAndReshedule() in CarryOutAction.Codeunit.al, which updates only the main work/service PO line. No event fires that the Subcontracting app subscribes to, so component PO lines (tracked via Subc. Prod. Order No. fields) are never recalculated.

By contrast, when no existing PO exists (Action Message = "New"), OnInsertPurchOrderLineOnAfterCheckInsertFinalizePurchaseOrderHeader fires and SubcReqWkshMakeOrd.Codeunit.al correctly creates component lines via TransferSubcontractingProdOrderComp().

## Linked work

Fixes [AB#637496](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637496)


