### PR TITLE
Bug 641271: Copy Location - Target Location Name hidden behind Show More

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Location/CopyLocation.Page.al
+++ b/src/Layers/W1/BaseApp/Inventory/Location/CopyLocation.Page.al
@@ -45,7 +45,6 @@ page 5711 "Copy Location"
                     ApplicationArea = Location;
                     Caption = 'Target Location Name';
                     ToolTip = 'Specifies the name of the new location that you want to copy the data to.';
-                    Importance = Additional;
                 }
                 field(CopyAllInformation; ShouldCopyAllInformation)
                 {


### PR DESCRIPTION
Fixes [AB#641271](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641271)

On the Copy Location request page (5711) the **Target Location Name** field had ``Importance = Additional``, hiding it behind "Show more" even though it is a primary input field when copying a location. Remove the ``Importance`` property so the field defaults to Standard and is always visible.

