### PR TITLE
[Subcontracting] Use vendor currency for subcontractor price in routing/standard-cost paths (638367)

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPriceManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPriceManagement.Codeunit.al
@@ -17,6 +17,7 @@ using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.Setup;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Document;
+using Microsoft.Purchases.Vendor;
 
 codeunit 99001508 "Subc. Price Management"
 {
@@ -564,6 +565,8 @@ codeunit 99001508 "Subc. Price Management"
     end;
 
     local procedure SetSubcontractorPriceForPriceCalculation(var SubcontractorPrice: Record "Subcontractor Price"; VendorNo: Code[20]; ItemNo: Code[20]; VariantCode: Code[10]; StandardTaskCode: Code[10]; WorkCenterNo: Code[20]; UoM: Code[10]; StartingDate: Date)
+    var
+        Vendor: Record Vendor;
     begin
         SubcontractorPrice."Vendor No." := VendorNo;
         SubcontractorPrice."Item No." := ItemNo;
@@ -572,7 +575,11 @@ codeunit 99001508 "Subc. Price Management"
         SubcontractorPrice."Variant Code" := VariantCode;
         SubcontractorPrice."Unit of Measure Code" := UoM;
         SubcontractorPrice."Starting Date" := StartingDate;
-        SubcontractorPrice."Currency Code" := '';
+        Vendor.SetLoadFields("Currency Code");
+        if Vendor.Get(VendorNo) then
+            SubcontractorPrice."Currency Code" := Vendor."Currency Code"
+        else
+            SubcontractorPrice."Currency Code" := '';
     end;
 
     local procedure GetQuantityBase(var PurchaseLine: Record "Purchase Line"): Decimal

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
@@ -367,7 +367,7 @@ codeunit 139982 "Subc. Pricing Test"
         Initialize();
 
         // [GIVEN] A subcontracting item with a single-operation routing on a subcontracting work center.
-        CreateSubcontractingItemWithSingleOperationRouting(Item, Vendor, WorkCenter);
+        CreateSubcontractingItemWithSingleOperationRouting(Item, Vendor, WorkCenter, '');
 
         // [GIVEN] A foreign currency with a non-LCY exchange rate whose code sorts after blank/LCY.
         ForeignCurrencyCode := LibraryERM.CreateCurrencyWithExchangeRate(WorkDate(), 15, 15);
@@ -416,7 +416,7 @@ codeunit 139982 "Subc. Pricing Test"
         Initialize();
 
         // [GIVEN] A subcontracting item with a single-operation routing on a subcontracting work center.
-        CreateSubcontractingItemWithSingleOperationRouting(Item, Vendor, WorkCenter);
+        CreateSubcontractingItemWithSingleOperationRouting(Item, Vendor, WorkCenter, '');
 
         // [GIVEN] Two foreign currencies with non-LCY exchange rates.
         FirstForeignCurrencyCode := LibraryERM.CreateCurrencyWithExchangeRate(WorkDate(), 15, 15);
@@ -452,6 +452,55 @@ codeunit 139982 "Subc. Pricing Test"
             'Prod. Order Routing Unit Cost per must use the LCY price even among multiple foreign-currency prices.');
     end;
 
+    [Test]
+    procedure ProdOrderRoutingUnitCostUsesVendorCurrencyPriceWhenVendorHasCurrency()
+    var
+        Item: Record Item;
+        Vendor: Record Vendor;
+        WorkCenter: Record "Work Center";
+        SubcontractorPrice: Record "Subcontractor Price";
+        ProductionOrder: Record "Production Order";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        VendorCurrencyCode: Code[10];
+        LCYPrice: Decimal;
+        VendorCurrencyPrice: Decimal;
+    begin
+        // [SCENARIO 638367] When the subcontractor vendor has a foreign Currency Code and a Subcontractor Price
+        // exists in that currency, the Prod. Order Routing line must be priced from the vendor-currency price
+        // (converted to LCY) so it stays consistent with the purchase order, not from the blank/LCY price.
+        Initialize();
+
+        // [GIVEN] A subcontractor vendor with a foreign currency (1:1 exchange rate) and a subcontracting item.
+        VendorCurrencyCode := LibraryERM.CreateCurrencyWithExchangeRate(WorkDate(), 1, 1);
+        CreateSubcontractingItemWithSingleOperationRouting(Item, Vendor, WorkCenter, VendorCurrencyCode);
+
+        // [GIVEN] Two subcontractor prices — LCY = 10 (blank currency) and vendor-currency = 20.
+        LCYPrice := 10;
+        VendorCurrencyPrice := 20;
+        SubcontractingMgmtLibrary.CreateSubContractingPrice(
+            SubcontractorPrice, WorkCenter."No.", Vendor."No.", Item."No.", '', '', WorkDate(), Item."Base Unit of Measure", 0, '');
+        SubcontractorPrice.Validate("Direct Unit Cost", LCYPrice);
+        SubcontractorPrice.Modify(true);
+        SubcontractingMgmtLibrary.CreateSubContractingPrice(
+            SubcontractorPrice, WorkCenter."No.", Vendor."No.", Item."No.", '', '', WorkDate(), Item."Base Unit of Measure", 0, VendorCurrencyCode);
+        SubcontractorPrice.Validate("Direct Unit Cost", VendorCurrencyPrice);
+        SubcontractorPrice.Modify(true);
+
+        // [WHEN] A Released Production Order for the item is created and refreshed.
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, "Prod. Order Source Type"::Item, Item."No.", 1);
+
+        // [THEN] The Prod. Order Routing line resolves to the vendor-currency price (20), converted 1:1 to LCY.
+        ProdOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderRoutingLine.FindFirst();
+        Assert.AreEqual(
+            VendorCurrencyPrice, ProdOrderRoutingLine."Direct Unit Cost",
+            'Prod. Order Routing Direct Unit Cost must use the vendor-currency subcontractor price, not the blank/LCY one.');
+        Assert.AreEqual(
+            VendorCurrencyPrice, ProdOrderRoutingLine."Unit Cost per",
+            'Prod. Order Routing Unit Cost per must use the vendor-currency subcontractor price, not the blank/LCY one.');
+    end;
+
     local procedure CreateItemVendorAndSubcontractingWorkCenter(var Item: Record Item; var Vendor: Record Vendor; var WorkCenter: Record "Work Center")
     begin
         LibraryInventory.CreateItem(Item);
@@ -463,11 +512,11 @@ codeunit 139982 "Subc. Pricing Test"
         WorkCenter.Modify(true);
     end;
 
-    local procedure CreateSubcontractingItemWithSingleOperationRouting(var Item: Record Item; var Vendor: Record Vendor; var WorkCenter: Record "Work Center")
+    local procedure CreateSubcontractingItemWithSingleOperationRouting(var Item: Record Item; var Vendor: Record Vendor; var WorkCenter: Record "Work Center"; VendorCurrencyCode: Code[10])
     var
         RoutingNo: Code[20];
     begin
-        Vendor.Get(LibraryMfgManagement.CreateSubcontractorWithCurrency(''));
+        Vendor.Get(LibraryMfgManagement.CreateSubcontractorWithCurrency(VendorCurrencyCode));
 
         LibraryMfgManagement.CreateWorkCenterWithCalendar(WorkCenter, 0);
         WorkCenter.Validate("Subcontractor No.", Vendor."No.");


### PR DESCRIPTION
## What & why

The Subcontracting app resolves prices from the `Subcontractor Price` table. The routing/standard-cost paths (`ApplySubcontractorPricingToProdOrderRouting`, `ApplySubcontractorPricingToPlanningRouting`, `CalcRtngCostPerUnit`, `GetSubcPriceList`) stage the lookup record via `SetSubcontractorPriceForPriceCalculation`, which **hard-coded `"Currency Code" := ''`**.

`SetRoutingPriceListCost` then filters with `SetFilter("Currency Code", '%1|%2', InSubcontractorPrice."Currency Code", '')`. With the staged currency forced to blank, that filter collapses to blank-only, so the routing/standard-cost paths always priced from the **blank-currency** subcontractor price - even when the subcontractor **vendor uses a foreign currency**. This diverged from the purchase order path (`GetSubcPriceForPurchLine`), which prices in the vendor currency.

This change seeds the lookup record's `Currency Code` from the **subcontractor Vendor's `Currency Code`**. The existing currency-or-blank filter then resolves to the vendor-currency price (converted to LCY) when one exists, and falls back to the blank/LCY price otherwise - keeping the routing/standard-cost paths consistent with the PO path.

## Linked work

[AB#638367](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638367)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Added `ProdOrderRoutingUnitCostUsesVendorCurrencyPriceWhenVendorHasCurrency` in `SubcPricingTest.Codeunit.al`: a subcontractor vendor with a foreign currency plus both an LCY (blank) and a vendor-currency subcontractor price; refreshing a Released Production Order resolves the routing line to the vendor-currency price.
- Existing blank-vendor tests (`ProdOrderRoutingUnitCostUsesLCYWhenForeignCurrencyPriceExists`, `...UsesLCYAmongMultipleForeignCurrencies`, `RoutingPriceUsesLCYWhenForeignCurrencyPriceExists`) still assert the LCY price wins when the vendor currency is blank.
- Build/run in BC pending; to be completed by the author before merge.

## Risk & compatibility

- Behavior change is intentional and limited to currency resolution on the routing/standard-cost paths; the PO and requisition paths are unchanged.
- For blank-currency vendors the resolved price is unchanged (still blank/LCY).



