### PR TITLE
[28.x] [Subcontracting] Bug 641028: Remove references to obsoleted base 'Subcontractor - Dispatch List' a…

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcWorkCenterCard.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcWorkCenterCard.PageExt.al
@@ -5,6 +5,7 @@
 namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.WorkCenter;
+using Microsoft.Purchases.Document;
 
 pageextension 99001506 "Subc. Work Center Card" extends "Work Center Card"
 {
@@ -47,6 +48,22 @@ pageextension 99001506 "Subc. Work Center Card" extends "Work Center Card"
                     RunObject = page "Subc. WIP Ledger Entries";
                     RunPageLink = "Work Center No." = field("No.");
                     ToolTip = 'View the Subcontracting WIP Entries that track work-in-progress quantities at this work center''s subcontracting location.';
+                }
+                action("Subcontractor - Dispatch List")
+                {
+                    ApplicationArea = Subcontracting;
+                    Caption = 'Subcontractor - Dispatch List';
+                    Enabled = IsSubcontractingWorkCenter;
+                    Image = Print;
+                    ToolTip = 'Print the dispatching list for the subcontractor assigned to this work center.';
+
+                    trigger OnAction()
+                    var
+                        PurchaseHeader: Record "Purchase Header";
+                    begin
+                        PurchaseHeader.SetRange("Buy-from Vendor No.", Rec."Subcontractor No.");
+                        Report.Run(Report::"Subc. Dispatching List", true, false, PurchaseHeader);
+                    end;
                 }
             }
         }

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcWorkCenterCard.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcWorkCenterCard.PageExt.al
@@ -49,7 +49,7 @@ pageextension 99001506 "Subc. Work Center Card" extends "Work Center Card"
                     RunPageLink = "Work Center No." = field("No.");
                     ToolTip = 'View the Subcontracting WIP Entries that track work-in-progress quantities at this work center''s subcontracting location.';
                 }
-                action("Subcontractor - Dispatch List")
+                action("Subcontractor Dispatch List")
                 {
                     ApplicationArea = Subcontracting;
                     Caption = 'Subcontractor - Dispatch List';

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcWorkCenterCard.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcWorkCenterCard.PageExt.al
@@ -50,10 +50,6 @@ pageextension 99001506 "Subc. Work Center Card" extends "Work Center Card"
                 }
             }
         }
-        modify("Subcontractor - Dispatch List")
-        {
-            Enabled = IsSubcontractingWorkCenter;
-        }
     }
 
     trigger OnOpenPage()

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcWorkCenterCard.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcWorkCenterCard.PageExt.al
@@ -67,6 +67,12 @@ pageextension 99001506 "Subc. Work Center Card" extends "Work Center Card"
                 }
             }
         }
+#if not CLEAN28
+        modify("Subcontractor - Dispatch List")
+        {
+            Enabled = IsSubcontractingWorkCenter;
+        }
+#endif
     }
 
     trigger OnOpenPage()

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingUITest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingUITest.Codeunit.al
@@ -278,6 +278,50 @@ codeunit 139990 "Subc. Subcontracting UI Test"
     end;
 
     [Test]
+    procedure WorkCenterCardDispatchListDisabledWhenNotSubcontracting()
+    var
+        WorkCenter: Record "Work Center";
+        WorkCenterCard: TestPage "Work Center Card";
+    begin
+        // [SCENARIO 633206] Subcontractor - Dispatch List action is disabled on Work Center Card when Work Center has no Subcontractor No.
+        Initialize();
+
+        // [GIVEN] A Work Center without a Subcontractor No.
+        LibraryMfgManagement.CreateWorkCenterWithCalendar(WorkCenter, 0);
+
+        // [WHEN] The Work Center Card page is opened for the Work Center
+        WorkCenterCard.OpenEdit();
+        WorkCenterCard.GotoRecord(WorkCenter);
+
+        // [THEN] Subcontractor - Dispatch List action is not enabled
+        Assert.IsFalse(WorkCenterCard."Subcontractor - Dispatch List".Enabled(), SubcontractingActionsEnabledErr);
+        WorkCenterCard.Close();
+    end;
+
+    [Test]
+    procedure WorkCenterCardDispatchListEnabledWhenSubcontracting()
+    var
+        WorkCenter: Record "Work Center";
+        WorkCenterCard: TestPage "Work Center Card";
+    begin
+        // [SCENARIO 633206] Subcontractor - Dispatch List action is enabled on Work Center Card when Work Center has a Subcontractor No.
+        Initialize();
+
+        // [GIVEN] A Work Center with a Subcontractor No.
+        LibraryMfgManagement.CreateWorkCenterWithCalendar(WorkCenter, 0);
+        WorkCenter.Validate("Subcontractor No.", LibraryMfgManagement.CreateSubcontractorWithCurrency(''));
+        WorkCenter.Modify(true);
+
+        // [WHEN] The Work Center Card page is opened for the Work Center
+        WorkCenterCard.OpenEdit();
+        WorkCenterCard.GotoRecord(WorkCenter);
+
+        // [THEN] Subcontractor - Dispatch List action is enabled
+        Assert.IsTrue(WorkCenterCard."Subcontractor - Dispatch List".Enabled(), SubcontractingActionsNotEnabledErr);
+        WorkCenterCard.Close();
+    end;
+
+    [Test]
     procedure WorkCenterListSubcontractingActionsDisabledWhenNotSubcontracting()
     var
         WorkCenter: Record "Work Center";

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingUITest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingUITest.Codeunit.al
@@ -278,50 +278,6 @@ codeunit 139990 "Subc. Subcontracting UI Test"
     end;
 
     [Test]
-    procedure WorkCenterCardDispatchListDisabledWhenNotSubcontracting()
-    var
-        WorkCenter: Record "Work Center";
-        WorkCenterCard: TestPage "Work Center Card";
-    begin
-        // [SCENARIO 633206] Subcontractor - Dispatch List action is disabled on Work Center Card when Work Center has no Subcontractor No.
-        Initialize();
-
-        // [GIVEN] A Work Center without a Subcontractor No.
-        LibraryMfgManagement.CreateWorkCenterWithCalendar(WorkCenter, 0);
-
-        // [WHEN] The Work Center Card page is opened for the Work Center
-        WorkCenterCard.OpenEdit();
-        WorkCenterCard.GotoRecord(WorkCenter);
-
-        // [THEN] Subcontractor - Dispatch List action is not enabled
-        Assert.IsFalse(WorkCenterCard."Subcontractor - Dispatch List".Enabled(), SubcontractingActionsEnabledErr);
-        WorkCenterCard.Close();
-    end;
-
-    [Test]
-    procedure WorkCenterCardDispatchListEnabledWhenSubcontracting()
-    var
-        WorkCenter: Record "Work Center";
-        WorkCenterCard: TestPage "Work Center Card";
-    begin
-        // [SCENARIO 633206] Subcontractor - Dispatch List action is enabled on Work Center Card when Work Center has a Subcontractor No.
-        Initialize();
-
-        // [GIVEN] A Work Center with a Subcontractor No.
-        LibraryMfgManagement.CreateWorkCenterWithCalendar(WorkCenter, 0);
-        WorkCenter.Validate("Subcontractor No.", LibraryMfgManagement.CreateSubcontractorWithCurrency(''));
-        WorkCenter.Modify(true);
-
-        // [WHEN] The Work Center Card page is opened for the Work Center
-        WorkCenterCard.OpenEdit();
-        WorkCenterCard.GotoRecord(WorkCenter);
-
-        // [THEN] Subcontractor - Dispatch List action is enabled
-        Assert.IsTrue(WorkCenterCard."Subcontractor - Dispatch List".Enabled(), SubcontractingActionsNotEnabledErr);
-        WorkCenterCard.Close();
-    end;
-
-    [Test]
     procedure WorkCenterListSubcontractingActionsDisabledWhenNotSubcontracting()
     var
         WorkCenter: Record "Work Center";

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingUITest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingUITest.Codeunit.al
@@ -294,7 +294,7 @@ codeunit 139990 "Subc. Subcontracting UI Test"
         WorkCenterCard.GotoRecord(WorkCenter);
 
         // [THEN] Subcontractor - Dispatch List action is not enabled
-        Assert.IsFalse(WorkCenterCard."Subcontractor - Dispatch List".Enabled(), SubcontractingActionsEnabledErr);
+        Assert.IsFalse(WorkCenterCard."Subcontractor Dispatch List".Enabled(), SubcontractingActionsEnabledErr);
         WorkCenterCard.Close();
     end;
 
@@ -317,7 +317,7 @@ codeunit 139990 "Subc. Subcontracting UI Test"
         WorkCenterCard.GotoRecord(WorkCenter);
 
         // [THEN] Subcontractor - Dispatch List action is enabled
-        Assert.IsTrue(WorkCenterCard."Subcontractor - Dispatch List".Enabled(), SubcontractingActionsNotEnabledErr);
+        Assert.IsTrue(WorkCenterCard."Subcontractor Dispatch List".Enabled(), SubcontractingActionsNotEnabledErr);
         WorkCenterCard.Close();
     end;
 


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#641028](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641028)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->









