### PR TITLE
Bug 638523: Test fix to ensure correct setup data is available

### DIFF
--- a/src/Apps/W1/Subcontracting/Test/app.json
+++ b/src/Apps/W1/Subcontracting/Test/app.json
@@ -34,7 +34,6 @@
   ],
   "platform": "29.0.0.0",
   "application": "29.0.0.0",
-  "propagateDependencies": false,
   "idRanges": [
     {
       "from": 139980,

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcFeatureFlagTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcFeatureFlagTest.Codeunit.al
@@ -14,6 +14,7 @@ codeunit 139993 "Subc. Feature Flag Test"
 {
     Subtype = Test;
     TestPermissions = Disabled;
+    TestType = IntegrationTest;
 
     trigger OnRun()
     begin

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcNonInvItemValidTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcNonInvItemValidTest.Codeunit.al
@@ -14,6 +14,7 @@ codeunit 149916 "Subc. Non-Inv Item Valid. Test"
     // [FEATURE] Component Supply Method Transfer validation for Non-Inventory items
     Subtype = Test;
     TestPermissions = Disabled;
+    TestType = IntegrationTest;
 
     [Test]
     procedure NonInventoryItemCannotBeSetToTransferOnProdBOMLine()


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

Fixes [AB#638523](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638523)





