### PR TITLE
[639745] [ALAppExtensions #30281] codeunit 1281 "Update Currency Exchange Rates" procedure SyncCurrencyExchangeRates()

### DIFF
--- a/src/Layers/W1/BaseApp/Finance/Currency/UpdateCurrencyExchangeRates.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/Currency/UpdateCurrencyExchangeRates.Codeunit.al
@@ -52,6 +52,7 @@ codeunit 1281 "Update Currency Exchange Rates"
         SourceName: Text;
     begin
         CurrExchRateUpdateSetup.SetRange(Enabled, true);
+        OnSyncCurrencyExchangeRatesOnBeforeFindCurrExchRateUpdateSetup(CurrExchRateUpdateSetup);
 
         if CurrExchRateUpdateSetup.FindSet() then
             repeat
@@ -254,6 +255,16 @@ codeunit 1281 "Update Currency Exchange Rates"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeSyncCurrencyExchangeRatesLoop(var CurrExchRateUpdateSetup: Record "Curr. Exch. Rate Update Setup")
+    begin
+    end;
+
+    /// <summary>
+    /// Integration event raised after the enabled filter is applied to the currency exchange rate update setup and before the setup records are read.
+    /// Enables subscribers to apply additional filters to the setup before the synchronization loop runs.
+    /// </summary>
+    /// <param name="CurrExchRateUpdateSetup">Currency exchange rate update setup, passed by reference so subscribers can apply additional filters.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnSyncCurrencyExchangeRatesOnBeforeFindCurrExchRateUpdateSetup(var CurrExchRateUpdateSetup: Record "Curr. Exch. Rate Update Setup")
     begin
     end;
 }


### PR DESCRIPTION
## What & why

Adds an integration event in `SyncCurrencyExchangeRates` so extensions can apply
their own filters on "Curr. Exch. Rate Update Setup" before the sync loop runs.
Today the setup is filtered to Enabled = true and read immediately, leaving no
room to narrow the set further. The new event fires right after that filter and
before FindSet, which is exactly where an extension needs to hook in.

## Linked work

Fixes [AB#639745](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639745)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

This is a pure publisher addition. The event has no subscribers in the base app,
so behavior is unchanged: the setup is still filtered to Enabled = true and read
the same way. No test added because there is no new base behavior to cover, only
a new extension point.

## Risk & compatibility

None. Non-breaking, additive event only.

