### PR TITLE
[DO NOT MERGE] Test: failOn newWarning with workspace compilation

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/39fa5591e01f7569384bba8cad40cabdb5618a01/Actions/.Modules/settings.schema.json",
+  "failOn": "newWarning",
   "type": "PTE",
   "templateUrl": "https://github.com/microsoft/AL-Go-PTE@preview",
   "bcContainerHelperVersion": "preview",

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -104,7 +104,7 @@ jobs:
           lfs: true
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/ReadSettings@0202919bc13d4d41aa99f8f9be9b991b10faf164
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Run Build Initialize hook
         if: hashFiles(format('{0}/.AL-Go/BuildInitialize.ps1', inputs.project)) != ''
-        uses: microsoft/AL-Go/Actions/RunHook@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/RunHook@0202919bc13d4d41aa99f8f9be9b991b10faf164
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Determine whether to build project
         id: DetermineBuildProject
-        uses: microsoft/AL-Go/Actions/DetermineBuildProject@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/DetermineBuildProject@0202919bc13d4d41aa99f8f9be9b991b10faf164
         with:
           shell: ${{ inputs.shell }}
           skippedProjectsJson: ${{ inputs.skippedProjectsJson }}
@@ -131,7 +131,7 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/ReadSecrets@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/ReadSecrets@0202919bc13d4d41aa99f8f9be9b991b10faf164
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -149,7 +149,7 @@ jobs:
       - name: Determine ArtifactUrl
         id: determineArtifactUrl
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@0202919bc13d4d41aa99f8f9be9b991b10faf164
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -164,7 +164,7 @@ jobs:
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@0202919bc13d4d41aa99f8f9be9b991b10faf164
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -177,14 +177,14 @@ jobs:
       - name: Download Previous Release
         id: DownloadPreviousRelease
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && env.skipUpgrade == 'False'
-        uses: microsoft/AL-Go/Actions/DownloadPreviousRelease@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/DownloadPreviousRelease@0202919bc13d4d41aa99f8f9be9b991b10faf164
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
 
       - name: Compile Apps
         id: compile
-        uses: microsoft/AL-Go/Actions/CompileApps@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/CompileApps@0202919bc13d4d41aa99f8f9be9b991b10faf164
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && fromJson(env.workspaceCompilation).enabled == true
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -211,7 +211,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "NeedsContext=$needsContextPath"
 
       - name: Build
-        uses: microsoft/AL-Go/Actions/RunPipeline@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/RunPipeline@0202919bc13d4d41aa99f8f9be9b991b10faf164
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -231,7 +231,7 @@ jobs:
       - name: Sign
         id: sign
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != '')) && (hashFiles(format('{0}/.buildartifacts/Apps/*.app',inputs.project)) != '')
-        uses: microsoft/AL-Go/Actions/Sign@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/Sign@0202919bc13d4d41aa99f8f9be9b991b10faf164
         with:
           shell: ${{ inputs.shell }}
           azureCredentialsJson: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).AZURE_CREDENTIALS }}'
@@ -239,7 +239,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@0202919bc13d4d41aa99f8f9be9b991b10faf164
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -354,7 +354,7 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: (success() || failure()) && env.doNotRunTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@0202919bc13d4d41aa99f8f9be9b991b10faf164
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -363,7 +363,7 @@ jobs:
       - name: Analyze BCPT Test Results
         id: analyzeTestResultsBCPT
         if: (success() || failure()) && env.doNotRunBcptTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@0202919bc13d4d41aa99f8f9be9b991b10faf164
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -372,7 +372,7 @@ jobs:
       - name: Analyze Page Scripting Test Results
         id: analyzeTestResultsPageScripting
         if: (success() || failure()) && env.doNotRunpageScriptingTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@0202919bc13d4d41aa99f8f9be9b991b10faf164
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -380,7 +380,7 @@ jobs:
 
       - name: Cleanup
         if: always() && steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/PipelineCleanup@8f90b059cf10cff132569f6e5e2159d66fbd810c
+        uses: microsoft/AL-Go/Actions/PipelineCleanup@0202919bc13d4d41aa99f8f9be9b991b10faf164
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -104,7 +104,7 @@ jobs:
           lfs: true
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/ReadSettings@8f90b059cf10cff132569f6e5e2159d66fbd810c
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Run Build Initialize hook
         if: hashFiles(format('{0}/.AL-Go/BuildInitialize.ps1', inputs.project)) != ''
-        uses: microsoft/AL-Go/Actions/RunHook@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/RunHook@8f90b059cf10cff132569f6e5e2159d66fbd810c
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Determine whether to build project
         id: DetermineBuildProject
-        uses: microsoft/AL-Go/Actions/DetermineBuildProject@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/DetermineBuildProject@8f90b059cf10cff132569f6e5e2159d66fbd810c
         with:
           shell: ${{ inputs.shell }}
           skippedProjectsJson: ${{ inputs.skippedProjectsJson }}
@@ -131,7 +131,7 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/ReadSecrets@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/ReadSecrets@8f90b059cf10cff132569f6e5e2159d66fbd810c
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -149,7 +149,7 @@ jobs:
       - name: Determine ArtifactUrl
         id: determineArtifactUrl
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@8f90b059cf10cff132569f6e5e2159d66fbd810c
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -164,7 +164,7 @@ jobs:
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@8f90b059cf10cff132569f6e5e2159d66fbd810c
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -177,14 +177,14 @@ jobs:
       - name: Download Previous Release
         id: DownloadPreviousRelease
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && env.skipUpgrade == 'False'
-        uses: microsoft/AL-Go/Actions/DownloadPreviousRelease@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/DownloadPreviousRelease@8f90b059cf10cff132569f6e5e2159d66fbd810c
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
 
       - name: Compile Apps
         id: compile
-        uses: microsoft/AL-Go/Actions/CompileApps@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/CompileApps@8f90b059cf10cff132569f6e5e2159d66fbd810c
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && fromJson(env.workspaceCompilation).enabled == true
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -211,7 +211,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "NeedsContext=$needsContextPath"
 
       - name: Build
-        uses: microsoft/AL-Go/Actions/RunPipeline@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/RunPipeline@8f90b059cf10cff132569f6e5e2159d66fbd810c
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -231,7 +231,7 @@ jobs:
       - name: Sign
         id: sign
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != '')) && (hashFiles(format('{0}/.buildartifacts/Apps/*.app',inputs.project)) != '')
-        uses: microsoft/AL-Go/Actions/Sign@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/Sign@8f90b059cf10cff132569f6e5e2159d66fbd810c
         with:
           shell: ${{ inputs.shell }}
           azureCredentialsJson: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).AZURE_CREDENTIALS }}'
@@ -239,7 +239,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@8f90b059cf10cff132569f6e5e2159d66fbd810c
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -354,7 +354,7 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: (success() || failure()) && env.doNotRunTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@8f90b059cf10cff132569f6e5e2159d66fbd810c
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -363,7 +363,7 @@ jobs:
       - name: Analyze BCPT Test Results
         id: analyzeTestResultsBCPT
         if: (success() || failure()) && env.doNotRunBcptTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@8f90b059cf10cff132569f6e5e2159d66fbd810c
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -372,7 +372,7 @@ jobs:
       - name: Analyze Page Scripting Test Results
         id: analyzeTestResultsPageScripting
         if: (success() || failure()) && env.doNotRunpageScriptingTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@8f90b059cf10cff132569f6e5e2159d66fbd810c
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -380,7 +380,7 @@ jobs:
 
       - name: Cleanup
         if: always() && steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/PipelineCleanup@39fa5591e01f7569384bba8cad40cabdb5618a01
+        uses: microsoft/AL-Go/Actions/PipelineCleanup@8f90b059cf10cff132569f6e5e2159d66fbd810c
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -104,7 +104,7 @@ jobs:
           lfs: true
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/ReadSettings@dff510b89d20243487b7b71780b71a5e2f38a5f5
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Run Build Initialize hook
         if: hashFiles(format('{0}/.AL-Go/BuildInitialize.ps1', inputs.project)) != ''
-        uses: microsoft/AL-Go/Actions/RunHook@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/RunHook@dff510b89d20243487b7b71780b71a5e2f38a5f5
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Determine whether to build project
         id: DetermineBuildProject
-        uses: microsoft/AL-Go/Actions/DetermineBuildProject@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/DetermineBuildProject@dff510b89d20243487b7b71780b71a5e2f38a5f5
         with:
           shell: ${{ inputs.shell }}
           skippedProjectsJson: ${{ inputs.skippedProjectsJson }}
@@ -131,7 +131,7 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/ReadSecrets@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/ReadSecrets@dff510b89d20243487b7b71780b71a5e2f38a5f5
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -149,7 +149,7 @@ jobs:
       - name: Determine ArtifactUrl
         id: determineArtifactUrl
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@dff510b89d20243487b7b71780b71a5e2f38a5f5
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -164,7 +164,7 @@ jobs:
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@dff510b89d20243487b7b71780b71a5e2f38a5f5
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -177,14 +177,14 @@ jobs:
       - name: Download Previous Release
         id: DownloadPreviousRelease
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && env.skipUpgrade == 'False'
-        uses: microsoft/AL-Go/Actions/DownloadPreviousRelease@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/DownloadPreviousRelease@dff510b89d20243487b7b71780b71a5e2f38a5f5
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
 
       - name: Compile Apps
         id: compile
-        uses: microsoft/AL-Go/Actions/CompileApps@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/CompileApps@dff510b89d20243487b7b71780b71a5e2f38a5f5
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && fromJson(env.workspaceCompilation).enabled == true
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -211,7 +211,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "NeedsContext=$needsContextPath"
 
       - name: Build
-        uses: microsoft/AL-Go/Actions/RunPipeline@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/RunPipeline@dff510b89d20243487b7b71780b71a5e2f38a5f5
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -231,7 +231,7 @@ jobs:
       - name: Sign
         id: sign
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != '')) && (hashFiles(format('{0}/.buildartifacts/Apps/*.app',inputs.project)) != '')
-        uses: microsoft/AL-Go/Actions/Sign@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/Sign@dff510b89d20243487b7b71780b71a5e2f38a5f5
         with:
           shell: ${{ inputs.shell }}
           azureCredentialsJson: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).AZURE_CREDENTIALS }}'
@@ -239,7 +239,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@dff510b89d20243487b7b71780b71a5e2f38a5f5
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -354,7 +354,7 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: (success() || failure()) && env.doNotRunTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@dff510b89d20243487b7b71780b71a5e2f38a5f5
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -363,7 +363,7 @@ jobs:
       - name: Analyze BCPT Test Results
         id: analyzeTestResultsBCPT
         if: (success() || failure()) && env.doNotRunBcptTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@dff510b89d20243487b7b71780b71a5e2f38a5f5
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -372,7 +372,7 @@ jobs:
       - name: Analyze Page Scripting Test Results
         id: analyzeTestResultsPageScripting
         if: (success() || failure()) && env.doNotRunpageScriptingTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@dff510b89d20243487b7b71780b71a5e2f38a5f5
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -380,7 +380,7 @@ jobs:
 
       - name: Cleanup
         if: always() && steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/PipelineCleanup@0202919bc13d4d41aa99f8f9be9b991b10faf164
+        uses: microsoft/AL-Go/Actions/PipelineCleanup@dff510b89d20243487b7b71780b71a5e2f38a5f5
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}

--- a/src/Apps/NZ/ContosoCoffeeDemoDatasetNZ/app/DemoTool/Contoso Helpers/ContosoNZCounty.Codeunit.al
+++ b/src/Apps/NZ/ContosoCoffeeDemoDatasetNZ/app/DemoTool/Contoso Helpers/ContosoNZCounty.Codeunit.al
@@ -15,7 +15,10 @@ codeunit 17118 "Contoso NZ County"
         tabledata County = rim;
 
     procedure SetOverwriteData(Overwrite: Boolean)
+    var
+        UnusedValue: Integer;
     begin
+        UnusedValue := 42;
         OverwriteData := Overwrite;
     end;
 


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE — test PR.** This validates an AL-Go fix and will be closed.

## Purpose
Validates microsoft/AL-Go change (branch `aholstrup1-vigilant-spork`, SHA 8f90b059) that makes `failOn: newWarning` work with **workspace compilation**. Previously the new-warning check only ran in the `RunPipeline` action, so it had no effect when `workspaceCompilation` was enabled (compilation happens in `CompileApps`).

## What this PR does
1. Repoints the AL-Go actions in `_BuildALGoProject.yaml` from the pinned SHA to the fix branch (`@8f90b059`).
2. Enables `"failOn": "newWarning"` at repo level.
3. Introduces one new warning (AA0206 — variable initialized but not used) in an NZ-only demo codeunit.

## Expected result
CI/CD **fails** for project **Apps NZ** with *"New warnings were introduced in this PR"* (AA0206), demonstrating the check now fires under workspace compilation. Other projects should build normally (transition note: baseline artifacts on main predate the fix).



