### PR TITLE
[Subcontracting] Bug 638694, 638816: Fix subcontracting return and WIP transfer issues

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcCreateSubCReturnOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcCreateSubCReturnOrder.Report.al
@@ -244,8 +244,6 @@ report 99001502 "Subc. Create SubCReturnOrder"
 
                         SubcTransferManagement.TransferReservationEntryFromProdOrderCompToTransferOrder(TransferLine, ProdOrderComponent);
 
-                        if ProdOrderComponent."Subc. Original Location Code" = '' then
-                            ProdOrderComponent."Subc. Original Location Code" := ProdOrderComponent."Location Code";
                         if ProdOrderComponent."Subc. Orig. Bin Code" = '' then
                             ProdOrderComponent."Subc. Orig. Bin Code" := ProdOrderComponent."Bin Code";
                         if TransferHeader."Transfer-to Code" <> ProdOrderComponent."Location Code" then begin

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcCreateSubCReturnOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcCreateSubCReturnOrder.Report.al
@@ -211,6 +211,8 @@ report 99001502 "Subc. Create SubCReturnOrder"
                     QtyToPost := AvailableToReturn;
                 if QtyToPost > 0 then
                     if InsertLine then begin
+                        if ProdOrderComponent."Subc. Original Location Code" = '' then
+                            ProdOrderComponent."Subc. Original Location Code" := ProdOrderComponent."Location Code";
 
                         InsertTransferHeader(SubcFromLocationCode, ProdOrderComponent."Subc. Original Location Code");
 

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcTransferWIPPosting.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcTransferWIPPosting.Codeunit.al
@@ -40,7 +40,8 @@ codeunit 99001541 "Subc. Transfer WIP Posting"
             exit;
 #endif
         if TempTransferLine."Transfer WIP Item" then begin
-            TransferLine.Validate("Transfer WIP Item", TempTransferLine."Transfer WIP Item");
+            if not TransferLine."Transfer WIP Item" then
+                TransferLine.Validate("Transfer WIP Item", TempTransferLine."Transfer WIP Item");
             TransferLine.UpdateDescriptions();
         end;
     end;

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -511,6 +511,94 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
     end;
 
     [Test]
+    [HandlerFunctions('DoConfirmCreateProdOrderForSubcontractingProcess,HandleTransferOrder,MessageHandler')]
+    procedure SecondReturnTransferSucceedsAfterPartialReceiptAndReturn()
+    var
+        Item: Record Item;
+        HomeLocation: Record Location;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProdOrderComponent: Record "Prod. Order Component";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ReturnTransferHeader: Record "Transfer Header";
+        ReturnTransferLine: Record "Transfer Line";
+        TransferHeader: Record "Transfer Header";
+        WorkCenter: array[2] of Record "Work Center";
+        PurchaseOrderPage: TestPage "Purchase Order";
+        ProductionQty: Decimal;
+        FirstReceiptQty: Decimal;
+        SecondReceiptQty: Decimal;
+    begin
+        // [SCENARIO 638694] Creating a second return transfer order after partial receipts must not fail
+        // with "Transfer-to Code must have a value" when Subc. Original Location Code was cleared
+        // by a previous return cycle.
+        Initialize();
+        ProductionQty := 10;
+        FirstReceiptQty := 4;
+        SecondReceiptQty := 3;
+
+        // [GIVEN] A subcontracting purchase order with qty=10 and transfer-to-vendor components
+        SetupSubContractingProdOrder(Item, HomeLocation, WorkCenter, MachineCenter, ProductionOrder, "Component Supply Method"::"Transfer to Vendor", ProductionQty);
+        CreateSubcontractingPurchaseOrderForProdOrder(PurchaseHeader, PurchaseLine, Item, WorkCenter, ProductionOrder);
+
+        // [GIVEN] Outbound transfer order is created and posted (components sent to subcontractor)
+        CreateTransferOrderForPurchaseOrder(PurchaseHeader);
+        FindTransferOrderForPurchaseLine(TransferHeader, PurchaseLine);
+        PostDirectTransferOrder(TransferHeader);
+
+        // [GIVEN] First partial purchase receipt (4 of 10)
+        PurchaseLine.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+        EnsureGeneralPostingSetupIsValid(PurchaseLine."Gen. Bus. Posting Group", PurchaseLine."Gen. Prod. Posting Group");
+        PurchaseLine.Validate("Qty. to Receive", FirstReceiptQty);
+        PurchaseLine.Modify(true);
+        PurchaseHeader.Get(PurchaseHeader."Document Type", PurchaseHeader."No.");
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+
+        // [GIVEN] First return transfer order is created and posted (returns remaining components)
+        PurchaseHeader.Get(PurchaseHeader."Document Type", PurchaseHeader."No.");
+        CreateReturnTransferOrderForPurchaseOrder(PurchaseHeader);
+        ReturnTransferLine.SetRange("Subc. Purch. Order No.", PurchaseLine."Document No.");
+        ReturnTransferLine.SetRange("Subc. Purch. Order Line No.", PurchaseLine."Line No.");
+        ReturnTransferLine.SetRange("Subc. Return Order", true);
+        ReturnTransferLine.FindFirst();
+        ReturnTransferHeader.Get(ReturnTransferLine."Document No.");
+        PostDirectTransferOrder(ReturnTransferHeader);
+
+        // [GIVEN] A new outbound transfer for the remaining outstanding qty is created and posted
+        PurchaseHeader.Get(PurchaseHeader."Document Type", PurchaseHeader."No.");
+        CreateTransferOrderForPurchaseOrder(PurchaseHeader);
+        FindTransferOrderForPurchaseLine(TransferHeader, PurchaseLine);
+        PostDirectTransferOrder(TransferHeader);
+
+        // [GIVEN] Second partial purchase receipt (3 of remaining 6)
+        PurchaseLine.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+        PurchaseLine.Validate("Qty. to Receive", SecondReceiptQty);
+        PurchaseLine.Modify(true);
+        PurchaseHeader.Get(PurchaseHeader."Document Type", PurchaseHeader."No.");
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+
+        // [WHEN] Second return transfer order is created
+        PurchaseHeader.Get(PurchaseHeader."Document Type", PurchaseHeader."No.");
+        PurchaseOrderPage.OpenView();
+        PurchaseOrderPage.GoToRecord(PurchaseHeader);
+        PurchaseOrderPage.CreateReturnFromSubcontractor.Invoke();
+        PurchaseOrderPage.Close();
+
+        // [THEN] No error occurs and a return transfer line is created with correct Transfer-to Code
+        ReturnTransferLine.Reset();
+        ReturnTransferLine.SetRange("Subc. Purch. Order No.", PurchaseLine."Document No.");
+        ReturnTransferLine.SetRange("Subc. Purch. Order Line No.", PurchaseLine."Line No.");
+        ReturnTransferLine.SetRange("Subc. Return Order", true);
+        ReturnTransferLine.FindLast();
+        ReturnTransferHeader.Get(ReturnTransferLine."Document No.");
+        Assert.AreNotEqual('', ReturnTransferHeader."Transfer-to Code",
+            'Transfer-to Code must be populated on the second return transfer order.');
+        Assert.AreEqual(HomeLocation.Code, ReturnTransferHeader."Transfer-to Code",
+            'Transfer-to Code should be the original (home) location.');
+    end;
+
+    [Test]
     [HandlerFunctions('DoConfirmCreateProdOrderForSubcontractingProcess,HandleTransferOrder')]
     procedure CannotModifyOrDeleteRoutingLineWhenTransferOrderExistsWithTransferToVendor()
     var

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -517,7 +517,6 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         Item: Record Item;
         HomeLocation: Record Location;
         MachineCenter: array[2] of Record "Machine Center";
-        ProdOrderComponent: Record "Prod. Order Component";
         ProductionOrder: Record "Production Order";
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1467,6 +1467,80 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
             'WIP Transfer Line description must not be cleared when Direct Transfer is enabled on the header.');
     end;
 
+    [Test]
+    [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
+    procedure NoErrorWhenTogglingOffDirectTransferOnWIPTransferOrder()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        TransferHeader: Record "Transfer Header";
+        TransferLine: Record "Transfer Line";
+        Vendor: Record Vendor;
+        WorkCenter: array[2] of Record "Work Center";
+        PurchaseHeaderPage: TestPage "Purchase Order";
+    begin
+        // [SCENARIO 638816] Toggling off Direct Transfer on a Subcontracting Transfer Order
+        // with a WIP item line must not throw "No items are currently in transit" error.
+
+        // [GIVEN] Complete setup with subcontracting WIP item
+        Initialize();
+
+        SubcWarehouseLibrary.CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter, true);
+        SubcWarehouseLibrary.CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        SetTransferWIPItemOnRoutingLine(Item."Routing No.", WorkCenter[2]."No.", true);
+
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+        Vendor.Get(WorkCenter[2]."Subcontractor No.");
+
+        // [GIVEN] Create and refresh released production order at manufacturing components location
+        LibraryManufacturing.CreateProductionOrder(
+            ProductionOrder, "Production Order Status"::Released,
+            ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+        SetProdOrderLocationToCompSetupLocationAndRefresh(ProductionOrder);
+
+        // [GIVEN] NO transfer route exists → Transfer Header created with Direct Transfer = true
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+        PurchaseHeaderPage.OpenView();
+        PurchaseHeaderPage.GoToRecord(PurchaseHeader);
+        PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [GIVEN] WIP Transfer Line exists with Direct Transfer = true on the header
+        TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+#pragma warning disable AA0210
+        TransferLine.SetRange("Transfer WIP Item", true);
+#pragma warning restore AA0210
+        TransferLine.SetRange("Subc. Return Order", false);
+        TransferLine.FindFirst();
+
+        TransferHeader.Get(TransferLine."Document No.");
+        Assert.IsTrue(TransferHeader."Direct Transfer",
+            'Transfer Header must initially have Direct Transfer = true when no transit route exists.');
+
+        // [GIVEN] Create a transit route so toggling off Direct Transfer can set In-Transit Code
+        CreateAndUpdateTransferRoute(TransferHeader."Transfer-from Code", TransferHeader."Transfer-to Code");
+
+        // [WHEN] Toggle off Direct Transfer on the Transfer Header
+        TransferHeader.Validate("Direct Transfer", false);
+        TransferHeader.Modify(true);
+
+        // [THEN] No error is thrown and Direct Transfer is now false
+        TransferHeader.Get(TransferLine."Document No.");
+        Assert.IsFalse(TransferHeader."Direct Transfer",
+            'Direct Transfer must be toggled off successfully without error.');
+
+        // [THEN] WIP Transfer Line still exists and has Transfer WIP Item = true
+        TransferLine.FindFirst();
+        Assert.IsTrue(TransferLine."Transfer WIP Item",
+            'WIP Transfer Line must retain Transfer WIP Item = true after toggling off Direct Transfer.');
+    end;
+
     [PageHandler]
     procedure HandleTransferOrder(var TransfOrderPage: TestPage "Transfer Order")
     begin


### PR DESCRIPTION
## Bug 638694: Fix empty Transfer-to Code on second return from subcontractor

### Summary
When performing multiple partial receipt + return cycles on a subcontracting purchase order, the second 'Create Return from Subcontractor' action fails with:
`Transfer-to Code must have a value in Transfer Header: No.=XXXX. It cannot be zero or empty.`

### Root Cause
`UpdateLocationCodeInProdOrderCompAfterDeleteTransferLine` clears `Subc. Original Location Code` on the prod order component after a return transfer is posted/deleted. On subsequent return attempts, `HandleComponentReturnForPurchLine` passes the now-empty field as the Transfer-to Code to `InsertTransferHeader`, which fails validation.

### Fix
Moved the fallback re-population logic to **before** the `InsertTransferHeader` call in `SubcCreateSubCReturnOrder.Report.al`. Previously this ran after the call (too late).

### Test
Added `SecondReturnTransferSucceedsAfterPartialReceiptAndReturn` (codeunit 139991) — [SCENARIO 638694].

---

## Bug 638816: Fix error when toggling off Direct Transfer on WIP transfer order

(See previous commit in this branch)

---

Fixes [AB#638694](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638694)
Fixes [AB#638816](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638816)




