### PR TITLE
[Subcontracting] Disable Adjustment Action on WIP Ledger Entries Page when Production Order has been deleted

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/WIP Item/SubcWIPLedgerEntries.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/WIP Item/SubcWIPLedgerEntries.Page.al
@@ -4,6 +4,8 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
+using Microsoft.Manufacturing.Document;
+
 page 99001560 "Subc. WIP Ledger Entries"
 {
     ApplicationArea = Manufacturing;
@@ -113,7 +115,7 @@ page 99001560 "Subc. WIP Ledger Entries"
                 Image = AdjustEntries;
                 ToolTip = 'Manually adjust the WIP quantity for the selected WIP ledger entry.';
                 Enabled = WIPAdjustmentEnabled;
-                Visible = WIPAdjustmentEnabled;
+                Visible = WIPAdjustmentVisible;
 
                 trigger OnAction()
                 var
@@ -135,10 +137,18 @@ page 99001560 "Subc. WIP Ledger Entries"
     }
 
     var
-        WIPAdjustmentEnabled: Boolean;
+        WIPAdjustmentEnabled, WIPAdjustmentVisible : Boolean;
 
     trigger OnOpenPage()
     begin
-        WIPAdjustmentEnabled := not Rec.IsTemporary();
+        WIPAdjustmentVisible := not Rec.IsTemporary();
+    end;
+
+    trigger OnAfterGetCurrRecord()
+    var
+        ProductionOrder: Record "Production Order";
+    begin
+        ProductionOrder.SetLoadFields(SystemId);
+        WIPAdjustmentEnabled := ProductionOrder.Get(Rec."Prod. Order Status", Rec."Prod. Order No.");
     end;
 }


### PR DESCRIPTION
## What & why

- Change visibility condition for WIP Adjustment action to use WIPAdjustmentVisible.
- Disable WIP Adjustment Page when Production Order has been deleted

## Linked work

Internal workitem: [AB#636827](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636827)

Fixes #

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->



