### PR TITLE
Match Bank Payments: pass Payment Reference to DocumentMatching

### DIFF
--- a/src/Layers/CH/BaseApp/Bank/Reconciliation/MatchBankPayments.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Bank/Reconciliation/MatchBankPayments.Codeunit.al
@@ -1081,7 +1081,8 @@ codeunit 1255 "Match Bank Payments"
                 DocumentMatching(
                     BankPmtApplRule, BankAccReconciliationLine,
                     TempLedgerEntryMatchingBuffer."Document No.",
-                    TempLedgerEntryMatchingBuffer."External Document No.", TempLedgerEntryMatchingBuffer."Payment Reference");
+                    TempLedgerEntryMatchingBuffer."External Document No.",
+                    TempLedgerEntryMatchingBuffer."Payment Reference");
                 TotalTimeDocumentNoMatching += CurrentDateTime() - StartTime;
             end else begin
                 StartTime := CurrentDateTime();

--- a/src/Layers/CH/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
+++ b/src/Layers/CH/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
@@ -432,6 +432,56 @@
     [Test]
     [HandlerFunctions('MessageHandler,VerifyMatchDetailsOnPaymentApplicationsPage')]
     [Scope('OnPrem')]
+    procedure TestCustPaymentReferenceMatch()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        BankPmtApplRule: Record "Bank Pmt. Appl. Rule";
+        Amount: Decimal;
+        DocumentNo: Code[20];
+        ExtDocNo: Code[20];
+        PaymentReference: Code[50];
+    begin
+        Initialize();
+
+        // Setup
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        ExtDocNo := '';
+        PaymentReference := 'PMTREF0001';
+        DocumentNo := CreateAndPostSalesInvoiceWithOneLine(Customer."No.", ExtDocNo, Amount);
+
+        // The W1 Sales Header has no Payment Reference field, so set the reference on the open ledger entry
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Invoice);
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document No.", DocumentNo);
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry."Payment Reference" := PaymentReference;
+        CustLedgerEntry.Modify();
+
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        // No document number in the transaction text, so the payment reference is the only possible match
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount / 2, '', '');
+        BankAccReconciliationLine.Validate("Payment Reference No.", PaymentReference);
+        BankAccReconciliationLine.Modify(true);
+
+        // Exercise
+        RunMatch(BankAccReconciliation, true);
+
+        // Verify
+        SetRule(BankPmtApplRule, BankPmtApplRule."Related Party Matched"::No,
+          BankPmtApplRule."Doc. No./Ext. Doc. No. Matched"::Yes, BankPmtApplRule."Amount Incl. Tolerance Matched"::"No Matches");
+        VerifyReconciliation(BankPmtApplRule, BankAccReconciliationLine."Statement Line No.");
+        VerifyEntryApplied(BankAccReconciliationLine, false);
+        VerifyMatchDetailsData(BankAccReconciliation, BankPmtApplRule,
+          BankAccReconciliationLine."Account Type"::Customer, Amount / 2, 0, 0, 1);
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,VerifyMatchDetailsOnPaymentApplicationsPage')]
+    [Scope('OnPrem')]
     procedure TestCustDocInAdditionalTextMatch()
     var
         BankAccReconciliation: Record "Bank Acc. Reconciliation";

--- a/src/Layers/DK/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
+++ b/src/Layers/DK/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
@@ -432,6 +432,56 @@
     [Test]
     [HandlerFunctions('MessageHandler,VerifyMatchDetailsOnPaymentApplicationsPage')]
     [Scope('OnPrem')]
+    procedure TestCustPaymentReferenceMatch()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        BankPmtApplRule: Record "Bank Pmt. Appl. Rule";
+        Amount: Decimal;
+        DocumentNo: Code[20];
+        ExtDocNo: Code[20];
+        PaymentReference: Code[50];
+    begin
+        Initialize();
+
+        // Setup
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        ExtDocNo := '';
+        PaymentReference := 'PMTREF0001';
+        DocumentNo := CreateAndPostSalesInvoiceWithOneLine(Customer."No.", ExtDocNo, Amount);
+
+        // The W1 Sales Header has no Payment Reference field, so set the reference on the open ledger entry
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Invoice);
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document No.", DocumentNo);
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry."Payment Reference" := PaymentReference;
+        CustLedgerEntry.Modify();
+
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        // No document number in the transaction text, so the payment reference is the only possible match
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount / 2, '', '');
+        BankAccReconciliationLine.Validate("Payment Reference No.", PaymentReference);
+        BankAccReconciliationLine.Modify(true);
+
+        // Exercise
+        RunMatch(BankAccReconciliation, true);
+
+        // Verify
+        SetRule(BankPmtApplRule, BankPmtApplRule."Related Party Matched"::No,
+          BankPmtApplRule."Doc. No./Ext. Doc. No. Matched"::Yes, BankPmtApplRule."Amount Incl. Tolerance Matched"::"No Matches");
+        VerifyReconciliation(BankPmtApplRule, BankAccReconciliationLine."Statement Line No.");
+        VerifyEntryApplied(BankAccReconciliationLine, false);
+        VerifyMatchDetailsData(BankAccReconciliation, BankPmtApplRule,
+          BankAccReconciliationLine."Account Type"::Customer, Amount / 2, 0, 0, 1);
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,VerifyMatchDetailsOnPaymentApplicationsPage')]
+    [Scope('OnPrem')]
     procedure TestCustDocInAdditionalTextMatch()
     var
         BankAccReconciliation: Record "Bank Acc. Reconciliation";

--- a/src/Layers/IT/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
+++ b/src/Layers/IT/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
@@ -433,6 +433,56 @@
     [Test]
     [HandlerFunctions('MessageHandler,VerifyMatchDetailsOnPaymentApplicationsPage')]
     [Scope('OnPrem')]
+    procedure TestCustPaymentReferenceMatch()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        BankPmtApplRule: Record "Bank Pmt. Appl. Rule";
+        Amount: Decimal;
+        DocumentNo: Code[20];
+        ExtDocNo: Code[20];
+        PaymentReference: Code[50];
+    begin
+        Initialize();
+
+        // Setup
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        ExtDocNo := '';
+        PaymentReference := 'PMTREF0001';
+        DocumentNo := CreateAndPostSalesInvoiceWithOneLine(Customer."No.", ExtDocNo, Amount);
+
+        // The W1 Sales Header has no Payment Reference field, so set the reference on the open ledger entry
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Invoice);
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document No.", DocumentNo);
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry."Payment Reference" := PaymentReference;
+        CustLedgerEntry.Modify();
+
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        // No document number in the transaction text, so the payment reference is the only possible match
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount / 2, '', '');
+        BankAccReconciliationLine.Validate("Payment Reference No.", PaymentReference);
+        BankAccReconciliationLine.Modify(true);
+
+        // Exercise
+        RunMatch(BankAccReconciliation, true);
+
+        // Verify
+        SetRule(BankPmtApplRule, BankPmtApplRule."Related Party Matched"::No,
+          BankPmtApplRule."Doc. No./Ext. Doc. No. Matched"::Yes, BankPmtApplRule."Amount Incl. Tolerance Matched"::"No Matches");
+        VerifyReconciliation(BankPmtApplRule, BankAccReconciliationLine."Statement Line No.");
+        VerifyEntryApplied(BankAccReconciliationLine, false);
+        VerifyMatchDetailsData(BankAccReconciliation, BankPmtApplRule,
+          BankAccReconciliationLine."Account Type"::Customer, Amount / 2, 0, 0, 1);
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,VerifyMatchDetailsOnPaymentApplicationsPage')]
+    [Scope('OnPrem')]
     procedure TestCustDocInAdditionalTextMatch()
     var
         BankAccReconciliation: Record "Bank Acc. Reconciliation";

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/MatchBankPayments.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/MatchBankPayments.Codeunit.al
@@ -1078,7 +1078,8 @@ codeunit 1255 "Match Bank Payments"
                 DocumentMatching(
                     BankPmtApplRule, BankAccReconciliationLine,
                     TempLedgerEntryMatchingBuffer."Document No.",
-                    TempLedgerEntryMatchingBuffer."External Document No.", '');
+                    TempLedgerEntryMatchingBuffer."External Document No.",
+                    TempLedgerEntryMatchingBuffer."Payment Reference");
                 TotalTimeDocumentNoMatching += CurrentDateTime() - StartTime;
             end else begin
                 StartTime := CurrentDateTime();

--- a/src/Layers/W1/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
+++ b/src/Layers/W1/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
@@ -432,6 +432,56 @@
     [Test]
     [HandlerFunctions('MessageHandler,VerifyMatchDetailsOnPaymentApplicationsPage')]
     [Scope('OnPrem')]
+    procedure TestCustPaymentReferenceMatch()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        BankPmtApplRule: Record "Bank Pmt. Appl. Rule";
+        Amount: Decimal;
+        DocumentNo: Code[20];
+        ExtDocNo: Code[20];
+        PaymentReference: Code[50];
+    begin
+        Initialize();
+
+        // Setup
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        ExtDocNo := '';
+        PaymentReference := 'PMTREF0001';
+        DocumentNo := CreateAndPostSalesInvoiceWithOneLine(Customer."No.", ExtDocNo, Amount);
+
+        // The W1 Sales Header has no Payment Reference field, so set the reference on the open ledger entry
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Invoice);
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document No.", DocumentNo);
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry."Payment Reference" := PaymentReference;
+        CustLedgerEntry.Modify();
+
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        // No document number in the transaction text, so the payment reference is the only possible match
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount / 2, '', '');
+        BankAccReconciliationLine.Validate("Payment Reference No.", PaymentReference);
+        BankAccReconciliationLine.Modify(true);
+
+        // Exercise
+        RunMatch(BankAccReconciliation, true);
+
+        // Verify
+        SetRule(BankPmtApplRule, BankPmtApplRule."Related Party Matched"::No,
+          BankPmtApplRule."Doc. No./Ext. Doc. No. Matched"::Yes, BankPmtApplRule."Amount Incl. Tolerance Matched"::"No Matches");
+        VerifyReconciliation(BankPmtApplRule, BankAccReconciliationLine."Statement Line No.");
+        VerifyEntryApplied(BankAccReconciliationLine, false);
+        VerifyMatchDetailsData(BankAccReconciliation, BankPmtApplRule,
+          BankAccReconciliationLine."Account Type"::Customer, Amount / 2, 0, 0, 1);
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,VerifyMatchDetailsOnPaymentApplicationsPage')]
+    [Scope('OnPrem')]
     procedure TestCustDocInAdditionalTextMatch()
     var
         BankAccReconciliation: Record "Bank Acc. Reconciliation";


### PR DESCRIPTION
## What & why

`DocumentMatching` in codeunit 1255 "Match Bank Payments" already accepts a `PaymentReference` parameter and contains the logic to match the bank rec line's `Payment Reference No.` against an open ledger entry's payment reference. The single W1 call site, however, hardcoded `''` for that argument, so the match never fired (typical SEPA flow).

The buffer record `Ledger Entry Matching Buffer` already exposes the field and is populated for customer, vendor, and employee ledger entries (see `InitializeCustomerLedgerEntriesMatchingBuffer`, `InitializeVendorLedgerEntriesMatchingBuffer`, `InitializeEmployeeLedgerEntriesMatchingBuffer`).

The fix is one line: pass `TempLedgerEntryMatchingBuffer."Payment Reference"` instead of `''`. Behavior is unchanged for buffers where the field is empty, since `DocumentMatching` early-exits when `PaymentReference = ''`.

A new test `TestCustPaymentReferenceMatch` is added to the W1/CH/DK/IT `BankPmtApplAlgorithm` test codeunits covering the SEPA scenario (no document number in the transaction text, so the payment reference is the only possible match).

## Linked work

Fixes [AB#640039](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640039)

Ported from the internal NAV PR 249652 (originally microsoft/BusinessCentralApps#1912), as the internal NAV repo is closed for PRs.

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior.

**What I tested and the outcome**

New test `TestCustPaymentReferenceMatch` added to the bank payment application test codeunits (W1, CH, DK, IT) verifying that an open customer ledger entry is matched on `Payment Reference` when the document number is absent from the transaction text.

## Risk & compatibility

Low. The only behavioral change is that a previously-suppressed match path (payment reference) now fires when the bank rec line carries a `Payment Reference No.`. Buffers with an empty payment reference are unaffected because `DocumentMatching` early-exits on an empty reference.


