### PR TITLE
[Subcontracting] Item Ledger Entries page shows wrong value for Purch. Order No. column (binds to Line No.)

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/SubcILEntries.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/SubcILEntries.PageExt.al
@@ -12,7 +12,7 @@ pageextension 99001501 "Subc. ILEntries" extends "Item Ledger Entries"
     {
         addlast(Control1)
         {
-            field("Subc. Purch. Order No."; Rec."Subc. Purch. Order Line No.")
+            field("Subc. Purch. Order No."; Rec."Subc. Purch. Order No.")
             {
                 ApplicationArea = Subcontracting;
                 ToolTip = 'Specifies the number of the related purchase order.';


### PR DESCRIPTION
Item Ledger Entries page shows wrong value for Purch. Order No. column (binds to Line No.)

Fixes [AB#638465](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638465)


