### PR TITLE
Enable multi-file attachment upload in Agent Designer

### DIFF
--- a/src/Apps/W1/AgentDesignExperience/app/Interaction/AgentMessageAttachments.Page.al
+++ b/src/Apps/W1/AgentDesignExperience/app/Interaction/AgentMessageAttachments.Page.al
@@ -71,28 +71,34 @@ page 4358 "Agent Message Attachments"
                     Rec.Delete();
                 end;
             }
-            action(New)
+            fileuploadaction(New)
             {
                 ApplicationArea = All;
                 Caption = 'Upload';
-                ToolTip = 'Upload a new attachment';
+                ToolTip = 'Upload new attachments';
                 Image = Import;
+                AllowMultipleFiles = true;
 
-                trigger OnAction()
+                trigger OnAction(Files: List of [FileUpload])
                 var
                     TempLastAgentTaskFile: Record "Agent Task File" temporary;
+                    SingleFile: FileUpload;
+                    NextID: Integer;
                 begin
                     TempLastAgentTaskFile.Copy(Rec, true);
                     TempLastAgentTaskFile.Reset();
                     TempLastAgentTaskFile.SetCurrentKey(ID);
-                    if TempLastAgentTaskFile.FindLast() then;
+                    if TempLastAgentTaskFile.FindLast() then
+                        NextID := TempLastAgentTaskFile.ID;
 
-                    if not AgentTaskMessageBuilder.UploadAttachment() then
-                        exit;
-
-                    Rec := AgentTaskMessageBuilder.GetLastAttachment();
-                    Rec.ID := TempLastAgentTaskFile.ID + 1;
-                    Rec.Insert();
+                    foreach SingleFile in Files do
+                        if SingleFile.FileName <> '' then begin
+                            AgentTaskMessageBuilder.AddAttachment(SingleFile);
+                            NextID += 1;
+                            Rec := AgentTaskMessageBuilder.GetLastAttachment();
+                            Rec.ID := NextID;
+                            Rec.Insert();
+                        end;
                 end;
             }
         }


### PR DESCRIPTION
Bug [AB#632807](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632807): switch the attachments Upload action to a multi-file fileuploadaction so users can select several files at once, using the AddAttachment(FileUpload) SDK overload. Consolidated into BCApps after the Agent Designer app moved here from NAV.

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->


