### PR TITLE
Skip automation on out-of-support branches

### DIFF
--- a/.github/actions/RunAutomation/HowToAddAnAutomation.md
+++ b/.github/actions/RunAutomation/HowToAddAnAutomation.md
@@ -1,5 +1,8 @@
 # How to add a new automation
 
+> [!NOTE]
+> Automations run through `RunAutomation` are automatically skipped on branches that are out of support (branches with the "Branch is out of support" ruleset). No pull request is created for those branches, so you don't need to handle this in your automation.
+
 1. Create a folder in `.github\actions\RunAutomations`. The name of the folder is the name of the automation, e.g. "_UpdateAppBaselines_".
 2. Create a `run.ps1` file in the new folder. It should contain the script with the automation's logic.
    - The script can accept the following parameters:

--- a/.github/actions/RunAutomation/UpdateSystemFilesSchedule/run.ps1
+++ b/.github/actions/RunAutomation/UpdateSystemFilesSchedule/run.ps1
@@ -1,0 +1,93 @@
+<#
+.Synopsis
+    Updates the branch list of the "Update AL-Go System Files" scheduled run so it only targets supported branches.
+.Description
+    The "Update AL-Go System Files" workflow (UpdateGitHubGoSystemFiles.yaml) is an AL-Go system file and
+    picks the branches to run on from the 'workflowSchedule.includeBranches' setting in
+    '.github/Update AL-Go System Files.settings.json'. Unlike the other BCApps automations, it does not use
+    the GetGitBranches action and therefore has no knowledge of the "Branch is out of support" ruleset.
+
+    This automation rewrites 'workflowSchedule.includeBranches' with the explicit list of every official
+    branch (main and releases/*) that is currently in support. The list contains no wildcards and is
+    recomputed on every run, so out-of-support branches are dropped and newly created branches are added.
+.Parameter runParameters
+    A hashtable with the parameters passed by the RunAutomation action (Repository and TargetBranch).
+#>
+param (
+    [Parameter(Mandatory = $true)]
+    $runParameters
+)
+
+Import-Module $PSScriptRoot\..\..\..\..\build\scripts\EnlistmentHelperFunctions.psm1 -DisableNameChecking
+
+$repository = $runParameters.Repository
+
+$result = @{
+    'Files'   = @()
+    'Message' = "No update available"
+}
+
+$settingsRelativePath = ".github/Update AL-Go System Files.settings.json"
+$settingsPath = Join-Path (Get-BaseFolder) $settingsRelativePath
+
+if (-not (Test-Path $settingsPath)) {
+    Write-Host "Settings file '$settingsRelativePath' not found. Nothing to update."
+    return $result
+}
+
+$settings = Get-Content -Path $settingsPath -Raw | ConvertFrom-Json
+
+if (-not $settings.workflowSchedule) {
+    Write-Host "No 'workflowSchedule' configured in '$settingsRelativePath'. Nothing to update."
+    return $result
+}
+
+$currentBranches = @($settings.workflowSchedule.includeBranches)
+Write-Host "Configured branches: $($currentBranches -join ', ')"
+
+# The official branches, matching the definition used by the GetGitBranches action.
+$officialBranchPatterns = @('main', 'releases/*')
+
+# Fetch all remote branches so the official branches can be listed explicitly.
+RunAndCheck git fetch --quiet origin "+refs/heads/*:refs/remotes/origin/*"
+$allBranches = @(RunAndCheck git for-each-ref --format="%(refname:short)" refs/remotes/origin/) | Where-Object { $_ -ne 'origin' } | ForEach-Object { $_ -replace '^origin/', '' }
+
+# Keep only the official branches (main and releases/*) that are in support.
+$supportedBranches = @(
+    $allBranches | Where-Object {
+        $branch = $_
+        ($officialBranchPatterns | Where-Object { $branch -like $_ }) -and (Test-IsBranchInSupport -BranchName $branch -Repository $repository)
+    }
+)
+
+# Order deterministically ('main' first, then release branches in natural numeric order) to keep diffs clean.
+function Get-BranchSortKey {
+    param([string] $Branch)
+    if ($Branch -eq 'main') {
+        return '0'
+    }
+    # Zero-pad numeric segments so e.g. releases/26.2 sorts before releases/26.10.
+    $padded = [regex]::Replace($Branch, '\d+', { param($m) $m.Value.PadLeft(10, '0') })
+    return "1$padded"
+}
+$supportedBranches = @($supportedBranches | Select-Object -Unique | Sort-Object { Get-BranchSortKey $_ })
+
+if ($supportedBranches.Count -eq 0) {
+    Write-Host "::Warning::No supported official branches found; leaving the schedule unchanged."
+    return $result
+}
+
+if (($currentBranches -join ',') -eq ($supportedBranches -join ',')) {
+    Write-Host "Scheduled branches already match the supported official branches. Nothing to update."
+    return $result
+}
+
+Write-Host "Updated branches: $($supportedBranches -join ', ')"
+
+$settings.workflowSchedule.includeBranches = @($supportedBranches)
+$settings | ConvertTo-Json -Depth 100 | Set-ContentLF -Path $settingsPath
+
+$result.Files = @($settingsRelativePath)
+$result.Message = "Update Update AL-Go System Files schedule to only include supported branches"
+
+return $result

--- a/.github/actions/RunAutomation/run.ps1
+++ b/.github/actions/RunAutomation/run.ps1
@@ -29,6 +29,15 @@ param(
 
 $ErrorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
 
+Import-Module $PSScriptRoot\..\..\..\build\scripts\EnlistmentHelperFunctions.psm1 -DisableNameChecking
+
+# Do not run automations on branches that are out of support (branches with the "Branch is out of support" ruleset).
+# This is a safety net that also covers manual (workflow_dispatch) runs, which bypass the GetGitBranches filtering.
+if (-not (Test-IsBranchInSupport -BranchName $TargetBranch -Repository $Repository)) {
+    Write-Host "::Notice::Skipping automations because branch '$TargetBranch' is out of support."
+    return
+}
+
 function RunAutomation {
     param(
         [Parameter(Mandatory=$true)]

--- a/.github/workflows/UpdateALGoSupportedBranches.yaml
+++ b/.github/workflows/UpdateALGoSupportedBranches.yaml
@@ -1,0 +1,45 @@
+name: Update AL-Go Supported Branches
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 5 5 * *' # Monthly on the 5th at 05:30 UTC
+
+defaults:
+  run:
+    shell: powershell
+
+permissions: read-all
+
+jobs:
+  UpdateALGoSupportedBranches:
+    name: Update AL-Go Supported Branches
+    if: github.repository_owner == 'microsoft'
+    permissions:
+      contents: write
+    environment: Official-Build
+    runs-on: windows-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Update AL-Go Supported Branches
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        uses: microsoft/BCApps/.github/actions/RunAutomation@main
+        with:
+          automations: UpdateSystemFilesSchedule
+          targetBranch: main


### PR DESCRIPTION
Fixes [AB#641122](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641122)

## Summary

BCApps automations that open PRs to official branches should not run on branches that are out of support (branches carrying the **"Branch is out of support"** ruleset). Most automations already filter these out via the `GetGitBranches` action, but there were two gaps this PR closes.

## Changes

**1. Defense-in-depth guard in the shared `RunAutomation` action** — `.github/actions/RunAutomation/run.ps1`
Before running any automation, the action now checks the target branch with `Test-IsBranchInSupport` and returns early with a `::Notice::` if the branch is out of support. This covers every current and future `RunAutomation`-based automation, including manual `workflow_dispatch` runs that bypass the `GetGitBranches` filtering.

**2. New automation to keep the AL-Go schedule in sync** — `.github/actions/RunAutomation/UpdateSystemFilesSchedule/run.ps1`
The **Update AL-Go System Files** workflow (`UpdateGitHubGoSystemFiles.yaml`) is an AL-Go–generated file that picks its branches from `workflowSchedule.includeBranches` in `.github/Update AL-Go System Files.settings.json`. Unlike the other automations it does **not** use `GetGitBranches`, so it has no knowledge of the ruleset and can create PRs against out-of-support branches (the list was already stale — e.g. `releases/25.*`).

This new automation rewrites `includeBranches` with the explicit list of every official branch (`main` + `releases/*`) that is currently in support:
- No wildcards — every branch is listed explicitly.
- Recomputed on each run, so out-of-support branches drop off and newly created branches are picked up.
- Deterministic ordering (`main` first, then natural numeric order) to keep diffs clean.

**3. New workflow** — `.github/workflows/UpdateALGoSupportedBranches.yaml`
Runs the new automation on `main` (monthly + `workflow_dispatch`), mirroring the structure of the existing automation workflows.

**4. Docs** — `.github/actions/RunAutomation/HowToAddAnAutomation.md`
Notes that automations are automatically skipped on out-of-support branches, so new automations don't need to handle it.

## Validation

Ran the new automation against the live rulesets. It correctly dropped the out-of-support branches (`releases/25.*`, `releases/26.0`–`26.3`) and produced the explicit in-support list (`main`, `releases/26.4`, `releases/26.5`, `releases/26.x`, `releases/27.0`–`27.5`, `releases/27.x`, `releases/28.0`–`28.3`, `releases/28.x`).


