### PR TITLE
(Bug 641079): [Subcontracting] Add Activate Legacy Subcontracting action

### DIFF
--- a/src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al
@@ -112,8 +112,6 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
     end;
 
     internal procedure SetLegacySubcontracting(var ManufacturingSetup: Record "Manufacturing Setup"; Enabled: Boolean)
-    var
-        ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
     begin
         if ManufacturingSetup."Legacy Subcontracting" = Enabled then
             exit;
@@ -128,8 +126,21 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
         ManufacturingSetup."Legacy Subcontracting" := Enabled;
         ManufacturingSetup.Modify(true);
 
-        ApplicationAreaMgmtFacade.RefreshExperienceTierCurrentCompany();
+        RefreshApplicationAreaSetup();
         RestartSession();
+    end;
+
+    local procedure RefreshApplicationAreaSetup()
+    var
+        ExperienceTierSetup: Record "Experience Tier Setup";
+        ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
+        ExperienceTier: Text;
+    begin
+        if ApplicationAreaMgmtFacade.GetExperienceTierCurrentCompany(ExperienceTier) then
+            if ExperienceTier = ExperienceTierSetup.FieldCaption(Custom) then
+                exit;
+
+        ApplicationAreaMgmtFacade.RefreshExperienceTierCurrentCompany();
     end;
 
     local procedure IsSubcontractingAppInstalled() Result: Boolean

--- a/src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al
@@ -25,6 +25,7 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
         ITMigrationAppNotInstalledErr: Label 'The app "IT Subcontracting Migration" must be installed before you can disable Legacy Subcontracting. Please install the app first and then use the dedicated action "Disable Legacy Subcontracting" to disable Legacy Subcontracting and migrate to the new subcontracting app.';
         SubcontractingAppIdTok: Label '1f32a50d-0057-4b95-b5df-cc04d7e89470', Locked = true;
         SubcontractingAppNotInstalledErr: Label 'The app "Subcontracting App" must be installed before you can disable Legacy Subcontracting. Please install the app first before migrating to the new subcontracting app.';
+        SubcontractingAppInstalledErr: Label 'Cannot activate legacy subcontracting while the Subcontracting app is installed. Use the Subcontracting app features instead.';
         OpenSubcontractingTransfersExistErr: Label 'There are still open transfer orders with WIP Items. All subcontracting transfer orders must be completed before disabling Legacy Subcontracting.';
         OpenWIPPurchaseOrdersExistErr: Label 'There are still open subcontracting purchase orders. All subcontracting purchase orders must be completed before disabling Legacy Subcontracting.';
         MigrationNotAllowedInProductionErr: Label 'To help you migrate safely, disabling Legacy Subcontracting and moving to the Subcontracting app is currently limited to sandbox environments. Test the migration in a sandbox copy of this environment first to validate the transition. Production environments will be enabled in a future release.';
@@ -71,6 +72,15 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
     end;
 
     /// <summary>
+    /// Checks whether Legacy Subcontracting can be enabled and raises an error if the preconditions are not met.
+    /// </summary>
+    procedure CheckCanEnableLegacySubcontracting()
+    begin
+        if IsSubcontractingAppInstalled() then
+            Error(SubcontractingAppInstalledErr);
+    end;
+
+    /// <summary>
     /// Returns whether the database contains Legacy Subcontracting data based on the presence of WIP Item related data in open transfer orders, open purchase orders, or capacity ledger entries.
     /// </summary>
     internal procedure DatabaseHasLegacySubcontractingData(): Boolean
@@ -112,7 +122,8 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
             CheckCanDisableLegacySubcontracting();
             if DatabaseHasLegacySubcontractingData() then
                 MigrateData();
-        end;
+        end else
+            CheckCanEnableLegacySubcontracting();
 
         ManufacturingSetup."Legacy Subcontracting" := Enabled;
         ManufacturingSetup.Modify(true);

--- a/src/Layers/IT/BaseApp/Manufacturing/Setup/ManufacturingSetup.Page.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/Setup/ManufacturingSetup.Page.al
@@ -271,6 +271,30 @@ page 99000768 "Manufacturing Setup"
                 ObsoleteReason = 'Preparation for replacement by Subcontracting app';
                 ObsoleteState = Pending;
                 ObsoleteTag = '28.0';
+
+                action("Activate Legacy Subcontracting")
+                {
+                    ApplicationArea = Manufacturing;
+                    Caption = 'Activate Legacy Subcontracting';
+                    ToolTip = 'Activates the Legacy Subcontracting application area so that the legacy subcontracting functionality becomes available. A session restart is required for the change to take effect.';
+                    Image = Change;
+                    Visible = not Rec."Legacy Subcontracting";
+                    ObsoleteReason = 'Legacy Subcontracting will be discontinued, environments should move to the Subcontracting App.';
+                    ObsoleteState = Pending;
+                    ObsoleteTag = '28.0';
+
+                    trigger OnAction()
+                    var
+                        LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
+                        ActivateLegacySubcontractingQst: Label 'Legacy subcontracting features are scheduled for removal in a future release. We recommend installing and using the Subcontracting app instead. Do you want to activate legacy subcontracting anyway?';
+                    begin
+                        LegacySubcFeatureHandler.CheckCanEnableLegacySubcontracting();
+                        if not Confirm(ActivateLegacySubcontractingQst, false) then
+                            exit;
+
+                        LegacySubcFeatureHandler.SetLegacySubcontracting(Rec, true);
+                    end;
+                }
                 action("Disable Legacy Subcontracting")
                 {
                     ApplicationArea = Manufacturing;

--- a/src/Layers/IT/BaseApp/Manufacturing/Setup/ManufacturingSetup.Page.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/Setup/ManufacturingSetup.Page.al
@@ -281,7 +281,7 @@ page 99000768 "Manufacturing Setup"
                     Visible = not Rec."Legacy Subcontracting";
                     ObsoleteReason = 'Legacy Subcontracting will be discontinued, environments should move to the Subcontracting App.';
                     ObsoleteState = Pending;
-                    ObsoleteTag = '28.0';
+                    ObsoleteTag = '29.0';
 
                     trigger OnAction()
                     var


### PR DESCRIPTION
## Summary

On new Italian Premium environments without pre-existing subcontracting data, Legacy Subcontracting was disabled and every control that could enable it was gated behind the feature already being on, leaving no supported way to turn it on.

This PR adds an **"Activate Legacy Subcontracting"** action (`ApplicationArea = Manufacturing`, visible only when the toggle is off) that:
- Blocks activation when the Subcontracting app is installed (new `CheckCanEnableLegacySubcontracting`).
- Confirms with the user before proceeding.
- Enables Legacy Subcontracting and refreshes the experience tier so `ApplicationArea = LegacySubcontracting` becomes active.

## Changes
- `src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al` — new `SubcontractingAppInstalledErr` label, `CheckCanEnableLegacySubcontracting()` procedure, and an `else` branch in `SetLegacySubcontracting`.
- `src/Layers/IT/BaseApp/Manufacturing/Setup/ManufacturingSetup.Page.al` — new `"Activate Legacy Subcontracting"` action.

Fixes [AB#641079](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641079)







