### PR TITLE
[Subcontracting] Routing Lines: Transfer WIP fields placed too far left; Transfer Description 2 should be hidden by default

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcRoutingLines.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcRoutingLines.PageExt.al
@@ -32,7 +32,7 @@ pageextension 99001508 "Subc. Routing Lines" extends "Routing Lines"
                 UpdateWIPEnabled();
             end;
         }
-        addafter(Description)
+        addafter("Send-Ahead Quantity")
         {
             field("Transfer WIP Item"; Rec."Transfer WIP Item")
             {
@@ -48,6 +48,7 @@ pageextension 99001508 "Subc. Routing Lines" extends "Routing Lines"
             {
                 ApplicationArea = Subcontracting;
                 Enabled = Rec."Transfer WIP Item";
+                Visible = false;
             }
         }
     }


### PR DESCRIPTION
[Subcontracting] Routing Lines: Transfer WIP fields placed too far left; Transfer Description 2 should be hidden by default

[AB#637757](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637757)

