### PR TITLE
Update action reference for unstable tests

### DIFF
--- a/.github/workflows/AddUnstableTestsFromRun.yaml
+++ b/.github/workflows/AddUnstableTestsFromRun.yaml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Add unstable tests from run
-        uses: microsoft/BCAppsPrivate/.github/actions/UpdateUnstableTests@main #TODO - point to public repo when action is published
+        uses: microsoft/BCApps/.github/actions/UpdateUnstableTests@main
         with:
           branch: ${{ matrix.branch }}
           run-id: ${{ inputs.runId }}

--- a/.github/workflows/UpdateUnstableTests.yaml
+++ b/.github/workflows/UpdateUnstableTests.yaml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Update unstable tests
         if: steps.calc.outputs.runIds != ''
-        uses: microsoft/BCAppsPrivate/.github/actions/UpdateUnstableTests@main #TODO - point to public repo when action is published
+        uses: microsoft/BCApps/.github/actions/UpdateUnstableTests@main
         with:
           branch: ${{ matrix.branch }}
           run-id: ${{ steps.calc.outputs.runIds }}


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

Pointing Add Unstable Tests action to BCApps instead of BCAppsPrivate.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->


