### PR TITLE
[Subcontracting] Purchase Order: Subcontracting fields should use Importance = Additional

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Purchase/SubcPurchOrder.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Purchase/SubcPurchOrder.PageExt.al
@@ -15,11 +15,13 @@ pageextension 99001523 "Subc. Purch. Order" extends "Purchase Order"
             field("Subc. Order"; Rec."Subc. Order")
             {
                 ApplicationArea = Subcontracting;
+                Importance = Additional;
             }
             field("Subc. Location Code"; Rec."Subc. Location Code")
             {
                 ApplicationArea = Subcontracting;
                 Editable = false;
+                Importance = Additional;
             }
         }
         addafter(WorkflowStatus)


### PR DESCRIPTION
Purchase Order: Subcontracting fields should use Importance = Additional

[AB#638946](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638946)

