### PR TITLE
[Subcontracting] Subcontracting reports "Create Transfer Order" and "Create Return Order" should not appear in Tell Me search

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcCreateSubCReturnOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcCreateSubCReturnOrder.Report.al
@@ -17,7 +17,6 @@ report 99001502 "Subc. Create SubCReturnOrder"
     ApplicationArea = Subcontracting;
     Caption = 'Create Subcontracting Return Order';
     ProcessingOnly = true;
-    UsageCategory = Tasks;
     dataset
     {
         dataitem("Purchase Header"; "Purchase Header")

--- a/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcCreateTransfOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Reports/SubcCreateTransfOrder.Report.al
@@ -18,7 +18,6 @@ report 99001501 "Subc. Create Transf. Order"
     ApplicationArea = Subcontracting;
     Caption = 'Create Subcontracting Transfer Order';
     ProcessingOnly = true;
-    UsageCategory = Tasks;
     dataset
     {
         dataitem("Purchase Header"; "Purchase Header")


### PR DESCRIPTION
Subcontracting reports "Create Transfer Order" and "Create Return Order" should not appear in Tell Me search

Fixes [AB#638865](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638865)


