### PR TITLE
[28.x] [Subcontracting] Purchase Line FactBox Shows Wrong Transfer Order Count When Return Exists

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchFactboxMgmt.Codeunit.al
@@ -139,8 +139,8 @@ codeunit 99001560 "Subc. Purch. Factbox Mgmt."
         TransferLine.SetCurrentKey("Subc. Purch. Order No.");
         TransferLine.SetRange("Subc. Purch. Order No.", PurchOrderNo);
         TransferLine.SetRange("Subc. Purch. Order Line No.", PurchOrderLineNo);
-        TransferLine.SetFilter("Subc. Operation No.", '%1', '');
-        TransferLine.SetFilter("Subc. Routing No.", '%1', '');
+        TransferLine.SetRange("Subc. Return Order", true);
+        TransferLine.SetRange("Derived From Line No.", 0);
         TransferLine.SetLoadFields(SystemId);
         if TransferLine.IsEmpty() then
             exit('');
@@ -635,7 +635,7 @@ codeunit 99001560 "Subc. Purch. Factbox Mgmt."
         TransferLine.SetCurrentKey("Subc. Purch. Order No.");
         TransferLine.SetRange("Subc. Purch. Order No.", PurchOrderNo);
         TransferLine.SetRange("Subc. Purch. Order Line No.", PurchOrderLineNo);
-        TransferLine.SetFilter("Subc. Operation No.", '<>%1', '');
-        TransferLine.SetFilter("Subc. Routing No.", '<>%1', '');
+        TransferLine.SetRange("Subc. Return Order", false);
+        TransferLine.SetRange("Derived From Line No.", 0);
     end;
 }

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -4039,6 +4039,194 @@ codeunit 139989 "Subc. Subcontracting Test"
         PurchaseLineComp.SetRange("No.", ComponentItemNo);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler,HandleTransferOrder')]
+    procedure PurchLineFactboxTransferOrderCountExcludesReturnOrder()
+    var
+        Bin: Record Bin;
+        Item: Record Item;
+        Location: Record Location;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProdOrderComp: Record "Prod. Order Component";
+        ProductionOrder: Record "Production Order";
+        PurchaseLine: Record "Purchase Line";
+        ReturnTransferHeader: Record "Transfer Header";
+        TransferHeader: Record "Transfer Header";
+        TransferLine: Record "Transfer Line";
+        WorkCenter: array[2] of Record "Work Center";
+        SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
+        PurchaseHeaderPage: TestPage "Purchase Order";
+        OutboundFromCode: Code[10];
+        QtyToShip: Decimal;
+    begin
+        // [SCENARIO 39] Purchase Line FactBox: No. of Transfer Orders is inflated by the return transfer
+        // order, and Return Transfer Order field is blank, when a return to subcontractor is created.
+
+        // [GIVEN] Standard subcontracting setup with an in-transit transfer route
+        Initialize();
+        SubcontractingMgmtLibrary.UpdateManufacturingSetupWithSubcontractingLocation();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateProdBomWithComponentSupplyMethod(Item, "Component Supply Method"::"Transfer to Vendor");
+        UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+        SubcontractingMgmtLibrary.UpdateProdOrderCompWithLocationCode(ProductionOrder."No.");
+        SubcontractingMgmtLibrary.CreateTransferRoute(WorkCenter[2], ProductionOrder);
+
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("No.", ProductionOrder."Source No.");
+        PurchaseLine.SetRange(Type, "Purchase Line Type"::Item);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+
+        // [GIVEN] Outbound Transfer Order created for the subcontracting purchase
+        PurchaseHeaderPage.OpenView();
+        PurchaseHeaderPage.GotoKey("Purchase Document Type"::Order, PurchaseLine."Document No.");
+        PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+
+        ProdOrderComp.SetRange("Prod. Order No.", ProductionOrder."No.");
+#pragma warning disable AA0210
+        ProdOrderComp.SetRange("Component Supply Method", ProdOrderComp."Component Supply Method"::"Transfer to Vendor");
+#pragma warning restore AA0210
+        ProdOrderComp.FindFirst();
+
+        TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+        TransferLine.SetRange("Item No.", ProdOrderComp."Item No.");
+        TransferLine.SetRange("Subc. Prod. Ord. Comp Line No.", ProdOrderComp."Line No.");
+        TransferLine.FindFirst();
+        TransferHeader.Get(TransferLine."Document No.");
+        OutboundFromCode := TransferHeader."Transfer-from Code";
+
+        // [GIVEN] Items are partially shipped to put them in transit (so AvailableToReturn > 0)
+        Location.Get(OutboundFromCode);
+        Item.Get(ProdOrderComp."Item No.");
+        CreateInventory(Item, Location, Bin, ProdOrderComp."Expected Qty. (Base)");
+        QtyToShip := Round(TransferLine.Quantity / 2, 1, '<');
+        TransferLine.Validate("Qty. to Ship", QtyToShip);
+        TransferLine.Modify(true);
+        LibraryWarehouse.PostTransferOrder(TransferHeader, true, false);
+
+        // [WHEN] A Return Transfer Order is created
+        PurchaseHeaderPage.GotoKey("Purchase Document Type"::Order, PurchaseLine."Document No.");
+        PurchaseHeaderPage.CreateReturnFromSubcontractor.Invoke();
+
+        // [THEN] A return transfer order is linked to the purchase
+        ReturnTransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseLine."Document No.");
+        ReturnTransferHeader.SetRange("Subc. Return Order", true);
+        Assert.IsTrue(ReturnTransferHeader.FindFirst(), 'Return Transfer Order must exist');
+
+        PurchaseLine.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+
+        // [THEN] No. of Transfer Orders in the FactBox equals 1 — only the outbound order is counted
+        Assert.AreEqual(
+            1, SubcPurchFactboxMgmt.GetNoOfTransferOrders(PurchaseLine),
+            'No. of Transfer Orders must be 1 (outbound only); the return transfer order must not be counted');
+
+        // [THEN] Return Transfer Order No. in the FactBox shows the return order number
+        Assert.AreEqual(
+            ReturnTransferHeader."No.", SubcPurchFactboxMgmt.GetReturnTransferOrderNo(PurchaseLine),
+            'Return Transfer Order No. must match the created return transfer order');
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler,HandleTransferOrder')]
+    procedure PurchLineFactboxTransferOrderCountIsZeroWhenOnlyReturnExists()
+    var
+        Bin: Record Bin;
+        Item: Record Item;
+        Location: Record Location;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProdOrderComp: Record "Prod. Order Component";
+        ProductionOrder: Record "Production Order";
+        PurchaseLine: Record "Purchase Line";
+        ReturnTransferHeader: Record "Transfer Header";
+        TransferHeader: Record "Transfer Header";
+        TransferLine: Record "Transfer Line";
+        WorkCenter: array[2] of Record "Work Center";
+        SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
+        PurchaseHeaderPage: TestPage "Purchase Order";
+        OutboundFromCode: Code[10];
+    begin
+        // [SCENARIO 39] Purchase Line FactBox: when the outbound Transfer Order has been fully posted
+        // (direct transfer) and only the return transfer order remains, No. of Transfer Orders must
+        // be 0 and Return Transfer Order must show the return order number.
+
+        // [GIVEN] Standard subcontracting setup with a direct transfer (no in-transit route)
+        Initialize();
+        SubcontractingMgmtLibrary.UpdateManufacturingSetupWithSubcontractingLocation();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateProdBomWithComponentSupplyMethod(Item, "Component Supply Method"::"Transfer to Vendor");
+        UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+        SubcontractingMgmtLibrary.UpdateProdOrderCompWithLocationCode(ProductionOrder."No.");
+
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("No.", ProductionOrder."Source No.");
+        PurchaseLine.SetRange(Type, "Purchase Line Type"::Item);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+
+        // [GIVEN] Outbound Transfer Order created for the subcontracting purchase (direct transfer)
+        PurchaseHeaderPage.OpenView();
+        PurchaseHeaderPage.GotoKey("Purchase Document Type"::Order, PurchaseLine."Document No.");
+        PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+
+        ProdOrderComp.SetRange("Prod. Order No.", ProductionOrder."No.");
+#pragma warning disable AA0210
+        ProdOrderComp.SetRange("Component Supply Method", ProdOrderComp."Component Supply Method"::"Transfer to Vendor");
+#pragma warning restore AA0210
+        ProdOrderComp.FindFirst();
+
+        TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+        TransferLine.SetRange("Item No.", ProdOrderComp."Item No.");
+        TransferLine.SetRange("Subc. Prod. Ord. Comp Line No.", ProdOrderComp."Line No.");
+        TransferLine.FindFirst();
+        TransferHeader.Get(TransferLine."Document No.");
+        OutboundFromCode := TransferHeader."Transfer-from Code";
+
+        // [GIVEN] All items are direct-transferred (ship + receive in one step) — outbound lines are consumed
+        Location.Get(OutboundFromCode);
+        Item.Get(ProdOrderComp."Item No.");
+        CreateInventory(Item, Location, Bin, ProdOrderComp."Expected Qty. (Base)");
+        LibraryWarehouse.PostTransferOrder(TransferHeader, true, true);
+
+        // [WHEN] A Return Transfer Order is created (outbound transfer lines no longer exist)
+        PurchaseHeaderPage.GotoKey("Purchase Document Type"::Order, PurchaseLine."Document No.");
+        PurchaseHeaderPage.CreateReturnFromSubcontractor.Invoke();
+
+        // [THEN] A return transfer order is linked to the purchase
+        ReturnTransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseLine."Document No.");
+        ReturnTransferHeader.SetRange("Subc. Return Order", true);
+        Assert.IsTrue(ReturnTransferHeader.FindFirst(), 'Return Transfer Order must exist');
+
+        PurchaseLine.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+
+        // [THEN] No. of Transfer Orders in the FactBox equals 0 — no outbound transfer lines remain
+        Assert.AreEqual(
+            0, SubcPurchFactboxMgmt.GetNoOfTransferOrders(PurchaseLine),
+            'No. of Transfer Orders must be 0 when only the return transfer order exists');
+
+        // [THEN] Return Transfer Order No. in the FactBox shows the return order number
+        Assert.AreEqual(
+            ReturnTransferHeader."No.", SubcPurchFactboxMgmt.GetReturnTransferOrderNo(PurchaseLine),
+            'Return Transfer Order No. must match the created return transfer order');
+    end;
+
     local procedure CreateUOMCodeSortingAfter(BaseUOMCode: Code[10]): Code[10]
     var
         UnitOfMeasure: Record "Unit of Measure";


### PR DESCRIPTION
# Bug: Purchase Line FactBox Shows Wrong Transfer Order Count When Return Exists

## Affected Objects

| Type | Name | ID |
|------|------|----|
| Page | Subc. Purchase Line Factbox | 99001518 |
| Codeunit | Subc. Purch. Factbox Mgmt. | 99001560 |

## Reproduction Steps

### Setup
- Standard subcontracting setup with an item, routing, and a released production order.
- Component supply method set to **Transfer to Vendor**.
- Vendor has a subcontracting location code; a transfer route exists between the source and subcontractor locations.
- A subcontracting Purchase Order is created from the Prod. Order Routing Line.
- An outbound Transfer Order is created from the Purchase Order.

### Given
1. Items are partially or fully shipped to the subcontractor location (or placed in transit).
2. The **Create Return from Subcontractor** action is used on the Purchase Order to create a Return Transfer Order.

### When
The **Subc. Purchase Line Factbox** is displayed for the Purchase Line.

### Then (pre-fix — wrong behavior)
- **No. of Transfer Orders** shows **2** (counts both the outbound and return transfer orders).
- **Return Transfer Order** field is **blank** (does not display the return order number).
- Drilldown on the **Return Transfer Order** field still navigates correctly because `ShowTransferOrdersAndReturnOrder` uses the `Subc. Return Order` boolean.

## False Behavior
- `GetNoOfTransferOrders` over-counts by including the return transfer order.
- `GetReturnTransferOrderNo` returns blank, unable to locate the return transfer order.

## Expected Behavior
- **No. of Transfer Orders** = 1 (only the outbound transfer order).
- **Return Transfer Order** field = the return transfer order number.

## Root Cause

`FilterTransferLineToSubcontractorPurchaseOrder` (used by `GetNoOfTransferOrders` and `GetTransferOrderNo`) identifies non-return lines by filtering `"Subc. Operation No." <> ''` and `"Subc. Routing No." <> ''`. However, the **SubcCreateSubCReturnOrder** report populates `Subc. Operation No.` and `Subc. Routing No.` on return transfer lines from the `Prod. Order Routing Line`. This means return lines pass the filter and are incorrectly included in the count.

`GetReturnTransferOrderNo` uses the inverse filter — `"Subc. Operation No." = ''` and `"Subc. Routing No." = ''` — to find return lines. Because return lines have these fields set, the query finds nothing and returns blank.

The `Subc. Return Order` boolean field (set to `true` on all return lines by the report) is the authoritative discriminator, as already used by `ShowTransferOrdersAndReturnOrder` and `SubcRoutingFactboxMgmt.GetNoOfTransferLinesFromRouting`.

## Fix Description

**File:** `src/Process/Codeunits/SubcPurchFactboxMgmt.Codeunit.al`

1. **`FilterTransferLineToSubcontractorPurchaseOrder`** — replace the `Subc. Operation No. <> ''` and `Subc. Routing No. <> ''` filters with `SetRange("Subc. Return Order", false)`.

2. **`GetReturnTransferOrderNo`** — replace the `Subc. Operation No. = ''` and `Subc. Routing No. = ''` filters with `SetRange("Subc. Return Order", true)`.

## Related Work Item
- (add links if known)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->
