### PR TITLE
Restart container before restoring demo data snapshot to free DB connections

### DIFF
--- a/build/scripts/ImportTestDataInBcContainer.ps1
+++ b/build/scripts/ImportTestDataInBcContainer.ps1
@@ -187,6 +187,11 @@ function Restore-TenantDatabaseForDemoDataRetry {
         [string]$BackupFile
     )
 
+    # Restart the container to drop lingering connections to 'default' so the restore can obtain exclusive access.
+    Write-Host "Restarting container to release lingering database connections before restoring snapshot..."
+    Restart-BcContainer -containerName $ContainerName
+    Wait-ForTenantReady -ContainerName $ContainerName
+
     Write-Host "Restoring tenant database from snapshot before retrying demo data generation..."
     Invoke-ScriptInBcContainer -containerName $ContainerName -scriptblock {
         Stop-NAVServerInstance -ServerInstance $ServerInstance


### PR DESCRIPTION
## What & why

CI runs that hit a transient deadlock during demo data generation were failing permanently instead of recovering. The demo-data retry logic (added in #8848) snapshots the tenant DB and restores it before re-attempting generation, but the restore itself died with:

```
Microsoft.Data.SqlClient.SqlError: Exclusive access could not be obtained because the database is in use.
```

Root cause: a failed generation attempt leaves a deadlocked/rolling-back NAV session whose SQL connection does not drain in time. `Stop-NAVServerInstance` returns before that connection is gone, so `Restore-SqlDatabase ... -ReplaceDatabase` can't get exclusive access to `default`. Because the deadlock reproduces consistently in some builds, the broken recovery path turned a recoverable retry into a guaranteed failure on every rerun.

This change restarts the container at the start of `Restore-TenantDatabaseForDemoDataRetry`. The restart forcibly terminates the SQL Server process (dropping every connection to `default`); NAV comes back idle, so the subsequent stop drains cleanly and the restore obtains exclusive access. The restore is still required afterward to discard the partial demo data the failed attempt left behind; the restart only clears connections, not data.

This only affects the recovery path, so the extra restart time is paid only when a generation attempt has already failed. The happy path is unchanged.

## Linked work

[AB#640951](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640951)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Build-script (PowerShell) change only, no AL app changes. Verified the script parses with no errors. The fix targets the CI demo-data import path; validation is via the affected pipeline reaching the restore-and-retry path successfully. No automated tests exist for this container/SQL orchestration script.

## Risk & compatibility

Low risk and confined to the demo-data retry recovery path used during CI test-data import. Adds a container restart (a few minutes) only when a generation attempt fails. The retry snapshot `.bak` lives inside the container filesystem, which a restart (not a recreate) preserves, so the subsequent restore still finds it.
