### PR TITLE
Disable incremental builds for pull requests

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -11,7 +11,7 @@
   "useProjectDependencies": true,
   "incrementalBuilds": {
     "onPush": false,
-    "onPull_Request": true,
+    "onPull_Request": false,
     "onSchedule": false,
     "retentionDays": 30,
     "mode": "modifiedApps"


### PR DESCRIPTION
## What & why

Disables incremental builds for pull request workflows by setting `incrementalBuilds.onPull_Request` to `false` in `.github/AL-Go-Settings.json`. This makes PR builds perform a full build rather than only rebuilding modified apps, ensuring CI builds are complete and reproducible. Incremental builds were already disabled for push and schedule triggers; this aligns the PR trigger with them.

## Linked work

Fixes [AB#640317](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640317)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Settings-only change. No tests added because this is a CI configuration change with no app code impact.

## Risk & compatibility

PR builds will take longer since they no longer reuse cached/modified-app results, but they will be more complete and reliable. No data, permission, or runtime impact.


