### PR TITLE
Bug 640321: Blanket Purch. Order to Order drops extended text for later items

### DIFF
--- a/src/Layers/IT/BaseApp/Purchases/Document/BlanketPurchOrdertoOrder.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/BlanketPurchOrdertoOrder.Codeunit.al
@@ -101,6 +101,7 @@ codeunit 97 "Blanket Purch. Order to Order"
                         PurchOrderLine."Shortcut Dimension 2 Code" := PurchBlanketOrderLine."Shortcut Dimension 2 Code";
                         PurchOrderLine."Dimension Set ID" := PurchBlanketOrderLine."Dimension Set ID";
                         PurchOrderLine.DefaultDeferralCode();
+                        RemapAttachedToLineNo(PurchBlanketOrderLine, PurchOrderLine);
                         if IsPurchOrderLineToBeInserted(PurchOrderLine) then begin
                             OnBeforeInsertPurchOrderLine(PurchOrderLine, PurchOrderHeader, PurchBlanketOrderLine, Rec);
                             PurchOrderLine.Insert();
@@ -340,6 +341,23 @@ codeunit 97 "Blanket Purch. Order to Order"
             PurchaseHeader.SetRange("Buy-from Vendor No.", PurchaseHeader."Buy-from Vendor No.");
         PurchaseHeader.Insert(true);
         PurchaseHeader.SetRange("Buy-from Vendor No.");
+    end;
+
+    local procedure RemapAttachedToLineNo(PurchBlanketOrderLine: Record "Purchase Line"; var PurchOrderLine: Record "Purchase Line")
+    var
+        ParentPurchaseLine: Record "Purchase Line";
+    begin
+        if PurchOrderLine."Attached to Line No." = 0 then
+            exit;
+
+        ParentPurchaseLine.SetCurrentKey("Document Type", "Blanket Order No.", "Blanket Order Line No.");
+        ParentPurchaseLine.SetLoadFields("Line No.");
+        ParentPurchaseLine.SetRange("Document Type", PurchOrderLine."Document Type");
+        ParentPurchaseLine.SetRange("Document No.", PurchOrderLine."Document No.");
+        ParentPurchaseLine.SetRange("Blanket Order No.", PurchBlanketOrderLine."Document No.");
+        ParentPurchaseLine.SetRange("Blanket Order Line No.", PurchBlanketOrderLine."Attached to Line No.");
+        if ParentPurchaseLine.FindFirst() then
+            PurchOrderLine."Attached to Line No." := ParentPurchaseLine."Line No.";
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/IT/Tests/ERM/ERMPurchaseBlanketOrder.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM/ERMPurchaseBlanketOrder.Codeunit.al
@@ -36,6 +36,7 @@
         PayToAddressFieldsEditableErr: Label 'Pay-to address fields should be editable.';
         DocumentDateError: Label '%1 cannot be greater than %2';
         DirectCostIsChangedErr: Label 'Direct Cost is changed on Quantity update.';
+        WrongAttachedExtTextCountErr: Label 'Purchase Order must contain 2 extended-text lines attached to item %1 (order line no %2).', Comment = '%1 = Item No.; %2 = Purchase Order Line No.';
 
     [Test]
     [Scope('OnPrem')]
@@ -1394,6 +1395,106 @@
 
         // [THEN] Verify Unit Cost is not changed if Purchase Order is related to Blanket Purchase Order
         Assert.IsTrue(PurchaseLine."Direct Unit Cost" = DirectCost, DirectCostIsChangedErr);
+    end;
+
+    [Test]
+    procedure ExtendedTextStaysAttachedToParentOnOrderWhenMakingOrderWithMultipleItems()
+    var
+        Vendor: Record Vendor;
+        Item: array[2] of Record Item;
+        BlanketPurchaseHeader: Record "Purchase Header";
+        OrderItemLine: Record "Purchase Line";
+        OrderAttachedLine: Record "Purchase Line";
+        NotificationLifecycleMgt: Codeunit "Notification Lifecycle Mgt.";
+        OrderNo: Code[20];
+        i: Integer;
+    begin
+        // [SCENARIO 640321] Each item's extended-text lines on the new purchase order must be attached to that
+        //                 item's order line, not to the blanket parent line, even when multiple items have extended texts.
+        Initialize();
+
+        // [GIVEN] Two items, each with two extended texts.
+        CreateItemWithTwoExtendedTexts(Item[1]);
+        CreateItemWithTwoExtendedTexts(Item[2]);
+
+        // [GIVEN] A vendor.
+        LibraryPurchase.CreateVendor(Vendor);
+
+        // [GIVEN] A blanket purchase order with both items (auto-inserts the extended texts).
+        CreateBlanketPurchaseOrder(Vendor, Item[1], Item[2]);
+
+        // [GIVEN] Find the blanket purchase header.
+        BlanketPurchaseHeader.SetRange("Document Type", BlanketPurchaseHeader."Document Type"::"Blanket Order");
+        BlanketPurchaseHeader.SetRange("Buy-from Vendor No.", Vendor."No.");
+        BlanketPurchaseHeader.FindFirst();
+
+        // [WHEN] Make Order is run.
+        OrderNo := LibraryPurchase.BlanketPurchaseOrderMakeOrder(BlanketPurchaseHeader);
+
+        // [THEN] Each item on the new order has two extended-text lines attached to its order line no.
+        for i := 1 to 2 do begin
+            OrderItemLine.Reset();
+            OrderItemLine.SetRange("Document Type", OrderItemLine."Document Type"::Order);
+            OrderItemLine.SetRange("Document No.", OrderNo);
+            OrderItemLine.SetRange("No.", Item[i]."No.");
+            OrderItemLine.FindFirst();
+
+            OrderAttachedLine.Reset();
+            OrderAttachedLine.SetRange("Document Type", OrderAttachedLine."Document Type"::Order);
+            OrderAttachedLine.SetRange("Document No.", OrderNo);
+            OrderAttachedLine.SetRange("Attached to Line No.", OrderItemLine."Line No.");
+            Assert.AreEqual(
+                2,
+                OrderAttachedLine.Count(),
+                StrSubstNo(WrongAttachedExtTextCountErr, Item[i]."No.", OrderItemLine."Line No."));
+        end;
+
+        NotificationLifecycleMgt.RecallAllNotifications();
+    end;
+
+    local procedure CreateItemWithTwoExtendedTexts(var Item: Record Item)
+    var
+        ExtendedTextHeader: Record "Extended Text Header";
+        ExtendedTextLine: array[2] of Record "Extended Text Line";
+    begin
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Automatic Ext. Texts", true);
+        Item.Modify(true);
+
+        LibraryInventory.CreateExtendedTextHeaderItem(ExtendedTextHeader, Item."No.");
+        ExtendedTextHeader.Validate("Purchase Blanket Order", true);
+        ExtendedTextHeader.Validate("Purchase Order", true);
+        ExtendedTextHeader.Modify(true);
+
+        LibraryInventory.CreateExtendedTextLineItem(ExtendedTextLine[1], ExtendedTextHeader);
+        ExtendedTextLine[1].Validate(Text, LibraryUtility.GenerateRandomText(MaxStrLen(Item."No.")));
+        ExtendedTextLine[1].Modify(true);
+
+        LibraryInventory.CreateExtendedTextLineItem(ExtendedTextLine[2], ExtendedTextHeader);
+        ExtendedTextLine[2].Validate(Text, LibraryUtility.GenerateRandomText(MaxStrLen(Item."No.")));
+        ExtendedTextLine[2].Modify(true);
+    end;
+
+    local procedure CreateBlanketPurchaseOrder(Vendor: Record Vendor; Item: Record Item; Item2: Record Item)
+    var
+        BlanketPurchaseOrder: TestPage "Blanket Purchase Order";
+    begin
+        BlanketPurchaseOrder.OpenNew();
+        BlanketPurchaseOrder."Buy-from Vendor No.".SetValue(Vendor."No.");
+        BlanketPurchaseOrder.PurchLines.First();
+        BlanketPurchaseOrder.PurchLines.Type.SetValue("Purchase Line Type"::Item);
+        BlanketPurchaseOrder.PurchLines."No.".SetValue(Item."No.");
+        BlanketPurchaseOrder.PurchLines.Quantity.SetValue(LibraryRandom.RandIntInRange(3, 3));
+        Commit();
+        BlanketPurchaseOrder.PurchLines.Next();
+        BlanketPurchaseOrder.PurchLines.Next();
+        BlanketPurchaseOrder.PurchLines.Next();
+        BlanketPurchaseOrder.PurchLines.Type.SetValue("Purchase Line Type"::Item);
+        BlanketPurchaseOrder.PurchLines."No.".SetValue(Item2."No.");
+        BlanketPurchaseOrder.PurchLines.Quantity.SetValue(LibraryRandom.RandIntInRange(4, 4));
+        Commit();
+        BlanketPurchaseOrder.PurchLines.Next();
+        BlanketPurchaseOrder.Close();
     end;
 
     local procedure Initialize()

--- a/src/Layers/NA/BaseApp/Purchases/Document/BlanketPurchOrdertoOrder.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Purchases/Document/BlanketPurchOrdertoOrder.Codeunit.al
@@ -101,6 +101,7 @@ codeunit 97 "Blanket Purch. Order to Order"
                         PurchOrderLine."Shortcut Dimension 2 Code" := PurchBlanketOrderLine."Shortcut Dimension 2 Code";
                         PurchOrderLine."Dimension Set ID" := PurchBlanketOrderLine."Dimension Set ID";
                         PurchOrderLine.DefaultDeferralCode();
+                        RemapAttachedToLineNo(PurchBlanketOrderLine, PurchOrderLine);
                         if IsPurchOrderLineToBeInserted(PurchOrderLine) then begin
                             OnBeforeInsertPurchOrderLine(PurchOrderLine, PurchOrderHeader, PurchBlanketOrderLine, Rec);
                             PurchOrderLine.Insert();
@@ -329,6 +330,23 @@ codeunit 97 "Blanket Purch. Order to Order"
         exit(
           AttachedToPurchaseLine.Get(
             PurchOrderLine."Document Type", PurchOrderLine."Document No.", PurchOrderLine."Attached to Line No."));
+    end;
+
+    local procedure RemapAttachedToLineNo(PurchBlanketOrderLine: Record "Purchase Line"; var PurchOrderLine: Record "Purchase Line")
+    var
+        ParentPurchaseLine: Record "Purchase Line";
+    begin
+        if PurchOrderLine."Attached to Line No." = 0 then
+            exit;
+
+        ParentPurchaseLine.SetCurrentKey("Document Type", "Blanket Order No.", "Blanket Order Line No.");
+        ParentPurchaseLine.SetLoadFields("Line No.");
+        ParentPurchaseLine.SetRange("Document Type", PurchOrderLine."Document Type");
+        ParentPurchaseLine.SetRange("Document No.", PurchOrderLine."Document No.");
+        ParentPurchaseLine.SetRange("Blanket Order No.", PurchBlanketOrderLine."Document No.");
+        ParentPurchaseLine.SetRange("Blanket Order Line No.", PurchBlanketOrderLine."Attached to Line No.");
+        if ParentPurchaseLine.FindFirst() then
+            PurchOrderLine."Attached to Line No." := ParentPurchaseLine."Line No.";
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/NA/Tests/ERM/ERMPurchaseBlanketOrder.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM/ERMPurchaseBlanketOrder.Codeunit.al
@@ -35,6 +35,7 @@ codeunit 134326 "ERM Purchase Blanket Order"
         PayToAddressFieldsNotEditableErr: Label 'Pay-to address fields should not be editable.';
         PayToAddressFieldsEditableErr: Label 'Pay-to address fields should be editable.';
         DirectCostIsChangedErr: Label 'Direct Cost is changed on Quantity update.';
+        WrongAttachedExtTextCountErr: Label 'Purchase Order must contain 2 extended-text lines attached to item %1 (order line no %2).', Comment = '%1 = Item No.; %2 = Purchase Order Line No.';
 
     [Test]
     [Scope('OnPrem')]
@@ -1431,6 +1432,106 @@ codeunit 134326 "ERM Purchase Blanket Order"
 
         // [THEN] Verify Unit Cost is not changed if Purchase Order is related to Blanket Purchase Order
         Assert.IsTrue(PurchaseLine."Direct Unit Cost" = DirectCost, DirectCostIsChangedErr);
+    end;
+
+    [Test]
+    procedure ExtendedTextStaysAttachedToParentOnOrderWhenMakingOrderWithMultipleItems()
+    var
+        Vendor: Record Vendor;
+        Item: array[2] of Record Item;
+        BlanketPurchaseHeader: Record "Purchase Header";
+        OrderItemLine: Record "Purchase Line";
+        OrderAttachedLine: Record "Purchase Line";
+        NotificationLifecycleMgt: Codeunit "Notification Lifecycle Mgt.";
+        OrderNo: Code[20];
+        i: Integer;
+    begin
+        // [SCENARIO 640321] Each item's extended-text lines on the new purchase order must be attached to that
+        //                 item's order line, not to the blanket parent line, even when multiple items have extended texts.
+        Initialize();
+
+        // [GIVEN] Two items, each with two extended texts.
+        CreateItemWithTwoExtendedTexts(Item[1]);
+        CreateItemWithTwoExtendedTexts(Item[2]);
+
+        // [GIVEN] A vendor.
+        LibraryPurchase.CreateVendor(Vendor);
+
+        // [GIVEN] A blanket purchase order with both items (auto-inserts the extended texts).
+        CreateBlanketPurchaseOrder(Vendor, Item[1], Item[2]);
+
+        // [GIVEN] Find the blanket purchase header.
+        BlanketPurchaseHeader.SetRange("Document Type", BlanketPurchaseHeader."Document Type"::"Blanket Order");
+        BlanketPurchaseHeader.SetRange("Buy-from Vendor No.", Vendor."No.");
+        BlanketPurchaseHeader.FindFirst();
+
+        // [WHEN] Make Order is run.
+        OrderNo := LibraryPurchase.BlanketPurchaseOrderMakeOrder(BlanketPurchaseHeader);
+
+        // [THEN] Each item on the new order has two extended-text lines attached to its order line no.
+        for i := 1 to 2 do begin
+            OrderItemLine.Reset();
+            OrderItemLine.SetRange("Document Type", OrderItemLine."Document Type"::Order);
+            OrderItemLine.SetRange("Document No.", OrderNo);
+            OrderItemLine.SetRange("No.", Item[i]."No.");
+            OrderItemLine.FindFirst();
+
+            OrderAttachedLine.Reset();
+            OrderAttachedLine.SetRange("Document Type", OrderAttachedLine."Document Type"::Order);
+            OrderAttachedLine.SetRange("Document No.", OrderNo);
+            OrderAttachedLine.SetRange("Attached to Line No.", OrderItemLine."Line No.");
+            Assert.AreEqual(
+                2,
+                OrderAttachedLine.Count(),
+                StrSubstNo(WrongAttachedExtTextCountErr, Item[i]."No.", OrderItemLine."Line No."));
+        end;
+
+        NotificationLifecycleMgt.RecallAllNotifications();
+    end;
+
+    local procedure CreateItemWithTwoExtendedTexts(var Item: Record Item)
+    var
+        ExtendedTextHeader: Record "Extended Text Header";
+        ExtendedTextLine: array[2] of Record "Extended Text Line";
+    begin
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Automatic Ext. Texts", true);
+        Item.Modify(true);
+
+        LibraryInventory.CreateExtendedTextHeaderItem(ExtendedTextHeader, Item."No.");
+        ExtendedTextHeader.Validate("Purchase Blanket Order", true);
+        ExtendedTextHeader.Validate("Purchase Order", true);
+        ExtendedTextHeader.Modify(true);
+
+        LibraryInventory.CreateExtendedTextLineItem(ExtendedTextLine[1], ExtendedTextHeader);
+        ExtendedTextLine[1].Validate(Text, LibraryUtility.GenerateRandomText(MaxStrLen(Item."No.")));
+        ExtendedTextLine[1].Modify(true);
+
+        LibraryInventory.CreateExtendedTextLineItem(ExtendedTextLine[2], ExtendedTextHeader);
+        ExtendedTextLine[2].Validate(Text, LibraryUtility.GenerateRandomText(MaxStrLen(Item."No.")));
+        ExtendedTextLine[2].Modify(true);
+    end;
+
+    local procedure CreateBlanketPurchaseOrder(Vendor: Record Vendor; Item: Record Item; Item2: Record Item)
+    var
+        BlanketPurchaseOrder: TestPage "Blanket Purchase Order";
+    begin
+        BlanketPurchaseOrder.OpenNew();
+        BlanketPurchaseOrder."Buy-from Vendor No.".SetValue(Vendor."No.");
+        BlanketPurchaseOrder.PurchLines.First();
+        BlanketPurchaseOrder.PurchLines.Type.SetValue("Purchase Line Type"::Item);
+        BlanketPurchaseOrder.PurchLines."No.".SetValue(Item."No.");
+        BlanketPurchaseOrder.PurchLines.Quantity.SetValue(LibraryRandom.RandIntInRange(3, 3));
+        Commit();
+        BlanketPurchaseOrder.PurchLines.Next();
+        BlanketPurchaseOrder.PurchLines.Next();
+        BlanketPurchaseOrder.PurchLines.Next();
+        BlanketPurchaseOrder.PurchLines.Type.SetValue("Purchase Line Type"::Item);
+        BlanketPurchaseOrder.PurchLines."No.".SetValue(Item2."No.");
+        BlanketPurchaseOrder.PurchLines.Quantity.SetValue(LibraryRandom.RandIntInRange(4, 4));
+        Commit();
+        BlanketPurchaseOrder.PurchLines.Next();
+        BlanketPurchaseOrder.Close();
     end;
 
     local procedure Initialize()

--- a/src/Layers/W1/BaseApp/Purchases/Document/BlanketPurchOrdertoOrder.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/BlanketPurchOrdertoOrder.Codeunit.al
@@ -101,6 +101,7 @@ codeunit 97 "Blanket Purch. Order to Order"
                         PurchOrderLine."Shortcut Dimension 2 Code" := PurchBlanketOrderLine."Shortcut Dimension 2 Code";
                         PurchOrderLine."Dimension Set ID" := PurchBlanketOrderLine."Dimension Set ID";
                         PurchOrderLine.DefaultDeferralCode();
+                        RemapAttachedToLineNo(PurchBlanketOrderLine, PurchOrderLine);
                         if IsPurchOrderLineToBeInserted(PurchOrderLine) then begin
                             OnBeforeInsertPurchOrderLine(PurchOrderLine, PurchOrderHeader, PurchBlanketOrderLine, Rec);
                             PurchOrderLine.Insert();
@@ -327,6 +328,23 @@ codeunit 97 "Blanket Purch. Order to Order"
         exit(
           AttachedToPurchaseLine.Get(
             PurchOrderLine."Document Type", PurchOrderLine."Document No.", PurchOrderLine."Attached to Line No."));
+    end;
+
+    local procedure RemapAttachedToLineNo(PurchBlanketOrderLine: Record "Purchase Line"; var PurchOrderLine: Record "Purchase Line")
+    var
+        ParentPurchaseLine: Record "Purchase Line";
+    begin
+        if PurchOrderLine."Attached to Line No." = 0 then
+            exit;
+
+        ParentPurchaseLine.SetCurrentKey("Document Type", "Blanket Order No.", "Blanket Order Line No.");
+        ParentPurchaseLine.SetLoadFields("Line No.");
+        ParentPurchaseLine.SetRange("Document Type", PurchOrderLine."Document Type");
+        ParentPurchaseLine.SetRange("Document No.", PurchOrderLine."Document No.");
+        ParentPurchaseLine.SetRange("Blanket Order No.", PurchBlanketOrderLine."Document No.");
+        ParentPurchaseLine.SetRange("Blanket Order Line No.", PurchBlanketOrderLine."Attached to Line No.");
+        if ParentPurchaseLine.FindFirst() then
+            PurchOrderLine."Attached to Line No." := ParentPurchaseLine."Line No.";
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/W1/Tests/ERM/ERMPurchaseBlanketOrder.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMPurchaseBlanketOrder.Codeunit.al
@@ -35,6 +35,7 @@ codeunit 134326 "ERM Purchase Blanket Order"
         PayToAddressFieldsNotEditableErr: Label 'Pay-to address fields should not be editable.';
         PayToAddressFieldsEditableErr: Label 'Pay-to address fields should be editable.';
         DirectCostIsChangedErr: Label 'Direct Cost is changed on Quantity update.';
+        WrongAttachedExtTextCountErr: Label 'Purchase Order must contain 2 extended-text lines attached to item %1 (order line no %2).', Comment = '%1 = Item No.; %2 = Purchase Order Line No.';
 
     [Test]
     [Scope('OnPrem')]
@@ -1447,6 +1448,106 @@ codeunit 134326 "ERM Purchase Blanket Order"
 
         // [THEN] Verify Unit Cost is not changed if Purchase Order is related to Blanket Purchase Order
         Assert.IsTrue(PurchaseLine."Direct Unit Cost" = DirectCost, DirectCostIsChangedErr);
+    end;
+
+    [Test]
+    procedure ExtendedTextStaysAttachedToParentOnOrderWhenMakingOrderWithMultipleItems()
+    var
+        Vendor: Record Vendor;
+        Item: array[2] of Record Item;
+        BlanketPurchaseHeader: Record "Purchase Header";
+        OrderItemLine: Record "Purchase Line";
+        OrderAttachedLine: Record "Purchase Line";
+        NotificationLifecycleMgt: Codeunit "Notification Lifecycle Mgt.";
+        OrderNo: Code[20];
+        i: Integer;
+    begin
+        // [SCENARIO 640321] Each item's extended-text lines on the new purchase order must be attached to that
+        //                 item's order line, not to the blanket parent line, even when multiple items have extended texts.
+        Initialize();
+
+        // [GIVEN] Two items, each with two extended texts.
+        CreateItemWithTwoExtendedTexts(Item[1]);
+        CreateItemWithTwoExtendedTexts(Item[2]);
+
+        // [GIVEN] A vendor.
+        LibraryPurchase.CreateVendor(Vendor);
+
+        // [GIVEN] A blanket purchase order with both items (auto-inserts the extended texts).
+        CreateBlanketPurchaseOrder(Vendor, Item[1], Item[2]);
+
+        // [GIVEN] Find the blanket purchase header.
+        BlanketPurchaseHeader.SetRange("Document Type", BlanketPurchaseHeader."Document Type"::"Blanket Order");
+        BlanketPurchaseHeader.SetRange("Buy-from Vendor No.", Vendor."No.");
+        BlanketPurchaseHeader.FindFirst();
+
+        // [WHEN] Make Order is run.
+        OrderNo := LibraryPurchase.BlanketPurchaseOrderMakeOrder(BlanketPurchaseHeader);
+
+        // [THEN] Each item on the new order has two extended-text lines attached to its order line no.
+        for i := 1 to 2 do begin
+            OrderItemLine.Reset();
+            OrderItemLine.SetRange("Document Type", OrderItemLine."Document Type"::Order);
+            OrderItemLine.SetRange("Document No.", OrderNo);
+            OrderItemLine.SetRange("No.", Item[i]."No.");
+            OrderItemLine.FindFirst();
+
+            OrderAttachedLine.Reset();
+            OrderAttachedLine.SetRange("Document Type", OrderAttachedLine."Document Type"::Order);
+            OrderAttachedLine.SetRange("Document No.", OrderNo);
+            OrderAttachedLine.SetRange("Attached to Line No.", OrderItemLine."Line No.");
+            Assert.AreEqual(
+                2,
+                OrderAttachedLine.Count(),
+                StrSubstNo(WrongAttachedExtTextCountErr, Item[i]."No.", OrderItemLine."Line No."));
+        end;
+
+        NotificationLifecycleMgt.RecallAllNotifications();
+    end;
+
+    local procedure CreateItemWithTwoExtendedTexts(var Item: Record Item)
+    var
+        ExtendedTextHeader: Record "Extended Text Header";
+        ExtendedTextLine: array[2] of Record "Extended Text Line";
+    begin
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Automatic Ext. Texts", true);
+        Item.Modify(true);
+
+        LibraryInventory.CreateExtendedTextHeaderItem(ExtendedTextHeader, Item."No.");
+        ExtendedTextHeader.Validate("Purchase Blanket Order", true);
+        ExtendedTextHeader.Validate("Purchase Order", true);
+        ExtendedTextHeader.Modify(true);
+
+        LibraryInventory.CreateExtendedTextLineItem(ExtendedTextLine[1], ExtendedTextHeader);
+        ExtendedTextLine[1].Validate(Text, LibraryUtility.GenerateRandomText(MaxStrLen(Item."No.")));
+        ExtendedTextLine[1].Modify(true);
+
+        LibraryInventory.CreateExtendedTextLineItem(ExtendedTextLine[2], ExtendedTextHeader);
+        ExtendedTextLine[2].Validate(Text, LibraryUtility.GenerateRandomText(MaxStrLen(Item."No.")));
+        ExtendedTextLine[2].Modify(true);
+    end;
+
+    local procedure CreateBlanketPurchaseOrder(Vendor: Record Vendor; Item: Record Item; Item2: Record Item)
+    var
+        BlanketPurchaseOrder: TestPage "Blanket Purchase Order";
+    begin
+        BlanketPurchaseOrder.OpenNew();
+        BlanketPurchaseOrder."Buy-from Vendor No.".SetValue(Vendor."No.");
+        BlanketPurchaseOrder.PurchLines.First();
+        BlanketPurchaseOrder.PurchLines.Type.SetValue("Purchase Line Type"::Item);
+        BlanketPurchaseOrder.PurchLines."No.".SetValue(Item."No.");
+        BlanketPurchaseOrder.PurchLines.Quantity.SetValue(LibraryRandom.RandIntInRange(3, 3));
+        Commit();
+        BlanketPurchaseOrder.PurchLines.Next();
+        BlanketPurchaseOrder.PurchLines.Next();
+        BlanketPurchaseOrder.PurchLines.Next();
+        BlanketPurchaseOrder.PurchLines.Type.SetValue("Purchase Line Type"::Item);
+        BlanketPurchaseOrder.PurchLines."No.".SetValue(Item2."No.");
+        BlanketPurchaseOrder.PurchLines.Quantity.SetValue(LibraryRandom.RandIntInRange(4, 4));
+        Commit();
+        BlanketPurchaseOrder.PurchLines.Next();
+        BlanketPurchaseOrder.Close();
     end;
 
     local procedure Initialize()


### PR DESCRIPTION
Fixes [AB#640321](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640321)

Codeunit 97 copied each blanket line to the order with ``"Attached to Line No."`` still pointing at the blanket line no.; ``IsPurchOrderLineToBeInserted`` then ``Get``s that stale line no. on the new order and, when the parent item lands on a different line no., skips the extended-text line. Add ``RemapAttachedToLineNo`` (mirroring the shipped Sales-side fix) to rewrite ``"Attached to Line No."`` to the parent's new order line no. before the insert check. Adds a test. Propagated to the IT and NA layers.

