### PR TITLE
[W1][Codeunit][8900][Email Impl] SourceRecordRef.ReadPermission() condition was removed from FilterRemovedSourceRecords-procedure. Fixes AB#8635

### DIFF
--- a/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
@@ -1112,9 +1112,4 @@ codeunit 8900 "Email Impl"
         GlobalLanguage(CurrentLanguage);
     end;
     #endregion
-
-    [IntegrationEvent(false, false)]
-    local procedure OnBeforeFilterRemovedSourceRecords(var EmailRelatedRecord: Record "Email Related Record"; var Handled: Boolean)
-    begin
-    end;
 }

--- a/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
@@ -746,18 +746,12 @@ codeunit 8900 "Email Impl"
     var
         AllObj: Record AllObj;
         SourceRecordRef: RecordRef;
-        Handled: Boolean;
     begin
-        OnBeforeFilterRemovedSourceRecords(EmailRelatedRecord, Handled);
-        if Handled then
-            exit;
-
         repeat
             if AllObj.Get(AllObj."Object Type"::Table, EmailRelatedRecord."Table Id") then begin
                 SourceRecordRef.Open(EmailRelatedRecord."Table Id");
-                if SourceRecordRef.ReadPermission() then
-                    if SourceRecordRef.GetBySystemId(EmailRelatedRecord."System Id") then
-                        EmailRelatedRecord.Mark(true);
+                if SourceRecordRef.GetBySystemId(EmailRelatedRecord."System Id") then
+                    EmailRelatedRecord.Mark(true);
                 SourceRecordRef.Close();
             end;
         until EmailRelatedRecord.Next() = 0;

--- a/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Email/EmailImpl.Codeunit.al
@@ -746,7 +746,12 @@ codeunit 8900 "Email Impl"
     var
         AllObj: Record AllObj;
         SourceRecordRef: RecordRef;
+        Handled: Boolean;
     begin
+        OnBeforeFilterRemovedSourceRecords(EmailRelatedRecord, Handled);
+        if Handled then
+            exit;
+
         repeat
             if AllObj.Get(AllObj."Object Type"::Table, EmailRelatedRecord."Table Id") then begin
                 SourceRecordRef.Open(EmailRelatedRecord."Table Id");
@@ -1113,4 +1118,9 @@ codeunit 8900 "Email Impl"
         GlobalLanguage(CurrentLanguage);
     end;
     #endregion
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeFilterRemovedSourceRecords(var EmailRelatedRecord: Record "Email Related Record"; var Handled: Boolean)
+    begin
+    end;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

If at least one security filter is applied to the ΓÇ£Purchase HeaderΓÇ¥ table, the user will have a problem when pushing the 'Add file from source documentΓÇÖ action on the ΓÇ£Email AttachmentsΓÇ¥ subpage. 
Result:
Message: "Did not find any attachments related to this email"
Expected result:
The page should show the list of attachments from the source purchase document. Like it works without applying security filters.

## Linked work
<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #8635

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required ΓÇö be specific: scenarios, commands, screenshots for UI changes)*

GetBySystemId() already respects the user's security filter. 
The blanket ReadPermission() check was the real problem because it:

- Bypasses fine-grained filters the admin set up
- Acts as an all-or-nothing gate instead of respecting row-level filtering
- Prevents filtered access even when the user should see specific records

By removing it, we let GetBySystemId() do what it's designed to doΓÇöcheck permissions filter-aware.

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->







Fixes [AB#640914](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640914)


