### PR TITLE
Resolve test app names from app.json to prevent silent CI test skips

### DIFF
--- a/build/scripts/ParallelTestExecution.psm1
+++ b/build/scripts/ParallelTestExecution.psm1
@@ -48,11 +48,50 @@ function Get-CachedTestRunResult {
 
 <#
 .SYNOPSIS
+    Resolves the authoritative app name for a project from its app.json "name" field.
+.DESCRIPTION
+    Get-ApplicationGroup exposes the projects.json key as ApplicationName. That key is required to
+    match the app.json "name", but the two can drift (typos, "-Tests" vs " Test", trailing dots).
+    When they drift, the container only ever knows the app.json "name", so any match keyed off
+    ApplicationName silently drops the app from the test dispatch set and skips ALL of its tests
+    while the build stays green. Reading the name straight from app.json (via AppJsonPath) makes
+    the dispatch robust against that drift. Falls back to ApplicationName if app.json is missing
+    or unreadable.
+.OUTPUTS
+    [string] The app.json "name", or ApplicationName as a fallback.
+#>
+function Get-AppNameFromMetadata {
+    param(
+        [Parameter(Mandatory=$true)]
+        $BuildMetadata
+    )
+
+    $appJsonPath = $BuildMetadata.AppJsonPath
+    if (-not [string]::IsNullOrWhiteSpace($appJsonPath) -and (Test-Path $appJsonPath -PathType Leaf)) {
+        try {
+            $appName = (Get-Content $appJsonPath -Raw | ConvertFrom-Json).name
+            if (-not [string]::IsNullOrWhiteSpace($appName)) {
+                if ($appName -ne $BuildMetadata.ApplicationName) {
+                    Write-Host "::warning::Test app projects.json key '$($BuildMetadata.ApplicationName)' does not match its app.json name '$appName'. Using the app.json name for test dispatch. Align the projects.json key (and build/groups.json name) with the app.json name to avoid confusion."
+                }
+                return $appName
+            }
+        } catch {
+            Write-Host "WARNING: Could not read app name from '$appJsonPath' ($($_.Exception.Message)); falling back to projects.json key '$($BuildMetadata.ApplicationName)'."
+        }
+    }
+    return $BuildMetadata.ApplicationName
+}
+
+<#
+.SYNOPSIS
     Returns the names of test apps that are both expected for a country and installed in the container.
 .DESCRIPTION
     Combines the project metadata in build/projects.json (via Get-ApplicationGroup) with
     Get-BcContainerAppInfo so we only ever try to dispatch apps that actually exist in the
     container. The country defaults to "w1" when unset or set to the repo-level "base" sentinel.
+    App names are resolved from each project's app.json "name" (via Get-AppNameFromMetadata) so a
+    projects.json-key vs app.json-name mismatch cannot silently exclude a test app from dispatch.
 #>
 function Get-InstalledTestAppNames {
     param(
@@ -68,7 +107,7 @@ function Get-InstalledTestAppNames {
     $allTestAppNames = @(
         Get-ApplicationGroup -GroupName "All" -CountryCode $Country -SkipLanguagePacks |
         Where-Object { $_.IsTest } |
-        Select-Object -ExpandProperty ApplicationName
+        ForEach-Object { Get-AppNameFromMetadata -BuildMetadata $_ }
     )
 
     $installedAppNames = @(
@@ -689,4 +728,4 @@ function Invoke-PerProjectTestRun {
     return (. $script -parameters $parameters -TestType $testType -AppNamesToTest $appNamesToTest)
 }
 
-Export-ModuleMember -Function Invoke-ParallelTestExecution, Get-AvailableBcTenants, Get-CachedTestRunResult, Get-InstalledTestAppNames, Get-AppNamesForBucket, Invoke-PerProjectTestRun
+Export-ModuleMember -Function Invoke-ParallelTestExecution, Get-AvailableBcTenants, Get-CachedTestRunResult, Get-InstalledTestAppNames, Get-AppNamesForBucket, Invoke-PerProjectTestRun, Get-AppNameFromMetadata

--- a/build/scripts/tests/ParallelTestExecution.Test.ps1
+++ b/build/scripts/tests/ParallelTestExecution.Test.ps1
@@ -1,0 +1,75 @@
+$errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
+
+Import-Module (Join-Path $PSScriptRoot '../ParallelTestExecution.psm1') -Force
+
+Describe "ParallelTestExecution app-name resolution" {
+    BeforeAll {
+        # Create real app.json files on disk so Get-AppNameFromMetadata can read them.
+        $script:tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("patest_" + [System.Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:tempRoot -Force | Out-Null
+
+        function New-AppJson {
+            param([string]$Folder, [string]$Name)
+            $dir = Join-Path $script:tempRoot $Folder
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+            $path = Join-Path $dir 'app.json'
+            @{ name = $Name; id = [System.Guid]::NewGuid().ToString() } | ConvertTo-Json | Set-Content -Path $path -Encoding utf8
+            return $path
+        }
+
+        # A metadata record whose projects.json key (ApplicationName) differs from its app.json name.
+        $script:mismatchAppJson = New-AppJson -Folder 'Mismatch' -Name 'Real App Name'
+        # A metadata record whose key and app.json name agree.
+        $script:matchAppJson = New-AppJson -Folder 'Match' -Name 'Aligned Tests'
+    }
+
+    AfterAll {
+        if (Test-Path $script:tempRoot) { Remove-Item $script:tempRoot -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    Context "Get-AppNameFromMetadata" {
+        It "returns the app.json name when it differs from the projects.json key" {
+            $md = [PSCustomObject]@{ ApplicationName = 'Projects-Json-Key'; AppJsonPath = $script:mismatchAppJson }
+            Get-AppNameFromMetadata -BuildMetadata $md | Should -Be 'Real App Name'
+        }
+
+        It "returns the app.json name when it matches the projects.json key" {
+            $md = [PSCustomObject]@{ ApplicationName = 'Aligned Tests'; AppJsonPath = $script:matchAppJson }
+            Get-AppNameFromMetadata -BuildMetadata $md | Should -Be 'Aligned Tests'
+        }
+
+        It "falls back to ApplicationName when the app.json path is missing" {
+            $md = [PSCustomObject]@{ ApplicationName = 'Fallback Name'; AppJsonPath = (Join-Path $script:tempRoot 'does-not-exist\app.json') }
+            Get-AppNameFromMetadata -BuildMetadata $md | Should -Be 'Fallback Name'
+        }
+
+        It "falls back to ApplicationName when AppJsonPath is empty" {
+            $md = [PSCustomObject]@{ ApplicationName = 'Fallback Name'; AppJsonPath = '' }
+            Get-AppNameFromMetadata -BuildMetadata $md | Should -Be 'Fallback Name'
+        }
+    }
+
+    Context "Get-InstalledTestAppNames resilience to key/name drift" {
+        It "dispatches a test app whose projects.json key differs from its installed (app.json) name" {
+            Mock -ModuleName ParallelTestExecution -CommandName Get-ApplicationGroup -MockWith {
+                @(
+                    [PSCustomObject]@{ IsTest = $true;  ApplicationName = 'Projects-Json-Key'; AppJsonPath = $script:mismatchAppJson }
+                    [PSCustomObject]@{ IsTest = $true;  ApplicationName = 'Aligned Tests';     AppJsonPath = $script:matchAppJson }
+                    [PSCustomObject]@{ IsTest = $false; ApplicationName = 'Some Prod App';     AppJsonPath = $null }
+                )
+            }
+            Mock -ModuleName ParallelTestExecution -CommandName Get-BcContainerAppInfo -MockWith {
+                @(
+                    [PSCustomObject]@{ IsInstalled = $true; Name = 'Real App Name' }   # installed under the app.json name
+                    [PSCustomObject]@{ IsInstalled = $true; Name = 'Aligned Tests' }
+                )
+            }
+
+            $result = Get-InstalledTestAppNames -ContainerName 'c' -Tenant 'default' -Country 'w1'
+
+            $result | Should -Contain 'Real App Name'
+            $result | Should -Contain 'Aligned Tests'
+            $result | Should -Not -Contain 'Projects-Json-Key'
+        }
+    }
+}

--- a/src/DisabledTests/Subcontracting_Test/Subcontracting_Test.DisabledTest.json
+++ b/src/DisabledTests/Subcontracting_Test/Subcontracting_Test.DisabledTest.json
@@ -16,5 +16,11 @@
     "codeunitId": 139989,
     "codeunitName": "Subc. Subcontracting Test",
     "method": "CancelInvoiceWithSubcontractingItemChargeIsBlocked"
+  },
+  {
+    "bug": "641388",
+    "codeunitId": 149911,
+    "codeunitName": "Subc. WIP Trans. Create Test",
+    "method": "WIPTransferRemainderCreatedWhenOpenLineQuantityReduced"
   }
 ]

--- a/src/DisabledTests/Subscription_Billing_Test/Subscription Billing Test.DisabledTest.json
+++ b/src/DisabledTests/Subscription_Billing_Test/Subscription Billing Test.DisabledTest.json
@@ -328,5 +328,11 @@
     "codeunitId": 139913,
     "codeunitName": "Vendor Deferrals Test",
     "method": "VerifyVendSubContrDefAccountBalancedForCreditMemoWithDiscount"
+  },
+  {
+    "bug": "641478",
+    "codeunitId": 139913,
+    "codeunitName": "Vendor Deferrals Test",
+    "method": "DeferralsReleaseSucceedsWhenGLAccountHasDefaultDeferralTemplateAndJournalTemplNotMandatory"
   }
 ]


### PR DESCRIPTION
## What & why

BCApps CI was silently skipping entire test apps. The parallel test dispatcher decided which test apps to run by matching each project's `projects.json` key (surfaced as `BuildMetadata.ApplicationName`, and also its `groups.json` name) against the app name the container reports (`app.json` `"name"`). Those two strings are *required* to be identical, but when they drift the app is dropped from the dispatch set and **all of its tests are silently skipped while the build stays green**.

This is how `WIPTransferRemainderCreatedWhenOpenLineQuantityReduced` (and the rest of the Subcontracting suite) failed in another build system yet never even ran in GitHub CI: `Subcontracting-Tests` (projects.json key) vs `Subcontracting Test` (app.json name).

A full scan found **7 affected test apps** with this drift: Subcontracting Test (~22 test codeunits), Subscription Billing Test (~30), OnPrem Permissions Test, Statistical Accounts Test, Dynamics SL Migration Tests, Tests for MX DIOT Extension, and Basic Experience Tests. All were installed in the container but never dispatched.

## Approach

Rather than hand-editing the metadata for all 7 (which fixes the symptom but leaves the mechanism fragile), this makes the dispatcher robust by using the authoritative source of truth. `Get-InstalledTestAppNames` now resolves each test app's name from its `app.json` (via `AppJsonPath`) using a new `Get-AppNameFromMetadata` helper, instead of trusting the projects.json key. That is the same string the container reports, so both the installed-name intersection and the downstream name-to-extensionId dispatch map line up, and any future key/name drift self-heals.

When the projects.json key and app.json name disagree, it emits a `::warning::` naming the offending app so the drift is visible instead of silent, while still dispatching the tests correctly.

Verified safe: all 40 legacy-bucket apps and every other test app already have `key == app.json name`, so switching the source of truth changes behavior only for the 7 that were broken.

## Linked work

<!-- This change needs an approved GitHub issue before it can merge. -->

Fixes #

Related to [AB#641388](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641388) (Subcontracting `WIPTransferRemainderCreatedWhenOpenLineQuantityReduced` failure surfaced and disabled by this change)
Related to [AB#641478](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641478) (Subscription Billing IT `DeferralsReleaseSucceedsWhenGLAccountHasDefaultDeferralTemplateAndJournalTemplNotMandatory` failure surfaced and disabled by this change)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- This is a build-script (PowerShell) change, not an AL app change, so there is no BC app to build or run.
- Added `build/scripts/tests/ParallelTestExecution.Test.ps1` (Pester). 5 tests, all green locally with Pester 5.7.1, covering: name resolved from app.json when it differs from the projects.json key, the aligned case, and both fallbacks (missing app.json path, empty path). The drift test also asserts `Get-InstalledTestAppNames` dispatches the app under its real installed name.
- Confirmed against the real failing run (28391219041): extensionId `32b0d4d1` (Subcontracting Test) was installed but never appeared in any `Dispatching '...'` line in the W1 or US IntegrationTests jobs; no codeunit 149911 header and no test-function output were present. This change makes that app resolve into the dispatch set.

## Risk & compatibility

- No metadata files (`projects.json`, `groups.json`, `app.json`) are changed; this is purely a resolution-logic change in `ParallelTestExecution.psm1`.
- Once merged, the ~7 previously-skipped test suites will start running in CI. Some may surface pre-existing real failures (for example the Subcontracting WIP transfer test), which is the intended outcome. Reviewers should expect newly-executing tests, not regressions from this change itself.
- Two such pre-existing failures found so far have been temporarily added to their apps' DisabledTests JSON and tracked by [AB#641388](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641388) and [AB#641478](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641478).
- Fallback preserves today's behavior for any app whose app.json cannot be read.
- Follow-up worth considering (not in this PR): a guard test asserting `projects.json key == groups.json name == app.json "name"` for every test project, so drift is caught at PR time.

