### PR TITLE
Disable reference documentation continuous deployment

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -131,7 +131,7 @@
   "PullRequestTrigger": "pull_request",
   "ALDoc": {
     "maxReleases": 0,
-    "continuousDeployment": true,
+    "continuousDeployment": false,
     "groupByProject": false,
     "includeProjects": [
       "build_projects_Apps W1"


### PR DESCRIPTION
## What & why

The reference documentation (aldoc) continuous deployment was recently re-enabled in PR #8921 (`"continuousDeployment": true` in `.github/AL-Go-Settings.json`), but the DeployToReferenceDocumentation step has been failing and blocking CI. This reverts `ALDoc.continuousDeployment` back to `false` to unblock the pipeline, matching the earlier "Disable reference documentation" (#8868) state.

## Linked work

Related to the re-enable in #8921.

[AB#612711](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612711)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Config-only change to an AL-Go settings flag; no app code or tests affected. The single-line diff flips `continuousDeployment` from `true` to `false`.

## Risk & compatibility

Low risk. This only disables continuous deployment of reference documentation; no product code, data, or permissions are affected. Reference docs can be re-enabled once the underlying DeployToReferenceDocumentation failure is fixed.
