### PR TITLE
[28.x] Subcontracting actions on Purchase Order and Transfer Order lines are always visible

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPOSubform.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPOSubform.PageExt.al
@@ -27,10 +27,10 @@ pageextension 99001524 "Subc. PO Subform" extends "Purchase Order Subform"
             group(Production)
             {
                 Caption = 'Production';
-                Visible = HasSubcontractingContext;
                 action("Production Order")
                 {
                     ApplicationArea = Subcontracting;
+                    Visible = HasSubcontractingContext;
                     Caption = 'Production Order';
                     Image = Production;
                     ToolTip = 'View the related production order.';
@@ -42,6 +42,7 @@ pageextension 99001524 "Subc. PO Subform" extends "Purchase Order Subform"
                 action("Production Order Routing")
                 {
                     ApplicationArea = Subcontracting;
+                    Visible = HasSubcontractingContext;
                     Caption = 'Production Order Routing';
                     Image = Route;
                     ToolTip = 'View the related production order routing.';
@@ -53,6 +54,7 @@ pageextension 99001524 "Subc. PO Subform" extends "Purchase Order Subform"
                 action("Production Order Components")
                 {
                     ApplicationArea = Subcontracting;
+                    Visible = HasSubcontractingContext;
                     Caption = 'Production Order Components';
                     Image = Components;
                     ToolTip = 'View the related production order components.';
@@ -64,6 +66,7 @@ pageextension 99001524 "Subc. PO Subform" extends "Purchase Order Subform"
                 action("Transfer Order")
                 {
                     ApplicationArea = Subcontracting;
+                    Visible = HasSubcontractingContext;
                     Caption = 'Subcontracting Transfer Order';
                     Image = TransferOrder;
                     ToolTip = 'View the related transfer order.';
@@ -75,6 +78,7 @@ pageextension 99001524 "Subc. PO Subform" extends "Purchase Order Subform"
                 action("Return Transfer Order")
                 {
                     ApplicationArea = Subcontracting;
+                    Visible = HasSubcontractingContext;
                     Caption = 'Subcontracting Return Transfer Order';
                     Image = ReturnRelated;
                     ToolTip = 'View the related return transfer order.';
@@ -88,14 +92,25 @@ pageextension 99001524 "Subc. PO Subform" extends "Purchase Order Subform"
     }
 
     var
+        PurchaseHeader: Record "Purchase Header";
+        SubcontractingManagement: Codeunit "Subcontracting Management";
         SubcProdOrderFactboxMgmt: Codeunit "Subc. ProdO. Factbox Mgmt.";
         SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
         HasSubcontractingContext: Boolean;
 
-    internal procedure SetIsSubcontracting(IsSubcontractingRelated: Boolean)
+    trigger OnAfterGetCurrRecord()
     begin
-        HasSubcontractingContext := IsSubcontractingRelated;
-        CurrPage.Update();
+        SetSubcontractingVisibility();
+    end;
+
+    local procedure SetSubcontractingVisibility()
+    begin
+        if (Rec."Document No." = PurchaseHeader."No.") and (Rec."Document Type" = PurchaseHeader."Document Type") then
+            exit;
+        if PurchaseHeader.Get(Rec."Document Type", Rec."Document No.") then
+            HasSubcontractingContext := SubcontractingManagement.IsSubcontractingPurchaseDocument(PurchaseHeader)
+        else
+            HasSubcontractingContext := false;
     end;
 
     local procedure ShowProductionOrder(RecRelatedVariant: Variant)

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchOrder.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchOrder.PageExt.al
@@ -42,10 +42,10 @@ pageextension 99001523 "Subc. Purch. Order" extends "Purchase Order"
             group(Subcontracting)
             {
                 Caption = 'Subcontracting';
-                Visible = HasSubcontractingContext;
                 action(CreateTransfOrdToSubcontractor)
                 {
                     ApplicationArea = Subcontracting;
+                    Visible = HasSubcontractingContext;
                     Caption = 'Create Transf. Ord. to Subcontractor';
                     Image = NewDocument;
                     ToolTip = 'Create a transfer order to send to the subcontractor.';
@@ -62,6 +62,7 @@ pageextension 99001523 "Subc. Purch. Order" extends "Purchase Order"
                 action(CreateReturnFromSubcontractor)
                 {
                     ApplicationArea = Subcontracting;
+                    Visible = HasSubcontractingContext;
                     Caption = 'Create Return from Subcontractor';
                     Image = ReturnRelated;
                     ToolTip = 'Create a return document from the subcontractor.';
@@ -78,6 +79,7 @@ pageextension 99001523 "Subc. Purch. Order" extends "Purchase Order"
                 action(PrintSubcDispatchingList)
                 {
                     ApplicationArea = Subcontracting;
+                    Visible = HasSubcontractingContext;
                     Caption = 'Print Subcontractor Dispatching List';
                     Image = Print;
                     ToolTip = 'Print the dispatching list for the subcontractor.';
@@ -114,7 +116,6 @@ pageextension 99001523 "Subc. Purch. Order" extends "Purchase Order"
             exit;
 #endif
         HasSubcontractingContext := SubcontractingManagement.IsSubcontractingPurchaseDocument(Rec);
-        CurrPage.PurchLines.Page.SetIsSubcontracting(HasSubcontractingContext);
     end;
 
     trigger OnAfterGetCurrRecord()
@@ -125,6 +126,5 @@ pageextension 99001523 "Subc. Purch. Order" extends "Purchase Order"
 
 #endif
         HasSubcontractingContext := SubcontractingManagement.IsSubcontractingPurchaseDocument(Rec);
-        CurrPage.PurchLines.Page.SetIsSubcontracting(HasSubcontractingContext);
     end;
 }

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransOrderSub.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransOrderSub.PageExt.al
@@ -103,10 +103,10 @@ pageextension 99001529 "Subc. Trans. Order Sub." extends "Transfer Order Subform
             group(Production)
             {
                 Caption = 'Production';
-                Visible = HasSubcontractingContext;
                 action("Production Order")
                 {
                     ApplicationArea = Subcontracting;
+                    Visible = HasSubcontractingContext;
                     Caption = 'Production Order';
                     Image = Production;
                     ToolTip = 'View the related production order.';
@@ -118,6 +118,7 @@ pageextension 99001529 "Subc. Trans. Order Sub." extends "Transfer Order Subform
                 action("Production Order Routing")
                 {
                     ApplicationArea = Subcontracting;
+                    Visible = HasSubcontractingContext;
                     Caption = 'Production Order Routing';
                     Image = Route;
                     ToolTip = 'View the related production order routing.';
@@ -129,6 +130,7 @@ pageextension 99001529 "Subc. Trans. Order Sub." extends "Transfer Order Subform
                 action("Production Order Components")
                 {
                     ApplicationArea = Subcontracting;
+                    Visible = HasSubcontractingContext;
                     Caption = 'Production Order Components';
                     Image = Components;
                     ToolTip = 'View the related production order components.';
@@ -140,6 +142,7 @@ pageextension 99001529 "Subc. Trans. Order Sub." extends "Transfer Order Subform
                 action("Purchase Order")
                 {
                     ApplicationArea = Subcontracting;
+                    Visible = HasSubcontractingContext;
                     Caption = 'Subcontracting Purchase Order';
                     Image = Order;
                     ToolTip = 'View the related subcontracting purchase order.';
@@ -152,9 +155,26 @@ pageextension 99001529 "Subc. Trans. Order Sub." extends "Transfer Order Subform
         }
     }
     var
+        TransferHeader: Record "Transfer Header";
+        SubcTransferManagement: Codeunit "Subc. Transfer Management";
         SubcProdOrderFactboxMgmt: Codeunit "Subc. ProdO. Factbox Mgmt.";
         SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
         HasSubcontractingContext: Boolean;
+
+    trigger OnAfterGetCurrRecord()
+    begin
+        SetSubcontractingVisibility();
+    end;
+
+    local procedure SetSubcontractingVisibility()
+    begin
+        if Rec."Document No." = TransferHeader."No." then
+            exit;
+        if TransferHeader.Get(Rec."Document No.") then
+            HasSubcontractingContext := SubcTransferManagement.IsSubcontractingTransferDocument(TransferHeader)
+        else
+            HasSubcontractingContext := false;
+    end;
 
     internal procedure SetIsSubcontracting(IsSubcontractingRelated: Boolean)
     begin


### PR DESCRIPTION
## What & why

Actions and fields added by the Subcontracting app on Purchase Order and Transfer Order pages were always visible — even on documents unrelated to subcontracting. The factbox correctly hid itself, but actions (like "Create Transfer Order to Subcontractor") and the "Transfer WIP Item" field stayed visible when navigating between documents using < and >.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#640433](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640433)

