### PR TITLE
[28.x] Enhance external file deletion logic for Document Attachments

### DIFF
--- a/src/Apps/W1/External Storage - Document Attachments/app/src/DocumentAttachmentIntegration/DAExternalStorageImpl.Codeunit.al
+++ b/src/Apps/W1/External Storage - Document Attachments/app/src/DocumentAttachmentIntegration/DAExternalStorageImpl.Codeunit.al
@@ -799,43 +799,52 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <param name="RunTrigger">Indicates if the trigger should run.</param>
     [EventSubscriber(ObjectType::Table, Database::"Document Attachment", OnAfterDeleteEvent, '', true, true)]
     local procedure OnAfterDeleteDocumentAttachment(var Rec: Record "Document Attachment"; RunTrigger: Boolean)
-    var
-        ExternalStorageSetup: Record "DA External Storage Setup";
     begin
         // Exit early if trigger is not running
         if not RunTrigger then
             exit;
 
-        // Temporary records are not processed
-        if Rec.IsTemporary() then
+        if not IsEligibleForExternalFileDeletionOnRecordDelete(Rec) then
             exit;
+
+        DeleteExternalFile(Rec."External File Path", Rec);
+    end;
+
+    /// <summary>
+    /// Evaluates whether the external blob backing a just-deleted Document Attachment row should be removed.
+    /// </summary>
+    /// <param name="DocumentAttachment">The document attachment record carrying the field values from the deleted row.</param>
+    /// <returns>True if the external file is eligible for deletion; otherwise false.</returns>
+    local procedure IsEligibleForExternalFileDeletionOnRecordDelete(var DocumentAttachment: Record "Document Attachment"): Boolean
+    var
+        ExternalStorageSetup: Record "DA External Storage Setup";
+    begin
+        if DocumentAttachment.IsTemporary() then
+            exit(false);
 
         // Check if auto delete is enabled
         if not ExternalStorageSetup.Get() then
-            exit;
+            exit(false);
 
         if not ExternalStorageSetup."Delete from External Storage" then
-            exit;
+            exit(false);
 
         // Only process files that were uploaded to external storage
-        if not Rec."Stored Externally" then
-            exit;
+        if not DocumentAttachment."Stored Externally" then
+            exit(false);
 
-        if Rec."External File Path" = '' then
-            exit;
+        if DocumentAttachment."External File Path" = '' then
+            exit(false);
 
         // Copied attachments share the source file - never delete the shared blob
-        if Rec."Skip Delete On Copy" then
-            exit;
+        if DocumentAttachment."Skip Delete On Copy" then
+            exit(false);
 
         // Files from another environment/company are managed by their owning environment
-        if IsFileFromAnotherEnvironmentOrCompany(Rec) then
-            exit;
+        if IsFileFromAnotherEnvironmentOrCompany(DocumentAttachment) then
+            exit(false);
 
-        // The Document Attachment row is already deleted at this point, so we cannot
-        // Find() or Modify() it. Delete the blob using the field values still carried
-        // on Rec, bypassing the record-based DeleteFromExternalStorage entry point.
-        DeleteExternalFile(Rec."External File Path", Rec);
+        exit(true);
     end;
 
     /// <summary>


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #8684
Fixes [AB#640446](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640446)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

