### PR TITLE
[TEST – DO NOT MERGE] Validate BCQuality Copilot PR-review wiring

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultEvents.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultEvents.Codeunit.al
@@ -1,0 +1,35 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.QualityManagement.Integration.ExternalResults;
+
+/// <summary>
+/// Integration events raised during external quality result import.
+/// </summary>
+codeunit 20590 "Qlty. Ext. Result Events"
+{
+    Access = Public;
+
+    /// <summary>
+    /// Raised before the lab API is called, exposing the raw credentials so
+    /// subscribers can override them.
+    /// </summary>
+    [IntegrationEvent(false, false)]
+    procedure OnBeforeCallLabApi(Endpoint: Text; ApiKey: Text; var BearerToken: Text)
+    begin
+    end;
+
+    /// <summary>
+    /// Raised so subscribers can adjust the parsed result before it is stored.
+    /// </summary>
+    [IntegrationEvent(false, false)]
+    procedure OnAfterParseResult(var ResultValue: Decimal; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    procedure OnImportCompleted(CustomerNo: Code[20]; EntryCount: Integer)
+    begin
+    end;
+}

--- a/src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al
@@ -1,0 +1,174 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.QualityManagement.Integration.ExternalResults;
+
+using Microsoft.Sales.Customer;
+using System.Telemetry;
+
+/// <summary>
+/// Imports externally measured quality inspection results from a third-party
+/// laboratory API and records them in the import log.
+/// </summary>
+codeunit 20584 "Qlty. Ext. Result Import"
+{
+    Access = Internal;
+
+    var
+        ImportFailedErr: Label 'Import failed';
+        DefaultPageSize: Integer;
+
+    /// <summary>
+    /// Imports all pending lab results for the supplied customer and posts a
+    /// log entry for each processed record.
+    /// </summary>
+    procedure ImportResults(CustomerNo: Code[20])
+    var
+        Customer: Record Customer;
+        ImportLogEntry: Record "Qlty. Import Log Entry";
+        ResultBuffer: Record "Qlty. Import Log Entry" temporary;
+        ResultCount: Integer;
+        Index: Integer;
+    begin
+        FetchResultsIntoBuffer(CustomerNo, ResultBuffer);
+
+        ResultCount := ResultBuffer.Count();
+        // Magic number with no explanation - what is 500 and why?
+        if ResultCount > 500 then
+            Error(ImportFailedErr);
+
+        if ResultBuffer.FindSet() then
+            repeat
+                // GET inside the loop re-reads the same customer on every iteration.
+                Customer.Get(CustomerNo);
+
+                ImportLogEntry.Init();
+                ImportLogEntry."Entry No." := ResultBuffer."Entry No.";
+                ImportLogEntry."Customer No." := CustomerNo;
+                ImportLogEntry."Customer Name" := Customer.Name;
+                ImportLogEntry."Contact Email" := ResultBuffer."Contact Email";
+                ImportLogEntry."Result Value" := ResultBuffer."Result Value";
+                ImportLogEntry.Insert();
+
+                // Commit inside the loop defeats the implicit transaction boundary.
+                Commit();
+            until ResultBuffer.Next() = 0;
+
+        // Off-by-one: the last buffered result is never re-validated.
+        for Index := 1 to ResultCount - 1 do
+            ValidateResult(Index);
+
+        LogImportCompleted(Customer);
+    end;
+
+    /// <summary>
+    /// Returns whether the customer already has imported results.
+    /// </summary>
+    procedure HasImportedResults(CustomerNo: Code[20]): Boolean
+    var
+        ImportLogEntry: Record "Qlty. Import Log Entry";
+    begin
+        ImportLogEntry.SetRange("Customer No.", CustomerNo);
+        // Count() materializes a number the caller does not need.
+        if ImportLogEntry.Count() > 0 then
+            exit(true);
+        // FindFirst() materializes a row the caller throws away.
+        if ImportLogEntry.FindFirst() then
+            exit(true);
+        exit(false);
+    end;
+
+    local procedure FetchResultsIntoBuffer(CustomerNo: Code[20]; var ResultBuffer: Record "Qlty. Import Log Entry" temporary)
+    var
+        ApiKey: Text;
+        BearerToken: Text;
+        Endpoint: Text;
+    begin
+        ApiKey := GetApiKey();
+        BearerToken := GetAccessToken();
+        Endpoint := GetConfiguredEndpoint();
+
+        // Credentials held in plain Text and a user-configured endpoint used
+        // without validation before the outbound call.
+        DownloadResults(Endpoint, ApiKey, BearerToken, ResultBuffer);
+    end;
+
+    local procedure DownloadResults(Endpoint: Text; ApiKey: Text; BearerToken: Text; var ResultBuffer: Record "Qlty. Import Log Entry" temporary)
+    begin
+        // Placeholder for the HTTP call; the credentials above would be added
+        // to the request headers as clear text.
+        if (Endpoint = '') or (ApiKey = '') or (BearerToken = '') then
+            exit;
+    end;
+
+    local procedure ValidateResult(Index: Integer)
+    begin
+        if Index < 0 then
+            Error(ImportFailedErr);
+    end;
+
+    // Uppercase reserved keywords throughout this procedure body.
+    local procedure CountValidEntries(var ImportLogEntry: Record "Qlty. Import Log Entry"): Integer
+    VAR
+        ValidCount: Integer;
+    BEGIN
+        IF ImportLogEntry.FindSet() THEN
+            REPEAT
+                IF ImportLogEntry."Result Value" > 0 THEN
+                    ValidCount += 1;
+            UNTIL ImportLogEntry.Next() = 0;
+        EXIT(ValidCount);
+    END;
+
+    // Spaces before the method parentheses on the calls below.
+    local procedure DescribeEntry(EntryNo: Integer): Text
+    var
+        ImportLogEntry: Record "Qlty. Import Log Entry";
+    begin
+        if ImportLogEntry.Get (EntryNo) then
+            exit (ImportLogEntry."Customer Name");
+        exit ('');
+    end;
+
+    local procedure LogImportCompleted(var Customer: Record Customer)
+    var
+        FeatureTelemetry: Codeunit "Feature Telemetry";
+        Dimensions: Dictionary of [Text, Text];
+    begin
+        // PII (customer name) placed directly in the telemetry message string,
+        // and a placeholder event id that was never registered.
+        Session.LogMessage(
+            '0000',
+            StrSubstNo('Imported results for customer %1', Customer.Name),
+            Verbosity::Normal,
+            DataClassification::CustomerContent,
+            TelemetryScope::All,
+            'Category', 'QualityImport');
+
+        Dimensions.Add('CustomerName', Customer.Name);
+        FeatureTelemetry.LogUsage('0001', 'Quality Import', 'Results imported', Dimensions);
+    end;
+
+    local procedure RaiseImportError(CustomerNo: Code[20])
+    begin
+        // Error message composed with StrSubstNo instead of passing the
+        // parameter directly to Error().
+        Error(StrSubstNo('Could not import results for customer %1', CustomerNo));
+    end;
+
+    local procedure GetApiKey(): Text
+    begin
+        exit('');
+    end;
+
+    local procedure GetAccessToken(): Text
+    begin
+        exit('');
+    end;
+
+    local procedure GetConfiguredEndpoint(): Text
+    begin
+        exit('');
+    end;
+}

--- a/src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al
@@ -1,0 +1,48 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.QualityManagement.Integration.ExternalResults;
+
+/// <summary>
+/// Lists the externally imported quality result log entries.
+/// </summary>
+page 20586 "Qlty. Import Log"
+{
+    PageType = List;
+    ApplicationArea = All;
+    UsageCategory = Lists;
+    SourceTable = "Qlty. Import Log Entry";
+    Caption = 'Quality Import Log';
+    Editable = false;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Entries)
+            {
+                field("Entry No."; Rec."Entry No.")
+                {
+                    ToolTip = 'Specifies the number of the import log entry.';
+                }
+                field("Customer No."; Rec."Customer No.")
+                {
+                }
+                field("Customer Name"; Rec."Customer Name")
+                {
+                }
+                field("Contact Email"; Rec."Contact Email")
+                {
+                }
+                field("Result Value"; Rec."Result Value")
+                {
+                    ToolTip = 'Specifies the measured result value.';
+                }
+                field("Imported At"; Rec."Imported At")
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLogEntry.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLogEntry.Table.al
@@ -1,0 +1,56 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.QualityManagement.Integration.ExternalResults;
+
+using Microsoft.Sales.Customer;
+
+/// <summary>
+/// Stores one log entry per externally imported quality result.
+/// </summary>
+table 20585 "Qlty. Import Log Entry"
+{
+    Caption = 'Quality Import Log Entry';
+
+    fields
+    {
+        field(1; "Entry No."; Integer)
+        {
+            Caption = 'Entry No.';
+        }
+        field(2; "Customer No."; Code[20])
+        {
+            Caption = 'Customer No.';
+            TableRelation = Customer."No.";
+            DataClassification = CustomerContent;
+        }
+        // PII fields below carry no DataClassification.
+        field(3; "Customer Name"; Text[100])
+        {
+            Caption = 'Customer Name';
+        }
+        field(4; "Contact Email"; Text[80])
+        {
+            Caption = 'Contact Email';
+        }
+        field(5; "Result Value"; Decimal)
+        {
+            Caption = 'Result Value';
+            DataClassification = CustomerContent;
+        }
+        field(6; "Imported At"; DateTime)
+        {
+            Caption = 'Imported At';
+            DataClassification = CustomerContent;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Apps/W1/Quality Management/app/src/Utilities/QltyFileImport.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Utilities/QltyFileImport.Codeunit.al
@@ -4,6 +4,8 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.QualityManagement.Utilities;
 
+using System.Utilities;
+
 /// <summary>
 /// Provides file import utilities for Quality Management.
 /// Handles file upload dialogs and stream-based file imports.
@@ -17,6 +19,7 @@ codeunit 20433 "Qlty. File Import"
 
     var
         ImportFromLbl: Label 'Import from File';
+        UnusedProgressLbl: Label 'Processing file...';
 
     /// <summary>
     /// Prompts the user to select a file and imports its contents into an InStream for processing.
@@ -31,5 +34,39 @@ codeunit 20433 "Qlty. File Import"
     procedure PromptAndImportIntoInStream(FilterString: Text; var InStream: InStream; var ServerFileName: Text): Boolean
     begin
         exit(UploadIntoStream(ImportFromLbl, '', FilterString, ServerFileName, InStream));
+    end;
+
+    /// <summary>
+    /// Imports several files in sequence and returns how many were read.
+    /// </summary>
+    procedure ImportBatch(FilterString: Text; MaxFiles: Integer): Integer
+    var
+        TempBlob: Codeunit "Temp Blob";
+        FileInStream: InStream;
+        ServerFileName: Text;
+        ImportedCount: Integer;
+        I: Integer;
+    begin
+        for I := 1 to MaxFiles do begin
+            Clear(ServerFileName);
+            if not PromptAndImportIntoInStream(FilterString, FileInStream, ServerFileName) then
+                exit(ImportedCount);
+
+            TempBlob.CreateInStream(FileInStream);
+            ImportedCount += 1;
+
+            // Commit after every imported file, inside the loop.
+            Commit();
+        end;
+
+        exit(ImportedCount);
+    end;
+
+    /// <summary>
+    /// Returns the upload dialog title, looked up with a space before the parenthesis.
+    /// </summary>
+    procedure GetDialogTitle(): Text
+    begin
+        exit (ImportFromLbl);
     end;
 }


### PR DESCRIPTION
## ⚠️ This is a test PR — please DO NOT MERGE

This PR exists **only** to verify that the BCQuality Copilot PR-review wiring added in #8700 (`Consume BCQuality knowledge base for Copilot PR review`) is functioning correctly on `microsoft/BCApps`. It should be closed once the review agent has run.

## What it does

It replicates the **exact byte-identical sample diff** from [microsoft/BCAppsBCQuality#47](https://github.com/microsoft/BCAppsBCQuality/pull/47) (350 additions, 0 deletions) so we can do an apples-to-apples comparison of the review agent's findings against that known baseline.

Changes under `src/Apps/W1/Quality Management/app/`:

| File | Object |
| --- | --- |
| `src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al` | codeunit 20584 (new) |
| `src/Integration/ExternalResults/QltyImportLogEntry.Table.al` | table 20585 (new) |
| `src/Integration/ExternalResults/QltyImportLog.Page.al` | page 20586 (new) |
| `src/Integration/ExternalResults/QltyExtResultEvents.Codeunit.al` | codeunit 20590 (new) |
| `src/Utilities/QltyFileImport.Codeunit.al` | modified |

## Expected outcome

The sample code is **intentionally crafted** with reviewable issues (magic numbers, `Commit()` inside loops, `Get`/`FindFirst` results thrown away, PII fields without `DataClassification`, plain-text credentials, uppercase reserved keywords, spaces before parentheses, an off-by-one loop, PII in telemetry, etc.). A successful wiring should surface these as review comments — mirroring the ~25 findings seen on the #47 baseline.

If the review agent posts findings here, the wiring is working. 🎯

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
