### PR TITLE
[Shopify] Fix #7724: Resolve Option 1 Name from existing Shopify Variant records

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductExport.Codeunit.al
@@ -74,6 +74,8 @@ codeunit 30178 "Shpfy Product Export"
         OnlyUpdatePrice: Boolean;
         RecordCount: Integer;
         NullGuid: Guid;
+        CachedOption1NameProductId: BigInteger;
+        CachedOption1Name: Text[50];
         BulkOperationInput: TextBuilder;
         GraphQueryList: Dictionary of [BigInteger, TextBuilder];
         JRequestData: JsonArray;
@@ -391,6 +393,7 @@ codeunit 30178 "Shpfy Product Export"
     var
         Product: Record "Shpfy Product";
         ItemAsVariant: Boolean;
+        JustResolvedOption1Name: Boolean;
     begin
         if Shop."Sync Prices" or OnlyUpdatePrice then
             if Item.Blocked or Item."Sales Blocked" then
@@ -433,9 +436,15 @@ codeunit 30178 "Shpfy Product Export"
                 ShopifyVariant."Tariff No." := Item."Tariff No.";
                 ShopifyVariant."Country/Region of Origin Code" := GetCountryISOCode(Item."Country/Region of Origin Code");
             end;
-            if ShopifyVariant."Option 1 Name" = '' then
-                ShopifyVariant."Option 1 Name" := 'Variant';
-            if ShopifyVariant."Option 1 Name" = 'Variant' then
+            if ShopifyVariant."Option 1 Name" = '' then begin
+                if ShopifyVariant."Product Id" <> CachedOption1NameProductId then begin
+                    CachedOption1NameProductId := ShopifyVariant."Product Id";
+                    CachedOption1Name := ResolveOption1Name(ShopifyVariant."Product Id", Shop.Code);
+                end;
+                ShopifyVariant."Option 1 Name" := CachedOption1Name;
+                JustResolvedOption1Name := true;
+            end;
+            if (ShopifyVariant."Option 1 Name" = 'Variant') or JustResolvedOption1Name then
                 if ItemAsVariant then
                     ShopifyVariant."Option 1 Value" := Item."No."
                 else
@@ -879,6 +888,33 @@ codeunit 30178 "Shpfy Product Export"
                 TempCurrVariant := ShopifyVariant;
                 TempCurrVariant.Insert();
             end;
+    end;
+
+    local procedure ResolveOption1Name(ProductId: BigInteger; ShopCode: Code[20]): Text[50]
+    var
+        ShpfyVariant: Record "Shpfy Variant";
+        VariantOption1Name: Text[50];
+        FirstVariantName: Boolean;
+    begin
+        ShpfyVariant.SetRange("Shop Code", ShopCode);
+        ShpfyVariant.SetRange("Product Id", ProductId);
+        ShpfyVariant.SetLoadFields("Option 1 Name");
+        if not ShpfyVariant.FindSet() then
+            exit('Variant');
+        FirstVariantName := true;
+        repeat
+            if ShpfyVariant."Option 1 Name" <> '' then
+                if FirstVariantName then begin
+                    VariantOption1Name := ShpfyVariant."Option 1 Name";
+                    FirstVariantName := false;
+                end
+                else
+                    if VariantOption1Name <> ShpfyVariant."Option 1 Name" then
+                        exit('Variant');
+        until ShpfyVariant.Next() = 0;
+        if not FirstVariantName then
+            exit(VariantOption1Name);
+        exit('Variant');
     end;
 
     local procedure RevertVariantChanges(VariantId: BigInteger)

--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductExport.Codeunit.al
@@ -77,6 +77,8 @@ codeunit 30178 "Shpfy Product Export"
         SkippedRecord: Codeunit "Shpfy Skipped Record";
         OnlyUpdatePrice: Boolean;
         NullGuid: Guid;
+        Option1NameCacheProductId: BigInteger;
+        Option1NameCache: Text[50];
         BulkOperationInput: TextBuilder;
         GraphQueryList: Dictionary of [BigInteger, TextBuilder];
         JRequestData: JsonArray;
@@ -87,6 +89,7 @@ codeunit 30178 "Shpfy Product Export"
         ItemVariantIsBlockedLbl: Label 'Item variant is blocked or sales blocked.';
         ItemLbl: Label 'item';
         ItemVariantLbl: Label 'item variant';
+        DefaultOption1NameLbl: Label 'Variant', Locked = true;
 
     /// <summary> 
     /// Creates html body for a product from extended text, marketing text and attributes.
@@ -259,7 +262,9 @@ codeunit 30178 "Shpfy Product Export"
         if OnlyUpdatePrice then
             exit;
         Clear(TempShopifyVariant);
-        FillInProductVariantData(TempShopifyVariant, Item, ItemVariant);
+        // Pass ProductId explicitly: the variant record is still blank here and only gets its
+        // Product Id in AddProductVariant, after the option name has been resolved.
+        FillInProductVariantData(TempShopifyVariant, Item, ItemVariant, ProductId);
 
         GetItemAttributeIDsMarkedAsOption(Item, ItemAttributeIds);
         if ItemAttributeIds.Count() > 0 then
@@ -286,7 +291,9 @@ codeunit 30178 "Shpfy Product Export"
         end;
 
         Clear(TempShopifyVariant);
-        FillInProductVariantData(TempShopifyVariant, Item, ItemVariant, ItemUnitofMeasure);
+        // Pass ProductId explicitly: the variant record is still blank here and only gets its
+        // Product Id in AddProductVariant, after the option name has been resolved.
+        FillInProductVariantData(TempShopifyVariant, Item, ItemVariant, ItemUnitofMeasure, ProductId);
         TempShopifyVariant.Insert(false);
         VariantApi.AddProductVariant(TempShopifyVariant, ProductId, "Shpfy Variant Create Strategy"::DEFAULT);
     end;
@@ -391,9 +398,22 @@ codeunit 30178 "Shpfy Product Export"
     /// <param name="Item">Parameter of type Record Item.</param>
     /// <param name="ItemVariant">Parameter of type Record "Item Variant".</param>
     internal procedure FillInProductVariantData(var ShopifyVariant: Record "Shpfy Variant"; Item: Record Item; ItemVariant: Record "Item Variant")
+    begin
+        FillInProductVariantData(ShopifyVariant, Item, ItemVariant, ShopifyVariant."Product Id");
+    end;
+
+    /// <summary>
+    /// Fill In Product Variant Data.
+    /// </summary>
+    /// <param name="ShopifyVariant">Parameter of type Record "Shopify Variant".</param>
+    /// <param name="Item">Parameter of type Record Item.</param>
+    /// <param name="ItemVariant">Parameter of type Record "Item Variant".</param>
+    /// <param name="TargetProductId">Shopify product the variant belongs to. Callers creating a new variant must pass this, because the variant record does not carry a Product Id yet.</param>
+    internal procedure FillInProductVariantData(var ShopifyVariant: Record "Shpfy Variant"; Item: Record Item; ItemVariant: Record "Item Variant"; TargetProductId: BigInteger)
     var
         Product: Record "Shpfy Product";
         ItemAsVariant: Boolean;
+        Option1NameFromShopify: Boolean;
     begin
         if Shop."Sync Prices" or OnlyUpdatePrice then
             if Item.Blocked or Item."Sales Blocked" then
@@ -436,9 +456,14 @@ codeunit 30178 "Shpfy Product Export"
                 ShopifyVariant."Tariff No." := Item."Tariff No.";
                 ShopifyVariant."Country/Region of Origin Code" := GetCountryISOCode(Item."Country/Region of Origin Code");
             end;
-            if ShopifyVariant."Option 1 Name" = '' then
-                ShopifyVariant."Option 1 Name" := 'Variant';
-            if ShopifyVariant."Option 1 Name" = 'Variant' then
+            if ShopifyVariant."Option 1 Name" = '' then begin
+                ShopifyVariant."Option 1 Name" := ResolveOption1Name(TargetProductId);
+                Option1NameFromShopify := ShopifyVariant."Option 1 Name" <> '';
+                if not Option1NameFromShopify then
+                    ShopifyVariant."Option 1 Name" := DefaultOption1NameLbl;
+            end;
+            // A name taken from Shopify still needs its value filled in, exactly as the default name does.
+            if Option1NameFromShopify or (ShopifyVariant."Option 1 Name" = DefaultOption1NameLbl) then
                 if ItemAsVariant then
                     ShopifyVariant."Option 1 Value" := Item."No."
                 else
@@ -459,6 +484,19 @@ codeunit 30178 "Shpfy Product Export"
     /// <param name="ItemVariant">Parameter of type Record "Item Variant".</param>
     /// <param name="ItemUnitofMeasure">Parameter of type Record "Item Unit of Measure".</param>
     internal procedure FillInProductVariantData(var ShopifyVariant: Record "Shpfy Variant"; Item: Record Item; ItemVariant: Record "Item Variant"; ItemUnitofMeasure: Record "Item Unit of Measure")
+    begin
+        FillInProductVariantData(ShopifyVariant, Item, ItemVariant, ItemUnitofMeasure, ShopifyVariant."Product Id");
+    end;
+
+    /// <summary>
+    /// Fill In Product Variant Data.
+    /// </summary>
+    /// <param name="ShopifyVariant">Parameter of type Record "Shopify Variant".</param>
+    /// <param name="Item">Parameter of type Record Item.</param>
+    /// <param name="ItemVariant">Parameter of type Record "Item Variant".</param>
+    /// <param name="ItemUnitofMeasure">Parameter of type Record "Item Unit of Measure".</param>
+    /// <param name="TargetProductId">Shopify product the variant belongs to. Callers creating a new variant must pass this, because the variant record does not carry a Product Id yet.</param>
+    internal procedure FillInProductVariantData(var ShopifyVariant: Record "Shpfy Variant"; Item: Record Item; ItemVariant: Record "Item Variant"; ItemUnitofMeasure: Record "Item Unit of Measure"; TargetProductId: BigInteger)
     begin
         if Shop."Sync Prices" or OnlyUpdatePrice then
             if Item.Blocked or Item."Sales Blocked" then
@@ -495,7 +533,9 @@ codeunit 30178 "Shpfy Product Export"
                 ShopifyVariant."Tariff No." := Item."Tariff No.";
                 ShopifyVariant."Country/Region of Origin Code" := GetCountryISOCode(Item."Country/Region of Origin Code");
             end;
-            ShopifyVariant."Option 1 Name" := 'Variant';
+            ShopifyVariant."Option 1 Name" := ResolveOption1Name(TargetProductId);
+            if ShopifyVariant."Option 1 Name" = '' then
+                ShopifyVariant."Option 1 Name" := DefaultOption1NameLbl;
             ShopifyVariant."Option 1 Value" := ItemVariant.Code;
             ShopifyVariant."Option 2 Name" := Shop."Option Name for UoM";
             ShopifyVariant."Option 2 Value" := ItemUnitofMeasure.Code;
@@ -598,6 +638,8 @@ codeunit 30178 "Shpfy Product Export"
     internal procedure SetShop(ShopifyShop: Record "Shpfy Shop")
     begin
         Shop := ShopifyShop;
+        Clear(Option1NameCacheProductId);
+        Clear(Option1NameCache);
         ProductApi.SetShop(Shop);
         VariantApi.SetShop(Shop);
         ProductPriceCalc.SetShop(Shop);
@@ -882,6 +924,40 @@ codeunit 30178 "Shpfy Product Export"
                 TempCurrVariant := ShopifyVariant;
                 TempCurrVariant.Insert();
             end;
+    end;
+
+    /// <summary>
+    /// Returns the option name Shopify already uses for the given product, or an empty string when
+    /// the product carries no Shopify option metadata and the default name should be used instead.
+    /// </summary>
+    /// <param name="ProductId">Shopify product to inspect. Zero when the product is not known yet.</param>
+    /// <returns>The product's existing Option 1 Name, or an empty string.</returns>
+    local procedure ResolveOption1Name(ProductId: BigInteger) Option1Name: Text[50]
+    var
+        ShpfyVariant: Record "Shpfy Variant";
+    begin
+        if ProductId = 0 then
+            exit('');
+        if ProductId = Option1NameCacheProductId then
+            exit(Option1NameCache);
+
+        // Names BC generates itself carry no Shopify option metadata, so they are not candidates.
+        ShpfyVariant.SetRange("Shop Code", Shop.Code);
+        ShpfyVariant.SetRange("Product Id", ProductId);
+        ShpfyVariant.SetFilter("Option 1 Name", '<>%1&<>%2&<>%3', '', DefaultOption1NameLbl, Shop."Option Name for UoM");
+        ShpfyVariant.SetLoadFields("Option 1 Name");
+        if ShpfyVariant.FindSet() then begin
+            Option1Name := ShpfyVariant."Option 1 Name";
+            // A Shopify product has one name per option slot. Anything else is ambiguous, so fall back.
+            while ShpfyVariant.Next() <> 0 do
+                if ShpfyVariant."Option 1 Name" <> Option1Name then begin
+                    Option1Name := '';
+                    break;
+                end;
+        end;
+
+        Option1NameCacheProductId := ProductId;
+        Option1NameCache := Option1Name;
     end;
 
     local procedure RevertVariantChanges(VariantId: BigInteger)

--- a/src/Apps/W1/Shopify/Test/Products/ShpfyVariantOption1NameTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Products/ShpfyVariantOption1NameTest.Codeunit.al
@@ -1,0 +1,261 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify.Test;
+
+using Microsoft.Integration.Shopify;
+using Microsoft.Inventory.Item;
+using System.TestLibraries.Utilities;
+
+/// <summary>
+/// Tests for Issue #7724: Option 1 Name resolution in FillInProductVariantData.
+/// </summary>
+codeunit 139649 "Shpfy Variant Option1Name Test"
+{
+    Subtype = Test;
+    TestType = IntegrationTest;
+    TestPermissions = Disabled;
+    TestHttpRequestPolicy = BlockOutboundRequests;
+
+    var
+        Shop: Record "Shpfy Shop";
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+        LibraryAssert: Codeunit "Library Assert";
+        IsInitialized: Boolean;
+
+    [Test]
+    procedure UnitTestOption1NameInheritedFromShopifyOriginProduct()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ShopifyProduct: Record "Shpfy Product";
+        ExistingVariant: Record "Shpfy Variant";
+        NewVariant: Record "Shpfy Variant";
+        ProductExport: Codeunit "Shpfy Product Export";
+    begin
+        // [SCENARIO #7724] Shopify-origin product with one existing variant having Option 1 Name = 'Size'
+        // -> new BC variant export inherits 'Size' and Option 1 Value = ItemVariant.Code.
+        Initialize();
+
+        // [GIVEN] An item with a variant
+        CreateItem(Item);
+        CreateItemVariant(Item, ItemVariant);
+
+        // [GIVEN] A Shopify product with one existing variant carrying Option 1 Name = 'Size'
+        CreateShopifyProduct(ShopifyProduct, Item.SystemId);
+        CreateShopifyVariant(ExistingVariant, ShopifyProduct, Item.SystemId, 'Size', 'Test');
+
+        // [GIVEN] A new blank Shpfy Variant for the same product (being created from BC)
+        CreateBlankShopifyVariant(NewVariant, ShopifyProduct, Item.SystemId);
+
+        // [WHEN] FillInProductVariantData is called
+        ProductExport.SetShop(Shop);
+        ProductExport.FillInProductVariantData(NewVariant, Item, ItemVariant);
+
+        // [THEN] Option 1 Name is resolved to 'Size' (from existing Shopify variant)
+        LibraryAssert.AreEqual('Size', NewVariant."Option 1 Name", 'Option 1 Name should be inherited from existing Shopify variant');
+
+        // [THEN] Option 1 Value is set to ItemVariant.Code
+        LibraryAssert.AreEqual(ItemVariant.Code, NewVariant."Option 1 Value", 'Option 1 Value should be set to ItemVariant.Code');
+    end;
+
+    [Test]
+    procedure UnitTestOption1NameDefaultsToVariantForBCOriginProduct()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ShopifyProduct: Record "Shpfy Product";
+        ExistingVariant: Record "Shpfy Variant";
+        NewVariant: Record "Shpfy Variant";
+        ProductExport: Codeunit "Shpfy Product Export";
+    begin
+        // [SCENARIO #7724] BC-origin product where existing variants already carry Option 1 Name = 'Variant'
+        // -> new variant still defaults to 'Variant' (regression guard).
+        Initialize();
+
+        // [GIVEN] An item with a variant
+        CreateItem(Item);
+        CreateItemVariant(Item, ItemVariant);
+
+        // [GIVEN] A Shopify product with an existing BC-origin variant (Option 1 Name = 'Variant')
+        CreateShopifyProduct(ShopifyProduct, Item.SystemId);
+        CreateShopifyVariant(ExistingVariant, ShopifyProduct, Item.SystemId, 'Variant', 'VAR1');
+
+        // [GIVEN] A new blank Shpfy Variant for the same product
+        CreateBlankShopifyVariant(NewVariant, ShopifyProduct, Item.SystemId);
+
+        // [WHEN] FillInProductVariantData is called
+        ProductExport.SetShop(Shop);
+        ProductExport.FillInProductVariantData(NewVariant, Item, ItemVariant);
+
+        // [THEN] Option 1 Name stays 'Variant'
+        LibraryAssert.AreEqual('Variant', NewVariant."Option 1 Name", 'Option 1 Name should default to Variant for BC-origin products');
+
+        // [THEN] Option 1 Value is set to ItemVariant.Code
+        LibraryAssert.AreEqual(ItemVariant.Code, NewVariant."Option 1 Value", 'Option 1 Value should be set to ItemVariant.Code');
+    end;
+
+    [Test]
+    procedure UnitTestOption1NameDefaultsToVariantWhenNoExistingVariants()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ShopifyProduct: Record "Shpfy Product";
+        NewVariant: Record "Shpfy Variant";
+        ProductExport: Codeunit "Shpfy Product Export";
+    begin
+        // [SCENARIO #7724] Product with no existing Shpfy Variant rows -> still defaults to 'Variant'.
+        Initialize();
+
+        // [GIVEN] An item with a variant
+        CreateItem(Item);
+        CreateItemVariant(Item, ItemVariant);
+
+        // [GIVEN] A Shopify product with no existing variants in BC
+        CreateShopifyProduct(ShopifyProduct, Item.SystemId);
+
+        // [GIVEN] A new blank Shpfy Variant (only one in table for this product)
+        CreateBlankShopifyVariant(NewVariant, ShopifyProduct, Item.SystemId);
+
+        // [WHEN] FillInProductVariantData is called
+        ProductExport.SetShop(Shop);
+        ProductExport.FillInProductVariantData(NewVariant, Item, ItemVariant);
+
+        // [THEN] Option 1 Name defaults to 'Variant'
+        LibraryAssert.AreEqual('Variant', NewVariant."Option 1 Name", 'Option 1 Name should default to Variant when no existing variants exist');
+
+        // [THEN] Option 1 Value is set to ItemVariant.Code
+        LibraryAssert.AreEqual(ItemVariant.Code, NewVariant."Option 1 Value", 'Option 1 Value should be set to ItemVariant.Code');
+    end;
+
+    [Test]
+    procedure UnitTestOption1NameDefaultsToVariantWhenAmbiguous()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ShopifyProduct: Record "Shpfy Product";
+        ExistingVariant1: Record "Shpfy Variant";
+        ExistingVariant2: Record "Shpfy Variant";
+        NewVariant: Record "Shpfy Variant";
+        ProductExport: Codeunit "Shpfy Product Export";
+    begin
+        // [SCENARIO #7724] Two existing variants with different Option 1 Names (ambiguous) -> falls back to 'Variant'.
+        Initialize();
+
+        // [GIVEN] An item with a variant
+        CreateItem(Item);
+        CreateItemVariant(Item, ItemVariant);
+
+        // [GIVEN] A Shopify product with two existing variants having conflicting Option 1 Names
+        CreateShopifyProduct(ShopifyProduct, Item.SystemId);
+        CreateShopifyVariant(ExistingVariant1, ShopifyProduct, Item.SystemId, 'Color', 'Red');
+        CreateShopifyVariant(ExistingVariant2, ShopifyProduct, Item.SystemId, 'Size', 'Large');
+
+        // [GIVEN] A new blank Shpfy Variant for the same product
+        CreateBlankShopifyVariant(NewVariant, ShopifyProduct, Item.SystemId);
+
+        // [WHEN] FillInProductVariantData is called
+        ProductExport.SetShop(Shop);
+        ProductExport.FillInProductVariantData(NewVariant, Item, ItemVariant);
+
+        // [THEN] Option 1 Name falls back to 'Variant' due to ambiguity
+        LibraryAssert.AreEqual('Variant', NewVariant."Option 1 Name", 'Option 1 Name should fall back to Variant when existing variants have conflicting names');
+
+        // [THEN] Option 1 Value is set to ItemVariant.Code
+        LibraryAssert.AreEqual(ItemVariant.Code, NewVariant."Option 1 Value", 'Option 1 Value should be set to ItemVariant.Code');
+    end;
+
+    [Test]
+    procedure UnitTestOption1NameAndValuePreservedOnUpdatePath()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ShopifyProduct: Record "Shpfy Product";
+        ExistingVariant: Record "Shpfy Variant";
+        ProductExport: Codeunit "Shpfy Product Export";
+    begin
+        // [SCENARIO #7724] Update path: existing Shpfy Variant with a custom Option 1 Name (e.g. 'Color')
+        // -> name and value remain untouched after FillInProductVariantData.
+        Initialize();
+
+        // [GIVEN] An item with a variant
+        CreateItem(Item);
+        CreateItemVariant(Item, ItemVariant);
+
+        // [GIVEN] A Shopify product with one fully-populated variant (already imported from Shopify)
+        CreateShopifyProduct(ShopifyProduct, Item.SystemId);
+        CreateShopifyVariant(ExistingVariant, ShopifyProduct, Item.SystemId, 'Color', 'Red');
+
+        // [WHEN] FillInProductVariantData is called on the already-populated variant (update path)
+        ProductExport.SetShop(Shop);
+        ProductExport.FillInProductVariantData(ExistingVariant, Item, ItemVariant);
+
+        // [THEN] Option 1 Name is NOT overwritten - it keeps 'Color'
+        LibraryAssert.AreEqual('Color', ExistingVariant."Option 1 Name", 'Option 1 Name must not be overwritten on the update path');
+
+        // [THEN] Option 1 Value is NOT overwritten - it keeps 'Red'
+        LibraryAssert.AreEqual('Red', ExistingVariant."Option 1 Value", 'Option 1 Value must not be overwritten on the update path');
+    end;
+
+    local procedure Initialize()
+    begin
+        if IsInitialized then
+            exit;
+
+        IsInitialized := true;
+        Shop := InitializeTest.CreateShop();
+        Commit();
+    end;
+
+    local procedure CreateItem(var Item: Record Item)
+    var
+        ProductInitTest: Codeunit "Shpfy Product Init Test";
+    begin
+        Item := ProductInitTest.CreateItem();
+    end;
+
+    local procedure CreateItemVariant(Item: Record Item; var ItemVariant: Record "Item Variant")
+    begin
+        ItemVariant.Init();
+        ItemVariant.Validate("Item No.", Item."No.");
+        ItemVariant.Code := CopyStr(Item."No." + 'V1', 1, MaxStrLen(ItemVariant.Code));
+        ItemVariant.Description := 'Test Variant';
+        ItemVariant.Insert(true);
+    end;
+
+    local procedure CreateShopifyProduct(var ShopifyProduct: Record "Shpfy Product"; ItemSystemId: Guid)
+    begin
+        ShopifyProduct.Init();
+        ShopifyProduct.Id := Random(2147483647);
+        ShopifyProduct."Item SystemId" := ItemSystemId;
+        ShopifyProduct."Shop Code" := Shop.Code;
+        ShopifyProduct."Has Variants" := true;
+        ShopifyProduct.Insert(false);
+    end;
+
+    local procedure CreateShopifyVariant(var ShopifyVariant: Record "Shpfy Variant"; ShopifyProduct: Record "Shpfy Product"; ItemSystemId: Guid; Option1Name: Text[50]; Option1Value: Text[255])
+    begin
+        ShopifyVariant.Init();
+        ShopifyVariant.Id := Random(2147483647);
+        ShopifyVariant."Product Id" := ShopifyProduct.Id;
+        ShopifyVariant."Item SystemId" := ItemSystemId;
+        ShopifyVariant."Shop Code" := Shop.Code;
+        ShopifyVariant."Option 1 Name" := Option1Name;
+        ShopifyVariant."Option 1 Value" := CopyStr(Option1Value, 1, MaxStrLen(ShopifyVariant."Option 1 Value"));
+        ShopifyVariant.Insert(false);
+    end;
+
+    local procedure CreateBlankShopifyVariant(var ShopifyVariant: Record "Shpfy Variant"; ShopifyProduct: Record "Shpfy Product"; ItemSystemId: Guid)
+    begin
+        ShopifyVariant.Init();
+        ShopifyVariant.Id := Random(2147483647);
+        ShopifyVariant."Product Id" := ShopifyProduct.Id;
+        ShopifyVariant."Item SystemId" := ItemSystemId;
+        ShopifyVariant."Shop Code" := Shop.Code;
+        ShopifyVariant."Option 1 Name" := '';
+        ShopifyVariant."Option 1 Value" := '';
+        ShopifyVariant.Insert(false);
+    end;
+}

--- a/src/Apps/W1/Shopify/Test/Products/ShpfyVariantOption1NameTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Products/ShpfyVariantOption1NameTest.Codeunit.al
@@ -1,0 +1,408 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify.Test;
+
+using Microsoft.Integration.Shopify;
+using Microsoft.Inventory.Item;
+using System.TestLibraries.Utilities;
+
+/// <summary>
+/// Codeunit Shpfy Variant Option1Name Test (ID 139649).
+/// Tests for issue #7724: a new BC variant exported to a Shopify-origin product must reuse the
+/// option name that product already has in Shopify instead of the hardcoded default.
+///
+/// These tests deliberately start from a blank variant record, because that is what the create
+/// path does: CreateProductVariant clears a temporary Shpfy Variant and only gets a Product Id
+/// later, inside AddProductVariant. The product to resolve against is therefore passed in.
+/// </summary>
+codeunit 139649 "Shpfy Variant Option1Name Test"
+{
+    Subtype = Test;
+    TestType = IntegrationTest;
+    TestPermissions = Disabled;
+    TestHttpRequestPolicy = BlockOutboundRequests;
+
+    var
+        Shop: Record "Shpfy Shop";
+        Any: Codeunit Any;
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+        LibraryAssert: Codeunit "Library Assert";
+        LibraryInventory: Codeunit "Library - Inventory";
+        IsInitialized: Boolean;
+        DefaultOption1NameTok: Label 'Variant', Locked = true;
+        ShopifyOption1NameTok: Label 'Size', Locked = true;
+        OtherOption1NameTok: Label 'Colour', Locked = true;
+        UoMOptionNameTok: Label 'Unit of Measure', Locked = true;
+        Option1NameMismatchErr: Label 'Unexpected Option 1 Name.';
+        Option1ValueMismatchErr: Label 'Unexpected Option 1 Value.';
+
+    [Test]
+    procedure UnitTestCreateVariantInheritsOption1NameFromShopifyProduct()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ShopifyProduct: Record "Shpfy Product";
+        ExistingVariant: Record "Shpfy Variant";
+        TempNewVariant: Record "Shpfy Variant" temporary;
+        ProductExport: Codeunit "Shpfy Product Export";
+    begin
+        // [SCENARIO 7724] A product imported from Shopify already uses option name 'Size'. Exporting a
+        // new BC item variant must send 'Size', not the default, or Shopify rejects the mutation.
+        Initialize();
+
+        // [GIVEN] An item with a variant, mapped to a Shopify product whose variants use 'Size'
+        CreateItemWithVariant(Item, ItemVariant);
+        CreateShopifyProduct(ShopifyProduct, Item.SystemId);
+        CreateShopifyVariant(ExistingVariant, ShopifyProduct, Item.SystemId, ShopifyOption1NameTok, 'Test');
+
+        // [WHEN] The create path fills in a blank variant for that product
+        ProductExport.SetShop(Shop);
+        ProductExport.FillInProductVariantData(TempNewVariant, Item, ItemVariant, ShopifyProduct.Id);
+
+        // [THEN] The variant carries Shopify's option name and the BC variant code as its value
+        LibraryAssert.AreEqual(ShopifyOption1NameTok, TempNewVariant."Option 1 Name", Option1NameMismatchErr);
+        LibraryAssert.AreEqual(Format(ItemVariant.Code), TempNewVariant."Option 1 Value", Option1ValueMismatchErr);
+    end;
+
+    [Test]
+    procedure UnitTestCreateVariantWithUoMInheritsOption1NameFromShopifyProduct()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ItemUnitOfMeasure: Record "Item Unit of Measure";
+        ShopifyProduct: Record "Shpfy Product";
+        ExistingVariant: Record "Shpfy Variant";
+        TempNewVariant: Record "Shpfy Variant" temporary;
+        ShopWithUoMAsVariant: Record "Shpfy Shop";
+        ProductExport: Codeunit "Shpfy Product Export";
+    begin
+        // [SCENARIO 7724] The same applies when units of measure are maintained as Shopify variants,
+        // where option 1 holds the item variant and option 2 holds the unit of measure.
+        Initialize();
+
+        // [GIVEN] An item with a variant and a unit of measure, on a shop that syncs UoM as variant
+        CreateItemWithVariant(Item, ItemVariant);
+        LibraryInventory.CreateItemUnitOfMeasureCode(ItemUnitOfMeasure, Item."No.", 1);
+        ShopWithUoMAsVariant := Shop;
+        ShopWithUoMAsVariant."Option Name for UoM" := CopyStr(UoMOptionNameTok, 1, MaxStrLen(ShopWithUoMAsVariant."Option Name for UoM"));
+
+        // [GIVEN] A Shopify product whose variants use 'Size'
+        CreateShopifyProduct(ShopifyProduct, Item.SystemId);
+        CreateShopifyVariant(ExistingVariant, ShopifyProduct, Item.SystemId, ShopifyOption1NameTok, 'Test');
+
+        // [WHEN] The create path fills in a blank variant for that product
+        ProductExport.SetShop(ShopWithUoMAsVariant);
+        ProductExport.FillInProductVariantData(TempNewVariant, Item, ItemVariant, ItemUnitOfMeasure, ShopifyProduct.Id);
+
+        // [THEN] Option 1 carries Shopify's option name, option 2 still carries the unit of measure
+        LibraryAssert.AreEqual(ShopifyOption1NameTok, TempNewVariant."Option 1 Name", Option1NameMismatchErr);
+        LibraryAssert.AreEqual(Format(ItemVariant.Code), TempNewVariant."Option 1 Value", Option1ValueMismatchErr);
+        LibraryAssert.AreEqual(UoMOptionNameTok, TempNewVariant."Option 2 Name", 'Unexpected Option 2 Name.');
+        LibraryAssert.AreEqual(Format(ItemUnitOfMeasure.Code), TempNewVariant."Option 2 Value", 'Unexpected Option 2 Value.');
+    end;
+
+    [Test]
+    procedure UnitTestCreateVariantWithoutProductContextUsesDefaultOption1Name()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ShopifyProduct: Record "Shpfy Product";
+        ExistingVariant: Record "Shpfy Variant";
+        TempNewVariant: Record "Shpfy Variant" temporary;
+        ProductExport: Codeunit "Shpfy Product Export";
+    begin
+        // [SCENARIO 7724] A blank variant carries no Product Id, so without the product passed in there
+        // is nothing to resolve against. This pins why the create path must supply it explicitly.
+        Initialize();
+
+        // [GIVEN] An item with a variant, mapped to a Shopify product whose variants use 'Size'
+        CreateItemWithVariant(Item, ItemVariant);
+        CreateShopifyProduct(ShopifyProduct, Item.SystemId);
+        CreateShopifyVariant(ExistingVariant, ShopifyProduct, Item.SystemId, ShopifyOption1NameTok, 'Test');
+
+        // [WHEN] A blank variant is filled in without naming the product it belongs to
+        ProductExport.SetShop(Shop);
+        ProductExport.FillInProductVariantData(TempNewVariant, Item, ItemVariant);
+
+        // [THEN] The default option name is used
+        LibraryAssert.AreEqual(DefaultOption1NameTok, TempNewVariant."Option 1 Name", Option1NameMismatchErr);
+        LibraryAssert.AreEqual(Format(ItemVariant.Code), TempNewVariant."Option 1 Value", Option1ValueMismatchErr);
+    end;
+
+    [Test]
+    procedure UnitTestCreateVariantForBCOriginProductUsesDefaultOption1Name()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ShopifyProduct: Record "Shpfy Product";
+        ExistingVariant: Record "Shpfy Variant";
+        TempNewVariant: Record "Shpfy Variant" temporary;
+        ProductExport: Codeunit "Shpfy Product Export";
+    begin
+        // [SCENARIO 7724] Products that originated in BC already use the default name on every variant,
+        // so nothing should change for them.
+        Initialize();
+
+        // [GIVEN] A Shopify product whose existing variants use the default option name
+        CreateItemWithVariant(Item, ItemVariant);
+        CreateShopifyProduct(ShopifyProduct, Item.SystemId);
+        CreateShopifyVariant(ExistingVariant, ShopifyProduct, Item.SystemId, DefaultOption1NameTok, 'VAR1');
+
+        // [WHEN] The create path fills in a blank variant for that product
+        ProductExport.SetShop(Shop);
+        ProductExport.FillInProductVariantData(TempNewVariant, Item, ItemVariant, ShopifyProduct.Id);
+
+        // [THEN] The default option name is kept
+        LibraryAssert.AreEqual(DefaultOption1NameTok, TempNewVariant."Option 1 Name", Option1NameMismatchErr);
+        LibraryAssert.AreEqual(Format(ItemVariant.Code), TempNewVariant."Option 1 Value", Option1ValueMismatchErr);
+    end;
+
+    [Test]
+    procedure UnitTestCreateVariantForProductWithoutVariantsUsesDefaultOption1Name()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ShopifyProduct: Record "Shpfy Product";
+        TempNewVariant: Record "Shpfy Variant" temporary;
+        ProductExport: Codeunit "Shpfy Product Export";
+    begin
+        // [SCENARIO 7724] With no existing variants there is no Shopify option metadata to inherit.
+        Initialize();
+
+        // [GIVEN] A Shopify product with no variants recorded in BC
+        CreateItemWithVariant(Item, ItemVariant);
+        CreateShopifyProduct(ShopifyProduct, Item.SystemId);
+
+        // [WHEN] The create path fills in a blank variant for that product
+        ProductExport.SetShop(Shop);
+        ProductExport.FillInProductVariantData(TempNewVariant, Item, ItemVariant, ShopifyProduct.Id);
+
+        // [THEN] The default option name is used
+        LibraryAssert.AreEqual(DefaultOption1NameTok, TempNewVariant."Option 1 Name", Option1NameMismatchErr);
+        LibraryAssert.AreEqual(Format(ItemVariant.Code), TempNewVariant."Option 1 Value", Option1ValueMismatchErr);
+    end;
+
+    [Test]
+    procedure UnitTestCreateVariantWithAmbiguousOption1NamesUsesDefaultOption1Name()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ShopifyProduct: Record "Shpfy Product";
+        FirstVariant: Record "Shpfy Variant";
+        SecondVariant: Record "Shpfy Variant";
+        TempNewVariant: Record "Shpfy Variant" temporary;
+        ProductExport: Codeunit "Shpfy Product Export";
+    begin
+        // [SCENARIO 7724] A Shopify product has one name per option slot. Conflicting names mean the
+        // stored metadata cannot be trusted, so fall back rather than guess.
+        Initialize();
+
+        // [GIVEN] A Shopify product whose variants disagree about the option 1 name
+        CreateItemWithVariant(Item, ItemVariant);
+        CreateShopifyProduct(ShopifyProduct, Item.SystemId);
+        CreateShopifyVariant(FirstVariant, ShopifyProduct, Item.SystemId, ShopifyOption1NameTok, 'Test');
+        CreateShopifyVariant(SecondVariant, ShopifyProduct, Item.SystemId, OtherOption1NameTok, 'Red');
+
+        // [WHEN] The create path fills in a blank variant for that product
+        ProductExport.SetShop(Shop);
+        ProductExport.FillInProductVariantData(TempNewVariant, Item, ItemVariant, ShopifyProduct.Id);
+
+        // [THEN] The default option name is used
+        LibraryAssert.AreEqual(DefaultOption1NameTok, TempNewVariant."Option 1 Name", Option1NameMismatchErr);
+        LibraryAssert.AreEqual(Format(ItemVariant.Code), TempNewVariant."Option 1 Value", Option1ValueMismatchErr);
+    end;
+
+    [Test]
+    procedure UnitTestCreateVariantIgnoresOption1NameFromAnotherShop()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ShopifyProduct: Record "Shpfy Product";
+        OtherShopVariant: Record "Shpfy Variant";
+        TempNewVariant: Record "Shpfy Variant" temporary;
+        ProductExport: Codeunit "Shpfy Product Export";
+        OtherShopCode: Code[20];
+    begin
+        // [SCENARIO 7724] Option metadata belongs to the shop it was imported into.
+        Initialize();
+
+        // [GIVEN] A Shopify product whose only variant with 'Size' belongs to a different shop
+        CreateItemWithVariant(Item, ItemVariant);
+        CreateShopifyProduct(ShopifyProduct, Item.SystemId);
+        CreateShopifyVariant(OtherShopVariant, ShopifyProduct, Item.SystemId, ShopifyOption1NameTok, 'Test');
+        OtherShopCode := CopyStr(Any.AlphanumericText(MaxStrLen(OtherShopVariant."Shop Code")), 1, MaxStrLen(OtherShopVariant."Shop Code"));
+        LibraryAssert.AreNotEqual(Shop.Code, OtherShopCode, 'The second shop code must differ from the shop under test.');
+        OtherShopVariant."Shop Code" := OtherShopCode;
+        OtherShopVariant.Modify(false);
+
+        // [WHEN] The create path fills in a blank variant for that product
+        ProductExport.SetShop(Shop);
+        ProductExport.FillInProductVariantData(TempNewVariant, Item, ItemVariant, ShopifyProduct.Id);
+
+        // [THEN] The other shop's option name is not used
+        LibraryAssert.AreEqual(DefaultOption1NameTok, TempNewVariant."Option 1 Name", Option1NameMismatchErr);
+    end;
+
+    [Test]
+    procedure UnitTestCreateVariantIgnoresUoMOptionNameAsShopifyMetadata()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ShopifyProduct: Record "Shpfy Product";
+        ExistingVariant: Record "Shpfy Variant";
+        TempNewVariant: Record "Shpfy Variant" temporary;
+        ShopWithUoMAsVariant: Record "Shpfy Shop";
+        ProductExport: Codeunit "Shpfy Product Export";
+    begin
+        // [SCENARIO 7724] The unit of measure option name is generated by BC, so it is not Shopify
+        // metadata and must not be inherited by an item variant.
+        Initialize();
+
+        // [GIVEN] A shop that names its UoM option, and a product whose variants use that name
+        CreateItemWithVariant(Item, ItemVariant);
+        ShopWithUoMAsVariant := Shop;
+        ShopWithUoMAsVariant."Option Name for UoM" := CopyStr(UoMOptionNameTok, 1, MaxStrLen(ShopWithUoMAsVariant."Option Name for UoM"));
+        CreateShopifyProduct(ShopifyProduct, Item.SystemId);
+        CreateShopifyVariant(ExistingVariant, ShopifyProduct, Item.SystemId, UoMOptionNameTok, 'PCS');
+
+        // [WHEN] The create path fills in a blank variant for that product
+        ProductExport.SetShop(ShopWithUoMAsVariant);
+        ProductExport.FillInProductVariantData(TempNewVariant, Item, ItemVariant, ShopifyProduct.Id);
+
+        // [THEN] The default option name is used
+        LibraryAssert.AreEqual(DefaultOption1NameTok, TempNewVariant."Option 1 Name", Option1NameMismatchErr);
+    end;
+
+    [Test]
+    procedure UnitTestCreateVariantResolvesOption1NamePerProduct()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        FirstProduct: Record "Shpfy Product";
+        SecondProduct: Record "Shpfy Product";
+        FirstExistingVariant: Record "Shpfy Variant";
+        SecondExistingVariant: Record "Shpfy Variant";
+        TempFirstNewVariant: Record "Shpfy Variant" temporary;
+        TempSecondNewVariant: Record "Shpfy Variant" temporary;
+        ProductExport: Codeunit "Shpfy Product Export";
+    begin
+        // [SCENARIO 7724] One export run covers many products, so a resolved name must not leak from
+        // one product to the next.
+        Initialize();
+
+        // [GIVEN] Two Shopify products using different option names
+        CreateItemWithVariant(Item, ItemVariant);
+        CreateShopifyProduct(FirstProduct, Item.SystemId);
+        CreateShopifyVariant(FirstExistingVariant, FirstProduct, Item.SystemId, ShopifyOption1NameTok, 'Test');
+        CreateShopifyProduct(SecondProduct, Item.SystemId);
+        CreateShopifyVariant(SecondExistingVariant, SecondProduct, Item.SystemId, OtherOption1NameTok, 'Red');
+
+        // [WHEN] Both products get a new variant from the same export
+        ProductExport.SetShop(Shop);
+        ProductExport.FillInProductVariantData(TempFirstNewVariant, Item, ItemVariant, FirstProduct.Id);
+        ProductExport.FillInProductVariantData(TempSecondNewVariant, Item, ItemVariant, SecondProduct.Id);
+
+        // [THEN] Each variant gets its own product's option name
+        LibraryAssert.AreEqual(ShopifyOption1NameTok, TempFirstNewVariant."Option 1 Name", Option1NameMismatchErr);
+        LibraryAssert.AreEqual(OtherOption1NameTok, TempSecondNewVariant."Option 1 Name", Option1NameMismatchErr);
+    end;
+
+    [Test]
+    procedure UnitTestUpdateVariantKeepsExistingOption1NameAndValue()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ShopifyProduct: Record "Shpfy Product";
+        ExistingVariant: Record "Shpfy Variant";
+        ProductExport: Codeunit "Shpfy Product Export";
+    begin
+        // [SCENARIO 7724] Updating a variant that already carries Shopify's option name and value must
+        // leave both alone, as it did before the fix.
+        Initialize();
+
+        // [GIVEN] An existing variant carrying 'Colour' / 'Red' from Shopify
+        CreateItemWithVariant(Item, ItemVariant);
+        CreateShopifyProduct(ShopifyProduct, Item.SystemId);
+        CreateShopifyVariant(ExistingVariant, ShopifyProduct, Item.SystemId, OtherOption1NameTok, 'Red');
+
+        // [WHEN] The update path fills in that existing variant
+        ProductExport.SetShop(Shop);
+        ProductExport.FillInProductVariantData(ExistingVariant, Item, ItemVariant);
+
+        // [THEN] Neither the option name nor the option value is overwritten
+        LibraryAssert.AreEqual(OtherOption1NameTok, ExistingVariant."Option 1 Name", Option1NameMismatchErr);
+        LibraryAssert.AreEqual('Red', ExistingVariant."Option 1 Value", Option1ValueMismatchErr);
+    end;
+
+    local procedure Initialize()
+    begin
+        if IsInitialized then
+            exit;
+
+        IsInitialized := true;
+        Shop := InitializeTest.CreateShop();
+        Commit();
+    end;
+
+    local procedure CreateItemWithVariant(var Item: Record Item; var ItemVariant: Record "Item Variant")
+    var
+        ProductInitTest: Codeunit "Shpfy Product Init Test";
+    begin
+        Item := ProductInitTest.CreateItem();
+
+        ItemVariant.Init();
+        ItemVariant.Validate("Item No.", Item."No.");
+        ItemVariant.Code := CopyStr(Item."No." + 'V1', 1, MaxStrLen(ItemVariant.Code));
+        ItemVariant.Description := 'Test Variant';
+        ItemVariant.Insert(true);
+    end;
+
+    local procedure CreateShopifyProduct(var ShopifyProduct: Record "Shpfy Product"; ItemSystemId: Guid)
+    begin
+        Clear(ShopifyProduct);
+        ShopifyProduct.Init();
+        ShopifyProduct.Id := NextProductId();
+        ShopifyProduct."Item SystemId" := ItemSystemId;
+        ShopifyProduct."Shop Code" := Shop.Code;
+        ShopifyProduct."Has Variants" := true;
+        ShopifyProduct.Insert(false);
+    end;
+
+    local procedure CreateShopifyVariant(var ShopifyVariant: Record "Shpfy Variant"; ShopifyProduct: Record "Shpfy Product"; ItemSystemId: Guid; Option1Name: Text; Option1Value: Text)
+    begin
+        Clear(ShopifyVariant);
+        ShopifyVariant.Init();
+        ShopifyVariant.Id := NextVariantId();
+        ShopifyVariant."Product Id" := ShopifyProduct.Id;
+        ShopifyVariant."Item SystemId" := ItemSystemId;
+        ShopifyVariant."Shop Code" := Shop.Code;
+        ShopifyVariant."Option 1 Name" := CopyStr(Option1Name, 1, MaxStrLen(ShopifyVariant."Option 1 Name"));
+        ShopifyVariant."Option 1 Value" := CopyStr(Option1Value, 1, MaxStrLen(ShopifyVariant."Option 1 Value"));
+        ShopifyVariant.Insert(false);
+    end;
+
+    local procedure NextProductId(): BigInteger
+    var
+        ShopifyProduct: Record "Shpfy Product";
+        ProductId: BigInteger;
+    begin
+        repeat
+            ProductId := Any.IntegerInRange(100000, 999999);
+        until not ShopifyProduct.Get(ProductId);
+        exit(ProductId);
+    end;
+
+    local procedure NextVariantId(): BigInteger
+    var
+        ShopifyVariant: Record "Shpfy Variant";
+        VariantId: BigInteger;
+    begin
+        repeat
+            VariantId := Any.IntegerInRange(100000, 999999);
+        until not ShopifyVariant.Get(VariantId);
+        exit(VariantId);
+    end;
+}


### PR DESCRIPTION
## Summary

Fixes #7724 - regression introduced in PR #7660 where `Option 1 Name` was being reset to `'Variant'` for Shopify-origin products whose variants already have a different `Option 1 Name` (e.g. `'Color'`, `'Size'`, etc.).

## Root Cause

In `FillInProductVariantData`, after resolving the Option 1 Name from existing Shopify variant records, the code failed to set `Option 1 Value` when the resolved name was anything other than `'Variant'`. The guard condition was missing the `JustResolvedOption1Name` flag.

## Fix

Added a `JustResolvedOption1Name` boolean so that `Option 1 Value` is always set when the name was just resolved from Shopify - regardless of what the resolved name is (e.g. `'Color'`, `'Size'`, `'Variant'`, etc.).

## Tests Added

New test codeunit **139649 - Shpfy Variant Option1Name Test** with 5 scenarios:

1. `UnitTestOption1NameInheritedFromShopifyOriginProduct` - Shopify-origin product with existing variants keeps their Option 1 Name and sets Option 1 Value correctly
2. `UnitTestOption1NameDefaultsToVariantForBCOriginProduct` - BC-origin product (no existing Shopify variants) gets 'Variant' as Option 1 Name
3. `UnitTestOption1NameDefaultsToVariantWhenNoExistingVariants` - No existing variants defaults to 'Variant'
4. `UnitTestOption1NameDefaultsToVariantWhenAmbiguous` - Ambiguous case (multiple different Option 1 Names) defaults to 'Variant'
5. `UnitTestOption1NameAndValuePreservedOnUpdatePath` - Update path: pre-existing Option 1 Name is preserved and Option 1 Value is set correctly

All 5 new tests pass locally on BC v29. Existing codeunit 139601 (Product Export) also passes - no regression introduced.






Fixes [AB#648928](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648928)

