### PR TITLE
[Subcontracting] Use purchase line quantity on creating WIP transfer logic

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Transfer/SubcTransferLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Transfer/SubcTransferLineExt.Codeunit.al
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
+using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Transfer;
 
 codeunit 99001544 "Subc. Transfer Line Ext."
@@ -32,6 +33,13 @@ codeunit 99001544 "Subc. Transfer Line Ext."
     local procedure OnValidateItemNoOnCopyFromTempTransLine_TransferLine(var TransferLine: Record "Transfer Line"; TempTransferLine: Record "Transfer Line")
     begin
         CopySubFieldsFromTempTransferLineToTransferLine(TransferLine, TempTransferLine);
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"Transfer Line", OnValidateUnitofMeasureCodeOnBeforeValidateQuantity, '', false, false)]
+    local procedure OnValidateUnitofMeasureCodeOnBeforeValidateQuantity(var TransferLine: Record "Transfer Line"; Item: Record Item; xTransferLine: Record "Transfer Line")
+    begin
+        if TransferLine."Transfer WIP Item" then
+            TransferLine."Qty. per Unit of Measure" := 0;
     end;
 
     local procedure CopySubFieldsFromTempTransferLineToTransferLine(var TransferLine: Record "Transfer Line"; TempTransferLine: Record "Transfer Line")

--- a/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcCreateTransfOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcCreateTransfOrder.Report.al
@@ -302,6 +302,8 @@ report 99001501 "Subc. Create Transf. Order"
         UOMManagement: Codeunit "Unit of Measure Management";
         TransferFromLoc: Code[10];
         WIPPreviousOperationNo: Code[10];
+        PurchLineQtyBase: Decimal;
+        QtyPerPurchUom: Decimal;
         WIPQtyBase: Decimal;
         WIPQtyInUOM: Decimal;
         WIPPreviousOperationNoDict: Dictionary of [Code[10], Code[10]];
@@ -320,7 +322,9 @@ report 99001501 "Subc. Create Transf. Order"
         if not CheckCreateWIPTransfer(PurchaseLine) then
             exit(false);
 
-        GetWIPTransferFromLocations(ProdOrderLine, ProdOrderRoutingLine, WIPSourceLocationList, WIPSourceQtyDict, WIPPreviousOperationNoDict);
+        PurchLineQtyBase := CalcPurchLineQtyBase(PurchaseLine, ProdOrderLine);
+
+        GetWIPTransferFromLocations(ProdOrderLine, ProdOrderRoutingLine, WIPSourceLocationList, WIPSourceQtyDict, WIPPreviousOperationNoDict, PurchLineQtyBase);
 
         if WIPSourceLocationList.Count() = 0 then
             exit(false);
@@ -328,14 +332,15 @@ report 99001501 "Subc. Create Transf. Order"
         if not InsertLine then
             exit(true);
 
-        Item.SetLoadFields("Base Unit of Measure", "Rounding Precision", Description, "Description 2");
+        Item.SetLoadFields("Base Unit of Measure");
         Item.Get(ProdOrderLine."Item No.");
+        QtyPerPurchUom := UOMManagement.GetQtyPerUnitOfMeasure(Item, PurchaseLine."Unit of Measure Code");
 
         foreach TransferFromLoc in WIPSourceLocationList do begin
             WIPQtyBase := WIPSourceQtyDict.Get(TransferFromLoc);
             WIPPreviousOperationNoDict.Get(TransferFromLoc, WIPPreviousOperationNo);
-            if ProdOrderLine."Qty. per Unit of Measure" <> 0 then
-                WIPQtyInUOM := Round(WIPQtyBase / ProdOrderLine."Qty. per Unit of Measure", UOMManagement.QtyRndPrecision())
+            if QtyPerPurchUom <> 0 then
+                WIPQtyInUOM := Round(WIPQtyBase / QtyPerPurchUom, UOMManagement.QtyRndPrecision())
             else
                 WIPQtyInUOM := Round(WIPQtyBase, UOMManagement.QtyRndPrecision());
             if WIPQtyInUOM > 0 then begin
@@ -359,7 +364,7 @@ report 99001501 "Subc. Create Transf. Order"
         TransferLine.Validate("Item No.", ProdOrderLine."Item No.");
         if ProdOrderLine."Variant Code" <> '' then
             TransferLine.Validate("Variant Code", ProdOrderLine."Variant Code");
-        TransferLine.Validate("Unit of Measure Code", ProdOrderLine."Unit of Measure Code");
+        TransferLine.Validate("Unit of Measure Code", PurchaseLine."Unit of Measure Code");
         TransferLine.Validate("Transfer WIP Item", true);
         TransferLine.Validate(Quantity, WIPQty);
 
@@ -382,7 +387,7 @@ report 99001501 "Subc. Create Transf. Order"
         TransferLine.Modify();
     end;
 
-    local procedure GetWIPTransferFromLocations(ProdOrderLine: Record "Prod. Order Line"; ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var WIPSourceLocationList: List of [Code[10]]; var WIPSourceQtyDict: Dictionary of [Code[10], Decimal]; var WIPPreviousOperationNoDict: Dictionary of [Code[10], Code[10]])
+    local procedure GetWIPTransferFromLocations(ProdOrderLine: Record "Prod. Order Line"; ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var WIPSourceLocationList: List of [Code[10]]; var WIPSourceQtyDict: Dictionary of [Code[10], Decimal]; var WIPPreviousOperationNoDict: Dictionary of [Code[10], Code[10]]; PurchLineQtyBase: Decimal)
     var
         PrevProdOrderRoutingLine: Record "Prod. Order Routing Line";
         LocCode: Code[10];
@@ -395,7 +400,7 @@ report 99001501 "Subc. Create Transf. Order"
             LocCode := ProdOrderLine."Location Code";
             if LocCode <> '' then begin
                 WIPSourceLocationList.Add(LocCode);
-                WIPSourceQtyDict.Add(LocCode, ProdOrderLine."Quantity (Base)");
+                WIPSourceQtyDict.Add(LocCode, PurchLineQtyBase);
                 WIPPreviousOperationNoDict.Add(LocCode, '');
             end;
             exit;
@@ -420,7 +425,7 @@ report 99001501 "Subc. Create Transf. Order"
                         Error(WIPItemTransferDifferentErr, PrevProdOrderRoutingLine.FieldCaption("Transfer WIP Item"));
 
                 GetWIPLocationAndQtyForPreviousOp(
-                    ProdOrderLine, PrevProdOrderRoutingLine, IsSerial, LocCode, WIPQtyBase);
+                    ProdOrderLine, PrevProdOrderRoutingLine, IsSerial, PurchLineQtyBase, LocCode, WIPQtyBase);
 
                 if (LocCode <> '') and (WIPQtyBase > 0) and (not WIPSourceQtyDict.ContainsKey(LocCode)) then begin
                     WIPSourceLocationList.Add(LocCode);
@@ -433,20 +438,20 @@ report 99001501 "Subc. Create Transf. Order"
             LocCode := ProdOrderLine."Location Code";
             if LocCode <> '' then begin
                 WIPSourceLocationList.Add(LocCode);
-                WIPSourceQtyDict.Add(LocCode, ProdOrderLine."Quantity (Base)");
+                WIPSourceQtyDict.Add(LocCode, PurchLineQtyBase);
                 WIPPreviousOperationNoDict.Add(LocCode, '');
             end;
         end;
     end;
 
-    local procedure GetWIPLocationAndQtyForPreviousOp(ProdOrderLine: Record "Prod. Order Line"; PrevProdOrderRoutingLine: Record "Prod. Order Routing Line"; IsSerial: Boolean; var LocationCode: Code[10]; var WIPQtyBase: Decimal)
+    local procedure GetWIPLocationAndQtyForPreviousOp(ProdOrderLine: Record "Prod. Order Line"; PrevProdOrderRoutingLine: Record "Prod. Order Routing Line"; IsSerial: Boolean; PurchLineQtyBase: Decimal; var LocationCode: Code[10]; var WIPQtyBase: Decimal)
     var
         WIPLedgerEntry: Record "Subcontractor WIP Ledger Entry";
         PrevVendor: Record Vendor;
         PrevWorkCenter: Record "Work Center";
     begin
         LocationCode := ProdOrderLine."Location Code";
-        WIPQtyBase := ProdOrderLine."Quantity (Base)";
+        WIPQtyBase := PurchLineQtyBase;
 
         if PrevProdOrderRoutingLine."Transfer WIP Item" then begin
             // Previous op has a subcontracting WIP transfer
@@ -482,10 +487,10 @@ report 99001501 "Subc. Create Transf. Order"
         ProdOrderLine: Record "Prod. Order Line";
         ProdOrderRoutingLine: Record "Prod. Order Routing Line";
         PurchaseHeader: Record "Purchase Header";
-        SubcontractorWIPLedgerEntry: Record "Subcontractor WIP Ledger Entry";
-        TransferLineToCheck: Record "Transfer Line";
         VendorFromPurchOrder: Record Vendor;
+        TransferLineToCheck: Record "Transfer Line";
         LocCode: Code[10];
+        PurchLineQtyBase: Decimal;
         TransferToLocationCode: Code[10];
         ExpectedQtyBase: Decimal;
         PostedWIPQtyBase: Decimal;
@@ -512,7 +517,9 @@ report 99001501 "Subc. Create Transf. Order"
         if not ProdOrderRoutingLine."Transfer WIP Item" then
             exit(false);
 
-        GetWIPTransferFromLocations(ProdOrderLine, ProdOrderRoutingLine, WIPSourceLocationList, WIPSourceQtyDict, WIPPreviousOperationNoDict);
+        PurchLineQtyBase := CalcPurchLineQtyBase(PurchaseLine, ProdOrderLine);
+
+        GetWIPTransferFromLocations(ProdOrderLine, ProdOrderRoutingLine, WIPSourceLocationList, WIPSourceQtyDict, WIPPreviousOperationNoDict, PurchLineQtyBase);
 
         ExpectedQtyBase := 0;
         foreach LocCode in WIPSourceLocationList do
@@ -532,16 +539,7 @@ report 99001501 "Subc. Create Transf. Order"
         if TransferToLocationCode = '' then
             exit(false);
 
-        SubcontractorWIPLedgerEntry.SetRange("Prod. Order Status", "Production Order Status"::Released);
-        SubcontractorWIPLedgerEntry.SetRange("Prod. Order No.", PurchaseLine."Prod. Order No.");
-        SubcontractorWIPLedgerEntry.SetRange("Prod. Order Line No.", PurchaseLine."Prod. Order Line No.");
-        SubcontractorWIPLedgerEntry.SetRange("Routing No.", PurchaseLine."Routing No.");
-        SubcontractorWIPLedgerEntry.SetRange("Routing Reference No.", PurchaseLine."Routing Reference No.");
-        SubcontractorWIPLedgerEntry.SetRange("Operation No.", PurchaseLine."Operation No.");
-        SubcontractorWIPLedgerEntry.SetRange("Location Code", TransferToLocationCode);
-        SubcontractorWIPLedgerEntry.SetRange("In Transit", false);
-        SubcontractorWIPLedgerEntry.CalcSums("Quantity (Base)");
-        PostedWIPQtyBase := SubcontractorWIPLedgerEntry."Quantity (Base)";
+        PostedWIPQtyBase := GetWIPQtyBase(PurchaseLine, TransferToLocationCode);
 
         if WIPPreviousOperationNoDict.Keys().Count() > 1 then
             foreach LocCode in WIPPreviousOperationNoDict.Keys() do
@@ -549,5 +547,33 @@ report 99001501 "Subc. Create Transf. Order"
                     exit(ExpectedQtyBase > 0);
 
         exit(PostedWIPQtyBase < ExpectedQtyBase);
+    end;
+
+    local procedure CalcPurchLineQtyBase(PurchaseLine: Record "Purchase Line"; ProdOrderLine: Record "Prod. Order Line"): Decimal
+    var
+        Item: Record Item;
+        UOMManagement: Codeunit "Unit of Measure Management";
+        QtyPerUom: Decimal;
+    begin
+        Item.SetLoadFields("Base Unit of Measure");
+        Item.Get(ProdOrderLine."Item No.");
+        QtyPerUom := UOMManagement.GetQtyPerUnitOfMeasure(Item, PurchaseLine."Unit of Measure Code");
+        exit(UOMManagement.CalcBaseQty(PurchaseLine.Quantity, QtyPerUom));
+    end;
+
+    local procedure GetWIPQtyBase(PurchaseLine: Record "Purchase Line"; LocationCode: Code[10]): Decimal
+    var
+        SubcontractorWIPLedgerEntry: Record "Subcontractor WIP Ledger Entry";
+    begin
+        SubcontractorWIPLedgerEntry.SetRange("Prod. Order Status", "Production Order Status"::Released);
+        SubcontractorWIPLedgerEntry.SetRange("Prod. Order No.", PurchaseLine."Prod. Order No.");
+        SubcontractorWIPLedgerEntry.SetRange("Prod. Order Line No.", PurchaseLine."Prod. Order Line No.");
+        SubcontractorWIPLedgerEntry.SetRange("Routing No.", PurchaseLine."Routing No.");
+        SubcontractorWIPLedgerEntry.SetRange("Routing Reference No.", PurchaseLine."Routing Reference No.");
+        SubcontractorWIPLedgerEntry.SetRange("Operation No.", PurchaseLine."Operation No.");
+        SubcontractorWIPLedgerEntry.SetRange("Location Code", LocationCode);
+        SubcontractorWIPLedgerEntry.SetRange("In Transit", false);
+        SubcontractorWIPLedgerEntry.CalcSums("Quantity (Base)");
+        exit(SubcontractorWIPLedgerEntry."Quantity (Base)");
     end;
 }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcCreateTransfOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcCreateTransfOrder.Report.al
@@ -301,7 +301,9 @@ report 99001501 "Subc. Create Transf. Order"
         ProdOrderRoutingLine: Record "Prod. Order Routing Line";
         UOMManagement: Codeunit "Unit of Measure Management";
         TransferFromLoc: Code[10];
+        TransferToLocCode: Code[10];
         WIPPreviousOperationNo: Code[10];
+        PostedWIPQtyBase: Decimal;
         PurchLineQtyBase: Decimal;
         QtyPerPurchUom: Decimal;
         WIPQtyBase: Decimal;
@@ -332,6 +334,11 @@ report 99001501 "Subc. Create Transf. Order"
         if not InsertLine then
             exit(true);
 
+        if WIPSourceLocationList.Count() = 1 then begin
+            GetTransferToLocationCodeForPurchaseHeader("Purchase Header", Vendor, TransferToLocCode);
+            PostedWIPQtyBase := GetWIPQtyBase(PurchaseLine, TransferToLocCode);
+        end;
+
         Item.SetLoadFields("Base Unit of Measure");
         Item.Get(ProdOrderLine."Item No.");
         QtyPerPurchUom := UOMManagement.GetQtyPerUnitOfMeasure(Item, PurchaseLine."Unit of Measure Code");
@@ -339,6 +346,9 @@ report 99001501 "Subc. Create Transf. Order"
         foreach TransferFromLoc in WIPSourceLocationList do begin
             WIPQtyBase := WIPSourceQtyDict.Get(TransferFromLoc);
             WIPPreviousOperationNoDict.Get(TransferFromLoc, WIPPreviousOperationNo);
+            if WIPSourceLocationList.Count() = 1 then
+                if WIPQtyBase > PurchLineQtyBase - PostedWIPQtyBase then
+                    WIPQtyBase := PurchLineQtyBase - PostedWIPQtyBase;
             if QtyPerPurchUom <> 0 then
                 WIPQtyInUOM := Round(WIPQtyBase / QtyPerPurchUom, UOMManagement.QtyRndPrecision())
             else

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1097,7 +1097,7 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         // [GIVEN] Verify the purchase line received the item's Purch. Unit of Measure (BOX)
         PurchaseLine.Validate("Unit of Measure Code", UnitOfMeasure.Code);
         PurchaseLine.Validate(Quantity, ProdOrderQty / BoxQtyPerPCS);
-        PurchaseLine.Modify();
+PurchaseLine.Modify(true);
 
         PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
 

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1120,6 +1120,172 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
             'WIP Transfer Line quantity must equal the purchase line quantity (in BOX).');
     end;
 
+    [Test]
+    [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
+    procedure WIPTransferPartiallyPostedTransfersRemainingQuantity()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProdOrderLine: Record "Prod. Order Line";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        WIPLedgerEntry: Record "Subcontractor WIP Ledger Entry";
+        TransferLine: Record "Transfer Line";
+        Vendor: Record Vendor;
+        WorkCenter: array[2] of Record "Work Center";
+        FullQty: Decimal;
+        AlreadyPostedQty: Decimal;
+        PurchaseHeaderPage: TestPage "Purchase Order";
+    begin
+        // [SCENARIO] When part of the WIP has already been posted at the vendor location,
+        // creating a Transfer Order to Subcontractor must only transfer the remaining
+        // quantity (FullQty - AlreadyPostedQty), not the full purchase line quantity.
+
+        // [GIVEN] Complete setup with Transfer WIP Item = true on the subcontracting routing line
+        Initialize();
+
+        SubcWarehouseLibrary.CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter, true);
+        SubcWarehouseLibrary.CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        SetTransferWIPItemOnRoutingLine(Item."Routing No.", WorkCenter[2]."No.", true);
+
+        // [GIVEN] Create and refresh production order with a quantity that allows a partial remainder
+        FullQty := LibraryRandom.RandIntInRange(6, 10);
+        LibraryManufacturing.CreateProductionOrder(
+            ProductionOrder, "Production Order Status"::Released,
+            ProductionOrder."Source Type"::Item, Item."No.", FullQty);
+        SetProdOrderLocationToCompSetupLocationAndRefresh(ProductionOrder);
+
+        // [GIVEN] Locate the Prod. Order line and the routing line
+        ProdOrderLine.SetRange(Status, "Production Order Status"::Released);
+        ProdOrderLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderLine.FindFirst();
+
+        ProdOrderRoutingLine.SetRange(Status, "Production Order Status"::Released);
+        ProdOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderRoutingLine.SetRange("Work Center No.", WorkCenter[2]."No.");
+        ProdOrderRoutingLine.FindFirst();
+
+        // [GIVEN] Create Subcontracting Purchase Order
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+
+        // [GIVEN] Simulate that a partial quantity has already been transferred and posted at the vendor location
+        AlreadyPostedQty := LibraryRandom.RandIntInRange(1, FullQty - 1);
+        Vendor.Get(WorkCenter[2]."Subcontractor No.");
+        SubcontractingMgmtLibrary.CreateWIPLedgerEntry(
+            WIPLedgerEntry, Item."No.", Vendor."Subc. Location Code",
+            ProductionOrder, ProdOrderLine, ProdOrderRoutingLine,
+            WorkCenter[2]."No.", AlreadyPostedQty, false);
+
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+
+        // [WHEN] Create Transfer Order to Subcontractor
+        PurchaseHeaderPage.OpenView();
+        PurchaseHeaderPage.GoToRecord(PurchaseHeader);
+        PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [THEN] Transfer line quantity equals only the remaining quantity
+        TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+        TransferLine.SetRange("Subc. Return Order", false);
+#pragma warning disable AA0210
+        TransferLine.SetRange("Transfer WIP Item", true);
+#pragma warning restore AA0210
+        Assert.RecordCount(TransferLine, 1);
+        TransferLine.FindFirst();
+        Assert.AreEqual(FullQty - AlreadyPostedQty, TransferLine.Quantity,
+            'WIP Transfer Line quantity must equal the remaining quantity (full qty minus already posted), not the full quantity.');
+    end;
+
+    [Test]
+    [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
+    procedure WIPTransferAfterQuantityIncreaseTransfersOnlyAdditionalQuantity()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProdOrderLine: Record "Prod. Order Line";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        WIPLedgerEntry: Record "Subcontractor WIP Ledger Entry";
+        TransferLine: Record "Transfer Line";
+        Vendor: Record Vendor;
+        WorkCenter: array[2] of Record "Work Center";
+        OriginalQty: Decimal;
+        ChangedQty: Decimal;
+        PurchaseHeaderPage: TestPage "Purchase Order";
+    begin
+        // [SCENARIO] When the purchase line quantity is increased after the original quantity
+        // has already been fully posted at the vendor location, creating a Transfer Order must
+        // only transfer the additional quantity (ChangedQty - OriginalQty), not the full new quantity.
+
+        // [GIVEN] Complete setup with Transfer WIP Item = true on the subcontracting routing line
+        Initialize();
+
+        SubcWarehouseLibrary.CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter, true);
+        SubcWarehouseLibrary.CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        SetTransferWIPItemOnRoutingLine(Item."Routing No.", WorkCenter[2]."No.", true);
+
+        // [GIVEN] Create and refresh production order with the original quantity
+        OriginalQty := LibraryRandom.RandIntInRange(3, 7);
+        LibraryManufacturing.CreateProductionOrder(
+            ProductionOrder, "Production Order Status"::Released,
+            ProductionOrder."Source Type"::Item, Item."No.", OriginalQty);
+        SetProdOrderLocationToCompSetupLocationAndRefresh(ProductionOrder);
+
+        // [GIVEN] Locate the Prod. Order line and routing line
+        ProdOrderLine.SetRange(Status, "Production Order Status"::Released);
+        ProdOrderLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderLine.FindFirst();
+
+        ProdOrderRoutingLine.SetRange(Status, "Production Order Status"::Released);
+        ProdOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderRoutingLine.SetRange("Work Center No.", WorkCenter[2]."No.");
+        ProdOrderRoutingLine.FindFirst();
+
+        // [GIVEN] Create Subcontracting Purchase Order
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+
+        // [GIVEN] Simulate that the original quantity has been fully posted at the vendor location
+        Vendor.Get(WorkCenter[2]."Subcontractor No.");
+        SubcontractingMgmtLibrary.CreateWIPLedgerEntry(
+            WIPLedgerEntry, Item."No.", Vendor."Subc. Location Code",
+            ProductionOrder, ProdOrderLine, ProdOrderRoutingLine,
+            WorkCenter[2]."No.", OriginalQty, false);
+
+        // [GIVEN] Increase the purchase line quantity beyond the already-posted amount
+        ChangedQty := OriginalQty + LibraryRandom.RandIntInRange(1, 5);
+        PurchaseLine.Validate(Quantity, ChangedQty);
+        PurchaseLine.Modify(true);
+
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+
+        // [WHEN] Create Transfer Order to Subcontractor
+        PurchaseHeaderPage.OpenView();
+        PurchaseHeaderPage.GoToRecord(PurchaseHeader);
+        PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [THEN] Transfer line quantity equals only the additional quantity (ChangedQty - OriginalQty)
+        TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+        TransferLine.SetRange("Subc. Return Order", false);
+#pragma warning disable AA0210
+        TransferLine.SetRange("Transfer WIP Item", true);
+#pragma warning restore AA0210
+        Assert.RecordCount(TransferLine, 1);
+        TransferLine.FindFirst();
+        Assert.AreEqual(ChangedQty - OriginalQty, TransferLine.Quantity,
+            'WIP Transfer Line quantity must equal only the additional quantity after the purchase line increase, not the full changed quantity.');
+    end;
+
     [PageHandler]
     procedure HandleTransferOrder(var TransfOrderPage: TestPage "Transfer Order")
     begin

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting.Test;
 
+using Microsoft.Foundation.UOM;
 using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Location;
 using Microsoft.Inventory.Requisition;
@@ -963,6 +964,160 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
                 (TransferLine."Item No." = FamilyItem[1]."No.") or (TransferLine."Item No." = FamilyItem[2]."No."),
                 'Each WIP Transfer Line must reference one of the two family items.');
         until TransferLine.Next() = 0;
+    end;
+
+    [Test]
+    [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
+    procedure WIPTransferQuantityFollowsChangedPurchaseLineQuantity()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        TransferLine: Record "Transfer Line";
+        WorkCenter: array[2] of Record "Work Center";
+        PurchaseHeaderPage: TestPage "Purchase Order";
+        OriginalQty: Decimal;
+        ChangedQty: Decimal;
+    begin
+        // [SCENARIO] When the purchase line quantity is changed from the original production order
+        // quantity, the WIP transfer line must use the updated purchase line quantity, not the
+        // original production order quantity.
+
+        // [GIVEN] Complete setup with Transfer WIP Item = true on the subcontracting routing line
+        Initialize();
+
+        SubcWarehouseLibrary.CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter, true);
+        SubcWarehouseLibrary.CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        SetTransferWIPItemOnRoutingLine(Item."Routing No.", WorkCenter[2]."No.", true);
+
+        // [GIVEN] Set up component transfer infrastructure (needed so TransferRoute can be created)
+        SubcWarehouseLibrary.UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateProdBomWithComponentSupplyMethod(Item, "Component Supply Method"::"Transfer to Vendor");
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        // [GIVEN] Create and refresh production order with the original quantity
+        OriginalQty := LibraryRandom.RandInt(5) + 2;
+        LibraryManufacturing.CreateProductionOrder(
+            ProductionOrder, "Production Order Status"::Released,
+            ProductionOrder."Source Type"::Item, Item."No.", OriginalQty);
+        SetProdOrderLocationToCompSetupLocationAndRefresh(ProductionOrder);
+        SubcontractingMgmtLibrary.CreateTransferRoute(WorkCenter[2], ProductionOrder);
+
+        // [GIVEN] Create Subcontracting Purchase Order (purchase line qty = OriginalQty initially)
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+
+        // [GIVEN] Change the purchase line quantity to a larger value
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+#pragma warning disable AA0210
+        PurchaseLine.SetRange("Work Center No.", WorkCenter[2]."No.");
+#pragma warning restore AA0210
+        PurchaseLine.FindFirst();
+        ChangedQty := OriginalQty + LibraryRandom.RandInt(5) + 1;
+        PurchaseLine.Validate(Quantity, ChangedQty);
+        PurchaseLine.Modify(true);
+
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+
+        // [WHEN] Create Transfer Order to Subcontractor
+        PurchaseHeaderPage.OpenView();
+        PurchaseHeaderPage.GoToRecord(PurchaseHeader);
+        PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [THEN] WIP Transfer Line quantity equals the changed purchase line quantity (not the original prod. order qty)
+        TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+        TransferLine.SetRange("Subc. Return Order", false);
+#pragma warning disable AA0210
+        TransferLine.SetRange("Transfer WIP Item", true);
+#pragma warning restore AA0210
+        Assert.RecordCount(TransferLine, 1);
+        TransferLine.FindFirst();
+        Assert.AreEqual(ChangedQty, TransferLine.Quantity,
+            'WIP Transfer Line quantity must follow the changed purchase line quantity, not the original production order quantity.');
+        Assert.AreNotEqual(OriginalQty, TransferLine.Quantity,
+            'WIP Transfer Line quantity must not equal the original production order quantity when the purchase line was changed.');
+    end;
+
+    [Test]
+    [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
+    procedure WIPTransferUsesUnitOfMeasureFromPurchaseLine()
+    var
+        Item: Record Item;
+        ItemUnitOfMeasure: Record "Item Unit of Measure";
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        TransferLine: Record "Transfer Line";
+        UnitOfMeasure: Record "Unit of Measure";
+        WorkCenter: array[2] of Record "Work Center";
+        PurchaseHeaderPage: TestPage "Purchase Order";
+        BoxQtyPerPCS: Decimal;
+        ProdOrderQty: Decimal;
+    begin
+        // [SCENARIO] When the item has a non-base Purchase Unit of Measure (e.g. BOX = 10 PCS),
+        // the WIP Transfer Order line must use the purchase line UOM (BOX) and quantity,
+        // not the base UOM (PCS) from the production order line.
+        Initialize();
+
+        SubcWarehouseLibrary.CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter, true);
+        SubcWarehouseLibrary.CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        SetTransferWIPItemOnRoutingLine(Item."Routing No.", WorkCenter[2]."No.", true);
+        SubcWarehouseLibrary.UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateProdBomWithComponentSupplyMethod(Item, "Component Supply Method"::"Transfer to Vendor");
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        // [GIVEN] Add a non-base UOM BOX (= 10 PCS) to the item and set it as the Purchase UOM
+        BoxQtyPerPCS := 10;
+        LibraryInventory.CreateUnitOfMeasureCode(UnitOfMeasure);
+        LibraryInventory.CreateItemUnitOfMeasure(ItemUnitOfMeasure, Item."No.", UnitOfMeasure.Code, BoxQtyPerPCS);
+        Item.Validate("Purch. Unit of Measure", UnitOfMeasure.Code);
+        Item.Modify(true);
+
+        // [GIVEN] Create and refresh production order with a quantity that is a whole multiple of BoxQtyPerPCS
+        ProdOrderQty := BoxQtyPerPCS * (LibraryRandom.RandInt(5) + 1);
+        LibraryManufacturing.CreateProductionOrder(
+            ProductionOrder, "Production Order Status"::Released,
+            ProductionOrder."Source Type"::Item, Item."No.", ProdOrderQty);
+        SetProdOrderLocationToCompSetupLocationAndRefresh(ProductionOrder);
+        SubcontractingMgmtLibrary.CreateTransferRoute(WorkCenter[2], ProductionOrder);
+
+        // [GIVEN] Create Subcontracting Purchase Order — the purchase line will carry UOM = BOX
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+#pragma warning disable AA0210
+        PurchaseLine.SetRange("Work Center No.", WorkCenter[2]."No.");
+#pragma warning restore AA0210
+        PurchaseLine.FindFirst();
+
+        // [GIVEN] Verify the purchase line received the item's Purch. Unit of Measure (BOX)
+        PurchaseLine.Validate("Unit of Measure Code", UnitOfMeasure.Code);
+        PurchaseLine.Validate(Quantity, ProdOrderQty / BoxQtyPerPCS);
+        PurchaseLine.Modify();
+
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+
+        // [WHEN] Create Transfer Order to Subcontractor
+        PurchaseHeaderPage.OpenView();
+        PurchaseHeaderPage.GoToRecord(PurchaseHeader);
+        PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [THEN] The WIP Transfer Line uses the purchase line UOM (BOX), not the base UOM (PCS)
+        TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+        TransferLine.SetRange("Subc. Return Order", false);
+#pragma warning disable AA0210
+        TransferLine.SetRange("Transfer WIP Item", true);
+#pragma warning restore AA0210
+        Assert.RecordCount(TransferLine, 1);
+        TransferLine.FindFirst();
+        Assert.AreEqual(UnitOfMeasure.Code, TransferLine."Unit of Measure Code",
+            'WIP Transfer Line Unit of Measure must match the purchase line UOM (BOX), not the base UOM (PCS).');
+        Assert.AreEqual(PurchaseLine.Quantity, TransferLine.Quantity,
+            'WIP Transfer Line quantity must equal the purchase line quantity (in BOX).');
     end;
 
     [PageHandler]


### PR DESCRIPTION
## What & why

- Introduce new procedures to calculate purchase line quantities and WIP quantities.
- Ensure WIP transfer line uses updated purchase line quantity instead of original production order quantity.
- Adjust unit of measure handling to align with purchase line specifications.
- Add tests to validate the behavior of WIP transfer lines with changed purchase quantities.

## Linked work

Internal workitem: [AB#636825](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636825)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

- Test WIP transfer creation with changing quantity / changing unit of measure on purchase line
- Introducing automated tests




