### PR TITLE
(Bug 638702): [Subcontracting] Disable test CancelInvoiceWithSubcontractingItemChargeIsBlocked in SubcSubcontractingTest.Codeunit.al

### DIFF
--- a/src/Apps/W1/Subcontracting/Test/DisabledTests/SubcSubcontractingTest.DisabledTest.json
+++ b/src/Apps/W1/Subcontracting/Test/DisabledTests/SubcSubcontractingTest.DisabledTest.json
@@ -1,0 +1,8 @@
+[
+    {
+        "bug": "638702",
+        "codeunitId": 139989,
+        "codeunitName": "Subc. Subcontracting Test",
+        "method": "CancelInvoiceWithSubcontractingItemChargeIsBlocked"
+    }
+]

--- a/src/Apps/W1/Subcontracting/Test/DisabledTests/SubcontractingTests.json
+++ b/src/Apps/W1/Subcontracting/Test/DisabledTests/SubcontractingTests.json
@@ -1,8 +1,0 @@
-[
-    {
-        "bug": "617432",
-        "codeunitId": 139989,
-        "codeunitName": "Subc. Subcontracting Test",
-        "method": "TestPostItemChargeAssignedToSubcontractingLingValueEntryWithCapacityRelation"
-    }
-]


### PR DESCRIPTION
Fixes [AB#638702](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638702)

