### PR TITLE
Add Dataverse Cloud endpoints override for sovereign clouds

### DIFF
--- a/src/Layers/W1/BaseApp/Integration/Dataverse/CDSConnectionSetup.Table.al
+++ b/src/Layers/W1/BaseApp/Integration/Dataverse/CDSConnectionSetup.Table.al
@@ -657,7 +657,7 @@ table 7200 "CDS Connection Setup"
     procedure SetDataverseCloud(NewDataverseCloud: Enum "Dataverse Cloud")
     begin
         if not Get() then
-            exit;
+            Error(SetupMissingErr);
         Validate("Dataverse Cloud", NewDataverseCloud);
         Modify(true);
     end;
@@ -686,6 +686,7 @@ table 7200 "CDS Connection Setup"
         CRMConnEnabledErr: Label 'To set up the connection with Dataverse, you must first disable the existing connection with Dynamics 365 Sales.';
         CRMConnEnabledTelemetryErr: Label 'User is trying to set up the connection with Dataverse, while the existing connection with Dynamics 365 Sales is enabled.', Locked = true;
         CannotDisableCDSErr: Label 'To disable the connection with Dataverse, you must first disable the existing connection with Dynamics 365 Sales.';
+        SetupMissingErr: Label 'The Dataverse cloud cannot be set because the Dataverse Connection Setup does not exist. Set up the Dataverse connection before choosing a cloud.';
         TransferringConnectionValuesFromCRMConnectionsetupTxt: Label 'Transferring connection string values from Dynamics 365 sales connection setup to Dataverse connection setup', Locked = true;
         TestServerAddressTok: Label '@@test@@', Locked = true;
         DefaultingToDataverseServiceClientTxt: Label 'Defaulting to DataverseServiceClient', Locked = true;

--- a/src/Layers/W1/BaseApp/Integration/Dataverse/CDSConnectionSetup.Table.al
+++ b/src/Layers/W1/BaseApp/Integration/Dataverse/CDSConnectionSetup.Table.al
@@ -656,10 +656,8 @@ table 7200 "CDS Connection Setup"
     /// <param name="NewDataverseCloud">The cloud to use for OAuth authority and Global Discovery endpoints.</param>
     procedure SetDataverseCloud(NewDataverseCloud: Enum "Dataverse Cloud")
     begin
-        if not Get() then begin
-            "Primary Key" := '';
-            Insert(); // TODONAT: not a fan. if not exists then just exit.
-        end;
+        if not Get() then
+            exit;
         Validate("Dataverse Cloud", NewDataverseCloud);
         Modify(true);
     end;

--- a/src/Layers/W1/BaseApp/Integration/Dataverse/CDSConnectionSetup.Table.al
+++ b/src/Layers/W1/BaseApp/Integration/Dataverse/CDSConnectionSetup.Table.al
@@ -257,6 +257,12 @@ table 7200 "CDS Connection Setup"
             TableRelation = "CRM Transactioncurrency".ISOCurrencyCode;
             DataClassification = SystemMetadata;
         }
+        field(242; "Dataverse Cloud"; Enum "Dataverse Cloud")
+        {
+            Caption = 'Dataverse Cloud';
+            Description = 'Identifies the cloud whose OAuth authority and Dataverse Global Discovery endpoints are used when connecting to Dataverse. Set to a sovereign cloud (for example GCC High) through SetDataverseCloud to override the worldwide defaults.';
+            DataClassification = SystemMetadata;
+        }
     }
 
     keys
@@ -639,6 +645,33 @@ table 7200 "CDS Connection Setup"
     [IntegrationEvent(false, false)]
     local procedure OnEnsureConnectionSetupIsDisabled()
     begin
+    end;
+
+    /// <summary>
+    /// Sets the cloud whose OAuth authority and Dataverse Global Discovery endpoints are used when
+    /// connecting to Dataverse, and persists the change. Call this from a per-tenant extension to
+    /// connect against a sovereign cloud (for example GCC High) by passing a value added to the
+    /// "Dataverse Cloud" enum.
+    /// </summary>
+    /// <param name="NewDataverseCloud">The cloud to use for OAuth authority and Global Discovery endpoints.</param>
+    procedure SetDataverseCloud(NewDataverseCloud: Enum "Dataverse Cloud")
+    begin
+        if not Get() then begin
+            "Primary Key" := '';
+            Insert(); // TODONAT: not a fan. if not exists then just exit.
+        end;
+        Validate("Dataverse Cloud", NewDataverseCloud);
+        Modify(true);
+    end;
+
+    /// <summary>
+    /// Gets the OAuth authority and Dataverse Global Discovery endpoints for the configured
+    /// <see cref="Dataverse Cloud"/>.
+    /// </summary>
+    /// <returns>The endpoints implementation for the configured cloud.</returns>
+    procedure GetDataverseCloudEndpoints(): Interface "Dataverse Cloud Endpoints"
+    begin
+        exit("Dataverse Cloud");
     end;
 
     var

--- a/src/Layers/W1/BaseApp/Integration/Dataverse/CDSConnectionSetupWizard.Page.al
+++ b/src/Layers/W1/BaseApp/Integration/Dataverse/CDSConnectionSetupWizard.Page.al
@@ -954,7 +954,6 @@ page 7201 "CDS Connection Setup Wizard"
         ConsentStepVisible: Boolean;
         ShowDifferentTenantWarning: Boolean;
         InitialSynchRecommendations: Dictionary of [Code[20], Integer];
-        ScopesLbl: Label 'https://globaldisco.crm.dynamics.com/user_impersonation', Locked = true;
         OpenCoupleSalespeoplePageQst: Label 'The Person ownership model requires that you couple salespeople in Business Central with users in Dataverse before you synchronize data. Otherwise, synchronization will not be successful.\\ Do you want to want to couple salespeople and users now?';
         SynchronizationRecommendationsLbl: Label 'Show synchronization recommendations';
         ConsentLbl: Label 'By enabling this feature, you consent to your data being shared with a Microsoft service that might be outside of your organization''s selected geographic boundaries and might have different compliance and security standards than Microsoft Dynamics Business Central. Your privacy is important to us, and you can choose whether to share data with the service. To learn more, follow the link below.';
@@ -993,15 +992,17 @@ page 7201 "CDS Connection Setup Wizard"
     local procedure GetCDSEnvironment()
     var
         OAuth2: Codeunit OAuth2;
+        Endpoints: Interface "Dataverse Cloud Endpoints";
         Scopes: List of [Text];
         Token: SecretText;
         RedirectUrl: Text;
     begin
+        Endpoints := Rec.GetDataverseCloudEndpoints();
         if SoftwareAsAService then
             RedirectUrl := CDSIntegrationImpl.GetRedirectURL()
         else
             RedirectUrl := Rec."Redirect URL";
-        Scopes.Add(ScopesLbl);
+        Scopes.Add(Endpoints.GetGlobalDiscoveryScope());
         OAuth2.AcquireOnBehalfOfToken(RedirectUrl, Scopes, Token);
         CDSEnvironment.SelectTenantEnvironment(Rec, Token, false);
     end;

--- a/src/Layers/W1/BaseApp/Integration/Dataverse/CDSEnvironment.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Dataverse/CDSEnvironment.Codeunit.al
@@ -17,8 +17,6 @@ codeunit 7203 "CDS Environment"
     end;
 
     var
-        OAuthAuthorityUrlAuthCodeTxt: Label 'https://login.microsoftonline.com/common/oauth2', Locked = true;
-        ScopesLbl: Label 'https://globaldisco.crm.dynamics.com/user_impersonation', Locked = true;
         GlobalDiscoOauthCategoryLbl: Label 'Global Discoverability OAuth', Locked = true;
         MissingKeyErr: Label 'The consumer key has not been initialized and are missing from the Azure Key Vault.';
         MissingSecretErr: Label 'The consumer secret has not been initialized and are missing from the Azure Key Vault.';
@@ -35,7 +33,6 @@ codeunit 7203 "CDS Environment"
         EnvironmentUrlEmptyTxt: Label 'Environment URL is empty.', Locked = true;
         NoEnvironmentsWhenUrlNotEmptyMsg: Label 'No Dataverse environments were discovered.';
         NoEnvironmentsWhenUrlEmptyMsg: Label 'No Dataverse environments were discovered. Enter the URL of the Dataverse environment to connect to.';
-        GlobalDiscoApiUrlTok: Label 'https://globaldisco.crm.dynamics.com/api/discovery/v2.0/Instances', Locked = true;
         RequestFailedWithStatusCodeTxt: Label 'Request failed with status code %1.', Locked = true;
         EnvironmentIdFilterTok: Label '?$filter=EnvironmentId eq ''%1''', Locked = true, Comment = '%1 = The environment id to filter on';
 
@@ -82,10 +79,12 @@ codeunit 7203 "CDS Environment"
     var
         OAuth2: Codeunit OAuth2;
         CDSIntegrationImpl: Codeunit "CDS Integration Impl.";
+        Endpoints: Interface "Dataverse Cloud Endpoints";
         Scopes: List of [Text];
         Token: SecretText;
     begin
-        Scopes.Add(ScopesLbl);
+        Endpoints := CDSIntegrationImpl.GetDataverseCloudEndpoints();
+        Scopes.Add(Endpoints.GetGlobalDiscoveryScope());
         OAuth2.AcquireOnBehalfOfToken(CDSIntegrationImpl.GetRedirectURL(), Scopes, Token);
         exit(Token);
     end;
@@ -97,6 +96,7 @@ codeunit 7203 "CDS Environment"
         OAuth2: Codeunit OAuth2;
         CDSIntegrationImpl: Codeunit "CDS Integration Impl.";
         PromptInteraction: Enum "Prompt Interaction";
+        Endpoints: Interface "Dataverse Cloud Endpoints";
         Scopes: List of [Text];
         ConsumerKey: Text;
         ConsumerSecret: SecretText;
@@ -106,7 +106,8 @@ codeunit 7203 "CDS Environment"
         Token: SecretText;
         Err: Text;
     begin
-        Scopes.Add(ScopesLbl);
+        Endpoints := CDSIntegrationImpl.GetDataverseCloudEndpoints();
+        Scopes.Add(Endpoints.GetGlobalDiscoveryScope());
         OAuth2.AcquireOnBehalfOfToken(CDSIntegrationImpl.GetRedirectURL(), Scopes, Token);
         if not Token.IsEmpty() then
             exit(Token);
@@ -118,9 +119,9 @@ codeunit 7203 "CDS Environment"
         RedirectUrl := CDSIntegrationImpl.GetRedirectURL();
         if (FirstPartyappId <> '') and (not (FirstPartyAppCertificate.IsEmpty())) then begin
             Session.LogMessage('0000EI6', AcquiringAuthCodeTokenWithCertificateTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', GlobalDiscoOauthCategoryLbl);
-            OAuth2.AcquireAuthorizationCodeTokenFromCacheWithCertificate(FirstPartyappId, FirstPartyAppCertificate, RedirectUrl, OAuthAuthorityUrlAuthCodeTxt, Scopes, Token);
+            OAuth2.AcquireAuthorizationCodeTokenFromCacheWithCertificate(FirstPartyappId, FirstPartyAppCertificate, RedirectUrl, Endpoints.GetOAuthAuthorityUrl(), Scopes, Token);
             if Token.IsEmpty() then
-                OAuth2.AcquireTokenByAuthorizationCodeWithCertificate(FirstPartyappId, FirstPartyAppCertificate, OAuthAuthorityUrlAuthCodeTxt, RedirectUrl, Scopes, PromptInteraction::Login, Token, Err);
+                OAuth2.AcquireTokenByAuthorizationCodeWithCertificate(FirstPartyappId, FirstPartyAppCertificate, Endpoints.GetOAuthAuthorityUrl(), RedirectUrl, Scopes, PromptInteraction::Login, Token, Err);
 
             if Token.IsEmpty() then
                 Session.LogMessage('0000EI7', ReceivedEmptyAuthCodeTokenErr, Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', GlobalDiscoOauthCategoryLbl);
@@ -138,9 +139,9 @@ codeunit 7203 "CDS Environment"
             Session.LogMessage('0000BRC', MissingSecretErr, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', GlobalDiscoOauthCategoryLbl);
 
         if (ConsumerKey <> '') and (not ConsumerSecret.IsEmpty()) then begin
-            OAuth2.AcquireAuthorizationCodeTokenFromCache(ConsumerKey, ConsumerSecret, RedirectUrl, OAuthAuthorityUrlAuthCodeTxt, Scopes, Token);
+            OAuth2.AcquireAuthorizationCodeTokenFromCache(ConsumerKey, ConsumerSecret, RedirectUrl, Endpoints.GetOAuthAuthorityUrl(), Scopes, Token);
             if Token.IsEmpty() then
-                OAuth2.AcquireTokenByAuthorizationCode(ConsumerKey, ConsumerSecret, OAuthAuthorityUrlAuthCodeTxt, RedirectUrl, Scopes, PromptInteraction::Login, Token, Err);
+                OAuth2.AcquireTokenByAuthorizationCode(ConsumerKey, ConsumerSecret, Endpoints.GetOAuthAuthorityUrl(), RedirectUrl, Scopes, PromptInteraction::Login, Token, Err);
         end;
         if Token.IsEmpty() then
             Session.LogMessage('0000C6I', ReceivedEmptyAuthCodeTokenErr, Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', GlobalDiscoOauthCategoryLbl);
@@ -151,7 +152,9 @@ codeunit 7203 "CDS Environment"
     local procedure GetCDSEnvironmentCount(var TempCDSEnvironment: Record "CDS Environment" temporary; Token: SecretText; FilterTxt: Text): Integer
     var
         EnvironmentInformation: Codeunit "Environment Information";
+        CDSIntegrationImpl: Codeunit "CDS Integration Impl.";
         TempBlob: Codeunit "Temp Blob";
+        Endpoints: Interface "Dataverse Cloud Endpoints";
         RequestMessage: HttpRequestMessage;
         ResponseMessage: HttpResponseMessage;
         RequestHeaders: HttpHeaders;
@@ -168,10 +171,11 @@ codeunit 7203 "CDS Environment"
         StatusCode: Integer;
         EnvironmentCount: Integer;
     begin
+        Endpoints := CDSIntegrationImpl.GetDataverseCloudEndpoints();
         RequestMessage.GetHeaders(RequestHeaders);
         RequestHeaders.Add('Authorization', SecretStrSubstNo('Bearer %1', Token));
 
-        RequestMessage.SetRequestUri(GlobalDiscoApiUrlTok + FilterTxt);
+        RequestMessage.SetRequestUri(Endpoints.GetGlobalDiscoveryApiUrl() + FilterTxt);
         RequestMessage.Method('GET');
 
         Clear(TempBlob);

--- a/src/Layers/W1/BaseApp/Integration/Dataverse/CDSIntegrationImpl.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Dataverse/CDSIntegrationImpl.Codeunit.al
@@ -267,8 +267,6 @@ codeunit 7201 "CDS Integration Impl."
         ConnectionDefaultNameTok: Label 'Dataverse', Locked = true;
         BaseSolutionUniqueNameTxt: Label 'bcbi_CdsBaseIntegration', Locked = true;
         BaseSolutionDisplayNameTxt: Label 'Business Central Dataverse Base Integration', Locked = true;
-        OAuthAuthorityUrlTxt: Label 'https://login.microsoftonline.com/common/oauth2', Locked = true;
-        ClientCredentialsTokenAuthorityUrlTxt: Label 'https://login.microsoftonline.com/organizations/oauth2/v2.0/token', Locked = true;
         TemporaryConnectionName: Text;
         CDSConnectionClientIdAKVSecretNameLbl: Label 'globaldisco-clientid', Locked = true;
         CDSConnectionFirstPartyAppIdAKVSecretNameLbl: Label 'bctocdsappid', Locked = true;
@@ -3400,11 +3398,22 @@ codeunit 7201 "CDS Integration Impl."
     end;
 
 
+    internal procedure GetDataverseCloudEndpoints() Endpoints: Interface "Dataverse Cloud Endpoints"
+    var
+        CDSConnectionSetup: Record "CDS Connection Setup";
+        DataverseCloud: Enum "Dataverse Cloud";
+    begin
+        if CDSConnectionSetup.Get() then
+            DataverseCloud := CDSConnectionSetup."Dataverse Cloud";
+        exit(DataverseCloud);
+    end;
+
     [Scope('OnPrem')]
     procedure GetAccessToken(ResourceURL: Text; GetTokenFromCache: Boolean; var AccessToken: SecretText)
     var
         OAuth2: Codeunit OAuth2;
         PromptInteraction: Enum "Prompt Interaction";
+        Endpoints: Interface "Dataverse Cloud Endpoints";
         Scopes: List of [Text];
         [NonDebuggable]
         ClientId: Text;
@@ -3416,6 +3425,7 @@ codeunit 7201 "CDS Integration Impl."
         RedirectUrl: Text;
         AuthCodeError: Text;
     begin
+        Endpoints := GetDataverseCloudEndpoints();
         Scopes.Add(ResourceURL + '/user_impersonation');
         ClientId := GetCDSConnectionClientId();
         ClientSecret := GetCDSConnectionClientSecret();
@@ -3430,10 +3440,10 @@ codeunit 7201 "CDS Integration Impl."
         if GetTokenFromCache then
             if (FirstPartyAppId <> '') and (not FirstPartyAppCertificate.IsEmpty()) then begin
                 Session.LogMessage('0000EI9', AttemptingAuthCodeTokenFromCacheWithCertTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CategoryTok);
-                OAuth2.AcquireAuthorizationCodeTokenFromCacheWithCertificate(FirstPartyAppId, FirstPartyAppCertificate, RedirectUrl, OAuthAuthorityUrlTxt, ResourceURL, AccessToken)
+                OAuth2.AcquireAuthorizationCodeTokenFromCacheWithCertificate(FirstPartyAppId, FirstPartyAppCertificate, RedirectUrl, Endpoints.GetOAuthAuthorityUrl(), ResourceURL, AccessToken)
             end else begin
                 Session.LogMessage('0000EIA', AttemptingAuthCodeTokenFromCacheWithClientSecretTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CategoryTok);
-                OAuth2.AcquireAuthorizationCodeTokenFromCache(ClientId, ClientSecret, RedirectUrl, OAuthAuthorityUrlTxt, Scopes, AccessToken);
+                OAuth2.AcquireAuthorizationCodeTokenFromCache(ClientId, ClientSecret, RedirectUrl, Endpoints.GetOAuthAuthorityUrl(), Scopes, AccessToken);
             end;
         if AccessToken.IsEmpty() then begin
             if not GuiAllowed then begin
@@ -3446,7 +3456,7 @@ codeunit 7201 "CDS Integration Impl."
                 OAuth2.AcquireTokenByAuthorizationCodeWithCertificate(
                     FirstPartyAppId,
                     FirstPartyAppCertificate,
-                    OAuthAuthorityUrlTxt,
+                    Endpoints.GetOAuthAuthorityUrl(),
                     RedirectUrl,
                     ResourceURL,
                     PromptInteraction::Consent,
@@ -3457,7 +3467,7 @@ codeunit 7201 "CDS Integration Impl."
                 OAuth2.AcquireTokenByAuthorizationCode(
                     ClientId,
                     ClientSecret,
-                    OAuthAuthorityUrlTxt,
+                    Endpoints.GetOAuthAuthorityUrl(),
                     RedirectUrl,
                     Scopes,
                     PromptInteraction::Consent,
@@ -3478,6 +3488,7 @@ codeunit 7201 "CDS Integration Impl."
     procedure GetBusinessEventAccessToken(ResourceURL: Text; GetTokenFromCache: Boolean; var AccessToken: SecretText)
     var
         OAuth2: Codeunit OAuth2;
+        Endpoints: Interface "Dataverse Cloud Endpoints";
         Scopes: List of [Text];
         [NonDebuggable]
         ClientId: Text;
@@ -3490,6 +3501,7 @@ codeunit 7201 "CDS Integration Impl."
         AuthCodeError: Text;
         IdToken: Text;
     begin
+        Endpoints := GetDataverseCloudEndpoints();
         Scopes.Add(ResourceURL + '/.default');
         ClientId := GetCDSConnectionClientId();
         ClientSecret := GetCDSConnectionClientSecret();
@@ -3504,19 +3516,19 @@ codeunit 7201 "CDS Integration Impl."
         if GetTokenFromCache then
             if (FirstPartyAppId <> '') and (not FirstPartyAppCertificate.IsEmpty()) then begin
                 Session.LogMessage('0000GIG', AttemptingClientCredentialsTokenFromCacheWithCertTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CategoryTok);
-                OAuth2.AcquireTokensFromCacheWithCertificate(FirstPartyAppId, FirstPartyAppCertificate, RedirectUrl, ClientCredentialsTokenAuthorityUrlTxt, Scopes, AccessToken, IdToken);
+                OAuth2.AcquireTokensFromCacheWithCertificate(FirstPartyAppId, FirstPartyAppCertificate, RedirectUrl, Endpoints.GetClientCredentialsTokenAuthorityUrl(), Scopes, AccessToken, IdToken);
             end else begin
                 Session.LogMessage('0000GIH', AttemptingClientCredentialsTokenFromCacheWithClientSecretTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CategoryTok);
-                OAuth2.AcquireTokensFromCache(ClientId, ClientSecret, RedirectUrl, ClientCredentialsTokenAuthorityUrlTxt, Scopes, AccessToken, IdToken);
+                OAuth2.AcquireTokensFromCache(ClientId, ClientSecret, RedirectUrl, Endpoints.GetClientCredentialsTokenAuthorityUrl(), Scopes, AccessToken, IdToken);
             end;
 
         if AccessToken.IsEmpty() then
             if (FirstPartyAppId <> '') and (not FirstPartyAppCertificate.IsEmpty()) then begin
                 Session.LogMessage('0000GII', AttemptingClientCredentialsTokenWithCertTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CategoryTok);
-                OAuth2.AcquireTokensWithCertificate(FirstPartyAppId, FirstPartyAppCertificate, RedirectUrl, ClientCredentialsTokenAuthorityUrlTxt, Scopes, AccessToken, IdToken);
+                OAuth2.AcquireTokensWithCertificate(FirstPartyAppId, FirstPartyAppCertificate, RedirectUrl, Endpoints.GetClientCredentialsTokenAuthorityUrl(), Scopes, AccessToken, IdToken);
             end else begin
                 Session.LogMessage('0000GIJ', AttemptingClientCredentialsTokenWithClientSecretTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CategoryTok);
-                OAuth2.AcquireTokenWithClientCredentials(ClientId, ClientSecret, ClientCredentialsTokenAuthorityUrlTxt, RedirectUrl, Scopes, AccessToken);
+                OAuth2.AcquireTokenWithClientCredentials(ClientId, ClientSecret, Endpoints.GetClientCredentialsTokenAuthorityUrl(), RedirectUrl, Scopes, AccessToken);
             end;
 
         if AccessToken.IsEmpty() then begin

--- a/src/Layers/W1/BaseApp/Integration/Dataverse/CDSIntegrationImpl.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Dataverse/CDSIntegrationImpl.Codeunit.al
@@ -3398,14 +3398,13 @@ codeunit 7201 "CDS Integration Impl."
     end;
 
 
-    internal procedure GetDataverseCloudEndpoints() Endpoints: Interface "Dataverse Cloud Endpoints"
+    internal procedure GetDataverseCloudEndpoints(): Interface "Dataverse Cloud Endpoints"
     var
         CDSConnectionSetup: Record "CDS Connection Setup";
-        DataverseCloud: Enum "Dataverse Cloud";
     begin
-        if CDSConnectionSetup.Get() then
-            DataverseCloud := CDSConnectionSetup."Dataverse Cloud";
-        exit(DataverseCloud);
+        if not CDSConnectionSetup.Get() then
+            CDSConnectionSetup.Init();
+        exit(CDSConnectionSetup.GetDataverseCloudEndpoints());
     end;
 
     [Scope('OnPrem')]

--- a/src/Layers/W1/BaseApp/Integration/Dataverse/CommercialDataverseEndpoints.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Dataverse/CommercialDataverseEndpoints.Codeunit.al
@@ -1,0 +1,40 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Integration.Dataverse;
+
+/// <summary>
+/// Default (commercial) implementation of <see cref="Dataverse Cloud Endpoints"/>, returning the
+/// worldwide OAuth authority and Dataverse Global Discovery endpoints.
+/// </summary>
+codeunit 7208 "Commercial Dataverse Endpoints" implements "Dataverse Cloud Endpoints"
+{
+    Access = Internal;
+
+    var
+        OAuthAuthorityUrlTxt: Label 'https://login.microsoftonline.com/common/oauth2', Locked = true;
+        ClientCredentialsTokenAuthorityUrlTxt: Label 'https://login.microsoftonline.com/organizations/oauth2/v2.0/token', Locked = true;
+        GlobalDiscoveryScopeTxt: Label 'https://globaldisco.crm.dynamics.com/user_impersonation', Locked = true;
+        GlobalDiscoveryApiUrlTxt: Label 'https://globaldisco.crm.dynamics.com/api/discovery/v2.0/Instances', Locked = true;
+
+    procedure GetOAuthAuthorityUrl(): Text
+    begin
+        exit(OAuthAuthorityUrlTxt);
+    end;
+
+    procedure GetClientCredentialsTokenAuthorityUrl(): Text
+    begin
+        exit(ClientCredentialsTokenAuthorityUrlTxt);
+    end;
+
+    procedure GetGlobalDiscoveryScope(): Text
+    begin
+        exit(GlobalDiscoveryScopeTxt);
+    end;
+
+    procedure GetGlobalDiscoveryApiUrl(): Text
+    begin
+        exit(GlobalDiscoveryApiUrlTxt);
+    end;
+}

--- a/src/Layers/W1/BaseApp/Integration/Dataverse/DataverseCloud.Enum.al
+++ b/src/Layers/W1/BaseApp/Integration/Dataverse/DataverseCloud.Enum.al
@@ -1,0 +1,26 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Integration.Dataverse;
+
+/// <summary>
+/// Identifies the cloud whose OAuth authority and Dataverse Global Discovery endpoints are used when
+/// connecting to Dataverse. Extend this enum and implement <see cref="Dataverse Cloud Endpoints"/> to
+/// add support for a sovereign cloud (for example GCC High, US-DoD or China), then select it per tenant
+/// through <c>CDS Connection Setup.SetDataverseCloud</c>.
+/// </summary>
+enum 7207 "Dataverse Cloud" implements "Dataverse Cloud Endpoints"
+{
+    Extensible = true;
+
+    /// <summary>
+    /// The worldwide (commercial) cloud, using the public login.microsoftonline.com and
+    /// globaldisco.crm.dynamics.com hosts. This is the default.
+    /// </summary>
+    value(0; Commercial)
+    {
+        Caption = 'Commercial';
+        Implementation = "Dataverse Cloud Endpoints" = "Commercial Dataverse Endpoints";
+    }
+}

--- a/src/Layers/W1/BaseApp/Integration/Dataverse/DataverseCloudEndpoints.Interface.al
+++ b/src/Layers/W1/BaseApp/Integration/Dataverse/DataverseCloudEndpoints.Interface.al
@@ -1,0 +1,39 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Integration.Dataverse;
+
+/// <summary>
+/// Provides the cloud-specific OAuth authority and Dataverse Global Discovery endpoints used when
+/// connecting to Dataverse. Implement this interface to support sovereign clouds (for example
+/// GCC High, US-DoD or China), where these hosts differ from the worldwide (commercial) defaults.
+/// </summary>
+interface "Dataverse Cloud Endpoints"
+{
+    Access = Public;
+
+    /// <summary>
+    /// Gets the OAuth authority URL used for the authorization code flow (delegated user sign-in).
+    /// </summary>
+    /// <returns>The OAuth authority URL, for example 'https://login.microsoftonline.com/common/oauth2'.</returns>
+    procedure GetOAuthAuthorityUrl(): Text;
+
+    /// <summary>
+    /// Gets the OAuth authority URL used for the client credentials flow (service-to-service tokens).
+    /// </summary>
+    /// <returns>The OAuth token authority URL, for example 'https://login.microsoftonline.com/organizations/oauth2/v2.0/token'.</returns>
+    procedure GetClientCredentialsTokenAuthorityUrl(): Text;
+
+    /// <summary>
+    /// Gets the OAuth scope requested when acquiring a token for the Dataverse Global Discovery service.
+    /// </summary>
+    /// <returns>The Global Discovery scope, for example 'https://globaldisco.crm.dynamics.com/user_impersonation'.</returns>
+    procedure GetGlobalDiscoveryScope(): Text;
+
+    /// <summary>
+    /// Gets the Dataverse Global Discovery service instances endpoint used to enumerate environments.
+    /// </summary>
+    /// <returns>The Global Discovery instances URL, for example 'https://globaldisco.crm.dynamics.com/api/discovery/v2.0/Instances'.</returns>
+    procedure GetGlobalDiscoveryApiUrl(): Text;
+}

--- a/src/Layers/W1/Tests/CRM integration/CDSConnectionSetupTest.Codeunit.al
+++ b/src/Layers/W1/Tests/CRM integration/CDSConnectionSetupTest.Codeunit.al
@@ -48,7 +48,7 @@ codeunit 139196 "CDS Connection Setup Test"
     [Scope('OnPrem')]
     procedure DataverseCloudDefaultsToCommercialEndpoints()
     var
-        CDSConnectionSetup: Record "CDS Connection Setup" temporary;
+        TempCDSConnectionSetup: Record "CDS Connection Setup" temporary;
         DataverseCloud: Enum "Dataverse Cloud";
         Endpoints: Interface "Dataverse Cloud Endpoints";
     begin
@@ -57,13 +57,13 @@ codeunit 139196 "CDS Connection Setup Test"
         Initialize();
 
         // [GIVEN] A Dataverse Connection Setup with the default Dataverse Cloud
-        CDSConnectionSetup.Init();
+        TempCDSConnectionSetup.Init();
 
         // [THEN] The Dataverse Cloud is Commercial
-        Assert.AreEqual(DataverseCloud::Commercial, CDSConnectionSetup."Dataverse Cloud", 'Dataverse Cloud should default to Commercial.');
+        Assert.AreEqual(DataverseCloud::Commercial, TempCDSConnectionSetup."Dataverse Cloud", 'Dataverse Cloud should default to Commercial.');
 
         // [THEN] The resolved endpoints are the worldwide commercial endpoints
-        Endpoints := CDSConnectionSetup.GetDataverseCloudEndpoints();
+        Endpoints := TempCDSConnectionSetup.GetDataverseCloudEndpoints();
         Assert.AreEqual(CommercialOAuthAuthorityUrlTxt, Endpoints.GetOAuthAuthorityUrl(), 'Unexpected OAuth authority URL.');
         Assert.AreEqual(CommercialClientCredentialsAuthorityUrlTxt, Endpoints.GetClientCredentialsTokenAuthorityUrl(), 'Unexpected client credentials authority URL.');
         Assert.AreEqual(CommercialGlobalDiscoveryScopeTxt, Endpoints.GetGlobalDiscoveryScope(), 'Unexpected Global Discovery scope.');
@@ -74,7 +74,7 @@ codeunit 139196 "CDS Connection Setup Test"
     [Scope('OnPrem')]
     procedure DataverseCloudOverrideReturnsPartnerEndpoints()
     var
-        CDSConnectionSetup: Record "CDS Connection Setup" temporary;
+        TempCDSConnectionSetup: Record "CDS Connection Setup" temporary;
         DataverseCloud: Enum "Dataverse Cloud";
         Endpoints: Interface "Dataverse Cloud Endpoints";
     begin
@@ -83,11 +83,11 @@ codeunit 139196 "CDS Connection Setup Test"
         Initialize();
 
         // [GIVEN] A Dataverse Connection Setup pointed at a partner (test) sovereign cloud
-        CDSConnectionSetup.Init();
-        CDSConnectionSetup."Dataverse Cloud" := DataverseCloud::TestSovereign;
+        TempCDSConnectionSetup.Init();
+        TempCDSConnectionSetup."Dataverse Cloud" := DataverseCloud::TestSovereign;
 
         // [THEN] The resolved endpoints come from the partner implementation, not the commercial defaults
-        Endpoints := CDSConnectionSetup.GetDataverseCloudEndpoints();
+        Endpoints := TempCDSConnectionSetup.GetDataverseCloudEndpoints();
         Assert.AreEqual(SovereignOAuthAuthorityUrlTxt, Endpoints.GetOAuthAuthorityUrl(), 'Unexpected OAuth authority URL.');
         Assert.AreEqual(SovereignGlobalDiscoveryApiUrlTxt, Endpoints.GetGlobalDiscoveryApiUrl(), 'Unexpected Global Discovery API URL.');
     end;
@@ -115,6 +115,27 @@ codeunit 139196 "CDS Connection Setup Test"
         // [THEN] The selection is persisted
         CDSConnectionSetupReread.Get();
         Assert.AreEqual(DataverseCloud::TestSovereign, CDSConnectionSetupReread."Dataverse Cloud", 'SetDataverseCloud should persist the selected cloud.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure SetDataverseCloudErrorsWhenSetupMissing()
+    var
+        CDSConnectionSetup: Record "CDS Connection Setup";
+        DataverseCloud: Enum "Dataverse Cloud";
+    begin
+        // [FEATURE] [Dataverse Cloud]
+        // [SCENARIO] SetDataverseCloud raises an error, instead of silently doing nothing, when no setup record exists.
+        Initialize();
+
+        // [GIVEN] No Dataverse Connection Setup record
+        CDSConnectionSetup.DeleteAll();
+
+        // [WHEN] A partner selects a sovereign cloud through SetDataverseCloud
+        asserterror CDSConnectionSetup.SetDataverseCloud(DataverseCloud::TestSovereign);
+
+        // [THEN] An error is raised so the no-op is not silent
+        Assert.ExpectedError('does not exist');
     end;
 
     [Test]

--- a/src/Layers/W1/Tests/CRM integration/CDSConnectionSetupTest.Codeunit.al
+++ b/src/Layers/W1/Tests/CRM integration/CDSConnectionSetupTest.Codeunit.al
@@ -36,7 +36,86 @@ codeunit 139196 "CDS Connection Setup Test"
         ClientIdTok: Label '{CLIENTID}', Locked = true;
         ClientSecretTok: Label '{CLIENTSECRET}', Locked = true;
         CertificateTok: Label '{CERTIFICATE}', Locked = true;
+        CommercialOAuthAuthorityUrlTxt: Label 'https://login.microsoftonline.com/common/oauth2', Locked = true;
+        CommercialClientCredentialsAuthorityUrlTxt: Label 'https://login.microsoftonline.com/organizations/oauth2/v2.0/token', Locked = true;
+        CommercialGlobalDiscoveryScopeTxt: Label 'https://globaldisco.crm.dynamics.com/user_impersonation', Locked = true;
+        CommercialGlobalDiscoveryApiUrlTxt: Label 'https://globaldisco.crm.dynamics.com/api/discovery/v2.0/Instances', Locked = true;
+        SovereignOAuthAuthorityUrlTxt: Label 'https://login.microsoftonline.us/common/oauth2', Locked = true;
+        SovereignGlobalDiscoveryApiUrlTxt: Label 'https://globaldisco.crm.microsoftdynamics.us/api/discovery/v2.0/Instances', Locked = true;
         IsInitialized: Boolean;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DataverseCloudDefaultsToCommercialEndpoints()
+    var
+        CDSConnectionSetup: Record "CDS Connection Setup" temporary;
+        DataverseCloud: Enum "Dataverse Cloud";
+        Endpoints: Interface "Dataverse Cloud Endpoints";
+    begin
+        // [FEATURE] [Dataverse Cloud]
+        // [SCENARIO] A new Dataverse Connection Setup uses the worldwide (commercial) endpoints by default.
+        Initialize();
+
+        // [GIVEN] A Dataverse Connection Setup with the default Dataverse Cloud
+        CDSConnectionSetup.Init();
+
+        // [THEN] The Dataverse Cloud is Commercial
+        Assert.AreEqual(DataverseCloud::Commercial, CDSConnectionSetup."Dataverse Cloud", 'Dataverse Cloud should default to Commercial.');
+
+        // [THEN] The resolved endpoints are the worldwide commercial endpoints
+        Endpoints := CDSConnectionSetup.GetDataverseCloudEndpoints();
+        Assert.AreEqual(CommercialOAuthAuthorityUrlTxt, Endpoints.GetOAuthAuthorityUrl(), 'Unexpected OAuth authority URL.');
+        Assert.AreEqual(CommercialClientCredentialsAuthorityUrlTxt, Endpoints.GetClientCredentialsTokenAuthorityUrl(), 'Unexpected client credentials authority URL.');
+        Assert.AreEqual(CommercialGlobalDiscoveryScopeTxt, Endpoints.GetGlobalDiscoveryScope(), 'Unexpected Global Discovery scope.');
+        Assert.AreEqual(CommercialGlobalDiscoveryApiUrlTxt, Endpoints.GetGlobalDiscoveryApiUrl(), 'Unexpected Global Discovery API URL.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DataverseCloudOverrideReturnsPartnerEndpoints()
+    var
+        CDSConnectionSetup: Record "CDS Connection Setup" temporary;
+        DataverseCloud: Enum "Dataverse Cloud";
+        Endpoints: Interface "Dataverse Cloud Endpoints";
+    begin
+        // [FEATURE] [Dataverse Cloud]
+        // [SCENARIO] A partner-supplied Dataverse Cloud implementation overrides the endpoints used to connect.
+        Initialize();
+
+        // [GIVEN] A Dataverse Connection Setup pointed at a partner (test) sovereign cloud
+        CDSConnectionSetup.Init();
+        CDSConnectionSetup."Dataverse Cloud" := DataverseCloud::TestSovereign;
+
+        // [THEN] The resolved endpoints come from the partner implementation, not the commercial defaults
+        Endpoints := CDSConnectionSetup.GetDataverseCloudEndpoints();
+        Assert.AreEqual(SovereignOAuthAuthorityUrlTxt, Endpoints.GetOAuthAuthorityUrl(), 'Unexpected OAuth authority URL.');
+        Assert.AreEqual(SovereignGlobalDiscoveryApiUrlTxt, Endpoints.GetGlobalDiscoveryApiUrl(), 'Unexpected Global Discovery API URL.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure SetDataverseCloudPersistsSelection()
+    var
+        CDSConnectionSetup: Record "CDS Connection Setup";
+        CDSConnectionSetupReread: Record "CDS Connection Setup";
+        DataverseCloud: Enum "Dataverse Cloud";
+    begin
+        // [FEATURE] [Dataverse Cloud]
+        // [SCENARIO] SetDataverseCloud persists the selected cloud on the Dataverse Connection Setup.
+        Initialize();
+
+        // [GIVEN] A Dataverse Connection Setup record
+        CDSConnectionSetup.DeleteAll();
+        CDSConnectionSetup.Init();
+        CDSConnectionSetup.Insert();
+
+        // [WHEN] A partner selects a sovereign cloud through SetDataverseCloud
+        CDSConnectionSetup.SetDataverseCloud(DataverseCloud::TestSovereign);
+
+        // [THEN] The selection is persisted
+        CDSConnectionSetupReread.Get();
+        Assert.AreEqual(DataverseCloud::TestSovereign, CDSConnectionSetupReread."Dataverse Cloud", 'SetDataverseCloud should persist the selected cloud.');
+    end;
 
     [Test]
     [HandlerFunctions('AssistedSetupModalHandler,ConfirmYes')]

--- a/src/Layers/W1/Tests/CRM integration/DataverseCloudTest.EnumExt.al
+++ b/src/Layers/W1/Tests/CRM integration/DataverseCloudTest.EnumExt.al
@@ -1,0 +1,15 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+// Test-only extension of the "Dataverse Cloud" enum, simulating a partner adding support for a
+// sovereign cloud with its own "Dataverse Cloud Endpoints" implementation.
+enumextension 139200 "Dataverse Cloud Test" extends "Dataverse Cloud"
+{
+    value(139200; TestSovereign)
+    {
+        Caption = 'Test Sovereign';
+        Implementation = "Dataverse Cloud Endpoints" = "Test Dataverse Cloud Endpoints";
+    }
+}

--- a/src/Layers/W1/Tests/CRM integration/DataverseCloudTest.EnumExt.al
+++ b/src/Layers/W1/Tests/CRM integration/DataverseCloudTest.EnumExt.al
@@ -5,9 +5,9 @@
 
 // Test-only extension of the "Dataverse Cloud" enum, simulating a partner adding support for a
 // sovereign cloud with its own "Dataverse Cloud Endpoints" implementation.
-enumextension 139200 "Dataverse Cloud Test" extends "Dataverse Cloud"
+enumextension 139202 "Dataverse Cloud Test" extends "Dataverse Cloud"
 {
-    value(139200; TestSovereign)
+    value(139202; TestSovereign)
     {
         Caption = 'Test Sovereign';
         Implementation = "Dataverse Cloud Endpoints" = "Test Dataverse Cloud Endpoints";

--- a/src/Layers/W1/Tests/CRM integration/TestDataverseCloudEndpoints.Codeunit.al
+++ b/src/Layers/W1/Tests/CRM integration/TestDataverseCloudEndpoints.Codeunit.al
@@ -6,7 +6,7 @@
 // Test double simulating a partner-supplied sovereign-cloud implementation of the
 // "Dataverse Cloud Endpoints" interface. Returns US Government (GCC High) style endpoints so tests
 // can assert that a partner override flows through the CDS connection code.
-codeunit 139197 "Test Dataverse Cloud Endpoints" implements "Dataverse Cloud Endpoints"
+codeunit 139201 "Test Dataverse Cloud Endpoints" implements "Dataverse Cloud Endpoints"
 {
     var
         OAuthAuthorityUrlTxt: Label 'https://login.microsoftonline.us/common/oauth2', Locked = true;

--- a/src/Layers/W1/Tests/CRM integration/TestDataverseCloudEndpoints.Codeunit.al
+++ b/src/Layers/W1/Tests/CRM integration/TestDataverseCloudEndpoints.Codeunit.al
@@ -1,0 +1,36 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+// Test double simulating a partner-supplied sovereign-cloud implementation of the
+// "Dataverse Cloud Endpoints" interface. Returns US Government (GCC High) style endpoints so tests
+// can assert that a partner override flows through the CDS connection code.
+codeunit 139197 "Test Dataverse Cloud Endpoints" implements "Dataverse Cloud Endpoints"
+{
+    var
+        OAuthAuthorityUrlTxt: Label 'https://login.microsoftonline.us/common/oauth2', Locked = true;
+        ClientCredentialsTokenAuthorityUrlTxt: Label 'https://login.microsoftonline.us/organizations/oauth2/v2.0/token', Locked = true;
+        GlobalDiscoveryScopeTxt: Label 'https://globaldisco.crm.microsoftdynamics.us/user_impersonation', Locked = true;
+        GlobalDiscoveryApiUrlTxt: Label 'https://globaldisco.crm.microsoftdynamics.us/api/discovery/v2.0/Instances', Locked = true;
+
+    procedure GetOAuthAuthorityUrl(): Text
+    begin
+        exit(OAuthAuthorityUrlTxt);
+    end;
+
+    procedure GetClientCredentialsTokenAuthorityUrl(): Text
+    begin
+        exit(ClientCredentialsTokenAuthorityUrlTxt);
+    end;
+
+    procedure GetGlobalDiscoveryScope(): Text
+    begin
+        exit(GlobalDiscoveryScopeTxt);
+    end;
+
+    procedure GetGlobalDiscoveryApiUrl(): Text
+    begin
+        exit(GlobalDiscoveryApiUrlTxt);
+    end;
+}


### PR DESCRIPTION
Fixes [AB#635858](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/635858)

## Problem
The BaseApp Dataverse integration hardcoded the worldwide OAuth authority host (`login.microsoftonline.com`) and Global Discovery host (`globaldisco.crm.dynamics.com`). In sovereign clouds (GCC High, US-DoD, China, etc.) these hosts differ, so sign-in and environment discovery could not complete. Partners had no supported override short of forking BaseApp.

## Solution
Add a structured, partner-extensible hook and route every sovereign-sensitive URL through it. Defaults are unchanged for commercial tenants; no UI and no auto-detection (all out of scope per the work item).

### New objects (`Microsoft.Integration.Dataverse`)
- **Interface `"Dataverse Cloud Endpoints"`** — `GetOAuthAuthorityUrl`, `GetClientCredentialsTokenAuthorityUrl`, `GetGlobalDiscoveryScope`, `GetGlobalDiscoveryApiUrl`.
- **Enum `7207 "Dataverse Cloud"`** (`Extensible = true`, default `Commercial`) implementing the interface.
- **Codeunit `7208 "Commercial Dataverse Endpoints"`** — the default implementation, holding the (moved) commercial URL labels.

### Selection
- New `field(242; "Dataverse Cloud")` on table `7200 "CDS Connection Setup"` (default `Commercial`, no page/UI).
- Public `SetDataverseCloud(NewDataverseCloud)` setter + `GetDataverseCloudEndpoints()` getter on the table.
- Internal resolver `"CDS Integration Impl.".GetDataverseCloudEndpoints()` reads the setup with a `Commercial` fallback.

### Call sites routed through the interface (old hardcoded labels removed)
- **CDS Environment** – Global Discovery scope, discovery API URL, and auth-code authority.
- **CDS Integration Impl.** – auth-code and client-credentials authorities.
- **CDS Connection Setup Wizard** – Global Discovery scope.

### Partner usage
```al
// Extension adds a value to the "Dataverse Cloud" enum + its own implementation, then:
CDSConnectionSetup.SetDataverseCloud(MyCloud::GCCHigh);
```

The new field defaults to `Commercial`, so existing tenants are unaffected and no upgrade code is needed.

## Test plan
Added to `CDSConnectionSetupTest.Codeunit.al`, backed by a partner-simulating enumextension (`139200 "Dataverse Cloud Test"`) and implementation codeunit (`139197 "Test Dataverse Cloud Endpoints"`):
- `DataverseCloudDefaultsToCommercialEndpoints` – default cloud is `Commercial` and returns the worldwide endpoints.
- `DataverseCloudOverrideReturnsPartnerEndpoints` – a partner cloud value returns the partner (sovereign) endpoints.
- `SetDataverseCloudPersistsSelection` – the public setter persists the selected cloud.




