### PR TITLE
[Master] Items by Location Matrix shows Non-Inventory and Service items that always have zero quantity

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Analysis/ItemsbyLocation.Page.al
+++ b/src/Layers/W1/BaseApp/Inventory/Analysis/ItemsbyLocation.Page.al
@@ -19,6 +19,7 @@ page 491 "Items by Location"
     PageType = ListPlus;
     SaveValues = true;
     SourceTable = Item;
+    SourceTableView = where(Type = const(Inventory));
 
     layout
     {

--- a/src/Layers/W1/BaseApp/Inventory/Analysis/ItemsbyLocationMatrix.Page.al
+++ b/src/Layers/W1/BaseApp/Inventory/Analysis/ItemsbyLocationMatrix.Page.al
@@ -16,6 +16,7 @@ page 9231 "Items by Location Matrix"
     LinksAllowed = false;
     PageType = ListPart;
     SourceTable = Item;
+    SourceTableView = where(Type = const(Inventory));
 
     layout
     {


### PR DESCRIPTION
[Bug 640830](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/640830): [ALL-E] Items by Location Matrix shows Non-Inventory and Service items that always have zero quantity

[AB#640830](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640830)


