### PR TITLE
[Permissions] Add Where-Used and Permissions Overview navigation actions

### DIFF
--- a/src/System Application/App/Permission Sets/src/PermissionSet.Page.al
+++ b/src/System Application/App/Permission Sets/src/PermissionSet.Page.al
@@ -119,6 +119,23 @@ page 9855 "Permission Set"
                 AboutTitle = 'About view all permissions';
                 AboutText = 'View all permissions gives you the big picture. It opens a flat list of the permissions in the set you''re working with and all added sets';
             }
+            action("Where-Used")
+            {
+                ApplicationArea = All;
+                Promoted = true;
+                PromotedOnly = true;
+                PromotedCategory = Process;
+                Image = Track;
+                Caption = 'Where-Used';
+                ToolTip = 'View where this permission set is used, including which users and security groups have been assigned with it.';
+
+                trigger OnAction()
+                var
+                    PermissionsOverviewCU: Codeunit "Permissions Overview";
+                begin
+                    PermissionsOverviewCU.OpenForPermissionSet(Rec."Role ID");
+                end;
+            }
             group("Record Permissions")
             {
                 Caption = 'Record Permissions';

--- a/src/System Application/App/Permission Sets/src/PermissionsOverview.Codeunit.al
+++ b/src/System Application/App/Permission Sets/src/PermissionsOverview.Codeunit.al
@@ -1,0 +1,67 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Security.AccessControl;
+
+/// <summary>
+/// Provides procedures to open the Permissions Overview page with optional filters.
+/// Raises integration events that allow the hosting application to handle the navigation.
+/// </summary>
+codeunit 9865 "Permissions Overview"
+{
+    Access = Public;
+
+    /// <summary>
+    /// Opens the Permissions Overview page without any filters.
+    /// </summary>
+    procedure Open()
+    begin
+        OnOpenPermissionsOverview();
+    end;
+
+    /// <summary>
+    /// Opens the Permissions Overview page filtered to a specific permission set (Where-Used).
+    /// </summary>
+    /// <param name="RoleID">The Role ID of the permission set to filter on.</param>
+    procedure OpenForPermissionSet(RoleID: Text[30])
+    begin
+        OnOpenPermissionsOverviewForPermissionSet(RoleID);
+    end;
+
+    /// <summary>
+    /// Opens the Permissions Overview page filtered to a specific table.
+    /// </summary>
+    /// <param name="TableNo">The table number to filter on.</param>
+    procedure OpenForTable(TableNo: Integer)
+    begin
+        OnOpenPermissionsOverviewForTable(TableNo);
+    end;
+
+    /// <summary>
+    /// Raised when the Permissions Overview page should be opened without filters.
+    /// </summary>
+    [IntegrationEvent(false, false)]
+    internal procedure OnOpenPermissionsOverview()
+    begin
+    end;
+
+    /// <summary>
+    /// Raised when the Permissions Overview page should be opened filtered to a permission set.
+    /// </summary>
+    /// <param name="RoleID">The Role ID to filter on.</param>
+    [IntegrationEvent(false, false)]
+    internal procedure OnOpenPermissionsOverviewForPermissionSet(RoleID: Text[30])
+    begin
+    end;
+
+    /// <summary>
+    /// Raised when the Permissions Overview page should be opened filtered to a table.
+    /// </summary>
+    /// <param name="TableNo">The table number to filter on.</param>
+    [IntegrationEvent(false, false)]
+    internal procedure OnOpenPermissionsOverviewForTable(TableNo: Integer)
+    begin
+    end;
+}

--- a/src/System Application/App/Permission Sets/src/permissions/PermissionSetsObjects.PermissionSet.al
+++ b/src/System Application/App/Permission Sets/src/permissions/PermissionSetsObjects.PermissionSet.al
@@ -11,6 +11,7 @@ permissionset 9862 "Permission Sets - Objects"
     Assignable = false;
     Permissions =
         codeunit "Permission Set Relation" = X,
+        codeunit "Permissions Overview" = X,
         codeunit "Log Activity Permissions" = X,
         page "Expanded Permissions" = X,
         page "Expanded Permissions Factbox" = X,

--- a/src/System Application/App/Table Information/app.json
+++ b/src/System Application/App/Table Information/app.json
@@ -16,6 +16,12 @@
       "name": "User Permissions",
       "publisher": "Microsoft",
       "version": "29.0.0.0"
+    },
+    {
+      "id": "4992eeac-2fd3-4515-a50b-7336a332d47f",
+      "name": "Permission Sets",
+      "publisher": "Microsoft",
+      "version": "29.0.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Table Information/src/TableInformation.Page.al
+++ b/src/System Application/App/Table Information/src/TableInformation.Page.al
@@ -8,6 +8,7 @@ namespace System.DataAdministration;
 using System.Diagnostics;
 using System.Environment;
 using System.Reflection;
+using System.Security.AccessControl;
 using System.Security.User;
 
 /// <summary>
@@ -109,6 +110,28 @@ page 8700 "Table Information"
                     OptionCaption = 'None,Row,Page,,';
                     ToolTip = 'Specifies the type of compression that is applied to the table in the database.';
                 }
+            }
+        }
+    }
+
+    actions
+    {
+        area(Navigation)
+        {
+            action("View Table Permissions")
+            {
+                ApplicationArea = All;
+                Caption = 'View Table Permissions';
+                Image = Permission;
+                Scope = Repeater;
+                ToolTip = 'View an overview of permissions that apply to this table across all permission sets.';
+
+                trigger OnAction()
+                var
+                    PermissionsOverviewCU: Codeunit "Permissions Overview";
+                begin
+                    PermissionsOverviewCU.OpenForTable(Rec."Table No.");
+                end;
             }
         }
     }


### PR DESCRIPTION
## Summary
Implements [AB#626501](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/626501) - Broader usage of the Permissions Overview page.

Adds navigation actions to open the Permissions Overview page (with optional filters) from:
- Permission Set card page (Where-Used action)
- Table Information page (View Table Permissions action)

## Changes
- **New** \Permissions Overview\ codeunit (9865) with integration events for cross-app navigation
- **Permission Set card**: Added Where-Used action
- **Table Information page**: Added View Table Permissions action
- **Table Information app.json**: Added dependency on Permission Sets module
- **PermissionSetsObjects.PermissionSet.al**: Registered new codeunit

## Design
Uses integration events so BaseApp can subscribe and handle the actual page navigation (since the Permissions Overview page lives in BaseApp, not System Application).

