### PR TITLE
[Subcontracting] Create TO to Subcontractor honors reduced open WIP line (Bug 639382)

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
@@ -347,7 +347,7 @@ report 99001501 "Subc. Create Transf. Order"
 
         if WIPSourceLocationList.Count() = 1 then begin
             GetTransferToLocationCodeForPurchaseHeader("Purchase Header", Vendor, TransferToLocCode);
-            PostedWIPQtyBase := GetWIPQtyBase(PurchaseLine, TransferToLocCode);
+            PostedWIPQtyBase := GetWIPQtyBase(PurchaseLine, TransferToLocCode) + GetOpenWIPTransferLineQtyBase(PurchaseLine);
         end;
 
         Item.SetLoadFields("Base Unit of Measure");
@@ -509,26 +509,16 @@ report 99001501 "Subc. Create Transf. Order"
         ProdOrderRoutingLine: Record "Prod. Order Routing Line";
         PurchaseHeader: Record "Purchase Header";
         VendorFromPurchOrder: Record Vendor;
-        TransferLineToCheck: Record "Transfer Line";
         LocCode: Code[10];
         PurchLineQtyBase: Decimal;
         TransferToLocationCode: Code[10];
         ExpectedQtyBase: Decimal;
         PostedWIPQtyBase: Decimal;
+        OpenWIPLineQtyBase: Decimal;
         WIPPreviousOperationNoDict: Dictionary of [Code[10], Code[10]];
         WIPSourceQtyDict: Dictionary of [Code[10], Decimal];
         WIPSourceLocationList: List of [Code[10]];
     begin
-        TransferLineToCheck.SetCurrentKey("Subc. Prod. Order No.", "Subc. Prod. Order Line No.", "Subc. Routing Reference No.", "Subc. Routing No.", "Subc. Operation No.");
-        TransferLineToCheck.SetRange("Subc. Purch. Order No.", PurchaseLine."Document No.");
-        TransferLineToCheck.SetRange("Subc. Prod. Order No.", PurchaseLine."Prod. Order No.");
-        TransferLineToCheck.SetRange("Subc. Prod. Order Line No.", PurchaseLine."Prod. Order Line No.");
-        TransferLineToCheck.SetRange("Subc. Operation No.", PurchaseLine."Operation No.");
-        TransferLineToCheck.SetRange("Derived From Line No.", 0);
-        TransferLineToCheck.SetRange("Transfer WIP Item", true);
-        if not TransferLineToCheck.IsEmpty() then
-            exit(false);
-
         if not ProdOrderLine.Get("Production Order Status"::Released, PurchaseLine."Prod. Order No.", PurchaseLine."Prod. Order Line No.") then
             exit(false);
 
@@ -561,13 +551,24 @@ report 99001501 "Subc. Create Transf. Order"
             exit(false);
 
         PostedWIPQtyBase := GetWIPQtyBase(PurchaseLine, TransferToLocationCode);
+        OpenWIPLineQtyBase := GetOpenWIPTransferLineQtyBase(PurchaseLine);
 
-        if WIPPreviousOperationNoDict.Keys().Count() > 1 then
-            foreach LocCode in WIPPreviousOperationNoDict.Keys() do
-                if LocCode <> '' then
-                    exit(ExpectedQtyBase > 0);
+        exit((PostedWIPQtyBase + OpenWIPLineQtyBase) < ExpectedQtyBase);
+    end;
 
-        exit(PostedWIPQtyBase < ExpectedQtyBase);
+    local procedure GetOpenWIPTransferLineQtyBase(PurchaseLine: Record "Purchase Line"): Decimal
+    var
+        TransferLineToCheck: Record "Transfer Line";
+    begin
+        TransferLineToCheck.SetCurrentKey("Subc. Prod. Order No.", "Subc. Prod. Order Line No.", "Subc. Routing Reference No.", "Subc. Routing No.", "Subc. Operation No.");
+        TransferLineToCheck.SetRange("Subc. Purch. Order No.", PurchaseLine."Document No.");
+        TransferLineToCheck.SetRange("Subc. Prod. Order No.", PurchaseLine."Prod. Order No.");
+        TransferLineToCheck.SetRange("Subc. Prod. Order Line No.", PurchaseLine."Prod. Order Line No.");
+        TransferLineToCheck.SetRange("Subc. Operation No.", PurchaseLine."Operation No.");
+        TransferLineToCheck.SetRange("Derived From Line No.", 0);
+        TransferLineToCheck.SetRange("Transfer WIP Item", true);
+        TransferLineToCheck.CalcSums("Quantity (Base)");
+        exit(TransferLineToCheck."Quantity (Base)");
     end;
 
     local procedure CalcPurchLineQtyBase(PurchaseLine: Record "Purchase Line"; ProdOrderLine: Record "Prod. Order Line"): Decimal

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
@@ -322,6 +322,7 @@ report 99001501 "Subc. Create Transf. Order"
         WIPPreviousOperationNoDict: Dictionary of [Code[10], Code[10]];
         WIPSourceQtyDict: Dictionary of [Code[10], Decimal];
         WIPSourceLocationList: List of [Code[10]];
+        OpenWIPLineQtyBase: Decimal;
     begin
         if not ProdOrderLine.Get("Production Order Status"::Released, PurchaseLine."Prod. Order No.", PurchaseLine."Prod. Order Line No.") then
             exit(false);
@@ -332,7 +333,7 @@ report 99001501 "Subc. Create Transf. Order"
         if not ProdOrderRoutingLine."Transfer WIP Item" then
             exit(false);
 
-        if not CheckCreateWIPTransfer(PurchaseLine) then
+        if not CheckCreateWIPTransfer(PurchaseLine, OpenWIPLineQtyBase) then
             exit(false);
 
         PurchLineQtyBase := CalcPurchLineQtyBase(PurchaseLine, ProdOrderLine);
@@ -347,7 +348,7 @@ report 99001501 "Subc. Create Transf. Order"
 
         if WIPSourceLocationList.Count() = 1 then begin
             GetTransferToLocationCodeForPurchaseHeader("Purchase Header", Vendor, TransferToLocCode);
-            PostedWIPQtyBase := GetWIPQtyBase(PurchaseLine, TransferToLocCode) + GetOpenWIPTransferLineQtyBase(PurchaseLine);
+            PostedWIPQtyBase := GetWIPQtyBase(PurchaseLine, TransferToLocCode) + OpenWIPLineQtyBase;
         end;
 
         Item.SetLoadFields("Base Unit of Measure");
@@ -503,7 +504,7 @@ report 99001501 "Subc. Create Transf. Order"
             WIPQtyBase := WIPLedgerEntry."Quantity (Base)";
     end;
 
-    local procedure CheckCreateWIPTransfer(PurchaseLine: Record "Purchase Line"): Boolean
+    local procedure CheckCreateWIPTransfer(PurchaseLine: Record "Purchase Line"; var OpenWIPLineQtyBase: Decimal): Boolean
     var
         ProdOrderLine: Record "Prod. Order Line";
         ProdOrderRoutingLine: Record "Prod. Order Routing Line";
@@ -514,11 +515,11 @@ report 99001501 "Subc. Create Transf. Order"
         TransferToLocationCode: Code[10];
         ExpectedQtyBase: Decimal;
         PostedWIPQtyBase: Decimal;
-        OpenWIPLineQtyBase: Decimal;
         WIPPreviousOperationNoDict: Dictionary of [Code[10], Code[10]];
         WIPSourceQtyDict: Dictionary of [Code[10], Decimal];
         WIPSourceLocationList: List of [Code[10]];
     begin
+        OpenWIPLineQtyBase := 0;
         if not ProdOrderLine.Get("Production Order Status"::Released, PurchaseLine."Prod. Order No.", PurchaseLine."Prod. Order Line No.") then
             exit(false);
 

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1392,6 +1392,75 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
 
     [Test]
     [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
+    procedure WIPTransferRemainderCreatedWhenOpenLineQuantityReduced()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        TransferLine: Record "Transfer Line";
+        WorkCenter: array[2] of Record "Work Center";
+        FullQty: Decimal;
+        ReducedQty: Decimal;
+        PurchaseHeaderPage: TestPage "Purchase Order";
+    begin
+        // [SCENARIO 639382] When an open (unposted) WIP transfer line had its quantity reduced,
+        // re-running "Create Transfer Order to Subcontractor" must create the remaining quantity
+        // instead of erroring that there is nothing to create.
+
+        // [GIVEN] Complete setup with Transfer WIP Item = true on the subcontracting routing line
+        Initialize();
+
+        SubcWarehouseLibrary.CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter, true);
+        SubcWarehouseLibrary.CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        SetTransferWIPItemOnRoutingLine(Item."Routing No.", WorkCenter[2]."No.", true);
+
+        // [GIVEN] Create and refresh production order with a quantity that allows a partial remainder
+        FullQty := LibraryRandom.RandIntInRange(6, 10);
+        LibraryManufacturing.CreateProductionOrder(
+            ProductionOrder, "Production Order Status"::Released,
+            ProductionOrder."Source Type"::Item, Item."No.", FullQty);
+        SetProdOrderLocationToCompSetupLocationAndRefresh(ProductionOrder);
+
+        // [GIVEN] Create Subcontracting Purchase Order
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+
+        // [GIVEN] Create the initial WIP Transfer Order with the full quantity
+        PurchaseHeaderPage.OpenView();
+        PurchaseHeaderPage.GoToRecord(PurchaseHeader);
+        PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [GIVEN] Reduce the open WIP transfer line quantity (do not post it)
+        TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+        TransferLine.SetRange("Subc. Return Order", false);
+#pragma warning disable AA0210
+        TransferLine.SetRange("Transfer WIP Item", true);
+#pragma warning restore AA0210
+        Assert.RecordCount(TransferLine, 1);
+        TransferLine.FindFirst();
+        ReducedQty := FullQty - LibraryRandom.RandIntInRange(1, FullQty - 1);
+        TransferLine.Validate(Quantity, ReducedQty);
+        TransferLine.Modify(true);
+
+        // [WHEN] Re-run Create Transfer Order to Subcontractor
+        PurchaseHeaderPage.OpenView();
+        PurchaseHeaderPage.GoToRecord(PurchaseHeader);
+        PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [THEN] The remaining quantity is now covered (reduced line + new remainder line = FullQty)
+        TransferLine.CalcSums(Quantity);
+        Assert.AreEqual(FullQty, TransferLine.Quantity,
+            'Re-running Create Transfer Order must create the remaining WIP quantity after the open line was reduced.');
+    end;
+
+    [Test]
+    [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
     procedure ToggleOffDirectTransferOnWIPTransferOrderDoesNotError()
     var
         Item: Record Item;

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1401,9 +1401,9 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         PurchaseLine: Record "Purchase Line";
         TransferLine: Record "Transfer Line";
         WorkCenter: array[2] of Record "Work Center";
+        PurchaseHeaderPage: TestPage "Purchase Order";
         FullQty: Decimal;
         ReducedQty: Decimal;
-        PurchaseHeaderPage: TestPage "Purchase Order";
     begin
         // [SCENARIO 639382] When an open (unposted) WIP transfer line had its quantity reduced,
         // re-running "Create Transfer Order to Subcontractor" must create the remaining quantity

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1435,6 +1435,7 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         PurchaseHeaderPage.OpenView();
         PurchaseHeaderPage.GoToRecord(PurchaseHeader);
         PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+        PurchaseHeaderPage.Close();
 
         // [GIVEN] Reduce the open WIP transfer line quantity (do not post it)
         TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");


### PR DESCRIPTION
Fixes ADO bug 639382.

## Problem
'Create Transfer Order to Subcontractor' failed with *Nothing to create. No components or WIP to transfer* after a WIP transfer line was reduced (e.g. qty 5 -> 3), instead of creating the remaining qty 2.

## Root cause
CheckCreateWIPTransfer had an early IsEmpty() short-circuit: if any open WIP transfer line existed it returned false. Coverage was measured only against posted WIP ledger entries, never against open transfer-line quantities, so a reduced (not deleted) line blocked all further creation.

## Fix
- Removed the IsEmpty() short-circuit.
- Added GetOpenWIPTransferLineQtyBase summing open (unposted, non-return) WIP transfer-line base qty.
- CheckCreateWIPTransfer returns true when posted + open < expected. HandleWIPTransferForPurchLine cap subtracts posted and open qty, inserting only the remainder.

## Test
WIPTransferRemainderCreatedWhenOpenLineQuantityReduced reproduces the scenario.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes [AB#639382](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639382)





