### PR TITLE
[releases/28.x] Shopify Connector: Remove B2B Plus-only plan restriction

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyUpgradeMgt.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyUpgradeMgt.Codeunit.al
@@ -42,6 +42,7 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         SetShopifyCatalogsType();
         CreateInvoicesFromOrdersUpgrade();
         OrderTransactionShopCodeUpgrade();
+        HasAdvancedShopifyPlanUpgrade();
     end;
 
     internal procedure UpgradeTemplatesData()
@@ -496,6 +497,24 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         UpgradeTag.SetUpgradeTag(GetOrderTransactionShopCodeUpgradeTag());
     end;
 
+    local procedure HasAdvancedShopifyPlanUpgrade()
+    var
+        Shop: Record "Shpfy Shop";
+        UpgradeTag: Codeunit "Upgrade Tag";
+        ShopDataTransfer: DataTransfer;
+    begin
+        if UpgradeTag.HasUpgradeTag(GetHasAdvancedShopifyPlanUpgradeTag()) then
+            exit;
+
+        ShopDataTransfer.SetTables(Database::"Shpfy Shop", Database::"Shpfy Shop");
+        ShopDataTransfer.AddSourceFilter(Shop.FieldNo("B2B Enabled"), '=%1', true);
+        ShopDataTransfer.AddConstantValue(true, Shop.FieldNo("Advanced Shopify Plan"));
+        ShopDataTransfer.UpdateAuditFields := false;
+        ShopDataTransfer.CopyFields();
+
+        UpgradeTag.SetUpgradeTag(GetHasAdvancedShopifyPlanUpgradeTag());
+    end;
+
     internal procedure GetAllowOutgoingRequestseUpgradeTag(): Code[250]
     begin
         exit('MS-445989-AllowOutgoingRequestseUpgradeTag-20220816');
@@ -571,6 +590,11 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         exit('MS-610671-OrderTransactionShopCodeUpgrade-20251022');
     end;
 
+    local procedure GetHasAdvancedShopifyPlanUpgradeTag(): Code[250]
+    begin
+        exit('MS-630316-HasAdvancedShopifyPlanUpgrade-20260408');
+    end;
+
     local procedure GetDateBeforeFeature(): DateTime
     begin
         exit(CreateDateTime(DMY2Date(1, 8, 2022), 0T));
@@ -590,5 +614,6 @@ codeunit 30106 "Shpfy Upgrade Mgt."
         PerCompanyUpgradeTags.Add(GetShopifyCatalogsTypeUpgradeTag());
         PerCompanyUpgradeTags.Add(GetCreateInvoicesFromOrdersUpgradeTag());
         PerCompanyUpgradeTags.Add(GetOrderTransactionShopCodeUpgradeTag());
+        PerCompanyUpgradeTags.Add(GetHasAdvancedShopifyPlanUpgradeTag());
     end;
 }

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyActivities.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyActivities.Page.al
@@ -38,7 +38,6 @@ page 30100 "Shpfy Activities"
                     ApplicationArea = All;
                     DrillDownPageId = "Shpfy Companies";
                     ToolTip = 'Specifies the number of imported companoes that aren''t mapped.';
-                    Visible = B2BEnabled;
                 }
                 field(UnmappedProducts; Rec."Unmapped Products")
                 {
@@ -154,10 +153,6 @@ page 30100 "Shpfy Activities"
                 Commit();
             end;
 
-        Shop.SetRange("B2B Enabled", true);
-        B2BEnabled := not Shop.IsEmpty();
-
-        Shop.Reset();
         Shop.SetRange(Enabled, true);
         if Shop.FindFirst() then begin
             ApiVersion := CommunicationMgt.GetApiVersion();
@@ -166,6 +161,4 @@ page 30100 "Shpfy Activities"
         end;
     end;
 
-    var
-        B2BEnabled: Boolean;
 }

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -401,7 +401,6 @@ page 30101 "Shpfy Shop Card"
             }
             group("B2B Company Synchronization")
             {
-                Visible = Rec."B2B Enabled";
                 field("Company Import From Shopify"; Rec."Company Import From Shopify")
                 {
                     ApplicationArea = All;
@@ -794,7 +793,6 @@ page 30101 "Shpfy Shop Card"
                 RunObject = Page "Shpfy Companies";
                 RunPageLink = "Shop Id" = field("Shop Id");
                 ToolTip = 'Add, view or edit detailed information for the companies.';
-                Visible = Rec."B2B Enabled";
             }
             action(Catalogs)
             {
@@ -808,7 +806,7 @@ page 30101 "Shpfy Shop Card"
                 RunObject = Page "Shpfy Catalogs";
                 RunPageLink = "Shop Code" = field(Code);
                 ToolTip = 'View a list of Shopify B2B catalogs for the shop.';
-                Visible = Rec."B2B Enabled";
+                Visible = Rec."Advanced Shopify Plan";
             }
             action(MarketCatalogs)
             {
@@ -822,7 +820,6 @@ page 30101 "Shpfy Shop Card"
                 RunObject = Page "Shpfy Market Catalogs";
                 RunPageLink = "Shop Code" = field(Code);
                 ToolTip = 'View a list of Shopify market catalogs for the shop.';
-                Visible = Rec."B2B Enabled";
             }
             action(Languages)
             {
@@ -888,7 +885,7 @@ page 30101 "Shpfy Shop Card"
                 RunObject = Page "Shpfy Staff Mapping";
                 RunPageLink = "Shop Code" = field(Code);
                 ToolTip = 'View a list of Shopify Staff Members for the shop.';
-                Visible = Rec."B2B Enabled";
+                Visible = Rec."Advanced Shopify Plan";
             }
         }
         area(Processing)
@@ -1058,7 +1055,6 @@ page 30101 "Shpfy Shop Card"
                     PromotedCategory = Category5;
                     PromotedOnly = true;
                     ToolTip = 'Synchronize the companies with Shopify. The way companies are synchronized depends on the B2B settings in the Shopify Shop Card.';
-                    Visible = Rec."B2B Enabled";
 
                     trigger OnAction()
                     var
@@ -1175,10 +1171,8 @@ page 30101 "Shpfy Shop Card"
                         BackgroundSyncs.InventorySync(Rec);
                         BackgroundSyncs.ProductImagesSync(Rec, '');
                         BackgroundSyncs.ProductPricesSync(Rec);
-                        if Rec."B2B Enabled" then begin
-                            BackgroundSyncs.CompanySync(Rec);
-                            BackgroundSyncs.CatalogPricesSync(Rec, '', "Shpfy Catalog Type"::" ");
-                        end;
+                        BackgroundSyncs.CompanySync(Rec);
+                        BackgroundSyncs.CatalogPricesSync(Rec, '', "Shpfy Catalog Type"::" ");
                     end;
                 }
             }

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -445,7 +445,7 @@ page 30101 "Shpfy Shop Card"
                 field("Auto Create Catalog"; Rec."Auto Create Catalog")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies whether a catalog is automatically created for new companies.';
+                    ToolTip = 'Specifies whether a B2B catalog is automatically created for new companies.';
                 }
                 field("Company Metafields To Shopify"; Rec."Company Metafields To Shopify")
                 {

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -653,11 +653,21 @@ table 30102 "Shpfy Shop"
             DataClassification = SystemMetadata;
             InitValue = true;
         }
+#if not CLEANSCHEMA32
         field(117; "B2B Enabled"; Boolean)
         {
             Caption = 'B2B Enabled';
             DataClassification = SystemMetadata;
+            ObsoleteReason = 'B2B features are now available on all Shopify plans.';
+#if CLEAN29
+            ObsoleteState = Removed;
+            ObsoleteTag = '32.0';
+#else
+            ObsoleteState = Pending;
+            ObsoleteTag = '29.0';
+#endif
         }
+#endif
         field(118; "Can Update Shopify Companies"; Boolean)
         {
             Caption = 'Can Update Shopify Companies';
@@ -830,6 +840,11 @@ table 30102 "Shpfy Shop"
 #endif
         }
 #endif
+        field(207; "Advanced Shopify Plan"; Boolean)
+        {
+            Caption = 'Advanced Shopify Plan';
+            DataClassification = SystemMetadata;
+        }
     }
 
     keys
@@ -1034,8 +1049,8 @@ table 30102 "Shpfy Shop"
         JResponse := CommunicationMgt.ExecuteGraphQL('{"query":"query { shop { name plan { publicDisplayName partnerDevelopment shopifyPlus } weightUnit } }"}');
         if JResponse.SelectToken('$.data.shop.plan', JItem) then
             if JItem.IsObject then
-                Rec."B2B Enabled" := JsonHelper.GetValueAsBoolean(JItem, 'shopifyPlus') or
-                                        (JsonHelper.GetValueAsText(JItem, 'publicDisplayName') in ['Plus Trial', 'Development']);
+                Rec."Advanced Shopify Plan" := JsonHelper.GetValueAsBoolean(JItem, 'shopifyPlus') or
+                                                (JsonHelper.GetValueAsText(JItem, 'publicDisplayName') in ['Plus Trial', 'Development', 'Advanced']);
         Rec."Weight Unit" := ConvertToWeightUnit(JsonHelper.GetValueAsText(JResponse, 'data.shop.weightUnit'));
     end;
 

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -688,7 +688,7 @@ table 30102 "Shpfy Shop"
         }
         field(120; "Auto Create Catalog"; Boolean)
         {
-            Caption = 'Auto Create Catalog';
+            Caption = 'Auto Create B2B Catalog';
             DataClassification = CustomerContent;
 
             trigger OnValidate()

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -690,6 +690,12 @@ table 30102 "Shpfy Shop"
         {
             Caption = 'Auto Create Catalog';
             DataClassification = CustomerContent;
+
+            trigger OnValidate()
+            begin
+                if Rec."Auto Create Catalog" and not Rec."Advanced Shopify Plan" then
+                    Error(AutoCreateCatalogPlanErr, Rec.FieldCaption("Auto Create Catalog"));
+            end;
         }
         field(121; "Company Import From Shopify"; Enum "Shpfy Company Import Range")
         {
@@ -844,6 +850,12 @@ table 30102 "Shpfy Shop"
         {
             Caption = 'Advanced Shopify Plan';
             DataClassification = SystemMetadata;
+
+            trigger OnValidate()
+            begin
+                if (not Rec."Advanced Shopify Plan") and Rec."Auto Create Catalog" then
+                    Rec.Validate("Auto Create Catalog", false);
+            end;
         }
     }
 
@@ -869,6 +881,7 @@ table 30102 "Shpfy Shop"
     var
         CurrencyExchangeRateNotDefinedErr: Label 'The specified currency must have exchange rates configured. If your online shop uses the same currency as Business Central then leave the field empty.';
         AutoCreateErrorMsg: Label 'You cannot turn "%1" off if "%2" is set to the value of "%3".', Comment = '%1 = Field Caption of "Auto Create Orders", %2 = Field Caption of "Return and Refund Process", %3 = Field Value of "Return and Refund Process"';
+        AutoCreateCatalogPlanErr: Label '%1 can only be enabled for Shopify Plus, Plus Trial, Development, or Advanced plans.', Comment = '%1 = Field Caption of "Auto Create Catalog"';
         ExpirationNotificationTxt: Label 'Shopify API version 30 days before expiry notification sent.', Locked = true;
         BlockedNotificationTxt: Label 'Shopify API version expired notification sent.', Locked = true;
         CategoryTok: Label 'Shopify Integration', Locked = true;
@@ -1049,8 +1062,8 @@ table 30102 "Shpfy Shop"
         JResponse := CommunicationMgt.ExecuteGraphQL('{"query":"query { shop { name plan { publicDisplayName partnerDevelopment shopifyPlus } weightUnit } }"}');
         if JResponse.SelectToken('$.data.shop.plan', JItem) then
             if JItem.IsObject then
-                Rec."Advanced Shopify Plan" := JsonHelper.GetValueAsBoolean(JItem, 'shopifyPlus') or
-                                                (JsonHelper.GetValueAsText(JItem, 'publicDisplayName') in ['Plus Trial', 'Development', 'Advanced']);
+                Rec.Validate("Advanced Shopify Plan", JsonHelper.GetValueAsBoolean(JItem, 'shopifyPlus') or
+                                                (JsonHelper.GetValueAsText(JItem, 'publicDisplayName') in ['Plus Trial', 'Development', 'Advanced']));
         Rec."Weight Unit" := ConvertToWeightUnit(JsonHelper.GetValueAsText(JResponse, 'data.shop.weightUnit'));
     end;
 

--- a/src/Apps/W1/Shopify/App/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
@@ -59,6 +59,7 @@ codeunit 30284 "Shpfy Company Export"
             exit;
         end;
 
+        ShopifyCompany.SetRange("Shop Code", Shop.Code);
         ShopifyCompany.SetRange("External Id", Customer."No.");
         if not ShopifyCompany.IsEmpty() then begin
             SkippedRecord.LogSkippedRecord(Customer.RecordId, StrSubstNo(CompanyWithExternalIdExistsLbl, Customer."No."), Shop);

--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
@@ -314,7 +314,7 @@ codeunit 30161 "Shpfy Import Order"
         JResponse: JsonToken;
     begin
         Parameters.Add('OrderId', Format(OrderId));
-        if Shop."B2B Enabled" then
+        if Shop."Advanced Shopify Plan" then
             Parameters.Add('StaffMember', 'staffMember { id }')
         else
             Parameters.Add('StaffMember', '');
@@ -387,7 +387,7 @@ codeunit 30161 "Shpfy Import Order"
         JsonHelper.GetValueIntoField(JOrder, 'presentmentCurrencyCode', OrderHeaderRecordRef, OrderHeader.FieldNo("Presentment Currency Code"));
         JsonHelper.GetValueIntoField(JOrder, 'test', OrderHeaderRecordRef, OrderHeader.FieldNo(Test));
         JsonHelper.GetValueIntoField(JOrder, 'edited', OrderHeaderRecordRef, OrderHeader.FieldNo(Edited));
-        if Shop."B2B Enabled" then begin
+        if Shop."Advanced Shopify Plan" then begin
             StaffMemberId := CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JOrder, 'staffMember.id'));
             SetSalespersonOnOrderHeader(OrderHeader."Shop Code", StaffMemberId, OrderHeaderRecordRef);
         end;

--- a/src/Apps/W1/Shopify/App/src/Staff/Codeunits/ShpfyStaffMemberAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Staff/Codeunits/ShpfyStaffMemberAPI.Codeunit.al
@@ -28,7 +28,7 @@ codeunit 30105 "Shpfy Staff Member API"
         Cursor: Text;
     begin
         Shop.Get(ShopCode);
-        if not Shop."B2B Enabled" then
+        if not Shop."Advanced Shopify Plan" then
             exit;
 
         CommunicationMgt.SetShop(Shop.Code);

--- a/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyExportTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyExportTest.Codeunit.al
@@ -48,7 +48,6 @@ codeunit 139636 "Shpfy Company Export Test"
         ShopifyShop."Name 2 Source" := Enum::"Shpfy Name Source"::None;
         ShopifyShop."Contact Source" := Enum::"Shpfy Name Source"::None;
         ShopifyShop."County Source" := Enum::"Shpfy County Source"::Name;
-        ShopifyShop."B2B Enabled" := true;
         ShopifyCompany.Init();
         CompanyLocation.Init();
         ShopifyPaymentTermsId := 0;
@@ -131,7 +130,6 @@ codeunit 139636 "Shpfy Company Export Test"
         ShopifyShop."Name 2 Source" := Enum::"Shpfy Name Source"::None;
         ShopifyShop."Contact Source" := Enum::"Shpfy Name Source"::None;
         ShopifyShop."County Source" := Enum::"Shpfy County Source"::Name;
-        ShopifyShop."B2B Enabled" := true;
         CompanyLocation.Init();
 
         // [GIVEN] Shop

--- a/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyImportTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyImportTest.Codeunit.al
@@ -38,7 +38,6 @@ codeunit 139647 "Shpfy Company Import Test"
         // [SCENARIO] Importing a company record that is already mapped to a customer record via email.
         Initialize();
         ShopifyShop := InitializeTest.CreateShop();
-        ShopifyShop."B2B Enabled" := true;
 
         // [GIVEN] Shop, Shopify company and Shopify customer
         CompanyMapping.SetShop(ShopifyShop);

--- a/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyLocationsTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Companies/ShpfyCompanyLocationsTest.Codeunit.al
@@ -170,8 +170,6 @@ codeunit 139539 "Shpfy Company Locations Test"
         Commit();
 
         Shop := InitializeTest.CreateShop();
-        Shop."B2B Enabled" := true;
-        Shop.Modify();
 
         CommunicationMgt.SetTestInProgress(false);
         CompanyLocation := CompanyInitialize.CreateShopifyCompanyLocation();

--- a/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
@@ -61,6 +61,51 @@ codeunit 139551 "Shpfy Staff Test"
     end;
 
     [Test]
+    procedure TestAutoCreateCatalogRequiresAdvancedPlan()
+    var
+        LibraryAssert: Codeunit "Library Assert";
+    begin
+        // [Given] A shop on a plan that does not support B2B catalogs
+        Initialize();
+        Shop."Advanced Shopify Plan" := false;
+        Shop."Auto Create Catalog" := false;
+        Shop.Modify(false);
+
+        // [When] The user tries to enable Auto Create Catalog
+        // [Then] A field error is raised mentioning the field
+        asserterror Shop.Validate("Auto Create Catalog", true);
+        LibraryAssert.ExpectedError('Auto Create Catalog');
+
+        // [Given] The shop is upgraded to a plan that supports B2B catalogs
+        Shop."Advanced Shopify Plan" := true;
+        Shop.Modify(false);
+
+        // [When] The user enables Auto Create Catalog
+        Shop.Validate("Auto Create Catalog", true);
+
+        // [Then] The field is enabled successfully
+        LibraryAssert.IsTrue(Shop."Auto Create Catalog", 'Auto Create Catalog should be enabled on an Advanced plan.');
+    end;
+
+    [Test]
+    procedure TestAdvancedPlanDowngradeDisablesAutoCreateCatalog()
+    var
+        LibraryAssert: Codeunit "Library Assert";
+    begin
+        // [Given] A shop on an Advanced plan with Auto Create Catalog enabled
+        Initialize();
+        Shop."Advanced Shopify Plan" := true;
+        Shop."Auto Create Catalog" := true;
+        Shop.Modify(false);
+
+        // [When] The shop's plan is downgraded (as happens during a plan sync from Shopify)
+        Shop.Validate("Advanced Shopify Plan", false);
+
+        // [Then] Auto Create Catalog is silently disabled
+        LibraryAssert.IsFalse(Shop."Auto Create Catalog", 'Auto Create Catalog should be disabled after the plan is downgraded.');
+    end;
+
+    [Test]
     [HandlerFunctions('HttpSubmitHandler')]
     procedure TestImportStaff()
     var

--- a/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
@@ -31,7 +31,7 @@ codeunit 139551 "Shpfy Staff Test"
     end;
 
     [Test]
-    procedure TestStaffMembersActionVisibleOnlyForB2BStore()
+    procedure TestStaffMembersActionVisibleOnlyForSupportedPlans()
     var
         LibraryAssert: Codeunit "Library Assert";
         ShpfyShopCard: TestPage "Shpfy Shop Card";
@@ -39,24 +39,24 @@ codeunit 139551 "Shpfy Staff Test"
         // [Given] Shop exists
         Initialize();
 
-        // [When] Set store as not B2B and check action is not visible
-        Shop."B2B Enabled" := false;
+        // [When] Set store as not having staff members enabled and check action is not visible
+        Shop."Advanced Shopify Plan" := false;
         Shop.Modify(false);
         ShpfyShopCard.OpenView();
         ShpfyShopCard.GoToRecord(Shop);
 
         // [Then] The action should not be visible
-        LibraryAssert.IsFalse(ShpfyShopCard.StaffMembers.Visible(), 'Staff Members action should not be visible for non-B2B store');
+        LibraryAssert.IsFalse(ShpfyShopCard.StaffMembers.Visible(), 'Staff Members action should not be visible for unsupported plan');
         ShpfyShopCard.Close();
 
-        // [When] Set store as B2B and check action is visible
-        Shop."B2B Enabled" := true;
+        // [When] Set store as having staff members enabled and check action is visible
+        Shop."Advanced Shopify Plan" := true;
         Shop.Modify(false);
         ShpfyShopCard.OpenView();
         ShpfyShopCard.GoToRecord(Shop);
 
         // [Then] The action should be visible
-        LibraryAssert.IsTrue(ShpfyShopCard.StaffMembers.Visible(), 'Staff Members action should be visible for B2B store');
+        LibraryAssert.IsTrue(ShpfyShopCard.StaffMembers.Visible(), 'Staff Members action should be visible for supported plan');
         ShpfyShopCard.Close();
     end;
 
@@ -251,7 +251,7 @@ codeunit 139551 "Shpfy Staff Test"
 
         // Creating Shopify Shop
         Shop := InitializeTest.CreateShop();
-        Shop."B2B Enabled" := true;
+        Shop."Advanced Shopify Plan" := true;
         Shop.Modify();
 
         CommunicationMgt.SetTestInProgress(false);

--- a/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
@@ -74,7 +74,7 @@ codeunit 139551 "Shpfy Staff Test"
         // [When] The user tries to enable Auto Create Catalog
         // [Then] A field error is raised mentioning the field
         asserterror Shop.Validate("Auto Create Catalog", true);
-        LibraryAssert.ExpectedError('Auto Create Catalog');
+        LibraryAssert.ExpectedError('Auto Create B2B Catalog');
 
         // [Given] The shop is upgraded to a plan that supports B2B catalogs
         Shop."Advanced Shopify Plan" := true;

--- a/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Staff/ShpfyStaffTest.Codeunit.al
@@ -74,7 +74,7 @@ codeunit 139551 "Shpfy Staff Test"
         // [When] The user tries to enable Auto Create Catalog
         // [Then] A field error is raised mentioning the field
         asserterror Shop.Validate("Auto Create Catalog", true);
-        LibraryAssert.ExpectedError('Auto Create B2B Catalog');
+        LibraryAssert.ExpectedError(Shop.FieldCaption("Auto Create Catalog"));
 
         // [Given] The shop is upgraded to a plan that supports B2B catalogs
         Shop."Advanced Shopify Plan" := true;


### PR DESCRIPTION
## Summary

Backport of bug **630316** (*Shopify Connector: Remove B2B Plus-only plan restriction*) to `releases/28.x`, combining four upstream changes into a single backport:

| # | Source | Change |
|---|--------|--------|
| 1 | PR #7605 | Remove B2B Plus-only plan restriction: obsolete `B2B Enabled` field, add `Advanced Shopify Plan` field + upgrade, drop B2B-Enabled visibility gating across the Shop Card (companies, catalogs, market catalogs, staff, sync), gate staff features on the new field |
| 2 | PR #8213 | `Auto Create Catalog` always visible in the Companies group, validate plan on enable via a table `OnValidate` guard |
| 3 | Bug 638864 | Rename `Auto Create Catalog` caption/tooltip to `Auto Create B2B Catalog` |
| 4 | Bug 638950 | `Market Catalogs` action no longer hidden behind `B2B Enabled` (delivered by the #7605 page change above) |

## Notes

- Both original PRs were squash-merged to `main` and cherry-picked here; conflicts were limited to the `Auto Create Catalog` page field (resolved to keep the tooltip with no visibility gate — the net effect of #7605 + #8213) and to documentation/AI-context files that do not exist on `releases/28.x` (correctly omitted).
- 638950 is fixed automatically: with the B2B-Enabled gating removed from the Shop Card, the `Market Catalogs` action is now visible on all plans.

## Test

Backports the existing test updates from #7605 and #8213 (`ShpfyStaffTest` plan-gating tests, company test setup cleanup). No new tests added.

Fixes [AB#638962](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638962)
Fixes [AB#638950](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638950)




