### PR TITLE
[Quality Management] [28.x] Do not show notification when inspections are not created

### DIFF
--- a/src/Apps/W1/Quality Management/Test Library/src/QltyInspectionUtility.Codeunit.al
+++ b/src/Apps/W1/Quality Management/Test Library/src/QltyInspectionUtility.Codeunit.al
@@ -1337,6 +1337,47 @@ codeunit 139940 "Qlty. Inspection Utility"
     end;
 
     /// <summary>
+    /// Wrapper for QltyInspectionCreate.CreateInspection that also reports whether the returned inspection was newly created or reused.
+    /// Use this in tests that verify the "newly created vs reused" distinction (e.g., to assert the inspection-created notification
+    /// is only raised for newly created inspections).
+    /// </summary>
+    /// <param name="TargetRecordRef">The source record to create an inspection from.</param>
+    /// <param name="IsManualCreation">True when user manually creates inspection; False for automatic/triggered creation.</param>
+    /// <param name="OutQltyInspectionHeader">Output: the created or reused inspection header.</param>
+    /// <param name="OutIsNewlyCreated">Output: true when the inspection was newly inserted; false when an existing inspection was reused.</param>
+    /// <returns>True if an inspection was created or found/reused.</returns>
+    internal procedure CreateInspectionAndReportIfNewlyCreated(TargetRecordRef: RecordRef; IsManualCreation: Boolean; var OutQltyInspectionHeader: Record "Qlty. Inspection Header"; var OutIsNewlyCreated: Boolean): Boolean
+    var
+        QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
+        Result: Boolean;
+    begin
+        Result := QltyInspectionCreate.CreateInspection(TargetRecordRef, IsManualCreation);
+        OutIsNewlyCreated := false;
+        if Result then begin
+            QltyInspectionCreate.GetCreatedInspection(OutQltyInspectionHeader);
+            OutIsNewlyCreated := QltyInspectionCreate.IsLastInspectionNewlyCreated();
+        end;
+        exit(Result);
+    end;
+
+    /// <summary>
+    /// Wrapper for internal QltyInspectionCreate.CreateMultipleInspectionsWithoutDisplaying.
+    /// Returns both the inspections that were newly created and the full set of inspections that were resolved
+    /// (new + reused).
+    /// </summary>
+    /// <param name="SetOfRecordsRecordRef">RecordRef containing the records to create inspections for.</param>
+    /// <param name="IsManualCreation">Whether this is a manual creation (affects display behavior).</param>
+    /// <param name="TempFiltersQltyInspectionGenRule">Temporary record with filters that constrain which generation rules apply.</param>
+    /// <param name="OutNewlyCreatedQltyInspectionIds">Output: list of inspection "No." values for inspections that were newly inserted.</param>
+    /// <param name="OutAllResolvedQltyInspectionIds">Output: list of inspection "No." values for every inspection that was newly inserted or reused.</param>
+    internal procedure CreateMultipleInspectionsWithoutDisplaying(var SetOfRecordsRecordRef: RecordRef; IsManualCreation: Boolean; var TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary; var OutNewlyCreatedQltyInspectionIds: List of [Code[20]]; var OutAllResolvedQltyInspectionIds: List of [Code[20]])
+    var
+        QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
+    begin
+        QltyInspectionCreate.CreateMultipleInspectionsWithoutDisplaying(SetOfRecordsRecordRef, IsManualCreation, TempFiltersQltyInspectionGenRule, OutNewlyCreatedQltyInspectionIds, OutAllResolvedQltyInspectionIds);
+    end;
+
+    /// <summary>
     /// Wrapper for QltyInspectionCreate.CreateInspectionWithVariant.
     /// Creates a quality inspection from a variant using generation rule configuration.
     /// </summary>
@@ -1527,7 +1568,7 @@ codeunit 139940 "Qlty. Inspection Utility"
         exit(QltyInspectionCreate.FindExistingInspectionWithVariant(TargetRecordRef, OptionalVariant2, OptionalVariant3, OptionalVariant4, TempQltyInspectionGenRule, OutQltyInspectionHeader, FindAll));
     end;
 
-    #endregion Qlty. Inspection - Create Wrappers
+    #endregion Qlty. Inspection - Create Wrappers         
 
     #region Qlty. Disposition Wrappers
 
@@ -1536,10 +1577,10 @@ codeunit 139940 "Qlty. Inspection Utility"
     /// Performs disposition and returns the created purchase return buffer.
     /// </summary>
     internal procedure PerformPurchaseReturnDisposition(var QltyInspectionHeader: Record "Qlty. Inspection Header"; QltyQuantityBehavior: Enum "Qlty. Quantity Behavior"; OptionalSpecificQuantity: Decimal;
-                                                                                                                                     OptionalSourceLocationFilter: Text;
-                                                                                                                                     OptionalSourceBinFilter: Text;
-                                                                                                                                     ReasonCode: Code[10];
-                                                                                                                                     ExternalDocumentNo: Code[35]; var TempCreatedBufferPurchaseHeader: Record "Purchase Header" temporary): Boolean
+                                                                                                                                              OptionalSourceLocationFilter: Text;
+                                                                                                                                              OptionalSourceBinFilter: Text;
+                                                                                                                                              ReasonCode: Code[10];
+                                                                                                                                              ExternalDocumentNo: Code[35]; var TempCreatedBufferPurchaseHeader: Record "Purchase Header" temporary): Boolean
     var
         QltyDispPurchaseReturn: Codeunit "Qlty. Disp. Purchase Return";
         Result: Boolean;
@@ -1553,9 +1594,9 @@ codeunit 139940 "Qlty. Inspection Utility"
     /// Wrapper for internal QltyDispNegAdjustInv.PerformDisposition (7-argument version).
     /// </summary>
     internal procedure PerformNegAdjustInvDisposition(var QltyInspectionHeader: Record "Qlty. Inspection Header"; OptionalSpecificQuantity: Decimal; QltyQuantityBehavior: Enum "Qlty. Quantity Behavior"; OptionalSourceLocationFilter: Text;
-                                                                                                                                                                      OptionalSourceBinFilter: Text;
-                                                                                                                                                                      PostingBehavior: Enum "Qlty. Item Adj. Post Behavior";
-                                                                                                                                                                      Reason: Code[10]): Boolean
+                                                                                                                                                                               OptionalSourceBinFilter: Text;
+                                                                                                                                                                               PostingBehavior: Enum "Qlty. Item Adj. Post Behavior";
+                                                                                                                                                                               Reason: Code[10]): Boolean
     var
         QltyDispNegAdjustInv: Codeunit "Qlty. Disp. Neg. Adjust Inv.";
     begin
@@ -1566,9 +1607,9 @@ codeunit 139940 "Qlty. Inspection Utility"
     /// Wrapper for internal QltyDispTransfer.PerformDisposition (7-argument version).
     /// </summary>
     internal procedure PerformTransferDisposition(QltyInspectionHeader: Record "Qlty. Inspection Header"; OptionalSpecificQuantity: Decimal; QltyQuantityBehavior: Enum "Qlty. Quantity Behavior"; OptionalSourceLocationFilter: Text;
-                                                                                                                                                              OptionalSourceBinFilter: Text;
-                                                                                                                                                              DestinationLocationCode: Code[10];
-                                                                                                                                                              OptionalInTransitLocationCode: Code[10]): Boolean
+                                                                                                                                                                       OptionalSourceBinFilter: Text;
+                                                                                                                                                                       DestinationLocationCode: Code[10];
+                                                                                                                                                                       OptionalInTransitLocationCode: Code[10]): Boolean
     var
         QltyDispTransfer: Codeunit "Qlty. Disp. Transfer";
     begin
@@ -3102,7 +3143,8 @@ codeunit 139940 "Qlty. Inspection Utility"
     /// <summary>
     /// Wrapper for QltyResultEvaluation.EvaluateResult
     /// </summary>
-    internal procedure EvaluateResult(var OptionalQltyInspectionHeader: Record "Qlty. Inspection Header"; var OptionalQltyInspectionLine: Record "Qlty. Inspection Line"; var QltyIResultConditConf: Record "Qlty. I. Result Condit. Conf."; QltyTestValueType: Enum "Qlty. Test Value Type"; TestValue: Text; QltyCaseSensitivity: Enum "Qlty. Case Sensitivity"): Code[20]
+    internal procedure EvaluateResult(var OptionalQltyInspectionHeader: Record "Qlty. Inspection Header"; var OptionalQltyInspectionLine: Record "Qlty. Inspection Line"; var QltyIResultConditConf: Record "Qlty. I. Result Condit. Conf."; QltyTestValueType: Enum "Qlty. Test Value Type"; TestValue: Text;
+                                                                                                                                                                                                                                                                    QltyCaseSensitivity: Enum "Qlty. Case Sensitivity"): Code[20]
     var
         QltyResultEvaluation: Codeunit "Qlty. Result Evaluation";
     begin

--- a/src/Apps/W1/Quality Management/app/src/API/QltyInspectionsAPI.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/API/QltyInspectionsAPI.Page.al
@@ -470,7 +470,7 @@ page 20414 "Qlty. Inspections API"
     /// <param name="optionalDestinationLocation">When left blank this assumes the same location as the from location.</param>
     /// <param name="optionalDestinationBin">The target bin to move to.</param>
     /// <param name="optionalSpecificQuantity">Quantity to move, if updating a specific quantity</param>
-    /// <param name="postImmediately">When set to TRUE this will post journals immediately or create the warehouse movement.  Verify you have sufficient licensing to use this flag.</param>
+    /// <param name="postImmediately">When set to TRUE this will post journals immediately or create the warehouse movement. Verify you have sufficient licensing to use this flag.</param>
     /// <param name="optionalSourceLocationFilter">Optionally restrict the locations to move from. </param>
     /// <param name="optionalSourceBinFilter">Optionally restrict the specific bins to move from.</param>
     /// <param name="useMoveSheet">When set to TRUE, will use the Movement Worksheet instead of a reclassification journal.</param>

--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/JobQueue/QltyScheduleInspection.Report.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/JobQueue/QltyScheduleInspection.Report.al
@@ -70,9 +70,11 @@ report 20412 "Qlty. Schedule Inspection"
         QltyManagementSetup: Record "Qlty. Management Setup";
         QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
         ShowWarningIfCreateInspection: Boolean;
-        CreatedQltyInspectionIds: List of [Code[20]];
-        ZeroInspectionsCreatedMsg: Label 'No inspections were created.';
-        SomeInspectionsWereCreatedQst: Label '%1 inspections were created. Do you want to see them?', Comment = '%1=the count of inspections that were created.';
+        NewlyCreatedQltyInspectionIds, AllResolvedQltyInspectionIds : List of [Code[20]];
+        ZeroInspectionsCreatedOrMatchedMsg: Label 'No inspections were created or existing inspections matched.';
+        SomeInspectionsCreatedQst: Label '%1 inspections were created. Do you want to see them?', Comment = '%1=the count of inspections that were newly created.';
+        SomeInspectionsMatchedQst: Label 'No new inspections were created, but %1 existing inspections matched. Do you want to see them?', Comment = '%1=the count of existing inspections that were matched (reused).';
+        SomeInspectionsCreatedOrMatchedQst: Label '%1 inspections were created and %2 existing inspections matched. Do you want to see all of them?', Comment = '%1=the count of newly created inspections, %2=the count of existing inspections that were matched (reused).';
         NoSourceConfigForScheduleErr: Label 'Cannot schedule inspections because no enabled source configuration with a table filter exists for source table %1. Navigate to the Quality Inspection Source Configuration page and ensure at least one enabled configuration exists for this table with a From Table Filter defined.', Comment = '%1=the source table number';
 
     trigger OnInitReport()
@@ -85,17 +87,39 @@ report 20412 "Qlty. Schedule Inspection"
     trigger OnPreReport()
     begin
         Clear(QltyInspectionCreate);
-        Clear(CreatedQltyInspectionIds);
+        Clear(NewlyCreatedQltyInspectionIds);
+        Clear(AllResolvedQltyInspectionIds);
     end;
 
     trigger OnPostReport()
+    var
+        NewlyCreatedCount, ExistingMatchedCount : Integer;
+        ShouldDisplay: Boolean;
     begin
-        if GuiAllowed() then
-            if CreatedQltyInspectionIds.Count() = 0 then
-                Message(ZeroInspectionsCreatedMsg)
+        if not GuiAllowed() then
+            exit;
+
+        if AllResolvedQltyInspectionIds.Count() = 0 then begin
+            Message(ZeroInspectionsCreatedOrMatchedMsg);
+            exit;
+        end;
+
+        NewlyCreatedCount := NewlyCreatedQltyInspectionIds.Count();
+        ExistingMatchedCount := AllResolvedQltyInspectionIds.Count() - NewlyCreatedCount;
+        if ExistingMatchedCount < 0 then
+            ExistingMatchedCount := 0;
+
+        case true of
+            (NewlyCreatedCount > 0) and (ExistingMatchedCount > 0):
+                ShouldDisplay := Confirm(StrSubstNo(SomeInspectionsCreatedOrMatchedQst, NewlyCreatedCount, ExistingMatchedCount), true);
+            NewlyCreatedCount > 0:
+                ShouldDisplay := Confirm(StrSubstNo(SomeInspectionsCreatedQst, NewlyCreatedCount), true);
             else
-                if Confirm(StrSubstNo(SomeInspectionsWereCreatedQst, CreatedQltyInspectionIds.Count())) then
-                    QltyInspectionCreate.DisplayInspectionsIfConfigured(true, CreatedQltyInspectionIds);
+                ShouldDisplay := Confirm(StrSubstNo(SomeInspectionsMatchedQst, ExistingMatchedCount), true);
+        end;
+
+        if ShouldDisplay then
+            QltyInspectionCreate.DisplayInspectionsIfConfigured(true, AllResolvedQltyInspectionIds);
     end;
 
     /// <summary>
@@ -140,7 +164,7 @@ report 20412 "Qlty. Schedule Inspection"
             SourceRecordRef.SetView(QltyInspectSourceConfig."From Table Filter");
             SourceRecordRef.FilterGroup(0);
             if SourceRecordRef.FindSet() then
-                QltyInspectionCreate.CreateMultipleInspectionsWithoutDisplaying(SourceRecordRef, GuiAllowed(), QltyInspectionGenRule, CreatedQltyInspectionIds);
+                QltyInspectionCreate.CreateMultipleInspectionsWithoutDisplaying(SourceRecordRef, GuiAllowed(), QltyInspectionGenRule, NewlyCreatedQltyInspectionIds, AllResolvedQltyInspectionIds);
         until QltyInspectSourceConfig.Next() = 0;
     end;
 }

--- a/src/Apps/W1/Quality Management/app/src/Dispositions/Move/QltyDispMoveAutoChoose.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Dispositions/Move/QltyDispMoveAutoChoose.Codeunit.al
@@ -84,7 +84,7 @@ codeunit 20442 "Qlty. Disp. Move Auto Choose" implements "Qlty. Disposition"
     end;
 
     /// <summary>
-    /// Do not use directly for net new code.  This method is an interim shim to help with obsoletions and refactoring for dispositions.
+    /// Do not use directly for net new code. This method is an interim shim to help with obsoletions and refactoring for dispositions.
     /// Instead use the new dispositions directly.
     /// </summary>
     /// <param name="QltyInspectionHeader"></param>

--- a/src/Apps/W1/Quality Management/app/src/Dispositions/PutAway/QltyDispWarehousePutAway.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Dispositions/PutAway/QltyDispWarehousePutAway.Codeunit.al
@@ -30,7 +30,7 @@ codeunit 20453 "Qlty. Disp. Warehouse Put-away" implements "Qlty. Disposition"
     /// You must be in a directed pick and put location, and you must be using lot warehouse tracking to use this feature.
     /// </summary>
     /// <param name="QltyInspectionHeader">The inspection to create the internal put-away from</param>
-    /// <param name="OptionalSpecificQuantity">Optional quantity.  Leave blank to use the entire lot or the quantity from the inspection.</param>
+    /// <param name="OptionalSpecificQuantity">Optional quantity. Leave blank to use the entire lot or the quantity from the inspection.</param>
     /// <param name="OptionalSourceLocationFilter">Optional limitations on the source location.</param>
     /// <param name="OptionalSourceBinFilter">Optional limitations on the source bin.</param>
     /// <param name="QltyQuantityBehavior">The quantity behavior</param>

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionCreate.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionCreate.Codeunit.al
@@ -36,6 +36,7 @@ codeunit 20404 "Qlty. Inspection - Create"
         LastQltyInspectionCreateStatus: Enum "Qlty. Inspection Create Status";
         PreventShowingGeneratedInspectionEvenIfConfigured: Boolean;
         AvoidThrowingErrorWhenPossible: Boolean;
+        LastInspectionIsNewlyCreated: Boolean;
         ProgrammerErrNotARecordRefErr: Label 'Cannot find inspections with %1. Please supply a "Record" or "RecordRef".', Comment = '%1=the variant being supplied that is not a RecordRef. Your system might have an extension or customization that needs to be re-configured.';
         CannotFindTemplateErr: Label 'Cannot find a Quality Inspection Template or Quality Inspection Generation Rule to match %1. Ensure there is a Quality Inspection Generation Rule that will match this record.', Comment = '%1=The record identifier';
         UnableToCreateInspectionForErr: Label 'Unable to create an inspection for the record [%1], please review the Quality Inspection Source Configuration and also the Quality Inspection Generation Rules, you likely need additional configuration to work with this record.', Comment = '%1=the record id of what is being attempted to have an inspection created for.';
@@ -43,9 +44,10 @@ codeunit 20404 "Qlty. Inspection - Create"
         MultiRecordInspectionSourceFieldErr: Label 'Inspection %1 has been created, however neither %2 nor %4 had applicable source fields to map to the inspection. Navigate to the Quality Source Configuration for table %3 and apply source field mapping.', Comment = '%1=the inspection, %2=target record,  %3=the number to set configuration for,%4=triggering record';
         RegisteredLogEventIDTok: Label 'QMERR0001', Locked = true;
         DetailRecordTok: Label 'Target', Locked = true;
-        UnableToCreateInspectionForParentOrChildErr: Label 'Cannot find enough details to make an inspection for your record(s).  Try making sure that there is a source configuration for your record, and then also make sure there is sufficient information in your inspection generation rules.  Two tables involved are %1 and %2.', Comment = '%1=the parent table, %2=the child and original table.';
-        UnableToCreateInspectionForRecordErr: Label 'Cannot find enough details to make an inspection for your record(s).  Try making sure that there is a source configuration for your record, and then also make sure there is sufficient information in your inspection generation rules.  The table involved is %1.', Comment = '%1=the table involved.';
+        UnableToCreateInspectionForParentOrChildErr: Label 'Cannot find enough details to make an inspection for your record(s). Try making sure that there is a source configuration for your record, and then also make sure there is sufficient information in your inspection generation rules. Two tables involved are %1 and %2.', Comment = '%1=the parent table, %2=the child and original table.';
+        UnableToCreateInspectionForRecordErr: Label 'Cannot find enough details to make an inspection for your record(s). Try making sure that there is a source configuration for your record, and then also make sure there is sufficient information in your inspection generation rules. The table involved is %1.', Comment = '%1=the table involved.';
         RecordShouldBeTemporaryErr: Label 'This code is only intended to run in a temporary fashion. This error is likely occurring from an integration issue.';
+        SomeInspectionsMatchedQst: Label 'No new inspections were created, but %1 existing inspections matched. Do you want to see them?', Comment = '%1=the count of existing inspections that were matched (reused).';
         UnknownRecordTok: Label 'Unknown record', Locked = true;
 
     /// <summary>
@@ -280,6 +282,8 @@ codeunit 20404 "Qlty. Inspection - Create"
         OriginalRecordTableNo: Integer;
         IsNewlyCreatedInspection: Boolean;
     begin
+        LastInspectionIsNewlyCreated := false;
+
         case true of
             TargetRecordRef.Number() = 0,
             not QltyManagementSetup.GetSetupRecord():
@@ -354,17 +358,22 @@ codeunit 20404 "Qlty. Inspection - Create"
 
             QltyInspectionHeader.SetIsCreating(false);
             LastCreatedQltyInspectionHeader := QltyInspectionHeader;
+            LastInspectionIsNewlyCreated := IsNewlyCreatedInspection;
 
             if IsNewlyCreatedInspection then
                 QltyStartWorkflow.StartWorkflowInspectionCreated(QltyInspectionHeader);
 
-            if GuiAllowed() and not PreventShowingGeneratedInspectionEvenIfConfigured
-                and (QltyInspectionHeader."No." <> '') then
+            if GuiAllowed() and
+               not PreventShowingGeneratedInspectionEvenIfConfigured and
+               (QltyInspectionHeader."No." <> '')
+            then
                 if IsManualCreation then
                     Page.Run(Page::"Qlty. Inspection", QltyInspectionHeader)
                 else
-                    QltyNotificationMgmt.NotifyInspectionCreated(QltyInspectionHeader);
+                    if IsNewlyCreatedInspection then
+                        QltyNotificationMgmt.NotifyInspectionCreated(QltyInspectionHeader);
         end else begin
+            LastInspectionIsNewlyCreated := false;
             LogCreateInspectionProblem(TargetRecordRef, UnableToCreateInspectionForErr, Format(OriginalRecordId));
             if IsManualCreation and (not AvoidThrowingErrorWhenPossible) then
                 Error(UnableToCreateInspectionForErr, Format(OriginalRecordId));
@@ -776,6 +785,21 @@ codeunit 20404 "Qlty. Inspection - Create"
     end;
 
     /// <summary>
+    /// Indicates whether the inspection returned by the last create call was newly inserted
+    /// or whether an existing matching inspection was reused (e.g. when the Inspection Creation
+    /// Option is configured to use an existing inspection if available).
+    /// Only valid immediately after a successful CreateInspection* call on this instance.
+    /// </summary>
+    /// <returns>True when the last inspection was newly created; false when it was reused, no inspection was returned.</returns>
+    internal procedure IsLastInspectionNewlyCreated(): Boolean
+    begin
+        if LastCreatedQltyInspectionHeader."No." = '' then
+            exit(false);
+
+        exit(LastInspectionIsNewlyCreated);
+    end;
+
+    /// <summary>
     /// Use this to log QMERR0001
     /// </summary>
     /// <param name="ContextRecordRef"></param>
@@ -835,15 +859,25 @@ codeunit 20404 "Qlty. Inspection - Create"
 
     internal procedure CreateMultipleInspectionsForMultipleRecords(var SetOfRecordsRecordRef: RecordRef; IsManualCreation: Boolean; var TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary)
     var
-        CreatedQltyInspectionIds: List of [Code[20]];
+        NewlyCreatedQltyInspectionIds, AllResolvedQltyInspectionIds : List of [Code[20]];
+        NewlyCreatedCount, ExistingMatchedCount : Integer;
     begin
-        CreateMultipleInspectionsWithoutDisplaying(SetOfRecordsRecordRef, IsManualCreation, TempFiltersQltyInspectionGenRule, CreatedQltyInspectionIds);
+        CreateMultipleInspectionsWithoutDisplaying(SetOfRecordsRecordRef, IsManualCreation, TempFiltersQltyInspectionGenRule, NewlyCreatedQltyInspectionIds, AllResolvedQltyInspectionIds);
 
-        if IsManualCreation and GuiAllowed() then
-            DisplayInspectionsIfConfigured(IsManualCreation, CreatedQltyInspectionIds);
+        if IsManualCreation and GuiAllowed() then begin
+            NewlyCreatedCount := NewlyCreatedQltyInspectionIds.Count();
+            if NewlyCreatedCount > 0 then
+                DisplayInspectionsIfConfigured(IsManualCreation, NewlyCreatedQltyInspectionIds)
+            else begin
+                ExistingMatchedCount := AllResolvedQltyInspectionIds.Count();
+                if ExistingMatchedCount > 0 then
+                    if Confirm(StrSubstNo(SomeInspectionsMatchedQst, ExistingMatchedCount), true) then
+                        DisplayInspectionsIfConfigured(IsManualCreation, AllResolvedQltyInspectionIds);
+            end;
+        end;
     end;
 
-    internal procedure DisplayInspectionsIfConfigured(IsManualCreation: Boolean; var CreatedQltyInspectionIds: List of [Code[20]])
+    internal procedure DisplayInspectionsIfConfigured(IsManualCreation: Boolean; var ToDisplayQltyInspectionIds: List of [Code[20]])
     var
         CreatedQltyInspectionHeader: Record "Qlty. Inspection Header";
         QltyNotificationMgmt: Codeunit "Qlty. Notification Mgmt.";
@@ -856,7 +890,7 @@ codeunit 20404 "Qlty. Inspection - Create"
         MaxSafeFilterLength := 1024;
 
         if GuiAllowed() then begin
-            foreach InspectionNo in CreatedQltyInspectionIds do
+            foreach InspectionNo in ToDisplayQltyInspectionIds do
                 if InspectionNo <> '' then begin
                     if StrLen(PipeSeparatedFilter) > 1 then
                         PipeSeparatedFilter += '|';
@@ -868,12 +902,12 @@ codeunit 20404 "Qlty. Inspection - Create"
                 end;
 
             if FilterExceedsMaxLength then begin
-                QltyNotificationMgmt.NotifyMultipleInspectionsCreatedByCount(CreatedQltyInspectionIds.Count());
+                QltyNotificationMgmt.NotifyMultipleInspectionsCreatedByCount(ToDisplayQltyInspectionIds.Count());
                 exit;
             end;
 
             CreatedQltyInspectionHeader.SetFilter("No.", PipeSeparatedFilter);
-            if CreatedQltyInspectionIds.Count() = 1 then begin
+            if ToDisplayQltyInspectionIds.Count() = 1 then begin
                 CreatedQltyInspectionHeader.SetCurrentKey("No.", "Re-inspection No.");
                 CreatedQltyInspectionHeader.FindLast();
                 if IsManualCreation then
@@ -892,17 +926,18 @@ codeunit 20404 "Qlty. Inspection - Create"
 
     /// <summary>
     /// Use this if you need to keep track of multiple inspections without displaying the results.
+    /// Distinguishes inspections that were newly inserted from inspections that were reused
+    /// (matched an existing open inspection).
     /// </summary>
     /// <param name="SetOfRecordsRecordRef"></param>
     /// <param name="IsManualCreation"></param>
-    /// <param name="ptrecOptionalFiltersGenerationRule"></param>
-    /// <param name="CreatedQltyInspectionIds"></param>
-    internal procedure CreateMultipleInspectionsWithoutDisplaying(var SetOfRecordsRecordRef: RecordRef; IsManualCreation: Boolean; var TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary; var CreatedQltyInspectionIds: List of [Code[20]])
+    /// <param name="TempFiltersQltyInspectionGenRule"></param>
+    /// <param name="NewlyCreatedQltyInspectionIds">Receives only inspections that were newly inserted by this call.</param>
+    /// <param name="AllResolvedQltyInspectionIds">Receives every inspection that was either newly inserted or reused (matched an existing open inspection).</param>
+    internal procedure CreateMultipleInspectionsWithoutDisplaying(var SetOfRecordsRecordRef: RecordRef; IsManualCreation: Boolean; var TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary; var NewlyCreatedQltyInspectionIds: List of [Code[20]]; var AllResolvedQltyInspectionIds: List of [Code[20]])
     var
         TempCopyOfSingleRecordRecordRef: RecordRef;
         ParentRecordRef: RecordRef;
-        FailedInspectionIds: List of [Text];
-        CountOfInspectionsCreatedForLine: Integer;
     begin
         QltyManagementSetup.Get();
 
@@ -915,18 +950,18 @@ codeunit 20404 "Qlty. Inspection - Create"
 
                 TempCopyOfSingleRecordRecordRef.Copy(SetOfRecordsRecordRef, false);
                 TempCopyOfSingleRecordRecordRef.Insert(false);
-                CountOfInspectionsCreatedForLine := CreateInspectionForSelfOrDirectParent(
+                CreateInspectionForSelfOrDirectParent(
                     TempCopyOfSingleRecordRecordRef,
                     TempFiltersQltyInspectionGenRule,
                     ParentRecordRef,
-                    CreatedQltyInspectionIds,
+                    NewlyCreatedQltyInspectionIds,
+                    AllResolvedQltyInspectionIds,
                     true,
                     IsManualCreation);
-                if CountOfInspectionsCreatedForLine = 0 then
-                    FailedInspectionIds.Add(Format(SetOfRecordsRecordRef.RecordId()));
             until SetOfRecordsRecordRef.Next() = 0;
 
-        if CreatedQltyInspectionIds.Count() = 0 then begin
+        // Error only when no inspection was resolved at all (neither newly created nor matching ones reused).
+        if AllResolvedQltyInspectionIds.Count() = 0 then begin
             if AvoidThrowingErrorWhenPossible then
                 exit;
 
@@ -937,9 +972,8 @@ codeunit 20404 "Qlty. Inspection - Create"
         end;
     end;
 
-    local procedure CreateInspectionForSelfOrDirectParent(var TempSelfRecordRef: RecordRef; var TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary; var FoundParentRecordRef: RecordRef; var CreatedQltyInspectionIds: List of [Code[20]]; PreventInspectionFromDisplayingEvenIfConfigured: Boolean; IsManualCreation: Boolean) InspectionCreatedCount: Integer
+    local procedure CreateInspectionForSelfOrDirectParent(var TempSelfRecordRef: RecordRef; var TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary; var FoundParentRecordRef: RecordRef; var NewlyCreatedQltyInspectionIds: List of [Code[20]]; var AllResolvedQltyInspectionIds: List of [Code[20]]; PreventInspectionFromDisplayingEvenIfConfigured: Boolean; IsManualCreation: Boolean)
     var
-        LastCreatedQltyInspectionHeader2: Record "Qlty. Inspection Header";
         Item: Record Item;
         TempTrackingSpecification: Record "Tracking Specification" temporary;
         LocalQltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
@@ -949,8 +983,6 @@ codeunit 20404 "Qlty. Inspection - Create"
         VariantEmptyOrTrackingSpecification: Variant;
         Dummy4Variant: Variant;
     begin
-        InspectionCreatedCount := 0;
-
         LocalQltyInspectionCreate.SetPreventDisplayingInspectionEvenIfConfigured(PreventInspectionFromDisplayingEvenIfConfigured);
 
         Clear(FoundParentRecordRef);
@@ -1013,11 +1045,7 @@ codeunit 20404 "Qlty. Inspection - Create"
                 end;
 
                 if LocalQltyInspectionCreate.CreateInspectionWithMultiVariants(ParentRecordRef, TempSelfRecordRef, VariantEmptyOrTrackingSpecification, Dummy4Variant, IsManualCreation, TempFiltersQltyInspectionGenRule) then
-                    if LocalQltyInspectionCreate.GetCreatedInspection(LastCreatedQltyInspectionHeader2) then begin
-                        InspectionCreatedCount += 1;
-                        if not CreatedQltyInspectionIds.Contains(LastCreatedQltyInspectionHeader2."No.") then
-                            CreatedQltyInspectionIds.Add(LastCreatedQltyInspectionHeader2."No.");
-                    end;
+                    TrackResolvedInspection(LocalQltyInspectionCreate, NewlyCreatedQltyInspectionIds, AllResolvedQltyInspectionIds);
             until RelatedReservFilterReservationEntry.Next() = 0;
         end else begin
             if TempFiltersQltyInspectionGenRule."Item Filter" <> '' then begin
@@ -1027,12 +1055,29 @@ codeunit 20404 "Qlty. Inspection - Create"
             end;
 
             if LocalQltyInspectionCreate.CreateInspectionWithMultiVariants(TempSelfRecordRef, ParentRecordRef, Dummy4Variant, Dummy4Variant, IsManualCreation, TempFiltersQltyInspectionGenRule) then
-                if LocalQltyInspectionCreate.GetCreatedInspection(LastCreatedQltyInspectionHeader2) then begin
-                    InspectionCreatedCount += 1;
-                    if not CreatedQltyInspectionIds.Contains(LastCreatedQltyInspectionHeader2."No.") then
-                        CreatedQltyInspectionIds.Add(LastCreatedQltyInspectionHeader2."No.");
-                end;
+                TrackResolvedInspection(LocalQltyInspectionCreate, NewlyCreatedQltyInspectionIds, AllResolvedQltyInspectionIds);
         end;
+    end;
+
+    /// <summary>
+    /// Records the inspection returned by the last create call on <paramref name="LocalQltyInspectionCreate"/> in the
+    /// supplied tracking lists, deduplicating by inspection "No.". The all-resolved list captures both newly created
+    /// and reused matching inspections so callers can detect reuse; the newly-created list only captures inspections that were
+    /// actually inserted and is used to drive "created inspections" notifications and display.
+    /// </summary>
+    local procedure TrackResolvedInspection(var LocalQltyInspectionCreate: Codeunit "Qlty. Inspection - Create"; var NewlyCreatedQltyInspectionIds: List of [Code[20]]; var AllResolvedQltyInspectionIds: List of [Code[20]])
+    var
+        LastResolvedQltyInspectionHeader: Record "Qlty. Inspection Header";
+    begin
+        if not LocalQltyInspectionCreate.GetCreatedInspection(LastResolvedQltyInspectionHeader) then
+            exit;
+
+        if not AllResolvedQltyInspectionIds.Contains(LastResolvedQltyInspectionHeader."No.") then
+            AllResolvedQltyInspectionIds.Add(LastResolvedQltyInspectionHeader."No.");
+
+        if LocalQltyInspectionCreate.IsLastInspectionNewlyCreated() then
+            if not NewlyCreatedQltyInspectionIds.Contains(LastResolvedQltyInspectionHeader."No.") then
+                NewlyCreatedQltyInspectionIds.Add(LastResolvedQltyInspectionHeader."No.");
     end;
 
     internal procedure SetPreventDisplayingInspectionEvenIfConfigured(PreventDisplayingInspectionEvenIfConfigured: Boolean)
@@ -1041,7 +1086,7 @@ codeunit 20404 "Qlty. Inspection - Create"
     end;
 
     /// <summary>
-    /// Stubs in and filles the source config fields.
+    /// Stubs in and fills the source config fields.
     /// </summary>
     /// <param name="InspectionStubToFillQualityOrder"></param>
     /// <param name="MandatoryPrimaryRecordRef"></param>
@@ -1189,9 +1234,9 @@ codeunit 20404 "Qlty. Inspection - Create"
     /// OnBeforeFindExistingInspection provides an opportunity to override how an existing inspection is found.
     /// </summary>
     /// <param name="TargetRecordRef">The main target record that the inspection will be created against</param>
-    /// <param name="Optional2RecordRef">Optional.  Some events, typically automatic events, will have multiple records to assist with setting source details.</param>
-    /// <param name="Optional3RecordRef">Optional.  Some events, typically automatic events, will have multiple records to assist with setting source details.</param>
-    /// <param name="Optional4RecordRef">Optional.  Some events, typically automatic events, will have multiple records to assist with setting source details.</param>
+    /// <param name="Optional2RecordRef">Optional. Some events, typically automatic events, will have multiple records to assist with setting source details.</param>
+    /// <param name="Optional3RecordRef">Optional. Some events, typically automatic events, will have multiple records to assist with setting source details.</param>
+    /// <param name="Optional4RecordRef">Optional. Some events, typically automatic events, will have multiple records to assist with setting source details.</param>
     /// <param name="QltyInspectionHeader">The found inspection</param>
     /// <param name="Result">Set to true if you found the record. If you set to true you must also supply QltyInspectionHeader</param>
     /// <param name="IsHandled">Set to true to replace the default behavior</param>

--- a/src/Apps/W1/Quality Management/app/src/Integration/Assembly/QltyAssemblyIntegration.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Assembly/QltyAssemblyIntegration.Codeunit.al
@@ -56,7 +56,7 @@ codeunit 20412 "Qlty. Assembly Integration"
                     if QltyInspectionHeader."No." <> '' then begin
                         QltyInspectionHeader."Source Quantity (Base)" := TempSpecTrackingSpecification."Quantity (Base)";
                         QltyInspectionHeader.Modify(false);
-                        QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                        QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
                     end;
                 end;
                 OnAfterAttemptCreateInspectionFromPostedAssembly(AssemblyHeader, PostedAssemblyHeader, TempSpecTrackingSpecification, QltyInspectionHeader);
@@ -69,7 +69,7 @@ codeunit 20412 "Qlty. Assembly Integration"
             HasInspection := QltyInspectionCreate.CreateInspectionWithMultiVariants(PostedAssemblyHeader, AssemblyHeader, UnusedVariant1, UnusedVariant2, false, TempQltyInspectionGenRule);
             if HasInspection then begin
                 QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
-                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
             end;
             OnAfterAttemptCreateInspectionFromPostedAssembly(AssemblyHeader, PostedAssemblyHeader, TempSpecTrackingSpecification, QltyInspectionHeader);
         end;

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
@@ -43,7 +43,7 @@ codeunit 20445 "Qlty. Inventory Availability"
     /// If multiple locations/bins are determined then those multiple locations/bins are supplied in TempBinContent
     /// </summary>
     /// <param name="QltyInspectionHeader">Record "Qlty. Inspection Header".</param>
-    /// <param name="TempBinContent">Temporary var Record "Bin Content".   Multiple bin locations could be available.</param>
+    /// <param name="TempBinContent">Temporary var Record "Bin Content". Multiple bin locations could be available.</param>
     /// <returns>Return variable of type Boolean.</returns>
     internal procedure GetCurrentLocationOfTrackedInventory(QltyInspectionHeader: Record "Qlty. Inspection Header"; var TempBinContent: Record "Bin Content" temporary): Boolean
     begin

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyItemTrackingMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyItemTrackingMgmt.Codeunit.al
@@ -465,7 +465,7 @@ codeunit 20439 "Qlty. Item Tracking Mgmt."
     end;
 
     /// <summary>
-    /// Adds/Removes Purchase Return Line item tracking entries.  When used with serial numbers only one serial number can be created at a time.
+    /// Adds/Removes Purchase Return Line item tracking entries. When used with serial numbers only one serial number can be created at a time.
     /// </summary>
     /// <param name="PurchPurchaseLine"></param>
     /// <param name="SerialNo"></param>

--- a/src/Apps/W1/Quality Management/app/src/Integration/Manufacturing/QltyManufacturIntegration.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Manufacturing/QltyManufacturIntegration.Codeunit.al
@@ -390,7 +390,7 @@ codeunit 20407 "Qlty. Manufactur. Integration"
                                 if MadeInspection then begin
                                     QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
                                     ListOfInspectionIds.Add(QltyInspectionHeader.RecordId());
-                                    QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                                    QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
                                     CreatedAtLeastOneInspectionForRoutingLine := true;
                                 end;
                             until ReservationEntry.Next() = 0;
@@ -400,7 +400,7 @@ codeunit 20407 "Qlty. Manufactur. Integration"
                             if MadeInspection then begin
                                 QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
                                 ListOfInspectionIds.Add(QltyInspectionHeader.RecordId());
-                                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
                                 CreatedAtLeastOneInspectionForRoutingLine := true;
                             end;
                         end;
@@ -421,7 +421,7 @@ codeunit 20407 "Qlty. Manufactur. Integration"
                             if MadeInspection then begin
                                 QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
                                 ListOfInspectionIds.Add(QltyInspectionHeader.RecordId());
-                                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
                                 CreatedAtLeastOneInspectionForOrderLine := true;
                             end;
 
@@ -431,7 +431,7 @@ codeunit 20407 "Qlty. Manufactur. Integration"
                         if MadeInspection then begin
                             QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
                             ListOfInspectionIds.Add(QltyInspectionHeader.RecordId());
-                            QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                            QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
                             CreatedAtLeastOneInspectionForOrderLine := true;
                         end;
                     end;
@@ -442,7 +442,7 @@ codeunit 20407 "Qlty. Manufactur. Integration"
             if MadeInspection then begin
                 QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
                 ListOfInspectionIds.Add(QltyInspectionHeader.RecordId());
-                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
                 CreatedInspectionForProdOrder := MadeInspection;
             end;
         end;
@@ -492,7 +492,7 @@ codeunit 20407 "Qlty. Manufactur. Integration"
     /// <param name="ProdOrderRoutingLine">Typically the 'main' record the inspections are associated against.</param>
     /// <param name="ItemLedgerEntry">The item ledger entry related to this sequence of events</param>
     /// <param name="ProdOrderLine">The production order line involved in this sequence of events</param>
-    /// <param name="ItemJournalLine">The item journal line record involved in this transaction.  Important: this record may no longer exist, and should not be altered.</param>
+    /// <param name="ItemJournalLine">The item journal line record involved in this transaction. Important: this record may no longer exist, and should not be altered.</param>
     /// <param name="IsHandled">Set to true to replace the default behavior</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeProductionAttemptCreatePostAutomaticInspection(var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var ItemLedgerEntry: Record "Item Ledger Entry"; var ProdOrderLine: Record "Prod. Order Line"; var ItemJournalLine: Record "Item Journal Line"; var IsHandled: Boolean)
@@ -505,7 +505,7 @@ codeunit 20407 "Qlty. Manufactur. Integration"
     /// <param name="ProdOrderRoutingLine">Typically the 'main' record the inspections are associated against.</param>
     /// <param name="ItemLedgerEntry">The item ledger entry related to this sequence of events</param>
     /// <param name="ProdOrderLine">The production order line involved in this sequence of events</param>
-    /// <param name="ItemJournalLine">The item journal line record involved in this transaction.  Important: this record may no longer exist, and should not be altered.</param>
+    /// <param name="ItemJournalLine">The item journal line record involved in this transaction. Important: this record may no longer exist, and should not be altered.</param>
     [IntegrationEvent(false, false)]
     local procedure OnAfterProductionAttemptCreateAutomaticInspection(var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var ItemLedgerEntry: Record "Item Ledger Entry"; var ProdOrderLine: Record "Prod. Order Line"; var ItemJournalLine: Record "Item Journal Line")
     begin
@@ -541,7 +541,7 @@ codeunit 20407 "Qlty. Manufactur. Integration"
     /// </summary>
     /// <param name="ItemLedgerEntry">The item ledger entry related to this sequence of events</param>
     /// <param name="ProdOrderLine">The production order line involved in this sequence of events</param>
-    /// <param name="ItemJournalLine">The item journal line record involved in this transaction.  Important: this record may no longer exist, and should not be altered.</param>
+    /// <param name="ItemJournalLine">The item journal line record involved in this transaction. Important: this record may no longer exist, and should not be altered.</param>
     /// <param name="IsHandled">Set to true to replace the default behavior</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeProductionHandleOnAfterPostOutput(var ItemLedgerEntry: Record "Item Ledger Entry"; var ProdOrderLine: Record "Prod. Order Line"; var ItemJournalLine: Record "Item Journal Line"; var IsHandled: Boolean)

--- a/src/Apps/W1/Quality Management/app/src/Integration/Receiving/QltyReceivingIntegration.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Receiving/QltyReceivingIntegration.Codeunit.al
@@ -170,14 +170,14 @@ codeunit 20411 "Qlty. Receiving Integration"
                     if QltyInspectionCreate.CreateInspectionWithMultiVariants(SalesLine, TempTrackingSpecification, DummyVariant, DummyVariant, false, QltyInspectionGenRule) then begin
                         HasInspection := true;
                         QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
-                        QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                        QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
                     end;
                 until TempTrackingSpecification.Next() = 0
             else
                 if QltyInspectionCreate.CreateInspectionWithMultiVariants(SalesLine, DummyVariant, DummyVariant, DummyVariant, false, QltyInspectionGenRule) then begin
                     HasInspection := true;
                     QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
-                    QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                    QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
                 end;
             QltyBatchNotifHelper.EndBatch();
         end;
@@ -306,7 +306,7 @@ codeunit 20411 "Qlty. Receiving Integration"
                 if QltyInspectionCreate.CreateInspectionWithMultiVariants(WarehouseReceiptLine, OptionalSourceLineVariant, WarehouseReceiptHeader, TempTrackingSpecification, false, TempQltyInspectionGenRule) then begin
                     HasInspection := true;
                     QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
-                    QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                    QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
                 end;
             until TempTrackingSpecification.Next() = 0
         else begin
@@ -314,7 +314,7 @@ codeunit 20411 "Qlty. Receiving Integration"
             if QltyInspectionCreate.CreateInspectionWithMultiVariants(WarehouseReceiptLine, OptionalSourceLineVariant, WarehouseReceiptHeader, DummyVariant, false, TempQltyInspectionGenRule) then begin
                 HasInspection := true;
                 QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
-                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
             end;
         end;
 
@@ -350,7 +350,7 @@ codeunit 20411 "Qlty. Receiving Integration"
                 if QltyInspectionCreate.CreateInspectionWithMultiVariants(WarehouseJournalLine, OptionalSourceRecordVariant, PostedWhseReceiptHeader, TempTrackingSpecification, false, TempQltyInspectionGenRule) then begin
                     HasInspection := true;
                     QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
-                    QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                    QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
                 end;
             until TempTrackingSpecification.Next() = 0
         else begin
@@ -358,7 +358,7 @@ codeunit 20411 "Qlty. Receiving Integration"
             if QltyInspectionCreate.CreateInspectionWithMultiVariants(WarehouseJournalLine, OptionalSourceRecordVariant, PostedWhseReceiptHeader, DummyVariant, false, TempQltyInspectionGenRule) then begin
                 HasInspection := true;
                 QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
-                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
             end;
         end;
 
@@ -384,7 +384,7 @@ codeunit 20411 "Qlty. Receiving Integration"
         HasInspection := QltyInspectionCreate.CreateInspectionWithMultiVariants(PurchaseLine, PurchaseHeader, TempTrackingSpecification, DummyVariant, false, TempQltyInspectionGenRule);
         if HasInspection then begin
             QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
-            QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+            QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
         end;
 
         OnAfterPurchaseAttemptCreateInspectionWithPurchaseLine(HasInspection, QltyInspectionHeader, PurchaseLine, PurchaseHeader, TempTrackingSpecification);
@@ -423,7 +423,7 @@ codeunit 20411 "Qlty. Receiving Integration"
 
                 if HasInspection then begin
                     QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
-                    QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                    QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
                 end;
             until TempTrackingSpecification.Next() = 0
         else begin
@@ -436,7 +436,7 @@ codeunit 20411 "Qlty. Receiving Integration"
 
             if HasInspection then begin
                 QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
-                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
             end;
         end;
         OnAfterTransferAttemptCreateInspectionWithInboundTransferLine(TransTransferLine, OptionalTransferReceiptHeader, OptionalDirectTransHeader, TempTrackingSpecification, QltyInspectionHeader, HasInspection);

--- a/src/Apps/W1/Quality Management/app/src/Integration/Warehouse/QltyWarehouseIntegration.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Warehouse/QltyWarehouseIntegration.Codeunit.al
@@ -70,14 +70,14 @@ codeunit 20438 "Qlty. Warehouse Integration"
                 if QltyInspectionCreate.CreateInspectionWithMultiVariants(WarehouseEntry, WarehouseJournalLine, TempTrackingSpecification, DummyVariant, false, QltyInspectionGenRule) then begin
                     HasInspection := true;
                     QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
-                    QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                    QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
                 end;
             until TempTrackingSpecification.Next() = 0
         else
             if QltyInspectionCreate.CreateInspectionWithMultiVariants(WarehouseEntry, WarehouseJournalLine, DummyVariant, DummyVariant, false, QltyInspectionGenRule) then begin
                 HasInspection := true;
                 QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
-                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.");
+                QltyBatchNotifHelper.TrackCreatedInspection(QltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated());
             end;
         QltyBatchNotifHelper.EndBatch();
 

--- a/src/Apps/W1/Quality Management/app/src/Utilities/QltyBatchNotifHelper.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Utilities/QltyBatchNotifHelper.Codeunit.al
@@ -9,12 +9,12 @@ using Microsoft.QualityManagement.Document;
 codeunit 20456 "Qlty. Batch Notif. Helper"
 {
     var
-        BatchCreatedInspectionIds: List of [Code[20]];
+        BatchCreatedQltyInspectionIds: List of [Code[20]];
         IsBatchActive: Boolean;
 
     internal procedure BeginBatch()
     begin
-        Clear(BatchCreatedInspectionIds);
+        Clear(BatchCreatedQltyInspectionIds);
         IsBatchActive := true;
     end;
 
@@ -26,23 +26,26 @@ codeunit 20456 "Qlty. Batch Notif. Helper"
             exit;
 
         IsBatchActive := false;
-        if BatchCreatedInspectionIds.Count() = 0 then
+        if BatchCreatedQltyInspectionIds.Count() = 0 then
             exit;
 
-        QltyInspectionCreate.DisplayInspectionsIfConfigured(false, BatchCreatedInspectionIds);
-        Clear(BatchCreatedInspectionIds);
+        QltyInspectionCreate.DisplayInspectionsIfConfigured(false, BatchCreatedQltyInspectionIds);
+        Clear(BatchCreatedQltyInspectionIds);
     end;
 
-    internal procedure TrackCreatedInspection(InspectionNo: Code[20])
+    internal procedure TrackCreatedInspection(InspectionNo: Code[20]; IsNewlyCreated: Boolean)
     begin
         if not IsBatchActive then
+            exit;
+
+        if not IsNewlyCreated then
             exit;
 
         if InspectionNo = '' then
             exit;
 
-        if not BatchCreatedInspectionIds.Contains(InspectionNo) then
-            BatchCreatedInspectionIds.Add(InspectionNo);
+        if not BatchCreatedQltyInspectionIds.Contains(InspectionNo) then
+            BatchCreatedQltyInspectionIds.Add(InspectionNo);
     end;
 
     internal procedure ConfigureForBatch(var QltyInspectionCreate: Codeunit "Qlty. Inspection - Create")

--- a/src/Apps/W1/Quality Management/app/src/Utilities/QltyMiscHelpers.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Utilities/QltyMiscHelpers.Codeunit.al
@@ -80,7 +80,7 @@ codeunit 20599 "Qlty. Misc Helpers"
     /// This will evaluate expressions!
     /// </summary>
     /// <param name="QltyTest"></param>
-    /// <param name="OptionalContextQltyInspectionHeader">Optional. Leave empty if you do not want search/replace fields.  Supply an inspection context if you want the lookup table filter to have square bracket [FIELDNAME] replacements </param>
+    /// <param name="OptionalContextQltyInspectionHeader">Optional. Leave empty if you do not want search/replace fields. Supply an inspection context if you want the lookup table filter to have square bracket [FIELDNAME] replacements </param>
     /// <param name="TempBufferQltyTestLookupValue"></param>
     internal procedure GetRecordsForTableField(var QltyTest: Record "Qlty. Test"; var OptionalContextQltyInspectionHeader: Record "Qlty. Inspection Header"; var TempBufferQltyTestLookupValue: Record "Qlty. Test Lookup Value" temporary)
     var

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsCreateInspect.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsCreateInspect.Codeunit.al
@@ -33,8 +33,8 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         QltyInspectionUtility: Codeunit "Qlty. Inspection Utility";
         CannotFindTemplateErr: Label 'Cannot find a Quality Inspection Template or Quality Inspection Generation Rule to match %1. Ensure there is a Quality Inspection Generation Rule that will match this record.', Comment = '%1=The record identifier';
         ProgrammerErrNotARecordRefErr: Label 'Cannot find inspections with %1. Please supply a "Record" or "RecordRef".', Comment = '%1=the variant being supplied that is not a RecordRef. Your system might have an extension or customization that needs to be re-configured.';
-        UnableToCreateInspectionForRecordErr: Label 'Cannot find enough details to make an inspection for your record(s).  Try making sure that there is a source configuration for your record, and then also make sure there is sufficient information in your inspection generation rules.  The table involved is %1.', Comment = '%1=the table involved.';
-        UnableToCreateInspectionForParentOrChildErr: Label 'Cannot find enough details to make an inspection for your record(s).  Try making sure that there is a source configuration for your record, and then also make sure there is sufficient information in your inspection generation rules.  Two tables involved are %1 and %2.', Comment = '%1=the parent table, %2=the child and original table.';
+        UnableToCreateInspectionForRecordErr: Label 'Cannot find enough details to make an inspection for your record(s). Try making sure that there is a source configuration for your record, and then also make sure there is sufficient information in your inspection generation rules. The table involved is %1.', Comment = '%1=the table involved.';
+        UnableToCreateInspectionForParentOrChildErr: Label 'Cannot find enough details to make an inspection for your record(s). Try making sure that there is a source configuration for your record, and then also make sure there is sufficient information in your inspection generation rules. Two tables involved are %1 and %2.', Comment = '%1=the parent table, %2=the child and original table.';
         IsInitialized: Boolean;
 
     [Test]
@@ -2483,6 +2483,174 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         asserterror QltyInspectionUtility.CreateMultipleInspectionsForMultipleRecords(ProdOrderRoutingLineRecordRef, false);
         // [THEN] An error is raised indicating unable to create an inspection for the parent or child record
         LibraryAssert.ExpectedError(StrSubstNo(UnableToCreateInspectionForParentOrChildErr, ProdOrderLine.TableName, ProdOrderRoutingLineRecordRef.Name));
+    end;
+
+    [Test]
+    procedure CreateInspection_NewInsertion_ReportedAsNewlyCreated()
+    var
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        ProdProductionOrder: Record "Production Order";
+        Item: Record Item;
+        CreatedQltyInspectionHeader: Record "Qlty. Inspection Header";
+        ProdOrderRoutingLineRecordRef: RecordRef;
+        ClaimedInspectionWasFoundOrCreated: Boolean;
+        IsNewlyCreated: Boolean;
+    begin
+        // [SCENARIO] When CreateInspection inserts a new inspection, IsLastInspectionNewlyCreated must report true (so the inspection-created notification is raised).
+
+        Initialize();
+
+        // [GIVEN] A quality inspection template, generation rule, item, and production order with routing line are set up
+        SetupCreateInspectionProductionOrder(QltyInspectionTemplateHdr, QltyInspectionGenRule, Item, ProdProductionOrder, ProdOrderRoutingLine);
+
+        ProdOrderRoutingLineRecordRef.GetTable(ProdOrderRoutingLine);
+
+        // [WHEN] CreateInspection is called for the routing line for the first time
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionUtility.CreateInspectionAndReportIfNewlyCreated(ProdOrderRoutingLineRecordRef, false, CreatedQltyInspectionHeader, IsNewlyCreated);
+
+        QltyInspectionGenRule.Delete();
+
+        // [THEN] The inspection is created and reported as newly created so the "Quality Inspection created" notification is raised
+        LibraryAssert.IsTrue(ClaimedInspectionWasFoundOrCreated, 'Should claim an inspection has been found/created.');
+        LibraryAssert.IsTrue(IsNewlyCreated, 'A newly inserted inspection must be reported as newly created so the inspection-created notification is raised.');
+    end;
+
+    [Test]
+    procedure CreateInspection_ReusedExisting_NotReportedAsNewlyCreated()
+    var
+        QltyManagementSetup: Record "Qlty. Management Setup";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        ProdProductionOrder: Record "Production Order";
+        Item: Record Item;
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        FirstCreatedQltyInspectionHeader: Record "Qlty. Inspection Header";
+        SecondQltyInspectionHeader: Record "Qlty. Inspection Header";
+        ProdOrderRoutingLineRecordRef: RecordRef;
+        PreviousQltyCreateInspectBehavior: Enum "Qlty. Inspect. Creation Option";
+        ClaimedInspectionWasFoundOrCreated: Boolean;
+        IsNewlyCreated: Boolean;
+        BeforeCount: Integer;
+        AfterCount: Integer;
+    begin
+        // [SCENARIO] When CreateInspection reuses an existing inspection (Inspection Creation Option = "Use existing open inspection if available"),
+        // IsLastInspectionNewlyCreated must report false so the inspection-created notification is suppressed.
+
+        Initialize();
+
+        // [GIVEN] A quality inspection template, generation rule, item, and production order with routing line are set up
+        SetupCreateInspectionProductionOrder(QltyInspectionTemplateHdr, QltyInspectionGenRule, Item, ProdProductionOrder, ProdOrderRoutingLine);
+
+        // [GIVEN] A first inspection is created and left open
+        ProdOrderRoutingLineRecordRef.GetTable(ProdOrderRoutingLine);
+        QltyInspectionUtility.CreateInspection(ProdOrderRoutingLineRecordRef, false, FirstCreatedQltyInspectionHeader);
+
+        // [GIVEN] The Inspection Creation Option is set to "Use existing open inspection if available"
+        QltyManagementSetup.Get();
+        PreviousQltyCreateInspectBehavior := QltyManagementSetup."Inspection Creation Option";
+        QltyManagementSetup."Inspection Creation Option" := QltyManagementSetup."Inspection Creation Option"::"Use existing open inspection if available";
+        QltyManagementSetup.Modify();
+
+        QltyInspectionHeader.Reset();
+        BeforeCount := QltyInspectionHeader.Count();
+
+        // [WHEN] CreateInspection is called again for the same routing line while the first inspection is still open
+        ClaimedInspectionWasFoundOrCreated := QltyInspectionUtility.CreateInspectionAndReportIfNewlyCreated(ProdOrderRoutingLineRecordRef, false, SecondQltyInspectionHeader, IsNewlyCreated);
+
+        QltyManagementSetup."Inspection Creation Option" := PreviousQltyCreateInspectBehavior;
+        QltyManagementSetup.Modify();
+        QltyInspectionGenRule.Delete();
+
+        QltyInspectionHeader.Reset();
+        AfterCount := QltyInspectionHeader.Count();
+
+        // [THEN] No new inspection is inserted, the existing inspection is returned, and the call is reported as a reuse so the inspection-created notification is suppressed
+        LibraryAssert.IsTrue(ClaimedInspectionWasFoundOrCreated, 'Should claim an inspection has been found/created.');
+        LibraryAssert.AreEqual(BeforeCount, AfterCount, 'No new inspection should have been inserted when reusing.');
+        LibraryAssert.AreEqual(FirstCreatedQltyInspectionHeader."No.", SecondQltyInspectionHeader."No.", 'Should have returned the existing inspection.');
+        LibraryAssert.IsFalse(IsNewlyCreated, 'A reused inspection must not be reported as newly created so the inspection-created notification is suppressed.');
+    end;
+
+    [Test]
+    procedure CreateMultipleInspections_ReusedExisting_ExcludedFromCreatedIdsList()
+    var
+        QltyManagementSetup: Record "Qlty. Management Setup";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        TempFilterQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary;
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        FirstCreatedQltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyProdOrderGenerator: Codeunit "Qlty. Prod. Order Generator";
+        FirstRoutingLineRecordRef: RecordRef;
+        AllRoutingLinesRecordRef: RecordRef;
+        CreatedQltyInspectionIds, AllResolvedQltyInspectionIds : List of [Code[20]];
+        OrdersList: List of [Code[20]];
+        ProductionOrder: Code[20];
+        PreviousQltyCreateInspectBehavior: Enum "Qlty. Inspect. Creation Option";
+        BeforeCount: Integer;
+        AfterCount: Integer;
+    begin
+        // [SCENARIO] CreateMultipleInspectionsWithoutDisplaying should only include newly inserted inspection numbers in the returned list of created inspection ids;
+        // inspections that were merely reused must not inflate the "created" list that drives the inspection-created notifications/display.
+
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+        QltyInspectionUtility.CreateTemplate(QltyInspectionTemplateHdr, 3);
+        QltyInspectionUtility.CreatePrioritizedRule(QltyInspectionTemplateHdr, Database::"Prod. Order Routing Line", QltyInspectionGenRule);
+
+        // [GIVEN] 3 production orders, each with a routing line
+        QltyProdOrderGenerator.Init(100);
+        QltyProdOrderGenerator.ToggleAllSources(false);
+        QltyProdOrderGenerator.ToggleSourceType("Prod. Order Source Type"::Item, true);
+        QltyProdOrderGenerator.Generate(3, OrdersList);
+
+        // [GIVEN] An inspection is pre-created for the first production order so it will be reused on the next call
+        ProdOrderRoutingLine.SetRange(Status, ProdOrderRoutingLine.Status::Released);
+        ProdOrderRoutingLine.SetRange("Prod. Order No.", OrdersList.Get(1));
+        ProdOrderRoutingLine.FindLast();
+        FirstRoutingLineRecordRef.GetTable(ProdOrderRoutingLine);
+        QltyInspectionUtility.CreateInspection(FirstRoutingLineRecordRef, false, FirstCreatedQltyInspectionHeader);
+
+        // [GIVEN] The Inspection Creation Option is set to "Use existing open inspection if available" so the first routing line reuses, the other two create new
+        QltyManagementSetup.Get();
+        PreviousQltyCreateInspectBehavior := QltyManagementSetup."Inspection Creation Option";
+        QltyManagementSetup."Inspection Creation Option" := QltyManagementSetup."Inspection Creation Option"::"Use existing open inspection if available";
+        QltyManagementSetup.Modify();
+
+        // [GIVEN] A RecordRef containing the routing lines of all three production orders
+        AllRoutingLinesRecordRef.Open(Database::"Prod. Order Routing Line", true);
+        foreach ProductionOrder in OrdersList do begin
+            ProdOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder);
+            ProdOrderRoutingLine.FindLast();
+            AllRoutingLinesRecordRef.Copy(ProdOrderRoutingLine, false);
+            AllRoutingLinesRecordRef.Insert();
+        end;
+
+        QltyInspectionHeader.Reset();
+        BeforeCount := QltyInspectionHeader.Count();
+
+        // [WHEN] CreateMultipleInspectionsWithoutDisplaying is called for all three routing lines
+        QltyInspectionUtility.CreateMultipleInspectionsWithoutDisplaying(AllRoutingLinesRecordRef, false, TempFilterQltyInspectionGenRule, CreatedQltyInspectionIds, AllResolvedQltyInspectionIds);
+
+        QltyManagementSetup."Inspection Creation Option" := PreviousQltyCreateInspectBehavior;
+        QltyManagementSetup.Modify();
+        QltyInspectionGenRule.Delete();
+
+        QltyInspectionHeader.Reset();
+        AfterCount := QltyInspectionHeader.Count();
+
+        // [THEN] Only 2 new inspections were inserted (for production orders 2 and 3)
+        LibraryAssert.AreEqual((BeforeCount + 2), AfterCount, 'Only the two non-reused routing lines should have inserted new inspections.');
+        // [THEN] The returned list of created inspection ids excludes the reused inspection so the "created inspections" notification is not falsely inflated
+        LibraryAssert.AreEqual(2, CreatedQltyInspectionIds.Count(), 'The created inspection ids list must exclude reused inspections.');
+        LibraryAssert.IsFalse(CreatedQltyInspectionIds.Contains(FirstCreatedQltyInspectionHeader."No."), 'A reused inspection must not appear in the created inspection ids list.');
+        // [THEN] The all-resolved list includes both the 2 newly created inspections and the 1 reused inspection
+        LibraryAssert.AreEqual(3, AllResolvedQltyInspectionIds.Count(), 'The all-resolved list must include every inspection that was newly created or reused.');
+        LibraryAssert.IsTrue(AllResolvedQltyInspectionIds.Contains(FirstCreatedQltyInspectionHeader."No."), 'The all-resolved list must include the reused inspection.');
     end;
 
     local procedure CreateInspectionWithTracking(var PurOrdPurchaseLine: Record "Purchase Line"; var TempSpecTrackingSpecification: Record "Tracking Specification" temporary; var OutQltyInspectionHeader: Record "Qlty. Inspection Header")

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsDispositions.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsDispositions.Codeunit.al
@@ -49,7 +49,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         QltyPurOrderGenerator: Codeunit "Qlty. Pur. Order Generator";
         LibraryWarehouse: Codeunit "Library - Warehouse";
         QltyInspectionUtility: Codeunit "Qlty. Inspection Utility";
-        ReUsedLibraryItemTracking: Codeunit "Library - Item Tracking";
+        LibraryItemTracking: Codeunit "Library - Item Tracking";
         NoPurchRcptLineErr: Label 'Could not find a related purchase receipt line with sufficient quantity for %1 from Quality Inspection %2,%3. Confirm the inspection source is a Purchase Line and that it has been received prior to creating a return.', Comment = '%1=item,%2=inspection,%3=re-inspection';
         WriteOffEntireItemTrackingErr: Label 'Reducing inventory using the item tracked quantity for inspection %1 was requested, however the item associated with this inspection does not require tracking.', Comment = '%1=the inspection';
         MissingAdjBatchErr: Label 'There is missing setup on the Quality Management Setup Card defining the adjustment batch.';
@@ -304,7 +304,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         ReclassWarehouseJournalLine."New Lot No." := ReclassWarehouseJournalLine."Lot No.";
         ReclassWarehouseJournalLine.Modify();
         // [GIVEN] Item tracking is created for the reclassification journal line
-        ReUsedLibraryItemTracking.CreateWhseJournalLineItemTracking(ReclassWarehouseJournalWhseItemTrackingLine, ReclassWarehouseJournalLine, '', PurOrdReservationEntry."Lot No.", 50);
+        LibraryItemTracking.CreateWhseJournalLineItemTracking(ReclassWarehouseJournalWhseItemTrackingLine, ReclassWarehouseJournalLine, '', PurOrdReservationEntry."Lot No.", 50);
         ReclassWarehouseJournalWhseItemTrackingLine."New Lot No." := ReclassWarehouseJournalWhseItemTrackingLine."Lot No.";
         ReclassWarehouseJournalWhseItemTrackingLine.Modify();
         // [GIVEN] The warehouse journal is registered to complete the movement
@@ -765,7 +765,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryAssert.AreEqual(1, NegativeAdjustmentItemJournalLine.Count(), 'test setup failed, should be only 1 line after a modify');
 
         // [GIVEN] Item tracking with lot number is assigned to the journal line
-        ReUsedLibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, InitialInspectionInventoryJnlItemJournalLine, '', OriginalLotNo, InitialInspectionInventoryJnlItemJournalLine.Quantity);
+        LibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, InitialInspectionInventoryJnlItemJournalLine, '', OriginalLotNo, InitialInspectionInventoryJnlItemJournalLine.Quantity);
 
         // [GIVEN] Item ledger entry filters are set up for validation
         ItemLedgerEntry.SetRange("Item No.", InitialInspectionInventoryJnlItemJournalLine."Item No.");
@@ -888,7 +888,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryUtility.CreateNoSeries(LotNoSeries, true, true, false);
         LibraryUtility.CreateNoSeriesLine(LotNoSeriesLine, LotNoSeries.Code, PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '0'), PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '9'));
 
-        ReUsedLibraryItemTracking.CreateItemTrackingCode(LotItemTrackingCode, false, true, false);
+        LibraryItemTracking.CreateItemTrackingCode(LotItemTrackingCode, false, true, false);
         LibraryInventory.CreateTrackedItem(Item, LotNoSeries.Code, '', LotItemTrackingCode.Code);
 
         // [GIVEN] Bin contents are created for all bins in the location
@@ -1218,7 +1218,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         ReclassWarehouseJournalLine."New Lot No." := ReclassWarehouseJournalLine."Lot No.";
         ReclassWarehouseJournalLine.Modify();
 
-        ReUsedLibraryItemTracking.CreateWhseJournalLineItemTracking(ReclassWarehouseJournalWhseItemTrackingLine, ReclassWarehouseJournalLine, '', PurOrdReservationEntry."Lot No.", 50);
+        LibraryItemTracking.CreateWhseJournalLineItemTracking(ReclassWarehouseJournalWhseItemTrackingLine, ReclassWarehouseJournalLine, '', PurOrdReservationEntry."Lot No.", 50);
         ReclassWarehouseJournalWhseItemTrackingLine."New Lot No." := ReclassWarehouseJournalWhseItemTrackingLine."Lot No.";
         ReclassWarehouseJournalWhseItemTrackingLine.Modify();
 
@@ -1822,7 +1822,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryUtility.CreateNoSeries(LotNoSeries, true, true, false);
         LibraryUtility.CreateNoSeriesLine(LotNoSeriesLine, LotNoSeries.Code, PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '0'), PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '9'));
 
-        ReUsedLibraryItemTracking.CreateItemTrackingCode(LotItemTrackingCode, false, true, false);
+        LibraryItemTracking.CreateItemTrackingCode(LotItemTrackingCode, false, true, false);
         LibraryInventory.CreateTrackedItem(Item, LotNoSeries.Code, '', LotItemTrackingCode.Code);
 
         // [GIVEN] Non-directed pick location with bins is created
@@ -1857,7 +1857,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryAssert.AreEqual(1, InitialInventoryItemJournalLine.Count(), 'test setup failed, should be only 1 line after a modify');
 
         // [GIVEN] Item tracking with original lot number is assigned to the journal line
-        ReUsedLibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, InitialInspectionInventoryJnlItemJournalLine, '', OriginalLotNo, InitialInspectionInventoryJnlItemJournalLine.Quantity);
+        LibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, InitialInspectionInventoryJnlItemJournalLine, '', OriginalLotNo, InitialInspectionInventoryJnlItemJournalLine.Quantity);
 
         // [GIVEN] Item ledger entry filters are set up and journal is posted
         ItemLedgerEntry.SetRange("Item No.", InitialInspectionInventoryJnlItemJournalLine."Item No.");
@@ -1973,7 +1973,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryUtility.CreateNoSeries(LotNoSeries, true, true, false);
         LibraryUtility.CreateNoSeriesLine(LotNoSeriesLine, LotNoSeries.Code, PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '0'), PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '9'));
 
-        ReUsedLibraryItemTracking.CreateItemTrackingCode(LotItemTrackingCode, false, true, false);
+        LibraryItemTracking.CreateItemTrackingCode(LotItemTrackingCode, false, true, false);
         LibraryInventory.CreateTrackedItem(Item, LotNoSeries.Code, '', LotItemTrackingCode.Code);
 
         // [GIVEN] Full WMS location is created with bins and bin content for the item
@@ -2136,7 +2136,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryUtility.CreateNoSeries(SerialNoSeries, true, true, false);
         LibraryUtility.CreateNoSeriesLine(SerialNoSeriesLine, SerialNoSeries.Code, PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '0'), PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '9'));
 
-        ReUsedLibraryItemTracking.CreateItemTrackingCode(SerialItemTrackingCode, true, false, false);
+        LibraryItemTracking.CreateItemTrackingCode(SerialItemTrackingCode, true, false, false);
         LibraryInventory.CreateTrackedItem(Item, '', SerialNoSeries.Code, SerialItemTrackingCode.Code);
 
         // [GIVEN] Non-directed pick location with bins is created
@@ -2172,7 +2172,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryAssert.AreEqual(1, InitialInventoryItemJournalLine.Count(), 'test setup failed, should be only 1 line after a modify');
 
         // [GIVEN] Item tracking with original serial number is assigned to the journal line
-        ReUsedLibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, InitialInspectionInventoryJnlItemJournalLine, OriginalSerialNo, '', InitialInspectionInventoryJnlItemJournalLine.Quantity);
+        LibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, InitialInspectionInventoryJnlItemJournalLine, OriginalSerialNo, '', InitialInspectionInventoryJnlItemJournalLine.Quantity);
 
         // [GIVEN] Item ledger entry filters are set up and journal is posted
         ItemLedgerEntry.SetRange("Item No.", InitialInspectionInventoryJnlItemJournalLine."Item No.");
@@ -2292,7 +2292,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryUtility.CreateNoSeriesLine(SerialNoSeriesLine, SerialNoSeries.Code, PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '0'), PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '9'));
 
         // [GIVEN] Item tracking code is created for serial tracking
-        ReUsedLibraryItemTracking.CreateItemTrackingCode(SerialItemTrackingCode, true, false, false);
+        LibraryItemTracking.CreateItemTrackingCode(SerialItemTrackingCode, true, false, false);
 
         // [GIVEN] Serial-tracked item is created with item tracking code
         LibraryInventory.CreateTrackedItem(Item, '', SerialNoSeries.Code, SerialItemTrackingCode.Code);
@@ -2484,7 +2484,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryUtility.CreateNoSeries(PackageNoSeries, true, true, false);
         LibraryUtility.CreateNoSeriesLine(PackageNoSeriesLine, PackageNoSeries.Code, PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '0'), PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '9'));
 
-        ReUsedLibraryItemTracking.CreateItemTrackingCode(PackageItemTrackingCode, false, false, true);
+        LibraryItemTracking.CreateItemTrackingCode(PackageItemTrackingCode, false, false, true);
         InventorySetup.Get();
         InventorySetup.Validate("Package Nos.", PackageNoSeries.Code);
         InventorySetup.Modify(true);
@@ -2523,7 +2523,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryAssert.AreEqual(1, InitialInventoryItemJournalLine.Count(), 'test setup failed, should be only 1 line after a modify');
 
         // [GIVEN] Item tracking with original package number is assigned to the journal line
-        ReUsedLibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, InitialInspectionInventoryJnlItemJournalLine, '', '', InitialInspectionInventoryJnlItemJournalLine.Quantity);
+        LibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, InitialInspectionInventoryJnlItemJournalLine, '', '', InitialInspectionInventoryJnlItemJournalLine.Quantity);
         ReservationEntry.Validate("Package No.", OriginalPackageNo);
         ReservationEntry.Validate("New Package No.", OriginalPackageNo);
         ReservationEntry.Modify();
@@ -2638,7 +2638,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryUtility.CreateNoSeries(PackageNoSeries, true, true, false);
         LibraryUtility.CreateNoSeriesLine(PackageNoSeriesLine, PackageNoSeries.Code, PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '0'), PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '9'));
 
-        ReUsedLibraryItemTracking.CreateItemTrackingCode(PackageItemTrackingCode, false, false, true);
+        LibraryItemTracking.CreateItemTrackingCode(PackageItemTrackingCode, false, false, true);
         InventorySetup.Get();
         InventorySetup.Validate("Package Nos.", PackageNoSeries.Code);
         InventorySetup.Modify(true);
@@ -2814,7 +2814,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryUtility.CreateNoSeriesLine(LotNoSeriesLine, LotNoSeries.Code, PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '0'), PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '9'));
 
         // [GIVEN] Item tracking code is created for lot tracking
-        ReUsedLibraryItemTracking.CreateItemTrackingCode(LotItemTrackingCode, false, true, false);
+        LibraryItemTracking.CreateItemTrackingCode(LotItemTrackingCode, false, true, false);
 
         // [GIVEN] Item tracking code is configured to use expiration dates
         LotItemTrackingCode."Use Expiration Dates" := true;
@@ -2868,7 +2868,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryAssert.AreEqual(1, InitialInventoryItemJournalLine.Count(), 'test setup failed, should be only 1 line after a modify');
 
         // [GIVEN] Item tracking with lot number is assigned to the journal line
-        ReUsedLibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, InitialInspectionInventoryJnlItemJournalLine, '', OriginalLotNo, InitialInspectionInventoryJnlItemJournalLine.Quantity);
+        LibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, InitialInspectionInventoryJnlItemJournalLine, '', OriginalLotNo, InitialInspectionInventoryJnlItemJournalLine.Quantity);
 
         // [GIVEN] Expiration date is set to work date for the reservation entry
         ReservationEntry."Expiration Date" := WorkDate();
@@ -3012,7 +3012,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryUtility.CreateNoSeries(LotNoSeries, true, true, false);
         LibraryUtility.CreateNoSeriesLine(LotNoSeriesLine, LotNoSeries.Code, PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '0'), PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '9'));
 
-        ReUsedLibraryItemTracking.CreateItemTrackingCode(LotItemTrackingCode, false, true, false);
+        LibraryItemTracking.CreateItemTrackingCode(LotItemTrackingCode, false, true, false);
         LotItemTrackingCode."Use Expiration Dates" := true;
         LotItemTrackingCode.Modify();
 
@@ -3168,7 +3168,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryUtility.CreateNoSeriesLine(LotNoSeriesLine, LotNoSeries.Code, PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '0'), PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '9'));
 
         // [GIVEN] Lot-tracked item tracking code and item are created
-        ReUsedLibraryItemTracking.CreateItemTrackingCode(LotItemTrackingCode, false, true, false);
+        LibraryItemTracking.CreateItemTrackingCode(LotItemTrackingCode, false, true, false);
         LibraryInventory.CreateTrackedItem(Item, LotNoSeries.Code, '', LotItemTrackingCode.Code);
 
         // [GIVEN] A full WMS location with bins and bin content is created
@@ -3373,7 +3373,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         ReclassWarehouseJournalLine.Modify();
 
         // [GIVEN] Warehouse item tracking line is created with lot and expiration information
-        ReUsedLibraryItemTracking.CreateWhseJournalLineItemTracking(ReclassWarehouseJournalWhseItemTrackingLine, ReclassWarehouseJournalLine, '', ReservationEntry."Lot No.", 50);
+        LibraryItemTracking.CreateWhseJournalLineItemTracking(ReclassWarehouseJournalWhseItemTrackingLine, ReclassWarehouseJournalLine, '', ReservationEntry."Lot No.", 50);
         ReclassWarehouseJournalWhseItemTrackingLine."New Lot No." := ReclassWarehouseJournalWhseItemTrackingLine."Lot No.";
         ReclassWarehouseJournalWhseItemTrackingLine."Expiration Date" := ReservationEntry."Expiration Date";
         ReclassWarehouseJournalWhseItemTrackingLine."New Expiration Date" := ReservationEntry."Expiration Date";
@@ -3489,7 +3489,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryUtility.CreateNoSeries(PackageNoSeries, true, true, false);
         LibraryUtility.CreateNoSeriesLine(PackageNoSeriesLine, PackageNoSeries.Code, PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '0'), PadStr(Format(CurrentDateTime(), 0, 'A<Year><Month,2><Day,2><Hours24><Minutes><Seconds>'), 19, '9'));
 
-        ReUsedLibraryItemTracking.CreateItemTrackingCode(PackageItemTrackingCode, false, false, true);
+        LibraryItemTracking.CreateItemTrackingCode(PackageItemTrackingCode, false, false, true);
         InventorySetup.Get();
         InventorySetup.Validate("Package Nos.", PackageNoSeries.Code);
         InventorySetup.Modify(true);
@@ -3530,7 +3530,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         LibraryAssert.AreEqual(1, InitialInventoryItemJournalLine.Count(), 'test setup failed, should be only 1 line after a modify');
 
         // [GIVEN] Item tracking with original package number is assigned to the journal line
-        ReUsedLibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, InitialInspectionInventoryJnlItemJournalLine, '', '', InitialInspectionInventoryJnlItemJournalLine.Quantity);
+        LibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, InitialInspectionInventoryJnlItemJournalLine, '', '', InitialInspectionInventoryJnlItemJournalLine.Quantity);
         ReservationEntry.Validate("Package No.", OriginalPackageNo);
         ReservationEntry.Validate("New Package No.", OriginalPackageNo);
         ReservationEntry.Modify();
@@ -4304,7 +4304,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         ReclassWarehouseJournalLine."Lot No." := ReservationEntry."Lot No.";
         ReclassWarehouseJournalLine."New Lot No." := ReclassWarehouseJournalLine."Lot No.";
         ReclassWarehouseJournalLine.Modify();
-        ReUsedLibraryItemTracking.CreateWhseJournalLineItemTracking(ReclassWarehouseJournalWhseItemTrackingLine, ReclassWarehouseJournalLine, '', ReservationEntry."Lot No.", 50);
+        LibraryItemTracking.CreateWhseJournalLineItemTracking(ReclassWarehouseJournalWhseItemTrackingLine, ReclassWarehouseJournalLine, '', ReservationEntry."Lot No.", 50);
         ReclassWarehouseJournalWhseItemTrackingLine."New Lot No." := ReclassWarehouseJournalWhseItemTrackingLine."Lot No.";
         ReclassWarehouseJournalWhseItemTrackingLine.Modify();
         LibraryWarehouse.RegisterWhseJournalLine(ReclassWhseItemWarehouseJournalTemplate.Name, ReclassWarehouseJournalBatch.Name, Location.Code, true);
@@ -4909,7 +4909,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         ReclassWarehouseJournalLine."Lot No." := ReservationEntry."Lot No.";
         ReclassWarehouseJournalLine."New Lot No." := ReclassWarehouseJournalLine."Lot No.";
         ReclassWarehouseJournalLine.Modify();
-        ReUsedLibraryItemTracking.CreateWhseJournalLineItemTracking(ReclassWarehouseJournalWhseItemTrackingLine, ReclassWarehouseJournalLine, '', ReservationEntry."Lot No.", 50);
+        LibraryItemTracking.CreateWhseJournalLineItemTracking(ReclassWarehouseJournalWhseItemTrackingLine, ReclassWarehouseJournalLine, '', ReservationEntry."Lot No.", 50);
         ReclassWarehouseJournalWhseItemTrackingLine."New Lot No." := ReclassWarehouseJournalWhseItemTrackingLine."Lot No.";
         ReclassWarehouseJournalWhseItemTrackingLine.Modify();
         LibraryWarehouse.RegisterWhseJournalLine(ReclassWhseItemWarehouseJournalTemplate.Name, ReclassWarehouseJournalBatch.Name, Location.Code, true);
@@ -5521,7 +5521,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         ReclassItemJournalLine."New Bin Code" := InitialChangeBin;
         ReclassItemJournalLine.Modify();
 
-        ReUsedLibraryItemTracking.CreateItemReclassJnLineItemTracking(ReclassReservationEntry, ReclassItemJournalLine, '', ReservationEntry."Lot No.", 50);
+        LibraryItemTracking.CreateItemReclassJnLineItemTracking(ReclassReservationEntry, ReclassItemJournalLine, '', ReservationEntry."Lot No.", 50);
         ReclassReservationEntry."New Lot No." := ReclassReservationEntry."Lot No.";
         ReclassReservationEntry.Modify();
         LibraryInventory.PostItemJournalBatch(ReclassItemJournalBatch);
@@ -6043,7 +6043,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         ReclassWarehouseJournalLine."Lot No." := ReservationEntry."Lot No.";
         ReclassWarehouseJournalLine."New Lot No." := ReclassWarehouseJournalLine."Lot No.";
         ReclassWarehouseJournalLine.Modify();
-        ReUsedLibraryItemTracking.CreateWhseJournalLineItemTracking(ReclassWarehouseJournalWhseItemTrackingLine, ReclassWarehouseJournalLine, '', ReservationEntry."Lot No.", 50);
+        LibraryItemTracking.CreateWhseJournalLineItemTracking(ReclassWarehouseJournalWhseItemTrackingLine, ReclassWarehouseJournalLine, '', ReservationEntry."Lot No.", 50);
         ReclassWarehouseJournalWhseItemTrackingLine."New Lot No." := ReclassWarehouseJournalWhseItemTrackingLine."Lot No.";
         ReclassWarehouseJournalWhseItemTrackingLine.Modify();
         LibraryWarehouse.RegisterWhseJournalLine(ReclassWhseItemWarehouseJournalTemplate.Name, ReclassWarehouseJournalBatch.Name, Location.Code, true);
@@ -6316,7 +6316,7 @@ codeunit 139960 "Qlty. Tests - Dispositions"
         ReclassItemJournalLine."New Bin Code" := InitialChangeBin;
         ReclassItemJournalLine.Modify();
 
-        ReUsedLibraryItemTracking.CreateItemReclassJnLineItemTracking(ReclassReservationEntry, ReclassItemJournalLine, '', ReservationEntry."Lot No.", 50);
+        LibraryItemTracking.CreateItemReclassJnLineItemTracking(ReclassReservationEntry, ReclassItemJournalLine, '', ReservationEntry."Lot No.", 50);
         ReclassReservationEntry."New Lot No." := ReclassReservationEntry."Lot No.";
         ReclassReservationEntry.Modify();
         LibraryInventory.PostItemJournalBatch(ReclassItemJournalBatch);


### PR DESCRIPTION
## What & why

Do not show notifications when new inspections are not created, for example due to setup that instructs to use existing inspections.

## Linked work
Fixes [AB#638475](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638475)


