### PR TITLE
[Master]-Aged account receivable EXCEL and Aged account payable EXCEL ignores "Period Count" specified by user.

### DIFF
--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccPayableExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccPayableExcel.Report.al
@@ -342,11 +342,17 @@ report 4403 "EXR Aged Acc Payable Excel"
     local procedure InsertAgingData(var Vendor: Record "Vendor")
     var
         VendorLedgerEntry: Record "Vendor Ledger Entry";
+        EarliestPeriodStart: Date;
     begin
+        EarliestPeriodStart := PeriodStarts.Get(PeriodStarts.Count());
         VendorLedgerEntry.SetCurrentKey("Vendor No.", Open, Positive, "Due Date", "Currency Code");
         VendorLedgerEntry.SetRange("Vendor No.", Vendor."No.");
         VendorLedgerEntry.SetRange("Posting Date", 0D, EndingDate);
         VendorLedgerEntry.SetRange("Date Filter", 0D, EndingDate);
+
+        if (TempEXRAgingReportBuffer."Aged By" = TempEXRAgingReportBuffer."Aged By"::"Due Date") and (PeriodCount <> 0) then
+            VendorLedgerEntry.SetRange("Due Date", EarliestPeriodStart, EndingDate);
+
         VendorLedgerEntry.SetAutoCalcFields("Remaining Amt. (LCY)", "Remaining Amount", "Original Amount", "Original Amt. (LCY)");
         VendorLedgerEntry.SetFilter("Remaining Amt. (LCY)", '<>0');
         if VendorLedgerEntry.FindSet() then

--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccPayableExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccPayableExcel.Report.al
@@ -350,8 +350,14 @@ report 4403 "EXR Aged Acc Payable Excel"
         VendorLedgerEntry.SetRange("Posting Date", 0D, EndingDate);
         VendorLedgerEntry.SetRange("Date Filter", 0D, EndingDate);
 
-        if (TempEXRAgingReportBuffer."Aged By" = TempEXRAgingReportBuffer."Aged By"::"Due Date") and (PeriodCount <> 0) then
-            VendorLedgerEntry.SetRange("Due Date", EarliestPeriodStart, EndingDate);
+        case TempEXRAgingReportBuffer."Aged By" of
+            TempEXRAgingReportBuffer."Aged By"::"Due Date":
+                VendorLedgerEntry.SetRange("Due Date", EarliestPeriodStart, EndingDate);
+            TempEXRAgingReportBuffer."Aged By"::"Posting Date":
+                VendorLedgerEntry.SetRange("Posting Date", EarliestPeriodStart, EndingDate);
+            TempEXRAgingReportBuffer."Aged By"::"Document Date":
+                VendorLedgerEntry.SetRange("Document Date", EarliestPeriodStart, EndingDate);
+        end;
 
         VendorLedgerEntry.SetAutoCalcFields("Remaining Amt. (LCY)", "Remaining Amount", "Original Amount", "Original Amt. (LCY)");
         VendorLedgerEntry.SetFilter("Remaining Amt. (LCY)", '<>0');

--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccountsRecExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccountsRecExcel.Report.al
@@ -341,11 +341,17 @@ report 4402 "EXR Aged Accounts Rec Excel"
     local procedure InsertAgingData(var Customer: Record Customer)
     var
         CustLedgerEntry: Record "Cust. Ledger Entry";
+        EarliestPeriodStart: Date;
     begin
+        EarliestPeriodStart := PeriodStarts.Get(PeriodStarts.Count());
         CustLedgerEntry.SetCurrentKey("Customer No.", Open, Positive, "Due Date", "Currency Code");
         CustLedgerEntry.SetRange("Customer No.", Customer."No.");
         CustLedgerEntry.SetRange("Posting Date", 0D, EndingDate);
         CustLedgerEntry.SetRange("Date Filter", 0D, EndingDate);
+
+        if (TempEXRAgingReportBuffer."Aged By" = TempEXRAgingReportBuffer."Aged By"::"Due Date") and (PeriodCount <> 0) then
+            CustLedgerEntry.SetRange("Due Date", EarliestPeriodStart, EndingDate);
+
         CustLedgerEntry.SetAutoCalcFields("Remaining Amt. (LCY)", "Remaining Amount", "Original Amount", "Original Amt. (LCY)");
         CustLedgerEntry.SetFilter("Remaining Amt. (LCY)", '<>0');
         if CustLedgerEntry.FindSet() then

--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccountsRecExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccountsRecExcel.Report.al
@@ -349,8 +349,14 @@ report 4402 "EXR Aged Accounts Rec Excel"
         CustLedgerEntry.SetRange("Posting Date", 0D, EndingDate);
         CustLedgerEntry.SetRange("Date Filter", 0D, EndingDate);
 
-        if (TempEXRAgingReportBuffer."Aged By" = TempEXRAgingReportBuffer."Aged By"::"Due Date") and (PeriodCount <> 0) then
-            CustLedgerEntry.SetRange("Due Date", EarliestPeriodStart, EndingDate);
+        case TempEXRAgingReportBuffer."Aged By" of
+            TempEXRAgingReportBuffer."Aged By"::"Due Date":
+                CustLedgerEntry.SetRange("Due Date", EarliestPeriodStart, EndingDate);
+            TempEXRAgingReportBuffer."Aged By"::"Posting Date":
+                CustLedgerEntry.SetRange("Posting Date", EarliestPeriodStart, EndingDate);
+            TempEXRAgingReportBuffer."Aged By"::"Document Date":
+                CustLedgerEntry.SetRange("Document Date", EarliestPeriodStart, EndingDate);
+        end;
 
         CustLedgerEntry.SetAutoCalcFields("Remaining Amt. (LCY)", "Remaining Amount", "Original Amount", "Original Amt. (LCY)");
         CustLedgerEntry.SetFilter("Remaining Amt. (LCY)", '<>0');

--- a/src/Apps/W1/ExcelReports/Test/src/AgedAccountsExcelReports.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/Test/src/AgedAccountsExcelReports.Codeunit.al
@@ -421,6 +421,7 @@ codeunit 139555 "Aged Accounts Excel Reports"
     procedure EXRAgedAccountsRecExcelHandlerWorkdate(var EXRAgedAccountsRecExcel: TestRequestPage "EXR Aged Accounts Rec Excel")
     begin
         EXRAgedAccountsRecExcel.AgedAsOfOption.SetValue(WorkDate());
+         EXRAgedAccountsRecExcel.PeriodCountOption.SetValue(1);
         EXRAgedAccountsRecExcel.OK().Invoke();
     end;
 }

--- a/src/Apps/W1/ExcelReports/Test/src/AgedAccountsExcelReports.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/Test/src/AgedAccountsExcelReports.Codeunit.al
@@ -275,7 +275,7 @@ codeunit 139555 "Aged Accounts Excel Reports"
         RequestPageXml := Report.RunRequestPage(Report::"EXR Aged Accounts Rec Excel", RequestPageXml);
         LibraryReportDataset.RunReportAndLoad(Report::"EXR Aged Accounts Rec Excel", Variant, RequestPageXml);
 
-        // [THEN] The exported data does not exists.
+        // [THEN] The exported data does not exist.
         LibraryReportDataset.SetXmlNodeList('DataItem[@name="AgingData"]');
         Assert.AreEqual(0, LibraryReportDataset.RowCount(), 'No aging entry should be exported');
     end;

--- a/src/Apps/W1/ExcelReports/Test/src/AgedAccountsExcelReports.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/Test/src/AgedAccountsExcelReports.Codeunit.al
@@ -252,6 +252,34 @@ codeunit 139555 "Aged Accounts Excel Reports"
         Assert.IsTrue(LcyRowSeen, 'LCY row should be present');
     end;
 
+    [Test]
+    [HandlerFunctions('EXRAgedAccountsRecExcelHandlerWorkdate')]
+    procedure AgedAccountsReceivableExcelReportExportsAsPerPeriodCount()
+    var
+        Customer: Record Customer;
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        Variant: Variant;
+        RequestPageXml: Text;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 640052] Aged Accounts Receivable Excel report exports as per Period count.
+        InitializeAgingData();
+
+        // [GIVEN] Customer "C" with an open customer ledger entry of type Invoice
+        // Create customer directly to avoid VAT posting setup requirements in some localizations
+        CreateMinimalCustomer(Customer);
+        CreateCustLedgerEntry(CustLedgerEntry, Customer."No.", "Gen. Journal Document Type"::Invoice);
+        Commit();
+
+        // [WHEN] Running the Aged Accounts Receivable Excel report
+        RequestPageXml := Report.RunRequestPage(Report::"EXR Aged Accounts Rec Excel", RequestPageXml);
+        LibraryReportDataset.RunReportAndLoad(Report::"EXR Aged Accounts Rec Excel", Variant, RequestPageXml);
+
+        // [THEN] The exported data does not exists.
+        LibraryReportDataset.SetXmlNodeList('DataItem[@name="AgingData"]');
+        Assert.AreEqual(0, LibraryReportDataset.RowCount(), 'One aging entry should be exported');
+    end;
+
     local procedure InitializeAgingData()
     var
         Vendor: Record Vendor;
@@ -370,22 +398,29 @@ codeunit 139555 "Aged Accounts Excel Reports"
     [RequestPageHandler]
     procedure EXRAgedAccPayableExcelHandler(var EXRAgedAccPayableExcel: TestRequestPage "EXR Aged Acc Payable Excel")
     begin
-        EXRAgedAccPayableExcel.AgedAsOfOption.SetValue(WorkDate());
+        EXRAgedAccPayableExcel.AgedAsOfOption.SetValue(WorkDate() + 30);
         EXRAgedAccPayableExcel.OK().Invoke();
     end;
 
     [RequestPageHandler]
     procedure EXRAgedAccountsRecExcelHandler(var EXRAgedAccountsRecExcel: TestRequestPage "EXR Aged Accounts Rec Excel")
     begin
-        EXRAgedAccountsRecExcel.AgedAsOfOption.SetValue(WorkDate());
+        EXRAgedAccountsRecExcel.AgedAsOfOption.SetValue(WorkDate() + 30);
         EXRAgedAccountsRecExcel.OK().Invoke();
     end;
 
     [RequestPageHandler]
     procedure EXRAgedAccPayablePostingDateHandler(var EXRAgedAccPayableExcel: TestRequestPage "EXR Aged Acc Payable Excel")
     begin
-        EXRAgedAccPayableExcel.AgedAsOfOption.SetValue(WorkDate());
+        EXRAgedAccPayableExcel.AgedAsOfOption.SetValue(WorkDate() + 30);
         EXRAgedAccPayableExcel.AgingbyOption.SetValue('Posting Date');
         EXRAgedAccPayableExcel.OK().Invoke();
+    end;
+
+    [RequestPageHandler]
+    procedure EXRAgedAccountsRecExcelHandlerWorkdate(var EXRAgedAccountsRecExcel: TestRequestPage "EXR Aged Accounts Rec Excel")
+    begin
+        EXRAgedAccountsRecExcel.AgedAsOfOption.SetValue(WorkDate());
+        EXRAgedAccountsRecExcel.OK().Invoke();
     end;
 }

--- a/src/Apps/W1/ExcelReports/Test/src/AgedAccountsExcelReports.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/Test/src/AgedAccountsExcelReports.Codeunit.al
@@ -280,6 +280,91 @@ codeunit 139555 "Aged Accounts Excel Reports"
         Assert.AreEqual(0, LibraryReportDataset.RowCount(), 'No aging entry should be exported');
     end;
 
+    [Test]
+    [HandlerFunctions('EXRAgedAccPayableExcelHandlerWorkdate')]
+    procedure AgedAccountsPayableExcelReportExportsAsPerPeriodCount()
+    var
+        Vendor: Record Vendor;
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        Variant: Variant;
+        RequestPageXml: Text;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 640052] Aged Accounts Payable Excel report exports as per Period count.
+        InitializeAgingData();
+
+        // [GIVEN] Vendor "V" with an open vendor ledger entry whose Due Date is after the selected period
+        CreateMinimalVendor(Vendor);
+        CreateVendorLedgerEntry(VendorLedgerEntry, Vendor."No.", "Gen. Journal Document Type"::Invoice);
+        Commit();
+
+        // [WHEN] Running the Aged Accounts Payable Excel report with Aged As Of = WorkDate() and Period Count = 1
+        RequestPageXml := Report.RunRequestPage(Report::"EXR Aged Acc Payable Excel", RequestPageXml);
+        LibraryReportDataset.RunReportAndLoad(Report::"EXR Aged Acc Payable Excel", Variant, RequestPageXml);
+
+        // [THEN] The exported data does not include entries whose Due Date is outside the selected period
+        LibraryReportDataset.SetXmlNodeList('DataItem[@name="AgingData"]');
+        Assert.AreEqual(0, LibraryReportDataset.RowCount(), 'No aging entry should be exported');
+    end;
+
+    [Test]
+    [HandlerFunctions('EXRAgedAccountsRecPostingDatePeriodCountHandler')]
+    procedure AgedAccountsRecExcelReportPostingDateRespectsPeriodCount()
+    var
+        Customer: Record Customer;
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        Variant: Variant;
+        RequestPageXml: Text;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 640052] Aged Accounts Receivable Excel report, when Aging by = Posting Date, respects Period Count.
+        InitializeAgingData();
+
+        // [GIVEN] Customer "C" with an open customer ledger entry whose Posting Date is before the earliest selected period
+        CreateMinimalCustomer(Customer);
+        CreateCustLedgerEntry(CustLedgerEntry, Customer."No.", "Gen. Journal Document Type"::Invoice);
+        CustLedgerEntry."Posting Date" := CalcDate('<-2M>', WorkDate());
+        CustLedgerEntry.Modify();
+        Commit();
+
+        // [WHEN] Running the Aged Accounts Receivable Excel report with Aging By = Posting Date and Period Count = 1
+        RequestPageXml := Report.RunRequestPage(Report::"EXR Aged Accounts Rec Excel", RequestPageXml);
+        LibraryReportDataset.RunReportAndLoad(Report::"EXR Aged Accounts Rec Excel", Variant, RequestPageXml);
+
+        // [THEN] The exported data does not include entries whose Posting Date is outside the selected period
+        LibraryReportDataset.SetXmlNodeList('DataItem[@name="AgingData"]');
+        Assert.AreEqual(0, LibraryReportDataset.RowCount(), 'No aging entry should be exported');
+    end;
+
+    [Test]
+    [HandlerFunctions('EXRAgedAccPayablePostingDatePeriodCountHandler')]
+    procedure AgedAccountsPayableExcelReportPostingDateRespectsPeriodCount()
+    var
+        Vendor: Record Vendor;
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        Variant: Variant;
+        RequestPageXml: Text;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 640052] Aged Accounts Payable Excel report, when Aging by = Posting Date, respects Period Count.
+        InitializeAgingData();
+
+        // [GIVEN] Vendor "V" with an open vendor ledger entry whose Posting Date is before the earliest selected period
+        CreateMinimalVendor(Vendor);
+        CreateVendorLedgerEntry(VendorLedgerEntry, Vendor."No.", "Gen. Journal Document Type"::Invoice);
+        VendorLedgerEntry."Posting Date" := CalcDate('<-2M>', WorkDate());
+        VendorLedgerEntry.Modify();
+        Commit();
+
+        // [WHEN] Running the Aged Accounts Payable Excel report with Aging By = Posting Date and Period Count = 1
+        RequestPageXml := Report.RunRequestPage(Report::"EXR Aged Acc Payable Excel", RequestPageXml);
+        LibraryReportDataset.RunReportAndLoad(Report::"EXR Aged Acc Payable Excel", Variant, RequestPageXml);
+
+        // [THEN] The exported data does not include entries whose Posting Date is outside the selected period
+        LibraryReportDataset.SetXmlNodeList('DataItem[@name="AgingData"]');
+        Assert.AreEqual(0, LibraryReportDataset.RowCount(), 'No aging entry should be exported');
+    end;
+
     local procedure InitializeAgingData()
     var
         Vendor: Record Vendor;
@@ -421,7 +506,33 @@ codeunit 139555 "Aged Accounts Excel Reports"
     procedure EXRAgedAccountsRecExcelHandlerWorkdate(var EXRAgedAccountsRecExcel: TestRequestPage "EXR Aged Accounts Rec Excel")
     begin
         EXRAgedAccountsRecExcel.AgedAsOfOption.SetValue(WorkDate());
-         EXRAgedAccountsRecExcel.PeriodCountOption.SetValue(1);
+        EXRAgedAccountsRecExcel.PeriodCountOption.SetValue(1);
         EXRAgedAccountsRecExcel.OK().Invoke();
+    end;
+
+    [RequestPageHandler]
+    procedure EXRAgedAccPayableExcelHandlerWorkdate(var EXRAgedAccPayableExcel: TestRequestPage "EXR Aged Acc Payable Excel")
+    begin
+        EXRAgedAccPayableExcel.AgedAsOfOption.SetValue(WorkDate());
+        EXRAgedAccPayableExcel.PeriodCountOption.SetValue(1);
+        EXRAgedAccPayableExcel.OK().Invoke();
+    end;
+
+    [RequestPageHandler]
+    procedure EXRAgedAccountsRecPostingDatePeriodCountHandler(var EXRAgedAccountsRecExcel: TestRequestPage "EXR Aged Accounts Rec Excel")
+    begin
+        EXRAgedAccountsRecExcel.AgedAsOfOption.SetValue(WorkDate());
+        EXRAgedAccountsRecExcel.AgingbyOption.SetValue('Posting Date');
+        EXRAgedAccountsRecExcel.PeriodCountOption.SetValue(1);
+        EXRAgedAccountsRecExcel.OK().Invoke();
+    end;
+
+    [RequestPageHandler]
+    procedure EXRAgedAccPayablePostingDatePeriodCountHandler(var EXRAgedAccPayableExcel: TestRequestPage "EXR Aged Acc Payable Excel")
+    begin
+        EXRAgedAccPayableExcel.AgedAsOfOption.SetValue(WorkDate());
+        EXRAgedAccPayableExcel.AgingbyOption.SetValue('Posting Date');
+        EXRAgedAccPayableExcel.PeriodCountOption.SetValue(1);
+        EXRAgedAccPayableExcel.OK().Invoke();
     end;
 }

--- a/src/Apps/W1/ExcelReports/Test/src/AgedAccountsExcelReports.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/Test/src/AgedAccountsExcelReports.Codeunit.al
@@ -277,7 +277,7 @@ codeunit 139555 "Aged Accounts Excel Reports"
 
         // [THEN] The exported data does not exists.
         LibraryReportDataset.SetXmlNodeList('DataItem[@name="AgingData"]');
-        Assert.AreEqual(0, LibraryReportDataset.RowCount(), 'One aging entry should be exported');
+        Assert.AreEqual(0, LibraryReportDataset.RowCount(), 'No aging entry should be exported');
     end;
 
     local procedure InitializeAgingData()


### PR DESCRIPTION
Fixes [AB#640052](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640052)

[Bug 640052](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/640052): [master] [All-e]Aged account receivable EXCEL and Aged account payable EXCEL ignores "Period Count" specified by user.










