### PR TITLE
[Subcontracting] Sync to 28.x: Subcontractor Price with Blank Unit of Measure Not Shown in Purchase Order FactBox

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchFactboxMgmt.Codeunit.al
@@ -626,7 +626,7 @@ codeunit 99001560 "Subc. Purch. Factbox Mgmt."
         SubcontractorPrice.SetRange("Item No.", PurchaseLine."No.");
         SubcontractorPrice.SetRange("Work Center No.", PurchaseLine."Work Center No.");
         SubcontractorPrice.SetRange("Variant Code", PurchaseLine."Variant Code");
-        SubcontractorPrice.SetRange("Unit of Measure Code", PurchaseLine."Unit of Measure Code");
+        SubcontractorPrice.SetFilter("Unit of Measure Code", '%1|%2', PurchaseLine."Unit of Measure Code", '');
         SubcontractorPrice.SetRange("Currency Code", PurchaseLine."Currency Code");
     end;
 

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
@@ -13,6 +13,7 @@ using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Manufacturing.WorkCenter;
+using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 using System.TestLibraries.Utilities;
 
@@ -534,6 +535,51 @@ codeunit 139982 "Subc. Pricing Test"
         RequisitionLine.Quantity := 1;
     end;
 
+    [Test]
+    procedure FactboxCountsBlankUoMPriceWhenPurchLineHasUoM()
+    var
+        Item: Record Item;
+        Vendor: Record Vendor;
+        WorkCenter: Record "Work Center";
+        SubcontractorPrice: Record "Subcontractor Price";
+        PurchaseLine: Record "Purchase Line";
+        SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
+    begin
+        // [SCENARIO] A subcontractor price with a blank Unit of Measure Code must be counted
+        // in the Purchase Order FactBox when the purchase line specifies a Unit of Measure Code.
+        // Previously, the FactBox used SetRange on Unit of Measure Code (exact match), so a
+        // blank-UoM price was invisible whenever the purchase line had a specific UoM.
+        Initialize();
+
+        // [GIVEN] An item, vendor, and work center linked as a subcontractor.
+        LibraryInventory.CreateItem(Item);
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryManufacturing.CreateWorkCenter(WorkCenter);
+        WorkCenter.Validate("Subcontractor No.", Vendor."No.");
+        WorkCenter.Modify(true);
+
+        // [GIVEN] A subcontractor price recorded with a blank Unit of Measure Code.
+        SubcontractingMgmtLibrary.CreateSubContractingPrice(
+            SubcontractorPrice, WorkCenter."No.", Vendor."No.", Item."No.", '', '', WorkDate(), '', 0, '');
+
+        // [GIVEN] A purchase line for the same item/vendor/work center with a specific UoM.
+        PurchaseLine.Init();
+        PurchaseLine.Type := PurchaseLine.Type::Item;
+        PurchaseLine."No." := Item."No.";
+        PurchaseLine."Buy-from Vendor No." := Vendor."No.";
+        PurchaseLine."Work Center No." := WorkCenter."No.";
+        PurchaseLine."Unit of Measure Code" := Item."Base Unit of Measure";
+        PurchaseLine."Currency Code" := '';
+        PurchaseLine."Variant Code" := '';
+
+        // [WHEN] The FactBox counts applicable subcontractor prices.
+        // [THEN] The blank-UoM price is counted even though the purchase line has a specific UoM.
+        Assert.AreEqual(
+            1, SubcPurchFactboxMgmt.CalcNoOfPurchasePrices(PurchaseLine),
+            'A subcontractor price with blank Unit of Measure must appear in the FactBox when the purchase line has a specific UoM.');
+    end;
+
+ 
     local procedure CreateUOMCodeSortingAfter(BaseUOMCode: Code[10]): Code[10]
     var
         UnitOfMeasure: Record "Unit of Measure";


### PR DESCRIPTION
# Bug: Subcontractor Price with Blank Unit of Measure Not Shown in Purchase Order FactBox

## Affected Objects

| Type     | Name                            | ID       |
|----------|---------------------------------|----------|
| Table    | Subcontractor Price             | 99001500 |
| Codeunit | Subc. Purch. Factbox Mgmt.      | 99001511 |
| Page     | Subc. Purchase Line Factbox     | 99001518 |

## Reproduction Steps

### Setup
- A Subcontractor Price entry exists for a Vendor / Item / Work Center combination with **Unit of Measure Code left blank** (meaning the price applies to any unit).

### Given
- A Subcontracting Purchase Order line for the same Vendor, Item, and Work Center.
- The Purchase Line has a specific Unit of Measure Code (e.g., `PCS`).

### When
- The user opens the Purchase Order and views the **Subcontracting Details** FactBox.

### Then
- The **Subcontractor Prices** field in the FactBox displays `0` instead of `1`.

## False Behavior

The FactBox shows `0 Subcontractor Prices` even though a matching price exists with a blank Unit of Measure Code. The price is not found because `FilterSubContractorPriceForPurchLine` uses `SetRange("Unit of Measure Code", PurchaseLine."Unit of Measure Code")`, which requires an exact match. A blank-UoM price is only found when the purchase line's UoM is also blank.

## Expected Behavior

A Subcontractor Price with a blank Unit of Measure Code should be treated as a "catch-all" using the base unit of measure. The FactBox should count (and drilldown should display) such entries regardless of the Unit of Measure Code on the purchase line.

## Root Cause

**File:** `src/Process/Codeunits/SubcPurchFactboxMgmt.Codeunit.al`  
**Procedure:** `FilterSubContractorPriceForPurchLine` (local)

The offending line:

```al
SubcontractorPrice.SetRange("Unit of Measure Code", PurchaseLine."Unit of Measure Code");
```

`SetRange` performs an exact equality filter. When the purchase line has `"Unit of Measure Code" = 'PCS'` and the Subcontractor Price has `"Unit of Measure Code" = ''`, no record is returned.

## Fix Description

Replace the `SetRange` on `"Unit of Measure Code"` with a `SetFilter` that also accepts blank entries:

```al
SubcontractorPrice.SetFilter("Unit of Measure Code", '%1|%2', PurchaseLine."Unit of Measure Code", '');
```

This ensures prices entered without a Unit of Measure (applicable to any unit) are included in the FactBox count and drilldown, while prices entered for a specific unit are still matched correctly when the purchase line uses that same unit.

When the purchase line itself has a blank UoM the filter becomes `'' | ''` (blank or blank), which is equivalent to the original `SetRange` — no regression for that case.

## Related Work Item

_To be added._

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.
