### PR TITLE
Bug 641085: Document Check factbox does not update live on Purchase Invoice/Cr.Memo/Return Order

### DIFF
--- a/src/Layers/W1/BaseApp/Utilities/DocumentErrorsMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Utilities/DocumentErrorsMgt.Codeunit.al
@@ -356,7 +356,7 @@ codeunit 9070 "Document Errors Mgt."
     begin
         if BackgroundValidationEnabled() then begin
             SetFullDocumentCheck(true);
-            GlobalPurchaseOrderPage.RunBackgroundCheck();
+            GlobalPurchaseInvoicePage.RunBackgroundCheck();
         end;
     end;
 
@@ -365,7 +365,7 @@ codeunit 9070 "Document Errors Mgt."
     begin
         if BackgroundValidationEnabled() then begin
             SetFullDocumentCheck(true);
-            GlobalPurchaseOrderPage.RunBackgroundCheck();
+            GlobalPurchaseCreditMemoPage.RunBackgroundCheck();
         end;
     end;
 
@@ -374,7 +374,7 @@ codeunit 9070 "Document Errors Mgt."
     begin
         if BackgroundValidationEnabled() then begin
             SetFullDocumentCheck(true);
-            GlobalPurchaseOrderPage.RunBackgroundCheck();
+            GlobalPurchaseReturnOrderPage.RunBackgroundCheck();
         end;
     end;
 


### PR DESCRIPTION
Fixes [AB#641085](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641085)

The subform ``OnModifyRecordEvent`` subscribers for Purchase Invoice, Purchase Credit Memo and Purchase Return Order all called ``GlobalPurchaseOrderPage.RunBackgroundCheck()`` instead of their own document's global page, so line edits never refreshed the open page's Document Check factbox (only F5 did). Point each subscriber at the matching global page, matching the already-correct Purchase Order and Sales subform handlers (three one-token fixes).

