### PR TITLE
[Main]-Incident 21000001049308 : [BC-IN] Purchase invoice with a deferral schedule and Non-availment GST is not functioning correctly

### DIFF
--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-PostingHandler/src/StandardPostingSubscribers/GenJnlPostHandler.Codeunit.al
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-PostingHandler/src/StandardPostingSubscribers/GenJnlPostHandler.Codeunit.al
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Finance.TaxEngine.PostingHandler;
 
+using Microsoft.Finance.Deferral;
 using Microsoft.Finance.GeneralLedger.Journal;
 using Microsoft.Finance.GeneralLedger.Posting;
 using Microsoft.Finance.TaxEngine.TaxTypeHandler;
@@ -53,6 +54,12 @@ codeunit 20334 "Gen. Jnl.-Post Handler"
             GenJnlLine."Line No.");
 
         OnAfterGenJnlLinePostFromTaxEngine(GenJnlLine);
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Deferral Utilities", 'OnBeforeCheckDeferralConditionForGenJournal', '', false, false)]
+    local procedure OnBeforeCheckDeferralConditionForGenJournal(var GenJournalLine: Record "Gen. Journal Line"; var IsHandled: Boolean)
+    begin
+        IsHandled := true;
     end;
 
     [IntegrationEvent(true, false)]


### PR DESCRIPTION
[Bug 641225](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/641225): Incident 21000001049308 : [BC-IN] Purchase invoice with a deferral schedule and Non-availment GST is not functioning correctly

[AB#641225](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640621)

**Issue:** A purchase invoice with Non-availment GST does not get posted when a Default Deferral Template is configured on the G/L Account Card.

**Cause:** The base application's CheckDeferralConditionForGenJournal validation in codeunit Deferral Utilities raises an error for the general journal line, which blocks the posting.

**Solution:** Subscribed to the OnBeforeCheckDeferralConditionForGenJournal event in codeunit Gen. Jnl.-Post Handler to handle this validation for the IN Localization in the Tax Engine application. This change also resolves the related Journal Voucher posting issue caused by the same validation.



