### PR TITLE
Add SetBypassBodySanitization API to Email Retrieval Filters

### DIFF
--- a/src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al
+++ b/src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al
@@ -83,6 +83,7 @@ table 8885 "Email Retrieval Filters"
 
     var
         CategoryFilters: List of [Text];
+        BypassBodySanitization: Boolean;
 
     /// <summary>Clears all category filters.</summary>
     procedure ClearCategoryFilters()
@@ -102,5 +103,29 @@ table 8885 "Email Retrieval Filters"
     procedure GetCategoryFilters(): List of [Text]
     begin
         exit(CategoryFilters);
+    end;
+
+    /// <summary>
+    /// Sets whether the email body sanitization should be bypassed when building retrieved messages.
+    /// By default sanitization is applied, which strips potentially unsafe HTML/script from the body.
+    /// This is restricted to on-premises, first-party (Microsoft) callers.
+    /// </summary>
+    /// <remarks>
+    /// Worth a moment's thought before turning this on: bypassing sanitization keeps the raw email body
+    /// exactly as received, including any unsafe HTML or script. Only use it when the calling code fully
+    /// controls how that content is subsequently processed and is not rendered to a user as-is.
+    /// </remarks>
+    /// <param name="Bypass">True to keep the body unsanitized; false (default) to sanitize the body.</param>
+    [Scope('OnPrem')]
+    procedure SetBypassBodySanitization(Bypass: Boolean)
+    begin
+        BypassBodySanitization := Bypass;
+    end;
+
+    /// <summary>Gets whether the email body sanitization should be bypassed.</summary>
+    /// <returns>True if the body should be kept unsanitized; otherwise false.</returns>
+    procedure GetBypassBodySanitization(): Boolean
+    begin
+        exit(BypassBodySanitization);
     end;
 }


### PR DESCRIPTION
## Summary
Adds `SetBypassBodySanitization` / `GetBypassBodySanitization` to the **Email Retrieval Filters** table (`table 8885`).

This lets on-prem, first-party (Microsoft) callers opt out of email body HTML/script sanitization when building retrieved messages. By default sanitization remains applied. The setter is marked `[Scope('OnPrem')]`.

## Changes
- `src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al`: new `BypassBodySanitization` field with documented getter/setter.



Related work item: [AB#640361](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640361) (this PR is only part of the fix).


