### PR TITLE
[Subcontracting] Bug 641399: Move Subcontracting Transfer Orders action out of Entries sub-group

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcFinishedProdOrder.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcFinishedProdOrder.PageExt.al
@@ -23,9 +23,6 @@ pageextension 99001548 "Subc. Finished Prod. Order" extends "Finished Production
                 RunPageLink = "Document Type" = const(Order), "Prod. Order No." = field("No.");
                 ToolTip = 'Show purchase order lines for subcontracting.';
             }
-        }
-        addafter("&Warehouse Entries")
-        {
             action("Subc. Transfer Orders")
             {
                 ApplicationArea = Subcontracting;
@@ -40,6 +37,9 @@ pageextension 99001548 "Subc. Finished Prod. Order" extends "Finished Production
                     SubcPurchFactboxMgmt.ShowTransferOrdersFromProductionOrder(Rec);
                 end;
             }
+        }
+        addafter("&Warehouse Entries")
+        {
             action("Subc. Transfer Entries")
             {
                 ApplicationArea = Subcontracting;

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcFinishedProdOrders.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcFinishedProdOrders.PageExt.al
@@ -23,9 +23,6 @@ pageextension 99001543 "Subc. Finished Prod. Orders" extends "Finished Productio
                 RunPageLink = "Document Type" = const(Order), "Prod. Order No." = field("No.");
                 ToolTip = 'Show purchase order lines for subcontracting.';
             }
-        }
-        addafter("&Warehouse Entries")
-        {
             action("Subc. Transfer Orders")
             {
                 ApplicationArea = Subcontracting;
@@ -40,6 +37,9 @@ pageextension 99001543 "Subc. Finished Prod. Orders" extends "Finished Productio
                     SubcPurchFactboxMgmt.ShowTransferOrdersFromProductionOrder(Rec);
                 end;
             }
+        }
+        addafter("&Warehouse Entries")
+        {
             action("Subc. Transfer Entries")
             {
                 ApplicationArea = Subcontracting;

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRelProdOrder.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRelProdOrder.PageExt.al
@@ -22,9 +22,6 @@ pageextension 99001504 "Subc. Rel. Prod. Order" extends "Released Production Ord
                 RunPageLink = "Document Type" = const(Order), "Prod. Order No." = field("No.");
                 ToolTip = 'Show purchase order lines for subcontracting.';
             }
-        }
-        addafter("&Warehouse Entries")
-        {
             action("Subc. Transfer Orders")
             {
                 ApplicationArea = Subcontracting;
@@ -39,6 +36,9 @@ pageextension 99001504 "Subc. Rel. Prod. Order" extends "Released Production Ord
                     SubcPurchFactboxMgmt.ShowTransferOrdersFromProductionOrder(Rec);
                 end;
             }
+        }
+        addafter("&Warehouse Entries")
+        {
             action("Subc. Transfer Entries")
             {
                 ApplicationArea = Subcontracting;

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRelProdOrders.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRelProdOrders.PageExt.al
@@ -22,9 +22,6 @@ pageextension 99001505 "Subc. Rel. Prod. Orders" extends "Released Production Or
                 RunPageLink = "Document Type" = const(Order), "Prod. Order No." = field("No.");
                 ToolTip = 'Show purchase order lines for subcontracting.';
             }
-        }
-        addafter("&Warehouse Entries")
-        {
             action("Subc. Transfer Orders")
             {
                 ApplicationArea = Subcontracting;
@@ -39,6 +36,9 @@ pageextension 99001505 "Subc. Rel. Prod. Orders" extends "Released Production Or
                     SubcPurchFactboxMgmt.ShowTransferOrdersFromProductionOrder(Rec);
                 end;
             }
+        }
+        addafter("&Warehouse Entries")
+        {
             action("Subc. Transfer Entries")
             {
                 ApplicationArea = Subcontracting;


### PR DESCRIPTION
Fixes [AB#641399](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641399)

The **Subcontracting Transfer Orders** action was placed inside the Entries sub-group (``addafter "&Warehouse Entries"``) alongside ledger-entry actions, but a transfer order is a document, not a ledger entry. Move it up to the Order group level next to **Subcontracting Order Lines** on all four production-order pages (Released/Finished card and list). ``Subc. Transfer Entries`` and ``WIP Ledger Entries`` stay in the Entries group.


