### PR TITLE
Fix VerifyAppChanges broken in release branches

### DIFF
--- a/.github/actions/TestObjectIdsAndManifests/action.ps1
+++ b/.github/actions/TestObjectIdsAndManifests/action.ps1
@@ -12,8 +12,10 @@ $w1Layers = @(Join-Path $sourceCodeFolder "Layers\W1")
 $allApps = @(Join-Path $sourceCodeFolder "Apps")
 
 # Build path sets for different validations
-[string[]] $w1OnlyPaths = $baseFolders + $w1Apps + $w1Layers
-[string[]] $allPaths = $baseFolders + $allApps + $w1Layers
+# Some folders (e.g. Layers) only exist on main and not on release branches, so filter out
+# any paths that do not exist to avoid Get-ChildItem failing on missing directories.
+[string[]] $w1OnlyPaths = @($baseFolders + $w1Apps + $w1Layers | Where-Object { Test-Path -Path $_ })
+[string[]] $allPaths = @($baseFolders + $allApps + $w1Layers | Where-Object { Test-Path -Path $_ })
 
 # Define exceptions
 $AllowedDuplicateObjects = @(


### PR DESCRIPTION
Add a Test-Path guard to the verify app changes script. Since the action is from main, it includes the check on layers, but as they do not exist (yet) in release branches, this fails.

