### PR TITLE
[Subcontracting] Block Get Order/Receipt Lines and item charges on undone subcontracting receipts

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/General/SubcontractingManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/General/SubcontractingManagement.Codeunit.al
@@ -280,7 +280,7 @@ codeunit 99001505 "Subcontracting Management"
                     end;
                 until (PurchaseLine.Next() = 0) or ProdOrderCompFound;
             if ProdOrderCompFound then
-                Error(PurchOrderExistErr, ProdOrderComponent."Item No.", PurchOrderNo, ProdOrderComponent.FieldCaption(ProdOrderComponent."Component Supply Method"));
+                Error(PurchOrderExistErr, ProdOrderComponent."Item No.", PurchOrderNo, ProdOrderComponent.FieldCaption("Component Supply Method"));
 
             if ProdOrderRoutingLine.Type = "Capacity Type"::"Work Center" then begin
                 if not GetSubcontractor(ProdOrderRoutingLine."No.", Vendor) then

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCompFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCompFactboxMgmt.Codeunit.al
@@ -36,14 +36,14 @@ codeunit 99001562 "Subc. Comp. Factbox Mgmt."
 #endif
         GetProdOrderRtngLineFromProdOrderComp(ProdOrderRoutingLine, ProdOrderComponent);
 
-        ItemLedgerEntry.SetCurrentKey(ItemLedgerEntry."Order Type", ItemLedgerEntry."Order No.", ItemLedgerEntry."Order Line No.", ItemLedgerEntry."Entry Type", ItemLedgerEntry."Prod. Order Comp. Line No.");
-        ItemLedgerEntry.SetRange(ItemLedgerEntry."Order Type", ItemLedgerEntry."Order Type"::Production);
-        ItemLedgerEntry.SetRange(ItemLedgerEntry."Order No.", ProdOrderComponent."Prod. Order No.");
-        ItemLedgerEntry.SetRange(ItemLedgerEntry."Order Line No.", ProdOrderComponent."Prod. Order Line No.");
-        ItemLedgerEntry.SetRange(ItemLedgerEntry."Entry Type", ItemLedgerEntry."Entry Type"::Consumption);
-        ItemLedgerEntry.SetRange(ItemLedgerEntry."Prod. Order Comp. Line No.", ProdOrderComponent."Line No.");
-        ItemLedgerEntry.SetRange(ItemLedgerEntry."Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
-        ItemLedgerEntry.CalcSums(ItemLedgerEntry.Quantity);
+        ItemLedgerEntry.SetCurrentKey("Order Type", "Order No.", "Order Line No.", "Entry Type", "Prod. Order Comp. Line No.");
+        ItemLedgerEntry.SetRange("Order Type", ItemLedgerEntry."Order Type"::Production);
+        ItemLedgerEntry.SetRange("Order No.", ProdOrderComponent."Prod. Order No.");
+        ItemLedgerEntry.SetRange("Order Line No.", ProdOrderComponent."Prod. Order Line No.");
+        ItemLedgerEntry.SetRange("Entry Type", ItemLedgerEntry."Entry Type"::Consumption);
+        ItemLedgerEntry.SetRange("Prod. Order Comp. Line No.", ProdOrderComponent."Line No.");
+        ItemLedgerEntry.SetRange("Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
+        ItemLedgerEntry.CalcSums(Quantity);
 
         exit(Abs(ItemLedgerEntry.Quantity));
     end;
@@ -65,13 +65,13 @@ codeunit 99001562 "Subc. Comp. Factbox Mgmt."
 #endif
         GetProdOrderRtngLineFromProdOrderComp(ProdOrderRoutingLine, ProdOrderComponent);
 
-        ItemLedgerEntry.SetCurrentKey(ItemLedgerEntry."Order Type", ItemLedgerEntry."Order No.", ItemLedgerEntry."Order Line No.", ItemLedgerEntry."Entry Type", ItemLedgerEntry."Prod. Order Comp. Line No.");
-        ItemLedgerEntry.SetRange(ItemLedgerEntry."Order Type", ItemLedgerEntry."Order Type"::Production);
-        ItemLedgerEntry.SetRange(ItemLedgerEntry."Order No.", ProdOrderComponent."Prod. Order No.");
-        ItemLedgerEntry.SetRange(ItemLedgerEntry."Order Line No.", ProdOrderComponent."Prod. Order Line No.");
-        ItemLedgerEntry.SetRange(ItemLedgerEntry."Entry Type", ItemLedgerEntry."Entry Type"::Consumption);
-        ItemLedgerEntry.SetRange(ItemLedgerEntry."Prod. Order Comp. Line No.", ProdOrderComponent."Line No.");
-        ItemLedgerEntry.SetRange(ItemLedgerEntry."Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
+        ItemLedgerEntry.SetCurrentKey("Order Type", "Order No.", "Order Line No.", "Entry Type", "Prod. Order Comp. Line No.");
+        ItemLedgerEntry.SetRange("Order Type", ItemLedgerEntry."Order Type"::Production);
+        ItemLedgerEntry.SetRange("Order No.", ProdOrderComponent."Prod. Order No.");
+        ItemLedgerEntry.SetRange("Order Line No.", ProdOrderComponent."Prod. Order Line No.");
+        ItemLedgerEntry.SetRange("Entry Type", ItemLedgerEntry."Entry Type"::Consumption);
+        ItemLedgerEntry.SetRange("Prod. Order Comp. Line No.", ProdOrderComponent."Line No.");
+        ItemLedgerEntry.SetRange("Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
         Page.Run(Page::"Item Ledger Entries", ItemLedgerEntry);
     end;
 
@@ -99,14 +99,14 @@ codeunit 99001562 "Subc. Comp. Factbox Mgmt."
 
         GetProdOrderRtngLineFromProdOrderComp(ProdOrderRoutingLine, ProdOrderComponent);
 
-        PurchaseLine.SetRange(PurchaseLine."Document Type", PurchaseLine."Document Type"::Order);
-        PurchaseLine.SetRange(PurchaseLine."Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Prod. Order Line No.", ProdOrderRoutingLine."Routing Reference No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Routing No.", ProdOrderRoutingLine."Routing No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Work Center No.", ProdOrderRoutingLine."Work Center No.");
-        PurchaseLine.SetRange(PurchaseLine."No.", ProdOrderComponent."Item No.");
-        PurchaseLine.CalcSums(PurchaseLine."Outstanding Qty. (Base)");
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        PurchaseLine.SetRange("Subc. Prod. Order Line No.", ProdOrderRoutingLine."Routing Reference No.");
+        PurchaseLine.SetRange("Subc. Routing No.", ProdOrderRoutingLine."Routing No.");
+        PurchaseLine.SetRange("Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
+        PurchaseLine.SetRange("Subc. Work Center No.", ProdOrderRoutingLine."Work Center No.");
+        PurchaseLine.SetRange("No.", ProdOrderComponent."Item No.");
+        PurchaseLine.CalcSums("Outstanding Qty. (Base)");
         exit(PurchaseLine."Outstanding Qty. (Base)");
     end;
 
@@ -132,13 +132,13 @@ codeunit 99001562 "Subc. Comp. Factbox Mgmt."
 
         GetProdOrderRtngLineFromProdOrderComp(ProdOrderRoutingLine, ProdOrderComponent);
 
-        PurchaseLine.SetRange(PurchaseLine."Document Type", PurchaseLine."Document Type"::Order);
-        PurchaseLine.SetRange(PurchaseLine."Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Prod. Order Line No.", ProdOrderRoutingLine."Routing Reference No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Routing No.", ProdOrderRoutingLine."Routing No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Work Center No.", ProdOrderRoutingLine."Work Center No.");
-        PurchaseLine.SetRange(PurchaseLine."No.", ProdOrderComponent."Item No.");
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        PurchaseLine.SetRange("Subc. Prod. Order Line No.", ProdOrderRoutingLine."Routing Reference No.");
+        PurchaseLine.SetRange("Subc. Routing No.", ProdOrderRoutingLine."Routing No.");
+        PurchaseLine.SetRange("Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
+        PurchaseLine.SetRange("Subc. Work Center No.", ProdOrderRoutingLine."Work Center No.");
+        PurchaseLine.SetRange("No.", ProdOrderComponent."Item No.");
         Page.Run(Page::"Purchase Lines", PurchaseLine);
     end;
 
@@ -166,14 +166,14 @@ codeunit 99001562 "Subc. Comp. Factbox Mgmt."
 
         GetProdOrderRtngLineFromProdOrderComp(ProdOrderRoutingLine, ProdOrderComponent);
 
-        PurchaseLine.SetRange(PurchaseLine."Document Type", PurchaseLine."Document Type"::Order);
-        PurchaseLine.SetRange(PurchaseLine."Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Prod. Order Line No.", ProdOrderRoutingLine."Routing Reference No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Routing No.", ProdOrderRoutingLine."Routing No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Work Center No.", ProdOrderRoutingLine."Work Center No.");
-        PurchaseLine.SetRange(PurchaseLine."No.", ProdOrderComponent."Item No.");
-        PurchaseLine.CalcSums(PurchaseLine."Qty. Received (Base)");
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        PurchaseLine.SetRange("Subc. Prod. Order Line No.", ProdOrderRoutingLine."Routing Reference No.");
+        PurchaseLine.SetRange("Subc. Routing No.", ProdOrderRoutingLine."Routing No.");
+        PurchaseLine.SetRange("Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
+        PurchaseLine.SetRange("Subc. Work Center No.", ProdOrderRoutingLine."Work Center No.");
+        PurchaseLine.SetRange("No.", ProdOrderComponent."Item No.");
+        PurchaseLine.CalcSums("Qty. Received (Base)");
         exit(PurchaseLine."Qty. Received (Base)");
     end;
 
@@ -198,13 +198,13 @@ codeunit 99001562 "Subc. Comp. Factbox Mgmt."
             exit;
         GetProdOrderRtngLineFromProdOrderComp(ProdOrderRoutingLine, ProdOrderComponent);
 
-        PurchaseLine.SetRange(PurchaseLine."Document Type", PurchaseLine."Document Type"::Order);
-        PurchaseLine.SetRange(PurchaseLine."Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Prod. Order Line No.", ProdOrderRoutingLine."Routing Reference No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Routing No.", ProdOrderRoutingLine."Routing No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
-        PurchaseLine.SetRange(PurchaseLine."Subc. Work Center No.", ProdOrderRoutingLine."Work Center No.");
-        PurchaseLine.SetRange(PurchaseLine."No.", ProdOrderComponent."Item No.");
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        PurchaseLine.SetRange("Subc. Prod. Order Line No.", ProdOrderRoutingLine."Routing Reference No.");
+        PurchaseLine.SetRange("Subc. Routing No.", ProdOrderRoutingLine."Routing No.");
+        PurchaseLine.SetRange("Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
+        PurchaseLine.SetRange("Subc. Work Center No.", ProdOrderRoutingLine."Work Center No.");
+        PurchaseLine.SetRange("No.", ProdOrderComponent."Item No.");
         Page.Run(Page::"Purchase Lines", PurchaseLine);
     end;
 

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcPlanningCompExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcPlanningCompExt.Codeunit.al
@@ -113,7 +113,7 @@ codeunit 99001522 "Subc. Planning Comp. Ext."
                       PlanningComponent."Item No.",
                       PlanningComponent."Variant Code",
                       PlanningComponent."Location Code");
-                    PlanningComponent.Validate(PlanningComponent."Location Code", StockkeepingUnit."Components at Location");
+                    PlanningComponent.Validate("Location Code", StockkeepingUnit."Components at Location");
                 end;
     end;
 

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingFactboxMgmt.Codeunit.al
@@ -81,11 +81,11 @@ codeunit 99001561 "Subc. Routing Factbox Mgmt."
             exit(0);
 
 #endif
-        PurchaseLine.SetRange(PurchaseLine."Document Type", PurchaseLine."Document Type"::Order);
-        PurchaseLine.SetRange(PurchaseLine."Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        PurchaseLine.SetRange(PurchaseLine."Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
-        PurchaseLine.SetRange(PurchaseLine."Operation No.", ProdOrderRoutingLine."Operation No.");
-        PurchaseLine.CalcSums(PurchaseLine.Quantity);
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        PurchaseLine.SetRange("Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
+        PurchaseLine.SetRange("Operation No.", ProdOrderRoutingLine."Operation No.");
+        PurchaseLine.CalcSums(Quantity);
         exit(PurchaseLine.Quantity);
     end;
 
@@ -103,10 +103,10 @@ codeunit 99001561 "Subc. Routing Factbox Mgmt."
 #pragma warning restore AL0432
             exit;
 #endif
-        PurchaseLine.SetRange(PurchaseLine."Document Type", PurchaseLine."Document Type"::Order);
-        PurchaseLine.SetRange(PurchaseLine."Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        PurchaseLine.SetRange(PurchaseLine."Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
-        PurchaseLine.SetRange(PurchaseLine."Operation No.", ProdOrderRoutingLine."Operation No.");
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        PurchaseLine.SetRange("Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
+        PurchaseLine.SetRange("Operation No.", ProdOrderRoutingLine."Operation No.");
 
         Page.Run(Page::"Purchase Lines", PurchaseLine);
     end;
@@ -127,10 +127,10 @@ codeunit 99001561 "Subc. Routing Factbox Mgmt."
             exit(0);
 
 #endif
-        PurchRcptLine.SetRange(PurchRcptLine."Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        PurchRcptLine.SetRange(PurchRcptLine."Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
-        PurchRcptLine.SetRange(PurchRcptLine."Operation No.", ProdOrderRoutingLine."Operation No.");
-        PurchRcptLine.CalcSums(PurchRcptLine.Quantity);
+        PurchRcptLine.SetRange("Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        PurchRcptLine.SetRange("Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
+        PurchRcptLine.SetRange("Operation No.", ProdOrderRoutingLine."Operation No.");
+        PurchRcptLine.CalcSums(Quantity);
         exit(PurchRcptLine.Quantity);
     end;
 
@@ -148,9 +148,9 @@ codeunit 99001561 "Subc. Routing Factbox Mgmt."
 #pragma warning restore AL0432
             exit;
 #endif
-        PurchRcptLine.SetRange(PurchRcptLine."Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        PurchRcptLine.SetRange(PurchRcptLine."Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
-        PurchRcptLine.SetRange(PurchRcptLine."Operation No.", ProdOrderRoutingLine."Operation No.");
+        PurchRcptLine.SetRange("Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        PurchRcptLine.SetRange("Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
+        PurchRcptLine.SetRange("Operation No.", ProdOrderRoutingLine."Operation No.");
 
         Page.Run(Page::"Purch. Receipt Lines", PurchRcptLine);
     end;
@@ -171,10 +171,10 @@ codeunit 99001561 "Subc. Routing Factbox Mgmt."
             exit(0);
 
 #endif
-        PurchInvLine.SetRange(PurchInvLine."Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        PurchInvLine.SetRange(PurchInvLine."Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
-        PurchInvLine.SetRange(PurchInvLine."Operation No.", ProdOrderRoutingLine."Operation No.");
-        PurchInvLine.CalcSums(PurchInvLine.Quantity);
+        PurchInvLine.SetRange("Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        PurchInvLine.SetRange("Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
+        PurchInvLine.SetRange("Operation No.", ProdOrderRoutingLine."Operation No.");
+        PurchInvLine.CalcSums(Quantity);
         exit(PurchInvLine.Quantity);
     end;
 
@@ -192,10 +192,10 @@ codeunit 99001561 "Subc. Routing Factbox Mgmt."
 #pragma warning restore AL0432
             exit;
 #endif
-        PurchInvLine.SetCurrentKey(PurchInvLine.Type, PurchInvLine."Prod. Order No.", PurchInvLine."Prod. Order Line No.");
-        PurchInvLine.SetRange(PurchInvLine."Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        PurchInvLine.SetRange(PurchInvLine."Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
-        PurchInvLine.SetRange(PurchInvLine."Operation No.", ProdOrderRoutingLine."Operation No.");
+        PurchInvLine.SetCurrentKey(Type, "Prod. Order No.", "Prod. Order Line No.");
+        PurchInvLine.SetRange("Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        PurchInvLine.SetRange("Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
+        PurchInvLine.SetRange("Operation No.", ProdOrderRoutingLine."Operation No.");
 
         Page.Run(Page::"Posted Purchase Invoice Lines", PurchInvLine);
     end;
@@ -216,11 +216,11 @@ codeunit 99001561 "Subc. Routing Factbox Mgmt."
             exit(0);
 
 #endif
-        TransferLine.SetCurrentKey(TransferLine."Subc. Prod. Order No.", TransferLine."Subc. Prod. Order Line No.", TransferLine."Subc. Routing Reference No.", TransferLine."Subc. Routing No.", TransferLine."Subc. Operation No.");
-        TransferLine.SetRange(TransferLine."Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        TransferLine.SetRange(TransferLine."Subc. Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
-        TransferLine.SetRange(TransferLine."Subc. Routing No.", ProdOrderRoutingLine."Routing No.");
-        TransferLine.SetRange(TransferLine."Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
+        TransferLine.SetCurrentKey("Subc. Prod. Order No.", "Subc. Prod. Order Line No.", "Subc. Routing Reference No.", "Subc. Routing No.", "Subc. Operation No.");
+        TransferLine.SetRange("Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        TransferLine.SetRange("Subc. Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
+        TransferLine.SetRange("Subc. Routing No.", ProdOrderRoutingLine."Routing No.");
+        TransferLine.SetRange("Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
         TransferLine.SetRange("Subc. Return Order", false);
         TransferLine.SetRange("Derived From Line No.", 0);
         exit(TransferLine.Count());
@@ -242,10 +242,10 @@ codeunit 99001561 "Subc. Routing Factbox Mgmt."
             exit(0);
 
 #endif
-        TransferLine.SetCurrentKey(TransferLine."Subc. Prod. Order No.", TransferLine."Subc. Prod. Order Line No.", TransferLine."Subc. Routing Reference No.", TransferLine."Subc. Operation No.");
-        TransferLine.SetRange(TransferLine."Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        TransferLine.SetRange(TransferLine."Subc. Routing Reference No.", 0);
-        TransferLine.SetRange(TransferLine."Subc. Operation No.", '');
+        TransferLine.SetCurrentKey("Subc. Prod. Order No.", "Subc. Prod. Order Line No.", "Subc. Routing Reference No.", "Subc. Operation No.");
+        TransferLine.SetRange("Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        TransferLine.SetRange("Subc. Routing Reference No.", 0);
+        TransferLine.SetRange("Subc. Operation No.", '');
         TransferLine.SetRange("Derived From Line No.", 0);
         TransferLine.SetRange("Subc. Return Order", true);
         exit(TransferLine.Count());
@@ -265,11 +265,11 @@ codeunit 99001561 "Subc. Routing Factbox Mgmt."
 #pragma warning restore AL0432
             exit;
 #endif
-        TransferLine.SetCurrentKey(TransferLine."Subc. Prod. Order No.", TransferLine."Subc. Prod. Order Line No.", TransferLine."Subc. Routing Reference No.", TransferLine."Subc. Routing No.", TransferLine."Subc. Operation No.");
-        TransferLine.SetRange(TransferLine."Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        TransferLine.SetRange(TransferLine."Subc. Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
-        TransferLine.SetRange(TransferLine."Subc. Routing No.", ProdOrderRoutingLine."Routing No.");
-        TransferLine.SetRange(TransferLine."Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
+        TransferLine.SetCurrentKey("Subc. Prod. Order No.", "Subc. Prod. Order Line No.", "Subc. Routing Reference No.", "Subc. Routing No.", "Subc. Operation No.");
+        TransferLine.SetRange("Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        TransferLine.SetRange("Subc. Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
+        TransferLine.SetRange("Subc. Routing No.", ProdOrderRoutingLine."Routing No.");
+        TransferLine.SetRange("Subc. Operation No.", ProdOrderRoutingLine."Operation No.");
         TransferLine.SetRange("Derived From Line No.", 0);
         Page.Run(Page::"Transfer Lines", TransferLine);
     end;
@@ -288,10 +288,10 @@ codeunit 99001561 "Subc. Routing Factbox Mgmt."
 #pragma warning restore AL0432
             exit;
 #endif
-        TransferLine.SetCurrentKey(TransferLine."Subc. Prod. Order No.", TransferLine."Subc. Prod. Order Line No.", TransferLine."Subc. Routing Reference No.", TransferLine."Subc. Operation No.");
-        TransferLine.SetRange(TransferLine."Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        TransferLine.SetRange(TransferLine."Subc. Routing Reference No.", 0);
-        TransferLine.SetRange(TransferLine."Subc. Operation No.", '');
+        TransferLine.SetCurrentKey("Subc. Prod. Order No.", "Subc. Prod. Order Line No.", "Subc. Routing Reference No.", "Subc. Operation No.");
+        TransferLine.SetRange("Subc. Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        TransferLine.SetRange("Subc. Routing Reference No.", 0);
+        TransferLine.SetRange("Subc. Operation No.", '');
         TransferLine.SetRange("Derived From Line No.", 0);
         Page.Run(Page::"Transfer Lines", TransferLine);
     end;
@@ -314,10 +314,10 @@ codeunit 99001561 "Subc. Routing Factbox Mgmt."
 #endif
         if ProdOrderRoutingLine."Routing Link Code" = '' then
             exit(0);
-        ProdOrderComponent.SetRange(ProdOrderComponent.Status, ProdOrderRoutingLine.Status);
-        ProdOrderComponent.SetRange(ProdOrderComponent."Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        ProdOrderComponent.SetRange(ProdOrderComponent."Prod. Order Line No.", ProdOrderRoutingLine."Routing Reference No.");
-        ProdOrderComponent.SetRange(ProdOrderComponent."Routing Link Code", ProdOrderRoutingLine."Routing Link Code");
+        ProdOrderComponent.SetRange(Status, ProdOrderRoutingLine.Status);
+        ProdOrderComponent.SetRange("Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        ProdOrderComponent.SetRange("Prod. Order Line No.", ProdOrderRoutingLine."Routing Reference No.");
+        ProdOrderComponent.SetRange("Routing Link Code", ProdOrderRoutingLine."Routing Link Code");
         exit(ProdOrderComponent.Count());
     end;
 
@@ -335,10 +335,10 @@ codeunit 99001561 "Subc. Routing Factbox Mgmt."
 #pragma warning restore AL0432
             exit;
 #endif
-        ProdOrderComponent.SetRange(ProdOrderComponent.Status, ProdOrderRoutingLine.Status);
-        ProdOrderComponent.SetRange(ProdOrderComponent."Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
-        ProdOrderComponent.SetRange(ProdOrderComponent."Prod. Order Line No.", ProdOrderRoutingLine."Routing Reference No.");
-        ProdOrderComponent.SetRange(ProdOrderComponent."Routing Link Code", ProdOrderRoutingLine."Routing Link Code");
+        ProdOrderComponent.SetRange(Status, ProdOrderRoutingLine.Status);
+        ProdOrderComponent.SetRange("Prod. Order No.", ProdOrderRoutingLine."Prod. Order No.");
+        ProdOrderComponent.SetRange("Prod. Order Line No.", ProdOrderRoutingLine."Routing Reference No.");
+        ProdOrderComponent.SetRange("Routing Link Code", ProdOrderRoutingLine."Routing Link Code");
         Page.Run(Page::"Subc. Prod. Order Components", ProdOrderComponent);
     end;
 }

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcCalculateSubcontracts.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcCalculateSubcontracts.Report.al
@@ -177,20 +177,18 @@ report 99001505 "Subc. Calculate Subcontracts"
         if not IsHandled then
             if ReqLine.Quantity <> 0 then begin
                 if WorkCenter."Unit Cost Calculation" = WorkCenter."Unit Cost Calculation"::Units then
-                    ReqLine.Validate(
-                        ReqLine."Direct Unit Cost",
+                    ReqLine.Validate("Direct Unit Cost",
                         Round(
                             ProdOrderRoutingLine."Direct Unit Cost" * ProdOrderLine."Qty. per Unit of Measure",
                             GLSetup."Unit-Amount Rounding Precision"))
                 else
-                    ReqLine.Validate(
-                        ReqLine."Direct Unit Cost",
+                    ReqLine.Validate("Direct Unit Cost",
                         Round(
                             (ProdOrderRoutingLine."Expected Operation Cost Amt." - ProdOrderRoutingLine."Expected Capacity Ovhd. Cost") /
                             ProdOrderLine."Total Exp. Oper. Output (Qty.)",
                             GLSetup."Unit-Amount Rounding Precision"));
             end else
-                ReqLine.Validate(ReqLine."Direct Unit Cost", 0);
+                ReqLine.Validate("Direct Unit Cost", 0);
         ReqLine."Qty. per Unit of Measure" := 0;
         ReqLine."Quantity (Base)" := 0;
         ReqLine."Qty. Rounding Precision" := ProdOrderLine."Qty. Rounding Precision";
@@ -205,7 +203,7 @@ report 99001505 "Subc. Calculate Subcontracts"
         ReqLine."Routing No." := ProdOrderRoutingLine."Routing No.";
         ReqLine."Operation No." := ProdOrderRoutingLine."Operation No.";
         ReqLine."Work Center No." := ProdOrderRoutingLine."Work Center No.";
-        ReqLine.Validate(ReqLine."Vendor No.", WorkCenter."Subcontractor No.");
+        ReqLine.Validate("Vendor No.", WorkCenter."Subcontractor No.");
         ReqLine.Description := ProdOrderRoutingLine.Description;
         ReqLine."Description 2" := ProdOrderRoutingLine."Description 2";
         SetVendorItemNo();
@@ -222,7 +220,7 @@ report 99001505 "Subc. Calculate Subcontracts"
         PurchLine.SetRange("Planning Flexibility", PurchLine."Planning Flexibility"::Unlimited);
         PurchLine.SetRange("Quantity Received", 0);
         if PurchLine.FindFirst() then begin
-            ReqLine.Validate(ReqLine.Quantity, ReqLine.Quantity + PurchLine."Outstanding Quantity");
+            ReqLine.Validate(Quantity, ReqLine.Quantity + PurchLine."Outstanding Quantity");
             ReqLine."Quantity (Base)" := 0;
             ReqLine."Replenishment System" := ReqLine."Replenishment System"::Purchase;
             ReqLine."Ref. Order No." := PurchLine."Document No.";

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcItemChargeAssPurchExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcItemChargeAssPurchExt.Codeunit.al
@@ -27,7 +27,7 @@ codeunit 99001536 "Subc. ItemChargeAssPurchExt"
 #pragma warning restore AL0432
             exit;
 #endif
-        if FromPurchRcptLine."Subc. Prod. Order No." = '' then
+        if FromPurchRcptLine."Prod. Order No." = '' then
             exit;
 
         IsHandled := true;

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcItemChargeAssPurchExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcItemChargeAssPurchExt.Codeunit.al
@@ -9,6 +9,9 @@ using Microsoft.Purchases.History;
 
 codeunit 99001536 "Subc. ItemChargeAssPurchExt"
 {
+    var
+        AssignToUndoneRcptErr: Label 'You cannot assign the item charge to subcontracting receipt %1, line %2, because it has been undone.', Comment = '%1 = Posted Receipt No., %2 = Posted Receipt Line No.';
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Item Charge Assgnt. (Purch.)", OnBeforeCreateRcptChargeAssgnt, '', false, false)]
     local procedure "Item Charge Assgnt. (Purch.)_OnBeforeCreateRcptChargeAssgnt"(var FromPurchRcptLine: Record "Purch. Rcpt. Line"; ItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)"; var IsHandled: Boolean)
 #if not CLEAN29
@@ -43,6 +46,9 @@ codeunit 99001536 "Subc. ItemChargeAssPurchExt"
         ItemChargeAssignmentPurch2.SetRange("Document Line No.", ItemChargeAssignmentPurch."Document Line No.");
         ItemChargeAssignmentPurch2.SetRange("Applies-to Doc. Type", "Purchase Applies-to Document Type"::Receipt);
         repeat
+            if (FromPurchRcptLine."Prod. Order No." <> '') and FromPurchRcptLine.Correction then
+                Error(AssignToUndoneRcptErr, FromPurchRcptLine."Document No.", FromPurchRcptLine."Line No.");
+
             ItemChargeAssignmentPurch2.SetRange("Applies-to Doc. No.", FromPurchRcptLine."Document No.");
             ItemChargeAssignmentPurch2.SetRange("Applies-to Doc. Line No.", FromPurchRcptLine."Line No.");
             if ItemChargeAssignmentPurch2.IsEmpty() then

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPriceManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPriceManagement.Codeunit.al
@@ -117,7 +117,7 @@ codeunit 99001508 "Subc. Price Management"
           RequisitionLine."Qty. per Unit of Measure",
           RequisitionLine."Quantity (Base)");
 
-        PlanningRoutingLine.Validate(PlanningRoutingLine."Direct Unit Cost");
+        PlanningRoutingLine.Validate("Direct Unit Cost");
 
         PlanningRoutingLine.UpdateDatetime();
     end;
@@ -366,8 +366,8 @@ codeunit 99001508 "Subc. Price Management"
 
     local procedure GetPriceByUOM(var SubcontractorPrice: Record "Subcontractor Price"; PriceListQty: Decimal; var PriceListCost: Decimal)
     begin
-        SubcontractorPrice.SetRange(SubcontractorPrice."Minimum Quantity", 0, PriceListQty);
-        SubcontractorPrice.SetRange(SubcontractorPrice."Unit of Measure Code", SubcontractorPrice."Unit of Measure Code");
+        SubcontractorPrice.SetRange("Minimum Quantity", 0, PriceListQty);
+        SubcontractorPrice.SetRange("Unit of Measure Code", SubcontractorPrice."Unit of Measure Code");
         if SubcontractorPrice.FindLast() then begin
             PriceListCost := SubcontractorPrice."Direct Unit Cost";
             if PriceListCost <> 0 then

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchPostExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchPostExt.Codeunit.al
@@ -25,6 +25,45 @@ codeunit 99001535 "Subc. Purch. Post Ext"
 #pragma warning restore AL0432
 #endif
         CancelNotSupportedErr: Label 'You cannot cancel or correct posted purchase invoice %1 because it contains item charges assigned to a subcontracting order receipt.\Use the ''Create Corrective Credit Memo'' action to create a credit memo for this invoice.', Comment = '%1 = Posted Purchase Invoice No.';
+        ItemChargeAgainstUndoneRcptErr: Label 'You cannot post the item charge because it is assigned to subcontracting receipt %1, line %2, which has been undone.\Remove the item charge assignment from the undone receipt line.', Comment = '%1 = Posted Receipt No., %2 = Posted Receipt Line No.';
+        GetSubcontractingRcptNotSupportedErr: Label 'You cannot copy subcontracting receipt lines into this document. Subcontracting purchase orders must be invoiced from the subcontracting order itself, not by getting the receipt lines into a separate document.';
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Purch.-Get Receipt", OnAfterPurchRcptLineSetFilters, '', false, false)]
+    local procedure ExcludeSubcontractingLinesOnAfterPurchRcptLineSetFilters(var PurchRcptLine: Record "Purch. Rcpt. Line"; PurchaseHeader: Record "Purchase Header")
+    begin
+#if not CLEAN29
+#pragma warning disable AL0432
+        if not SubcFeatureFlagHandler.IsSubcontractingEnabled() then
+#pragma warning restore AL0432
+            exit;
+#endif
+        PurchRcptLine.SetRange("Prod. Order No.", '');
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Purch.-Get Receipt", OnCreateInvLinesOnBeforeInsertLineIteration, '', false, false)]
+    local procedure BlockSubcontractingLinesOnCreateInvLinesOnBeforeInsertLineIteration(var PurchRcptLine2: Record "Purch. Rcpt. Line"; var PurchRcptHeader: Record "Purch. Rcpt. Header"; var PurchaseHeader: Record "Purchase Header"; var PurchaseLine: Record "Purchase Line"; var TransferLine: Boolean; var IsHandled: Boolean)
+    begin
+#if not CLEAN29
+#pragma warning disable AL0432
+        if not SubcFeatureFlagHandler.IsSubcontractingEnabled() then
+#pragma warning restore AL0432
+            exit;
+#endif
+        if PurchRcptLine2."Prod. Order No." <> '' then
+            Error(GetSubcontractingRcptNotSupportedErr);
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Matched Order Line Mgmt.", OnGetPurchaseOrderLinesOnAfterSetPurchaseLineOrderFilters, '', false, false)]
+    local procedure ExcludeSubcontractingLinesOnGetPurchaseOrderLines(var PurchaseLineOrder: Record "Purchase Line"; PurchaseHeaderInvoice: Record "Purchase Header")
+    begin
+#if not CLEAN29
+#pragma warning disable AL0432
+        if not SubcFeatureFlagHandler.IsSubcontractingEnabled() then
+#pragma warning restore AL0432
+            exit;
+#endif
+        PurchaseLineOrder.SetRange("Prod. Order No.", '');
+    end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Correct Posted Purch. Invoice", OnAfterTestCorrectInvoiceIsAllowed, '', false, false)]
     local procedure BlockCancelIfHasSubcontractingItemChargeValueEntry(var PurchInvHeader: Record "Purch. Inv. Header"; Cancelling: Boolean)
@@ -93,6 +132,8 @@ codeunit 99001535 "Subc. Purch. Post Ext"
             exit;
         if not PurchRcptLineHasProdOrder(PurchRcptLine) then
             exit;
+        if PurchRcptLine.Correction then
+            Error(ItemChargeAgainstUndoneRcptErr, PurchRcptLine."Document No.", PurchRcptLine."Line No.");
 
         CopySubcontractingProdOrderFieldsToItemJnlLine(ItemJournalLine, PurchRcptLine);
     end;

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineExt.Codeunit.al
@@ -301,7 +301,7 @@ codeunit 99001534 "Subc. Purchase Line Ext"
             exit;
 #endif
         if PurchaseLine."Prod. Order No." <> '' then
-            Error(ChangeVariantNoNotAllowedErr, PurchaseLine.FieldCaption(PurchaseLine."Variant Code"), PurchaseLine."Prod. Order No.");
+            Error(ChangeVariantNoNotAllowedErr, PurchaseLine.FieldCaption("Variant Code"), PurchaseLine."Prod. Order No.");
     end;
 
     local procedure GetSubcontractingPrice(var PurchaseLine: Record "Purchase Line")

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseOrderCreator.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseOrderCreator.Codeunit.al
@@ -458,8 +458,8 @@ codeunit 99001557 "Subc. Purchase Order Creator"
         RequisitionLine2: Record "Requisition Line";
         NextLineNo: Integer;
     begin
-        RequisitionLine2.SetRange(RequisitionLine2."Worksheet Template Name", RequisitionLine."Worksheet Template Name");
-        RequisitionLine2.SetRange(RequisitionLine2."Journal Batch Name", RequisitionLine."Journal Batch Name");
+        RequisitionLine2.SetRange("Worksheet Template Name", RequisitionLine."Worksheet Template Name");
+        RequisitionLine2.SetRange("Journal Batch Name", RequisitionLine."Journal Batch Name");
         RequisitionLine2.SetLoadFields("Line No.");
         if RequisitionLine2.FindLast() then
             NextLineNo := RequisitionLine2."Line No." + 10000
@@ -553,14 +553,12 @@ codeunit 99001557 "Subc. Purchase Order Creator"
         GeneralLedgerSetup.Get();
         if RequisitionLine.Quantity <> 0 then begin
             if WorkCenter."Unit Cost Calculation" = "Unit Cost Calculation Type"::Units then
-                RequisitionLine.Validate(
-                    RequisitionLine."Direct Unit Cost",
+                RequisitionLine.Validate("Direct Unit Cost",
                     Round(
                         ProdOrderRoutingLine."Direct Unit Cost" * ProdOrderLine."Qty. per Unit of Measure",
                         GeneralLedgerSetup."Unit-Amount Rounding Precision"))
             else
-                RequisitionLine.Validate(
-                    RequisitionLine."Direct Unit Cost",
+                RequisitionLine.Validate("Direct Unit Cost",
                     Round(
                         (ProdOrderRoutingLine."Expected Operation Cost Amt." - ProdOrderRoutingLine."Expected Capacity Ovhd. Cost") /
                         ProdOrderLine."Total Exp. Oper. Output (Qty.)",

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcTransferWIPPosting.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcTransferWIPPosting.Codeunit.al
@@ -253,7 +253,7 @@ codeunit 99001541 "Subc. Transfer WIP Posting"
 #endif
         WarehouseReceiptLine."Transfer WIP Item" := TransferLine."Transfer WIP Item";
         if WarehouseReceiptLine."Transfer WIP Item" then begin
-            WarehouseReceiptLine.Validate(WarehouseReceiptLine."Qty. Received", TransferLine."Quantity Received");
+            WarehouseReceiptLine.Validate("Qty. Received", TransferLine."Quantity Received");
             TransferLine.CalcFields("Whse. Inbnd. Otsdg. Qty");
             WarehouseReceiptLine.Quantity := TransferLine."Quantity Received" + TransferLine."Qty. in Transit" - TransferLine."Whse. Inbnd. Otsdg. Qty";
             WarehouseReceiptLine."Qty. (Base)" := 0;

--- a/src/Apps/W1/Subcontracting/Test/DisabledTests/SubcSubcontractingTest.DisabledTest.json
+++ b/src/Apps/W1/Subcontracting/Test/DisabledTests/SubcSubcontractingTest.DisabledTest.json
@@ -1,8 +1,0 @@
-[
-    {
-        "bug": "638702",
-        "codeunitId": 139989,
-        "codeunitName": "Subc. Subcontracting Test",
-        "method": "CancelInvoiceWithSubcontractingItemChargeIsBlocked"
-    }
-]

--- a/src/Apps/W1/Subcontracting/Test/Libraries/SubcLibraryMfgManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Libraries/SubcLibraryMfgManagement.Codeunit.al
@@ -45,12 +45,12 @@ codeunit 139984 "Subc. Library Mfg. Management"
     begin
         if not MfgSetup.Get() then
             MfgSetup.Insert();
-        MfgSetup.Validate(MfgSetup."Normal Starting Time", 080000T);
-        MfgSetup.Validate(MfgSetup."Normal Ending Time", 230000T);
-        MfgSetup.Validate(MfgSetup."Doc. No. Is Prod. Order No.", true);
-        MfgSetup.Validate(MfgSetup."Cost Incl. Setup", true);
-        MfgSetup.Validate(MfgSetup."Planning Warning", true);
-        MfgSetup.Validate(MfgSetup."Dynamic Low-Level Code", true);
+        MfgSetup.Validate("Normal Starting Time", 080000T);
+        MfgSetup.Validate("Normal Ending Time", 230000T);
+        MfgSetup.Validate("Doc. No. Is Prod. Order No.", true);
+        MfgSetup.Validate("Cost Incl. Setup", true);
+        MfgSetup.Validate("Planning Warning", true);
+        MfgSetup.Validate("Dynamic Low-Level Code", true);
         MfgSetup."Simulated Order Nos." := LibraryERM.CreateNoSeriesCode();
         MfgSetup."Planned Order Nos." := LibraryERM.CreateNoSeriesCode();
         MfgSetup."Firm Planned Order Nos." := LibraryERM.CreateNoSeriesCode();
@@ -294,11 +294,10 @@ codeunit 139984 "Subc. Library Mfg. Management"
         ProdOrderRtngCommentLine."Routing No." := RoutingNo;
         ProdOrderRtngCommentLine."Operation No." := OperationNo;
         RecRef.GetTable(ProdOrderRtngCommentLine);
-        ProdOrderRtngCommentLine.Validate(ProdOrderRtngCommentLine."Line No.", LibraryUtility.GetNewLineNo(RecRef, ProdOrderRtngCommentLine.FieldNo("Line No.")));
+        ProdOrderRtngCommentLine.Validate("Line No.", LibraryUtility.GetNewLineNo(RecRef, ProdOrderRtngCommentLine.FieldNo("Line No.")));
         ProdOrderRtngCommentLine.Insert(true);
 
-        ProdOrderRtngCommentLine.Validate(
-            ProdOrderRtngCommentLine.Comment,
+        ProdOrderRtngCommentLine.Validate(Comment,
             Format(ProdOrderRtngCommentLine."Prod. Order No.") + Format(ProdOrderRtngCommentLine."Routing Reference No.") + Format(ProdOrderRtngCommentLine."Line No."));
         ProdOrderRtngCommentLine.Modify(true);
     end;

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -3534,6 +3534,61 @@ codeunit 139989 "Subc. Subcontracting Test"
         CreateItem(Item, "Costing Method"::FIFO, "Reordering Policy"::"Lot-for-Lot", "Flushing Method"::"Pick + Manual", RoutingHeader."No.", ProductionBOMHeader."No.");
     end;
 
+    local procedure CreateItemWithNonLastSubcontractingOperation(var Item: Record Item; var SubcWorkCenter: Record "Work Center")
+    var
+        CapacityUnitOfMeasure: Record "Capacity Unit of Measure";
+        ComponentItem1: Record Item;
+        ComponentItem2: Record Item;
+        LastWorkCenter: Record "Work Center";
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        ShopCalendarCode: Code[10];
+        LastWorkCenterNo: Code[20];
+        WorkCenterNo: Code[20];
+    begin
+        LibraryManufacturing.CreateCapacityUnitOfMeasure(CapacityUnitOfMeasure, "Capacity Unit of Measure"::Minutes);
+        ShopCalendarCode := LibraryManufacturing.UpdateShopCalendarWorkingDays();
+
+        // Subcontracting work center for the first operation, which must not be the last operation so the item charge is
+        // posted against the work center capacity (capacity ledger entry) instead of the produced item's output entry.
+        CreateWorkCenter(WorkCenterNo, ShopCalendarCode, "Flushing Method"::"Pick + Manual", true, UnitCostCalculation, '');
+        SubcWorkCenter.Get(WorkCenterNo);
+        LibraryManufacturing.CalculateWorkCenterCalendar(SubcWorkCenter, CalcDate('<-CY-1Y>', WorkDate()), CalcDate('<CM>', WorkDate()));
+
+        // Regular (non-subcontracting) work center for the last operation
+        CreateWorkCenter(LastWorkCenterNo, ShopCalendarCode, "Flushing Method"::"Pick + Manual", false, UnitCostCalculation, '');
+        LastWorkCenter.Get(LastWorkCenterNo);
+        LibraryManufacturing.CalculateWorkCenterCalendar(LastWorkCenter, CalcDate('<-CY-1Y>', WorkDate()), CalcDate('<CM>', WorkDate()));
+
+        LibraryManufacturing.CreateRoutingHeader(RoutingHeader, RoutingHeader.Type::Serial);
+
+        // Operation 10 - subcontracting work center (not the last operation)
+        LibraryManufacturing.CreateRoutingLine(RoutingHeader, RoutingLine, '', '10', RoutingLine.Type::"Work Center", SubcWorkCenter."No.");
+        RoutingLine.Validate("Setup Time", LibraryRandom.RandInt(5));
+        RoutingLine.Validate("Run Time", LibraryRandom.RandInt(5));
+        RoutingLine.Validate("Run Time Unit of Meas. Code", CapacityUnitOfMeasure.Code);
+        RoutingLine.Validate("Setup Time Unit of Meas. Code", CapacityUnitOfMeasure.Code);
+        RoutingLine.Modify(true);
+
+        // Operation 20 - regular work center (the last operation)
+        LibraryManufacturing.CreateRoutingLine(RoutingHeader, RoutingLine, '', '20', RoutingLine.Type::"Work Center", LastWorkCenter."No.");
+        RoutingLine.Validate("Setup Time", LibraryRandom.RandInt(5));
+        RoutingLine.Validate("Run Time", LibraryRandom.RandInt(5));
+        RoutingLine.Validate("Run Time Unit of Meas. Code", CapacityUnitOfMeasure.Code);
+        RoutingLine.Validate("Setup Time Unit of Meas. Code", CapacityUnitOfMeasure.Code);
+        RoutingLine.Modify(true);
+
+        RoutingHeader.Validate(Status, RoutingHeader.Status::Certified);
+        RoutingHeader.Modify(true);
+
+        LibraryInventory.CreateItem(ComponentItem1);
+        LibraryInventory.CreateItem(ComponentItem2);
+        LibraryManufacturing.CreateCertifProdBOMWithTwoComp(ProductionBOMHeader, ComponentItem1."No.", ComponentItem2."No.", 1);
+
+        CreateItem(Item, "Costing Method"::FIFO, "Reordering Policy"::"Lot-for-Lot", "Flushing Method"::"Pick + Manual", RoutingHeader."No.", ProductionBOMHeader."No.");
+    end;
+
     local procedure UpdateVendorWithSubcontractingLocationCode(WorkCenter: Record "Work Center")
     var
         Location: Record Location;
@@ -3977,34 +4032,29 @@ codeunit 139989 "Subc. Subcontracting Test"
     procedure CancelInvoiceWithSubcontractingItemChargeIsBlocked()
     var
         Item: Record Item;
-        RegularItem: Record Item;
         ProductionOrder: Record "Production Order";
         SubcWorkCenter: Record "Work Center";
         SubcPurchaseHeader: Record "Purchase Header";
         SubcPurchaseLine: Record "Purchase Line";
-        RegularPurchaseHeader: Record "Purchase Header";
-        RegularPurchaseLine: Record "Purchase Line";
         SubcPurchRcptLine: Record "Purch. Rcpt. Line";
-        RegPurchRcptLine: Record "Purch. Rcpt. Line";
         ItemCharge: Record "Item Charge";
         ItemChargeInvHeader: Record "Purchase Header";
         ItemChargeInvLine: Record "Purchase Line";
         PurchInvHeader: Record "Purch. Inv. Header";
         CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
         PostedInvoiceNo: Code[20];
-        SubcVendorNo: Code[20];
     begin
-        // [SCENARIO 637502] Cancelling a Posted Purchase Invoice whose Item Charge is split between a regular item receipt
-        // line and a subcontracting service receipt line must be blocked. Letting the cancel run today silently skips the
-        // capacity portion (Value Entry has Item Ledger Entry No. = 0) and redistributes it to inventory, corrupting cost.
-        // Until a proper reversal path exists, the Subcontracting App blocks the cancel with a clear error so the user
-        // creates a corrective credit memo manually.
+        // [SCENARIO 637502] Cancelling a Posted Purchase Invoice whose Item Charge is assigned to a subcontracting service
+        // receipt line must be blocked. Letting the cancel run today silently skips the capacity portion (Value Entry has
+        // Item Ledger Entry No. = 0) and redistributes it to inventory, corrupting cost. Until a proper reversal path exists,
+        // the Subcontracting App blocks the cancel with a clear error so the user creates a corrective credit memo manually.
 
-        // [GIVEN] Subcontracting setup with a single-operation subcontracting routing on Item
+        // [GIVEN] Subcontracting setup with a routing whose subcontracting operation is not the last operation, so the
+        // item charge is booked against the work center capacity
         Initialize();
         Subcontracting := true;
         UnitCostCalculation := UnitCostCalculation::Units;
-        CreateItemWithSingleSubcontractingOperation(Item, SubcWorkCenter);
+        CreateItemWithNonLastSubcontractingOperation(Item, SubcWorkCenter);
         SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(SubcWorkCenter);
 
         // [GIVEN] Released production order and a subcontracting purchase order received in full
@@ -4021,7 +4071,6 @@ codeunit 139989 "Subc. Subcontracting Test"
         SubcPurchaseLine.FindFirst();
         SubcPurchaseHeader.Get(SubcPurchaseLine."Document Type", SubcPurchaseLine."Document No.");
         EnsureGeneralPostingSetupIsValid(SubcPurchaseLine."Gen. Bus. Posting Group", SubcPurchaseLine."Gen. Prod. Posting Group");
-        SubcVendorNo := SubcPurchaseHeader."Buy-from Vendor No.";
 
         LibraryPurchase.PostPurchaseDocument(SubcPurchaseHeader, true, false);
 
@@ -4029,28 +4078,14 @@ codeunit 139989 "Subc. Subcontracting Test"
         SubcPurchRcptLine.SetRange("Order Line No.", SubcPurchaseLine."Line No.");
         SubcPurchRcptLine.FindFirst();
 
-        // [GIVEN] A separate regular purchase order for the same vendor that receives a normal inventory item
-        LibraryInventory.CreateItem(RegularItem);
-        LibraryPurchase.CreatePurchHeader(RegularPurchaseHeader, RegularPurchaseHeader."Document Type"::Order, SubcVendorNo);
-        LibraryPurchase.CreatePurchaseLineWithUnitCost(
-            RegularPurchaseLine, RegularPurchaseHeader, RegularItem."No.",
-            LibraryRandom.RandDecInRange(50, 100, 2), LibraryRandom.RandIntInRange(2, 5));
-        EnsureGeneralPostingSetupIsValid(RegularPurchaseLine."Gen. Bus. Posting Group", RegularPurchaseLine."Gen. Prod. Posting Group");
-        LibraryPurchase.PostPurchaseDocument(RegularPurchaseHeader, true, false);
-
-        RegPurchRcptLine.SetRange("Order No.", RegularPurchaseHeader."No.");
-        RegPurchRcptLine.SetRange("Order Line No.", RegularPurchaseLine."Line No.");
-        RegPurchRcptLine.FindFirst();
-
-        // [GIVEN] A purchase invoice with a single Item Charge line of quantity 2 allocated 1:1 across both receipt lines
+        // [GIVEN] A separate purchase invoice with a single Item Charge line assigned to the subcontracting receipt line
         LibraryInventory.CreateItemCharge(ItemCharge);
-        LibraryPurchase.CreatePurchHeader(ItemChargeInvHeader, ItemChargeInvHeader."Document Type"::Invoice, SubcVendorNo);
-        LibraryPurchase.CreatePurchaseLine(ItemChargeInvLine, ItemChargeInvHeader, ItemChargeInvLine.Type::"Charge (Item)", ItemCharge."No.", 2);
+        LibraryPurchase.CreatePurchHeader(ItemChargeInvHeader, ItemChargeInvHeader."Document Type"::Invoice, '');
+        LibraryPurchase.CreatePurchaseLine(ItemChargeInvLine, ItemChargeInvHeader, ItemChargeInvLine.Type::"Charge (Item)", ItemCharge."No.", 1);
         ItemChargeInvLine.Validate("Direct Unit Cost", LibraryRandom.RandDecInRange(100, 200, 2));
         ItemChargeInvLine.Modify(true);
         EnsureGeneralPostingSetupIsValid(ItemChargeInvLine."Gen. Bus. Posting Group", ItemChargeInvLine."Gen. Prod. Posting Group");
 
-        AssignItemChargeToReceiptLine(ItemChargeInvLine, RegPurchRcptLine, 1);
         AssignItemChargeToReceiptLine(ItemChargeInvLine, SubcPurchRcptLine, 1);
 
         // [GIVEN] The invoice is posted

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -3228,6 +3228,13 @@ codeunit 139989 "Subc. Subcontracting Test"
         end;
     end;
 
+    [ModalPageHandler]
+    procedure GetOrderLinesPurchaseLinesPageHandler(var PurchaseLines: TestPage "Purchase Lines")
+    begin
+        Assert.IsFalse(PurchaseLines.First(), 'Subcontracting purchase order lines must be excluded from the Get Order Lines selection.');
+        PurchaseLines.Cancel().Invoke();
+    end;
+
     [ConfirmHandler]
     procedure RoutingLinkCodeDuplicateConfirmHandler(Question: Text[1024]; var Reply: Boolean)
     begin
@@ -4056,6 +4063,116 @@ codeunit 139989 "Subc. Subcontracting Test"
 
         // [THEN] The Subcontracting App blocks the cancel with the dedicated error
         Assert.ExpectedError('contains item charges assigned to a subcontracting order receipt');
+    end;
+
+    [Test]
+    procedure GetReceiptLinesBlocksSubcontractingReceiptLine()
+    var
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        InvoiceHeader: Record "Purchase Header";
+        Vendor: Record Vendor;
+        PurchGetReceipt: Codeunit "Purch.-Get Receipt";
+    begin
+        // [SCENARIO 632785] Copying a subcontracting service receipt line into a separate purchase document is not
+        // supported (Direct Unit Cost, Gen. Prod. Posting Group, etc. are not transferred) and must be blocked.
+
+        // [GIVEN] A purchase invoice and a posted subcontracting receipt line linked to a production order
+        Initialize();
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(InvoiceHeader, InvoiceHeader."Document Type"::Invoice, Vendor."No.");
+        MockSubcontractingPurchRcptLine(PurchRcptLine, false);
+
+        // [WHEN] Getting the subcontracting receipt line into the invoice
+        PurchRcptLine.SetRecFilter();
+        PurchGetReceipt.SetPurchHeader(InvoiceHeader);
+        asserterror PurchGetReceipt.CreateInvLines(PurchRcptLine);
+
+        // [THEN] It is blocked
+        Assert.ExpectedError('subcontracting receipt lines');
+    end;
+
+    [Test]
+    [HandlerFunctions('GetOrderLinesPurchaseLinesPageHandler')]
+    procedure GetOrderLinesExcludesSubcontractingPurchaseOrderLines()
+    var
+        OrderHeader: Record "Purchase Header";
+        OrderLine: Record "Purchase Line";
+        InvoiceHeader: Record "Purchase Header";
+        InvoiceLine: Record "Purchase Line";
+        Item: Record Item;
+        Vendor: Record Vendor;
+        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+        LibraryUtility: Codeunit "Library - Utility";
+    begin
+        // [SCENARIO 632785] Subcontracting purchase order lines must not appear in the Get Order Lines selection on a
+        // separate purchase invoice, because invoicing them there is not supported.
+
+        // [GIVEN] A purchase order line linked to a production order, received but not invoiced
+        Initialize();
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        LibraryPurchase.CreatePurchHeader(OrderHeader, OrderHeader."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(OrderLine, OrderHeader, OrderLine.Type::Item, Item."No.", LibraryRandom.RandIntInRange(5, 10));
+        OrderLine."Qty. Rcd. Not Invoiced" := OrderLine.Quantity;
+        OrderLine."Prod. Order No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(OrderLine."Prod. Order No."));
+        OrderLine.Modify();
+
+        // [GIVEN] A separate purchase invoice for the same vendor
+        LibraryPurchase.CreatePurchHeader(InvoiceHeader, InvoiceHeader."Document Type"::Invoice, Vendor."No.");
+        InvoiceLine."Document Type" := InvoiceHeader."Document Type";
+        InvoiceLine."Document No." := InvoiceHeader."No.";
+
+        // [WHEN] Running Get Order Lines [THEN] the page handler verifies the subcontracting order line is not offered
+        MatchedOrderLineMgmt.GetPurchaseOrderLines(InvoiceLine);
+    end;
+
+    [Test]
+    procedure AssignItemChargeToUndoneSubcontractingReceiptIsBlocked()
+    var
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        ItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)";
+        ItemChargeAssgntPurch: Codeunit "Item Charge Assgnt. (Purch.)";
+        LibraryUtility: Codeunit "Library - Utility";
+    begin
+        // [SCENARIO 637503] Assigning an item charge to a subcontracting receipt line that has been undone must be blocked,
+        // otherwise posting it would book the capacity cost onto the original entry while the undo entry stays at 0.
+
+        // [GIVEN] An undone subcontracting receipt line
+        Initialize();
+        MockSubcontractingPurchRcptLine(PurchRcptLine, true);
+
+        // [GIVEN] An item charge assignment context on a purchase invoice line
+        ItemChargeAssignmentPurch."Document Type" := ItemChargeAssignmentPurch."Document Type"::Invoice;
+        ItemChargeAssignmentPurch."Document No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(ItemChargeAssignmentPurch."Document No."));
+        ItemChargeAssignmentPurch."Document Line No." := 10000;
+        ItemChargeAssignmentPurch."Line No." := 10000;
+
+        // [WHEN] Assigning the item charge to the undone receipt line
+        PurchRcptLine.SetRecFilter();
+        asserterror ItemChargeAssgntPurch.CreateRcptChargeAssgnt(PurchRcptLine, ItemChargeAssignmentPurch);
+
+        // [THEN] It is blocked
+        Assert.ExpectedError('has been undone');
+    end;
+
+    local procedure MockSubcontractingPurchRcptLine(var PurchRcptLine: Record "Purch. Rcpt. Line"; Undone: Boolean)
+    var
+        Item: Record Item;
+        LibraryUtility: Codeunit "Library - Utility";
+    begin
+        LibraryInventory.CreateItem(Item);
+        PurchRcptLine.Init();
+        PurchRcptLine."Document No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(PurchRcptLine."Document No."));
+        PurchRcptLine."Line No." := 10000;
+        PurchRcptLine.Type := PurchRcptLine.Type::Item;
+        PurchRcptLine."No." := Item."No.";
+        PurchRcptLine."Prod. Order No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(PurchRcptLine."Prod. Order No."));
+        PurchRcptLine."Routing No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(PurchRcptLine."Routing No."));
+        PurchRcptLine."Operation No." := '10';
+        PurchRcptLine.Quantity := LibraryRandom.RandIntInRange(5, 10);
+        PurchRcptLine."Qty. Rcd. Not Invoiced" := PurchRcptLine.Quantity;
+        PurchRcptLine.Correction := Undone;
+        PurchRcptLine.Insert();
     end;
 
     local procedure Initialize()


### PR DESCRIPTION
Fixes **[AB#632785](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632785)** and **[AB#637503](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637503)** by blocking subcontracting scenarios that aren't supported and corrupt cost.

Also fixes **[AB#638702](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638702)** by re-enabling test.

**632785** - subcontracting lines must not be invoiced through a separate document:
- Exclude subcontracting receipt lines (Prod. Order No. set) from Get Receipt Lines and block copying them, in SubcPurchPostExt (Purch.-Get Receipt subscribers).
- Exclude subcontracting purchase order lines from Get Order Lines, via the new Matched Order Line Mgmt. filter event.

**637503** - item charges against undone subcontracting receipts create orphaned capacity cost:
- Block assigning an item charge to an undone (Correction) subcontracting receipt line in SubcItemChargeAssPurchExt.
- Block posting an item charge assigned to an undone subcontracting receipt line in SubcPurchPostExt.

Tests: lightweight mock-based tests in SubcSubcontractingTest covering all three blocks.

Recreated from #8678 on a clean branch off latest main (resolves the folder-rename conflict).





