### PR TITLE
Aligining Library Assert and Assert library

### DIFF
--- a/src/Layers/W1/Tests/ApplicationTestLibrary/Assert.Codeunit.al
+++ b/src/Layers/W1/Tests/ApplicationTestLibrary/Assert.Codeunit.al
@@ -1,3 +1,5 @@
+using System.TestLibraries.Utilities;
+
 /// <summary>
 /// Provides assertion functions for verifying test conditions and comparing expected versus actual values in test scenarios.
 /// </summary>
@@ -20,13 +22,7 @@ codeunit 130000 Assert
         TableIsEmptyErr: Label 'Assert.TableIsEmpty failed. Table <%1> with filter <%2> must not contain records.', Locked = true;
         TableIsNotEmptyErr: Label 'Assert.TableIsNotEmpty failed. Table <%1> with filter <%2> must contain records.', Locked = true;
         ExpectedErrorFailed: Label 'Assert.ExpectedError failed. Expected: %1. Actual: %2.';
-        ExpectedTestFieldFailedErr: Label 'Assert.ExpectedError failed. Could not find the value: %1 in the raised error text: %2.';
-        WrongErrorCodeErr: Label 'Assert.ExpectedErrorCode failed. Error code raised: %1. Actual error message: %2.', Comment = '%1 - Error code that was raised. %2 - Error message reported.', Locked = true;
         ExpectedErrorCodeFailed: Label 'Assert.ExpectedErrorCode failed. Expected: %1. Actual: %2. Actual error message: %3.';
-        ExpectedMessageFailedErr: Label 'Assert.ExpectedMessage failed. Expected: %1. Actual: %2.';
-        ExpectedConfirmFailedErr: Label 'Assert.ExpectedConfirm failed. Expected: %1. Actual: %2.';
-        ExpectedStrMenuInstructionFailedErr: Label 'Assert.ExpectedStrMenu failed. Expected instruction: %1. Actual instruction: %2.';
-        ExpectedStrMenuOptionsFailedErr: Label 'Assert.ExpectedStrMenu failed. Expected options: %1. Actual options: %2.';
         IsSubstringFailedErr: Label 'Assert.IsSubstring failed. Expected <%1> to be a substring of <%2>.';
         RecordCountErr: Label 'Assert.RecordCount failed. Expected number of %1 entries: %2. Actual: %3. Filters: %4.', Locked = true;
         RecordCountWithListErr: Label 'Assert.RecordCount failed. Expected number of %1 entries: %2. Actual: %3. Filters: %4. Records: %5', Locked = true;
@@ -40,19 +36,7 @@ codeunit 130000 Assert
         ErrorHasNotBeenThrownErr: Label 'The error has not been thrown.';
         TextEndsWithErr: Label 'Assert.TextEndsWith failed. The text <%1> must end with <%2>';
         TextEndSubstringIsBlankErr: Label 'Substring must not be blank.';
-        TestFieldFormat1Tok: Label ' must be ';
-        TestFieldFormat1Part2Tok: Label 'Currently it''s';
-        TestFieldFormat2Tok: Label ' must have a value in ';
-        TestFieldFormat2Part2Tok: Label 'It can''t be zero or empty.';
-        TestFieldFormat3Tok: Label ' can''t be ';
-        //CantFindTok: Label 'Can''t find ';
-        TestFieldValidationCodeTxt: Label 'TestValidation';
-        NCLCSRTSTableErrorStrTxt: Label 'NCLCSRTS:TableErrorStr';
-        TestWrappedTxt: Label 'TestWrapped';
-        TestWrappedCSideRecordNotFoundTxt: Label 'TestWrapped:CSideRecordNotFound';
-        TestFieldCodeTxt: Label 'TestField';
-        DialogTxt: Label 'Dialog';
-        ErrorMessageIsNotMatchingExpectedErrorFormatErr: Label 'Assert.ExpectedError failed. The error message is not matching the expected error format. Error message: %1', Comment = '%1 error message that was raised.';
+        LibraryAssert: Codeunit "Library Assert";
 
     procedure IsTrue(Condition: Boolean; Msg: Text)
     begin
@@ -195,156 +179,66 @@ codeunit 130000 Assert
     end;
 
     /// <summary>
-    /// Checks for the field error that it cannot find the record
+    /// Verifies that the last error thrown is a "cannot find record" error for the given table.
+    /// Use this instead of <see cref="ExpectedError"/> for record-not-found failures: it asserts on the
+    /// error code and table caption rather than the full error text, so the test stays resilient and keeps
+    /// passing when the underlying error label wording changes.
     /// </summary>
-    /// Old formats: The {0} does not exist. Identification fields and values: {1}.  
-    /// New format:  Can't find {0} in {1}.
-    /// <param name="TableID">Table ID Raising the erro</param>
+    /// <param name="TableID">Table ID raising the error</param>
     procedure ExpectedErrorCannotFind(TableID: Integer)
     begin
-        ExpectedErrorCannotFind(TableID, '');
+        LibraryAssert.ExpectedErrorCannotFind(TableID);
     end;
 
     /// <summary>
-    /// Checks for the field error that it cannot find the record
+    /// Verifies that the last error thrown is a "cannot find record" error for the given table.
+    /// Use this instead of <see cref="ExpectedError"/> for record-not-found failures: it asserts on the
+    /// error code and table caption rather than the full error text, so the test stays resilient and keeps
+    /// passing when the underlying error label wording changes.
     /// </summary>
-    /// Old formats: The {0} does not exist. Identification fields and values: {1}.  
-    /// New format:  Can't find {0} in {1}.
-    /// <param name="TableID">Table ID Raising the erro</param>
+    /// <param name="TableID">Table ID raising the error</param>
     /// <param name="RecordIndentificationText">Identification text of the record that it cannot find</param>
     procedure ExpectedErrorCannotFind(TableID: Integer; RecordIndentificationText: Text)
-    var
-        LastErrorText: Text;
-        LastErrorCode: Text;
     begin
-        LastErrorText := GetLastErrorText();
-        if (GetLastErrorText() = '') then
-            if GetLastErrorCallStack() = '' then
-                Error(ErrorHasNotBeenThrownErr);
-
-        LastErrorCode := GetLastErrorCode();
-        if (LastErrorCode <> RecordNotFoundErrorCode) and
-           (LastErrorCode <> PrimRecordNotFoundErrorCode) and
-           (LastErrorCode <> TestWrappedCSideRecordNotFoundTxt) and
-           (not LastErrorCode.Contains(TestFieldValidationCodeTxt))
-        then
-            Error(WrongErrorCodeErr, LastErrorCode, LastErrorText);
-
-        ExpectedMessageCannotFind(LastErrorText, TableID, RecordIndentificationText);
+        LibraryAssert.ExpectedErrorCannotFind(TableID, RecordIndentificationText);
     end;
 
     procedure ExpectedMessageCannotFind(LastErrorText: Text; TableID: Integer; RecordIndentificationText: Text)
-    var
-        AllObjWithCaption: Record AllObjWithCaption;
-        TableCaption: Text;
-        IsCantFindError: Boolean;
     begin
-        AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Table);
-        AllObjWithCaption.SetRange("Object ID", TableID);
-        AllObjWithCaption.FindFirst();
-        TableCaption := AllObjWithCaption."Object Caption";
-
-        IsCantFindError := true;
-        if not IsCantFindError then
-            Error(ErrorMessageIsNotMatchingExpectedErrorFormatErr, LastErrorText);
-
-        if TableCaption <> '' then
-            if StrPos(LastErrorText, TableCaption) = 0 then
-                Error(ExpectedTestFieldFailedErr, TableCaption, LastErrorText);
-
-        if RecordIndentificationText <> '' then
-            if StrPos(LastErrorText, RecordIndentificationText) = 0 then
-                Error(ExpectedTestFieldFailedErr, TableCaption, LastErrorText);
+        LibraryAssert.ExpectedMessageCannotFind(LastErrorText, TableID, RecordIndentificationText);
     end;
 
     /// <summary>
-    /// Checks for the test filed errors. 
-    /// Old formats: {0} must not be {1} in {2} {3}.
-    ///              {0} must have a value in {1}: {2}. It cannot be zero or empty.
-    ///              {0} must be equal to “{2}” in {1}: {4}. Current value is “{3}”.    
-    /// New format:  {0} can’t be {1} in {2}.
-    ///              {0} must have a value in {1}: {2}. It can’t be zero or empty. 
-    ///              {0} must be {2} for {1}: {4}. Currently it’s {3}.
+    /// Verifies that the last error thrown is a TestField/Validate error for the given field.
+    /// Use this instead of <see cref="ExpectedError"/> for TestField and Validate failures: it asserts on the
+    /// error code and field caption/value rather than the full error text, so the test stays resilient and
+    /// keeps passing when the underlying error label wording changes.
     /// </summary>
     /// <param name="FieldCaptionTested">Name of the field raising the error</param>
     /// <param name="ExpectedValue">Expected value in the error message</param>
     procedure ExpectedTestFieldError(FieldCaptionTested: Text; ExpectedValue: Text)
     begin
-        ExpectedTestFieldError(FieldCaptionTested, ExpectedValue, '', '');
+        LibraryAssert.ExpectedTestFieldError(FieldCaptionTested, ExpectedValue);
     end;
 
     /// <summary>
-    /// Checks for the test filed errors. 
-    /// New format:  {0} can’t be {1} in {2}.
-    ///              {0} must have a value in {1}: {2}. It can’t be zero or empty. 
-    ///              {0} must be {2} for {1}: {4}. Currently it’s {3}.
-    /// Old formats: {0} must not be {1} in {2} {3}.
-    ///              {0} must have a value in {1}: {2}. It cannot be zero or empty.
-    ///              {0} must be equal to “{2}” in {1}: {4}. Current value is “{3}”.
+    /// Verifies that the last error thrown is a TestField/Validate error for the given field.
+    /// Use this instead of <see cref="ExpectedError"/> for TestField and Validate failures: it asserts on the
+    /// error code and field caption/value rather than the full error text, so the test stays resilient and
+    /// keeps passing when the underlying error label wording changes.
     /// </summary>
     /// <param name="FieldCaptionTested">Name of the field raising the error</param>
     /// <param name="ExpectedValue">Expected value in the error message</param>
     /// <param name="ActualValue">Actual value in the error message</param>
     /// <param name="TableCaptionTested">Name of the table raising the error</param>
     procedure ExpectedTestFieldError(FieldCaptionTested: Text; ExpectedValue: Text; ActualValue: Text; TableCaptionTested: Text)
-    var
-        LastErrorText: Text;
-        LastErrorCode: Text;
     begin
-        LastErrorText := GetLastErrorText();
-        if (GetLastErrorText() = '') then
-            if GetLastErrorCallStack() = '' then
-                Error(ErrorHasNotBeenThrownErr);
-
-        LastErrorCode := GetLastErrorCode();
-        if not (LastErrorCode.Contains(TestFieldValidationCodeTxt) or
-               (LastErrorCode in [NCLCSRTSTableErrorStrTxt, TestWrappedTxt]) or
-               (LastErrorCode.Contains(TestFieldCodeTxt)) or
-               (LastErrorCode.Contains(DialogTxt)))
-        then
-            Error(WrongErrorCodeErr, LastErrorCode, LastErrorText);
-
-        ExpectedTestFieldMessage(LastErrorText, FieldCaptionTested, ExpectedValue, ActualValue, TableCaptionTested);
+        LibraryAssert.ExpectedTestFieldError(FieldCaptionTested, ExpectedValue, ActualValue, TableCaptionTested);
     end;
 
     procedure ExpectedTestFieldMessage(LastErrorText: Text; FieldCaptionTested: Text; ExpectedValue: Text; ActualValue: Text; TableCaptionTested: Text)
-    var
-        IsTestFieldError: Boolean;
     begin
-        if ExpectedValue <> '' then
-            if StrPos(LastErrorText, ExpectedValue) = 0 then
-                Error(ExpectedTestFieldFailedErr, ExpectedValue, LastErrorText);
-
-        if ActualValue <> '' then
-            if StrPos(LastErrorText, ActualValue) = 0 then
-                Error(ExpectedTestFieldFailedErr, ActualValue, LastErrorText);
-
-        if FieldCaptionTested <> '' then
-            if StrPos(LastErrorText, FieldCaptionTested) = 0 then
-                Error(ExpectedTestFieldFailedErr, FieldCaptionTested, LastErrorText);
-
-        if TableCaptionTested <> '' then
-            if StrPos(LastErrorText, TableCaptionTested) = 0 then
-                Error(ExpectedTestFieldFailedErr, TableCaptionTested, LastErrorText);
-
-        IsTestFieldError := true;
-
-        if not IsTestFieldError then
-            Error(ErrorMessageIsNotMatchingExpectedErrorFormatErr, LastErrorText);
-    end;
-
-    internal procedure MatchesTestFieldMessageFormat(ErrorMessage: Text): Boolean
-    begin
-        if (StrPos(ErrorMessage, TestFieldFormat1Tok) > 0) and (StrPos(ErrorMessage, TestFieldFormat1Part2Tok) > 0) then
-            exit(true);
-
-        if (StrPos(ErrorMessage, TestFieldFormat2Tok) > 0) and (StrPos(ErrorMessage, TestFieldFormat2Part2Tok) > 0) then
-            exit(true);
-
-        if StrPos(ErrorMessage, TestFieldFormat3Tok) > 0 then
-            exit(true);
-
-        exit(false);
+        LibraryAssert.ExpectedTestFieldMessage(LastErrorText, FieldCaptionTested, ExpectedValue, ActualValue, TableCaptionTested);
     end;
 
     procedure ExpectedErrorCode(Expected: Text)
@@ -355,26 +249,17 @@ codeunit 130000 Assert
 
     procedure ExpectedMessage(Expected: Text; Actual: Text)
     begin
-        ExpectedDialog(Expected, Actual, ExpectedMessageFailedErr);
+        LibraryAssert.ExpectedMessage(Expected, Actual);
     end;
 
     procedure ExpectedConfirm(Expected: Text; Actual: Text)
     begin
-        ExpectedDialog(Expected, Actual, ExpectedConfirmFailedErr);
+        LibraryAssert.ExpectedConfirm(Expected, Actual);
     end;
 
     procedure ExpectedStrMenu(ExpectedInstruction: Text; ExpectedOptions: Text; ActualInstruction: Text; ActualOptions: Text)
     begin
-        ExpectedDialog(ExpectedInstruction, ActualInstruction, ExpectedStrMenuInstructionFailedErr);
-        ExpectedDialog(ExpectedOptions, ActualOptions, ExpectedStrMenuOptionsFailedErr);
-    end;
-
-    local procedure ExpectedDialog(Expected: Text; Actual: Text; ErrorMessage: Text)
-    begin
-        if Expected = Actual then
-            exit;
-        if StrPos(Actual, Expected) = 0 then
-            Error(ErrorMessage, Expected, Actual);
+        LibraryAssert.ExpectedStrMenu(ExpectedInstruction, ExpectedOptions, ActualInstruction, ActualOptions);
     end;
 
     procedure IsDataTypeSupported(Value: Variant): Boolean

--- a/src/Layers/W1/Tests/ApplicationTestLibrary/Assert.Codeunit.al
+++ b/src/Layers/W1/Tests/ApplicationTestLibrary/Assert.Codeunit.al
@@ -1,5 +1,3 @@
-using System.TestLibraries.Utilities;
-
 /// <summary>
 /// Provides assertion functions for verifying test conditions and comparing expected versus actual values in test scenarios.
 /// </summary>

--- a/src/Tools/Test Framework/Test Libraries/Assert/src/LibraryAssert.Codeunit.al
+++ b/src/Tools/Test Framework/Test Libraries/Assert/src/LibraryAssert.Codeunit.al
@@ -393,6 +393,16 @@ codeunit 130002 "Library Assert"
         ExpectedTestFieldMessage(LastErrorText, FieldCaptionTested, ExpectedValue, ActualValue, TableCaptionTested);
     end;
 
+    /// <summary>
+    /// Verifies that the given error text is a TestField/Validate error containing the expected field caption and values.
+    /// Asserts on the field caption/value substrings in the error text rather than the full message, so the test stays
+    /// resilient and keeps passing when the underlying error label wording changes.
+    /// </summary>
+    /// <param name="LastErrorText">The error text to verify (typically the value of GetLastErrorText).</param>
+    /// <param name="FieldCaptionTested">Name of the field raising the error</param>
+    /// <param name="ExpectedValue">Expected value in the error message</param>
+    /// <param name="ActualValue">Actual value in the error message</param>
+    /// <param name="TableCaptionTested">Name of the table raising the error</param>
     procedure ExpectedTestFieldMessage(LastErrorText: Text; FieldCaptionTested: Text; ExpectedValue: Text; ActualValue: Text; TableCaptionTested: Text)
     var
         IsTestFieldError: Boolean;
@@ -477,6 +487,14 @@ codeunit 130002 "Library Assert"
         ExpectedMessageCannotFind(LastErrorText, TableID, RecordIndentificationText);
     end;
 
+    /// <summary>
+    /// Verifies that the given error text is a "cannot find record" error containing the table caption and record identification.
+    /// Asserts on the table caption/record identification substrings in the error text rather than the full message, so the test
+    /// stays resilient and keeps passing when the underlying error label wording changes.
+    /// </summary>
+    /// <param name="LastErrorText">The error text to verify (typically the value of GetLastErrorText).</param>
+    /// <param name="TableID">Table ID raising the error</param>
+    /// <param name="RecordIndentificationText">Identification text of the record that it cannot find</param>
     procedure ExpectedMessageCannotFind(LastErrorText: Text; TableID: Integer; RecordIndentificationText: Text)
     var
         AllObjWithCaption: Record AllObjWithCaption;

--- a/src/Tools/Test Framework/Test Libraries/Assert/src/LibraryAssert.Codeunit.al
+++ b/src/Tools/Test Framework/Test Libraries/Assert/src/LibraryAssert.Codeunit.al
@@ -31,6 +31,9 @@ codeunit 130002 "Library Assert"
         ExpectedErrorFailedErr: Label 'Assert.ExpectedError failed. Expected: %1. Actual: %2.', Locked = true;
         ExpectedErrorCodeFailedErr: Label 'Assert.ExpectedErrorCode failed. Expected: %1. Actual: %2. Actual error message: %3.', Locked = true;
         ExpectedMessageFailedErr: Label 'Assert.ExpectedMessage failed. Expected: %1. Actual: %2.', Locked = true;
+        ExpectedConfirmFailedErr: Label 'Assert.ExpectedConfirm failed. Expected: %1. Actual: %2.', Locked = true;
+        ExpectedStrMenuInstructionFailedErr: Label 'Assert.ExpectedStrMenu failed. Expected instruction: %1. Actual instruction: %2.', Locked = true;
+        ExpectedStrMenuOptionsFailedErr: Label 'Assert.ExpectedStrMenu failed. Expected options: %1. Actual options: %2.', Locked = true;
         RecordCountErr: Label 'Assert.RecordCount failed. Expected number of %1 entries: %2. Actual: %3.', Locked = true;
         UnsupportedTypeErr: Label 'Equality assertions only support Boolean, Option, Integer, BigInteger, Decimal, Code, Text, Date, DateFormula, Time, Duration, and DateTime values. Current value:%1.', Locked = true;
         RecordNotFoundTok: Label 'DB:RecordNotFound';
@@ -43,6 +46,20 @@ codeunit 130002 "Library Assert"
         DictionaryDifferentSizeErr: Label 'Sizes of dictionaries do not match. Expected: %1, Actual: %2.', Locked = true;
         MissingKeyErr: Label 'Key %1 is missing from the actual dictionary.', Locked = true;
         DifferentKeyValueErr: Label 'Values for key %1 do not match. Expected: %2. Actual: %3.', Locked = true;
+        ExpectedTestFieldFailedErr: Label 'Assert.ExpectedError failed. Could not find the value: %1 in the raised error text: %2.', Locked = true;
+        WrongErrorCodeErr: Label 'Assert.ExpectedErrorCode failed. Error code raised: %1. Actual error message: %2.', Comment = '%1 - Error code that was raised. %2 - Error message reported.', Locked = true;
+        ErrorMessageIsNotMatchingExpectedErrorFormatErr: Label 'Assert.ExpectedError failed. The error message is not matching the expected error format. Error message: %1', Comment = '%1 error message that was raised.', Locked = true;
+        TestFieldValidationCodeTxt: Label 'TestValidation', Locked = true;
+        NCLCSRTSTableErrorStrTxt: Label 'NCLCSRTS:TableErrorStr', Locked = true;
+        TestWrappedTxt: Label 'TestWrapped', Locked = true;
+        TestWrappedCSideRecordNotFoundTxt: Label 'TestWrapped:CSideRecordNotFound', Locked = true;
+        TestFieldCodeTxt: Label 'TestField', Locked = true;
+        DialogTxt: Label 'Dialog', Locked = true;
+        TestFieldFormat1Tok: Label ' must be ', Locked = true;
+        TestFieldFormat1Part2Tok: Label 'Currently it''s', Locked = true;
+        TestFieldFormat2Tok: Label ' must have a value in ', Locked = true;
+        TestFieldFormat2Part2Tok: Label 'It can''t be zero or empty.', Locked = true;
+        TestFieldFormat3Tok: Label ' can''t be ', Locked = true;
 
     /// <summary>
     /// Tests whether the specified condition is true and throws an exception if the condition is false.
@@ -296,8 +313,187 @@ codeunit 130002 "Library Assert"
     /// <param name="Actual">The second value to compare. This is the value produced by the code under test.</param>
     procedure ExpectedMessage(Expected: Text; Actual: Text)
     begin
+        ExpectedDialog(Expected, Actual, ExpectedMessageFailedErr);
+    end;
+
+    /// <summary>
+    /// Tests that the Expected confirm matches the Actual confirm
+    /// </summary>
+    /// <param name="Expected">The expected confirm text.</param>
+    /// <param name="Actual">The actual confirm text produced by the code under test.</param>
+    procedure ExpectedConfirm(Expected: Text; Actual: Text)
+    begin
+        ExpectedDialog(Expected, Actual, ExpectedConfirmFailedErr);
+    end;
+
+    /// <summary>
+    /// Tests that the Expected StrMenu instruction and options match the Actual instruction and options
+    /// </summary>
+    /// <param name="ExpectedInstruction">The expected StrMenu instruction.</param>
+    /// <param name="ExpectedOptions">The expected StrMenu options.</param>
+    /// <param name="ActualInstruction">The actual StrMenu instruction produced by the code under test.</param>
+    /// <param name="ActualOptions">The actual StrMenu options produced by the code under test.</param>
+    procedure ExpectedStrMenu(ExpectedInstruction: Text; ExpectedOptions: Text; ActualInstruction: Text; ActualOptions: Text)
+    begin
+        ExpectedDialog(ExpectedInstruction, ActualInstruction, ExpectedStrMenuInstructionFailedErr);
+        ExpectedDialog(ExpectedOptions, ActualOptions, ExpectedStrMenuOptionsFailedErr);
+    end;
+
+    local procedure ExpectedDialog(Expected: Text; Actual: Text; ErrorMessage: Text)
+    begin
+        if Expected = Actual then
+            exit;
         if StrPos(Actual, Expected) = 0 then
-            Error(ExpectedMessageFailedErr, Expected, Actual);
+            Error(ErrorMessage, Expected, Actual);
+    end;
+
+    /// <summary>
+    /// Verifies that the last error thrown is a TestField/Validate error for the given field.
+    /// Use this instead of <see cref="ExpectedError"/> for TestField and Validate failures: it asserts on the
+    /// error code and on the field caption/value appearing in the error text, rather than on the full error
+    /// message. This makes the test resilient, so it keeps passing when the underlying error label wording
+    /// changes and protects you from having to update tests whenever a platform error message is reworded.
+    /// </summary>
+    /// <param name="FieldCaptionTested">Name of the field raising the error</param>
+    /// <param name="ExpectedValue">Expected value in the error message</param>
+    procedure ExpectedTestFieldError(FieldCaptionTested: Text; ExpectedValue: Text)
+    begin
+        ExpectedTestFieldError(FieldCaptionTested, ExpectedValue, '', '');
+    end;
+
+    /// <summary>
+    /// Verifies that the last error thrown is a TestField/Validate error for the given field.
+    /// Use this instead of <see cref="ExpectedError"/> for TestField and Validate failures: it asserts on the
+    /// error code and on the field caption/value appearing in the error text, rather than on the full error
+    /// message. This makes the test resilient, so it keeps passing when the underlying error label wording
+    /// changes and protects you from having to update tests whenever a platform error message is reworded.
+    /// </summary>
+    /// <param name="FieldCaptionTested">Name of the field raising the error</param>
+    /// <param name="ExpectedValue">Expected value in the error message</param>
+    /// <param name="ActualValue">Actual value in the error message</param>
+    /// <param name="TableCaptionTested">Name of the table raising the error</param>
+    procedure ExpectedTestFieldError(FieldCaptionTested: Text; ExpectedValue: Text; ActualValue: Text; TableCaptionTested: Text)
+    var
+        LastErrorText: Text;
+        LastErrorCode: Text;
+    begin
+        LastErrorText := GetLastErrorText();
+        if (GetLastErrorText() = '') then
+            if GetLastErrorCallStack() = '' then
+                Error(ErrorHasNotBeenThrownErr);
+
+        LastErrorCode := GetLastErrorCode();
+        if not (LastErrorCode.Contains(TestFieldValidationCodeTxt) or
+               (LastErrorCode in [NCLCSRTSTableErrorStrTxt, TestWrappedTxt]) or
+               (LastErrorCode.Contains(TestFieldCodeTxt)) or
+               (LastErrorCode.Contains(DialogTxt)))
+        then
+            Error(WrongErrorCodeErr, LastErrorCode, LastErrorText);
+
+        ExpectedTestFieldMessage(LastErrorText, FieldCaptionTested, ExpectedValue, ActualValue, TableCaptionTested);
+    end;
+
+    procedure ExpectedTestFieldMessage(LastErrorText: Text; FieldCaptionTested: Text; ExpectedValue: Text; ActualValue: Text; TableCaptionTested: Text)
+    var
+        IsTestFieldError: Boolean;
+    begin
+        if ExpectedValue <> '' then
+            if StrPos(LastErrorText, ExpectedValue) = 0 then
+                Error(ExpectedTestFieldFailedErr, ExpectedValue, LastErrorText);
+
+        if ActualValue <> '' then
+            if StrPos(LastErrorText, ActualValue) = 0 then
+                Error(ExpectedTestFieldFailedErr, ActualValue, LastErrorText);
+
+        if FieldCaptionTested <> '' then
+            if StrPos(LastErrorText, FieldCaptionTested) = 0 then
+                Error(ExpectedTestFieldFailedErr, FieldCaptionTested, LastErrorText);
+
+        if TableCaptionTested <> '' then
+            if StrPos(LastErrorText, TableCaptionTested) = 0 then
+                Error(ExpectedTestFieldFailedErr, TableCaptionTested, LastErrorText);
+
+        IsTestFieldError := true;
+
+        if not IsTestFieldError then
+            Error(ErrorMessageIsNotMatchingExpectedErrorFormatErr, LastErrorText);
+    end;
+
+    internal procedure MatchesTestFieldMessageFormat(ErrorMessage: Text): Boolean
+    begin
+        if (StrPos(ErrorMessage, TestFieldFormat1Tok) > 0) and (StrPos(ErrorMessage, TestFieldFormat1Part2Tok) > 0) then
+            exit(true);
+
+        if (StrPos(ErrorMessage, TestFieldFormat2Tok) > 0) and (StrPos(ErrorMessage, TestFieldFormat2Part2Tok) > 0) then
+            exit(true);
+
+        if StrPos(ErrorMessage, TestFieldFormat3Tok) > 0 then
+            exit(true);
+
+        exit(false);
+    end;
+
+    /// <summary>
+    /// Verifies that the last error thrown is a "cannot find record" error for the given table.
+    /// Use this instead of <see cref="ExpectedError"/> for record-not-found failures: it asserts on the
+    /// error code and on the table caption appearing in the error text, rather than on the full error
+    /// message. This makes the test resilient, so it keeps passing when the underlying error label wording
+    /// changes and protects you from having to update tests whenever a platform error message is reworded.
+    /// </summary>
+    /// <param name="TableID">Table ID raising the error</param>
+    procedure ExpectedErrorCannotFind(TableID: Integer)
+    begin
+        ExpectedErrorCannotFind(TableID, '');
+    end;
+
+    /// <summary>
+    /// Verifies that the last error thrown is a "cannot find record" error for the given table.
+    /// Use this instead of <see cref="ExpectedError"/> for record-not-found failures: it asserts on the
+    /// error code and on the table caption/record identification appearing in the error text, rather than on
+    /// the full error message. This makes the test resilient, so it keeps passing when the underlying error
+    /// label wording changes and protects you from having to update tests whenever a platform error message
+    /// is reworded.
+    /// </summary>
+    /// <param name="TableID">Table ID raising the error</param>
+    /// <param name="RecordIndentificationText">Identification text of the record that it cannot find</param>
+    procedure ExpectedErrorCannotFind(TableID: Integer; RecordIndentificationText: Text)
+    var
+        LastErrorText: Text;
+        LastErrorCode: Text;
+    begin
+        LastErrorText := GetLastErrorText();
+        if (GetLastErrorText() = '') then
+            if GetLastErrorCallStack() = '' then
+                Error(ErrorHasNotBeenThrownErr);
+
+        LastErrorCode := GetLastErrorCode();
+        if (LastErrorCode <> RecordNotFoundTok) and
+           (LastErrorCode <> PrimRecordNotFoundTok) and
+           (LastErrorCode <> TestWrappedCSideRecordNotFoundTxt) and
+           (not LastErrorCode.Contains(TestFieldValidationCodeTxt))
+        then
+            Error(WrongErrorCodeErr, LastErrorCode, LastErrorText);
+
+        ExpectedMessageCannotFind(LastErrorText, TableID, RecordIndentificationText);
+    end;
+
+    procedure ExpectedMessageCannotFind(LastErrorText: Text; TableID: Integer; RecordIndentificationText: Text)
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+        TableCaption: Text;
+    begin
+        AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Table);
+        AllObjWithCaption.SetRange("Object ID", TableID);
+        AllObjWithCaption.FindFirst();
+        TableCaption := AllObjWithCaption."Object Caption";
+
+        if TableCaption <> '' then
+            if StrPos(LastErrorText, TableCaption) = 0 then
+                Error(ExpectedTestFieldFailedErr, TableCaption, LastErrorText);
+
+        if RecordIndentificationText <> '' then
+            if StrPos(LastErrorText, RecordIndentificationText) = 0 then
+                Error(ExpectedTestFieldFailedErr, TableCaption, LastErrorText);
     end;
 
     /// <summary>

--- a/src/Tools/Test Framework/Test Libraries/Assert/src/LibraryAssert.Codeunit.al
+++ b/src/Tools/Test Framework/Test Libraries/Assert/src/LibraryAssert.Codeunit.al
@@ -482,9 +482,7 @@ codeunit 130002 "Library Assert"
         AllObjWithCaption: Record AllObjWithCaption;
         TableCaption: Text;
     begin
-        AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Table);
-        AllObjWithCaption.SetRange("Object ID", TableID);
-        AllObjWithCaption.FindFirst();
+        AllObjWithCaption.Get(AllObjWithCaption."Object Type"::Table, TableID);
         TableCaption := AllObjWithCaption."Object Caption";
 
         if TableCaption <> '' then


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

Library assert is missing few helper methods that are present on Assert library. We should move the helpers to the new library and have the old library call the new library.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#641493](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641493)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->






