### PR TITLE
[PEPPOL] Skip Allocation Account lines in sales document validation

### DIFF
--- a/src/Apps/W1/PEPPOL/App/src/Sales/PEPPOL30SalesValidationImpl.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Sales/PEPPOL30SalesValidationImpl.Codeunit.al
@@ -118,6 +118,11 @@ codeunit 37203 "PEPPOL30 Sales Validation Impl"
         unitCode: Text;
         unitCodeListID: Text;
     begin
+        // Allocation account lines are placeholder lines that are expanded into their underlying
+        // distribution lines during posting and are never exported in the electronic document.
+        if SalesLine.Type = SalesLine.Type::"Allocation Account" then
+            exit;
+
         PEPPOL30Management.GetLineUnitCodeInfo(SalesLine, unitCode, unitCodeListID);
         if (SalesLine.Type <> SalesLine.Type::" ") and (SalesLine."No." <> '') and (unitCode = '') then
             Error(EmptyUnitOfMeasureErr, SalesLine."Unit of Measure Code");

--- a/src/Apps/W1/PEPPOL/App/src/Sales/PEPPOL30SalesValidationImpl.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Sales/PEPPOL30SalesValidationImpl.Codeunit.al
@@ -149,7 +149,7 @@ codeunit 37203 "PEPPOL30 Sales Validation Impl"
     local procedure CheckAllocationAccountExpandedLines(SalesLine: Record "Sales Line")
     var
         AllocationAccount: Record "Allocation Account";
-        AllocationLine: Record "Allocation Line";
+        TempAllocationLine: Record "Allocation Line";
         ExpandedSalesLine: Record "Sales Line";
         AllocationAccountMgt: Codeunit "Allocation Account Mgt.";
     begin
@@ -157,18 +157,18 @@ codeunit 37203 "PEPPOL30 Sales Validation Impl"
             exit;
 
         AllocationAccountMgt.GenerateAllocationLines(
-            AllocationAccount, AllocationLine, SalesLine.Amount,
+            AllocationAccount, TempAllocationLine, SalesLine.Amount,
             SalesLine.GetSalesHeader()."Posting Date", SalesLine."Dimension Set ID", SalesLine."Currency Code");
 
-        if AllocationLine.FindSet() then
+        if TempAllocationLine.FindSet() then
             repeat
-                if AllocationLine."Destination Account Type" = AllocationLine."Destination Account Type"::"G/L Account" then begin
+                if TempAllocationLine."Destination Account Type" = TempAllocationLine."Destination Account Type"::"G/L Account" then begin
                     ExpandedSalesLine := SalesLine;
                     ExpandedSalesLine.Type := ExpandedSalesLine.Type::"G/L Account";
-                    ExpandedSalesLine."No." := AllocationLine."Destination Account Number";
+                    ExpandedSalesLine."No." := TempAllocationLine."Destination Account Number";
                     this.CheckSalesDocumentLine(ExpandedSalesLine);
                 end;
-            until AllocationLine.Next() = 0;
+            until TempAllocationLine.Next() = 0;
     end;
 
     procedure CheckPostedDocument(PostedDocumentVariant: Variant)

--- a/src/Apps/W1/PEPPOL/App/src/Sales/PEPPOL30SalesValidationImpl.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Sales/PEPPOL30SalesValidationImpl.Codeunit.al
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Peppol;
 
+using Microsoft.Finance.AllocationAccount;
 using Microsoft.Finance.Currency;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Setup;
@@ -118,10 +119,13 @@ codeunit 37203 "PEPPOL30 Sales Validation Impl"
         unitCode: Text;
         unitCodeListID: Text;
     begin
-        // Allocation account lines are placeholder lines that are expanded into their underlying
-        // distribution lines during posting and are never exported in the electronic document.
-        if SalesLine.Type = SalesLine.Type::"Allocation Account" then
+        // Allocation account lines are placeholder lines that are expanded into their underlying G/L
+        // distribution lines during posting and are never themselves exported in the electronic
+        // document. Validate the G/L accounts they will be expanded into instead.
+        if SalesLine.Type = SalesLine.Type::"Allocation Account" then begin
+            this.CheckAllocationAccountExpandedLines(SalesLine);
             exit;
+        end;
 
         PEPPOL30Management.GetLineUnitCodeInfo(SalesLine, unitCode, unitCodeListID);
         if (SalesLine.Type <> SalesLine.Type::" ") and (SalesLine."No." <> '') and (unitCode = '') then
@@ -140,6 +144,31 @@ codeunit 37203 "PEPPOL30 Sales Validation Impl"
                 if not ConfirmManagement.GetResponseOrDefault(StrSubstNo(NegativeUnitPriceErr, SalesLine.RecordId), false) then
                     Error('');
         end;
+    end;
+
+    local procedure CheckAllocationAccountExpandedLines(SalesLine: Record "Sales Line")
+    var
+        AllocationAccount: Record "Allocation Account";
+        AllocationLine: Record "Allocation Line";
+        ExpandedSalesLine: Record "Sales Line";
+        AllocationAccountMgt: Codeunit "Allocation Account Mgt.";
+    begin
+        if not AllocationAccount.Get(SalesLine."No.") then
+            exit;
+
+        AllocationAccountMgt.GenerateAllocationLines(
+            AllocationAccount, AllocationLine, SalesLine.Amount,
+            SalesLine.GetSalesHeader()."Posting Date", SalesLine."Dimension Set ID", SalesLine."Currency Code");
+
+        if AllocationLine.FindSet() then
+            repeat
+                if AllocationLine."Destination Account Type" = AllocationLine."Destination Account Type"::"G/L Account" then begin
+                    ExpandedSalesLine := SalesLine;
+                    ExpandedSalesLine.Type := ExpandedSalesLine.Type::"G/L Account";
+                    ExpandedSalesLine."No." := AllocationLine."Destination Account Number";
+                    this.CheckSalesDocumentLine(ExpandedSalesLine);
+                end;
+            until AllocationLine.Next() = 0;
     end;
 
     procedure CheckPostedDocument(PostedDocumentVariant: Variant)

--- a/src/Apps/W1/PEPPOL/Test/src/PEPPOL30ManagementTests.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/Test/src/PEPPOL30ManagementTests.Codeunit.al
@@ -5,6 +5,7 @@
 namespace Microsoft.Peppol.Test;
 
 using Microsoft.CRM.Team;
+using Microsoft.Finance.AllocationAccount;
 using Microsoft.Finance.Currency;
 using Microsoft.Finance.GeneralLedger.Account;
 using Microsoft.Finance.GeneralLedger.Journal;
@@ -2521,6 +2522,33 @@ codeunit 139235 "PEPPOL30 Management Tests"
         // Exercise
         asserterror CODEUNIT.Run(CODEUNIT::"PEPPOL30 Sales Validation", SalesHeader);
         Assert.ExpectedError(StrSubstNo(NoUnitOfMeasureErr, SalesHeader."No."));
+    end;
+
+    [Test]
+    procedure TestPeppolValidationSalesInvoiceAllocationAccountLineSkipped()
+    var
+        AllocationAccount: Record "Allocation Account";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+    begin
+        // [SCENARIO 632064] PEPPOL validation does not fail on sales lines of type Allocation Account.
+        // Allocation account lines are placeholder lines that are expanded into their underlying
+        // distribution lines during posting and are never exported in the electronic document.
+        Initialize();
+
+        // [GIVEN] An allocation account
+        AllocationAccount."No." := Format(LibraryRandom.RandText(5));
+        AllocationAccount."Account Type" := AllocationAccount."Account Type"::Fixed;
+        AllocationAccount.Name := Format(LibraryRandom.RandText(10));
+        AllocationAccount.Insert();
+
+        // [GIVEN] A sales invoice with a line of type Allocation Account and no Unit of Measure Code
+        CreateGenericSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::"Allocation Account", AllocationAccount."No.", 1);
+
+        // [WHEN] PEPPOL validation runs on the document
+        // [THEN] No error is thrown for the allocation account line
+        CODEUNIT.Run(CODEUNIT::"PEPPOL30 Sales Validation", SalesHeader);
     end;
 
     [Test]


### PR DESCRIPTION
### Summary

Releasing a sales document that contains a sales line of type **Allocation Account** failed PEPPOL BIS 3 validation with *"You must specify a valid International Standard Code for the Unit of Measure for ."* (empty UoM message tail). Posting the same document works.

### Root cause

`PEPPOL30 Sales Validation Impl.CheckSalesDocumentLine` calls `PEPPOL30.GetLineUnitCodeInfo`, whose `case SalesLine.Type` only handles Item, Resource, G/L Account, Fixed Asset and Charge (Item). There is no branch for `Type::"Allocation Account"`, so `unitCode` stays empty and the guard `(Type <> ' ') and ("No." <> '') and (unitCode = '')` errors.

Allocation account lines are placeholder lines that are expanded into their underlying G/L distribution lines during posting and are never themselves exported in the electronic document. Posting works because the post-time PEPPOL check iterates the *posted* lines (only G/L Account lines); the release-time check iterates the *unposted* sales lines, which still contain the allocation account placeholder.

### Fix

Skip lines of type `Allocation Account` early in `CheckSalesDocumentLine`, mirroring posting behavior. Adds a regression test (`TestPeppolValidationSalesInvoiceAllocationAccountLineSkipped`).

This mirrors the equivalent fix in the Base Application (internal Bug 632064).

[AB#632064](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632064)




