### PR TITLE
[639592][ALAppExtensions #30277][Event Request] Codeunit 426 "Payment Tolerance Management" OnPmtTolGenJnlOnAfterCheckConditions

### DIFF
--- a/src/Layers/NL/BaseApp/Finance/ReceivablesPayables/PaymentToleranceManagement.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Finance/ReceivablesPayables/PaymentToleranceManagement.Codeunit.al
@@ -227,6 +227,7 @@ codeunit 426 "Payment Tolerance Management"
             exit(true);
 
         OnPmtTolGenJnlOnAfterCheckConditions(TempGenJnlLine, SuppressCommit, Result);
+        OnPmtTolGenJnlOnAfterCheckConditionsGenJnlLineByRef(TempGenJnlLine, SuppressCommit, Result);
 
         case true of
             (TempGenJnlLine."Account Type" = TempGenJnlLine."Account Type"::Customer) or
@@ -3059,6 +3060,18 @@ codeunit 426 "Payment Tolerance Management"
     /// <param name="Result">Result of tolerance condition checking</param>
     [IntegrationEvent(false, false)]
     local procedure OnPmtTolGenJnlOnAfterCheckConditions(GenJournalLine: Record "Gen. Journal Line"; var SuppressCommit: Boolean; var Result: Boolean)
+    begin
+    end;
+
+    /// <summary>
+    /// Integration event raised after checking conditions for payment tolerance in general journal processing.
+    /// Exposes the general journal line by reference so subscribers can modify it before standard payment tolerance processing continues.
+    /// </summary>
+    /// <param name="GenJournalLine">General journal line being processed, passed by reference</param>
+    /// <param name="SuppressCommit">Whether database commit should be suppressed</param>
+    /// <param name="Result">Result of tolerance condition checking</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnPmtTolGenJnlOnAfterCheckConditionsGenJnlLineByRef(var GenJournalLine: Record "Gen. Journal Line"; var SuppressCommit: Boolean; var Result: Boolean)
     begin
     end;
 

--- a/src/Layers/NL/BaseApp/Finance/ReceivablesPayables/PaymentToleranceManagement.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Finance/ReceivablesPayables/PaymentToleranceManagement.Codeunit.al
@@ -226,8 +226,7 @@ codeunit 426 "Payment Tolerance Management"
         if (TempGenJnlLine."Applies-to Doc. No." = '') and (TempGenJnlLine."Applies-to ID" = '') then
             exit(true);
 
-        OnPmtTolGenJnlOnAfterCheckConditions(TempGenJnlLine, SuppressCommit, Result);
-        OnPmtTolGenJnlOnAfterCheckConditionsGenJnlLineByRef(TempGenJnlLine, SuppressCommit, Result);
+        OnPmtTolGenJnlOnAfterCheckConditions(TempGenJnlLine, SuppressCommit, Result, TempGenJnlLine);
 
         case true of
             (TempGenJnlLine."Account Type" = TempGenJnlLine."Account Type"::Customer) or
@@ -3058,20 +3057,9 @@ codeunit 426 "Payment Tolerance Management"
     /// <param name="GenJournalLine">General journal line being processed</param>
     /// <param name="SuppressCommit">Whether database commit should be suppressed</param>
     /// <param name="Result">Result of tolerance condition checking</param>
+    /// <param name="GenJournalLineByRef">General journal line being processed, passed by reference so subscribers can modify it before standard payment tolerance processing continues</param>
     [IntegrationEvent(false, false)]
-    local procedure OnPmtTolGenJnlOnAfterCheckConditions(GenJournalLine: Record "Gen. Journal Line"; var SuppressCommit: Boolean; var Result: Boolean)
-    begin
-    end;
-
-    /// <summary>
-    /// Integration event raised after checking conditions for payment tolerance in general journal processing.
-    /// Exposes the general journal line by reference so subscribers can modify it before standard payment tolerance processing continues.
-    /// </summary>
-    /// <param name="GenJournalLine">General journal line being processed, passed by reference</param>
-    /// <param name="SuppressCommit">Whether database commit should be suppressed</param>
-    /// <param name="Result">Result of tolerance condition checking</param>
-    [IntegrationEvent(false, false)]
-    local procedure OnPmtTolGenJnlOnAfterCheckConditionsGenJnlLineByRef(var GenJournalLine: Record "Gen. Journal Line"; var SuppressCommit: Boolean; var Result: Boolean)
+    local procedure OnPmtTolGenJnlOnAfterCheckConditions(GenJournalLine: Record "Gen. Journal Line"; var SuppressCommit: Boolean; var Result: Boolean; var GenJournalLineByRef: Record "Gen. Journal Line")
     begin
     end;
 


### PR DESCRIPTION
## What & why

Adds a by-reference variant of `OnPmtTolGenJnlOnAfterCheckConditions` so
subscribers can change the general journal line before payment tolerance
processing continues into the sales or purchase path. The existing event passes
the line by value, and changing its signature would break current subscribers, so
this adds a parallel event that exposes the line as var. Scoped to the NL layer.

## Linked work

Fixes [AB#639592](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639592)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior or explained below why none are needed.

**What I tested and the outcome**

The new event is raised immediately after the existing one, over the same
temporary line, so nothing changes when there is no subscriber. Existing
subscribers to the by-value event are untouched. No test added since this only
adds an extension point.

## Risk & compatibility

The event lives in the NL layer only, so it is available to NL builds where the
requesting partner needs it. Non-breaking and additive.


