### PR TITLE
Re-enable BCPT Setup Card tests: fix NoOfSqlCallsAreLogged SQL assertion (Bug 618568)

### DIFF
--- a/src/Tools/Performance Toolkit/Test/src/BCPTSetupCardTest.Codeunit.al
+++ b/src/Tools/Performance Toolkit/Test/src/BCPTSetupCardTest.Codeunit.al
@@ -129,6 +129,7 @@ codeunit 144741 "BCPT Setup Card Test"
         BCPTSetupCardTest: Codeunit "BCPT Setup Card Test";
         BCPTStartTests: Codeunit "BCPT Start Tests";
         BCPTSetupCard: TestPage "BCPT Setup Card";
+        ActualNoOfIterations: Integer;
         UnexpectedNoOfSqlStmtsLbl: Label 'Unexpected value in %1. Expected %2, Actual %3', Locked = true;
     begin
         Initialize();
@@ -145,8 +146,13 @@ codeunit 144741 "BCPT Setup Card Test"
         BCPTSetupCard.OpenView();
         BCPTSetupCard.GoToRecord(BCPTHeader);
         BCPTSetupCard.BCPTLines.Status.AssertEquals(BCPTLine.Status::Completed);
-        Assert.IsTrue(BCPTSetupCard.BCPTLines.NoOfIterations.AsInteger() >= NoOfIterationsToRun, StrSubstNo(UnexpectedNoOfSqlStmtsLbl, BCPTLogEntry.FieldCaption("No. of SQL Statements"), NoOfIterationsToRun, BCPTSetupCard.BCPTLines.NoOfIterations.AsInteger()));
-        BCPTSetupCard.BCPTLines.NoOfSQLStmts.AssertEquals(NoOfIterationsToRun);
+        ActualNoOfIterations := BCPTSetupCard.BCPTLines.NoOfIterations.AsInteger();
+        Assert.IsTrue(ActualNoOfIterations >= NoOfIterationsToRun, StrSubstNo(UnexpectedNoOfSqlStmtsLbl, BCPTSetupCard.BCPTLines.NoOfIterations.Caption, NoOfIterationsToRun, ActualNoOfIterations));
+        // The codeunit issues exactly 1 SQL statement per iteration, but the very first database access in the session also
+        // counts 2 extra SQL statements from system tables. Therefore the total is either ActualNoOfIterations or ActualNoOfIterations + 2.
+        Assert.IsTrue(
+            BCPTSetupCard.BCPTLines.NoOfSQLStmts.AsInteger() in [ActualNoOfIterations, ActualNoOfIterations + 2],
+            StrSubstNo(UnexpectedNoOfSqlStmtsLbl, BCPTLogEntry.FieldCaption("No. of SQL Statements"), StrSubstNo('%1 or %2', ActualNoOfIterations, ActualNoOfIterations + 2), BCPTSetupCard.BCPTLines.NoOfSQLStmts.AsInteger()));
         BCPTSetupCard.BCPTLines.AvgSQLStmts.AssertEquals(1);
         BCPTSetupCard.Close();
     end;


### PR DESCRIPTION
## Problem

Bug  [AB#618568](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/618568). The test `NoOfSqlCallsAreLogged` in codeunit 144741 "BCPT Setup Card Test" was disabled during the platform 28.0.44646 uptake (PR 237052) because it started failing:

```
AssertEquals for Field: NoOfSQLStmts Expected = '5', Actual = '7'
```

## Root cause

The test runs 5 iterations of `BCPT Codeunit With 1 Sql` (1 SQL statement each) and asserted `NoOfSQLStmts = 5`. However, the very first database access in a session also counts **2 extra SQL statements from system tables**, making the total either `5` (iterations) or `7` (iterations + 2). This is the same non-determinism already documented in the sibling test `LogsAreGeneratedAfterTheExecution`, which accepts `[0, 2]` for a single entry.

`AvgSQLStmts` is computed via integer division (`GetAvgSQLStmts` = `No. of SQL Statements div No. of Iterations`), so `7 div 5 = 1` and `5 div 5 = 1` — the average assertion is unaffected.

## Solution

Updated the assertion to accept the total being either the actual number of iterations or that number + 2, deriving the expectation from the measured iteration count rather than a hard-coded `5`.

## Changes

- `src/Tools/Performance Toolkit/Test/src/BCPTSetupCardTest.Codeunit.al`: tolerant `NoOfSQLStmts` assertion in `NoOfSqlCallsAreLogged`.

## Testing

- AL static analysis: no diagnostics.
- Full validation pending CI (`RunALTestDevTools`) once the test is re-enabled (the corresponding NAV-side change removes the DisabledTests entry).

## Related

- Re-enables tests disabled in PR 237052.
- Paired with the NAV (ADO) change removing `App/DisabledTests/BCPTSetupCardTest.DisabledTest.json`.








