### PR TITLE
[master] - NewPosting service order without External document no. will copy the 'Service Order No.' to GL entries

### DIFF
--- a/src/Layers/ES/BaseApp/Service/Posting/ServDocumentsMgt.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Service/Posting/ServDocumentsMgt.Codeunit.al
@@ -932,7 +932,7 @@ codeunit 5988 "Serv-Documents Mgt."
         end;
 
         UseAsExternalDocumentNo := ServInvHeader."External Document No.";
-        if UseAsExternalDocumentNo = '' then
+        if (UseAsExternalDocumentNo = '') and ServMgtSetup."Ext. Doc. No. Mandatory" then
             UseAsExternalDocumentNo := ServHeader."No.";
         SetGenJnlLineDocNos(GenJnlLineDocType::Invoice, ServInvHeader."No.", UseAsExternalDocumentNo);
 
@@ -997,7 +997,7 @@ codeunit 5988 "Serv-Documents Mgt."
         ServLogMgt.ServCrMemoPost(ServHeader."No.", ServCrMemoHeader."No.");
 
         UseAsExternalDocumentNo := ServCrMemoHeader."External Document No.";
-        if UseAsExternalDocumentNo = '' then
+        if (UseAsExternalDocumentNo = '') and ServMgtSetup."Ext. Doc. No. Mandatory" then
             UseAsExternalDocumentNo := ServHeader."No.";
         SetGenJnlLineDocNos(GenJnlLineDocType::"Credit Memo", ServCrMemoHeader."No.", UseAsExternalDocumentNo);
 

--- a/src/Layers/IT/BaseApp/Service/Posting/ServDocumentsMgt.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Service/Posting/ServDocumentsMgt.Codeunit.al
@@ -989,7 +989,7 @@ codeunit 5988 "Serv-Documents Mgt."
         end;
 
         UseAsExternalDocumentNo := ServInvHeader."External Document No.";
-        if UseAsExternalDocumentNo = '' then
+        if (UseAsExternalDocumentNo = '') and ServMgtSetup."Ext. Doc. No. Mandatory" then
             UseAsExternalDocumentNo := ServHeader."No.";
         SetGenJnlLineDocNos(GenJnlLineDocType::Invoice, ServInvHeader."No.", UseAsExternalDocumentNo);
 
@@ -1054,7 +1054,7 @@ codeunit 5988 "Serv-Documents Mgt."
         ServLogMgt.ServCrMemoPost(ServHeader."No.", ServCrMemoHeader."No.");
 
         UseAsExternalDocumentNo := ServCrMemoHeader."External Document No.";
-        if UseAsExternalDocumentNo = '' then
+        if (UseAsExternalDocumentNo = '') and ServMgtSetup."Ext. Doc. No. Mandatory" then
             UseAsExternalDocumentNo := ServHeader."No.";
         SetGenJnlLineDocNos(GenJnlLineDocType::"Credit Memo", ServCrMemoHeader."No.", UseAsExternalDocumentNo);
 

--- a/src/Layers/NA/BaseApp/Service/Posting/ServDocumentsMgt.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Service/Posting/ServDocumentsMgt.Codeunit.al
@@ -932,7 +932,7 @@ codeunit 5988 "Serv-Documents Mgt."
         end;
 
         UseAsExternalDocumentNo := ServInvHeader."External Document No.";
-        if UseAsExternalDocumentNo = '' then
+        if (UseAsExternalDocumentNo = '') and ServMgtSetup."Ext. Doc. No. Mandatory" then
             UseAsExternalDocumentNo := ServHeader."No.";
         SetGenJnlLineDocNos(GenJnlLineDocType::Invoice, ServInvHeader."No.", UseAsExternalDocumentNo);
 
@@ -997,7 +997,7 @@ codeunit 5988 "Serv-Documents Mgt."
         ServLogMgt.ServCrMemoPost(ServHeader."No.", ServCrMemoHeader."No.");
 
         UseAsExternalDocumentNo := ServCrMemoHeader."External Document No.";
-        if UseAsExternalDocumentNo = '' then
+        if (UseAsExternalDocumentNo = '') and ServMgtSetup."Ext. Doc. No. Mandatory" then
             UseAsExternalDocumentNo := ServHeader."No.";
         SetGenJnlLineDocNos(GenJnlLineDocType::"Credit Memo", ServCrMemoHeader."No.", UseAsExternalDocumentNo);
 

--- a/src/Layers/NA/Tests/SCM-Service/ServicePostingInvoice.Codeunit.al
+++ b/src/Layers/NA/Tests/SCM-Service/ServicePostingInvoice.Codeunit.al
@@ -2656,10 +2656,10 @@ codeunit 136108 "Service Posting - Invoice"
         // [WHEN] Service invoice is being posted
         LibraryService.PostServiceOrder(ServiceHeader, true, false, true);
 
-        // [THEN] Created customer ledger entry has External Document No. = ServiceHeader."No."
+        // [THEN] Created customer ledger entry has External Document No. = ''
         CustLedgerEntry.SetRange("Customer No.", CustomerNo);
         CustLedgerEntry.FindFirst();
-        CustLedgerEntry.TestField("External Document No.", ServiceHeader."No.");
+        CustLedgerEntry.TestField("External Document No.", '');
     end;
 
     [Test]
@@ -3220,6 +3220,51 @@ codeunit 136108 "Service Posting - Invoice"
 
         // Cleanup
         ActivityLog.DeleteAll();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PostServiceOrderWithoutExternalDocNoLeavesGLEntriesBlank()
+    var
+        ServiceHeader: Record "Service Header";
+        ServiceItemLine: Record "Service Item Line";
+        ServiceLine: Record "Service Line";
+        ServiceItem: Record "Service Item";
+        ServiceInvoiceHeader: Record "Service Invoice Header";
+        GLEntry: Record "G/L Entry";
+        Customer: Record Customer;
+        ServiceMgtSetup: Record "Service Mgt. Setup";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638182] GL entries have blank External Document No. when service order is posted without External Document No.
+        Initialize();
+
+        // [GIVEN] Service Mgt. Setup with "Ext. Doc. No. Mandatory" disabled
+        ServiceMgtSetup.Get();
+        ServiceMgtSetup.Validate("Ext. Doc. No. Mandatory", false);
+        ServiceMgtSetup.Modify(true);
+
+        // [GIVEN] Service Order "SO" for Customer "C" with blank External Document No.
+        LibrarySales.CreateCustomer(Customer);
+        LibraryService.CreateServiceItem(ServiceItem, Customer."No.");
+        LibraryService.CreateServiceHeader(ServiceHeader, ServiceHeader."Document Type"::Order, Customer."No.");
+        LibraryService.CreateServiceItemLine(ServiceItemLine, ServiceHeader, ServiceItem."No.");
+        CreateServiceLineWithItem(ServiceLine, ServiceHeader, ServiceItem."No.");
+        ServiceHeader.Validate("External Document No.", '');
+        ServiceHeader.Modify(true);
+
+        // [WHEN] Post service order with Ship and Invoice
+        LibraryService.PostServiceOrder(ServiceHeader, true, false, true);
+
+        // [THEN] GL entries for posted service invoice have blank External Document No.
+        ServiceInvoiceHeader.SetRange("Order No.", ServiceHeader."No.");
+        ServiceInvoiceHeader.FindFirst();
+        GLEntry.SetRange("Document Type", GLEntry."Document Type"::Invoice);
+        GLEntry.SetRange("Document No.", ServiceInvoiceHeader."No.");
+        GLEntry.FindSet();
+        repeat
+            Assert.AreEqual('', GLEntry."External Document No.", 'External Document No. should be blank on G/L Entry when not specified on Service Order');
+        until GLEntry.Next() = 0;
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Service-Post", OnSetCommitBehavior, '', false, false)]

--- a/src/Layers/W1/BaseApp/Service/Posting/ServDocumentsMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Service/Posting/ServDocumentsMgt.Codeunit.al
@@ -932,7 +932,7 @@ codeunit 5988 "Serv-Documents Mgt."
         end;
 
         UseAsExternalDocumentNo := ServInvHeader."External Document No.";
-        if UseAsExternalDocumentNo = '' then
+        if (UseAsExternalDocumentNo = '') and ServMgtSetup."Ext. Doc. No. Mandatory" then
             UseAsExternalDocumentNo := ServHeader."No.";
         SetGenJnlLineDocNos(GenJnlLineDocType::Invoice, ServInvHeader."No.", UseAsExternalDocumentNo);
 
@@ -997,7 +997,7 @@ codeunit 5988 "Serv-Documents Mgt."
         ServLogMgt.ServCrMemoPost(ServHeader."No.", ServCrMemoHeader."No.");
 
         UseAsExternalDocumentNo := ServCrMemoHeader."External Document No.";
-        if UseAsExternalDocumentNo = '' then
+        if (UseAsExternalDocumentNo = '') and ServMgtSetup."Ext. Doc. No. Mandatory" then
             UseAsExternalDocumentNo := ServHeader."No.";
         SetGenJnlLineDocNos(GenJnlLineDocType::"Credit Memo", ServCrMemoHeader."No.", UseAsExternalDocumentNo);
 

--- a/src/Layers/W1/Tests/SCM-Service/ServicePostingInvoice.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Service/ServicePostingInvoice.Codeunit.al
@@ -2656,10 +2656,10 @@ codeunit 136108 "Service Posting - Invoice"
         // [WHEN] Service invoice is being posted
         LibraryService.PostServiceOrder(ServiceHeader, true, false, true);
 
-        // [THEN] Created customer ledger entry has External Document No. = ServiceHeader."No."
+        // [THEN] Created customer ledger entry has External Document No. = ''
         CustLedgerEntry.SetRange("Customer No.", CustomerNo);
         CustLedgerEntry.FindFirst();
-        CustLedgerEntry.TestField("External Document No.", ServiceHeader."No.");
+        CustLedgerEntry.TestField("External Document No.", '');
     end;
 
     [Test]
@@ -3173,6 +3173,51 @@ codeunit 136108 "Service Posting - Invoice"
 
         // Cleanup
         ActivityLog.DeleteAll();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PostServiceOrderWithoutExternalDocNoLeavesGLEntriesBlank()
+    var
+        ServiceHeader: Record "Service Header";
+        ServiceItemLine: Record "Service Item Line";
+        ServiceLine: Record "Service Line";
+        ServiceItem: Record "Service Item";
+        ServiceInvoiceHeader: Record "Service Invoice Header";
+        GLEntry: Record "G/L Entry";
+        Customer: Record Customer;
+        ServiceMgtSetup: Record "Service Mgt. Setup";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638182] GL entries have blank External Document No. when service order is posted without External Document No.
+        Initialize();
+
+        // [GIVEN] Service Mgt. Setup with "Ext. Doc. No. Mandatory" disabled
+        ServiceMgtSetup.Get();
+        ServiceMgtSetup.Validate("Ext. Doc. No. Mandatory", false);
+        ServiceMgtSetup.Modify(true);
+
+        // [GIVEN] Service Order "SO" for Customer "C" with blank External Document No.
+        LibrarySales.CreateCustomer(Customer);
+        LibraryService.CreateServiceItem(ServiceItem, Customer."No.");
+        LibraryService.CreateServiceHeader(ServiceHeader, ServiceHeader."Document Type"::Order, Customer."No.");
+        LibraryService.CreateServiceItemLine(ServiceItemLine, ServiceHeader, ServiceItem."No.");
+        CreateServiceLineWithItem(ServiceLine, ServiceHeader, ServiceItem."No.");
+        ServiceHeader.Validate("External Document No.", '');
+        ServiceHeader.Modify(true);
+
+        // [WHEN] Post service order with Ship and Invoice
+        LibraryService.PostServiceOrder(ServiceHeader, true, false, true);
+
+        // [THEN] GL entries for posted service invoice have blank External Document No.
+        ServiceInvoiceHeader.SetRange("Order No.", ServiceHeader."No.");
+        ServiceInvoiceHeader.FindFirst();
+        GLEntry.SetRange("Document Type", GLEntry."Document Type"::Invoice);
+        GLEntry.SetRange("Document No.", ServiceInvoiceHeader."No.");
+        GLEntry.FindSet();
+        repeat
+            Assert.AreEqual('', GLEntry."External Document No.", 'External Document No. should be blank on G/L Entry when not specified on Service Order');
+        until GLEntry.Next() = 0;
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Service-Post", OnSetCommitBehavior, '', false, false)]


### PR DESCRIPTION
[Bug 638670](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/638670): [master][ALL-E] Posting service order without External document no. will copy the 'Service Order No.' to GL entries

Fixes [AB#638670](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638670)




