### PR TITLE
Sync W1 GL Posting changes to ES

### DIFF
--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Ledger/GLRegister.Table.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Ledger/GLRegister.Table.al
@@ -183,7 +183,7 @@ table 45 "G/L Register"
 
     }
 
-    procedure GetNextEntryNo(UseLegacyPosting: Boolean): Integer
+    procedure GetNextRegisterNo(UseLegacyPosting: Boolean): Integer
     begin
         if not UseLegacyPosting then
             exit(GetNextEntryNo());

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -28,6 +28,7 @@ using Microsoft.FixedAssets.Maintenance;
 using Microsoft.FixedAssets.Posting;
 using Microsoft.Foundation.AuditCodes;
 using Microsoft.Foundation.Enums;
+using Microsoft.Foundation.NoSeries;
 using Microsoft.Foundation.Period;
 using Microsoft.HumanResources.Employee;
 using Microsoft.HumanResources.Payables;
@@ -109,6 +110,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
     var
         GLSetup: Record "General Ledger Setup";
         GlobalGLEntry: Record "G/L Entry";
+        GlobalGLTransaction: Record "G/L Transaction";
         TempGLEntryBuf: Record "G/L Entry" temporary;
         TempGLEntryVAT: Record "G/L Entry" temporary;
         TempGLEntryPreview: Record "G/L Entry" temporary;
@@ -130,6 +132,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         PaymentToleranceMgt: Codeunit "Payment Tolerance Management";
         DeferralUtilities: Codeunit "Deferral Utilities";
         NonDeductibleVAT: Codeunit "Non-Deductible VAT";
+        SequenceNoMgt: Codeunit "Sequence No. Mgt.";
         DeferralDocType: Enum "Deferral Document Type";
         LastDocType: Enum "Gen. Journal Document Type";
         AddCurrencyCode: Code[10];
@@ -257,6 +260,9 @@ codeunit 12 "Gen. Jnl.-Post Line"
         if IsHandled then
             exit(GLEntryNo);
 
+        if GLReg."No." = 0 then
+            SequenceNoMgt.ClearSequenceNoCheck();
+
         GenJnlLine.Copy(GenJnlLine2);
         Code(GenJnlLine, true);
         OnAfterRunWithCheck(GenJnlLine);
@@ -289,6 +295,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
 
     local procedure "Code"(var GenJnlLine: Record "Gen. Journal Line"; CheckLine: Boolean)
     var
+        xGLEntryNo: Integer;
         Balancing: Boolean;
         IsTransactionConsistent: Boolean;
         IsPosted: Boolean;
@@ -297,6 +304,9 @@ codeunit 12 "Gen. Jnl.-Post Line"
         OnBeforeCode(GenJnlLine, CheckLine, IsPosted, GLReg, GLEntryNo);
         if IsPosted then
             exit;
+
+        xGLEntryNo := GLEntryNo;
+        ValidateSequenceNo(GLEntryNo, xGLEntryNo, Database::"G/L Entry");
 
         GetJournalsSourceCode();
 
@@ -373,6 +383,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         OnAfterGLFinishPosting(
             GlobalGLEntry, GenJnlLine, IsTransactionConsistent, FirstTransactionNo, GLReg, TempGLEntryBuf,
             NextEntryNo, NextTransactionNo);
+        ValidateSequenceNo(GLEntryNo, xGLEntryNo, Database::"G/L Entry");
 
         GLEntryInconsistent := not IsTransactionConsistent;
     end;
@@ -950,8 +961,9 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 VATEntry."Base Before Pmt. Disc." := GenJnlLine."VAT Base Before Pmt. Disc."
             else
                 VATEntry."Base Before Pmt. Disc." := GLEntryAmount;
-
             VATEntry.UpdateRates(VATPostingSetup);
+            VATEntry."G/L Register No." := GLReg."No.";
+            VATEntry.TestField("G/L Register No.");
             OnBeforeInsertVATEntry(VATEntry, GenJnlLine, NextVATEntryNo, TempGLEntryVATEntryLink, TempGLEntryBuf, GLReg);
             VATEntry.Insert(true);
             TempGLEntryVATEntryLink.InsertLinkSelf(TempGLEntryBuf."Entry No.", VATEntry."Entry No.");
@@ -1433,6 +1445,8 @@ codeunit 12 "Gen. Jnl.-Post Line"
             end;
             if SalesSetup."Copy Customer Name to Entries" then
                 CustLedgEntry."Customer Name" := Cust.Name;
+            CustLedgEntry."G/L Register No." := GLReg."No.";
+            CustLedgEntry.TestField("G/L Register No.");
             OnBeforeCustLedgEntryInsert(CustLedgEntry, GenJournalLine, GLReg, TempDtldCVLedgEntryBuf, NextEntryNo);
             CustLedgEntry.Insert(true);
 
@@ -1586,6 +1600,8 @@ codeunit 12 "Gen. Jnl.-Post Line"
         VendLedgEntry."Applies-to ID" := '';
         if PurchSetup."Copy Vendor Name to Entries" then
             VendLedgEntry."Vendor Name" := Vend.Name;
+        VendLedgEntry."G/L Register No." := GLReg."No.";
+        VendLedgEntry.TestField("G/L Register No.");
         OnBeforeVendLedgEntryInsert(VendLedgEntry, GenJournalLine, GLReg);
         VendLedgEntry.Insert(true);
 
@@ -1667,9 +1683,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
         EmployeeLedgerEntry."Amount to Apply" := 0;
         EmployeeLedgerEntry."Applies-to Doc. No." := '';
         EmployeeLedgerEntry."Applies-to ID" := '';
+        EmployeeLedgerEntry."G/L Register No." := GLReg."No.";
+        EmployeeLedgerEntry.TestField("G/L Register No.");
         OnPostEmployeeOnBeforeEmployeeLedgerEntryInsert(GenJnlLine, EmployeeLedgerEntry, GLReg);
         EmployeeLedgerEntry.Insert(true);
-
         EmployeeLedgerEntry.CopyLinks(GenJnlLine);
 
         // Post detailed employee entries
@@ -2146,6 +2163,17 @@ codeunit 12 "Gen. Jnl.-Post Line"
         exit(NewTransaction);
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"G/L Entry", 'r')]
+    [InherentPermissions(PermissionObjectType::TableData, Database::"G/L Transaction", 'r')]
+    local procedure ValidateSequenceNo(LedgEntryNo: Integer; xLedgEntryNo: Integer; TableNo: Integer)
+    begin
+        if LedgEntryNo = xLedgEntryNo then
+            exit;
+        if not GLSetup.UseConcurrentPosting() then
+            exit;
+        SequenceNoMgt.ValidateSeqNo(TableNo);
+    end;
+
     /// <summary>
     /// Checks if transaction is balanced for both local and additional currencies, inserts all G/L Entries that were created for the Gen. Journal Line.
     /// If posting is performed for application purpose, original Customer and Vendor Ledger Entries are updated to reflect that.
@@ -2185,9 +2213,12 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 end;
                 GlobalGLEntry."Prior-Year Entry" := GlobalGLEntry."Posting Date" < FiscalYearStartDate;
                 OnBeforeInsertGlobalGLEntry(GlobalGLEntry, GenJournalLine, GLReg, FiscalYearStartDate);
+                GlobalGLEntry."G/L Register No." := GLReg."No.";
+                GlobalGLEntry.TestField("G/L Register No.");
                 GlobalGLEntry.Insert(true);
                 if GlobalGLEntry."Source Currency Code" <> '' then
                     InsertGLAccountSourceCurrency(GlobalGLEntry);
+                GlobalGLTransaction.InsertFromGLEntry(GlobalGLEntry, GLReg);
                 OnAfterInsertGlobalGLEntry(GlobalGLEntry, TempGLEntryBuf, NextEntryNo, GenJournalLine);
 
                 GlobalGLEntry.CopyLinks(GenJournalLine);
@@ -6390,6 +6421,8 @@ codeunit 12 "Gen. Jnl.-Post Line"
         VATEntry."Unrealized VAT Entry No." := VATEntry2."Entry No.";
         VATEntry."Base Before Pmt. Disc." := VATEntry.Base;
         VATEntry."G/L Acc. No." := '';
+        VATEntry."G/L Register No." := GLReg."No.";
+        VATEntry.TestField("G/L Register No.");
         OnBeforeInsertPostUnrealVATEntry(VATEntry, GenJnlLine, VATEntry2);
         VATEntry.Insert(true);
         OnPostUnrealVATEntryOnBeforeInsertLinkSelf(TempGLEntryVATEntryLink, VATEntry, GLEntryNo, NextVATEntryNo);
@@ -7220,6 +7253,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                                 GLEntryNoFromVAT := PostUnrealVATByUnapply(GenJnlLine, VATPostingSetup, VATEntry, TempVATEntry);
                         VATEntry2 := TempVATEntry;
                         VATEntry2."Entry No." := NextVATEntryNo;
+                        VATEntry2."G/L Register No." := GLReg."No.";
                         OnPostUnapplyOnBeforeVATEntryInsert(VATEntry2, GenJnlLine, VATEntry);
                         VATEntry2.Insert();
                         OnPostUnapplyOnAfterVATEntryInsert(VATEntry2, GenJnlLine, VATEntry);
@@ -7832,6 +7866,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
             repeat
                 VATEntry := TempVATEntry;
                 VATEntry."Entry No." := NextVATEntryNo;
+                VATEntry.TestField("G/L Register No.");
                 OnInsertVATEntriesFromTempOnBeforeVATEntryInsert(VATEntry, TempVATEntry, GLReg, GLEntry);
                 VATEntry.Insert(true);
                 NextVATEntryNo := NextVATEntryNo + 1;


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->
Change propage concurrency posting foundation from W1 to ES. It includes assigning Transaction No. and G/L Register No. to each G/L Entry. 

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#624164](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624164)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->



