### PR TITLE
[Subcontracting] Block Cancel of purchase invoice with subcontracting item charge (Bug 637502)

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubcPurchPostExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubcPurchPostExt.Codeunit.al
@@ -17,6 +17,26 @@ using Microsoft.Purchases.History;
 using Microsoft.Purchases.Posting;
 codeunit 99001535 "Subc. Purch. Post Ext"
 {
+    var
+        CancelNotSupportedErr: Label 'You cannot cancel or correct posted purchase invoice %1 because it contains item charge(s) assigned to a subcontracting service receipt. Create a purchase credit memo manually and assign the item charge to the posted subcontracting receipt line.', Comment = '%1 = Posted Purchase Invoice No.';
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Correct Posted Purch. Invoice", OnAfterTestCorrectInvoiceIsAllowed, '', false, false)]
+    local procedure "Correct Posted Purch. Invoice_OnAfterTestCorrectInvoiceIsAllowed"(var PurchInvHeader: Record "Purch. Inv. Header"; Cancelling: Boolean)
+    begin
+        BlockIfHasSubcontractingItemChargeValueEntry(PurchInvHeader);
+    end;
+
+    local procedure BlockIfHasSubcontractingItemChargeValueEntry(PurchInvHeader: Record "Purch. Inv. Header")
+    var
+        ValueEntry: Record "Value Entry";
+    begin
+        ValueEntry.SetRange("Document Type", ValueEntry."Document Type"::"Purchase Invoice");
+        ValueEntry.SetRange("Document No.", PurchInvHeader."No.");
+        ValueEntry.SetFilter("Capacity Ledger Entry No.", '<>%1', 0);
+        if not ValueEntry.IsEmpty() then
+            Error(CancelNotSupportedErr, PurchInvHeader."No.");
+    end;
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Purch.-Post", OnBeforeItemJnlPostLine, '', false, false)]
     local procedure "Purch.-Post_OnBeforeItemJnlPostLine"(var ItemJournalLine: Record "Item Journal Line"; TempItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)" temporary)
     begin

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubcPurchPostExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubcPurchPostExt.Codeunit.al
@@ -18,20 +18,16 @@ using Microsoft.Purchases.Posting;
 codeunit 99001535 "Subc. Purch. Post Ext"
 {
     var
-        CancelNotSupportedErr: Label 'You cannot cancel or correct posted purchase invoice %1 because it contains item charge(s) assigned to a subcontracting service receipt. Create a purchase credit memo manually and assign the item charge to the posted subcontracting receipt line.', Comment = '%1 = Posted Purchase Invoice No.';
+        CancelNotSupportedErr: Label 'You cannot cancel or correct posted purchase invoice %1 because it contains item charges assigned to a subcontracting order receipt.\Create a purchase credit memo manually and assign the item charge to the posted subcontracting receipt line.', Comment = '%1 = Posted Purchase Invoice No.';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Correct Posted Purch. Invoice", OnAfterTestCorrectInvoiceIsAllowed, '', false, false)]
-    local procedure "Correct Posted Purch. Invoice_OnAfterTestCorrectInvoiceIsAllowed"(var PurchInvHeader: Record "Purch. Inv. Header"; Cancelling: Boolean)
-    begin
-        BlockIfHasSubcontractingItemChargeValueEntry(PurchInvHeader);
-    end;
-
-    local procedure BlockIfHasSubcontractingItemChargeValueEntry(PurchInvHeader: Record "Purch. Inv. Header")
+    local procedure BlockCancelIfHasSubcontractingItemChargeValueEntry(var PurchInvHeader: Record "Purch. Inv. Header"; Cancelling: Boolean)
     var
         ValueEntry: Record "Value Entry";
     begin
         ValueEntry.SetRange("Document Type", ValueEntry."Document Type"::"Purchase Invoice");
         ValueEntry.SetRange("Document No.", PurchInvHeader."No.");
+        ValueEntry.SetFilter("Item Charge No.", '<>%1', '');
         ValueEntry.SetFilter("Capacity Ledger Entry No.", '<>%1', 0);
         if not ValueEntry.IsEmpty() then
             Error(CancelNotSupportedErr, PurchInvHeader."No.");

--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/SubcItemJnlPostLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/SubcItemJnlPostLineExt.Codeunit.al
@@ -41,6 +41,7 @@ codeunit 99001515 "Subc. ItemJnlPostLine Ext"
     local procedure "Item Jnl.-Post Line_OnBeforeInsertCapValueEntry"(var ValueEntry: Record "Value Entry"; ItemJnlLine: Record "Item Journal Line")
     begin
         ClearInvoicedQuantityForItemChargeSubAssign(ValueEntry, ItemJnlLine);
+        CopyItemChargeNoForItemChargeSubAssign(ValueEntry, ItemJnlLine);
     end;
 
     local procedure UpdateProdOrderRoutingLine(var ProdOrderLine: Record "Prod. Order Line"; var ItemJournalLine: Record "Item Journal Line")
@@ -89,5 +90,11 @@ codeunit 99001515 "Subc. ItemJnlPostLine Ext"
     begin
         if ItemJournalLine."Subc. Item Charge Assign." and (ValueEntry."Entry Type" = "Cost Entry Type"::"Direct Cost") then
             ValueEntry."Invoiced Quantity" := 0;
+    end;
+
+    local procedure CopyItemChargeNoForItemChargeSubAssign(var ValueEntry: Record "Value Entry"; ItemJournalLine: Record "Item Journal Line")
+    begin
+        if ItemJournalLine."Subc. Item Charge Assign." and (ItemJournalLine."Item Charge No." <> '') then
+            ValueEntry."Item Charge No." := ItemJournalLine."Item Charge No.";
     end;
 }

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -28,6 +28,7 @@ using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Archive;
 using Microsoft.Purchases.Comment;
 using Microsoft.Purchases.Document;
+using Microsoft.Purchases.History;
 using Microsoft.Purchases.Vendor;
 using Microsoft.Sales.Customer;
 using Microsoft.Sales.Document;
@@ -3548,6 +3549,99 @@ codeunit 139989 "Subc. Subcontracting Test"
         exit(UnitOfMeasure.Code);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    procedure CancelInvoiceWithSubcontractingItemChargeIsBlocked()
+    var
+        Item: Record Item;
+        RegularItem: Record Item;
+        ProductionOrder: Record "Production Order";
+        SubcWorkCenter: Record "Work Center";
+        SubcPurchaseHeader: Record "Purchase Header";
+        SubcPurchaseLine: Record "Purchase Line";
+        RegularPurchaseHeader: Record "Purchase Header";
+        RegularPurchaseLine: Record "Purchase Line";
+        SubcPurchRcptLine: Record "Purch. Rcpt. Line";
+        RegPurchRcptLine: Record "Purch. Rcpt. Line";
+        ItemCharge: Record "Item Charge";
+        ItemChargeInvHeader: Record "Purchase Header";
+        ItemChargeInvLine: Record "Purchase Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        PostedInvoiceNo: Code[20];
+        SubcVendorNo: Code[20];
+    begin
+        // [SCENARIO 637502] Cancelling a Posted Purchase Invoice whose Item Charge is split between a regular item receipt
+        // line and a subcontracting service receipt line must be blocked. Letting the cancel run today silently skips the
+        // capacity portion (Value Entry has Item Ledger Entry No. = 0) and redistributes it to inventory, corrupting cost.
+        // Until a proper reversal path exists, the Subcontracting App blocks the cancel with a clear error so the user
+        // creates a corrective credit memo manually.
+
+        // [GIVEN] Subcontracting setup with a single-operation subcontracting routing on Item
+        Initialize();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        CreateItemWithSingleSubcontractingOperation(Item, SubcWorkCenter);
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(SubcWorkCenter);
+
+        // [GIVEN] Released production order and a subcontracting purchase order received in full
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandIntInRange(5, 10));
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", SubcWorkCenter."No.");
+
+        SubcPurchaseLine.SetRange("Document Type", SubcPurchaseLine."Document Type"::Order);
+        SubcPurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+#pragma warning disable AA0210
+        SubcPurchaseLine.SetRange("Work Center No.", SubcWorkCenter."No.");
+#pragma warning restore AA0210
+        SubcPurchaseLine.FindFirst();
+        SubcPurchaseHeader.Get(SubcPurchaseLine."Document Type", SubcPurchaseLine."Document No.");
+        EnsureGeneralPostingSetupIsValid(SubcPurchaseLine."Gen. Bus. Posting Group", SubcPurchaseLine."Gen. Prod. Posting Group");
+        SubcVendorNo := SubcPurchaseHeader."Buy-from Vendor No.";
+
+        LibraryPurchase.PostPurchaseDocument(SubcPurchaseHeader, true, false);
+
+        SubcPurchRcptLine.SetRange("Order No.", SubcPurchaseHeader."No.");
+        SubcPurchRcptLine.SetRange("Order Line No.", SubcPurchaseLine."Line No.");
+        SubcPurchRcptLine.FindFirst();
+
+        // [GIVEN] A separate regular purchase order for the same vendor that receives a normal inventory item
+        LibraryInventory.CreateItem(RegularItem);
+        LibraryPurchase.CreatePurchHeader(RegularPurchaseHeader, RegularPurchaseHeader."Document Type"::Order, SubcVendorNo);
+        LibraryPurchase.CreatePurchaseLineWithUnitCost(
+            RegularPurchaseLine, RegularPurchaseHeader, RegularItem."No.",
+            LibraryRandom.RandDecInRange(50, 100, 2), LibraryRandom.RandIntInRange(2, 5));
+        EnsureGeneralPostingSetupIsValid(RegularPurchaseLine."Gen. Bus. Posting Group", RegularPurchaseLine."Gen. Prod. Posting Group");
+        LibraryPurchase.PostPurchaseDocument(RegularPurchaseHeader, true, false);
+
+        RegPurchRcptLine.SetRange("Order No.", RegularPurchaseHeader."No.");
+        RegPurchRcptLine.SetRange("Order Line No.", RegularPurchaseLine."Line No.");
+        RegPurchRcptLine.FindFirst();
+
+        // [GIVEN] A purchase invoice with a single Item Charge line of quantity 2 allocated 1:1 across both receipt lines
+        LibraryInventory.CreateItemCharge(ItemCharge);
+        LibraryPurchase.CreatePurchHeader(ItemChargeInvHeader, ItemChargeInvHeader."Document Type"::Invoice, SubcVendorNo);
+        LibraryPurchase.CreatePurchaseLine(ItemChargeInvLine, ItemChargeInvHeader, ItemChargeInvLine.Type::"Charge (Item)", ItemCharge."No.", 2);
+        ItemChargeInvLine.Validate("Direct Unit Cost", LibraryRandom.RandDecInRange(100, 200, 2));
+        ItemChargeInvLine.Modify(true);
+        EnsureGeneralPostingSetupIsValid(ItemChargeInvLine."Gen. Bus. Posting Group", ItemChargeInvLine."Gen. Prod. Posting Group");
+
+        AssignItemChargeToReceiptLine(ItemChargeInvLine, RegPurchRcptLine, 1);
+        AssignItemChargeToReceiptLine(ItemChargeInvLine, SubcPurchRcptLine, 1);
+
+        // [GIVEN] The invoice is posted
+        PostedInvoiceNo := LibraryPurchase.PostPurchaseDocument(ItemChargeInvHeader, false, true);
+        PurchInvHeader.Get(PostedInvoiceNo);
+        Commit();
+
+        // [WHEN] The user tries to cancel the posted invoice
+        asserterror CorrectPostedPurchInvoice.CancelPostedInvoice(PurchInvHeader);
+
+        // [THEN] The Subcontracting App blocks the cancel with the dedicated error
+        Assert.ExpectedError('contains item charges assigned to a subcontracting order receipt');
+    end;
+
     local procedure Initialize()
     begin
         LibraryTestInitialize.OnTestInitialize(Codeunit::"Subc. Subcontracting Test");
@@ -3638,6 +3732,18 @@ codeunit 139989 "Subc. Subcontracting Test"
             ReqWkshTemplate.Modify(true);
         end;
         exit(ReqWkshTemplate.Name);
+    end;
+
+    local procedure AssignItemChargeToReceiptLine(ItemChargeInvLine: Record "Purchase Line"; PurchRcptLine: Record "Purch. Rcpt. Line"; QtyToAssign: Decimal)
+    var
+        ItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)";
+    begin
+        LibraryInventory.CreateItemChargeAssignPurchase(
+            ItemChargeAssignmentPurch, ItemChargeInvLine,
+            ItemChargeAssignmentPurch."Applies-to Doc. Type"::Receipt,
+            PurchRcptLine."Document No.", PurchRcptLine."Line No.", PurchRcptLine."No.");
+        ItemChargeAssignmentPurch.Validate("Qty. to Assign", QtyToAssign);
+        ItemChargeAssignmentPurch.Modify(true);
     end;
 
     procedure UpdateProdOrderComponentWithComponentSupplyMethod(ProductionOrder: Record "Production Order"; ComponentSupplyMethod: Enum "Component Supply Method")


### PR DESCRIPTION
Fixes [AB#637502](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637502)

Cancelling a Posted Purchase Invoice whose Item Charge is split between a regular item receipt line and a subcontracting service receipt line silently skipped the capacity portion. `CopyDocumentMgt.CopyFromPurchLineItemChargeAssign` rebuilds assignments by iterating Value Entries and looking up the linked Item Ledger Entry; subcontracting item-charge Value Entries have `Item Ledger Entry No. = 0` (only `Capacity Ledger Entry No.` is set), so they were dropped and the orphaned amount was redistributed to inventory entries, corrupting inventory cost.

Until a proper reversal path exists in BaseApp, this PR narrows the blast radius from the Subcontracting App:

- `SubcItemJnlPostLineExt`: in `OnBeforeInsertCapValueEntry`, populate `ValueEntry."Item Charge No."` from `ItemJnlLine."Item Charge No."` when `ItemJnlLine."Subc. Item Charge Assign."` is set, so capacity-side Value Entries carry the item charge they came from.
- `SubcPurchPostExt`: subscribe to `Correct Posted Purch. Invoice.OnAfterTestCorrectInvoiceIsAllowed` and block Cancel/Correct when the posted invoice has any Value Entry with `Item Charge No. <> ''` AND `Capacity Ledger Entry No. <> 0`. Plain subcontracting invoices are unaffected.
- Add integration test `CancelInvoiceWithSubcontractingItemChargeIsBlocked` reproducing the bug repro (mixed regular + subcontracting receipt charge assignment) and asserting the block fires.

