### PR TITLE
Auto-classify CustomerContent fields on system tables as Company Confidential

### DIFF
--- a/src/Layers/W1/BaseApp/Utilities/DataClassificationEvalData.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Utilities/DataClassificationEvalData.Codeunit.al
@@ -190,6 +190,13 @@ codeunit 1751 "Data Classification Eval. Data"
 
         DataClassEvalDataCountry.ClassifyCountrySpecificTables();
 
+        // All unclassified CustomerContent fields on system tables default to Company Confidential
+        DataSensitivity.SetRange("Data Sensitivity", DataSensitivity."Data Sensitivity"::Unclassified);
+        DataSensitivity.SetFilter("Table No", '%1..', 2000000000);
+        DataSensitivity.SetRange("Data Classification", DataSensitivity."Data Classification"::CustomerContent);
+        DataSensitivity.ModifyAll("Data Sensitivity", DataSensitivity."Data Sensitivity"::"Company Confidential");
+        DataSensitivity.Reset();
+
         // All EUII and EUPI Fields are set to Personal
         DataSensitivity.SetFilter("Data Classification", '%1|%2',
             DataSensitivity."Data Classification"::EndUserIdentifiableInformation,


### PR DESCRIPTION
## Why we are doing this

Today every system table that ships `CustomerContent`/EUII/EUPI fields needs a hand-written `Classify*()` method in `DataClassificationEvalData.Codeunit.al` (~770 such per-table calls). Since we do not control when the platform adds tables/fields, the test breaks on uptake and someone must manually add another classification before the build goes green. This is pure friction — the answer for an unknown platform content field is always the same. This change gives those fields a sensible default so new platform tables/fields are classified automatically.

## What the change does

`CreateEvaluationData()` inserts every CustomerContent/EUII/EUPI field as `Unclassified`, then runs all explicit per-table classifications. After those (and the country-specific ones), we add one generic bulk step:

```al
// Unclassified CustomerContent fields on system tables default to Company Confidential
DataSensitivity.SetRange("Data Sensitivity", ...::Unclassified);
DataSensitivity.SetFilter("Table No", '%1..', 2000000000);
DataSensitivity.SetRange("Data Classification", ...::CustomerContent);
DataSensitivity.ModifyAll("Data Sensitivity", ...::"Company Confidential");
```

## Reasoning behind the choices

- **Only system tables (>= 2000000000):** Application tables are owned by this repo, so a missing classification there is a real authoring bug we *want* the test to catch. 
- **Company Confidential (not Normal):** Matches how existing system tables already classify content fields (e.g. Agent data tables mark Instructions/Content/Details as Company Confidential), and is the safer default for unknown platform data — better to over-protect.
- **Only Unclassified entries:** The step is a backstop, not an override — it only touches fields no explicit method already classified.
- **Placed after explicit classifications, before the EUII/EUPI step:** so it cannot clobber a specific decision, and EUII/EUPI handling still has the final say.

Fixes [AB#640608](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640608)
