### PR TITLE
Add OnAfterShowStatusMsg integration event to Job Queue Entry (AB#641298)

### DIFF
--- a/src/Layers/W1/BaseApp/Modules/System/JobQueue/JobQueueEntry.Table.al
+++ b/src/Layers/W1/BaseApp/Modules/System/JobQueue/JobQueueEntry.Table.al
@@ -1142,6 +1142,8 @@ table 472 "Job Queue Entry"
                 else
                     Message(ScheduledForPostingMsg, JobQueueEntry."User Session Started", JobQueueEntry."User ID");
             end;
+
+        OnAfterShowStatusMsg(Rec, JQID);
     end;
 
     procedure LookupRecordToProcess()
@@ -1710,6 +1712,11 @@ table 472 "Job Queue Entry"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterSetStatusValue(var JobQueueEntry: Record "Job Queue Entry"; var xJobQueueEntry: Record "Job Queue Entry")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterShowStatusMsg(var JobQueueEntry: Record "Job Queue Entry"; var JQID: Guid)
     begin
     end;
 }


### PR DESCRIPTION
Event request for Table 472 "Job Queue Entry": `ShowStatusMsg` had no extensibility point, so partners cannot run additional notification/logging after the standard Job Queue status message is shown.

## What & why

Adds an `OnAfterShowStatusMsg` integration event publisher to `JobQueueEntry.Table.al` and raises it at the end of `ShowStatusMsg`, giving subscribers a hook after the status message is displayed.

- **Publisher** — new `[IntegrationEvent(false, false)] OnAfterShowStatusMsg(var JobQueueEntry: Record "Job Queue Entry"; var JQID: Guid)`, matching the existing event conventions in the same table.
- **Call site** — raises the event after the status `case` block:

```al
procedure ShowStatusMsg(JQID: Guid)
begin
    if JobQueueEntry.Get(JQID) then
        case JobQueueEntry.Status of
            ...
        end;

    OnAfterShowStatusMsg(Rec, JQID);
end;
```

## Linked work

[AB#641298](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641298)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Additive-only change (7 lines): a new integration event publisher plus its invocation. No behavioral change to existing logic.
- No tests added — publishing an event is additive and mirrors the 30+ existing `OnAfter*/OnBefore*` publishers in this table; it references only existing symbols (`Rec`, `JQID`). Compilation is exercised by the `Pull Request Build` workflow.

## Risk & compatibility

Low. Purely additive extensibility point; no changes to control flow, data, or permissions. New subscribers run inside the caller's context, so a subscriber that raises an error could surface to the caller of `ShowStatusMsg` — standard for `OnAfter` events.

---
Promoted from microsoft/BCAppsBugFix#22: https://github.com/microsoft/BCAppsBugFix/pull/22

Fixes [AB#641298](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641298)

