### PR TITLE
Add VerifyMiappSync and ValidateCountryProjects actions

### DIFF
--- a/.github/actions/ValidateCountryProjects/action.ps1
+++ b/.github/actions/ValidateCountryProjects/action.ps1
@@ -1,0 +1,6 @@
+$repoRoot = & git rev-parse --show-toplevel
+$result = & "$repoRoot/build/scripts/Update-CountryProjectSettings.ps1" -Validate
+if ($result -eq $false) {
+    Write-Host "::error::Country project settings are out of date. Run 'build/scripts/Update-CountryProjectSettings.ps1' and commit the changes."
+    exit 1
+}

--- a/.github/actions/ValidateCountryProjects/action.yaml
+++ b/.github/actions/ValidateCountryProjects/action.yaml
@@ -1,0 +1,13 @@
+name: Validate Country Projects
+author: Microsoft Corporation
+description: Validates that country project settings.json files have correct W1 app dependencies.
+runs:
+  using: composite
+  steps:
+    - name: Validate Country Projects
+      shell: pwsh
+      run: |
+        ${{ github.action_path }}/action.ps1
+branding:
+  icon: terminal
+  color: blue

--- a/.github/actions/VerifyMiappSync/action.ps1
+++ b/.github/actions/VerifyMiappSync/action.ps1
@@ -1,0 +1,9 @@
+# Current path is .github/actions/VerifyMiappSync
+
+# Miapp check is temporarily disabled
+Write-Host "Miapp sync verification is currently disabled."
+return
+
+Import-Module "$PSScriptRoot\..\..\..\build\scripts\Miapp\MicroSnapApp.psm1" -Force
+$env:RepoBranchName = $env:GITHUB_BASE_REF
+Invoke-MiSnapApp

--- a/.github/actions/VerifyMiappSync/action.yaml
+++ b/.github/actions/VerifyMiappSync/action.yaml
@@ -1,0 +1,13 @@
+name: Verify Miapp Sync
+author: Microsoft Corporation
+description: Verifies that all Miapp-dependent files are synchronized using Invoke-MiSnapApp.
+runs:
+  using: composite
+  steps:
+    - name: Verify Miapp sync
+      shell: pwsh
+      run: |
+        ${{ github.action_path }}/action.ps1
+branding:
+  icon: terminal
+  color: blue


### PR DESCRIPTION
These composite actions are referenced @main by the VerifyAppChanges workflow in PR #8848. They must exist on main first so the @main references resolve.

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

