### PR TITLE
[AT] Support reduced VAT rate 4.9% in VAT Statement AT (KZ124/KZ125)

### DIFF
--- a/src/Layers/AT/BaseApp/Local/Finance/VAT/VATStatementAT.Report.al
+++ b/src/Layers/AT/BaseApp/Local/Finance/VAT/VATStatementAT.Report.al
@@ -543,7 +543,7 @@ report 11110 "VAT Statement AT"
         then
             Error(TaxFreeBiggerErr);
 
-        if (Position[22] + Position[29] + Position[6] + Position[37] + Position[52] + Position[7] + Position[9]) <>
+        if (Position[22] + Position[29] + Position[6] + Position[37] + Position[52] + Position[7] + Position[9] + Position[124]) <>
            (Position[1000] + Position[1001] - Position[1021]) -
            (Position[1011] + Position[1012] + Position[1015] + Position[1017] +
             Position[1018] + Position[1019] + Position[1016] + Position[1020])
@@ -556,7 +556,7 @@ report 11110 "VAT Statement AT"
         if Position[71] > Position[70] then
             Error(TaxFreeECBiggerErr);
 
-        if Position[70] - Position[71] <> Position[72] + Position[73] + Position[8] + Position[88] + Position[10] then
+        if Position[70] - Position[71] <> Position[72] + Position[73] + Position[8] + Position[88] + Position[10] + Position[125] then
             Error(TaxableRevDiffersErr);
 
         if ((Position[1057] = 0) and (Position[1066] <> 0)) or ((Position[1057] <> 0) and (Position[1066] = 0)) then
@@ -816,6 +816,7 @@ report 11110 "VAT Statement AT"
 
         XMLFile.Write('<VERSTEUERT>');
         WriteXMLNodeForPosition(22, 'KZ022');
+        WriteXMLNodeForPosition(124, 'KZ124');
         WriteXMLNodeForPosition(29, 'KZ029');
         WriteXMLNodeForPosition(6, 'KZ006');
         WriteXMLNodeForPosition(37, 'KZ037');
@@ -839,6 +840,7 @@ report 11110 "VAT Statement AT"
 
         XMLFile.Write('<VERSTEUERT_IGE>');
         WriteXMLNodeForPosition(72, 'KZ072');
+        WriteXMLNodeForPosition(125, 'KZ125');
         WriteXMLNodeForPosition(73, 'KZ073');
         WriteXMLNodeForPosition(8, 'KZ008');
         WriteXMLNodeForPosition(88, 'KZ088');

--- a/src/Layers/AT/Tests/Local/VATSTAT.Codeunit.al
+++ b/src/Layers/AT/Tests/Local/VATSTAT.Codeunit.al
@@ -1507,6 +1507,145 @@ codeunit 144001 VATSTAT
         VerifyXMLLine(LibraryXPathXMLReader, 'LIEFERUNGEN_LEISTUNGEN_EIGENVERBRAUCH/KZ000', 0);
     end;
 
+    [Test]
+    [HandlerFunctions('VATStmtATRequestPageHandler,VATStmtATMessageHandler')]
+    [Scope('OnPrem')]
+    procedure VAT49PctDomesticInvoiceKZ124()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        VATStatementLine: Record "VAT Statement Line";
+        VATEntry: Record "VAT Entry";
+        Item: Record Item;
+        VATStatementAT: Report "VAT Statement AT";
+        LibraryXPathXMLReader: Codeunit "Library - XPath XML Reader";
+        VATTotalRowNo: Code[10];
+        DocNo: Code[20];
+        VATBusPostingGroupCode: Code[20];
+        VATProPostingGroupCode: Code[20];
+    begin
+        // [FEATURE] [AI test 0.3] [VAT 4.9%]
+        // [SCENARIO 639547] New reduced VAT rate 4.9% is exported in cipher KZ124 (VERSTEUERT) from 1 July 2026
+        Initialize();
+
+        // [GIVEN] VAT Statement Line with Row No. '124' totaling a domestic VAT base amount
+        CreateVATPostingGroup(VATBusPostingGroupCode, VATProPostingGroupCode);
+        VATTotalRowNo := LibraryUtility.GenerateRandomCode(VATStatementLine.FieldNo("Row No."), DATABASE::"VAT Statement Line");
+        CreateVATEntTotVATStmtLine(VATTotalRowNo, VATBusPostingGroupCode, VATProPostingGroupCode);
+        VATStatementLine.SetRange("Row No.", VATTotalRowNo);
+        VATStatementLine.SetRange(Type, VATStatementLine.Type::"VAT Entry Totaling");
+        VATStatementLine.FindFirst();
+        VATStatementLine.Validate("Amount Type", VATStatementLine."Amount Type"::Base);
+        VATStatementLine.Modify(true);
+        CreateRowTotVATStmtLine('124', VATTotalRowNo);
+        CreateItem(Item, VATProPostingGroupCode);
+        EnqueRequestPageFields(WorkDate(), WorkDate(), "VAT Statement Report Selection"::"Open and Closed", "VAT Statement Report Period Selection"::"Within Period",
+          ReportingType::"Defined period", false, false, false, false, 0);
+
+        // [GIVEN] Posted purchase invoice
+        DocNo := CreateAndPostPurchaseDocumentOnItem(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, VATBusPostingGroupCode, Item);
+
+        // [WHEN] Export VAT Statement
+        VATStatementAT.InitializeRequest(FdfFileName, XmlFileName);
+        VATStatementAT.RunModal();
+
+        // [THEN] XML file has KZ124 in LIEFERUNGEN_LEISTUNGEN_EIGENVERBRAUCH/VERSTEUERT
+        GetVATEntry(VATEntry, DocNo, VATEntry."Document Type"::Invoice, VATEntry.Type::Purchase);
+        LibraryXPathXMLReader.Initialize(XmlFileName, '');
+        VerifyXMLHeader(LibraryXPathXMLReader);
+        VerifyXMLLine(LibraryXPathXMLReader, 'LIEFERUNGEN_LEISTUNGEN_EIGENVERBRAUCH/VERSTEUERT/KZ124', VATEntry.Base);
+    end;
+
+    [Test]
+    [HandlerFunctions('VATStmtATRequestPageHandler,VATStmtATMessageHandler')]
+    [Scope('OnPrem')]
+    procedure VAT49PctIntraCommunityInvoiceKZ125()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        VATStatementLine: Record "VAT Statement Line";
+        VATEntry: Record "VAT Entry";
+        Item: Record Item;
+        VATStatementAT: Report "VAT Statement AT";
+        LibraryXPathXMLReader: Codeunit "Library - XPath XML Reader";
+        VATTotalRowNo: Code[10];
+        DocNo: Code[20];
+        VATBusPostingGroupCode: Code[20];
+        VATProPostingGroupCode: Code[20];
+    begin
+        // [FEATURE] [AI test 0.3] [VAT 4.9%]
+        // [SCENARIO 639547] New reduced VAT rate 4.9% is exported in cipher KZ125 (VERSTEUERT_IGE) from 1 July 2026
+        Initialize();
+
+        // [GIVEN] VAT Statement Line with Row No. '125' totaling an intra-community VAT base amount
+        CreateVATPostingGroup(VATBusPostingGroupCode, VATProPostingGroupCode);
+        VATTotalRowNo := LibraryUtility.GenerateRandomCode(VATStatementLine.FieldNo("Row No."), DATABASE::"VAT Statement Line");
+        CreateVATEntTotVATStmtLine(VATTotalRowNo, VATBusPostingGroupCode, VATProPostingGroupCode);
+        VATStatementLine.SetRange("Row No.", VATTotalRowNo);
+        VATStatementLine.SetRange(Type, VATStatementLine.Type::"VAT Entry Totaling");
+        VATStatementLine.FindFirst();
+        VATStatementLine.Validate("Amount Type", VATStatementLine."Amount Type"::Base);
+        VATStatementLine.Modify(true);
+        CreateRowTotVATStmtLine('125', VATTotalRowNo);
+        CreateItem(Item, VATProPostingGroupCode);
+        EnqueRequestPageFields(WorkDate(), WorkDate(), "VAT Statement Report Selection"::"Open and Closed", "VAT Statement Report Period Selection"::"Within Period",
+          ReportingType::"Defined period", false, false, false, false, 0);
+
+        // [GIVEN] Posted purchase invoice
+        DocNo := CreateAndPostPurchaseDocumentOnItem(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, VATBusPostingGroupCode, Item);
+
+        // [WHEN] Export VAT Statement
+        VATStatementAT.InitializeRequest(FdfFileName, XmlFileName);
+        VATStatementAT.RunModal();
+
+        // [THEN] XML file has KZ125 in INNERGEMEINSCHAFTLICHE_ERWERBE/VERSTEUERT_IGE
+        GetVATEntry(VATEntry, DocNo, VATEntry."Document Type"::Invoice, VATEntry.Type::Purchase);
+        LibraryXPathXMLReader.Initialize(XmlFileName, '');
+        VerifyXMLHeader(LibraryXPathXMLReader);
+        VerifyXMLLine(LibraryXPathXMLReader, 'INNERGEMEINSCHAFTLICHE_ERWERBE/VERSTEUERT_IGE/KZ125', VATEntry.Base);
+    end;
+
+    [Test]
+    [HandlerFunctions('VATStmtATRequestPageHandler,VATStmtATMessageHandler')]
+    [Scope('OnPrem')]
+    procedure VAT49PctKZ124PositionCheckBalanced()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        VATStatementLine: Record "VAT Statement Line";
+        VATStatementAT: Report "VAT Statement AT";
+        Item: Record Item;
+        VATTotalRowNo: Code[10];
+        VATBusPostingGroupCode: Code[20];
+        VATProPostingGroupCode: Code[20];
+    begin
+        // [FEATURE] [AI test 0.3] [VAT 4.9%]
+        // [SCENARIO 639547] VAT Statement AT report balances KZ124 in the position check (KZ022+124 = KZ000) without errors
+        Initialize();
+
+        // [GIVEN] The same revenue base feeds KZ000 and the new KZ124 (Row '124'), so the taxed-revenue check balances
+        CreateVATPostingGroup(VATBusPostingGroupCode, VATProPostingGroupCode);
+        VATTotalRowNo := LibraryUtility.GenerateRandomCode(VATStatementLine.FieldNo("Row No."), DATABASE::"VAT Statement Line");
+        CreateVATEntTotVATStmtLine(VATTotalRowNo, VATBusPostingGroupCode, VATProPostingGroupCode);
+        VATStatementLine.SetRange("Row No.", VATTotalRowNo);
+        VATStatementLine.SetRange(Type, VATStatementLine.Type::"VAT Entry Totaling");
+        VATStatementLine.FindFirst();
+        VATStatementLine.Validate("Amount Type", VATStatementLine."Amount Type"::Base);
+        VATStatementLine.Modify(true);
+        CreateRowTotVATStmtLine('124', VATTotalRowNo);
+        CreateRowTotVATStmtLine('1000', VATTotalRowNo);
+        CreateItem(Item, VATProPostingGroupCode);
+
+        // [GIVEN] Position check is enabled
+        EnqueRequestPageFields(WorkDate(), WorkDate(), "VAT Statement Report Selection"::"Open and Closed", "VAT Statement Report Period Selection"::"Within Period",
+          ReportingType::"Defined period", true, false, false, false, 0);
+        CreateAndPostPurchaseDocumentOnItem(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, VATBusPostingGroupCode, Item);
+
+        // [WHEN] Run VAT Statement AT report with CheckPositions = true
+        VATStatementAT.InitializeRequest(FdfFileName, XmlFileName);
+        VATStatementAT.RunModal();
+
+        // [THEN] No position-check error is raised (KZ124 included in the taxed-revenue total) and the file is generated
+        Assert.IsTrue(Exists(XmlFileName), StrSubstNo('File %1 must be generated', XmlFileName));
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";


### PR DESCRIPTION
Adds positions KZ124 (VERSTEUERT) and KZ125 (VERSTEUERT_IGE) to the VAT Statement AT XML export and includes them in the position-balance checks. Adds AT tests for the new 4.9% reduced rate. Replicates NAV PR 250098.

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

This is an urgent additive regulatory requirement that mut be implemented by July 1st 2026

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#640792](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640792)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

Added three automated tests that test the additional functionality.
<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->




