### PR TITLE
(Bug 640115): IT. Subcontracting orders not visible in list views

### DIFF
--- a/src/Layers/IT/BaseApp/Inventory/Transfer/TransferOrder.Page.al
+++ b/src/Layers/IT/BaseApp/Inventory/Transfer/TransferOrder.Page.al
@@ -21,12 +21,7 @@ page 5740 "Transfer Order"
     PageType = Document;
     RefreshOnActivate = true;
     SourceTable = "Transfer Header";
-#if not CLEAN28
-    SourceTableView = sorting("No.")
-                      where("Subcontracting Order" = const(false));
-#else
     SourceTableView = sorting("No.");
-#endif
 
     layout
     {

--- a/src/Layers/IT/BaseApp/Inventory/Transfer/TransferOrders.Page.al
+++ b/src/Layers/IT/BaseApp/Inventory/Transfer/TransferOrders.Page.al
@@ -24,9 +24,6 @@ page 5742 "Transfer Orders"
     AboutTitle = 'About Transfer Orders';
     AboutText = 'Manage and track the movement of inventory items between locations by creating, posting, and monitoring transfer orders, including handling shipment, receipt, and serial or lot number assignments.';
     SourceTable = "Transfer Header";
-#if not CLEAN28
-    SourceTableView = where("Subcontracting Order" = const(false));
-#endif
     UsageCategory = Lists;
 
     layout

--- a/src/Layers/IT/BaseApp/Purchases/Document/PurchaseOrderList.Page.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/PurchaseOrderList.Page.al
@@ -39,12 +39,7 @@ page 9307 "Purchase Order List"
     QueryCategory = 'Purchase Order List';
     RefreshOnActivate = true;
     SourceTable = "Purchase Header";
-#if not CLEAN28
-    SourceTableView = where("Document Type" = const(Order),
-                            "Subcontracting Order" = const(false));
-#else
     SourceTableView = where("Document Type" = const(Order));
-#endif
     UsageCategory = Lists;
     AdditionalSearchTerms = 'Procurement List, Buy Order Overview, Vendor Orders, Order Purchase Log, Acquisition List, Supplier Orders, Buy List, Purchase Log, Supply Order List, Goods Order Overview';
 


### PR DESCRIPTION
**IT localization only**

Removes the obsolete `Subcontracting Order = const(false)` `SourceTableView` filter (field 12180) from the IT Purchase Order List, Transfer Order and Transfer Orders pages. The filter is applied in `OnOpenPage` for legacy subcontracting instead.

Port of internal NAV PR #249963 to the relocated BCApps IT layer.

Fixes [AB#640115](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640115)

