### PR TITLE
Cap unstable tests artifact retention at 30 days

### DIFF
--- a/.github/actions/UpdateUnstableTests/action.yaml
+++ b/.github/actions/UpdateUnstableTests/action.yaml
@@ -43,7 +43,7 @@ runs:
         name: ${{ steps.update.outputs.artifactName }}
         path: .unstable-tests/unstable-tests.json
         if-no-files-found: warn
-        retention-days: 90
+        retention-days: 30
 branding:
   icon: terminal
   color: blue


### PR DESCRIPTION
The `UpdateUnstableTests` action requested `retention-days: 90` when uploading the unstable-tests artifact, but the repository's maximum allowed retention is 30 days. This produced a warning on every run:

> Retention days cannot be greater than the maximum allowed retention set within the repository. Using 30 instead.

Setting the value to `30` matches the repository cap and removes the warning (behavior is unchanged — GitHub was already clamping it to 30).

### Changed
- `.github/actions/UpdateUnstableTests/action.yaml` — `retention-days: 90` -> `30`

[AB#612711](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612711)


