### PR TITLE
[Main] [Subscription Billing] Infinite loop in CalculateBillingPeriod when HarmonizeNextBillingTo caps at stale "Next Billing To" date

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/BillingProposal.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/BillingProposal.Codeunit.al
@@ -483,6 +483,7 @@ codeunit 8062 "Billing Proposal"
     local procedure CalculateBillingPeriod(ServiceCommitment: Record "Subscription Line"; BillingDate: Date; BillToDate: Date; var BillingPeriodStart: Date; var BillingPeriodEnd: Date)
     var
         UsageDataBilling: Record "Usage Data Billing";
+        PreviousBillingPeriodEnd: Date;
     begin
         BillingPeriodEnd := 0D;
         BillingPeriodStart := ServiceCommitment."Next Billing Date";
@@ -505,10 +506,14 @@ codeunit 8062 "Billing Proposal"
         end;
 
         BillingPeriodEnd := CalculateNextBillingToDateForServiceCommitment(ServiceCommitment, BillingPeriodStart);
+        PreviousBillingPeriodEnd := 0D;
         while (BillingPeriodEnd < BillingDate) and
-              ((BillingPeriodEnd < ServiceCommitment."Subscription Line End Date") or (ServiceCommitment."Subscription Line End Date" = 0D))
-        do
+              ((BillingPeriodEnd < ServiceCommitment."Subscription Line End Date") or (ServiceCommitment."Subscription Line End Date" = 0D)) and
+              (BillingPeriodEnd > PreviousBillingPeriodEnd)
+        do begin
+            PreviousBillingPeriodEnd := BillingPeriodEnd;
             BillingPeriodEnd := CalculateNextBillingToDateForServiceCommitment(ServiceCommitment, BillingPeriodEnd + 1);
+        end;
     end;
 
     procedure CalculateNextBillingToDateForServiceCommitment(ServiceCommitment: Record "Subscription Line"; BillingFromDate: Date) NextBillingToDate: Date

--- a/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingTest.Codeunit.al
@@ -68,6 +68,7 @@ codeunit 139688 "Recurring Billing Test"
         PostedDocumentNo: Code[20];
         StrMenuHandlerStep: Integer;
         BillingProposalNotCreatedErr: Label 'Billing proposal not created.', Locked = true;
+        BillingToCappedErr: Label 'Billing to should be capped at the harmonized Next Billing To date.', Locked = true;
         ExtendedTextValueErr: Label 'Sales line with extended text description should be created.', Locked = true;
         ExtendedTextPurchValueErr: Label 'Purchase line with extended text description should be created.', Locked = true;
         RecurringBillingPage: TestPage "Recurring Billing";
@@ -1569,6 +1570,49 @@ codeunit 139688 "Recurring Billing Test"
         ExpectedNextBillingDate := CalcDate('<1D>', BillingLine."Billing to");
         ServiceCommitment.Get(ServiceCommitment."Entry No.");
         Assert.AreEqual(ExpectedNextBillingDate, ServiceCommitment."Next Billing Date", 'Next Billing Date should be the day after the last Billing To date.');
+    end;
+
+    [Test]
+    procedure CreateBillingProposalForHarmonizedContractWithCappedNextBillingToDoesNotHang()
+    var
+        ContractType: Record "Subscription Contract Type";
+        BillingDate: Date;
+        CappedNextBillingTo: Date;
+      begin
+        // [SCENARIO 637042] Creating a Billing Proposal for a harmonized billing contract must not hang when the contract "Next Billing To" caps the calculated billing period below the Billing Date
+        Initialize();
+
+        // [GIVEN] An LCY Customer Subscription Contract with a monthly Subscription Line
+        CreateCustomerContract('<1M>', '<12M>');
+        FindFirstServiceCommitment();
+
+        // [GIVEN] The contract uses a harmonized billing contract type
+        ContractTestLibrary.CreateContractType(ContractType);
+        ContractType.HarmonizedBillingCustContracts := true;
+        ContractType.Modify(false);
+
+        // [GIVEN] The harmonized "Next Billing To" is frozen at the first billing period end, which is earlier than the Billing Date
+        CappedNextBillingTo := ServiceCommitment.CalculateNextToDate(ServiceCommitment."Billing Rhythm", ServiceCommitment."Next Billing Date");
+        BillingDate := CalcDate('<+6M>', ServiceCommitment."Next Billing Date");
+        CustomerContract.Get(CustomerContract."No.");
+        CustomerContract."Contract Type" := ContractType.Code;
+        CustomerContract."Next Billing To" := CappedNextBillingTo;
+        CustomerContract.Modify(false);
+
+        // [GIVEN] A Billing Template filtered on the harmonized contract
+        CustomerContract.SetRecFilter();
+        ContractTestLibrary.CreateRecurringBillingTemplate(BillingTemplate, '', '', CustomerContract.GetView(), Enum::"Service Partner"::Customer);
+
+        // [WHEN] Create Billing Proposal up to a Billing Date that lies beyond the frozen "Next Billing To"
+        // [THEN] The process completes without entering an infinite loop in CalculateBillingPeriod (before the fix it would spin until a SQL timeout)
+        ContractTestLibrary.CreateBillingProposal(BillingTemplate, Enum::"Service Partner"::Customer, BillingDate, 0D);
+
+        // [THEN] A Billing Line is created and its "Billing to" is capped at the harmonized "Next Billing To" date
+        BillingLine.Reset();
+        BillingLine.SetRange("Subscription Contract No.", CustomerContract."No.");
+        Assert.RecordIsNotEmpty(BillingLine);
+        BillingLine.FindLast();
+        Assert.AreEqual(CappedNextBillingTo, BillingLine."Billing to", BillingToCappedErr);
     end;
 
     #endregion Tests


### PR DESCRIPTION
[AB#640056](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640056)

Bug 640056: [master] [ALL-E][Subscription Billing] Infinite loop in CalculateBillingPeriod when HarmonizeNextBillingTo caps at stale "Next Billing To" date


**Issue:-** CalculateBillingPeriod in BillingProposal.Codeunit.al enters an infinite loop (hang / no response) when generating a billing proposal for a harmonized customer subscription contract whose "Next Billing To" date is stale (older than the current billing period being calculated).

**Cause :-** Root Cause
The while loop advances the billing period end date by repeatedly calling CalculateNextBillingToDateForServiceCommitment:

For a harmonized contract, CalculateNextBillingToDateForServiceCommitment calls HarmonizeNextBillingTo, which caps the computed date at CustomerContract."Next Billing To":

When the contract's "Next Billing To" is a stale date earlier than BillingDate, every iteration gets capped back to that same stale value. So BillingPeriodEnd never advances past it, the loop condition BillingPeriodEnd < BillingDate stays true forever, and the loop never terminates.
Solution
Add a progress guard that breaks the loop as soon as BillingPeriodEnd stops advancing (i.e., is capped to the same/earlier date). A PreviousBillingPeriodEnd tracker is introduced, and the loop only continues while BillingPeriodEnd > PreviousBillingPeriodEnd:


