### PR TITLE
[Subcontracting] Backport: Fix bug 640115 - Subc. Order FlowField incorrect

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseHeader.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseHeader.TableExt.al
@@ -34,8 +34,7 @@ tableextension 99001509 "Subc. Purchase Header" extends "Purchase Header"
         {
             CalcFormula = exist("Purchase Line" where("Document Type" = const(Order),
                                                        "Document No." = field("No."),
-                                                       "Prod. Order No." = filter(<> ''),
-                                                       "Prod. Order Line No." = filter(<> 0)));
+                                                       "Subc. Purchase Line Type" = filter(<> None)));
             Caption = 'Subcontracting Order';
             Editable = false;
             FieldClass = FlowField;

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcLocationHandlerTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcLocationHandlerTest.Codeunit.al
@@ -499,6 +499,9 @@ codeunit 139981 "Subc. Location Handler Test"
         PurchaseLine."Routing No." := ProdOrderRtngLine."Routing No.";
         PurchaseLine."Operation No." := ProdOrderRtngLine."Operation No.";
         PurchaseLine."Routing Reference No." := ProdOrderRtngLine."Routing Reference No.";
+        // Mirror SetSubcontractingLineType() since fields are assigned directly (no Validate trigger).
+        // The single routing line created here is the last operation, so the type is LastOperation.
+        PurchaseLine."Subc. Purchase Line Type" := PurchaseLine."Subc. Purchase Line Type"::LastOperation;
         PurchaseLine.Modify();
     end;
 

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -754,6 +754,7 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         ProductionBOMHeader.Validate(Status, ProductionBOMHeader.Status::Certified);
         ProductionBOMHeader.Modify(true);
         FinishedItem.Validate("Production BOM No.", ProductionBOMHeader."No.");
+        FinishedITem.Validate("Routing No.", RoutingHeader."No.");
         FinishedItem.Modify(true);
 
         // [GIVEN] A released production order

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -746,13 +746,15 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         RoutingHeader.Modify(true);
 
         // [GIVEN] A finished good item with the routing
-        LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, WorkCenter."Unit of Measure Code");
-        ProductionBOMHeader.Validate(Status, ProductionBOMHeader.Status::Certified);
-        ProductionBOMHeader.Modify(true);
         LibraryManufacturing.CreateItemManufacturing(
             FinishedItem, "Costing Method"::FIFO, LibraryRandom.RandInt(10),
             "Reordering Policy"::"Lot-for-Lot", "Flushing Method"::"Pick + Manual",
-            RoutingHeader."No.", ProductionBOMHeader."No.");
+            RoutingHeader."No.", '');
+        LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, FinishedItem."Base Unit of Measure");
+        ProductionBOMHeader.Validate(Status, ProductionBOMHeader.Status::Certified);
+        ProductionBOMHeader.Modify(true);
+        FinishedItem.Validate("Production BOM No.", ProductionBOMHeader."No.");
+        FinishedItem.Modify(true);
 
         // [GIVEN] A released production order
         SubcWarehouseLibrary.CreateAndRefreshProductionOrder(

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -713,10 +713,12 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
     var
         FinishedItem: Record Item;
         Location: Record Location;
+        ProdOrderRtngLine: Record "Prod. Order Routing Line";
         ProductionBOMHeader: Record "Production BOM Header";
         ProductionOrder: Record "Production Order";
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
+        ReleasedProdOrderRtng: TestPage "Prod. Order Routing";
         RoutingHeader: Record "Routing Header";
         RoutingLine: Record "Routing Line";
         Vendor: Record Vendor;
@@ -763,8 +765,18 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         LibraryMfgManagement.CreateSubcontractingReqWkshTemplateAndNameAndUpdateSetup();
 
         // [WHEN] Create subcontracting purchase order from Prod. Order Routing
-        SubcWarehouseLibrary.CreateSubcontractingOrderFromProdOrderRouting(
-            RoutingHeader."No.", WorkCenter."No.", PurchaseLine);
+        ProdOrderRtngLine.SetRange(Status, "Production Order Status"::Released);
+        ProdOrderRtngLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderRtngLine.SetRange(Type, ProdOrderRtngLine.Type::"Work Center");
+        ProdOrderRtngLine.SetRange("Work Center No.", WorkCenter."No.");
+        ProdOrderRtngLine.FindFirst();
+        ReleasedProdOrderRtng.OpenView();
+        ReleasedProdOrderRtng.GoToRecord(ProdOrderRtngLine);
+        ReleasedProdOrderRtng.CreateSubcontracting.Invoke();
+
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
 
         // [THEN] A purchase order was created and the "Subc. Order" FlowField is true
         PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -713,7 +713,6 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
     var
         FinishedItem: Record Item;
         Location: Record Location;
-        ProdOrderRtngLine: Record "Prod. Order Routing Line";
         ProductionBOMHeader: Record "Production BOM Header";
         ProductionOrder: Record "Production Order";
         PurchaseHeader: Record "Purchase Header";
@@ -722,7 +721,6 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         RoutingLine: Record "Routing Line";
         Vendor: Record Vendor;
         WorkCenter: Record "Work Center";
-        ReleasedProdOrderRtng: TestPage "Prod. Order Routing";
     begin
         // [SCENARIO 640115] After creating a subcontracting purchase order from a Prod. Order Routing Line,
         // the "Subc. Order" FlowField on the Purchase Header must evaluate to true so the order is visible
@@ -765,18 +763,10 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         LibraryMfgManagement.CreateSubcontractingReqWkshTemplateAndNameAndUpdateSetup();
 
         // [WHEN] Create subcontracting purchase order from Prod. Order Routing
-        ProdOrderRtngLine.SetRange("Routing No.", RoutingHeader."No.");
-        ProdOrderRtngLine.SetRange("Work Center No.", WorkCenter."No.");
-        ProdOrderRtngLine.FindFirst();
-
-        ReleasedProdOrderRtng.OpenView();
-        ReleasedProdOrderRtng.GoToRecord(ProdOrderRtngLine);
-        ReleasedProdOrderRtng.CreateSubcontracting.Invoke();
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRouting(
+            RoutingHeader."No.", WorkCenter."No.", PurchaseLine);
 
         // [THEN] A purchase order was created and the "Subc. Order" FlowField is true
-        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
-        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
-        PurchaseLine.FindFirst();
         PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
         PurchaseHeader.CalcFields("Subc. Order");
         Assert.IsTrue(PurchaseHeader."Subc. Order",

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -763,7 +763,7 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         LibraryMfgManagement.CreateSubcontractingReqWkshTemplateAndNameAndUpdateSetup();
 
         // [WHEN] Create subcontracting purchase order from Prod. Order Routing
-        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRouting(
+        SubcWarehouseLibrary.CreateSubcontractingOrderFromProdOrderRouting(
             RoutingHeader."No.", WorkCenter."No.", PurchaseLine);
 
         // [THEN] A purchase order was created and the "Subc. Order" FlowField is true

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -707,6 +707,79 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         Assert.RecordIsEmpty(PurchaseLine);
     end;
 
+    [Test]
+    [HandlerFunctions('DoConfirmCreateProdOrderForSubcontractingProcess')]
+    procedure SubcOrderFlowFieldIsTrueAfterCreatingSubcontractingPurchaseOrder()
+    var
+        FinishedItem: Record Item;
+        Location: Record Location;
+        ProdOrderRtngLine: Record "Prod. Order Routing Line";
+        ProductionBOMHeader: Record "Production BOM Header";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        Vendor: Record Vendor;
+        WorkCenter: Record "Work Center";
+        ReleasedProdOrderRtng: TestPage "Prod. Order Routing";
+    begin
+        // [SCENARIO 640115] After creating a subcontracting purchase order from a Prod. Order Routing Line,
+        // the "Subc. Order" FlowField on the Purchase Header must evaluate to true so the order is visible
+        // in the "Subcontracting Orders" view of the Purchase Order List.
+
+        Initialize();
+
+        // [GIVEN] A subcontracting work center with vendor and location
+        CreateAndCalculateNeededWorkCenter(WorkCenter, true);
+        Vendor.Get(WorkCenter."Subcontractor No.");
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(Location);
+        Vendor."Subc. Location Code" := Location.Code;
+        Vendor.Modify();
+
+        // [GIVEN] A routing with a single subcontracting operation
+        LibraryManufacturing.CreateRoutingHeader(RoutingHeader, RoutingHeader.Type::Serial);
+        LibraryManufacturing.CreateRoutingLineSetup(
+            RoutingLine, RoutingHeader, WorkCenter."No.", '100',
+            LibraryRandom.RandInt(5), LibraryRandom.RandInt(5));
+        RoutingHeader.Validate(Status, RoutingHeader.Status::Certified);
+        RoutingHeader.Modify(true);
+
+        // [GIVEN] A finished good item with the routing
+        LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, WorkCenter."Unit of Measure Code");
+        ProductionBOMHeader.Validate(Status, ProductionBOMHeader.Status::Certified);
+        ProductionBOMHeader.Modify(true);
+        LibraryManufacturing.CreateItemManufacturing(
+            FinishedItem, "Costing Method"::FIFO, LibraryRandom.RandInt(10),
+            "Reordering Policy"::"Lot-for-Lot", "Flushing Method"::"Pick + Manual",
+            RoutingHeader."No.", ProductionBOMHeader."No.");
+
+        // [GIVEN] A released production order
+        SubcWarehouseLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released,
+            ProductionOrder."Source Type"::Item, FinishedItem."No.", LibraryRandom.RandInt(10), Location.Code);
+
+        // [GIVEN] Requisition worksheet template for subcontracting
+        LibraryMfgManagement.CreateSubcontractingReqWkshTemplateAndNameAndUpdateSetup();
+
+        // [WHEN] Create subcontracting purchase order from Prod. Order Routing
+        ProdOrderRtngLine.SetRange("Routing No.", RoutingHeader."No.");
+        ProdOrderRtngLine.SetRange("Work Center No.", WorkCenter."No.");
+        ProdOrderRtngLine.FindFirst();
+
+        ReleasedProdOrderRtng.OpenView();
+        ReleasedProdOrderRtng.GoToRecord(ProdOrderRtngLine);
+        ReleasedProdOrderRtng.CreateSubcontracting.Invoke();
+
+        // [THEN] A purchase order was created and the "Subc. Order" FlowField is true
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+        PurchaseHeader.CalcFields("Subc. Order");
+        Assert.IsTrue(PurchaseHeader."Subc. Order",
+            'The Subc. Order FlowField must be true for a subcontracting purchase order');
+    end;
     [ModalPageHandler]
     procedure ItemTrackingLinesSimpleHandler(var ItemTrackingLines: TestPage "Item Tracking Lines")
     begin

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPurchSubcontTest.Codeunit.al
@@ -718,11 +718,11 @@ codeunit 139991 "Subc. Purch. Subcont. Test"
         ProductionOrder: Record "Production Order";
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
-        ReleasedProdOrderRtng: TestPage "Prod. Order Routing";
         RoutingHeader: Record "Routing Header";
         RoutingLine: Record "Routing Line";
         Vendor: Record Vendor;
         WorkCenter: Record "Work Center";
+        ReleasedProdOrderRtng: TestPage "Prod. Order Routing";
     begin
         // [SCENARIO 640115] After creating a subcontracting purchase order from a Prod. Order Routing Line,
         // the "Subc. Order" FlowField on the Purchase Header must evaluate to true so the order is visible


### PR DESCRIPTION
Backport of #8757 to releases/28.x.

Cherry-picked from commit 63cfaf5464 (Bug 640115: Fix Subc. Order FlowField to use Subc. Purchase Line Type).

Fixes [AB#640115](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640115)








