### PR TITLE
[Bug] Subcontracting Order Lines only for work centers (consistency with subcontracting worksheet)

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchaseOrderCreator.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Codeunits/SubcPurchaseOrderCreator.Codeunit.al
@@ -13,6 +13,7 @@ using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Item.Catalog;
 using Microsoft.Inventory.Requisition;
 using Microsoft.Inventory.Tracking;
+using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Setup;
 using Microsoft.Manufacturing.WorkCenter;
@@ -317,6 +318,19 @@ codeunit 99001557 "Subc. Purchase Order Creator"
         PurchaseLine.SetRange(Type, "Purchase Line Type"::Item);
         PurchaseLine.SetRange("Prod. Order No.", ProdOrderNo);
         PageManagement.PageRun(PurchaseLine);
+    end;
+
+    internal procedure CreateSubcontractingOrdersForRoutingLineSelection(var ProdOrderRoutingLine: Record "Prod. Order Routing Line"): Integer
+    var
+        NoOfCreatedPurchOrder: Integer;
+    begin
+        ProdOrderRoutingLine.SetRange(Type, "Capacity Type"::"Work Center");
+        ShowExistingPurchaseOrdersForRoutingLines(ProdOrderRoutingLine);
+        if ProdOrderRoutingLine.FindSet() then
+            repeat
+                NoOfCreatedPurchOrder += CreateSubcontractingPurchaseOrderFromRoutingLine(ProdOrderRoutingLine);
+            until ProdOrderRoutingLine.Next() = 0;
+        exit(NoOfCreatedPurchOrder);
     end;
 
     local procedure CheckProdOrderComponentLines(ProdOrderRoutingLine: Record "Prod. Order Routing Line"): Boolean

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcProdOrderRtng.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcProdOrderRtng.PageExt.al
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
-using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
 
@@ -118,37 +117,9 @@ pageextension 99001503 "Subc. Prod. Order Rtng." extends "Prod. Order Routing"
                 trigger OnAction()
                 var
                     ProdOrderRoutingLine: Record "Prod. Order Routing Line";
-                    PurchaseLine: Record "Purchase Line";
-                    SubcPurchaseOrderCreator: Codeunit "Subc. Purchase Order Creator";
-                    NoOfCreatedPurchOrder: Integer;
                 begin
                     CurrPage.SetSelectionFilter(ProdOrderRoutingLine);
-                    ProdOrderRoutingLine.SetRange(Type, "Capacity Type"::"Machine Center");
-                    SubcPurchaseOrderCreator.ShowExistingPurchaseOrdersForRoutingLines(ProdOrderRoutingLine);
-                    ProdOrderRoutingLine.FindSet();
-                    repeat
-                        NoOfCreatedPurchOrder += SubcPurchaseOrderCreator.CreateSubcontractingPurchaseOrderFromRoutingLine(ProdOrderRoutingLine);
-                    until ProdOrderRoutingLine.Next() = 0;
-
-                    if NoOfCreatedPurchOrder = 0 then begin
-                        PurchaseLine.SetCurrentKey("Document Type", Type, "Prod. Order No.");
-                        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
-                        PurchaseLine.SetRange(Type, PurchaseLine.Type::Item);
-                        PurchaseLine.SetRange("Prod. Order No.", Rec."Prod. Order No.");
-                        PurchaseLine.SetRange("Routing No.", Rec."Routing No.");
-                        PurchaseLine.SetRange("Routing Reference No.", Rec."Routing Reference No.");
-                        PurchaseLine.SetRange("Operation No.", Rec."Operation No.");
-                        if PurchaseLine.IsEmpty() then
-                            Message(NoPurchOrderCreatedMsg, ProdOrderRoutingLine."Prod. Order No.")
-                    end else begin
-                        if NoOfCreatedPurchOrder = 1 then begin
-                            SubcPurchaseOrderCreator.ClearOperationNoForCreatedPurchaseOrder();
-                            SubcPurchaseOrderCreator.SetOperationNoForCreatedPurchaseOrder(Rec."Operation No.");
-                            SubcPurchaseOrderCreator.ClearRoutingReferenceNoForCreatedPurchaseOrder();
-                            SubcPurchaseOrderCreator.SetRoutingReferenceNoForCreatedPurchaseOrder(Rec."Routing Reference No.");
-                        end;
-                        SubcPurchaseOrderCreator.ShowCreatedPurchaseOrder(Rec."Prod. Order No.", NoOfCreatedPurchOrder);
-                    end;
+                    CreateSubcontractingOrders(ProdOrderRoutingLine);
                 end;
             }
             action("WIP Adjustment")
@@ -225,5 +196,34 @@ pageextension 99001503 "Subc. Prod. Order Rtng." extends "Prod. Order Routing"
     begin
         Rec.Calcfields(Subcontracting);
         TransferWIPItemEnabled := Rec.Subcontracting;
+    end;
+
+    internal procedure CreateSubcontractingOrders(var ProdOrderRoutingLine: Record "Prod. Order Routing Line")
+    var
+        PurchaseLine: Record "Purchase Line";
+        SubcPurchaseOrderCreator: Codeunit "Subc. Purchase Order Creator";
+        NoOfCreatedPurchOrder: Integer;
+    begin
+        NoOfCreatedPurchOrder := SubcPurchaseOrderCreator.CreateSubcontractingOrdersForRoutingLineSelection(ProdOrderRoutingLine);
+
+        if NoOfCreatedPurchOrder = 0 then begin
+            PurchaseLine.SetCurrentKey("Document Type", Type, "Prod. Order No.");
+            PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+            PurchaseLine.SetRange(Type, PurchaseLine.Type::Item);
+            PurchaseLine.SetRange("Prod. Order No.", Rec."Prod. Order No.");
+            PurchaseLine.SetRange("Routing No.", Rec."Routing No.");
+            PurchaseLine.SetRange("Routing Reference No.", Rec."Routing Reference No.");
+            PurchaseLine.SetRange("Operation No.", Rec."Operation No.");
+            if PurchaseLine.IsEmpty() then
+                Message(NoPurchOrderCreatedMsg, ProdOrderRoutingLine."Prod. Order No.")
+        end else begin
+            if NoOfCreatedPurchOrder = 1 then begin
+                SubcPurchaseOrderCreator.ClearOperationNoForCreatedPurchaseOrder();
+                SubcPurchaseOrderCreator.SetOperationNoForCreatedPurchaseOrder(Rec."Operation No.");
+                SubcPurchaseOrderCreator.ClearRoutingReferenceNoForCreatedPurchaseOrder();
+                SubcPurchaseOrderCreator.SetRoutingReferenceNoForCreatedPurchaseOrder(Rec."Routing Reference No.");
+            end;
+            SubcPurchaseOrderCreator.ShowCreatedPurchaseOrder(Rec."Prod. Order No.", NoOfCreatedPurchOrder);
+        end;
     end;
 }

--- a/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcProdOrderRtng.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Process/Pageextensions/Manufacturing/SubcProdOrderRtng.PageExt.al
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
+using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
 
@@ -122,6 +123,7 @@ pageextension 99001503 "Subc. Prod. Order Rtng." extends "Prod. Order Routing"
                     NoOfCreatedPurchOrder: Integer;
                 begin
                     CurrPage.SetSelectionFilter(ProdOrderRoutingLine);
+                    ProdOrderRoutingLine.SetRange(Type, "Capacity Type"::"Machine Center");
                     SubcPurchaseOrderCreator.ShowExistingPurchaseOrdersForRoutingLines(ProdOrderRoutingLine);
                     ProdOrderRoutingLine.FindSet();
                     repeat

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Libraries/SubcManagementLibrary.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Libraries/SubcManagementLibrary.Codeunit.al
@@ -129,7 +129,7 @@ codeunit 139983 "Subc. Management Library"
         LibraryManufacturing.CreateAndRefreshProductionOrder(ProductionOrder, ProdOrderStatus, ProdOrderSourceType, SourceNo, Quantity);
     end;
 
-    procedure CreateAndRefreshProductionOrder(var ProductionOrder: Record "Production Order"; ProdOrderStatus: Enum "Production Order Status"; ProdOrderSourceType: Enum "Prod. Order Source Type"; SourceNo: Code[20]; Quantity: Decimal; LocationCode: Code[20])
+    procedure CreateAndRefreshProductionOrder(var ProductionOrder: Record "Production Order"; ProdOrderStatus: Enum "Production Order Status"; ProdOrderSourceType: Enum "Prod. Order Source Type"; SourceNo: Code[20]; Quantity: Decimal; LocationCode: Code[10])
     var
         LibraryManufacturing: Codeunit "Library - Manufacturing";
     begin

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -622,6 +622,91 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         Assert.ExpectedError('You cannot change this routing line because transfer orders exist');
     end;
 
+    [Test]
+    procedure WorkCenterRoutingLinesExcludedFromMultiSelectionWhenMachineCenterPresent()
+    var
+        CapacityUnitOfMeasure: Record "Capacity Unit of Measure";
+        Item, Item2 : Record Item;
+        MachineCenter: Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        PurchaseLine: Record "Purchase Line";
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        WorkCenter: Record "Work Center";
+        SubcPurchaseOrderCreator: Codeunit "Subc. Purchase Order Creator";
+        MachineCenterNo: Code[20];
+        NoOfCreatedOrders: Integer;
+    begin
+        // [SCENARIO] When CreateSubcontractingOrdersForRoutingLineSelection is called with a mixed
+        // selection containing both Work Center and Machine Center routing lines, only the
+        // Machine Center lines result in a subcontracting purchase order.
+        // This verifies that the Machine Center type filter is applied correctly when simulating
+        // multi-record selection (CurrPage.SetSelectionFilter cannot be used in test framework).
+        Initialize();
+
+        // [GIVEN] A subcontracting Work Center with a vendor
+        CreateAndCalculateNeededWorkCenter(WorkCenter, true);
+
+        // [GIVEN] A Machine Center belonging to the subcontracting Work Center
+        LibraryMfgManagement.CreateMachineCenter(MachineCenterNo, WorkCenter."No.", "Flushing Method"::"Pick + Manual".AsInteger());
+        MachineCenter.Get(MachineCenterNo);
+        LibraryManufacturing.CalculateMachCenterCalendar(MachineCenter, CalcDate('<-CY-1Y>', WorkDate()), CalcDate('<CM>', WorkDate()));
+
+        // [GIVEN] A routing with a Work Center line (Op 010) and a Machine Center line (Op 020),
+        // both referencing the same subcontracting Work Center
+        LibraryManufacturing.CreateCapacityUnitOfMeasure(CapacityUnitOfMeasure, "Capacity Unit of Measure"::Minutes);
+        LibraryManufacturing.CreateRoutingHeader(RoutingHeader, RoutingHeader.Type::Serial);
+
+        LibraryManufacturing.CreateRoutingLineSetup(RoutingLine, RoutingHeader, WorkCenter."No.", '010', 1, 1);
+        RoutingLine.Validate("Run Time Unit of Meas. Code", CapacityUnitOfMeasure.Code);
+        RoutingLine.Validate("Setup Time Unit of Meas. Code", CapacityUnitOfMeasure.Code);
+        RoutingLine.Modify(true);
+
+        RoutingLine.Type := RoutingLine.Type::"Machine Center";
+        LibraryManufacturing.CreateRoutingLineSetup(RoutingLine, RoutingHeader, MachineCenter."No.", '020', 1, 1);
+        RoutingLine.Validate("Run Time Unit of Meas. Code", CapacityUnitOfMeasure.Code);
+        RoutingLine.Validate("Setup Time Unit of Meas. Code", CapacityUnitOfMeasure.Code);
+        RoutingLine.Modify(true);
+
+        RoutingHeader.Validate(Status, RoutingHeader.Status::Certified);
+        RoutingHeader.Modify(true);
+
+        LibraryInventory.CreateItem(Item2);
+        LibraryManufacturing.CreateProductionBOM(Item2, 2);
+
+        // [GIVEN] An item with the routing and a released production order
+        LibraryManufacturing.CreateItemManufacturing(
+            Item, "Costing Method"::FIFO, LibraryRandom.RandInt(10),
+            "Reordering Policy"::"Lot-for-Lot", "Flushing Method"::"Pick + Manual",
+            RoutingHeader."No.", Item2."Production BOM No.");
+
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released,
+            ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 1);
+
+        LibraryMfgManagement.CreateSubcontractingReqWkshTemplateAndNameAndUpdateSetup();
+
+        // [WHEN] All routing lines (Work Center Op 010 + Machine Center Op 020) are passed to
+        // CreateSubcontractingOrdersForRoutingLineSelection, simulating a multi-record selection
+        ProdOrderRoutingLine.SetRange(Status, "Production Order Status"::Released);
+        ProdOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        NoOfCreatedOrders := SubcPurchaseOrderCreator.CreateSubcontractingOrdersForRoutingLineSelection(ProdOrderRoutingLine);
+
+        // [THEN] Exactly one purchase order is created (Work Center line is filtered out)
+        Assert.AreEqual(1, NoOfCreatedOrders, 'Exactly one subcontracting purchase order must be created.');
+
+        // [THEN] The purchase order is linked to the Machine Center operation (Op 020)
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.SetRange("Operation No.", '010');
+        Assert.RecordCount(PurchaseLine, 1);
+
+        // [THEN] No purchase order is created for the Work Center operation (Op 010)
+        PurchaseLine.SetRange("Operation No.", '020');
+        Assert.RecordIsEmpty(PurchaseLine);
+    end;
+
     [ModalPageHandler]
     procedure ItemTrackingLinesSimpleHandler(var ItemTrackingLines: TestPage "Item Tracking Lines")
     begin

--- a/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/src/Codeunits/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -640,8 +640,8 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
     begin
         // [SCENARIO] When CreateSubcontractingOrdersForRoutingLineSelection is called with a mixed
         // selection containing both Work Center and Machine Center routing lines, only the
-        // Machine Center lines result in a subcontracting purchase order.
-        // This verifies that the Machine Center type filter is applied correctly when simulating
+        // Work Center lines result in a subcontracting purchase order.
+        // This verifies that the Work Center type filter is applied correctly when simulating
         // multi-record selection (CurrPage.SetSelectionFilter cannot be used in test framework).
         Initialize();
 
@@ -696,13 +696,13 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         // [THEN] Exactly one purchase order is created (Work Center line is filtered out)
         Assert.AreEqual(1, NoOfCreatedOrders, 'Exactly one subcontracting purchase order must be created.');
 
-        // [THEN] The purchase order is linked to the Machine Center operation (Op 020)
+        // [THEN] The purchase order is linked to the Work Center operation (Op 010)
         PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
         PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
         PurchaseLine.SetRange("Operation No.", '010');
         Assert.RecordCount(PurchaseLine, 1);
 
-        // [THEN] No purchase order is created for the Work Center operation (Op 010)
+        // [THEN] No purchase order is created for the Machine Center operation (Op 020)
         PurchaseLine.SetRange("Operation No.", '020');
         Assert.RecordIsEmpty(PurchaseLine);
     end;


### PR DESCRIPTION
…cy with subcontracting worksheet)

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->
This pull request introduces a minor update to the `Subc. Prod. Order Rtng.` page extension in the subcontracting app. The main change is the addition of a filter to only include routing lines of type "Work Center" when showing existing purchase orders for routing lines.

Filtering and dependencies:

* Added a `SetRange` filter on the `Type` field to only include `"Capacity Type"::"Work Center"` routing lines before displaying existing purchase orders in the `Subc. Prod. Order Rtng.` page extension.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#639699](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639699)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*
- Run in Client and add automatic test
<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->
None


