### PR TITLE
Fix Copilot PR review agent diffing against wrong base (two-dot → three-dot)

### DIFF
--- a/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
+++ b/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
@@ -636,9 +636,9 @@ The base branch is: origin/$BaseBranch
 The repository is: $Repository (PR #$PrNumber)
 
 Use git commands to analyze the changes:
-- git -C "$prWorktree" diff origin/$BaseBranch to see all changes
-- git -C "$prWorktree" diff origin/$BaseBranch -- <file> to see changes in a specific file
-- git -C "$prWorktree" diff --name-only origin/$BaseBranch to list changed files
+- git -C "$prWorktree" diff origin/$BaseBranch...HEAD to see all changes
+- git -C "$prWorktree" diff origin/$BaseBranch...HEAD -- <file> to see changes in a specific file
+- git -C "$prWorktree" diff --name-only origin/$BaseBranch...HEAD to list changed files
 
 CONTRACT:
 The current working directory is a BCQuality checkout. BCQuality is the


### PR DESCRIPTION
## Problem

The Copilot PR Review agent can generate findings against files that aren't part of the PR. The publish phase then discards every finding (`Skipping <domain> finding for non-PR file`) and posts **0** comments — wasting review/model tokens and leaving the PR's actual changed file unreviewed.

Example: [run 28174269963](https://github.com/microsoft/BCApps/actions/runs/28174269963) on PR #8821. That PR changes exactly **one** file (`DAExternalStorageImpl.Codeunit.al`), but the agent reviewed ~15 Subcontracting/Email files and produced 7 findings against them — all rejected at posting → *Posted 0 finding(s) across 4 domain(s)*.

## Root cause

`Build-BootstrapPrompt` instructed the agent to discover changes with the **two-dot** form:

```
git -C "$prWorktree" diff origin/$BaseBranch
```

Two-dot `diff origin/main` (= `origin/main HEAD`) shows the total divergence between main's *current tip* and the PR head. Because `origin/main` is freshly fetched and has advanced past the PR's branch point, every file changed *on main* since then appears as a reverse delta and looks "changed." The agent treats all of them as PR changes and reviews them.

Meanwhile the workflow's authoritative discovery — `Get-GitChangedFiles` and the posting guard's `$ChangedFileSet` — uses the correct **three-dot** merge-base form `origin/$BaseBranch...HEAD`, which returns only the PR's actual changes. The agent's view and the posting filter disagree, so every off-target finding is dropped.

## Fix

Align the three git diff hints in the bootstrap prompt with the authoritative discovery by using three-dot `origin/$BaseBranch...HEAD`.

## Work item

Fixes [AB#640492](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640492)




