### PR TITLE
Update entitlement CODEOWNERS ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,7 +25,8 @@
 dotnet.al @microsoft/d365-bc-app-security
 
 # App Permissions
-*.Entitlement.al @microsoft/d365-bc-app-permissions
+*.Entitlement.al @microsoft/d365-bc-integrations
+*.entitlement.al @microsoft/d365-bc-integrations
 
 # app.json files are owned by Engineering Systems to control the versions and BC app team to control the other metadata
 app.json @microsoft/d365-bc-engineering-systems @microsoft/d365-bc-app-required


### PR DESCRIPTION
## What & why

Entitlement file ownership is moving from the app permissions group to the integrations team as part of the BCAppsPrivate ruleset migration decision. This updates CODEOWNERS so entitlement AL files request review from `@microsoft/d365-bc-integrations`, including both uppercase and lowercase filename variants for ruleset coverage parity.

## Linked work

[AB#639517](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639517)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required - be specific: scenarios, commands, screenshots for UI changes)*

- Inspected the CODEOWNERS diff and confirmed only the entitlement ownership lines changed.
- No build, BC runtime validation, or tests were run because this is a CODEOWNERS-only ownership metadata change.

## Risk & compatibility

Low risk. This only changes reviewer ownership for entitlement files and does not affect application code or runtime behavior. The app.json CODEOWNERS line and broader ruleset-derived ownership entries were left unchanged.

