### PR TITLE
[Fixed Assets] Fix Straight-Line % depreciation to use basis reduced by bonus depreciation

### DIFF
--- a/src/Apps/FR/EDocument_FR/EReportingFR/test/src/ExportEReportingTests.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/test/src/ExportEReportingTests.Codeunit.al
@@ -22,7 +22,9 @@ codeunit 148145 "Export E-Reporting Tests"
                   tabledata "E-Document Service" = rimd,
                   tabledata "E-Document Service Status" = rimd,
                   tabledata "VAT Entry" = rimd,
-                  tabledata "VAT Posting Setup" = rimd;
+                  tabledata "VAT Posting Setup" = rimd,
+                  tabledata "VAT Business Posting Group" = rimd,
+                  tabledata "VAT Product Posting Group" = rimd;
 
     trigger OnRun()
     begin
@@ -912,8 +914,23 @@ codeunit 148145 "Export E-Reporting Tests"
 
     local procedure CreateVATPostingSetup(VATBusPostingGroup: Code[20]; VATProdPostingGroup: Code[20]; VATPercent: Decimal)
     var
+        VATBusinessPostingGroup: Record "VAT Business Posting Group";
+        VATProductPostingGroup: Record "VAT Product Posting Group";
         VATPostingSetup: Record "VAT Posting Setup";
     begin
+        // Create the backing posting groups so the fabricated VAT Posting Setup is not orphaned.
+        // Otherwise LibraryERM.FindVATPostingSetupInvt (used by LibrarySales.CreateCustomer) can pick up
+        // a setup whose VAT Business Posting Group does not exist, breaking customer creation in other tests.
+        if not VATBusinessPostingGroup.Get(VATBusPostingGroup) then begin
+            VATBusinessPostingGroup.Init();
+            VATBusinessPostingGroup.Code := VATBusPostingGroup;
+            VATBusinessPostingGroup.Insert();
+        end;
+        if not VATProductPostingGroup.Get(VATProdPostingGroup) then begin
+            VATProductPostingGroup.Init();
+            VATProductPostingGroup.Code := VATProdPostingGroup;
+            VATProductPostingGroup.Insert();
+        end;
         VATPostingSetup.Init();
         VATPostingSetup."VAT Bus. Posting Group" := VATBusPostingGroup;
         VATPostingSetup."VAT Prod. Posting Group" := VATProdPostingGroup;

--- a/src/Layers/FR/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/FR/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -396,6 +396,22 @@ codeunit 5611 "Calculate Normal Depreciation"
         exit(false);
     end;
 
+    local procedure StraightLineBonusBaseReduction(): Decimal
+    begin
+        // Bonus depreciation reduces the book value but not the depreciable basis, so the straight-line base must be lowered by it.
+        // Skip the database lookups below for the majority of assets that do not use bonus depreciation.
+        if not FADeprBook."Use Bonus Depreciation" then
+            exit(0);
+
+        if FADeprBook.BonusDepreciationApplied() then begin
+            // Depreciation has already been posted: the posted bonus depreciation in the ledger is the source of truth.
+            FADeprBook.CalcFields("Bonus Depr. Applied Amount");
+            exit(DepreciationCalc.GetMinusBookValue(FA."No.", DeprBookCode, 0D, 0D) - FADeprBook."Bonus Depr. Applied Amount");
+        end;
+        // First depreciation: the bonus depreciation line is created together with this line and is not posted yet.
+        exit(DepreciationCalc.GetMinusBookValue(FA."No.", DeprBookCode, 0D, 0D) + DepreciationCalc.GetUnpostedBonusDepreciationForCalc(FADeprBook, 0D, 0D));
+    end;
+
     local procedure CalcSLAmount(): Decimal
     var
         RemainingLife: Decimal;
@@ -406,7 +422,7 @@ codeunit 5611 "Calculate Normal Depreciation"
             exit(TempDeprAmount);
 
         if SLPercent > 0 then begin
-            Result := (-SLPercent / 100) * (NumberOfDays / DaysInFiscalYear) * DeprBasis;
+            Result := (-SLPercent / 100) * (NumberOfDays / DaysInFiscalYear) * (DeprBasis - StraightLineBonusBaseReduction());
             OnCalcSLAmountOnAfterCalcFromSLPercent(FA, FADeprBook, BookValue, DeprBasis, DaysInFiscalYear, NumberOfDays, SLPercent, Result);
             exit(Result);
         end;

--- a/src/Layers/FR/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/FR/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -30,6 +30,8 @@ codeunit 5611 "Calculate Normal Depreciation"
         DaysInFiscalYear: Integer;
         EntryAmounts: array[4] of Decimal;
         MinusBookValue: Decimal;
+        StraightLineBonusBaseReductionAmount: Decimal;
+        StraightLineBonusBaseReductionCalculated: Boolean;
         DateFromProjection: Date;
         SkipOnZero: Boolean;
         UntilDate: Date;
@@ -397,6 +399,17 @@ codeunit 5611 "Calculate Normal Depreciation"
     end;
 
     local procedure StraightLineBonusBaseReduction(): Decimal
+    begin
+        // The reduction only depends on FA/FADeprBook/DeprBookCode and the posted ledger, none of which change during a
+        // single Calculate run, so cache it to avoid repeating the CalcSums lookups on every period of the depreciation loop.
+        if not StraightLineBonusBaseReductionCalculated then begin
+            StraightLineBonusBaseReductionAmount := CalcStraightLineBonusBaseReduction();
+            StraightLineBonusBaseReductionCalculated := true;
+        end;
+        exit(StraightLineBonusBaseReductionAmount);
+    end;
+
+    local procedure CalcStraightLineBonusBaseReduction(): Decimal
     begin
         // Bonus depreciation reduces the book value but not the depreciable basis, so the straight-line base must be lowered by it.
         // Skip the database lookups below for the majority of assets that do not use bonus depreciation.

--- a/src/Layers/GB/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/GB/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -394,6 +394,22 @@ codeunit 5611 "Calculate Normal Depreciation"
         exit(false);
     end;
 
+    local procedure StraightLineBonusBaseReduction(): Decimal
+    begin
+        // Bonus depreciation reduces the book value but not the depreciable basis, so the straight-line base must be lowered by it.
+        // Skip the database lookups below for the majority of assets that do not use bonus depreciation.
+        if not FADeprBook."Use Bonus Depreciation" then
+            exit(0);
+
+        if FADeprBook.BonusDepreciationApplied() then begin
+            // Depreciation has already been posted: the posted bonus depreciation in the ledger is the source of truth.
+            FADeprBook.CalcFields("Bonus Depr. Applied Amount");
+            exit(DepreciationCalc.GetMinusBookValue(FA."No.", DeprBookCode, 0D, 0D) - FADeprBook."Bonus Depr. Applied Amount");
+        end;
+        // First depreciation: the bonus depreciation line is created together with this line and is not posted yet.
+        exit(DepreciationCalc.GetMinusBookValue(FA."No.", DeprBookCode, 0D, 0D) + DepreciationCalc.GetUnpostedBonusDepreciationForCalc(FADeprBook, 0D, 0D));
+    end;
+
     local procedure CalcSLAmount(): Decimal
     var
         RemainingLife: Decimal;
@@ -404,7 +420,7 @@ codeunit 5611 "Calculate Normal Depreciation"
             exit(TempDeprAmount);
 
         if SLPercent > 0 then begin
-            Result := (-SLPercent / 100) * (NumberOfDays / DaysInFiscalYear) * DeprBasis;
+            Result := (-SLPercent / 100) * (NumberOfDays / DaysInFiscalYear) * (DeprBasis - StraightLineBonusBaseReduction());
             OnCalcSLAmountOnAfterCalcFromSLPercent(FA, FADeprBook, BookValue, DeprBasis, DaysInFiscalYear, NumberOfDays, SLPercent, Result);
             exit(Result);
         end;

--- a/src/Layers/GB/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/GB/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -28,6 +28,8 @@ codeunit 5611 "Calculate Normal Depreciation"
         DaysInFiscalYear: Integer;
         EntryAmounts: array[4] of Decimal;
         MinusBookValue: Decimal;
+        StraightLineBonusBaseReductionAmount: Decimal;
+        StraightLineBonusBaseReductionCalculated: Boolean;
         DateFromProjection: Date;
         SkipOnZero: Boolean;
         UntilDate: Date;
@@ -395,6 +397,17 @@ codeunit 5611 "Calculate Normal Depreciation"
     end;
 
     local procedure StraightLineBonusBaseReduction(): Decimal
+    begin
+        // The reduction only depends on FA/FADeprBook/DeprBookCode and the posted ledger, none of which change during a
+        // single Calculate run, so cache it to avoid repeating the CalcSums lookups on every period of the depreciation loop.
+        if not StraightLineBonusBaseReductionCalculated then begin
+            StraightLineBonusBaseReductionAmount := CalcStraightLineBonusBaseReduction();
+            StraightLineBonusBaseReductionCalculated := true;
+        end;
+        exit(StraightLineBonusBaseReductionAmount);
+    end;
+
+    local procedure CalcStraightLineBonusBaseReduction(): Decimal
     begin
         // Bonus depreciation reduces the book value but not the depreciable basis, so the straight-line base must be lowered by it.
         // Skip the database lookups below for the majority of assets that do not use bonus depreciation.

--- a/src/Layers/IT/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/IT/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -433,6 +433,22 @@ codeunit 5611 "Calculate Normal Depreciation"
         exit(false);
     end;
 
+    local procedure StraightLineBonusBaseReduction(): Decimal
+    begin
+        // Bonus depreciation reduces the book value but not the depreciable basis, so the straight-line base must be lowered by it.
+        // Skip the database lookups below for the majority of assets that do not use bonus depreciation.
+        if not FADeprBook."Use Bonus Depreciation" then
+            exit(0);
+
+        if FADeprBook.BonusDepreciationApplied() then begin
+            // Depreciation has already been posted: the posted bonus depreciation in the ledger is the source of truth.
+            FADeprBook.CalcFields("Bonus Depr. Applied Amount");
+            exit(DepreciationCalc.GetMinusBookValue(FA."No.", DeprBookCode, 0D, 0D) - FADeprBook."Bonus Depr. Applied Amount");
+        end;
+        // First depreciation: the bonus depreciation line is created together with this line and is not posted yet.
+        exit(DepreciationCalc.GetMinusBookValue(FA."No.", DeprBookCode, 0D, 0D) + DepreciationCalc.GetUnpostedBonusDepreciationForCalc(FADeprBook, 0D, 0D));
+    end;
+
     local procedure CalcSLAmount(): Decimal
     var
         RemainingLife: Decimal;
@@ -443,7 +459,7 @@ codeunit 5611 "Calculate Normal Depreciation"
             exit(TempDeprAmount);
 
         if SLPercent > 0 then begin
-            Result := (-SLPercent / 100) * (NumberOfDays / DaysInFiscalYear) * DeprBasis;
+            Result := (-SLPercent / 100) * (NumberOfDays / DaysInFiscalYear) * (DeprBasis - StraightLineBonusBaseReduction());
             OnCalcSLAmountOnAfterCalcFromSLPercent(FA, FADeprBook, BookValue, DeprBasis, DaysInFiscalYear, NumberOfDays, SLPercent, Result);
             exit(Result);
         end;

--- a/src/Layers/IT/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/IT/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -28,6 +28,8 @@ codeunit 5611 "Calculate Normal Depreciation"
         DaysInFiscalYear: Integer;
         EntryAmounts: array[4] of Decimal;
         MinusBookValue: Decimal;
+        StraightLineBonusBaseReductionAmount: Decimal;
+        StraightLineBonusBaseReductionCalculated: Boolean;
         DateFromProjection: Date;
         SkipOnZero: Boolean;
         UntilDate: Date;
@@ -434,6 +436,17 @@ codeunit 5611 "Calculate Normal Depreciation"
     end;
 
     local procedure StraightLineBonusBaseReduction(): Decimal
+    begin
+        // The reduction only depends on FA/FADeprBook/DeprBookCode and the posted ledger, none of which change during a
+        // single Calculate run, so cache it to avoid repeating the CalcSums lookups on every period of the depreciation loop.
+        if not StraightLineBonusBaseReductionCalculated then begin
+            StraightLineBonusBaseReductionAmount := CalcStraightLineBonusBaseReduction();
+            StraightLineBonusBaseReductionCalculated := true;
+        end;
+        exit(StraightLineBonusBaseReductionAmount);
+    end;
+
+    local procedure CalcStraightLineBonusBaseReduction(): Decimal
     begin
         // Bonus depreciation reduces the book value but not the depreciable basis, so the straight-line base must be lowered by it.
         // Skip the database lookups below for the majority of assets that do not use bonus depreciation.

--- a/src/Layers/RU/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/RU/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -29,6 +29,8 @@ codeunit 5611 "Calculate Normal Depreciation"
         DaysInFiscalYear: Integer;
         EntryAmounts: array[4] of Decimal;
         MinusBookValue: Decimal;
+        StraightLineBonusBaseReductionAmount: Decimal;
+        StraightLineBonusBaseReductionCalculated: Boolean;
         DateFromProjection: Date;
         SkipOnZero: Boolean;
         UntilDate: Date;
@@ -527,6 +529,17 @@ codeunit 5611 "Calculate Normal Depreciation"
     end;
 
     local procedure StraightLineBonusBaseReduction(): Decimal
+    begin
+        // The reduction only depends on FA/FADeprBook/DeprBookCode and the posted ledger, none of which change during a
+        // single Calculate run, so cache it to avoid repeating the CalcSums lookups on every period of the depreciation loop.
+        if not StraightLineBonusBaseReductionCalculated then begin
+            StraightLineBonusBaseReductionAmount := CalcStraightLineBonusBaseReduction();
+            StraightLineBonusBaseReductionCalculated := true;
+        end;
+        exit(StraightLineBonusBaseReductionAmount);
+    end;
+
+    local procedure CalcStraightLineBonusBaseReduction(): Decimal
     begin
         // Bonus depreciation reduces the book value but not the depreciable basis, so the straight-line base must be lowered by it.
         // Skip the database lookups below for the majority of assets that do not use bonus depreciation.

--- a/src/Layers/RU/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/RU/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -526,6 +526,22 @@ codeunit 5611 "Calculate Normal Depreciation"
         exit(false);
     end;
 
+    local procedure StraightLineBonusBaseReduction(): Decimal
+    begin
+        // Bonus depreciation reduces the book value but not the depreciable basis, so the straight-line base must be lowered by it.
+        // Skip the database lookups below for the majority of assets that do not use bonus depreciation.
+        if not FADeprBook."Use Bonus Depreciation" then
+            exit(0);
+
+        if FADeprBook.BonusDepreciationApplied() then begin
+            // Depreciation has already been posted: the posted bonus depreciation in the ledger is the source of truth.
+            FADeprBook.CalcFields("Bonus Depr. Applied Amount");
+            exit(DepreciationCalc.GetMinusBookValue(FA."No.", DeprBookCode, 0D, 0D) - FADeprBook."Bonus Depr. Applied Amount");
+        end;
+        // First depreciation: the bonus depreciation line is created together with this line and is not posted yet.
+        exit(DepreciationCalc.GetMinusBookValue(FA."No.", DeprBookCode, 0D, 0D) + DepreciationCalc.GetUnpostedBonusDepreciationForCalc(FADeprBook, 0D, 0D));
+    end;
+
     local procedure CalcSLAmount(): Decimal
     var
         RemainingLife: Decimal;
@@ -536,7 +552,7 @@ codeunit 5611 "Calculate Normal Depreciation"
             exit(TempDeprAmount);
 
         if SLPercent > 0 then begin
-            Result := (-SLPercent / 100) * (NumberOfDays / DaysInFiscalYear) * DeprBasis;
+            Result := (-SLPercent / 100) * (NumberOfDays / DaysInFiscalYear) * (DeprBasis - StraightLineBonusBaseReduction());
             OnCalcSLAmountOnAfterCalcFromSLPercent(FA, FADeprBook, BookValue, DeprBasis, DaysInFiscalYear, NumberOfDays, SLPercent, Result);
             exit(Result);
         end;

--- a/src/Layers/RU/Tests/Fixed Asset/ERMFABonusDepreciation.Codeunit.al
+++ b/src/Layers/RU/Tests/Fixed Asset/ERMFABonusDepreciation.Codeunit.al
@@ -1328,3 +1328,4 @@ codeunit 134454 "ERM FA Bonus Depreciation"
         Reply := true;
     end;
 }
+

--- a/src/Layers/W1/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/W1/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -394,6 +394,22 @@ codeunit 5611 "Calculate Normal Depreciation"
         exit(false);
     end;
 
+    local procedure StraightLineBonusBaseReduction(): Decimal
+    begin
+        // Bonus depreciation reduces the book value but not the depreciable basis, so the straight-line base must be lowered by it.
+        // Skip the database lookups below for the majority of assets that do not use bonus depreciation.
+        if not FADeprBook."Use Bonus Depreciation" then
+            exit(0);
+
+        if FADeprBook.BonusDepreciationApplied() then begin
+            // Depreciation has already been posted: the posted bonus depreciation in the ledger is the source of truth.
+            FADeprBook.CalcFields("Bonus Depr. Applied Amount");
+            exit(DepreciationCalc.GetMinusBookValue(FA."No.", DeprBookCode, 0D, 0D) - FADeprBook."Bonus Depr. Applied Amount");
+        end;
+        // First depreciation: the bonus depreciation line is created together with this line and is not posted yet.
+        exit(DepreciationCalc.GetMinusBookValue(FA."No.", DeprBookCode, 0D, 0D) + DepreciationCalc.GetUnpostedBonusDepreciationForCalc(FADeprBook, 0D, 0D));
+    end;
+
     local procedure CalcSLAmount(): Decimal
     var
         RemainingLife: Decimal;
@@ -404,7 +420,7 @@ codeunit 5611 "Calculate Normal Depreciation"
             exit(TempDeprAmount);
 
         if SLPercent > 0 then begin
-            Result := (-SLPercent / 100) * (NumberOfDays / DaysInFiscalYear) * DeprBasis;
+            Result := (-SLPercent / 100) * (NumberOfDays / DaysInFiscalYear) * (DeprBasis - StraightLineBonusBaseReduction());
             OnCalcSLAmountOnAfterCalcFromSLPercent(FA, FADeprBook, BookValue, DeprBasis, DaysInFiscalYear, NumberOfDays, SLPercent, Result);
             exit(Result);
         end;

--- a/src/Layers/W1/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/W1/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -28,6 +28,8 @@ codeunit 5611 "Calculate Normal Depreciation"
         DaysInFiscalYear: Integer;
         EntryAmounts: array[4] of Decimal;
         MinusBookValue: Decimal;
+        StraightLineBonusBaseReductionAmount: Decimal;
+        StraightLineBonusBaseReductionCalculated: Boolean;
         DateFromProjection: Date;
         SkipOnZero: Boolean;
         UntilDate: Date;
@@ -395,6 +397,17 @@ codeunit 5611 "Calculate Normal Depreciation"
     end;
 
     local procedure StraightLineBonusBaseReduction(): Decimal
+    begin
+        // The reduction only depends on FA/FADeprBook/DeprBookCode and the posted ledger, none of which change during a
+        // single Calculate run, so cache it to avoid repeating the CalcSums lookups on every period of the depreciation loop.
+        if not StraightLineBonusBaseReductionCalculated then begin
+            StraightLineBonusBaseReductionAmount := CalcStraightLineBonusBaseReduction();
+            StraightLineBonusBaseReductionCalculated := true;
+        end;
+        exit(StraightLineBonusBaseReductionAmount);
+    end;
+
+    local procedure CalcStraightLineBonusBaseReduction(): Decimal
     begin
         // Bonus depreciation reduces the book value but not the depreciable basis, so the straight-line base must be lowered by it.
         // Skip the database lookups below for the majority of assets that do not use bonus depreciation.

--- a/src/Layers/W1/Tests/Fixed Asset/ERMFABonusDepreciation.Codeunit.al
+++ b/src/Layers/W1/Tests/Fixed Asset/ERMFABonusDepreciation.Codeunit.al
@@ -1078,6 +1078,116 @@ codeunit 134454 "ERM FA Bonus Depreciation"
         Assert.AreEqual(-ExpectedBonusDeprAmount, FAJournalLine.Amount, 'Bonus depreciation amount should use Adv. Setup percentage.');
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('DepreciationCalcConfirmHandler')]
+    procedure StraightLinePctDeprUsesBasisReducedByBonusDepreciation()
+    var
+        DepreciationBook: Record "Depreciation Book";
+        FADepreciationBookBonus: Record "FA Depreciation Book";
+        FADepreciationBookControl: Record "FA Depreciation Book";
+        FixedAssetBonus: Record "Fixed Asset";
+        FixedAssetControl: Record "Fixed Asset";
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        FAJournalLine: Record "FA Journal Line";
+        BonusDeprPct: Decimal;
+        StraightLinePct: Decimal;
+        AcquisitionAmount: Decimal;
+        BonusAmount: Decimal;
+        ControlDeprAmount: Decimal;
+        BonusFADeprAmount: Decimal;
+    begin
+        // [SCENARIO 640613] Straight-Line % depreciation following a bonus depreciation is calculated on the depreciable basis reduced by the bonus amount, not on the full acquisition cost.
+        Initialize();
+
+        // [GIVEN] FA Setup with 20% bonus depreciation effective on the depreciation starting date
+        BonusDeprPct := 20;
+        StraightLinePct := 10;
+        AcquisitionAmount := 100000;
+        GeneralLedgerSetup.Get();
+        BonusAmount := Round(AcquisitionAmount * BonusDeprPct * 0.01, GeneralLedgerSetup."Amount Rounding Precision");
+        SetupBonusDepreciation(BonusDeprPct, WorkDate());
+
+        CreateJournalSetupDepreciation(DepreciationBook);
+
+        // [GIVEN] Fixed asset "Bonus" with acquisition cost 100,000, Straight-Line 10% and bonus depreciation enabled
+        LibraryFixedAsset.CreateFAWithPostingGroup(FixedAssetBonus);
+        CreateStraightLinePctFADepreciationBook(FADepreciationBookBonus, FixedAssetBonus, DepreciationBook.Code, StraightLinePct);
+        FADepreciationBookBonus.Validate("Use Bonus Depreciation", true);
+        FADepreciationBookBonus.Modify(true);
+        PostAcquisitionFAJournalLine(FADepreciationBookBonus, AcquisitionAmount);
+
+        // [GIVEN] Control fixed asset with acquisition cost already reduced to 80,000, Straight-Line 10% and no bonus depreciation
+        LibraryFixedAsset.CreateFAWithPostingGroup(FixedAssetControl);
+        CreateStraightLinePctFADepreciationBook(FADepreciationBookControl, FixedAssetControl, DepreciationBook.Code, StraightLinePct);
+        PostAcquisitionFAJournalLine(FADepreciationBookControl, AcquisitionAmount - BonusAmount);
+
+        // [WHEN] Calculate Depreciation is run for both fixed assets over the same period
+        LibraryLowerPermissions.SetJournalsPost();
+        LibraryLowerPermissions.AddO365FAEdit();
+        RunCalculateDepreciation(FixedAssetBonus."No.", DepreciationBook.Code);
+        RunCalculateDepreciation(FixedAssetControl."No.", DepreciationBook.Code);
+
+        // [THEN] A bonus depreciation line of -20,000 is created for the bonus fixed asset
+        FindFAJournalLineForFA(FAJournalLine, DepreciationBook.Code, FAJournalLine."FA Posting Type"::"Bonus Depreciation", FixedAssetBonus."No.");
+        Assert.AreEqual(-BonusAmount, FAJournalLine.Amount, 'Bonus depreciation amount is incorrect.');
+
+        // [THEN] The Straight-Line depreciation of the bonus fixed asset equals the depreciation of the control asset, i.e. it is calculated on the 80,000 basis reduced by the bonus, not on 100,000
+        FindFAJournalLineForFA(FAJournalLine, DepreciationBook.Code, FAJournalLine."FA Posting Type"::Depreciation, FixedAssetBonus."No.");
+        BonusFADeprAmount := FAJournalLine.Amount;
+        FindFAJournalLineForFA(FAJournalLine, DepreciationBook.Code, FAJournalLine."FA Posting Type"::Depreciation, FixedAssetControl."No.");
+        ControlDeprAmount := FAJournalLine.Amount;
+        Assert.AreEqual(
+            ControlDeprAmount, BonusFADeprAmount,
+            'Straight-Line % depreciation should be calculated on the depreciable basis reduced by the bonus depreciation.');
+
+        // Clean up the shared FA journal batch so leftover lines do not affect other tests.
+        DeleteFAJournalLines(DepreciationBook.Code);
+    end;
+
+    local procedure CreateStraightLinePctFADepreciationBook(var FADepreciationBook: Record "FA Depreciation Book"; FixedAsset: Record "Fixed Asset"; DepreciationBookCode: Code[10]; StraightLinePct: Decimal)
+    begin
+        LibraryFixedAsset.CreateFADepreciationBook(FADepreciationBook, FixedAsset."No.", DepreciationBookCode);
+        FADepreciationBook.Validate("FA Posting Group", FixedAsset."FA Posting Group");
+        FADepreciationBook.Validate("Depreciation Method", FADepreciationBook."Depreciation Method"::"Straight-Line");
+        FADepreciationBook.Validate("Depreciation Starting Date", WorkDate());
+        FADepreciationBook.Validate("Straight-Line %", StraightLinePct);
+        FADepreciationBook.Modify(true);
+    end;
+
+    local procedure PostAcquisitionFAJournalLine(FADepreciationBook: Record "FA Depreciation Book"; Amount: Decimal)
+    var
+        FAJournalLine: Record "FA Journal Line";
+    begin
+        CreateFAJournalLineWithPostingType(
+            FAJournalLine, FADepreciationBook."FA No.", FADepreciationBook."Depreciation Book Code",
+            FAJournalLine."FA Posting Type"::"Acquisition Cost", Amount);
+        LibraryFixedAsset.PostFAJournalLine(FAJournalLine);
+    end;
+
+    local procedure FindFAJournalLineForFA(var FAJournalLine: Record "FA Journal Line"; DepreciationBookCode: Code[10]; FAPostingType: Enum "FA Journal Line FA Posting Type"; FANo: Code[20])
+    var
+        FAJournalSetup: Record "FA Journal Setup";
+    begin
+        FAJournalSetup.Get(DepreciationBookCode, '');
+        FAJournalLine.SetRange("Journal Template Name", FAJournalSetup."FA Jnl. Template Name");
+        FAJournalLine.SetRange("Journal Batch Name", FAJournalSetup."FA Jnl. Batch Name");
+        FAJournalLine.SetRange("FA Posting Type", FAPostingType);
+        FAJournalLine.SetRange("FA No.", FANo);
+        FAJournalLine.FindFirst();
+    end;
+
+    local procedure DeleteFAJournalLines(DepreciationBookCode: Code[10])
+    var
+        FAJournalLine: Record "FA Journal Line";
+        FAJournalSetup: Record "FA Journal Setup";
+    begin
+        FAJournalSetup.Get(DepreciationBookCode, '');
+        FAJournalLine.SetRange("Journal Template Name", FAJournalSetup."FA Jnl. Template Name");
+        FAJournalLine.SetRange("Journal Batch Name", FAJournalSetup."FA Jnl. Batch Name");
+        FAJournalLine.DeleteAll();
+    end;
+
     local procedure Initialize()
     var
         AdvBonusDeprSetup: Record "Adv. Bonus Depreciation Setup";


### PR DESCRIPTION
Fixes  [AB#640613](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640613)

Bonus depreciation reduces book value but not the depreciable basis, so the straight-line base must be lowered by the bonus amount each period. Applies the reduction in CalcSLAmount across W1/FR/GB/IT/RU and adds a W1 test.

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

Bonus depreciation reduces book value but not the depreciable basis, so the straight-line base must be lowered by the bonus amount each period. Applies the reduction in CalcSLAmount across W1/FR/GB/IT/RU and adds a W1 test.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#640613](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640613)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

I made automated tests that make sure that straight-line depreciation method uses the bonus-reduced acquisition cost as the basis for the first and any further depreciation.

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

















