### PR TITLE
Bug 637846: Item Age Composition '...before' quantity reflected only last entry

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Reports/ItemAgeCompositionValue.Report.al
+++ b/src/Layers/W1/BaseApp/Inventory/Reports/ItemAgeCompositionValue.Report.al
@@ -236,7 +236,10 @@ report 5808 "Item Age Composition - Value"
 
                         TotalInvtValueRTC += UnitCost * Abs(TotalInvtQty);
                         InvtValueRTC[i] += UnitCost * Abs(InvtQty[i]);
-                    end
+                    end;
+
+                    for j := 1 to 5 do
+                        InvtQtyTotal[j] += InvtQty[j];
                 end;
 
                 trigger OnPostDataItem()
@@ -256,6 +259,7 @@ report 5808 "Item Age Composition - Value"
                     for i := 1 to 5 do
                         InvtValue[i] := 0;
                     RemainingQty := 0;
+                    Clear(InvtQtyTotal);
                 end;
             }
             dataitem("Integer"; "Integer")
@@ -285,27 +289,27 @@ report 5808 "Item Age Composition - Value"
                 {
                     AutoFormatType = 1;
                 }
-                column(InvtQty1_ItemLedgEntry; InvtQty[1])
+                column(InvtQty1_ItemLedgEntry; InvtQtyTotal[1])
                 {
                     DecimalPlaces = 0 : 2;
                 }
-                column(InvtQty2_ItemLedgEntry; InvtQty[2])
+                column(InvtQty2_ItemLedgEntry; InvtQtyTotal[2])
                 {
                     DecimalPlaces = 0 : 2;
                 }
-                column(InvtQty3_ItemLedgEntry; InvtQty[3])
+                column(InvtQty3_ItemLedgEntry; InvtQtyTotal[3])
                 {
                     DecimalPlaces = 0 : 2;
                 }
-                column(InvtQty4_ItemLedgEntry; InvtQty[4])
+                column(InvtQty4_ItemLedgEntry; InvtQtyTotal[4])
                 {
                     DecimalPlaces = 0 : 2;
                 }
-                column(InvtQty5_ItemLedgEntry; InvtQty[5])
+                column(InvtQty5_ItemLedgEntry; InvtQtyTotal[5])
                 {
                     DecimalPlaces = 0 : 2;
                 }
-                column(TotalInvtQty; TotalInvtQty)
+                column(TotalInvtQty; RemainingQty)
                 {
                     DecimalPlaces = 0 : 2;
                 }
@@ -506,9 +510,11 @@ report 5808 "Item Age Composition - Value"
         InvtValue: array[6] of Decimal;
         InvtValueRTC: array[6] of Decimal;
         InvtQty: array[6] of Decimal;
+        InvtQtyTotal: array[5] of Decimal;
         UnitCost: Decimal;
         PeriodStartDate: array[6] of Date;
         i: Integer;
+        j: Integer;
         TotalInvtValue_Item: Decimal;
         TotalInvtValueRTC: Decimal;
         TotalInvtQty: Decimal;

--- a/src/Layers/W1/Tests/SCM/SCMInventoryReportsIV.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMInventoryReportsIV.Codeunit.al
@@ -118,6 +118,36 @@ codeunit 137351 "SCM Inventory Reports - IV"
     end;
 
     [Test]
+    [HandlerFunctions('ItemAgeCompositionValueRequestPageHandler')]
+    [Scope('OnPrem')]
+    procedure ItemAgeCompositionBeforeBucketSumsAllEntries()
+    var
+        Item: Record Item;
+        PostingDate: Date;
+    begin
+        // [FEATURE] [Item Age Composition]
+        // [SCENARIO 637846] The "...before" quantity bucket sums the remaining quantity of all item ledger entries, not just the last one.
+
+        // [GIVEN] An item with three posted receipts (6, 10, 15), all dated in the "...before" bucket
+        Initialize();
+        PostingDate := CalcDate('<-4M>', WorkDate());
+        CreateItem(Item, Item."Replenishment System"::Purchase);
+        PostPositiveAdjustmentWithDate(Item."No.", 6, PostingDate);
+        PostPositiveAdjustmentWithDate(Item."No.", 10, PostingDate);
+        PostPositiveAdjustmentWithDate(Item."No.", 15, PostingDate);
+
+        // [WHEN] Running the Item Age Composition by Quantity and Value report
+        Commit();
+        RunItemAgeCompositionValueReport(Item."No.");
+
+        // [THEN] The "...before" quantity column shows the total remaining quantity (6 + 10 + 15 = 31), not just the last entry
+        LibraryReportDataset.LoadDataSetFile();
+        LibraryReportDataset.SetRange('No_Item', Item."No.");
+        LibraryReportDataset.GetNextRow();
+        LibraryReportDataset.AssertCurrentRowValueEquals('InvtQty1_ItemLedgEntry', 31);
+    end;
+
+    [Test]
     [HandlerFunctions('ImplementStandardCostChangePageHandler,MessageHandler')]
     [Scope('OnPrem')]
     procedure RevaluationJournalLinesUsingStdCostWorksheet()
@@ -3005,6 +3035,21 @@ codeunit 137351 "SCM Inventory Reports - IV"
         LibraryVariableStorage.Enqueue(WorkDate() - 1);
         LibraryVariableStorage.Enqueue(PeriodLength);
         REPORT.Run(REPORT::"Item Age Composition - Value", true, false, Item);
+    end;
+
+    local procedure PostPositiveAdjustmentWithDate(ItemNo: Code[20]; Qty: Decimal; PostingDate: Date)
+    var
+        ItemJournalBatch: Record "Item Journal Batch";
+        ItemJournalLine: Record "Item Journal Line";
+        ItemJournalTemplate: Record "Item Journal Template";
+    begin
+        CreateItemJournalBatch(ItemJournalBatch, ItemJournalTemplate.Type::Item);
+        LibraryInventory.CreateItemJournalLine(
+          ItemJournalLine, ItemJournalBatch."Journal Template Name", ItemJournalBatch.Name,
+          ItemJournalLine."Entry Type"::"Positive Adjmt.", ItemNo, Qty);
+        ItemJournalLine.Validate("Posting Date", PostingDate);
+        ItemJournalLine.Modify(true);
+        LibraryInventory.PostItemJournalLine(ItemJournalLine."Journal Template Name", ItemJournalLine."Journal Batch Name");
     end;
 
     local procedure RunItemBudgetReport(No: Code[20])


### PR DESCRIPTION
Fixes [AB#637846](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637846)

Report 5808 set the quantity buckets ``InvtQty[1..5]``/``TotalInvtQty`` per item ledger entry in ``CalcRemainingQty`` (clearing then setting one bucket) but output them once after the ILE loop, so quantities reflected only the last ILE. Value columns were correct because they accumulate with ``+=``. Accumulate the quantities into ``InvtQtyTotal[]`` and bind the quantity columns (total to ``RemainingQty``). Column names unchanged so layout bindings are preserved. Extends the report test.

