### PR TITLE
Bug 602230: Fix exchange-rate dates in Dimension-Must-Be-Same test setup

### DIFF
--- a/src/Apps/W1/ErrorMessagesWithRecommendations/Test/ErrMsgScenarioTestHelper.Codeunit.al
+++ b/src/Apps/W1/ErrorMessagesWithRecommendations/Test/ErrMsgScenarioTestHelper.Codeunit.al
@@ -139,8 +139,8 @@ codeunit 139620 ErrMsgScenarioTestHelper
     begin
         // Create a new currency with GL account setup and two exchange rates for the currency
         CurrencyCode := LibraryERM.CreateCurrencyWithGLAccountSetup();
-        LibraryERM.CreateExchangeRate(CurrencyCode, Today() - 1, 100, 100);
-        LibraryERM.CreateExchangeRate(CurrencyCode, Today() + 5, 101, 101);
+        LibraryERM.CreateExchangeRate(CurrencyCode, WorkDate() - 1, 100, 100);
+        LibraryERM.CreateExchangeRate(CurrencyCode, WorkDate() + 5, 101, 101);
 
         // Create a customer with new currency
         LibrarySales.CreateCustomer(Customer);

--- a/src/DisabledTests/Error_Messages_with_Recommendations_Tests/Error Messages with Recommendations Tests.DisabledTest.json
+++ b/src/DisabledTests/Error_Messages_with_Recommendations_Tests/Error Messages with Recommendations Tests.DisabledTest.json
@@ -1,6 +1,0 @@
-{
-  "bug": "602230",
-  "codeunitId": 139621,
-  "CodeunitName": "ErrorMessageExtensibilityTests",
-  "Method": "GlobalDimensionsWhenDimensionMustBeSameErrorFixWithDrillDownUI"
-}


### PR DESCRIPTION
Fixes [AB#602230](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/602230)

Test-fixture fix. ``SetupForDimensionMustBeSameError`` anchored exchange rates on ``Today()``, but the sales document is created on ``WorkDate()``. When the pipeline WorkDate precedes the earliest rate, Currency Factor resolved to 0 and the Sales Line insert failed. Anchor the rates on ``WorkDate()-1`` / ``WorkDate()+5`` to match the document date. Product code unchanged; covered by existing CU 139621.



