### PR TITLE
[Backport 28.x] Fix E-Doc V1 PEPPOL import: Sub Total uses LineExtensionAmount from XML (#8313)

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/EDocImport.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocImport.Codeunit.al
@@ -840,7 +840,7 @@ codeunit 6140 "E-Doc. Import"
         EDocumentPurchaseLine.Quantity := PurchaseLine.Quantity;
         EDocumentPurchaseLine."Unit Price" := PurchaseLine."Direct Unit Cost";
         EDocumentPurchaseLine."Unit of Measure" := PurchaseLine."Unit of Measure Code";
-        EDocumentPurchaseLine."Sub Total" := PurchaseLine."Direct Unit Cost" * PurchaseLine.Quantity;
+        EDocumentPurchaseLine."Sub Total" := PurchaseLine.Amount;
         EDocumentPurchaseLine."Total Discount" := PurchaseLine."Line Discount Amount";
         EDocumentPurchaseLine."VAT Rate" := PurchaseLine."VAT %";
         EDocumentPurchaseLine."Currency Code" := PurchaseLine."Currency Code";

--- a/src/Apps/W1/EDocument/Test/.resources/peppol/PEPPOL_LineRounding.xml
+++ b/src/Apps/W1/EDocument/Test/.resources/peppol/PEPPOL_LineRounding.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+    <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+    <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+    <cbc:ID>INV-ROUNDING-001</cbc:ID>
+    <cbc:IssueDate>2026-01-22</cbc:IssueDate>
+    <cbc:DueDate>2026-02-22</cbc:DueDate>
+    <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>GBP</cbc:DocumentCurrencyCode>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cbc:EndpointID schemeID="9925">GB123456789</cbc:EndpointID>
+            <cac:PartyName>
+                <cbc:Name>Test Supplier</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>1 Test Street</cbc:StreetName>
+                <cbc:CityName>London</cbc:CityName>
+                <cbc:CountrySubentity>England</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>GB</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>GB123456789</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Test Supplier Ltd</cbc:RegistrationName>
+                <cbc:CompanyID>12345678</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Test Customer</cbc:Name>
+            </cac:PartyName>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="GBP">2.35</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="GBP">11.20</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="GBP">2.35</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.00</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="GBP">11.20</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="GBP">11.20</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="GBP">13.55</cbc:TaxInclusiveAmount>
+        <cbc:PrepaidAmount currencyID="GBP">0.00</cbc:PrepaidAmount>
+        <cbc:PayableAmount currencyID="GBP">13.55</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="NAR">1.65000</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="GBP">11.20</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>RECDN2550</cbc:Description>
+            <cbc:Name>REMOVAL SERVICE</cbc:Name>
+            <cac:SellersItemIdentification>
+                <cbc:ID>RECDN2550</cbc:ID>
+            </cac:SellersItemIdentification>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.00</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="GBP">6.79000</cbc:PriceAmount>
+            <cbc:BaseQuantity>1</cbc:BaseQuantity>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/src/Apps/W1/EDocument/Test/src/Receive/EDocReceiveFiles.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Receive/EDocReceiveFiles.Codeunit.al
@@ -11,4 +11,9 @@ codeunit 139635 "E-Doc. Receive Files"
         exit(NavApp.GetResourceAsText('peppol/PEPPOL1.xml'));
     end;
 
+    procedure GetLineRoundingDocument(): Text
+    begin
+        exit(NavApp.GetResourceAsText('peppol/PEPPOL_LineRounding.xml'));
+    end;
+
 }

--- a/src/Apps/W1/EDocument/Test/src/Receive/EDocReceiveTest.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Receive/EDocReceiveTest.Codeunit.al
@@ -7,6 +7,7 @@ namespace Microsoft.eServices.EDocument.Test;
 using Microsoft.eServices.EDocument;
 using Microsoft.eServices.EDocument.Integration;
 using Microsoft.eServices.EDocument.IO.Peppol;
+using Microsoft.eServices.EDocument.Processing.Import.Purchase;
 using Microsoft.Finance.GeneralLedger.Journal;
 using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Address;
@@ -60,6 +61,7 @@ codeunit 139628 "E-Doc. Receive Test"
         VATRegistrationLbl: Label 'GB123456789';
         ImportDataExchDefLbl: Label 'EDOCPEPPOLINVIMP';
         EndpointPathLbl: label '/Invoice/cac:AccountingSupplierParty/cac:Party/cbc:EndpointID';
+        SubTotalMismatchErr: Label 'Sub Total should be %1 from XML LineExtensionAmount, not %2 (Qty*Price)', Comment = '%1 = expected Sub Total, %2 = actual Qty*Price', Locked = true;
 
     [Test]
     procedure ReceiveSinglePurchaseInvoice()
@@ -256,6 +258,64 @@ codeunit 139628 "E-Doc. Receive Test"
         DocumentAttachment.SetRange("No.", CreatedPurchaseHeader."No.");
         DocumentAttachment.SetRange("Table ID", Database::"Purchase Header");
         Assert.RecordCount(DocumentAttachment, 2);
+    end;
+
+    [Test]
+    procedure ReceivePeppolInvoice_LineSubTotalFromXml()
+    var
+        EDocService: Record "E-Document Service";
+        EDocument: Record "E-Document";
+        EDocumentPurchaseLine: Record "E-Document Purchase Line";
+        VATPostingSetup: Record "VAT Posting Setup";
+        EDocServicePage: TestPage "E-Document Service";
+        ExpectedSubTotal: Decimal;
+    begin
+        // [SCENARIO] V1 PEPPOL import stores LineExtensionAmount as Sub Total, not recalculated Qty*Price
+        // Regression for: Qty=1.65, Price=6.79, LineExtensionAmount=11.20 -> was stored as 1.65*6.79=11.2035
+        Initialize();
+        BindSubscription(EDocImplState);
+
+        // [GIVEN] E-Document service with PEPPOL BIS 3.0 format and V1 import, all item lookups disabled
+        LibraryEDoc.CreateTestReceiveServiceForEDoc(EDocService, Enum::"Service Integration"::"Mock");
+        EDocService."Document Format" := "E-Document Format"::"PEPPOL BIS 3.0";
+        EDocService."Lookup Account Mapping" := false;
+        EDocService."Lookup Item GTIN" := false;
+        EDocService."Lookup Item Reference" := false;
+        EDocService."Resolve Unit Of Measure" := false;
+        EDocService."Validate Line Discount" := false;
+        EDocService."Verify Totals" := false;
+        EDocService."Validate Receiving Company" := false;
+        EDocService."Use Batch Processing" := false;
+        EDocService.Modify();
+
+        // [GIVEN] Vendor matching the XML supplier VAT registration
+        LibraryPurchase.CreateVendorWithVATRegNo(Vendor);
+        LibraryERM.CreateVATPostingSetupWithAccounts(VATPostingSetup, Enum::"Tax Calculation Type"::"Normal VAT", 1);
+        Vendor."VAT Bus. Posting Group" := VATPostingSetup."VAT Bus. Posting Group";
+        Vendor."VAT Registration No." := VATRegistrationLbl;
+        Vendor."Receive E-Document To" := Vendor."Receive E-Document To"::"Purchase Invoice";
+        Vendor."Country/Region Code" := CountryRegion.Code;
+        Vendor.Modify();
+
+        // [GIVEN] PEPPOL XML: Qty=1.65, PriceAmount=6.79, LineExtensionAmount=11.20 (vendor-rounded value)
+        LibraryVariableStorage.Clear();
+        LibraryVariableStorage.Enqueue(EDocReceiveFiles.GetLineRoundingDocument());
+        LibraryVariableStorage.Enqueue(1);
+        EDocImplState.SetVariableStorage(LibraryVariableStorage);
+
+        // [WHEN] Receive is invoked
+        EDocServicePage.OpenView();
+        EDocServicePage.Filter.SetFilter(Code, EDocService.Code);
+        EDocServicePage.Receive.Invoke();
+
+        // [THEN] EDocumentPurchaseLine."Sub Total" = 11.20 (from XML LineExtensionAmount), not 11.2035 (Qty*Price)
+        EDocument.FindLast();
+        EDocumentPurchaseLine.SetRange("E-Document Entry No.", EDocument."Entry No");
+        Assert.IsTrue(EDocumentPurchaseLine.FindFirst(), 'Expected at least one E-Document purchase line');
+        ExpectedSubTotal := 11.20;
+        Assert.AreEqual(ExpectedSubTotal, EDocumentPurchaseLine."Sub Total",
+            StrSubstNo(SubTotalMismatchErr,
+                ExpectedSubTotal, EDocumentPurchaseLine.Quantity * EDocumentPurchaseLine."Unit Price"));
     end;
 
     [Test]


### PR DESCRIPTION
Backports #8313 to `releases/28.x`.

Cherry-pick of commit e9452a19d3 (squash-merge of #8313).

## Summary
- `EDocImport.Codeunit.al` (`V1_CopyFromPurchaseLine`) — set `"Sub Total"` to `PurchaseLine.Amount` (the `LineExtensionAmount` parsed from the PEPPOL XML) instead of recalculating `Direct Unit Cost * Quantity`, which lost the vendor-rounded value (e.g. 6.79 * 1.65 = 11.2035 instead of the XML's 11.20).
- Adds regression test `ReceivePeppolInvoice_LineSubTotalFromXml` and test invoice `PEPPOL_LineRounding.xml`.

Original PR: #8313
[AB#613698](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/613698)

