### PR TITLE
Fix DeployToReferenceDocumentation

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -132,7 +132,6 @@
     "maxReleases": 0,
     "continuousDeployment": false,
     "groupByProject": false,
-    "deployToGitHubPages": false,
     "excludeProjects": [
       "build_projects_System Application Modules",
       "build_projects_Test Apps *"

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -31,6 +31,16 @@
           "CLEAN29"
         ]
       }
+    },
+    {
+      "projects": [
+        "."
+      ],
+      "settings": {
+        "appFolders": [
+          "src/Layers/W1/DemoTool"
+        ]
+      }
     }
   ],
   "customALGoFiles": {

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -132,9 +132,11 @@
     "maxReleases": 0,
     "continuousDeployment": false,
     "groupByProject": false,
+    "includeProjects": [
+      "build_projects_Apps W1"
+    ],
     "excludeProjects": [
-      "build_projects_System Application Modules",
-      "build_projects_Test Apps *"
+      "build_projects_System Application Modules"
     ]
   },
   "UpdateALGoSystemFilesEnvironment": "Official-Build",

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -130,7 +130,7 @@
   "PullRequestTrigger": "pull_request",
   "ALDoc": {
     "maxReleases": 0,
-    "continuousDeployment": false,
+    "continuousDeployment": true,
     "groupByProject": false,
     "includeProjects": [
       "build_projects_Apps W1"

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -122,6 +122,7 @@
     "maxReleases": 0,
     "continuousDeployment": false,
     "groupByProject": false,
+    "deployToGitHubPages": false,
     "excludeProjects": [
       "build_projects_System Application Modules"
     ]

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -133,7 +133,8 @@
     "continuousDeployment": false,
     "groupByProject": false,
     "excludeProjects": [
-      "build_projects_System Application Modules"
+      "build_projects_System Application Modules",
+      "build_projects_Test Apps *"
     ]
   },
   "UpdateALGoSystemFilesEnvironment": "Official-Build",


### PR DESCRIPTION
## What & why

The reference documentation flow (both stand-alone and in CICD) was broken due to duplicate app ids caused by the localization of layers.
Specifically the DetermineArtifactUrl step fails when running with no specific project `project="."`. 

The fix was to add a conditional setting, that when no project is selected, we use the appFolders setting to point to any random app.

Working run here: https://github.com/microsoft/BCApps/actions/runs/28441725835

[AB#612711](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612711)

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->






