### PR TITLE
Fix duplicate fullBuildPatterns key in AL-Go-Settings.json

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -114,6 +114,7 @@
   "fullBuildPatterns": [
     "build/*",
     "src/rulesets/*",
+    "src/Layers/*",
     ".github/workflows/PullRequestHandler.yaml",
     ".github/workflows/_BuildALGoProject.yaml"
   ],
@@ -141,8 +142,5 @@
     "onPull_Request": true,
     "onSchedule": false,
     "mode": "modifiedApps"
-  },
-  "fullBuildPatterns": [
-    "src/Layers/*"
-  ]
+  }
 }


### PR DESCRIPTION
The second fullBuildPatterns key (added in #8939) silently overrode the original patterns when parsed by ConvertFrom-Json, dropping build/*, src/rulesets/* and the workflow patterns. Merge src/Layers/* into the single existing array so all patterns trigger a full build again.

[AB#612711](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612711)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

