### PR TITLE
[28.x] Fix Document Date for e-document purchase invoice duplicate check

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchaseInvoice.Codeunit.al
@@ -131,6 +131,7 @@ codeunit 6117 "E-Doc. Create Purchase Invoice" implements IEDocumentFinishDraft,
         PurchaseHeader.SetRange("Buy-from Vendor No.", EDocumentPurchaseHeader."[BC] Vendor No."); // Setting the filter, so that the insert trigger assigns the right vendor to the purchase header
         PurchaseHeader."Document Type" := "Purchase Document Type"::Invoice;
         PurchaseHeader."Pay-to Vendor No." := EDocumentPurchaseHeader."[BC] Vendor No.";
+        PurchaseHeader.Insert(true);
         if EDocumentPurchaseHeader."Document Date" <> 0D then
             EDocPurchaseDocumentHelper.ValidateFieldWithContext(PurchaseHeader, PurchaseHeader.FieldNo("Document Date"), EDocumentPurchaseHeader."Document Date");
         if EDocumentPurchaseHeader."Due Date" <> 0D then
@@ -146,7 +147,6 @@ codeunit 6117 "E-Doc. Create Purchase Invoice" implements IEDocumentFinishDraft,
         end;
 
         EDocPurchaseDocumentHelper.ValidateFieldWithContext(PurchaseHeader, PurchaseHeader.FieldNo("Vendor Invoice No."), VendorInvoiceNo);
-        PurchaseHeader.Insert(true);
 
         PurchaseHeader."Invoice Received Date" := PurchaseHeader."Document Date";
         EDocPurchaseDocumentHelper.ApplyDefaultPostingDateFromSetup(PurchaseHeader, EDocumentPurchaseHeader);

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocProcessTest.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocProcessTest.Codeunit.al
@@ -1120,8 +1120,10 @@ codeunit 139883 "E-Doc Process Test"
         // Set a currency that can be used across all localizations
         Currency.Init();
         Currency.Validate(Code, 'XYZ');
-        if Currency.Insert(true) then
+        if Currency.Insert(true) then begin
             LibraryERM.CreateExchangeRate(Currency.Code, Today(), 1.0, 1.0);
+            LibraryERM.CreateExchangeRate(Currency.Code, 20260122D, 1.0, 1.0);
+        end;
 
         EDocument.DeleteAll();
         EDocumentServiceStatus.DeleteAll();


### PR DESCRIPTION
## Why

When finalizing an inbound e-document into a purchase invoice, the Italian "Same Ext. Doc. No. in Diff. FY" feature checks for an existing posted document by filtering vendor ledger entries on the fiscal/calendar year of the purchase header's Document Date (via the IT `OnAfterSetFilterForExternalDocNo` subscriber). The Document Date was validated *before* `PurchaseHeader.Insert(true)`, but the insert trigger's `InitRecord` unconditionally resets `"Document Date" := WorkDate()`. By the time `FindPostedDocumentWithSameExternalDocNo` ran, the e-document's real document date had been lost — breaking the duplicate check and preventing PA purchase invoices from being finalized in Italy.

This backports 8740 and its follow-up test fix 8957 to `releases/28.x`.

## Summary

- **Moved** `PurchaseHeader.Insert(true)` ahead of the Document Date/Due Date validations in `EDocCreatePurchaseInvoice` — so the e-document Document Date survives `InitRecord` and is correct when the duplicate check runs.
- **Added** an exchange rate for `20260122D` in `EDocProcessTest` — so the test's exchange rate lookup succeeds after the Document Date fix.

Fixes: [AB#640107](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640107)
