### PR TITLE
Get rid of new warnings in new AT tests

### DIFF
--- a/src/Layers/AT/Tests/Local/VATSTAT.Codeunit.al
+++ b/src/Layers/AT/Tests/Local/VATSTAT.Codeunit.al
@@ -1610,8 +1610,8 @@ codeunit 144001 VATSTAT
     var
         PurchaseHeader: Record "Purchase Header";
         VATStatementLine: Record "VAT Statement Line";
-        VATStatementAT: Report "VAT Statement AT";
         Item: Record Item;
+        VATStatementAT: Report "VAT Statement AT";
         VATTotalRowNo: Code[10];
         VATBusPostingGroupCode: Code[20];
         VATProPostingGroupCode: Code[20];


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

We must not introduce new warnings - it breaks BCApps uptake

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#641121](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641121)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->


