### PR TITLE
Refactor file account variable naming and enhance external file deletion eligibility checks

### DIFF
--- a/src/Apps/W1/External Storage - Document Attachments/app/src/DocumentAttachmentIntegration/DAExternalStorageImpl.Codeunit.al
+++ b/src/Apps/W1/External Storage - Document Attachments/app/src/DocumentAttachmentIntegration/DAExternalStorageImpl.Codeunit.al
@@ -31,7 +31,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     procedure BeforeAddOrModifyFileScenarioCheck(Scenario: Enum "File Scenario"; Connector: Enum "Ext. File Storage Connector"): Boolean;
     var
         ExternalStorageSetup: Record "DA External Storage Setup";
-        FileAccount: Record "File Account";
+        TempFileAccount: Record "File Account";
         FileScenarioCU: Codeunit "File Scenario";
         ConfirmManagement: Codeunit "Confirm Management";
         ExternalStorageSetupPage: Page "DA External Storage Setup";
@@ -42,7 +42,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
             exit;
 
         // Check if scenario is already assigned to a different account
-        if FileScenarioCU.GetSpecificFileAccount(Scenario, FileAccount) then
+        if FileScenarioCU.GetSpecificFileAccount(Scenario, TempFileAccount) then
             // If feature is enabled and has uploaded files, don't allow reassignment
             if ExternalStorageSetup.Get() then
                 if ExternalStorageSetup.Enabled then begin
@@ -133,7 +133,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>True if upload was successful, false otherwise.</returns>
     procedure UploadToExternalStorage(var DocumentAttachment: Record "Document Attachment"): Boolean
     var
-        FileAccount: Record "File Account";
+        TempFileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         DAFeatureTelemetry: Codeunit "DA Feature Telemetry";
@@ -168,7 +168,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
 
         // Search for External Storage assigned File Scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
             exit(false);
 
         // Create the file with connector using the File Account framework
@@ -193,7 +193,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>True if download was successful, false otherwise.</returns>
     procedure DownloadFromExternalStorage(var DocumentAttachment: Record "Document Attachment"): Boolean
     var
-        FileAccount: Record "File Account";
+        TempFileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         DAFeatureTelemetry: Codeunit "DA Feature Telemetry";
@@ -218,7 +218,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
 
         // Search for External Storage assigned File Scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
             exit(false);
 
         // Get the file with connector using the File Account framework
@@ -240,7 +240,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>True if download and import was successful, false otherwise.</returns>
     procedure DownloadFromExternalStorageToInternal(var DocumentAttachment: Record "Document Attachment"): Boolean
     var
-        FileAccount: Record "File Account";
+        TempFileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         FileScenario: Enum "File Scenario";
@@ -260,7 +260,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
 
         // Search for External Storage assigned File Scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
             exit(false);
 
         // Get the file with connector using the File Account framework
@@ -284,7 +284,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>True if the download was successful, false otherwise.</returns>
     procedure DownloadFromExternalStorageToStream(ExternalFilePath: Text; var AttachmentOutStream: OutStream): Boolean
     var
-        FileAccount: Record "File Account";
+        TempFileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         FileScenario: Enum "File Scenario";
@@ -292,7 +292,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     begin
         // Search for External Storage assigned File Scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
             exit(false);
 
         // Get the file from external storage
@@ -313,7 +313,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>True if the download was successful, false otherwise.</returns>
     procedure DownloadFromExternalStorageToTempBlob(ExternalFilePath: Text; var TempBlob: Codeunit "Temp Blob"): Boolean
     var
-        FileAccount: Record "File Account";
+        TempFileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         FileScenario: Enum "File Scenario";
@@ -322,7 +322,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     begin
         // Search for External Storage assigned File Scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
             exit(false);
 
         // Get the file from external storage
@@ -343,14 +343,14 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>True if the file exists, false otherwise.</returns>
     procedure CheckIfFileExistInExternalStorage(ExternalFilePath: Text): Boolean
     var
-        FileAccount: Record "File Account";
+        TempFileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         FileScenario: Enum "File Scenario";
     begin
         // Search for External Storage assigned File Scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
             exit(false);
 
         // Get the file from external storage
@@ -397,14 +397,14 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
 
     local procedure DeleteExternalFile(ExternalFilePath: Text; DocumentAttachmentForTelemetry: Record "Document Attachment"): Boolean
     var
-        FileAccount: Record "File Account";
+        TempFileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         DAFeatureTelemetry: Codeunit "DA Feature Telemetry";
         FileScenario: Enum "File Scenario";
     begin
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
             exit(false);
 
         ExternalFileStorage.Initialize(FileScenario);
@@ -520,7 +520,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>The selected folder path, or empty string if cancelled.</returns>
     procedure SelectRootFolder(): Text
     var
-        FileAccount: Record "File Account";
+        TempFileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         SelectFolderPathLbl: Label 'Select Root Folder for Attachments';
@@ -528,7 +528,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     begin
         // Initialize external file storage with the scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
             exit('');
 
         ExternalFileStorage.Initialize(FileScenario);
@@ -613,14 +613,14 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
 
     local procedure EnsureFolderExists(CompanyFolderPath: Text)
     var
-        FileAccount: Record "File Account";
+        TempFileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         FileScenario: Enum "File Scenario";
     begin
         // Initialize external file storage with the scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
             exit;
 
         ExternalFileStorage.Initialize(FileScenario);
@@ -675,7 +675,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>True if migration was successful, false otherwise.</returns>
     procedure MigrateFileToCurrentEnvironment(var DocumentAttachment: Record "Document Attachment"): Boolean
     var
-        FileAccount: Record "File Account";
+        TempFileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         TempBlob: Codeunit "Temp Blob";
@@ -693,7 +693,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
 
         // Initialize external file storage
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
             exit(false);
 
         ExternalFileStorage.Initialize(FileScenario);

--- a/src/Apps/W1/External Storage - Document Attachments/app/src/DocumentAttachmentIntegration/DAExternalStorageImpl.Codeunit.al
+++ b/src/Apps/W1/External Storage - Document Attachments/app/src/DocumentAttachmentIntegration/DAExternalStorageImpl.Codeunit.al
@@ -31,7 +31,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     procedure BeforeAddOrModifyFileScenarioCheck(Scenario: Enum "File Scenario"; Connector: Enum "Ext. File Storage Connector"): Boolean;
     var
         ExternalStorageSetup: Record "DA External Storage Setup";
-        TempFileAccount: Record "File Account";
+        FileAccount: Record "File Account";
         FileScenarioCU: Codeunit "File Scenario";
         ConfirmManagement: Codeunit "Confirm Management";
         ExternalStorageSetupPage: Page "DA External Storage Setup";
@@ -42,7 +42,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
             exit;
 
         // Check if scenario is already assigned to a different account
-        if FileScenarioCU.GetSpecificFileAccount(Scenario, TempFileAccount) then
+        if FileScenarioCU.GetSpecificFileAccount(Scenario, FileAccount) then
             // If feature is enabled and has uploaded files, don't allow reassignment
             if ExternalStorageSetup.Get() then
                 if ExternalStorageSetup.Enabled then begin
@@ -133,7 +133,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>True if upload was successful, false otherwise.</returns>
     procedure UploadToExternalStorage(var DocumentAttachment: Record "Document Attachment"): Boolean
     var
-        TempFileAccount: Record "File Account";
+        FileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         DAFeatureTelemetry: Codeunit "DA Feature Telemetry";
@@ -168,7 +168,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
 
         // Search for External Storage assigned File Scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
             exit(false);
 
         // Create the file with connector using the File Account framework
@@ -193,7 +193,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>True if download was successful, false otherwise.</returns>
     procedure DownloadFromExternalStorage(var DocumentAttachment: Record "Document Attachment"): Boolean
     var
-        TempFileAccount: Record "File Account";
+        FileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         DAFeatureTelemetry: Codeunit "DA Feature Telemetry";
@@ -218,7 +218,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
 
         // Search for External Storage assigned File Scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
             exit(false);
 
         // Get the file with connector using the File Account framework
@@ -240,7 +240,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>True if download and import was successful, false otherwise.</returns>
     procedure DownloadFromExternalStorageToInternal(var DocumentAttachment: Record "Document Attachment"): Boolean
     var
-        TempFileAccount: Record "File Account";
+        FileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         FileScenario: Enum "File Scenario";
@@ -260,7 +260,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
 
         // Search for External Storage assigned File Scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
             exit(false);
 
         // Get the file with connector using the File Account framework
@@ -284,7 +284,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>True if the download was successful, false otherwise.</returns>
     procedure DownloadFromExternalStorageToStream(ExternalFilePath: Text; var AttachmentOutStream: OutStream): Boolean
     var
-        TempFileAccount: Record "File Account";
+        FileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         FileScenario: Enum "File Scenario";
@@ -292,7 +292,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     begin
         // Search for External Storage assigned File Scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
             exit(false);
 
         // Get the file from external storage
@@ -313,7 +313,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>True if the download was successful, false otherwise.</returns>
     procedure DownloadFromExternalStorageToTempBlob(ExternalFilePath: Text; var TempBlob: Codeunit "Temp Blob"): Boolean
     var
-        TempFileAccount: Record "File Account";
+        FileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         FileScenario: Enum "File Scenario";
@@ -322,7 +322,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     begin
         // Search for External Storage assigned File Scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
             exit(false);
 
         // Get the file from external storage
@@ -343,14 +343,14 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>True if the file exists, false otherwise.</returns>
     procedure CheckIfFileExistInExternalStorage(ExternalFilePath: Text): Boolean
     var
-        TempFileAccount: Record "File Account";
+        FileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         FileScenario: Enum "File Scenario";
     begin
         // Search for External Storage assigned File Scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
             exit(false);
 
         // Get the file from external storage
@@ -397,14 +397,14 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
 
     local procedure DeleteExternalFile(ExternalFilePath: Text; DocumentAttachmentForTelemetry: Record "Document Attachment"): Boolean
     var
-        TempFileAccount: Record "File Account";
+        FileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         DAFeatureTelemetry: Codeunit "DA Feature Telemetry";
         FileScenario: Enum "File Scenario";
     begin
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
             exit(false);
 
         ExternalFileStorage.Initialize(FileScenario);
@@ -520,7 +520,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>The selected folder path, or empty string if cancelled.</returns>
     procedure SelectRootFolder(): Text
     var
-        TempFileAccount: Record "File Account";
+        FileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         SelectFolderPathLbl: Label 'Select Root Folder for Attachments';
@@ -528,7 +528,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     begin
         // Initialize external file storage with the scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
             exit('');
 
         ExternalFileStorage.Initialize(FileScenario);
@@ -613,14 +613,14 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
 
     local procedure EnsureFolderExists(CompanyFolderPath: Text)
     var
-        TempFileAccount: Record "File Account";
+        FileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         FileScenario: Enum "File Scenario";
     begin
         // Initialize external file storage with the scenario
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
             exit;
 
         ExternalFileStorage.Initialize(FileScenario);
@@ -675,7 +675,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <returns>True if migration was successful, false otherwise.</returns>
     procedure MigrateFileToCurrentEnvironment(var DocumentAttachment: Record "Document Attachment"): Boolean
     var
-        TempFileAccount: Record "File Account";
+        FileAccount: Record "File Account";
         ExternalFileStorage: Codeunit "External File Storage";
         FileScenarioCU: Codeunit "File Scenario";
         TempBlob: Codeunit "Temp Blob";
@@ -693,7 +693,7 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
 
         // Initialize external file storage
         FileScenario := FileScenario::"Doc. Attach. - External Storage";
-        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, TempFileAccount) then
+        if not FileScenarioCU.GetSpecificFileAccount(FileScenario, FileAccount) then
             exit(false);
 
         ExternalFileStorage.Initialize(FileScenario);
@@ -799,43 +799,52 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// <param name="RunTrigger">Indicates if the trigger should run.</param>
     [EventSubscriber(ObjectType::Table, Database::"Document Attachment", OnAfterDeleteEvent, '', true, true)]
     local procedure OnAfterDeleteDocumentAttachment(var Rec: Record "Document Attachment"; RunTrigger: Boolean)
-    var
-        ExternalStorageSetup: Record "DA External Storage Setup";
     begin
         // Exit early if trigger is not running
         if not RunTrigger then
             exit;
 
-        // Temporary records are not processed
-        if Rec.IsTemporary() then
+        if not IsEligibleForExternalFileDeletionOnRecordDelete(Rec) then
             exit;
+
+        DeleteExternalFile(Rec."External File Path", Rec);
+    end;
+
+    /// <summary>
+    /// Evaluates whether the external blob backing a just-deleted Document Attachment row should be removed.
+    /// </summary>
+    /// <param name="DocumentAttachment">The document attachment record carrying the field values from the deleted row.</param>
+    /// <returns>True if the external file is eligible for deletion; otherwise false.</returns>
+    local procedure IsEligibleForExternalFileDeletionOnRecordDelete(var DocumentAttachment: Record "Document Attachment"): Boolean
+    var
+        ExternalStorageSetup: Record "DA External Storage Setup";
+    begin
+        if DocumentAttachment.IsTemporary() then
+            exit(false);
 
         // Check if auto delete is enabled
         if not ExternalStorageSetup.Get() then
-            exit;
+            exit(false);
 
         if not ExternalStorageSetup."Delete from External Storage" then
-            exit;
+            exit(false);
 
         // Only process files that were uploaded to external storage
-        if not Rec."Stored Externally" then
-            exit;
+        if not DocumentAttachment."Stored Externally" then
+            exit(false);
 
-        if Rec."External File Path" = '' then
-            exit;
+        if DocumentAttachment."External File Path" = '' then
+            exit(false);
 
         // Copied attachments share the source file - never delete the shared blob
-        if Rec."Skip Delete On Copy" then
-            exit;
+        if DocumentAttachment."Skip Delete On Copy" then
+            exit(false);
 
         // Files from another environment/company are managed by their owning environment
-        if IsFileFromAnotherEnvironmentOrCompany(Rec) then
-            exit;
+        if IsFileFromAnotherEnvironmentOrCompany(DocumentAttachment) then
+            exit(false);
 
-        // The Document Attachment row is already deleted at this point, so we cannot
-        // Find() or Modify() it. Delete the blob using the field values still carried
-        // on Rec, bypassing the record-based DeleteFromExternalStorage entry point.
-        DeleteExternalFile(Rec."External File Path", Rec);
+        exit(true);
     end;
 
     /// <summary>


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #8162
Fixes [AB#640445](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640445)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->
