### PR TITLE
[28.x] [Subcontracting] Disable "WIP Item Transfer" for Machine Center

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingLine.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingLine.TableExt.al
@@ -99,6 +99,7 @@ tableextension 99001560 "Subc. Routing Line" extends "Routing Line"
                 if "Transfer WIP Item" then begin
                     CalcFields(Subcontracting);
                     TestField(Subcontracting, true);
+                    TestField(Type, Type::"Work Center");
                 end;
             end;
         }

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingLines.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingLines.PageExt.al
@@ -112,7 +112,7 @@ pageextension 99001508 "Subc. Routing Lines" extends "Routing Lines"
     local procedure UpdateWIPEnabled()
     begin
         Rec.Calcfields(Subcontracting);
-        TransferWIPItemEnabled := Rec.Subcontracting;
+        TransferWIPItemEnabled := Rec.Subcontracting and (Rec.Type = Rec.Type::"Work Center");
     end;
 
     procedure ShowRelatedSubcontractorPrices()

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingVersionLines.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingVersionLines.PageExt.al
@@ -106,7 +106,7 @@ pageextension 99001509 "Subc. Routing Version Lines" extends "Routing Version Li
     local procedure UpdateWIPEnabled()
     begin
         Rec.Calcfields(Subcontracting);
-        TransferWIPItemEnabled := Rec.Subcontracting;
+        TransferWIPItemEnabled := Rec.Subcontracting and (Rec.Type = Rec.Type::"Work Center");
     end;
 
     procedure ShowRelatedSubcontractorPrices()

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPOSubform.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPOSubform.PageExt.al
@@ -16,6 +16,7 @@ pageextension 99001524 "Subc. PO Subform" extends "Purchase Order Subform"
             {
                 ApplicationArea = Subcontracting;
                 Visible = false;
+                Editable = false;
             }
         }
     }

--- a/src/Apps/W1/Subcontracting/Test/Libraries/SubcLibraryMfgManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Libraries/SubcLibraryMfgManagement.Codeunit.al
@@ -124,6 +124,12 @@ codeunit 139984 "Subc. Library Mfg. Management"
         MachineCenterNo := MachineCenter."No.";
     end;
 
+    procedure CreateRoutingLineForMachineCenter(var RoutingLine: Record "Routing Line"; RoutingHeader: Record "Routing Header"; MachineCenterNo: Code[20])
+    begin
+        RoutingLine.Type := RoutingLine.Type::"Machine Center";
+        CreateRoutingLine(RoutingLine, RoutingHeader, MachineCenterNo);
+    end;
+
     procedure CreateRouting(var RoutingNo: Code[20]; MachineCenterNo: Code[20]; MachineCenterNo2: Code[20]; WorkCenterNo: Code[20]; WorkCenterNo2: Code[20])
     var
         RoutingHeader: Record "Routing Header";
@@ -143,7 +149,7 @@ codeunit 139984 "Subc. Library Mfg. Management"
         RoutingNo := RoutingHeader."No.";
     end;
 
-    local procedure CreateRoutingLine(var RoutingLine: Record "Routing Line"; RoutingHeader: Record "Routing Header"; CenterNo: Code[20])
+    procedure CreateRoutingLine(var RoutingLine: Record "Routing Line"; RoutingHeader: Record "Routing Header"; CenterNo: Code[20])
     var
         CapacityUnitOfMeasure: Record "Capacity Unit of Measure";
         OperationNo: Code[10];

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingUITest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingUITest.Codeunit.al
@@ -620,6 +620,228 @@ codeunit 139990 "Subc. Subcontracting UI Test"
         ItemLedgerEntry.Delete();
     end;
 
+    [Test]
+    procedure RoutingLinesTransferWIPItemDisabledForMachineCenterLine()
+    var
+        WorkCenter: Record "Work Center";
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        RoutingLines: TestPage "Routing Lines";
+        MachineCenterNo: Code[20];
+    begin
+        // [SCENARIO] Transfer WIP Item field is disabled on Routing Lines page for a Machine Center routing line,
+        // even when the parent Work Center has a Subcontractor No.
+        Initialize();
+
+        // [GIVEN] A Work Center with a Subcontractor No.
+        LibraryMfgManagement.CreateWorkCenterWithCalendar(WorkCenter, 0);
+        WorkCenter.Validate("Subcontractor No.", LibraryMfgManagement.CreateSubcontractorWithCurrency(''));
+        WorkCenter.Modify(true);
+
+        // [GIVEN] A Machine Center belonging to that Work Center
+        LibraryMfgManagement.CreateMachineCenter(MachineCenterNo, WorkCenter."No.", 0);
+
+        // [GIVEN] A Routing with a Machine Center routing line
+        LibraryManufacturing.CreateRoutingHeader(RoutingHeader, RoutingHeader.Type::Serial);
+        LibraryMfgManagement.CreateRoutingLineForMachineCenter(RoutingLine, RoutingHeader, MachineCenterNo);
+
+        // [WHEN] The Routing Lines page is opened for that line
+        RoutingLines.OpenEdit();
+        RoutingLines.GoToRecord(RoutingLine);
+
+        // [THEN] Transfer WIP Item is not enabled (Machine Center type is not eligible for Transfer WIP Item)
+        Assert.IsFalse(RoutingLines."Transfer WIP Item".Enabled(), RoutingLineTransferWIPEnabledErr);
+        RoutingLines.Close();
+    end;
+
+    [Test]
+    procedure RoutingLinesTransferWIPItemEnabledForSubcontractingWorkCenterLine()
+    var
+        WorkCenter: Record "Work Center";
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        RoutingLines: TestPage "Routing Lines";
+    begin
+        // [SCENARIO] Transfer WIP Item field is enabled on Routing Lines page for a Work Center routing line
+        // when the Work Center has a Subcontractor No.
+        Initialize();
+
+        // [GIVEN] A Work Center with a Subcontractor No.
+        LibraryMfgManagement.CreateWorkCenterWithCalendar(WorkCenter, 0);
+        WorkCenter.Validate("Subcontractor No.", LibraryMfgManagement.CreateSubcontractorWithCurrency(''));
+        WorkCenter.Modify(true);
+
+        // [GIVEN] A Routing with a Work Center routing line
+        LibraryManufacturing.CreateRoutingHeader(RoutingHeader, RoutingHeader.Type::Serial);
+        LibraryMfgManagement.CreateRoutingLine(RoutingLine, RoutingHeader, WorkCenter."No.");
+
+        // [WHEN] The Routing Lines page is opened for that line
+        RoutingLines.OpenEdit();
+        RoutingLines.GoToRecord(RoutingLine);
+
+        // [THEN] Transfer WIP Item is enabled (subcontracting Work Center type)
+        Assert.IsTrue(RoutingLines."Transfer WIP Item".Enabled(), RoutingLineTransferWIPNotEnabledErr);
+        RoutingLines.Close();
+    end;
+
+    [Test]
+    procedure RoutingVersionLinesTransferWIPItemDisabledForMachineCenterLine()
+    var
+        WorkCenter: Record "Work Center";
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        RoutingVersionLines: TestPage "Routing Version Lines";
+        MachineCenterNo: Code[20];
+        VersionCode: Code[20];
+    begin
+        // [SCENARIO] Transfer WIP Item field is disabled on Routing Version Lines page for a Machine Center
+        // routing line, even when the parent Work Center has a Subcontractor No.
+        Initialize();
+
+        // [GIVEN] A Work Center with a Subcontractor No.
+        LibraryMfgManagement.CreateWorkCenterWithCalendar(WorkCenter, 0);
+        WorkCenter.Validate("Subcontractor No.", LibraryMfgManagement.CreateSubcontractorWithCurrency(''));
+        WorkCenter.Modify(true);
+
+        // [GIVEN] A Machine Center belonging to that Work Center
+        LibraryMfgManagement.CreateMachineCenter(MachineCenterNo, WorkCenter."No.", 0);
+
+        // [GIVEN] A Routing Version with a Machine Center routing line
+        LibraryManufacturing.CreateRoutingHeader(RoutingHeader, RoutingHeader.Type::Serial);
+        VersionCode := '1';
+        CreateRoutingVersionAndMachineCenterLine(RoutingHeader."No.", VersionCode, MachineCenterNo, RoutingLine);
+
+        // [WHEN] The Routing Version Lines page is opened for that line
+        RoutingVersionLines.OpenEdit();
+        RoutingVersionLines.Filter.SetFilter("Routing No.", RoutingHeader."No.");
+        RoutingVersionLines.Filter.SetFilter("Version Code", VersionCode);
+        RoutingVersionLines.GoToRecord(RoutingLine);
+
+        // [THEN] Transfer WIP Item is not enabled (Machine Center type is not eligible for Transfer WIP Item)
+        Assert.IsFalse(RoutingVersionLines."Transfer WIP Item".Enabled(), RoutingLineTransferWIPEnabledErr);
+        RoutingVersionLines.Close();
+    end;
+
+    [Test]
+    procedure RoutingVersionLinesTransferWIPItemEnabledForSubcontractingWorkCenterLine()
+    var
+        WorkCenter: Record "Work Center";
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        RoutingVersionLines: TestPage "Routing Version Lines";
+        VersionCode: Code[20];
+    begin
+        // [SCENARIO] Transfer WIP Item field is enabled on Routing Version Lines page for a Work Center routing line
+        // when the Work Center has a Subcontractor No.
+        Initialize();
+
+        // [GIVEN] A Work Center with a Subcontractor No.
+        LibraryMfgManagement.CreateWorkCenterWithCalendar(WorkCenter, 0);
+        WorkCenter.Validate("Subcontractor No.", LibraryMfgManagement.CreateSubcontractorWithCurrency(''));
+        WorkCenter.Modify(true);
+
+        // [GIVEN] A Routing Version with a Work Center routing line
+        LibraryManufacturing.CreateRoutingHeader(RoutingHeader, RoutingHeader.Type::Serial);
+        VersionCode := '1';
+        CreateRoutingVersionAndWorkCenterLine(RoutingHeader."No.", VersionCode, WorkCenter."No.", RoutingLine);
+
+        // [WHEN] The Routing Version Lines page is opened for that line
+        RoutingVersionLines.OpenEdit();
+        RoutingVersionLines.Filter.SetFilter("Routing No.", RoutingHeader."No.");
+        RoutingVersionLines.Filter.SetFilter("Version Code", VersionCode);
+        RoutingVersionLines.GoToRecord(RoutingLine);
+
+        // [THEN] Transfer WIP Item is enabled (subcontracting Work Center type)
+        Assert.IsTrue(RoutingVersionLines."Transfer WIP Item".Enabled(), RoutingLineTransferWIPNotEnabledErr);
+        RoutingVersionLines.Close();
+    end;
+
+    [Test]
+    procedure RoutingLineTransferWIPItemValidationFailsForMachineCenterType()
+    var
+        WorkCenter: Record "Work Center";
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        MachineCenterNo: Code[20];
+    begin
+        // [SCENARIO] Validating Transfer WIP Item = true on a Machine Center routing line fails
+        // with an error because the Type must be Work Center.
+        Initialize();
+
+        // [GIVEN] A Work Center with a Subcontractor No.
+        LibraryMfgManagement.CreateWorkCenterWithCalendar(WorkCenter, 0);
+        WorkCenter.Validate("Subcontractor No.", LibraryMfgManagement.CreateSubcontractorWithCurrency(''));
+        WorkCenter.Modify(true);
+
+        // [GIVEN] A Machine Center belonging to that Work Center
+        LibraryMfgManagement.CreateMachineCenter(MachineCenterNo, WorkCenter."No.", 0);
+
+        // [GIVEN] A Routing with a Machine Center routing line
+        LibraryManufacturing.CreateRoutingHeader(RoutingHeader, RoutingHeader.Type::Serial);
+        LibraryMfgManagement.CreateRoutingLineForMachineCenter(RoutingLine, RoutingHeader, MachineCenterNo);
+
+        // [WHEN] Transfer WIP Item is set to true on the Machine Center routing line
+        // [THEN] An error is raised because the line type must be Work Center
+        asserterror RoutingLine.Validate("Transfer WIP Item", true);
+        Assert.ExpectedTestFieldError(RoutingLine.FieldCaption(Type), Format(RoutingLine.Type::"Work Center"));
+    end;
+
+    local procedure CreateRoutingVersionAndWorkCenterLine(RoutingNo: Code[20]; VersionCode: Code[20]; WorkCenterNo: Code[20]; var RoutingLine: Record "Routing Line")
+    var
+        RoutingVersion: Record "Routing Version";
+        CapacityUoM: Record "Capacity Unit of Measure";
+    begin
+        RoutingVersion.Init();
+        RoutingVersion.Validate("Routing No.", RoutingNo);
+        RoutingVersion."Version Code" := VersionCode;
+        RoutingVersion.Insert(true);
+
+#pragma warning disable AA0210
+        CapacityUoM.SetRange(Type, CapacityUoM.Type::Minutes);
+#pragma warning restore AA0210
+        CapacityUoM.FindFirst();
+
+        RoutingLine.Init();
+        RoutingLine.Validate("Routing No.", RoutingNo);
+        RoutingLine.Validate("Version Code", VersionCode);
+        RoutingLine.Validate("Operation No.", '10');
+        RoutingLine.Validate(Type, RoutingLine.Type::"Work Center");
+        RoutingLine.Validate("No.", WorkCenterNo);
+        RoutingLine.Validate("Setup Time", 1);
+        RoutingLine.Validate("Run Time", 1);
+        RoutingLine.Validate("Run Time Unit of Meas. Code", CapacityUoM.Code);
+        RoutingLine.Validate("Setup Time Unit of Meas. Code", CapacityUoM.Code);
+        RoutingLine.Insert(true);
+    end;
+
+    local procedure CreateRoutingVersionAndMachineCenterLine(RoutingNo: Code[20]; VersionCode: Code[20]; MachineCenterNo: Code[20]; var RoutingLine: Record "Routing Line")
+    var
+        RoutingVersion: Record "Routing Version";
+        CapacityUoM: Record "Capacity Unit of Measure";
+    begin
+        RoutingVersion.Init();
+        RoutingVersion.Validate("Routing No.", RoutingNo);
+        RoutingVersion."Version Code" := VersionCode;
+        RoutingVersion.Insert(true);
+
+#pragma warning disable AA0210
+        CapacityUoM.SetRange(Type, CapacityUoM.Type::Minutes);
+#pragma warning restore AA0210
+        CapacityUoM.FindFirst();
+
+        RoutingLine.Init();
+        RoutingLine.Validate("Routing No.", RoutingNo);
+        RoutingLine.Validate("Version Code", VersionCode);
+        RoutingLine.Validate("Operation No.", '10');
+        RoutingLine.Validate(Type, RoutingLine.Type::"Machine Center");
+        RoutingLine.Validate("No.", MachineCenterNo);
+        RoutingLine.Validate("Setup Time", 1);
+        RoutingLine.Validate("Run Time", 1);
+        RoutingLine.Validate("Run Time Unit of Meas. Code", CapacityUoM.Code);
+        RoutingLine.Validate("Setup Time Unit of Meas. Code", CapacityUoM.Code);
+        RoutingLine.Insert(true);
+    end;
+
     local procedure GetNextItemLedgerEntryNo(): Integer
     var
         ItemLedgerEntry: Record "Item Ledger Entry";
@@ -634,6 +856,7 @@ codeunit 139990 "Subc. Subcontracting UI Test"
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
+        LibraryManufacturing: Codeunit "Library - Manufacturing";
         LibraryMfgManagement: Codeunit "Subc. Library Mfg. Management";
         SubcontractingMgmtLibrary: Codeunit "Subc. Management Library";
         SubSetupLibrary: Codeunit "Subc. Setup Library";
@@ -647,4 +870,6 @@ codeunit 139990 "Subc. Subcontracting UI Test"
         ILEProdActionsNotEnabledErr: Label 'Production actions should be enabled for a subcontracting Item Ledger Entry.';
         ILEPurchActionsEnabledErr: Label 'Purchase Order action should not be enabled for a non-subcontracting Item Ledger Entry.';
         ILEPurchActionsNotEnabledErr: Label 'Purchase Order action should be enabled for a subcontracting Item Ledger Entry.';
+        RoutingLineTransferWIPEnabledErr: Label 'Transfer WIP Item should not be enabled for a Machine Center routing line.';
+        RoutingLineTransferWIPNotEnabledErr: Label 'Transfer WIP Item should be enabled for a subcontracting Work Center routing line.';
 }


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

this is a cherry pick from main branch

<!-- A few sentences: what does this change do, and what problem does it solve? -->
This pull request introduces stricter validation and improved UI logic for the "Transfer WIP Item" field on routing lines, ensuring that this field is only enabled and valid for "Work Center" type routing lines with subcontracting enabled. It also adds comprehensive automated UI and validation tests to guarantee correct behavior, and refactors some test utilities for better coverage and maintainability.

**Validation and UI logic improvements:**

* The "Transfer WIP Item" field is now only enabled and valid for routing lines of type "Work Center" with subcontracting enabled; it is disabled and validation fails for "Machine Center" types. [[1]](diffhunk://#diff-9a268e4cc43f60d7ac26985d97730eb89ca87a7ca35872b7072fad683d2c335aR102) [[2]](diffhunk://#diff-a0bcf722a61752235db281827d000fe8694de969ee099db6c0b5929c25b78001L115-R115) [[3]](diffhunk://#diff-925a025cf36f56f41591be26a6552fa61ea3f2d0c0177433c7104b355117205eL109-R109)
* The "Transfer WIP Item" field is explicitly set as non-editable and invisible in the `Subc. PO Subform` page extension.

**Automated test coverage:**

* Added multiple UI and validation tests in `Subc. Subcontracting UI Test` to verify that the "Transfer WIP Item" field is only enabled for eligible Work Center lines and not for Machine Center lines, and that validation fails if incorrectly set.

**Test utility enhancements:**

* Introduced a new `CreateRoutingLineForMachineCenter` helper in the manufacturing management test library to streamline test setup for Machine Center routing lines, and made `CreateRoutingLine` public for broader utility. [[1]](diffhunk://#diff-f78cce36ae350530fdc05b17c49751c8548d257b83ec62bbb86da71c256890e9R127-R132) [[2]](diffhunk://#diff-f78cce36ae350530fdc05b17c49751c8548d257b83ec62bbb86da71c256890e9L146-R152)
* Added necessary codeunit references and error labels to support the new test scenarios. [[1]](diffhunk://#diff-46d1076472b5ff73cd80345a191884f4b52d530018313808166b90b6f47486b3R859) [[2]](diffhunk://#diff-46d1076472b5ff73cd80345a191884f4b52d530018313808166b90b6f47486b3R873-R874)
## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#640173](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640173)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*
Added Tests and do a manual validation in client

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->
None

