### PR TITLE
[ALAppExtensions #30245][W1][Report][1701][Deferral Summary - Sales] Add integration event OnBeforeReturnSalesDocTypeString in ReturnSalesDocTypeString Procedure

### DIFF
--- a/src/Layers/W1/BaseApp/Finance/Deferral/DeferralSummarySales.Report.al
+++ b/src/Layers/W1/BaseApp/Finance/Deferral/DeferralSummarySales.Report.al
@@ -481,11 +481,11 @@ report 1701 "Deferral Summary - Sales"
         DocumentFilter := NewDocumentNoFilter;
     end;
 
-    local procedure ReturnSalesDocTypeString(SalesDocType: Integer) Result: Text
+    local procedure ReturnSalesDocTypeString(SalesDocType: Integer): Text
     var
+        Result: Text;
         IsHandled: Boolean;
     begin
-        IsHandled := false;
         OnBeforeReturnSalesDocTypeString(SalesDocType, Result, IsHandled);
         if IsHandled then
             exit(Result);

--- a/src/Layers/W1/BaseApp/Finance/Deferral/DeferralSummarySales.Report.al
+++ b/src/Layers/W1/BaseApp/Finance/Deferral/DeferralSummarySales.Report.al
@@ -481,8 +481,15 @@ report 1701 "Deferral Summary - Sales"
         DocumentFilter := NewDocumentNoFilter;
     end;
 
-    local procedure ReturnSalesDocTypeString(SalesDocType: Integer): Text
+    local procedure ReturnSalesDocTypeString(SalesDocType: Integer) Result: Text
+    var
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforeReturnSalesDocTypeString(SalesDocType, Result, IsHandled);
+        if IsHandled then
+            exit(Result);
+
         case SalesDocType of
             0:
                 exit(QuoteLbl);
@@ -507,5 +514,17 @@ report 1701 "Deferral Summary - Sales"
             else
                 exit('');
         end;
+    end;
+
+    /// <summary>
+    /// Integration event raised before the sales document type integer is converted to its display string.
+    /// Enables subscribers to fully replace the returned document type text by setting IsHandled.
+    /// </summary>
+    /// <param name="SalesDocType">Sales document type integer value being converted.</param>
+    /// <param name="Result">Resulting document type text, can be set by subscribers.</param>
+    /// <param name="IsHandled">Set to true by a subscriber to skip the standard conversion and use Result.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeReturnSalesDocTypeString(SalesDocType: Integer; var Result: Text; var IsHandled: Boolean)
+    begin
     end;
 }


### PR DESCRIPTION
## What & why

Adds an IsHandled-style event to `ReturnSalesDocTypeString` so extensions can
replace the document type text the report shows. The procedure is local and maps
each type with a hardcoded case, so there was no way to override the result. With
this event a subscriber can, for example, derive the text from the
"Sales Comment Document Type" enum instead.

## Linked work

Fixes [AB#639936](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639936)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

When no subscriber sets IsHandled, the original case statement runs unchanged and
returns the same labels as before. I confirmed the return value is now surfaced
through a named return so the event can override it cleanly. No test added, the
default path is identical to today's behavior.

## Risk & compatibility

None. Additive event, default output unchanged.










