### PR TITLE
Classify Data Sensitivity for E-Document Sales Header/Line tables

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/EDocumentSubscribers.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocumentSubscribers.Codeunit.al
@@ -10,6 +10,7 @@ using Microsoft.eServices.EDocument.OrderMatch;
 using Microsoft.EServices.EDocument.Processing;
 using Microsoft.eServices.EDocument.Processing.Import;
 using Microsoft.eServices.EDocument.Processing.Import.Purchase;
+using Microsoft.eServices.EDocument.Processing.Import.Sales;
 using Microsoft.eServices.EDocument.Service.Participant;
 using Microsoft.Finance.GeneralLedger.Journal;
 using Microsoft.Finance.GeneralLedger.Ledger;
@@ -521,6 +522,8 @@ codeunit 6103 "E-Document Subscribers"
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document Line Mapping");
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document Purchase Header");
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document Purchase Line");
+        DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document Sales Header");
+        DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document Sales Line");
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Doc. Imported Line");
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Doc. Order Match");
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Doc. Service Supported Type");


### PR DESCRIPTION
## What & why

The Data Classification test `CU 135153 "Data Classs Demo Data Tests".TestDataSensitivities` started failing with `Field 2 of Table 6153 has Data Sensitivity Unclassified`.

Tables `6153 "E-Document Sales Header"` and `6154 "E-Document Sales Line"` were added by the sales-order receive-path feature (#8558) with `CustomerContent` fields, but were never registered in the E-Document `ClassifyDataSensitivity` subscriber. `CreateEvaluationData` inserts every classifiable field into the Data Sensitivity table as `Unclassified`, and expects each app to classify its own tables via the `OnCreateEvaluationDataOnAfterClassifyTablesToNormal` event. Because these two tables were missing from that subscriber, their fields stayed `Unclassified` and the test failed.

## Linked work

<!-- TODO: link approved GitHub issue and ADO work item before requesting review -->

Fixes #

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Traced the failure: `CreateEvaluationData` (DataClassificationEvalData.Codeunit.al lines 158-171) inserts all `CustomerContent`/EUII/EUPI fields as `Unclassified`, then raises `OnCreateEvaluationDataOnAfterClassifyTablesToNormal` (line 189) for apps to classify their own tables. The E-Document subscriber `ClassifyDataSensitivity` listed the Purchase Header/Line siblings but not the new Sales Header/Line, leaving 6153/6154 unclassified.
- Fix registers both tables with `SetTableFieldsToNormal`, matching the existing pattern for the Purchase equivalents, and adds the missing `Microsoft.eServices.EDocument.Processing.Import.Sales` using directive so the references resolve.
- No new test needed: existing `CU 135153 TestDataSensitivities` is the regression guard and will now pass for these tables.

## Risk & compatibility

Low risk. Change only affects evaluation/demo data classification for two internal E-Document staging tables; both are classified as `Normal`, consistent with the other E-Document tables (including the Purchase Header/Line siblings). No production data, permissions, or upgrade impact.
