### PR TITLE
[28.x] Fix insert of metadata permissions (backport #8377)

### DIFF
--- a/src/System Application/App/Permission Sets/src/xmlports/ImportPermissionSets.xmlport.al
+++ b/src/System Application/App/Permission Sets/src/xmlports/ImportPermissionSets.xmlport.al
@@ -223,18 +223,18 @@ xmlport 9864 "Import Permission Sets"
 
                 trigger OnBeforeInsertRecord()
                 var
-                    MetadataPermission: Record "Metadata Permission";
-                    MetadataPermissionSetRel: Record "Metadata Permission Set Rel.";
+                    TenantPermission: Record "Tenant Permission";
+                    TenantPermissionSetRel: Record "Tenant Permission Set Rel.";
                 begin
                     if TempMetadataPermissionSet.Get(TempMetadataPermissionSet."App ID", TempMetadataPermissionSet."Role ID") then
                         currXMLport.Skip();
                     if not UpdatePermissions then begin
-                        MetadataPermissionSetRel.SetFilter("App ID", TempMetadataPermissionSet."App ID");
-                        MetadataPermissionSetRel.SetFilter("Role ID", TempMetadataPermissionSet."Role ID");
-                        MetadataPermissionSetRel.DeleteAll();
-                        MetadataPermission.SetFilter("App ID", TempMetadataPermissionSet."App ID");
-                        MetadataPermission.SetFilter("Role ID", TempTenantPermissionSet."Role ID");
-                        MetadataPermission.DeleteAll();
+                        TenantPermissionSetRel.SetRange("App ID", TempMetadataPermissionSet."App ID");
+                        TenantPermissionSetRel.SetRange("Role ID", TempMetadataPermissionSet."Role ID");
+                        TenantPermissionSetRel.DeleteAll();
+                        TenantPermission.SetRange("App ID", TempMetadataPermissionSet."App ID");
+                        TenantPermission.SetRange("Role ID", TempMetadataPermissionSet."Role ID");
+                        TenantPermission.DeleteAll();
                     end;
                 end;
             }


### PR DESCRIPTION
## What & why
Backport of #8377 to `releases/28.x`: fix import of tenant permission sets.

The `OnBeforeInsertRecord` trigger in `Import Permission Sets` (XMLport 9864) wrote to the read-only `Metadata Permission` / `Metadata Permission Set Rel.` tables, causing `The Metadata Permission Set Rel. table is read-only` errors and silently ignored changes. It now uses the writable `Tenant Permission` / `Tenant Permission Set Rel.` tables and `SetRange` filters.

Cherry-picked from commit 4896692 (PR #8377).

## Linked work

Fixes [AB#639487](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/639487)

28.x backport of [AB#631431](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/631431) / #8377.

## How I validated this

- [X] I read the full diff and it contains only changes I intended.

Backport-only PR — change is identical to the already-reviewed and merged #8377.
