### PR TITLE
Bug 631472: Cost Shares Breakdown (WIP) does not filter by Item

### DIFF
--- a/src/Layers/W1/BaseApp/Manufacturing/Reports/CostSharesBreakdown.Report.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Reports/CostSharesBreakdown.Report.al
@@ -66,7 +66,17 @@ report 5848 "Cost Shares Breakdown"
                 DataItemTableView = sorting("Order Type", "Order No.", "Order Line No.") where("Order Type" = const(Production));
 
                 trigger OnAfterGetRecord()
+                var
+                    TempItem: Record Item temporary;
                 begin
+                    if Item.Get("Capacity Ledger Entry"."Item No.") then begin
+                        TempItem := Item;
+                        TempItem.Insert();
+                        TempItem.CopyFilters(Item);
+                        if TempItem.IsEmpty() then
+                            CurrReport.Skip();
+                    end;
+
                     InsertCapLedgEntryCostShare("Capacity Ledger Entry");
                 end;
 

--- a/src/Layers/W1/Tests/SCM/SCMInventoryReportsIV.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMInventoryReportsIV.Codeunit.al
@@ -539,6 +539,63 @@ codeunit 137351 "SCM Inventory Reports - IV"
     end;
 
     [Test]
+    [HandlerFunctions('ProductionJournalPageHandler,ConfirmHandler,MessageHandler,CostSharesBreakdownRequestPageHandler')]
+    [Scope('OnPrem')]
+    procedure CostSharesBreakdownReportForWIPInventoryFiltersByItem()
+    var
+        ChildItem: Record Item;
+        ProdItem: Record Item;
+        OtherProdItem: Record Item;
+        ItemJournalLine: Record "Item Journal Line";
+        ProductionBOMHeader: Record "Production BOM Header";
+        OtherProductionBOMHeader: Record "Production BOM Header";
+        ProductionOrder: Record "Production Order";
+        OtherProductionOrder: Record "Production Order";
+        PrintCostShare: Option Sale,Inventory,"WIP Inventory";
+    begin
+        // [FEATURE] [Cost Shares Breakdown] [WIP]
+        // [SCENARIO 631472] Cost Shares Breakdown in WIP Inventory mode only reports the produced item that matches the request-page Item filter.
+        Initialize();
+
+        // [GIVEN] A component item with posted inventory
+        CreateItem(ChildItem, ChildItem."Replenishment System"::Purchase);
+        CreateAndPostItemJournalLine(ItemJournalLine, ChildItem."No.");
+
+        // [GIVEN] Two produced items, each with the component in its production BOM
+        CreateItem(ProdItem, ProdItem."Replenishment System"::"Prod. Order");
+        CreateAndCertifyProductionBOM(ProductionBOMHeader, ChildItem."No.", ProdItem."Base Unit of Measure", 1);
+        UpdateProductionBOMOnItem(ProdItem, ProductionBOMHeader."No.");
+
+        CreateItem(OtherProdItem, OtherProdItem."Replenishment System"::"Prod. Order");
+        CreateAndCertifyProductionBOM(OtherProductionBOMHeader, ChildItem."No.", OtherProdItem."Base Unit of Measure", 1);
+        UpdateProductionBOMOnItem(OtherProdItem, OtherProductionBOMHeader."No.");
+
+        // [GIVEN] A released production order is posted for each produced item, generating capacity entries
+        CreateAndRefreshProductionOrder(ProductionOrder, ProductionOrder.Status::Released, ProdItem."No.", ItemJournalLine.Quantity / 4);
+        LibraryVariableStorage.Enqueue(PostingMessage);
+        LibraryVariableStorage.Enqueue(PostedLinesMessage);
+        CreateAndPostProductionJournal(ProductionOrder);
+
+        CreateAndRefreshProductionOrder(OtherProductionOrder, OtherProductionOrder.Status::Released, OtherProdItem."No.", ItemJournalLine.Quantity / 4);
+        LibraryVariableStorage.Enqueue(PostingMessage);
+        LibraryVariableStorage.Enqueue(PostedLinesMessage);
+        CreateAndPostProductionJournal(OtherProductionOrder);
+
+        // [WHEN] Running the report in WIP Inventory mode filtered on the first produced item
+        Commit();
+        RunCostSharesBreakdownReport(ProdItem."No.", PrintCostShare::"WIP Inventory", false);
+
+        // [THEN] The filtered item is reported and the other produced item is not
+        LibraryReportDataset.LoadDataSetFile();
+        Assert.IsTrue(
+            LibraryReportDataset.SearchForElementByValue('CostShareBufItemNo', ProdItem."No."),
+            'The filtered produced item must be reported in the Cost Shares Breakdown (WIP).');
+        Assert.IsFalse(
+            LibraryReportDataset.SearchForElementByValue('CostShareBufItemNo', OtherProdItem."No."),
+            'Cost Shares Breakdown (WIP) must not report items outside the request-page Item filter.');
+    end;
+
+    [Test]
     [HandlerFunctions('CostSharesBreakdownRequestPageHandler')]
     [Scope('OnPrem')]
     procedure CostSharesBreakdownReportInDetail()


### PR DESCRIPTION
Fixes [AB#631472](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/631472)

Under **Print Cost Share = WIP Inventory** the Production Order / Capacity Ledger Entry dataitems enumerated every released production order regardless of the request-page Item filter. Skip capacity entries whose produced item is not in the Item filter, using the same temp-item ``CopyFilters``/``IsEmpty`` idiom already used for the WIP buffer output in this report. Adds a WIP test asserting only the filtered item is reported.

