### PR TITLE
Fix agent setup field lookup casing

### DIFF
--- a/src/System Application/App/Agent/Setup/AgentImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Setup/AgentImpl.Codeunit.al
@@ -533,7 +533,7 @@ codeunit 4301 "Agent Impl."
         SetupPageRecordRef.Open(PageMetadata.SourceTable, PageMetadata.SourceTableTemporary);
 
         FieldMetadata.SetRange(TableNo, PageMetadata.SourceTable);
-        FieldMetadata.SetFilter(FieldName, '@''%1''', UserSecurityIdTok);
+        FieldMetadata.SetFilter(FieldName, StrSubstNo('@%1', UserSecurityIdTok));
         if not FieldMetadata.FindFirst() then
             Error(SetupPageSourceTableMissingFieldErr, SetupPageId, UserSecurityIdTok);
 

--- a/src/System Application/App/Agent/Setup/AgentImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Setup/AgentImpl.Codeunit.al
@@ -533,7 +533,7 @@ codeunit 4301 "Agent Impl."
         SetupPageRecordRef.Open(PageMetadata.SourceTable, PageMetadata.SourceTableTemporary);
 
         FieldMetadata.SetRange(TableNo, PageMetadata.SourceTable);
-        FieldMetadata.SetRange(FieldName, UserSecurityIdTok);
+        FieldMetadata.SetFilter(FieldName, '@' + UserSecurityIdTok);
         if not FieldMetadata.FindFirst() then
             Error(SetupPageSourceTableMissingFieldErr, SetupPageId, UserSecurityIdTok);
 

--- a/src/System Application/App/Agent/Setup/AgentImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Setup/AgentImpl.Codeunit.al
@@ -533,7 +533,7 @@ codeunit 4301 "Agent Impl."
         SetupPageRecordRef.Open(PageMetadata.SourceTable, PageMetadata.SourceTableTemporary);
 
         FieldMetadata.SetRange(TableNo, PageMetadata.SourceTable);
-        FieldMetadata.SetFilter(FieldName, '@' + UserSecurityIdTok);
+        FieldMetadata.SetFilter(FieldName, '@''%1''', UserSecurityIdTok);
         if not FieldMetadata.FindFirst() then
             Error(SetupPageSourceTableMissingFieldErr, SetupPageId, UserSecurityIdTok);
 


### PR DESCRIPTION
Fixes the agent setup page validation to locate the required "User Security ID" field case-insensitively.

[AB#640664](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640664)









