### PR TITLE
Allow retrieving Outlook emails unsanitized via bypass flag

### DIFF
--- a/src/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPIHelper.Codeunit.al
+++ b/src/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPIHelper.Codeunit.al
@@ -433,7 +433,7 @@ codeunit 4509 "Email - Outlook API Helper"
         HTMLBody := Filters."Body Type" = Filters."Body Type"::HTML;
         if Filters."Last Message Only" then
             Body := KeepLastMessageOnly(Body);
-        EmailMessage.Create('', Subject, Body, HTMLBody, true);
+        EmailMessage.Create('', Subject, Body, HTMLBody, not Filters.GetBypassBodySanitization());
 
         if HasAttachments then
             AddAttachmentsToMessage(EmailJsonObject, EmailMessage);

--- a/src/Apps/W1/Email - Outlook REST API/test/HttpResponseFiles/RetrieveEmailWithUnsafeBody.txt
+++ b/src/Apps/W1/Email - Outlook REST API/test/HttpResponseFiles/RetrieveEmailWithUnsafeBody.txt
@@ -1,0 +1,25 @@
+{
+  "@odata.count": 1,
+  "value": [
+    {
+      "id": "test-message-id-unsafe-001",
+      "conversationId": "test-conversation-id-unsafe-001",
+      "subject": "Test Email With Unsafe Body",
+      "receivedDateTime": "2026-04-21T10:00:00Z",
+      "sentDateTime": "2026-04-21T09:55:00Z",
+      "sender": {
+        "emailAddress": {
+          "name": "Test Sender",
+          "address": "sender@test.com"
+        }
+      },
+      "body": {
+        "contentType": "HTML",
+        "content": "<p>Safe Content</p><script>alert('xss')</script><img src=\"x\" onerror=\"alert('1')\">"
+      },
+      "hasAttachments": false,
+      "isRead": false,
+      "isDraft": false
+    }
+  ]
+}

--- a/src/Apps/W1/Email - Outlook REST API/test/OutlookAPIHelperTests.Codeunit.al
+++ b/src/Apps/W1/Email - Outlook REST API/test/OutlookAPIHelperTests.Codeunit.al
@@ -320,6 +320,104 @@ codeunit 139752 "Outlook API Helper Tests"
         LibraryAssert.IsFalse(EmailMessage.GetHeader('X-MS-Exchange-Organization-AuthAs', HeaderValue), 'AuthAs must not be persisted when Load Headers is false');
     end;
 
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    [HandlerFunctions('GraphRetrieveEmailsUnsafeBodyHandler')]
+    procedure TestRetrieveEmailSanitizesBodyByDefault()
+    var
+        OutlookAccount: Record "Email - Outlook Account";
+        EmailInbox: Record "Email Inbox";
+        TempFilters: Record "Email Retrieval Filters" temporary;
+        SkipTokenRequest: Codeunit "Skip Outlook API Token Request";
+        EmailMessage: Codeunit "Email Message";
+        EmailOutlookAPIHelper: Codeunit "Email - Outlook API Helper";
+        Body: Text;
+    begin
+        // [SCENARIO] By default, retrieved email bodies are sanitized, stripping unsafe HTML.
+
+        // [GIVEN] An Outlook account exists
+        OutlookAccount.Init();
+        OutlookAccount.Id := CreateGuid();
+        OutlookAccount."Email Address" := 'testuser@test.com';
+        OutlookAccount.Name := 'Test User';
+        OutlookAccount."Outlook API Email Connector" := Enum::"Email Connector"::"Test Outlook REST API";
+        OutlookAccount.Insert();
+
+        // [GIVEN] OAuth token request is skipped
+        BindSubscription(SkipTokenRequest);
+        SkipTokenRequest.SetSkipTokenRequest(true);
+
+        // [GIVEN] Filters that do not opt out of sanitization (default)
+        TempFilters.Init();
+        TempFilters."Max No. of Emails" := 10;
+        TempFilters."Body Type" := TempFilters."Body Type"::HTML;
+
+        // [WHEN] Emails are retrieved (response body contains unsafe HTML)
+        EmailInbox.Init();
+        EmailOutlookAPIHelper.RetrieveEmails(OutlookAccount.Id, EmailInbox, TempFilters);
+
+        // [THEN] An email inbox record was created
+        EmailInbox.MarkedOnly(true);
+        LibraryAssert.IsTrue(EmailInbox.FindFirst(), 'Expected an email inbox record to be created');
+
+        // [THEN] The unsafe markup is stripped from the body, but safe content remains
+        EmailMessage.Get(EmailInbox."Message Id");
+        Body := EmailMessage.GetBody();
+        LibraryAssert.IsTrue(Body.Contains('Safe Content'), 'Safe content should be preserved');
+        LibraryAssert.IsFalse(Body.ToLower().Contains('<script'), 'Script element should be sanitized out by default');
+        LibraryAssert.IsFalse(Body.ToLower().Contains('onerror'), 'Event handler attribute should be sanitized out by default');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    [HandlerFunctions('GraphRetrieveEmailsUnsafeBodyHandler')]
+    procedure TestRetrieveEmailBypassSanitizationKeepsRawBody()
+    var
+        OutlookAccount: Record "Email - Outlook Account";
+        EmailInbox: Record "Email Inbox";
+        TempFilters: Record "Email Retrieval Filters" temporary;
+        SkipTokenRequest: Codeunit "Skip Outlook API Token Request";
+        EmailMessage: Codeunit "Email Message";
+        EmailOutlookAPIHelper: Codeunit "Email - Outlook API Helper";
+        Body: Text;
+    begin
+        // [SCENARIO] When a first-party caller opts out via SetBypassBodySanitization, the raw
+        // email body (including unsafe HTML) is preserved unsanitized.
+
+        // [GIVEN] An Outlook account exists
+        OutlookAccount.Init();
+        OutlookAccount.Id := CreateGuid();
+        OutlookAccount."Email Address" := 'testuser@test.com';
+        OutlookAccount.Name := 'Test User';
+        OutlookAccount."Outlook API Email Connector" := Enum::"Email Connector"::"Test Outlook REST API";
+        OutlookAccount.Insert();
+
+        // [GIVEN] OAuth token request is skipped
+        BindSubscription(SkipTokenRequest);
+        SkipTokenRequest.SetSkipTokenRequest(true);
+
+        // [GIVEN] Filters that opt out of body sanitization
+        TempFilters.Init();
+        TempFilters."Max No. of Emails" := 10;
+        TempFilters."Body Type" := TempFilters."Body Type"::HTML;
+        TempFilters.SetBypassBodySanitization(true);
+
+        // [WHEN] Emails are retrieved (response body contains unsafe HTML)
+        EmailInbox.Init();
+        EmailOutlookAPIHelper.RetrieveEmails(OutlookAccount.Id, EmailInbox, TempFilters);
+
+        // [THEN] An email inbox record was created
+        EmailInbox.MarkedOnly(true);
+        LibraryAssert.IsTrue(EmailInbox.FindFirst(), 'Expected an email inbox record to be created');
+
+        // [THEN] The raw body is kept verbatim, including the unsafe markup
+        EmailMessage.Get(EmailInbox."Message Id");
+        Body := EmailMessage.GetBody();
+        LibraryAssert.IsTrue(Body.Contains('Safe Content'), 'Safe content should be preserved');
+        LibraryAssert.IsTrue(Body.ToLower().Contains('<script'), 'Script element should be preserved when sanitization is bypassed');
+        LibraryAssert.IsTrue(Body.ToLower().Contains('onerror'), 'Event handler attribute should be preserved when sanitization is bypassed');
+    end;
+
     local procedure DeleteAllFromTablePlanAndUserPlan()
     var
         AzureADPlanTestLibraries: Codeunit "Azure AD Plan Test Library";
@@ -361,6 +459,16 @@ codeunit 139752 "Outlook API Helper Tests"
     procedure GraphRetrieveEmailsWithHeadersHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
     var
         RetrieveEmailFileTok: Label 'RetrieveEmailWithHeaders.txt', Locked = true;
+    begin
+        Response.Content.WriteFrom(NavApp.GetResourceAsText(RetrieveEmailFileTok, TextEncoding::UTF8));
+        Response.HttpStatusCode := 200;
+        exit(false);
+    end;
+
+    [HttpClientHandler]
+    procedure GraphRetrieveEmailsUnsafeBodyHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    var
+        RetrieveEmailFileTok: Label 'RetrieveEmailWithUnsafeBody.txt', Locked = true;
     begin
         Response.Content.WriteFrom(NavApp.GetResourceAsText(RetrieveEmailFileTok, TextEncoding::UTF8));
         Response.HttpStatusCode := 200;


### PR DESCRIPTION
## What & why

Lets first-party callers retrieve Outlook emails **without** body sanitization. `Email - Outlook API Helper` now passes `not Filters.GetBypassBodySanitization()` to `EmailMessage.Create` instead of a hard-coded `true`. Sanitization stays on by default; only callers that explicitly call `SetBypassBodySanitization(true)` keep the raw body. That API is `[Scope('OnPrem')]` on the *Email Retrieval Filters* table, so 3rd-party AppSource extensions cannot opt out — only on-prem, first-party (Microsoft) code can.

This is the GitHub counterpart of an internal Azure DevOps PR (NAV repo #250087); porting it here since the app is migrating to microsoft/BCApps.

## Linked work

Related ADO work item: [AB#640361](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/640361) — *Expense Agent: provide full (unsanitized) email content to handle complex HTML receipts*.

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Added two tests in `OutlookAPIHelperTests.Codeunit.al`: `TestRetrieveEmailSanitizesBodyByDefault` (unsafe `<script>`/`onerror` stripped by default) and `TestRetrieveEmailBypassSanitizationKeepsRawBody` (raw body preserved when bypass is set), backed by a new `RetrieveEmailWithUnsafeBody.txt` response fixture.
- The `Email - Outlook REST API` app compiles against current `main` (the `GetBypassBodySanitization`/`SetBypassBodySanitization` API is already present in the System Application). Full in-product test run still pending on a complete BC environment.

## Risk & compatibility

Low. Default behavior is unchanged (bodies remain sanitized). The opt-out is gated to on-prem first-party callers via `[Scope('OnPrem')]`. No schema, upgrade, or permission changes.


