### PR TITLE
Widen Text[30] FlowFields to Text[100] for platform Object Name uptake

### DIFF
--- a/src/Apps/W1/EDocumentConnectors/Avalara/App/src/Extensions/TransformationRule.TableExt.al
+++ b/src/Apps/W1/EDocumentConnectors/Avalara/App/src/Extensions/TransformationRule.TableExt.al
@@ -26,7 +26,7 @@ tableextension 6374 "Transformation Rule" extends "Transformation Rule"
                     CalcFields("Lookup Table Name");
             end;
         }
-        field(6371; "Lookup Table Name"; Text[30])
+        field(6371; "Lookup Table Name"; Text[100])
         {
             CalcFormula = lookup(AllObjWithCaption."Object Name" where("Object Type" = const(Table), "Object ID" = field("Lookup Table ID")));
             Caption = 'Lookup Table Name';

--- a/src/Layers/BE/BaseApp/Local/BankMgt/Payment/ExportProtocol.Table.al
+++ b/src/Layers/BE/BaseApp/Local/BankMgt/Payment/ExportProtocol.Table.al
@@ -37,7 +37,7 @@ table 2000005 "Export Protocol"
                 CalcFields("Check Object Name");
             end;
         }
-        field(26; "Check Object Name"; Text[30])
+        field(26; "Check Object Name"; Text[100])
         {
             CalcFormula = lookup(AllObj."Object Name" where("Object Type" = const(Codeunit),
                                                              "Object ID" = field("Check Object ID")));

--- a/src/Layers/W1/BaseApp/Modules/System/EventRecorder/RecordedEventBuffer.Table.al
+++ b/src/Layers/W1/BaseApp/Modules/System/EventRecorder/RecordedEventBuffer.Table.al
@@ -43,7 +43,7 @@ table 9804 "Recorded Event Buffer"
             else
             if ("Object Type" = const(System)) AllObj."Object ID" where("Object Type" = const(System));
         }
-        field(4; "Object Name"; Text[30])
+        field(4; "Object Name"; Text[100])
         {
             CalcFormula = lookup(AllObjWithCaption."Object Name" where("Object Type" = field("Object Type"),
                                                                         "Object ID" = field("Object ID")));
@@ -85,7 +85,7 @@ table 9804 "Recorded Event Buffer"
             Caption = 'Calling Object ID';
             DataClassification = SystemMetadata;
         }
-        field(11; "Calling Object Name"; Text[30])
+        field(11; "Calling Object Name"; Text[100])
         {
             CalcFormula = lookup(AllObjWithCaption."Object Name" where("Object Type" = field("Calling Object Type"),
                                                                         "Object ID" = field("Calling Object ID")));

--- a/src/Layers/W1/BaseApp/Modules/System/Translation/ObjectTranslation.Table.al
+++ b/src/Layers/W1/BaseApp/Modules/System/Translation/ObjectTranslation.Table.al
@@ -50,7 +50,7 @@ table 377 "Object Translation"
         {
             Caption = 'Description';
         }
-        field(6; "Object Name"; Text[30])
+        field(6; "Object Name"; Text[100])
         {
             CalcFormula = lookup(AllObj."Object Name" where("Object Type" = field("Object Type"),
                                                     "Object ID" = field("Object ID")));

--- a/src/Layers/W1/Tests/TestLibraries/Referencedatafieldlist.Table.al
+++ b/src/Layers/W1/Tests/TestLibraries/Referencedatafieldlist.Table.al
@@ -13,7 +13,7 @@ table 130060 "Reference data - field list"
         {
             TableRelation = AllObj."Object ID" where("Object Type" = const(Table));
         }
-        field(3; "Table name"; Text[30])
+        field(3; "Table name"; Text[100])
         {
             CalcFormula = lookup(AllObj."Object Name" where("Object Type" = const(Table),
                                                              "Object ID" = field("Table ID")));

--- a/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Table.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Table.al
@@ -39,7 +39,7 @@ table 3901 "Retention Policy Setup"
                 Rec.Validate("Table Id", RetentionPolicy.TableIdLookup(Rec."Table Id"));
             end;
         }
-        field(2; "Table Name"; Text[30])
+        field(2; "Table Name"; Text[100])
         {
             FieldClass = FlowField;
             CalcFormula = lookup(AllObjWithCaption."Object Name" where("Object Type" = const(Table), "Object ID" = field("Table Id")));

--- a/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetupLine.Table.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetupLine.Table.al
@@ -20,7 +20,7 @@ table 3902 "Retention Policy Setup Line"
             DataClassification = SystemMetadata;
             Editable = false;
         }
-        field(2; "Table Name"; Text[30])
+        field(2; "Table Name"; Text[100])
         {
             FieldClass = FlowField;
             CalcFormula = lookup(AllObjWithCaption."Object Name" where("Object Type" = const(Table), "Object ID" = field("Table Id")));


### PR DESCRIPTION
## Summary

Widens 8 `FlowField` declarations from `Text[30]` to `Text[100]` so their `CalcFormula` lookups into `AllObj."Object Name"` and `AllObjWithCaption."Object Name"` remain valid once BC Platform widens those source fields from `Text[30]` to `Text[100]` (fixes AL0685).

## Files

| File | Field | Sources |
|------|-------|---------|
| `src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Table.al` | 2 `"Table Name"` | `AllObjWithCaption."Object Name"` |
| `src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetupLine.Table.al` | 2 `"Table Name"` | `AllObjWithCaption."Object Name"` |
| `src/Layers/W1/BaseApp/Modules/System/EventRecorder/RecordedEventBuffer.Table.al` | 4 `"Object Name"` | `AllObjWithCaption."Object Name"` |
| `src/Layers/W1/BaseApp/Modules/System/EventRecorder/RecordedEventBuffer.Table.al` | 11 `"Calling Object Name"` | `AllObjWithCaption."Object Name"` |
| `src/Layers/W1/BaseApp/Modules/System/Translation/ObjectTranslation.Table.al` | 6 `"Object Name"` | `AllObj."Object Name"` |
| `src/Layers/W1/Tests/TestLibraries/Referencedatafieldlist.Table.al` | 3 `"Table name"` | `AllObj."Object Name"` |
| `src/Layers/BE/BaseApp/Local/BankMgt/Payment/ExportProtocol.Table.al` | 26 `"Check Object Name"` | `AllObj."Object Name"` |
| `src/Apps/W1/EDocumentConnectors/Avalara/App/src/Extensions/TransformationRule.TableExt.al` | 6371 `"Lookup Table Name"` | `AllObjWithCaption."Object Name"` |

Every changed field is a `FieldClass = FlowField`. No storage, no data migration, no upgrade codeunit, no permission or telemetry impact.

## Compatibility

Forward- **and** backward-compatible. AL0685 fires only when the source is *wider* than the destination, so `Text[100]` FlowFields sourcing a still-`Text[30]` platform field remain legal today, and become an exact fit once the platform widens to `Text[100]`. This PR can land ahead of the platform change.

Why `Text[100]` (not `Text[249]`/`Text[250]`): `AllObj."Object Name"` and `AllObjWithCaption."Object Name"` are the raw AL object identifier — the platform's new authoritative maximum for that identifier is `Text[100]`. Matching that width exactly is the intended fix. (Some pre-existing FlowFields declare `Text[249]` on the same lookup; that is legacy over-sizing on a `Text[30]` source, not a design convention.)

## Linked work

Fixes [AB#485120](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/485120)

