### PR TITLE
Bug 639373: Fix misleading error message for blocked cancel/correct of subcontracting invoice

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubcPurchPostExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/Extensions/Purchase/SubcPurchPostExt.Codeunit.al
@@ -24,7 +24,7 @@ codeunit 99001535 "Subc. Purch. Post Ext"
         SubcFeatureFlagHandler: Codeunit "Subc. Feature Flag Handler";
 #pragma warning restore AL0432
 #endif
-        CancelNotSupportedErr: Label 'You cannot cancel or correct posted purchase invoice %1 because it contains item charges assigned to a subcontracting order receipt.\Create a purchase credit memo manually and assign the item charge to the posted subcontracting receipt line.', Comment = '%1 = Posted Purchase Invoice No.';
+        CancelNotSupportedErr: Label 'You cannot cancel or correct posted purchase invoice %1 because it contains item charges assigned to a subcontracting order receipt.\Use the ''Create Corrective Credit Memo'' action to create a credit memo for this invoice.', Comment = '%1 = Posted Purchase Invoice No.';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Correct Posted Purch. Invoice", OnAfterTestCorrectInvoiceIsAllowed, '', false, false)]
     local procedure BlockCancelIfHasSubcontractingItemChargeValueEntry(var PurchInvHeader: Record "Purch. Inv. Header"; Cancelling: Boolean)


### PR DESCRIPTION
## Summary
- The CancelNotSupportedErr label in codeunit 99001535 Subc. Purch. Post Ext told users to create a purchase credit memo manually when Cancel/Correct is blocked for invoices with subcontracting item charges.
- This is misleading because the Create Corrective Credit Memo action on the same page (Posted Purchase Invoice, page 138) handles this scenario correctly.

## Root Cause
The error message text was written without awareness of the existing Create Corrective Credit Memo action that already works for this scenario.

## Fix
Updated the label to guide users to the existing action:
> Use the Create Corrective Credit Memo action to create a credit memo for this invoice.

## Test
No automated test added - this is a purely cosmetic label text change with no logic impact.

Fixes [AB#639373](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639373)


