### PR TITLE
[639867][ALAppExtensions #30251][NL][Report][11403][CreateElecVATDeclaration][CalcVATAmount] Add integration event OnCalcVATAmountOnAfterSetDateFilter

### DIFF
--- a/src/Layers/NL/BaseApp/Local/Finance/VAT/Reporting/CreateElecVATDeclaration.Report.al
+++ b/src/Layers/NL/BaseApp/Local/Finance/VAT/Reporting/CreateElecVATDeclaration.Report.al
@@ -294,6 +294,7 @@ report 11403 "Create Elec. VAT Declaration"
 
         VATStatementLine.SetRange("Date Filter",
           "Elec. Tax Declaration Header"."Declaration Period From Date", "Elec. Tax Declaration Header"."Declaration Period To Date");
+        OnCalcVATAmountOnAfterSetDateFilter(VATStatementLine, "Elec. Tax Declaration Header");
         VATStatement.SetElectronicVAT(true);
         VATStatement.InitializeRequest(
           VATStatementName, VATStatementLine, "VAT Statement Report Selection"::Open,
@@ -345,6 +346,17 @@ report 11403 "Create Elec. VAT Declaration"
     local procedure ExtractSurname(FullName: Text[35]) Surname: Text[35]
     begin
         Surname := CopyStr(FullName, StrPos(FullName, ' ') + 1)
+    end;
+
+    /// <summary>
+    /// Integration event raised after the date filter has been set on the VAT statement line in CalcVATAmount.
+    /// Enables subscribers to override the date filter on the VAT statement line before the VAT statement is calculated.
+    /// </summary>
+    /// <param name="VATStatementLine">VAT statement line, passed by reference so subscribers can change the date filter.</param>
+    /// <param name="ElecTaxDeclarationHeader">Electronic tax declaration header providing the declaration period context.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnCalcVATAmountOnAfterSetDateFilter(var VATStatementLine: Record "VAT Statement Line"; ElecTaxDeclarationHeader: Record "Elec. Tax Declaration Header")
+    begin
     end;
 }
 


### PR DESCRIPTION
## What & why

Adds an event in `CalcVATAmount` right after the report sets the date filter on
the VAT statement line. A partner needs to offer users a second option (before
and within the period, not just within it), which means overriding that date
filter before the VAT statement is calculated. The event exposes the statement
line by reference plus the tax declaration header for context.

## Linked work

Fixes [AB#639867](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639867)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

The event is raised after the existing SetRange on "Date Filter" and before
InitializeRequest, so with no subscriber the filter and calculation are exactly
as before. No test added, this is an additive extension point on an NL local
report.

## Risk & compatibility

None. NL layer only, additive event.


