### PR TITLE
[28.3] [E-Document] Remove Access = Internal from E-Doc. Data Exchange Impl. codeunit

### DIFF
--- a/src/Apps/W1/EDocument/App/src/DataExchange/EDocDataExchangeImpl.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/DataExchange/EDocDataExchangeImpl.Codeunit.al
@@ -19,7 +19,6 @@ using System.Utilities;
 
 codeunit 6152 "E-Doc. Data Exchange Impl." implements "E-Document"
 {
-    Access = Internal;
     procedure Check(var SourceDocumentHeader: RecordRef; EDocumentService: Record "E-Document Service"; EDocumentProcessingPhase: Enum "E-Document Processing Phase")
     var
         SalesHeader: Record "Sales Header";

--- a/src/Apps/W1/EDocument/App/src/DataExchange/EDocServiceDataExchDef.Table.al
+++ b/src/Apps/W1/EDocument/App/src/DataExchange/EDocServiceDataExchDef.Table.al
@@ -9,7 +9,6 @@ using System.IO;
 
 table 6139 "E-Doc. Service Data Exch. Def."
 {
-    Access = Internal;
     DataClassification = CustomerContent;
     ReplicateData = false;
 


### PR DESCRIPTION
Fixes [AB#641218](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641218)

Port of the change to releases/28.3. Removes `Access = Internal` from the `E-Doc. Data Exchange Impl.` codeunit (6152) so partners can reuse the functions in their own E-Document implementations.


