### PR TITLE
[QM] Fix error evaluating Option test values with special characters in result conditions

### DIFF
--- a/src/Apps/W1/Quality Management/Test Library/src/QltyInspectionUtility.Codeunit.al
+++ b/src/Apps/W1/Quality Management/Test Library/src/QltyInspectionUtility.Codeunit.al
@@ -898,7 +898,7 @@ codeunit 139940 "Qlty. Inspection Utility"
     /// Wrapper for internal procedure CheckIfValueIsInPredefinedList from Qlty. Result Evaluation codeunit.
     /// </summary>
     /// <param name="ValueToCheck">The value to check.</param>
-    /// <param name="AcceptableValue">The acceptable value condition (comma or pipe separated literal values).</param>
+    /// <param name="AcceptableValue">The acceptable value condition (comma or pipe separated literal values; '' means no condition; '&lt;&gt;''''/&lt;&gt;0' means any non-empty value).</param>
     /// <param name="QltyCaseSensitivity">The case sensitivity option.</param>
     /// <returns>True if the value matches one of the listed literal values, false otherwise.</returns>
     internal procedure CheckIfValueIsInPredefinedList(ValueToCheck: Text; AcceptableValue: Text; QltyCaseSensitivity: Enum "Qlty. Case Sensitivity"): Boolean

--- a/src/Apps/W1/Quality Management/Test Library/src/QltyInspectionUtility.Codeunit.al
+++ b/src/Apps/W1/Quality Management/Test Library/src/QltyInspectionUtility.Codeunit.al
@@ -895,6 +895,20 @@ codeunit 139940 "Qlty. Inspection Utility"
     end;
 
     /// <summary>
+    /// Wrapper for internal procedure CheckIfValueIsInPredefinedList from Qlty. Result Evaluation codeunit.
+    /// </summary>
+    /// <param name="ValueToCheck">The value to check.</param>
+    /// <param name="AcceptableValue">The acceptable value condition (comma or pipe separated literal values).</param>
+    /// <param name="QltyCaseSensitivity">The case sensitivity option.</param>
+    /// <returns>True if the value matches one of the listed literal values, false otherwise.</returns>
+    internal procedure CheckIfValueIsInPredefinedList(ValueToCheck: Text; AcceptableValue: Text; QltyCaseSensitivity: Enum "Qlty. Case Sensitivity"): Boolean
+    var
+        QltyResultEvaluation: Codeunit "Qlty. Result Evaluation";
+    begin
+        exit(QltyResultEvaluation.CheckIfValueIsInPredefinedList(ValueToCheck, AcceptableValue, QltyCaseSensitivity));
+    end;
+
+    /// <summary>
     /// Wrapper for internal procedure ValidateQltyInspectionLine from Qlty. Result Evaluation codeunit.
     /// Validates an inspection line using the single-parameter internal signature.
     /// </summary>

--- a/src/Apps/W1/Quality Management/Test Library/src/QltyInspectionUtility.Codeunit.al
+++ b/src/Apps/W1/Quality Management/Test Library/src/QltyInspectionUtility.Codeunit.al
@@ -898,7 +898,7 @@ codeunit 139940 "Qlty. Inspection Utility"
     /// Wrapper for internal procedure CheckIfValueIsInPredefinedList from Qlty. Result Evaluation codeunit.
     /// </summary>
     /// <param name="ValueToCheck">The value to check.</param>
-    /// <param name="AcceptableValue">The acceptable value condition (comma or pipe separated literal values; '' means no condition; '&lt;&gt;''''/&lt;&gt;0' means any non-empty value).</param>
+    /// <param name="AcceptableValue">The acceptable value condition: a comma or pipe separated list of literal values. A blank value means no condition, and the default "anything except empty" tokens are also accepted.</param>
     /// <param name="QltyCaseSensitivity">The case sensitivity option.</param>
     /// <returns>True if the value matches one of the listed literal values, false otherwise.</returns>
     internal procedure CheckIfValueIsInPredefinedList(ValueToCheck: Text; AcceptableValue: Text; QltyCaseSensitivity: Enum "Qlty. Case Sensitivity"): Boolean

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultEvaluation.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultEvaluation.Codeunit.al
@@ -104,7 +104,9 @@ codeunit 20410 "Qlty. Result Evaluation"
                                 LoopConditionMet := QltyBooleanParsing.GetBooleanFor(TestValue) = QltyBooleanParsing.GetBooleanFor(Condition)
                             else
                                 LoopConditionMet := CheckIfValueIsString(TestValue, Condition, QltyCaseSensitivity);
-                        QltyTestValueType::"Value Type Text", QltyTestValueType::"Value Type Option", QltyTestValueType::"Value Type Table Lookup", QltyTestValueType::"Value Type Text Expression":
+                        QltyTestValueType::"Value Type Option", QltyTestValueType::"Value Type Table Lookup":
+                            LoopConditionMet := CheckIfValueIsInPredefinedList(TestValue, Condition, QltyCaseSensitivity);
+                        QltyTestValueType::"Value Type Text", QltyTestValueType::"Value Type Text Expression":
                             LoopConditionMet := CheckIfValueIsString(TestValue, Condition, QltyCaseSensitivity);
                         QltyTestValueType::"Value Type Date":
                             begin
@@ -699,6 +701,33 @@ codeunit 20410 "Qlty. Result Evaluation"
         TempTestStringValueQltyTest.SetFilter("Allowable Values", AcceptableValue);
         exit(not TempTestStringValueQltyTest.IsEmpty());
     end;
+
+    internal procedure CheckIfValueIsInPredefinedList(ValueToCheck: Text; AcceptableValue: Text; QltyCaseSensitivity: Enum "Qlty. Case Sensitivity"): Boolean
+    var
+        SingleAcceptableValue: Text;
+    begin
+        // Option and Table Lookup tests use a fixed set of predefined values. Their conditions are a
+        // comma or pipe separated list of literal values that may contain special filter characters such
+        // as parentheses, so they must be compared literally instead of being interpreted as a filter.
+        if IsAnythingExceptEmptyCondition(AcceptableValue) then
+            exit(ValueToCheck <> '');
+
+        if IsBlankOrEmptyCondition(AcceptableValue) then
+            exit(true);
+
+        if QltyCaseSensitivity = QltyCaseSensitivity::Insensitive then begin
+            ValueToCheck := ValueToCheck.ToLower();
+            AcceptableValue := AcceptableValue.ToLower();
+        end;
+
+        AcceptableValue := AcceptableValue.Replace('|', ',');
+        foreach SingleAcceptableValue in AcceptableValue.Split(',') do
+            if ValueToCheck = SingleAcceptableValue.Trim() then
+                exit(true);
+
+        exit(false);
+    end;
+
 
     /// <summary>
     /// OnBeforeEvaluateResult gives an opportunity to change how a result is evaluated.

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultEvaluation.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultEvaluation.Codeunit.al
@@ -721,9 +721,13 @@ codeunit 20410 "Qlty. Result Evaluation"
         end;
 
         AcceptableValue := AcceptableValue.Replace('|', ',');
-        foreach SingleAcceptableValue in AcceptableValue.Split(',') do
-            if ValueToCheck = SingleAcceptableValue.Trim() then
+        foreach SingleAcceptableValue in AcceptableValue.Split(',') do begin
+            SingleAcceptableValue := SingleAcceptableValue.Trim();
+            if SingleAcceptableValue = '' then
+                continue;
+            if ValueToCheck = SingleAcceptableValue then
                 exit(true);
+        end;
 
         exit(false);
     end;

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsResultEval.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsResultEval.Codeunit.al
@@ -172,6 +172,38 @@ codeunit 139963 "Qlty. Tests - Result Eval."
         LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsString('wildCardSearch', 'wild*'), 'String wildcard 2');
     end;
 
+    [Test]
+    procedure ValueOptionWithSpecialCharacters()
+    var
+        QltyInspectionUtility: Codeunit "Qlty. Inspection Utility";
+        CaseOption: Enum "Qlty. Case Sensitivity";
+    begin
+        // [SCENARIO] Option/Table Lookup conditions are matched literally, so predefined values containing
+        // special filter characters such as parentheses do not raise a filter error (bug 640910).
+
+        // [GIVEN] An option test with values that contain parentheses 'Test(1),Test(2)'
+        // [WHEN] Evaluating a selected option value against a comma separated pass condition
+        // [THEN] The value matches its literal option without interpreting '(' as a filter operator
+        LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsInPredefinedList('Test(1)', 'Test(1),Test(2)', CaseOption::Sensitive), 'Option special chars comma list first');
+        LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsInPredefinedList('Test(2)', 'Test(1),Test(2)', CaseOption::Sensitive), 'Option special chars comma list second');
+        LibraryAssert.IsFalse(QltyInspectionUtility.CheckIfValueIsInPredefinedList('Test(3)', 'Test(1),Test(2)', CaseOption::Sensitive), 'Option special chars not in list');
+
+        // [THEN] A trailing space after the condition list is tolerated
+        LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsInPredefinedList('Test(2)', 'Test(1),Test(2) ', CaseOption::Sensitive), 'Option special chars trailing space');
+
+        // [THEN] Pipe separated lists are also supported
+        LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsInPredefinedList('C', 'C|D', CaseOption::Sensitive), 'Option pipe list match');
+        LibraryAssert.IsFalse(QltyInspectionUtility.CheckIfValueIsInPredefinedList('A', 'C|D', CaseOption::Sensitive), 'Option pipe list no match');
+
+        // [THEN] Empty value does not match a non-empty condition and an empty condition matches anything
+        LibraryAssert.IsFalse(QltyInspectionUtility.CheckIfValueIsInPredefinedList('', 'C|D', CaseOption::Sensitive), 'Option empty value');
+        LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsInPredefinedList('A', '', CaseOption::Sensitive), 'Option empty condition');
+
+        // [THEN] Case insensitive comparison matches values that differ only by case
+        LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsInPredefinedList('test(1)', 'Test(1),Test(2)', CaseOption::Insensitive), 'Option special chars case insensitive');
+    end;
+
+
     [TryFunction]
     procedure Try_TestValueDateIntentionallyBad()
     var

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsResultEval.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsResultEval.Codeunit.al
@@ -199,6 +199,11 @@ codeunit 139963 "Qlty. Tests - Result Eval."
         LibraryAssert.IsFalse(QltyInspectionUtility.CheckIfValueIsInPredefinedList('', 'C|D', CaseOption::Sensitive), 'Option empty value');
         LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsInPredefinedList('A', '', CaseOption::Sensitive), 'Option empty condition');
 
+        // [THEN] Empty tokens from a malformed list (trailing or doubled delimiters) do not match an empty value
+        LibraryAssert.IsFalse(QltyInspectionUtility.CheckIfValueIsInPredefinedList('', 'A,', CaseOption::Sensitive), 'Option empty token trailing delimiter');
+        LibraryAssert.IsFalse(QltyInspectionUtility.CheckIfValueIsInPredefinedList('', 'A||B', CaseOption::Sensitive), 'Option empty token doubled delimiter');
+        LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsInPredefinedList('B', 'A||B', CaseOption::Sensitive), 'Option doubled delimiter still matches real value');
+
         // [THEN] Case insensitive comparison matches values that differ only by case
         LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsInPredefinedList('test(1)', 'Test(1),Test(2)', CaseOption::Insensitive), 'Option special chars case insensitive');
     end;

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsResultEval.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsResultEval.Codeunit.al
@@ -178,8 +178,8 @@ codeunit 139963 "Qlty. Tests - Result Eval."
         QltyInspectionUtility: Codeunit "Qlty. Inspection Utility";
         CaseOption: Enum "Qlty. Case Sensitivity";
     begin
-        // [SCENARIO] Option/Table Lookup conditions are matched literally, so predefined values containing
-        // special filter characters such as parentheses do not raise a filter error (bug 640910).
+        // [SCENARIO 639903] Option/Table Lookup conditions are matched literally, so predefined values containing
+        // special filter characters such as parentheses do not raise a filter error.
 
         // [GIVEN] An option test with values that contain parentheses 'Test(1),Test(2)'
         // [WHEN] Evaluating a selected option value against a comma separated pass condition


### PR DESCRIPTION
Fixes [AB#640910](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640910)

Needs backport to 28.x, see bug https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/639903





