### PR TITLE
Bug 640249: [Subcontracting] Enable Item Ledger Entries production actions via Order No./Order Type

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/General/SubcILEntries.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/General/SubcILEntries.PageExt.al
@@ -49,7 +49,7 @@ pageextension 99001501 "Subc. ILEntries" extends "Item Ledger Entries"
                 {
                     ApplicationArea = Subcontracting;
                     Caption = 'Production Order';
-                    Enabled = Rec."Subc. Prod. Order No." <> '';
+                    Enabled = (Rec."Order Type" = Rec."Order Type"::Production) and (Rec."Order No." <> '');
                     Image = Production;
                     ToolTip = 'View the related production order.';
                     trigger OnAction()
@@ -61,7 +61,7 @@ pageextension 99001501 "Subc. ILEntries" extends "Item Ledger Entries"
                 {
                     ApplicationArea = Subcontracting;
                     Caption = 'Production Order Routing';
-                    Enabled = Rec."Subc. Prod. Order No." <> '';
+                    Enabled = (Rec."Order Type" = Rec."Order Type"::Production) and (Rec."Order No." <> '');
                     Image = Route;
                     ToolTip = 'View the related production order routing.';
                     trigger OnAction()
@@ -73,7 +73,7 @@ pageextension 99001501 "Subc. ILEntries" extends "Item Ledger Entries"
                 {
                     ApplicationArea = Subcontracting;
                     Caption = 'Production Order Components';
-                    Enabled = Rec."Subc. Prod. Order No." <> '';
+                    Enabled = (Rec."Order Type" = Rec."Order Type"::Production) and (Rec."Order No." <> '');
                     Image = Components;
                     ToolTip = 'View the related production order components.';
                     trigger OnAction()

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingUITest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingUITest.Codeunit.al
@@ -553,12 +553,12 @@ codeunit 139990 "Subc. Subcontracting UI Test"
         // [SCENARIO 638458] Subcontracting actions on Item Ledger Entries are disabled when the entry has no subcontracting production order or purchase order.
         Initialize();
 
-        // [GIVEN] An Item Ledger Entry that is NOT related to subcontracting (no Subc. Prod. Order No. or Subc. Purch. Order No.)
+        // [GIVEN] An Item Ledger Entry that is NOT related to subcontracting (no production order or Subc. Purch. Order No.)
         ItemLedgerEntry.Init();
         ItemLedgerEntry."Entry No." := GetNextItemLedgerEntryNo();
         ItemLedgerEntry."Item No." := 'TEST-ITEM';
         ItemLedgerEntry."Entry Type" := ItemLedgerEntry."Entry Type"::Purchase;
-        ItemLedgerEntry."Subc. Prod. Order No." := '';
+        ItemLedgerEntry."Order No." := '';
         ItemLedgerEntry."Subc. Purch. Order No." := '';
         ItemLedgerEntry.Insert();
 
@@ -595,8 +595,9 @@ codeunit 139990 "Subc. Subcontracting UI Test"
         ItemLedgerEntry."Entry No." := GetNextItemLedgerEntryNo();
         ItemLedgerEntry."Item No." := 'TEST-ITEM';
         ItemLedgerEntry."Entry Type" := ItemLedgerEntry."Entry Type"::Purchase;
-        ItemLedgerEntry."Subc. Prod. Order No." := 'PO-SUBC-001';
-        ItemLedgerEntry."Subc. Prod. Order Line No." := 10000;
+        ItemLedgerEntry."Order Type" := ItemLedgerEntry."Order Type"::Production;
+        ItemLedgerEntry."Order No." := 'PO-SUBC-001';
+        ItemLedgerEntry."Order Line No." := 10000;
         ItemLedgerEntry."Subc. Purch. Order No." := 'PURCH-SUBC-001';
         ItemLedgerEntry."Subc. Purch. Order Line No." := 10000;
         ItemLedgerEntry.Insert();


### PR DESCRIPTION
## Summary
Fixes [AB#640249](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640249)

The bug claimed the `Subc. Prod. Order No.`/`Line No.` fields on Item Ledger Entry (and similar `Subc.*` fields on Item Journal Line / Purchase Line / Purch. Rcpt. Line) are **redundant duplicates** of BaseApp fields and should be removed.

Investigation showed the premise is incorrect — these fields are **complementary, not duplicates**:
- ILE `Subc. Prod. Order No.`/`Line No.` are populated **only on transfer (WIP) entries**, where BaseApp `Order No.` holds the *transfer* order, so `Subc. Prod. Order No.` is the sole record of the *production* order. On normal production entries it is blank (never equals `Order No.`).
- The posted-purchase `Subc.*` fields (99001543–548) are populated via BaseApp `InitFromPurchLine` -> `TransferFields` on vendor-supplied **component** lines, where the BaseApp prod-order fields are blank.

So the fields are **kept**. The actual defect was on the **Item Ledger Entries page**: the Production Order / Routing / Components actions gated `Enabled` on `Rec."Subc. Prod. Order No."` while their navigation reads BaseApp `Order No.` — meaning they were enabled on transfer entries (navigation fails) and disabled on production entries (navigation works).

## Changes
- `SubcILEntries.PageExt.al`: the three Production actions now enable on `(Rec."Order Type" = Production) and (Rec."Order No." <> '')`, matching what the navigation actually uses.
- `SubcSubcontractingUITest.Codeunit.al`: scenario 638458 updated (both enabled and disabled cases) to drive the BaseApp `Order Type`/`Order No.`/`Order Line No.` fields.

## Not addressed (and why)
- **No fields were removed.** The fields are not redundant; removing them would lose genuinely-new data (production-order linkage on transfer ILEs and on vendor-supplied component receipt lines).
- Recommend resolving the "redundant fields" aspect of 640249 as **by design**.

## Follow-up (out of scope)
`SubcPurchPostExt.al:175` sets the capacity journal line `"No."` from `Subc. Work Center No.`, which is blank on the service lines that routine runs on (line 179 uses BaseApp `Work Center No.`). Looks like a latent bug worth its own tracking item.

