### PR TITLE
(Bug 637499): [Subcontracting] Subcontracting Type not populated on Planning Components when refreshing from Production BOM

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcPlanningLineMgmtExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Manufacturing/SubcPlanningLineMgmtExt.Codeunit.al
@@ -28,6 +28,12 @@ codeunit 99001518 "Subc. Planning Line Mgmt Ext."
         SubcPriceManagement.ApplySubcontractorPricingToPlanningRouting(ReqLine, RoutingLine, PlanningRoutingLine);
     end;
 
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Mfg. Planning Line Management", OnCreatePlanningComponentFromProdBOMOnBeforeGetPlanningParameters, '', false, false)]
+    local procedure TransferComponentSupplyMethod_OnCreatePlanningComponentFromProdBOMOnBeforeGetPlanningParameters(var PlanningComponent: Record "Planning Component"; ProductionBOMLine: Record "Production BOM Line")
+    begin
+        PlanningComponent."Component Supply Method" := ProductionBOMLine."Component Supply Method";
+    end;
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Mfg. Planning Line Management", OnTransferBOMOnBeforeUpdatePlanningComp, '', false, false)]
     local procedure IgnorePurchaseComponentsFromSubcontracting_OnTransferBOMOnBeforeUpdatePlanningComp(var ProductionBOMLine: Record "Production BOM Line"; var UpdateCondition: Boolean; var IsHandled: Boolean; var ReqQty: Decimal)
     begin

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcSubcontractingTest.Codeunit.al
@@ -1644,10 +1644,14 @@ codeunit 139989 "Subc. Subcontracting Test"
         MachineCenter: array[2] of Record "Machine Center";
         PlanningComponent: Record "Planning Component";
         ProductionBOMLine: Record "Production BOM Line";
+        RequisitionLine: Record "Requisition Line";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
         SalesHeader: Record "Sales Header";
         SalesLine: Record "Sales Line";
         Vendor: Record Vendor;
         WorkCenter: array[2] of Record "Work Center";
+        ReqWkshTemplateName: Code[10];
+        Direction: Option Forward,Backward;
     begin
         // [SCENARIO] Create Sales Order and test Planning Component
 
@@ -1686,9 +1690,32 @@ codeunit 139989 "Subc. Subcontracting Test"
         PlanningComponent.FindFirst();
 
         // [THEN]
-        Assert.Equal(ProductionBOMLine."Component Supply Method", PlanningComponent."Component Supply Method");
+        PlanningComponent.TestField("Component Supply Method", "Component Supply Method"::"Consignment at Vendor");
         Vendor.Get(WorkCenter[2]."Subcontractor No.");
-        Assert.Equal(Vendor."Subc. Location Code", PlanningComponent."Location Code");
+        PlanningComponent.TestField("Location Code", Vendor."Subc. Location Code");
+
+        // [WHEN] A Planning Worksheet line is added manually for the same item and Refresh Planning Line is run (bug 637499 repro)
+        ReqWkshTemplateName := LibraryPlanning.SelectRequisitionTemplateName();
+        LibraryPlanning.CreateRequisitionWkshName(RequisitionWkshName, ReqWkshTemplateName);
+        LibraryPlanning.CreateRequisitionLine(RequisitionLine, ReqWkshTemplateName, RequisitionWkshName.Name);
+        RequisitionLine.Validate(Type, RequisitionLine.Type::Item);
+        RequisitionLine.Validate("No.", Item."No.");
+        RequisitionLine.Validate(Quantity, LibraryRandom.RandInt(10) + 5);
+        RequisitionLine.Validate("Location Code", Location.Code);
+        RequisitionLine.Validate("Ending Date", WorkDate());
+        RequisitionLine.Modify(true);
+        LibraryPlanning.RefreshPlanningLine(RequisitionLine, Direction::Backward, true, true);
+
+        // [THEN] The Subcontracting Type (Component Supply Method) is copied from the Production BOM Line to the Planning Component
+        Clear(PlanningComponent);
+        PlanningComponent.SetRange("Worksheet Template Name", RequisitionLine."Worksheet Template Name");
+        PlanningComponent.SetRange("Worksheet Batch Name", RequisitionLine."Journal Batch Name");
+        PlanningComponent.SetRange("Worksheet Line No.", RequisitionLine."Line No.");
+        PlanningComponent.SetRange("Item No.", ProductionBOMLine."No.");
+        PlanningComponent.FindFirst();
+        PlanningComponent.TestField("Component Supply Method", "Component Supply Method"::"Consignment at Vendor");
+        // [THEN] and the component is relocated to the subcontractor location, matching the Production Order behavior
+        PlanningComponent.TestField("Location Code", Vendor."Subc. Location Code");
     end;
 
 


### PR DESCRIPTION
**Title:** Fix: Subcontracting Type not populated on Planning Components created from Production BOM ([AB#637499](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637499))

## Summary
When a Planning Worksheet line is refreshed (**Refresh Planning Line**) or regenerative planning runs, Planning Components are created from the Production BOM Lines. The **Subcontracting Type** (`Component Supply Method`) was always empty on the resulting Planning Components, even when the source Production BOM Line had it set (e.g. Consignment at Vendor, Vendor-Supplied, Transfer to Vendor).

Fixes [AB#637499](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637499)

## Root cause
The Subcontracting app covered every other transfer path but had no subscriber on the **BOM → Planning Component** path:

| Transfer path | Copies Subcontracting Type? | Subscriber |
|---|---|---|
| BOM → Prod. Order Component | Yes | `SubcCalcProdOrderExt` |
| Prod. Order Comp → Planning Component | Yes | `SubcPlanningCompExt` |
| Planning Comp → Prod. Order Component | Yes | `SubcCarryOutActionExt` |
| **BOM → Planning Component** | **No (bug)** | **— missing —** |

## Fix
Added a subscriber in `SubcPlanningLineMgmtExt.Codeunit.al` to `Mfg. Planning Line Management.OnCreatePlanningComponentFromProdBOMOnBeforeGetPlanningParameters`, copying `ProductionBOMLine."Component Supply Method"` to `PlanningComponent."Component Supply Method"`.

This event fires **before** `Routing Link Code` is validated during component creation. Setting the field there (rather than on the later `OnBeforeInsertPlanningComponent`) means the existing routing-link relocation logic (`HandleRoutingLinkCodeValidation`) sees the supply method and relocates the component to the subcontractor location automatically — so both the field value and the location now match the Production Order behavior, with no duplicated relocation code. The event is raised in both `CLEAN27` and non-`CLEAN27` compilation, so no conditional is needed.
