### PR TITLE
Trigger full PR build on changes under src/Layers

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -141,5 +141,8 @@
     "onPull_Request": true,
     "onSchedule": false,
     "mode": "modifiedApps"
-  }
+  },
+  "fullBuildPatterns": [
+    "src/Layers/*"
+  ]
 }


### PR DESCRIPTION
## What & why

Incremental PR builds (`incrementalBuilds.onPull_Request: true`) only build projects whose `appFolders`/`testFolders` cover the modified files. The `src/Layers/*` folders (for example `src/Layers/NL/BaseApp`, `src/Layers/W1/BaseApp`) are consumed by projects but are not listed as project folders, so a PR that only touches a layer maps to zero projects. The "Determine Projects To Build" step then logs `Did not find any projects to add to the build order`, emits `ProjectsJson=[]`, and every build job is skipped, producing a green PR build that compiled nothing.

Rather than disable incremental builds entirely, this adds a `fullBuildPatterns` entry for `src/Layers/*`. AL-Go's `DetermineProjectsToBuild` matches modified files against these patterns with PowerShell `-like` (where `*` spans path separators), so any change nested under `src/Layers` forces a full Pull Request build. Normal app-only changes keep fast incremental builds.

## Linked work

[AB#640966](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640966)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Configuration-only change to `.github/AL-Go-Settings.json`; no app code affected, so no AL build or BC run applies. Root cause verified against the failing run on PR #8933 (run 28448705321), where the Initialization job logged `Did not find any projects to add to the build order` and `ProjectsJson=[]`, causing all Build jobs to be skipped. Pattern semantics confirmed from AL-Go `DetermineProjectsToBuild.psm1` (`IsFullBuildRequired` uses `$modifiedFiles -like $fullBuildFolder` after joining with the base folder).

## Risk & compatibility

Low. Incremental builds stay enabled, so the only behavior change is that PRs touching `src/Layers/*` now build all projects (intended). If additional shared-but-unmapped roots are found later, they can be added to `fullBuildPatterns` the same way.


