### PR TITLE
[28.x] [Subcontracting] SubcPurchaseOrderCreator has guards (Gen. Prod. Posting Group, blocked items) that SubcCalculateSubcontracts lacks

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/General/SubcontractingManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/General/SubcontractingManagement.Codeunit.al
@@ -5,6 +5,7 @@
 namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Foundation.Company;
+using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Location;
 using Microsoft.Inventory.Planning;
 using Microsoft.Inventory.Requisition;
@@ -31,6 +32,8 @@ codeunit 99001505 "Subcontracting Management"
         UpdateIsCancelledErr: Label 'The update is cancelled.';
         WorkCenterVendorDoesntExistErr: Label 'Subcontractor %1 on Work Center %2 does not exist.', Comment = 'Parameter %1 - subcontractor/vendor number, %2 - work center number.';
         PurchOrderExistErr: Label 'The currently selected component %1 is already used in Purchase Order %2. Therefore, it is not permitted to change the %3 field.', Comment = '%1=Item No, %2=Purchase Order No, %3=Field Caption';
+        ProductionBlockedOutputItemErr: Label 'You cannot produce %1 %2 because the %3 is %4 on the %1 card.', Comment = '%1 - Table Caption (Item), %2 - Item No., %3 - Field Caption, %4 - Field Value';
+        ProductionBlockedOutputItemVariantErr: Label 'You cannot produce variant %1 for %2 %3 because it is blocked for production output.', Comment = '%1 - Item Variant Code, %2 - Table Caption (Item), %3 - Item No.';
         HasManufacturingSetup: Boolean;
 
     procedure ChangeLocationOnProdOrderComponent(var ProdOrderComponent: Record "Prod. Order Component"; VendorSubcontrLocation: Code[10]; OriginalLocationCode: Code[10]; OriginalBinCode: Code[20])
@@ -158,6 +161,37 @@ codeunit 99001505 "Subcontracting Management"
             exit(true);
         end;
         exit(false);
+    end;
+
+    internal procedure CheckSubcontractingWorkCenter(WorkCenterNo: Code[20])
+    var
+        WorkCenter: Record "Work Center";
+    begin
+        WorkCenter.SetLoadFields("Subcontractor No.", "Gen. Prod. Posting Group");
+        WorkCenter.Get(WorkCenterNo);
+        WorkCenter.TestField("Subcontractor No.");
+        WorkCenter.TestField("Gen. Prod. Posting Group");
+    end;
+
+    internal procedure CheckProdNotBlockedForOutput(ItemNo: Code[20]; VariantCode: Code[20])
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+    begin
+        if ItemNo = '' then
+            exit;
+
+        Item.SetLoadFields("Production Blocked");
+        Item.Get(ItemNo);
+        if Item."Production Blocked" = Item."Production Blocked"::Output then
+            Error(ProductionBlockedOutputItemErr, Item.TableCaption(), ItemNo, Item.FieldCaption("Production Blocked"), Item."Production Blocked");
+
+        if VariantCode <> '' then begin
+            ItemVariant.SetLoadFields("Production Blocked");
+            ItemVariant.Get(ItemNo, VariantCode);
+            if ItemVariant."Production Blocked" = ItemVariant."Production Blocked"::Output then
+                Error(ProductionBlockedOutputItemVariantErr, VariantCode, Item.TableCaption(), ItemNo);
+        end;
     end;
 
     procedure UpdateSubcontractorPriceForRequisitionLine(var RequisitionLine: Record "Requisition Line")

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcCalculateSubcontracts.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcCalculateSubcontracts.Report.al
@@ -114,7 +114,6 @@ report 99001505 "Subc. Calculate Subcontracts"
         GLSetup: Record "General Ledger Setup";
         PurchLine: Record "Purchase Line";
         Item: Record Item;
-        ItemVariant: Record "Item Variant";
         TempProdOrderRoutingLine: Record "Prod. Order Routing Line" temporary;
         MfgCostCalcMgt: Codeunit "Mfg. Cost Calculation Mgt.";
 #if not CLEAN28
@@ -123,6 +122,7 @@ report 99001505 "Subc. Calculate Subcontracts"
 #pragma warning restore AL0432
 #endif
         UOMMgt: Codeunit "Unit of Measure Management";
+        SubcontractingManagement: Codeunit "Subcontracting Management";
         Window: Dialog;
         BaseQtyToPurch: Decimal;
         QtyToPurch: Decimal;
@@ -130,8 +130,6 @@ report 99001505 "Subc. Calculate Subcontracts"
 
         ProcessingWorkCentersLbl: Label 'Processing Work Centers   #1##########\', Comment = '#1 = current work center number being processed';
         ProcessingOrdersLbl: Label 'Processing Orders         #2########## ', Comment = '#2 = current order number being processed';
-        ProductionBlockedOutputItemQst: Label 'Item %1 is blocked for production output and cannot be calculated. Do you want to continue?', Comment = '%1 Item No.';
-        ProductionBlockedOutputItemVariantQst: Label 'Variant %1 for item %2 is blocked for production output and cannot be calculated. Do you want to continue?', Comment = '%1 - Item Variant Code, %2 - Item No.';
 
     procedure SetWkShLine(NewReqLine: Record "Requisition Line")
     begin
@@ -156,13 +154,15 @@ report 99001505 "Subc. Calculate Subcontracts"
         if IsHandled then
             exit;
 
+        if ProdOrderRoutingLine.Type = ProdOrderRoutingLine.Type::"Work Center" then
+            SubcontractingManagement.CheckSubcontractingWorkCenter(ProdOrderRoutingLine."No.");
+
         ProdOrderLine.CalcFields("Total Exp. Oper. Output (Qty.)");
 
         ReqLine.SetSubcontracting(true);
         ReqLine.BlockDynamicTracking(true);
 
-        if not CanCreateRequisitionLineFromProdOrderLine(ProdOrderLine."Item No.", ProdOrderLine."Variant Code") then
-            exit;
+        SubcontractingManagement.CheckProdNotBlockedForOutput(ProdOrderLine."Item No.", ProdOrderLine."Variant Code");
 
         ReqLine.Init();
         ReqLine."Line No." := ReqLine."Line No." + 10000;
@@ -290,42 +290,6 @@ report 99001505 "Subc. Calculate Subcontracts"
         OnAfterSetVendorItemNo(ReqLine, ItemVendor, Item);
     end;
 
-    local procedure CanCreateRequisitionLineFromProdOrderLine(ItemNo: Code[20]; VariantCode: Code[20]): Boolean
-    begin
-        if not GuiAllowed() then
-            exit;
-
-        if ItemNo <> '' then begin
-            if Item."No." <> ItemNo then begin
-                Item.SetLoadFields("Production Blocked");
-                Item.Get(ItemNo);
-            end;
-            case Item."Production Blocked" of
-                Item."Production Blocked"::Output:
-                    begin
-                        ShowProdBlockedForItemConfirmation(ItemNo);
-                        exit(false);
-                    end;
-            end;
-        end;
-
-        if (ItemNo <> '') and (VariantCode <> '') then begin
-            if (ItemVariant."Item No." <> ItemNo) or (ItemVariant.Code <> VariantCode) then begin
-                ItemVariant.SetLoadFields("Production Blocked");
-                ItemVariant.Get(ItemNo, VariantCode);
-            end;
-            case ItemVariant."Production Blocked" of
-                ItemVariant."Production Blocked"::Output:
-                    begin
-                        ShowProdBlockedForItemVariantConfirmation(ItemNo, VariantCode);
-                        exit(false);
-                    end;
-            end;
-        end;
-
-        exit(true);
-    end;
-
     local procedure CalculateSubContractRequirements()
     begin
         OnProdOrderRoutingLineOnBeforeCalculateSubContractRequirements(TempProdOrderRoutingLine);
@@ -360,18 +324,6 @@ report 99001505 "Subc. Calculate Subcontracts"
                     until ProdOrderLine.Next() = 0;
                 end;
             until TempProdOrderRoutingLine.Next() = 0;
-    end;
-
-    local procedure ShowProdBlockedForItemConfirmation(ItemNo: Code[20])
-    begin
-        if not Confirm(StrSubstNo(ProductionBlockedOutputItemQst, ItemNo)) then
-            Error('');
-    end;
-
-    local procedure ShowProdBlockedForItemVariantConfirmation(ItemNo: Code[20]; VariantCode: Code[20])
-    begin
-        if not Confirm(StrSubstNo(ProductionBlockedOutputItemVariantQst, VariantCode, ItemNo)) then
-            Error('');
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseOrderCreator.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseOrderCreator.Codeunit.al
@@ -28,6 +28,7 @@ codeunit 99001557 "Subc. Purchase Order Creator"
         ManufacturingSetup: Record "Manufacturing Setup";
         PageManagement: Codeunit "Page Management";
         UnitofMeasureManagement: Codeunit "Unit of Measure Management";
+        SubcontractingManagement: Codeunit "Subcontracting Management";
 #if not CLEAN28
 #pragma warning disable AL0432
         SubcFeatureFlagHandler: Codeunit "Subc. Feature Flag Handler";
@@ -72,11 +73,13 @@ codeunit 99001557 "Subc. Purchase Order Creator"
         repeat
             BaseQtyToPurch := GetBaseQtyToPurchase(ProdOrderRoutingLine, ProdOrderLine);
             QtyToPurch := Round(BaseQtyToPurch / ProdOrderLine."Qty. per Unit of Measure", UnitofMeasureManagement.QtyRndPrecision());
-            if QtyToPurch > 0 then
+            if QtyToPurch > 0 then begin
+                SubcontractingManagement.CheckProdNotBlockedForOutput(ProdOrderLine."Item No.", ProdOrderLine."Variant Code");
                 CreateSubcontractingPurchase(ProdOrderRoutingLine,
                   ProdOrderLine,
                   QtyToPurch,
                   NoOfCreatedPurchOrder);
+            end;
         until ProdOrderLine.Next() = 0;
 
         exit(NoOfCreatedPurchOrder);
@@ -261,8 +264,6 @@ codeunit 99001557 "Subc. Purchase Order Creator"
     end;
 
     local procedure CheckProdOrderRtngLine(ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var ProdOrderLine: Record "Prod. Order Line"): Boolean
-    var
-        WorkCenter: Record "Work Center";
     begin
         if ProdOrderRoutingLine.Status <> "Production Order Status"::Released then
             Error(CreationOfSubcontractingOrderIsNotAllowedErr, ProdOrderRoutingLine."Prod. Order No.");
@@ -276,10 +277,7 @@ codeunit 99001557 "Subc. Purchase Order Creator"
         if ProdOrderLine.IsEmpty() then
             exit(false);
 
-        WorkCenter.SetLoadFields("Gen. Prod. Posting Group", "Subcontractor No.");
-        WorkCenter.Get(ProdOrderRoutingLine."Work Center No.");
-        WorkCenter.TestField("Subcontractor No.");
-        WorkCenter.TestField("Gen. Prod. Posting Group");
+        SubcontractingManagement.CheckSubcontractingWorkCenter(ProdOrderRoutingLine."Work Center No.");
         exit(true);
     end;
 

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2358,6 +2358,150 @@ codeunit 139989 "Subc. Subcontracting Test"
     end;
 
     [Test]
+    procedure CalculateSubcontractsErrorsWhenWorkCenterMissingGenProdPostingGroup()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        WorkCenter: array[2] of Record "Work Center";
+    begin
+        // [SCENARIO 635775] Calculate Subcontracts must error up front when the subcontracting Work Center has a blank Gen. Prod. Posting Group
+        Initialize();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+
+        // [GIVEN] Manufacturing setup with an item, routing and subcontracting work center
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        // [GIVEN] A released production order
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+
+        // [GIVEN] The subcontracting Work Center has a blank Gen. Prod. Posting Group
+        WorkCenter[2].Get(WorkCenter[2]."No.");
+        WorkCenter[2].Validate("Gen. Prod. Posting Group", '');
+        WorkCenter[2].Modify(true);
+
+        // [WHEN] Calculate Subcontracts is run on the worksheet
+        asserterror RunCalculateSubcontracts();
+
+        // [THEN] It errors immediately instead of deferring to posting time
+        Assert.ExpectedError('Gen. Prod. Posting Group must have a value');
+    end;
+
+    [Test]
+    procedure CreateSubcOrderFromRoutingErrorsWhenWorkCenterMissingGenProdPostingGroup()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        WorkCenter: array[2] of Record "Work Center";
+    begin
+        // [SCENARIO 635775] Creating a Subcontracting Order from the Prod. Order Routing must error when the Work Center has a blank Gen. Prod. Posting Group
+        Initialize();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+
+        // [GIVEN] Manufacturing setup with an item, routing and subcontracting work center
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        // [GIVEN] A released production order
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+
+        // [GIVEN] The subcontracting Work Center has a blank Gen. Prod. Posting Group
+        WorkCenter[2].Get(WorkCenter[2]."No.");
+        WorkCenter[2].Validate("Gen. Prod. Posting Group", '');
+        WorkCenter[2].Modify(true);
+
+        // [WHEN] Create Subcontracting Order is invoked from the Prod. Order Routing
+        asserterror SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+
+        // [THEN] It errors on the missing Gen. Prod. Posting Group
+        Assert.ExpectedError('Gen. Prod. Posting Group must have a value');
+    end;
+
+    [Test]
+    procedure CalculateSubcontractsErrorsWhenItemBlockedForOutput()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        WorkCenter: array[2] of Record "Work Center";
+    begin
+        // [SCENARIO 635775] Calculate Subcontracts must error when the manufactured item is blocked for production output
+        Initialize();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+
+        // [GIVEN] Manufacturing setup with an item, routing and subcontracting work center
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        // [GIVEN] A released production order
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+
+        // [GIVEN] The manufactured item is blocked for production output
+        Item.Get(Item."No.");
+        Item.Validate("Production Blocked", Item."Production Blocked"::Output);
+        Item.Modify(true);
+
+        // [WHEN] Calculate Subcontracts is run on the worksheet
+        asserterror RunCalculateSubcontracts();
+
+        // [THEN] It errors because the item is blocked for production output
+        Assert.ExpectedError('You cannot produce');
+    end;
+
+    [Test]
+    procedure CreateSubcOrderFromRoutingErrorsWhenItemBlockedForOutput()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        WorkCenter: array[2] of Record "Work Center";
+    begin
+        // [SCENARIO 635775] Creating a Subcontracting Order from the Prod. Order Routing must error when the item is blocked for production output
+        Initialize();
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+
+        // [GIVEN] Manufacturing setup with an item, routing and subcontracting work center
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        // [GIVEN] A released production order
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+
+        // [GIVEN] The manufactured item is blocked for production output
+        Item.Get(Item."No.");
+        Item.Validate("Production Blocked", Item."Production Blocked"::Output);
+        Item.Modify(true);
+
+        // [WHEN] Create Subcontracting Order is invoked from the Prod. Order Routing
+        asserterror SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+
+        // [THEN] It errors because the item is blocked for production output
+        Assert.ExpectedError('You cannot produce');
+    end;
+
+    [Test]
     [HandlerFunctions('RoutingLinkCodeDuplicateConfirmHandler')]
     procedure ValidateRoutingLinkCodeOnProdOrderRtngLineShowsConfirmOnce()
     var
@@ -4183,6 +4327,21 @@ codeunit 139989 "Subc. Subcontracting Test"
     local procedure UpdateSubMgmtSetupWithReqWkshTemplate()
     begin
         LibraryMfgManagement.CreateSubcontractingReqWkshTemplateAndNameAndUpdateSetup();
+    end;
+
+    local procedure RunCalculateSubcontracts()
+    var
+        ReqWkshTemplate: Record "Req. Wksh. Template";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
+        RequisitionLine: Record "Requisition Line";
+        SubcCalculateSubContract: Report "Subc. Calculate Subcontracts";
+    begin
+        SubcontractingMgmtLibrary.CreateReqWkshTemplateAndName(ReqWkshTemplate, RequisitionWkshName);
+        RequisitionLine."Worksheet Template Name" := RequisitionWkshName."Worksheet Template Name";
+        RequisitionLine."Journal Batch Name" := RequisitionWkshName.Name;
+        SubcCalculateSubContract.SetWkShLine(RequisitionLine);
+        SubcCalculateSubContract.UseRequestPage(false);
+        SubcCalculateSubContract.RunModal();
     end;
 
     local procedure UpdateSubMgmtSetupTransferInfoLine(Update: Boolean)


### PR DESCRIPTION
Fixes [AB#640352](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640352)


