### PR TITLE
Exclude all system fields from field-enumeration tests

### DIFF
--- a/src/Layers/AU/Tests/ERM/ERMSalesInvoiceAggregateUT.Codeunit.al
+++ b/src/Layers/AU/Tests/ERM/ERMSalesInvoiceAggregateUT.Codeunit.al
@@ -2561,12 +2561,7 @@ codeunit 134396 "ERM Sales Invoice Aggregate UT"
     begin
         Field.SetRange(TableNo, DATABASE::"Sales Invoice Entity Aggregate");
         Field.SetFilter(ObsoleteState, '<>%1', Field.ObsoleteState::Removed);
-        Field.SetFilter("No.", '<>%1&<>%2&<>%3&<>%4&<>%5',
-            Field.FieldNo(SystemId),
-            Field.FieldNo(SystemCreatedAt),
-            Field.FieldNo(SystemCreatedBy),
-            Field.FieldNo(SystemModifiedAt),
-            Field.FieldNo(SystemModifiedBy));
+        Field.SetFilter("No.", '<%1', Field.FieldNo(SystemId));
     end;
 
     local procedure AssignStaticValues524113(var UnitPrice: array[4] of Decimal; var Quantity: array[4] of Integer)

--- a/src/Layers/CH/Tests/ERM/ERMSalesInvoiceAggregateUT.Codeunit.al
+++ b/src/Layers/CH/Tests/ERM/ERMSalesInvoiceAggregateUT.Codeunit.al
@@ -2561,12 +2561,7 @@ codeunit 134396 "ERM Sales Invoice Aggregate UT"
     begin
         Field.SetRange(TableNo, DATABASE::"Sales Invoice Entity Aggregate");
         Field.SetFilter(ObsoleteState, '<>%1', Field.ObsoleteState::Removed);
-        Field.SetFilter("No.", '<>%1&<>%2&<>%3&<>%4&<>%5',
-            Field.FieldNo(SystemId),
-            Field.FieldNo(SystemCreatedAt),
-            Field.FieldNo(SystemCreatedBy),
-            Field.FieldNo(SystemModifiedAt),
-            Field.FieldNo(SystemModifiedBy));
+        Field.SetFilter("No.", '<%1', Field.FieldNo(SystemId));
     end;
 
     local procedure AssignStaticValues524113(var UnitPrice: array[4] of Decimal; var Quantity: array[4] of Integer)

--- a/src/Layers/IT/Tests/ERM/ERMSalesInvoiceAggregateUT.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM/ERMSalesInvoiceAggregateUT.Codeunit.al
@@ -2554,12 +2554,7 @@ codeunit 134396 "ERM Sales Invoice Aggregate UT"
     begin
         Field.SetRange(TableNo, DATABASE::"Sales Invoice Entity Aggregate");
         Field.SetFilter(ObsoleteState, '<>%1', Field.ObsoleteState::Removed);
-        Field.SetFilter("No.", '<>%1&<>%2&<>%3&<>%4&<>%5',
-            Field.FieldNo(SystemId),
-            Field.FieldNo(SystemCreatedAt),
-            Field.FieldNo(SystemCreatedBy),
-            Field.FieldNo(SystemModifiedAt),
-            Field.FieldNo(SystemModifiedBy));
+        Field.SetFilter("No.", '<%1', Field.FieldNo(SystemId));
     end;
 
     local procedure AssignStaticValues524113(var UnitPrice: array[4] of Decimal; var Quantity: array[4] of Integer)

--- a/src/Layers/NA/Tests/ERM/ERMSalesInvoiceAggregateUT.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM/ERMSalesInvoiceAggregateUT.Codeunit.al
@@ -2530,12 +2530,7 @@ codeunit 134396 "ERM Sales Invoice Aggregate UT"
     begin
         Field.SetRange(TableNo, DATABASE::"Sales Invoice Entity Aggregate");
         Field.SetFilter(ObsoleteState, '<>%1', Field.ObsoleteState::Removed);
-        Field.SetFilter("No.", '<>%1&<>%2&<>%3&<>%4&<>%5',
-            Field.FieldNo(SystemId),
-            Field.FieldNo(SystemCreatedAt),
-            Field.FieldNo(SystemCreatedBy),
-            Field.FieldNo(SystemModifiedAt),
-            Field.FieldNo(SystemModifiedBy));
+        Field.SetFilter("No.", '<%1', Field.FieldNo(SystemId));
     end;
 
     local procedure AssignStaticValues524113(var UnitPrice: array[4] of Decimal; var Quantity: array[4] of Integer)

--- a/src/Layers/W1/Tests/CRM integration/IntegrationRecordSynchTest.Codeunit.al
+++ b/src/Layers/W1/Tests/CRM integration/IntegrationRecordSynchTest.Codeunit.al
@@ -523,13 +523,7 @@ codeunit 139166 "Integration Record Synch. Test"
         "Field": Record "Field";
     begin
         Field.SetRange(TableNo, Database::"Comparison Type");
-        Field.SetFilter("No.", '<>%1&<>%2&<>%3&<>%4&<>%5&<>%6',
-                            1, // Ignore the key
-                            Field.FieldNo(SystemId),
-                            Field.FieldNo(SystemCreatedAt),
-                            Field.FieldNo(SystemCreatedBy),
-                            Field.FieldNo(SystemModifiedAt),
-                            Field.FieldNo(SystemModifiedBy));
+        Field.SetFilter("No.", '>%1&<%2', 1, Field.FieldNo(SystemId)); // Ignore the key and the system fields
         Field.FindSet();
 
         if IncludePrimaryKeyDefault then begin
@@ -592,13 +586,7 @@ codeunit 139166 "Integration Record Synch. Test"
 
         // Validate fields are equal;
         Field.SetRange(TableNo, DATABASE::"Comparison Type");
-        Field.SetFilter("No.", '<>%1&<>%2&<>%3&<>%4&<>%5&<>%6',
-                            1, // Ignore the key
-                            Field.FieldNo(SystemId),
-                            Field.FieldNo(SystemCreatedAt),
-                            Field.FieldNo(SystemCreatedBy),
-                            Field.FieldNo(SystemModifiedAt),
-                            Field.FieldNo(SystemModifiedBy));
+        Field.SetFilter("No.", '>%1&<%2', 1, Field.FieldNo(SystemId)); // Ignore the key and the system fields
         Field.FindSet();
 
         repeat

--- a/src/Layers/W1/Tests/ERM/ERMSalesInvoiceAggregateUT.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMSalesInvoiceAggregateUT.Codeunit.al
@@ -2555,12 +2555,7 @@ codeunit 134396 "ERM Sales Invoice Aggregate UT"
     begin
         Field.SetRange(TableNo, DATABASE::"Sales Invoice Entity Aggregate");
         Field.SetFilter(ObsoleteState, '<>%1', Field.ObsoleteState::Removed);
-        Field.SetFilter("No.", '<>%1&<>%2&<>%3&<>%4&<>%5',
-            Field.FieldNo(SystemId),
-            Field.FieldNo(SystemCreatedAt),
-            Field.FieldNo(SystemCreatedBy),
-            Field.FieldNo(SystemModifiedAt),
-            Field.FieldNo(SystemModifiedBy));
+        Field.SetFilter("No.", '<%1', Field.FieldNo(SystemId));
     end;
 
     local procedure AssignStaticValues524113(var UnitPrice: array[4] of Decimal; var Quantity: array[4] of Integer)


### PR DESCRIPTION
## What & why

Several tests exclude system fields from field count / comparison assertions by enumerating the five known system fields (`SystemId`, `SystemCreatedAt`, `SystemCreatedBy`, `SystemModifiedAt`, `SystemModifiedBy`). When new system fields are added, they are not in that list, so the assertions break (e.g. the `AggregateField.Count` equality in `ERM Sales Invoice Aggregate UT`).

This replaces the explicit enumeration with a single lower bound, `"No." < FieldNo(SystemId)`, which excludes **all** system fields (field numbers >= 2000000000), including any added later.

- `ERM Sales Invoice Aggregate UT` (W1, CH, NA, AU, IT) — `SetFieldFilters`
- `Integration Record Synch. Test` — two field-comparison helpers; the primary key is still skipped (`>%1&<%2`, `1`, `FieldNo(SystemId)`)

## Linked work

[AB#641373](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641373)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Test-only refactor. The new filter is functionally identical to the previous one for the current field set (it excludes exactly `{SystemId..SystemModifiedBy}`, plus the key in the Integration Record Synch. Test) and additionally excludes any future system fields, which is the intended fix.
- No new test added — this makes the existing reflection/count tests robust; behavior under test is unchanged.

## Risk & compatibility

- Low. Test code only; no product/runtime code changed.
- Behaviorally equivalent to the previous filter for existing fields; the only difference is that newly added system fields (No. >= 2000000000) are now also excluded.



