### PR TITLE
[28.x] [All-e]Fixed asset report 5607 and 4413 showing different results with Declining Balance

### DIFF
--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRFixedAssetProjected.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRFixedAssetProjected.Report.al
@@ -336,15 +336,15 @@ report 4413 "EXR Fixed Asset Projected"
                 DaysInPeriod := 0;
             end;
 
-            if ProjectionDate = EndCurrentFiscalYear then begin
-                EntryAmounts[3] := 0;
-                UpdateToNextFiscalYearEndDate(DepreciationBook, EndCurrentFiscalYear);
-            end;
-
             if AssetWasDepreciated then begin
                 AccumulateProjectionEntryAmounts(DepreciationAmount, Custom1Amount, EntryAmounts);
                 if ProjectDisposal then
                     CalculateDisposal.CalcGainLoss(FixedAssetNo, DepreciationBookCode, EntryAmounts);
+            end;
+
+            if ProjectionDate = EndCurrentFiscalYear then begin
+                EntryAmounts[3] := 0;
+                UpdateToNextFiscalYearEndDate(DepreciationBook, EndCurrentFiscalYear);
             end;
 
             InsertProjectedFixedAssetLedgerEntry(ProjectionDate, FixedAssetNo, DepreciationAmount, NumberOfDays, TempFixedAssetLedgerEntry);


### PR DESCRIPTION
Workitem : 

[Bug 636726](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/636726): [28.x] [All-e]Fixed asset report 5607 and 4413 showing different results with Declining Balance

Fixes [AB#636726](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636726)

**Issue:** Report 4413 (Fixed Asset Projected Value Excel) calculates incorrect depreciation amounts for Declining Balance assets when projections cross a fiscal year boundary, producing different results than the legacy Report 5607.

**Cause:** In InsertProjectedEntries, EntryAmounts[3] (depreciation in fiscal year) was reset to 0 before accumulating the current period's depreciation, causing the last fiscal period's depreciation to spill into the new fiscal year and shifting the effective book value base back one month.

**Solution:** Moved AccumulateProjectionEntryAmounts before the fiscal year boundary reset (EntryAmounts[3] := 0) so the outgoing fiscal year's final depreciation is fully accumulated before the counter resets, matching the order used in Report 5607.
