### PR TITLE
Reapply "Bug6451 email without top domain (#6781)" (#7925)

### DIFF
--- a/src/System Application/App/Email/src/Account/EmailAccountImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Account/EmailAccountImpl.Codeunit.al
@@ -294,6 +294,14 @@ codeunit 8889 "Email Account Impl."
             ValidatedEmailAddress := EmailAddress;
             if not ConvertEmailAddress(ValidatedEmailAddress) then
                 Error(InvalidEmailAddressErr, EmailAddress);
+
+            // Check that there is a top domain
+            if StrPos(CopyStr(ValidatedEmailAddress, StrPos(ValidatedEmailAddress, '@') + 2), '.') = 0 then
+                Error(InvalidEmailAddressErr, EmailAddress);
+
+            // Check that the top domain is at least 2 characters long
+            if (ValidatedEmailAddress[StrLen(ValidatedEmailAddress)] = '.') or (ValidatedEmailAddress[StrLen(ValidatedEmailAddress) - 1] = '.') then
+                Error(InvalidEmailAddressErr, EmailAddress);
         end;
 
         EmailAccount.OnAfterValidateEmailAddress(EmailAddress, AllowEmptyValue);

--- a/src/System Application/Test/Email/src/EmailAccountsTest.Codeunit.al
+++ b/src/System Application/Test/Email/src/EmailAccountsTest.Codeunit.al
@@ -652,6 +652,17 @@ codeunit 134686 "Email Accounts Test"
         Assert.AreEqual(SecondAccountId, TempEmailAccount."Account Id", 'The second email account should still exist.');
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure TestInvalidEmailAddress()
+    var
+        EmailAccount: Codeunit "Email Account";
+    begin
+        asserterror EmailAccount.ValidateEmailAddress('a@contoso');
+        asserterror EmailAccount.ValidateEmailAddress('a@contoso.');
+        asserterror EmailAccount.ValidateEmailAddress('a@contoso.b');
+    end;
+
     [ModalPageHandler]
     procedure AddAccountModalPageHandler(var AccountWizardTestPage: TestPage "Email Account Wizard")
     begin


### PR DESCRIPTION
This reverts commit 2ff8d4bce886c42c7ab6119d2829cc2678fe038d.

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#633276](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633276)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->



