### PR TITLE
[Shopify] Base price-sync bulk threshold on changed price count

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductExport.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductExport.Codeunit.al
@@ -42,13 +42,13 @@ codeunit 30178 "Shpfy Product Export"
         BulkOperationMgt: Codeunit "Shpfy Bulk Operation Mgt.";
         BulkOperationType: Enum "Shpfy Bulk Operation Type";
         VariantId: BigInteger;
+        SendPricesIndividually: Boolean;
     begin
         ShopifyProduct.SetFilter("Item SystemId", '<>%1', NullGuid);
         ShopifyProduct.SetFilter("Shop Code", Rec.GetFilter(Code));
 
         ProductEvents.OnAfterProductsToSynchronizeFiltersSet(ShopifyProduct, Shop, OnlyUpdatePrice);
 
-        RecordCount := ShopifyProduct.Count();
         if ShopifyProduct.FindSet(false) then
             repeat
                 SetShop(ShopifyProduct."Shop Code");
@@ -57,11 +57,15 @@ codeunit 30178 "Shpfy Product Export"
             until ShopifyProduct.Next() = 0;
 
         if OnlyUpdatePrice then
-            if BulkOperationInput.Length > 0 then
-                if not BulkOperationMgt.SendBulkMutation(Shop, BulkOperationType::UpdateProductPrice, BulkOperationInput.ToText(), JRequestData) then
+            if GraphQueryList.Count() > 0 then begin
+                SendPricesIndividually := true;
+                if GraphQueryList.Count() >= BulkOperationMgt.GetBulkOperationThreshold() then
+                    SendPricesIndividually := not BulkOperationMgt.SendBulkMutation(Shop, BulkOperationType::UpdateProductPrice, BulkOperationInput.ToText(), JRequestData);
+                if SendPricesIndividually then
                     foreach VariantId in GraphQueryList.Keys do
-                        if not VariantAPI.UpdateProductPrice(GraphQueryList.Get(VariantId)) then
+                        if not VariantAPI.UpdateProductPrice(VariantId, GraphQueryList.Get(VariantId)) then
                             RevertVariantChanges(VariantId);
+            end;
     end;
 
     var
@@ -72,7 +76,6 @@ codeunit 30178 "Shpfy Product Export"
         VariantApi: Codeunit "Shpfy Variant API";
         SkippedRecord: Codeunit "Shpfy Skipped Record";
         OnlyUpdatePrice: Boolean;
-        RecordCount: Integer;
         NullGuid: Guid;
         BulkOperationInput: TextBuilder;
         GraphQueryList: Dictionary of [BigInteger, TextBuilder];
@@ -819,7 +822,7 @@ codeunit 30178 "Shpfy Product Export"
         TempShopifyVariant := ShopifyVariant;
         FillInProductVariantData(ShopifyVariant, Item, ItemUnitofMeasure);
         if OnlyUpdatePrice then
-            VariantApi.UpdateProductPrice(ShopifyVariant, TempShopifyVariant, BulkOperationInput, GraphQueryList, RecordCount, JRequestData)
+            VariantApi.UpdateProductPrice(ShopifyVariant, TempShopifyVariant, BulkOperationInput, GraphQueryList, JRequestData)
         else
             if TempCurrVariant.Get(ShopifyVariant.Id) then begin
                 TempCurrVariant := ShopifyVariant;
@@ -844,7 +847,7 @@ codeunit 30178 "Shpfy Product Export"
         TempShopifyVariant := ShopifyVariant;
         FillInProductVariantData(ShopifyVariant, Item, ItemVariant);
         if OnlyUpdatePrice then
-            VariantApi.UpdateProductPrice(ShopifyVariant, TempShopifyVariant, BulkOperationInput, GraphQueryList, RecordCount, JRequestData)
+            VariantApi.UpdateProductPrice(ShopifyVariant, TempShopifyVariant, BulkOperationInput, GraphQueryList, JRequestData)
         else
             if TempCurrVariant.Get(ShopifyVariant.Id) then begin
                 TempCurrVariant := ShopifyVariant;
@@ -870,7 +873,7 @@ codeunit 30178 "Shpfy Product Export"
         TempShopifyVariant := ShopifyVariant;
         FillInProductVariantData(ShopifyVariant, Item, ItemVariant, ItemUnitofMeasure);
         if OnlyUpdatePrice then
-            VariantApi.UpdateProductPrice(ShopifyVariant, TempShopifyVariant, BulkOperationInput, GraphQueryList, RecordCount, JRequestData)
+            VariantApi.UpdateProductPrice(ShopifyVariant, TempShopifyVariant, BulkOperationInput, GraphQueryList, JRequestData)
         else
             if TempCurrVariant.Get(ShopifyVariant.Id) then begin
                 TempCurrVariant := ShopifyVariant;

--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyVariantAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyVariantAPI.Codeunit.al
@@ -661,23 +661,17 @@ codeunit 30189 "Shpfy Variant API"
         exit(NewImageId);
     end;
 
-    internal procedure UpdateProductPrice(ShopifyVariant: Record "Shpfy Variant"; xShopifyVariant: Record "Shpfy Variant"; var BulkOperationInput: TextBuilder; var GraphQueryList: Dictionary of [BigInteger, TextBuilder]; RecordCount: Integer; var JRequestData: JsonArray)
+    internal procedure UpdateProductPrice(ShopifyVariant: Record "Shpfy Variant"; xShopifyVariant: Record "Shpfy Variant"; var BulkOperationInput: TextBuilder; var GraphQueryList: Dictionary of [BigInteger, TextBuilder]; var JRequestData: JsonArray)
     var
-        BulkOperationMgt: Codeunit "Shpfy Bulk Operation Mgt.";
         BulkOperationType: Enum "Shpfy Bulk Operation Type";
         IBulkOperation: Interface "Shpfy IBulk Operation";
         HasChange: Boolean;
-        IsBulkOperationEnabled: Boolean;
-        JResponse: JsonToken;
-        JVariant: JsonToken;
-        JVariants: JsonArray;
         JRequest: JsonObject;
         GraphQuery: TextBuilder;
         Price: Text;
         CompareAtPrice: Text;
         UnitCost: Text;
     begin
-        IsBulkOperationEnabled := RecordCount >= BulkOperationMgt.GetBulkOperationThreshold();
         GraphQuery.Append('{"query":"mutation { productVariantsBulkUpdate(productId: \"gid://shopify/Product/');
         GraphQuery.Append(Format(ShopifyVariant."Product Id"));
         GraphQuery.Append('\", variants: [{id: \"gid://shopify/ProductVariant/');
@@ -688,8 +682,7 @@ codeunit 30189 "Shpfy Variant API"
             GraphQuery.Append(', price: \"');
             GraphQuery.Append(Format(ShopifyVariant.Price, 0, 9));
             GraphQuery.Append('\"');
-            if IsBulkOperationEnabled then
-                Price := Format(ShopifyVariant.Price, 0, 9);
+            Price := Format(ShopifyVariant.Price, 0, 9);
         end;
         if (ShopifyVariant."Compare at Price" <> xShopifyVariant."Compare at Price") then
             if (ShopifyVariant.Price < ShopifyVariant."Compare at Price") then begin
@@ -697,8 +690,7 @@ codeunit 30189 "Shpfy Variant API"
                 GraphQuery.Append(', compareAtPrice: \"');
                 GraphQuery.Append(Format(ShopifyVariant."Compare at Price", 0, 9));
                 GraphQuery.Append('\"');
-                if IsBulkOperationEnabled then
-                    CompareAtPrice := ', "compareAtPrice": "' + Format(ShopifyVariant."Compare at Price", 0, 9) + '"';
+                CompareAtPrice := ', "compareAtPrice": "' + Format(ShopifyVariant."Compare at Price", 0, 9) + '"';
             end else begin
                 HasChange := true;
                 GraphQuery.Append(', compareAtPrice: null');
@@ -709,55 +701,52 @@ codeunit 30189 "Shpfy Variant API"
             GraphQuery.Append(', inventoryItem: {cost: \"');
             GraphQuery.Append(Format(ShopifyVariant."Unit Cost", 0, 9));
             GraphQuery.Append('\"}');
-            if IsBulkOperationEnabled then
-                UnitCost := Format(ShopifyVariant."Unit Cost", 0, 9);
+            UnitCost := Format(ShopifyVariant."Unit Cost", 0, 9);
         end;
 
         GraphQuery.Append('}]) {productVariants {updatedAt}, userErrors {field, message}}}"}');
 
-        if HasChange then
-            if IsBulkOperationEnabled then begin
-                IBulkOperation := BulkOperationType::UpdateProductPrice;
-                if Price = '' then
-                    Price := Format(ShopifyVariant.Price, 0, 9);
-                if UnitCost = '' then
-                    UnitCost := Format(ShopifyVariant."Unit Cost", 0, 9);
+        if HasChange then begin
+            IBulkOperation := BulkOperationType::UpdateProductPrice;
+            if Price = '' then
+                Price := Format(ShopifyVariant.Price, 0, 9);
+            if UnitCost = '' then
+                UnitCost := Format(ShopifyVariant."Unit Cost", 0, 9);
 
-                GraphQueryList.Add(ShopifyVariant.Id, GraphQuery);
-                JRequest.Add('id', ShopifyVariant.Id);
-                JRequest.Add('price', xShopifyVariant.Price);
-                JRequest.Add('compareAtPrice', xShopifyVariant."Compare at Price");
-                JRequest.Add('unitCost', xShopifyVariant."Unit Cost");
-                JRequest.Add('updatedAt', xShopifyVariant."Updated At");
-                JRequestData.Add(JRequest);
+            GraphQueryList.Add(ShopifyVariant.Id, GraphQuery);
+            JRequest.Add('id', ShopifyVariant.Id);
+            JRequest.Add('price', xShopifyVariant.Price);
+            JRequest.Add('compareAtPrice', xShopifyVariant."Compare at Price");
+            JRequest.Add('unitCost', xShopifyVariant."Unit Cost");
+            JRequest.Add('updatedAt', xShopifyVariant."Updated At");
+            JRequestData.Add(JRequest);
 
-                BulkOperationInput.AppendLine(StrSubstNo(IBulkOperation.GetInput(), ShopifyVariant."Product Id", ShopifyVariant.Id, Price, CompareAtPrice, UnitCost));
-                ShopifyVariant."Updated At" := CurrentDateTime();
-                ShopifyVariant.Modify();
-            end else begin
-                JResponse := CommunicationMgt.ExecuteGraphQL(GraphQuery.ToText());
-                if JsonHelper.GetJsonArray(JResponse, JVariants, 'data.productVariantsBulkUpdate.productVariants') then
-                    if JVariants.Get(0, JVariant) then begin
-                        ShopifyVariant."Updated At" := JsonHelper.GetValueAsDateTime(JVariant, 'updatedAt');
-                        if ShopifyVariant."Updated At" > 0DT then
-                            ShopifyVariant.Modify();
-                    end;
-            end;
+            BulkOperationInput.AppendLine(StrSubstNo(IBulkOperation.GetInput(), ShopifyVariant."Product Id", ShopifyVariant.Id, Price, CompareAtPrice, UnitCost));
+            ShopifyVariant."Updated At" := CurrentDateTime();
+            ShopifyVariant.Modify();
+        end;
     end;
 
-    [TryFunction]
-    internal procedure UpdateProductPrice(GraphQuery: TextBuilder)
+    internal procedure UpdateProductPrice(VariantId: BigInteger; GraphQuery: TextBuilder): Boolean
     var
+        ShopifyVariant: Record "Shpfy Variant";
         JVariants: JsonArray;
         JVariant: JsonToken;
         JResponse: JsonToken;
-        VariantUpdateFailedErr: Label 'Failed to update variant price.';
+        UpdatedAt: DateTime;
     begin
         JResponse := CommunicationMgt.ExecuteGraphQL(GraphQuery.ToText());
         if JsonHelper.GetJsonArray(JResponse, JVariants, 'data.productVariantsBulkUpdate.productVariants') then
-            if JVariants.Get(0, JVariant) then
-                if JsonHelper.GetValueAsDateTime(JVariant, 'updatedAt') <= 0DT then
-                    Error(VariantUpdateFailedErr);
+            if JVariants.Get(0, JVariant) then begin
+                UpdatedAt := JsonHelper.GetValueAsDateTime(JVariant, 'updatedAt');
+                if UpdatedAt <= 0DT then
+                    exit(false);
+                if ShopifyVariant.Get(VariantId) then begin
+                    ShopifyVariant."Updated At" := UpdatedAt;
+                    ShopifyVariant.Modify();
+                end;
+            end;
+        exit(true);
     end;
 
     /// <summary> 

--- a/src/Apps/W1/Shopify/Test/Bulk Operations/Codeunits/ShpfyBulkOperationsTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Bulk Operations/Codeunits/ShpfyBulkOperationsTest.Codeunit.al
@@ -405,8 +405,8 @@ codeunit 139633 "Shpfy Bulk Operations Test"
         xShopifyVariant := ShopifyVariant;
         xShopifyVariant."Compare at Price" := 200;
 
-        // [WHEN] UpdateProductPrice runs on the bulk path (RecordCount >= 100)
-        VariantApi.UpdateProductPrice(ShopifyVariant, xShopifyVariant, BulkOperationInput, GraphQueryList, 100, JRequestData);
+        // [WHEN] UpdateProductPrice accumulates the bulk input
+        VariantApi.UpdateProductPrice(ShopifyVariant, xShopifyVariant, BulkOperationInput, GraphQueryList, JRequestData);
 
         // [THEN] The JSONL line clears Compare at Price with the literal token null, not the string "0"
         Jsonl := BulkOperationInput.ToText();
@@ -444,8 +444,8 @@ codeunit 139633 "Shpfy Bulk Operations Test"
         xShopifyVariant := ShopifyVariant;
         xShopifyVariant.Price := 80;
 
-        // [WHEN] UpdateProductPrice runs on the bulk path
-        VariantApi.UpdateProductPrice(ShopifyVariant, xShopifyVariant, BulkOperationInput, GraphQueryList, 100, JRequestData);
+        // [WHEN] UpdateProductPrice accumulates the bulk input
+        VariantApi.UpdateProductPrice(ShopifyVariant, xShopifyVariant, BulkOperationInput, GraphQueryList, JRequestData);
 
         // [THEN] compareAtPrice is not in the JSONL at all - Shopify preserves its existing value
         Jsonl := BulkOperationInput.ToText();
@@ -480,8 +480,8 @@ codeunit 139633 "Shpfy Bulk Operations Test"
         xShopifyVariant := ShopifyVariant;
         xShopifyVariant."Compare at Price" := 0;
 
-        // [WHEN] UpdateProductPrice runs on the bulk path
-        VariantApi.UpdateProductPrice(ShopifyVariant, xShopifyVariant, BulkOperationInput, GraphQueryList, 100, JRequestData);
+        // [WHEN] UpdateProductPrice accumulates the bulk input
+        VariantApi.UpdateProductPrice(ShopifyVariant, xShopifyVariant, BulkOperationInput, GraphQueryList, JRequestData);
 
         // [THEN] Compare at Price is sent as a quoted decimal string
         Jsonl := BulkOperationInput.ToText();
@@ -517,8 +517,8 @@ codeunit 139633 "Shpfy Bulk Operations Test"
         xShopifyVariant := ShopifyVariant;
         xShopifyVariant."Unit Cost" := 50;
 
-        // [WHEN] UpdateProductPrice runs on the bulk path
-        VariantApi.UpdateProductPrice(ShopifyVariant, xShopifyVariant, BulkOperationInput, GraphQueryList, 100, JRequestData);
+        // [WHEN] UpdateProductPrice accumulates the bulk input
+        VariantApi.UpdateProductPrice(ShopifyVariant, xShopifyVariant, BulkOperationInput, GraphQueryList, JRequestData);
 
         // [THEN] compareAtPrice is omitted entirely - Shopify keeps its current value
         Jsonl := BulkOperationInput.ToText();

--- a/src/Apps/W1/Shopify/Test/Products/ShpfyCreateProductTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Products/ShpfyCreateProductTest.Codeunit.al
@@ -26,6 +26,7 @@ codeunit 139601 "Shpfy Create Product Test"
         LibraryRandom: Codeunit "Library - Random";
         ShpfyInitializeTest: Codeunit "Shpfy Initialize Test";
         ExportIsInitialized: Boolean;
+        PriceUpdateHttpCallCount: Integer;
 
     [Test]
     procedure UnitTestCreateTempProductFromItem()
@@ -3144,6 +3145,61 @@ codeunit 139601 "Shpfy Create Product Test"
             0:
                 Error(UnexpectedAPICallsErr);
         end;
+        exit(false);
+    end;
+
+    [Test]
+    [HandlerFunctions('ProductPriceSyncHttpHandler')]
+    procedure UnitTestPriceUpdateBelowThresholdUsesIndividualSyncNotBulk()
+    var
+        Item: Record Item;
+        ShopifyProduct: Record "Shpfy Product";
+        BulkOperation: Record "Shpfy Bulk Operation";
+        ProductExport: Codeunit "Shpfy Product Export";
+        ProductInitTest: Codeunit "Shpfy Product Init Test";
+        NullGuid: Guid;
+        Index: Integer;
+        ChangedVariantCount: Integer;
+    begin
+        // [SCENARIO 640288] When the number of changed prices is below the bulk-operation threshold,
+        // [SCENARIO] the connector updates prices with individual synchronous mutations instead of a bulk operation.
+        InitializeProductExport();
+        ExportShop."UoM as Variant" := false;
+        ExportShop.Modify();
+        PriceUpdateHttpCallCount := 0;
+
+        // [GIVEN] A few Shopify products mapped to BC items whose prices differ from Shopify (all will change).
+        ChangedVariantCount := 3;
+        for Index := 1 to ChangedVariantCount do begin
+            Item := ProductInitTest.CreateItem(ExportShop."Item Templ. Code", Any.DecimalInRange(10, 100, 2), Any.DecimalInRange(100, 500, 2), false);
+            ShopifyProduct := CreateShopifyProductForExport(Item.SystemId);
+            CreateMappedShopifyVariantForExport(ShopifyProduct.Id, Item.SystemId, NullGuid);
+        end;
+
+        // [WHEN] The price-only product export runs for the shop.
+        ProductExport.SetShop(ExportShop);
+        ProductExport.SetOnlyUpdatePriceOn();
+        ExportShop.SetRange(Code, ExportShop.Code);
+        ProductExport.Run(ExportShop);
+        ExportShop.SetRange(Code);
+
+        // [THEN] Each changed variant was updated with its own synchronous mutation.
+        LibraryAssert.AreEqual(ChangedVariantCount, PriceUpdateHttpCallCount, 'Each changed variant should be updated with an individual synchronous mutation.');
+
+        // [THEN] No bulk operation was created, because the number of changed prices is below the threshold.
+        BulkOperation.SetRange("Shop Code", ExportShop.Code);
+        LibraryAssert.IsTrue(BulkOperation.IsEmpty(), 'No bulk operation should be created when the number of changed prices is below the threshold.');
+    end;
+
+    [HttpClientHandler]
+    internal procedure ProductPriceSyncHttpHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    var
+        ProductVariantsBulkUpdateResponseTok: Label 'Products/ProductVariantsBulkUpdateResponse.txt', Locked = true;
+    begin
+        if not ShpfyInitializeTest.VerifyRequestUrl(Request.Path, ExportShop."Shopify URL") then
+            exit(true);
+        PriceUpdateHttpCallCount += 1;
+        Response.Content.WriteFrom(NavApp.GetResourceAsText(ProductVariantsBulkUpdateResponseTok, TextEncoding::UTF8));
         exit(false);
     end;
 

--- a/src/Apps/W1/Shopify/Test/Products/ShpfyCreateProductTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Products/ShpfyCreateProductTest.Codeunit.al
@@ -3154,6 +3154,7 @@ codeunit 139601 "Shpfy Create Product Test"
     var
         Item: Record Item;
         ShopifyProduct: Record "Shpfy Product";
+        ShopifyVariant: Record "Shpfy Variant";
         BulkOperation: Record "Shpfy Bulk Operation";
         ProductExport: Codeunit "Shpfy Product Export";
         ProductInitTest: Codeunit "Shpfy Product Init Test";
@@ -3167,6 +3168,12 @@ codeunit 139601 "Shpfy Create Product Test"
         ExportShop."UoM as Variant" := false;
         ExportShop.Modify();
         PriceUpdateHttpCallCount := 0;
+
+        // [GIVEN] No pre-existing Shopify products/variants for the shop, so only the ones created below are exported.
+        ShopifyVariant.SetRange("Shop Code", ExportShop.Code);
+        ShopifyVariant.DeleteAll(false);
+        ShopifyProduct.SetRange("Shop Code", ExportShop.Code);
+        ShopifyProduct.DeleteAll(false);
 
         // [GIVEN] A few Shopify products mapped to BC items whose prices differ from Shopify (all will change).
         ChangedVariantCount := 3;


### PR DESCRIPTION
Fixes [AB#640288](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640288)

## Problem
`Shpfy Product Export` chose between an asynchronous **bulk operation** and **synchronous** price updates based on the *total number of Shopify products mapped to items* for the shop. A shop with 100+ mapped products therefore spawned a bulk operation even when only a single price actually changed.

## Change
Decide based on the **actual number of changed variants** instead:
- `UpdateProductPrice` now always accumulates the per-variant mutation; `GraphQueryList.Count()` is the real change count.
- After the export loop, `OnRun` sends a bulk operation only when the change count reaches `GetBulkOperationThreshold()` (100); below that it sends individual synchronous mutations (with revert-on-failure).
- The synchronous send is no longer a `[TryFunction]`, so `ExecuteGraphQL`'s request-logging `INSERT` is permitted; it reports success/failure via a Boolean and writes back Shopify's authoritative `updatedAt`.

## Tests
- Added `UnitTestPriceUpdateBelowThresholdUsesIndividualSyncNotBulk`: a few changed prices are sent as individual synchronous mutations and no bulk operation is created.
- Updated the existing bulk price-update tests for the new `UpdateProductPrice` signature.


