### PR TITLE
Bug 638184: Price Worksheet Line "Line No." no longer uses AutoIncrement

### DIFF
--- a/src/Layers/APAC/BaseApp/Pricing/Worksheet/PriceWorksheetLine.Table.al
+++ b/src/Layers/APAC/BaseApp/Pricing/Worksheet/PriceWorksheetLine.Table.al
@@ -39,7 +39,6 @@ table 7022 "Price Worksheet Line"
         {
             Caption = 'Line No.';
             DataClassification = CustomerContent;
-            AutoIncrement = true;
         }
         field(3; "Source Type"; Enum "Price Source Type")
         {
@@ -737,6 +736,20 @@ table 7022 "Price Worksheet Line"
     begin
         if "Price List Code" = '' then
             "Price List Code" := PriceListManagement.GetDefaultPriceListCode("Price Type", "Source Group", false);
+        if "Line No." = 0 then
+            SetNextLineNo();
+    end;
+
+    procedure SetNextLineNo()
+    var
+        PriceWorksheetLine: Record "Price Worksheet Line";
+    begin
+        "Line No." := 10000;
+        PriceWorksheetLine.SetLoadFields("Line No.");
+        PriceWorksheetLine.SetRange("Price List Code", "Price List Code");
+        PriceWorksheetLine.SetRange("Existing Line", "Existing Line");
+        if PriceWorksheetLine.FindLast() then
+            "Line No." += PriceWorksheetLine."Line No.";
     end;
 
     protected var

--- a/src/Layers/W1/BaseApp/Pricing/PriceList/PriceListManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Pricing/PriceList/PriceListManagement.Codeunit.al
@@ -981,6 +981,7 @@ codeunit 7017 "Price List Management"
         PriceWorksheetLine."Existing Direct Unit Cost" := FromPriceListLine."Direct Unit Cost";
         PriceWorksheetLine."Existing Unit Cost" := FromPriceListLine."Unit Cost";
         PriceWorksheetLine.Validate("Existing Line", not CreateNewLine);
+        PriceWorksheetLine."Line No." := 0;
         OnCopyToWorksheetLineOnBeforeInsert(PriceWorksheetLine, FromPriceListLine);
         PriceWorksheetLine.Insert(true);
     end;

--- a/src/Layers/W1/BaseApp/Pricing/Worksheet/PriceWorksheetLine.Table.al
+++ b/src/Layers/W1/BaseApp/Pricing/Worksheet/PriceWorksheetLine.Table.al
@@ -39,7 +39,6 @@ table 7022 "Price Worksheet Line"
         {
             Caption = 'Line No.';
             DataClassification = CustomerContent;
-            AutoIncrement = true;
         }
         field(3; "Source Type"; Enum "Price Source Type")
         {
@@ -693,6 +692,20 @@ table 7022 "Price Worksheet Line"
     begin
         if "Price List Code" = '' then
             "Price List Code" := PriceListManagement.GetDefaultPriceListCode("Price Type", "Source Group", false);
+        if "Line No." = 0 then
+            SetNextLineNo();
+    end;
+
+    procedure SetNextLineNo()
+    var
+        PriceWorksheetLine: Record "Price Worksheet Line";
+    begin
+        "Line No." := 10000;
+        PriceWorksheetLine.SetLoadFields("Line No.");
+        PriceWorksheetLine.SetRange("Price List Code", "Price List Code");
+        PriceWorksheetLine.SetRange("Existing Line", "Existing Line");
+        if PriceWorksheetLine.FindLast() then
+            "Line No." += PriceWorksheetLine."Line No.";
     end;
 
     protected var

--- a/src/Layers/W1/Tests/ERM/PriceWorksheetLineUT.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/PriceWorksheetLineUT.Codeunit.al
@@ -553,6 +553,47 @@ codeunit 134198 "Price Worksheet Line UT"
     end;
 
     [Test]
+    procedure T019b_LineNoAssignedPerPriceListCodeInStepsOf10000()
+    var
+        PriceListHeader: Record "Price List Header";
+        PriceWorksheetLine: Record "Price Worksheet Line";
+    begin
+        // [SCENARIO 638184] Price Worksheet Line "Line No." is assigned per Price List Code in steps of 10000 instead of a global AutoIncrement identity.
+        Initialize();
+
+        // [GIVEN] A Price List Header
+        LibraryPriceCalculation.CreatePriceHeader(
+            PriceListHeader, "Price Type"::Sale, "Price Source Type"::"All Customers", '');
+
+        // [WHEN] Inserting three worksheet lines under the header
+        // [THEN] Their "Line No." values are 10000, 20000, 30000
+        PriceWorksheetLine.Init();
+        PriceWorksheetLine."Price List Code" := PriceListHeader.Code;
+        PriceWorksheetLine.Insert(true);
+        Assert.AreEqual(10000, PriceWorksheetLine."Line No.", 'First worksheet line must be numbered 10000.');
+
+        PriceWorksheetLine.Init();
+        PriceWorksheetLine."Price List Code" := PriceListHeader.Code;
+        PriceWorksheetLine.Insert(true);
+        Assert.AreEqual(20000, PriceWorksheetLine."Line No.", 'Second worksheet line must be numbered 20000.');
+
+        PriceWorksheetLine.Init();
+        PriceWorksheetLine."Price List Code" := PriceListHeader.Code;
+        PriceWorksheetLine.Insert(true);
+        Assert.AreEqual(30000, PriceWorksheetLine."Line No.", 'Third worksheet line must be numbered 30000.');
+
+        // [WHEN] Deleting all lines and inserting again
+        PriceWorksheetLine.SetRange("Price List Code", PriceListHeader.Code);
+        PriceWorksheetLine.DeleteAll();
+        PriceWorksheetLine.Init();
+        PriceWorksheetLine."Price List Code" := PriceListHeader.Code;
+        PriceWorksheetLine.Insert(true);
+
+        // [THEN] Numbering restarts at 10000 (no global identity carry-over)
+        Assert.AreEqual(10000, PriceWorksheetLine."Line No.", 'Numbering must restart at 10000 after deleting all lines.');
+    end;
+
+    [Test]
     procedure T020_InsertNewLineDoesNotControlConsistency()
     var
         TempPriceWorksheetLine: Record "Price Worksheet Line" temporary;


### PR DESCRIPTION
Fixes [AB#638184](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638184)

Field 2 ``"Line No."`` on table 7022 used ``AutoIncrement`` (a global SQL identity never reset on delete), so it climbed toward the Integer maximum over time until inserts failed. Remove ``AutoIncrement`` and compute the next line number per key (10000 + last line no for the same Price List Code / Existing Line) in ``OnInsert``, mirroring the shipped Price List Line ``SetNextLineNo`` pattern. Zero the transferred line number in ``CopyToWorksheetLine`` so it also gets a fresh per-key number. Adds a UT. Propagated to the APAC layer.

