### PR TITLE
[27.5] - Vendor Subscription Contract Deferral Release fails with "Gen. Journal Template does not exist (Name = '')"

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Deferrals/Reports/ContractDeferralsRelease.Report.al
+++ b/src/Apps/W1/Subscription Billing/App/Deferrals/Reports/ContractDeferralsRelease.Report.al
@@ -359,13 +359,16 @@ report 8051 "Contract Deferrals Release"
     var
         GenJnlLine: Record "Gen. Journal Line";
     begin
+        if IsNullGuid(ServiceContractSetup.SystemId) then
+            ServiceContractSetup.Get();
         GenJnlLine.Init();
         GenJnlLine."Journal Template Name" := ServiceContractSetup."Def. Rel. Jnl. Template Name";
         GenJnlLine."Journal Batch Name" := ServiceContractSetup."Def. Rel. Jnl. Batch Name";
         GenJnlLine."Document No." := InputTempGenJournalLine."Document No.";
         GenJnlLine."Account Type" := GenJnlLine."Account Type"::"G/L Account";
         GenJnlLine."VAT Posting" := GenJnlLine."VAT Posting"::"Manual VAT Entry";
-        GenJnlLine.Validate("Account No.", InputTempGenJournalLine."Account No.");
+        GenJnlLine."Account No." := InputTempGenJournalLine."Account No.";
+        GenJnlLine."Deferral Code" := '';
         GenJnlLine."Posting Date" := InputPostingDate;
         GenJnlLine.Description := StrSubstNo(ReleasingOfContractNoTxt, Format(GenJnlLine."Posting Date", 0, '<Month Text> <Year4>'));
         GenJnlLine."Subscription Contract No." := InputTempGenJournalLine."Subscription Contract No.";
@@ -380,7 +383,8 @@ report 8051 "Contract Deferrals Release"
         GenJnlLine."VAT Prod. Posting Group" := '';
         GenJnlPostLine.RunWithCheck(GenJnlLine);
 
-        GenJnlLine.Validate("Account No.", InputTempGenJournalLine."Bal. Account No.");
+        GenJnlLine."Account No." := InputTempGenJournalLine."Bal. Account No.";
+        GenJnlLine."Deferral Code" := '';
         GenJnlLine.Validate("Dimension Set ID", InputTempGenJournalLine."Dimension Set ID");
         GenJnlLine.Validate(Amount, -InputTempGenJournalLine.Amount);
         GenJnlLine."Gen. Posting Type" := GenJnlLine."Gen. Posting Type"::" ";

--- a/src/Apps/W1/Subscription Billing/App/Deferrals/Tables/VendSubContractDeferral.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Deferrals/Tables/VendSubContractDeferral.Table.al
@@ -1,10 +1,11 @@
 namespace Microsoft.SubscriptionBilling;
 
-using Microsoft.Purchases.Vendor;
+using Microsoft.Finance.Dimension;
+using Microsoft.Finance.GeneralLedger.Ledger;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
-using Microsoft.Finance.GeneralLedger.Ledger;
-using Microsoft.Finance.Dimension;
+using Microsoft.Purchases.Vendor;
 using System.Security.User;
 
 table 8072 "Vend. Sub. Contract Deferral"
@@ -135,6 +136,18 @@ table 8072 "Vend. Sub. Contract Deferral"
         {
             Caption = 'Currency Code';
         }
+        field(74; "Gen. Bus. Posting Group"; Code[20])
+        {
+            Caption = 'Gen. Bus. Posting Group';
+            ToolTip = 'Specifies the general business posting group.';
+            TableRelation = "Gen. Business Posting Group";
+        }
+        field(75; "Gen. Prod. Posting Group"; Code[20])
+        {
+            Caption = 'Gen. Prod. Posting Group';
+            ToolTip = 'Specifies the general product posting group.';
+            TableRelation = "Gen. Product Posting Group";
+        }
         field(480; "Dimension Set ID"; Integer)
         {
             Caption = 'Dimension Set ID';
@@ -180,6 +193,8 @@ table 8072 "Vend. Sub. Contract Deferral"
         Rec."Pay-to Vendor No." := PurchaseLine."Pay-to Vendor No.";
         Rec.Discount := PurchaseLine."Discount";
         Rec."Currency Code" := PurchaseLine."Currency Code";
+        Rec."Gen. Bus. Posting Group" := PurchaseLine."Gen. Bus. Posting Group";
+        Rec."Gen. Prod. Posting Group" := PurchaseLine."Gen. Prod. Posting Group";
     end;
 
     internal procedure ShowDimensions()

--- a/src/Apps/W1/Subscription Billing/App/Deferrals/Tables/VendSubContractDeferral.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Deferrals/Tables/VendSubContractDeferral.Table.al
@@ -1,11 +1,10 @@
 namespace Microsoft.SubscriptionBilling;
 
-using Microsoft.Finance.Dimension;
-using Microsoft.Finance.GeneralLedger.Ledger;
-using Microsoft.Finance.GeneralLedger.Setup;
+using Microsoft.Purchases.Vendor;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
-using Microsoft.Purchases.Vendor;
+using Microsoft.Finance.GeneralLedger.Ledger;
+using Microsoft.Finance.Dimension;
 using System.Security.User;
 
 table 8072 "Vend. Sub. Contract Deferral"
@@ -136,18 +135,6 @@ table 8072 "Vend. Sub. Contract Deferral"
         {
             Caption = 'Currency Code';
         }
-        field(74; "Gen. Bus. Posting Group"; Code[20])
-        {
-            Caption = 'Gen. Bus. Posting Group';
-            ToolTip = 'Specifies the general business posting group.';
-            TableRelation = "Gen. Business Posting Group";
-        }
-        field(75; "Gen. Prod. Posting Group"; Code[20])
-        {
-            Caption = 'Gen. Prod. Posting Group';
-            ToolTip = 'Specifies the general product posting group.';
-            TableRelation = "Gen. Product Posting Group";
-        }
         field(480; "Dimension Set ID"; Integer)
         {
             Caption = 'Dimension Set ID';
@@ -193,8 +180,6 @@ table 8072 "Vend. Sub. Contract Deferral"
         Rec."Pay-to Vendor No." := PurchaseLine."Pay-to Vendor No.";
         Rec.Discount := PurchaseLine."Discount";
         Rec."Currency Code" := PurchaseLine."Currency Code";
-        Rec."Gen. Bus. Posting Group" := PurchaseLine."Gen. Bus. Posting Group";
-        Rec."Gen. Prod. Posting Group" := PurchaseLine."Gen. Prod. Posting Group";
     end;
 
     internal procedure ShowDimensions()

--- a/src/Apps/W1/Subscription Billing/Test/Deferrals/VendorDeferralsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Deferrals/VendorDeferralsTest.Codeunit.al
@@ -48,6 +48,7 @@ codeunit 139913 "Vendor Deferrals Test"
         Assert: Codeunit Assert;
         ContractTestLibrary: Codeunit "Contract Test Library";
         CorrectPostedPurchaseInvoice: Codeunit "Correct Posted Purch. Invoice";
+        LibraryERM: Codeunit "Library - ERM";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryUtility: Codeunit "Library - Utility";
@@ -62,7 +63,6 @@ codeunit 139913 "Vendor Deferrals Test"
         TotalNumberOfMonths: Integer;
         VendorDeferralsCount: Integer;
         IsInitialized: Boolean;
-        ReleasedContractDeferralErr: Label 'Released Contract Deferrals were not reversed properly';
         AmountNotMovedFromDeferralsAccountErr: Label 'Amount was not moved from Deferrals Account to Contract Account';
 
     #region Tests
@@ -761,98 +761,6 @@ codeunit 139913 "Vendor Deferrals Test"
     end;
 
     [Test]
-    [HandlerFunctions('CreateVendorBillingDocsContractPageHandler,MessageHandler')]
-    procedure TestPostingGroupsAreFilledOnVendorContractDeferrals()
-    var
-        TotalDeferralCount: Integer;
-    begin
-        // [SCENARIO] When posting a purchase invoice with contract deferrals, the Gen. Bus. Posting Group and Gen. Prod. Posting Group fields are populated on the deferral entries.
-        Initialize();
-
-        // [GIVEN] A vendor contract with deferrals
-        CreateVendorContractWithDeferrals('<2M-CM>', true);
-        CreateBillingProposalAndCreateBillingDocuments('<2M-CM>', '<8M+CM>');
-
-        // [WHEN] The purchase document is posted
-        BillingLine.FindLast();
-        PostPurchDocumentAndFetchDeferrals();
-
-        // [THEN] Gen. Bus. Posting Group and Gen. Prod. Posting Group are filled on each deferral entry
-        PurchInvLine.SetRange("Document No.", PostedDocumentNo);
-        PurchInvLine.SetFilter("No.", '<>%1', '');
-        PurchInvLine.FindFirst();
-        VendorContractDeferral.SetRange("Document No.", PostedDocumentNo);
-        TotalDeferralCount := VendorContractDeferral.Count;
-        VendorContractDeferral.SetRange("Gen. Bus. Posting Group", PurchInvLine."Gen. Bus. Posting Group");
-        VendorContractDeferral.SetRange("Gen. Prod. Posting Group", PurchInvLine."Gen. Prod. Posting Group");
-        Assert.RecordIsNotEmpty(VendorContractDeferral);
-        Assert.RecordCount(VendorContractDeferral, TotalDeferralCount);
-    end;
-
-    [Test]
-    [HandlerFunctions('CreateVendorBillingDocsContractPageHandler,ContractDeferralsReleaseRequestPageHandler,MessageHandler')]
-    procedure TestZeroAmountVendorDeferralsReleasedWithoutGLEntries()
-    var
-        ContractDeferralsRelease: Report "Contract Deferrals Release";
-    begin
-        // [SCENARIO] Zero-amount vendor contract deferrals should be marked as released without creating GL entries.
-        Initialize();
-        SetPostingAllowTo(0D);
-
-        // [GIVEN] A vendor contract with deferrals that have been posted
-        CreateVendorContractWithDeferrals('<2M-CM>', true);
-        CreateBillingProposalAndCreateBillingDocuments('<2M-CM>', '<8M+CM>');
-        BillingLine.FindLast();
-        PostPurchDocumentAndFetchDeferrals();
-
-        // [GIVEN] All deferral amounts are set to 0 (simulating zero-amount service commitments)
-        VendorContractDeferral.Reset();
-        VendorContractDeferral.SetRange("Document No.", PostedDocumentNo);
-        VendorContractDeferral.ModifyAll(Amount, 0, false);
-        VendorContractDeferral.ModifyAll("Discount Amount", 0, false);
-        VendorContractDeferral.FindFirst();
-
-        // [WHEN] Release deferrals is run
-        PostingDate := VendorContractDeferral."Posting Date";
-        Commit();
-        ContractDeferralsRelease.Run(); // ContractDeferralsReleaseRequestPageHandler
-
-        // [THEN] The first deferral is released without creating a GL entry
-        VendorContractDeferral.Get(VendorContractDeferral."Entry No.");
-        VendorContractDeferral.TestField(Released, true);
-        VendorContractDeferral.TestField("G/L Entry No.", 0);
-    end;
-
-    [Test]
-    [HandlerFunctions('CreateVendorBillingDocsContractPageHandler,MessageHandler')]
-    procedure DeferralCodeNotAllowedWithContractDeferralsOnPurchaseLine()
-    var
-        DeferralTemplate: Record "Deferral Template";
-        DeferralCodeCannotBeUsedWithContractDeferralsErr: Label 'A Deferral Code cannot be used on a line where Subscription Contract Deferrals are active. Either remove the Deferral Code or disable Contract Deferrals on the subscription line or contract.', Locked = true;
-    begin
-        // [SCENARIO] A standard Deferral Code must not be assigned to a purchase invoice line
-        //            that already has subscription contract deferrals enabled.
-        Initialize();
-
-        // [GIVEN] A vendor contract with deferrals enabled and a billing document
-        CreateVendorContractWithDeferrals('<2M-CM>', true);
-        CreateBillingProposalAndCreateBillingDocuments('<2M-CM>', '<8M+CM>');
-
-        // [GIVEN] A standard BC deferral template
-        LibraryERM.CreateDeferralTemplate(DeferralTemplate, Enum::"Deferral Calculation Method"::"Straight-Line",
-            Enum::"Deferral Calculation Start Date"::"Posting Date", 3);
-
-        // [WHEN] Assigning the Deferral Code to the purchase line that has contract deferrals
-        PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
-        PurchaseLine.SetFilter("No.", '<>%1', '');
-        PurchaseLine.FindFirst();
-
-        // [THEN] An error is raised preventing double deferrals
-        asserterror PurchaseLine.Validate("Deferral Code", DeferralTemplate."Deferral Code");
-        Assert.ExpectedError(DeferralCodeCannotBeUsedWithContractDeferralsErr);
-    end;
-
-    [Test]
     [HandlerFunctions('CreateVendorBillingDocsContractPageHandler,ContractDeferralsReleaseRequestPageHandler,MessageHandler')]
     procedure DeferralsReleaseSucceedsWhenGLAccountHasDefaultDeferralTemplateAndJournalTemplMandatory()
     var
@@ -997,7 +905,6 @@ codeunit 139913 "Vendor Deferrals Test"
         GLAccount: Record "G/L Account";
         GenJournalBatch: Record "Gen. Journal Batch";
         GenJournalLine: Record "Gen. Journal Line";
-        LibraryERM: Codeunit "Library - ERM";
     begin
         CreateGeneralJournalBatch(GenJournalBatch);
         LibraryERM.CreateGLAccount(GLAccount);
@@ -1068,7 +975,6 @@ codeunit 139913 "Vendor Deferrals Test"
     local procedure CreateGeneralJournalBatch(var GenJournalBatch: Record "Gen. Journal Batch")
     var
         GenJournalTemplate: Record "Gen. Journal Template";
-        LibraryERM: Codeunit "Library - ERM";
     begin
         GenJournalTemplate.SetRange(Recurring, false);
         GenJournalTemplate.SetRange(Type, GenJournalTemplate.Type::General);

--- a/src/Apps/W1/Subscription Billing/Test/Deferrals/VendorDeferralsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Deferrals/VendorDeferralsTest.Codeunit.al
@@ -48,7 +48,6 @@ codeunit 139913 "Vendor Deferrals Test"
         Assert: Codeunit Assert;
         ContractTestLibrary: Codeunit "Contract Test Library";
         CorrectPostedPurchaseInvoice: Codeunit "Correct Posted Purch. Invoice";
-        LibraryERM: Codeunit "Library - ERM";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryUtility: Codeunit "Library - Utility";
@@ -998,6 +997,7 @@ codeunit 139913 "Vendor Deferrals Test"
         GLAccount: Record "G/L Account";
         GenJournalBatch: Record "Gen. Journal Batch";
         GenJournalLine: Record "Gen. Journal Line";
+        LibraryERM: Codeunit "Library - ERM";
     begin
         CreateGeneralJournalBatch(GenJournalBatch);
         LibraryERM.CreateGLAccount(GLAccount);
@@ -1068,6 +1068,7 @@ codeunit 139913 "Vendor Deferrals Test"
     local procedure CreateGeneralJournalBatch(var GenJournalBatch: Record "Gen. Journal Batch")
     var
         GenJournalTemplate: Record "Gen. Journal Template";
+        LibraryERM: Codeunit "Library - ERM";
     begin
         GenJournalTemplate.SetRange(Recurring, false);
         GenJournalTemplate.SetRange(Type, GenJournalTemplate.Type::General);

--- a/src/Apps/W1/Subscription Billing/Test/Deferrals/VendorDeferralsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Deferrals/VendorDeferralsTest.Codeunit.al
@@ -1,16 +1,18 @@
 namespace Microsoft.SubscriptionBilling;
 
-using System.Security.User;
-using Microsoft.Utilities;
-using Microsoft.Inventory.Item;
-using Microsoft.Purchases.Vendor;
-using Microsoft.Purchases.Document;
-using Microsoft.Purchases.History;
 using Microsoft.Finance.Currency;
-using Microsoft.Finance.GeneralLedger.Setup;
+using Microsoft.Finance.Deferral;
 using Microsoft.Finance.GeneralLedger.Account;
 using Microsoft.Finance.GeneralLedger.Journal;
 using Microsoft.Finance.GeneralLedger.Ledger;
+using Microsoft.Finance.GeneralLedger.Setup;
+using Microsoft.Inventory.Item;
+using Microsoft.Purchases.Document;
+using Microsoft.Purchases.History;
+using Microsoft.Purchases.Setup;
+using Microsoft.Purchases.Vendor;
+using Microsoft.Utilities;
+using System.Security.User;
 
 #pragma warning disable AA0210
 codeunit 139913 "Vendor Deferrals Test"
@@ -60,6 +62,8 @@ codeunit 139913 "Vendor Deferrals Test"
         TotalNumberOfMonths: Integer;
         VendorDeferralsCount: Integer;
         IsInitialized: Boolean;
+        ReleasedContractDeferralErr: Label 'Released Contract Deferrals were not reversed properly';
+        AmountNotMovedFromDeferralsAccountErr: Label 'Amount was not moved from Deferrals Account to Contract Account';
 
     #region Tests
 
@@ -756,6 +760,218 @@ codeunit 139913 "Vendor Deferrals Test"
         Assert.IsTrue(PurchaseLine2.CreateContractDeferrals(), FunctionReturnedWrongResultErr);
     end;
 
+    [Test]
+    [HandlerFunctions('CreateVendorBillingDocsContractPageHandler,MessageHandler')]
+    procedure TestPostingGroupsAreFilledOnVendorContractDeferrals()
+    var
+        TotalDeferralCount: Integer;
+    begin
+        // [SCENARIO] When posting a purchase invoice with contract deferrals, the Gen. Bus. Posting Group and Gen. Prod. Posting Group fields are populated on the deferral entries.
+        Initialize();
+
+        // [GIVEN] A vendor contract with deferrals
+        CreateVendorContractWithDeferrals('<2M-CM>', true);
+        CreateBillingProposalAndCreateBillingDocuments('<2M-CM>', '<8M+CM>');
+
+        // [WHEN] The purchase document is posted
+        BillingLine.FindLast();
+        PostPurchDocumentAndFetchDeferrals();
+
+        // [THEN] Gen. Bus. Posting Group and Gen. Prod. Posting Group are filled on each deferral entry
+        PurchInvLine.SetRange("Document No.", PostedDocumentNo);
+        PurchInvLine.SetFilter("No.", '<>%1', '');
+        PurchInvLine.FindFirst();
+        VendorContractDeferral.SetRange("Document No.", PostedDocumentNo);
+        TotalDeferralCount := VendorContractDeferral.Count;
+        VendorContractDeferral.SetRange("Gen. Bus. Posting Group", PurchInvLine."Gen. Bus. Posting Group");
+        VendorContractDeferral.SetRange("Gen. Prod. Posting Group", PurchInvLine."Gen. Prod. Posting Group");
+        Assert.RecordIsNotEmpty(VendorContractDeferral);
+        Assert.RecordCount(VendorContractDeferral, TotalDeferralCount);
+    end;
+
+    [Test]
+    [HandlerFunctions('CreateVendorBillingDocsContractPageHandler,ContractDeferralsReleaseRequestPageHandler,MessageHandler')]
+    procedure TestZeroAmountVendorDeferralsReleasedWithoutGLEntries()
+    var
+        ContractDeferralsRelease: Report "Contract Deferrals Release";
+    begin
+        // [SCENARIO] Zero-amount vendor contract deferrals should be marked as released without creating GL entries.
+        Initialize();
+        SetPostingAllowTo(0D);
+
+        // [GIVEN] A vendor contract with deferrals that have been posted
+        CreateVendorContractWithDeferrals('<2M-CM>', true);
+        CreateBillingProposalAndCreateBillingDocuments('<2M-CM>', '<8M+CM>');
+        BillingLine.FindLast();
+        PostPurchDocumentAndFetchDeferrals();
+
+        // [GIVEN] All deferral amounts are set to 0 (simulating zero-amount service commitments)
+        VendorContractDeferral.Reset();
+        VendorContractDeferral.SetRange("Document No.", PostedDocumentNo);
+        VendorContractDeferral.ModifyAll(Amount, 0, false);
+        VendorContractDeferral.ModifyAll("Discount Amount", 0, false);
+        VendorContractDeferral.FindFirst();
+
+        // [WHEN] Release deferrals is run
+        PostingDate := VendorContractDeferral."Posting Date";
+        Commit();
+        ContractDeferralsRelease.Run(); // ContractDeferralsReleaseRequestPageHandler
+
+        // [THEN] The first deferral is released without creating a GL entry
+        VendorContractDeferral.Get(VendorContractDeferral."Entry No.");
+        VendorContractDeferral.TestField(Released, true);
+        VendorContractDeferral.TestField("G/L Entry No.", 0);
+    end;
+
+    [Test]
+    [HandlerFunctions('CreateVendorBillingDocsContractPageHandler,MessageHandler')]
+    procedure DeferralCodeNotAllowedWithContractDeferralsOnPurchaseLine()
+    var
+        DeferralTemplate: Record "Deferral Template";
+        DeferralCodeCannotBeUsedWithContractDeferralsErr: Label 'A Deferral Code cannot be used on a line where Subscription Contract Deferrals are active. Either remove the Deferral Code or disable Contract Deferrals on the subscription line or contract.', Locked = true;
+    begin
+        // [SCENARIO] A standard Deferral Code must not be assigned to a purchase invoice line
+        //            that already has subscription contract deferrals enabled.
+        Initialize();
+
+        // [GIVEN] A vendor contract with deferrals enabled and a billing document
+        CreateVendorContractWithDeferrals('<2M-CM>', true);
+        CreateBillingProposalAndCreateBillingDocuments('<2M-CM>', '<8M+CM>');
+
+        // [GIVEN] A standard BC deferral template
+        LibraryERM.CreateDeferralTemplate(DeferralTemplate, Enum::"Deferral Calculation Method"::"Straight-Line",
+            Enum::"Deferral Calculation Start Date"::"Posting Date", 3);
+
+        // [WHEN] Assigning the Deferral Code to the purchase line that has contract deferrals
+        PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
+        PurchaseLine.SetFilter("No.", '<>%1', '');
+        PurchaseLine.FindFirst();
+
+        // [THEN] An error is raised preventing double deferrals
+        asserterror PurchaseLine.Validate("Deferral Code", DeferralTemplate."Deferral Code");
+        Assert.ExpectedError(DeferralCodeCannotBeUsedWithContractDeferralsErr);
+    end;
+
+    [Test]
+    [HandlerFunctions('CreateVendorBillingDocsContractPageHandler,ContractDeferralsReleaseRequestPageHandler,MessageHandler')]
+    procedure DeferralsReleaseSucceedsWhenGLAccountHasDefaultDeferralTemplateAndJournalTemplMandatory()
+    var
+        DeferralTemplate: Record "Deferral Template";
+        GLAccount: Record "G/L Account";
+        GLEntry: Record "G/L Entry";
+        ContractDeferralsRelease: Report "Contract Deferrals Release";
+        GLAmountBeforeRelease: Decimal;
+        GLAmountAfterRelease: Decimal;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 632489] When "Journal Templ. Name Mandatory" is TRUE and G/L Account has a Default Deferral Template Code,
+        // the Contract Deferrals Release report should successfully post without error
+        // "Gen. Journal Template does not exist (Name = '')".
+        Initialize();
+
+        // [GIVEN] General Ledger Setup has "Journal Templ. Name Mandatory" = TRUE.
+        SetPostingAllowTo(0D);
+        SetJournalTemplateNameMandatory(true);
+
+        // [GIVEN] Purchases & Payables Setup has "P. Invoice Template Name" set.
+        SetupPurchInvoiceTemplateInPurchSetup();
+
+        // [GIVEN] Subscription Contract Setup has "Def. Rel. Jnl. Template Name" and "Def. Rel. Jnl. Batch Name" set.
+        SetupDeferralReleaseJournalTemplateAndBatch();
+
+        // [GIVEN] A vendor contract with deferrals enabled.
+        CreateVendorContractWithDeferrals('<2M-CM>', true);
+        CreateBillingProposalAndCreateBillingDocuments('<2M-CM>', '<8M+CM>');
+
+        // [GIVEN] The G/L Account used for Vendor Sub. Contract Deferral has a Default Deferral Template Code set.
+        GeneralPostingSetup.Get(Vendor."Gen. Bus. Posting Group", Item."Gen. Prod. Posting Group");
+        LibraryERM.CreateDeferralTemplate(DeferralTemplate, Enum::"Deferral Calculation Method"::"Straight-Line",
+            Enum::"Deferral Calculation Start Date"::"Posting Date", 12);
+        GLAccount.Get(GeneralPostingSetup."Vend. Sub. Contr. Def. Account");
+        GLAccount."Default Deferral Template Code" := DeferralTemplate."Deferral Code";
+        GLAccount.Modify(false);
+
+        // [GIVEN] Post the contract invoice
+        PostPurchDocumentAndFetchDeferrals();
+
+        // [WHEN] Run Contract Deferrals Release
+        GetGLEntryAmountFromAccountNo(GLAmountBeforeRelease, GeneralPostingSetup."Vend. Sub. Contr. Def. Account");
+        PostingDate := VendorContractDeferral."Posting Date";
+        Commit();
+        ContractDeferralsRelease.Run();
+
+        // [THEN] The deferral is successfully released without error
+        VendorContractDeferral.Get(VendorContractDeferral."Entry No.");
+        VendorContractDeferral.TestField(Released, true);
+        VendorContractDeferral.TestField("G/L Entry No.");
+
+        // [THEN] GL entry is posted with Subscription Contract No. and the amount is released from the deferral account.
+        GLEntry.Get(VendorContractDeferral."G/L Entry No.");
+        GLEntry.TestField("Subscription Contract No.", VendorContractDeferral."Subscription Contract No.");
+        GetGLEntryAmountFromAccountNo(GLAmountAfterRelease, GeneralPostingSetup."Vend. Sub. Contr. Def. Account");
+        Assert.AreEqual(GLAmountBeforeRelease - VendorContractDeferral.Amount, GLAmountAfterRelease, AmountNotMovedFromDeferralsAccountErr);
+    end;
+
+    [Test]
+    [HandlerFunctions('CreateVendorBillingDocsContractPageHandler,ContractDeferralsReleaseRequestPageHandler,MessageHandler')]
+    procedure DeferralsReleaseSucceedsWhenGLAccountHasDefaultDeferralTemplateAndJournalTemplNotMandatory()
+    var
+        DeferralTemplate: Record "Deferral Template";
+        GLAccount: Record "G/L Account";
+        GLEntry: Record "G/L Entry";
+        ContractDeferralsRelease: Report "Contract Deferrals Release";
+        GLAmountBeforeRelease: Decimal;
+        GLAmountAfterRelease: Decimal;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 632489] When "Journal Templ. Name Mandatory" is FALSE and Subscription Contract Setup has no journal template/batch,
+        // and G/L Account has a Default Deferral Template Code, the Contract Deferrals Release report should
+        // successfully post without error "Gen. Journal Template does not exist (Name = '')".
+        Initialize();
+
+        // [GIVEN] General Ledger Setup has "Journal Templ. Name Mandatory" = FALSE.
+        SetPostingAllowTo(0D);
+        SetJournalTemplateNameMandatory(false);
+
+        // [GIVEN] Purchases & Payables Setup has "P. Invoice Template Name" set.
+        SetupPurchInvoiceTemplateInPurchSetup();
+
+        // [GIVEN] Subscription Contract Setup has empty "Def. Rel. Jnl. Template Name" and "Def. Rel. Jnl. Batch Name".
+        ClearDeferralReleaseJournalTemplateAndBatch();
+
+        // [GIVEN] A vendor contract with deferrals enabled.
+        CreateVendorContractWithDeferrals('<2M-CM>', true);
+        CreateBillingProposalAndCreateBillingDocuments('<2M-CM>', '<8M+CM>');
+
+        // [GIVEN] The G/L Account used for Vendor Sub. Contract Deferral has a Default Deferral Template Code set.
+        GeneralPostingSetup.Get(Vendor."Gen. Bus. Posting Group", Item."Gen. Prod. Posting Group");
+        LibraryERM.CreateDeferralTemplate(DeferralTemplate, Enum::"Deferral Calculation Method"::"Straight-Line",
+            Enum::"Deferral Calculation Start Date"::"Posting Date", 12);
+        GLAccount.Get(GeneralPostingSetup."Vend. Sub. Contr. Def. Account");
+        GLAccount."Default Deferral Template Code" := DeferralTemplate."Deferral Code";
+        GLAccount.Modify(false);
+
+        // [GIVEN] Post the contract invoice.
+        PostPurchDocumentAndFetchDeferrals();
+
+        // [WHEN] Run Contract Deferrals Release.
+        GetGLEntryAmountFromAccountNo(GLAmountBeforeRelease, GeneralPostingSetup."Vend. Sub. Contr. Def. Account");
+        PostingDate := VendorContractDeferral."Posting Date";
+        Commit();
+        ContractDeferralsRelease.Run();
+
+        // [THEN] The deferral is successfully released without error.
+        VendorContractDeferral.Get(VendorContractDeferral."Entry No.");
+        VendorContractDeferral.TestField(Released, true);
+        VendorContractDeferral.TestField("G/L Entry No.");
+
+        // [THEN] GL entry is posted with Subscription Contract No. and the amount is released from the deferral account.
+        GLEntry.Get(VendorContractDeferral."G/L Entry No.");
+        GLEntry.TestField("Subscription Contract No.", VendorContractDeferral."Subscription Contract No.");
+        GetGLEntryAmountFromAccountNo(GLAmountAfterRelease, GeneralPostingSetup."Vend. Sub. Contr. Def. Account");
+        Assert.AreEqual(GLAmountBeforeRelease - VendorContractDeferral.Amount, GLAmountAfterRelease, AmountNotMovedFromDeferralsAccountErr);
+    end;
+
     #endregion Tests
 
     #region Procedures
@@ -1060,6 +1276,53 @@ codeunit 139913 "Vendor Deferrals Test"
         VendorContractDeferral.TestField("Vendor No.", PurchaseHeader."Buy-from Vendor No.");
         VendorContractDeferral.TestField("Pay-to Vendor No.", PurchaseHeader."Pay-to Vendor No.");
         VendorContractDeferral.TestField("Document Posting Date", PurchaseHeader."Posting Date");
+    end;
+
+    local procedure SetJournalTemplateNameMandatory(NewValue: Boolean)
+    begin
+        GLSetup.Get();
+        GLSetup."Journal Templ. Name Mandatory" := NewValue;
+        GLSetup.Modify(false);
+    end;
+
+    local procedure SetupDeferralReleaseJournalTemplateAndBatch()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        ServiceContractSetup: Record "Subscription Contract Setup";
+    begin
+        LibraryERM.CreateGenJournalTemplate(GenJournalTemplate);
+        LibraryERM.CreateGenJournalBatch(GenJournalBatch, GenJournalTemplate.Name);
+        ServiceContractSetup.Get();
+        ServiceContractSetup."Def. Rel. Jnl. Template Name" := GenJournalBatch."Journal Template Name";
+        ServiceContractSetup."Def. Rel. Jnl. Batch Name" := GenJournalBatch.Name;
+        ServiceContractSetup.Modify(false);
+    end;
+
+    local procedure ClearDeferralReleaseJournalTemplateAndBatch()
+    var
+        ServiceContractSetup: Record "Subscription Contract Setup";
+    begin
+        ServiceContractSetup.Get();
+        ServiceContractSetup."Def. Rel. Jnl. Template Name" := '';
+        ServiceContractSetup."Def. Rel. Jnl. Batch Name" := '';
+        ServiceContractSetup.Modify(false);
+    end;
+
+    local procedure SetupPurchInvoiceTemplateInPurchSetup()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
+    begin
+        PurchasesPayablesSetup.Get();
+        if PurchasesPayablesSetup."P. Invoice Template Name" <> '' then
+            exit;
+        LibraryERM.CreateGenJournalTemplate(GenJournalTemplate);
+        GenJournalTemplate.Type := GenJournalTemplate.Type::Purchases;
+        GenJournalTemplate."Posting No. Series" := LibraryERM.CreateNoSeriesCode();
+        GenJournalTemplate.Modify(false);
+        PurchasesPayablesSetup."P. Invoice Template Name" := GenJournalTemplate.Name;
+        PurchasesPayablesSetup.Modify(false);
     end;
 
     #endregion Procedures

--- a/src/Apps/W1/Subscription Billing/Test/Deferrals/VendorDeferralsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Deferrals/VendorDeferralsTest.Codeunit.al
@@ -48,6 +48,7 @@ codeunit 139913 "Vendor Deferrals Test"
         Assert: Codeunit Assert;
         ContractTestLibrary: Codeunit "Contract Test Library";
         CorrectPostedPurchaseInvoice: Codeunit "Correct Posted Purch. Invoice";
+        LibraryERM: Codeunit "Library - ERM";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryUtility: Codeunit "Library - Utility";
@@ -997,7 +998,6 @@ codeunit 139913 "Vendor Deferrals Test"
         GLAccount: Record "G/L Account";
         GenJournalBatch: Record "Gen. Journal Batch";
         GenJournalLine: Record "Gen. Journal Line";
-        LibraryERM: Codeunit "Library - ERM";
     begin
         CreateGeneralJournalBatch(GenJournalBatch);
         LibraryERM.CreateGLAccount(GLAccount);
@@ -1068,7 +1068,6 @@ codeunit 139913 "Vendor Deferrals Test"
     local procedure CreateGeneralJournalBatch(var GenJournalBatch: Record "Gen. Journal Batch")
     var
         GenJournalTemplate: Record "Gen. Journal Template";
-        LibraryERM: Codeunit "Library - ERM";
     begin
         GenJournalTemplate.SetRange(Recurring, false);
         GenJournalTemplate.SetRange(Type, GenJournalTemplate.Type::General);


### PR DESCRIPTION
Cherry-pick of 2f18fdd9192521eb2063a064d0de972b8bd14d67 from releases/27.x to releases/27.5.

[AB#632489](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/632489)

Bug 632489: [ALL-E] Vendor Subscription Contract Deferral Release fails with "Gen. Journal Template does not exist (Name = '')"

**Fix:** In `ContractDeferralsRelease.Report.al`, avoid calling `Validate("Account No.")` which triggers deferral code logic on G/L accounts with a default deferral template. Instead, directly assign `"Account No."` and clear `"Deferral Code"`. Also ensure `ServiceContractSetup.Get()` is called when the record hasn't been loaded yet.



