### PR TITLE
Fix WorkItemValidation for merge queues

### DIFF
--- a/.github/workflows/WorkitemValidation.yaml
+++ b/.github/workflows/WorkitemValidation.yaml
@@ -3,6 +3,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited]
     branches: [ 'main', 'releases/*' ]
+  merge_group:
 
 permissions:
   contents: read
@@ -15,7 +16,7 @@ defaults:
 
 jobs:
   GitHubIssueValidation:
-    if: github.repository_owner == 'microsoft' && github.event.pull_request.state == 'open'
+    if: github.repository_owner == 'microsoft' && github.event.pull_request.state == 'open' && github.event_name != 'merge_group'
     name: 'Validate link to issues'
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +35,7 @@ jobs:
           build/scripts/PullRequestValidation/ValidateIssuesForPullRequest.ps1 -PullRequestNumber ${{ github.event.pull_request.number }} -Repository ${{ github.repository }}
 
   WorkItemValidationForMicrosoft:
-    if: github.repository_owner == 'microsoft' && github.event.pull_request.state == 'open'
+    if: github.repository_owner == 'microsoft' && github.event.pull_request.state == 'open' && github.event_name != 'merge_group'
     name: 'For Microsoft: Validate link to internal work items'
     runs-on: ubuntu-latest
     needs: GitHubIssueValidation


### PR DESCRIPTION
Fixes WorkItemValidation workflow for merge queues by adding correct trigger and skipping jobs.

[AB#612711](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612711)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

