### PR TITLE
[Subcontracting] Bug 638816: Fix error toggling off Direct Transfer on WIP Transfer Order

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcTransferWIPPosting.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcTransferWIPPosting.Codeunit.al
@@ -39,11 +39,11 @@ codeunit 99001541 "Subc. Transfer WIP Posting"
 #pragma warning restore AL0432
             exit;
 #endif
-        if TempTransferLine."Transfer WIP Item" then
-            if not TransferLine."Transfer WIP Item" then begin
+        if TempTransferLine."Transfer WIP Item" then begin
+            if not TransferLine."Transfer WIP Item" then
                 TransferLine.Validate("Transfer WIP Item", TempTransferLine."Transfer WIP Item");
-                TransferLine.UpdateDescriptions();
-            end;
+            TransferLine.UpdateDescriptions();
+        end;
     end;
 
     [EventSubscriber(ObjectType::Table, Database::"Transfer Header", OnBeforeValidateEvent, "Direct Transfer", false, false)]

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcTransferWIPPosting.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcTransferWIPPosting.Codeunit.al
@@ -39,10 +39,11 @@ codeunit 99001541 "Subc. Transfer WIP Posting"
 #pragma warning restore AL0432
             exit;
 #endif
-        if TempTransferLine."Transfer WIP Item" then begin
-            TransferLine.Validate("Transfer WIP Item", TempTransferLine."Transfer WIP Item");
-            TransferLine.UpdateDescriptions();
-        end;
+        if TempTransferLine."Transfer WIP Item" then
+            if not TransferLine."Transfer WIP Item" then begin
+                TransferLine.Validate("Transfer WIP Item", TempTransferLine."Transfer WIP Item");
+                TransferLine.UpdateDescriptions();
+            end;
     end;
 
     [EventSubscriber(ObjectType::Table, Database::"Transfer Header", OnBeforeValidateEvent, "Direct Transfer", false, false)]

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1414,6 +1414,8 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         SubcWarehouseLibrary.CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
         SetTransferWIPItemOnRoutingLine(Item."Routing No.", WorkCenter[2]."No.", true);
 
+        SubcWarehouseLibrary.UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateProdBomWithComponentSupplyMethod(Item, "Component Supply Method"::"Transfer to Vendor");
         SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
 
         // [GIVEN] Create and refresh released production order
@@ -1422,7 +1424,7 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
             ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
         SetProdOrderLocationToCompSetupLocationAndRefresh(ProductionOrder);
 
-        // [GIVEN] No in-transit transfer route exists (ensures Direct Transfer = Yes)
+        // [GIVEN] Transfer route with in-transit location (ensures Direct Transfer = Yes initially)
         SubcontractingMgmtLibrary.CreateTransferRoute(WorkCenter[2], ProductionOrder);
 
         // [GIVEN] Create subcontracting purchase order and WIP Transfer Order

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1424,8 +1424,7 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
             ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
         SetProdOrderLocationToCompSetupLocationAndRefresh(ProductionOrder);
 
-        // [GIVEN] No in-transit transfer route exists for the WIP path (ensures Direct Transfer = Yes)
-        SubcontractingMgmtLibrary.CreateTransferRoute(WorkCenter[2], ProductionOrder);
+        // [GIVEN] No transfer route with in-transit exists (ensures Direct Transfer = Yes)
 
         // [GIVEN] Create subcontracting purchase order and WIP Transfer Order
         SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1465,7 +1465,9 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         TransferLine.Reset();
         TransferLine.SetRange("Document No.", TransferHeader."No.");
         TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+#pragma warning disable AA0210
         TransferLine.SetRange("Transfer WIP Item", true);
+#pragma warning restore AA0210
         TransferLine.SetRange("Subc. Return Order", false);
         TransferLine.FindFirst();
         Assert.IsTrue(TransferLine."Transfer WIP Item",

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1424,7 +1424,7 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
             ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
         SetProdOrderLocationToCompSetupLocationAndRefresh(ProductionOrder);
 
-        // [GIVEN] Transfer route with in-transit location (ensures Direct Transfer = Yes initially)
+        // [GIVEN] No in-transit transfer route exists for the WIP path (ensures Direct Transfer = Yes)
         SubcontractingMgmtLibrary.CreateTransferRoute(WorkCenter[2], ProductionOrder);
 
         // [GIVEN] Create subcontracting purchase order and WIP Transfer Order

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1466,7 +1466,9 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         TransferLine.SetRange("Document No.", TransferHeader."No.");
         TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
 #pragma warning disable AA0210
+#pragma warning disable AA0210
         TransferLine.SetRange("Transfer WIP Item", true);
+#pragma warning restore AA0210
 #pragma warning restore AA0210
         TransferLine.SetRange("Subc. Return Order", false);
         TransferLine.FindFirst();

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1434,9 +1434,6 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         PurchaseHeaderPage.GoToRecord(PurchaseHeader);
         PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
 
-        // [GIVEN] Create the transfer route after the order exists so the toggle-off validation can resolve it
-        SubcontractingMgmtLibrary.CreateTransferRoute(WorkCenter[2], ProductionOrder);
-
         // [GIVEN] Transfer Order created with Direct Transfer = Yes and WIP Transfer Line
         TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
 #pragma warning disable AA0210
@@ -1446,6 +1443,12 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         TransferLine.FindFirst();
 
         TransferHeader.Get(TransferLine."Document No.");
+
+        // IMPORTANT: this route must be created only after the transfer order is created.
+        // The missing route at creation time forces Direct Transfer = true on the header.
+        // Creating a matching in-transit route now allows toggling Direct Transfer off.
+        CreateAndUpdateTransferRoute(TransferHeader."Transfer-from Code", TransferHeader."Transfer-to Code");
+
         Assert.IsTrue(TransferHeader."Direct Transfer",
             'Transfer Header must have Direct Transfer = true when no in-transit route exists.');
 
@@ -1459,6 +1462,11 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
             'Transfer Header Direct Transfer must be false after toggling off.');
 
         // [THEN] WIP Transfer Line still exists with correct quantity
+        TransferLine.Reset();
+        TransferLine.SetRange("Document No.", TransferHeader."No.");
+        TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+        TransferLine.SetRange("Transfer WIP Item", true);
+        TransferLine.SetRange("Subc. Return Order", false);
         TransferLine.FindFirst();
         Assert.IsTrue(TransferLine."Transfer WIP Item",
             'WIP Transfer Line must still have Transfer WIP Item = true after Direct Transfer toggle.');

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1424,8 +1424,6 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
             ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
         SetProdOrderLocationToCompSetupLocationAndRefresh(ProductionOrder);
 
-        // [GIVEN] No transfer route with in-transit exists (ensures Direct Transfer = Yes)
-
         // [GIVEN] Create subcontracting purchase order and WIP Transfer Order
         SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
         PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
@@ -1435,6 +1433,9 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         PurchaseHeaderPage.OpenView();
         PurchaseHeaderPage.GoToRecord(PurchaseHeader);
         PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [GIVEN] Create the transfer route after the order exists so the toggle-off validation can resolve it
+        SubcontractingMgmtLibrary.CreateTransferRoute(WorkCenter[2], ProductionOrder);
 
         // [GIVEN] Transfer Order created with Direct Transfer = Yes and WIP Transfer Line
         TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1392,6 +1392,78 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
 
     [Test]
     [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
+    procedure ToggleOffDirectTransferOnWIPTransferOrderDoesNotError()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        TransferHeader: Record "Transfer Header";
+        TransferLine: Record "Transfer Line";
+        WorkCenter: array[2] of Record "Work Center";
+        PurchaseHeaderPage: TestPage "Purchase Order";
+    begin
+        // [SCENARIO 638816] Toggling off "Direct Transfer" on a Transfer Order with a WIP item line
+        // must not throw "No items are currently in transit" error.
+
+        // [GIVEN] Complete setup with Transfer WIP Item enabled
+        Initialize();
+
+        SubcWarehouseLibrary.CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter, true);
+        SubcWarehouseLibrary.CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        SetTransferWIPItemOnRoutingLine(Item."Routing No.", WorkCenter[2]."No.", true);
+
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        // [GIVEN] Create and refresh released production order
+        LibraryManufacturing.CreateProductionOrder(
+            ProductionOrder, "Production Order Status"::Released,
+            ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+        SetProdOrderLocationToCompSetupLocationAndRefresh(ProductionOrder);
+
+        // [GIVEN] No in-transit transfer route exists (ensures Direct Transfer = Yes)
+        SubcontractingMgmtLibrary.CreateTransferRoute(WorkCenter[2], ProductionOrder);
+
+        // [GIVEN] Create subcontracting purchase order and WIP Transfer Order
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+        PurchaseHeaderPage.OpenView();
+        PurchaseHeaderPage.GoToRecord(PurchaseHeader);
+        PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [GIVEN] Transfer Order created with Direct Transfer = Yes and WIP Transfer Line
+        TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+#pragma warning disable AA0210
+        TransferLine.SetRange("Transfer WIP Item", true);
+#pragma warning restore AA0210
+        TransferLine.SetRange("Subc. Return Order", false);
+        TransferLine.FindFirst();
+
+        TransferHeader.Get(TransferLine."Document No.");
+        Assert.IsTrue(TransferHeader."Direct Transfer",
+            'Transfer Header must have Direct Transfer = true when no in-transit route exists.');
+
+        // [WHEN] Toggle Direct Transfer from Yes to No
+        TransferHeader.Validate("Direct Transfer", false);
+        TransferHeader.Modify(true);
+
+        // [THEN] No error is thrown - Direct Transfer is successfully turned off
+        TransferHeader.Get(TransferLine."Document No.");
+        Assert.IsFalse(TransferHeader."Direct Transfer",
+            'Transfer Header Direct Transfer must be false after toggling off.');
+
+        // [THEN] WIP Transfer Line still exists with correct quantity
+        TransferLine.FindFirst();
+        Assert.IsTrue(TransferLine."Transfer WIP Item",
+            'WIP Transfer Line must still have Transfer WIP Item = true after Direct Transfer toggle.');
+    end;
+
+    [Test]
+    [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
     procedure WIPTransferLineDescriptionNotClearedWhenDirectTransferEnabled()
     var
         Item: Record Item;

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1460,6 +1460,8 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         TransferLine.FindFirst();
         Assert.IsTrue(TransferLine."Transfer WIP Item",
             'WIP Transfer Line must still have Transfer WIP Item = true after Direct Transfer toggle.');
+        Assert.AreEqual(ProductionOrder.Quantity, TransferLine.Quantity,
+            'WIP Transfer Line quantity must be preserved after toggling Direct Transfer.');
     end;
 
     [Test]


### PR DESCRIPTION
## Summary
- When toggling off **Direct Transfer** on a Transfer Order created via Subcontracting (with a WIP item line), the system threw error *'No items are currently in transit.'*
- This blocked users from switching a subcontracting transfer order from Direct Transfer to via-transit transfer.

## Root Cause
The OnUpdateTransLinesOnAfterUpdateFromDirectTransfer subscriber in Codeunit 99001541 unconditionally re-validated Transfer WIP Item on every Direct Transfer toggle, even when the value was not changing. This triggered the cascade: Validate(Quantity) -> UpdateWithWarehouseShipReceive -> Validate(Qty. to Receive).

In the Qty. to Receive OnValidate trigger, the guard condition passed incorrectly because the line-level Direct Transfer field had not been updated yet, causing the error when Qty. in Transit = 0.

## Fix
Skip the Validate(Transfer WIP Item) call when TransferLine already has the correct value (not changing), preventing the unnecessary validation cascade.

## Test
Added ToggleOffDirectTransferOnWIPTransferOrderDoesNotError in codeunit 149911 [SCENARIO 638816].

Fixes [AB#638816](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638816)

:robot: Generated with GitHub Copilot










