### PR TITLE
Config. Packages with Native AL XML Data Types

### DIFF
--- a/src/Layers/W1/BaseApp/Modules/System/Xml/XMLDOMManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Modules/System/Xml/XMLDOMManagement.Codeunit.al
@@ -538,6 +538,16 @@ codeunit 6224 "XML DOM Management"
     end;
 
     [Scope('OnPrem')]
+    procedure LoadXMLDocumentFromFile(FileName: Text; var OutXmlDocument: XmlDocument)
+    var
+        FileManagement: Codeunit "File Management";
+        File: DotNet File;
+    begin
+        FileManagement.IsAllowedPath(FileName, false);
+        XmlDocument.ReadFrom(File.ReadAllText(FileName), OutXmlDocument);
+    end;
+
+    [Scope('OnPrem')]
     procedure LoadXMLDocumentFromFileWithXmlReaderSettings(FileName: Text; var XmlDocument: DotNet XmlDocument; XmlReaderSettings: DotNet XmlReaderSettings)
     var
         FileManagement: Codeunit "File Management";

--- a/src/Layers/W1/BaseApp/System/RapidStart/AutomationImportRSPackage.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/RapidStart/AutomationImportRSPackage.Codeunit.al
@@ -24,9 +24,9 @@ codeunit 5432 "Automation - Import RSPackage"
         ConfigXMLExchange.SetHideDialog(true);
         ConfigXMLExchange.DecompressPackageToBlob(TempBlob, TempBlobDecompressed);
         TempBlobDecompressed.CreateInStream(InStream);
-        ConfigXMLExchange.ImportPackageXMLWithCodeFromStream(InStream, Rec.Code);
+        ConfigXMLExchange.ImportPackageXMLWithCode(InStream, Rec.Code);
 
-        // refreshing the record as ImportPackageXMLWithCodeFromStream updated the Configuration package with the number of records in the package, etc.
+        // refreshing the record as ImportPackageXMLWithCode updated the Configuration package with the number of records in the package, etc.
         Rec.Find();
         Rec.Validate("Import Status", Rec."Import Status"::Completed);
         Rec.Modify(true);

--- a/src/Layers/W1/BaseApp/System/RapidStart/ConfigExcelExchange.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/RapidStart/ConfigExcelExchange.Codeunit.al
@@ -408,7 +408,7 @@ codeunit 8618 "Config. Excel Exchange"
         DurationAsInt := CurrentDateTime() - StartTime;
 
         Session.LogMessage('00009QD', StrSubstNo(ExcelImportFinishMsg, DurationAsInt, FileSize), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', RapidStartTxt);
-        if ConfigXMLExchange.ImportPackageXMLFromStream(InStream) then
+        if ConfigXMLExchange.ImportPackageXML(InStream) then
             Imported := true;
 
         exit(Imported);

--- a/src/Layers/W1/BaseApp/System/RapidStart/ConfigImportTableinBackgr.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/RapidStart/ConfigImportTableinBackgr.Codeunit.al
@@ -1,6 +1,5 @@
 namespace System.IO;
 
-using System;
 using System.Threading;
 
 codeunit 8626 "Config. Import Table in Backgr"
@@ -11,9 +10,9 @@ codeunit 8626 "Config. Import Table in Backgr"
     var
         ConfigXMLExchange: Codeunit "Config. XML Exchange";
         MemoryMappedFile: Codeunit "Memory Mapped File";
-        PackageXML: DotNet XmlDocument;
-        DocumentElement: DotNet XmlElement;
-        TableNode: DotNet XmlNode;
+        PackageXML: XmlDocument;
+        DocumentElement: XmlElement;
+        TableNode: XmlNode;
         nodetext: Text;
         PackageCode: Code[20];
     begin
@@ -26,18 +25,26 @@ codeunit 8626 "Config. Import Table in Backgr"
         MemoryMappedFile.ReadTextWithSeparatorsFromMemoryMappedFile(nodetext);
         MemoryMappedFile.Dispose();
 
-        PackageXML := PackageXML.XmlDocument();
-        PackageXML.LoadXml(nodetext);
-        if IsNull(PackageXML) then
+        if not XmlDocument.ReadFrom(nodetext, PackageXML) then
             exit;
-        DocumentElement := PackageXML.DocumentElement;
-        if IsNull(DocumentElement) then
+
+        if not PackageXML.GetRoot(DocumentElement) then
             exit;
-        TableNode := DocumentElement.FirstChild;
-        if IsNull(TableNode) then
+
+        if not GetFirstChildNode(DocumentElement.AsXmlNode(), TableNode) then
             exit;
+
         ConfigXMLExchange.SetHideDialog(true);
         ConfigXMLExchange.ImportTableFromXMLNode(TableNode, PackageCode);
     end;
-}
 
+    local procedure GetFirstChildNode(ParentNode: XmlNode; var FirstChild: XmlNode): Boolean
+    var
+        ChildNodes: XmlNodeList;
+    begin
+        ChildNodes := ParentNode.AsXmlElement().GetChildNodes();
+        if ChildNodes.Count() = 0 then
+            exit(false);
+        exit(ChildNodes.Get(1, FirstChild));
+    end;
+}

--- a/src/Layers/W1/BaseApp/System/RapidStart/ConfigPackages.Page.al
+++ b/src/Layers/W1/BaseApp/System/RapidStart/ConfigPackages.Page.al
@@ -153,7 +153,7 @@ page 8615 "Config. Packages"
                         TempBlob.FromRecord(ConfigurationPackageFile, ConfigurationPackageFile.FieldNo(Package));
                         ConfigXMLExchange.DecompressPackageToBlob(TempBlob, TempBlobUncompressed);
                         TempBlobUncompressed.CreateInStream(InStream);
-                        ConfigXMLExchange.ImportPackageXMLFromStream(InStream);
+                        ConfigXMLExchange.ImportPackageXML(InStream);
                     end;
                 }
                 action(ExportToExcel)

--- a/src/Layers/W1/BaseApp/System/RapidStart/ConfigSetup.Table.al
+++ b/src/Layers/W1/BaseApp/System/RapidStart/ConfigSetup.Table.al
@@ -4,7 +4,6 @@ using Microsoft.Bank.BankAccount;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
 using Microsoft.Sales.Setup;
-using System;
 using System.Environment.Configuration;
 using System.Globalization;
 using System.Reflection;
@@ -356,7 +355,7 @@ table 8627 "Config. Setup"
     procedure ReadPackageHeader(DecompressedFileName: Text)
     var
         XMLDOMManagement: Codeunit "XML DOM Management";
-        PackageXML: DotNet XmlDocument;
+        PackageXML: XmlDocument;
     begin
         if "Package File Name" <> '' then begin
             XMLDOMManagement.LoadXMLDocumentFromFile(DecompressedFileName, PackageXML);
@@ -371,11 +370,10 @@ table 8627 "Config. Setup"
 
     procedure ReadPackageHeaderFromStream(InStream: InStream)
     var
-        XMLDOMManagement: Codeunit "XML DOM Management";
-        PackageXML: DotNet XmlDocument;
+        PackageXML: XmlDocument;
     begin
         if "Package File Name" <> '' then begin
-            XMLDOMManagement.LoadXMLDocumentFromInStream(InStream, PackageXML);
+            XmlDocument.ReadFrom(InStream, PackageXML);
             ReadPackageHeaderCommon(PackageXML);
         end else begin
             "Package Code" := '';
@@ -385,35 +383,37 @@ table 8627 "Config. Setup"
         end;
     end;
 
-    local procedure ReadPackageHeaderCommon(PackageXML: DotNet XmlDocument)
+    local procedure ReadPackageHeaderCommon(PackageXML: XmlDocument)
     var
         ConfigPackage: Record "Config. Package";
         ConfigXMLExchange: Codeunit "Config. XML Exchange";
-        DocumentElement: DotNet XmlElement;
+        DocumentElement: XmlElement;
+        DocumentElementNode: XmlNode;
         LanguageID: Text;
     begin
-        DocumentElement := PackageXML.DocumentElement;
+        PackageXML.GetRoot(DocumentElement);
+        DocumentElementNode := DocumentElement.AsXmlNode();
         "Package Code" :=
           CopyStr(
             ConfigXMLExchange.GetAttribute(
-              ConfigXMLExchange.GetElementName(ConfigPackage.FieldName(Code)), DocumentElement),
+              ConfigXMLExchange.GetElementName(ConfigPackage.FieldName(Code)), DocumentElementNode),
             1, MaxStrLen("Package Code"));
         if "Package Code" = '' then
             Error(PackageDataNotDefinedErr, FieldCaption("Package Code"));
         "Package Name" :=
           CopyStr(
             ConfigXMLExchange.GetAttribute(
-              ConfigXMLExchange.GetElementName(ConfigPackage.FieldName("Package Name")), DocumentElement),
+              ConfigXMLExchange.GetElementName(ConfigPackage.FieldName("Package Name")), DocumentElementNode),
             1, MaxStrLen("Package Name"));
         if "Package Name" = '' then
             Error(PackageDataNotDefinedErr, FieldCaption("Package Name"));
         "Product Version" :=
           CopyStr(
             ConfigXMLExchange.GetAttribute(
-              ConfigXMLExchange.GetElementName(ConfigPackage.FieldName("Product Version")), DocumentElement),
+              ConfigXMLExchange.GetElementName(ConfigPackage.FieldName("Product Version")), DocumentElementNode),
             1, MaxStrLen("Product Version"));
         LanguageID := ConfigXMLExchange.GetAttribute(
-            ConfigXMLExchange.GetElementName(ConfigPackage.FieldName("Language ID")), DocumentElement);
+            ConfigXMLExchange.GetElementName(ConfigPackage.FieldName("Language ID")), DocumentElementNode);
         if LanguageID <> '' then
             Evaluate("Language ID", LanguageID);
         Modify();
@@ -434,7 +434,7 @@ table 8627 "Config. Setup"
                     Error('');
 
         ConfigXMLExchange.SetHideDialog(HideDialog);
-        ConfigXMLExchange.ImportPackageXML(DecompressedFileName);
+        ConfigXMLExchange.ImportPackageXMLFromFile(DecompressedFileName);
         Commit();
     end;
 
@@ -452,7 +452,7 @@ table 8627 "Config. Setup"
                     Error('');
 
         ConfigXMLExchange.SetHideDialog(HideDialog);
-        ConfigXMLExchange.ImportPackageXMLFromStream(InStream);
+        ConfigXMLExchange.ImportPackageXML(InStream);
         Commit();
     end;
 

--- a/src/Layers/W1/BaseApp/System/RapidStart/ConfigXMLExchange.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/RapidStart/ConfigXMLExchange.Codeunit.al
@@ -60,6 +60,9 @@ codeunit 8614 "Config. XML Exchange"
         PackageExportFinishScopeAllMsg: Label 'Configuration package exported successfully: %1', Comment = '%1 - package code', Locked = true;
         ImportingIsNotAllowedDuringUpgradeOrInstallationErr: Label 'Importing configuration packages is not allowed during upgrade or installation. Importing configuration packages requires multiple threads and sessions which is not supported.';
 
+
+#if not CLEAN29
+    [Obsolete('Replaced by procedure AddXMLComment', '29.0')]
     local procedure AddXMLComment(var PackageXML: DotNet XmlDocument; var Node: DotNet XmlNode; Comment: Text[250])
     var
         CommentNode: DotNet XmlNode;
@@ -67,7 +70,17 @@ codeunit 8614 "Config. XML Exchange"
         CommentNode := PackageXML.CreateComment(Comment);
         Node.AppendChild(CommentNode);
     end;
+#endif
+    local procedure AddXMLComment(var ParentXmlNode: XmlNode; Comment: Text[250])
+    var
+        CommentNode: XmlNode;
+    begin
+        CommentNode := XmlComment.Create(Comment).AsXmlNode();
+        ParentXmlNode.AsXmlElement().Add(CommentNode);
+    end;
 
+#if not CLEAN29
+    [Obsolete('Replaced by procedure AddTableAttributes', '29.0')]
     local procedure AddTableAttributes(ConfigPackageTable: Record "Config. Package Table"; var PackageXML: DotNet XmlDocument; var TableNode: DotNet XmlNode)
     var
         FieldNode: DotNet XmlNode;
@@ -125,7 +138,35 @@ codeunit 8614 "Config. XML Exchange"
 
         OnAfterAddTableAttributes(ConfigPackageTable, PackageXML, TableNode);
     end;
+#endif
+    local procedure AddTableAttributes(ConfigPackageTable: Record "Config. Package Table"; var TableNode: XmlNode)
+    begin
+        if ConfigPackageTable."Page ID" > 0 then
+            TableNode.AsXmlElement().Add(XmlElement.Create(GetElementName(ConfigPackageTable.FieldName("Page ID")), '', Format(ConfigPackageTable."Page ID")));
+        if ConfigPackageTable."Package Processing Order" > 0 then
+            TableNode.AsXmlElement().Add(XmlElement.Create(GetElementName(ConfigPackageTable.FieldName("Package Processing Order")), '', Format(ConfigPackageTable."Package Processing Order")));
+        if ConfigPackageTable."Processing Order" > 0 then
+            TableNode.AsXmlElement().Add(XmlElement.Create(GetElementName(ConfigPackageTable.FieldName("Processing Order")), '', Format(ConfigPackageTable."Processing Order")));
+        if ConfigPackageTable."Data Template" <> '' then
+            TableNode.AsXmlElement().Add(XmlElement.Create(GetElementName(ConfigPackageTable.FieldName("Data Template")), '', Format(ConfigPackageTable."Data Template")));
+        if ConfigPackageTable.Comments <> '' then
+            TableNode.AsXmlElement().Add(XmlElement.Create(GetElementName(ConfigPackageTable.FieldName(Comments)), '', Format(ConfigPackageTable.Comments)));
+        if ConfigPackageTable."Created by User ID" <> '' then
+            TableNode.AsXmlElement().Add(XmlElement.Create(GetElementName(ConfigPackageTable.FieldName("Created by User ID")), '', Format(ConfigPackageTable."Created by User ID")));
+        if ConfigPackageTable."Skip Table Triggers" then
+            TableNode.AsXmlElement().Add(XmlElement.Create(GetElementName(ConfigPackageTable.FieldName("Skip Table Triggers")), '', '1'));
+        if ConfigPackageTable."Parent Table ID" > 0 then
+            TableNode.AsXmlElement().Add(XmlElement.Create(GetElementName(ConfigPackageTable.FieldName("Parent Table ID")), '', Format(ConfigPackageTable."Parent Table ID")));
+        if ConfigPackageTable."Delete Recs Before Processing" then
+            TableNode.AsXmlElement().Add(XmlElement.Create(GetElementName(ConfigPackageTable.FieldName("Delete Recs Before Processing")), '', '1'));
+        if ConfigPackageTable."Dimensions as Columns" then
+            TableNode.AsXmlElement().Add(XmlElement.Create(GetElementName(ConfigPackageTable.FieldName("Dimensions as Columns")), '', '1'));
 
+        OnAfterAddTableAttributesProcedure(ConfigPackageTable, TableNode);
+    end;
+
+#if not CLEAN29
+    [Obsolete('Replaced by procedure AddFieldAttributes', '29.0')]
     local procedure AddFieldAttributes(ConfigPackageField: Record "Config. Package Field"; var FieldNode: DotNet XmlNode)
     begin
         if ConfigPackageField."Primary Key" then
@@ -140,7 +181,25 @@ codeunit 8614 "Config. XML Exchange"
 
         OnAfterAddFieldAttributes(ConfigPackageField, FieldNode);
     end;
+#endif
+    local procedure AddFieldAttributes(ConfigPackageField: Record "Config. Package Field"; var FieldNode: XmlNode)
+    begin
+        if ConfigPackageField."Primary Key" then
+            XMLDOMMgt.AddAttribute(FieldNode, GetElementName(ConfigPackageField.FieldName("Primary Key")), '1');
+        if ConfigPackageField."Validate Field" then
+            XMLDOMMgt.AddAttribute(FieldNode, GetElementName(ConfigPackageField.FieldName("Validate Field")), '1');
+        if ConfigPackageField."Create Missing Codes" then
+            XMLDOMMgt.AddAttribute(FieldNode, GetElementName(ConfigPackageField.FieldName("Create Missing Codes")), '1');
+        if ConfigPackageField."Processing Order" <> 0 then
+            XMLDOMMgt.AddAttribute(
+              FieldNode, GetElementName(ConfigPackageField.FieldName("Processing Order")), Format(ConfigPackageField."Processing Order"));
 
+        OnAfterAddFieldAttributesProcedure(ConfigPackageField, FieldNode);
+    end;
+
+
+#if not CLEAN29
+    [Obsolete('Replaced by procedure AddDimensionFields', '29.0')]
     local procedure AddDimensionFields(var ConfigPackageField: Record "Config. Package Field"; var RecRef: RecordRef; var PackageXML: DotNet XmlDocument; var RecordNode: DotNet XmlNode; var FieldNode: DotNet XmlNode; ExportValue: Boolean)
     var
         DimCode: Code[20];
@@ -161,8 +220,59 @@ codeunit 8614 "Config. XML Exchange"
                 end;
             until ConfigPackageField.Next() = 0;
     end;
+#endif
+    local procedure AddDimensionFields(var ConfigPackageField: Record "Config. Package Field"; var RecRef: RecordRef; var RecordNode: XmlNode; ExportValue: Boolean)
+    var
+        DimCode: Code[20];
+        FieldValue: Text;
+    begin
+        ConfigPackageField.SetRange(Dimension, true);
+        if ConfigPackageField.FindSet() then
+            repeat
+                if ExportValue then begin
+                    DimCode := CopyStr(ConfigPackageField."Field Name", 1, 20);
+                    FieldValue := GetDimValueFromTable(RecRef, DimCode);
+                end else
+                    FieldValue := '';
+                RecordNode.AsXmlElement().Add(
+                    XmlElement.Create(GetElementName(CopyStr(ConfigValidateMgt.CheckName(ConfigPackageField."Field Name"), 1, 250)), '', FieldValue));
+            until ConfigPackageField.Next() = 0;
+    end;
 
+#if not CLEAN29
+    [Obsolete('Replaced by procedure AddDimPackageFields', '29.0')]
     local procedure AddDimPackageFields(var ConfigPackageTable: Record "Config. Package Table"; RecordNode: DotNet XmlNode)
+    var
+        ConfigPackageField: Record "Config. Package Field";
+        TempConfigPackageField: Record "Config. Package Field" temporary;
+        Dimension: Record Dimension;
+        i: Integer;
+        DimsAsColumns: Boolean;
+    begin
+        if not (ConfigMgt.IsDimSetIDTable(ConfigPackageTable."Table ID") or ConfigMgt.IsDefaultDimTable(ConfigPackageTable."Table ID")) then
+            exit;
+        i := 1;
+        if Dimension.FindSet() then
+            repeat
+                ConfigPackageMgt.InsertPackageField(
+                  TempConfigPackageField, ConfigPackageTable."Package Code", ConfigPackageTable."Table ID", ConfigMgt.DimensionFieldID() + i,
+                  Dimension.Code, Dimension."Code Caption", true, false, false, true);
+                if FieldNodeExists(RecordNode, GetElementName(TempConfigPackageField."Field Name")) then begin
+                    ConfigPackageField := TempConfigPackageField;
+                    ConfigPackageField.Insert();
+                    DimsAsColumns := true;
+                    i := i + 1;
+                end;
+            until Dimension.Next() = 0;
+
+        if DimsAsColumns then begin
+            ConfigPackageTable."Dimensions as Columns" := true;
+            ConfigPackageTable.Modify();
+        end;
+    end;
+#endif
+
+    local procedure AddDimPackageFields(var ConfigPackageTable: Record "Config. Package Table"; RecordNode: XmlNode)
     var
         ConfigPackageField: Record "Config. Package Field";
         TempConfigPackageField: Record "Config. Package Field" temporary;
@@ -217,6 +327,8 @@ codeunit 8614 "Config. XML Exchange"
             RecRef.FilterGroup(0);
     end;
 
+#if not CLEAN29
+    [Obsolete('Replaced by procedure CreateRecordNodes', '29.0')]
     local procedure CreateRecordNodes(var PackageXML: DotNet XmlDocument; ConfigPackageTable: Record "Config. Package Table")
     var
         "Field": Record "Field";
@@ -362,6 +474,145 @@ codeunit 8614 "Config. XML Exchange"
             OnCreateRecordNodesOnAfterNotFoundRecordProcessed(ConfigPackageTable, ConfigPackageField, RecRef, PackageXML, RecordNode, FieldNode, ExcelMode);
         end;
     end;
+#endif
+    local procedure CreateRecordNodes(var PackageXML: XmlDocument; ConfigPackageTable: Record "Config. Package Table")
+    var
+        "Field": Record "Field";
+        ConfigPackageField: Record "Config. Package Field";
+        ConfigPackage: Record "Config. Package";
+        ConfigProgressBarRecord: Codeunit "Config. Progress Bar";
+        RecRef: RecordRef;
+        FieldRef: FieldRef;
+        DocumentElement: XmlElement;
+        DocumentElementNode: XmlNode;
+        FieldNode: XmlNode;
+        RecordNode: XmlNode;
+        TableNode: XmlNode;
+        RecordCount: Integer;
+        ProcessedRecordCount: Integer;
+        StepCount: Integer;
+        ExportMetadata: Boolean;
+        ShowDialog: Boolean;
+        IsHandled: Boolean;
+        FieldNameLookup: Dictionary of [Integer, Text];
+        FieldElementName: Text;
+    begin
+        IsHandled := false;
+        OnBeforeCreateRecordNodesProcedure(ConfigPackageTable, ConfigPackageField, WorkingFolder, ExcelMode, Advanced, HideDialog, IsHandled);
+        if IsHandled then
+            exit;
+
+        if ConfigMgt.IsSystemTable(ConfigPackageTable."Table ID") then
+            exit;
+
+        ConfigPackageTable.TestField("Package Code");
+        ConfigPackageTable.TestField("Table ID");
+        ConfigPackage.Get(ConfigPackageTable."Package Code");
+        ExcludeRemovedFields(ConfigPackageTable);
+        PackageXML.GetRoot(DocumentElement);
+        DocumentElementNode := DocumentElement.AsXmlNode();
+        TableNode := XmlElement.Create(GetElementName(ConfigPackageTable."Table Name" + 'List')).AsXmlNode();
+        DocumentElementNode.AsXmlElement().Add(TableNode);
+
+        TableNode.AsXmlElement().Add(XmlElement.Create(GetElementName(ConfigPackageTable.FieldName("Table ID")), '', Format(ConfigPackageTable."Table ID")));
+
+        if ExcelMode then
+            TableNode.AsXmlElement().Add(XmlElement.Create(GetElementName(ConfigPackageTable.FieldName("Package Code")), '', Format(ConfigPackageTable."Package Code")))
+        else
+            AddTableAttributes(ConfigPackageTable, TableNode);
+
+        ExportMetadata := true;
+        RecRef.Open(ConfigPackageTable."Table ID");
+        IsHandled := false;
+        OnCreateRecordNodesOnBeforeApplyPackageFilter(ConfigPackageTable, RecRef, IsHandled);
+        if not IsHandled then
+            ApplyPackageFilter(ConfigPackageTable, RecRef);
+        OnCreateRecordNodesOnAfterApplyPackageFilter(ConfigPackageTable, ConfigPackage, RecRef);
+        if RecRef.FindSet() then begin
+            RecordCount := RecRef.Count();
+            ShowDialog := (not HideDialog) and (RecordCount > 1000);
+            if ShowDialog then begin
+                StepCount := Round(RecordCount / 100, 1);
+                ConfigProgressBarRecord.Init(RecordCount, StepCount, ExportPackageTxt);
+            end;
+            repeat
+                IsHandled := false;
+                OnCreateRecordNodesOnBeforeRecRefLoopIteration(ConfigPackageTable, ConfigPackage, RecRef, ConfigProgressBar, IsHandled);
+                if not IsHandled then begin
+                    RecordNode := XmlElement.Create(GetTableElementName(ConfigPackageTable."Table Name")).AsXmlNode();
+                    TableNode.AsXmlElement().Add(RecordNode);
+
+                    ConfigPackageField.SetRange("Package Code", ConfigPackageTable."Package Code");
+                    ConfigPackageField.SetRange("Table ID", ConfigPackageTable."Table ID");
+                    ConfigPackageField.SetRange("Include Field", true);
+                    ConfigPackageField.SetCurrentKey("Package Code", "Table ID", "Processing Order");
+                    OnCreateRecordNodesOnAfterConfigPackageFieldSetFilters(ConfigPackageTable, ConfigPackageField);
+                    if ConfigPackageField.FindSet() then
+                        repeat
+                            if ConfigPackageField.Dimension then begin
+                                if ConfigPackageTable."Dimensions as Columns" and ExcelMode then
+                                    AddDimensionFieldsWhenProcessingOrder(ConfigPackageField, RecRef, RecordNode, true);
+                            end else begin
+                                FieldRef := RecRef.Field(ConfigPackageField."Field ID");
+
+                                // Reuse validated field name. Validating and creating field names is expensive when done many times.
+                                if not (FieldNameLookup.Get(FieldRef.Number, FieldElementName)) then
+                                    if TypeHelper.GetField(RecRef.Number, FieldRef.Number, Field) then begin
+                                        FieldElementName := GetFieldElementName(ConfigPackageField.GetValidatedElementName());
+                                        FieldNameLookup.Add(FieldRef.Number, FieldElementName);
+                                    end;
+
+                                if (FieldElementName <> '') then begin
+                                    FieldNode := XmlElement.Create(FieldElementName, '', FormatFieldValue(FieldRef, ConfigPackage)).AsXmlNode();
+                                    if Advanced and ConfigPackageField."Localize Field" then
+                                        AddXMLComment(FieldNode, '_locComment_text="{MaxLength=' + Format(Field.Len) + '}"');
+                                    RecordNode.AsXmlElement().Add(FieldNode); // must be after AddXMLComment and before AddAttribute.
+                                    if not ExcelMode and ExportMetadata then
+                                        AddFieldAttributes(ConfigPackageField, FieldNode);
+                                    if Advanced then
+                                        if ConfigPackageField."Localize Field" then
+                                            XMLDOMMgt.AddAttribute(FieldNode, '_loc', 'locData')
+                                        else
+                                            XMLDOMMgt.AddAttribute(FieldNode, '_loc', 'locNone');
+                                end;
+                            end;
+                        until ConfigPackageField.Next() = 0;
+
+                    OnCreateRecordNodesProcedureOnAfterRecordProcessed(ConfigPackageTable, ConfigPackageField, RecRef, PackageXML, RecordNode, FieldNode, ExcelMode);
+                    ExportMetadata := false;
+                    ProcessedRecordCount += 1;
+
+                    if ShowDialog then
+                        ConfigProgressBarRecord.Update(StrSubstNo(ProgressStatusTxt, ConfigPackageTable."Table Name", ProcessedRecordCount, RecordCount));
+                end;
+            until RecRef.Next() = 0;
+            // Tag used for analytics
+            Session.LogMessage('0000BV0', StrSubstNo(ExportedTableContentTxt, RecRef.Name, RecordCount, ConfigPackageField.Count()), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', RapidStartTxt);
+            if ShowDialog then
+                ConfigProgressBarRecord.Close();
+        end else begin
+            RecordNode := XmlElement.Create(GetTableElementName(ConfigPackageTable."Table Name")).AsXmlNode();
+            TableNode.AsXmlElement().Add(RecordNode);
+
+            ConfigPackageField.SetRange("Package Code", ConfigPackageTable."Package Code");
+            ConfigPackageField.SetRange("Table ID", ConfigPackageTable."Table ID");
+            ConfigPackageField.SetRange("Include Field", true);
+            ConfigPackageField.SetRange(Dimension, false);
+            OnCreateRecordNodesOnNotFoundOnAfterConfigPackageFieldSetFilters(ConfigPackageTable, ConfigPackageField);
+            if ConfigPackageField.FindSet() then
+                repeat
+                    FieldRef := RecRef.Field(ConfigPackageField."Field ID");
+                    FieldNode := XmlElement.Create(GetFieldElementName(ConfigPackageField.GetValidatedElementName())).AsXmlNode();
+                    RecordNode.AsXmlElement().Add(FieldNode);
+                    if not ExcelMode then
+                        AddFieldAttributes(ConfigPackageField, FieldNode);
+                until ConfigPackageField.Next() = 0;
+
+            if ConfigPackageTable."Dimensions as Columns" and ExcelMode then
+                AddDimensionFields(ConfigPackageField, RecRef, RecordNode, false);
+            OnCreateRecordNodesProcedureOnAfterNotFoundRecordProcessed(ConfigPackageTable, ConfigPackageField, RecRef, PackageXML, RecordNode, FieldNode, ExcelMode);
+        end;
+    end;
 
     /// <summary>
     /// Export the provided configuration package to an OutStream.
@@ -408,6 +659,107 @@ codeunit 8614 "Config. XML Exchange"
     procedure ExportPackageXML(var ConfigPackageTable: Record "Config. Package Table"; XMLDataFile: Text): Boolean
     var
         ConfigPackage: Record "Config. Package";
+        PackageXML: XmlDocument;
+        FileFilter: Text;
+        ToFile: Text[50];
+        CompressedFileName: Text;
+        PackageExportStartMsg: Label 'Export of RS package started.', Locked = true;
+        PackageExportFinishMsg: Label 'Export of RS package finished. Duration: %1 milliseconds.', Locked = true;
+        DurationAsInt: BigInteger;
+        StartTime: DateTime;
+        ExecutionId: Guid;
+        Dimensions: Dictionary of [Text, Text];
+        OutStream: OutStream;
+        XMLFile: File;
+    begin
+        StartTime := CurrentDateTime();
+        Session.LogMessage('00009Q4', PackageExportStartMsg, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', RapidStartTxt);
+
+        ConfigPackageTable.FindFirst();
+        ConfigPackage.Get(ConfigPackageTable."Package Code");
+        ConfigPackage.TestField(Code);
+        ConfigPackage.TestField("Package Name");
+
+        ExecutionId := CreateGuid();
+        Dimensions.Add('Category', RapidStartTxt);
+        Dimensions.Add('PackageCode', ConfigPackage.SystemId);
+        Dimensions.Add('ExecutionId', Format(ExecutionId, 0, 4));
+        Session.LogMessage('0000E3F', StrSubstNo(PackageExportStartScopeAllMsg, ConfigPackage.SystemId), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, Dimensions);
+
+        if not ConfigPackage."Exclude Config. Tables" and not ExcelMode then
+            ConfigPackageMgt.AddConfigTables(ConfigPackage.Code);
+
+        if not CalledFromCode then
+            XMLDataFile := FileManagement.ServerTempFileName('');
+        FileFilter := GetFileDialogFilter();
+        if ToFile = '' then
+            ToFile := StrSubstNo(PackageFileNameTxt, ConfigPackage.Code);
+        OnExportPackageXMLOnAfterAssignToFile(ConfigPackage, ToFile);
+
+        SetWorkingFolder(FileManagement.GetDirectoryName(XMLDataFile));
+        ExportPackageToXMLDocument(PackageXML, ConfigPackageTable, ConfigPackage, Advanced);
+
+        XMLFile.Create(XMLDataFile, TextEncoding::UTF16);
+        XMLFile.CreateOutStream(OutStream);
+        PackageXML.WriteTo(OutStream);
+        XMLFile.Close();
+
+        DurationAsInt := CurrentDateTime() - StartTime;
+        Dimensions.Add('ExecutionTimeInMs', Format(DurationAsInt));
+        Session.LogMessage('0000E3G', StrSubstNo(PackageExportFinishScopeAllMsg, ConfigPackage.SystemId), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, Dimensions);
+
+        // Tag used for analytics
+        Session.LogMessage('00009Q5', StrSubstNo(PackageExportFinishMsg, DurationAsInt), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', RapidStartTxt);
+
+        if not CalledFromCode then begin
+            CompressedFileName := FileManagement.ServerTempFileName('');
+            OnOnExportPackageXMLOnAfterAssignToFileOnAfterSetCompressedFileName(CompressedFileName, XMLDataFile);
+            ConfigPckgCompressionMgt.ServersideCompress(XMLDataFile, CompressedFileName);
+
+            FileManagement.DownloadHandler(CompressedFileName, DownloadTxt, '', FileFilter, ToFile);
+        end;
+
+        exit(true);
+    end;
+
+#if not CLEAN29
+
+    /// <summary>
+    /// Export the provided configuration package to an OutStream.
+    /// </summary>
+    /// <param name="ConfigPackage">Configuration package to export.</param>
+    /// <param name="PackageOutStream">OutStream object that the content of the package will be written to.</param>
+    [Obsolete('Replaced by procedure ExportPackageXMLToStream', '29.0')]
+    procedure ExportPackageXMLToStreamLegacy(ConfigPackage: Record "Config. Package"; PackageOutStream: OutStream)
+    var
+        ConfigPackageTable: Record "Config. Package Table";
+        XMLDataFile: File;
+        XMLDataFileName: Text;
+        XMLDataFileInStream: InStream;
+        OriginalCalledFromCode: Boolean;
+    begin
+        ConfigPackage.TestField(ConfigPackage.Code);
+        ConfigPackage.TestField(ConfigPackage."Package Name");
+        ConfigPackageTable.SetRange("Package Code", ConfigPackage.Code);
+
+        XMLDataFileName := FileManagement.ServerTempFileName('');
+
+        OriginalCalledFromCode := CalledFromCode;
+        SetCalledFromCode(true);
+        ExportPackageXMLLegacy(ConfigPackageTable, XMLDataFileName);
+        CalledFromCode := OriginalCalledFromCode;
+
+        XMLDataFile.Open(XMLDataFileName);
+        XMLDataFile.CreateInStream(XMLDataFileInStream);
+        CopyStream(PackageOutStream, XMLDataFileInStream);
+        XMLDataFile.Close();
+    end;
+
+    [Scope('OnPrem')]
+    [Obsolete('Replaced by procedure ExportPackageXML', '29.0')]
+    procedure ExportPackageXMLLegacy(var ConfigPackageTable: Record "Config. Package Table"; XMLDataFile: Text): Boolean
+    var
+        ConfigPackage: Record "Config. Package";
         PackageXML: DotNet XmlDocument;
         FileFilter: Text;
         ToFile: Text[50];
@@ -418,6 +770,9 @@ codeunit 8614 "Config. XML Exchange"
         StartTime: DateTime;
         ExecutionId: Guid;
         Dimensions: Dictionary of [Text, Text];
+        XMLText: Text;
+        OutStream: OutStream;
+        XMLFile: File;
     begin
         StartTime := CurrentDateTime();
         Session.LogMessage('00009Q4', PackageExportStartMsg, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', RapidStartTxt);
@@ -468,6 +823,7 @@ codeunit 8614 "Config. XML Exchange"
     end;
 
     [Scope('OnPrem')]
+    [Obsolete('Replaced by procedure ExportPackageToXMLDocument', '29.0')]
     procedure ExportPackageXMLDocument(var PackageXML: DotNet XmlDocument; var ConfigPackageTable: Record "Config. Package Table"; ConfigPackage: Record "Config. Package"; Advanced: Boolean)
     var
         FeatureTelemetry: Codeunit "Feature Telemetry";
@@ -533,8 +889,87 @@ codeunit 8614 "Config. XML Exchange"
 
         OnAfterExportPackageXMLDocument(ConfigPackage, HideDialog);
     end;
+#endif
 
+    procedure ExportPackageToXMLDocument(var PackageXML: XmlDocument; var ConfigPackageTable: Record "Config. Package Table"; ConfigPackage: Record "Config. Package"; Advanced: Boolean)
+    var
+        FeatureTelemetry: Codeunit "Feature Telemetry";
+        DocumentElement: XmlElement;
+        DocumentElementNode: XmlNode;
+        LocXML: Text[1024];
+        XmlText: Text;
+    begin
+        FeatureTelemetry.LogUptake('0000E3X', 'Configuration packages', Enum::"Feature Uptake Status"::"Used");
+        ConfigPackage.TestField(Code);
+        ConfigPackage.TestField("Package Name");
+
+        if Advanced then
+            LocXML := '<_locDefinition><_locDefault _loc="locNone"/></_locDefinition>';
+        XmlText := StrSubstNo(
+            '<?xml version="1.0" encoding="UTF-16" standalone="yes"?><%1>%2</%1>',
+            GetPackageTag(),
+            LocXML);
+        XmlDocument.ReadFrom(XmlText, PackageXML);
+
+        CleanUpConfigPackageData(ConfigPackage);
+
+        if not ExcelMode then begin
+            InitializeMediaTempFolder();
+            PackageXML.GetRoot(DocumentElement);
+            DocumentElementNode := DocumentElement.AsXmlNode();
+            XMLDOMMgt.AddAttribute(
+              DocumentElementNode, GetElementName(ConfigPackage.FieldName("Min. Count For Async Import")),
+              Format(ConfigPackage."Min. Count For Async Import"));
+            if ConfigPackage."Exclude Config. Tables" then
+                XMLDOMMgt.AddAttribute(DocumentElementNode, GetElementName(ConfigPackage.FieldName("Exclude Config. Tables")), '1');
+            if ConfigPackage."Processing Order" > 0 then
+                XMLDOMMgt.AddAttribute(
+                  DocumentElementNode, GetElementName(ConfigPackage.FieldName("Processing Order")), Format(ConfigPackage."Processing Order"));
+            if ConfigPackage."Language ID" > 0 then
+                XMLDOMMgt.AddAttribute(
+                  DocumentElementNode, GetElementName(ConfigPackage.FieldName("Language ID")), Format(ConfigPackage."Language ID"));
+            XMLDOMMgt.AddAttribute(
+              DocumentElementNode, GetElementName(ConfigPackage.FieldName("Product Version")), ConfigPackage."Product Version");
+            XMLDOMMgt.AddAttribute(DocumentElementNode, GetElementName(ConfigPackage.FieldName("Package Name")), ConfigPackage."Package Name");
+            XMLDOMMgt.AddAttribute(DocumentElementNode, GetElementName(ConfigPackage.FieldName(Code)), ConfigPackage.Code);
+            OnExportPackageToXMLDocumentOnAfterSetAttributes(ConfigPackage, DocumentElementNode);
+        end;
+
+        OnExportPackageToXMLDocumentOnBeforeConfigProgressBarInit(ConfigPackageTable, ConfigPackage, Advanced, HideDialog);
+
+        if not HideDialog then
+            ConfigProgressBar.Init(ConfigPackageTable.Count, 1, ExportPackageTxt);
+        ConfigPackageTable.SetAutoCalcFields("Table Name");
+        if ConfigPackageTable.FindSet() then
+            repeat
+                if not HideDialog then
+                    ConfigProgressBar.Update(ConfigPackageTable."Table Name");
+
+                ExportConfigTableToXML(ConfigPackageTable, PackageXML);
+            until ConfigPackageTable.Next() = 0;
+
+        if not ExcelMode then begin
+            UpdateConfigPackageMediaSet(ConfigPackage);
+            ExportConfigPackageMediaSetToXML(PackageXML, ConfigPackage);
+        end;
+
+        if not HideDialog then
+            ConfigProgressBar.Close();
+
+        OnAfterExportPackageToXMLDocument(ConfigPackage, HideDialog);
+    end;
+
+#if not CLEAN29
+    [Obsolete('Replaced by procedure ExportConfigTableToXML', '29.0')]
     local procedure ExportConfigTableToXML(var ConfigPackageTable: Record "Config. Package Table"; var PackageXML: DotNet XmlDocument)
+    begin
+        CreateRecordNodes(PackageXML, ConfigPackageTable);
+        ConfigPackageTable."Exported Date and Time" := CreateDateTime(Today, Time);
+        ConfigPackageTable.Modify();
+    end;
+#endif
+
+    local procedure ExportConfigTableToXML(var ConfigPackageTable: Record "Config. Package Table"; var PackageXML: XmlDocument)
     begin
         CreateRecordNodes(PackageXML, ConfigPackageTable);
         ConfigPackageTable."Exported Date and Time" := CreateDateTime(Today, Time);
@@ -556,6 +991,9 @@ codeunit 8614 "Config. XML Exchange"
         DummyModifyDate: Date;
         DummyModifyTime: Time;
         FileSize: BigInteger;
+#if not CLEAN29
+        UseImportWithDotNet: Boolean;
+#endif
     begin
         ServerFileName := FileManagement.ServerTempFileName('.xml');
         if not UploadXMLPackage(ServerFileName) then
@@ -567,9 +1005,17 @@ codeunit 8614 "Config. XML Exchange"
                 exit(false);
         DecompressedFileName := DecompressPackage(ServerFileName);
 
-        exit(ImportPackageXML(DecompressedFileName));
+#if not CLEAN29
+        UseImportWithDotNet := false;
+        OnImportPackageXMLFromClientOnBeforeImportPackage(UseImportWithDotNet);
+        if UseImportWithDotNet then
+            exit(ImportPackageXML(DecompressedFileName));
+#endif
+        exit(ImportPackageXMLFromFile(DecompressedFileName));
     end;
 
+#if not CLEAN29
+    [Obsolete('Replaced by procedure ImportPackageXMLFromFile(XMLDataFile: Text)', '29.0')]
     procedure ImportPackageXML(XMLDataFile: Text): Boolean
     var
         PackageXML: DotNet XmlDocument;
@@ -579,6 +1025,7 @@ codeunit 8614 "Config. XML Exchange"
         exit(ImportPackageXMLDocument(PackageXML, ''));
     end;
 
+    [Obsolete('Replaced by procedure ImportPackageXML(InStream: InStream)', '29.0')]
     procedure ImportPackageXMLFromStream(InStream: InStream): Boolean
     var
         PackageXML: DotNet XmlDocument;
@@ -588,6 +1035,7 @@ codeunit 8614 "Config. XML Exchange"
         exit(ImportPackageXMLDocument(PackageXML, ''));
     end;
 
+    [Obsolete('Replaced by procedure ImportPackageXMLWithCode(InStream: InStream; PackageCode: Code[20])', '29.0')]
     procedure ImportPackageXMLWithCodeFromStream(InStream: InStream; PackageCode: Code[20]): Boolean
     var
         PackageXML: DotNet XmlDocument;
@@ -599,8 +1047,41 @@ codeunit 8614 "Config. XML Exchange"
 
         exit(ImportPackageXMLDocument(PackageXML, PackageCode));
     end;
+#endif
 
     [Scope('OnPrem')]
+    procedure ImportPackageXMLFromFile(XMLDataFile: Text): Boolean
+    var
+        PackageXML: XmlDocument;
+    begin
+        XMLDOMMgt.LoadXMLDocumentFromFile(XMLDataFile, PackageXML);
+
+        exit(ImportPackageXMLDocument(PackageXML, ''));
+    end;
+
+    procedure ImportPackageXML(InStream: InStream): Boolean
+    var
+        PackageXML: XmlDocument;
+    begin
+        XmlDocument.ReadFrom(InStream, PackageXML);
+        exit(ImportPackageXMLDocument(PackageXML, ''));
+    end;
+
+    procedure ImportPackageXMLWithCode(InStream: InStream; PackageCode: Code[20]): Boolean
+    var
+        PackageXML: XmlDocument;
+    begin
+        XmlDocument.ReadFrom(InStream, PackageXML);
+        if PackageCode <> '' then
+            if PackageCode <> GetPackageCode(PackageXML) then
+                Error(PackageCodesMustMatchErr);
+
+        exit(ImportPackageXMLDocument(PackageXML, PackageCode));
+    end;
+
+#if not CLEAN29
+    [Scope('OnPrem')]
+    [Obsolete('Replaced by procedure ImportPackageXMLDocument', '29.0')]
     procedure ImportPackageXMLDocument(PackageXML: DotNet XmlDocument; PackageCode: Code[20]) Result: Boolean
     var
         ConfigPackage: Record "Config. Package";
@@ -767,8 +1248,182 @@ codeunit 8614 "Config. XML Exchange"
         Result := true;
         OnAfterImportPackageXMLDocument(PackageCode, ExcelMode, Result);
     end;
+#endif
 
+    procedure ImportPackageXMLDocument(PackageXML: XmlDocument; PackageCode: Code[20]) Result: Boolean
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageRecord: Record "Config. Package Record";
+        ConfigPackageData: Record "Config. Package Data";
+        TempBlob: Codeunit "Temp Blob";
+        ParallelSessionManagement: Codeunit "Parallel Session Management";
+        FeatureTelemetry: Codeunit "Feature Telemetry";
+        DurationAsInt: BigInteger;
+        DocumentElement: XmlElement;
+        TableNodes: XmlNodeList;
+        TableNode: XmlNode;
+        OutStream: OutStream;
+        Value: Text;
+        PackageImportStartMsg: Label 'Import of RS package started.', Locked = true;
+        PackageImportFinishMsg: Label 'Import of RS package finished. Duration: %1 milliseconds. File size: %2.', Locked = true;
+        StartTime: DateTime;
+        TableID: Integer;
+        NodeCount: Integer;
+        Confirmed: Boolean;
+        NoOfChildNodes: Integer;
+        FileSize: Integer;
+        CurrTableName: Text;
+        CurrRecordCount: Integer;
+        TotalTableFields: Integer;
+        ImportedTableFields: Integer;
+        ExecutionId: Guid;
+        Dimensions: Dictionary of [Text, Text];
+        IsHandled: Boolean;
+        DocumentElementNode: XmlNode;
+        PackageXMLText: Text;
+    begin
+        VerifyCanImportConfigurationPackage();
+        StartTime := CurrentDateTime();
+        Session.LogMessage('00009Q6', PackageImportStartMsg, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, Dimensions);
+        FeatureTelemetry.LogUptake('0000E3D', 'Configuration packages', Enum::"Feature Uptake Status"::"Set up");
+
+        PackageXML.WriteTo(PackageXMLText);
+        FileSize := StrLen(PackageXMLText) * 2; // due to UTF-16 encoding
+        PackageXML.GetRoot(DocumentElement);
+        DocumentElementNode := DocumentElement.AsXmlNode();
+
+        if not ExcelMode then begin
+            if PackageCode = '' then begin
+                PackageCode := GetPackageCode(PackageXML);
+                if ConfigPackage.Get(PackageCode) then begin
+                    ConfigPackage.CalcFields("No. of Records");
+                    Confirmed := true;
+                    if not HideDialog then
+                        if ConfigPackage."No. of Records" > 0 then
+                            if not Confirm(PackageAllreadyContainsDataQst, true, PackageCode) then
+                                Confirmed := false;
+                    if not Confirmed then
+                        exit(false);
+                    ConfigPackage.Delete(true);
+                    Commit();
+                end;
+                ConfigPackage.Init();
+                ConfigPackage.Code := PackageCode;
+                ConfigPackage.Insert();
+            end else
+                ConfigPackage.Get(PackageCode);
+            ImportedPackageCode := PackageCode;
+
+            ConfigPackage."Package Name" :=
+              CopyStr(
+                GetAttribute(GetElementName(ConfigPackage.FieldName("Package Name")), DocumentElementNode), 1,
+                MaxStrLen(ConfigPackage."Package Name"));
+            Value := GetAttribute(GetElementName(ConfigPackage.FieldName("Language ID")), DocumentElementNode);
+            if Value <> '' then
+                Evaluate(ConfigPackage."Language ID", Value);
+            ConfigPackage."Product Version" :=
+              CopyStr(
+                GetAttribute(GetElementName(ConfigPackage.FieldName("Product Version")), DocumentElementNode), 1,
+                MaxStrLen(ConfigPackage."Product Version"));
+            Value := GetAttribute(GetElementName(ConfigPackage.FieldName("Processing Order")), DocumentElementNode);
+            if Value <> '' then
+                Evaluate(ConfigPackage."Processing Order", Value);
+            Value := GetAttribute(GetElementName(ConfigPackage.FieldName("Exclude Config. Tables")), DocumentElementNode);
+            if Value <> '' then
+                Evaluate(ConfigPackage."Exclude Config. Tables", Value);
+            Value := GetAttribute(GetElementName(ConfigPackage.FieldName("Min. Count For Async Import")), DocumentElementNode);
+            if Value <> '' then begin
+                IsHandled := false;
+                OnBeforeEvaluateMinCountForAsyncImport(ConfigPackage, Value, IsHandled);
+                if not IsHandled then
+                    Evaluate(ConfigPackage."Min. Count For Async Import", Value);
+            end;
+            OnImportPackageXMLDocumentOnBeforeModifyConfigPackage(ConfigPackage, DocumentElementNode);
+            ConfigPackage.Modify();
+        end;
+
+        ExecutionId := CreateGuid();
+        Dimensions.Add('Category', RapidStartTxt);
+        Dimensions.Add('ExecutionId', Format(ExecutionId, 0, 4));
+        Session.LogMessage('0000E3H', StrSubstNo(PackageImportStartScopeAllMsg, ConfigPackage.SystemId), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, Dimensions);
+
+        Commit(); // to enable background processes to reference the ConfigPackage
+
+        TableNodes := DocumentElement.GetChildElements();
+        if not HideDialog then
+            ConfigProgressBar.Init(TableNodes.Count(), 1, ImportPackageTxt);
+        foreach TableNode in TableNodes do begin
+            NodeCount += 1;
+            if GetTableIdFromXmlNode(TableNode, TableID) then begin
+                if GetTableStatisticsForTelemetry(TableNode, CurrTableName, CurrRecordCount, TotalTableFields, ImportedTableFields) then
+                    Session.LogMessage('0000BV1', StrSubstNo(ImportedTableContentTxt, CurrTableName, CurrRecordCount, TotalTableFields, ImportedTableFields), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', RapidStartTxt);
+
+                NoOfChildNodes := GetChildNodeCount(TableNode);
+                if (NoOfChildNodes < ConfigPackage."Min. Count For Async Import") or ExcelMode then
+                    ImportTableFromXMLNode(TableNode, PackageCode)
+                else begin
+                    // Send to background
+                    Clear(TempBlob);
+                    TempBlob.CreateOutStream(OutStream, TEXTENCODING::UTF8);
+                    OutStream.WriteText('<doc>' + GetNodeOuterXml(TableNode) + '</doc>');
+                    ParallelSessionManagement.NewSessionRunCodeunitWithBlob(
+                      CODEUNIT::"Config. Import Table in Backgr", PackageCode, TempBlob);
+                end;
+                if ExcelMode then
+                    case true of // Dimensions
+                        ConfigMgt.IsDefaultDimTable(TableID):
+                            begin
+                                ConfigPackageRecord.SetRange("Package Code", PackageCode);
+                                ConfigPackageRecord.SetRange("Table ID", TableID);
+                                OnImportPackageXMLDocumentOnDefaultDimOnAfterConfigPackageRecordSetFilters(ConfigPackageRecord, ConfigPackageData, PackageCode);
+                                if ConfigPackageRecord.FindSet() then
+                                    repeat
+                                        ConfigPackageData.Get(
+                                          ConfigPackageRecord."Package Code", ConfigPackageRecord."Table ID",
+                                          ConfigPackageRecord."No.", GetDefaultDimensionNoLinkFieldNumber(TableID));
+                                        ConfigPackageMgt.UpdateDefaultDimValues(ConfigPackageRecord, CopyStr(ConfigPackageData.Value, 1, 20));
+                                    until ConfigPackageRecord.Next() = 0;
+                            end;
+                        ConfigMgt.IsDimSetIDTable(TableID):
+                            begin
+                                ConfigPackageRecord.SetRange("Package Code", PackageCode);
+                                ConfigPackageRecord.SetRange("Table ID", TableID);
+                                if ConfigPackageRecord.FindSet() then
+                                    repeat
+                                        ConfigPackageMgt.HandlePackageDataDimSetIDForRecord(ConfigPackageRecord);
+                                    until ConfigPackageRecord.Next() = 0;
+                            end;
+                    end;
+            end;
+        end;
+
+        Commit(); // to ensure no deadlock occurs when waiting for background processes
+
+        if not HideDialog then
+            ConfigProgressBar.Close();
+        if not ExcelMode then
+            ParallelSessionManagement.WaitForAllToFinish(0);
+
+        ConfigPackageMgt.UpdateConfigLinePackageData(ConfigPackage.Code);
+        DurationAsInt := CurrentDateTime() - StartTime;
+
+        Dimensions.Add('ExecutionTimeInMs', Format(DurationAsInt));
+        Dimensions.Add('FileSizeInBytes', Format(FileSize));
+        Session.LogMessage('0000E3I', StrSubstNo(PackageImportFinishScopeAllMsg, ConfigPackage.SystemId), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, Dimensions);
+        Session.LogMessage('00009Q7', StrSubstNo(PackageImportFinishMsg, DurationAsInt, FileSize), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', RapidStartTxt);
+
+        // autoapply configuration lines
+        ConfigPackageMgt.ApplyConfigTables(ConfigPackage);
+
+        ConfigPackageMgt.SentPackageImportedNotification(PackageCode);
+
+        Result := true;
+        OnAfterImportPackageXMLDocument(PackageCode, ExcelMode, Result);
+    end;
+
+#if not CLEAN29
     [TryFunction]
+    [Obsolete('Replaced by procedure GetTableStatisticsForTelemetry', '29.0')]
     internal procedure GetTableStatisticsForTelemetry(TableNode: DotNet XmlNode; var TableName: Text; var RecordCount: Integer; var TotalTableFields: Integer; var ImportedTableFields: Integer)
     var
         CurrTableRecordRef: RecordRef;
@@ -801,8 +1456,97 @@ codeunit 8614 "Config. XML Exchange"
         if RecordCount > 0 then
             ImportedTableFields := TableNode.LastChild().ChildNodes().Count();
     end;
+#endif
 
+    local procedure GetTableIdFromXmlNode(TableNode: XmlNode; var TableID: Integer): Boolean
+    var
+        FirstChildNode: XmlNode;
+        ChildElements: XmlNodeList;
+    begin
+        if TableNode.IsXmlElement() then
+            ChildElements := TableNode.AsXmlElement().GetChildElements()
+        else
+            exit(false);
+        if ChildElements.Count() > 0 then begin
+            ChildElements.Get(1, FirstChildNode);
+            exit(Evaluate(TableID, FirstChildNode.AsXmlElement().InnerText()));
+        end;
+    end;
+
+    local procedure GetChildNodeCount(TableNode: XmlNode): Integer
+    var
+        ChildElements: XmlNodeList;
+    begin
+        if TableNode.IsXmlElement() then
+            ChildElements := TableNode.AsXmlElement().GetChildElements()
+        else
+            exit(0);
+        exit(ChildElements.Count());
+    end;
+
+    local procedure GetNodeOuterXml(TableNode: XmlNode): Text
+    var
+        XMLText: Text;
+    begin
+        TableNode.WriteTo(XMLText);
+        exit(XMLText);
+    end;
+
+    [TryFunction]
+    internal procedure GetTableStatisticsForTelemetry(TableNode: XmlNode; var TableName: Text; var RecordCount: Integer; var TotalTableFields: Integer; var ImportedTableFields: Integer)
+    var
+        CurrTableRecordRef: RecordRef;
+        TableNodeList: XmlNodeList;
+        TableChildNode: XmlNode;
+        NoOfChildNodes: Integer;
+        TableID: Integer;
+        NonRecordNodeCount: Integer;
+        TableElementName: Text;
+        FirstChildNode: XmlNode;
+        ChildElements: XmlNodeList;
+        LastChildNode: XmlNode;
+        LastChildChildElements: XmlNodeList;
+    begin
+        if TableNode.IsXmlElement() then
+            ChildElements := TableNode.AsXmlElement().GetChildElements()
+        else
+            exit;
+        if ChildElements.Count() > 0 then begin
+            ChildElements.Get(1, FirstChildNode);
+            Evaluate(TableID, FirstChildNode.AsXmlElement().InnerText());
+        end;
+        CurrTableRecordRef.Open(TableID);
+        TableName := CurrTableRecordRef.Name();
+        TotalTableFields := CurrTableRecordRef.FieldCount();
+        CurrTableRecordRef.Close();
+
+        if TableNode.IsXmlElement() then
+            TableNodeList := TableNode.AsXmlElement().GetChildElements()
+        else
+            exit;
+        NoOfChildNodes := TableNodeList.Count();
+
+        // ignore TableID, PageID, SkipTableTriggers etc child nodes for the table
+        TableElementName := GetElementName(CopyStr(TableName, 1, 250));
+        NonRecordNodeCount := 0;
+        foreach TableChildNode in TableNodeList do begin
+            if TableChildNode.AsXmlElement().Name.Contains(TableElementName) then
+                break;
+            NonRecordNodeCount += 1;
+        end;
+
+        RecordCount := NoOfChildNodes - NonRecordNodeCount;
+        if (RecordCount > 0) and (TableNodeList.Count() > 0) then begin
+            TableNodeList.Get(TableNodeList.Count(), LastChildNode);
+            if LastChildNode.IsXmlElement() then
+                LastChildChildElements := LastChildNode.AsXmlElement().GetChildElements();
+            ImportedTableFields := LastChildChildElements.Count();
+        end;
+    end;
+
+#if not CLEAN29
     [Scope('OnPrem')]
+    [Obsolete('Replaced by procedure ImportTableFromXMLNode', '29.0')]
     procedure ImportTableFromXMLNode(var TableNode: DotNet XmlNode; var PackageCode: Code[20])
     var
         ConfigPackageRecord: Record "Config. Package Record";
@@ -821,6 +1565,7 @@ codeunit 8614 "Config. XML Exchange"
         end;
     end;
 
+    [Obsolete('Replaced by procedure PackageDataExistsInXML', '29.0')]
     local procedure PackageDataExistsInXML(PackageCode: Code[20]; TableID: Integer; var TableNode: DotNet XmlNode): Boolean
     var
         ConfigPackageTable: Record "Config. Package Table";
@@ -857,6 +1602,7 @@ codeunit 8614 "Config. XML Exchange"
 
         exit(false);
     end;
+#endif
 
     [TryFunction]
     local procedure TryOpenTable(TableId: Integer)
@@ -866,6 +1612,8 @@ codeunit 8614 "Config. XML Exchange"
         RecordRef.Open(TableId);
     end;
 
+#if not CLEAN29
+    [Obsolete('Replaced by procedure FillPackageMetadataFromXML', '29.0')]
     local procedure FillPackageMetadataFromXML(var PackageCode: Code[20]; TableID: Integer; var TableNode: DotNet XmlNode)
     var
         ConfigPackage: Record "Config. Package";
@@ -984,6 +1732,7 @@ codeunit 8614 "Config. XML Exchange"
         end;
     end;
 
+    [Obsolete('Replaced by procedure FillPackageDataFromXML', '29.0')]
     local procedure FillPackageDataFromXML(PackageCode: Code[20]; TableID: Integer; var TableNode: DotNet XmlNode)
     var
         ConfigPackageTable: Record "Config. Package Table";
@@ -1088,6 +1837,7 @@ codeunit 8614 "Config. XML Exchange"
                 ConfigProgressBarRecord.Close();
         end;
     end;
+#endif
 
     local procedure ExcludeRemovedFields(ConfigPackageTable: Record "Config. Package Table")
     var
@@ -1105,6 +1855,8 @@ codeunit 8614 "Config. XML Exchange"
             until Field.Next() = 0;
     end;
 
+#if not CLEAN29
+    [Obsolete('Replaced by procedure FieldNodeExists', '29.0')]
     local procedure FieldNodeExists(var RecordNode: DotNet XmlNode; FieldNodeName: Text[250]): Boolean
     var
         FieldNode: DotNet XmlNode;
@@ -1113,6 +1865,14 @@ codeunit 8614 "Config. XML Exchange"
 
         if not IsNull(FieldNode) then
             exit(true);
+    end;
+#endif
+
+    local procedure FieldNodeExists(var RecordNode: XmlNode; FieldNodeName: Text[250]): Boolean
+    var
+        FieldNode: XmlNode;
+    begin
+        exit(RecordNode.SelectSingleNode(FieldNodeName, FieldNode));
     end;
 
     local procedure FormatFieldValue(var FieldRef: FieldRef; ConfigPackage: Record "Config. Package") InnerText: Text
@@ -1157,7 +1917,9 @@ codeunit 8614 "Config. XML Exchange"
         exit(InnerText);
     end;
 
+#if not CLEAN29
     [Scope('OnPrem')]
+    [Obsolete('Replaced by procedure GetAttribute', '29.0')]
     procedure GetAttribute(AttributeName: Text[1024]; var XMLNode: DotNet XmlNode): Text[1000]
     var
         XMLAttributes: DotNet XmlNamedNodeMap;
@@ -1168,6 +1930,12 @@ codeunit 8614 "Config. XML Exchange"
         if IsNull(XMLAttributeNode) then
             exit('');
         exit(Format(XMLAttributeNode.InnerText));
+    end;
+#endif
+
+    procedure GetAttribute(AttributeName: Text[1024]; var XMLNode: XmlNode): Text[1000]
+    begin
+        exit(XMLDOMMgt.GetAttributeValue(XMLNode, AttributeName));
     end;
 
     local procedure GetDimValueFromTable(var RecRef: RecordRef; DimCode: Code[20]): Code[20]
@@ -1232,6 +2000,7 @@ codeunit 8614 "Config. XML Exchange"
         exit(GetElementName(NameIn));
     end;
 
+    [Obsolete('Replaced by procedure GetNodeValue', '29.0')]
     local procedure GetNodeValue(var RecordNode: DotNet XmlNode; FieldNodeName: Text[250]): Text
     var
         FieldNode: DotNet XmlNode;
@@ -1241,12 +2010,22 @@ codeunit 8614 "Config. XML Exchange"
             exit(FieldNode.InnerText);
     end;
 
+    local procedure GetNodeValue(var RecordNode: XmlNode; FieldNodeName: Text): Text
+    var
+        FieldNode: XmlNode;
+    begin
+        if RecordNode.SelectSingleNode(FieldNodeName, FieldNode) then
+            exit(FieldNode.AsXmlElement().InnerText());
+    end;
+
     local procedure GetPackageTag(): Text
     begin
         exit(DataListTxt);
     end;
 
+#if not CLEAN29
     [Scope('OnPrem')]
+    [Obsolete('Replaced by procedure GetPackageCode', '29.0')]
     procedure GetPackageCode(PackageXML: DotNet XmlDocument): Code[20]
     var
         ConfigPackage: Record "Config. Package";
@@ -1254,6 +2033,17 @@ codeunit 8614 "Config. XML Exchange"
     begin
         DocumentElement := PackageXML.DocumentElement;
         exit(CopyStr(GetAttribute(GetElementName(ConfigPackage.FieldName(Code)), DocumentElement), 1, MaxStrLen(ConfigPackage.Code)));
+    end;
+#endif
+    procedure GetPackageCode(PackageXML: XmlDocument): Code[20]
+    var
+        ConfigPackage: Record "Config. Package";
+        DocumentElement: XmlElement;
+        DocumentElementNode: XmlNode;
+    begin
+        PackageXML.GetRoot(DocumentElement);
+        DocumentElementNode := DocumentElement.AsXmlNode();
+        exit(CopyStr(GetAttribute(GetElementName(ConfigPackage.FieldName(Code)), DocumentElementNode), 1, MaxStrLen(ConfigPackage.Code)));
     end;
 
     local procedure GetDefaultDimensionNoLinkFieldNumber(TableID: Integer): Integer
@@ -1490,6 +2280,8 @@ codeunit 8614 "Config. XML Exchange"
         exit(MediaIDGuidText);
     end;
 
+#if not CLEAN29
+    [Obsolete('Replaced by procedure GetConfigPackageDataValue', '29.0')]
     local procedure GetConfigPackageDataValue(var ConfigPackageData: Record "Config. Package Data"; var RecordNode: DotNet XmlNode; FieldNodeName: Text[250])
     var
         Base64Convert: Codeunit "Base64 Convert";
@@ -1501,7 +2293,7 @@ codeunit 8614 "Config. XML Exchange"
         end else
             ConfigPackageData.Value := CopyStr(GetNodeValue(RecordNode, FieldNodeName), 1, MaxStrLen(ConfigPackageData.Value));
     end;
-
+#endif
     local procedure UpdateConfigPackageMediaSet(ConfigPackage: Record "Config. Package")
     var
         TempNameValueBuffer: Record "Name/Value Buffer" temporary;
@@ -1522,7 +2314,29 @@ codeunit 8614 "Config. XML Exchange"
         FileManagement.ServerRemoveDirectory(MediaFolder, true);
     end;
 
+#if not CLEAN29
+    [Obsolete('Replaced by procedure ExportConfigPackageMediaSetToXML', '29.0')]
     local procedure ExportConfigPackageMediaSetToXML(var PackageXML: DotNet XmlDocument; ConfigPackage: Record "Config. Package")
+    var
+        ConfigMediaBuffer: Record "Config. Media Buffer";
+        ConfigPackageTable: Record "Config. Package Table";
+        ConfigPackageFilter: Record "Config. Package Filter";
+        ConfigPackageManagement: Codeunit "Config. Package Management";
+    begin
+        ConfigMediaBuffer.SetRange("Package Code", ConfigPackage.Code);
+        if ConfigMediaBuffer.IsEmpty() then
+            exit;
+
+        ConfigPackageManagement.InsertPackageTable(ConfigPackageTable, ConfigPackage.Code, DATABASE::"Config. Media Buffer");
+        ConfigPackageManagement.InsertPackageFilter(
+            ConfigPackageFilter, ConfigPackage.Code, DATABASE::"Config. Media Buffer", 0,
+            ConfigMediaBuffer.FieldNo("Package Code"), ConfigPackage.Code);
+        ConfigPackageTable.CalcFields("Table Name");
+        ExportConfigTableToXML(ConfigPackageTable, PackageXML);
+    end;
+#endif
+
+    local procedure ExportConfigPackageMediaSetToXML(var PackageXML: XmlDocument; ConfigPackage: Record "Config. Package")
     var
         ConfigMediaBuffer: Record "Config. Media Buffer";
         ConfigPackageTable: Record "Config. Package Table";
@@ -1570,6 +2384,8 @@ codeunit 8614 "Config. XML Exchange"
         ConfigMediaBuffer.DeleteAll();
     end;
 
+#if not CLEAN29
+    [Obsolete('Replaced by procedure AddDimensionFieldsWhenProcessingOrder', '29.0')]
     local procedure AddDimensionFieldsWhenProcessingOrder(var ConfigPackageField: Record "Config. Package Field"; var RecRef: RecordRef; var PackageXML: DotNet XmlDocument; var RecordNode: DotNet XmlNode; var FieldNode: DotNet XmlNode; ExportValue: Boolean)
     var
         DimCode: Code[20];
@@ -1586,6 +2402,317 @@ codeunit 8614 "Config. XML Exchange"
             RecordNode.AppendChild(FieldNode);
         end;
     end;
+#endif
+
+    local procedure AddDimensionFieldsWhenProcessingOrder(var ConfigPackageField: Record "Config. Package Field"; var RecRef: RecordRef; var RecordNode: XmlNode; ExportValue: Boolean)
+    var
+        FieldNode: XmlNode;
+        DimCode: Code[20];
+        FieldValue: Text;
+    begin
+        if ExportValue then begin
+            DimCode := CopyStr(ConfigPackageField."Field Name", 1, 20);
+            FieldValue := GetDimValueFromTable(RecRef, DimCode);
+        end else
+            FieldValue := '';
+        FieldNode := XmlElement.Create(
+            GetElementName(CopyStr(ConfigValidateMgt.CheckName(ConfigPackageField."Field Name"), 1, 250)), '', FieldValue).AsXmlNode();
+        RecordNode.AsXmlElement().Add(FieldNode);
+    end;
+
+    procedure ImportTableFromXMLNode(var TableNode: XmlNode; var PackageCode: Code[20])
+    var
+        ConfigPackageRecord: Record "Config. Package Record";
+        ConfigPackageTable: Record "Config. Package Table";
+        TableID: Integer;
+    begin
+        if GetTableIdFromXmlNode(TableNode, TableID) then begin
+            FillPackageMetadataFromXML(PackageCode, TableID, TableNode);
+            if not TableObjectExists(TableID) then begin
+                ConfigPackageMgt.InsertPackageTableWithoutValidation(ConfigPackageTable, PackageCode, TableID);
+                ConfigPackageMgt.InitPackageRecord(ConfigPackageRecord, PackageCode, TableID);
+                ConfigPackageMgt.RecordError(ConfigPackageRecord, 0, CopyStr(StrSubstNo(TableDoesNotExistErr, TableID), 1, 250));
+            end else
+                if PackageDataExistsInXML(PackageCode, TableID, TableNode) then
+                    FillPackageDataFromXML(PackageCode, TableID, TableNode);
+        end;
+    end;
+
+    local procedure PackageDataExistsInXML(PackageCode: Code[20]; TableID: Integer; var TableNode: XmlNode): Boolean
+    var
+        ConfigPackageTable: Record "Config. Package Table";
+        ConfigPackageField: Record "Config. Package Field";
+        RecRef: RecordRef;
+        RecordNodes: XmlNodeList;
+        RecordNode: XmlNode;
+        I: Integer;
+    begin
+        if not ConfigPackageTable.Get(PackageCode, TableID) then
+            exit(false);
+
+        ConfigPackageTable.CalcFields("Table Name");
+        if not TableNode.IsXmlElement() then
+            exit(false);
+
+        TableNode.SelectNodes(GetElementName(ConfigPackageTable."Table Name"), RecordNodes);
+        if RecordNodes.Count() = 0 then
+            exit(false);
+
+        for I := 1 to RecordNodes.Count() do begin
+            RecordNodes.Get(I, RecordNode);
+            if RecordNode.AsXmlElement().HasElements() then begin
+                RecRef.Open(ConfigPackageTable."Table ID");
+                ConfigPackageField.SetRange("Package Code", ConfigPackageTable."Package Code");
+                ConfigPackageField.SetRange("Table ID", ConfigPackageTable."Table ID");
+                if ConfigPackageField.FindSet() then
+                    repeat
+                        if ConfigPackageField."Include Field" and FieldNodeExists(RecordNode, GetElementName(ConfigPackageField."Field Name")) then
+                            if GetNodeValue(RecordNode, GetElementName(ConfigPackageField."Field Name")) <> '' then begin
+                                RecRef.Close();
+                                exit(true);
+                            end;
+                    until ConfigPackageField.Next() = 0;
+                RecRef.Close();
+            end;
+        end;
+
+        exit(false);
+    end;
+
+    local procedure FillPackageMetadataFromXML(var PackageCode: Code[20]; TableID: Integer; var TableNode: XmlNode)
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        ConfigPackageField: Record "Config. Package Field";
+        "Field": Record "Field";
+        ConfigMgt: Codeunit "Config. Management";
+        RecordNode: XmlNode;
+        FieldNode: XmlNode;
+        Value: Text;
+        IsTableInserted: Boolean;
+        ChildElements: XmlNodeList;
+    begin
+        if ExcelMode then begin
+            PackageCode :=
+              CopyStr(GetNodeValue(TableNode, GetElementName(ConfigPackageTable.FieldName("Package Code"))), 1, MaxStrLen(PackageCode));
+            if PackageCode = '' then
+                Error(MissingInExcelFileErr, ConfigPackageTable.FieldCaption("Package Code"));
+        end;
+        if (TableID > 0) and (not ConfigPackageTable.Get(PackageCode, TableID)) and TryOpenTable(TableID) then begin
+            if not ExcelMode then begin
+                ConfigPackageTable.Init();
+                ConfigPackageTable."Package Code" := PackageCode;
+                ConfigPackageTable."Table ID" := TableID;
+                Value := GetNodeValue(TableNode, GetElementName(ConfigPackageTable.FieldName("Page ID")));
+                if Value <> '' then
+                    Evaluate(ConfigPackageTable."Page ID", Value);
+                if ConfigPackageTable."Page ID" = 0 then
+                    ConfigPackageTable."Page ID" := ConfigMgt.FindPage(TableID);
+                Value := GetNodeValue(TableNode, GetElementName(ConfigPackageTable.FieldName("Package Processing Order")));
+                if Value <> '' then
+                    Evaluate(ConfigPackageTable."Package Processing Order", Value);
+                Value := GetNodeValue(TableNode, GetElementName(ConfigPackageTable.FieldName("Processing Order")));
+                if Value <> '' then
+                    Evaluate(ConfigPackageTable."Processing Order", Value);
+                Value := GetNodeValue(TableNode, GetElementName(ConfigPackageTable.FieldName("Dimensions as Columns")));
+                if Value <> '' then
+                    Evaluate(ConfigPackageTable."Dimensions as Columns", Value);
+                Value := GetNodeValue(TableNode, GetElementName(ConfigPackageTable.FieldName("Skip Table Triggers")));
+                if Value <> '' then
+                    Evaluate(ConfigPackageTable."Skip Table Triggers", Value);
+                Value := GetNodeValue(TableNode, GetElementName(ConfigPackageTable.FieldName("Parent Table ID")));
+                if Value <> '' then
+                    Evaluate(ConfigPackageTable."Parent Table ID", Value);
+                Value := GetNodeValue(TableNode, GetElementName(ConfigPackageTable.FieldName("Delete Recs Before Processing")));
+                if Value <> '' then
+                    Evaluate(ConfigPackageTable."Delete Recs Before Processing", Value);
+                Value := GetNodeValue(TableNode, GetElementName(ConfigPackageTable.FieldName("Created by User ID")));
+                if Value <> '' then
+                    Evaluate(ConfigPackageTable."Created by User ID", CopyStr(Value, 1, 50));
+                OnFillPackageMetadataFromXMLOnAfterGetPackageTableValueFromTableNode(ConfigPackageTable, TableNode);
+                ConfigPackageTable."Data Template" :=
+                  CopyStr(
+                    GetNodeValue(TableNode, GetElementName(ConfigPackageTable.FieldName("Data Template"))), 1,
+                    MaxStrLen(ConfigPackageTable."Data Template"));
+                ConfigPackageTable.Comments :=
+                  CopyStr(
+                    GetNodeValue(TableNode, GetElementName(ConfigPackageTable.FieldName(Comments))),
+                    1, MaxStrLen(ConfigPackageTable.Comments));
+                ConfigPackageTable."Imported Date and Time" := CreateDateTime(Today, Time);
+                ConfigPackageTable."Imported by User ID" := UserId;
+                ConfigPackageTable.Insert(true);
+                ConfigPackageField.SetRange("Package Code", ConfigPackageTable."Package Code");
+                ConfigPackageField.SetRange("Table ID", ConfigPackageTable."Table ID");
+                ConfigPackageMgt.SelectAllPackageFields(ConfigPackageField, false);
+            end else begin // Excel import
+                if not ConfigPackage.Get(PackageCode) then begin
+                    ConfigPackage.Init();
+                    ConfigPackage.Validate(Code, PackageCode);
+                    ConfigPackage.Insert(true);
+                end;
+                ConfigPackageTable.Init();
+                ConfigPackageTable."Package Code" := PackageCode;
+                ConfigPackageTable."Table ID" := TableID;
+                ConfigPackageTable.Insert(true);
+                IsTableInserted := true;
+            end;
+
+            ConfigPackageTable.CalcFields("Table Name");
+            if ConfigPackageTable."Table Name" <> '' then begin
+                TableNode.SelectNodes(GetElementName(ConfigPackageTable."Table Name"), ChildElements);
+                if ChildElements.Count() > 0 then begin
+                    ChildElements.Get(1, RecordNode);
+                    if RecordNode.AsXmlElement().HasElements() then begin
+                        ConfigPackageMgt.SetFieldFilter(Field, TableID, 0);
+                        if Field.FindSet() then
+                            repeat
+                                if FieldNodeExists(RecordNode, GetElementName(Field.FieldName)) then begin
+                                    ConfigPackageField.Get(PackageCode, TableID, Field."No.");
+                                    ConfigPackageField."Primary Key" := ConfigValidateMgt.IsKeyField(TableID, Field."No.");
+                                    ConfigPackageField."Include Field" := true;
+                                    if RecordNode.SelectSingleNode(GetElementName(Field.FieldName), FieldNode) and not ExcelMode then begin
+                                        Value := GetAttribute(GetElementName(ConfigPackageField.FieldName("Primary Key")), FieldNode);
+                                        ConfigPackageField."Primary Key" := Value = '1';
+                                        Value := GetAttribute(GetElementName(ConfigPackageField.FieldName("Validate Field")), FieldNode);
+                                        ConfigPackageField."Validate Field" := (Value = '1') and
+                                          not ConfigPackageMgt.ValidateException(TableID, Field."No.");
+                                        Value := GetAttribute(GetElementName(ConfigPackageField.FieldName("Create Missing Codes")), FieldNode);
+                                        ConfigPackageField."Create Missing Codes" := (Value = '1') and
+                                          not ConfigPackageMgt.ValidateException(TableID, Field."No.");
+                                        Value := GetAttribute(GetElementName(ConfigPackageField.FieldName("Processing Order")), FieldNode);
+                                        if Value <> '' then
+                                            Evaluate(ConfigPackageField."Processing Order", Value);
+
+                                        OnFillPackageMetadataFromXMLOnBeforeModifyConfigPackageField(ConfigPackageField, Value, FieldNode);
+                                    end;
+                                    ConfigPackageField.Modify();
+                                end;
+                            until Field.Next() = 0;
+                        if IsTableInserted then
+                            AddDimPackageFields(ConfigPackageTable, RecordNode);
+                    end;
+                end;
+            end;
+        end;
+    end;
+
+    local procedure FillPackageDataFromXML(PackageCode: Code[20]; TableID: Integer; var TableNode: XmlNode)
+    var
+        ConfigPackageTable: Record "Config. Package Table";
+        ConfigPackageData: Record "Config. Package Data";
+        ConfigPackageRecord: Record "Config. Package Record";
+        ConfigPackageField: Record "Config. Package Field";
+        TempConfigPackageField: Record "Config. Package Field" temporary;
+        ConfigProgressBarRecord: Codeunit "Config. Progress Bar";
+        RecRef: RecordRef;
+        FieldRef: FieldRef;
+        RecordNodes: XmlNodeList;
+        RecordNode: XmlNode;
+        NodeCount: Integer;
+        RecordCount: Integer;
+        StepCount: Integer;
+        ErrorText: Text[250];
+        ShouldAssignValue: Boolean;
+        ShouldShowTableContainsRecordsQst: Boolean;
+    begin
+        if ConfigMgt.IsSystemTable(TableID) then
+            exit;
+
+        if ConfigPackageTable.Get(PackageCode, TableID) then begin
+            ExcludeRemovedFields(ConfigPackageTable);
+            if ExcelMode then begin
+                ConfigPackageTable.CalcFields("No. of Package Records");
+                ShouldShowTableContainsRecordsQst := ConfigPackageTable."No. of Package Records" > 0;
+                OnFillPackageDataFromXMLOnAfterCalcShouldShowTableContainsRecordsQst(ConfigPackageTable, PackageCode, TableID, HideDialog, ShouldShowTableContainsRecordsQst);
+                if ShouldShowTableContainsRecordsQst then
+                    if Confirm(TableContainsRecordsQst, true, TableID, PackageCode, ConfigPackageTable."No. of Package Records") then
+                        ConfigPackageTable.DeletePackageData()
+                    else
+                        exit;
+            end;
+            ConfigPackageTable.CalcFields("Table Name");
+            if not HideDialog then
+                ConfigProgressBar.Update(ConfigPackageTable."Table Name");
+
+            TableNode.SelectNodes(GetElementName(ConfigPackageTable."Table Name"), RecordNodes);
+            RecordCount := RecordNodes.Count();
+
+            if not HideDialog and (RecordCount > 1000) then begin
+                StepCount := Round(RecordCount / 100, 1);
+                ConfigProgressBarRecord.Init(RecordCount, StepCount, StrSubstNo(RecordProgressTxt, ConfigPackageTable."Table Name"));
+            end;
+
+            ConfigPackageField.SetRange("Package Code", ConfigPackageTable."Package Code");
+            ConfigPackageField.SetRange("Table ID", ConfigPackageTable."Table ID");
+            ConfigPackageField.SetRange("Include Field", true);
+            if ConfigPackageField.FindSet() then
+                repeat
+                    TempConfigPackageField := ConfigPackageField;
+                    TempConfigPackageField.Insert();
+                until ConfigPackageField.Next() = 0;
+
+            for NodeCount := 1 to RecordCount do begin
+                RecordNodes.Get(NodeCount, RecordNode);
+
+                if RecordNode.AsXmlElement().HasElements() then begin
+                    ConfigPackageMgt.InitPackageRecord(ConfigPackageRecord, PackageCode, ConfigPackageTable."Table ID");
+                    RecRef.Close();
+                    RecRef.Open(ConfigPackageTable."Table ID");
+                    TempConfigPackageField.Reset();
+                    if TempConfigPackageField.FindSet() then
+                        repeat
+                            ConfigPackageData.Init();
+                            OnFillPackageDataFromXMLOnAfterConfigPackageDataInit(ConfigPackageData, TempConfigPackageField);
+                            ConfigPackageData."Package Code" := TempConfigPackageField."Package Code";
+                            ConfigPackageData."Table ID" := TempConfigPackageField."Table ID";
+                            ConfigPackageData."Field ID" := TempConfigPackageField."Field ID";
+                            ConfigPackageData."No." := ConfigPackageRecord."No.";
+                            if FieldNodeExists(RecordNode, TempConfigPackageField.GetElementName()) or
+                               TempConfigPackageField.Dimension
+                            then
+                                GetConfigPackageDataValue(ConfigPackageData, RecordNode, TempConfigPackageField.GetElementName());
+                            OnFillPackageDataFromXMLOnAfterConfigPackageDataInsert(ConfigPackageData, TempConfigPackageField, ExcelMode);
+                            ConfigPackageData.Insert();
+
+                            ShouldAssignValue := not TempConfigPackageField.Dimension;
+                            OnFillPackageDataFromXMLOnAfterCalcShouldAssignValue(ConfigPackageField, ConfigPackageData, ConfigPackageRecord, TempConfigPackageField, ShouldAssignValue);
+                            if ShouldAssignValue then begin
+                                FieldRef := RecRef.Field(ConfigPackageData."Field ID");
+                                if ConfigPackageData.Value <> '' then begin
+                                    ErrorText := CopyStr(ConfigValidateMgt.EvaluateValue(FieldRef, ConfigPackageData.Value, not ExcelMode), 1, MaxStrLen(ErrorText));
+                                    if ErrorText <> '' then
+                                        ConfigPackageMgt.FieldError(ConfigPackageData, ErrorText, ErrorTypeEnum::General)
+                                    else
+                                        ConfigPackageData.Value := Format(FieldRef.Value);
+
+                                    ConfigPackageData.Modify();
+                                end;
+                            end;
+                        until TempConfigPackageField.Next() = 0;
+
+                    ConfigPackageTable."Imported Date and Time" := CurrentDateTime;
+                    ConfigPackageTable."Imported by User ID" := UserId;
+                    ConfigPackageTable.Modify();
+                    if not HideDialog and (RecordCount > 1000) then
+                        ConfigProgressBarRecord.Update(StrSubstNo('Records: %1 of %2', ConfigPackageRecord."No.", RecordCount));
+                end;
+            end;
+            if not HideDialog and (RecordCount > 1000) then
+                ConfigProgressBarRecord.Close();
+        end;
+    end;
+
+    local procedure GetConfigPackageDataValue(var ConfigPackageData: Record "Config. Package Data"; var RecordNode: XmlNode; FieldNodeName: Text[250])
+    var
+        Base64Convert: Codeunit "Base64 Convert";
+        OutStream: OutStream;
+    begin
+        if ConfigPackageMgt.IsBLOBField(ConfigPackageData."Table ID", ConfigPackageData."Field ID") then begin
+            ConfigPackageData."BLOB Value".CreateOutStream(OutStream);
+            Base64Convert.FromBase64(GetNodeValue(RecordNode, FieldNodeName), OutStream);
+        end else
+            ConfigPackageData.Value := CopyStr(GetNodeValue(RecordNode, FieldNodeName), 1, MaxStrLen(ConfigPackageData.Value));
+    end;
 
     local procedure VerifyCanImportConfigurationPackage()
     var
@@ -1599,20 +2726,25 @@ codeunit 8614 "Config. XML Exchange"
             Error(ImportingIsNotAllowedDuringUpgradeOrInstallationErr);
     end;
 
+#if not CLEAN29
     [IntegrationEvent(false, false)]
+    [Obsolete('Replaced by event OnAfterAddFieldAttributesProcedure', '29.0')]
     local procedure OnAfterAddFieldAttributes(var ConfigPackageField: Record "Config. Package Field"; var FieldNode: DotNet XmlNode)
     begin
     end;
 
     [IntegrationEvent(false, false)]
+    [Obsolete('Replaced by event OnAfterAddTableAttributesProcedure', '29.0')]
     local procedure OnAfterAddTableAttributes(ConfigPackageTable: Record "Config. Package Table"; var PackageXML: DotNet XmlDocument; var TableNode: DotNet XmlNode)
     begin
     end;
 
     [IntegrationEvent(false, false)]
+    [Obsolete('Replaced by event OnAfterExportPackageToXMLDocument', '29.0')]
     local procedure OnAfterExportPackageXMLDocument(var ConfigPackage: Record "Config. Package"; HideDialog: Boolean)
     begin
     end;
+#endif
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterImportPackageXMLDocument(PackageCode: Code[20]; ExcelMode: Boolean; var Result: Boolean)
@@ -1624,10 +2756,13 @@ codeunit 8614 "Config. XML Exchange"
     begin
     end;
 
+#if not CLEAN29
     [IntegrationEvent(false, false)]
+    [Obsolete('Replaced by event OnBeforeCreateRecordNodesProcedure', '29.0')]
     local procedure OnBeforeCreateRecordNodes(var ConfigPackageTable: Record "Config. Package Table"; var ConfigPackageField: Record "Config. Package Field"; var TypeHelper: Codeunit "Type Helper"; var XMLDOMManagement: Codeunit "XML DOM Management"; var WorkingFolder: Text; var ExcelMode: Boolean; var Advanced: Boolean; var HideDialog: Boolean; var IsHandled: Boolean)
     begin
     end;
+#endif
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeEvaluateMinCountForAsyncImport(var ConfigPackage: Record "Config. Package"; var Value: Text; var IsHandled: Boolean)
@@ -1659,30 +2794,38 @@ codeunit 8614 "Config. XML Exchange"
     begin
     end;
 
+#if not CLEAN29
     [IntegrationEvent(false, false)]
+    [Obsolete('Replaced by event OnCreateRecordNodesProcedureOnAfterRecordProcessed', '29.0')]
     local procedure OnCreateRecordNodesOnAfterRecordProcessed(ConfigPackageTable: Record "Config. Package Table"; var ConfigPackageField: Record "Config. Package Field"; var RecRef: RecordRef; var PackageXML: DotNet XmlDocument; var RecordNode: DotNet XmlNode; var FieldNode: DotNet XmlNode; ExcelMode: Boolean)
     begin
     end;
+#endif
 
     [IntegrationEvent(false, false)]
     local procedure OnCreateRecordNodesOnNotFoundOnAfterConfigPackageFieldSetFilters(ConfigPackageTable: Record "Config. Package Table"; var ConfigPackageField: Record "Config. Package Field")
     begin
     end;
 
+#if not CLEAN29
     [IntegrationEvent(false, false)]
+    [Obsolete('Replaced by event OnCreateRecordNodesProcedureOnAfterNotFoundRecordProcessed', '29.0')]
     local procedure OnCreateRecordNodesOnAfterNotFoundRecordProcessed(ConfigPackageTable: Record "Config. Package Table"; var ConfigPackageField: Record "Config. Package Field"; var RecRef: RecordRef; var PackageXML: DotNet XmlDocument; var RecordNode: DotNet XmlNode; var FieldNode: DotNet XmlNode; ExcelMode: Boolean)
     begin
     end;
 
     [IntegrationEvent(false, false)]
+    [Obsolete('Replaced by event OnExportPackageToXMLDocumentOnAfterSetAttributes', '29.0')]
     local procedure OnExportPackageXMLDocumentOnAfterSetAttributes(var ConfigPackage: Record "Config. Package"; var XMLDOMMgt: Codeunit "XML DOM Management"; var DocumentElement: DotNet XmlElement)
     begin
     end;
 
     [IntegrationEvent(false, false)]
+    [Obsolete('Replaced by event OnExportPackageToXMLDocumentOnBeforeConfigProgressBarInit', '29.0')]
     local procedure OnExportPackageXMLDocumentOnBeforeConfigProgressBarInit(var ConfigPackageTable: Record "Config. Package Table"; var ConfigPackage: Record "Config. Package"; var XMLDOMMgt: Codeunit "XML DOM Management"; Advanced: Boolean; HideDialog: Boolean)
     begin
     end;
+#endif
 
     [IntegrationEvent(false, false)]
     local procedure OnExportPackageXMLOnAfterAssignToFile(ConfigPackage: Record "Config. Package"; var ToFile: Text[50])
@@ -1694,10 +2837,13 @@ codeunit 8614 "Config. XML Exchange"
     begin
     end;
 
+#if not CLEAN29
     [IntegrationEvent(false, false)]
+    [Obsolete('Replaced by event OnFillPackageMetadataFromXMLOnAfterGetPackageTableValueFromTableNode', '29.0')]
     local procedure OnFillPackageMetadataFromXMLOnAfterGetPackageTableValueFromXML(ConfigPackageTable: Record "Config. Package Table"; var TableNode: DotNet XmlNode)
     begin
     end;
+#endif
 
     [IntegrationEvent(false, false)]
     local procedure OnFillPackageDataFromXMLOnAfterConfigPackageDataInit(var ConfigPackageData: Record "Config. Package Data"; var ConfigPackageField: Record "Config. Package Field")
@@ -1734,10 +2880,13 @@ codeunit 8614 "Config. XML Exchange"
     begin
     end;
 
+#if not CLEAN29
     [IntegrationEvent(false, false)]
+    [Obsolete('Replaced by event OnFillPackageMetadataFromXMLOnBeforeModifyConfigPackageField', '29.0')]
     local procedure OnFillPackageMetadataFromXMLOnBeforeConfigPackageFieldModify(var ConfigPackageField: Record "Config. Package Field"; var Value: Text; var FieldNode: DotNet XmlNode)
     begin
     end;
+#endif
 
     [IntegrationEvent(false, false)]
     local procedure OnFormatFieldValueOnBeforeExitInnerText(var FieldRef: FieldRef; ConfigPackage: Record "Config. Package"; var InnerText: Text)
@@ -1751,6 +2900,66 @@ codeunit 8614 "Config. XML Exchange"
 
     [IntegrationEvent(false, false)]
     local procedure OnVerifyCanImportConfigurationPackage(var CanImportConfigurationPackage: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterAddTableAttributesProcedure(ConfigPackageTable: Record "Config. Package Table"; var TableNode: XmlNode)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterAddFieldAttributesProcedure(var ConfigPackageField: Record "Config. Package Field"; var FieldNode: XmlNode)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnImportPackageXMLDocumentOnBeforeModifyConfigPackage(var ConfigPackage: Record "Config. Package"; var DocumentElement: XmlNode)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCreateRecordNodesProcedure(ConfigPackageTable: Record "Config. Package Table"; var ConfigPackageField: Record "Config. Package Field"; WorkingFolder: Text; ExcelMode: Boolean; Advanced: Boolean; HideDialog: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCreateRecordNodesProcedureOnAfterRecordProcessed(ConfigPackageTable: Record "Config. Package Table"; var ConfigPackageField: Record "Config. Package Field"; var RecRef: RecordRef; var PackageXML: XmlDocument; var RecordNode: XmlNode; var FieldNode: XmlNode; ExcelMode: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCreateRecordNodesProcedureOnAfterNotFoundRecordProcessed(ConfigPackageTable: Record "Config. Package Table"; var ConfigPackageField: Record "Config. Package Field"; var RecRef: RecordRef; var PackageXML: XmlDocument; var RecordNode: XmlNode; var FieldNode: XmlNode; ExcelMode: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnFillPackageMetadataFromXMLOnAfterGetPackageTableValueFromTableNode(ConfigPackageTable: Record "Config. Package Table"; var TableNode: XmlNode)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnFillPackageMetadataFromXMLOnBeforeModifyConfigPackageField(var ConfigPackageField: Record "Config. Package Field"; var Value: Text; var FieldNode: XmlNode)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnExportPackageToXMLDocumentOnAfterSetAttributes(var ConfigPackage: Record "Config. Package"; var DocumentElement: XmlNode)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnExportPackageToXMLDocumentOnBeforeConfigProgressBarInit(var ConfigPackageTable: Record "Config. Package Table"; var ConfigPackage: Record "Config. Package"; Advanced: Boolean; HideDialog: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterExportPackageToXMLDocument(var ConfigPackage: Record "Config. Package"; HideDialog: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnImportPackageXMLFromClientOnBeforeImportPackage(var UseImportWithDotNet: Boolean)
     begin
     end;
 }

--- a/src/Layers/W1/Tests/Rapid Start/ERMRSDimensionsasColumns.Codeunit.al
+++ b/src/Layers/W1/Tests/Rapid Start/ERMRSDimensionsasColumns.Codeunit.al
@@ -128,6 +128,58 @@ codeunit 136611 "ERM RS Dimensions as Columns"
         ApplyConfigLineAndVerifyApplication(ConfigLine, Customer."No.", DimensionCode);
     end;
 
+#if not CLEAN29
+    [Test]
+    [HandlerFunctions('ConfirmAddDimTablesHandlerYes')]
+    [Scope('OnPrem')]
+    procedure ApplyPackageWithDimensionsAsColumnsNewCustomerWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        ConfigLine: Record "Config. Line";
+        Customer: Record Customer;
+        DimVal: Record "Dimension Value";
+        NewCustomerNo: Code[20];
+    begin
+        Initialize();
+
+        NewCustomerNo := LibraryUtility.GenerateRandomCode(Customer.FieldNo("No."), DATABASE::Customer);
+        FindDimensionWithValue(DimVal);
+
+        CreateConfigPackageWithNewCustomer(ConfigPackage, ConfigPackageTable, ConfigLine, NewCustomerNo);
+        ExportImportPackageSetNewCustAndDimWithDotNet(ConfigPackage, ConfigPackageTable, NewCustomerNo, DimVal."Dimension Code", DimVal.Code);
+
+        ApplyConfigLineAndVerifyApplication(ConfigLine, NewCustomerNo, DimVal."Dimension Code");
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ApplyPackageWithDimAsColumnsWithoutSettingDimSetIDFieldWithDotNet()
+    var
+        DimVal: Record "Dimension Value";
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        SalesHeader: Record "Sales Header";
+        OldManualNos: Boolean;
+    begin
+        // Verify that dimensions can be applied from package when field "Dimension Set ID" is not included.
+
+        Initialize();
+        CreatePackageExcludingDimSetIDField(ConfigPackage, ConfigPackageTable, SalesHeader);
+
+        FindDimValueFromDefDim(DimVal, DATABASE::Customer, SalesHeader."Sell-to Customer No.");
+        ExportImportPackageSetNewDimensionWithDotNet(ConfigPackage, ConfigPackageTable, DimVal."Dimension Code", DimVal.Code);
+
+        OldManualNos := SetupManualNos(SalesHeader."No. Series", true);
+
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+        SalesHeader.Find(); // get latest version after applying package
+        VerifyDimValueExistsInSalesHeaderDimSetID(SalesHeader, DimVal);
+
+        SetupManualNos(SalesHeader."No. Series", OldManualNos);
+    end;
+#endif
+
     [Test]
     [HandlerFunctions('ConfirmAddDimTablesHandlerYes')]
     [Scope('OnPrem')]
@@ -440,17 +492,18 @@ codeunit 136611 "ERM RS Dimensions as Columns"
         ConfigPackageTable.SetFilter("Table ID", ConfigMgt.MakeTableFilter(ConfigLine, true));
     end;
 
-    local procedure ExportImportPackageSetNewCustAndDim(var ConfigPackage: Record "Config. Package"; var ConfigPackageTable: Record "Config. Package Table"; CustomerNo: Code[20]; DimCode: Code[20]; DimValCode: Code[20])
+#if not CLEAN29
+    local procedure ExportImportPackageSetNewCustAndDimWithDotNet(var ConfigPackage: Record "Config. Package"; var ConfigPackageTable: Record "Config. Package Table"; CustomerNo: Code[20]; DimCode: Code[20]; DimValCode: Code[20])
     begin
-        ExportImportPackageSetNewValues(ConfigPackage, ConfigPackageTable, CustomerNo, DimCode, DimValCode);
+        ExportImportPackageSetNewValuesWithDotNet(ConfigPackage, ConfigPackageTable, CustomerNo, DimCode, DimValCode);
     end;
 
-    local procedure ExportImportPackageSetNewDimension(var ConfigPackage: Record "Config. Package"; var ConfigPackageTable: Record "Config. Package Table"; DimCode: Code[20]; DimValCode: Code[20])
+    local procedure ExportImportPackageSetNewDimensionWithDotNet(var ConfigPackage: Record "Config. Package"; var ConfigPackageTable: Record "Config. Package Table"; DimCode: Code[20]; DimValCode: Code[20])
     begin
-        ExportImportPackageSetNewValues(ConfigPackage, ConfigPackageTable, '', DimCode, DimValCode);
+        ExportImportPackageSetNewValuesWithDotNet(ConfigPackage, ConfigPackageTable, '', DimCode, DimValCode);
     end;
 
-    local procedure ExportImportPackageSetNewValues(var ConfigPackage: Record "Config. Package"; var ConfigPackageTable: Record "Config. Package Table"; CustomerNo: Code[20]; DimCode: Code[20]; DimValCode: Code[20])
+    local procedure ExportImportPackageSetNewValuesWithDotNet(var ConfigPackage: Record "Config. Package"; var ConfigPackageTable: Record "Config. Package Table"; CustomerNo: Code[20]; DimCode: Code[20]; DimValCode: Code[20])
     var
         Customer: Record Customer;
         ConfigXMLExchange: Codeunit "Config. XML Exchange";
@@ -475,6 +528,43 @@ codeunit 136611 "ERM RS Dimensions as Columns"
         XMLNode := PackageXML.SelectSingleNode('//' + NodeName);
         XMLNode.InnerText := NodeValue;
     end;
+#endif
+
+    local procedure ExportImportPackageSetNewCustAndDim(var ConfigPackage: Record "Config. Package"; var ConfigPackageTable: Record "Config. Package Table"; CustomerNo: Code[20]; DimCode: Code[20]; DimValCode: Code[20])
+    begin
+        ExportImportPackageSetNewValuesNative(ConfigPackage, ConfigPackageTable, CustomerNo, DimCode, DimValCode);
+    end;
+
+    local procedure ExportImportPackageSetNewDimension(var ConfigPackage: Record "Config. Package"; var ConfigPackageTable: Record "Config. Package Table"; DimCode: Code[20]; DimValCode: Code[20])
+    begin
+        ExportImportPackageSetNewValuesNative(ConfigPackage, ConfigPackageTable, '', DimCode, DimValCode);
+    end;
+
+    local procedure ExportImportPackageSetNewValuesNative(var ConfigPackage: Record "Config. Package"; var ConfigPackageTable: Record "Config. Package Table"; CustomerNo: Code[20]; DimCode: Code[20]; DimValCode: Code[20])
+    var
+        Customer: Record Customer;
+        ConfigXMLExchange: Codeunit "Config. XML Exchange";
+        PackageXML: XmlDocument;
+    begin
+        ConfigXMLExchange.SetExcelMode(true);
+        ConfigXMLExchange.ExportPackageToXMLDocument(PackageXML, ConfigPackageTable, ConfigPackage, false);
+
+        if CustomerNo <> '' then
+            SetXMLNodeValue(PackageXML, ConfigXMLExchange.GetElementName(Customer.FieldName("No.")), CustomerNo);
+        if DimCode <> '' then
+            SetXMLNodeValue(PackageXML, ConfigXMLExchange.GetElementName(DimCode), DimValCode);
+
+        ConfigXMLExchange.ImportPackageXMLDocument(PackageXML, '');
+    end;
+
+    local procedure SetXMLNodeValue(var PackageXML: XmlDocument; NodeName: Text[250]; NodeValue: Code[20])
+    var
+        XMLNode: XmlNode;
+    begin
+        PackageXML.SelectSingleNode('//' + NodeName, XMLNode);
+        XMLNode.AsXmlElement().ReplaceNodes(NodeValue);
+    end;
+
 
     local procedure FindDimensionWithValue(var DimVal: Record "Dimension Value")
     var

--- a/src/Layers/W1/Tests/Rapid Start/ERMRSPackageBaseOperations.Codeunit.al
+++ b/src/Layers/W1/Tests/Rapid Start/ERMRSPackageBaseOperations.Codeunit.al
@@ -816,6 +816,48 @@ codeunit 136610 "ERM RS Package Base Operations"
         Assert.AreEqual(Format(TableTok), ConfigXMLExchange.GetTableElementName(TableTok), '');
     end;
 
+#if not CLEAN29
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportPackageWithBlankLineWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        CustomerPriceGroup: Record "Customer Price Group";
+        ConfigXMLExchange: Codeunit "Config. XML Exchange";
+        XMLDocument: DotNet XmlDocument;
+        FilePath: Text;
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO 217909] "Config. XML Exchange".ImportPackageXMLDocument is preparing data for applying package when XML contains the first record with no data
+        Initialize();
+
+        // [GIVEN] Exported XML file with empty table "Customer Price Group"
+        CustomerPriceGroup.DeleteAll();
+        FilePath := CreateConfigPackageAndExportToXML(ConfigPackage);
+
+        // [GIVEN] Add new record to XML file "Customer Price Group".Code = "TEST"
+        // [GIVEN] "Customer Price Group"."Price Includes VAT" = FALSE
+        // [GIVEN] "Customer Price Group"."Allow Invoice Disc." = FALSE
+        // [GIVEN] "Customer Price Group"."VAT Bus. Posting Gr. (Price)" = "POSTGR01"
+        // [GIVEN] "Customer Price Group"."Description" = "Test Description"
+        // [GIVEN] "Customer Price Group"."Allow Line Disc." = FALSE
+        AddCustPriceGroupToXML(CustomerPriceGroup, XMLDocument, FilePath);
+
+        // [WHEN] Importing updated XML file
+        ConfigXMLExchange.ImportPackageXMLDocument(XMLDocument, '');
+
+        // [THEN] Table Config. Package Data contains 6 records with value = '' for the first record
+        // [THEN] Table Config. Package Data contains 6 records for the second record
+        // [THEN] Config. Package Data for field "Code" with "Value" = TEST
+        // [THEN] Config. Package Data for field "Price Includes VAT" with "Value" = FALSE
+        // [THEN] Config. Package Data for field "Allow Invoice Disc." with "Value" = FALSE
+        // [THEN] Config. Package Data for field "VAT Bus. Posting Gr. (Price)" with "Value" = "POSTGR01"
+        // [THEN] Config. Package Data for field "Description" with "Value" = "Test Description"
+        // [THEN] Config. Package Data for field "Allow Line Disc." with "Value" = FALSE
+        VerifyConfigPackageData(CustomerPriceGroup, ConfigPackage.Code, DATABASE::"Customer Price Group");
+    end;
+#endif
+
     [Test]
     [Scope('OnPrem')]
     procedure ImportPackageWithBlankLine()
@@ -823,7 +865,7 @@ codeunit 136610 "ERM RS Package Base Operations"
         ConfigPackage: Record "Config. Package";
         CustomerPriceGroup: Record "Customer Price Group";
         ConfigXMLExchange: Codeunit "Config. XML Exchange";
-        XMLDocument: DotNet XmlDocument;
+        XMLDocument: XmlDocument;
         FilePath: Text;
     begin
         // [FEATURE] [XML]
@@ -1210,6 +1252,7 @@ codeunit 136610 "ERM RS Package Base Operations"
         ExportToXML(ConfigPackage.Code, ConfigPackageTable, FilePath);
     end;
 
+#if not CLEAN29
     local procedure AddCustPriceGroupToXML(var CustomerPriceGroup: Record "Customer Price Group"; var XMLDocument: DotNet XmlDocument; FilePath: Text)
     var
         XMLDOMManagement: Codeunit "XML DOM Management";
@@ -1223,6 +1266,41 @@ codeunit 136610 "ERM RS Package Base Operations"
         CreateDummyCustPriceGroup(CustomerPriceGroup);
         XMLDOMManagement.AddElement(
           DocumentElement, ConfigXMLExchange.GetElementName(CustomerPriceGroup.TableName), '', '', XMLNode);
+        XMLDOMManagement.AddElement(
+          XMLNode, ConfigXMLExchange.GetElementName(CustomerPriceGroup.FieldName(Code)), CustomerPriceGroup.Code, '', DummyXMLNode);
+        XMLDOMManagement.AddElement(
+          XMLNode, ConfigXMLExchange.GetElementName(CustomerPriceGroup.FieldName("Price Includes VAT")),
+          Format(CustomerPriceGroup."Price Includes VAT"), '', DummyXMLNode);
+        XMLDOMManagement.AddElement(
+          XMLNode, ConfigXMLExchange.GetElementName(CustomerPriceGroup.FieldName("Allow Invoice Disc.")),
+          Format(CustomerPriceGroup."Allow Invoice Disc."), '', DummyXMLNode);
+        XMLDOMManagement.AddElement(
+          XMLNode, ConfigXMLExchange.GetElementName(CustomerPriceGroup.FieldName("VAT Bus. Posting Gr. (Price)")),
+          CustomerPriceGroup."VAT Bus. Posting Gr. (Price)", '', DummyXMLNode);
+        XMLDOMManagement.AddElement(
+          XMLNode, ConfigXMLExchange.GetElementName(CustomerPriceGroup.FieldName(Description)),
+          CustomerPriceGroup.Description, '', DummyXMLNode);
+        XMLDOMManagement.AddElement(
+          XMLNode, ConfigXMLExchange.GetElementName(CustomerPriceGroup.FieldName("Allow Line Disc.")),
+          Format(CustomerPriceGroup."Allow Line Disc."), '', DummyXMLNode);
+    end;
+#endif
+
+    local procedure AddCustPriceGroupToXML(var CustomerPriceGroup: Record "Customer Price Group"; var XMLDoc: XmlDocument; FilePath: Text)
+    var
+        XMLDOMManagement: Codeunit "XML DOM Management";
+        ConfigXMLExchange: Codeunit "Config. XML Exchange";
+        RootElement: XmlElement;
+        XMLNode: XmlNode;
+        DummyXMLNode: XmlNode;
+        TableNode: XmlNode;
+    begin
+        XMLDOMManagement.LoadXMLDocumentFromFile(FilePath, XMLDoc);
+        XMLDoc.GetRoot(RootElement);
+        RootElement.SelectSingleNode(ConfigXMLExchange.GetElementName(CustomerPriceGroup.TableName() + 'List'), TableNode);
+        CreateDummyCustPriceGroup(CustomerPriceGroup);
+        XMLDOMManagement.AddElement(
+          TableNode, ConfigXMLExchange.GetElementName(CustomerPriceGroup.TableName), '', '', XMLNode);
         XMLDOMManagement.AddElement(
           XMLNode, ConfigXMLExchange.GetElementName(CustomerPriceGroup.FieldName(Code)), CustomerPriceGroup.Code, '', DummyXMLNode);
         XMLDOMManagement.AddElement(

--- a/src/Layers/W1/Tests/Rapid Start/ERMRSPackageOperations.Codeunit.al
+++ b/src/Layers/W1/Tests/Rapid Start/ERMRSPackageOperations.Codeunit.al
@@ -189,6 +189,53 @@ codeunit 136603 "ERM RS Package Operations"
         TableAutoIncrementOutOfPK.TestField(ID, LastID - 1);
     end;
 
+#if not CLEAN29
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportAndApplyPackageWithBlobFieldWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        SalesHeader: Record "Sales Header";
+        FilePath: Text;
+        OriginalWorkDescription: Text;
+    begin
+        // [FEATURE] [Config Package]
+        // [SCENARIO] Blob field can be exported, imported and applied
+        Initialize();
+
+        // [GIVEN] Sales Header with non-blank "Work Description" field exists
+        CreateSalesOrderWithWorkDescription(SalesHeader);
+        OriginalWorkDescription := SalesHeader.GetWorkDescription();
+
+        // [GIVEN] Package for Sales Header with the work description field included
+        CreatePackageWithBlobField(ConfigPackage, SalesHeader);
+
+        // [WHEN] The package is exported
+        ExportToXML(ConfigPackage.Code, ConfigPackageTable, FilePath);
+
+        // [WHEN] The work description is set to empty value in system
+        SalesHeader.Find(); // Reload SalesHeader
+        SalesHeader.SetWorkDescription('');
+        SalesHeader.Modify();
+
+        // [WHEN] The package is exported back to system
+        ImportPackageXML(ConfigPackage.Code, FilePath);
+        Erase(FilePath);
+
+        // [THEN] The work description is still blank
+        SalesHeader.Find(); // Reload SalesHeader
+        Assert.AreEqual('', SalesHeader.GetWorkDescription(), SalesHeader.FieldCaption("Work Description"));
+
+        // [WHEN] The package is applied
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        // [THEN] The work description is set to the value from the excel package
+        SalesHeader.Find(); // Reload SalesHeader
+        Assert.AreEqual(OriginalWorkDescription, SalesHeader.GetWorkDescription(), SalesHeader.FieldCaption("Work Description"));
+    end;
+#endif
+
     [Test]
     [Scope('OnPrem')]
     procedure ExportImportAndApplyPackageWithBlobField()
@@ -214,23 +261,23 @@ codeunit 136603 "ERM RS Package Operations"
         ExportToXML(ConfigPackage.Code, ConfigPackageTable, FilePath);
 
         // [WHEN] The work description is set to empty value in system    
-        SalesHeader.FindFirst();
+        SalesHeader.Find(); // Reload SalesHeader
         SalesHeader.SetWorkDescription('');
         SalesHeader.Modify();
 
         // [WHEN] The package is exported back to system
-        ImportPackageXML(ConfigPackage.Code, FilePath);
+        ImportPackageXMLNew(ConfigPackage.Code, FilePath);
         Erase(FilePath);
 
         // [THEN] The work description is still blank
-        SalesHeader.FindFirst();
+        SalesHeader.Find(); // Reload SalesHeader
         Assert.AreEqual('', SalesHeader.GetWorkDescription(), SalesHeader.FieldCaption("Work Description"));
 
         // [WHEN] The package is applied
         LibraryRapidStart.ApplyPackage(ConfigPackage, true);
 
         // [THEN] The work description is set to the value from the excel package
-        SalesHeader.FindFirst();
+        SalesHeader.Find(); // Reload SalesHeader
         Assert.AreEqual(OriginalWorkDescription, SalesHeader.GetWorkDescription(), SalesHeader.FieldCaption("Work Description"));
     end;
 
@@ -295,9 +342,10 @@ codeunit 136603 "ERM RS Package Operations"
         Assert.AreEqual(OriginalWorkDescription, SalesHeader.GetWorkDescription(), SalesHeader.FieldCaption("Work Description"));
     end;
 
+#if not CLEAN29
     [Test]
     [Scope('OnPrem')]
-    procedure ApplyDependentTableWithEmpyParentTableID()
+    procedure ApplyDependentTableWithEmptyParentTableIDWithDotNet()
     var
         ConfigPackage: Record "Config. Package";
         ConfigPackageTable: Record "Config. Package Table";
@@ -326,7 +374,7 @@ codeunit 136603 "ERM RS Package Operations"
 
     [Test]
     [Scope('OnPrem')]
-    procedure ApplyDependentTableWithFilledParentTableID()
+    procedure ApplyDependentTableWithFilledParentTableIDWithDotNet()
     var
         ConfigPackage: Record "Config. Package";
         ConfigPackageTable: Record "Config. Package Table";
@@ -343,6 +391,63 @@ codeunit 136603 "ERM RS Package Operations"
 
         DeleteCustomerRelatedData(CustomerNo);
         ImportPackageXML(ConfigPackage.Code, FilePath);
+        Erase(FilePath);
+
+        // [WHEN] Apply the package
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+        // [THEN] The package is applied without errors
+        VerifyNoConfigPackageErrors(ConfigPackage.Code);
+    end;
+#endif
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ApplyDependentTableWithEmptyParentTableID()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        SalesHeader: Record "Sales Header";
+        CustomerNo: Code[20];
+        FilePath: Text;
+    begin
+        // [FEATURE] [Config Package]
+        // [SCENARIO 158249] Dependent table with empty 'Parent Table ID' should not be applied due to a confirmation request
+        Initialize();
+        // [GIVEN] Imported a package with 3 tables: Customer, Sales Header, Sales Line
+        // [GIVEN] The dependent table Sales Line has 'Parent Table ID' = 0
+        CustomerNo := CreateSalesInvPackage(ConfigPackage, 0);
+        ExportToXML(ConfigPackage.Code, ConfigPackageTable, FilePath);
+
+        DeleteCustomerRelatedData(CustomerNo);
+        ImportPackageXMLNew(ConfigPackage.Code, FilePath);
+        Erase(FilePath);
+
+        // [WHEN] Apply the package
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        // [THEN] The package application interrupted by a request for user confirmation
+        VerifyConfigPackageError(ConfigPackage.Code, 36, SalesHeader.FieldNo("Sell-to Customer No."), UnhandledConfirmErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ApplyDependentTableWithFilledParentTableID()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        CustomerNo: Code[20];
+        FilePath: Text;
+    begin
+        // [FEATURE] [Config Package]
+        // [SCENARIO 158249] Dependent table with filled 'Parent Table ID' should be applied without errors
+        Initialize();
+        // [GIVEN] Imported a package with 3 tables: Customer, Sales Header, Sales Line
+        // [GIVEN] The dependent table Sales Line has 'Parent Table ID' = 36
+        CustomerNo := CreateSalesInvPackage(ConfigPackage, DATABASE::"Sales Header");
+        ExportToXML(ConfigPackage.Code, ConfigPackageTable, FilePath);
+
+        DeleteCustomerRelatedData(CustomerNo);
+        ImportPackageXMLNew(ConfigPackage.Code, FilePath);
         Erase(FilePath);
 
         // [WHEN] Apply the package
@@ -395,6 +500,493 @@ codeunit 136603 "ERM RS Package Operations"
 
         Erase(FilePath);
     end;
+
+#if not CLEAN29
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportPackageFromXMLWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO 122579] The new Package can be imported from XML.
+        Initialize();
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Customer);
+
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        Assert.IsTrue(ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::Customer), NoDataAfterImportErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CannotApplyPackageWithIntegrationTableMappingWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        IntegrationTableMapping: Record "Integration Table Mapping";
+        ConfigPackageError: Record "Config. Package Error";
+        IntegrationTableMappingRecordCount: Integer;
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO] A package can be created, exported and imported with integration table mappings, but not applied.
+        Initialize();
+        InitializeCRM();
+
+        // [GIVEN] Integration table mappings
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, Database::"Integration Table Mapping");
+        Assert.RecordIsNotEmpty(IntegrationTableMapping);
+        IntegrationTableMappingRecordCount := IntegrationTableMapping.Count();
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        Assert.IsTrue(ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::"Integration Table Mapping"), NoDataAfterImportErr);
+        IntegrationTableMapping.DeleteAll();
+        Assert.RecordIsEmpty(IntegrationTableMapping);
+
+        // [WHEN] Attempting to apply the package
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        // [THEN] No integration table mapping records are imported and an error message is logged for each record in the package.
+        Assert.RecordIsEmpty(IntegrationTableMapping);
+        ConfigPackageError.SetRange("Package Code", ConfigPackage.Code);
+        ConfigPackageError.SetRange("Table ID", DATABASE::"Integration Table Mapping");
+        ConfigPackageError.SetRange("Error Text", StrSubstNo(ImportNotAllowedErr, IntegrationTableMapping.TableCaption()));
+        Assert.RecordCount(ConfigPackageError, IntegrationTableMappingRecordCount);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CannotApplyPackageWithIntegrationFieldMappingWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        IntegrationFieldMapping: Record "Integration Field Mapping";
+        ConfigPackageError: Record "Config. Package Error";
+        IntegrationFieldMappingRecordCount: Integer;
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO] A package can be created, exported and imported with integration field mappings, but not applied.
+        Initialize();
+        InitializeCRM();
+
+        // [GIVEN] Integration field mappings
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, Database::"Integration Field Mapping");
+        Assert.RecordIsNotEmpty(IntegrationFieldMapping);
+        IntegrationFieldMappingRecordCount := IntegrationFieldMapping.Count();
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        Assert.IsTrue(ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::"Integration Field Mapping"), NoDataAfterImportErr);
+        IntegrationFieldMapping.DeleteAll();
+        Assert.RecordIsEmpty(IntegrationFieldMapping);
+
+        // [WHEN] Attempting to apply the package
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        // [THEN] No integration field mapping records are imported and an error message is loggee for each record in the package.
+        Assert.RecordIsEmpty(IntegrationFieldMapping);
+        ConfigPackageError.SetRange("Package Code", ConfigPackage.Code);
+        ConfigPackageError.SetRange("Table ID", DATABASE::"Integration Field Mapping");
+        ConfigPackageError.SetRange("Error Text", StrSubstNo(ImportNotAllowedErr, IntegrationFieldMapping.TableCaption()));
+        Assert.RecordCount(ConfigPackageError, IntegrationFieldMappingRecordCount);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportLocalizedPackageToXMLWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        PackageXML: DotNet XmlDocument;
+        XMLNode: DotNet XmlNode;
+        XMLAttributes: DotNet XmlNodeList;
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO] localization attributes are exported to XML
+        Initialize();
+
+        // [GIVEN] Generated a localized package
+        CreateConfigPackage(ConfigPackage);
+        ConfigPackage.Validate("Language ID", FindFirstLanguage());
+        ConfigPackage.Modify(true);
+
+        LibraryRapidStart.CreatePackageTable(ConfigPackageTable, ConfigPackage.Code, FindRandomTableID(100));
+        SetLocalizeFields(ConfigPackage.Code, ConfigPackageTable."Table ID");
+
+        // [WHEN] Export Package to XML
+        PackageXML := PackageXML.XmlDocument();
+        ConfigPackageTable.SetRange("Package Code", ConfigPackage.Code);
+        ConfigXMLExchange.ExportPackageXMLDocument(PackageXML, ConfigPackageTable, ConfigPackage, true);
+
+        // [THEN] '_locDefinition' node and '_loc' attributes have been generated in XML document
+        XMLNode := PackageXML.SelectSingleNode('//_locDefinition');
+        XMLAttributes := PackageXML.SelectNodes('//@_loc');
+
+        Assert.IsTrue((XMLNode.InnerXml <> '') and (XMLAttributes.Count <> 0), XMLGeneratedIncorrectlyErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackage_ExportPackageTableWithPageID_DataImportedWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        RandomPageId: Integer;
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO] 'Page ID' field can be stored to and restored from XML
+        Initialize();
+        // [GIVEN] Package with Table, where 'Page ID' = "X"
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Customer);
+        RandomPageId := LibraryRandom.RandInt(1000);
+        ConfigPackageTable."Page ID" := RandomPageId;
+        ConfigPackageTable.Modify();
+
+        // [GIVEN] Package exported to an XML file
+        // [WHEN] Import Package from the XML file
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        // [THEN] Package contains Table, where 'Page ID' = "X"
+        ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::Customer);
+        Assert.AreEqual(RandomPageId, ConfigPackageTable."Page ID", NoDataAfterImportErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackage_ExportPackageTableWithPackageProcessingOrder_DataImportedWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        RandomId: Integer;
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO] 'Package Processing Order' field can be stored to and restored from XML
+        Initialize();
+        // [GIVEN] Package with Table, where 'Package Processing Order' = "X"
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Customer);
+        RandomId := LibraryRandom.RandInt(1000);
+        ConfigPackageTable."Package Processing Order" := RandomId;
+        ConfigPackageTable.Modify();
+
+        // [GIVEN] Package exported to an XML file
+        // [WHEN] Import Package from the XML file
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        // [THEN] Package contains Table, where 'Package Processing Order' = "X"
+        ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::Customer);
+        Assert.AreEqual(RandomId, ConfigPackageTable."Package Processing Order", NoDataAfterImportErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackage_ExportPackageTableWithParentTableID_DataImportedWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO 158249] Filled 'Parent Table ID' field can be stored to and restored from XML
+        Initialize();
+        // [GIVEN] Package with Table, where 'Table ID' = 37, 'Parent Table ID' = 36
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::"Sales Line");
+
+        ConfigPackageTable."Parent Table ID" := DATABASE::"Sales Header";
+        ConfigPackageTable.Modify();
+        // [GIVEN] Package exported to an XML file
+        // [WHEN] Import Package from the XML file
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        // [THEN] Package contains Table, where 'Table ID' = 37, 'Parent Table ID' = 36
+        ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::"Sales Line");
+        Assert.AreEqual(DATABASE::"Sales Header", ConfigPackageTable."Parent Table ID", NoDataAfterImportErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackage_ExportPackageTableWithDeleteRecsBeforeProcessing_DataImportedWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO] Filled 'Delete Recs Before Processing' field can be stored to and restored from XML
+        Initialize();
+        // [GIVEN] Package with Table, where 'Delete Recs Before Processing' = "Yes"
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Customer);
+        ConfigPackageTable."Delete Recs Before Processing" := true;
+        ConfigPackageTable.Modify();
+
+        // [GIVEN] Package exported to an XML file
+        // [WHEN] Import Package from the XML file
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        // [THEN] Package contains Table, where 'Delete Recs Before Processing' = "Yes"
+        ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::Customer);
+        Assert.AreEqual(true, ConfigPackageTable."Delete Recs Before Processing", NoDataAfterImportErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackage_ExportPackageTableWithProcessingOrder_DataImportedWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        RandomId: Integer;
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO 158249] Filled 'Processing Order' field can be stored to and restored from XML
+        Initialize();
+        // [GIVEN] Package with Table, where 'Processing Order' = "X"
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Customer);
+        RandomId := LibraryRandom.RandInt(1000);
+        ConfigPackageTable."Processing Order" := RandomId;
+        ConfigPackageTable.Modify();
+
+        // [GIVEN] Package exported to an XML file
+        // [WHEN] Import Package from the XML file
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        // [THEN] Package contains Table, where 'Processing Order' = "X"
+        ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::Customer);
+        Assert.AreEqual(RandomId, ConfigPackageTable."Processing Order", NoDataAfterImportErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackage_ExportPackageTableWithDataTemplate_DataImportedWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        RandomCode: Code[10];
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO] Filled 'Data Template' field can be stored to and restored from XML
+        Initialize();
+        // [GIVEN] Package with Table, where 'Data Template' = "X"
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Customer);
+        RandomCode := LibraryUtility.GenerateRandomCode(ConfigPackageTable.FieldNo("Data Template"), DATABASE::"Config. Package Table");
+        ConfigPackageTable."Data Template" := RandomCode;
+        ConfigPackageTable.Modify();
+
+        // [GIVEN] Package exported to an XML file
+        // [WHEN] Import Package from the XML file
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        // [THEN] Package contains Table, where 'Data Template' = "X"
+        ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::Customer);
+        Assert.AreEqual(RandomCode, ConfigPackageTable."Data Template", NoDataAfterImportErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackage_ExportPackageTableWithComments_DataImportedWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        RandomCode: Code[10];
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO] Filled 'Comments' field can be stored to and restored from XML
+        Initialize();
+        // [GIVEN] Package with Table, where 'Comments' = "X"
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Customer);
+        RandomCode := LibraryUtility.GenerateRandomCode(ConfigPackageTable.FieldNo(Comments), DATABASE::"Config. Package Table");
+        ConfigPackageTable.Comments := RandomCode;
+        ConfigPackageTable.Modify();
+
+        // [GIVEN] Package exported to an XML file
+        // [WHEN] Import Package from the XML file
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        // [THEN] Package contains Table, where 'Comments' = "X"
+        ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::Customer);
+        Assert.AreEqual(RandomCode, ConfigPackageTable.Comments, NoDataAfterImportErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackage_ExportPackageTableWithCreatedByUser_DataImportedWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        RandomCode: Code[10];
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO] Filled 'Created by User ID' field can be stored to and restored from XML
+        Initialize();
+        // [GIVEN] Package with Table, where 'Created by User ID' = "X"
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Customer);
+        RandomCode :=
+          LibraryUtility.GenerateRandomCode(ConfigPackageTable.FieldNo("Created by User ID"), DATABASE::"Config. Package Table");
+        ConfigPackageTable."Created by User ID" := RandomCode;
+        ConfigPackageTable.Modify();
+
+        // [GIVEN] Package exported to an XML file
+        // [WHEN] Import Package from the XML file
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        // [THEN] Package contains Table, where 'Created by User ID' = "X"
+        ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::Customer);
+        Assert.AreEqual(RandomCode, ConfigPackageTable."Created by User ID", NoDataAfterImportErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackage_ExportPackageTableWithSkipTableTriggers_DataImportedWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO] Filled 'Skip Table Triggers' field can be stored to and restored from XML
+        Initialize();
+        // [GIVEN] Package with Table, where 'Skip Table Triggers' = "Yes"
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Customer);
+        ConfigPackageTable."Skip Table Triggers" := true;
+        ConfigPackageTable.Modify();
+
+        // [GIVEN] Package exported to an XML file
+        // [WHEN] Import Package from the XML file
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        // [THEN] Package contains Table, where 'Skip Table Triggers' = "Yes"
+        ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::Customer);
+        Assert.AreEqual(true, ConfigPackageTable."Skip Table Triggers", NoDataAfterImportErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackage_ExportPackageTableWithDimensionsAsColumns_DataImportedWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+    begin
+        // [FEATURE] [Dimension] [XML]
+        // [SCENARIO] Filled 'Dimensions as Columns' field can be stored to and restored from XML
+        Initialize();
+        // [GIVEN] Package with Table, where 'Dimensions as Columns' = "Yes"
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Customer);
+        ConfigPackageTable."Dimensions as Columns" := true;
+        ConfigPackageTable.Modify();
+
+        // [GIVEN] Package exported to an XML file
+        // [WHEN] Import Package from the XML file
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        // [THEN] Package contains Table, where 'Dimensions as Columns' = "Yes"
+        ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::Customer);
+        Assert.AreEqual(true, ConfigPackageTable."Dimensions as Columns", NoDataAfterImportErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackage_ExportPackageTableWithBLOBFieldWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        GLAccFilter: Text[250];
+    begin
+        // [SCENARIO] Pass BLOB (binary files) via RapidStart package
+        Initialize();
+        // [GIVEN] Two G/L Accounts, first one has a picture (BLOB value)
+        CreateTwoGLAccountsFirstWithBLOB(GLAccFilter);
+        // [GIVEN] Config. Package with 'G/L Account' table
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::"G/L Account");
+        // [GIVEN] Set all fields excluded except PK and Picture to decrease package processing time
+        IncludeGLAccountPictureConfigPackageField(ConfigPackage.Code);
+        // [GIVEN] Set filter for two Contacts to decrease package processing time
+        SetContactConfigPackageFilter(ConfigPackage.Code, GLAccFilter);
+        // [WHEN] Export and then import package
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+        // [THEN] "Config. Package Data"."BLOB Value" = Contact.Picture per each Contact
+        VerifyConfigPackageDataBLOBValues(ConfigPackage.Code, GLAccFilter);
+        Assert.IsTrue(ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::"G/L Account"), NoDataAfterImportErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackage_ExportPackageTableWithMediaSetFieldWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        TempConfigMediaBuffer: Record "Config. Media Buffer" temporary;
+        ItemFilter: Text[250];
+        FilePath: Text;
+    begin
+        // [SCENARIO] Pass MediaSet (binary files) via RapidStart package
+        Initialize();
+        // [GIVEN] Two Items, first item has a picture (MediaSet value)
+        CreateTwoItemsFirstWithMediaSet(ItemFilter);
+        // [GIVEN] Config. Package with Item table
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Item);
+        // [GIVEN] Set all fields excluded except PK and Picture to decrease package processing time
+        IncludeItemPictureConfigPackageField(ConfigPackage.Code);
+        // [GIVEN] Set filter for two items to decrease package processing time
+        SetItemConfigPackageFilter(ConfigPackage.Code, ItemFilter);
+
+        ExportToXML(ConfigPackage.Code, ConfigPackageTable, FilePath);
+        GetExpectedMediaSet(TempConfigMediaBuffer);
+
+        LibraryRapidStart.CleanUp(ConfigPackage.Code);
+        ConfigXMLExchange.ImportPackageXML(FilePath);
+        Erase(FilePath);
+
+        // [WHEN] Export and then import package
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+        // [THEN] "Config. Package Data"."BLOB Value" = Item.Picture per each item
+        VerifyConfigPackageDataMediaSetValues(ConfigPackage.Code, ItemFilter, TempConfigMediaBuffer);
+        Assert.IsTrue(ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::Item), NoDataAfterImportErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackages_ExportOneOfTwoPackage_ImpordDoNotSpoiledExistingDataWithDotNet()
+    var
+        ConfigPackage1: Record "Config. Package";
+        ConfigPackage2: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        FilePath: Text;
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO] Imported package should not affect existing equal package
+        Initialize();
+        // [GIVEN] Two equal packages: "A" and "B"
+        CreateSimplePackage(ConfigPackage1);
+        CreateSimplePackage(ConfigPackage2);
+        // [GIVEN] Package "A" is exported to XML
+        ExportToXML(ConfigPackage1.Code, ConfigPackageTable, FilePath);
+        // [WHEN] Import Package "A" from XML
+        ConfigXMLExchange.ImportPackageXML(FilePath);
+        Erase(FilePath);
+        // [THEN] Package "B" is not affected
+        Assert.IsTrue(IsPackageDataExists(ConfigPackage2.Code, false), ExportImportWrongPackageErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackages_ImportOneOfTwoPackage_RequiredPackageProcessedWithDotNet()
+    var
+        ConfigPackage1: Record "Config. Package";
+        ConfigPackage2: Record "Config. Package";
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO] Deleted package should not contains data, while there is equal package
+        Initialize();
+        // [GIVEN] Two equal packages: "A" and "B"
+        CreateSimplePackage(ConfigPackage1);
+        CreateSimplePackage(ConfigPackage2);
+
+        // [GIVEN] Package "A" is exported, removed, and imported back
+        ExportImportXMLWithDotNet(ConfigPackage1.Code);
+        // [WHEN] remove Package "B"
+        LibraryRapidStart.CleanUp(ConfigPackage2.Code);
+
+        // [THEN] Package "A" contains data, Package "B" does not.
+        Assert.IsTrue(
+          IsPackageDataExists(ConfigPackage1.Code, false) and not IsPackageDataExists(ConfigPackage2.Code, true),
+          ExportImportInterfereErr);
+    end;
+#endif
 
     [Test]
     [Scope('OnPrem')]
@@ -478,7 +1070,7 @@ codeunit 136603 "ERM RS Package Operations"
         // [WHEN] Attempting to apply the package
         LibraryRapidStart.ApplyPackage(ConfigPackage, true);
 
-        // [THEN] No integration field mapping records are imported and an error message is loggee for each record in the package.
+        // [THEN] No integration field mapping records are imported and an error message is logged for each record in the package.
         Assert.RecordIsEmpty(IntegrationFieldMapping);
         ConfigPackageError.SetRange("Package Code", ConfigPackage.Code);
         ConfigPackageError.SetRange("Table ID", DATABASE::"Integration Field Mapping");
@@ -492,9 +1084,9 @@ codeunit 136603 "ERM RS Package Operations"
     var
         ConfigPackage: Record "Config. Package";
         ConfigPackageTable: Record "Config. Package Table";
-        PackageXML: DotNet XmlDocument;
-        XMLNode: DotNet XmlNode;
-        XMLAttributes: DotNet XmlNodeList;
+        PackageXML: XmlDocument;
+        XMLNode: XmlNode;
+        XMLAttributes: XmlNodeList;
     begin
         // [FEATURE] [XML]
         // [SCENARIO] localization attributes are exported to XML
@@ -509,15 +1101,15 @@ codeunit 136603 "ERM RS Package Operations"
         SetLocalizeFields(ConfigPackage.Code, ConfigPackageTable."Table ID");
 
         // [WHEN] Export Package to XML
-        PackageXML := PackageXML.XmlDocument();
+        PackageXML := XmlDocument.Create();
         ConfigPackageTable.SetRange("Package Code", ConfigPackage.Code);
-        ConfigXMLExchange.ExportPackageXMLDocument(PackageXML, ConfigPackageTable, ConfigPackage, true);
+        ConfigXMLExchange.ExportPackageToXMLDocument(PackageXML, ConfigPackageTable, ConfigPackage, true);
 
         // [THEN] '_locDefinition' node and '_loc' attributes have been generated in XML document
-        XMLNode := PackageXML.SelectSingleNode('//_locDefinition');
-        XMLAttributes := PackageXML.SelectNodes('//@_loc');
+        PackageXML.SelectSingleNode('//_locDefinition', XMLNode);
+        PackageXML.SelectNodes('//@_loc', XMLAttributes);
 
-        Assert.IsTrue((XMLNode.InnerXml <> '') and (XMLAttributes.Count <> 0), XMLGeneratedIncorrectlyErr);
+        Assert.IsTrue((XMLNode.AsXmlElement().InnerXml() <> '') and (XMLAttributes.Count <> 0), XMLGeneratedIncorrectlyErr);
     end;
 
     [Test]
@@ -823,7 +1415,7 @@ codeunit 136603 "ERM RS Package Operations"
         GetExpectedMediaSet(TempConfigMediaBuffer);
 
         LibraryRapidStart.CleanUp(ConfigPackage.Code);
-        ConfigXMLExchange.ImportPackageXML(FilePath);
+        ConfigXMLExchange.ImportPackageXMLFromFile(FilePath);
         Erase(FilePath);
 
         // [WHEN] Export and then import package
@@ -851,7 +1443,7 @@ codeunit 136603 "ERM RS Package Operations"
         // [GIVEN] Package "A" is exported to XML
         ExportToXML(ConfigPackage1.Code, ConfigPackageTable, FilePath);
         // [WHEN] Import Package "A" from XML
-        ConfigXMLExchange.ImportPackageXML(FilePath);
+        ConfigXMLExchange.ImportPackageXMLFromFile(FilePath);
         Erase(FilePath);
         // [THEN] Package "B" is not affected
         Assert.IsTrue(IsPackageDataExists(ConfigPackage2.Code, false), ExportImportWrongPackageErr);
@@ -936,9 +1528,10 @@ codeunit 136603 "ERM RS Package Operations"
           DecompressWrongResultErr);
     end;
 
+#if not CLEAN29
     [Test]
     [Scope('OnPrem')]
-    procedure ImportPackageFromXMLMultiple()
+    procedure ImportPackageFromXMLMultipleWithDotNet()
     var
         ConfigPackage: Record "Config. Package";
         ConfigPackageTable: Record "Config. Package Table";
@@ -986,7 +1579,7 @@ codeunit 136603 "ERM RS Package Operations"
 
     [Test]
     [Scope('OnPrem')]
-    procedure ImportPackageFromXMLValidate()
+    procedure ImportPackageFromXMLValidateWithDotNet()
     var
         ConfigPackage: Record "Config. Package";
         ConfigPackageTable: Record "Config. Package Table";
@@ -1023,7 +1616,7 @@ codeunit 136603 "ERM RS Package Operations"
 
     [Test]
     [Scope('OnPrem')]
-    procedure ImportPackageFromXMLApply()
+    procedure ImportPackageFromXMLApplyWithDotNet()
     var
         ConfigPackage: Record "Config. Package";
         Country: Record "Country/Region";
@@ -1035,6 +1628,116 @@ codeunit 136603 "ERM RS Package Operations"
         Initialize();
         // [GIVEN] Import Package from XML, that contains records: Country "C", and Location "L" linked to "C"
         ImportFromXML(ConfigPackage, CountryCode, LocationCode);
+
+        // [GIVEN] Apply Package
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        // [THEN] Country 'C' and Location 'L' exist in database
+        Assert.IsTrue(Country.Get(CountryCode) and Location.Get(LocationCode), ApplyErr);
+    end;
+#endif
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportPackageFromXMLMultiple()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        FilePath: Text;
+        PackageCode: Code[20];
+    begin
+        // [FEATURE] [XML]
+        // [SCENARIO] the new Package can be imported from XML for related tables.
+        Initialize();
+        // [GIVEN] Package with 7 tables
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::"VAT Product Posting Group");
+        LibraryRapidStart.CreatePackageTable(ConfigPackageTable, ConfigPackage.Code, DATABASE::"VAT Business Posting Group");
+        LibraryRapidStart.CreatePackageTable(ConfigPackageTable, ConfigPackage.Code, DATABASE::"VAT Posting Setup");
+        LibraryRapidStart.CreatePackageTable(ConfigPackageTable, ConfigPackage.Code, DATABASE::"Gen. Business Posting Group");
+        LibraryRapidStart.CreatePackageTable(ConfigPackageTable, ConfigPackage.Code, DATABASE::"Gen. Product Posting Group");
+        LibraryRapidStart.CreatePackageTable(ConfigPackageTable, ConfigPackage.Code, DATABASE::"General Posting Setup");
+        LibraryRapidStart.CreatePackageTable(ConfigPackageTable, ConfigPackage.Code, DATABASE::"G/L Account");
+        // [GIVEN] Package exported to XML
+        FilePath := FileMgt.ServerTempFileName('xml');
+        ConfigPackageTable.SetRange("Package Code", ConfigPackage.Code);
+        if ConfigPackageTable.FindSet() then
+            repeat
+                ConfigXMLExchange.ExportPackageXML(ConfigPackageTable, FilePath);
+            until ConfigPackageTable.Next() = 0;
+
+        PackageCode := ConfigPackage.Code;
+        LibraryRapidStart.CleanUp(PackageCode);
+
+        // [WHEN] Import package from XML
+        ConfigXMLExchange.ImportPackageXMLFromFile(FilePath);
+        // [THEN] Package contains 7 tables
+        ConfigPackage.Get(PackageCode);
+        Assert.IsTrue(
+          ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::"VAT Product Posting Group") and
+          ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::"VAT Business Posting Group") and
+          ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::"VAT Posting Setup") and
+          ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::"Gen. Business Posting Group") and
+          ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::"Gen. Product Posting Group") and
+          ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::"General Posting Setup") and
+          ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::"G/L Account"),
+          PackageDataErr);
+
+        Erase(FilePath);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportPackageFromXMLValidate()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        ConfigPackageError: Record "Config. Package Error";
+        Customer: Record Customer;
+        ConfigPackageField: Record "Config. Package Field";
+        RecRef: RecordRef;
+        PackageXML: XmlDocument;
+        DocumentElement: XmlElement;
+        DocumentNode: XmlNode;
+        XmlText: Text;
+    begin
+        // [SCENARIO] the new Package can be validated with function Validate Table Relation.
+        Initialize();
+        // [GIVEN] XML file contains Customer data
+        XmlText := '<?xml version="1.0" encoding="UTF-16" standalone="yes"?><DataList></DataList>';
+        XmlDocument.ReadFrom(XmlText, PackageXML);
+        PackageXML.GetRoot(DocumentElement);
+        DocumentNode := DocumentElement.AsXmlNode();
+
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Customer);
+        ConfigPackageMgt.SelectAllPackageFields(ConfigPackageField, false);
+        ConfigPackageTable.CalcFields("Table Name");
+
+        LibrarySales.CreateCustomer(Customer);
+        RecRef.GetTable(Customer);
+        AddConfigPackageTableToXML(DocumentNode, ConfigPackageTable, RecRef);
+        // [GIVEN] PAckage is imported from XML
+        ConfigXMLExchange.ImportPackageXMLDocument(PackageXML, '');
+
+        // [WHEN] Validate table relation
+        LibraryRapidStart.ValidatePackage(ConfigPackage, false);
+        // [THEN] Config Package Error table is empty
+        Assert.IsTrue(ConfigPackageError.IsEmpty, PackageDataErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportPackageFromXMLApply()
+    var
+        ConfigPackage: Record "Config. Package";
+        Country: Record "Country/Region";
+        Location: Record Location;
+        CountryCode: Code[10];
+        LocationCode: Code[10];
+    begin
+        // [SCENARIO] Records of package tables imported from XML should be inserted by Apply package
+        Initialize();
+        // [GIVEN] Import Package from XML, that contains records: Country "C", and Location "L" linked to "C"
+        ImportFromXMLNew(ConfigPackage, CountryCode, LocationCode);
 
         // [GIVEN] Apply Package
         LibraryRapidStart.ApplyPackage(ConfigPackage, true);
@@ -1081,6 +1784,172 @@ codeunit 136603 "ERM RS Package Operations"
         Erase(CompressedServerFileName);
     end;
 
+#if not CLEAN29
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportPackageFromXMLKeyApplyWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        GenBusPostingGroup: Record "Gen. Business Posting Group";
+        GenProductPostingGroup: Record "Gen. Product Posting Group";
+        GeneralPostingSetup: Record "General Posting Setup";
+        GenProductPostingGroupCode: Code[20];
+        GenBusPostingGroupCode: Code[20];
+    begin
+        Initialize();
+        ImportFromXMLKey(ConfigPackage, GenProductPostingGroupCode, GenBusPostingGroupCode);
+
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        LibraryRapidStart.CleanUp(ConfigPackage.Code);
+
+        Assert.IsTrue(
+          GenBusPostingGroup.Get(GenBusPostingGroupCode) and
+          GenProductPostingGroup.Get(GenProductPostingGroupCode) and
+          GeneralPostingSetup.Get(GenBusPostingGroupCode, GenProductPostingGroupCode),
+          ApplyErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportDataFromXMLValidatedYesWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        Location: Record Location;
+        PostCode: Record "Post Code";
+        LocationCode: Code[20];
+        PostCode2: Code[20];
+        City2: Text[30];
+        FilePath: Text;
+    begin
+        Initialize();
+
+        // Create new location
+        LibraryWarehouse.CreateLocation(Location);
+        LibraryERM.CreatePostCode(PostCode);
+        Location.City := PostCode.City;
+        Location."Post Code" := PostCode.Code;
+        Location.Modify();
+        LocationCode := Location.Code;
+        PostCode2 := Location."Post Code";
+        City2 := Location.City;
+
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Location);
+        LibraryRapidStart.SetIncludeOneField(ConfigPackage.Code, DATABASE::Location, Location.FieldNo(Name), true);
+        LibraryRapidStart.SetIncludeOneField(ConfigPackage.Code, DATABASE::Location, Location.FieldNo("Name 2"), true);
+        LibraryRapidStart.SetIncludeOneField(ConfigPackage.Code, DATABASE::Location, Location.FieldNo(City), true);
+        LibraryRapidStart.SetIncludeOneField(ConfigPackage.Code, DATABASE::Location, Location.FieldNo("Post Code"), true);
+
+        ExportToXML(ConfigPackage.Code, ConfigPackageTable, FilePath);
+
+        LibraryRapidStart.CleanUp(ConfigPackage.Code);
+        PostCode.Delete();
+        Location.Delete();
+
+        ConfigXMLExchange.ImportPackageXML(FilePath);
+        LibraryRapidStart.SetValidateOneField(ConfigPackage.Code, DATABASE::Location, Location.FieldNo(City), false);
+        LibraryRapidStart.SetValidateOneField(ConfigPackage.Code, DATABASE::Location, Location.FieldNo("Post Code"), false);
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        Location.Get(LocationCode);
+        Assert.IsTrue(
+          (City2 = Location.City) and
+          (PostCode2 = Location."Post Code"),
+          ErrorInApplyingWithoutValidationFlagErr);
+
+        Erase(FilePath);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportNormalFieldsOnlyWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        ConfigPackageField: Record "Config. Package Field";
+        AvailableFields: Integer;
+    begin
+        // [SCENARIO] no FlowFields or FlowFilters are created after import
+        Initialize();
+
+        // Package Table Fields are automatically initialized here and contain only normal field class fields and no blobs
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Customer);
+        // Export all package table fields
+        ConfigPackageField.SetRange("Package Code", ConfigPackage.Code);
+        ConfigPackageField.SetRange("Table ID", DATABASE::Customer);
+        ConfigPackageMgt.SelectAllPackageFields(ConfigPackageField, true);
+        AvailableFields := GetNoOfAvailableFields(ConfigPackageTable);
+
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        // Check number of available fields after import
+        ConfigPackageTable.Get(ConfigPackage.Code, DATABASE::Customer);
+        Assert.AreEqual(AvailableFields, GetNoOfAvailableFields(ConfigPackageTable), FlowFieldAppearedInDataErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportGenJnlLineAndPostWithDotNet()
+    var
+        GenJnlLine: Record "Gen. Journal Line";
+        ConfigPackage: Record "Config. Package";
+        GLAccount: Record "G/L Account";
+        PaymentMethod: Record "Payment Method";
+        GenBusinessPostingGroup: Record "Gen. Business Posting Group";
+        GenProductPostingGroup: Record "Gen. Product Posting Group";
+        GeneralPostingSetup: Record "General Posting Setup";
+        VATBusinessPostingGroup: Record "VAT Business Posting Group";
+        VATProductPostingGroup: Record "VAT Product Posting Group";
+        VendorPostingGroup: Record "Vendor Posting Group";
+        PaymentTerms: Record "Payment Terms";
+        DocumentNo: Code[20];
+        Amount: Decimal;
+        FilePath: Text;
+    begin
+        Initialize();
+
+        // Init general setup
+        CreateGenJnlLineSetup(
+          GLAccount,
+          PaymentMethod,
+          GenBusinessPostingGroup,
+          GenProductPostingGroup,
+          GeneralPostingSetup,
+          VATBusinessPostingGroup,
+          VATProductPostingGroup,
+          VendorPostingGroup,
+          PaymentTerms);
+
+        CreateGenJnlLines(GenJnlLine, Amount, GLAccount."No.", DocumentNo);
+        // Export data to XML
+        CreateAndExportPackageDataForGenJnlLine(ConfigPackage, FilePath);
+
+        // Delete the created line before import
+        GenJnlLine.Delete(true);
+        LibraryRapidStart.CleanUp(ConfigPackage.Code);
+        // Import created file
+        ConfigXMLExchange.ImportPackageXML(FilePath);
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        PostGenJnlLines(GLAccount."No.", DocumentNo);
+
+        // Verification
+        VerifyGenJnlLineAmount(GenJnlLine."Document Type"::Invoice, DocumentNo, GLAccount."No.", Amount);
+
+        Erase(FilePath);
+        CleanupGenJnlSetupData(
+          PaymentMethod,
+          GenBusinessPostingGroup,
+          GenProductPostingGroup,
+          GeneralPostingSetup,
+          VATBusinessPostingGroup,
+          VATProductPostingGroup,
+          VendorPostingGroup,
+          PaymentTerms);
+    end;
+#endif
+
     [Test]
     [Scope('OnPrem')]
     procedure ImportPackageFromXMLKeyApply()
@@ -1093,7 +1962,7 @@ codeunit 136603 "ERM RS Package Operations"
         GenBusPostingGroupCode: Code[20];
     begin
         Initialize();
-        ImportFromXMLKey(ConfigPackage, GenProductPostingGroupCode, GenBusPostingGroupCode);
+        ImportFromXMLKeyNew(ConfigPackage, GenProductPostingGroupCode, GenBusPostingGroupCode);
 
         LibraryRapidStart.ApplyPackage(ConfigPackage, true);
 
@@ -1143,7 +2012,7 @@ codeunit 136603 "ERM RS Package Operations"
         PostCode.Delete();
         Location.Delete();
 
-        ConfigXMLExchange.ImportPackageXML(FilePath);
+        ConfigXMLExchange.ImportPackageXMLFromFile(FilePath);
         LibraryRapidStart.SetValidateOneField(ConfigPackage.Code, DATABASE::Location, Location.FieldNo(City), false);
         LibraryRapidStart.SetValidateOneField(ConfigPackage.Code, DATABASE::Location, Location.FieldNo("Post Code"), false);
         LibraryRapidStart.ApplyPackage(ConfigPackage, true);
@@ -1225,7 +2094,7 @@ codeunit 136603 "ERM RS Package Operations"
         GenJnlLine.Delete(true);
         LibraryRapidStart.CleanUp(ConfigPackage.Code);
         // Import created file
-        ConfigXMLExchange.ImportPackageXML(FilePath);
+        ConfigXMLExchange.ImportPackageXMLFromFile(FilePath);
         LibraryRapidStart.ApplyPackage(ConfigPackage, true);
 
         PostGenJnlLines(GLAccount."No.", DocumentNo);
@@ -1245,8 +2114,9 @@ codeunit 136603 "ERM RS Package Operations"
           PaymentTerms);
     end;
 
+#if not CLEAN29
     [Test]
-    procedure TestExportPackageXMLToStream()
+    procedure TestExportPackageXMLToStreamWithDotNet()
     var
         ConfigPackage: Record "Config. Package";
         DummyRSTable: Record DummyRSTable;
@@ -1264,9 +2134,112 @@ codeunit 136603 "ERM RS Package Operations"
         // [GIVEN] A record of DummyRSTable in the database
         DummyRSTable.DeleteAll();
         DummyRSTable."Entry No." := 1;
+        DummyRSTable."Code Field" := 'TEST';
         DummyRSTable."Decimal Field" := 3.21;
         DummyRSTable."Date Field" := 20180325D;
         DummyRSTable."Text Field" := 'Lorem ipsum dolor sit amet';
+        DummyRSTable."Long Text Field" := 'Lorem ipsum dolor sit amet';
+        DummyRSTable.Insert();
+
+        // [GIVEN] Rapidstart package is created from DummyRSTable table
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::DummyRSTable);
+
+        // [GIVEN] No other tables are included in the package
+        ConfigPackage."Exclude Config. Tables" := true;
+        ConfigPackage.Modify();
+
+        // [WHEN] The package is exported
+        TempBlob.CreateOutStream(PackageOutStream);
+        ConfigXMLExchange.ExportPackageXMLToStreamLegacy(ConfigPackage, PackageOutStream);
+
+        // [THEN] The content corresponds to the package that was exported
+        TempBlob.CreateInStream(TempBlobInStream);
+        Assert.AreEqual(1674, TempBlob.Length(), 'Wrong length of the exported package.');
+        while not TempBlobInStream.EOS do begin
+            TempBlobInStream.Read(SingleLine);
+            PackageOutput += SingleLine;
+        end;
+        Assert.IsSubstring(PackageOutput, '<TableID>136607</TableID>');
+        Assert.IsSubstring(PackageOutput, 'Lorem ipsum dolor sit amet');
+    end;
+
+    [Test]
+    procedure TestImportTextFieldsWith2048CharactersWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        DummyRSTable: Record DummyRSTable;
+        ConfigPackageTable: Record "Config. Package Table";
+        ConfigXMLExchange: Codeunit "Config. XML Exchange";
+        TempBlob: Codeunit "Temp Blob";
+        TempBlobInStream: InStream;
+        PackageOutStream: OutStream;
+    begin
+        // [SCENARIO] Text fields larger than 250 characters are not truncated on import.
+        Initialize();
+
+        // [GIVEN] A record of DummyRSTable in the database
+        DummyRSTable.DeleteAll();
+        DummyRSTable."Entry No." := 1;
+        DummyRSTable."Decimal Field" := 3.21;
+        DummyRSTable."Date Field" := 20180325D;
+        DummyRSTable."Text Field" := 'Lorem ipsum dolor sit amet';
+        DummyRSTable."Long Text Field" := GetLongText();
+        DummyRSTable.Insert();
+
+        // [GIVEN] Rapidstart package is created from DummyRSTable table
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::DummyRSTable);
+
+        // [GIVEN] No other tables are included in the package
+        ConfigPackage."Exclude Config. Tables" := true;
+        ConfigPackage.Modify();
+
+        // [GIVEN] The package is exported
+        TempBlob.CreateOutStream(PackageOutStream);
+        ConfigXMLExchange.ExportPackageXMLToStream(ConfigPackage, PackageOutStream);
+
+        // Cleanup before import
+        DummyRSTable.DeleteAll();
+        LibraryRapidStart.CleanUp(ConfigPackage.Code);
+
+        // [WHEN] the rapidstart package is imported and applied
+        TempBlob.CreateInStream(TempBlobInStream);
+        ConfigXMLExchange.ImportPackageXMLFromStream(TempBlobInStream);
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        // [THEN] DummyRSTable records are properly applied
+        VerifyDummyRSTableRecords(DummyRSTable);
+        // [THEN] The text field with 2048 characters is filled properly
+        DummyRSTable.FindFirst();
+        Assert.AreEqual(GetLongText(), DummyRSTable."Long Text Field", 'Incorrect content of the long text field.');
+    end;
+#endif
+
+    [Test]
+    procedure TestExportPackageXMLToStream()
+    var
+        ConfigPackage: Record "Config. Package";
+        DummyRSTable: Record DummyRSTable;
+        ConfigPackageTable: Record "Config. Package Table";
+        ConfigXMLExchange: Codeunit "Config. XML Exchange";
+        TempBlob: Codeunit "Temp Blob";
+        TempBlobOld: Codeunit "Temp Blob";
+        TempBlobInStream: InStream;
+        PackageOutStream: OutStream;
+        PackageOutput: Text;
+        PackageOutputOld: Text;
+        SingleLine: Text;
+    begin
+        // [SCENARIO] Exporting a package to an OutStream.
+        Initialize();
+
+        // [GIVEN] A record of DummyRSTable in the database
+        DummyRSTable.DeleteAll();
+        DummyRSTable."Entry No." := 1;
+        DummyRSTable."Code Field" := 'TEST';
+        DummyRSTable."Decimal Field" := 3.21;
+        DummyRSTable."Date Field" := 20180325D;
+        DummyRSTable."Text Field" := 'Lorem ipsum dolor sit amet';
+        DummyRSTable."Long Text Field" := 'Lorem ipsum dolor sit amet';
         DummyRSTable.Insert();
 
         // [GIVEN] Rapidstart package is created from DummyRSTable table
@@ -1282,7 +2255,7 @@ codeunit 136603 "ERM RS Package Operations"
 
         // [THEN] The content corresponds to the package that was exported
         TempBlob.CreateInStream(TempBlobInStream);
-        Assert.AreEqual(1646, TempBlob.Length(), 'Wrong length of the exported package.');
+        Assert.AreEqual(1674, TempBlob.Length(), 'Wrong length of the exported package.');
         while not TempBlobInStream.EOS do begin
             TempBlobInStream.Read(SingleLine);
             PackageOutput += SingleLine;
@@ -1331,7 +2304,7 @@ codeunit 136603 "ERM RS Package Operations"
 
         // [WHEN] the rapidstart package is imported and applied
         TempBlob.CreateInStream(TempBlobInStream);
-        ConfigXMLExchange.ImportPackageXMLFromStream(TempBlobInStream);
+        ConfigXMLExchange.ImportPackageXML(TempBlobInStream);
         LibraryRapidStart.ApplyPackage(ConfigPackage, true);
 
         // [THEN] DummyRSTable records are properly applied
@@ -1373,6 +2346,68 @@ codeunit 136603 "ERM RS Package Operations"
         // [THEN] Validate field show correct data
         Assert.AreEqual(NoOfFields, ConfigPackageTable."No. of Fields Included", Text101Err);
     end;
+
+#if not CLEAN29
+    [Test]
+    [Scope('OnPrem')]
+    procedure PackageOverviewPage_DatabaseDataActionWithDotNet()
+    var
+        ConfigPackageCard: TestPage "Config. Package Card";
+        VendorList: TestPage "Vendor List";
+    begin
+        // Preparation
+        Initialize();
+        InitializePackageCardWithDotNet(ConfigPackageCard, false);
+
+        // [THEN] Check page Vendor List is opened by Database Records
+        VendorList.Trap();
+        ConfigPackageCard.Control10.DatabaseRecords.Invoke();
+        VendorList.Close();
+    end;
+
+    [Test]
+    [HandlerFunctions('PackageRecordsPageHandler')]
+    [Scope('OnPrem')]
+    procedure PackageOverviewPage_PackageDataActionWithDotNet()
+    var
+        ConfigPackageCard: TestPage "Config. Package Card";
+    begin
+        Initialize();
+        InitializePackageCardWithDotNet(ConfigPackageCard, true);
+
+        // [WHEN] Package Records page open
+        ConfigPackageCard.Control10.PackageRecords.Invoke();
+    end;
+
+    [Test]
+    [HandlerFunctions('PackageFieldsPageHandler')]
+    [Scope('OnPrem')]
+    procedure PackageOverviewPage_PackageFieldsActionWithDotNet()
+    var
+        ConfigPackageCard: TestPage "Config. Package Card";
+    begin
+        Initialize();
+        InitializePackageCardWithDotNet(ConfigPackageCard, true);
+
+        // [WHEN] Package Fields page open
+        ConfigPackageCard.Control10.PackageFields.Invoke();
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmYesHandler,MessageHandler')]
+    [Scope('OnPrem')]
+    procedure PackageOverviewPage_ValidateRelationsActionWithDotNet()
+    var
+        ConfigPackageCard: TestPage "Config. Package Card";
+    begin
+        Initialize();
+        InitializePackageCardWithDotNet(ConfigPackageCard, true);
+
+        // [WHEN] Validate relations
+        ConfigPackageCard.Control10.ValidateRelations.Invoke();
+    end;
+#endif
+
 
     [Test]
     [Scope('OnPrem')]
@@ -1733,6 +2768,106 @@ codeunit 136603 "ERM RS Package Operations"
         Assert.AreEqual(GetTableName(TableID), ConfigPackageCard.Control10."Table Name".Value, TableNotValidatedErr);
     end;
 
+#if not CLEAN29
+    [Test]
+    [HandlerFunctions('ConfirmYesHandler')]
+    [Scope('OnPrem')]
+    procedure ExportImportStructuredPackageWithDimAsColWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigLine: Record "Config. Line";
+        PackageCode: Code[20];
+    begin
+        // [SCENARIO 333276] Export/Import package with structured config. lines with Dim As Columns in additional area
+        HideDialog();
+
+        CreateConfigPackage(ConfigPackage);
+        PackageCode := ConfigPackage.Code;
+
+        FillInWorksheet(PackageCode);
+
+        // EXECUTE
+        ExportImportXMLWithDotNet(PackageCode);
+
+        // VERIFY that last config line has correct Table ID value
+        ConfigLine.SetRange("Package Code", PackageCode);
+        ConfigLine.FindLast();
+        Assert.AreEqual(DATABASE::Customer, ConfigLine."Table ID", StrSubstNo(ValueIsIncorrectErr, ConfigLine.FieldName("Table ID")));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportPackageWithMultilineConfigTemplateWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        ConfigTemplateHeaderCode: Code[10];
+    begin
+        // [SCENARIO 101422] TestHierarchy function of Config Template should work successfully when importing multiple lines from package.
+
+        // [GIVEN] Create package with multiline configuration template.
+        Initialize();
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::"Config. Template Line");
+        ConfigTemplateHeaderCode := CreateConfigTemplateWithMultipleLines();
+
+        // [WHEN] Export package, cleanup all packages and templates and import package?
+        ExportImportXMLWithPackageAndTemplateCleanup(ConfigPackage.Code, ConfigTemplateHeaderCode);
+
+        // [THEN] Check that there are no errors of import.
+        ConfigPackage.CalcFields("No. of Errors");
+        Assert.AreEqual(0, ConfigPackage."No. of Errors", StrSubstNo(PackageErr, ConfigPackage.Code));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmYesHandler')]
+    procedure ExportImportPackageWithAutoIncrementFieldMarkedAsPKWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageField: Record "Config. Package Field";
+        ConfigPackageTable: Record "Config. Package Table";
+        DimensionSetTreeNode: array[2] of Record "Dimension Set Tree Node";
+    begin
+        // [FEATURE] [Apply] [Primary Key] [AutoIncrement]
+        // [SCENARIO] The exported AutoIncrement field marked as "Primary Key" member should be imported and applied
+        Initialize();
+        // [GIVEN] Dimension Set Tree Node, where (AutoIncrement) "Dimension Set ID"  = 3
+        DimensionSetTreeNode[1].DeleteAll();
+        DimensionSetTreeNode[1].Init();
+        DimensionSetTreeNode[1]."Parent Dimension Set ID" := 1;
+        DimensionSetTreeNode[1]."Dimension Value ID" := 2;
+        DimensionSetTreeNode[1]."Dimension Set ID" := 3;
+        DimensionSetTreeNode[1]."In Use" := true;
+        DimensionSetTreeNode[1].Insert();
+
+        // [GIVEN] Config package for table 481 "Dimension Set Tree Node"
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::"Dimension Set Tree Node");
+        ConfigPackage."Exclude Config. Tables" := true;
+        ConfigPackage.Modify();
+        // [GIVEN] Field "Dimension Set ID" is marked as "Primary Key" (though it is not in PK actually)
+        ConfigPackageField.Get(
+          ConfigPackage.Code, DATABASE::"Dimension Set Tree Node", DimensionSetTreeNode[1].FieldNo("Dimension Set ID"));
+        ConfigPackageField."Primary Key" := true;
+        ConfigPackageField.Modify();
+
+        // [GIVEN] Export/Import the package
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+        // [GIVEN] Dimension Set Tree Node is deleted
+        DimensionSetTreeNode[2].DeleteAll();
+
+        // [WHEN] Apply the package
+        LibraryRapidStart.ApplyPackage(ConfigPackage, false);
+
+        // [THEN] Dimension Set Tree Node is restored, without errors
+        Assert.RecordCount(DimensionSetTreeNode[2], 1);
+        DimensionSetTreeNode[2].FindFirst();
+        DimensionSetTreeNode[2].TestField("Parent Dimension Set ID", DimensionSetTreeNode[1]."Parent Dimension Set ID");
+        DimensionSetTreeNode[2].TestField("Dimension Value ID", DimensionSetTreeNode[1]."Dimension Value ID");
+        DimensionSetTreeNode[2].TestField("Dimension Set ID", DimensionSetTreeNode[1]."Dimension Set ID");
+        DimensionSetTreeNode[2].TestField("In Use", DimensionSetTreeNode[1]."In Use");
+    end;
+#endif
+
     [Test]
     [HandlerFunctions('ConfirmYesHandler')]
     [Scope('OnPrem')]
@@ -1775,7 +2910,7 @@ codeunit 136603 "ERM RS Package Operations"
         ConfigTemplateHeaderCode := CreateConfigTemplateWithMultipleLines();
 
         // [WHEN] Export package, cleanup all packages and templates and import package?
-        ExportImportXMLWithPackageAndTemplateCleanup(ConfigPackage.Code, ConfigTemplateHeaderCode);
+        ExportImportXMLWithPackageAndTemplateCleanupNew(ConfigPackage.Code, ConfigTemplateHeaderCode);
 
         // [THEN] Check that there are no errors of import.
         ConfigPackage.CalcFields("No. of Errors");
@@ -2287,9 +3422,10 @@ codeunit 136603 "ERM RS Package Operations"
             until SalesHeader.Next() = 0;
     end;
 
+#if not CLEAN29
     [Test]
     [Scope('OnPrem')]
-    procedure ImportPackageWithNonExistingTable()
+    procedure ImportPackageWithNonExistingTableWithDotNet()
     var
         ConfigPackageError: Record "Config. Package Error";
         XMLDOMManagement: Codeunit "XML DOM Management";
@@ -2318,6 +3454,43 @@ codeunit 136603 "ERM RS Package Operations"
         // [WHEN] Importing "PACK01"
         // [THEN] Package imported
         ConfigXMLExchange.ImportPackageXMLDocument(XMLDocument, '');
+
+        // [THEN] A config. package error is created for "PACK01" informing that table "-452" does not exists
+        ConfigPackageError.SetRange("Package Code", PackageCode);
+        ConfigPackageError.FindFirst();
+        ConfigPackageError.TestField("Table ID", TableID);
+        ConfigPackageError.TestField("Error Text", StrSubstNo(PackageImportErr, TableID));
+    end;
+#endif
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportPackageWithNonExistingTable()
+    var
+        ConfigPackageError: Record "Config. Package Error";
+        PackageXML: XmlDocument;
+        TableID: Integer;
+        TextXMLPackage: Text;
+        PackageCode: Code[20];
+    begin
+        // [SCENARIO 380200] Importing of Package with non existing table does not break import process, but creates Package Error
+        // [FEATURE] [UT]
+
+        // [GIVEN] Package "PACK01" with non existing table "-452"
+        PackageCode := 'PACK01';
+        TableID := -452;
+        TextXMLPackage :=
+          StrSubstNo(
+            '<?xml version="1.0" encoding="UTF-16" standalone="yes"?>' +
+            '<DataList LanguageID="1033" ProductVersion="NAV 7.1" PackageName="Tables" Code="%1">' +
+            '<ApprovalSetupList><TableID>%2</TableID></ApprovalSetupList></DataList>',
+            PackageCode,
+            TableID);
+        XmlDocument.ReadFrom(TextXMLPackage, PackageXML);
+
+        // [WHEN] Importing "PACK01"
+        // [THEN] Package imported
+        ConfigXMLExchange.ImportPackageXMLDocument(PackageXML, '');
 
         // [THEN] A config. package error is created for "PACK01" informing that table "-452" does not exists
         ConfigPackageError.SetRange("Package Code", PackageCode);
@@ -2385,6 +3558,49 @@ codeunit 136603 "ERM RS Package Operations"
         ProcedureResult := ConfigPackageTable.GetNoOfDatabaseRecords();
         Assert.AreEqual(0, ProcedureResult, 'GetNoOfDatabaseRecords result must be 0');
     end;
+
+#if not CLEAN29
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportPackage_ImportCreateMissingCodesValueInFieldPackageWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        ConfigPackageField: Record "Config. Package Field";
+        Customer: Record Customer;
+        FieldNo1: Integer;
+        FieldNo2: Integer;
+    begin
+        // [FEATURE] [UT]
+        // [SCENARIO 382272] Import Config Package should save the "Create Missing Codes" package field value
+        Initialize();
+
+        // [GIVEN] Config Package for Customer
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::Customer);
+
+        // [GIVEN] Config Package Field setup for Customer.City and Customer."Territory Code"
+        FieldNo1 := Customer.FieldNo(City);
+        FieldNo2 := Customer.FieldNo("Territory Code");
+        LibraryRapidStart.SetIncludeOneField(ConfigPackage.Code, DATABASE::Customer, FieldNo1, true);
+        LibraryRapidStart.SetIncludeOneField(ConfigPackage.Code, DATABASE::Customer, FieldNo2, true);
+
+        // [GIVEN] Customer.City field setup "Create Missing Codes" set to TRUE
+        LibraryRapidStart.SetCreateMissingCodesForField(ConfigPackage.Code, DATABASE::Customer, FieldNo1, true);
+        // [GIVEN] Customer."Territory Code" field setup "Create Missing Codes" set to FALSE
+        LibraryRapidStart.SetCreateMissingCodesForField(ConfigPackage.Code, DATABASE::Customer, FieldNo2, false);
+
+        // [WHEN] Import Config Package
+        ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        // [THEN] Customer.City field setup "Create Missing Codes" is TRUE
+        ConfigPackageField.Get(ConfigPackage.Code, DATABASE::Customer, FieldNo1);
+        ConfigPackageField.TestField("Create Missing Codes", true);
+
+        // [THEN] Customer."Territory Code" field setup "Create Missing Codes" is FALSE
+        ConfigPackageField.Get(ConfigPackage.Code, DATABASE::Customer, FieldNo2);
+        ConfigPackageField.TestField("Create Missing Codes", false);
+    end;
+#endif
 
     [Test]
     [Scope('OnPrem')]
@@ -2580,9 +3796,10 @@ codeunit 136603 "ERM RS Package Operations"
         Assert.RecordCount(ConfigPackageTable, 2);
     end;
 
+#if not CLEAN29
     [Test]
     [Scope('OnPrem')]
-    procedure ImportPackageWithOptionsAndEnums()
+    procedure ImportPackageWithOptionsAndEnumsWithDotNet()
     var
         OptionAndEnumRS: Record OptionAndEnumRS;
         ConfigPackage: Record "Config. Package";
@@ -2616,7 +3833,7 @@ codeunit 136603 "ERM RS Package Operations"
 
     [Test]
     [Scope('OnPrem')]
-    procedure ImportPackageWithTranslatedOptionsAndEnums()
+    procedure ImportPackageWithTranslatedOptionsAndEnumsWithDotNet()
     var
         OptionAndEnumRS: Record OptionAndEnumRS;
         ConfigPackage: Record "Config. Package";
@@ -2657,7 +3874,7 @@ codeunit 136603 "ERM RS Package Operations"
 
     [Test]
     [Scope('OnPrem')]
-    procedure ExportImportConfigPackageWithPercentInColumn()
+    procedure ExportImportConfigPackageWithPercentInColumnWithDotNet()
     var
         ConfigPackage: Record "Config. Package";
         ConfigPackageTable: Record "Config. Package Table";
@@ -2686,6 +3903,169 @@ codeunit 136603 "ERM RS Package Operations"
         // [WHEN] Package "A" is imported from XML
         // [THEN] No error message appears 
         ImportPackageXML(ConfigPackage.Code, FilePath);
+        Erase(FilePath);
+
+        // [WHEN] Apply the package 
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        // [THEN] The package is applied without errors
+        // [THEN] "Inventory Adjmt. Entry Order" has original values of "Indirect Cost %" and "Indirect Cost" 
+        VerifyNoConfigPackageErrors(ConfigPackage.Code);
+        VerifyInventoryAdjmtEntryOrderLines(3);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportConfigPackageWithDecimalRoundingWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        Item: Record Item;
+        ItemUnitOfMeasure: Record "Item Unit of Measure";
+        BaseUnitOfMeasure: Record "Unit of Measure";
+        OtherUnitOfMeasure: Record "Unit of Measure";
+        FilePath: Text;
+    begin
+        // [SCENARIO 453468] Export and import of Config. Package with Qty. per Unit of Measure require rounding to 5 decimals
+        Initialize();
+
+        // [GIVEN] Create Item with 2 units of measure and Qty. per Unit of Measure with more than 5 decimals
+        LibraryInventory.CreateItem(Item);
+        LibraryInventory.CreateUnitOfMeasureCode(BaseUnitOfMeasure);
+        LibraryInventory.CreateItemUnitOfMeasure(ItemUnitOfMeasure, Item."No.", BaseUnitOfMeasure.Code, 1);
+        LibraryInventory.CreateUnitOfMeasureCode(OtherUnitOfMeasure);
+        LibraryInventory.CreateItemUnitOfMeasure(ItemUnitOfMeasure, Item."No.", OtherUnitOfMeasure.Code, 1.23456789);
+
+        // [GIVEN] Create Package with Item Unit Of Measure table
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::"Item Unit of Measure");
+
+        // [GIVEN] Config. Package is exported to XML
+        ExportToXML(ConfigPackage.Code, ConfigPackageTable, FilePath);
+
+        // [GIVEN] Delete created other unit of measure
+        ItemUnitOfMeasure.Delete();
+
+        // [WHEN] Package is imported from XML
+        // [THEN] No error message appears 
+        ImportPackageXML(ConfigPackage.Code, FilePath);
+        Erase(FilePath);
+
+        // [WHEN] Apply the package 
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        // [THEN] The package is applied without errors
+        // [THEN] and Qty. per Unit of Measure" rounded to 5 decimals
+        ItemUnitOfMeasure.Get(Item."No.", OtherUnitOfMeasure.Code);
+        Assert.AreEqual(ItemUnitOfMeasure."Qty. per Unit of Measure", 1.23457, 'value should be rounded to 5 decimals.');
+    end;
+#endif
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportPackageWithOptionsAndEnums()
+    var
+        OptionAndEnumRS: Record OptionAndEnumRS;
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        FilePath: Text;
+    begin
+        // Init
+        Initialize();
+        OptionAndEnumRS.DeleteAll();
+
+        // [GIVEN] that we have tables with both enums and options
+        InsertOptionAndEnumRs(0, OptionAndEnumRS.OptionField::Zero, OptionAndEnumRS.EnumField::Eight);
+        InsertOptionAndEnumRs(1, OptionAndEnumRS.OptionField::One, OptionAndEnumRS.EnumField::Nine);
+        InsertOptionAndEnumRs(2, OptionAndEnumRS.OptionField::Two, OptionAndEnumRS.EnumField::Ten);
+
+        // [GIVEN] a rapidstart package is create from that table
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::OptionAndEnumRS);
+        ExportToXML(ConfigPackage.Code, ConfigPackageTable, FilePath);
+
+        // Cleanup before import
+        OptionAndEnumRS.DeleteAll();
+        LibraryRapidStart.CleanUp(ConfigPackage.Code);
+
+        // [WHEN] the rapidstart package is imported and applied
+        ConfigXMLExchange.ImportPackageXMLFromFile(FilePath);
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        // [THEN] the options and enums are properly applied
+        VerifyEnumsAndOptionsAfterApplyingPackage()
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportPackageWithTranslatedOptionsAndEnums()
+    var
+        OptionAndEnumRS: Record OptionAndEnumRS;
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        FilePath: Text;
+        LanguageId: Integer;
+    begin
+        // Init
+        Initialize();
+        OptionAndEnumRS.DeleteAll();
+
+        // [GIVEN] that the system is running in a different language
+        LanguageId := GlobalLanguage();
+        // Change to DAN
+        GlobalLanguage(1030);
+
+        // [GIVEN] that we have tables with both enums and options
+        InsertOptionAndEnumRs(0, OptionAndEnumRS.OptionField::Zero, OptionAndEnumRS.EnumField::Eight);
+        InsertOptionAndEnumRs(1, OptionAndEnumRS.OptionField::One, OptionAndEnumRS.EnumField::Nine);
+        InsertOptionAndEnumRs(2, OptionAndEnumRS.OptionField::Two, OptionAndEnumRS.EnumField::Ten);
+
+        // [GIVEN] a rapidstart package is create from that table
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::OptionAndEnumRS);
+        ExportToXML(ConfigPackage.Code, ConfigPackageTable, FilePath);
+
+        // Cleanup before import
+        OptionAndEnumRS.DeleteAll();
+        LibraryRapidStart.CleanUp(ConfigPackage.Code);
+
+        // [WHEN] the rapidstart package is imported and applied
+        ConfigXMLExchange.ImportPackageXMLFromFile(FilePath);
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        // [THEN] the option and enums are properly applied
+        VerifyEnumsAndOptionsAfterApplyingPackage();
+        GlobalLanguage(LanguageId);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExportImportConfigPackageWithPercentInColumn()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        InventoryAdjmtEntryOrder: Record "Inventory Adjmt. Entry (Order)";
+        FilePath: Text;
+    begin
+        // [SCENARIO 390268] Export and import of Config. Package with record that has similar columns differ by % symbol
+        Initialize();
+
+        // [GIVEN] 3 "Inventory Adjmt. Entry Order" lines
+        // 1st Line "Indirect Cost %" = 0, Indirect Cost = 1;
+        // 2nd Line "Indirect Cost %" = 0, Indirect Cost = 2;
+        // 3rd Line "Indirect Cost %" = 0, Indirect Cost = 3;
+        InventoryAdjmtEntryOrder.DeleteAll();
+        MockInventoryAdjmtEntryOrderLines(3);
+
+        // [GIVEN] Config. Package with Inventory Adjmt. Entry Order table
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::"Inventory Adjmt. Entry (Order)");
+
+        // [GIVEN] Package "A" is exported to XML
+        ExportToXML(ConfigPackage.Code, ConfigPackageTable, FilePath);
+
+        // [GIVEN] All Inventory Adjmt. Entry Order records are deleted;
+        InventoryAdjmtEntryOrder.DeleteAll();
+
+        // [WHEN] Package "A" is imported from XML
+        // [THEN] No error message appears 
+        ImportPackageXMLNew(ConfigPackage.Code, FilePath);
         Erase(FilePath);
 
         // [WHEN] Apply the package 
@@ -2730,7 +4110,7 @@ codeunit 136603 "ERM RS Package Operations"
 
         // [WHEN] Package is imported from XML
         // [THEN] No error message appears 
-        ImportPackageXML(ConfigPackage.Code, FilePath);
+        ImportPackageXMLNew(ConfigPackage.Code, FilePath);
         Erase(FilePath);
 
         // [WHEN] Apply the package 
@@ -2741,6 +4121,41 @@ codeunit 136603 "ERM RS Package Operations"
         ItemUnitOfMeasure.Get(Item."No.", OtherUnitOfMeasure.Code);
         Assert.AreEqual(ItemUnitOfMeasure."Qty. per Unit of Measure", 1.23457, 'value should be rounded to 5 decimals.');
     end;
+
+#if not CLEAN29
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportPackageWithDuplicatedXMLFieldsWithDotNet()
+    var
+        DuplicatedXMLFields: Record DuplicatedXMLFields;
+        TempDuplicatedXMLFields: Record DuplicatedXMLFields temporary;
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        FilePath: Text;
+    begin
+        // [SCENARIO 390268] Table with duplicated XML field names can be imported with XML package
+        Initialize();
+        DuplicatedXMLFields.DeleteAll();
+
+        // [GIVEN] Create several records of DuplicatedXMLFields table
+        InsertDuplicatedXMLFieldsRecords(LibraryRandom.RandIntInRange(5, 10), TempDuplicatedXMLFields);
+
+        // [GIVEN] Rapidstart package is created from DuplicatedXMLFields table
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::DuplicatedXMLFields);
+        ExportToXML(ConfigPackage.Code, ConfigPackageTable, FilePath);
+
+        // Cleanup before import
+        DuplicatedXMLFields.DeleteAll();
+        LibraryRapidStart.CleanUp(ConfigPackage.Code);
+
+        // [WHEN] the rapidstart package is imported and applied
+        ConfigXMLExchange.ImportPackageXML(FilePath);
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        // [THEN] DuplicatedXMLFields records are properly applied
+        VerifyDuplicatedXMLFieldsRecords(TempDuplicatedXMLFields);
+    end;
+#endif
 
     [Test]
     [Scope('OnPrem')]
@@ -2768,7 +4183,7 @@ codeunit 136603 "ERM RS Package Operations"
         LibraryRapidStart.CleanUp(ConfigPackage.Code);
 
         // [WHEN] the rapidstart package is imported and applied
-        ConfigXMLExchange.ImportPackageXML(FilePath);
+        ConfigXMLExchange.ImportPackageXMLFromFile(FilePath);
         LibraryRapidStart.ApplyPackage(ConfigPackage, true);
 
         // [THEN] DuplicatedXMLFields records are properly applied
@@ -2841,6 +4256,46 @@ codeunit 136603 "ERM RS Package Operations"
         VerifyDuplicatedXMLFieldsRecords(TempDuplicatedXMLFields);
     end;
 
+#if not CLEAN29
+    [Test]
+    [Scope('OnPrem')]
+    procedure ImportPackageWithEmptyXMLFieldNamesWithDotNet()
+    var
+        DummyRSTable: Record DummyRSTable;
+        TempDummyRSTable: Record DummyRSTable temporary;
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        ConfigPackageField: Record "Config. Package Field";
+        FilePath: Text;
+    begin
+        // [SCENARIO 390268] Package can be imported with empty "XML Field Name" fields in the "Config. Package Field" table (old package import scenario)
+        Initialize();
+        DummyRSTable.DeleteAll();
+
+        // [GIVEN] Create several records of DummyRSTable table
+        InsertDummyRSTableRecords(LibraryRandom.RandIntInRange(5, 10), TempDummyRSTable);
+
+        // [GIVEN] Rapidstart package "P" is created from DummyRSTable table
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, DATABASE::DummyRSTable);
+        ExportToXML(ConfigPackage.Code, ConfigPackageTable, FilePath);
+
+        // [GIVEN] Make "XML Field Name" empty for all "Config. Package Field" records of package "P"
+        ConfigPackageField.SetRange("Package Code", ConfigPackage.Code);
+        ConfigPackageField.ModifyAll("XML Field Name", '');
+
+        // Cleanup before import
+        DummyRSTable.DeleteAll();
+        LibraryRapidStart.CleanUp(ConfigPackage.Code);
+
+        // [WHEN] the rapidstart package is imported and applied
+        ConfigXMLExchange.ImportPackageXML(FilePath);
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+
+        // [THEN] DummyRSTable records are properly applied
+        VerifyDummyRSTableRecords(TempDummyRSTable);
+    end;
+#endif
+
     [Test]
     [Scope('OnPrem')]
     procedure ImportPackageWithEmptyXMLFieldNames()
@@ -2872,7 +4327,7 @@ codeunit 136603 "ERM RS Package Operations"
         LibraryRapidStart.CleanUp(ConfigPackage.Code);
 
         // [WHEN] the rapidstart package is imported and applied
-        ConfigXMLExchange.ImportPackageXML(FilePath);
+        ConfigXMLExchange.ImportPackageXMLFromFile(FilePath);
         LibraryRapidStart.ApplyPackage(ConfigPackage, true);
 
         // [THEN] DummyRSTable records are properly applied
@@ -3152,6 +4607,7 @@ codeunit 136603 "ERM RS Package Operations"
         ConfigPackageField."Field ID" := Field."No.";
     end;
 
+#if not CLEAN29
     local procedure ImportFromXML(var ConfigPackage: Record "Config. Package"; var CountryCode: Code[10]; var LocationCode: Code[10])
     var
         ConfigPackageTable: Record "Config. Package Table";
@@ -3285,6 +4741,147 @@ codeunit 136603 "ERM RS Package Operations"
             repeat
                 FieldRef := RecRef.Field(ConfigPackageField."Field ID");
                 AddXMLNode(XMLDocument, RecordNode, FieldNode, CopyStr(FieldRef.Name(), 1, 250), Format(FieldRef.Value()));
+            until ConfigPackageField.Next() = 0;
+    end;
+#endif
+
+    local procedure ImportFromXMLNew(var ConfigPackage: Record "Config. Package"; var CountryCode: Code[10]; var LocationCode: Code[10])
+    var
+        ConfigPackageTable: Record "Config. Package Table";
+        Country: Record "Country/Region";
+        Location: Record Location;
+        RecRef: RecordRef;
+        PackageXML: XmlDocument;
+        DocumentElement: XmlElement;
+        DocumentNode: XmlNode;
+        XmlText: Text;
+    begin
+        LibraryERM.CreateCountryRegion(Country);
+        CountryCode := Country.Code;
+
+        LibraryWarehouse.CreateLocation(Location);
+        Location."Country/Region Code" := CountryCode;
+        Location.Modify();
+        LocationCode := Location.Code;
+
+        CreateConfigPackage(ConfigPackage);
+        XmlText := '<?xml version="1.0" encoding="UTF-16" standalone="yes"?><DataList Code="' + ConfigPackage.Code + '"></DataList>';
+        XmlDocument.ReadFrom(XmlText, PackageXML);
+        PackageXML.GetRoot(DocumentElement);
+        DocumentNode := DocumentElement.AsXmlNode();
+
+        // Add CountryRegionList
+        LibraryRapidStart.CreatePackageTable(ConfigPackageTable, ConfigPackage.Code, DATABASE::"Country/Region");
+        IncludeField(ConfigPackageTable, 0, false);
+        IncludeField(ConfigPackageTable, Country.FieldNo(Code), true);
+        RecRef.GetTable(Country);
+        AddConfigPackageTableToXML(DocumentNode, ConfigPackageTable, RecRef);
+        // Add LocationList
+        LibraryRapidStart.CreatePackageTable(ConfigPackageTable, ConfigPackage.Code, DATABASE::Location);
+        IncludeField(ConfigPackageTable, 0, false);
+        IncludeField(ConfigPackageTable, Location.FieldNo(Code), true);
+        IncludeField(ConfigPackageTable, Location.FieldNo("Country/Region Code"), true);
+        RecRef.GetTable(Location);
+        AddConfigPackageTableToXML(DocumentNode, ConfigPackageTable, RecRef);
+
+        Country.Delete();
+        Location.Delete();
+        LibraryRapidStart.CleanUp(ConfigPackage.Code);
+
+        ConfigXMLExchange.ImportPackageXMLDocument(PackageXML, '');
+    end;
+
+    local procedure ImportPackageXMLNew(PackageCode: Code[20]; XMLDataFile: text)
+    var
+        XMLDOMManagement: Codeunit "XML DOM Management";
+        XMLDocument: XmlDocument;
+    begin
+        XMLDOMManagement.LoadXMLDocumentFromFile(XMLDataFile, XMLDocument);
+        ConfigXMLExchange.ImportPackageXMLDocument(XMLDocument, PackageCode);
+    end;
+
+
+    local procedure ImportFromXMLKeyNew(var ConfigPackage: Record "Config. Package"; var GenProductPostingGroupCode: Code[20]; var GenBusPostingGroupCode: Code[20])
+    var
+        ConfigPackageTable: Record "Config. Package Table";
+        GeneralPostingSetup: Record "General Posting Setup";
+        GenBusPostingGroup: Record "Gen. Business Posting Group";
+        GenProductPostingGroup: Record "Gen. Product Posting Group";
+        RecRef: RecordRef;
+        PackageXML: XmlDocument;
+        DocumentElement: XmlElement;
+        DocumentNode: XmlNode;
+        XmlText: Text;
+    begin
+        LibraryERM.CreateGenProdPostingGroup(GenProductPostingGroup);
+        GenProductPostingGroupCode := GenProductPostingGroup.Code;
+        LibraryERM.CreateGenBusPostingGroup(GenBusPostingGroup);
+        GenBusPostingGroupCode := GenBusPostingGroup.Code;
+        LibraryERM.CreateGeneralPostingSetup(GeneralPostingSetup, GenBusPostingGroup.Code, GenProductPostingGroup.Code);
+
+        CreateConfigPackage(ConfigPackage);
+        XmlText := '<?xml version="1.0" encoding="UTF-16" standalone="yes"?><DataList Code="' + ConfigPackage.Code + '"></DataList>';
+        XmlDocument.ReadFrom(XmlText, PackageXML);
+        PackageXML.GetRoot(DocumentElement);
+        DocumentNode := DocumentElement.AsXmlNode();
+
+        LibraryRapidStart.CreatePackageTable(ConfigPackageTable, ConfigPackage.Code, DATABASE::"General Posting Setup");
+        RecRef.GetTable(GeneralPostingSetup);
+        AddConfigPackageTableToXML(DocumentNode, ConfigPackageTable, RecRef);
+
+        LibraryRapidStart.CreatePackageTable(ConfigPackageTable, ConfigPackage.Code, DATABASE::"Gen. Business Posting Group");
+        RecRef.GetTable(GenBusPostingGroup);
+        AddConfigPackageTableToXML(DocumentNode, ConfigPackageTable, RecRef);
+
+        LibraryRapidStart.CreatePackageTable(ConfigPackageTable, ConfigPackage.Code, DATABASE::"Gen. Product Posting Group");
+        RecRef.GetTable(GenProductPostingGroup);
+        AddConfigPackageTableToXML(DocumentNode, ConfigPackageTable, RecRef);
+
+        GenProductPostingGroup.Delete();
+        GenBusPostingGroup.Delete();
+        GeneralPostingSetup.Delete();
+        LibraryRapidStart.CleanUp(ConfigPackage.Code);
+
+        ConfigXMLExchange.ImportPackageXMLDocument(PackageXML, '');
+    end;
+
+    local procedure AddXMLNode(var ParentNode: XmlNode; FieldName: Text[250]; FieldText: Text[250])
+    var
+        FieldXmlElement: XmlElement;
+    begin
+        FieldXmlElement := XmlElement.Create(ConfigXMLExchange.GetElementName(FieldName));
+        if FieldText <> '' then
+            FieldXmlElement.Add(XmlText.Create(Format(FieldText)));
+        ParentNode.AsXmlElement().Add(FieldXmlElement);
+    end;
+
+    local procedure AddConfigPackageTableToXML(var DocumentElement: XmlNode; ConfigPackageTable: Record "Config. Package Table"; RecRef: RecordRef)
+    var
+        ConfigPackageField: Record "Config. Package Field";
+        FieldRef: FieldRef;
+        TableNode: XmlNode;
+        RecordNode: XmlNode;
+    begin
+        ConfigPackageTable.CalcFields("Table Name");
+
+        TableNode := XmlElement.Create(ConfigXMLExchange.GetElementName(CopyStr(ConfigPackageTable."Table Name" + 'List', 1, 250))).AsXmlNode();
+        DocumentElement.AsXmlElement().Add(TableNode);
+
+        AddXMLNode(TableNode, CopyStr(ConfigPackageTable.FieldName("Table ID"), 1, 250), Format(ConfigPackageTable."Table ID"));
+        AddXMLNode(TableNode, CopyStr(ConfigPackageTable.FieldName("Page ID"), 1, 250), Format(ConfigPackageTable."Page ID"));
+        AddXMLNode(TableNode, CopyStr(ConfigPackageTable.FieldName("Processing Order"), 1, 250), Format(ConfigPackageTable."Processing Order"));
+
+        RecordNode := XmlElement.Create(ConfigXMLExchange.GetElementName(ConfigPackageTable."Table Name")).AsXmlNode();
+        TableNode.AsXmlElement().Add(RecordNode);
+
+        ConfigPackageField.Reset();
+        ConfigPackageField.SetRange("Package Code", ConfigPackageTable."Package Code");
+        ConfigPackageField.SetRange("Table ID", ConfigPackageTable."Table ID");
+        ConfigPackageField.SetRange("Include Field", true);
+        if ConfigPackageField.FindSet() then
+            repeat
+                FieldRef := RecRef.Field(ConfigPackageField."Field ID");
+                AddXMLNode(RecordNode, CopyStr(FieldRef.Name(), 1, 250), Format(FieldRef.Value()));
             until ConfigPackageField.Next() = 0;
     end;
 
@@ -3688,7 +5285,8 @@ codeunit 136603 "ERM RS Package Operations"
                 LibraryERM.PostGeneralJnlLine(GenJnlLine);
     end;
 
-    local procedure ExportImportXML(PackageCode: Code[20])
+#if not CLEAN29
+    local procedure ExportImportXMLWithDotNet(PackageCode: Code[20])
     var
         ConfigPackageTable: Record "Config. Package Table";
         FilePath: Text;
@@ -3707,6 +5305,29 @@ codeunit 136603 "ERM RS Package Operations"
         ExportToXML(PackageCode, ConfigPackageTable, FilePath);
         CleanupPackageAndTemplate(PackageCode, ConfigTemplateHeaderCode);
         ConfigXMLExchange.ImportPackageXML(FilePath);
+        Erase(FilePath);
+    end;
+#endif
+
+    local procedure ExportImportXML(PackageCode: Code[20])
+    var
+        ConfigPackageTable: Record "Config. Package Table";
+        FilePath: Text;
+    begin
+        ExportToXML(PackageCode, ConfigPackageTable, FilePath);
+        LibraryRapidStart.CleanUp(PackageCode);
+        ConfigXMLExchange.ImportPackageXMLFromFile(FilePath);
+        Erase(FilePath);
+    end;
+
+    local procedure ExportImportXMLWithPackageAndTemplateCleanupNew(PackageCode: Code[20]; ConfigTemplateHeaderCode: Code[10])
+    var
+        ConfigPackageTable: Record "Config. Package Table";
+        FilePath: Text;
+    begin
+        ExportToXML(PackageCode, ConfigPackageTable, FilePath);
+        CleanupPackageAndTemplate(PackageCode, ConfigTemplateHeaderCode);
+        ConfigXMLExchange.ImportPackageXMLFromFile(FilePath);
         Erase(FilePath);
     end;
 
@@ -3854,6 +5475,27 @@ codeunit 136603 "ERM RS Package Operations"
         CompressedServerFileName := FileMgt.ServerTempFileName('');
         ConfigPckgCompressionMgt.ServersideCompress(ServerFileName, CompressedServerFileName);
     end;
+
+#if not CLEAN29
+    local procedure InitializePackageCardWithDotNet(var ConfigPackageCard: TestPage "Config. Package Card"; FillPackageData: Boolean)
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        TableID: Integer;
+    begin
+        // Create package
+        TableID := DATABASE::Vendor;
+
+        CreatePackageWithTable(ConfigPackage, ConfigPackageTable, TableID);
+        // Export and import data to fill package tables
+        if FillPackageData then
+            ExportImportXMLWithDotNet(ConfigPackage.Code);
+
+        // Open Package Card page and add table
+        ConfigPackageCard.OpenEdit();
+        ConfigPackageCard.GotoRecord(ConfigPackage);
+    end;
+#endif
 
     local procedure InitializePackageCard(var ConfigPackageCard: TestPage "Config. Package Card"; FillPackageData: Boolean)
     var

--- a/src/Layers/W1/Tests/SINGLESERVER/ERMRSPackageDimensions.Codeunit.al
+++ b/src/Layers/W1/Tests/SINGLESERVER/ERMRSPackageDimensions.Codeunit.al
@@ -159,6 +159,67 @@ codeunit 136604 "ERM RS Package Dimensions"
         DimensionSetEntry.Delete();
     end;
 
+#if not CLEAN29
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmHandlerYes')]
+    procedure ApplyBlankDimSetIDToJnlLineWithDefDimensionWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        GenJnlTemplate: Record "Gen. Journal Template";
+        GenJnlBatch: Record "Gen. Journal Batch";
+        GenJnlLine: Record "Gen. Journal Line";
+        LineNo: Integer;
+        DimSetID: Integer;
+    begin
+        Initialize();
+        // Verify that default dimensions are inherited from the G/L Account if "Dimension Set ID" from package is zero.
+
+        HideDialog();
+        CreatePackageAndFields(ConfigPackage, ConfigPackageTable);
+
+        LineNo := 10000;
+        CreateGenJnlLineWithAccNoAndDefDimensions(ConfigPackage, ConfigPackageTable, LineNo, GenJnlTemplate, GenJnlBatch, DimSetID);
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+        ExportImportPackageWithDotNet(ConfigPackage.Code);
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+        GenJnlLine.Get(GenJnlTemplate.Name, GenJnlBatch.Name, LineNo);
+        Assert.AreEqual(DimSetID, GenJnlLine."Dimension Set ID", IncorrectDimSetError);
+
+        LibraryERM.ClearGenJournalLines(GenJnlBatch);
+        GenJnlBatch.Delete();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ApplyPackageToJnlLineWithoutDimensionWithDotNet()
+    var
+        ConfigPackage: Record "Config. Package";
+        GenJnlTemplate: Record "Gen. Journal Template";
+        GenJnlBatch: Record "Gen. Journal Batch";
+        GenJnlLine: Record "Gen. Journal Line";
+        LineNo: Integer;
+    begin
+        Initialize();
+        // Verify that there is no need to define "Dimension Set ID" field for package without dimensions
+
+        HideDialog();
+        LibraryRapidStart.CreatePackage(ConfigPackage);
+
+        LineNo := 10000;
+        CreateGenJnlLinePackageDataWithoutDimSetID(ConfigPackage, LineNo, GenJnlTemplate, GenJnlBatch);
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+        ExportImportPackageWithDotNet(ConfigPackage.Code);
+        LibraryRapidStart.ApplyPackage(ConfigPackage, true);
+        GenJnlLine.Get(GenJnlTemplate.Name, GenJnlBatch.Name, LineNo);
+        Assert.AreEqual(0, GenJnlLine."Dimension Set ID", IncorrectDimSetError);
+
+        LibraryERM.ClearGenJournalLines(GenJnlBatch);
+        GenJnlBatch.Delete();
+    end;
+#endif
+
     [Test]
     [Scope('OnPrem')]
     procedure ApplyPackageToJnlLineWithoutDimension()
@@ -404,7 +465,8 @@ codeunit 136604 "ERM RS Package Dimensions"
         until DimSetEntry.Next() = 0;
     end;
 
-    local procedure ExportImportPackage(ConfigPackageCode: Code[20])
+#if not CLEAN29
+    local procedure ExportImportPackageWithDotNet(ConfigPackageCode: Code[20])
     var
         ConfigPackage: Record "Config. Package";
         ConfigPackageTable: Record "Config. Package Table";
@@ -417,6 +479,22 @@ codeunit 136604 "ERM RS Package Dimensions"
         PackageXML := PackageXML.XmlDocument();
         ConfigXMLExchange.SetExcelMode(true);
         ConfigXMLExchange.ExportPackageXMLDocument(PackageXML, ConfigPackageTable, ConfigPackage, false);
+        ConfigXMLExchange.ImportPackageXMLDocument(PackageXML, '');
+    end;
+#endif
+
+    local procedure ExportImportPackage(ConfigPackageCode: Code[20])
+    var
+        ConfigPackage: Record "Config. Package";
+        ConfigPackageTable: Record "Config. Package Table";
+        ConfigXMLExchange: Codeunit "Config. XML Exchange";
+        PackageXML: XmlDocument;
+    begin
+        ConfigPackage.Get(ConfigPackageCode);
+        ConfigPackageTable.SetRange("Package Code", ConfigPackage.Code);
+
+        ConfigXMLExchange.SetExcelMode(true);
+        ConfigXMLExchange.ExportPackageToXMLDocument(PackageXML, ConfigPackageTable, ConfigPackage, false);
         ConfigXMLExchange.ImportPackageXMLDocument(PackageXML, '');
     end;
 


### PR DESCRIPTION
Complete refactoring of codeunit 8618 "Config. Excel Exchange" to use the native XML Data Types.
## What & why

Complete refactoring of codeunit 8618 "Config. Excel Exchange" to use the native XML Data Types.
This enables cloud ready app development for partners.

## Linked work

Fixes #8895

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

- Added test for the new methods similar to the old tests.

## Risk & compatibility

If anything is incorrec then the RapidStart feature wouldn't work.




