### PR TITLE
Harden Copilot PR-review JSON parser against resume-fence corruption

### DIFF
--- a/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
+++ b/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
@@ -1038,6 +1038,109 @@ function Remove-StructuralFences {
     return $sb.ToString()
 }
 
+function Repair-ResumeFenceJson {
+    <#
+    Repairs the interrupted-emission shape where the agent breaks off
+    mid-string — leaving an UNTERMINATED JSON string — and resumes by
+    re-opening a fresh ```json fence WITHOUT emitting a "Placeholder ..."
+    marker. Observed in production (run 28168894037), inside a
+    `suggested-code` value:
+
+        "confidence": "high",
+        "suggested-code": "    ODataKeyFields =
+                                              <- raw newline(s) inside the string
+        ```json                               <- bare resume fence, no marker
+              "suggested-code": "    ODataKeyFields = SystemId;"
+
+    A raw newline inside a string literal is always invalid JSON, so this
+    shape is unambiguous. A single malformed value like this makes
+    ConvertFrom-Json reject the ENTIRE document, discarding every finding
+    (the run above found 42 issues across 11 sub-skills and posted 0). The
+    broken partial line is discarded and the post-fence resumption spliced in
+    its place; because the agent re-emits the field from its start, the
+    splice de-duplicates naturally.
+
+    This is the third repair path, filling the gap between the other two:
+      - Repair-InterruptedAgentJson keys off the "Placeholder ..." marker,
+        which is absent here.
+      - Remove-StructuralFences removes whole-line fences that sit OUTSIDE a
+        string literal, and deliberately PRESERVES fences inside a string
+        (e.g. a ```al code sample in suggested-code). Here the resume fence
+        sits inside an *unterminated* string, so the conservative
+        fence-stripper must leave it alone — only a string-aware splice keyed
+        off the malformed newline can clear it without harming legitimate
+        in-string fences.
+
+    Conservative by construction: it acts only on a bare ```-fence line that is
+    immediately preceded by a JSON property whose string value was left
+    unterminated (`"key": "...` with an odd count of unescaped quotes) and
+    immediately followed by a re-emission of that SAME `"key":`. That triple
+    signature is what distinguishes the interrupted-emission resume from
+    ordinary CLI transcript noise (shell echoes, tool-call boxes), which also
+    contain stray quotes and fences but never re-emit a matching JSON key
+    across a fence. Callers try the unmodified candidates first, so well-formed
+    output is never altered.
+    #>
+    param([string] $Output)
+    if (-not $Output) { return $Output }
+
+    # Count quotes that are not backslash-escaped. An odd count on a line that
+    # opens a JSON property means the string value was left unterminated.
+    $unescapedQuoteCount = {
+        param([string] $s)
+        $n = 0; $esc = $false
+        foreach ($c in $s.ToCharArray()) {
+            if ($esc) { $esc = $false; continue }
+            if ($c -eq '\') { $esc = $true; continue }
+            if ($c -eq '"') { $n++ }
+        }
+        return $n
+    }
+
+    $result = $Output
+    $maxPasses = 50
+    for ($pass = 0; $pass -lt $maxPasses; $pass++) {
+        $lines = $result -split "`n"
+        $repaired = $false
+
+        for ($li = 0; $li -lt $lines.Count; $li++) {
+            if (($lines[$li].Trim()) -notmatch '^```[A-Za-z0-9]*$') { continue }
+
+            # Nearest non-blank line before the fence: must be a JSON property
+            # whose string value was left unterminated (odd unescaped quotes).
+            $p = $li - 1
+            while ($p -ge 0 -and $lines[$p].Trim().Length -eq 0) { $p-- }
+            if ($p -lt 0) { continue }
+            $before = $lines[$p].Trim()
+            if ($before -notmatch '^"([^"\\]+)"\s*:') { continue }
+            $key = $Matches[1]
+            if (((& $unescapedQuoteCount $before) % 2) -eq 0) { continue }
+
+            # Nearest non-blank line after the fence: must re-emit the same key,
+            # i.e. the model resumed by restarting the interrupted property.
+            $a = $li + 1
+            while ($a -lt $lines.Count -and $lines[$a].Trim().Length -eq 0) { $a++ }
+            if ($a -ge $lines.Count) { continue }
+            $after = $lines[$a].Trim()
+            if ($after -notmatch ('^"' + [regex]::Escape($key) + '"\s*:')) { continue }
+
+            # Discard the broken partial line, the blank lines, and the fence;
+            # keep the re-emission onward. The re-emission re-includes the field
+            # from its start, so the splice de-duplicates naturally.
+            $newLines = [System.Collections.Generic.List[string]]::new()
+            if ($p -gt 0) { for ($x = 0; $x -lt $p; $x++) { $newLines.Add($lines[$x]) | Out-Null } }
+            for ($x = $a; $x -lt $lines.Count; $x++) { $newLines.Add($lines[$x]) | Out-Null }
+            $result = ($newLines -join "`n")
+            $repaired = $true
+            break
+        }
+
+        if (-not $repaired) { break }
+    }
+
+    return $result
+}
+
 function Parse-BCQualityReport {
     <#
     Parses Copilot CLI output into a findings-report. Returns a PSCustomObject:
@@ -1090,19 +1193,64 @@ function Parse-BCQualityReport {
     }
     foreach ($clean in $defenced) { $candidates.Add($clean) | Out-Null }
 
+    # Resume-fence repair: handles the interrupted-emission shape where the
+    # agent breaks off mid-string (leaving an unterminated JSON string) and
+    # resumes by re-opening a bare ```json fence with NO Placeholder marker.
+    # Because the break sits inside an unterminated string, Remove-StructuralFences
+    # (which preserves in-string fences) cannot clear it. Extract candidates from
+    # the repaired text and append them AFTER the originals so clean output is
+    # never disturbed.
+    $resumeRepaired = Repair-ResumeFenceJson -Output $stripped
+    if ($resumeRepaired -ne $stripped) {
+        $resumeCandidates = [System.Collections.Generic.List[string]]::new()
+        foreach ($m in [regex]::Matches($resumeRepaired, '```(?:json)?\s*([\s\S]*?)\s*```')) { $resumeCandidates.Add($m.Groups[1].Value) | Out-Null }
+        foreach ($balanced in (Find-BalancedJsonCandidates -Text $resumeRepaired)) { $resumeCandidates.Add($balanced) | Out-Null }
+        foreach ($candidate in $resumeCandidates) {
+            $candidates.Add($candidate) | Out-Null
+            $clean = Remove-StructuralFences -Text $candidate
+            if ($clean -ne $candidate) { $candidates.Add($clean) | Out-Null }
+        }
+    }
+
+    # A candidate can parse cleanly yet be the WRONG fragment. The transcript
+    # echoes every sub-skill's own JSON report inside ```json fences, and the
+    # top-level findings-report's `findings[]` is itself a large balanced JSON
+    # array. When the full document is unparseable (e.g. a corrupt value deep in
+    # sub-results) the scan happily parses one of those fragments first: a bare
+    # sub-skill report has `findings` but no `sub-results`, and a bare array has
+    # neither — either way the real report is silently dropped (observed in run
+    # 28168894037: 42 findings recovered to 0). Prefer the orchestrator report
+    # shape (exposes `sub-results` or a `dispatch`), then a findings-bearing
+    # object, then any parseable candidate, so leniency is preserved while the
+    # correct fragment always wins.
     $report = $null
+    $shapedReport = $null
+    $fallbackReport = $null
     foreach ($candidate in $candidates) {
         $trimmed = $candidate.Trim()
         if (-not $trimmed) { continue }
+        $parsed = $null
         try {
-            $report = $trimmed | ConvertFrom-Json -ErrorAction Stop
-            break
+            $parsed = $trimmed | ConvertFrom-Json -ErrorAction Stop
         } catch {
             $preview = $trimmed
             if ($preview.Length -gt 200) { $preview = $preview.Substring(0, 200) + '...' }
             $parseErrors.Add("$($_.Exception.Message) | candidate: $preview") | Out-Null
+            continue
         }
+
+        $isObject = $parsed -is [System.Management.Automation.PSCustomObject]
+        $isOrchestratorShaped = $isObject -and (
+            $parsed.PSObject.Properties.Match('sub-results').Count -gt 0 -or
+            $parsed.PSObject.Properties.Match('dispatch').Count -gt 0)
+        if ($isOrchestratorShaped) { $report = $parsed; break }
+        if ($null -eq $shapedReport -and $isObject -and $parsed.PSObject.Properties.Match('findings').Count -gt 0) {
+            $shapedReport = $parsed
+        }
+        if ($null -eq $fallbackReport) { $fallbackReport = $parsed }
     }
+    if ($null -eq $report) { $report = $shapedReport }
+    if ($null -eq $report) { $report = $fallbackReport }
 
     $script:LastParsingErrors = $parseErrors
 

--- a/tools/Code Review/scripts/Test-InterruptedJsonRepair.ps1
+++ b/tools/Code Review/scripts/Test-InterruptedJsonRepair.ps1
@@ -1,0 +1,277 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Regression tests for the interrupted/contaminated agent-JSON repair paths
+    in Invoke-CopilotPRReview.ps1.
+
+.DESCRIPTION
+    The Copilot CLI occasionally fragments the agent's final findings-report
+    JSON when its output stream is sliced by a tool-call boundary. Two distinct
+    corruption shapes have been observed in production runner logs, both of
+    which caused the parser to recover ZERO findings:
+
+      1. Bare interior fence: the model re-opens a ```json fence in the middle
+         of the JSON body (no TUI marker). The balanced-brace candidate stays
+         structurally complete but is syntactically invalid because of the
+         spliced fence line. Repair: Remove-StructuralFences.
+
+      2. Placeholder-marker drift: the CLI injects a
+         "Placeholder to satisfy parallel tool call requirement (shell)" block
+         mid-string, then resumes in a fresh fence. The original repair matched
+         the literal "...parallel tool requirement" wording, which drifted
+         (the CLI added "call" and a "(shell)" suffix), so the repair silently
+         no-opped. Repair: Repair-InterruptedAgentJson tolerant marker regex.
+
+    This test extracts the three parser helpers from the orchestrator script via
+    the PowerShell AST (so it can never drift from the real implementation) and
+    asserts that both shapes parse back to the expected findings.
+
+.NOTES
+    Standalone (no Pester dependency). Exits non-zero on any failure so it can
+    gate CI.
+#>
+[CmdletBinding()]
+param(
+    [string] $ScriptPath = (Join-Path $PSScriptRoot 'Invoke-CopilotPRReview.ps1')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $ScriptPath)) {
+    throw "Orchestrator script not found at: $ScriptPath"
+}
+
+# --- Load the parser helpers from the orchestrator without running main() -----
+# The orchestrator executes top-level logic on load, so we extract just the
+# pure functions we need via the AST and dot-source those.
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$null, [ref]$null)
+$wanted = 'Find-BalancedJsonCandidates', 'Remove-StructuralFences', 'Repair-InterruptedAgentJson', 'Repair-ResumeFenceJson'
+$funcs = $ast.FindAll(
+    { param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $wanted -contains $n.Name },
+    $true)
+foreach ($name in $wanted) {
+    if ($funcs.Name -notcontains $name) { throw "Could not locate function '$name' in $ScriptPath" }
+}
+Invoke-Expression (($funcs | ForEach-Object { $_.Extent.Text }) -join "`n`n")
+
+$failures = [System.Collections.Generic.List[string]]::new()
+function Assert-True([bool] $Condition, [string] $Message) {
+    if ($Condition) { Write-Host "  PASS  $Message" -ForegroundColor Green }
+    else { Write-Host "  FAIL  $Message" -ForegroundColor Red; $script:failures.Add($Message) | Out-Null }
+}
+
+# Mirror the first-stage extraction Parse-BCQualityReport performs, then return
+# the first candidate (incl. de-fenced fallbacks) that yields valid JSON.
+function Get-FirstParsedReport([string] $Output) {
+    $repaired = Repair-InterruptedAgentJson -Output $Output
+    $stripped = [regex]::Replace($repaired, "`e\[[\d;]*[A-Za-z]", '')
+    $candidates = [System.Collections.Generic.List[string]]::new()
+    foreach ($m in [regex]::Matches($stripped, '```(?:json)?\s*([\s\S]*?)\s*```')) { $candidates.Add($m.Groups[1].Value) | Out-Null }
+    foreach ($b in (Find-BalancedJsonCandidates -Text $stripped)) { $candidates.Add($b) | Out-Null }
+    if ($candidates.Count -eq 0) { $candidates.Add($stripped.Trim()) | Out-Null }
+    $defenced = [System.Collections.Generic.List[string]]::new()
+    foreach ($c in $candidates) { $clean = Remove-StructuralFences -Text $c; if ($clean -ne $c) { $defenced.Add($clean) | Out-Null } }
+    foreach ($c in $defenced) { $candidates.Add($c) | Out-Null }
+    $resumeRepaired = Repair-ResumeFenceJson -Output $stripped
+    if ($resumeRepaired -ne $stripped) {
+        $resumeCandidates = [System.Collections.Generic.List[string]]::new()
+        foreach ($m in [regex]::Matches($resumeRepaired, '```(?:json)?\s*([\s\S]*?)\s*```')) { $resumeCandidates.Add($m.Groups[1].Value) | Out-Null }
+        foreach ($b in (Find-BalancedJsonCandidates -Text $resumeRepaired)) { $resumeCandidates.Add($b) | Out-Null }
+        foreach ($c in $resumeCandidates) {
+            $candidates.Add($c) | Out-Null
+            $clean = Remove-StructuralFences -Text $c
+            if ($clean -ne $c) { $candidates.Add($clean) | Out-Null }
+        }
+    }
+    $shaped = $null
+    $fallback = $null
+    foreach ($c in $candidates) {
+        $t = $c.Trim(); if (-not $t) { continue }
+        $parsed = $null
+        try { $parsed = $t | ConvertFrom-Json -ErrorAction Stop } catch { continue }
+        $isObject = $parsed -is [System.Management.Automation.PSCustomObject]
+        $isOrchestratorShaped = $isObject -and (
+            $parsed.PSObject.Properties.Match('sub-results').Count -gt 0 -or
+            $parsed.PSObject.Properties.Match('dispatch').Count -gt 0)
+        if ($isOrchestratorShaped) { return $parsed }
+        if ($null -eq $shaped -and $isObject -and $parsed.PSObject.Properties.Match('findings').Count -gt 0) { $shaped = $parsed }
+        if ($null -eq $fallback) { $fallback = $parsed }
+    }
+    if ($null -ne $shaped) { return $shaped }
+    return $fallback
+}
+
+# --- Shape 1: bare interior ```json fence spliced into the JSON body ----------
+$shape1 = @'
+* Read entry.md
+Here is the report:
+```json
+{
+  "skill": { "id": "al-code-review" },
+  "outcome": "completed",
+  "findings": [
+    { "id": "k/style/a.md", "severity": "major", "message": "top-level rollup finding",
+      "from-sub-skill": "al-style-review", "references": [ { "path": "k/style/a.md" } ] }
+  ],
+  "sub-results": [
+    { "skill": { "id": "al-style-review" }, "outcome": "completed",
+      "summary": { "counts": { "major": 1 } }
+```json
+      ,
+      "findings": [ { "id": "k/style/a.md", "severity": "major", "message": "leaf finding" } ] }
+  ]
+}
+```
+'@
+Write-Host "`nShape 1: bare interior fence (no marker)" -ForegroundColor Cyan
+$r1 = Get-FirstParsedReport -Output $shape1
+Assert-True ($null -ne $r1) 'recovers a parseable report'
+if ($r1) {
+    Assert-True (@($r1.findings).Count -eq 1) "top-level findings recovered (got $(@($r1.findings).Count), expected 1)"
+    Assert-True (@($r1.'sub-results').Count -eq 1) "sub-results recovered (got $(@($r1.'sub-results').Count), expected 1)"
+}
+
+# --- Shape 2: drifted placeholder marker + resume fence -----------------------
+$shape2 = @'
+* Read entry.md
+```json
+{
+  "skill": { "id": "al-code-review" },
+  "outcome": "completed",
+  "findings": [
+    { "id": "k/style/a.md", "severity": "major", "message": "this line is truncated mid-emi
+● Placeholder to satisfy parallel tool call requirement (shell)
+  │ echo "Resuming JSON output"
+  └ 2 lines
+```json
+    { "id": "k/style/a.md", "severity": "major", "message": "fully re-emitted finding",
+      "from-sub-skill": "al-style-review", "references": [ { "path": "k/style/a.md" } ] }
+  ],
+  "sub-results": []
+}
+```
+'@
+Write-Host "`nShape 2: drifted placeholder marker ('parallel tool call requirement (shell)')" -ForegroundColor Cyan
+$r2 = Get-FirstParsedReport -Output $shape2
+Assert-True ($null -ne $r2) 'recovers a parseable report'
+if ($r2) {
+    Assert-True (@($r2.findings).Count -eq 1) "truncated finding repaired to a single clean finding (got $(@($r2.findings).Count), expected 1)"
+    Assert-True ([string]$r2.findings[0].message -eq 'fully re-emitted finding') 'partial pre-marker line discarded; full re-emission kept'
+}
+
+# --- Shape 3: bare resume fence inside an unterminated string (no marker) ------
+# The agent breaks off mid-value, leaving "suggested-code": "... with no closing
+# quote, then resumes by re-opening a ```json fence and re-emitting the SAME
+# property. Repair-InterruptedAgentJson does not fire (no Placeholder marker) and
+# Remove-StructuralFences must not fire (the fence sits inside a string literal),
+# so only Repair-ResumeFenceJson recovers it. The top-level findings[] is itself
+# a large balanced array, so the parser must also prefer the report-shaped
+# object over that bare array. Captured from production run 28168894037.
+$shape3 = @'
+* Read entry.md
+```json
+{
+  "skill": { "id": "al-code-review" },
+  "outcome": "completed",
+  "findings": [
+    { "id": "k/web/a.md", "severity": "major", "message": "top-level rollup finding",
+      "from-sub-skill": "al-web-services-review", "references": [ { "path": "k/web/a.md" } ] }
+  ],
+  "sub-results": [
+    { "skill": { "id": "al-web-services-review" }, "outcome": "completed",
+      "findings": [
+        { "id": "k/web/a.md", "severity": "major", "message": "leaf finding",
+          "confidence": "high",
+          "suggested-code": "    ODataKeyFields =
+
+
+
+```json
+          "suggested-code": "    ODataKeyFields = SystemId;" }
+      ] }
+  ]
+}
+```
+'@
+Write-Host "`nShape 3: bare resume fence inside an unterminated string (no marker)" -ForegroundColor Cyan
+$r5 = Get-FirstParsedReport -Output $shape3
+Assert-True ($null -ne $r5) 'recovers a parseable report'
+if ($r5) {
+    Assert-True ([string]$r5.skill.id -eq 'al-code-review') "report-shaped object preferred over the bare findings[] array (got skill.id '$([string]$r5.skill.id)')"
+    Assert-True (@($r5.findings).Count -eq 1) "top-level findings recovered (got $(@($r5.findings).Count), expected 1)"
+    Assert-True (@($r5.'sub-results').Count -eq 1) "sub-results recovered (got $(@($r5.'sub-results').Count), expected 1)"
+    $sc = [string]$r5.'sub-results'[0].findings[0].'suggested-code'
+    Assert-True ($sc -eq '    ODataKeyFields = SystemId;') "broken partial discarded, re-emission kept (got '$sc')"
+}
+
+# --- Guard: a clean single-fence report is unaffected -------------------------
+$clean = @'
+```json
+{ "skill": { "id": "al-code-review" }, "outcome": "completed",
+  "findings": [ { "id": "k/style/a.md", "severity": "minor", "message": "ok",
+    "from-sub-skill": "al-style-review", "references": [ { "path": "k/style/a.md" } ] } ],
+  "sub-results": [] }
+```
+'@
+Write-Host "`nGuard: clean single-fence report unaffected" -ForegroundColor Cyan
+$r3 = Get-FirstParsedReport -Output $clean
+Assert-True ($null -ne $r3 -and @($r3.findings).Count -eq 1) 'clean report still parses to 1 finding'
+
+# --- Guard: a fenced code sample inside a string value is preserved -----------
+$stringFence = @'
+```json
+{ "outcome": "completed",
+  "findings": [ { "id": "k/style/a.md", "severity": "minor",
+    "message": "sample", "suggested-code": "```al\nprocedure Foo()\n```",
+    "from-sub-skill": "al-style-review", "references": [ { "path": "k/style/a.md" } ] } ],
+  "sub-results": [] }
+```
+'@
+Write-Host "`nGuard: code fence inside a JSON string value is preserved" -ForegroundColor Cyan
+$r4 = Get-FirstParsedReport -Output $stringFence
+Assert-True ($null -ne $r4) 'string-internal fence report parses'
+if ($r4) {
+    Assert-True ([string]$r4.findings[0].'suggested-code' -like '*```al*') 'fenced code sample survived inside the string value'
+}
+
+# --- Real-artifact regression fixtures ----------------------------------------
+# Captured stdout from two production runner runs that posted ZERO findings on
+# the byte-identical sample diff (the regression). These are the exact bytes the
+# live runner failed to parse; the patched parser must recover the full report.
+#   run 26953567514: drifted placeholder marker ("parallel tool call requirement
+#                    (shell)") -> 25 findings.
+#   run 26956415628 (PR #47): bare interior ```json fence -> 22 findings.
+#   run 28168894037 (PR #52): bare resume fence inside an unterminated
+#                    `suggested-code` string in sub-result 11 -> 42 findings,
+#                    11 sub-results. The unpatched parser stopped at the bare
+#                    top-level findings[] array and posted 0.
+# The unpatched main parser returned 0 for all three (measured).
+$fixtureDir = Join-Path (Split-Path -Parent $PSScriptRoot) 'tests/fixtures'
+$realFixtures = @(
+    @{ Run = '26953567514'; File = 'run-26953567514-al-code-review-raw.txt'; Findings = 25; SubResults = 6 },
+    @{ Run = '26956415628'; File = 'run-26956415628-al-code-review-raw.txt'; Findings = 22; SubResults = 6 },
+    @{ Run = '28168894037'; File = 'run-28168894037-al-code-review-raw.txt'; Findings = 42; SubResults = 11 }
+)
+Write-Host "`nReal runner artifacts (regression fixtures)" -ForegroundColor Cyan
+foreach ($fx in $realFixtures) {
+    $path = Join-Path $fixtureDir $fx.File
+    if (-not (Test-Path -LiteralPath $path)) { Assert-True $false "fixture present: $($fx.File)"; continue }
+    $raw = Get-Content -LiteralPath $path -Raw
+    $rep = Get-FirstParsedReport -Output $raw
+    Assert-True ($null -ne $rep) "run $($fx.Run): recovers a parseable report (was 0 on unpatched parser)"
+    if ($rep) {
+        $fc = @($rep.findings).Count
+        $sc = @($rep.'sub-results').Count
+        Assert-True ($fc -eq $fx.Findings) "run $($fx.Run): top-level findings recovered (got $fc, expected $($fx.Findings))"
+        Assert-True ($sc -eq $fx.SubResults) "run $($fx.Run): sub-results recovered (got $sc, expected $($fx.SubResults))"
+    }
+}
+
+Write-Host ''
+if ($failures.Count -gt 0) {
+    Write-Host "FAILED: $($failures.Count) assertion(s) failed." -ForegroundColor Red
+    exit 1
+}
+Write-Host 'All interrupted-JSON repair regression tests passed.' -ForegroundColor Green
+exit 0

--- a/tools/Code Review/tests/fixtures/.gitattributes
+++ b/tools/Code Review/tests/fixtures/.gitattributes
@@ -1,0 +1,3 @@
+# Regression fixtures are captured runner stdout. Preserve bytes exactly
+# (no EOL conversion) so the parser sees the same input on every platform.
+*.txt -text

--- a/tools/Code Review/tests/fixtures/run-26953567514-al-code-review-raw.txt
+++ b/tools/Code Review/tests/fixtures/run-26953567514-al-code-review-raw.txt
@@ -1,0 +1,1004 @@
+● Read entry.md
+  │ skills/entry.md
+  └ 178 lines read
+
+● Read _task-context.json
+  └ 16 lines read
+
+● List bcquality root and skills directory (shell)
+  │ ls /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/ && ls
+  │ /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/skills/
+  │ 2>/dev/null
+  └ 4 lines...
+
+● List changed files in PR (shell)
+  │ git -C "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/review-target"
+  │ diff --name-only origin/main 2>/dev/null | head -50
+  └ 6 lines...
+
+● Check knowledge index existence (shell)
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/knowledge-in
+  │ dex.json 2>/dev/null | head -20 || echo "No knowledge-index.json found"
+  └ 1 line...
+
+● List microsoft skills (shell)
+  │ ls /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/ski
+  │ lls/ 2>/dev/null && find /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/b
+  │ cquality/microsoft/skills/ -name "*.md" 2>/dev/null
+  └ 9 lines...
+
+● Read al-code-review.md
+  │ microsoft/skills/review/al-code-review.md
+  └ 316 lines read
+
+● Check knowledge index file (shell)
+  │ ls /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/knowledge-ind
+  │ ex.json 2>/dev/null || echo "missing"
+  └ 2 lines...
+
+● Read do.md
+  │ skills/do.md
+  └ 1 line read
+
+● Read read.md
+  │ skills/read.md
+  └ 148 lines read
+
+● Build knowledge index (shell)
+  │ cd /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality && pwsh
+  │ ./tools/Build-KnowledgeIndex.ps1 2>&1 | tail -5
+  └ 3 lines...
+
+● Read do.md
+  │ skills/do.md
+  └ L1:120 (120 lines read)
+
+● Read do.md
+  │ skills/do.md
+  └ L120:250 (131 lines read)
+
+● Read al-performance-review.md
+  │ microsoft/skills/review/al-performance-review.md
+  └ 136 lines read
+
+● Read al-security-review.md
+  │ microsoft/skills/review/al-security-review.md
+  └ 136 lines read
+
+● Get full PR diff (shell)
+  │ git -C "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/review-target"
+  │ diff origin/main 2>/dev/null
+  └ 79 lines...
+
+● Stop shell
+  └ 1 line...
+
+● Read al-privacy-review.md
+  │ microsoft/skills/review/al-privacy-review.md
+  └ 108 lines read
+
+● Read al-upgrade-review.md
+  │ microsoft/skills/review/al-upgrade-review.md
+  └ 107 lines read
+
+● Read al-style-review.md
+  │ microsoft/skills/review/al-style-review.md
+  └ 105 lines read
+
+● Read al-ui-review.md
+  │ microsoft/skills/review/al-ui-review.md
+  └ 105 lines read
+
+● Get full PR diff without pager (shell)
+  │ git -C "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/review-target"
+  │ --no-pager diff origin/main 2>/dev/null | cat
+  └ 398 lines...
+
+Now I have the full diff. Let me read the knowledge index to understand what knowledge articles are available.
+
+● List all knowledge articles with details (shell)
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/knowledge-in
+  │ dex.json | python3 -c "import json,sys; idx=json.load(sys.stdin);
+  │ [print(f\"{a['path']} | {a['domain']} | {a.get('keywords',[])} |
+  │ {a.get('description','')}\") for a in idx['articles']]" 2>/dev/null | head
+  │ -160
+  └ 7 lines...
+
+● Filter knowledge articles by relevant domains (shell)
+  │ cat /tmp/copilot-tool-output-1780578565327-cpjfdh.txt | grep -E
+  │ "^microsoft/knowledge/(performance|security|privacy|style|ui|upgrade)" |
+  │ head -200
+  └ 7 lines...
+
+● Print knowledge articles by relevant domains (shell)
+  │ python3 -c "
+  │ import json
+  │ with open('/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/kno
+  │ wledge-index.json') as f:
+  │ idx = json.load(f)…
+  └ 15 lines...
+
+● List knowledge articles by domain (shell)
+  │ python3 - << 'EOF'
+  │ import json
+  │ with open('/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/kno
+  │ wledge-index.json') as f:
+  │ idx = json.load(f)…
+  └ 16 lines...
+
+● Read full list of knowledge articles (shell)
+  │ cat /tmp/copilot-tool-output-1780578583277-xca9u7.txt
+  └ 8 lines...
+
+● Print all relevant knowledge articles (shell)
+  │ python3 - << 'EOF'
+  │ import json
+  │ with open('/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/kno
+  │ wledge-index.json') as f:
+  │ idx = json.load(f)…
+  └ 19 lines...
+
+● Write knowledge list to file and inspect (shell)
+  │ python3 - << 'PYEOF' > /tmp/knowledge_list.txt
+  │ import json
+  │ with open('/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/kno
+  │ wledge-index.json') as f:
+  │ idx = json.load(f)…
+  └ 111 lines...
+
+● List UI and upgrade knowledge articles (shell)
+  │ cat /tmp/knowledge_list.txt | grep -E "\| (ui|upgrade) \|"
+  └ 38 lines...
+
+Now I have all the diff information and knowledge index. Let me read the specific knowledge articles that are relevant to the identified issues in the diff.
+
+● Read avoid-commit-inside-loops.md
+  │ microsoft/knowledge/performance/avoid-commit-inside-loops.md
+  └ 28 lines read
+
+● Read use-isempty-for-existence-check.md
+  │ microsoft/knowledge/performance/use-isempty-for-existence-check.md
+  └ 26 lines read
+
+● Read avoid-get-inside-loop-on-large-table.md
+  │ microsoft/knowledge/performance/avoid-get-inside-loop-on-large-table.md
+  └ 26 lines read
+
+● Read secrettext-for-credentials.md
+  │ microsoft/knowledge/security/secrettext-for-credentials.md
+  └ 22 lines read
+
+● Read integrationevent-must-not-expose-secrets.md
+  │ microsoft/knowledge/security/integrationevent-must-not-expose-secrets.md
+  └ 22 lines read
+
+● Read data-classification-required-on-pii-fields.md
+  │ microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md
+  └ 26 lines read
+
+● Read no-pii-in-telemetry-message-string.md
+  │ microsoft/knowledge/privacy/no-pii-in-telemetry-message-string.md
+  └ 33 lines read
+
+● Read featuretelemetry-customdimensions-no-pii.md
+  │ microsoft/knowledge/privacy/featuretelemetry-customdimensions-no-pii.md
+  └ 26 lines read
+
+● Read avoid-strsubstno-prebuild-before-error.md
+  │ microsoft/knowledge/privacy/avoid-strsubstno-prebuild-before-error.md
+  └ 26 lines read
+
+● Read lowercase-reserved-keywords.md
+  │ microsoft/knowledge/style/lowercase-reserved-keywords.md
+  └ 28 lines read
+
+● Read error-passes-parameters-directly-not-strsubstno.md
+  │ microsoft/knowledge/style/error-passes-parameters-directly-not-strsubstno.md
+  └ 26 lines read
+
+● Read show-caption-on-editable-fields.md
+  │ microsoft/knowledge/ui/show-caption-on-editable-fields.md
+  └ 28 lines read
+
+● Read no-space-before-method-parenthesis.md
+  │ microsoft/knowledge/style/no-space-before-method-parenthesis.md
+  └ 26 lines read
+
+● List UI knowledge files (shell)
+  │ ls /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/kno
+  │ wledge/ui/ | head -30
+  └ 31 lines...
+
+● Read labels-declared-at-object-scope.md
+  │ microsoft/knowledge/style/labels-declared-at-object-scope.md
+  └ 30 lines read
+
+● Read session-logmessage-requires-dataclassification.md
+  │ microsoft/knowledge/privacy/session-logmessage-requires-dataclassification.m
+  │ d
+  └ 26 lines read
+
+● Search for tooltip-related knowledge articles (shell)
+  │ grep -i tooltip /tmp/knowledge_list.txt
+  └ 2 lines...
+
+● Read tooltip-required-on-page-fields.md
+  │ microsoft/knowledge/style/tooltip-required-on-page-fields.md
+  └ 28 lines read
+
+● Read label-suffix-approved-list.md
+  │ microsoft/knowledge/style/label-suffix-approved-list.md
+  └ 26 lines read
+
+Let me read a few more knowledge articles that may be relevant:
+
+● Read telemetry-event-id-stable-unique.md
+  │ microsoft/knowledge/style/telemetry-event-id-stable-unique.md
+  └ 32 lines read
+
+● Read register-integration-in-privacy-notice-registrations.md
+  │ microsoft/knowledge/privacy/register-integration-in-privacy-notice-registrat
+  │ ions.md
+  └ 24 lines read
+
+● Read validate-user-configurable-urls.md
+  │ microsoft/knowledge/security/validate-user-configurable-urls.md
+  └ 22 lines read
+
+● Read privacy-notice-consent-for-external-data-transfer.md
+  │ microsoft/knowledge/privacy/privacy-notice-consent-for-external-data-transfe
+  │ r.md
+  └ 26 lines read
+
+Now I have all the information needed to execute each sub-skill. Let me produce the full review.
+
+[sub-skill al-performance-review: worklist=3 findings=5]
+
+[sub-skill al-security-review: worklist=2 findings=3]
+
+[sub-skill al-privacy-review: worklist=4 findings=5]
+
+[sub-skill al-upgrade-review: worklist=0 findings=0]
+
+[sub-skill al-style-review: worklist=5 findings=12]
+
+[sub-skill al-ui-review: worklist=1 findings=0]
+
+[self-review: agent-findings=0]
+
+```json
+{
+  "skill": { "id": "al-code-review", "version": 1 },
+  "outcome": "completed",
+  "summary": {
+    "counts": { "blocker": 0, "major": 11, "minor": 14, "info": 0 },
+    "coverage": { "worklist-size": 15, "items-evaluated": 15 }
+  },
+  "findings": [
+    {
+      "id": "microsoft/knowledge/performance/avoid-commit-inside-loops.md",
+      "severity": "major",
+      "message": "Commit() is called inside the repeat...until loop in ImportResults. Each iteration starts a new write transaction, defeats atomicity for the whole import, and adds transaction-start overhead per row. Per the referenced guidance, Commit belongs outside the per-row loop; use bounded checkpoints that each process N rows, or wrap each chunk in Codeunit.Run for native rollback on failure.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 53
+      },
+      "references": [{ "path": "microsoft/knowledge/performance/avoid-commit-inside-loops.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-performance-review",
+      "suggested-code-omission-reason": "fix requires restructuring the loop into bounded checkpoints; no safe single-line replacement"
+    },
+    {
+      "id": "microsoft/knowledge/performance/avoid-commit-inside-loops.md",
+      "severity": "major",
+      "message": "Commit() is called inside the for loop in ImportBatch after each file is processed. This produces one transaction per file, removes atomicity for the batch, and adds per-iteration overhead. Move checkpointing outside the loop.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Utilities/QltyFileImport.Codeunit.al",
+        "line": 59
+      },
+      "references": [{ "path": "microsoft/knowledge/performance/avoid-commit-inside-loops.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-performance-review",
+      "suggested-code-omission-reason": "fix requires restructuring the loop into bounded checkpoints"
+    },
+    {
+      "id": "microsoft/knowledge/performance/use-isempty-for-existence-check.md",
+      "severity": "minor",
+      "message": "Count() > 0 is used in HasImportedResults solely to test existence. Count() forces the database to materialise the full row count; IsEmpty() stops at the first matching row. Replace with if not ImportLogEntry.IsEmpty() then.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 72
+      },
+      "references": [{ "path": "microsoft/knowledge/performance/use-isempty-for-existence-check.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-performance-review",
+      "suggested-code": "        if not ImportLogEntry.IsEmpty() then"
+    },
+    {
+      "id": "microsoft/knowledge/performance/use-isempty-for-existence-check.md",
+      "severity": "minor",
+      "message": "FindFirst() is used in HasImportedResults solely to test existence (the result record is never read). FindFirst() materialises a full row the caller discards. Use IsEmpty() instead. Note: this second check is also redundant — if Count() > 0 exits true, this line is never reached; if Count() returned 0, FindFirst() also returns false. The entire procedure body can be reduced to exit(not ImportLogEntry.IsEmpty());.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 75
+      },
+      "references": [{ "path": "microsoft/knowledge/performance/use-isempty-for-existence-check.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-performance-review",
+      "suggested-code-omission-reason": "fix spans lines 72-77; the entire procedure body should be replaced with a single exit(not ImportLogEntry.IsEmpty());"
+    },
+    {
+      "id": "microsoft/knowledge/performance/avoid-get-inside-loop-on-large-table.md",
+      "severity": "major",
+      "message": "Customer.Get(CustomerNo) is called on every iteration of the repeat loop in ImportResults, re-reading the same Customer row on each pass. Customer is a production-scale table; this is a classic N+1 pattern. Because the same CustomerNo is looked up every iteration, the fix is to hoist the Get() call above the repeat block so it executes once.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 42
+      },
+      "references": [{ "path": "microsoft/knowledge/performance/avoid-get-inside-loop-on-large-table.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-performance-review",
+      "suggested-code-omission-reason": "fix requires moving Customer.Get() above the repeat loop and removing it from the loop body"
+    },
+    {
+      "id": "microsoft/knowledge/security/secrettext-for-credentials.md",
+      "severity": "major",
+      "message": "ApiKey and BearerToken are declared as Text local variables in FetchResultsIntoBuffer. Credentials held as Text are fully visible in the debugger and in any error or log that captures the variable. Per the referenced guidance, every credential-bearing variable must be declared as SecretText from the retrieval point all the way to the HTTP call site, so the compiler prevents accidental inspection or round-tripping.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 82,
+        "range": { "start-line": 82, "end-line": 83 }
+      },
+      "references": [{ "path": "microsoft/knowledge/security/secrettext-for-credentials.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-security-review",
+      "suggested-code-omission-reason": "fix requires changing both local variable declarations and the DownloadResults procedure signature to SecretText end-to-end"
+    },
+    {
+      "id": "microsoft/knowledge/security/secrettext-for-credentials.md",
+      "severity": "major",
+      "message": "DownloadResults accepts ApiKey and BearerToken as Text parameters. Per the code comment, these are added to HTTP request headers as clear text. The referenced guidance requires credentials to flow as SecretText all the way to the HTTP call site; passing them as Text here breaks the SecretText chain and exposes them to the debugger.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 95
+      },
+      "references": [{ "path": "microsoft/knowledge/security/secrettext-for-credentials.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-security-review",
+      "suggested-code-omission-reason": "fix requires changing ApiKey and BearerToken parameter types to SecretText across both FetchResultsIntoBuffer and DownloadResults"
+    },
+    {
+      "id": "microsoft/knowledge/security/integrationevent-must-not-expose-secrets.md",
+      "severity": "major",
+      "message": "OnBeforeCallLabApi exposes ApiKey and BearerToken as IntegrationEvent parameters. Every extension on the tenant can subscribe to this event and read or persist these credentials — there is no partner-only filter. Per the referenced guidance, event signatures must never carry secrets; the event should expose only non-sensitive context (the operation, an IsHandled flag) and authentication must be handled by the publisher entirely outside the event.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultEvents.Codeunit.al",
+        "line": 19
+      },
+      "references": [{ "path": "microsoft/knowledge/security/integrationevent-must-not-expose-secrets.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-security-review",
+      "suggested-code-omission-reason": "fix requires removing ApiKey and BearerToken from the event signature and redesigning authentication to occur entirely within the publisher"
+    },
+    {
+      "id": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md",
+      "severity": "major",
+      "message": "The 'Customer Name' field stores a personal data value (customer name) but has no DataClassification property. Without an explicit classification the platform defaults to SystemMetadata, misclassifying customer PII in telemetry, GDPR exports, and admin reports. Set DataClassification = CustomerContent.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLogEntry.Table.al",
+        "line": 29,
+        "range": { "start-line": 29, "end-line": 32 }
+      },
+      "references": [{ "path": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code": "        field(3; \"Customer Name\"; Text[100])\n        {\n            Caption = 'Customer Name';\n            DataClassification = CustomerContent;\n        }"
+    },
+    {
+      "id": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md",
+      "severity": "major",
+      "message": "The 'Contact Email' field stores an email address (PII) but has no DataClassification property. The platform defaults to SystemMetadata, misclassifying this data. Set DataClassification = CustomerContent (or EndUserIdentifiableInformation if this is an individual's personal address rather than a business contact).",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLogEntry.Table.al",
+        "line": 33,
+        "range": { "start-line": 33, "end-line": 36 }
+      },
+      "references": [{ "path": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code": "        field(4; \"Contact Email\"; Text[80])\n        {\n            Caption = 'Contact Email';\n            DataClassification = CustomerContent;\n        }"
+    },
+    {
+      "id": "microsoft/knowledge/privacy/no-pii-in-telemetry-message-string.md",
+      "severity": "major",
+      "message": "Session.LogMessage receives a message built via StrSubstNo('Imported results for customer %1', Customer.Name). The platform cannot classify or strip PII from this plain-text string; the customer name is logged verbatim in telemetry regardless of the DataClassification argument on the same call. Use a static message string ('Lab results import completed') and attach any needed context through custom dimensions using non-PII values.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 141,
+        "range": { "start-line": 139, "end-line": 145 }
+      },
+      "references": [{ "path": "microsoft/knowledge/privacy/no-pii-in-telemetry-message-string.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code-omission-reason": "fix requires replacing the StrSubstNo message with a static string and removing Customer.Name from the message"
+    },
+    {
+      "id": "microsoft/knowledge/privacy/featuretelemetry-customdimensions-no-pii.md",
+      "severity": "major",
+      "message": "Dimensions.Add('CustomerName', Customer.Name) places a customer name into the FeatureTelemetry custom dimensions dictionary. Per the referenced guidance, custom dimensions follow the same privacy rules as Session.LogMessage message text — customer names (CustomerContent/EUII) must not be logged. Replace with a non-identifying value such as a pseudonymous record count or remove the dimension entirely.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 147
+      },
+      "references": [{ "path": "microsoft/knowledge/privacy/featuretelemetry-customdimensions-no-pii.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code-omission-reason": "fix requires removing the PII dimension; if structured context is needed, substitute a non-PII value such as an import count"
+    },
+    {
+      "id": "microsoft/knowledge/privacy/avoid-strsubstno-prebuild-before-error.md",
+      "severity": "major",
+      "message": "RaiseImportError calls Error(StrSubstNo('Could not import results for customer %1', CustomerNo)). The platform sees a single opaque Text argument with no field references left to inspect, so it cannot apply DataClassification to anything inside it — CustomerNo is baked in verbatim. Per the referenced guidance, pass the format string and arguments directly to Error() so the platform can handle each parameter individually.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 155
+      },
+      "references": [{ "path": "microsoft/knowledge/privacy/avoid-strsubstno-prebuild-before-error.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code": "        Error('Could not import results for customer %1', CustomerNo);"
+    },
+    {
+      "id": "microsoft/knowledge/style/lowercase-reserved-keywords.md",
+      "severity": "minor",
+      "message": "CountValidEntries uses uppercase AL reserved keywords throughout its body: VAR, BEGIN, IF, THEN, REPEAT, UNTIL, EXIT, END. CodeCop AA0241 requires reserved keywords in lowercase. Run the AL formatter to normalize casing.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 111,
+        "range": { "start-line": 111, "end-line": 120 }
+      },
+      "references": [{ "path": "microsoft/knowledge/style/lowercase-reserved-keywords.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code-omission-reason": "fix spans 10 lines with multiple uppercase keywords; use the AL code formatter to normalize all at once"
+    },
+    {
+      "id": "microsoft/knowledge/style/no-space-before-method-parenthesis.md",
+      "severity": "minor",
+      "message": "ImportLogEntry.Get (EntryNo) has a space between the method name and its opening parenthesis, violating CodeCop AA0002. Remove the space.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 127
+      },
+      "references": [{ "path": "microsoft/knowledge/style/no-space-before-method-parenthesis.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "        if ImportLogEntry.Get(EntryNo) then"
+    },
+    {
+      "id": "microsoft/knowledge/style/no-space-before-method-parenthesis.md",
+      "severity": "minor",
+      "message": "exit (ImportLogEntry.\"Customer Name\") has a space before the opening parenthesis, violating CodeCop AA0002.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 128
+      },
+      "references": [{ "path": "microsoft/knowledge/style/no-space-before-method-parenthesis.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "            exit(ImportLogEntry.\"Customer Name\");"
+    },
+    {
+      "id": "microsoft/knowledge/style/no-space-before-method-parenthesis.md",
+      "severity": "minor",
+      "message": "exit ('') has a space before the opening parenthesis, violating CodeCop AA0002.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 129
+      },
+      "references": [{ "path": "microsoft/knowledge/style/no-space-before-method-parenthesis.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "        exit('');"
+    },
+    {
+      "id": "microsoft/knowledge/style/no-space-before-method-parenthesis.md",
+      "severity": "minor",
+      "message": "exit (ImportFromLbl) in GetDialogTitle has a space before the opening parenthesis, violating CodeCop AA0002.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Utilities/QltyFileImport.Codeunit.al",
+        "line": 70
+      },
+      "references": [{ "path": "microsoft/knowledge/style/no-space-before-method-parenthesis.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "        exit(ImportFromLbl);"
+    },
+    {
+      "id": "microsoft/knowledge/style/error-passes-parameters-directly-not-strsubstno.md",
+      "severity": "minor",
+      "message": "RaiseImportError wraps the format string in StrSubstNo and passes the result to Error(). This defeats the translation pipeline and CodeCop AA0231 analysis (the call can no longer be matched to its Label). Pass the format string and CustomerNo directly to Error(); also declare a Label with the Err suffix for the message text.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 155
+      },
+      "references": [{ "path": "microsoft/knowledge/style/error-passes-parameters-directly-not-strsubstno.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "        Error('Could not import results for customer %1', CustomerNo);"
+    },
+    {
+      "id": "microsoft/knowledge/style/tooltip-required-on-page-fields.md",
+      "severity": "minor",
+      "message": "The 'Customer No.' field on the Qlty. Import Log page has no ToolTip property. CodeCop AA0218 requires a non-empty ToolTip on every page field; missing tooltips also fail AppSource technical validation.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al",
+        "line": 29,
+        "range": { "start-line": 29, "end-line": 31 }
+      },
+      "references": [{ "path": "microsoft/knowledge/style/tooltip-required-on-page-fields.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "                field(\"Customer No.\"; Rec.\"Customer No
+
+
+
+● Placeholder to satisfy parallel tool call requirement (shell)
+  │ echo "Resuming JSON output"
+  └ 2 lines...
+
+Continuing the JSON findings-report from the cut-off point:
+
+```json
+      "suggested-code": "                field(\"Customer No.\"; Rec.\"Customer No.\")\n                {\n                    ToolTip = 'Specifies the customer number.';\n                }"
+    },
+    {
+      "id": "microsoft/knowledge/style/tooltip-required-on-page-fields.md",
+      "severity": "minor",
+      "message": "The 'Customer Name' field on the Qlty. Import Log page has no ToolTip property. CodeCop AA0218 requires a non-empty ToolTip on every page field.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al",
+        "line": 32,
+        "range": { "start-line": 32, "end-line": 34 }
+      },
+      "references": [{ "path": "microsoft/knowledge/style/tooltip-required-on-page-fields.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "                field(\"Customer Name\"; Rec.\"Customer Name\")\n                {\n                    ToolTip = 'Specifies the name of the customer.';\n                }"
+    },
+    {
+      "id": "microsoft/knowledge/style/tooltip-required-on-page-fields.md",
+      "severity": "minor",
+      "message": "The 'Contact Email' field on the Qlty. Import Log page has no ToolTip property. CodeCop AA0218 requires a non-empty ToolTip on every page field.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al",
+        "line": 35,
+        "range": { "start-line": 35, "end-line": 37 }
+      },
+      "references": [{ "path": "microsoft/knowledge/style/tooltip-required-on-page-fields.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "                field(\"Contact Email\"; Rec.\"Contact Email\")\n                {\n                    ToolTip = 'Specifies the contact email address.';\n                }"
+    },
+    {
+      "id": "microsoft/knowledge/style/tooltip-required-on-page-fields.md",
+      "severity": "minor",
+      "message": "The 'Imported At' field on the Qlty. Import Log page has no ToolTip property. CodeCop AA0218 requires a non-empty ToolTip on every page field.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al",
+        "line": 42,
+        "range": { "start-line": 42, "end-line": 44 }
+      },
+      "references": [{ "path": "microsoft/knowledge/style/tooltip-required-on-page-fields.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "                field(\"Imported At\"; Rec.\"Imported At\")\n                {\n                    ToolTip = 'Specifies when the result was imported.';\n                }"
+    },
+    {
+      "id": "microsoft/knowledge/style/telemetry-event-id-stable-unique.md",
+      "severity": "minor",
+      "message": "Session.LogMessage is called with placeholder event ID '0000'. Placeholder IDs are non-unique across extensions and cannot be reliably filtered or alerted on in Application Insights. Per the referenced guidance, assign a real, registered, unique event ID from the extension's telemetry catalogue before shipping.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 140
+      },
+      "references": [{ "path": "microsoft/knowledge/style/telemetry-event-id-stable-unique.md" }],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code-omission-reason": "fix requires assigning a real registered event ID from the extension's telemetry catalogue; no safe default replacement exists"
+    },
+    {
+      "id": "al-style-review:agent:unused-label",
+      "severity": "minor",
+      "message": "UnusedProgressLbl is declared as a Label in QltyFileImport but is never referenced anywhere in the codeunit. Dead labels are still extracted into the XLIFF translation bundle, creating translation overhead for text that is never shown to users. Remove the label or wire it into the planned progress dialog.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Utilities/QltyFileImport.Codeunit.al",
+        "line": 20
+      },
+      "references": [],
+      "confidence": "medium",
+      "from-sub-skill": "al-style-review",
+      "suggested-code-omission-reason": "fix is to delete the line entirely; no replacement text needed"
+    }
+  ],
+  "sub-results": [
+    {
+      "skill": { "id": "al-performance-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 3, "minor": 2, "info": 0 },
+        "coverage": { "worklist-size": 3, "items-evaluated": 3 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/performance/avoid-commit-inside-loops.md",
+          "severity": "major",
+          "message": "Commit() inside repeat...until loop in ImportResults — one transaction per row, defeats atomicity.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 53
+          },
+          "references": [{ "path": "microsoft/knowledge/performance/avoid-commit-inside-loops.md" }],
+          "confidence": "high",
+          "suggested-code-omission-reason": "fix requires restructuring into bounded checkpoints"
+        },
+        {
+          "id": "microsoft/knowledge/performance/avoid-commit-inside-loops.md",
+          "severity": "major",
+          "message": "Commit() inside for loop in ImportBatch — one transaction per file.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Utilities/QltyFileImport.Codeunit.al",
+            "line": 59
+          },
+          "references": [{ "path": "microsoft/knowledge/performance/avoid-commit-inside-loops.md" }],
+          "confidence": "high",
+          "suggested-code-omission-reason": "fix requires restructuring into bounded checkpoints"
+        },
+        {
+          "id": "microsoft/knowledge/performance/use-isempty-for-existence-check.md",
+          "severity": "minor",
+          "message": "Count() > 0 used for existence check in HasImportedResults; replace with IsEmpty().",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 72
+          },
+          "references": [{ "path": "microsoft/knowledge/performance/use-isempty-for-existence-check.md" }],
+          "confidence": "high",
+          "suggested-code": "        if not ImportLogEntry.IsEmpty() then"
+        },
+        {
+          "id": "microsoft/knowledge/performance/use-isempty-for-existence-check.md",
+          "severity": "minor",
+          "message": "FindFirst() used solely for existence check in HasImportedResults; replace with IsEmpty(). Also unreachable when Count() > 0 branch exits.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 75
+          },
+          "references": [{ "path": "microsoft/knowledge/performance/use-isempty-for-existence-check.md" }],
+          "confidence": "high",
+          "suggested-code-omission-reason": "fix spans lines 72-77; replace entire body with exit(not ImportLogEntry.IsEmpty());"
+        },
+        {
+          "id": "microsoft/knowledge/performance/avoid-get-inside-loop-on-large-table.md",
+          "severity": "major",
+          "message": "Customer.Get(CustomerNo) inside repeat loop in ImportResults — N+1 on the Customer table. Hoist above the loop.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 42
+          },
+          "references": [{ "path": "microsoft/knowledge/performance/avoid-get-inside-loop-on-large-table.md" }],
+          "confidence": "high",
+          "suggested-code-omission-reason": "fix requires moving Customer.Get() above the repeat block"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-security-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 3, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 2, "items-evaluated": 2 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/security/secrettext-for-credentials.md",
+          "severity": "major",
+          "message": "ApiKey and BearerToken declared as Text local variables in FetchResultsIntoBuffer — credentials visible in debugger and error diagnostics.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 82,
+            "range": { "start-line": 82, "end-line": 83 }
+          },
+          "references": [{ "path": "microsoft/knowledge/security/secrettext-for-credentials.md" }],
+          "confidence": "high",
+          "suggested-code-omission-reason": "fix requires changing both variable declarations and DownloadResults signature to SecretText"
+        },
+        {
+          "id": "microsoft/knowledge/security/secrettext-for-credentials.md",
+          "severity": "major",
+          "message": "DownloadResults accepts ApiKey and BearerToken as Text parameters, breaking the SecretText chain before the HTTP call site.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 95
+          },
+          "references": [{ "path": "microsoft/knowledge/security/secrettext-for-credentials.md" }],
+          "confidence": "high",
+          "suggested-code-omission-reason": "fix requires changing parameter types to SecretText across both procedures"
+        },
+        {
+          "id": "microsoft/knowledge/security/integrationevent-must-not-expose-secrets.md",
+          "severity": "major",
+          "message": "OnBeforeCallLabApi IntegrationEvent exposes ApiKey and BearerToken as event parameters — any tenant extension can subscribe and read them.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultEvents.Codeunit.al",
+            "line": 19
+          },
+          "references": [{ "path": "microsoft/knowledge/security/integrationevent-must-not-expose-secrets.md" }],
+          "confidence": "high",
+          "suggested-code-omission-reason": "fix requires removing credential parameters from event signature and handling auth inside the publisher"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-privacy-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 5, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 4, "items-evaluated": 4 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md",
+          "severity": "major",
+          "message": "'Customer Name' field missing DataClassification — defaults to SystemMetadata, misclassifying PII.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLogEntry.Table.al",
+            "line": 29,
+            "range": { "start-line": 29, "end-line": 32 }
+          },
+          "references": [{ "path": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md" }],
+          "confidence": "high",
+          "suggested-code": "        field(3; \"Customer Name\"; Text[100])\n        {\n            Caption = 'Customer Name';\n            DataClassification = CustomerContent;\n        }"
+        },
+        {
+          "id": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md",
+          "severity": "major",
+          "message": "'Contact Email' field missing DataClassification — defaults to SystemMetadata, misclassifying PII.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLogEntry.Table.al",
+            "line": 33,
+            "range": { "start-line": 33, "end-line": 36 }
+          },
+          "references": [{ "path": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md" }],
+          "confidence": "high",
+          "suggested-code": "        field(4; \"Contact Email\"; Text[80])\n        {\n            Caption = 'Contact Email';\n            DataClassification = CustomerContent;\n        }"
+        },
+        {
+          "id": "microsoft/knowledge/privacy/no-pii-in-telemetry-message-string.md",
+          "severity": "major",
+          "message": "Session.LogMessage message is built with StrSubstNo that embeds Customer.Name — PII logged verbatim regardless of DataClassification argument.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 141,
+            "range": { "start-line": 139, "end-line": 145 }
+          },
+          "references": [{ "path": "microsoft/knowledge/privacy/no-pii-in-telemetry-message-string.md" }],
+          "confidence": "high",
+          "suggested-code-omission-reason": "fix requires replacing the StrSubstNo message with a static string and removing Customer.Name"
+        },
+        {
+          "id": "microsoft/knowledge/privacy/featuretelemetry-customdimensions-no-pii.md",
+          "severity": "major",
+          "message": "Dimensions.Add('CustomerName', Customer.Name) places customer name PII into FeatureTelemetry custom dimensions.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 147
+          },
+          "references": [{ "path": "microsoft/knowledge/privacy/featuretelemetry-customdimensions-no-pii.md" }],
+          "confidence": "high",
+          "suggested-code-omission-reason": "fix requires removing the PII dimension; substitute a non-PII value if context is needed"
+        },
+        {
+          "id": "microsoft/knowledge/privacy/avoid-strsubstno-prebuild-before-error.md",
+          "severity": "major",
+          "message": "Error(StrSubstNo('Could not import results for customer %1', CustomerNo)) — opaque pre-built Text prevents platform from classifying the embedded argument.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 155
+          },
+          "references": [{ "path": "microsoft/knowledge/privacy/avoid-strsubstno-prebuild-before-error.md" }],
+          "confidence": "high",
+          "suggested-code": "        Error('Could not import results for customer %1', CustomerNo);"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-upgrade-review", "version": 1 },
+      "outcome": "not-applicable",
+      "summary": {
+        "counts": { "blocker": 0, "major": 0, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 0, "items-evaluated": 0 }
+      },
+      "findings": [],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-style-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 0, "minor": 12, "info": 0 },
+        "coverage": { "worklist-size": 5, "items-evaluated": 5 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/style/lowercase-reserved-keywords.md",
+          "severity": "minor",
+          "message": "CountValidEntries uses uppercase reserved keywords (VAR, BEGIN, IF, THEN, REPEAT, UNTIL, EXIT, END) — CodeCop AA0241 violation.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 111,
+            "range": { "start-line": 111, "end-line": 120 }
+          },
+          "references": [{ "path": "microsoft/knowledge/style/lowercase-reserved-keywords.md" }],
+          "confidence": "high",
+          "suggested-code-omission-reason": "fix spans 10 lines; use the AL formatter to normalise"
+        },
+        {
+          "id": "microsoft/knowledge/style/no-space-before-method-parenthesis.md",
+          "severity": "minor",
+          "message": "ImportLogEntry.Get (EntryNo) — space before parenthesis, AA0002.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 127
+          },
+          "references": [{ "path": "microsoft/knowledge/style/no-space-before-method-parenthesis.md" }],
+          "confidence": "high",
+          "suggested-code": "        if ImportLogEntry.Get(EntryNo) then"
+        },
+        {
+          "id": "microsoft/knowledge/style/no-space-before-method-parenthesis.md",
+          "severity": "minor",
+          "message": "exit (ImportLogEntry.\"Customer Name\") — space before parenthesis, AA0002.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 128
+          },
+          "references": [{ "path": "microsoft/knowledge/style/no-space-before-method-parenthesis.md" }],
+          "confidence": "high",
+          "suggested-code": "            exit(ImportLogEntry.\"Customer Name\");"
+        },
+        {
+          "id": "microsoft/knowledge/style/no-space-before-method-parenthesis.md",
+          "severity": "minor",
+          "message": "exit ('') — space before parenthesis, AA0002.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 129
+          },
+          "references": [{ "path": "microsoft/knowledge/style/no-space-before-method-parenthesis.md" }],
+          "confidence": "high",
+          "suggested-code": "        exit('');"
+        },
+        {
+          "id": "microsoft/knowledge/style/no-space-before-method-parenthesis.md",
+          "severity": "minor",
+          "message": "exit (ImportFromLbl) in GetDialogTitle — space before parenthesis, AA0002.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Utilities/QltyFileImport.Codeunit.al",
+            "line": 70
+          },
+          "references": [{ "path": "microsoft/knowledge/style/no-space-before-method-parenthesis.md" }],
+          "confidence": "high",
+          "suggested-code": "        exit(ImportFromLbl);"
+        },
+        {
+          "id": "microsoft/knowledge/style/error-passes-parameters-directly-not-strsubstno.md",
+          "severity": "minor",
+          "message": "Error(StrSubstNo(...)) in RaiseImportError defeats translation tooling and CodeCop AA0231 analysis. Pass arguments directly to Error() and declare a Label with the Err suffix.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 155
+          },
+          "references": [{ "path": "microsoft/knowledge/style/error-passes-parameters-directly-not-strsubstno.md" }],
+          "confidence": "high",
+          "suggested-code": "        Error('Could not import results for customer %1', CustomerNo);"
+        },
+        {
+          "id": "microsoft/knowledge/style/tooltip-required-on-page-fields.md",
+          "severity": "minor",
+          "message": "'Customer No.' field missing ToolTip — AA0218.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al",
+            "line": 29,
+            "range": { "start-line": 29, "end-line": 31 }
+          },
+          "references": [{ "path": "microsoft/knowledge/style/tooltip-required-on-page-fields.md" }],
+          "confidence": "high",
+          "suggested-code": "                field(\"Customer No.\"; Rec.\"Customer No.\")\n                {\n                    ToolTip = 'Specifies the customer number.';\n                }"
+        },
+        {
+          "id": "microsoft/knowledge/style/tooltip-required-on-page-fields.md",
+          "severity": "minor",
+          "message": "'Customer Name' field missing ToolTip — AA0218.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al",
+            "line": 32,
+            "range": { "start-line": 32, "end-line": 34 }
+          },
+          "references": [{ "path": "microsoft/knowledge/style/tooltip-required-on-page-fields.md" }],
+          "confidence": "high",
+          "suggested-code": "                field(\"Customer Name\"; Rec.\"Customer Name\")\n                {\n                    ToolTip = 'Specifies the name of the customer.';\n                }"
+        },
+        {
+          "id": "microsoft/knowledge/style/tooltip-required-on-page-fields.md",
+          "severity": "minor",
+          "message": "'Contact Email' field missing ToolTip — AA0218.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al",
+            "line": 35,
+            "range": { "start-line": 35, "end-line": 37 }
+          },
+          "references": [{ "path": "microsoft/knowledge/style/tooltip-required-on-page-fields.md" }],
+          "confidence": "high",
+          "suggested-code": "                field(\"Contact Email\"; Rec.\"Contact Email\")\n                {\n                    ToolTip = 'Specifies the contact email address.';\n                }"
+        },
+        {
+          "id": "microsoft/knowledge/style/tooltip-required-on-page-fields.md",
+          "severity": "minor",
+          "message": "'Imported At' field missing ToolTip — AA0218.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al",
+            "line": 42,
+            "range": { "start-line": 42, "end-line": 44 }
+          },
+          "references": [{ "path": "microsoft/knowledge/style/tooltip-required-on-page-fields.md" }],
+          "confidence": "high",
+          "suggested-code": "                field(\"Imported At\"; Rec.\"Imported At\")\n                {\n                    ToolTip = 'Specifies when the result was imported.';\n                }"
+        },
+        {
+          "id": "microsoft/knowledge/style/telemetry-event-id-stable-unique.md",
+          "severity": "minor",
+          "message": "Session.LogMessage called with placeholder event ID '0000' — non-unique across extensions, cannot be filtered in Application Insights.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 140
+          },
+          "references": [{ "path": "microsoft/knowledge/style/telemetry-event-id-stable-unique.md" }],
+          "confidence": "high",
+          "suggested-code-omission-reason": "fix requires assigning a real registered event ID from the extension's telemetry catalogue"
+        },
+        {
+          "id": "agent:unused-label",
+          "severity": "minor",
+          "message": "UnusedProgressLbl is declared but never referenced. Dead labels are extracted into the XLIFF bundle, creating translation overhead for text that is never shown. Remove the label or wire it into the planned progress dialog.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Utilities/QltyFileImport.Codeunit.al",
+            "line": 20
+          },
+          "references": [],
+          "confidence": "medium",
+          "suggested-code-omission-reason": "fix is to delete the line entirely; no replacement text needed"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-ui-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 0, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 1, "items-evaluated": 1 }
+      },
+      "findings": [],
+      "suppressed": []
+    }
+  ],
+  "skipped-sub-skills": [],
+  "suppressed": []
+}
+```
+
+

--- a/tools/Code Review/tests/fixtures/run-26956415628-al-code-review-raw.txt
+++ b/tools/Code Review/tests/fixtures/run-26956415628-al-code-review-raw.txt
@@ -1,0 +1,916 @@
+● Read entry.md
+  │ skills/entry.md
+  └ 178 lines read
+
+● Read _task-context.json
+  └ 16 lines read
+
+● List bcquality structure and review skills (shell)
+  │ ls /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/ && ls
+  │ /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/skills
+  │ /review/ 2>/dev/null || echo "No review skills found"
+  └ 5 lines...
+
+● List changed files in PR (shell)
+  │ git -C "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/review-target"
+  │ diff --name-only origin/main
+  └ 6 lines...
+
+● Read al-code-review.md
+  │ microsoft/skills/review/al-code-review.md
+  └ 316 lines read
+
+● Check knowledge index (shell)
+  │ ls /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/knowledge-ind
+  │ ex.json 2>/dev/null && echo "exists" || echo "missing"
+  └ 2 lines...
+
+● Build knowledge index (shell)
+  │ cd /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality && pwsh
+  │ ./tools/Build-KnowledgeIndex.ps1 2>&1 | tail -5
+  └ 3 lines...
+
+● Get full PR diff (shell)
+  │ git -C "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/review-target"
+  │ diff origin/main
+  └ 79 lines...
+
+● Read shell output Waiting up to 15 seconds for command output
+  └ 79 lines...
+
+● Stop shell
+  └ 1 line...
+
+● Get full PR diff no pager (shell)
+  │ git -C "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/review-target"
+  │ --no-pager diff origin/main 2>&1
+  └ 398 lines...
+
+Now let me read all the sub-skills and the knowledge index in parallel.
+
+● Read knowledge-index.json
+  └ 1 line read
+
+● Read al-performance-review.md
+  │ microsoft/skills/review/al-performance-review.md
+  └ 136 lines read
+
+● Read al-security-review.md
+  │ microsoft/skills/review/al-security-review.md
+  └ 136 lines read
+
+● Read al-privacy-review.md
+  │ microsoft/skills/review/al-privacy-review.md
+  └ 108 lines read
+
+● Read al-upgrade-review.md
+  │ microsoft/skills/review/al-upgrade-review.md
+  └ 107 lines read
+
+● Read al-style-review.md
+  │ microsoft/skills/review/al-style-review.md
+  └ 105 lines read
+
+● Read al-ui-review.md
+  │ microsoft/skills/review/al-ui-review.md
+  └ 105 lines read
+
+● List knowledge index by domain (shell)
+  │ cd /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality && python3
+  │ -c "
+  │ import json
+  │ with open('knowledge-index.json') as f:
+  │ idx = json.load(f)…
+  └ 20 lines...
+
+● Find relevant knowledge articles for the diff (shell)
+  │ cd /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality && python3
+  │ -c "
+  │ import json
+  │ with open('knowledge-index.json') as f:
+  │ idx = json.load(f)…
+  └ 53 lines...
+
+Now let me read the key knowledge articles for the worklist:
+
+● Read relevant knowledge articles (shell)
+  │ for f in \
+  │ "microsoft/knowledge/performance/avoid-commit-inside-loops.md" \
+  │
+  │ "microsoft/knowledge/performance/avoid-get-inside-loop-on-large-table.md"
+  │ \…
+  └ 48 lines...
+
+● Read knowledge articles output (shell)
+  │ cat /tmp/copilot-tool-output-1780581770742-vels7i.txt
+  └ 22 lines...
+
+● Read knowledge article content (shell)
+  │ python3 -c "
+  │ with open('/tmp/copilot-tool-output-1780581777747-zpxnhc.txt') as f:
+  │ content = f.read()
+  │ print(content)
+  │ " 2>&1 | head -1000
+  └ 22 lines...
+
+● Read performance knowledge articles (shell)
+  │ for f in \
+  │ "microsoft/knowledge/performance/avoid-commit-inside-loops.md" \
+  │
+  │ "microsoft/knowledge/performance/avoid-get-inside-loop-on-large-table.md"
+  │ \…
+  └ 92 lines...
+
+● Read security knowledge articles (shell)
+  │ for f in \
+  │
+  │ "microsoft/knowledge/security/integrationevent-must-not-expose-secrets.md"
+  │ \
+  │ "microsoft/knowledge/security/secrettext-for-credentials.md" \…
+  └ 77 lines...
+
+● Read privacy and style knowledge articles (shell)
+  │ for f in \
+  │ "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.
+  │ md" \
+  │ "microsoft/knowledge/privacy/no-pii-in-telemetry-message-string.md" \…
+  └ 251 lines...
+
+● Read UI and style knowledge articles (shell)
+  │ for f in \
+  │ "microsoft/knowledge/ui/field-tooltips-start-with-specifies-and-end-with
+  │ -period.md" \
+  │ "microsoft/knowledge/style/labels-declared-at-object-scope.md"; do
+  │ echo "=== $f ==="…
+  └ 39 lines...
+
+● List UI knowledge articles (shell)
+  │ ls /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/kno
+  │ wledge/ui/
+  └ 18 lines...
+
+● Read tooltip style knowledge article (shell)
+  │ cat "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/k
+  │ nowledge/style/tooltip-required-on-page-fields.md" 2>/dev/null
+  └ 29 lines...
+
+● Read do.md
+  │ skills/do.md
+  └ 1 line read
+
+● Read read.md
+  │ skills/read.md
+  └ 148 lines read
+
+● Read do.md
+  │ skills/do.md
+  └ L1:150 (150 lines read)
+
+● Read do.md
+  │ skills/do.md
+  └ L150:250 (101 lines read)
+
+● List all style and UI knowledge articles (shell)
+  │ cd /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality && python3
+  │ -c "
+  │ import json
+  │ with open('knowledge-index.json') as f:
+  │ idx = json.load(f)…
+  └ 61 lines...
+
+● Read lowercase keywords and label comment articles (shell)
+  │ cat "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/k
+  │ nowledge/style/lowercase-reserved-keywords.md" && echo "---" && cat
+  │ "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/knowl
+  │ edge/style/label-comment-explains-placeholders.md"
+  └ 56 lines...
+
+I now have all the information needed to execute the full review. Let me produce the output systematically.
+
+[sub-skill al-performance-review: worklist=3 findings=5]
+[sub-skill al-security-review: worklist=2 findings=2]
+[sub-skill al-privacy-review: worklist=4 findings=5]
+[sub-skill al-upgrade-review: worklist=0 findings=0]
+[sub-skill al-style-review: worklist=5 findings=7]
+[sub-skill al-ui-review: worklist=0 findings=0]
+[self-review: agent-findings=0]
+
+```json
+{
+  "skill": { "id": "al-code-review", "version": 1 },
+  "outcome": "completed",
+  "summary": {
+    "counts": { "blocker": 0, "major": 13, "minor": 6, "info": 0 },
+    "coverage": { "worklist-size": 14, "items-evaluated": 14 }
+  },
+  "findings": [
+    {
+      "id": "microsoft/knowledge/performance/avoid-commit-inside-loops.md",
+      "severity": "major",
+      "message": "Commit() is called inside a repeat...until loop in ImportResults. Each iteration ends the current write transaction, preventing the whole import from being rolled back atomically on failure and imposing one transaction boundary per row. Move Commit() to a clearly defined checkpoint outside the loop, or wrap each bounded batch in Codeunit.Run for native rollback on failure.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 55,
+        "range": { "start-line": 55, "end-line": 55 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/performance/avoid-commit-inside-loops.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-performance-review",
+      "suggested-code-omission-reason": "Complete fix requires both removing Commit from inside the loop and adding it at a safe transaction boundary after the loop; spans non-contiguous code."
+    },
+    {
+      "id": "microsoft/knowledge/performance/avoid-commit-inside-loops.md",
+      "severity": "major",
+      "message": "Commit() is called inside a for loop in ImportBatch (QltyFileImport). Each file upload iteration ends the transaction, preventing batch-level rollback and imposing per-file transaction overhead. Move Commit() outside the loop to a single checkpoint after all files are processed.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Utilities/QltyFileImport.Codeunit.al",
+        "line": 59,
+        "range": { "start-line": 59, "end-line": 59 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/performance/avoid-commit-inside-loops.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-performance-review",
+      "suggested-code-omission-reason": "Complete fix requires removing Commit from inside the for loop and placing it after the loop ends; spans non-contiguous code."
+    },
+    {
+      "id": "microsoft/knowledge/performance/avoid-get-inside-loop-on-large-table.md",
+      "severity": "major",
+      "message": "Customer.Get(CustomerNo) is called on every iteration of the repeat loop in ImportResults. Although CustomerNo is the same on every iteration, this still issues N round-trips against the Customer table (a large production-scale table) when one lookup before the loop would suffice. Move Customer.Get(CustomerNo) to before the FindSet call and reference the already-fetched record inside the loop.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 44,
+        "range": { "start-line": 44, "end-line": 44 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/performance/avoid-get-inside-loop-on-large-table.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-performance-review",
+      "suggested-code-omission-reason": "Fix requires moving Customer.Get before the loop start; spans non-contiguous code."
+    },
+    {
+      "id": "microsoft/knowledge/performance/use-isempty-for-existence-check.md",
+      "severity": "major",
+      "message": "HasImportedResults uses Count() > 0 to test whether any matching rows exist. Count() materializes a full row count the caller does not need. Replace with not ImportLogEntry.IsEmpty(), which stops at the first matching record.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 74,
+        "range": { "start-line": 74, "end-line": 74 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/performance/use-isempty-for-existence-check.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-performance-review",
+      "suggested-code": "        if not ImportLogEntry.IsEmpty() then"
+    },
+    {
+      "id": "microsoft/knowledge/performance/use-isempty-for-existence-check.md",
+      "severity": "major",
+      "message": "HasImportedResults calls FindFirst() solely to test existence — the record fields are never read. FindFirst() materialises a full row the caller discards. Replace with not ImportLogEntry.IsEmpty(). Note: after also fixing the Count() > 0 check above, this branch becomes dead code and can be removed entirely.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 77,
+        "range": { "start-line": 77, "end-line": 77 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/performance/use-isempty-for-existence-check.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-performance-review",
+      "suggested-code": "        if not ImportLogEntry.IsEmpty() then"
+    },
+    {
+      "id": "microsoft/knowledge/security/integrationevent-must-not-expose-secrets.md",
+      "severity": "major",
+      "message": "OnBeforeCallLabApi exposes ApiKey and BearerToken as plain-Text parameters of an IntegrationEvent. Any extension on the tenant can subscribe to this event, read those values, and persist or exfiltrate them — there is no subscriber permission filter. Restrict the event payload to non-sensitive context (e.g. the CustomerNo being processed and an IsHandled flag). Authentication must be resolved by the publisher before or after the event, never in the event parameters.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultEvents.Codeunit.al",
+        "line": 19,
+        "range": { "start-line": 18, "end-line": 21 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/security/integrationevent-must-not-expose-secrets.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-security-review",
+      "suggested-code-omission-reason": "Fix requires redesigning the event signature to remove credential parameters and restructuring the publisher to handle authentication independently; spans non-contiguous code."
+    },
+    {
+      "id": "microsoft/knowledge/security/secrettext-for-credentials.md",
+      "severity": "major",
+      "message": "ApiKey and BearerToken are declared as Text variables in FetchResultsIntoBuffer and passed as Text parameters to DownloadResults. Credentials held in Text are visible in the AL debugger and in any error message that prints the variable. Declare both as SecretText from the retrieval call-site (GetApiKey/GetAccessToken) all the way to the HTTP call-site, and use the SecretText-aware HttpClient surface (HttpHeaders.Add overload accepting SecretText) to avoid any unwrap to plain Text.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 84,
+        "range": { "start-line": 84, "end-line": 85 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/security/secrettext-for-credentials.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-security-review",
+      "suggested-code-omission-reason": "Fix requires changing parameter types in FetchResultsIntoBuffer, DownloadResults, and their callers across multiple procedure signatures."
+    },
+    {
+      "id": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md",
+      "severity": "major",
+      "message": "The 'Customer Name' field (Text[100]) in QltyImportLogEntry stores a customer name — personal data that requires explicit DataClassification. Without the property the platform defaults to SystemMetadata, which misclassifies customer PII in telemetry, GDPR exports, and audit surfaces. Add DataClassification = CustomerContent to this field.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLogEntry.Table.al",
+        "line": 29,
+        "range": { "start-line": 29, "end-line": 32 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code": "        field(3; \"Customer Name\"; Text[100])\n        {\n            Caption = 'Customer Name';\n            DataClassification = CustomerContent;\n        }"
+    },
+    {
+      "id": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md",
+      "severity": "major",
+      "message": "The 'Contact Email' field (Text[80]) in QltyImportLogEntry stores an email address — directly identifying personal data that requires explicit DataClassification. Without it the platform defaults to SystemMetadata. Add the appropriate DataClassification (EndUserIdentifiableInformation for an individual's personal email, or CustomerContent for a company contact email, depending on the data model).",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLogEntry.Table.al",
+        "line": 33,
+        "range": { "start-line": 33, "end-line": 36 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code-omission-reason": "Correct classification is EndUserIdentifiableInformation if the email belongs to an individual, or CustomerContent if it is a company contact address; choose the appropriate value for the data model."
+    },
+    {
+      "id": "microsoft/knowledge/privacy/no-pii-in-telemetry-message-string.md",
+      "severity": "major",
+      "message": "Session.LogMessage is called with StrSubstNo('Imported results for customer %1', Customer.Name) as the message argument. The platform does not inspect the pre-built Text string, so Customer.Name ships verbatim to telemetry regardless of the DataClassification argument on the same call. Replace the dynamic message with a static, non-personal string (e.g. 'Import results processing completed') and attach any structured context through custom dimensions where individual values can be reviewed.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 143,
+        "range": { "start-line": 143, "end-line": 143 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/privacy/no-pii-in-telemetry-message-string.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code": "            'Import results processing completed',"
+    },
+    {
+      "id": "microsoft/knowledge/privacy/featuretelemetry-customdimensions-no-pii.md",
+      "severity": "major",
+      "message": "Dimensions.Add('CustomerName', Customer.Name) places a customer name into the FeatureTelemetry.LogUsage CustomDimensions dictionary. The platform does not classify individual dimension values, so Customer.Name is logged verbatim. Pass only non-personal context through CustomDimensions (feature names, status enums, counts, error codes). Remove or replace the 'CustomerName' dimension with a non-identifying alternative.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 149,
+        "range": { "start-line": 149, "end-line": 149 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/privacy/featuretelemetry-customdimensions-no-pii.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code-omission-reason": "The appropriate fix depends on what non-PII context should replace or remove the customer name dimension; multiple defensible alternatives exist."
+    },
+    {
+      "id": "microsoft/knowledge/privacy/avoid-strsubstno-prebuild-before-error.md",
+      "severity": "major",
+      "message": "RaiseImportError calls Error(StrSubstNo('Could not import results for customer %1', CustomerNo)). The StrSubstNo result is a plain Text with the substitution already applied; the platform cannot classify CustomerNo individually and it ships verbatim to error telemetry. Call Error() directly with the format Label and CustomerNo as separate parameters so the platform can classify each argument.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 157,
+        "range": { "start-line": 157, "end-line": 157 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/privacy/avoid-strsubstno-prebuild-before-error.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code-omission-reason": "Fix requires declaring a new Label with the error message text in the object var block, then calling Error(LabelErr, CustomerNo); spans non-contiguous code."
+    },
+    {
+      "id": "microsoft/knowledge/style/error-passes-parameters-directly-not-strsubstno.md",
+      "severity": "major",
+      "message": "RaiseImportError wraps the format string in StrSubstNo before passing it to Error(). This defeats the translation pipeline (the Label's format-string identity is lost at the call site) and prevents analyzers from matching the call to its Label. Declare a Label with the Err suffix and a Comment naming the %1 placeholder, then call Error(CannotImportResultsErr, CustomerNo).",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 157,
+        "range": { "start-line": 157, "end-line": 157 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/style/error-passes-parameters-directly-not-strsubstno.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code-omission-reason": "Fix requires adding a new Label declaration with the Err suffix in the object var block and replacing the inline string; spans non-contiguous code."
+    },
+    {
+      "id": "microsoft/knowledge/style/lowercase-reserved-keywords.md",
+      "severity": "minor",
+      "message": "CountValidEntries uses uppercase AL reserved keywords throughout its body: VAR, BEGIN, IF, THEN, REPEAT, UNTIL, EXIT, END. CodeCop AA0241 requires all reserved keywords to be lowercase. This is C/AL-era casing; modernize to lowercase as the AL formatter would produce.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 113,
+        "range": { "start-line": 113, "end-line": 122 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/style/lowercase-reserved-keywords.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "    var\n        ValidCount: Integer;\n    begin\n        if ImportLogEntry.FindSet() then\n            repeat\n                if ImportLogEntry.\"Result Value\" > 0 then\n                    ValidCount += 1;\n            until ImportLogEntry.Next() = 0;\n        exit(ValidCount);\n    end;"
+    },
+    {
+      "id": "microsoft/knowledge/style/no-space-before-method-parenthesis.md",
+      "severity": "minor",
+      "message": "DescribeEntry has spaces between method names and their opening parentheses on three call sites: 'Get (EntryNo)', 'exit (ImportLogEntry.\"Customer Name\")', and 'exit (\\'\\')'. CodeCop AA0002 forbids whitespace between a method name and its '('. Remove the spaces on all three lines.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 129,
+        "range": { "start-line": 129, "end-line": 131 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/style/no-space-before-method-parenthesis.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "        if ImportLogEntry.Get(EntryNo) then\n            exit(ImportLogEntry.\"Customer Name\");\n        exit('');"
+    },
+    {
+      "id": "microsoft/knowledge/style/no-space-before-method-parenthesis.md",
+      "severity": "minor",
+      "message": "GetDialogTitle contains 'exit (ImportFromLbl)' — a space between 'exit' and its opening parenthesis. CodeCop AA0002 forbids this whitespace. Remove the space.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Utilities/QltyFileImport.Codeunit.al",
+        "line": 70,
+        "range": { "start-line": 70, "end-line": 70 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/style/no-space-before-method-parenthesis.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "        exit(ImportFromLbl);"
+    },
+    {
+      "id": "microsoft/knowledge/style/tooltip-required-on-page-fields.md",
+      "severity": "minor",
+      "message": "The 'Customer No.' field on QltyImportLog page has no ToolTip property. CodeCop AA0218 requires a non-empty ToolTip on every page field control. Add a ToolTip starting with 'Specifies'.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al",
+        "line": 29,
+        "range": { "start-line": 29, "end-line": 31 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/style/tooltip-required-on-page-fields.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "                field(\"Customer No.\"; Rec.\"Customer No.\")\n                {\n                    ToolTip = 'Specifies the customer number for the import log entry.';\n                }"
+    },
+    {
+      "id": "microsoft/knowledge/style/tooltip-required-on-page-fields.md",
+      "severity": "minor",
+      "message": "The 'Customer Name' field on QltyImportLog page has no ToolTip property. CodeCop AA0218 requires a non-empty ToolTip on every page field control. Add a ToolTip starting with 'Specifies'.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al",
+        "line": 32,
+        "range": { "start-line": 32, "end-line": 34 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/style/tooltip-required-on-page-fields.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "                field(\"Customer Name\"; Rec.\"Customer Name\")\n                {\n                    ToolTip = 'Specifies the name of the customer for the import log entry.';\n                }"
+    },
+    {
+      "id": "microsoft/knowledge/style/tooltip-required-on-page-fields.md",
+      "severity": "minor",
+      "message": "The 'Contact Email' field on QltyImportLog page has no ToolTip property. CodeCop AA0218 requires a non-empty ToolTip on every page field control. Add a ToolTip starting with 'Specifies'.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al",
+        "line": 35,
+        "range": { "start-line": 35, "end-line": 37 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/style/tooltip-required-on-page-fields.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "                field(\"Contact Email\"; Rec.\"Contact Email\")\n                {\n                    ToolTip = 'Specifies the contact email address for the import log entry.';\n                }"
+    },
+    {
+      "id": "microsoft/knowledge/style/tooltip-required-on-page-fields.md",
+      "severity": "minor",
+      "message": "The 'Imported At' field on QltyImportLog page has no ToolTip property. CodeCop AA0218 requires a non-empty ToolTip on every page field control. Add a ToolTip starting with 'Specifies'.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al",
+        "line": 42,
+        "range": { "start-line": 42, "end-line": 44 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/style/tooltip-required-on-page-fields.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "                field(\"Imported At\"; Rec.\"Imported At\")\n                {\n                    ToolTip = 'Specifies the date and time when the result was imported.';\n                }"
+    },
+    {
+      "id": "microsoft/knowledge/style/telemetry-event-id-stable-unique.md",
+      "severity": "minor",
+      "message": "Session.LogMessage is called with '0000' as the event ID — a well-known placeholder that collides with any other extension using the same placeholder, is unsearchable in Application Insights, and indicates the telemetry catalogue entry was never registered. Assign a real, stable, registered event ID drawn from this extension's telemetry catalogue.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+        "line": 142,
+        "range": { "start-line": 142, "end-line": 142 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/style/telemetry-event-id-stable-unique.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code-omission-reason": "Requires choosing a real, registered event ID from the extension's telemetry catalogue; no mechanical replacement is possible."
+    },
+    {
+      "id": "al-style-review:agent:unused-label",
+      "severity": "minor",
+      "message": "UnusedProgressLbl is declared in the QltyFileImport codeunit var block but is not referenced anywhere in the added code (ImportBatch or GetDialogTitle). Unused Label declarations add noise to the XLIFF translation catalogue, may trigger AA0005 or similar compiler warnings, and mislead translators into providing localizations for text that is never displayed. Remove the declaration if it is not referenced in any existing procedure; if it was intended for use, add the reference.",
+      "location": {
+        "file": "src/Apps/W1/Quality Management/app/src/Utilities/QltyFileImport.Codeunit.al",
+        "line": 22,
+        "range": { "start-line": 22, "end-line": 22 }
+      },
+      "references": [],
+      "confidence": "medium",
+      "from-sub-skill": "al-style-review",
+      "suggested-code-omission-reason": "Cannot confirm the label is unused in procedures not visible in the diff; remove only after verifying no existing procedure references UnusedProgressLbl."
+    }
+  ],
+  "suppressed": [],
+  "skipped-sub-skills": [],
+  "sub-results": [
+    {
+      "skill": { "id": "al-performance-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 5, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 3, "items-evaluated": 3 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/performance/avoid-commit-inside-loops.md",
+          "severity": "major",
+          "message": "Commit() is called inside a repeat...until loop in ImportResults. Each iteration ends the current write transaction, preventing the whole import from being rolled back atomically on failure and imposing one transaction boundary per row. Move Commit() to a clearly defined checkpoint outside the loop.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 55,
+            "range": { "start-line": 55, "end-line": 55 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/performance/avoid-commit-inside-loops.md" }
+          ],
+          "confidence": "high",
+          "suggested-code-omission-reason": "Complete fix requires both removing Commit from inside the loop and adding it at a safe transaction boundary after the loop; spans non-contiguous code."
+        },
+        {
+          "id": "microsoft/knowledge/performance/avoid-commit-inside-loops.md",
+          "severity": "major",
+          "message": "Commit() is called inside a for loop in ImportBatch. Each file upload iteration ends the transaction, preventing batch-level rollback and imposing per-file transaction overhead. Move Commit() outside the loop.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Utilities/QltyFileImport.Codeunit.al",
+            "line": 59,
+            "range": { "start-line": 59, "end-line": 59 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/performance/avoid-commit-inside-loops.md" }
+          ],
+          "confidence": "high",
+          "suggested-code-omission-reason": "Complete fix requires removing Commit from inside the for loop and placing it after the loop ends; spans non-contiguous code."
+        },
+        {
+          "id": "microsoft/knowledge/performance/avoid-get-inside-loop-on-large-table.md",
+          "severity": "major",
+          "message": "Customer.Get(CustomerNo) is called on every iteration of the repeat loop in ImportResults. Although CustomerNo is constant, this still issues N round-trips against the Customer table. Move the Get call before the FindSet invocation.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 44,
+            "range": { "start-line": 44, "end-line": 44 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/performance/avoid-get-inside-loop-on-large-table.md" }
+          ],
+          "confidence": "high",
+          "suggested-code-omission-reason": "Fix requires moving Customer.Get before the loop start; spans non-contiguous code."
+        },
+        {
+          "id": "microsoft/knowledge/performance/use-isempty-for-existence-check.md",
+          "severity": "major",
+          "message": "HasImportedResults uses Count() > 0 to test existence. Count() materialises a full row count that is discarded. Replace with not ImportLogEntry.IsEmpty().",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 74,
+            "range": { "start-line": 74, "end-line": 74 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/performance/use-isempty-for-existence-check.md" }
+          ],
+          "confidence": "high",
+          "suggested-code": "        if not ImportLogEntry.IsEmpty() then"
+        },
+        {
+          "id": "microsoft/knowledge/performance/use-isempty-for-existence-check.md",
+          "severity": "major",
+          "message": "HasImportedResults calls FindFirst() solely to test existence — the record fields are never read. FindFirst() materialises a full row that is discarded. Replace with not ImportLogEntry.IsEmpty(). After fixing the Count() > 0 check above, this branch becomes dead code and can be removed.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 77,
+            "range": { "start-line": 77, "end-line": 77 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/performance/use-isempty-for-existence-check.md" }
+          ],
+          "confidence": "high",
+          "suggested-code": "        if not ImportLogEntry.IsEmpty() then"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-security-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 2, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 2, "items-evaluated": 2 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/security/integrationevent-must-not-expose-secrets.md",
+          "severity": "major",
+          "message": "OnBeforeCallLabApi exposes ApiKey and BearerToken as plain-Text parameters of an IntegrationEvent. Any extension on the tenant can subscribe, read those values, and exfiltrate them. Restrict the event payload to non-sensitive context and handle authentication in the publisher before or after the event.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultEvents.Codeunit.al",
+            "line": 19,
+            "range": { "start-line": 18, "end-line": 21 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/security/integrationevent-must-not-expose-secrets.md" }
+          ],
+          "confidence": "high",
+          "suggested-code-omission-reason": "Fix requires redesigning the event signature to remove credential parameters and restructuring the publisher; spans non-contiguous code."
+        },
+        {
+          "id": "microsoft/knowledge/security/secrettext-for-credentials.md",
+          "severity": "major",
+          "message": "ApiKey and BearerToken are declared as Text in FetchResultsIntoBuffer and passed as Text to DownloadResults. Credentials in Text are visible in the debugger and any error output. Declare both as SecretText throughout the call chain and use the SecretText-aware HttpClient surface for the outbound request.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 84,
+            "range": { "start-line": 84, "end-line": 85 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/security/secrettext-for-credentials.md" }
+          ],
+          "confidence": "high",
+          "suggested-code-omission-reason": "Fix requires changing parameter types across FetchResultsIntoBuffer, DownloadResults, and their callers."
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-privacy-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 5, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 4, "items-evaluated": 4 }
+      },
+
+
+
+```json
+      "findings": [
+        {
+          "id": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md",
+          "severity": "major",
+          "message": "The 'Customer Name' field (Text[100]) stores a customer name — personal data requiring explicit DataClassification. Without the property the platform defaults to SystemMetadata, misclassifying PII in telemetry, GDPR exports, and audit surfaces. Add DataClassification = CustomerContent.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLogEntry.Table.al",
+            "line": 29,
+            "range": { "start-line": 29, "end-line": 32 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md" }
+          ],
+          "confidence": "high",
+          "suggested-code": "        field(3; \"Customer Name\"; Text[100])\n        {\n            Caption = 'Customer Name';\n            DataClassification = CustomerContent;\n        }"
+        },
+        {
+          "id": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md",
+          "severity": "major",
+          "message": "The 'Contact Email' field (Text[80]) stores an email address — directly identifying personal data requiring explicit DataClassification. Without it the platform defaults to SystemMetadata. Add DataClassification = EndUserIdentifiableInformation (for an individual's personal email) or CustomerContent (for a company contact email).",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLogEntry.Table.al",
+            "line": 33,
+            "range": { "start-line": 33, "end-line": 36 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md" }
+          ],
+          "confidence": "high",
+          "suggested-code-omission-reason": "Correct classification is EndUserIdentifiableInformation for an individual's personal email or CustomerContent for a company contact; choose the value appropriate to the data model."
+        },
+        {
+          "id": "microsoft/knowledge/privacy/no-pii-in-telemetry-message-string.md",
+          "severity": "major",
+          "message": "Session.LogMessage receives StrSubstNo('Imported results for customer %1', Customer.Name) as its message argument. The platform does not inspect a pre-built Text string, so Customer.Name ships verbatim to telemetry regardless of the DataClassification argument. Replace the dynamic message with a static, non-personal string and move any structured context to custom dimensions.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 143,
+            "range": { "start-line": 143, "end-line": 143 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/privacy/no-pii-in-telemetry-message-string.md" }
+          ],
+          "confidence": "high",
+          "suggested-code": "            'Import results processing completed',"
+        },
+        {
+          "id": "microsoft/knowledge/privacy/featuretelemetry-customdimensions-no-pii.md",
+          "severity": "major",
+          "message": "Dimensions.Add('CustomerName', Customer.Name) places a customer name into the FeatureTelemetry.LogUsage CustomDimensions dictionary. The platform does not classify individual dimension values, so Customer.Name is logged verbatim. Pass only non-personal context through CustomDimensions (feature names, status enums, counts, error codes).",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 149,
+            "range": { "start-line": 149, "end-line": 149 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/privacy/featuretelemetry-customdimensions-no-pii.md" }
+          ],
+          "confidence": "high",
+          "suggested-code-omission-reason": "The appropriate replacement depends on what non-PII context should be logged; multiple defensible alternatives exist."
+        },
+        {
+          "id": "microsoft/knowledge/privacy/avoid-strsubstno-prebuild-before-error.md",
+          "severity": "major",
+          "message": "RaiseImportError calls Error(StrSubstNo('Could not import results for customer %1', CustomerNo)). The StrSubstNo pre-builds a plain Text, preventing the platform from classifying CustomerNo individually; it ships verbatim to error telemetry. Call Error() directly with the format Label and CustomerNo as a separate parameter.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 157,
+            "range": { "start-line": 157, "end-line": 157 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/privacy/avoid-strsubstno-prebuild-before-error.md" }
+          ],
+          "confidence": "high",
+          "suggested-code-omission-reason": "Fix requires declaring a new Label with the Err suffix in the object var block and calling Error(LabelErr, CustomerNo); spans non-contiguous code."
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-upgrade-review", "version": 1 },
+      "outcome": "not-applicable",
+      "summary": {
+        "counts": { "blocker": 0, "major": 0, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 0, "items-evaluated": 0 }
+      },
+      "findings": [],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-style-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 1, "minor": 6, "info": 0 },
+        "coverage": { "worklist-size": 5, "items-evaluated": 5 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/style/error-passes-parameters-directly-not-strsubstno.md",
+          "severity": "major",
+          "message": "RaiseImportError wraps the format string in StrSubstNo before passing it to Error(). This defeats the translation pipeline (the Label's format-string identity is lost) and prevents analyzers from linking the call to its Label. Declare a Label with the Err suffix and a Comment naming the %1 placeholder, then call Error(CannotImportResultsErr, CustomerNo).",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 157,
+            "range": { "start-line": 157, "end-line": 157 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/style/error-passes-parameters-directly-not-strsubstno.md" }
+          ],
+          "confidence": "high",
+          "suggested-code-omission-reason": "Fix requires adding a new Label declaration in the object var block and replacing the inline string; spans non-contiguous code."
+        },
+        {
+          "id": "microsoft/knowledge/style/lowercase-reserved-keywords.md",
+          "severity": "minor",
+          "message": "CountValidEntries uses uppercase reserved keywords throughout its body (VAR, BEGIN, IF, THEN, REPEAT, UNTIL, EXIT, END). CodeCop AA0241 requires all reserved keywords to be lowercase. Modernize to lowercase as the AL formatter produces.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 113,
+            "range": { "start-line": 113, "end-line": 122 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/style/lowercase-reserved-keywords.md" }
+          ],
+          "confidence": "high",
+          "suggested-code": "    var\n        ValidCount: Integer;\n    begin\n        if ImportLogEntry.FindSet() then\n            repeat\n                if ImportLogEntry.\"Result Value\" > 0 then\n                    ValidCount += 1;\n            until ImportLogEntry.Next() = 0;\n        exit(ValidCount);\n    end;"
+        },
+        {
+          "id": "microsoft/knowledge/style/no-space-before-method-parenthesis.md",
+          "severity": "minor",
+          "message": "DescribeEntry has spaces between method names and their opening parentheses on three call sites: 'Get (EntryNo)', 'exit (ImportLogEntry.\"Customer Name\")', and 'exit (\\'\\')'. CodeCop AA0002 forbids whitespace between a method name and its '('. Remove the spaces on all three lines.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 129,
+            "range": { "start-line": 129, "end-line": 131 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/style/no-space-before-method-parenthesis.md" }
+          ],
+          "confidence": "high",
+          "suggested-code": "        if ImportLogEntry.Get(EntryNo) then\n            exit(ImportLogEntry.\"Customer Name\");\n        exit('');"
+        },
+        {
+          "id": "microsoft/knowledge/style/no-space-before-method-parenthesis.md",
+          "severity": "minor",
+          "message": "GetDialogTitle contains 'exit (ImportFromLbl)' — a space between 'exit' and its opening parenthesis. CodeCop AA0002 forbids this whitespace. Remove the space.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Utilities/QltyFileImport.Codeunit.al",
+            "line": 70,
+            "range": { "start-line": 70, "end-line": 70 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/style/no-space-before-method-parenthesis.md" }
+          ],
+          "confidence": "high",
+          "suggested-code": "        exit(ImportFromLbl);"
+        },
+        {
+          "id": "microsoft/knowledge/style/tooltip-required-on-page-fields.md",
+          "severity": "minor",
+          "message": "Four field controls on QltyImportLog page have no ToolTip property: 'Customer No.' (line 29), 'Customer Name' (line 32), 'Contact Email' (line 35), and 'Imported At' (line 42). CodeCop AA0218 requires a non-empty ToolTip on every page field. Add a ToolTip starting with 'Specifies' to each.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyImportLog.Page.al",
+            "line": 29,
+            "range": { "start-line": 29, "end-line": 44 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/style/tooltip-required-on-page-fields.md" }
+          ],
+          "confidence": "high",
+          "suggested-code-omission-reason": "Fix spans four non-contiguous field blocks; apply a separate suggested-code per field as provided in the top-level findings."
+        },
+        {
+          "id": "microsoft/knowledge/style/telemetry-event-id-stable-unique.md",
+          "severity": "minor",
+          "message": "Session.LogMessage is called with '0000' as the event ID — a placeholder that is unsearchable in Application Insights, collides with any other extension using the same placeholder, and indicates the telemetry catalogue entry was never registered. Assign a real, stable, registered event ID from this extension's telemetry catalogue.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Integration/ExternalResults/QltyExtResultImport.Codeunit.al",
+            "line": 142,
+            "range": { "start-line": 142, "end-line": 142 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/style/telemetry-event-id-stable-unique.md" }
+          ],
+          "confidence": "high",
+          "suggested-code-omission-reason": "Requires choosing a real, registered event ID from the extension's telemetry catalogue; no mechanical replacement is possible."
+        },
+        {
+          "id": "agent:unused-label",
+          "severity": "minor",
+          "message": "UnusedProgressLbl is declared in the QltyFileImport codeunit var block but is not referenced in any of the new code added by this PR (ImportBatch or GetDialogTitle). Unused Label declarations pollute the XLIFF translation catalogue and may cause translators to localise text that is never displayed. Remove the declaration if it is confirmed unused across all procedures; if it was intended for use, add the reference.",
+          "location": {
+            "file": "src/Apps/W1/Quality Management/app/src/Utilities/QltyFileImport.Codeunit.al",
+            "line": 22,
+            "range": { "start-line": 22, "end-line": 22 }
+          },
+          "references": [],
+          "confidence": "medium",
+          "suggested-code-omission-reason": "Cannot confirm the label is unused in procedures not visible in the diff; remove only after verifying no existing procedure references UnusedProgressLbl."
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-ui-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 0, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 0, "items-evaluated": 0 }
+      },
+      "findings": [],
+      "suppressed": []
+    }
+  ]
+}
+```
+
+

--- a/tools/Code Review/tests/fixtures/run-28168894037-al-code-review-raw.txt
+++ b/tools/Code Review/tests/fixtures/run-28168894037-al-code-review-raw.txt
@@ -1,0 +1,1525 @@
+● Read task context (shell)
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/_task-context.json
+  └ 17 lines…
+
+● Read entry.md skill file (shell)
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/skills/entry.md
+  └ 179 lines…
+
+● List available skills and check for knowledge index (shell)
+  │ find /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/skills -name "*.md" |
+  │ sort; ls /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/
+  └ 25 lines…
+
+● Read al-code-review skill (shell)
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/skills/review/al-code-
+  │ review.md
+  └ 313 lines…
+
+● Check for knowledge index (shell)
+  │ ls /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/knowledge-index.json 2>/dev/null
+  │ && echo "EXISTS" || echo "MISSING"
+  └ 2 lines…
+
+● List changed files in PR (shell)
+  │ git -C "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/review-target" diff --name-only
+  │ origin/main
+  └ 36 lines…
+
+● Build knowledge index (shell)
+  │ cd /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality && pwsh
+  │ ./tools/Build-KnowledgeIndex.ps1 2>&1 | tail -5
+  └ 3 lines…
+
+● Get diff for install/upgrade/member files (shell)
+  │ git -C "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/review-target" diff origin/main --
+  │ "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyInstall.Codeunit.al"
+  │ "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyUpgrade.Codeunit.al"
+  │ "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMember.Table.al"
+  │ "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberAPI.Page.al" …
+  └ 293 lines…
+
+● Get diff for core loyalty codeunits (shell)
+  │ git -C "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/review-target" diff origin/main --
+  │ "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyAuditSubscriber.Codeunit.al"
+  │ "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyEvents.Codeunit.al"
+  │ "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al"
+  │ "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyPublicApi.Codeunit.al" …
+  └ 373 lines…
+
+● Get diff for tier and badge files (shell)
+  │ git -C "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/review-target" diff origin/main --
+  │ "src/Apps/W1/LoyaltySample/app/src/Tier/ILoyaltyTierPolicy.Interface.al"
+  │ "src/Apps/W1/LoyaltySample/app/src/Tier/LoyaltyOrderValidator.Codeunit.al"
+  │ "src/Apps/W1/LoyaltySample/app/src/Tier/LoyaltyTierPricing.Codeunit.al"
+  │ "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyBadge.ControlAddIn.al"
+  └ 88 lines…
+
+● Get diff for member pages, notification files (shell)
+  │ git -C "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/review-target" diff origin/main --
+  │ "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberData.Page.al"
+  │ "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberList.Page.al"
+  │ "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyPointEntry.Table.al"
+  │ "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyTier.Enum.al" …
+  └ 281 lines…
+
+Now let me read the sub-skills and knowledge files to execute each sub-skill properly.
+
+● Read the READ skill (shell)
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/skills/read.md
+  └ 150 lines…
+
+● Read the DO skill (shell)
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/skills/do.md
+  └ 17 lines…
+
+● Read DO skill full content (shell)
+  │ cat /tmp/copilot-tool-output-1782389316349-al7bar.txt
+  └ 17 lines…
+
+● Read do.md
+  │ skills/do.md
+  └ 1 line read
+
+● Read do.md
+  │ skills/do.md
+  └ L100:250 (151 lines read)
+
+● Read do.md
+  │ skills/do.md
+  └ L1:100 (100 lines read)
+
+● List knowledge index articles with paths and domains (shell)
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/knowledge-index.json | python3
+  │ -c "import json,sys; data=json.load(sys.stdin);
+  │ [print(a['path']+'|'+a.get('domain','')+'|'+','.join(a.get('keywords',[]))) for a in
+  │ data['articles']]" 2>/dev/null | head -200
+  └ 8 lines…
+
+● Read full knowledge index (shell)
+  │ cat /tmp/copilot-tool-output-1782389330463-zkgemr.txt
+  └ 8 lines…
+
+● List all knowledge index articles (shell)
+  │ python3 -c "
+  │ import json
+  │ with open('/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/knowledge-index.json')
+  │ as f:
+  │ data = json.load(f)…
+  └ 11 lines…
+
+● Print knowledge index articles (shell)
+  │ python3 << 'EOF'
+  │ import json
+  │ with open('/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/knowledge-index.json')
+  │ as f:
+  │ data = json.load(f)…
+  └ 14 lines…
+
+● List knowledge article paths only (shell)
+  │ python3 -c "
+  │ import json
+  │ with open('/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/knowledge-index.json')
+  │ as f:
+  │ data = json.load(f)…
+  └ 180 lines…
+
+Now I'll read all sub-skill files in parallel to execute them.
+
+● Read al-performance-review skill (shell)
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/skills/review/al-perfo
+  │ rmance-review.md
+  └ 137 lines…
+
+● Read al-security-review skill (shell)
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/skills/review/al-secur
+  │ ity-review.md
+  └ 137 lines…
+
+● Read style and error-handling review skills (shell)
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/skills/review/al-style
+  │ -review.md
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/skills/review/al-error
+  │ -handling-review.md
+  └ 243 lines…
+
+● Read privacy and upgrade review skills (shell)
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/skills/review/al-priva
+  │ cy-review.md
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/skills/review/al-upgra
+  │ de-review.md
+  └ 22 lines…
+
+Now I'll read the relevant knowledge articles in parallel for each domain.
+
+● Read performance knowledge articles (shell)
+  │ for f in \
+  │ microsoft/knowledge/performance/avoid-commit-inside-loops.md \
+  │ microsoft/knowledge/performance/apply-filters-before-iterating.md \
+  │ microsoft/knowledge/performance/use-isempty-for-existence-check.md \
+  │ microsoft/knowledge/performance/avoid-user-prompts-inside-transactions.md \…
+  └ 175 lines…
+
+● Read security knowledge articles (shell)
+  │ for f in \
+  │ microsoft/knowledge/security/secrettext-for-credentials.md \
+  │ microsoft/knowledge/security/secrettext-with-httpclient.md \
+  │ microsoft/knowledge/security/nondebuggable-required-when-unwrapping-secrettext.md \
+  │ microsoft/knowledge/security/isolatedstorage-setencrypted-for-sensitive-values.md \…
+  └ 148 lines…
+
+● Read privacy knowledge articles (shell)
+  │ for f in \
+  │ microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md \
+  │ microsoft/knowledge/privacy/featuretelemetry-customdimensions-no-pii.md \
+  │ microsoft/knowledge/privacy/resolve-tobeclassified-before-release.md \
+  │ microsoft/knowledge/privacy/getlasterrortext-customer-content-in-errors.md \…
+  └ 139 lines…
+
+● Read upgrade knowledge articles (shell)
+  │ for f in \
+  │ microsoft/knowledge/upgrade/no-external-calls-in-upgrade.md \
+  │ microsoft/knowledge/upgrade/use-upgrade-tags-not-version-checks.md \
+  │ microsoft/knowledge/upgrade/guard-database-reads.md \
+  │ microsoft/knowledge/upgrade/do-not-block-upgrade-on-data-errors.md \…
+  └ 150 lines…
+
+● Read error-handling knowledge articles (shell)
+  │ for f in \
+  │ microsoft/knowledge/error-handling/prefer-errorinfo-for-actionable-errors.md \
+  │ microsoft/knowledge/error-handling/errortype-internal-vs-client-for-diagnostics.md \
+  │ microsoft/knowledge/error-handling/collect-validation-errors-with-errorbehavior.md; do
+  │ echo "=== $f ==="; cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/$f; echo…
+  └ 85 lines…
+
+● Read style knowledge articles (shell)
+  │ for f in \
+  │ microsoft/knowledge/style/error-passes-parameters-directly-not-strsubstno.md \
+  │ microsoft/knowledge/style/label-suffix-approved-list.md \
+  │ microsoft/knowledge/style/labels-declared-at-object-scope.md \
+  │ microsoft/knowledge/style/api-page-camelcase-properties.md \…
+  └ 176 lines…
+
+● Read web-services knowledge articles (shell)
+  │ for f in \
+  │ microsoft/knowledge/web-services/expose-systemid-as-the-api-key.md \
+  │ microsoft/knowledge/web-services/set-required-api-page-properties.md \
+  │ microsoft/knowledge/web-services/disable-write-operations-on-read-only-api-pages.md; do
+  │ echo "=== $f ==="; cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/$f; echo…
+  └ 85 lines…
+
+● Read events knowledge articles (shell)
+  │ for f in \
+  │ microsoft/knowledge/events/do-not-publish-events-inside-loops.md \
+  │ microsoft/knowledge/events/initialize-ishandled-to-false-before-publishing.md \
+  │ microsoft/knowledge/events/do-not-bypass-critical-operations-with-ishandled.md \
+  │ microsoft/knowledge/events/publish-thin-onbefore-onafter-integration-events.md; do…
+  └ 114 lines…
+
+● Read interfaces knowledge articles (shell)
+  │ for f in \
+  │ microsoft/knowledge/interfaces/set-defaultimplementation-on-enum.md \
+  │ microsoft/knowledge/interfaces/prefer-interface-over-case-branching.md; do
+  │ echo "=== $f ==="; cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/$f; echo
+  │ done
+  └ 56 lines…
+
+● Read breaking-changes knowledge articles (shell)
+  │ for f in \
+  │ microsoft/knowledge/breaking-changes/choose-access-modifiers-deliberately.md \
+  │ microsoft/knowledge/breaking-changes/do-not-expose-sensitive-data-through-public-api.md \
+  │
+  │ microsoft/knowledge/breaking-changes/deprecate-public-members-with-the-obsolete-lifecycle.md; …
+  └ 87 lines…
+
+● Read additional knowledge articles (shell)
+  │ for f in \
+  │ microsoft/knowledge/events/preserve-onafter-execution-when-ishandled-skips-the-body.md \
+  │ microsoft/knowledge/web-services/expose-systemid-as-the-api-key.md; do
+  │ echo "=== $f ==="; cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/$f; echo
+  │ done
+  └ 56 lines…
+
+● Read UI knowledge articles (shell)
+  │ for f in \
+  │ microsoft/knowledge/ui/show-caption-on-editable-fields.md \
+  │ microsoft/knowledge/ui/style-expr-text-vs-boolean.md \
+  │ microsoft/knowledge/ui/semantic-styles-need-independent-textual-meaning.md \
+  │ microsoft/knowledge/ui/cosmetic-styles-need-no-textual-context.md; do…
+  └ 125 lines…
+
+● Read events review skill briefly (shell)
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/skills/review/al-event
+  │ s-review.md | head -60
+  └ 61 lines…
+
+● Get app.json diff (shell)
+  │ git -C "/home/runner/work/BCAppsBCQuality/BCAppsBCQuality/review-target" diff origin/main --
+  │ "src/Apps/W1/LoyaltySample/app/app.json"
+  └ 37 lines…
+
+● Read inherent-permissions knowledge article (shell)
+  │ cat /home/runner/work/BCAppsBCQuality/BCAppsBCQuality/bcquality/microsoft/knowledge/security/inh
+  │ erent-permissions-minimal-grant.md
+  └ 23 lines…
+
+Now I have all the data needed. Let me produce the findings report.
+
+[sub-skill al-performance-review: worklist=2 findings=2]
+[sub-skill al-security-review: worklist=5 findings=6]
+[sub-skill al-privacy-review: worklist=4 findings=5]
+[sub-skill al-upgrade-review: worklist=5 findings=5]
+[sub-skill al-style-review: worklist=4 findings=5]
+[sub-skill al-ui-review: worklist=2 findings=2]
+[sub-skill al-error-handling-review: worklist=3 findings=4]
+[sub-skill al-events-review: worklist=4 findings=4]
+[sub-skill al-interfaces-review: worklist=1 findings=1]
+[sub-skill al-breaking-changes-review: worklist=1 findings=2]
+[sub-skill al-web-services-review: worklist=2 findings=2]
+[self-review: agent-findings=2]
+
+```json
+{
+  "skill": { "id": "al-code-review", "version": 1 },
+  "outcome": "completed",
+  "summary": {
+    "counts": { "blocker": 3, "major": 26, "minor": 13, "info": 0 },
+    "coverage": { "worklist-size": 33, "items-evaluated": 33 }
+  },
+  "findings": [
+    {
+      "id": "microsoft/knowledge/performance/avoid-commit-inside-loops.md",
+      "severity": "major",
+      "message": "Commit() is called inside the repeat\u2026until loop in RecalculateAllBalances. Each iteration opens and commits its own transaction, preventing atomic rollback of the whole batch and imposing per-row transaction overhead. Remove the Commit and let the AL module auto-commit on completion, or restructure into bounded N-row checkpoints each wrapped in Codeunit.Run.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+        "line": 32
+      },
+      "references": [
+        { "path": "microsoft/knowledge/performance/avoid-commit-inside-loops.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-performance-review",
+      "suggested-code-omission-reason": "Correct fix requires restructuring the loop into bounded checkpoints; a single-line replacement would be misleading."
+    },
+    {
+      "id": "microsoft/knowledge/performance/avoid-user-prompts-inside-transactions.md",
+      "severity": "major",
+      "message": "ArchiveMember calls Member.Delete() unconditionally and only then shows a Confirm dialog. The delete already committed (or is in an open write transaction) while the dialog holds any acquired locks for as long as the user takes to respond. Move the Confirm before the Delete so locks are acquired only after the user confirms.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+        "line": 39,
+        "range": { "start-line": 38, "end-line": 40 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/performance/avoid-user-prompts-inside-transactions.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-performance-review",
+      "suggested-code-omission-reason": "Fix requires reordering the Delete and Confirm calls, which spans non-contiguous logic."
+    },
+    {
+      "id": "microsoft/knowledge/security/secrettext-for-credentials.md",
+      "severity": "blocker",
+      "message": "GatewayApiKey is a Label (plain Text) holding a live API key 'sk-live-\u2026'. The value is hardcoded in source, visible in the debugger, and returned as Text from GetGatewayToken(). Remove the hardcoded key entirely; retrieve secrets at runtime via IsolatedStorage.Get with a SecretText destination, and never store a credential as a Label or Text variable.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+        "line": 9
+      },
+      "references": [
+        { "path": "microsoft/knowledge/security/secrettext-for-credentials.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-security-review",
+      "suggested-code-omission-reason": "Fix requires deleting the Label and updating GetGatewayToken to propagate the IsolatedStorage miss as an error; spans multiple non-contiguous locations."
+    },
+    {
+      "id": "microsoft/knowledge/security/nondebuggable-required-when-unwrapping-secrettext.md",
+      "severity": "major",
+      "message": "UnwrapGatewaySecret calls Secret.Unwrap() but the procedure is not marked [NonDebuggable]. The unwrapped Text value is visible in the debugger, defeating the SecretText protection. Add [NonDebuggable] to the procedure declaration.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+        "line": 57
+      },
+      "references": [
+        { "path": "microsoft/knowledge/security/nondebuggable-required-when-unwrapping-secrettext.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-security-review",
+      "suggested-code": "    [NonDebuggable]\n    procedure UnwrapGatewaySecret(Secret: SecretText): Text"
+    },
+    {
+      "id": "microsoft/knowledge/security/nondebuggable-required-when-unwrapping-secrettext.md",
+      "severity": "major",
+      "message": "GetApiToken calls ApiToken.Unwrap() and returns the result as plain Text, but the procedure is not marked [NonDebuggable]. The unwrapped token is visible in the debugger. Add [NonDebuggable] to the procedure declaration.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyPublicApi.Codeunit.al",
+        "line": 25
+      },
+      "references": [
+        { "path": "microsoft/knowledge/security/nondebuggable-required-when-unwrapping-secrettext.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-security-review",
+      "suggested-code": "    [NonDebuggable]\n    procedure GetApiToken(): Text"
+    },
+    {
+      "id": "microsoft/knowledge/security/isolatedstorage-setencrypted-for-sensitive-values.md",
+      "severity": "major",
+      "message": "ConfigureGateway uses IsolatedStorage.Set to store the gateway token. Because the key name indicates a credential, it must be stored with SetEncrypted so the value is protected at rest.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+        "line": 45
+      },
+      "references": [
+        { "path": "microsoft/knowledge/security/isolatedstorage-setencrypted-for-sensitive-values.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-security-review",
+      "suggested-code": "        IsolatedStorage.SetEncrypted('GatewayToken', Token, DataScope::Module);"
+    },
+    {
+      "id": "microsoft/knowledge/security/integrationevent-must-not-expose-secrets.md",
+      "severity": "blocker",
+      "message": "OnBeforeChargeMember exposes 'var GatewayToken: SecretText' as an IntegrationEvent parameter. Every subscriber on the tenant receives this var parameter and can read or replace the secret. Even SecretText must not flow through an event surface. Remove the GatewayToken parameter from the event signature; perform authentication before or after the event inside the publisher.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+        "line": 103,
+        "range": { "start-line": 102, "end-line": 105 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/security/integrationevent-must-not-expose-secrets.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-security-review",
+      "suggested-code-omission-reason": "Removing GatewayToken from the event signature is a breaking change to the event contract that requires redesigning the surrounding call site."
+    },
+    {
+      "id": "microsoft/knowledge/security/al-has-no-built-in-htmlencode.md",
+      "severity": "major",
+      "message": "BuildMemberBadgeHtml concatenates Member.\"Member Name\" and Member.\"Email Address\" directly into an HTML string with no encoding. AL has no built-in HtmlEncode; a name containing '<' or '>' will produce malformed HTML or inject markup in the consuming renderer. Encode each user-supplied value before concatenation, replacing '&' with '&amp;', '<' with '&lt;', '>' with '&gt;', and '\"' with '&quot;', or avoid building raw HTML entirely.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+        "line": 99
+      },
+      "references": [
+        { "path": "microsoft/knowledge/security/al-has-no-built-in-htmlencode.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-security-review",
+      "suggested-code-omission-reason": "The fix requires a multi-step encoding helper; a single-line replacement would be incomplete."
+    },
+    {
+      "id": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md",
+      "severity": "major",
+      "message": "Fields 'Member Name' and 'Email Address' in table 'Loyalty Member' have no DataClassification property and therefore default to SystemMetadata, which misrepresents personal data as system metadata for GDPR exports and telemetry. Both fields store customer PII and must be classified as CustomerContent (or EndUserIdentifiableInformation for Email Address).",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMember.Table.al",
+        "line": 15,
+        "range": { "start-line": 15, "end-line": 22 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code-omission-reason": "Fix must be applied independently to two separate field declarations at non-contiguous lines."
+    },
+    {
+      "id": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md",
+      "severity": "major",
+      "message": "Field 'Customer Email' in table 'Loyalty Point Entry' has no DataClassification property and defaults to SystemMetadata. An email address is customer PII and must be classified as CustomerContent.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyPointEntry.Table.al",
+        "line": 37,
+        "range": { "start-line": 37, "end-line": 40 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code": "        field(6; \"Customer Email\"; Text[80])\n        {\n            Caption = 'Customer Email';\n            DataClassification = CustomerContent;\n        }"
+    },
+    {
+      "id": "microsoft/knowledge/privacy/resolve-tobeclassified-before-release.md",
+      "severity": "minor",
+      "message": "Fields 'Phone No.' (line 26) and 'Points Balance' (line 35) in table 'Loyalty Member' are declared with DataClassification = ToBeClassified. This sentinel must be resolved to a real classification before release. 'Phone No.' should be CustomerContent; 'Points Balance' is account-level data and should be CustomerContent or AccountData.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMember.Table.al",
+        "line": 26
+      },
+      "references": [
+        { "path": "microsoft/knowledge/privacy/resolve-tobeclassified-before-release.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code-omission-reason": "Correct classification requires a data-ownership decision; a mechanical replacement would substitute one guess for another."
+    },
+    {
+      "id": "microsoft/knowledge/privacy/featuretelemetry-customdimensions-no-pii.md",
+      "severity": "major",
+      "message": "LogMemberUsage adds 'MemberName' (Member.\"Member Name\") and 'MemberEmail' (Member.\"Email Address\") to the FeatureTelemetry CustomDimensions dictionary. Customer name and email address are PII and must not appear in telemetry. Replace them with non-personal context such as a count, a tier enum, or a stable identifier that does not identify the individual.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+        "line": 79,
+        "range": { "start-line": 79, "end-line": 80 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/privacy/featuretelemetry-customdimensions-no-pii.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code-omission-reason": "Requires choosing non-PII replacement dimensions; the right values depend on the telemetry intent."
+    },
+    {
+      "id": "microsoft/knowledge/privacy/privacy-notice-consent-for-external-data-transfer.md",
+      "severity": "major",
+      "message": "CallPaymentGateway posts member name, email address, and phone number to an external endpoint with no PrivacyNotice.GetPrivacyNoticeApprovalState check anywhere upstream in the code path. The Privacy Notice framework requires admin consent before customer data is sent to external services.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+        "line": 71
+      },
+      "references": [
+        { "path": "microsoft/knowledge/privacy/privacy-notice-consent-for-external-data-transfer.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code-omission-reason": "Requires registering a privacy notice and adding a consent check upstream; spans multiple files and non-contiguous code."
+    },
+    {
+      "id": "microsoft/knowledge/privacy/privacy-notice-consent-for-external-data-transfer.md",
+      "severity": "major",
+      "message": "SendExternalAuditEmail posts member data to 'https://audit.contoso.example/loyalty' with no PrivacyNotice.GetPrivacyNoticeApprovalState check. The Privacy Notice framework requires admin consent before any customer data is sent to external services.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyAuditSubscriber.Codeunit.al",
+        "line": 18
+      },
+      "references": [
+        { "path": "microsoft/knowledge/privacy/privacy-notice-consent-for-external-data-transfer.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-privacy-review",
+      "suggested-code-omission-reason": "Requires registering a privacy notice and adding a consent guard; spans multiple files."
+    },
+    {
+      "id": "microsoft/knowledge/upgrade/no-external-calls-in-upgrade.md",
+      "severity": "blocker",
+      "message": "OnUpgradePerCompany calls Client.Get('https://api.contoso-pay.example/migrate', ...). External HTTP calls inside upgrade triggers are forbidden: DNS failure, an expired token, or a temporarily unavailable service will abort the entire upgrade. Defer this call to runtime code (e.g. a job queue entry written during upgrade).",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyUpgrade.Codeunit.al",
+        "line": 20
+      },
+      "references": [
+        { "path": "microsoft/knowledge/upgrade/no-external-calls-in-upgrade.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-upgrade-review",
+      "suggested-code-omission-reason": "Fix requires removing the HTTP call and adding a deferred job-queue mechanism; spans multiple non-contiguous locations."
+    },
+    {
+      "id": "microsoft/knowledge/upgrade/use-upgrade-tags-not-version-checks.md",
+      "severity": "major",
+      "message": "Neither OnUpgradePerCompany nor OnValidateUpgradePerCompany uses HasUpgradeTag / SetUpgradeTag to guard execution. Without tags the upgrade logic runs on every upgrade pass for every tenant, regardless of whether the work was already done. Add a unique upgrade tag per feature and guard each procedure with HasUpgradeTag at entry and SetUpgradeTag after successful completion.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyUpgrade.Codeunit.al",
+        "line": 7
+      },
+      "references": [
+        { "path": "microsoft/knowledge/upgrade/use-upgrade-tags-not-version-checks.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-upgrade-review",
+      "suggested-code-omission-reason": "Requires adding tag constants and guard calls in multiple locations across the codeunit."
+    },
+    {
+      "id": "microsoft/knowledge/upgrade/guard-database-reads.md",
+      "severity": "major",
+      "message": "Member.FindSet(true) in OnUpgradePerCompany is unguarded: if no Loyalty Member records exist on a tenant the loop executes on an unpositioned cursor, producing a runtime error that aborts the upgrade. Wrap with 'if Member.FindSet(true) then' so an empty table is handled gracefully.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyUpgrade.Codeunit.al",
+        "line": 13
+      },
+      "references": [
+        { "path": "microsoft/knowledge/upgrade/guard-database-reads.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-upgrade-review",
+      "suggested-code": "        if Member.FindSet(true) then\n            repeat\n                Member.CalcFields(\"Total Points\");\n                Member.\"Points Balance\" := Member.\"Total Points\" * 2;\n                Member.Modify();\n            until Member.Next() = 0;"
+    },
+    {
+      "id": "microsoft/knowledge/upgrade/do-not-block-upgrade-on-data-errors.md",
+      "severity": "major",
+      "message": "OnUpgradePerCompany raises Error('No loyalty members were found during upgrade.') when the table is empty. Raising an Error inside an upgrade trigger aborts the upgrade for the affected company. Log a telemetry warning and exit instead so the upgrade proceeds.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyUpgrade.Codeunit.al",
+        "line": 23,
+        "range": { "start-line": 22, "end-line": 23 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/upgrade/do-not-block-upgrade-on-data-errors.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-upgrade-review",
+      "suggested-code": "        if Member.IsEmpty() then begin\n            Session.LogMessage('LOY-UPG-001', 'No loyalty members found during upgrade.', Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Upgrade');\n            exit;\n        end;"
+    },
+    {
+      "id": "microsoft/knowledge/upgrade/minimize-onvalidate-upgrade-triggers.md",
+      "severity": "major",
+      "message": "OnValidateUpgradePerCompany calls RecalculateAllBalances(), which performs a full-table scan with per-row Commit. This expensive work runs on every upgrade pass with no upgrade-tag guard to skip it once complete. Add an upgrade tag guard and justify why this validation must run on every upgrade.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyUpgrade.Codeunit.al",
+        "line": 30
+      },
+      "references": [
+        { "path": "microsoft/knowledge/upgrade/minimize-onvalidate-upgrade-triggers.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-upgrade-review",
+      "suggested-code-omission-reason": "Requires adding an upgrade tag constant and guard; spans multiple non-contiguous locations."
+    },
+    {
+      "id": "microsoft/knowledge/style/error-passes-parameters-directly-not-strsubstno.md",
+      "severity": "major",
+      "message": "ThrowMemberError builds the error message with StrSubstNo(Text000, Member.\"Member Name\") and passes the pre-built Text to Error(). This hides the label template from the translation pipeline and prevents analyzers from correlating the call with its label. Replace with Error(Text000, Member.\"Member Name\").",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+        "line": 93,
+        "range": { "start-line": 93, "end-line": 94 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/style/error-passes-parameters-directly-not-strsubstno.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "        Error(Text000, Member.\"Member Name\");"
+    },
+    {
+      "id": "microsoft/knowledge/style/label-suffix-approved-list.md",
+      "severity": "minor",
+      "message": "The label 'Text000' has no approved suffix (Msg/Err/Qst/Lbl/Tok/Txt). It is passed to Error(), so it should be renamed with the 'Err' suffix, e.g. 'FailedToProcessMemberErr'. This also applies across all usages of the variable.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+        "line": 8
+      },
+      "references": [
+        { "path": "microsoft/knowledge/style/label-suffix-approved-list.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code-omission-reason": "Rename requires updating the declaration and all usages; spans multiple non-contiguous locations."
+    },
+    {
+      "id": "microsoft/knowledge/style/api-page-camelcase-properties.md",
+      "severity": "minor",
+      "message": "LoyaltyMemberAPI sets EntityName = 'Loyalty_Member' and EntitySetName = 'Loyalty_Members'. The underscore character is not allowed in API page property values; they must be camelCase alphanumeric only. Use EntityName = 'loyaltyMember' and EntitySetName = 'loyaltyMembers'. The field identifier 'Member_Name' also contains an underscore and must be changed to 'memberName'.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberAPI.Page.al",
+        "line": 9,
+        "range": { "start-line": 9, "end-line": 10 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/style/api-page-camelcase-properties.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code-omission-reason": "Fix spans EntityName, EntitySetName, and field identifier declarations at non-contiguous lines."
+    },
+    {
+      "id": "microsoft/knowledge/style/api-page-delayedinsert-true.md",
+      "severity": "minor",
+      "message": "LoyaltyMemberAPI explicitly sets DelayedInsert = false. API pages must set DelayedInsert = true so the record insert fires once with all fields populated. With DelayedInsert = false, validation triggers fire on partially populated records and callers receive errors for fields the JSON payload was about to supply.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberAPI.Page.al",
+        "line": 12
+      },
+      "references": [
+        { "path": "microsoft/knowledge/style/api-page-delayedinsert-true.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code": "    DelayedInsert = true;"
+    },
+    {
+      "id": "microsoft/knowledge/style/api-page-delayedinsert-true.md",
+      "severity": "minor",
+      "message": "LoyaltyMemberData is a PageType = API page with no DelayedInsert property, which defaults to false. API pages must declare DelayedInsert = true.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberData.Page.al",
+        "line": 5
+      },
+      "references": [
+        { "path": "microsoft/knowledge/style/api-page-delayedinsert-true.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-style-review",
+      "suggested-code-omission-reason": "Requires adding a new property line rather than replacing an existing line; insertion point is ambiguous without seeing the full page header."
+    },
+    {
+      "id": "microsoft/knowledge/ui/show-caption-on-editable-fields.md",
+      "severity": "minor",
+      "message": "The 'Member Name' field on LoyaltyMemberCard has Editable = true and ShowCaption = false. Removing the caption from an editable field is an accessibility violation: screen reader users lose the field label. Remove ShowCaption = false or set it to true.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberCard.Page.al",
+        "line": 26
+      },
+      "references": [
+        { "path": "microsoft/knowledge/ui/show-caption-on-editable-fields.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-ui-review",
+      "suggested-code": "                ShowCaption = true;"
+    },
+    {
+      "id": "microsoft/knowledge/ui/semantic-styles-need-independent-textual-meaning.md",
+      "severity": "minor",
+      "message": "The 'Points Balance' field on LoyaltyMemberCard uses StyleExpr = 'Unfavorable' as a static literal, so every member's balance is always rendered in bold red regardless of its value. 'Unfavorable' is a semantic style whose meaning must be independently derivable from the caption, value, or an adjacent field. A positive balance rendered as Unfavorable conveys false negative meaning. Drive the style dynamically from the field value (e.g. apply Unfavorable only when the balance is negative).",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberCard.Page.al",
+        "line": 37
+      },
+      "references": [
+        { "path": "microsoft/knowledge/ui/semantic-styles-need-independent-textual-meaning.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-ui-review",
+      "suggested-code-omission-reason": "Fix requires adding a Text variable, assigning it in OnAfterGetRecord, and changing StyleExpr to reference the variable; spans non-contiguous locations."
+    },
+    {
+      "id": "microsoft/knowledge/error-handling/errortype-internal-vs-client-for-diagnostics.md",
+      "severity": "minor",
+      "message": "EnsureBucketInitialized raises Error('Unexpected state: loyalty ledger bucket %1 is not initialized.') as a plain client-visible error. The wording targets a developer, not a user. Use ErrorInfo with ErrorType::Internal so the detail goes to telemetry and the user sees a generic message.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyValidation.Codeunit.al",
+        "line": 23
+      },
+      "references": [
+        { "path": "microsoft/knowledge/error-handling/errortype-internal-vs-client-for-diagnostics.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-error-handling-review",
+      "suggested-code-omission-reason": "Fix requires constructing an ErrorInfo object with ErrorType::Internal and a DetailedMessage; the replacement spans several statements."
+    },
+    {
+      "id": "microsoft/knowledge/error-handling/collect-validation-errors-with-errorbehavior.md",
+      "severity": "major",
+      "message": "ValidateBalances manually accumulates errors into an ErrorText variable using string concatenation and then raises a single Error(ErrorText). This re-implements the platform's collectible-errors feature, loses each error's ErrorInfo structure, and skips telemetry classification. Replace with [ErrorBehavior(ErrorBehavior::Collect)], raise individual errors per row, and inspect HasCollectedErrors / GetCollectedErrors at the end.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyValidation.Codeunit.al",
+        "line": 46,
+        "range": { "start-line": 41, "end-line": 49 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/error-handling/collect-validation-errors-with-errorbehavior.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-error-handling-review",
+      "suggested-code-omission-reason": "Fix requires refactoring the entire procedure to use ErrorBehavior::Collect and GetCollectedErrors; spans multiple non-contiguous statements."
+    },
+    {
+      "id": "microsoft/knowledge/error-handling/collect-validation-errors-with-errorbehavior.md",
+      "severity": "major",
+      "message": "ValidateAllMembers is marked [ErrorBehavior(ErrorBehavior::Collect)] but never calls HasCollectedErrors or GetCollectedErrors. Errors accumulate silently and spill into the platform's concatenated end-of-procedure dialog, which is hard for users to read. Handle the collected errors explicitly by inspecting HasCollectedErrors and surfacing GetCollectedErrors after the loop.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyValidation.Codeunit.al",
+        "line": 27,
+        "range": { "start-line": 26, "end-line": 36 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/error-handling/collect-validation-errors-with-errorbehavior.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-error-handling-review",
+      "suggested-code-omission-reason": "Fix requires adding GetCollectedErrors handling after the loop and deciding how to surface the result; context-dependent."
+    },
+    {
+      "id": "microsoft/knowledge/error-handling/prefer-errorinfo-for-actionable-errors.md",
+      "severity": "minor",
+      "message": "ValidateRedemption raises Error('You cannot redeem more than %1 points.', LoyaltyMember.\"Points Balance\") naming the exact maximum but offering no action. Because the code knows the maximum, this is a candidate for an ErrorInfo with a Fix-it AddAction that sets the redemption amount to the allowed maximum, letting the user unblock themselves without leaving their task.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyValidation.Codeunit.al",
+        "line": 8,
+        "range": { "start-line": 7, "end-line": 8 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/error-handling/prefer-errorinfo-for-actionable-errors.md" }
+      ],
+      "confidence": "medium",
+      "from-sub-skill": "al-error-handling-review",
+      "suggested-code-omission-reason": "Fix requires an ErrorInfo with AddAction pointing to a handler codeunit that applies the maximum; requires choosing real object names."
+    },
+    {
+      "id": "microsoft/knowledge/events/do-not-publish-events-inside-loops.md",
+      "severity": "major",
+      "message": "NotifyMembers raises OnMemberNotified inside the repeat\u2026until loop, firing once per member record. Every subscriber's cost is multiplied by the row count; on large datasets this can cause timeouts. Move the event outside the loop or publish a single batch event passing the filtered record set.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyEvents.Codeunit.al",
+        "line": 56
+      },
+      "references": [
+        { "path": "microsoft/knowledge/events/do-not-publish-events-inside-loops.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-events-review",
+      "suggested-code-omission-reason": "Fix requires redesigning the event to pass a batch context rather than a single record; the replacement shape depends on what subscribers need."
+    },
+    {
+      "id": "microsoft/knowledge/events/publish-thin-onbefore-onafter-integration-events.md",
+      "severity": "major",
+      "message": "OnBeforeRecalculate is an IntegrationEvent publisher whose body contains business logic: it resets Points Balance and sets it to 100 for Platinum members. An IntegrationEvent body must be empty; placing logic there causes it to run on every raise, bypassing the subscriber override pattern and surprising every reader. Move the logic to the calling routine (RecalculateMember) and leave the event body empty.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyEvents.Codeunit.al",
+        "line": 71,
+        "range": { "start-line": 68, "end-line": 74 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/events/publish-thin-onbefore-onafter-integration-events.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-events-review",
+      "suggested-code": "    [IntegrationEvent(false, false)]\n    local procedure OnBeforeRecalculate(var LoyaltyMember: Record \"Loyalty Member\"; var IsHandled: Boolean)\n    begin\n    end;"
+    },
+    {
+      "id": "microsoft/knowledge/events/preserve-onafter-execution-when-ishandled-skips-the-body.md",
+      "severity": "minor",
+      "message": "CalculateTotal guards the default body with 'if IsHandled then exit', but this exit skips OnAfterCalculateTotal as well. Subscribers that depend on the after-event will not fire when another subscriber handles the before-event. Wrap only the default work in 'if not IsHandled then begin \u2026 end' and leave the OnAfterCalculateTotal raise after that block so it always fires.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyEvents.Codeunit.al",
+        "line": 19,
+        "range": { "start-line": 19, "end-line": 20 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/events/preserve-onafter-execution-when-ishandled-skips-the-body.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-events-review",
+      "suggested-code": "        if not IsHandled then\n            DoRecalculate(LoyaltyMember);\n        OnAfterCalculateTotal(LoyaltyMember);"
+    },
+    {
+      "id": "microsoft/knowledge/events/initialize-ishandled-to-false-before-publishing.md",
+      "severity": "minor",
+      "message": "RecalculateMember raises OnBeforeRecalculate(LoyaltyMember, IsHandled) without first assigning IsHandled := false. Although a freshly declared Boolean defaults to false, the explicit assignment makes the control flow self-documenting and stays correct if a second event raise is added to the routine later. Add 'IsHandled := false;' immediately before the raise.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyEvents.Codeunit.al",
+        "line": 9
+      },
+      "references": [
+        { "path": "microsoft/knowledge/events/initialize-ishandled-to-false-before-publishing.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-events-review",
+      "suggested-code": "        IsHandled := false;\n        OnBeforeRecalculate(LoyaltyMember, IsHandled);"
+    },
+    {
+      "id": "microsoft/knowledge/interfaces/set-defaultimplementation-on-enum.md",
+      "severity": "major",
+      "message": "Enum 'Loyalty Channel' implements INotificationSender but value(0; \" \") has no Implementation property and the enum declares no DefaultImplementation. Assigning the blank channel value to an INotificationSender variable and calling Send will fail at runtime. Add a DefaultImplementation at the enum level pointing at a safe no-op implementation, or add an Implementation to value(0).",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Notification/LoyaltyChannel.Enum.al",
+        "line": 7,
+        "range": { "start-line": 7, "end-line": 10 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/interfaces/set-defaultimplementation-on-enum.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-interfaces-review",
+      "suggested-code-omission-reason": "Requires deciding which codeunit should serve as the default (no-op) implementation; not unambiguous from the diff."
+    },
+    {
+      "id": "microsoft/knowledge/breaking-changes/do-not-expose-sensitive-data-through-public-api.md",
+      "severity": "major",
+      "message": "GetApiToken() is a public procedure that returns ApiToken.Unwrap() as plain Text. This turns a SecretText credential into a permanently public API contract that any dependent extension can consume. Mark the procedure internal or local so the secret stays within the codeunit boundary.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyPublicApi.Codeunit.al",
+        "line": 25
+      },
+      "references": [
+        { "path": "microsoft/knowledge/breaking-changes/do-not-expose-sensitive-data-through-public-api.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-breaking-changes-review",
+      "suggested-code": "    local procedure GetApiToken(): Text"
+    },
+    {
+      "id": "microsoft/knowledge/breaking-changes/do-not-expose-sensitive-data-through-public-api.md",
+      "severity": "major",
+      "message": "GetGatewayToken() is a public procedure that returns the gateway token as plain Text (falling back to the hardcoded Label when IsolatedStorage is empty). Any extension can call this public getter to read the credential. Mark the procedure internal or local and ensure callers consume the token as SecretText.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+        "line": 48
+      },
+      "references": [
+        { "path": "microsoft/knowledge/breaking-changes/do-not-expose-sensitive-data-through-public-api.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-breaking-changes-review",
+      "suggested-code": "    local procedure GetGatewayToken(): Text"
+    },
+    {
+      "id": "microsoft/knowledge/web-services/set-required-api-page-properties.md",
+      "severity": "major",
+      "message": "LoyaltyMemberData is declared PageType = API but is missing all six required identifying properties: APIPublisher, APIGroup, APIVersion, EntityName, EntitySetName. Without them the OData route cannot be composed and the endpoint will never be reachable by any integration client.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberData.Page.al",
+        "line": 5,
+        "range": { "start-line": 5, "end-line": 8 }
+      },
+      "references": [
+        { "path": "microsoft/knowledge/web-services/set-required-api-page-properties.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-web-services-review",
+      "suggested-code-omission-reason": "Requires adding six new property declarations; publisher tag, group, version, and entity names must be chosen by the developer."
+    },
+    {
+      "id": "microsoft/knowledge/web-services/expose-systemid-as-the-api-key.md",
+      "severity": "major",
+      "message": "LoyaltyMemberData sets ODataKeyFields = \"No.\", using the business key as the OData key. If a user renames the member number, all existing API references will dangle. Change to ODataKeyFields = SystemId and expose Rec.SystemId as a non-editable 'id' field.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberData.Page.al",
+        "line": 7
+      },
+      "references": [
+        { "path": "microsoft/knowledge/web-services/expose-systemid-as-the-api-key.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-web-services-review",
+      "suggested-code": "    ODataKeyFields = SystemId;"
+    },
+    {
+      "id": "microsoft/knowledge/security/inherent-permissions-minimal-grant.md",
+      "severity": "major",
+      "message": "RecalculateAllBalances declares [InherentPermissions(PermissionObjectType::TableData, Database::\"Loyalty Point Entry\", 'RIMDX')]. The procedure body only reads Loyalty Point Entry records (SetRange, FindSet, PointEntry.Points) and performs no Insert, Modify, Delete, or Execute on that table. The grant must be narrowed to 'R' to match the actual operations performed.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+        "line": 11
+      },
+      "references": [
+        { "path": "microsoft/knowledge/security/inherent-permissions-minimal-grant.md" }
+      ],
+      "confidence": "high",
+      "from-sub-skill": "al-security-review",
+      "suggested-code": "    [InherentPermissions(PermissionObjectType::TableData, Database::\"Loyalty Point Entry\", 'R')]"
+    },
+    {
+      "id": "agent:delete-before-confirm-in-archivemember",
+      "severity": "minor",
+      "message": "ArchiveMember calls Member.Delete() unconditionally before showing the Confirm dialog. The member record is always deleted regardless of whether the user clicks Yes or No; the Confirm only controls whether 'Archived.' is shown. This is a logic error: the delete should be inside 'if Confirm(...) then'. The current ordering leaves the member permanently removed even when the user declines.",
+      "location": {
+        "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+        "line": 38,
+        "range": { "start-line": 37, "end-line": 41 }
+      },
+      "references": [],
+      "confidence": "high",
+      "from-sub-skill": "agent",
+      "suggested-code": "    procedure ArchiveMember(var Member: Record \"Loyalty Member\")\n    begin\n        if Confirm('Do you want to archive member %1?', false, Member.\"Member Name\") then begin\n            Member.Delete();\n            Message('Archived.');\n        end;\n    end;"
+    },
+    {
+      "id": "agent:httpclient-response-unchecked",
+      "severity": "minor",
+      "message": "Both CallPaymentGateway (LoyaltyManagement.Codeunit.al line 71) and SendExternalAuditEmail (LoyaltyAuditSubscriber.Codeunit.al line 18) call HttpClient.Post but never inspect the HttpResponseMessage status. Network failures, 4xx/5xx responses, and server-side errors are silently swallowed. Add a check on Response.IsSuccessStatusCode and either raise a controlled error or log a telemetry warning so failures are observable.",
+      "references": [],
+      "confidence": "medium",
+      "from-sub-skill": "agent",
+      "suggested-code-omission-reason": "Fix must be applied at two separate locations and the appropriate error-handling strategy (retry, log, surface to user) is context-dependent."
+    }
+  ],
+  "suppressed": [],
+  "skipped-sub-skills": [],
+  "sub-results": [
+    {
+      "skill": { "id": "al-performance-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 2, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 2, "items-evaluated": 2 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/performance/avoid-commit-inside-loops.md",
+          "severity": "major",
+          "message": "Commit() is called inside the repeat\u2026until loop in RecalculateAllBalances. Each iteration opens and commits its own transaction, preventing atomic rollback of the whole batch and imposing per-row transaction overhead. Remove the Commit and let the AL module auto-commit on completion, or restructure into bounded N-row checkpoints each wrapped in Codeunit.Run.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+            "line": 32
+          },
+          "references": [
+            { "path": "microsoft/knowledge/performance/avoid-commit-inside-loops.md" }
+          ],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/performance/avoid-user-prompts-inside-transactions.md",
+          "severity": "major",
+          "message": "ArchiveMember calls Member.Delete() unconditionally and only then shows a Confirm dialog. The write transaction holds locks while the dialog waits for user input. Move the Confirm before the Delete so locks are acquired only after the user confirms.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+            "line": 39,
+            "range": { "start-line": 38, "end-line": 40 }
+          },
+          "references": [
+            { "path": "microsoft/knowledge/performance/avoid-user-prompts-inside-transactions.md" }
+          ],
+          "confidence": "high"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-security-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 2, "major": 5, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 5, "items-evaluated": 5 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/security/secrettext-for-credentials.md",
+          "severity": "blocker",
+          "message": "GatewayApiKey is a Label (plain Text) holding a live API key. Remove the hardcoded key; retrieve secrets at runtime via IsolatedStorage with a SecretText destination.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+            "line": 9
+          },
+          "references": [{ "path": "microsoft/knowledge/security/secrettext-for-credentials.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/security/nondebuggable-required-when-unwrapping-secrettext.md",
+          "severity": "major",
+          "message": "UnwrapGatewaySecret calls Secret.Unwrap() without [NonDebuggable]. Add [NonDebuggable] to the procedure.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+            "line": 57
+          },
+          "references": [{ "path": "microsoft/knowledge/security/nondebuggable-required-when-unwrapping-secrettext.md" }],
+          "confidence": "high",
+          "suggested-code": "    [NonDebuggable]\n    procedure UnwrapGatewaySecret(Secret: SecretText): Text"
+        },
+        {
+          "id": "microsoft/knowledge/security/nondebuggable-required-when-unwrapping-secrettext.md",
+          "severity": "major",
+          "message": "GetApiToken calls ApiToken.Unwrap() without [NonDebuggable]. Add [NonDebuggable] to the procedure.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyPublicApi.Codeunit.al",
+            "line": 25
+          },
+          "references": [{ "path": "microsoft/knowledge/security/nondebuggable-required-when-unwrapping-secrettext.md" }],
+          "confidence": "high",
+          "suggested-code": "    [NonDebuggable]\n    procedure GetApiToken(): Text"
+        },
+        {
+          "id": "microsoft/knowledge/security/isolatedstorage-setencrypted-for-sensitive-values.md",
+          "severity": "major",
+          "message": "ConfigureGateway uses IsolatedStorage.Set for a gateway token. Use SetEncrypted to protect the value at rest.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+            "line": 45
+          },
+          "references": [{ "path": "microsoft/knowledge/security/isolatedstorage-setencrypted-for-sensitive-values.md" }],
+          "confidence": "high",
+          "suggested-code": "        IsolatedStorage.SetEncrypted('GatewayToken', Token, DataScope::Module);"
+        },
+        {
+          "id": "microsoft/knowledge/security/integrationevent-must-not-expose-secrets.md",
+          "severity": "blocker",
+          "message": "OnBeforeChargeMember exposes var GatewayToken: SecretText as an event parameter. Every subscriber on the tenant can read or replace the secret. Remove the credential from the event signature.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+            "line": 103,
+            "range": { "start-line": 102, "end-line": 105 }
+          },
+          "references": [{ "path": "microsoft/knowledge/security/integrationevent-must-not-expose-secrets.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/security/al-has-no-built-in-htmlencode.md",
+          "severity": "major",
+          "message": "BuildMemberBadgeHtml concatenates Member Name and Email Address directly into HTML without encoding. AL has no built-in HtmlEncode; a name containing HTML metacharacters will inject markup. Encode each value before concatenation.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+            "line": 99
+          },
+          "references": [{ "path": "microsoft/knowledge/security/al-has-no-built-in-htmlencode.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/security/inherent-permissions-minimal-grant.md",
+          "severity": "major",
+          "message": "[InherentPermissions(..., 'RIMDX')] on RecalculateAllBalances grants Insert, Modify, Delete, and Execute on Loyalty Point Entry but the body only reads. Narrow to 'R'.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+            "line": 11
+          },
+          "references": [{ "path": "microsoft/knowledge/security/inherent-permissions-minimal-grant.md" }],
+          "confidence": "high",
+          "suggested-code": "    [InherentPermissions(PermissionObjectType::TableData, Database::\"Loyalty Point Entry\", 'R')]"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-privacy-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 4, "minor": 1, "info": 0 },
+        "coverage": { "worklist-size": 4, "items-evaluated": 4 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md",
+          "severity": "major",
+          "message": "Fields 'Member Name' and 'Email Address' in Loyalty Member have no DataClassification and default to SystemMetadata. Both store customer PII and must be classified CustomerContent (or EndUserIdentifiableInformation for Email Address).",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMember.Table.al",
+            "line": 15,
+            "range": { "start-line": 15, "end-line": 22 }
+          },
+          "references": [{ "path": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md",
+          "severity": "major",
+          "message": "Field 'Customer Email' in Loyalty Point Entry has no DataClassification and defaults to SystemMetadata. It stores an email address and must be classified CustomerContent.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyPointEntry.Table.al",
+            "line": 37,
+            "range": { "start-line": 37, "end-line": 40 }
+          },
+          "references": [{ "path": "microsoft/knowledge/privacy/data-classification-required-on-pii-fields.md" }],
+          "confidence": "high",
+          "suggested-code": "        field(6; \"Customer Email\"; Text[80])\n        {\n            Caption = 'Customer Email';\n            DataClassification = CustomerContent;\n        }"
+        },
+        {
+          "id": "microsoft/knowledge/privacy/resolve-tobeclassified-before-release.md",
+          "severity": "minor",
+          "message": "Fields 'Phone No.' and 'Points Balance' in Loyalty Member are DataClassification = ToBeClassified. Resolve before release: Phone No. should be CustomerContent; Points Balance should be CustomerContent or AccountData.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMember.Table.al",
+            "line": 26
+          },
+          "references": [{ "path": "microsoft/knowledge/privacy/resolve-tobeclassified-before-release.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/privacy/featuretelemetry-customdimensions-no-pii.md",
+          "severity": "major",
+          "message": "LogMemberUsage adds MemberName (customer name) and MemberEmail (email address) to FeatureTelemetry CustomDimensions. Both are PII and must not appear in telemetry. Replace with non-personal context.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+            "line": 79,
+            "range": { "start-line": 79, "end-line": 80 }
+          },
+          "references": [{ "path": "microsoft/knowledge/privacy/featuretelemetry-customdimensions-no-pii.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/privacy/privacy-notice-consent-for-external-data-transfer.md",
+          "severity": "major",
+          "message": "CallPaymentGateway posts member name, email, and phone to an external endpoint with no PrivacyNotice.GetPrivacyNoticeApprovalState check. SendExternalAuditEmail also sends member data externally without consent check. Add a privacy notice check upstream in both code paths.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+            "line": 71
+          },
+          "references": [{ "path": "microsoft/knowledge/privacy/privacy-notice-consent-for-external-data-transfer.md" }],
+          "confidence": "high"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-upgrade-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 1, "major": 4, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 5, "items-evaluated": 5 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/upgrade/no-external-calls-in-upgrade.md",
+          "severity": "blocker",
+          "message": "OnUpgradePerCompany calls Client.Get against an external URL. External HTTP calls inside upgrade triggers are forbidden; a service outage will abort the upgrade. Defer this call to runtime.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyUpgrade.Codeunit.al",
+            "line": 20
+          },
+          "references": [{ "path": "microsoft/knowledge/upgrade/no-external-calls-in-upgrade.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/upgrade/use-upgrade-tags-not-version-checks.md",
+          "severity": "major",
+          "message": "Neither OnUpgradePerCompany nor OnValidateUpgradePerCompany uses HasUpgradeTag / SetUpgradeTag. Without tags the upgrade logic runs on every upgrade pass. Add unique upgrade tags.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyUpgrade.Codeunit.al",
+            "line": 7
+          },
+          "references": [{ "path": "microsoft/knowledge/upgrade/use-upgrade-tags-not-version-checks.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/upgrade/guard-database-reads.md",
+          "severity": "major",
+          "message": "Member.FindSet(true) in OnUpgradePerCompany is unguarded; an empty table causes a runtime abort. Wrap with 'if Member.FindSet(true) then'.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyUpgrade.Codeunit.al",
+            "line": 13
+          },
+          "references": [{ "path": "microsoft/knowledge/upgrade/guard-database-reads.md" }],
+          "confidence": "high",
+          "suggested-code": "        if Member.FindSet(true) then\n            repeat\n                Member.CalcFields(\"Total Points\");\n                Member.\"Points Balance\" := Member.\"Total Points\" * 2;\n                Member.Modify();\n            until Member.Next() = 0;"
+        },
+        {
+          "id": "microsoft/knowledge/upgrade/do-not-block-upgrade-on-data-errors.md",
+          "severity": "major",
+          "message": "OnUpgradePerCompany raises Error() when no members are found, aborting the upgrade. Log telemetry and exit instead.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyUpgrade.Codeunit.al",
+            "line": 23,
+            "range": { "start-line": 22, "end-line": 23 }
+          },
+          "references": [{ "path": "microsoft/knowledge/upgrade/do-not-block-upgrade-on-data-errors.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/upgrade/minimize-onvalidate-upgrade-triggers.md",
+          "severity": "major",
+          "message": "OnValidateUpgradePerCompany calls RecalculateAllBalances() (full-table scan + per-row Commit) on every upgrade pass with no upgrade-tag guard. Add a tag guard and justify why this must run on every upgrade.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyUpgrade.Codeunit.al",
+            "line": 30
+          },
+          "references": [{ "path": "microsoft/knowledge/upgrade/minimize-onvalidate-upgrade-triggers.md" }],
+          "confidence": "high"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-style-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 1, "minor": 4, "info": 0 },
+        "coverage": { "worklist-size": 4, "items-evaluated": 4 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/style/error-passes-parameters-directly-not-strsubstno.md",
+          "severity": "major",
+          "message": "ThrowMemberError wraps Text000 with StrSubstNo before passing it to Error(). This defeats the translation pipeline. Use Error(Text000, Member.\"Member Name\") directly.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+            "line": 93,
+            "range": { "start-line": 93, "end-line": 94 }
+          },
+          "references": [{ "path": "microsoft/knowledge/style/error-passes-parameters-directly-not-strsubstno.md" }],
+          "confidence": "high",
+          "suggested-code": "        Error(Text000, Member.\"Member Name\");"
+        },
+        {
+          "id": "microsoft/knowledge/style/label-suffix-approved-list.md",
+          "severity": "minor",
+          "message": "Label 'Text000' has no approved suffix. It is used in Error(), so the correct suffix is 'Err'. Rename to e.g. 'FailedToProcessMemberErr'.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+            "line": 8
+          },
+          "references": [{ "path": "microsoft/knowledge/style/label-suffix-approved-list.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/style/api-page-camelcase-properties.md",
+          "severity": "minor",
+          "message": "LoyaltyMemberAPI uses EntityName = 'Loyalty_Member', EntitySetName = 'Loyalty_Members', and field identifier 'Member_Name', all containing underscores. API page property values must be camelCase alphanumeric only. Use 'loyaltyMember', 'loyaltyMembers', and 'memberName'.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberAPI.Page.al",
+            "line": 9,
+            "range": { "start-line": 9, "end-line": 10 }
+          },
+          "references": [{ "path": "microsoft/knowledge/style/api-page-camelcase-properties.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/style/api-page-delayedinsert-true.md",
+          "severity": "minor",
+          "message": "LoyaltyMemberAPI sets DelayedInsert = false. API pages must set DelayedInsert = true.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberAPI.Page.al",
+            "line": 12
+          },
+          "references": [{ "path": "microsoft/knowledge/style/api-page-delayedinsert-true.md" }],
+          "confidence": "high",
+          "suggested-code": "    DelayedInsert = true;"
+        },
+        {
+          "id": "microsoft/knowledge/style/api-page-delayedinsert-true.md",
+          "severity": "minor",
+          "message": "LoyaltyMemberData (PageType = API) has no DelayedInsert property; it defaults to false. Declare DelayedInsert = true.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberData.Page.al",
+            "line": 5
+          },
+          "references": [{ "path": "microsoft/knowledge/style/api-page-delayedinsert-true.md" }],
+          "confidence": "high"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-ui-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 0, "minor": 2, "info": 0 },
+        "coverage": { "worklist-size": 2, "items-evaluated": 2 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/ui/show-caption-on-editable-fields.md",
+          "severity": "minor",
+          "message": "The 'Member Name' field on LoyaltyMemberCard has Editable = true and ShowCaption = false. Removing the caption from an editable field is an accessibility violation. Remove ShowCaption = false.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberCard.Page.al",
+            "line": 26
+          },
+          "references": [{ "path": "microsoft/knowledge/ui/show-caption-on-editable-fields.md" }],
+          "confidence": "high",
+          "suggested-code": "                ShowCaption = true;"
+        },
+        {
+          "id": "microsoft/knowledge/ui/semantic-styles-need-independent-textual-meaning.md",
+          "severity": "minor",
+          "message": "The 'Points Balance' field on LoyaltyMemberCard uses StyleExpr = 'Unfavorable' as a static literal, rendering all balances as bold red regardless of value. Apply 'Unfavorable' only when the balance is negative; use a Text variable assigned in OnAfterGetRecord.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberCard.Page.al",
+            "line": 37
+          },
+          "references": [{ "path": "microsoft/knowledge/ui/semantic-styles-need-independent-textual-meaning.md" }],
+          "confidence": "high"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-error-handling-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 2, "minor": 2, "info": 0 },
+        "coverage": { "worklist-size": 3, "items-evaluated": 3 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/error-handling/errortype-internal-vs-client-for-diagnostics.md",
+          "severity": "minor",
+          "message": "EnsureBucketInitialized raises a developer-facing 'Unexpected state' error with default Client visibility. Use ErrorInfo with ErrorType::Internal so the detail goes to telemetry and the user sees a generic message.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyValidation.Codeunit.al",
+            "line": 23
+          },
+          "references": [{ "path": "microsoft/knowledge/error-handling/errortype-internal-vs-client-for-diagnostics.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/error-handling/collect-validation-errors-with-errorbehavior.md",
+          "severity": "major",
+          "message": "ValidateBalances manually accumulates errors into a Text variable and raises Error(ErrorText). Use [ErrorBehavior(ErrorBehavior::Collect)] and GetCollectedErrors instead.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyValidation.Codeunit.al",
+            "line": 46,
+            "range": { "start-line": 41, "end-line": 49 }
+          },
+          "references": [{ "path": "microsoft/knowledge/error-handling/collect-validation-errors-with-errorbehavior.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/error-handling/collect-validation-errors-with-errorbehavior.md",
+          "severity": "major",
+          "message": "ValidateAllMembers is marked [ErrorBehavior(ErrorBehavior::Collect)] but never calls HasCollectedErrors or GetCollectedErrors. Collected errors spill into the platform's concatenated end-of-procedure dialog. Handle the collected list explicitly.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyValidation.Codeunit.al",
+            "line": 27,
+            "range": { "start-line": 26, "end-line": 36 }
+          },
+          "references": [{ "path": "microsoft/knowledge/error-handling/collect-validation-errors-with-errorbehavior.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/error-handling/prefer-errorinfo-for-actionable-errors.md",
+          "severity": "minor",
+          "message": "ValidateRedemption raises Error('You cannot redeem more than %1 points.') naming the exact maximum. Because the code knows the limit, consider an ErrorInfo with a Fix-it AddAction to set the redemption amount to the allowed maximum.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyValidation.Codeunit.al",
+            "line": 8,
+            "range": { "start-line": 7, "end-line": 8 }
+          },
+          "references": [{ "path": "microsoft/knowledge/error-handling/prefer-errorinfo-for-actionable-errors.md" }],
+          "confidence": "medium"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-events-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 2, "minor": 2, "info": 0 },
+        "coverage": { "worklist-size": 4, "items-evaluated": 4 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/events/do-not-publish-events-inside-loops.md",
+          "severity": "major",
+          "message": "NotifyMembers raises OnMemberNotified inside the repeat\u2026until loop. Move the event outside the loop or publish a batch event.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyEvents.Codeunit.al",
+            "line": 56
+          },
+          "references": [{ "path": "microsoft/knowledge/events/do-not-publish-events-inside-loops.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/events/publish-thin-onbefore-onafter-integration-events.md",
+          "severity": "major",
+          "message": "OnBeforeRecalculate is an IntegrationEvent whose body contains business logic (resetting Points Balance). An IntegrationEvent body must be empty. Move the logic to the calling routine.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyEvents.Codeunit.al",
+            "line": 71,
+            "range": { "start-line": 68, "end-line": 74 }
+          },
+          "references": [{ "path": "microsoft/knowledge/events/publish-thin-onbefore-onafter-integration-events.md" }],
+          "confidence": "high",
+          "suggested-code": "    [IntegrationEvent(false, false)]\n    local procedure OnBeforeRecalculate(var LoyaltyMember: Record \"Loyalty Member\"; var IsHandled: Boolean)\n    begin\n    end;"
+        },
+        {
+          "id": "microsoft/knowledge/events/preserve-onafter-execution-when-ishandled-skips-the-body.md",
+          "severity": "minor",
+          "message": "CalculateTotal uses 'if IsHandled then exit' which also skips OnAfterCalculateTotal. Wrap only the default work in 'if not IsHandled then' and keep the after-event raise unconditional.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyEvents.Codeunit.al",
+            "line": 19,
+            "range": { "start-line": 19, "end-line": 20 }
+          },
+          "references": [{ "path": "microsoft/knowledge/events/preserve-onafter-execution-when-ishandled-skips-the-body.md" }],
+          "confidence": "high",
+          "suggested-code": "        if not IsHandled then\n            DoRecalculate(LoyaltyMember);\n        OnAfterCalculateTotal(LoyaltyMember);"
+        },
+        {
+          "id": "microsoft/knowledge/events/initialize-ishandled-to-false-before-publishing.md",
+          "severity": "minor",
+          "message": "RecalculateMember raises OnBeforeRecalculate without first assigning IsHandled := false. Add an explicit assignment immediately before the raise.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyEvents.Codeunit.al",
+            "line": 9
+          },
+          "references": [{ "path": "microsoft/knowledge/events/initialize-ishandled-to-false-before-publishing.md" }],
+          "confidence": "high",
+          "suggested-code": "        IsHandled := false;\n        OnBeforeRecalculate(LoyaltyMember, IsHandled);"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-interfaces-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 1, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 1, "items-evaluated": 1 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/interfaces/set-defaultimplementation-on-enum.md",
+          "severity": "major",
+          "message": "Enum 'Loyalty Channel' implements INotificationSender but value(0; \" \") has no Implementation and the enum has no DefaultImplementation. Calling Send on the blank channel value will fail at runtime. Add a DefaultImplementation pointing at a safe no-op codeunit.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Notification/LoyaltyChannel.Enum.al",
+            "line": 7,
+            "range": { "start-line": 7, "end-line": 10 }
+          },
+          "references": [{ "path": "microsoft/knowledge/interfaces/set-defaultimplementation-on-enum.md" }],
+          "confidence": "high"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-breaking-changes-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 2, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 1, "items-evaluated": 1 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/breaking-changes/do-not-expose-sensitive-data-through-public-api.md",
+          "severity": "major",
+          "message": "GetApiToken() is a public procedure returning ApiToken.Unwrap() as Text. This creates a permanent public contract that leaks a credential to all dependents. Mark it local or internal.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyPublicApi.Codeunit.al",
+            "line": 25
+          },
+          "references": [{ "path": "microsoft/knowledge/breaking-changes/do-not-expose-sensitive-data-through-public-api.md" }],
+          "confidence": "high",
+          "suggested-code": "    local procedure GetApiToken(): Text"
+        },
+        {
+          "id": "microsoft/knowledge/breaking-changes/do-not-expose-sensitive-data-through-public-api.md",
+          "severity": "major",
+          "message": "GetGatewayToken() is a public procedure returning the gateway token as Text. Any extension can call this getter to read the credential. Mark it local or internal.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Loyalty/LoyaltyManagement.Codeunit.al",
+            "line": 48
+          },
+          "references": [{ "path": "microsoft/knowledge/breaking-changes/do-not-expose-sensitive-data-through-public-api.md" }],
+          "confidence": "high",
+          "suggested-code": "    local procedure GetGatewayToken(): Text"
+        }
+      ],
+      "suppressed": []
+    },
+    {
+      "skill": { "id": "al-web-services-review", "version": 1 },
+      "outcome": "completed",
+      "summary": {
+        "counts": { "blocker": 0, "major": 2, "minor": 0, "info": 0 },
+        "coverage": { "worklist-size": 2, "items-evaluated": 2 }
+      },
+      "findings": [
+        {
+          "id": "microsoft/knowledge/web-services/set-required-api-page-properties.md",
+          "severity": "major",
+          "message": "LoyaltyMemberData (PageType = API) is missing APIPublisher, APIGroup, APIVersion, EntityName, and EntitySetName. Without all six the OData route cannot be composed and the endpoint is unreachable.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberData.Page.al",
+            "line": 5,
+            "range": { "start-line": 5, "end-line": 8 }
+          },
+          "references": [{ "path": "microsoft/knowledge/web-services/set-required-api-page-properties.md" }],
+          "confidence": "high"
+        },
+        {
+          "id": "microsoft/knowledge/web-services/expose-systemid-as-the-api-key.md",
+          "severity": "major",
+          "message": "LoyaltyMemberData sets ODataKeyFields = \"No.\". If a member number is renamed, all stored API references break. Change to ODataKeyFields = SystemId and expose Rec.SystemId as a non-editable 'id' field.",
+          "location": {
+            "file": "src/Apps/W1/LoyaltySample/app/src/Member/LoyaltyMemberData.Page.al",
+            "line": 7
+          },
+          "references": [{ "path": "microsoft/knowledge/web-services/expose-systemid-as-the-api-key.md" }],
+          "confidence": "high",
+          "suggested-code": "    ODataKeyFields =
+
+
+
+```json
+          "suggested-code": "    ODataKeyFields = SystemId;"
+        }
+      ],
+      "suppressed": []
+    }
+  ]
+}
+```
+
+


### PR DESCRIPTION
## Problem

When the review agent breaks off mid-string and resumes, a single malformed in-string value can make `ConvertFrom-Json` reject the **entire** findings report — so a full set of findings is posted as **0**. Observed in a production run that found 42 issues across 11 sub-skills and posted none.

Two compounding bugs in `Parse-BCQualityReport`:

1. **Resume-fence corruption.** The agent glitched mid-string inside a `suggested-code` value, emitting a bare ` ```json ` resume fence inside an unterminated string (no "Placeholder" marker). `Repair-InterruptedAgentJson` keys off that marker so it does not fire, and `Remove-StructuralFences` deliberately preserves in-string fences — so neither existing repair clears it, and the whole document fails to parse.
2. **Wrong fragment wins.** Even after repair, the candidate loop accepted the *first* parseable fragment. The transcript echoes each sub-skill's own JSON and the top-level `findings[]` is itself a large balanced array — so a bare sub-skill report (or the bare array) parsed first and the real orchestrator report was silently dropped.

## Fix

- **`Repair-ResumeFenceJson`** — a third, conservative repair path. Key-anchored, transcript-safe splice that removes a bare resume fence sitting inside an *unterminated* string, keeping the re-emitted property and discarding the broken partial. It acts only on the unambiguous triple signature (unterminated property → bare fence → re-emission of the same key), so well-formed output and legitimate in-string code fences are never touched.
- **Tiered candidate preference** — prefer the orchestrator report shape (`sub-results`/`dispatch`) → then any `findings`-bearing object → then the first parseable candidate. Leniency preserved; the correct document always wins.
- **`Test-InterruptedJsonRepair.ps1`** — new regression suite. Extracts the parser functions from `Invoke-CopilotPRReview.ps1` via the PowerShell AST so tests cannot drift, covers synthetic Shapes 1–3 plus guards (clean report unaffected, in-string ` ```al ` code sample preserved), and pins three real-runner fixtures that the unpatched parser returned 0 for.

## Verification

All 30 assertions pass, including the real fixture recovering **42 findings / 11 sub-results** (the unpatched parser returned 0), plus the two existing real-runner fixtures (25 and 22 findings).

## Context

This was first found and fixed in microsoft/BCAppsBCQuality (which carries a port of this reviewer); this PR brings the same hardening upstream. The `$DomainMap` is intentionally left unchanged here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes: [AB#640481](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640481)

