### PR TITLE
[SOA] Mail Signature not appearing in outgoing emails from Sales Order Agent

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Codeunit.al
@@ -493,6 +493,7 @@ codeunit 4400 "SOA Setup"
         end;
 
         if SOASetup.GetBasedOnAgentUserSecurityID(TempSOASetup."User Security ID", false) then begin
+            SOASetup.CalcFields("Email Template");
             TempSOASetup := SOASetup;
             TempSOASetup.Insert();
         end


### PR DESCRIPTION
## What & why

The setup page loads agent settings from the database into a temporary working copy. The email signature is stored separately from the other fields (as a large data blob), so it requires an extra "fetch" step to load it.

When you open the page from the agent list, the code took a path that included this extra fetch — so the signature appeared correctly.

When you open it from the agent task pane, the code took a different path that skipped that fetch — so the signature field came up empty, even though the data was there in the database.

The fix adds the missing fetch step to the second path, so the signature loads regardless of how you open the page.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#636705](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636705)

