### PR TITLE
Point UpdateUnstableTests action to public BCApps repo

### DIFF
--- a/.github/workflows/AddUnstableTestsFromRun.yaml
+++ b/.github/workflows/AddUnstableTestsFromRun.yaml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Add unstable tests from run
-        uses: microsoft/BCAppsPrivate/.github/actions/UpdateUnstableTests@main #TODO - point to public repo when action is published
+        uses: microsoft/BCApps/.github/actions/UpdateUnstableTests@main
         with:
           branch: ${{ matrix.branch }}
           run-id: ${{ inputs.runId }}

--- a/.github/workflows/UpdateUnstableTests.yaml
+++ b/.github/workflows/UpdateUnstableTests.yaml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Update unstable tests
         if: steps.calc.outputs.runIds != ''
-        uses: microsoft/BCAppsPrivate/.github/actions/UpdateUnstableTests@main #TODO - point to public repo when action is published
+        uses: microsoft/BCApps/.github/actions/UpdateUnstableTests@main
         with:
           branch: ${{ matrix.branch }}
           run-id: ${{ steps.calc.outputs.runIds }}

--- a/build/scripts/ALAppBuild.psm1
+++ b/build/scripts/ALAppBuild.psm1
@@ -118,7 +118,7 @@ class BuildMetadataProvider
     {
         if (![BuildMetadataProvider]::ApplicationBuildInfo)
         {
-            # BCAppsPrivate uses build\projects.json and build\groups.json
+            # BCApps uses build\projects.json and build\groups.json
             [BuildMetadataProvider]::ApplicationBuildInfo = Get-Content -Path "$ENV:INETROOT\build\projects.json" -Raw | ConvertFrom-Json
             [BuildMetadataProvider]::ApplicationGroupInfo = Get-Content -Path "$ENV:INETROOT\build\groups.json" -Raw | ConvertFrom-Json
         }

--- a/build/scripts/TestTolerance/TestTolerance.Test.ps1
+++ b/build/scripts/TestTolerance/TestTolerance.Test.ps1
@@ -398,13 +398,13 @@ Describe "TestTolerance" {
                 'ext-1::300::t1' = [pscustomobject]@{ ExtensionId = 'ext-1'; CodeunitId = 300; CodeunitName = 'A'; TestMethod = 'T1'; FailureMessage = 'm1'; FailureDetail = 's1'; SourceRunId = '999' }
             }
 
-            $merged = @(Add-FailedTestsToUnstableTests -ExistingTests @() -FailedTests $failed -Repository 'microsoft/BCAppsPrivate')
+            $merged = @(Add-FailedTestsToUnstableTests -ExistingTests @() -FailedTests $failed -Repository 'microsoft/BCApps')
             $merged.Count | Should -Be 1
             $merged[0].extensionId | Should -Be 'ext-1'
             $merged[0].codeunitId | Should -Be 300
             $merged[0].testMethod | Should -Be 'T1'
             $merged[0].reason | Should -Match '999'
-            $merged[0].sourceRunUrl | Should -Be 'https://github.com/microsoft/BCAppsPrivate/actions/runs/999'
+            $merged[0].sourceRunUrl | Should -Be 'https://github.com/microsoft/BCApps/actions/runs/999'
         }
 
         It "preserves existing entries verbatim and only appends new ones" {


### PR DESCRIPTION
The `UpdateUnstableTests` action is now published in the public `microsoft/BCApps` repo, so the two workflows that still referenced `microsoft/BCAppsPrivate/.github/actions/UpdateUnstableTests@main` are updated to use the public action and the stale TODO comments are removed.

### Changed
- `.github/workflows/AddUnstableTestsFromRun.yaml`
- `.github/workflows/UpdateUnstableTests.yaml`

Both now use `microsoft/BCApps/.github/actions/UpdateUnstableTests@main`.

