### PR TITLE
[28.x] Bug 636248: Guard against empty No. in Subc. ProdOrderRtngLine Ext. OnAfterValidate

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderRtngLineExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderRtngLineExt.TableExt.al
@@ -58,10 +58,11 @@ tableextension 99001506 "Subc. ProdOrderRtngLine Ext." extends "Prod. Order Rout
 #endif
                 if "No." = xRec."No." then
                     exit;
-                if Type <> "Capacity Type"::"Work Center" then begin
+                if (Type <> "Capacity Type"::"Work Center") or ("No." = '') then begin
                     "Transfer WIP Item" := false;
                     exit;
                 end;
+
                 WorkCenter.SetLoadFields("Subcontractor No.");
                 WorkCenter.Get("No.");
                 if WorkCenter."Subcontractor No." = '' then


### PR DESCRIPTION
Summary
The OnAfterValidate trigger on the No. field in table extension Subc. ProdOrderRtngLine Ext. (99001506) calls WorkCenter.Get(No.) without first checking if No. is empty.
When the Sustainability test VerifySustainabilityFieldsShouldBeUpdatedFromItemAndWorkCenter clears the No. field (validates to '' before setting a new value), this causes: The Work Center does not exist. Identification fields and values: No.=''
Root Cause
Missing empty-string guard before WorkCenter.Get(No.) in the modify(No.) trigger.

Fix
Exit early and reset Transfer WIP Item to false when No. is empty, consistent with the existing pattern for non-Work Center types.

Test
Re-enables disabled tests in codeunit 148190 Sust. Value Entry Test:

VerifySustainabilityFieldsShouldBeUpdatedFromItemAndWorkCenter
VerifySustainabilityValueEntryShouldBeCreatedWhenPurchDocumentIsPosted
Fixes [AB#636248](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636248)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

