### PR TITLE
Use GitHub-BCAppsPL pool for test projects

### DIFF
--- a/build/projects/Test Apps AT/.AL-Go/settings.json
+++ b/build/projects/Test Apps AT/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (AT)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps AT"
   ],

--- a/build/projects/Test Apps AU/.AL-Go/settings.json
+++ b/build/projects/Test Apps AU/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (AU)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps AU"
   ],

--- a/build/projects/Test Apps BE/.AL-Go/settings.json
+++ b/build/projects/Test Apps BE/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (BE)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps BE"
   ],

--- a/build/projects/Test Apps CA/.AL-Go/settings.json
+++ b/build/projects/Test Apps CA/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (CA)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps CA"
   ],

--- a/build/projects/Test Apps CH/.AL-Go/settings.json
+++ b/build/projects/Test Apps CH/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (CH)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps CH"
   ],

--- a/build/projects/Test Apps CZ/.AL-Go/settings.json
+++ b/build/projects/Test Apps CZ/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (CZ)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps CZ"
   ],

--- a/build/projects/Test Apps DE/.AL-Go/settings.json
+++ b/build/projects/Test Apps DE/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (DE)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps DE"
   ],

--- a/build/projects/Test Apps DK/.AL-Go/settings.json
+++ b/build/projects/Test Apps DK/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (DK)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps DK"
   ],

--- a/build/projects/Test Apps ES/.AL-Go/settings.json
+++ b/build/projects/Test Apps ES/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (ES)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps ES"
   ],

--- a/build/projects/Test Apps FI/.AL-Go/settings.json
+++ b/build/projects/Test Apps FI/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (FI)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps FI"
   ],

--- a/build/projects/Test Apps FR/.AL-Go/settings.json
+++ b/build/projects/Test Apps FR/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (FR)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps FR"
   ],

--- a/build/projects/Test Apps GB/.AL-Go/settings.json
+++ b/build/projects/Test Apps GB/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (GB)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps GB"
   ],

--- a/build/projects/Test Apps IN/.AL-Go/settings.json
+++ b/build/projects/Test Apps IN/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (IN)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps IN"
   ],

--- a/build/projects/Test Apps IS/.AL-Go/settings.json
+++ b/build/projects/Test Apps IS/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (IS)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps IS"
   ],

--- a/build/projects/Test Apps IT/.AL-Go/settings.json
+++ b/build/projects/Test Apps IT/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (IT)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps IT"
   ],

--- a/build/projects/Test Apps MX/.AL-Go/settings.json
+++ b/build/projects/Test Apps MX/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (MX)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps MX"
   ],

--- a/build/projects/Test Apps NL/.AL-Go/settings.json
+++ b/build/projects/Test Apps NL/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (NL)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps NL"
   ],

--- a/build/projects/Test Apps NO/.AL-Go/settings.json
+++ b/build/projects/Test Apps NO/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (NO)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps NO"
   ],

--- a/build/projects/Test Apps NZ/.AL-Go/settings.json
+++ b/build/projects/Test Apps NZ/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (NZ)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps NZ"
   ],

--- a/build/projects/Test Apps SE/.AL-Go/settings.json
+++ b/build/projects/Test Apps SE/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (SE)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps SE"
   ],

--- a/build/projects/Test Apps US/.AL-Go/settings.json
+++ b/build/projects/Test Apps US/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests (US)",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "projectsToTest": [
     "build/projects/Apps US"
   ],

--- a/build/projects/Test Apps W1/.AL-Go/settings.json
+++ b/build/projects/Test Apps W1/.AL-Go/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
   "projectName": "Unit Tests",
-  "gitHubRunner": "GitHub-BCAppsPL2",
+  "gitHubRunner": "GitHub-BCAppsPL",
   "country": "w1",
   "projectsToTest": [
     "build/projects/Apps W1"


### PR DESCRIPTION
Switches the `gitHubRunner` for all test app projects from `GitHub-BCAppsPL2` to `GitHub-BCAppsPL`.

Updates the 22 `Test Apps */.AL-Go/settings.json` files (AT, AU, BE, CA, CH, CZ, DE, DK, ES, FI, FR, GB, IN, IS, IT, MX, NL, NO, NZ, SE, US, W1).


[AB#612711](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612711)

