### PR TITLE
Disable alteration UI actions for Index Mgmt page

### DIFF
--- a/src/System Application/App/Table Information/src/TableInformationCard.Page.al
+++ b/src/System Application/App/Table Information/src/TableInformationCard.Page.al
@@ -18,9 +18,9 @@ page 8705 "Table Information Card"
     AdditionalSearchTerms = 'Database,Size,Storage';
     SourceTable = "Table Metadata";
     Caption = 'Table Data Management - Card';
-    InsertAllowed = false;
     DeleteAllowed = false;
-    Editable = false;
+    InsertAllowed = false;
+    ModifyAllowed = false;
     DataCaptionExpression = StrSubstNo('%1 - %2', Rec.Name, Rec.ID);
     Permissions = tabledata "Table Metadata" = r,
                   tabledata "Database Index" = r;

--- a/src/System Application/App/Table Information/src/TableInformationCard.Page.al
+++ b/src/System Application/App/Table Information/src/TableInformationCard.Page.al
@@ -18,6 +18,9 @@ page 8705 "Table Information Card"
     AdditionalSearchTerms = 'Database,Size,Storage';
     SourceTable = "Table Metadata";
     Caption = 'Table Data Management - Card';
+    InsertAllowed = false;
+    DeleteAllowed = false;
+    Editable = false;
     DataCaptionExpression = StrSubstNo('%1 - %2', Rec.Name, Rec.ID);
     Permissions = tabledata "Table Metadata" = r,
                   tabledata "Database Index" = r;


### PR DESCRIPTION
Kennie pointed out the UI alteration actions make no sense, they also throw errors or lead to strange behavours:
<img width="1487" height="718" alt="image" src="https://github.com/user-attachments/assets/f2baa53d-b1b6-4348-bab1-075abb176a70" />

So disable them (grey them out):
<img width="1355" height="553" alt="image" src="https://github.com/user-attachments/assets/5591b03f-51ad-4f9a-91f3-7aa36fcb4b94" />


Fixes [AB#641404](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641404)




