### PR TITLE
Fix AI triage dispatch: pass explicit --ref to gh workflow run

### DIFF
--- a/.github/workflows/ai-triage-dispatch.yml
+++ b/.github/workflows/ai-triage-dispatch.yml
@@ -34,6 +34,12 @@ env:
   # Bare repository name — the create-github-app-token `repositories` input takes
   # names without the owner prefix when `owner` is set.
   AGENT_REPO_NAME: BCAppsTriage
+  # Branch of the agent repo to dispatch against. Passing an explicit --ref avoids
+  # a `repository.defaultBranchRef` GraphQL lookup that `gh workflow run` would
+  # otherwise do — the App token (Actions + Metadata only, no Contents) is not
+  # permitted to read that field, which fails with
+  # "unable to determine default branch ... Resource not accessible by integration".
+  AGENT_REF: main
 
 jobs:
   triage:
@@ -72,7 +78,7 @@ jobs:
           RUN_TOKEN: ${{ steps.token.outputs.run_token }}
         run: |
           set -euo pipefail
-          gh workflow run "$AGENT_WORKFLOW" -R "$AGENT_REPO" \
+          gh workflow run "$AGENT_WORKFLOW" -R "$AGENT_REPO" --ref "$AGENT_REF" \
             -f issue_number="$ISSUE_NUMBER" \
             -f run_token="$RUN_TOKEN"
 


### PR DESCRIPTION
Fixes a runtime failure in the AI triage dispatch workflow (added in #9027):

> unable to determine default branch for microsoft/BCAppsTriage: GraphQL: Resource not accessible by integration (repository.defaultBranchRef)

### Cause
`gh workflow run` without `--ref` resolves the target repo's default branch via a `repository.defaultBranchRef` GraphQL query. The GitHub App installation token used here has only **Actions** + **Metadata** permissions (no **Contents**), so it cannot read that field and the dispatch never happens.

### Fix
Add an `AGENT_REF` env (the agent repo's default branch, `main`) and pass it as `gh workflow run --ref "\"`. With an explicit ref there is no default-branch lookup, so no extra App permission is needed.

Only change is the `AGENT_REF` env var + the `--ref` flag. Source template + docs updated in microsoft/BCAppsTriage#29.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>

Fixes: [AB#641237](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641237)
