### PR TITLE
Bug 639857: Project journal ignores task-level Bill-to Customer for pricing

### DIFF
--- a/src/Layers/W1/BaseApp/Projects/Project/Journal/JobJournalLinePrice.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Projects/Project/Journal/JobJournalLinePrice.Codeunit.al
@@ -199,6 +199,7 @@ codeunit 7023 "Job Journal Line - Price" implements "Line With Price"
     local procedure AddSources()
     var
         Job: Record Job;
+        JobTask: Record "Job Task";
         SourceType: Enum "Price Source Type";
         IsHandled: Boolean;
     begin
@@ -213,8 +214,14 @@ codeunit 7023 "Job Journal Line - Price" implements "Line With Price"
             CurrPriceType::Sale:
                 begin
                     PriceSourceList.Add(SourceType::"All Customers");
-                    PriceSourceList.Add(SourceType::Customer, Job."Bill-to Customer No.");
-                    PriceSourceList.Add(SourceType::Contact, Job."Bill-to Contact No.");
+                    if Job."Task Billing Method" = Job."Task Billing Method"::"One customer" then begin
+                        PriceSourceList.Add(SourceType::Customer, Job."Bill-to Customer No.");
+                        PriceSourceList.Add(SourceType::Contact, Job."Bill-to Contact No.");
+                    end else begin
+                        JobTask.Get(JobJournalLine."Job No.", JobJournalLine."Job Task No.");
+                        PriceSourceList.Add(SourceType::Customer, JobTask."Bill-to Customer No.");
+                        PriceSourceList.Add(SourceType::Contact, JobTask."Bill-to Contact No.");
+                    end;
                     PriceSourceList.Add(SourceType::"Customer Price Group", JobJournalLine."Customer Price Group");
                     PriceSourceList.Add(SourceType::"Customer Disc. Group", Job."Customer Disc. Group");
                 end;

--- a/src/Layers/W1/BaseApp/Sales/Pricing/SalesPriceCalcMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/Pricing/SalesPriceCalcMgt.Codeunit.al
@@ -666,7 +666,7 @@ codeunit 7000 "Sales Price Calc. Mgt."
         AllowInvDisc := AllowInvDisc2;
     end;
 
-    local procedure SetBillToCustomerDependingOnBillingMethod(Job: Record "Job"; JobPlanningLine: Record "Job Planning Line"; var BillToCustomerNo: Code[20]; var BillToContactNo: Code[20])
+    local procedure SetBillToCustomerDependingOnBillingMethod(Job: Record "Job"; JobNo: Code[20]; JobTaskNo: Code[20]; var BillToCustomerNo: Code[20]; var BillToContactNo: Code[20])
     var
         JobTask: Record "Job Task";
     begin
@@ -676,7 +676,7 @@ codeunit 7000 "Sales Price Calc. Mgt."
         if Job."Task Billing Method" = Job."Task Billing Method"::"One customer" then
             exit;
 
-        JobTask.Get(JobPlanningLine."Job No.", JobPlanningLine."Job Task No.");
+        JobTask.Get(JobNo, JobTaskNo);
         if (JobTask."Bill-to Customer No." <> '') and (JobTask."Bill-to Customer No." <> Job."Bill-to Customer No.") then begin
             BillToCustomerNo := JobTask."Bill-to Customer No.";
             BillToContactNo := JobTask."Bill-to Contact No.";
@@ -1241,7 +1241,7 @@ codeunit 7000 "Sales Price Calc. Mgt."
                     Job.Get(JobPlanningLine."Job No.");
                     Item.Get(JobPlanningLine."No.");
                     JobPlanningLine.TestField("Qty. per Unit of Measure");
-                    SetBillToCustomerDependingOnBillingMethod(Job, JobPlanningLine, BillToCustomerNo, BillToContactNo);
+                    SetBillToCustomerDependingOnBillingMethod(Job, JobPlanningLine."Job No.", JobPlanningLine."Job Task No.", BillToCustomerNo, BillToContactNo);
                     FindSalesPrice(
                       TempSalesPrice, BillToCustomerNo, BillToContactNo,
                       Job."Customer Price Group", '', JobPlanningLine."No.", JobPlanningLine."Variant Code", JobPlanningLine."Unit of Measure Code",
@@ -1423,6 +1423,7 @@ codeunit 7000 "Sales Price Calc. Mgt."
     procedure FindJobJnlLinePrice(var JobJnlLine: Record "Job Journal Line"; CalledByFieldNo: Integer)
     var
         Job: Record Job;
+        BillToCustomerNo, BillToContactNo : Code[20];
         IsHandled: Boolean;
     begin
         IsHandled := false;
@@ -1441,8 +1442,9 @@ codeunit 7000 "Sales Price Calc. Mgt."
                     JobJnlLine.TestField("Qty. per Unit of Measure");
                     Job.Get(JobJnlLine."Job No.");
 
+                    SetBillToCustomerDependingOnBillingMethod(Job, JobJnlLine."Job No.", JobJnlLine."Job Task No.", BillToCustomerNo, BillToContactNo);
                     FindSalesPrice(
-                      TempSalesPrice, Job."Bill-to Customer No.", Job."Bill-to Contact No.",
+                      TempSalesPrice, BillToCustomerNo, BillToContactNo,
                       JobJnlLine."Customer Price Group", '', JobJnlLine."No.", JobJnlLine."Variant Code", JobJnlLine."Unit of Measure Code",
                       JobJnlLine."Currency Code", JobJnlLine."Posting Date", false);
                     CalcBestUnitPrice(TempSalesPrice);

--- a/src/Layers/W1/Tests/Job/JobsMultipleCustomers.Codeunit.al
+++ b/src/Layers/W1/Tests/Job/JobsMultipleCustomers.Codeunit.al
@@ -323,6 +323,57 @@ codeunit 136323 "Jobs - Multiple Customers"
     end;
 
     [Test]
+    [HandlerFunctions('ConfirmYesHandler')]
+    procedure SalesPriceIsPulledFromCustomerOnJobTaskForJournalLine()
+    var
+        Item: Record Item;
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobJournalLine: Record "Job Journal Line";
+        PriceListHeader: Record "Price List Header";
+        PriceListLines: array[2] of Record "Price List Line";
+        Customers: array[2] of Record Customer;
+    begin
+        // [SCENARIO 639857] The Job Journal Line price honors the task-level Bill-to Customer under Multiple customers billing.
+        Initialize();
+
+        // [GIVEN] New pricing enabled
+        LibraryPriceCalculation.EnableExtendedPriceCalculation();
+        LibraryPriceCalculation.SetupDefaultHandler("Price Calculation Handler"::"Business Central (Version 16.0)");
+
+        // [GIVEN] Set Multiple Customers on Project Setup
+        SetMultiupleCustomersOnProjectSetup();
+
+        // [GIVEN] New Item and two Customers with distinct Sales Prices
+        LibraryInventory.CreateItem(Item);
+        LibrarySales.CreateCustomer(Customers[1]);
+        LibrarySales.CreateCustomer(Customers[2]);
+        CreatePriceLineForCustomer(PriceListHeader, PriceListLines[1], Customers[1]."No.", Item."No.");
+        CreatePriceLineForCustomer(PriceListHeader, PriceListLines[2], Customers[2]."No.", Item."No.");
+
+        // [GIVEN] Project billed to Customer 1 with a task inheriting the project customer
+        LibraryJob.CreateJob(Job, Customers[1]."No.");
+        LibraryJob.CreateJobTask(Job, JobTask);
+
+        // [WHEN] Creating a Job Journal Line for the task
+        CreateJobJournalLineWithItem(JobJournalLine, JobTask, Item."No.", 1);
+
+        // [THEN] The unit price is Customer 1's price
+        Assert.AreEqual(PriceListLines[1]."Unit Price", JobJournalLine."Unit Price", 'Sales Price is not equal to Customer Sales Price');
+
+        // [GIVEN] A second task billed to Customer 2
+        LibraryJob.CreateJobTask(Job, JobTask);
+        JobTask.Validate("Sell-to Customer No.", Customers[2]."No.");
+        JobTask.Modify(true);
+
+        // [WHEN] Creating a Job Journal Line for the second task
+        CreateJobJournalLineWithItem(JobJournalLine, JobTask, Item."No.", 1);
+
+        // [THEN] The unit price is Customer 2's price (task-level Bill-to Customer honored)
+        Assert.AreEqual(PriceListLines[2]."Unit Price", JobJournalLine."Unit Price", 'Sales Price is not equal to Customer Sales Price');
+    end;
+
+    [Test]
     [HandlerFunctions('JobTransferToSalesInvoiceRequestPageHandler,MessageHandler')]
     procedure SalesInvoiceIsCreatedForJobTaskCustomer()
     var
@@ -2002,6 +2053,15 @@ codeunit 136323 "Jobs - Multiple Customers"
         JobPlanningLine.Validate("No.", ItemNo);
         JobPlanningLine.Validate(Quantity, Quantity);
         JobPlanningLine.Modify(true);
+    end;
+
+    local procedure CreateJobJournalLineWithItem(var JobJournalLine: Record "Job Journal Line"; JobTask: Record "Job Task"; ItemNo: Code[20]; Quantity: Decimal)
+    begin
+        LibraryJob.CreateJobJournalLine(LibraryJob.UsageLineTypeBoth(), JobTask, JobJournalLine);
+        JobJournalLine.Validate(Type, JobJournalLine.Type::Item);
+        JobJournalLine.Validate("No.", ItemNo);
+        JobJournalLine.Validate(Quantity, Quantity);
+        JobJournalLine.Modify(true);
     end;
 
     local procedure CreateCustomerwithDimension(var Customer: Record Customer; var DimensionValue: Record "Dimension Value")


### PR DESCRIPTION
Fixes [AB#639857](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639857)

The Job Journal Line price path always used ``Job."Bill-to Customer No."``, ignoring the task-level Bill-to Customer under the Multiple customers task-billing feature (the Job Planning Line path was already fixed). Mirror the planning-line branch: when Task Billing Method is not "One customer", use the Job Task Bill-to Customer/Contact. Adds a test in the Jobs - Multiple Customers codeunit.


