### PR TITLE
Align Bill-to Name 2 editability with the other bill-to address fields on sales documents

### DIFF
--- a/src/Layers/APAC/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
+++ b/src/Layers/APAC/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
@@ -627,8 +627,8 @@ page 507 "Blanket Sales Order"
                         {
                             ApplicationArea = Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/APAC/BaseApp/Sales/Document/SalesInvoice.Page.al
+++ b/src/Layers/APAC/BaseApp/Sales/Document/SalesInvoice.Page.al
@@ -817,8 +817,8 @@ page 43 "Sales Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/BE/BaseApp/Sales/Document/SalesInvoice.Page.al
+++ b/src/Layers/BE/BaseApp/Sales/Document/SalesInvoice.Page.al
@@ -823,8 +823,8 @@ page 43 "Sales Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/BE/BaseApp/Sales/Document/SalesOrder.Page.al
+++ b/src/Layers/BE/BaseApp/Sales/Document/SalesOrder.Page.al
@@ -838,8 +838,8 @@ page 42 "Sales Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/CH/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
+++ b/src/Layers/CH/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
@@ -663,8 +663,8 @@ page 507 "Blanket Sales Order"
                         {
                             ApplicationArea = Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/CH/BaseApp/Sales/Document/SalesInvoice.Page.al
+++ b/src/Layers/CH/BaseApp/Sales/Document/SalesInvoice.Page.al
@@ -817,8 +817,8 @@ page 43 "Sales Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/CH/BaseApp/Sales/Document/SalesOrder.Page.al
+++ b/src/Layers/CH/BaseApp/Sales/Document/SalesOrder.Page.al
@@ -833,8 +833,8 @@ page 42 "Sales Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/CH/BaseApp/Sales/Document/SalesQuote.Page.al
+++ b/src/Layers/CH/BaseApp/Sales/Document/SalesQuote.Page.al
@@ -797,8 +797,8 @@ page 41 "Sales Quote"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/ES/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
+++ b/src/Layers/ES/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
@@ -638,8 +638,8 @@ page 507 "Blanket Sales Order"
                         {
                             ApplicationArea = Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/ES/BaseApp/Sales/Document/SalesInvoice.Page.al
+++ b/src/Layers/ES/BaseApp/Sales/Document/SalesInvoice.Page.al
@@ -845,8 +845,8 @@ page 43 "Sales Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/ES/BaseApp/Sales/Document/SalesOrder.Page.al
+++ b/src/Layers/ES/BaseApp/Sales/Document/SalesOrder.Page.al
@@ -844,8 +844,8 @@ page 42 "Sales Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/ES/BaseApp/Sales/Document/SalesQuote.Page.al
+++ b/src/Layers/ES/BaseApp/Sales/Document/SalesQuote.Page.al
@@ -810,8 +810,8 @@ page 41 "Sales Quote"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/FR/BaseApp/Sales/Document/SalesInvoice.Page.al
+++ b/src/Layers/FR/BaseApp/Sales/Document/SalesInvoice.Page.al
@@ -822,8 +822,8 @@ page 43 "Sales Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/FR/BaseApp/Sales/Document/SalesOrder.Page.al
+++ b/src/Layers/FR/BaseApp/Sales/Document/SalesOrder.Page.al
@@ -838,8 +838,8 @@ page 42 "Sales Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/GB/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
+++ b/src/Layers/GB/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
@@ -629,8 +629,8 @@ page 507 "Blanket Sales Order"
                         {
                             ApplicationArea = Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/IT/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
+++ b/src/Layers/IT/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
@@ -668,8 +668,8 @@ page 507 "Blanket Sales Order"
                         {
                             ApplicationArea = Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/IT/BaseApp/Sales/Document/SalesInvoice.Page.al
+++ b/src/Layers/IT/BaseApp/Sales/Document/SalesInvoice.Page.al
@@ -887,8 +887,8 @@ page 43 "Sales Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/IT/BaseApp/Sales/Document/SalesOrder.Page.al
+++ b/src/Layers/IT/BaseApp/Sales/Document/SalesOrder.Page.al
@@ -916,8 +916,8 @@ page 42 "Sales Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/IT/BaseApp/Sales/Document/SalesQuote.Page.al
+++ b/src/Layers/IT/BaseApp/Sales/Document/SalesQuote.Page.al
@@ -806,8 +806,8 @@ page 41 "Sales Quote"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NA/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
+++ b/src/Layers/NA/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
@@ -638,8 +638,8 @@ page 507 "Blanket Sales Order"
                         {
                             ApplicationArea = Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NA/BaseApp/Sales/Document/SalesInvoice.Page.al
+++ b/src/Layers/NA/BaseApp/Sales/Document/SalesInvoice.Page.al
@@ -874,8 +874,8 @@ page 43 "Sales Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NA/BaseApp/Sales/Document/SalesOrder.Page.al
+++ b/src/Layers/NA/BaseApp/Sales/Document/SalesOrder.Page.al
@@ -891,8 +891,8 @@ page 42 "Sales Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NA/BaseApp/Sales/Document/SalesQuote.Page.al
+++ b/src/Layers/NA/BaseApp/Sales/Document/SalesQuote.Page.al
@@ -803,8 +803,8 @@ page 41 "Sales Quote"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NL/BaseApp/Sales/Document/SalesInvoice.Page.al
+++ b/src/Layers/NL/BaseApp/Sales/Document/SalesInvoice.Page.al
@@ -827,8 +827,8 @@ page 43 "Sales Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NL/BaseApp/Sales/Document/SalesOrder.Page.al
+++ b/src/Layers/NL/BaseApp/Sales/Document/SalesOrder.Page.al
@@ -842,8 +842,8 @@ page 42 "Sales Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NL/BaseApp/Sales/Document/SalesQuote.Page.al
+++ b/src/Layers/NL/BaseApp/Sales/Document/SalesQuote.Page.al
@@ -807,8 +807,8 @@ page 41 "Sales Quote"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NO/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
+++ b/src/Layers/NO/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
@@ -673,8 +673,8 @@ page 507 "Blanket Sales Order"
                         {
                             ApplicationArea = Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NO/BaseApp/Sales/Document/SalesInvoice.Page.al
+++ b/src/Layers/NO/BaseApp/Sales/Document/SalesInvoice.Page.al
@@ -821,8 +821,8 @@ page 43 "Sales Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NO/BaseApp/Sales/Document/SalesOrder.Page.al
+++ b/src/Layers/NO/BaseApp/Sales/Document/SalesOrder.Page.al
@@ -833,8 +833,8 @@ page 42 "Sales Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/RU/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
+++ b/src/Layers/RU/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
@@ -671,8 +671,8 @@ page 507 "Blanket Sales Order"
                         {
                             ApplicationArea = Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/RU/BaseApp/Sales/Document/SalesInvoice.Page.al
+++ b/src/Layers/RU/BaseApp/Sales/Document/SalesInvoice.Page.al
@@ -842,8 +842,8 @@ page 43 "Sales Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/RU/BaseApp/Sales/Document/SalesOrder.Page.al
+++ b/src/Layers/RU/BaseApp/Sales/Document/SalesOrder.Page.al
@@ -866,8 +866,8 @@ page 42 "Sales Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/RU/BaseApp/Sales/Document/SalesQuote.Page.al
+++ b/src/Layers/RU/BaseApp/Sales/Document/SalesQuote.Page.al
@@ -807,8 +807,8 @@ page 41 "Sales Quote"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/W1/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/BlanketSalesOrder.Page.al
@@ -663,8 +663,8 @@ page 507 "Blanket Sales Order"
                         {
                             ApplicationArea = Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/W1/BaseApp/Sales/Document/SalesInvoice.Page.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/SalesInvoice.Page.al
@@ -817,8 +817,8 @@ page 43 "Sales Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/W1/BaseApp/Sales/Document/SalesOrder.Page.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/SalesOrder.Page.al
@@ -832,8 +832,8 @@ page 42 "Sales Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = (BillToOptions = BillToOptions::"Another Customer");
-                            Enabled = (BillToOptions = BillToOptions::"Another Customer");
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/W1/BaseApp/Sales/Document/SalesQuote.Page.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/SalesQuote.Page.al
@@ -797,8 +797,8 @@ page 41 "Sales Quote"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = BillToOptions = BillToOptions::"Another Customer";
-                            Enabled = BillToOptions = BillToOptions::"Another Customer";
+                            Editable = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
+                            Enabled = (BillToOptions = BillToOptions::"Custom Address") or (Rec."Bill-to Customer No." <> Rec."Sell-to Customer No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/W1/Tests/Misc/UTPageActionsControls.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/UTPageActionsControls.Codeunit.al
@@ -3406,7 +3406,8 @@ codeunit 134341 "UT Page Actions & Controls"
 
         // [THEN] Bill-to address fields are editable, and "Bill-to Name" field is not
         Assert.IsFalse(SalesQuotePage."Bill-to Name".Editable(), '');
-        Assert.IsTrue(SalesQuotePage."Bill-to Address".Editable() and
+        Assert.IsTrue(SalesQuotePage."Bill-to Name 2".Editable() and
+          SalesQuotePage."Bill-to Address".Editable() and
           SalesQuotePage."Bill-to Address 2".Editable() and
           SalesQuotePage."Bill-to City".Editable() and
           SalesQuotePage."Bill-to County".Editable() and
@@ -3437,7 +3438,8 @@ codeunit 134341 "UT Page Actions & Controls"
 
         // [THEN] Bill-to address fields are editable, and "Bill-to Name" field is not
         Assert.IsFalse(SalesOrderPage."Bill-to Name".Editable(), '');
-        Assert.IsTrue(SalesOrderPage."Bill-to Address".Editable() and
+        Assert.IsTrue(SalesOrderPage."Bill-to Name 2".Editable() and
+          SalesOrderPage."Bill-to Address".Editable() and
           SalesOrderPage."Bill-to Address 2".Editable() and
           SalesOrderPage."Bill-to City".Editable() and
           SalesOrderPage."Bill-to County".Editable() and
@@ -3468,7 +3470,8 @@ codeunit 134341 "UT Page Actions & Controls"
 
         // [THEN] Bill-to address fields are editable, and "Bill-to Name" field is not
         Assert.IsFalse(SalesInvoicePage."Bill-to Name".Editable(), '');
-        Assert.IsTrue(SalesInvoicePage."Bill-to Address".Editable() and
+        Assert.IsTrue(SalesInvoicePage."Bill-to Name 2".Editable() and
+          SalesInvoicePage."Bill-to Address".Editable() and
           SalesInvoicePage."Bill-to Address 2".Editable() and
           SalesInvoicePage."Bill-to City".Editable() and
           SalesInvoicePage."Bill-to County".Editable() and
@@ -3500,7 +3503,8 @@ codeunit 134341 "UT Page Actions & Controls"
 
         // [THEN] Bill-to address fields are editable, and "Bill-to Name" field is not
         Assert.IsFalse(BlanketSalesOrderPage."Bill-to Name".Editable(), '');
-        Assert.IsTrue(BlanketSalesOrderPage."Bill-to Address".Editable() and
+        Assert.IsTrue(BlanketSalesOrderPage."Bill-to Name 2".Editable() and
+          BlanketSalesOrderPage."Bill-to Address".Editable() and
           BlanketSalesOrderPage."Bill-to Address 2".Editable() and
           BlanketSalesOrderPage."Bill-to City".Editable() and
           BlanketSalesOrderPage."Bill-to Post Code".Editable() and

--- a/src/Layers/W1/Tests/Misc/UTPageActionsControls.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/UTPageActionsControls.Codeunit.al
@@ -3407,6 +3407,7 @@ codeunit 134341 "UT Page Actions & Controls"
         // [THEN] Bill-to address fields are editable, and "Bill-to Name" field is not
         Assert.IsFalse(SalesQuotePage."Bill-to Name".Editable(), '');
         Assert.IsTrue(SalesQuotePage."Bill-to Name 2".Editable() and
+          SalesQuotePage."Bill-to Name 2".Enabled() and
           SalesQuotePage."Bill-to Address".Editable() and
           SalesQuotePage."Bill-to Address 2".Editable() and
           SalesQuotePage."Bill-to City".Editable() and
@@ -3439,6 +3440,7 @@ codeunit 134341 "UT Page Actions & Controls"
         // [THEN] Bill-to address fields are editable, and "Bill-to Name" field is not
         Assert.IsFalse(SalesOrderPage."Bill-to Name".Editable(), '');
         Assert.IsTrue(SalesOrderPage."Bill-to Name 2".Editable() and
+          SalesOrderPage."Bill-to Name 2".Enabled() and
           SalesOrderPage."Bill-to Address".Editable() and
           SalesOrderPage."Bill-to Address 2".Editable() and
           SalesOrderPage."Bill-to City".Editable() and
@@ -3471,6 +3473,7 @@ codeunit 134341 "UT Page Actions & Controls"
         // [THEN] Bill-to address fields are editable, and "Bill-to Name" field is not
         Assert.IsFalse(SalesInvoicePage."Bill-to Name".Editable(), '');
         Assert.IsTrue(SalesInvoicePage."Bill-to Name 2".Editable() and
+          SalesInvoicePage."Bill-to Name 2".Enabled() and
           SalesInvoicePage."Bill-to Address".Editable() and
           SalesInvoicePage."Bill-to Address 2".Editable() and
           SalesInvoicePage."Bill-to City".Editable() and
@@ -3504,6 +3507,7 @@ codeunit 134341 "UT Page Actions & Controls"
         // [THEN] Bill-to address fields are editable, and "Bill-to Name" field is not
         Assert.IsFalse(BlanketSalesOrderPage."Bill-to Name".Editable(), '');
         Assert.IsTrue(BlanketSalesOrderPage."Bill-to Name 2".Editable() and
+          BlanketSalesOrderPage."Bill-to Name 2".Enabled() and
           BlanketSalesOrderPage."Bill-to Address".Editable() and
           BlanketSalesOrderPage."Bill-to Address 2".Editable() and
           BlanketSalesOrderPage."Bill-to City".Editable() and


### PR DESCRIPTION
## What & why

On the Sales Order, Sales Quote, Blanket Sales Order, and Sales Invoice pages, "Bill-to Name 2" is only editable when the Bill-to option is "Another Customer". Every other field in the bill-to address group (Address, Address 2, City, County, Post Code, Country/Region Code, Contact No., Contact) is editable when "Custom Address" is selected or when the bill-to customer differs from the sell-to customer. As noted in the issue triage, the field was simply missed when that editability logic was applied to the group.

This change gives "Bill-to Name 2" the same Editable and Enabled expression as the rest of the group on those four pages. The country layers that carry copies of these pages (APAC, BE, CH, ES, FR, GB, IT, NA, NL, NO, RU) receive the identical two-property change, following the established practice of propagating W1 fixes to the localization layers.

## Linked work

Fixes #8312
[AB#647616](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647616)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Extended the four existing bill-to editability tests (CustomAddressBillToOptionOnSalesQuotePage, ...SalesOrderPage, ...SalesInvoicePage, ...SalesBlanketOrderPage in UTPageActionsControls.Codeunit.al) so they now also assert that "Bill-to Name 2" is editable when "Custom Address" is selected, alongside the sibling address fields they already cover.
- Verified that every page copy across the localization layers received the identical two-line change and nothing else (the diff is uniform, and byte order marks and line endings of the touched files are preserved).
- Confirmed on the Sales Header table that "Bill-to Name 2" (field 6) is a plain text field with no OnValidate logic and no table relation, so widening its page editability has no side effects beyond allowing input.
- I did not build the Base Application locally; the change is limited to two page control properties per page, replicating the exact expression already used by all sibling fields, and relies on the extended test coverage in CI.

## Risk & compatibility

- The Sales Credit Memo and Sales Return Order pages are intentionally not touched: they have no BillToOptions control, which the triage comment on the issue asks to track as a separate item.
- The purchase documents have the same inconsistency on "Pay-to Name 2" (Purchase Quote, Purchase Order, Purchase Invoice). That is deliberately out of scope here and will be reported as its own issue.
- No breaking changes: no object signatures, events, or table schema are affected.




