### PR TITLE
[28.x] ABC Analysis page - improve caption

### DIFF
--- a/src/Apps/W1/PowerBIReports/App/Inventory/Embedded/Inventory/PowerBIABCAnalysis.Page.al
+++ b/src/Apps/W1/PowerBIReports/App/Inventory/Embedded/Inventory/PowerBIABCAnalysis.Page.al
@@ -11,7 +11,7 @@ page 37111 "PowerBI ABC Analysis"
     UsageCategory = ReportsAndAnalysis;
     ApplicationArea = All;
     PageType = UserControlHost;
-    Caption = 'ABC Analysis';
+    Caption = 'ABC Analysis (Power BI)';
     AboutTitle = 'About ABC Analysis';
     AboutText = 'The ABC Analysis page provides insights into customer segmentation based on sales volume, helping to identify key customers and prioritize sales efforts.';
 
@@ -52,4 +52,3 @@ page 37111 "PowerBI ABC Analysis"
         ReportId := SetupHelper.OpenPowerBIEmbeddedReportPageValidation("PBI Report Setup"::"Inventory App");
     end;
 }
-


### PR DESCRIPTION
Backport of #8422 to `releases/28.x`.

Changes page 37111 `PowerBI ABC Analysis` caption from `'ABC Analysis'` to `'ABC Analysis (Power BI)'` so it can be distinguished from the Excel-based `Item - ABC Analysis` report when using Tell Me.

Related ADO work item: [AB#637463](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637463)






