### PR TITLE
[639939][ALAppExtensions #30250] codeunit 9200 "Matrix Management" - Add integration events for custom rounding

### DIFF
--- a/src/Layers/W1/BaseApp/Finance/Analysis/MatrixManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/Analysis/MatrixManagement.Codeunit.al
@@ -613,15 +613,16 @@ codeunit 9200 "Matrix Management"
 
         case RoundingFactor of
             RoundingFactor::"1":
-                exit(Round(Amount, 1));
+                Amount := Round(Amount, 1);
             RoundingFactor::"1000":
-                exit(Round(Amount / 1000, 0.1));
+                Amount := Round(Amount / 1000, 0.1);
             RoundingFactor::"1000000":
-                exit(Round(Amount / 1000000, 0.1));
+                Amount := Round(Amount / 1000000, 0.1);
             else
                 OnRoundAmountOnElse(Amount, RoundingFactor);
         end;
 
+        OnRoundAmountOnAfterRound(Amount, RoundingFactor);
         exit(Amount);
     end;
 
@@ -694,6 +695,9 @@ codeunit 9200 "Matrix Management"
             else
                 OnFormatRoundingFactorOnElse(AmountDecimal, RoundingFactor);
         end;
+
+        OnFormatRoundingFactorOnAfterSetAmountDecimal(RoundingFactor, AmountDecimal);
+
         case NegativeAmountFormat of
             NegativeAmountFormat::"Minus Sign":
                 Result := StrSubstNo(RoundingFormatTxt, AmountDecimal, '');
@@ -775,6 +779,28 @@ codeunit 9200 "Matrix Management"
     /// <param name="RoundingFactor">Rounding factor option being applied</param>
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountOnElse(var Amount: Decimal; RoundingFactor: Enum "Analysis Rounding Factor")
+    begin
+    end;
+
+    /// <summary>
+    /// Integration event raised after an amount has been rounded according to the rounding factor.
+    /// Allows subscribers to further adjust the rounded amount, for example to round to whole numbers.
+    /// </summary>
+    /// <param name="Amount">Rounded amount, passed by reference so subscribers can change it.</param>
+    /// <param name="RoundingFactor">Rounding factor that was applied.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnRoundAmountOnAfterRound(var Amount: Decimal; RoundingFactor: Enum "Analysis Rounding Factor")
+    begin
+    end;
+
+    /// <summary>
+    /// Integration event raised after the decimal format text has been set for the rounding factor and before the negative amount format is applied.
+    /// Allows subscribers to change the decimal formatting based on the rounding factor.
+    /// </summary>
+    /// <param name="RoundingFactor">Rounding factor being formatted.</param>
+    /// <param name="AmountDecimal">Decimal format text, passed by reference so subscribers can change it.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnFormatRoundingFactorOnAfterSetAmountDecimal(RoundingFactor: Enum "Analysis Rounding Factor"; var AmountDecimal: Text)
     begin
     end;
 


### PR DESCRIPTION
## What & why

Adds two events so extensions can customize rounding in analysis and financial
reports. Customers picking the "1000" rounding option still see a decimal place,
and they want whole numbers. `OnRoundAmountOnAfterRound` lets a subscriber adjust
the rounded amount, and `OnFormatRoundingFactorOnAfterSetAmountDecimal` lets them
change the decimal formatting for the chosen factor.

## Linked work

Fixes [AB#639939](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639939)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

`RoundAmount` now assigns the rounded value and raises the event before returning
instead of exiting inside each case. The math is identical, so with no subscriber
the returned amount and formatting match today's output. No test added because the
default behavior is unchanged and the events are extension points.

## Risk & compatibility

None expected. RoundAmount was refactored from early exits to a single exit; the
computed values are the same. Worth a quick reviewer glance at that refactor.



