### PR TITLE
[Shopify] Add Transactions navigation action to Shopify Refund page

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order Refunds/Pages/ShpfyRefund.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/Pages/ShpfyRefund.Page.al
@@ -192,10 +192,21 @@ page 30145 "Shpfy Refund"
                 RunObject = Page "Shpfy Refund Shipping Lines";
                 RunPageLink = "Refund Id" = field("Refund Id");
             }
+            action(Transactions)
+            {
+                ApplicationArea = All;
+                Caption = 'Transactions';
+                Image = Payment;
+                ToolTip = 'View the transactions created for this refund that results in exchange of money.';
+                RunObject = Page "Shpfy Order Transactions";
+                RunPageLink = "Refund Id" = field("Refund Id");
+                RunPageMode = View;
+            }
         }
         area(Promoted)
         {
             actionref(PromotedShippingLines; ShippingLines) { }
+            actionref(PromotedTransactions; Transactions) { }
             actionref(PromotedCreateCreditNoted; CreateCreditMemo) { }
             actionref(PromotedRetrievedShopifyData; RetrievedShopifyData) { }
         }


### PR DESCRIPTION
Fixes [AB#640429](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640429)

## Summary

The Shopify Order page (30118) has a **Transactions** navigation action that opens `Shpfy Order Transactions`, but the Shopify Refund page (30145) had no equivalent action, even though the data connection already exists.

The `Shpfy Order Transaction` table already has a `Refund Id` field (field 26) that is populated by `ShpfyRefundsAPI.UpdateTransactions()` during refund sync, so transactions linked to a specific refund are already identifiable.

## Changes

- Added a **Transactions** action to the Navigation area of the Shopify Refund page that opens `Shpfy Order Transactions` filtered by `Refund Id`.
- Added a matching promoted `actionref`, consistent with the page's other promoted actions.

This provides parity with the Shopify Order page for reviewing payment transactions associated with a refund.

