### PR TITLE
Add shared CompanyMetadata data source for report layouts

### DIFF
--- a/src/Layers/W1/BaseApp/Foundation/Reporting/CompanyMetadataBuilder.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/CompanyMetadataBuilder.Codeunit.al
@@ -1,0 +1,189 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Foundation.Reporting;
+
+/// <summary>
+/// Builds the CompanyMetadata JSON payload the platform reads at report run time. Typed setters
+/// centralize the wire keys so the subscriber never hand-writes raw key strings (a silent key
+/// mismatch would just yield blank fields). Keys mirror the platform ReportInformationStrings and
+/// are scoped by the &lt;CompanyMetadata&gt; container emitted into BCReportInformation.
+/// </summary>
+codeunit 9666 "Company Metadata Builder"
+{
+    Access = Internal;
+
+    var
+        Payload: JsonObject;
+        AddressLines: JsonArray;
+
+    procedure SetName(Value: Text)
+    begin
+        Put('CompanyName', Value);
+    end;
+
+    procedure SetDisplayName(Value: Text)
+    begin
+        Put('CompanyDisplayName', Value);
+    end;
+
+    procedure AddAddressLine(Value: Text)
+    begin
+        // Empty lines are skipped by the platform repeater, but keep the array clean here too.
+        if Value <> '' then
+            AddressLines.Add(Value);
+    end;
+
+    procedure SetPhone(Value: Text)
+    begin
+        Put('CompanyPhone', Value);
+    end;
+
+    procedure SetPhoneCaption(Value: Text)
+    begin
+        Put('CompanyPhoneCaption', Value);
+    end;
+
+    procedure SetFaxNo(Value: Text)
+    begin
+        Put('CompanyFaxNo', Value);
+    end;
+
+    procedure SetFaxNoCaption(Value: Text)
+    begin
+        Put('CompanyFaxNoCaption', Value);
+    end;
+
+    procedure SetEmail(Value: Text)
+    begin
+        Put('CompanyEmail', Value);
+    end;
+
+    procedure SetEmailCaption(Value: Text)
+    begin
+        Put('CompanyEmailCaption', Value);
+    end;
+
+    procedure SetHomePage(Value: Text)
+    begin
+        Put('CompanyHomePage', Value);
+    end;
+
+    procedure SetHomePageCaption(Value: Text)
+    begin
+        Put('CompanyHomePageCaption', Value);
+    end;
+
+    procedure SetLogo(Base64Value: Text)
+    begin
+        Put('CompanyLogo', Base64Value);
+    end;
+
+    procedure SetVATRegistrationNo(Value: Text)
+    begin
+        Put('CompanyVATRegistrationNo', Value);
+    end;
+
+    procedure SetVATRegistrationNoCaption(Value: Text)
+    begin
+        Put('CompanyVATRegistrationNoCaption', Value);
+    end;
+
+    procedure SetRegistrationNo(Value: Text)
+    begin
+        Put('CompanyRegistrationNo', Value);
+    end;
+
+    procedure SetRegistrationNoCaption(Value: Text)
+    begin
+        Put('CompanyRegistrationNoCaption', Value);
+    end;
+
+    procedure SetBankName(Value: Text)
+    begin
+        Put('CompanyBankName', Value);
+    end;
+
+    procedure SetBankNameCaption(Value: Text)
+    begin
+        Put('CompanyBankNameCaption', Value);
+    end;
+
+    procedure SetBankAccountNo(Value: Text)
+    begin
+        Put('CompanyBankAccountNo', Value);
+    end;
+
+    procedure SetBankAccountNoCaption(Value: Text)
+    begin
+        Put('CompanyBankAccountNoCaption', Value);
+    end;
+
+    procedure SetBankBranchNo(Value: Text)
+    begin
+        Put('CompanyBankBranchNo', Value);
+    end;
+
+    procedure SetBankBranchNoCaption(Value: Text)
+    begin
+        Put('CompanyBankBranchNoCaption', Value);
+    end;
+
+    procedure SetIBAN(Value: Text)
+    begin
+        Put('CompanyIBAN', Value);
+    end;
+
+    procedure SetIBANCaption(Value: Text)
+    begin
+        Put('CompanyIBANCaption', Value);
+    end;
+
+    procedure SetBankSWIFT(Value: Text)
+    begin
+        Put('CompanyBankSWIFT', Value);
+    end;
+
+    procedure SetBankSWIFTCaption(Value: Text)
+    begin
+        Put('CompanyBankSWIFTCaption', Value);
+    end;
+
+    procedure SetGiroNo(Value: Text)
+    begin
+        Put('CompanyGiroNo', Value);
+    end;
+
+    procedure SetGiroNoCaption(Value: Text)
+    begin
+        Put('CompanyGiroNoCaption', Value);
+    end;
+
+    /// <summary>
+    /// Merges the built payload (including the address-line repeater) into the JsonObject the
+    /// platform passed to the subscriber. Modifies the passed object in place.
+    /// </summary>
+    procedure WriteTo(var CompanyMetadata: JsonObject)
+    var
+        JToken: JsonToken;
+        KeyText: Text;
+    begin
+        Payload.Add('CompanyAddressLines', AddressLines);
+        foreach KeyText in Payload.Keys() do begin
+            Payload.Get(KeyText, JToken);
+            if CompanyMetadata.Contains(KeyText) then
+                CompanyMetadata.Replace(KeyText, JToken)
+            else
+                CompanyMetadata.Add(KeyText, JToken);
+        end;
+    end;
+
+    local procedure Put(KeyText: Text; Value: Text)
+    begin
+        if Payload.Contains(KeyText) then
+            Payload.Replace(KeyText, Value)
+        else
+            Payload.Add(KeyText, Value);
+    end;
+}

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportManagement.Codeunit.al
@@ -4,10 +4,13 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Foundation.Reporting;
 
+using Microsoft.Foundation.Address;
+using Microsoft.Foundation.Company;
 using System.Device;
 using System.Environment;
 using System.Environment.Configuration;
 using System.Reflection;
+using System.Text;
 using System.Utilities;
 
 codeunit 44 ReportManagement
@@ -262,6 +265,93 @@ codeunit 44 ReportManagement
             exit;
 
         OnGetFilename(ReportID, Caption, ObjectPayload, FileExtension, ReportRecordRef, Filename, Success);
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Reporting Triggers", 'GetCompanyMetadata', '', false, false)]
+    local procedure GetCompanyMetadataSubscriber(ReportId: Integer; var CompanyMetadata: JsonObject)
+    begin
+        GetCompanyMetadata(CompanyMetadata);
+    end;
+
+    /// <summary>
+    /// Populates the shared CompanyMetadata payload from Company Information for the report layouts'
+    /// company block. Empty-safe: with no Company Information record the fields are emitted blank
+    /// rather than erroring. Localizations can add their own fields by subscribing to the platform
+    /// GetCompanyMetadata event as well (the payload is additive).
+    /// </summary>
+    procedure GetCompanyMetadata(var CompanyMetadata: JsonObject)
+    var
+        CompanyInfo: Record "Company Information";
+        FormatAddress: Codeunit "Format Address";
+        CompanyMetadataBuilder: Codeunit "Company Metadata Builder";
+        AddrArray: array[8] of Text[100];
+        Index: Integer;
+    begin
+        if not CompanyInfo.Get() then
+            CompanyInfo.Init();
+
+        CompanyMetadataBuilder.SetName(CompanyInfo.Name);
+        CompanyMetadataBuilder.SetDisplayName(GetCompanyDisplayName());
+
+        FormatAddress.Company(AddrArray, CompanyInfo);
+        for Index := 1 to ArrayLen(AddrArray) do
+            CompanyMetadataBuilder.AddAddressLine(AddrArray[Index]);
+
+        CompanyMetadataBuilder.SetPhone(CompanyInfo."Phone No.");
+        CompanyMetadataBuilder.SetPhoneCaption(CompanyInfo.FieldCaption("Phone No."));
+        CompanyMetadataBuilder.SetFaxNo(CompanyInfo."Fax No.");
+        CompanyMetadataBuilder.SetFaxNoCaption(CompanyInfo.FieldCaption("Fax No."));
+        CompanyMetadataBuilder.SetEmail(CompanyInfo."E-Mail");
+        CompanyMetadataBuilder.SetEmailCaption(CompanyInfo.FieldCaption("E-Mail"));
+        CompanyMetadataBuilder.SetHomePage(CompanyInfo."Home Page");
+        CompanyMetadataBuilder.SetHomePageCaption(CompanyInfo.FieldCaption("Home Page"));
+        CompanyMetadataBuilder.SetLogo(GetLogoBase64(CompanyInfo));
+        CompanyMetadataBuilder.SetVATRegistrationNo(CompanyInfo."VAT Registration No.");
+        CompanyMetadataBuilder.SetVATRegistrationNoCaption(CompanyInfo.FieldCaption("VAT Registration No."));
+        CompanyMetadataBuilder.SetRegistrationNo(CompanyInfo."Registration No.");
+        CompanyMetadataBuilder.SetRegistrationNoCaption(CompanyInfo.FieldCaption("Registration No."));
+        CompanyMetadataBuilder.SetBankName(CompanyInfo."Bank Name");
+        CompanyMetadataBuilder.SetBankNameCaption(CompanyInfo.FieldCaption("Bank Name"));
+        CompanyMetadataBuilder.SetBankAccountNo(CompanyInfo."Bank Account No.");
+        CompanyMetadataBuilder.SetBankAccountNoCaption(CompanyInfo.FieldCaption("Bank Account No."));
+        CompanyMetadataBuilder.SetBankBranchNo(CompanyInfo."Bank Branch No.");
+        CompanyMetadataBuilder.SetBankBranchNoCaption(CompanyInfo.FieldCaption("Bank Branch No."));
+        CompanyMetadataBuilder.SetIBAN(CompanyInfo.IBAN);
+        CompanyMetadataBuilder.SetIBANCaption(CompanyInfo.FieldCaption(IBAN));
+        CompanyMetadataBuilder.SetBankSWIFT(CompanyInfo."SWIFT Code");
+        CompanyMetadataBuilder.SetBankSWIFTCaption(CompanyInfo.FieldCaption("SWIFT Code"));
+        CompanyMetadataBuilder.SetGiroNo(CompanyInfo."Giro No.");
+        CompanyMetadataBuilder.SetGiroNoCaption(CompanyInfo.FieldCaption("Giro No."));
+
+        CompanyMetadataBuilder.WriteTo(CompanyMetadata);
+    end;
+
+    /// <summary>
+    /// Company display name, mirroring how the platform builds ReportRequest/CompanyDisplayName
+    /// (ReportRequestXmlRuntime): the tenant Company record's display name
+    /// (CompanyProperty.DisplayName() -> session.Company.CompanyDisplayName), falling back to the
+    /// company name when the display name is blank. NOT Company Information."Name 2".
+    /// </summary>
+    local procedure GetCompanyDisplayName(): Text
+    var
+        DisplayName: Text;
+    begin
+        DisplayName := CompanyProperty.DisplayName();
+        if DisplayName = '' then
+            DisplayName := CompanyName();
+        exit(DisplayName);
+    end;
+
+    local procedure GetLogoBase64(var CompanyInfo: Record "Company Information"): Text
+    var
+        Base64Convert: Codeunit "Base64 Convert";
+        InStr: InStream;
+    begin
+        CompanyInfo.CalcFields(Picture);
+        if not CompanyInfo.Picture.HasValue() then
+            exit('');
+        CompanyInfo.Picture.CreateInStream(InStr);
+        exit(Base64Convert.ToBase64(InStr));
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/W1/Tests/Report/CompanyMetadataTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/CompanyMetadataTest.Codeunit.al
@@ -1,0 +1,186 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+codeunit 139596 "Company Metadata Test"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "Library Assert";
+        Name2SentinelTxt: Label 'SENTINEL-NAME2', Locked = true;
+
+    [Test]
+    procedure PopulatesCompanyInformationValues()
+    var
+        CompanyInformation: Record "Company Information";
+        ReportManagement: Codeunit ReportManagement;
+        CompanyMetadata: JsonObject;
+    begin
+        // [SCENARIO] GetCompanyMetadata writes Company Information values under the frozen wire keys.
+        // [GIVEN] Company Information populated with known values.
+        SetCompanyInformation(CompanyInformation);
+
+        // [WHEN] The shared company metadata is built.
+        ReportManagement.GetCompanyMetadata(CompanyMetadata);
+
+        // [THEN] Each scalar value carries the Company Information value under its frozen key.
+        Assert.AreEqual(CompanyInformation.Name, GetValue(CompanyMetadata, 'CompanyName'), 'CompanyName');
+        Assert.AreEqual(CompanyInformation."Phone No.", GetValue(CompanyMetadata, 'CompanyPhone'), 'CompanyPhone');
+        Assert.AreEqual(CompanyInformation."Fax No.", GetValue(CompanyMetadata, 'CompanyFaxNo'), 'CompanyFaxNo');
+        Assert.AreEqual(CompanyInformation."E-Mail", GetValue(CompanyMetadata, 'CompanyEmail'), 'CompanyEmail');
+        Assert.AreEqual(CompanyInformation."Home Page", GetValue(CompanyMetadata, 'CompanyHomePage'), 'CompanyHomePage');
+        Assert.AreEqual(CompanyInformation."VAT Registration No.", GetValue(CompanyMetadata, 'CompanyVATRegistrationNo'), 'CompanyVATRegistrationNo');
+        Assert.AreEqual(CompanyInformation."Registration No.", GetValue(CompanyMetadata, 'CompanyRegistrationNo'), 'CompanyRegistrationNo');
+        Assert.AreEqual(CompanyInformation."Bank Name", GetValue(CompanyMetadata, 'CompanyBankName'), 'CompanyBankName');
+        Assert.AreEqual(CompanyInformation."Bank Account No.", GetValue(CompanyMetadata, 'CompanyBankAccountNo'), 'CompanyBankAccountNo');
+        Assert.AreEqual(CompanyInformation."Bank Branch No.", GetValue(CompanyMetadata, 'CompanyBankBranchNo'), 'CompanyBankBranchNo');
+        Assert.AreEqual(CompanyInformation.IBAN, GetValue(CompanyMetadata, 'CompanyIBAN'), 'CompanyIBAN');
+        Assert.AreEqual(CompanyInformation."SWIFT Code", GetValue(CompanyMetadata, 'CompanyBankSWIFT'), 'CompanyBankSWIFT');
+        Assert.AreEqual(CompanyInformation."Giro No.", GetValue(CompanyMetadata, 'CompanyGiroNo'), 'CompanyGiroNo');
+    end;
+
+    [Test]
+    procedure CaptionsMatchFieldCaptions()
+    var
+        CompanyInformation: Record "Company Information";
+        ReportManagement: Codeunit ReportManagement;
+        CompanyMetadata: JsonObject;
+    begin
+        // [SCENARIO] Each labeled value carries a paired caption sourced from the Company Information
+        // field caption (so a layout swap keeps localized labels).
+        SetCompanyInformation(CompanyInformation);
+
+        ReportManagement.GetCompanyMetadata(CompanyMetadata);
+
+        Assert.AreEqual(CompanyInformation.FieldCaption("Phone No."), GetValue(CompanyMetadata, 'CompanyPhoneCaption'), 'CompanyPhoneCaption');
+        Assert.AreEqual(CompanyInformation.FieldCaption("Fax No."), GetValue(CompanyMetadata, 'CompanyFaxNoCaption'), 'CompanyFaxNoCaption');
+        Assert.AreEqual(CompanyInformation.FieldCaption("VAT Registration No."), GetValue(CompanyMetadata, 'CompanyVATRegistrationNoCaption'), 'CompanyVATRegistrationNoCaption');
+        Assert.AreEqual(CompanyInformation.FieldCaption(IBAN), GetValue(CompanyMetadata, 'CompanyIBANCaption'), 'CompanyIBANCaption');
+        Assert.AreEqual(CompanyInformation.FieldCaption("Giro No."), GetValue(CompanyMetadata, 'CompanyGiroNoCaption'), 'CompanyGiroNoCaption');
+    end;
+
+    [Test]
+    procedure DisplayNameFromCompanyRecordNotName2()
+    var
+        CompanyInformation: Record "Company Information";
+        ReportManagement: Codeunit ReportManagement;
+        CompanyMetadata: JsonObject;
+        ExpectedDisplayName: Text;
+    begin
+        // [SCENARIO] CompanyDisplayName mirrors ReportRequest: the tenant Company record's display
+        // name (CompanyProperty.DisplayName(), fallback to CompanyName()), NOT Company Information."Name 2".
+        // [GIVEN] Company Information."Name 2" set to a distinct sentinel.
+        CompanyInformation.Get();
+        CompanyInformation."Name 2" := Name2SentinelTxt;
+        CompanyInformation.Modify();
+
+        // [WHEN] The shared company metadata is built.
+        ReportManagement.GetCompanyMetadata(CompanyMetadata);
+
+        // [THEN] DisplayName equals the Company record display name (with company-name fallback)...
+        ExpectedDisplayName := CompanyProperty.DisplayName();
+        if ExpectedDisplayName = '' then
+            ExpectedDisplayName := CompanyName();
+        Assert.AreEqual(ExpectedDisplayName, GetValue(CompanyMetadata, 'CompanyDisplayName'), 'CompanyDisplayName should come from the Company record.');
+
+        // [THEN] ...and is never the Company Information "Name 2" sentinel.
+        Assert.AreNotEqual(Name2SentinelTxt, GetValue(CompanyMetadata, 'CompanyDisplayName'), 'CompanyDisplayName must not be sourced from "Name 2".');
+    end;
+
+    [Test]
+    procedure EmptyCompanyInformationEmitsEmptyValues()
+    var
+        CompanyInformation: Record "Company Information";
+        ReportManagement: Codeunit ReportManagement;
+        CompanyMetadata: JsonObject;
+    begin
+        // [SCENARIO] Empty-safe: blank Company Information fields are emitted as present-but-empty keys
+        // rather than erroring or omitting the keys.
+        ClearCompanyInformation(CompanyInformation);
+
+        ReportManagement.GetCompanyMetadata(CompanyMetadata);
+
+        Assert.IsTrue(CompanyMetadata.Contains('CompanyBankSWIFT'), 'Key should be present even when empty.');
+        Assert.AreEqual('', GetValue(CompanyMetadata, 'CompanyBankSWIFT'), 'Empty field should emit an empty value.');
+        Assert.AreEqual('', GetValue(CompanyMetadata, 'CompanyIBAN'), 'Empty field should emit an empty value.');
+    end;
+
+    [Test]
+    procedure AddressIsArrayAndSkipsEmptyLines()
+    var
+        CompanyInformation: Record "Company Information";
+        ReportManagement: Codeunit ReportManagement;
+        CompanyMetadata: JsonObject;
+        AddressToken: JsonToken;
+        LineToken: JsonToken;
+        AddressLines: JsonArray;
+        Index: Integer;
+    begin
+        // [SCENARIO] CompanyAddressLines is a JSON array (repeater) with no empty entries.
+        SetCompanyInformation(CompanyInformation);
+
+        ReportManagement.GetCompanyMetadata(CompanyMetadata);
+
+        Assert.IsTrue(CompanyMetadata.Get('CompanyAddressLines', AddressToken), 'CompanyAddressLines key should exist.');
+        Assert.IsTrue(AddressToken.IsArray(), 'CompanyAddressLines should be a JSON array.');
+        AddressLines := AddressToken.AsArray();
+        Assert.IsTrue(AddressLines.Count() > 0, 'Address should have at least one line.');
+        for Index := 0 to AddressLines.Count() - 1 do begin
+            AddressLines.Get(Index, LineToken);
+            Assert.AreNotEqual('', LineToken.AsValue().AsText(), 'Address array should not contain empty lines.');
+        end;
+    end;
+
+    local procedure SetCompanyInformation(var CompanyInformation: Record "Company Information")
+    begin
+        // Direct assignment (not Validate) to avoid country-specific format validations on VAT/IBAN.
+        CompanyInformation.Get();
+        CompanyInformation.Name := 'CML Test Company';
+        CompanyInformation.Address := '5 The Ring';
+        CompanyInformation.City := 'London';
+        CompanyInformation."Post Code" := 'W2 8HG';
+        CompanyInformation."Phone No." := '111-222-333';
+        CompanyInformation."Fax No." := '111-222-334';
+        CompanyInformation."E-Mail" := 'test@contoso.com';
+        CompanyInformation."Home Page" := 'https://contoso.com';
+        CompanyInformation."VAT Registration No." := 'GB123456789';
+        CompanyInformation."Registration No." := 'REG-001';
+        CompanyInformation."Bank Name" := 'Test Bank';
+        CompanyInformation."Bank Account No." := '12-34-567';
+        CompanyInformation."Bank Branch No." := 'BR-99';
+        CompanyInformation.IBAN := 'GB12TEST08929965044991';
+        CompanyInformation."SWIFT Code" := 'TESTGB2L';
+        CompanyInformation."Giro No." := '888-9999';
+        CompanyInformation.Modify();
+    end;
+
+    local procedure ClearCompanyInformation(var CompanyInformation: Record "Company Information")
+    begin
+        CompanyInformation.Get();
+        CompanyInformation."Phone No." := '';
+        CompanyInformation."Fax No." := '';
+        CompanyInformation."E-Mail" := '';
+        CompanyInformation."Home Page" := '';
+        CompanyInformation."VAT Registration No." := '';
+        CompanyInformation."Registration No." := '';
+        CompanyInformation."Bank Name" := '';
+        CompanyInformation."Bank Account No." := '';
+        CompanyInformation."Bank Branch No." := '';
+        CompanyInformation.IBAN := '';
+        CompanyInformation."SWIFT Code" := '';
+        CompanyInformation."Giro No." := '';
+        CompanyInformation.Modify();
+    end;
+
+    local procedure GetValue(CompanyMetadata: JsonObject; KeyName: Text): Text
+    var
+        ValueToken: JsonToken;
+    begin
+        if not CompanyMetadata.Get(KeyName, ValueToken) then
+            Assert.Fail(StrSubstNo('CompanyMetadata is missing key %1.', KeyName));
+        exit(ValueToken.AsValue().AsText());
+    end;
+}


### PR DESCRIPTION
Adds a shared **CompanyMetadata** data source so report layouts can bind one shared company block instead of each report hand-coding Company Information fields.

### What
- `ReportManagement` subscribes to the platform `GetCompanyMetadata` business event and populates the shared company block (name, formatted address repeater, phone/fax/email/home page, bank details, VAT/registration/giro, logo) from `Company Information`.
- New `Company Metadata Builder` codeunit (`Access = Internal`): typed setters centralize the wire keys so the subscriber never hand-writes raw key strings; includes the address-line repeater and the paired field captions.
- `CompanyDisplayName` is sourced from the Company record (`CompanyProperty.DisplayName()`, falling back to `CompanyName()`) to match how the platform builds `ReportRequest` — not Company Information "Name 2".
- Empty-safe: absent Company Information fields emit present-but-empty values.
- Adds `Tests-Report` coverage for values, captions, the display-name source, empty-safe behavior, and the address repeater.

### Why draft
This consumes the `GetCompanyMetadata` business event on `Reporting Triggers`. The AL will compile in CI once BCApps uptakes a BCPlatform build that includes that event (current pin `29.0.51074.0` predates it). Kept as a draft until the platform uptake lands so the AL can be reviewed in the meantime.