### PR TITLE
Bug 640113: Vendor-Supplied components visible in Planning Worksheet after refresh

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcPlanningLineMgmtExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcPlanningLineMgmtExt.Codeunit.al
@@ -61,8 +61,9 @@ codeunit 99001518 "Subc. Planning Line Mgmt Ext."
 #pragma warning restore AL0432
             exit;
 #endif
-        if ProductionBOMLine."Component Supply Method" = "Component Supply Method"::"Vendor-Supplied" then
-            IsHandled := true;
+        // Vendor-Supplied components must still be transferred as planning components so they appear
+        // in the Planning Worksheet component list (required for consumption registration).
+        // Exclusion from planning demand is handled by ProdOrderComponent_OnAfterFilterLinesWithItemToPlan.
     end;
 
     [EventSubscriber(ObjectType::Table, Database::"Prod. Order Component", OnAfterFilterLinesWithItemToPlan, '', false, false)]

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2002,6 +2002,13 @@ codeunit 139989 "Subc. Subcontracting Test"
         // [THEN] The component is relocated to the subcontractor location for consumption registration
         Vendor.Get(WorkCenter[2]."Subcontractor No.");
         PlanningComponent.TestField("Location Code", Vendor."Subc. Location Code");
+
+        // [THEN] No separate replenishment Requisition Line is generated for the vendor-supplied component item
+        RequisitionLine.Reset();
+        RequisitionLine.SetRange("Worksheet Template Name", ReqWkshTemplateName);
+        RequisitionLine.SetRange("Journal Batch Name", RequisitionWkshName.Name);
+        RequisitionLine.SetRange("No.", ProductionBOMLine."No.");
+        Assert.RecordIsEmpty(RequisitionLine);
     end;
 
     [Test]

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -1934,6 +1934,77 @@ codeunit 139989 "Subc. Subcontracting Test"
     end;
 
     [Test]
+    procedure VendorSuppliedComponentVisibleInPlanningWorksheetAfterRefresh()
+    var
+        Item: Record Item;
+        Location: Record Location;
+        MachineCenter: array[2] of Record "Machine Center";
+        PlanningComponent: Record "Planning Component";
+        ProductionBOMLine: Record "Production BOM Line";
+        RequisitionLine: Record "Requisition Line";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
+        Vendor: Record Vendor;
+        WorkCenter: array[2] of Record "Work Center";
+        ReqWkshTemplateName: Code[10];
+        Direction: Option Forward,Backward;
+    begin
+        // [SCENARIO 640113] Lines with Subcontracting Type = Vendor Supplied should appear in Planning
+        // Worksheet components when refreshing from Production BOM so consumption can be registered.
+
+        // [GIVEN] Complete Setup of Manufacturing, include Work- and Machine Centers, Item
+        Initialize();
+        SubcontractingMgmtLibrary.SetupInventorySetup();
+
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+
+        // [GIVEN] Create Item for Production include Routing and Prod. BOM
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+
+        // [GIVEN] Assign Routing Link Code between subcontracting routing line and last BOM line
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+
+        // [GIVEN] Set Component Supply Method = Vendor-Supplied on the linked BOM line
+        SubcontractingMgmtLibrary.UpdateProdBomWithComponentSupplyMethod(Item, "Component Supply Method"::"Vendor-Supplied");
+
+        // [GIVEN] Set up vendor with subcontracting location
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        // [GIVEN] A Planning Worksheet line is added manually for the item
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(Location);
+        ReqWkshTemplateName := LibraryPlanning.SelectRequisitionTemplateName();
+        LibraryPlanning.CreateRequisitionWkshName(RequisitionWkshName, ReqWkshTemplateName);
+        LibraryPlanning.CreateRequisitionLine(RequisitionLine, ReqWkshTemplateName, RequisitionWkshName.Name);
+        RequisitionLine.Validate(Type, RequisitionLine.Type::Item);
+        RequisitionLine.Validate("No.", Item."No.");
+        RequisitionLine.Validate(Quantity, LibraryRandom.RandInt(10) + 5);
+        RequisitionLine.Validate("Location Code", Location.Code);
+        RequisitionLine.Validate("Ending Date", WorkDate());
+        RequisitionLine.Modify(true);
+
+        // [WHEN] Refresh Planning Line is run
+        LibraryPlanning.RefreshPlanningLine(RequisitionLine, Direction::Backward, true, true);
+
+        // [THEN] The component with Vendor-Supplied type is present in Planning Components
+        ProductionBOMLine.SetRange("Production BOM No.", Item."Production BOM No.");
+        ProductionBOMLine.FindLast();
+        PlanningComponent.SetRange("Worksheet Template Name", RequisitionLine."Worksheet Template Name");
+        PlanningComponent.SetRange("Worksheet Batch Name", RequisitionLine."Journal Batch Name");
+        PlanningComponent.SetRange("Worksheet Line No.", RequisitionLine."Line No.");
+        PlanningComponent.SetRange("Item No.", ProductionBOMLine."No.");
+        Assert.RecordIsNotEmpty(PlanningComponent);
+
+        // [THEN] The Component Supply Method is correctly transferred
+        PlanningComponent.FindFirst();
+        PlanningComponent.TestField("Component Supply Method", "Component Supply Method"::"Vendor-Supplied");
+        // [THEN] The component is relocated to the subcontractor location for consumption registration
+        Vendor.Get(WorkCenter[2]."Subcontractor No.");
+        PlanningComponent.TestField("Location Code", Vendor."Subc. Location Code");
+    end;
+
+    [Test]
     [HandlerFunctions('ConfirmHandler')]
     procedure SubcontractingFieldsPopulatedOnIleAfterSubcontractingPurchaseReceipt()
     var


### PR DESCRIPTION
## Summary
- **Bug**: Lines with Subcontracting Type = Vendor Supplied are missing in Planning Worksheet when refreshing from Production BOM
- **Root cause**: The OnTransferBOMOnBeforeUpdatePlanningComp event subscriber was setting IsHandled := true for Vendor-Supplied components, completely blocking them from being created as Planning Components during the Refresh Planning Line operation.

## Fix
Removed the IsHandled := true from IgnorePurchaseComponentsFromSubcontracting_OnTransferBOMOnBeforeUpdatePlanningComp. Vendor-Supplied components are now transferred as planning components (so they appear in the Planning Worksheet component list and consumption can be registered). The exclusion from planning demand calculations remains correctly handled by ProdOrderComponent_OnAfterFilterLinesWithItemToPlan.

## Test
Added VendorSuppliedComponentVisibleInPlanningWorksheetAfterRefresh [SCENARIO 640113] verifying:
1. The Vendor-Supplied component exists in Planning Components after refresh
2. The Component Supply Method is correctly transferred
3. The component is relocated to the subcontractor location

Fixes [AB#640113](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640113)


