### PR TITLE
[master][Bug]: Page 615 "IC Inbox Transactions".RunInboxTransactions

### DIFF
--- a/src/Layers/CH/Tests/ERM/ERMIntercompanyIII.Codeunit.al
+++ b/src/Layers/CH/Tests/ERM/ERMIntercompanyIII.Codeunit.al
@@ -1739,7 +1739,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerEnqueueQuestion')]
+    [HandlerFunctions('ConfirmHandlerEnqueueQuestion,RequestPageHandler')]
     procedure AcceptSalesInvoiceFromICInboxMoreThanOnceConfirmYes()
     var
         HandledICInboxTrans: Record "Handled IC Inbox Trans.";
@@ -1792,7 +1792,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerEnqueueQuestion')]
+    [HandlerFunctions('ConfirmHandlerEnqueueQuestion,RequestPageHandler')]
     procedure AcceptSalesInvoiceFromICInboxMoreThanOnceConfirmNo()
     var
         HandledICInboxTrans: Record "Handled IC Inbox Trans.";
@@ -2299,6 +2299,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure SendRejectedICTransactionWhenAutoAcceptTransactionIsSet()
     var
         ICOutboxTransaction: Record "IC Outbox Transaction";
@@ -2749,6 +2750,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure ICNavigateFromIncomingSalesOrderLine()
     var
         ICInboxSalesHeader: Record "IC Inbox Sales Header";
@@ -2853,6 +2855,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure ICNavigateFromIncomingPurchaseOrderLine()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -2894,6 +2897,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure ICNavigateFromPurchaseInvoiceLine()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -2966,7 +2970,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICSalesOrder()
     var
         Customer: Record Customer;
@@ -3024,7 +3028,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICPurchaseOrder()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -3074,7 +3078,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICSalesInvoice()
     var
         Customer: Record Customer;
@@ -3130,7 +3134,7 @@ codeunit 134154 "ERM Intercompany III"
 
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICPurchaseInvoice()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -3245,6 +3249,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure VerifySalesOrderIsCreatedFromICInboxForLineDiscountOver50AndPricesIncludingVATinICPurchaseOrder()
     var
         Customer: Record Customer;
@@ -4758,6 +4763,13 @@ codeunit 134154 "ERM Intercompany III"
     begin
         Reply := LibraryVariableStorage.DequeueBoolean();
         LibraryVariableStorage.Enqueue(Question);
+    end;
+
+    [RequestPageHandler]
+    [Scope('OnPrem')]
+    procedure RequestPageHandler(var RequestPage: TestRequestPage "Complete IC Inbox Action")
+    begin
+        RequestPage.OK().Invoke();
     end;
 
     [ModalPageHandler]

--- a/src/Layers/CZ/Tests/ERM/ERMIntercompanyIII.Codeunit.al
+++ b/src/Layers/CZ/Tests/ERM/ERMIntercompanyIII.Codeunit.al
@@ -1682,7 +1682,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerEnqueueQuestion')]
+    [HandlerFunctions('ConfirmHandlerEnqueueQuestion,RequestPageHandler')]
     procedure AcceptSalesInvoiceFromICInboxMoreThanOnceConfirmYes()
     var
         HandledICInboxTrans: Record "Handled IC Inbox Trans.";
@@ -1735,7 +1735,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerEnqueueQuestion')]
+    [HandlerFunctions('ConfirmHandlerEnqueueQuestion,RequestPageHandler')]
     procedure AcceptSalesInvoiceFromICInboxMoreThanOnceConfirmNo()
     var
         HandledICInboxTrans: Record "Handled IC Inbox Trans.";
@@ -2242,6 +2242,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure SendRejectedICTransactionWhenAutoAcceptTransactionIsSet()
     var
         ICOutboxTransaction: Record "IC Outbox Transaction";
@@ -2692,6 +2693,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure ICNavigateFromIncomingSalesOrderLine()
     var
         ICInboxSalesHeader: Record "IC Inbox Sales Header";
@@ -2796,6 +2798,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure ICNavigateFromIncomingPurchaseOrderLine()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -2837,6 +2840,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure ICNavigateFromPurchaseInvoiceLine()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -2909,7 +2913,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICSalesOrder()
     var
         Customer: Record Customer;
@@ -2967,7 +2971,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICPurchaseOrder()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -3017,7 +3021,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICSalesInvoice()
     var
         Customer: Record Customer;
@@ -3073,7 +3077,7 @@ codeunit 134154 "ERM Intercompany III"
 
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICPurchaseInvoice()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -3188,6 +3192,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure VerifySalesOrderIsCreatedFromICInboxForLineDiscountOver50AndPricesIncludingVATinICPurchaseOrder()
     var
         Customer: Record Customer;
@@ -4701,6 +4706,13 @@ codeunit 134154 "ERM Intercompany III"
     begin
         Reply := LibraryVariableStorage.DequeueBoolean();
         LibraryVariableStorage.Enqueue(Question);
+    end;
+
+    [RequestPageHandler]
+    [Scope('OnPrem')]
+    procedure RequestPageHandler(var RequestPage: TestRequestPage "Complete IC Inbox Action")
+    begin
+        RequestPage.OK().Invoke();
     end;
 
     [ModalPageHandler]

--- a/src/Layers/NL/Tests/ERM/ERMIntercompanyIII.Codeunit.al
+++ b/src/Layers/NL/Tests/ERM/ERMIntercompanyIII.Codeunit.al
@@ -1682,7 +1682,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerEnqueueQuestion')]
+    [HandlerFunctions('ConfirmHandlerEnqueueQuestion,RequestPageHandler')]
     procedure AcceptSalesInvoiceFromICInboxMoreThanOnceConfirmYes()
     var
         HandledICInboxTrans: Record "Handled IC Inbox Trans.";
@@ -1735,7 +1735,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerEnqueueQuestion')]
+    [HandlerFunctions('ConfirmHandlerEnqueueQuestion,RequestPageHandler')]
     procedure AcceptSalesInvoiceFromICInboxMoreThanOnceConfirmNo()
     var
         HandledICInboxTrans: Record "Handled IC Inbox Trans.";
@@ -2242,6 +2242,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure SendRejectedICTransactionWhenAutoAcceptTransactionIsSet()
     var
         ICOutboxTransaction: Record "IC Outbox Transaction";
@@ -2692,6 +2693,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure ICNavigateFromIncomingSalesOrderLine()
     var
         ICInboxSalesHeader: Record "IC Inbox Sales Header";
@@ -2796,6 +2798,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure ICNavigateFromIncomingPurchaseOrderLine()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -2837,6 +2840,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure ICNavigateFromPurchaseInvoiceLine()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -2909,7 +2913,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICSalesOrder()
     var
         Customer: Record Customer;
@@ -2967,7 +2971,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICPurchaseOrder()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -3017,7 +3021,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICSalesInvoice()
     var
         Customer: Record Customer;
@@ -3073,7 +3077,7 @@ codeunit 134154 "ERM Intercompany III"
 
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICPurchaseInvoice()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -3188,6 +3192,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure VerifySalesOrderIsCreatedFromICInboxForLineDiscountOver50AndPricesIncludingVATinICPurchaseOrder()
     var
         Customer: Record Customer;
@@ -4701,6 +4706,13 @@ codeunit 134154 "ERM Intercompany III"
     begin
         Reply := LibraryVariableStorage.DequeueBoolean();
         LibraryVariableStorage.Enqueue(Question);
+    end;
+
+    [RequestPageHandler]
+    [Scope('OnPrem')]
+    procedure RequestPageHandler(var RequestPage: TestRequestPage "Complete IC Inbox Action")
+    begin
+        RequestPage.OK().Invoke();
     end;
 
     [ModalPageHandler]

--- a/src/Layers/W1/BaseApp/Finance/Intercompany/Inbox/ICInboxTransactions.Page.al
+++ b/src/Layers/W1/BaseApp/Finance/Intercompany/Inbox/ICInboxTransactions.Page.al
@@ -455,7 +455,7 @@ page 615 "IC Inbox Transactions"
         RunReport: Boolean;
         PurchaseInvoicePreviouslySentAsOrderMsg: Label 'A purchase order for this invoice has already been received from intercompany partner %1. Receiving it again can lead to duplicate information. Do you want to receive it?', Comment = '%1 - Intercompany Partner Code';
     begin
-        if ApplicationAreaMgmtFacade.IsFoundationEnabled() then
+        if ApplicationAreaMgmtFacade.IsBasicOnlyEnabled() then
             RunReport := false
         else
             RunReport := true;

--- a/src/Layers/W1/Tests/ERM/ERMIntercompanyIII.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMIntercompanyIII.Codeunit.al
@@ -1736,7 +1736,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerEnqueueQuestion')]
+    [HandlerFunctions('ConfirmHandlerEnqueueQuestion,RequestPageHandler')]
     procedure AcceptSalesInvoiceFromICInboxMoreThanOnceConfirmYes()
     var
         HandledICInboxTrans: Record "Handled IC Inbox Trans.";
@@ -1789,7 +1789,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerEnqueueQuestion')]
+    [HandlerFunctions('ConfirmHandlerEnqueueQuestion,RequestPageHandler')]
     procedure AcceptSalesInvoiceFromICInboxMoreThanOnceConfirmNo()
     var
         HandledICInboxTrans: Record "Handled IC Inbox Trans.";
@@ -2296,6 +2296,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure SendRejectedICTransactionWhenAutoAcceptTransactionIsSet()
     var
         ICOutboxTransaction: Record "IC Outbox Transaction";
@@ -2746,6 +2747,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure ICNavigateFromIncomingSalesOrderLine()
     var
         ICInboxSalesHeader: Record "IC Inbox Sales Header";
@@ -2850,6 +2852,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure ICNavigateFromIncomingPurchaseOrderLine()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -2891,6 +2894,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure ICNavigateFromPurchaseInvoiceLine()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -2963,7 +2967,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICSalesOrder()
     var
         Customer: Record Customer;
@@ -3021,7 +3025,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICPurchaseOrder()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -3071,7 +3075,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICSalesInvoice()
     var
         Customer: Record Customer;
@@ -3127,7 +3131,7 @@ codeunit 134154 "ERM Intercompany III"
 
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandlerYes,RequestPageHandler')]
     procedure RejectICPurchaseInvoice()
     var
         ICInboxTransaction: Record "IC Inbox Transaction";
@@ -3242,6 +3246,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure VerifySalesOrderIsCreatedFromICInboxForLineDiscountOver50AndPricesIncludingVATinICPurchaseOrder()
     var
         Customer: Record Customer;
@@ -4755,6 +4760,13 @@ codeunit 134154 "ERM Intercompany III"
     begin
         Reply := LibraryVariableStorage.DequeueBoolean();
         LibraryVariableStorage.Enqueue(Question);
+    end;
+
+    [RequestPageHandler]
+    [Scope('OnPrem')]
+    procedure RequestPageHandler(var RequestPage: TestRequestPage "Complete IC Inbox Action")
+    begin
+        RequestPage.OK().Invoke();
     end;
 
     [ModalPageHandler]


### PR DESCRIPTION
Fixes [AB#633619](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633619)

Changes the check of IsFoundationEnabled to IsBasicOnlyEnabled, such that the request page opens when the user is more than basic.

The tests are updated because now a request page is opened and is handled by clicking OK.

