### PR TITLE
Fix posting description not transferred when finalizing E-Document draft

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
@@ -109,7 +109,6 @@ codeunit 6117 "E-Doc. Create Purchase Invoice" implements IEDocumentFinishDraft,
         PurchaseHeader.SetRange("Buy-from Vendor No.", EDocumentPurchaseHeader."[BC] Vendor No."); // Setting the filter, so that the insert trigger assigns the right vendor to the purchase header
         PurchaseHeader."Document Type" := "Purchase Document Type"::Invoice;
         PurchaseHeader."Pay-to Vendor No." := EDocumentPurchaseHeader."[BC] Vendor No.";
-        PurchaseHeader."Posting Description" := EDocumentPurchaseHeader."Posting Description";
         if EDocumentPurchaseHeader."Document Date" <> 0D then
             EDocPurchaseDocumentHelper.ValidateFieldWithContext(PurchaseHeader, PurchaseHeader.FieldNo("Document Date"), EDocumentPurchaseHeader."Document Date");
         if EDocumentPurchaseHeader."Due Date" <> 0D then
@@ -131,6 +130,8 @@ codeunit 6117 "E-Doc. Create Purchase Invoice" implements IEDocumentFinishDraft,
 
         EDocPurchaseDocumentHelper.ApplyDefaultPostingDateFromSetup(PurchaseHeader, EDocumentPurchaseHeader);
         PurchaseHeader."Invoice Received Date" := PurchaseHeader."Document Date";
+        if EDocumentPurchaseHeader."Posting Description" <> '' then
+            PurchaseHeader."Posting Description" := EDocumentPurchaseHeader."Posting Description";
         PurchaseHeader.Modify();
 
         // Validate of currency has to happen after insert.


### PR DESCRIPTION
## Why

When finishing an inbound E-Document draft into a purchase invoice, the posting description from the draft was lost. The assignment happened before `PurchaseHeader.Insert(true)`, so the purchase header's `OnInsert` trigger subsequently overwrote the `Posting Description` field, discarding the value taken from the E-Document.

## Summary

- **Moved** the `Posting Description` assignment to run right before `PurchaseHeader.Modify()` (after `Insert`), so the `OnInsert` trigger can no longer overwrite it.
- **Guarded** the assignment with a non-empty check so an empty draft posting description does not clear a value already set on the purchase header.

Fixes [AB#635024](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/635024)

