### PR TITLE
Harden Copilot PR-review JSON parser against resume-fence corruption

### DIFF
--- a/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
+++ b/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
@@ -1039,16 +1039,13 @@ function Remove-StructuralFences {
 }
   
 function Repair-ResumeFenceJson {
-    # The agent sometimes stops in the middle of a value and starts the same
-    # field over on a new line. Between the two it prints a leftover code-fence
-    # line (the literal text: three backticks followed by "json"). Example:
-    #
-    #     "suggested-code": "    ODataKey            (string never closed)
-    #     <leftover code-fence line>
-    #     "suggested-code": "    ODataKey = SystemId;"   (same field, retried)
-    #
-    # The unclosed string makes the whole report fail to parse. This removes the
-    # fence line and the broken half, and keeps the retried line.
+    # The agent sometimes cuts off mid-value and restarts the line after a stray
+    # ```json fence, like:
+    #     "suggested-code": "    ODataKey        <- string never closed
+    #     ```json
+    #     "suggested-code": "    ODataKey = SystemId;"   <- same field, retried
+    # The unclosed string breaks the whole report. This drops the fence and the
+    # broken half, keeping the retried line.
     param([string] $Output)
     if (-not $Output) { return $Output }
 

--- a/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
+++ b/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
@@ -1038,6 +1038,109 @@ function Remove-StructuralFences {
     return $sb.ToString()
 }
 
+function Repair-ResumeFenceJson {
+    <#
+    Repairs the interrupted-emission shape where the agent breaks off
+    mid-string — leaving an UNTERMINATED JSON string — and resumes by
+    re-opening a fresh ```json fence WITHOUT emitting a "Placeholder ..."
+    marker. Observed in production (run 28168894037), inside a
+    `suggested-code` value:
+
+        "confidence": "high",
+        "suggested-code": "    ODataKeyFields =
+                                             <- raw newline(s) inside the string
+        ```json                              <- bare resume fence, no marker
+              "suggested-code": "    ODataKeyFields = SystemId;"
+
+    A raw newline inside a string literal is always invalid JSON, so this
+    shape is unambiguous. A single malformed value like this makes
+    ConvertFrom-Json reject the ENTIRE document, discarding every finding
+    (the run above found 42 issues across 11 sub-skills and posted 0). The
+    broken partial line is discarded and the post-fence resumption spliced in
+    its place; because the agent re-emits the field from its start, the
+    splice de-duplicates naturally.
+
+    This is the third repair path, filling the gap between the other two:
+      - Repair-InterruptedAgentJson keys off the "Placeholder ..." marker,
+        which is absent here.
+      - Remove-StructuralFences removes whole-line fences that sit OUTSIDE a
+        string literal, and deliberately PRESERVES fences inside a string
+        (e.g. a ```al code sample in suggested-code). Here the resume fence
+        sits inside an *unterminated* string, so the conservative
+        fence-stripper must leave it alone — only a string-aware splice keyed
+        off the malformed newline can clear it without harming legitimate
+        in-string fences.
+
+    Conservative by construction: it acts only on a bare ```-fence line that is
+    immediately preceded by a JSON property whose string value was left
+    unterminated (`"key": "...` with an odd count of unescaped quotes) and
+    immediately followed by a re-emission of that SAME `"key":`. That triple
+    signature is what distinguishes the interrupted-emission resume from
+    ordinary CLI transcript noise (shell echoes, tool-call boxes), which also
+    contain stray quotes and fences but never re-emit a matching JSON key
+    across a fence. Callers try the unmodified candidates first, so well-formed
+    output is never altered.
+    #>
+    param([string] $Output)
+    if (-not $Output) { return $Output }
+
+    # Count quotes that are not backslash-escaped. An odd count on a line that
+    # opens a JSON property means the string value was left unterminated.
+    $unescapedQuoteCount = {
+        param([string] $s)
+        $n = 0; $esc = $false
+        foreach ($c in $s.ToCharArray()) {
+            if ($esc) { $esc = $false; continue }
+            if ($c -eq '\') { $esc = $true; continue }
+            if ($c -eq '"') { $n++ }
+        }
+        return $n
+    }
+
+    $result = $Output
+    $maxPasses = 50
+    for ($pass = 0; $pass -lt $maxPasses; $pass++) {
+        $lines = $result -split "`n"
+        $repaired = $false
+
+        for ($li = 0; $li -lt $lines.Count; $li++) {
+            if (($lines[$li].Trim()) -notmatch '^```[A-Za-z0-9]*$') { continue }
+
+            # Nearest non-blank line before the fence: must be a JSON property
+            # whose string value was left unterminated (odd unescaped quotes).
+            $p = $li - 1
+            while ($p -ge 0 -and $lines[$p].Trim().Length -eq 0) { $p-- }
+            if ($p -lt 0) { continue }
+            $before = $lines[$p].Trim()
+            if ($before -notmatch '^"([^"\\]+)"\s*:') { continue }
+            $key = $Matches[1]
+            if (((& $unescapedQuoteCount $before) % 2) -eq 0) { continue }
+
+            # Nearest non-blank line after the fence: must re-emit the same key,
+            # i.e. the model resumed by restarting the interrupted property.
+            $a = $li + 1
+            while ($a -lt $lines.Count -and $lines[$a].Trim().Length -eq 0) { $a++ }
+            if ($a -ge $lines.Count) { continue }
+            $after = $lines[$a].Trim()
+            if ($after -notmatch ('^"' + [regex]::Escape($key) + '"\s*:')) { continue }
+
+            # Discard the broken partial line, the blank lines, and the fence;
+            # keep the re-emission onward. The re-emission re-includes the field
+            # from its start, so the splice de-duplicates naturally.
+            $newLines = [System.Collections.Generic.List[string]]::new()
+            if ($p -gt 0) { for ($x = 0; $x -lt $p; $x++) { $newLines.Add($lines[$x]) | Out-Null } }
+            for ($x = $a; $x -lt $lines.Count; $x++) { $newLines.Add($lines[$x]) | Out-Null }
+            $result = ($newLines -join "`n")
+            $repaired = $true
+            break
+        }
+
+        if (-not $repaired) { break }
+    }
+
+    return $result
+}
+
 function Parse-BCQualityReport {
     <#
     Parses Copilot CLI output into a findings-report. Returns a PSCustomObject:
@@ -1090,19 +1193,64 @@ function Parse-BCQualityReport {
     }
     foreach ($clean in $defenced) { $candidates.Add($clean) | Out-Null }
 
+    # Resume-fence repair: handles the interrupted-emission shape where the
+    # agent breaks off mid-string (leaving an unterminated JSON string) and
+    # resumes by re-opening a bare ```json fence with NO Placeholder marker.
+    # Because the break sits inside an unterminated string, Remove-StructuralFences
+    # (which preserves in-string fences) cannot clear it. Extract candidates from
+    # the repaired text and append them AFTER the originals so clean output is
+    # never disturbed.
+    $resumeRepaired = Repair-ResumeFenceJson -Output $stripped
+    if ($resumeRepaired -ne $stripped) {
+        $resumeCandidates = [System.Collections.Generic.List[string]]::new()
+        foreach ($m in [regex]::Matches($resumeRepaired, '```(?:json)?\s*([\s\S]*?)\s*```')) { $resumeCandidates.Add($m.Groups[1].Value) | Out-Null }
+        foreach ($balanced in (Find-BalancedJsonCandidates -Text $resumeRepaired)) { $resumeCandidates.Add($balanced) | Out-Null }
+        foreach ($candidate in $resumeCandidates) {
+            $candidates.Add($candidate) | Out-Null
+            $clean = Remove-StructuralFences -Text $candidate
+            if ($clean -ne $candidate) { $candidates.Add($clean) | Out-Null }
+        }
+    }
+
+    # A candidate can parse cleanly yet be the WRONG fragment. The transcript
+    # echoes every sub-skill's own JSON report inside ```json fences, and the
+    # top-level findings-report's `findings[]` is itself a large balanced JSON
+    # array. When the full document is unparseable (e.g. a corrupt value deep in
+    # sub-results) the scan happily parses one of those fragments first: a bare
+    # sub-skill report has `findings` but no `sub-results`, and a bare array has
+    # neither — either way the real report is silently dropped (observed in run
+    # 28168894037: 42 findings recovered to 0). Prefer the orchestrator report
+    # shape (exposes `sub-results` or a `dispatch`), then a findings-bearing
+    # object, then any parseable candidate, so leniency is preserved while the
+    # correct fragment always wins.
     $report = $null
+    $shapedReport = $null
+    $fallbackReport = $null
     foreach ($candidate in $candidates) {
         $trimmed = $candidate.Trim()
         if (-not $trimmed) { continue }
+        $parsed = $null
         try {
-            $report = $trimmed | ConvertFrom-Json -ErrorAction Stop
-            break
+            $parsed = $trimmed | ConvertFrom-Json -ErrorAction Stop
         } catch {
             $preview = $trimmed
             if ($preview.Length -gt 200) { $preview = $preview.Substring(0, 200) + '...' }
             $parseErrors.Add("$($_.Exception.Message) | candidate: $preview") | Out-Null
+            continue
         }
+
+        $isObject = $parsed -is [System.Management.Automation.PSCustomObject]
+        $isOrchestratorShaped = $isObject -and (
+            $parsed.PSObject.Properties.Match('sub-results').Count -gt 0 -or
+            $parsed.PSObject.Properties.Match('dispatch').Count -gt 0)
+        if ($isOrchestratorShaped) { $report = $parsed; break }
+        if ($null -eq $shapedReport -and $isObject -and $parsed.PSObject.Properties.Match('findings').Count -gt 0) {
+            $shapedReport = $parsed
+        }
+        if ($null -eq $fallbackReport) { $fallbackReport = $parsed }
     }
+    if ($null -eq $report) { $report = $shapedReport }
+    if ($null -eq $report) { $report = $fallbackReport }
 
     $script:LastParsingErrors = $parseErrors
 

--- a/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
+++ b/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
@@ -1039,13 +1039,16 @@ function Remove-StructuralFences {
 }
   
 function Repair-ResumeFenceJson {
-    # The agent sometimes cuts off mid-value and restarts the line after a stray
-    # ```json fence, like:
-    #     "suggested-code": "    ODataKey        <- string never closed
-    #     ```json
-    #     "suggested-code": "    ODataKey = SystemId;"   <- same field, retried
-    # The unclosed string breaks the whole report. This drops the fence and the
-    # broken half, keeping the retried line.
+    # The agent sometimes stops in the middle of a value and starts the same
+    # field over on a new line. Between the two it prints a leftover code-fence
+    # line (the literal text: three backticks followed by "json"). Example:
+    #
+    #     "suggested-code": "    ODataKey            (string never closed)
+    #     <leftover code-fence line>
+    #     "suggested-code": "    ODataKey = SystemId;"   (same field, retried)
+    #
+    # The unclosed string makes the whole report fail to parse. This removes the
+    # fence line and the broken half, and keeps the retried line.
     param([string] $Output)
     if (-not $Output) { return $Output }
 

--- a/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
+++ b/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
@@ -1039,9 +1039,13 @@ function Remove-StructuralFences {
 }
   
 function Repair-ResumeFenceJson {
-    # Removes a stray ```json fence the agent leaves when it restarts a property
-    # mid-string. Only acts when the line before has a half-open string and the
-    # line after repeats the same key.
+    # The agent sometimes cuts off mid-value and restarts the line after a stray
+    # ```json fence, like:
+    #     "suggested-code": "    ODataKey        <- string never closed
+    #     ```json
+    #     "suggested-code": "    ODataKey = SystemId;"   <- same field, retried
+    # The unclosed string breaks the whole report. This drops the fence and the
+    # broken half, keeping the retried line.
     param([string] $Output)
     if (-not $Output) { return $Output }
 

--- a/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
+++ b/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
@@ -1040,19 +1040,22 @@ function Remove-StructuralFences {
   
 function Repair-ResumeFenceJson {
     <#
-    Clears a bare ```json resume fence the agent emits mid-string with no
-    "Placeholder" marker, which leaves an unterminated JSON string and makes
-    ConvertFrom-Json reject the whole document. Remove-StructuralFences can't
-    help (it preserves in-string fences) and Repair-InterruptedAgentJson needs
-    the marker that's absent here. Conservative: only acts when a bare fence is
-    preceded by a property left unterminated (odd unescaped quotes) and followed
-    by a re-emission of the same key. Callers try unmodified candidates first,
-    so clean output is never altered.
+    Sometimes the agent stops in the middle of a JSON string and starts over on
+    a new ```json line. That leaves a half-finished string, so the whole JSON
+    fails to parse and all findings are lost.
+
+    This removes that stray fence. To stay safe it only acts when the line
+    before the fence is a property with a half-open string (an odd number of
+    unescaped quotes) and the line after the fence repeats the same key. The
+    other two repairs don't cover this: Remove-StructuralFences keeps fences
+    that are inside strings, and Repair-InterruptedAgentJson needs a
+    "Placeholder" marker that isn't here. Callers parse the original text
+    first, so clean output is never changed.
     #>
     param([string] $Output)
     if (-not $Output) { return $Output }
 
-    # Odd count of unescaped quotes => the property's string value was left open.
+    # An odd number of unescaped quotes means the string was never closed.
     $unescapedQuoteCount = {
         param([string] $s)
         $n = 0; $esc = $false
@@ -1073,7 +1076,7 @@ function Repair-ResumeFenceJson {
         for ($li = 0; $li -lt $lines.Count; $li++) {
             if (($lines[$li].Trim()) -notmatch '^```[A-Za-z0-9]*$') { continue }
 
-            # Line before the fence must be a property left unterminated.
+            # The line before the fence must be a property whose string is still open.
             $p = $li - 1
             while ($p -ge 0 -and $lines[$p].Trim().Length -eq 0) { $p-- }
             if ($p -lt 0) { continue }
@@ -1082,15 +1085,15 @@ function Repair-ResumeFenceJson {
             $key = $Matches[1]
             if (((& $unescapedQuoteCount $before) % 2) -eq 0) { continue }
 
-            # Line after the fence must re-emit the same key (the resumed property).
+            # The line after the fence must start the same key again.
             $a = $li + 1
             while ($a -lt $lines.Count -and $lines[$a].Trim().Length -eq 0) { $a++ }
             if ($a -ge $lines.Count) { continue }
             $after = $lines[$a].Trim()
             if ($after -notmatch ('^"' + [regex]::Escape($key) + '"\s*:')) { continue }
 
-            # Drop the broken line and fence; keep the re-emission, which
-            # restarts the field and so de-duplicates naturally.
+            # Drop the broken line and the fence, and keep the restart. The agent
+            # rewrites the field from scratch, so nothing is duplicated.
             $newLines = [System.Collections.Generic.List[string]]::new()
             if ($p -gt 0) { for ($x = 0; $x -lt $p; $x++) { $newLines.Add($lines[$x]) | Out-Null } }
             for ($x = $a; $x -lt $lines.Count; $x++) { $newLines.Add($lines[$x]) | Out-Null }
@@ -1157,9 +1160,9 @@ function Parse-BCQualityReport {
     }
     foreach ($clean in $defenced) { $candidates.Add($clean) | Out-Null }
 
-    # Repair the resume-fence shape (bare ```json fence inside an unterminated
-    # string, which Remove-StructuralFences can't clear) and append its
-    # candidates after the originals so clean output is untouched.
+    # Repair the resume-fence shape (a stray ```json fence inside an open
+    # string, which Remove-StructuralFences leaves alone), then add its
+    # candidates after the originals so clean output stays untouched.
     $resumeRepaired = Repair-ResumeFenceJson -Output $stripped
     if ($resumeRepaired -ne $stripped) {
         $resumeCandidates = [System.Collections.Generic.List[string]]::new()
@@ -1172,11 +1175,11 @@ function Parse-BCQualityReport {
         }
     }
 
-    # A fragment can parse cleanly yet be the wrong one: the transcript echoes
-    # each sub-skill report and the findings[] array as standalone JSON, so when
-    # the full document is unparseable one of those wins and the real report is
-    # dropped. Prefer the orchestrator shape (sub-results/dispatch), then any
-    # findings-bearing object, then any parseable candidate.
+    # A fragment can parse fine but still be the wrong one. The output repeats
+    # each sub-skill report and the findings[] array as separate JSON, so if the
+    # full document won't parse, one of those can win and the real report is
+    # lost. Pick the orchestrator report first (it has sub-results or dispatch),
+    # then any object with findings, then any fragment that parses.
     $report = $null
     $shapedReport = $null
     $fallbackReport = $null

--- a/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
+++ b/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
@@ -1039,19 +1039,9 @@ function Remove-StructuralFences {
 }
   
 function Repair-ResumeFenceJson {
-    <#
-    Sometimes the agent stops in the middle of a JSON string and starts over on
-    a new ```json line. That leaves a half-finished string, so the whole JSON
-    fails to parse and all findings are lost.
-
-    This removes that stray fence. To stay safe it only acts when the line
-    before the fence is a property with a half-open string (an odd number of
-    unescaped quotes) and the line after the fence repeats the same key. The
-    other two repairs don't cover this: Remove-StructuralFences keeps fences
-    that are inside strings, and Repair-InterruptedAgentJson needs a
-    "Placeholder" marker that isn't here. Callers parse the original text
-    first, so clean output is never changed.
-    #>
+    # Removes a stray ```json fence the agent leaves when it restarts a property
+    # mid-string. Only acts when the line before has a half-open string and the
+    # line after repeats the same key.
     param([string] $Output)
     if (-not $Output) { return $Output }
 

--- a/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
+++ b/tools/Code Review/scripts/Invoke-CopilotPRReview.ps1
@@ -1037,55 +1037,22 @@ function Remove-StructuralFences {
 
     return $sb.ToString()
 }
-
+  
 function Repair-ResumeFenceJson {
     <#
-    Repairs the interrupted-emission shape where the agent breaks off
-    mid-string — leaving an UNTERMINATED JSON string — and resumes by
-    re-opening a fresh ```json fence WITHOUT emitting a "Placeholder ..."
-    marker. Observed in production (run 28168894037), inside a
-    `suggested-code` value:
-
-        "confidence": "high",
-        "suggested-code": "    ODataKeyFields =
-                                             <- raw newline(s) inside the string
-        ```json                              <- bare resume fence, no marker
-              "suggested-code": "    ODataKeyFields = SystemId;"
-
-    A raw newline inside a string literal is always invalid JSON, so this
-    shape is unambiguous. A single malformed value like this makes
-    ConvertFrom-Json reject the ENTIRE document, discarding every finding
-    (the run above found 42 issues across 11 sub-skills and posted 0). The
-    broken partial line is discarded and the post-fence resumption spliced in
-    its place; because the agent re-emits the field from its start, the
-    splice de-duplicates naturally.
-
-    This is the third repair path, filling the gap between the other two:
-      - Repair-InterruptedAgentJson keys off the "Placeholder ..." marker,
-        which is absent here.
-      - Remove-StructuralFences removes whole-line fences that sit OUTSIDE a
-        string literal, and deliberately PRESERVES fences inside a string
-        (e.g. a ```al code sample in suggested-code). Here the resume fence
-        sits inside an *unterminated* string, so the conservative
-        fence-stripper must leave it alone — only a string-aware splice keyed
-        off the malformed newline can clear it without harming legitimate
-        in-string fences.
-
-    Conservative by construction: it acts only on a bare ```-fence line that is
-    immediately preceded by a JSON property whose string value was left
-    unterminated (`"key": "...` with an odd count of unescaped quotes) and
-    immediately followed by a re-emission of that SAME `"key":`. That triple
-    signature is what distinguishes the interrupted-emission resume from
-    ordinary CLI transcript noise (shell echoes, tool-call boxes), which also
-    contain stray quotes and fences but never re-emit a matching JSON key
-    across a fence. Callers try the unmodified candidates first, so well-formed
-    output is never altered.
+    Clears a bare ```json resume fence the agent emits mid-string with no
+    "Placeholder" marker, which leaves an unterminated JSON string and makes
+    ConvertFrom-Json reject the whole document. Remove-StructuralFences can't
+    help (it preserves in-string fences) and Repair-InterruptedAgentJson needs
+    the marker that's absent here. Conservative: only acts when a bare fence is
+    preceded by a property left unterminated (odd unescaped quotes) and followed
+    by a re-emission of the same key. Callers try unmodified candidates first,
+    so clean output is never altered.
     #>
     param([string] $Output)
     if (-not $Output) { return $Output }
 
-    # Count quotes that are not backslash-escaped. An odd count on a line that
-    # opens a JSON property means the string value was left unterminated.
+    # Odd count of unescaped quotes => the property's string value was left open.
     $unescapedQuoteCount = {
         param([string] $s)
         $n = 0; $esc = $false
@@ -1106,8 +1073,7 @@ function Repair-ResumeFenceJson {
         for ($li = 0; $li -lt $lines.Count; $li++) {
             if (($lines[$li].Trim()) -notmatch '^```[A-Za-z0-9]*$') { continue }
 
-            # Nearest non-blank line before the fence: must be a JSON property
-            # whose string value was left unterminated (odd unescaped quotes).
+            # Line before the fence must be a property left unterminated.
             $p = $li - 1
             while ($p -ge 0 -and $lines[$p].Trim().Length -eq 0) { $p-- }
             if ($p -lt 0) { continue }
@@ -1116,17 +1082,15 @@ function Repair-ResumeFenceJson {
             $key = $Matches[1]
             if (((& $unescapedQuoteCount $before) % 2) -eq 0) { continue }
 
-            # Nearest non-blank line after the fence: must re-emit the same key,
-            # i.e. the model resumed by restarting the interrupted property.
+            # Line after the fence must re-emit the same key (the resumed property).
             $a = $li + 1
             while ($a -lt $lines.Count -and $lines[$a].Trim().Length -eq 0) { $a++ }
             if ($a -ge $lines.Count) { continue }
             $after = $lines[$a].Trim()
             if ($after -notmatch ('^"' + [regex]::Escape($key) + '"\s*:')) { continue }
 
-            # Discard the broken partial line, the blank lines, and the fence;
-            # keep the re-emission onward. The re-emission re-includes the field
-            # from its start, so the splice de-duplicates naturally.
+            # Drop the broken line and fence; keep the re-emission, which
+            # restarts the field and so de-duplicates naturally.
             $newLines = [System.Collections.Generic.List[string]]::new()
             if ($p -gt 0) { for ($x = 0; $x -lt $p; $x++) { $newLines.Add($lines[$x]) | Out-Null } }
             for ($x = $a; $x -lt $lines.Count; $x++) { $newLines.Add($lines[$x]) | Out-Null }
@@ -1193,13 +1157,9 @@ function Parse-BCQualityReport {
     }
     foreach ($clean in $defenced) { $candidates.Add($clean) | Out-Null }
 
-    # Resume-fence repair: handles the interrupted-emission shape where the
-    # agent breaks off mid-string (leaving an unterminated JSON string) and
-    # resumes by re-opening a bare ```json fence with NO Placeholder marker.
-    # Because the break sits inside an unterminated string, Remove-StructuralFences
-    # (which preserves in-string fences) cannot clear it. Extract candidates from
-    # the repaired text and append them AFTER the originals so clean output is
-    # never disturbed.
+    # Repair the resume-fence shape (bare ```json fence inside an unterminated
+    # string, which Remove-StructuralFences can't clear) and append its
+    # candidates after the originals so clean output is untouched.
     $resumeRepaired = Repair-ResumeFenceJson -Output $stripped
     if ($resumeRepaired -ne $stripped) {
         $resumeCandidates = [System.Collections.Generic.List[string]]::new()
@@ -1212,17 +1172,11 @@ function Parse-BCQualityReport {
         }
     }
 
-    # A candidate can parse cleanly yet be the WRONG fragment. The transcript
-    # echoes every sub-skill's own JSON report inside ```json fences, and the
-    # top-level findings-report's `findings[]` is itself a large balanced JSON
-    # array. When the full document is unparseable (e.g. a corrupt value deep in
-    # sub-results) the scan happily parses one of those fragments first: a bare
-    # sub-skill report has `findings` but no `sub-results`, and a bare array has
-    # neither — either way the real report is silently dropped (observed in run
-    # 28168894037: 42 findings recovered to 0). Prefer the orchestrator report
-    # shape (exposes `sub-results` or a `dispatch`), then a findings-bearing
-    # object, then any parseable candidate, so leniency is preserved while the
-    # correct fragment always wins.
+    # A fragment can parse cleanly yet be the wrong one: the transcript echoes
+    # each sub-skill report and the findings[] array as standalone JSON, so when
+    # the full document is unparseable one of those wins and the real report is
+    # dropped. Prefer the orchestrator shape (sub-results/dispatch), then any
+    # findings-bearing object, then any parseable candidate.
     $report = $null
     $shapedReport = $null
     $fallbackReport = $null


### PR DESCRIPTION
## Problem

The Copilot PR-review reviewer silently posted **0 findings** on a run where the agent actually produced **42** (run `28168894037`: blocker × 5, major × 24, minor × 13). The job stayed green because "parsed to zero findings" is indistinguishable from "clean PR" — the findings were lost in **parsing**, not in review.

Two compounding causes in `Parse-BCQualityReport`:

1. **Resume-fence corruption.** The agent breaks off mid-emission and resumes by re-opening a bare ` ```json ` fence with **no `Placeholder ...` marker**. When that fence lands *inside an unterminated string*, `Remove-StructuralFences` (which deliberately preserves in-string fences, e.g. a ` ```al ` sample in `suggested-code`) cannot clear it, so `ConvertFrom-Json` rejects the **entire** document.

2. **Wrong-fragment-wins.** The candidate scan accepted the *first* parseable fragment. The transcript echoes every sub-skill's own JSON report inside fences, and bare arrays (e.g. `['articles']` from reasoning text) parse as valid JSON. So when the full document is unparseable, a wrong fragment is accepted and the real report is silently dropped — and because that fragment reports `outcome: completed` / `findings: []`, it even slips past the `fail-on-parse-error` safeguard.

## Fix

- **`Repair-ResumeFenceJson`** (new, third repair path): a conservative, string-aware splice that clears a bare resume fence **only** when it sits between an unterminated property (`"key": "...` with an odd count of unescaped quotes) and a re-emission of that **same** key. That triple signature distinguishes interrupted-emission resumes from ordinary transcript noise. Clean output is never touched (callers try unmodified candidates first).

- **Tiered candidate preference** (replaces first-parseable-wins): orchestrator-shaped (`sub-results`/`dispatch`) → findings-bearing object → any parseable candidate. Leniency is preserved, but the correct fragment always wins and bare fragments like `['articles']` can only be a last-resort fallback.

## Why both bugs are needed

The most recent production instance had its stray fence **between two top-level members** (outside any string), which `Remove-StructuralFences` already clears — so for that case the tiered preference alone recovers all 42 findings. `Repair-ResumeFenceJson` additionally covers the variant where the fence is trapped inside an unterminated string, which the fence-stripper cannot touch.

## Testing

Validated locally against a regression suite that AST-extracts the parser functions and replays the corruption shapes (resume-fence-in-string, wrong-fragment selection, Placeholder-marker interruption, and the exact production instance with `['articles']` + a stray mid-object fence), plus guards confirming clean reports and legitimate in-string code fences are unaffected — 16/16 assertions pass.

> Note: the regression test script is intentionally **not** included in this PR, as there is currently no pipeline wired up to execute it.

Refs [AB#640481](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640481) (related: [AB#638957](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638957)).







