### PR TITLE
Bugs/8639 correct obsoletion warning

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/General/SubcFeatureFlagHandler.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/General/SubcFeatureFlagHandler.Codeunit.al
@@ -11,9 +11,9 @@ codeunit 99001569 "Subc. Feature Flag Handler"
 {
     ObsoleteState = Pending;
     ObsoleteTag = '28.0';
-    ObsoleteReason = 'Legacy Subcontracting will be discontinued, environments should move to the Subcontracting App so this codeunit will be removed in a future release.';
+    ObsoleteReason = 'This codeunit is a temporary transition guard for the migration from Legacy Subcontracting to the Subcontracting App. It will be removed once the Legacy Subcontracting field and all related conditional compilation blocks are cleaned up.';
 
-    [Obsolete('Legacy Subcontracting will be discontinued, environments should move to the Subcontracting App so this codeunit will be removed in a future release.', '28.0')]
+    [Obsolete('This codeunit is a temporary transition guard for the migration from Legacy Subcontracting to the Subcontracting App. It will be removed once the Legacy Subcontracting field and all related conditional compilation blocks are cleaned up.', '28.0')]
     procedure IsSubcontractingEnabled(): Boolean
     var
         ManufacturingSetup: Record "Manufacturing Setup";


### PR DESCRIPTION
Correct Obsoletion Message in SubcFeatureFlagHandler

Fixes #9938

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.