### PR TITLE
Added the interface method override

### DIFF
--- a/src/System Application/Test/Agent/src/Setup/MockAgent/Integration/MockAgentMetaProv.Codeunit.al
+++ b/src/System Application/Test/Agent/src/Setup/MockAgent/Integration/MockAgentMetaProv.Codeunit.al
@@ -66,6 +66,11 @@ codeunit 133952 "Mock Agent Meta. Prov." implements IAgentMetadata, IAgentFactor
         exit(Page::"Agent Task Message Card");
     end;
 
+    procedure GetCreateAgentTaskPageId(AgentUserId: Guid): Integer
+    begin
+        exit(0);
+    end;
+
     procedure GetDefaultProfile(var TempAllProfile: Record "All Profile" temporary)
     begin
         MockAgentSetup.GetDefaultProfile(TempAllProfile);


### PR DESCRIPTION
## What & why

A new interface method was added to IAgentMetadata. This has a default implementation, but this is currently enforced by consumers to explicitly override it.

## Linked work

Fixes [AB#640126](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640126)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

There's nothing to test for this as it is only adding a default method which is not consumed yet.

## Risk & compatibility

The risk is low as no one uses the added method right now.



