### PR TITLE
[Shopify] Skip refund credit memo while transaction is pending

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order Refunds/Codeunits/ShpfyRefundsAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/Codeunits/ShpfyRefundsAPI.Codeunit.al
@@ -12,6 +12,7 @@ codeunit 30228 "Shpfy Refunds API"
         JsonHelper: Codeunit "Shpfy Json Helper";
         RefundEnumConvertor: Codeunit "Shpfy Refund Enum Convertor";
         RefundCantCreateCreditMemoErr: Label 'This refund cannot be used to create a credit memo or return order because it has already been considered during order import and reduced the quantity and amounts of the order. Only refunds with a non-zero refunded amount and related to real item returns can be used to create credit memos or return orders.';
+        RefundHasPendingTransactionsErr: Label 'This refund cannot be used to create a credit memo or return order yet because it has one or more pending transactions. The refunded amount is only final once the related transactions succeed. Retry after the transactions are no longer pending.';
 
     internal procedure GetRefunds(JRefunds: JsonArray)
     var
@@ -29,6 +30,25 @@ codeunit 30228 "Shpfy Refunds API"
         RefundLine.SetRange("Can Create Credit Memo", false);
         if not RefundLine.IsEmpty() then
             Error(RefundCantCreateCreditMemoErr);
+        if HasPendingRefundTransactions(RefundId) then
+            Error(RefundHasPendingTransactionsErr);
+    end;
+
+    /// <summary>
+    /// Checks whether the refund still has transactions that are pending in Shopify. While a refund
+    /// transaction is pending, Shopify reports a refunded amount of 0, so creating a credit memo at
+    /// that point would produce a balancing line that zeroes out the document.
+    /// </summary>
+    /// <param name="RefundId">The Shopify refund id.</param>
+    /// <returns>True if at least one refund transaction is still pending.</returns>
+    internal procedure HasPendingRefundTransactions(RefundId: BigInteger): Boolean
+    var
+        OrderTransaction: Record "Shpfy Order Transaction";
+    begin
+        OrderTransaction.SetRange("Refund Id", RefundId);
+        OrderTransaction.SetRange(Type, "Shpfy Transaction Type"::Refund);
+        OrderTransaction.SetRange(Status, "Shpfy Transaction Status"::Pending);
+        exit(not OrderTransaction.IsEmpty());
     end;
 
     local procedure GetRefund(RefundId: BigInteger; UpdatedAt: DateTime)

--- a/src/Apps/W1/Shopify/App/src/Order Refunds/Codeunits/ShpfyRefundsAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/Codeunits/ShpfyRefundsAPI.Codeunit.al
@@ -45,6 +45,7 @@ codeunit 30228 "Shpfy Refunds API"
     var
         OrderTransaction: Record "Shpfy Order Transaction";
     begin
+        OrderTransaction.SetCurrentKey("Refund Id", Type, Status);
         OrderTransaction.SetRange("Refund Id", RefundId);
         OrderTransaction.SetRange(Type, "Shpfy Transaction Type"::Refund);
         OrderTransaction.SetRange(Status, "Shpfy Transaction Status"::Pending);

--- a/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyRetRefProcCrMemo.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyRetRefProcCrMemo.Codeunit.al
@@ -66,6 +66,7 @@ codeunit 30243 "Shpfy RetRefProc Cr.Memo" implements "Shpfy IReturnRefund Proces
         RefundLine: Record "Shpfy Refund Line";
         Shop: Record "Shpfy Shop";
         CreateSalesDocRefund: Codeunit "Shpfy Create Sales Doc. Refund";
+        RefundsAPI: Codeunit "Shpfy Refunds API";
         IDocumentSource: Interface "Shpfy IDocument Source";
         ErrorInfo: ErrorInfo;
         TextBuilder: TextBuilder;
@@ -82,6 +83,9 @@ codeunit 30243 "Shpfy RetRefProc Cr.Memo" implements "Shpfy IReturnRefund Proces
         RefundLine.SetRange("Refund Id", SourceDocumentId);
         RefundLine.SetRange("Can Create Credit Memo", false);
         if not RefundLine.IsEmpty() then
+            exit;
+
+        if (SourceDocumentType = "Shpfy Source Document Type"::Refund) and RefundsAPI.HasPendingRefundTransactions(SourceDocumentId) then
             exit;
 
         RefundHeader.Get(SourceDocumentId);

--- a/src/Apps/W1/Shopify/App/src/Transactions/Tables/ShpfyOrderTransaction.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Transactions/Tables/ShpfyOrderTransaction.Table.al
@@ -298,7 +298,7 @@ table 30133 "Shpfy Order Transaction"
         key(Key5; "Shopify Order Id", Status)
         {
         }
-        key(Idx004; "Refund Id", Type, Status)
+        key(Key6; "Refund Id", Type, Status)
         {
         }
     }

--- a/src/Apps/W1/Shopify/App/src/Transactions/Tables/ShpfyOrderTransaction.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Transactions/Tables/ShpfyOrderTransaction.Table.al
@@ -298,6 +298,9 @@ table 30133 "Shpfy Order Transaction"
         key(Key5; "Shopify Order Id", Status)
         {
         }
+        key(Idx004; "Refund Id", Type, Status)
+        {
+        }
     }
 
     fieldgroups

--- a/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
@@ -571,6 +571,105 @@ codeunit 139611 "Shpfy Order Refund Test"
         LibraryAssert.AreEqual(SubtotalAmount - RefundSubtotalAmount, OrderHeader."Subtotal Amount", 'Subtotal Amount must be reduced by refund subtotal.');
     end;
 
+    [Test]
+    procedure UnitTestDoesNotCreateCrMemoFromRefundWithPendingTransaction()
+    var
+        SalesHeader: Record "Sales Header";
+        Shop: Record "Shpfy Shop";
+        OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
+        IReturnRefundProcess: Interface "Shpfy IReturnRefund Process";
+        RefundId: BigInteger;
+        OrderId, OrderLineId : BigInteger;
+        ReturnId: BigInteger;
+    begin
+        // [SCENARIO] A credit memo is not created from a refund while it still has a pending transaction (Bug 640432).
+        Initialize();
+
+        // [GIVEN] Shop configured to auto create credit memos
+        Shop := InitializeTest.CreateShop();
+        Shop."Process Returns As" := "Sales Document Type"::"Credit Memo";
+        Shop.Modify(false);
+
+        // [GIVEN] A processed Shopify order with a return and a refund that can create a credit memo
+        CerateProcessedShopifyOrder(OrderId, OrderLineId);
+        CreateShopifyReturn(ReturnId, OrderId);
+        RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, ReturnId, 156.38, Shop.Code);
+        OrderRefundsHelper.CreateRefundLine(RefundId, OrderLineId, "Shpfy Restock Type"::Return);
+        // [GIVEN] The refund still has a pending transaction in Shopify
+        OrderRefundsHelper.CreateRefundTransaction(OrderId, RefundId, 156.38, "Shpfy Transaction Status"::Pending);
+
+        // [WHEN] Execute IReturnRefundProcess.CreateSalesDocument(Enum::"Shpfy Source Document Type"::Refund, RefundId)
+        IReturnRefundProcess := Enum::"Shpfy ReturnRefund ProcessType"::"Auto Create Credit Memo";
+        SalesHeader := IReturnRefundProcess.CreateSalesDocument(Enum::"Shpfy Source Document Type"::Refund, RefundId);
+
+        // [THEN] No sales document is created (creation is skipped and retried on a later sync)
+        LibraryAssert.AreEqual('', SalesHeader."No.", 'No credit memo must be created while the refund has a pending transaction.');
+    end;
+
+    [Test]
+    procedure UnitTestCreatesCrMemoFromRefundWithSucceededTransaction()
+    var
+        SalesHeader: Record "Sales Header";
+        Shop: Record "Shpfy Shop";
+        OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
+        IReturnRefundProcess: Interface "Shpfy IReturnRefund Process";
+        RefundId: BigInteger;
+        OrderId, OrderLineId : BigInteger;
+        ReturnId: BigInteger;
+    begin
+        // [SCENARIO] The pending-transaction guard only blocks pending transactions; a succeeded transaction still creates the credit memo (Bug 640432).
+        Initialize();
+
+        // [GIVEN] Shop configured to auto create credit memos
+        Shop := InitializeTest.CreateShop();
+        Shop."Process Returns As" := "Sales Document Type"::"Credit Memo";
+        Shop.Modify(false);
+
+        // [GIVEN] A processed Shopify order with a return and a refund that can create a credit memo
+        CerateProcessedShopifyOrder(OrderId, OrderLineId);
+        CreateShopifyReturn(ReturnId, OrderId);
+        RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, ReturnId, 156.38, Shop.Code);
+        OrderRefundsHelper.CreateRefundLine(RefundId, OrderLineId, "Shpfy Restock Type"::Return);
+        // [GIVEN] The refund transaction has already succeeded
+        OrderRefundsHelper.CreateRefundTransaction(OrderId, RefundId, 156.38, "Shpfy Transaction Status"::Success);
+
+        // [WHEN] Execute IReturnRefundProcess.CreateSalesDocument(Enum::"Shpfy Source Document Type"::Refund, RefundId)
+        IReturnRefundProcess := Enum::"Shpfy ReturnRefund ProcessType"::"Auto Create Credit Memo";
+        SalesHeader := IReturnRefundProcess.CreateSalesDocument(Enum::"Shpfy Source Document Type"::Refund, RefundId);
+
+        // [THEN] A credit memo is created
+        LibraryAssert.AreEqual(Enum::"Sales Document Type"::"Credit Memo", SalesHeader."Document Type", 'A credit memo must be created when the refund transaction has succeeded.');
+        LibraryAssert.AreNotEqual('', SalesHeader."No.", 'The credit memo must have a number.');
+    end;
+
+    [Test]
+    procedure UnitTestVerifyRefundCanCreateCreditMemoErrorsWithPendingTransaction()
+    var
+        Shop: Record "Shpfy Shop";
+        OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
+        RefundsAPI: Codeunit "Shpfy Refunds API";
+        RefundId: BigInteger;
+        OrderId, OrderLineId : BigInteger;
+        ReturnId: BigInteger;
+    begin
+        // [SCENARIO] Manually verifying a refund that still has a pending transaction throws an error (Bug 640432).
+        Initialize();
+        Shop := InitializeTest.CreateShop();
+
+        // [GIVEN] A refund that can create a credit memo but still has a pending transaction
+        CerateProcessedShopifyOrder(OrderId, OrderLineId);
+        CreateShopifyReturn(ReturnId, OrderId);
+        RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, ReturnId, 156.38, Shop.Code);
+        OrderRefundsHelper.CreateRefundLine(RefundId, OrderLineId, "Shpfy Restock Type"::Return);
+        OrderRefundsHelper.CreateRefundTransaction(OrderId, RefundId, 156.38, "Shpfy Transaction Status"::Pending);
+
+        // [WHEN] Execute RefundsAPI.VerifyRefundCanCreateCreditMemo
+        asserterror RefundsAPI.VerifyRefundCanCreateCreditMemo(RefundId);
+
+        // [THEN] It throws the pending-transactions error
+        LibraryAssert.ExpectedError('This refund cannot be used to create a credit memo or return order yet because it has one or more pending transactions. The refunded amount is only final once the related transactions succeed. Retry after the transactions are no longer pending.');
+    end;
+
     local procedure Initialize()
     var
         OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";

--- a/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundsHelper.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundsHelper.Codeunit.al
@@ -399,6 +399,20 @@ codeunit 139564 "Shpfy Order Refunds Helper"
         exit(RefundHeader."Refund Id");
     end;
 
+    internal procedure CreateRefundTransaction(OrderId: BigInteger; RefundId: BigInteger; Amount: Decimal; Status: Enum "Shpfy Transaction Status"): BigInteger
+    var
+        OrderTransaction: Record "Shpfy Order Transaction";
+    begin
+        OrderTransaction."Shopify Transaction Id" := Any.IntegerInRange(100000, 9999999);
+        OrderTransaction."Shopify Order Id" := OrderId;
+        OrderTransaction."Refund Id" := RefundId;
+        OrderTransaction.Type := "Shpfy Transaction Type"::Refund;
+        OrderTransaction.Status := Status;
+        OrderTransaction.Amount := Amount;
+        OrderTransaction.Insert();
+        exit(OrderTransaction."Shopify Transaction Id");
+    end;
+
     internal procedure SetDefaultSeed()
     begin
         Any.SetDefaultSeed();


### PR DESCRIPTION
Fixes [AB#640432](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640432)

## Summary

When a Shopify refund is synced while its payment transaction is still **pending**, Shopify's `totalRefundedSet` returns 0 (it only counts `SUCCESS` transactions). If a credit memo is created at that moment, the balancing line in `CreateSalesLinesFromRemainingAmount` calculates `Unit Price = 0 - <item total>`, producing a credit memo whose total is 0 — a financially useless document.

## Root cause

`ShpfyCreateSalesDocRefund.Codeunit.al` balances the document against `RefundHeader."Total Refunded Amount"`, which is 0 while the refund transaction is still pending, even though the item/return lines already sum to the real amount.

## Fix

Block credit memo / return order creation while the refund still has a pending transaction, mirroring the existing `"Can Create Credit Memo"` dual-guard pattern:

- **`ShpfyRefundsAPI.Codeunit.al`** — new internal helper `HasPendingRefundTransactions(RefundId)` that checks for refund transactions with `Type = Refund` and `Status = Pending`. `VerifyRefundCanCreateCreditMemo` now throws a clear error when a pending transaction exists (manual **Create Sales Document** path).
- **`ShpfyRetRefProcCrMemo.Codeunit.al`** — `CreateSalesDocument` now exits early (silent skip) when the refund still has a pending transaction (auto-sync path). The refund stays unprocessed and is retried on the next sync; once the transaction reaches `SUCCESS`, `totalRefundedSet` is final and the credit memo is created correctly.

This is safe because the auto-processing loop (`ProcessShopifyRefunds`) retries all unprocessed refunds on every sync, and no data is guessed or approximated.

## Test plan

Added to `ShpfyOrderRefundTest.Codeunit.al` (with a `CreateRefundTransaction` helper in `ShpfyOrderRefundsHelper.Codeunit.al`):

- `UnitTestDoesNotCreateCrMemoFromRefundWithPendingTransaction` — no credit memo is created while the refund has a pending transaction.
- `UnitTestCreatesCrMemoFromRefundWithSucceededTransaction` — the guard is specific to pending; a succeeded transaction still creates the credit memo.
- `UnitTestVerifyRefundCanCreateCreditMemoErrorsWithPendingTransaction` — the manual path throws the pending-transaction error.



