### PR TITLE
[VAT Group Management] Optimize setup validation

### DIFF
--- a/src/Apps/W1/VATGroupManagement/app/src/Codeunits/VATGroupCommunication.Codeunit.al
+++ b/src/Apps/W1/VATGroupManagement/app/src/Codeunits/VATGroupCommunication.Codeunit.al
@@ -80,8 +80,6 @@ codeunit 4700 "VAT Group Communication"
         else
             RequestUri := PrepareURI(Endpoint);
 
-        // Re-validate the host right before sending so a request carrying the OAuth bearer token can never be
-        // directed to a host outside the allowlist, even if the stored URL was set through another code path.
         if EnvironmentInformation.IsSaaSInfrastructure() then
             if not VATReportSetup.IsAllowedGroupRepresentativeAPIURL(RequestUri) then
                 Error(InvalidGroupRepresentativeURLErr);

--- a/src/Apps/W1/VATGroupManagement/app/src/Codeunits/VATGroupCommunication.Codeunit.al
+++ b/src/Apps/W1/VATGroupManagement/app/src/Codeunits/VATGroupCommunication.Codeunit.al
@@ -16,6 +16,7 @@ codeunit 4700 "VAT Group Communication"
     var
         VATReportSetup: Record "VAT Report Setup";
         NoVATSetupErr: Label 'The VAT Report Setup could not be found.';
+        InvalidGroupRepresentativeURLErr: Label 'The Group Representative API URL is not a valid Microsoft Business Central endpoint.';
         BearerTokenFromCacheErr: Label 'The OAuth2 token could not be retrieved from cache. Choose the action Renew OAuth2 Token on the page %1 and log in to get a new token.', Comment = '%1 the caption of a page.';
         OAuthFailedNoErr: label 'Authorization has failed with an unexpected error.';
         OAuthFailedErr: Label 'Authorization has failed with the error %1', Comment = '%1 is the error description.';
@@ -66,17 +67,27 @@ codeunit 4700 "VAT Group Communication"
     [TryFunction]
     internal procedure Send(Method: Text; Endpoint: Text; Content: Text; var HttpResponseBodyText: Text; IsBatch: Boolean)
     var
+        EnvironmentInformation: Codeunit "Environment Information";
         HttpClient: HttpClient;
         HttpRequestMessage: HttpRequestMessage;
         HttpResponseMessage: HttpResponseMessage;
+        RequestUri: Text;
     begin
         CheckLoadVATReportSetup();
 
-        HttpRequestMessage.Method(Method);
         if IsBatch then
-            HttpRequestMessage.SetRequestUri(PrepareBatchURI(Endpoint))
+            RequestUri := PrepareBatchURI(Endpoint)
         else
-            HttpRequestMessage.SetRequestUri(PrepareURI(Endpoint));
+            RequestUri := PrepareURI(Endpoint);
+
+        // Re-validate the host right before sending so a request carrying the OAuth bearer token can never be
+        // directed to a host outside the allowlist, even if the stored URL was set through another code path.
+        if EnvironmentInformation.IsSaaSInfrastructure() then
+            if not VATReportSetup.IsAllowedGroupRepresentativeAPIURL(RequestUri) then
+                Error(InvalidGroupRepresentativeURLErr);
+
+        HttpRequestMessage.Method(Method);
+        HttpRequestMessage.SetRequestUri(RequestUri);
         PrepareHeaders(HttpRequestMessage, IsBatch);
         PrepareContent(HttpRequestMessage, Content);
 

--- a/src/Apps/W1/VATGroupManagement/app/src/Tables/VATReportSetupExtension.TableExt.al
+++ b/src/Apps/W1/VATGroupManagement/app/src/Tables/VATReportSetupExtension.TableExt.al
@@ -269,14 +269,14 @@ tableextension 4701 "VAT Report Setup Extension" extends "VAT Report Setup"
     internal procedure IsAllowedGroupRepresentativeAPIURL(ApiUrl: Text): Boolean
     var
         Uri: Codeunit Uri;
-        Host: Text;
     begin
         Uri.Init(ApiUrl);
         if LowerCase(Uri.GetScheme()) <> 'https' then
             exit(false);
 
-        Host := LowerCase(Uri.GetHost());
-        exit((Host = 'api.businesscentral.dynamics.com') or (Host = 'api.businesscentral.dynamics-tie.com'));
+        exit(
+            Uri.AreURIsHaveSameHost(ApiUrl, 'https://api.businesscentral.dynamics.com') or
+            Uri.AreURIsHaveSameHost(ApiUrl, 'https://api.businesscentral.dynamics-tie.com'));
     end;
 
     var

--- a/src/Apps/W1/VATGroupManagement/app/src/Tables/VATReportSetupExtension.TableExt.al
+++ b/src/Apps/W1/VATGroupManagement/app/src/Tables/VATReportSetupExtension.TableExt.al
@@ -9,6 +9,7 @@ using Microsoft.Finance.GeneralLedger.Journal;
 using Microsoft.Finance.VAT.Reporting;
 using System.Environment;
 using System.Telemetry;
+using System.Utilities;
 
 tableextension 4701 "VAT Report Setup Extension" extends "VAT Report Setup"
 {
@@ -259,12 +260,26 @@ tableextension 4701 "VAT Report Setup Extension" extends "VAT Report Setup"
 
     internal procedure ValidateGroupRepresentativeAPIURL(): Boolean
     begin
-        if Rec."Group Representative API URL" <> '' then
-            if not Lowercase(Rec."Group Representative API URL").StartsWith('https://api.businesscentral.dynamics.com') then
-                if not Lowercase(Rec."Group Representative API URL").StartsWith('https://api.businesscentral.dynamics-tie.com') then
-                    exit(false);
+        if Rec."Group Representative API URL" = '' then
+            exit(true);
 
-        exit(true);
+        exit(IsAllowedGroupRepresentativeAPIURL(Rec."Group Representative API URL"));
+    end;
+
+    internal procedure IsAllowedGroupRepresentativeAPIURL(ApiUrl: Text): Boolean
+    var
+        Uri: Codeunit Uri;
+        Host: Text;
+    begin
+        // Parse the URL and match the host exactly against the allowlist. A prefix/suffix string check can be
+        // bypassed with crafted hosts such as https://api.businesscentral.dynamics.com.attacker.com/ or
+        // https://api.businesscentral.dynamics.com@attacker.com/ where the real host is attacker.com.
+        Uri.Init(ApiUrl);
+        if LowerCase(Uri.GetScheme()) <> 'https' then
+            exit(false);
+
+        Host := LowerCase(Uri.GetHost());
+        exit((Host = 'api.businesscentral.dynamics.com') or (Host = 'api.businesscentral.dynamics-tie.com'));
     end;
 
     var

--- a/src/Apps/W1/VATGroupManagement/app/src/Tables/VATReportSetupExtension.TableExt.al
+++ b/src/Apps/W1/VATGroupManagement/app/src/Tables/VATReportSetupExtension.TableExt.al
@@ -271,9 +271,6 @@ tableextension 4701 "VAT Report Setup Extension" extends "VAT Report Setup"
         Uri: Codeunit Uri;
         Host: Text;
     begin
-        // Parse the URL and match the host exactly against the allowlist. A prefix/suffix string check can be
-        // bypassed with crafted hosts such as https://api.businesscentral.dynamics.com.attacker.com/ or
-        // https://api.businesscentral.dynamics.com@attacker.com/ where the real host is attacker.com.
         Uri.Init(ApiUrl);
         if LowerCase(Uri.GetScheme()) <> 'https' then
             exit(false);

--- a/src/Apps/W1/VATGroupManagement/test/src/VATGroupHelperFunctTest.Codeunit.al
+++ b/src/Apps/W1/VATGroupManagement/test/src/VATGroupHelperFunctTest.Codeunit.al
@@ -876,14 +876,7 @@ codeunit 139520 "VAT Group Helper Funct Test"
     var
         VATReportSetup: Record "VAT Report Setup";
     begin
-        // [FEATURE] [AI test]
-        // [SCENARIO 641094] Validate URL rejects a crafted host that only has the allowed host as a prefix
-
-        // [GIVEN] VAT Report Setup with a URL whose real host is an attacker domain that starts with the allowed host
         VATReportSetup."Group Representative API URL" := 'https://api.businesscentral.dynamics.com.attacker.com/api';
-
-        // [WHEN] ValidateURL is called
-        // [THEN] ValidateURL returns false (host is api.businesscentral.dynamics.com.attacker.com, not the allowed host)
         Assert.IsFalse(VATReportSetup.ValidateGroupRepresentativeAPIURL(), 'A suffix-host URL should not be valid');
     end;
 
@@ -892,14 +885,7 @@ codeunit 139520 "VAT Group Helper Funct Test"
     var
         VATReportSetup: Record "VAT Report Setup";
     begin
-        // [FEATURE] [AI test]
-        // [SCENARIO 641094] Validate URL rejects a URL where the allowed host is placed in the userinfo and the real host is an attacker domain
-
-        // [GIVEN] VAT Report Setup with a URL using the userinfo trick
         VATReportSetup."Group Representative API URL" := 'https://api.businesscentral.dynamics.com@attacker.com/api';
-
-        // [WHEN] ValidateURL is called
-        // [THEN] ValidateURL returns false (real host is attacker.com)
         Assert.IsFalse(VATReportSetup.ValidateGroupRepresentativeAPIURL(), 'A userinfo-host URL should not be valid');
     end;
 
@@ -908,14 +894,7 @@ codeunit 139520 "VAT Group Helper Funct Test"
     var
         VATReportSetup: Record "VAT Report Setup";
     begin
-        // [FEATURE] [AI test]
-        // [SCENARIO 641094] Validate URL rejects a non-https scheme even for an otherwise allowed host
-
-        // [GIVEN] VAT Report Setup with an http (not https) URL to the allowed host
         VATReportSetup."Group Representative API URL" := 'http://api.businesscentral.dynamics.com/api';
-
-        // [WHEN] ValidateURL is called
-        // [THEN] ValidateURL returns false (scheme is not https)
         Assert.IsFalse(VATReportSetup.ValidateGroupRepresentativeAPIURL(), 'A non-https URL should not be valid');
     end;
 

--- a/src/Apps/W1/VATGroupManagement/test/src/VATGroupHelperFunctTest.Codeunit.al
+++ b/src/Apps/W1/VATGroupManagement/test/src/VATGroupHelperFunctTest.Codeunit.al
@@ -871,6 +871,54 @@ codeunit 139520 "VAT Group Helper Funct Test"
         Assert.IsFalse(VATReportSetup.ValidateGroupRepresentativeAPIURL(), 'The invalid API URL should not be valid');
     end;
 
+    [Test]
+    procedure ValidateURLWithSuffixHostIsRejected()
+    var
+        VATReportSetup: Record "VAT Report Setup";
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 641094] Validate URL rejects a crafted host that only has the allowed host as a prefix
+
+        // [GIVEN] VAT Report Setup with a URL whose real host is an attacker domain that starts with the allowed host
+        VATReportSetup."Group Representative API URL" := 'https://api.businesscentral.dynamics.com.attacker.com/api';
+
+        // [WHEN] ValidateURL is called
+        // [THEN] ValidateURL returns false (host is api.businesscentral.dynamics.com.attacker.com, not the allowed host)
+        Assert.IsFalse(VATReportSetup.ValidateGroupRepresentativeAPIURL(), 'A suffix-host URL should not be valid');
+    end;
+
+    [Test]
+    procedure ValidateURLWithUserInfoHostIsRejected()
+    var
+        VATReportSetup: Record "VAT Report Setup";
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 641094] Validate URL rejects a URL where the allowed host is placed in the userinfo and the real host is an attacker domain
+
+        // [GIVEN] VAT Report Setup with a URL using the userinfo trick
+        VATReportSetup."Group Representative API URL" := 'https://api.businesscentral.dynamics.com@attacker.com/api';
+
+        // [WHEN] ValidateURL is called
+        // [THEN] ValidateURL returns false (real host is attacker.com)
+        Assert.IsFalse(VATReportSetup.ValidateGroupRepresentativeAPIURL(), 'A userinfo-host URL should not be valid');
+    end;
+
+    [Test]
+    procedure ValidateURLWithNonHttpsSchemeIsRejected()
+    var
+        VATReportSetup: Record "VAT Report Setup";
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 641094] Validate URL rejects a non-https scheme even for an otherwise allowed host
+
+        // [GIVEN] VAT Report Setup with an http (not https) URL to the allowed host
+        VATReportSetup."Group Representative API URL" := 'http://api.businesscentral.dynamics.com/api';
+
+        // [WHEN] ValidateURL is called
+        // [THEN] ValidateURL returns false (scheme is not https)
+        Assert.IsFalse(VATReportSetup.ValidateGroupRepresentativeAPIURL(), 'A non-https URL should not be valid');
+    end;
+
     local procedure Initialize()
     begin
         LibraryVATGroup.EnableDefaultVATMemberSetup();


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

Improving the hostname check for VAT Group Management feature

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#641094](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641094)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

Added more automated tests
<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->









