### PR TITLE
[Main]-[Escalated] [Strategic] [BC-IN]Online: Performance issue in General journal line from June 17th 2026 - 2606170030006074

### DIFF
--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/FAGLGeneral.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/FAGLGeneral.PageExt.al
@@ -173,7 +173,6 @@ pageextension 18251 "FA GL General" extends "Fixed Asset G/L Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTBankPaymentVoucherExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTBankPaymentVoucherExt.PageExt.al
@@ -185,7 +185,6 @@ pageextension 18243 "GST Bank Payment Voucher Ext" extends "Bank Payment Voucher
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTBankReceiptVoucherExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTBankReceiptVoucherExt.PageExt.al
@@ -198,7 +198,6 @@ pageextension 18244 "GST Bank Receipt Voucher Ext" extends "Bank Receipt Voucher
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTCashPaymentVoucherExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTCashPaymentVoucherExt.PageExt.al
@@ -116,7 +116,6 @@ pageextension 18245 "GST Cash Payment Voucher Ext" extends "Cash Payment Voucher
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTCashReceiptJournalExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTCashReceiptJournalExt.PageExt.al
@@ -114,7 +114,6 @@ pageextension 18256 "GST Cash Receipt Journal Ext" extends "Cash Receipt Journal
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTCashReceiptVoucherExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTCashReceiptVoucherExt.PageExt.al
@@ -122,7 +122,6 @@ pageextension 18252 "GST Cash Receipt Voucher Ext" extends "Cash Receipt Voucher
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTGeneralJournalExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTGeneralJournalExt.PageExt.al
@@ -305,7 +305,6 @@ pageextension 18246 "GST General Journal Ext" extends "General Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTPaymentJournalExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTPaymentJournalExt.PageExt.al
@@ -189,7 +189,6 @@ pageextension 18250 "GST Payment Journal Ext" extends "Payment Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTPurchaseJournalExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTPurchaseJournalExt.PageExt.al
@@ -227,7 +227,6 @@ pageextension 18248 "GST Purchase Journal Ext" extends "Purchase Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTSalesJournalExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTSalesJournalExt.PageExt.al
@@ -133,7 +133,6 @@ pageextension 18249 "GST Sales Journal Ext" extends "Sales Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSBase/src/pageextension/GeneralJournalTCS.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSBase/src/pageextension/GeneralJournalTCS.PageExt.al
@@ -62,7 +62,6 @@ pageextension 18809 "General Journal TCS" extends "General Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/BankPaymentVoucher.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/BankPaymentVoucher.PageExt.al
@@ -114,7 +114,6 @@ pageextension 18900 "Bank Payment Voucher" extends "Bank Payment Voucher"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/BankReceiptVoucher.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/BankReceiptVoucher.PageExt.al
@@ -127,7 +127,6 @@ pageextension 18901 "Bank Receipt Voucher" extends "Bank Receipt Voucher"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/CashPaymentVoucher.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/CashPaymentVoucher.PageExt.al
@@ -115,7 +115,6 @@ pageextension 18902 "Cash Payment Voucher" extends "Cash Payment Voucher"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/CashReceiptJournalExt.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/CashReceiptJournalExt.PageExt.al
@@ -138,7 +138,6 @@ pageextension 18904 "Cash Receipt Journal Ext" extends "Cash Receipt Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/CashReceiptVoucher.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/CashReceiptVoucher.PageExt.al
@@ -127,7 +127,6 @@ pageextension 18903 "Cash Receipt Voucher" extends "Cash Receipt Voucher"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/PaymentJournalTCS.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/PaymentJournalTCS.PageExt.al
@@ -116,7 +116,6 @@ pageextension 18905 "Payment Journal TCS" extends "Payment Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSOnSales/src/pageextension/SalesJournal.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSOnSales/src/pageextension/SalesJournal.PageExt.al
@@ -58,7 +58,6 @@ pageextension 18840 "Sales Journal" extends "Sales Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSForCustomer/src/pageextension/CashReceiptJournalTDS.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSForCustomer/src/pageextension/CashReceiptJournalTDS.PageExt.al
@@ -45,7 +45,6 @@ pageextension 18667 "Cash Receipt Journal TDS" extends "Cash Receipt Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/BankReceiptVoucher.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/BankReceiptVoucher.PageExt.al
@@ -73,7 +73,6 @@ pageextension 18767 "Bank Receipt Voucher" extends "Bank Receipt Voucher"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/CashReceiptVoucher.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/CashReceiptVoucher.PageExt.al
@@ -73,7 +73,6 @@ pageextension 18769 "Cash Receipt Voucher" extends "Cash Receipt Voucher"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/GeneralJournalExt.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/GeneralJournalExt.PageExt.al
@@ -152,7 +152,6 @@ pageextension 18766 "General Journal Ext" extends "General Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/JournalVoucher.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/JournalVoucher.PageExt.al
@@ -152,7 +152,6 @@ pageextension 18770 "Journal Voucher" extends "Journal Voucher"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/PurchaseJournalTDS.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/PurchaseJournalTDS.PageExt.al
@@ -125,7 +125,6 @@ pageextension 18768 "Purchase Journal TDS" extends "Purchase Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSReturnAndSettlement/src/pageextension/BankPaymentVoucher.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSReturnAndSettlement/src/pageextension/BankPaymentVoucher.PageExt.al
@@ -89,7 +89,6 @@ pageextension 18747 "Bank Payment Voucher" extends "Bank Payment Voucher"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSReturnAndSettlement/src/pageextension/CashPaymentVoucher.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSReturnAndSettlement/src/pageextension/CashPaymentVoucher.PageExt.al
@@ -89,7 +89,6 @@ pageextension 18748 "Cash Payment Voucher" extends "Cash Payment Voucher"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSReturnAndSettlement/src/pageextension/PaymentJnl.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSReturnAndSettlement/src/pageextension/PaymentJnl.PageExt.al
@@ -118,7 +118,6 @@ pageextension 18746 "Payment Jnl" extends "Payment Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTaxBase/app/src/pageextension/CashReceiptJournal.PageExt.al
+++ b/src/Apps/IN/INTaxBase/app/src/pageextension/CashReceiptJournal.PageExt.al
@@ -88,7 +88,6 @@ pageextension 18575 "Cash Receipt Journal" extends "Cash Receipt Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTaxBase/app/src/pageextension/GeneralJournal.PageExt.al
+++ b/src/Apps/IN/INTaxBase/app/src/pageextension/GeneralJournal.PageExt.al
@@ -88,7 +88,6 @@ pageextension 18545 "General Journal" extends "General Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTaxBase/app/src/pageextension/PaymentJournal.PageExt.al
+++ b/src/Apps/IN/INTaxBase/app/src/pageextension/PaymentJournal.PageExt.al
@@ -88,7 +88,6 @@ pageextension 18549 "Payment Journal" extends "Payment Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTaxBase/app/src/pageextension/PurchaseJournal.PageExt.al
+++ b/src/Apps/IN/INTaxBase/app/src/pageextension/PurchaseJournal.PageExt.al
@@ -85,7 +85,6 @@ pageextension 18551 "Purchase Journal" extends "Purchase Journal"
     var
         CalculateTax: Codeunit "Calculate Tax";
     begin
-        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }


### PR DESCRIPTION
[Bug 640621](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/640621): [Master]-[Escalated] [Strategic] [BC-IN]Online: Performance issue in General journal line from June 17th 2026 - 2606170030006074

[AB#640621](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640621)

**Issue:** TCS journal pages (General Journal, Cash/Bank Vouchers, Payment/Sales Journals) lag on line entry, worsened in environments with many enabled workflows.

**Cause:** UpdateTaxAmount() called a redundant CurrPage.SaveRecord(); before CallTaxEngineOnGenJnlLine, triggering an extra DB write + workflow evaluation per line. GST/TDS/Tax Base pages were already fixed; TCS was missed.

**Solution:** Removed the redundant CurrPage.SaveRecord(); from the affected TCS journal page extensions (8 files), aligning them with the other modules. Tax calculation behavior unchanged.


