### PR TITLE
[28.2] E-Document import: vendor-matching telemetry and Posting Description fixes

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Helpers/EDocumentImportHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Helpers/EDocumentImportHelper.Codeunit.al
@@ -5,9 +5,7 @@
 namespace Microsoft.eServices.EDocument;
 
 using Microsoft.Bank.Reconciliation;
-#if not CLEAN26
 using Microsoft.eServices.EDocument.Processing.Import;
-#endif
 using Microsoft.eServices.EDocument.Service.Participant;
 using Microsoft.Finance.Currency;
 using Microsoft.Finance.GeneralLedger.Journal;
@@ -433,19 +431,26 @@ codeunit 6109 "E-Document Import Helper"
     /// <returns>Vendor number if exists or empty string.</returns>
     procedure FindVendor(VendorNoText: Code[20]; GLN: Code[13]; VATRegistrationNo: Text[20]): Code[20]
     var
+        EDocImpSessionTelemetry: Codeunit "E-Doc. Imp. Session Telemetry";
         VendorNo: Code[20];
     begin
         VendorNo := FindVendorByNo(VendorNoText);
-        if VendorNo <> '' then
+        if VendorNo <> '' then begin
+            EDocImpSessionTelemetry.SetText('Vendor Match Method', 'No');
             exit(VendorNo);
+        end;
 
         VendorNo := FindVendorByGLN(GLN);
-        if VendorNo <> '' then
+        if VendorNo <> '' then begin
+            EDocImpSessionTelemetry.SetText('Vendor Match Method', 'GLN');
             exit(VendorNo);
+        end;
 
         VendorNo := FindVendorByVATRegistrationNo(VATRegistrationNo);
-        if VendorNo <> '' then
+        if VendorNo <> '' then begin
+            EDocImpSessionTelemetry.SetText('Vendor Match Method', 'VAT Id');
             exit(VendorNo);
+        end;
     end;
 
     /// <summary>
@@ -566,9 +571,11 @@ codeunit 6109 "E-Document Import Helper"
         Vendor: Record Vendor;
         RecordMatchMgt: Codeunit "Record Match Mgt.";
         EDocumentNotification: Codeunit "E-Document Notification";
+        EDocImpSessionTelemetry: Codeunit "E-Doc. Imp. Session Telemetry";
         NameNearness: Integer;
         AddressNearness: Integer;
         MatchedByAddress: Boolean;
+        NameOnlyCandidateFound: Boolean;
     begin
         Vendor.SetCurrentKey(Blocked);
         Vendor.SetLoadFields(Name, Address);
@@ -583,10 +590,14 @@ codeunit 6109 "E-Document Import Helper"
                     MatchedByAddress := AddressNearness >= RequiredNearness();
                     if MatchedByAddress then
                         exit(Vendor."No.");
+                    NameOnlyCandidateFound := true;
                     if EDocEntryNoForNotification <> 0 then
                         EDocumentNotification.AddVendorMatchedByNameNotAddressNotification(EDocEntryNoForNotification);
                 end;
             until Vendor.Next() = 0;
+
+        if NameOnlyCandidateFound then
+            EDocImpSessionTelemetry.SetBool('Vendor Matched By Name Not Address', true);
     end;
 
     /// <summary>

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
@@ -131,7 +131,6 @@ codeunit 6117 "E-Doc. Create Purchase Invoice" implements IEDocumentFinishDraft,
         PurchaseHeader.SetRange("Buy-from Vendor No.", EDocumentPurchaseHeader."[BC] Vendor No."); // Setting the filter, so that the insert trigger assigns the right vendor to the purchase header
         PurchaseHeader."Document Type" := "Purchase Document Type"::Invoice;
         PurchaseHeader."Pay-to Vendor No." := EDocumentPurchaseHeader."[BC] Vendor No.";
-        PurchaseHeader."Posting Description" := EDocumentPurchaseHeader."Posting Description";
         if EDocumentPurchaseHeader."Document Date" <> 0D then
             EDocPurchaseDocumentHelper.ValidateFieldWithContext(PurchaseHeader, PurchaseHeader.FieldNo("Document Date"), EDocumentPurchaseHeader."Document Date");
         if EDocumentPurchaseHeader."Due Date" <> 0D then
@@ -151,6 +150,8 @@ codeunit 6117 "E-Doc. Create Purchase Invoice" implements IEDocumentFinishDraft,
 
         PurchaseHeader."Invoice Received Date" := PurchaseHeader."Document Date";
         EDocPurchaseDocumentHelper.ApplyDefaultPostingDateFromSetup(PurchaseHeader, EDocumentPurchaseHeader);
+        if EDocumentPurchaseHeader."Posting Description" <> '' then
+            PurchaseHeader."Posting Description" := EDocumentPurchaseHeader."Posting Description";
         PurchaseHeader.Modify();
 
         // Validate of currency has to happen after insert.

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/PrepareDraft/EDocProviders.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/PrepareDraft/EDocProviders.Codeunit.al
@@ -32,18 +32,23 @@ codeunit 6124 "E-Doc. Providers" implements IPurchaseLineProvider, IUnitOfMeasur
         ServiceParticipant: Record "Service Participant";
         EDocErrorHelper: Codeunit "E-Document Error Helper";
         EDocumentImportHelper: Codeunit "E-Document Import Helper";
+        EDocImpSessionTelemetry: Codeunit "E-Doc. Imp. Session Telemetry";
         EDocumentHasNoVendorInformation: Boolean;
     begin
         EDocumentPurchaseHeader.GetFromEDocument(EDocument);
         EDocumentHasNoVendorInformation := (EDocumentPurchaseHeader."Vendor GLN" = '') and (EDocumentPurchaseHeader."Vendor VAT Id" = '') and (EDocumentPurchaseHeader."Vendor External Id" = '') and (EDocumentPurchaseHeader."Vendor Company Name" = '') and (EDocumentPurchaseHeader."Vendor Address" = '');
-        if EDocumentHasNoVendorInformation then
+
+        EDocImpSessionTelemetry.SetBool('Vendor Info Present', not EDocumentHasNoVendorInformation);
+
+        if EDocumentHasNoVendorInformation then begin
             // We warn if there's no vendor information extracted from the E-Document, unless we are aware that it is a blank draft
             if EDocument."Read into Draft Impl." <> "E-Doc. Read into Draft"::"Blank Draft" then
                 EDocErrorHelper.LogWarningMessage(EDocument, EDocumentPurchaseHeader, EDocumentPurchaseHeader.FieldNo("[BC] Vendor No."), NoVendorInformationErr);
 
-        // If the E-Document has no vendor information, we can't find the vendor, so we exit early
-        if EDocumentHasNoVendorInformation then
+            // If the E-Document has no vendor information, we can't find the vendor, so we exit early
+            EDocImpSessionTelemetry.SetText('Vendor Match Method', 'None - No Vendor Info');
             exit;
+        end;
 
         if Vendor.Get(EDocumentImportHelper.FindVendor('', EDocumentPurchaseHeader."Vendor GLN", CopyStr(EDocumentPurchaseHeader."Vendor VAT Id", 1, 20))) then
             exit;
@@ -55,10 +60,17 @@ codeunit 6124 "E-Doc. Providers" implements IPurchaseLineProvider, IUnitOfMeasur
             ServiceParticipant.SetRange(Service);
             if ServiceParticipant.FindFirst() then;
         end;
-        if Vendor.Get(ServiceParticipant.Participant) then
+        if Vendor.Get(ServiceParticipant.Participant) then begin
+            EDocImpSessionTelemetry.SetText('Vendor Match Method', 'Service Participant');
             exit;
+        end;
 
-        if Vendor.Get(EDocumentImportHelper.FindVendorByNameAndAddress(EDocumentPurchaseHeader."Vendor Company Name", EDocumentPurchaseHeader."Vendor Address")) then;
+        if Vendor.Get(EDocumentImportHelper.FindVendorByNameAndAddress(EDocumentPurchaseHeader."Vendor Company Name", EDocumentPurchaseHeader."Vendor Address")) then begin
+            EDocImpSessionTelemetry.SetText('Vendor Match Method', 'Name and Address');
+            exit;
+        end;
+
+        EDocImpSessionTelemetry.SetText('Vendor Match Method', 'None - No Match');
     end;
 
     procedure GetUnitOfMeasure(EDocumentHeader: Record "E-Document"; EDocumentLineId: Integer; ExternalUnitOfMeasure: Text) UnitOfMeasure: Record "Unit of Measure"

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/PrepareDraft/PreparePurchaseEDocDraft.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/PrepareDraft/PreparePurchaseEDocDraft.Codeunit.al
@@ -39,6 +39,8 @@ codeunit 6125 "Prepare Purchase E-Doc. Draft" implements IProcessStructuredData
         LineAmount: Decimal;
         LineVATAmount: Decimal;
         TotalLineVATAmount: Decimal;
+        VendorAlreadyAssigned: Boolean;
+        VendorFoundByProvider: Boolean;
     begin
         IUnitOfMeasureProvider := EDocImportParameters."Processing Customizations";
         IPurchaseLineProvider := EDocImportParameters."Processing Customizations";
@@ -48,10 +50,12 @@ codeunit 6125 "Prepare Purchase E-Doc. Draft" implements IProcessStructuredData
 
         EDocumentPurchaseHeader.GetFromEDocument(EDocument);
         EDocumentPurchaseHeader.TestField("E-Document Entry No.");
-        if EDocumentPurchaseHeader."[BC] Vendor No." = '' then begin
+        VendorAlreadyAssigned := EDocumentPurchaseHeader."[BC] Vendor No." <> '';
+        if not VendorAlreadyAssigned then begin
             Vendor := GetVendor(EDocument, EDocImportParameters."Processing Customizations");
             EDocumentPurchaseHeader."[BC] Vendor No." := Vendor."No.";
         end;
+        VendorFoundByProvider := (not VendorAlreadyAssigned) and (EDocumentPurchaseHeader."[BC] Vendor No." <> '');
 
         PurchaseOrder := IPurchaseOrderProvider.GetPurchaseOrder(EDocumentPurchaseHeader);
         if PurchaseOrder."No." <> '' then begin
@@ -65,6 +69,17 @@ codeunit 6125 "Prepare Purchase E-Doc. Draft" implements IProcessStructuredData
 
         // If we can't find a vendor 
         EDocImpSessionTelemetry.SetBool('Vendor', EDocumentPurchaseHeader."[BC] Vendor No." <> '');
+
+        case true of
+            VendorAlreadyAssigned:
+                EDocImpSessionTelemetry.SetText('Vendor Assignment Source', 'Already Assigned');
+            VendorFoundByProvider:
+                EDocImpSessionTelemetry.SetText('Vendor Assignment Source', 'Provider');
+            EDocumentPurchaseHeader."[BC] Vendor No." <> '':
+                EDocImpSessionTelemetry.SetText('Vendor Assignment Source', 'History');
+            else
+                EDocImpSessionTelemetry.SetText('Vendor Assignment Source', 'None');
+        end;
         if EDocumentPurchaseHeader."[BC] Vendor No." <> '' then begin
 
             // Get all purchase lines for the document


### PR DESCRIPTION
#### Summary
Backport to `releases/28.2` of the E-Document purchase import improvements:

- **Vendor-match telemetry**: emit `E-Doc. Imp. Session Telemetry` signals throughout the prepare-draft pipeline — `Vendor Match Method` (No / GLN / VAT Id / Service Participant / Name and Address / None), `Vendor Info Present`, `Vendor Assignment Source` (Already Assigned / Provider / History / None), and `Vendor Matched By Name Not Address`.
- **Name-and-Address fallback fix**: the result of `FindVendorByNameAndAddress` was previously discarded (trailing `;`); it now actually assigns the matched vendor and exits.
- **Posting Description fix**: only copy `Posting Description` from the E-Document onto the Purchase Header when it is non-empty, and apply it after the default posting date logic so a blank value no longer overwrites the header.
- Remove the obsolete `#if not CLEAN26` guard around the `Microsoft.eServices.EDocument.Processing.Import` using statement (now always required).

#### Work Item(s)
Fixes [AB#640639](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/640639)
Fixes [AB#640635](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/640635)

