### PR TITLE
Add start date field to Sales Order Agent setup

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Page.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Page.al
@@ -319,55 +319,72 @@ page 4400 "SOA Setup"
             group(SOAManageMailboxConfigCard)
             {
                 Caption = 'Manage mailbox';
-
                 group(IncomingMail)
                 {
                     Caption = 'Incoming mail';
-                    InstructionalText = 'Analyze new messages to determine the sender''s intent and how to respond.';
+                    InstructionalText = 'Read emails received from the start date onwards.';
 
-                    group(AnalyzeAttachmentsGrp)
+                    field(EarliestSyncAt;
+                    Rec."Earliest Sync At")
                     {
-                        Caption = 'Analyze attachments';
-                        InstructionalText = 'Includes attachments when analyzing intent. Supported formats: PDF, PNG, JPG.';
+                        Caption = 'Start Date';
+                        ToolTip = 'Specifies the date from which the agent starts reading emails in the selected mailbox.';
 
-                        field(AnalyzeAttachments; Rec."Analyze Attachments")
+                        trigger OnValidate()
+                        begin
+                            ConfigUpdated();
+                        end;
+                    }
+                    group(AnalyzeNewMessagesGrp)
+                    {
+                        ShowCaption = false;
+                        InstructionalText = 'Analyze new messages to determine the sender''s intent and how to respond.';
+
+                        group(AnalyzeAttachmentsGrp)
                         {
                             Caption = 'Analyze attachments';
-                            ToolTip = 'Includes attachments when analyzing intent. Supported formats: PDF, PNG, JPG.';
-                            ShowCaption = false;
+                            InstructionalText = 'Includes attachments when analyzing intent. Supported formats: PDF, PNG, JPG.';
 
-                            trigger OnValidate()
-                            begin
-                                ConfigUpdated();
-                            end;
+                            field(AnalyzeAttachments; Rec."Analyze Attachments")
+                            {
+                                Caption = 'Analyze attachments';
+                                ToolTip = 'Includes attachments when analyzing intent. Supported formats: PDF, PNG, JPG.';
+                                ShowCaption = false;
+
+                                trigger OnValidate()
+                                begin
+                                    ConfigUpdated();
+                                end;
+                            }
                         }
-                    }
-                    group(MarkEmailAsReadGrp)
-                    {
-                        Caption = 'Mark email as read';
-                        InstructionalText = 'Mark emails as read after the agent processes them.';
-
-                        field(MarkEmailAsRead; Rec."Mark Email As Read")
+                        group(MarkEmailAsReadGrp)
                         {
                             Caption = 'Mark email as read';
-                            ToolTip = 'Specifies whether the agent marks emails as read after processing them.';
-                            ShowCaption = false;
+                            InstructionalText = 'Mark emails as read after the agent processes them.';
 
-                            trigger OnValidate()
-                            begin
-                                ConfigUpdated();
-                            end;
+                            field(MarkEmailAsRead; Rec."Mark Email As Read")
+                            {
+                                Caption = 'Mark email as read';
+                                ToolTip = 'Specifies whether the agent marks emails as read after processing them.';
+                                ShowCaption = false;
+
+                                trigger OnValidate()
+                                begin
+                                    ConfigUpdated();
+                                end;
+                            }
+                        }
+
+                        field(LastSync; LastSync)
+                        {
+                            Caption = 'Last sync';
+                            ToolTip = 'Specifies the date and time of the last sync with the mailbox.';
+                            Editable = false;
+                            Visible = ShowLastSync;
                         }
                     }
-
-                    field(LastSync; LastSync)
-                    {
-                        Caption = 'Last sync';
-                        ToolTip = 'Specifies the date and time of the last sync with the mailbox.';
-                        Editable = false;
-                        Visible = ShowLastSync;
-                    }
                 }
+
 
                 group(ProcessingLimits)
                 {


### PR DESCRIPTION
## Summary
- add a Start Date field to the Sales Order Agent setup page
- place the field in the Incoming mail section ahead of message analysis settings
- align the related instructional text and tooltip wording with date-only behavior

<img width="890" height="624" alt="image" src="https://github.com/user-attachments/assets/0c811701-62a4-4388-b63f-1d69e72fa52b" />

## Related work item
Fixes [AB#621547](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/621547)

