### PR TITLE
[Quality Management] [28.x] Improvements in "Value Type Text Expression" and tooltips

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateLine.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateLine.Table.al
@@ -97,7 +97,7 @@ table 20403 "Qlty. Inspection Template Line"
                 Rec.CalcFields("Test Value Type");
                 if Rec."Expression Formula" <> '' then begin
                     if not (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Text Expression"]) then
-                        Error(OnlyFieldExpressionErr);
+                        Error(ExpressionFormulaOnlyForTextExpressionErr);
 
                     ValidateExpressionFormula();
                 end;
@@ -123,7 +123,7 @@ table 20403 "Qlty. Inspection Template Line"
     }
 
     var
-        OnlyFieldExpressionErr: Label 'The Expression Formula can only be used with fields that are a type of Expression';
+        ExpressionFormulaOnlyForTextExpressionErr: Label 'The Expression Formula can only be used with tests that are a type of Text Expression';
 
     trigger OnInsert()
     begin

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateLine.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateLine.Table.al
@@ -48,6 +48,7 @@ table 20403 "Qlty. Inspection Template Line"
                     if QltyTest.Get("Test Code") then begin
                         Rec.Description := QltyTest.Description;
                         Rec."Unit of Measure Code" := QltyTest."Unit of Measure Code";
+                        Rec."Expression Formula" := QltyTest."Expression Formula";
                     end;
 
                 EnsureResultsExist(Rec."Test Code" <> xRec."Test Code");

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateSubf.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateSubf.Page.al
@@ -65,6 +65,12 @@ page 20403 "Qlty. Inspection Template Subf"
                 {
                     StyleExpr = RowStyleText;
                 }
+                field("Expression Formula"; Rec."Expression Formula")
+                {
+                    StyleExpr = RowStyleText;
+                    Editable = IsExpressionFormulaEditable;
+                    Visible = false;
+                }
                 field("Unit of Measure Code"; Rec."Unit of Measure Code")
                 {
                     StyleExpr = RowStyleText;
@@ -503,6 +509,7 @@ page 20403 "Qlty. Inspection Template Subf"
         MatrixArrayCaptionSet: array[10] of Text;
         Visible1, Visible2, Visible3, Visible4, Visible5, Visible6, Visible7, Visible8, Visible9, Visible10 : Boolean;
         Editable1, Editable2, Editable3, Editable4, Editable5, Editable6, Editable7, Editable8, Editable9, Editable10 : Boolean;
+        IsExpressionFormulaEditable: Boolean;
         DescriptionLbl: Label '%1 Description', Comment = '%1 = Matrix field caption';
         ConditionLbl: Label '%1 Condition', Comment = '%1 = Matrix field caption';
 
@@ -573,6 +580,8 @@ page 20403 "Qlty. Inspection Template Subf"
         Editable8 := Visible8 and not RowIsLabel;
         Editable9 := Visible9 and not RowIsLabel;
         Editable10 := Visible10 and not RowIsLabel;
+
+        IsExpressionFormulaEditable := Rec."Test Value Type" = Rec."Test Value Type"::"Value Type Text Expression";
     end;
 
     local procedure UpdateMatrixDataCondition(Matrix: Integer)

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTest.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTest.Table.al
@@ -160,7 +160,7 @@ table 20401 "Qlty. Test"
         field(17; "Case Sensitive"; Enum "Qlty. Case Sensitivity")
         {
             Caption = 'Case Sensitivity';
-            ToolTip = 'Specifies if case sensitivity will be enabled for text-based fields.';
+            ToolTip = 'Specifies if case sensitivity will be enabled for text-based tests.';
         }
         field(18; "Expression Formula"; Text[500])
         {
@@ -170,7 +170,7 @@ table 20401 "Qlty. Test"
             trigger OnValidate()
             begin
                 if (Rec."Expression Formula" <> '') and not (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Text Expression"]) then
-                    Error(OnlyFieldExpressionErr);
+                    Error(ExpressionFormulaOnlyForTextExpressionErr);
             end;
         }
         field(22; "Unit of Measure Code"; Code[10])
@@ -204,7 +204,7 @@ table 20401 "Qlty. Test"
         GenericTestTok: Label 'MYTEST', Locked = true;
         ThereIsNoResultErr: Label 'There is no result called "%1". Please add the result, or change the existing result conditions.', Comment = '%1=the result';
         ReviewResultsErr: Label 'Advanced configuration required. Please review the result configurations for test "%1", for result "%2".', Comment = '%1=the test, %2=the result';
-        OnlyFieldExpressionErr: Label 'The Expression Formula can only be used with fields that are a type of Expression';
+        ExpressionFormulaOnlyForTextExpressionErr: Label 'The Expression Formula can only be used with tests that are a type of Text Expression';
         BooleanChoiceListLbl: Label 'No,Yes';
         ExistingInspectionErr: Label 'The test %1 exists on %2 inspections (such as %3 with template %4). The test cannot be deleted if it is being used on a quality inspection.', Comment = '%1=the test, %2=count of inspections, %3=one example inspection, %4=example template.';
         DeleteQst: Label 'The test %3 exists on %1 Quality Inspection Template(s) (such as template %2) that will be deleted. Do you wish to proceed?', Comment = '%1 = the lines, %2= the Template Code, %3=the test';
@@ -601,7 +601,7 @@ table 20401 "Qlty. Test"
         Expression: Text;
     begin
         if not (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Text Expression"]) then
-            Error(OnlyFieldExpressionErr);
+            Error(ExpressionFormulaOnlyForTextExpressionErr);
 
         Expression := Rec."Expression Formula";
 

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTest.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTest.Table.al
@@ -154,6 +154,9 @@ table 20401 "Qlty. Test"
 
             trigger OnValidate()
             begin
+                if (Rec."Default Value" <> '') and (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Text Expression"]) then
+                    Error(DefaultValueNotAllowedForTextExpressionErr);
+
                 Rec.ValidateAllowableValuesOnDefault();
             end;
         }
@@ -205,6 +208,7 @@ table 20401 "Qlty. Test"
         ThereIsNoResultErr: Label 'There is no result called "%1". Please add the result, or change the existing result conditions.', Comment = '%1=the result';
         ReviewResultsErr: Label 'Advanced configuration required. Please review the result configurations for test "%1", for result "%2".', Comment = '%1=the test, %2=the result';
         ExpressionFormulaOnlyForTextExpressionErr: Label 'The Expression Formula can only be used with tests that are a type of Text Expression';
+        DefaultValueNotAllowedForTextExpressionErr: Label 'The Default Value cannot be set on tests that are a type of Text Expression. The value is computed from the Expression Formula.';
         BooleanChoiceListLbl: Label 'No,Yes';
         ExistingInspectionErr: Label 'The test %1 exists on %2 inspections (such as %3 with template %4). The test cannot be deleted if it is being used on a quality inspection.', Comment = '%1=the test, %2=count of inspections, %3=one example inspection, %4=example template.';
         DeleteQst: Label 'The test %3 exists on %1 Quality Inspection Template(s) (such as template %2) that will be deleted. Do you wish to proceed?', Comment = '%1 = the lines, %2= the Template Code, %3=the test';

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
@@ -77,6 +77,8 @@ page 20479 "Qlty. Test Card"
                     }
                     field("Default Value"; Rec."Default Value")
                     {
+                        Editable = not IsExpressionFormulaEditable;
+
                         trigger OnAssistEdit()
                         begin
                             Rec.AssistEditDefaultValue();
@@ -652,7 +654,7 @@ page 20479 "Qlty. Test Card"
 
         EditableResult := (Rec.Code <> '') and (CurrPage.Editable) and (Visible1) and (MatrixArrayCaptionSet[1] <> '');
 
-        IsExpressionFormulaEditable := (Rec."Test Value Type" = Rec."Test Value Type"::"Value Type Text Expression");
+        IsExpressionFormulaEditable := Rec."Test Value Type" = Rec."Test Value Type"::"Value Type Text Expression";
     end;
 
     local procedure UpdateMatrixDataCondition(Matrix: Integer)

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
@@ -27,6 +27,8 @@ page 20406 "Qlty. Inspection"
 {
     UsageCategory = None;
     Caption = 'Quality Inspection';
+    AboutTitle = 'About Quality Inspection document';
+    AboutText = 'The Quality Inspection document is used to manage quality inspections for items, including recording inspection results, taking pictures, and navigating to related documents. The header contains general information about the inspection, while the lines contain details about each quality test performed. You can also create re-inspections, print reports, and perform actions like moving inventory or changing item tracking information based on the inspection results.';
     DataCaptionExpression = GetDataCaptionExpression();
     InsertAllowed = false;
     PageType = Card;

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionLine.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionLine.Table.al
@@ -409,6 +409,8 @@ table 20406 "Qlty. Inspection Line"
         if not GetInspection() then
             exit;
 
+        EvaluateSelfIfOnlyLineIsTextExpression();
+
         OthersInSameQltyInspectionLine.SetRange("Inspection No.", Rec."Inspection No.");
         OthersInSameQltyInspectionLine.SetRange("Re-inspection No.", Rec."Re-inspection No.");
         OthersInSameQltyInspectionLine.SetFilter("Test Value Type", '%1', QltyInspectionTemplateLine."Test Value Type"::"Value Type Text Expression");
@@ -463,6 +465,21 @@ table 20406 "Qlty. Inspection Line"
                     OthersInSameQltyInspectionLine.ValidateTestValue();
 
             until OthersInSameQltyInspectionLine.Next() = 0;
+    end;
+
+    local procedure EvaluateSelfIfOnlyLineIsTextExpression()
+    var
+        OtherQltyInspectionLine: Record "Qlty. Inspection Line";
+    begin
+        Rec.CalcFields("Test Value Type");
+        if Rec."Test Value Type" <> Rec."Test Value Type"::"Value Type Text Expression" then
+            exit;
+
+        OtherQltyInspectionLine.SetRange("Inspection No.", Rec."Inspection No.");
+        OtherQltyInspectionLine.SetRange("Re-inspection No.", Rec."Re-inspection No.");
+        OtherQltyInspectionLine.SetFilter("Line No.", '<>%1', Rec."Line No.");
+        if OtherQltyInspectionLine.IsEmpty() then
+            Rec.EvaluateTextExpression(QltyInspectionHeader);
     end;
 
     internal procedure EvaluateTextExpression(var EvaluateAgainstQltyInspectionHeader: Record "Qlty. Inspection Header")

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionSubform.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionSubform.Page.al
@@ -59,7 +59,7 @@ page 20407 "Qlty. Inspection Subform"
                     trigger OnAssistEdit()
                     begin
                         Rec.CalcFields("Test Value Type");
-                        if Rec."Test Value Type" = Rec."Test Value Type"::"Value Type Label" then
+                        if Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Label", Rec."Test Value Type"::"Value Type Text Expression"] then
                             exit;
                         UpdateRowData();
 
@@ -371,7 +371,7 @@ page 20407 "Qlty. Inspection Subform"
     begin
         OnBeforeCanEditTestValue(Rec, Result, IsHandled);
         if IsHandled then
-            exit;
+            exit(Result);
 
         Rec.CalcFields("Test Value Type");
         exit(not (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Label", Rec."Test Value Type"::"Value Type Text Expression"]));

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionSubform.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionSubform.Page.al
@@ -374,7 +374,7 @@ page 20407 "Qlty. Inspection Subform"
             exit;
 
         Rec.CalcFields("Test Value Type");
-        exit(not (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Label"]));
+        exit(not (Rec."Test Value Type" in [Rec."Test Value Type"::"Value Type Label", Rec."Test Value Type"::"Value Type Text Expression"]));
     end;
 
     /// <summary>

--- a/src/Apps/W1/Quality Management/app/src/Setup/SetupGuide/QltyGuidedExperience.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/SetupGuide/QltyGuidedExperience.Codeunit.al
@@ -28,13 +28,13 @@ codeunit 20419 "Qlty. Guided Experience"
         DemoDataDescriptionTxt: Label 'Install or explore Contoso demo data for Quality Management with sample quality tests, templates, generation rules, and inspections. This lets you learn how quality checks work without setting up your own data.';
         QualityResultsShortTitleTxt: Label 'Inspection results';
         QualityResultsTitleTxt: Label 'Set up quality inspection results';
-        QualityResultsDescriptionTxt: Label 'Define possible outcomes for quality inspections, like Pass, Fail, or In Progress. Create custom results and set priorities to match your organization''s standards. These results control how inspections are evaluated and how items are blocked or released.';
+        QualityResultsDescriptionTxt: Label 'Define custom grades for quality inspections, to match your organization''s standards. You can decide evaluation priorities and set conditions for allowed transactions.';
         QualityTestsShortTitleTxt: Label 'Quality tests';
         QualityTestsTitleTxt: Label 'Understand quality tests';
         QualityTestsDescriptionTxt: Label 'Quality tests define what is measured. Visit the Quality Tests list to see available tests, then open a test card to review parameters, limits, and expected values used during inspections.';
         QualityTemplatesShortTitleTxt: Label 'Quality templates';
         QualityTemplatesTitleTxt: Label 'Reuse inspection templates';
-        QualityTemplatesDescriptionTxt: Label 'With templates you can group and reuse quality tests so you can apply consistent inspection standards across items, processes, or scenarios. From the list you can create a new template card to understand its structure and purpose.';
+        QualityTemplatesDescriptionTxt: Label 'With templates you can group and reuse quality tests to ensure consistent inspection standards. Try creating a new template card to understand its structure and purpose.';
         GenerationRulesShortTitleTxt: Label 'Generation rules';
         GenerationRulesTitleTxt: Label 'Set up inspection generation rules';
         GenerationRulesDescriptionTxt: Label 'Inspection generation rules define when quality inspections are created automatically, such as during receiving, production, or assembly.';

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
@@ -2373,30 +2373,18 @@ codeunit 139965 "Qlty. Tests - More Tests"
         QltyTest2: Record "Qlty. Test";
         QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
         QltyInspectionTemplateLine: Record "Qlty. Inspection Template Line";
-        TestCode1: Text;
-        TestCode2: Text;
         ExpressionFormula2Tok: Label '[Source Item No.]', Locked = true;
     begin
         // [SCENARIO] Expression Formula is updated when the Test Code on a template line is changed to a different test
         Initialize();
 
-        // [GIVEN] Two random test codes are generated
-        QltyInspectionUtility.GenerateRandomCharacters(20, TestCode1);
-        QltyInspectionUtility.GenerateRandomCharacters(20, TestCode2);
-
         // [GIVEN] A first quality test with an Expression Formula is created
-        QltyTest1.Validate(Code, CopyStr(TestCode1, 1, MaxStrLen(QltyTest1.Code)));
-        QltyTest1.Validate(Description, LibraryUtility.GenerateRandomText(MaxStrLen(QltyTest1.Description)));
-        QltyTest1.Validate("Test Value Type", QltyTest1."Test Value Type"::"Value Type Text Expression");
-        QltyTest1.Insert();
+        QltyInspectionUtility.CreateTest(QltyTest1, QltyTest1."Test Value Type"::"Value Type Text Expression");
         QltyTest1.Validate("Expression Formula", ExpressionFormulaTok);
         QltyTest1.Modify();
 
         // [GIVEN] A second quality test with a different Expression Formula is created
-        QltyTest2.Validate(Code, CopyStr(TestCode2, 1, MaxStrLen(QltyTest2.Code)));
-        QltyTest2.Validate(Description, LibraryUtility.GenerateRandomText(MaxStrLen(QltyTest2.Description)));
-        QltyTest2.Validate("Test Value Type", QltyTest2."Test Value Type"::"Value Type Text Expression");
-        QltyTest2.Insert();
+        QltyInspectionUtility.CreateTest(QltyTest2, QltyTest2."Test Value Type"::"Value Type Text Expression");
         QltyTest2.Validate("Expression Formula", ExpressionFormula2Tok);
         QltyTest2.Modify();
 

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
@@ -2271,6 +2271,151 @@ codeunit 139965 "Qlty. Tests - More Tests"
         LibraryAssert.AreEqual(LotNo, QltyInspectionHeader."Source Lot No.", 'Inspection should have the correct lot number.');
     end;
 
+    [Test]
+    procedure TestTable_DefaultValueNotAllowedForTextExpression()
+    var
+        QltyTest: Record "Qlty. Test";
+        TestCode: Text;
+    begin
+        // [SCENARIO] Default Value cannot be set on tests that are a type of Text Expression
+        Initialize();
+
+        // [GIVEN] A random test code is generated
+        QltyInspectionUtility.GenerateRandomCharacters(20, TestCode);
+
+        // [GIVEN] A new quality test with Test Value Type "Value Type Text Expression" is created
+        QltyTest.Validate(Code, CopyStr(TestCode, 1, MaxStrLen(QltyTest.Code)));
+        QltyTest.Validate(Description, LibraryUtility.GenerateRandomText(MaxStrLen(QltyTest.Description)));
+        QltyTest.Validate("Test Value Type", QltyTest."Test Value Type"::"Value Type Text Expression");
+        QltyTest.Insert();
+
+        // [WHEN] Attempting to set Default Value on a Text Expression test
+        asserterror QltyTest.Validate("Default Value", 'some text');
+
+        // [THEN] An error is raised indicating Default Value is not allowed for Text Expression tests
+        LibraryAssert.ExpectedError('The Default Value cannot be set on tests that are a type of Text Expression.');
+    end;
+
+    [Test]
+    procedure TemplateLine_ExpressionFormulaCopiedFromTest()
+    var
+        QltyTest: Record "Qlty. Test";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionTemplateLine: Record "Qlty. Inspection Template Line";
+        TestCode: Text;
+    begin
+        // [SCENARIO] Expression Formula is copied from the test to the template line when the test is added
+        Initialize();
+
+        // [GIVEN] A random test code is generated
+        QltyInspectionUtility.GenerateRandomCharacters(20, TestCode);
+
+        // [GIVEN] A quality test with Test Value Type "Value Type Text Expression" and an Expression Formula is created
+        QltyTest.Validate(Code, CopyStr(TestCode, 1, MaxStrLen(QltyTest.Code)));
+        QltyTest.Validate(Description, LibraryUtility.GenerateRandomText(MaxStrLen(QltyTest.Description)));
+        QltyTest.Validate("Test Value Type", QltyTest."Test Value Type"::"Value Type Text Expression");
+        QltyTest.Insert();
+        QltyTest.Validate("Expression Formula", ExpressionFormulaTok);
+        QltyTest.Modify();
+
+        // [GIVEN] A template is created
+        QltyInspectionUtility.CreateTemplate(QltyInspectionTemplateHdr, 0);
+
+        // [WHEN] A template line is created with the test code
+        QltyInspectionTemplateLine.Init();
+        QltyInspectionTemplateLine."Template Code" := QltyInspectionTemplateHdr.Code;
+        QltyInspectionTemplateLine.InitLineNoIfNeeded();
+        QltyInspectionTemplateLine.Validate("Test Code", QltyTest.Code);
+        QltyInspectionTemplateLine.Insert(true);
+
+        // [THEN] The Expression Formula is copied from the test to the template line
+        LibraryAssert.AreEqual(ExpressionFormulaTok, QltyInspectionTemplateLine."Expression Formula", 'Expression Formula should be copied from the test to the template line.');
+    end;
+
+    [Test]
+    procedure TemplateLine_ExpressionFormulaEmptyWhenTestHasNoFormula()
+    var
+        QltyTest: Record "Qlty. Test";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionTemplateLine: Record "Qlty. Inspection Template Line";
+        TestCode: Text;
+    begin
+        // [SCENARIO] Expression Formula on template line is empty when the test has no formula
+        Initialize();
+
+        // [GIVEN] A random test code is generated
+        QltyInspectionUtility.GenerateRandomCharacters(20, TestCode);
+
+        // [GIVEN] A quality test with Test Value Type "Value Type Text Expression" but no Expression Formula is created
+        QltyTest.Validate(Code, CopyStr(TestCode, 1, MaxStrLen(QltyTest.Code)));
+        QltyTest.Validate(Description, LibraryUtility.GenerateRandomText(MaxStrLen(QltyTest.Description)));
+        QltyTest.Validate("Test Value Type", QltyTest."Test Value Type"::"Value Type Text Expression");
+        QltyTest.Insert();
+
+        // [GIVEN] A template is created
+        QltyInspectionUtility.CreateTemplate(QltyInspectionTemplateHdr, 0);
+
+        // [WHEN] A template line is created with the test code
+        QltyInspectionTemplateLine.Init();
+        QltyInspectionTemplateLine."Template Code" := QltyInspectionTemplateHdr.Code;
+        QltyInspectionTemplateLine.InitLineNoIfNeeded();
+        QltyInspectionTemplateLine.Validate("Test Code", QltyTest.Code);
+        QltyInspectionTemplateLine.Insert(true);
+
+        // [THEN] The Expression Formula on the template line is empty
+        LibraryAssert.AreEqual('', QltyInspectionTemplateLine."Expression Formula", 'Expression Formula should be empty when the test has no formula.');
+    end;
+
+    [Test]
+    procedure TemplateLine_ExpressionFormulaUpdatedWhenTestCodeChanges()
+    var
+        QltyTest1: Record "Qlty. Test";
+        QltyTest2: Record "Qlty. Test";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionTemplateLine: Record "Qlty. Inspection Template Line";
+        TestCode1: Text;
+        TestCode2: Text;
+        ExpressionFormula2Tok: Label '[Source Item No.]', Locked = true;
+    begin
+        // [SCENARIO] Expression Formula is updated when the Test Code on a template line is changed to a different test
+        Initialize();
+
+        // [GIVEN] Two random test codes are generated
+        QltyInspectionUtility.GenerateRandomCharacters(20, TestCode1);
+        QltyInspectionUtility.GenerateRandomCharacters(20, TestCode2);
+
+        // [GIVEN] A first quality test with an Expression Formula is created
+        QltyTest1.Validate(Code, CopyStr(TestCode1, 1, MaxStrLen(QltyTest1.Code)));
+        QltyTest1.Validate(Description, LibraryUtility.GenerateRandomText(MaxStrLen(QltyTest1.Description)));
+        QltyTest1.Validate("Test Value Type", QltyTest1."Test Value Type"::"Value Type Text Expression");
+        QltyTest1.Insert();
+        QltyTest1.Validate("Expression Formula", ExpressionFormulaTok);
+        QltyTest1.Modify();
+
+        // [GIVEN] A second quality test with a different Expression Formula is created
+        QltyTest2.Validate(Code, CopyStr(TestCode2, 1, MaxStrLen(QltyTest2.Code)));
+        QltyTest2.Validate(Description, LibraryUtility.GenerateRandomText(MaxStrLen(QltyTest2.Description)));
+        QltyTest2.Validate("Test Value Type", QltyTest2."Test Value Type"::"Value Type Text Expression");
+        QltyTest2.Insert();
+        QltyTest2.Validate("Expression Formula", ExpressionFormula2Tok);
+        QltyTest2.Modify();
+
+        // [GIVEN] A template is created with the first test
+        QltyInspectionUtility.CreateTemplate(QltyInspectionTemplateHdr, 0);
+        QltyInspectionTemplateLine.Init();
+        QltyInspectionTemplateLine."Template Code" := QltyInspectionTemplateHdr.Code;
+        QltyInspectionTemplateLine.InitLineNoIfNeeded();
+        QltyInspectionTemplateLine.Validate("Test Code", QltyTest1.Code);
+        QltyInspectionTemplateLine.Insert(true);
+
+        // [WHEN] The Test Code on the template line is changed to the second test
+        QltyInspectionTemplateLine.Validate("Test Code", QltyTest2.Code);
+        QltyInspectionTemplateLine.Modify(true);
+
+        // [THEN] The Expression Formula is updated to the second test's formula
+        LibraryAssert.AreEqual(ExpressionFormula2Tok, QltyInspectionTemplateLine."Expression Formula", 'Expression Formula should be updated when the test code is changed.');
+    end;
+
     local procedure Initialize()
     begin
         if IsInitialized then

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
@@ -61,7 +61,7 @@ codeunit 139965 "Qlty. Tests - More Tests"
         DefaultScheduleGroupTok: Label 'QM', Locked = true;
         ExpressionFormulaTok: Label '[No.]';
         TestValueTypeChangeErrInfoMsg: Label 'Consider replacing this test in the template with a new one, or deleting existing inspections (if allowed). The test was last used on Inspection %1, Re-inspection %2.', Comment = '%1 = Quality Inspection No., %2 = Re-inspection No.';
-        OnlyFieldExpressionErr: Label 'The Expression Formula can only be used with fields that are a type of Expression';
+        ExpressionFormulaOnlyForTextExpressionErr: Label 'The Expression Formula can only be used with tests that are a type of Text Expression';
         VendorFilterCountryTok: Label 'WHERE(Country/Region Code=FILTER(CA))', Locked = true;
         VendorFilterNoTok: Label 'WHERE(No.=FILTER(%1))', Comment = '%1 = Vendor No.', Locked = true;
         ThereIsNoResultErr: Label 'There is no result called "%1". Please add the result, or change the existing result conditions.', Comment = '%1=the result';
@@ -105,7 +105,7 @@ codeunit 139965 "Qlty. Tests - More Tests"
         asserterror ToLoadQltyTest.Validate("Expression Formula", ExpressionFormulaTok);
 
         // [THEN] An error is raised indicating Expression Formula is only for Expression test value types
-        LibraryAssert.ExpectedError(OnlyFieldExpressionErr);
+        LibraryAssert.ExpectedError(ExpressionFormulaOnlyForTextExpressionErr);
     end;
 
     [Test]
@@ -612,7 +612,7 @@ codeunit 139965 "Qlty. Tests - More Tests"
         asserterror ConfigurationToLoadQltyInspectionTemplateLine.Validate("Expression Formula", ExpressionFormulaTok);
 
         // [THEN] An error is raised indicating Expression Formula is only for Expression field types
-        LibraryAssert.ExpectedError(OnlyFieldExpressionErr);
+        LibraryAssert.ExpectedError(ExpressionFormulaOnlyForTextExpressionErr);
     end;
 
     [Test]


### PR DESCRIPTION
## What & why

Fixes:
1. Expression Formula not copied to template, not visible on template subform, Default Value not guarded for Text Expression tests
2. Text Expression test value is editable - manual overrides silently lost on re-evaluation
3. Single-line text expression inspection never evaluates the expression

Improvements:
1. Quality Inspection document teaching tips
2. Setup guide text

## Linked work

Fixes [AB#638192](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638192)
Fixes [AB#638193](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638193)
Fixes [AB#638194](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638194)


