### PR TITLE
Add System Application dependency to Test Framework apps

### DIFF
--- a/src/Tools/Test Framework/Test Libraries/Any/app.json
+++ b/src/Tools/Test Framework/Test Libraries/Any/app.json
@@ -11,7 +11,14 @@
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "contextSensitiveHelpUrl": "https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-testing-application/",
   "logo": "ExtensionLogo.png",
-  "dependencies": [],
+  "dependencies": [
+    {
+      "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
+      "name": "System Application",
+      "publisher": "Microsoft",
+      "version": "29.0.0.0"
+    }
+  ],
   "screenshots": [],
   "platform": "29.0.0.0",
   "idRanges": [

--- a/src/Tools/Test Framework/Test Libraries/Assert/app.json
+++ b/src/Tools/Test Framework/Test Libraries/Assert/app.json
@@ -11,7 +11,14 @@
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "contextSensitiveHelpUrl": "https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-testing-application/",
   "logo": "ExtensionLogo.png",
-  "dependencies": [],
+  "dependencies": [
+    {
+      "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
+      "name": "System Application",
+      "publisher": "Microsoft",
+      "version": "29.0.0.0"
+    }
+  ],
   "screenshots": [],
   "platform": "29.0.0.0",
   "idRanges": [

--- a/src/Tools/Test Framework/Test Libraries/Variable Storage/app.json
+++ b/src/Tools/Test Framework/Test Libraries/Variable Storage/app.json
@@ -13,6 +13,12 @@
   "logo": "ExtensionLogo.png",
   "dependencies": [
     {
+      "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
+      "name": "System Application",
+      "publisher": "Microsoft",
+      "version": "29.0.0.0"
+    },
+    {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "publisher": "Microsoft",
       "name": "Library Assert",

--- a/src/Tools/Test Framework/Test Runner/app.json
+++ b/src/Tools/Test Framework/Test Runner/app.json
@@ -11,7 +11,14 @@
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "contextSensitiveHelpUrl": "https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-testing-application/",
   "logo": "ExtensionLogo.png",
-  "dependencies": [],
+  "dependencies": [
+    {
+      "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
+      "name": "System Application",
+      "publisher": "Microsoft",
+      "version": "29.0.0.0"
+    }
+  ],
   "screenshots": [],
   "platform": "29.0.0.0",
   "idRanges": [


### PR DESCRIPTION
## What

Adds an explicit dependency on **System Application** (`63ca2fa4-4f03-4f2b-a480-172fef340d3f`) to the four Test Framework library apps:

- Any
- Library Assert
- Test Runner
- Library Variable Storage

## Why

These apps previously declared **no application-level dependency** (platform only). As a result the app dependency resolver treats them as compatible across application builds, so a tenant can end up with a newer build of these apps published than the application schema being applied during an environment upgrade — which blocks the upgrade sync (forward-only schema guard).

Declaring a dependency on System Application version-gates the apps to the application build, modelling the dependency the same way other first-party apps (e.g. Business Foundation) already do.

## Circular dependency check

None introduced:

- The umbrella `System Application` app declares `dependencies: []`.
- **0** of the 111 runtime sub-apps under `System Application/App/` depend on any Test Framework app.
- The only consumers of the Test Framework inside System Application are the separate `Test` / `Test Library` / `Partner Test` packages, which sit **above** the framework in the graph.

Graph stays acyclic: `System Application (App) -> Test Framework -> System Application Test`.

> [!NOTE]
> Draft / experimental — raised in the context of an upgrade-compatibility investigation. Architectural note: this inverts the conceptual layering (the Test Framework would sit above the entire System Application runtime surface).

