### PR TITLE
(Bug 638459): [Subscription Billing] End Date not set when Subsequent…

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
@@ -752,6 +752,8 @@ table 8059 "Subscription Line"
     begin
         if IsInitialTermEmpty() then
             exit;
+        if not IsExtensionTermEmpty() then
+            exit;
 
         TestField("Subscription Line Start Date");
         "Subscription Line End Date" := CalcDate("Initial Term", "Subscription Line Start Date");
@@ -764,10 +766,16 @@ table 8059 "Subscription Line"
         if "Subscription Line End Date" <> 0D then
             "Term Until" := "Subscription Line End Date"
         else
-            if not IsNoticePeriodEmpty() then begin
+            if not IsExtensionTermEmpty() then begin
                 TestField("Subscription Line Start Date");
-                "Term Until" := CalcDate("Notice Period", "Subscription Line Start Date");
-                "Term Until" := CalcDate('<-1D>', "Term Until");
+                if not IsInitialTermEmpty() then begin
+                    "Term Until" := CalcDate("Initial Term", "Subscription Line Start Date");
+                    "Term Until" := CalcDate('<-1D>', "Term Until");
+                end else
+                    if not IsNoticePeriodEmpty() then begin
+                        "Term Until" := CalcDate("Notice Period", "Subscription Line Start Date");
+                        "Term Until" := CalcDate('<-1D>', "Term Until");
+                    end;
             end;
         CalculateCancellationPossibleUntil();
     end;

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
@@ -1921,6 +1921,32 @@ codeunit 139915 "Sales Service Commitment Test"
         Assert.AreEqual(SalespersonPurchaser.Code, ServiceObject."Salesperson Code", 'Salesperson Code should be populated from Customer');
     end;
 
+    [Test]
+    procedure CheckSubscriptionLineEndDateNotSetWhenSubsequentTermIsUsed()
+    begin
+        // [SCENARIO] When posting a Sales Order for an item with both Initial Term and Subsequent Term,
+        // the resulting Subscription Line End Date must remain empty (contract auto-renews indefinitely)
+        Initialize();
+
+        // [GIVEN] A Sales Service Commitment Item with a package having Initial Term <12M> and Subsequent Term <12M>
+        // Note: InitServiceCommitmentPackageLineFields (called in Initialize) already sets both terms
+        ContractTestLibrary.SetupSalesServiceCommitmentItemAndAssignToServiceCommitmentPackage(Item, Enum::"Item Service Commitment Type"::"Sales with Service Commitment", ServiceCommitmentPackage.Code);
+
+        // [GIVEN] A Sales Order for the item
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, '');
+        LibrarySales.CreateSalesLineWithShipmentDate(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", WorkDate(), 1);
+
+        // [WHEN] The Sales Order is posted
+        LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] The resulting Subscription Line End Date is empty because a Subsequent Term is defined
+        ServiceObject.FilterOnItemNo(Item."No.");
+        ServiceObject.FindFirst();
+        ServiceCommitment.SetRange("Subscription Header No.", ServiceObject."No.");
+        ServiceCommitment.FindFirst();
+        ServiceCommitment.TestField("Subscription Line End Date", 0D);
+    end;
+
     #endregion Tests
 
     #region Procedures

--- a/src/Apps/W1/Subscription Billing/Test/Service Objects/ServiceObjectTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Objects/ServiceObjectTest.Codeunit.al
@@ -308,8 +308,8 @@ codeunit 148157 "Service Object Test"
         SubscriptionLine.SetRange("Subscription Header No.", SubscriptionHeader."No.");
         SubscriptionLine.FindFirst();
 
-        // [GIVEN] The Subscription Line End Date, Term Until, and Cancellation Possible Until are populated
-        Assert.AreNotEqual(0D, SubscriptionLine."Subscription Line End Date", '"Service End Date" not set.');
+        // [GIVEN] End Date is not auto-set because Subsequent Term (Extension Term) is defined; Term Until and Cancellation are still populated
+        Assert.AreEqual(0D, SubscriptionLine."Subscription Line End Date", '"Service End Date" should not be set when Subsequent Term is defined.');
         Assert.AreNotEqual(0D, SubscriptionLine."Term Until", '"Term Until" not set.');
         Assert.AreNotEqual(0D, SubscriptionLine."Cancellation Possible Until", '"Cancellation Possible Until" is not set.');
 
@@ -687,6 +687,34 @@ codeunit 148157 "Service Object Test"
         // [THEN] Subscription Line End Date remains empty (0D)
         SubscriptionLine.TestField("Subscription Line End Date", 0D);
     end;
+
+    [Test]
+    procedure CheckSubscriptionLineEndDateNotSetWhenSubsequentTermIsUsed()
+    var
+        Item: Record Item;
+        SubscriptionLine: Record "Subscription Line";
+        SubscriptionHeader: Record "Subscription Header";
+        DateFormulaVariable: DateFormula;
+    begin
+        // [SCENARIO] CalculateServiceEndDate does not set End Date when Subsequent Term (Extension Term) is defined
+        Initialize();
+
+        SetupServiceObjectWithServiceCommitment(Item, SubscriptionHeader, false, false);
+        FindServiceCommitment(SubscriptionLine, SubscriptionHeader."No.");
+
+        // [GIVEN] A Subscription Line with Start Date, Initial Term of 1 month, and Subsequent Term of 1 month
+        SubscriptionLine.Validate("Subscription Line Start Date", WorkDate());
+        Evaluate(DateFormulaVariable, '<1M>');
+        SubscriptionLine.Validate("Initial Term", DateFormulaVariable);
+        SubscriptionLine.Validate("Extension Term", DateFormulaVariable);
+
+        // [WHEN] CalculateServiceEndDate is called
+        SubscriptionLine.CalculateServiceEndDate();
+
+        // [THEN] Subscription Line End Date remains empty because Subsequent Term is defined
+        SubscriptionLine.TestField("Subscription Line End Date", 0D);
+    end;
+
 
     [Test]
     procedure CheckServiceCommitmentServiceInitialTerminationDatesCalculation()
@@ -1925,8 +1953,11 @@ codeunit 148157 "Service Object Test"
         ExpectedTermUntil: Date;
         ExpectedCancellationPossibleUntil: Date;
     begin
-        ExpectedEndDate := CalcDate(InitialTerm + '-1D', StartDate);
-        ExpectedTermUntil := ExpectedEndDate;
+        ExpectedTermUntil := CalcDate(InitialTerm + '-1D', StartDate);
+        if Format(SubscriptionLine."Extension Term") = '' then
+            ExpectedEndDate := ExpectedTermUntil
+        else
+            ExpectedEndDate := 0D;
         ExpectedCancellationPossibleUntil := CalcDate('-' + NoticePeriod, ExpectedTermUntil);
 
         SubscriptionLine.TestField("Subscription Line Start Date", StartDate);


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

- This is a backport of PR for 29: to 28.x https://github.com/microsoft/BCApps/pull/8513
- CalculateServiceEndDate: exit early when Extension Term is set
- CalculateTermUntilDate: when End Date is 0D and Extension Term is set, derive Term Until from Initial Term (or Notice Period as fallback) instead of falling through to the Notice Period path unconditionally; mirrors the logic already encoded in the GetTermUntilDate/GetCancellationPossibleUntilDate test helpers
- Update CheckClearTerminationPeriods: End Date is intentionally 0D when Subsequent Term is defined
- Update VerifySubscriptionLineDates: expect End Date = 0D when Extension Term is set on the Subscription Line
- Add CheckSubscriptionLineEndDateNotSetWhenSubsequentTermIsUsed (unit test on CalculateServiceEndDate) and the corresponding integration test via sales order posting in SalesServiceCommitmentTest
## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #8428

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required ΓÇö be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->
Low risk. The change affects two internal procedures (CalculateServiceEndDate, CalculateTermUntilDate) that are not part of the public API surface.

Existing data: Subscription Lines already in the database are not affected ╬ô├ç├╢ the fix only applies at creation/calculation time. Lines that were created before this fix with an incorrect End Date will keep that value until manually cleared or recalculated via "Update Subscription Line Dates".

Behavior change: For Subscription Lines with both an Initial Term and a Subsequent Term:

End Date is no longer auto-populated (was Start + Initial Term ╬ô├¬├å 1D, now blank). This is the intended correction.
Term Until and Cancellation Possible Until continue to be calculated correctly from the Initial Term, so invoicing and cancellation logic is unaffected.
No behavior change for Subscription Lines without a Subsequent Term ╬ô├ç├╢ CalculateServiceEndDate and CalculateTermUntilDate follow the same paths as before.
Fixes [AB#638951](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638951)

