### PR TITLE
[639868][ALAppExtensions #30242] Add parameter in event OnBeforePostBalanceAccount on codeunit 12172 "Customer Bill - Post + Print"

### DIFF
--- a/src/Layers/IT/BaseApp/Local/Bank/Payment/CustomerBillPostPrint.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Local/Bank/Payment/CustomerBillPostPrint.Codeunit.al
@@ -245,7 +245,7 @@ codeunit 12172 "Customer Bill - Post + Print"
         IsHandled: Boolean;
     begin
         IsHandled := false;
-        OnBeforePostBalanceAccount(GenJnlLine, CustomerBillHeader, CustLedgEntry, BalanceAmount, IsHandled);
+        OnBeforePostBalanceAccount(GenJnlLine, CustomerBillHeader, CustLedgEntry, BalanceAmount, IsHandled, GenJnlPostLine);
         if IsHandled then
             exit;
 
@@ -374,7 +374,7 @@ codeunit 12172 "Customer Bill - Post + Print"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforePostBalanceAccount(var GenJournalLine: Record "Gen. Journal Line"; CustomerBillHeader: Record "Customer Bill Header"; CustLedgerEntry: Record "Cust. Ledger Entry"; var BalanceAmount: Decimal; var IsHandled: Boolean)
+    local procedure OnBeforePostBalanceAccount(var GenJournalLine: Record "Gen. Journal Line"; CustomerBillHeader: Record "Customer Bill Header"; CustLedgerEntry: Record "Cust. Ledger Entry"; var BalanceAmount: Decimal; var IsHandled: Boolean; var GenJnlPostLine: Codeunit "Gen. Jnl.-Post Line")
     begin
     end;
 }


### PR DESCRIPTION
## What & why

Extends the existing `OnBeforePostBalanceAccount` event with the
`Gen. Jnl.-Post Line` codeunit, passed by reference. A partner needs to post
several balance-account lines (one per due date) through the same posting
instance the base app uses, which isn't possible with a local variable. Passing
the existing instance out lets subscribers post through it directly.

## Linked work

Fixes [AB#639868](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639868)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

The new parameter is appended to the end of the event, so existing subscribers
that don't declare it keep working. The base call now passes the same
GenJnlPostLine instance it already uses to post. No functional change without a
subscriber. No test added since this only widens an existing extension point.

## Risk & compatibility

None. Trailing parameter on an integration event is non-breaking for existing
subscribers.

