### PR TITLE
[Quality Management] [28.x] Auto-calculate Pass/Fail Quantity fields and tooltip improvements

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspection.Page.al
@@ -519,7 +519,7 @@ page 20406 "Qlty. Inspection"
                 PromotedCategory = Process;
                 PromotedIsBig = true;
                 PromotedOnly = true;
-                ToolTip = 'Reopen';
+                ToolTip = 'Reopen a finished inspection. Only users with the Quality Admin & Supervisor role can perform this action.';
                 Enabled = CanReopen;
 
                 trigger OnAction()

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
@@ -93,13 +93,13 @@ table 20405 "Qlty. Inspection Header"
         {
             AutoFormatType = 0;
             Caption = 'Quantity (Base)';
-            ToolTip = 'Specifies a reference to the quantity involved.';
+            ToolTip = 'Specifies a reference to the quantity involved. Only users with the Quality Admin & Supervisor role can change this value.';
             DecimalPlaces = 0 : 5;
 
             trigger OnValidate()
             begin
                 if not Rec.IsTemporary() then
-                    if not GetIsCreating() then
+                    if not Rec.GetIsCreating() then
                         QltyPermissionMgmt.VerifyCanChangeSourceQuantity();
 
                 if Rec."Source Quantity (Base)" < 0 then
@@ -113,7 +113,7 @@ table 20405 "Qlty. Inspection Header"
         {
             Caption = 'Pass Quantity';
             AutoFormatType = 0;
-            ToolTip = 'Specifies the quantity that passed inspection. A manually entered quantity for non-sampling inspections, or derived from the quantity of passed sampling lines for sampling inspections.';
+            ToolTip = 'Specifies the quantity that passed quality inspection. When the inspection is finished with acceptable results, this value is automatically derived from sample size or source quantity. It is reset to zero when the inspection is reopened. Only users with the Quality Admin & Supervisor role are allowed to manually change this value.';
             DecimalPlaces = 0 : 5;
             MinValue = 0;
 
@@ -132,7 +132,7 @@ table 20405 "Qlty. Inspection Header"
         {
             Caption = 'Fail Quantity';
             AutoFormatType = 0;
-            ToolTip = 'Specifies the quantity that failed inspection. A manually entered quantity for non-sampling inspections, or derived from the quantity of failed sampling lines for sampling inspections.';
+            ToolTip = 'Specifies the quantity that failed quality inspection. When the inspection is finished with non-acceptable results, this value is automatically derived from sample size or source quantity. It is reset to zero when the inspection is reopened. Only users with the Quality Admin & Supervisor role are allowed to manually change this value.';
             DecimalPlaces = 0 : 5;
             MinValue = 0;
 
@@ -140,6 +140,7 @@ table 20405 "Qlty. Inspection Header"
             begin
                 if Rec.IsTemporary() then
                     exit;
+
                 if not Rec.GetIsCreating() then
                     QltyPermissionMgmt.VerifyCanChangeSourceQuantity();
 
@@ -149,12 +150,16 @@ table 20405 "Qlty. Inspection Header"
         field(17; "Sample Size"; Integer)
         {
             Caption = 'Sample Size';
-            ToolTip = 'Specifies the number of units that must be inspected. This will be used to fill out the sample size field on a Quality Inspection when possible based on the other characteristics that were applied.';
+            ToolTip = 'Specifies the number of units that must be inspected. This will be used to fill out the sample size field on a Quality Inspection when possible based on the other characteristics that were applied. Only users with the Quality Admin & Supervisor role can change this value.';
 
             trigger OnValidate()
             var
                 Math: Codeunit Math;
             begin
+                if not Rec.IsTemporary() then
+                    if not Rec.GetIsCreating() then
+                        QltyPermissionMgmt.VerifyCanChangeSourceQuantity();
+
                 if (Rec."Sample Size" > Rec."Source Quantity (Base)") and (Rec."Source Quantity (Base)" > 0) then begin
                     if GuiAllowed() and not Rec.GetIsCreating() and (not Rec.IsTemporary()) then
                         Message(SampleSizeInvalidMsg, Rec."Sample Size", Rec."No.", Rec."Source Quantity (Base)");
@@ -169,7 +174,7 @@ table 20405 "Qlty. Inspection Header"
             Editable = false;
             TableRelation = User."User Name";
             Caption = 'Assigned User ID';
-            ToolTip = 'Specifies the user this inspection is assigned to.';
+            ToolTip = 'Specifies the user this inspection is assigned to. Changing another user''s assignment requires the Quality Admin & Supervisor role.';
 
             trigger OnValidate()
             var
@@ -350,7 +355,7 @@ table 20405 "Qlty. Inspection Header"
                 if (Rec.Status = Rec.Status::Finished) and (Rec."Source Serial No." <> xRec."Source Serial No.") then
                     Error(TrackingCannotChangeForFinishedInspectionErr, Rec."No.", Rec."Re-inspection No.");
 
-                if not GetIsCreating() then
+                if not Rec.GetIsCreating() then
                     QltyPermissionMgmt.VerifyCanChangeItemTracking();
             end;
         }
@@ -365,7 +370,7 @@ table 20405 "Qlty. Inspection Header"
                 if (Rec.Status = Rec.Status::Finished) and (Rec."Source Lot No." <> xRec."Source Lot No.") then
                     Error(TrackingCannotChangeForFinishedInspectionErr, Rec."No.", Rec."Re-inspection No.");
 
-                if not GetIsCreating() then
+                if not Rec.GetIsCreating() then
                     QltyPermissionMgmt.VerifyCanChangeItemTracking();
             end;
         }
@@ -380,7 +385,7 @@ table 20405 "Qlty. Inspection Header"
                 if (Rec.Status = Rec.Status::Finished) and (Rec."Source Package No." <> xRec."Source Package No.") then
                     Error(TrackingCannotChangeForFinishedInspectionErr, Rec."No.", Rec."Re-inspection No.");
 
-                if not GetIsCreating() then
+                if not Rec.GetIsCreating() then
                     QltyPermissionMgmt.VerifyCanChangeItemTracking();
             end;
         }
@@ -1289,6 +1294,8 @@ table 20405 "Qlty. Inspection Header"
             if QltyInspectionResult."Finish Allowed" <> QltyInspectionResult."Finish Allowed"::"Allow Finish" then
                 Error(CannotFinishInspectionBecauseTheInspectionIsInResultErr, Rec."No.", QltyInspectionResult.Code);
 
+        CalculatePassFailQuantities();
+
         Rec."Finished By User ID" := CopyStr(UserId(), 1, MaxStrLen(Rec."Finished By User ID"));
         Rec."Finished Date" := CurrentDateTime();
         Rec.Modify(false);
@@ -1304,8 +1311,11 @@ table 20405 "Qlty. Inspection Header"
     begin
         if xRec.Status <> xRec.Status::Finished then
             exit;
+
         if Rec.Status <> Rec.Status::Open then
             exit;
+
+        ClearPassFailQuantities();
 
         Rec.Modify(false);
 
@@ -1552,24 +1562,6 @@ table 20405 "Qlty. Inspection Header"
     end;
 
     /// <summary>
-    ///Returns the quantity of samples with acceptable measures for all sampling fields.
-    ///If no sampling fields, will return the sample size if all measures are acceptable.
-    /// </summary>
-    /// <returns>Quantity of samples</returns>
-    internal procedure GetPassSampleQuantity() PassQuantity: Decimal
-    begin
-    end;
-
-    /// <summary>
-    ///Returns the quantity of samples with any not acceptable measure for all sampling fields.
-    ///If no sampling fields, will return the sample size if any measures are not acceptable.
-    /// </summary>
-    /// <returns>Quantity of samples</returns>
-    internal procedure GetFailedSampleQuantity() FailQuantity: Decimal
-    begin
-    end;
-
-    /// <summary>
     /// Initializes the Qlty. Related Transfers page with the Quality Inspection record and runs it
     /// </summary>
     internal procedure RunModalRelatedTransfers()
@@ -1609,6 +1601,55 @@ table 20405 "Qlty. Inspection Header"
             else
                 exit('None');
         end;
+    end;
+
+    /// <summary>
+    /// Calculates and assigns the Pass Quantity or Fail Quantity based on the inspection's Result Category.
+    /// Uses Sample Size when greater than zero; otherwise falls back to Source Quantity (Base).
+    /// Acceptable results populate Pass Quantity; any other category populates Fail Quantity.
+    /// The opposite quantity is always cleared so the values stay mutually exclusive.
+    /// Intended to be called when the inspection transitions to Finished.
+    /// </summary>
+    local procedure CalculatePassFailQuantities()
+    var
+        QltyInspectionResult: Record "Qlty. Inspection Result";
+        QuantityToApply: Decimal;
+    begin
+        if Rec."Result Code" = '' then
+            exit;
+
+        QltyInspectionResult.SetLoadFields("Result Category");
+        if not QltyInspectionResult.Get(Rec."Result Code") then
+            exit;
+
+        if (Rec."Sample Size" > Rec."Source Quantity (Base)") and (Rec."Source Quantity (Base)" > 0) then
+            exit;
+
+        if Rec."Sample Size" > 0 then
+            QuantityToApply := Rec."Sample Size"
+        else
+            QuantityToApply := Rec."Source Quantity (Base)";
+
+        if QuantityToApply <= 0 then
+            exit;
+
+        if QltyInspectionResult."Result Category" = QltyInspectionResult."Result Category"::Acceptable then begin
+            Rec."Pass Quantity" := QuantityToApply;
+            Rec."Fail Quantity" := 0;
+        end else begin
+            Rec."Fail Quantity" := QuantityToApply;
+            Rec."Pass Quantity" := 0;
+        end;
+    end;
+
+    /// <summary>
+    /// Resets the Pass Quantity and Fail Quantity to zero. Used when an inspection is reopened
+    /// so the values calculated at finish do not linger on the open inspection.
+    /// </summary>
+    local procedure ClearPassFailQuantities()
+    begin
+        Rec."Pass Quantity" := 0;
+        Rec."Fail Quantity" := 0;
     end;
 
     /// <summary>

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
@@ -279,7 +279,7 @@ page 20408 "Qlty. Inspection List"
                 PromotedCategory = Process;
                 PromotedIsBig = true;
                 PromotedOnly = true;
-                ToolTip = 'Reopen';
+                ToolTip = 'Reopen a finished inspection. Only users with the Quality Admin & Supervisor role can perform this action.';
                 Enabled = CanReopen;
 
                 trigger OnAction()

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsInsepctions.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsInsepctions.Codeunit.al
@@ -11,6 +11,7 @@ using Microsoft.Inventory.Location;
 using Microsoft.Inventory.Tracking;
 using Microsoft.Purchases.Document;
 using Microsoft.QualityManagement.Configuration.GenerationRule;
+using Microsoft.QualityManagement.Configuration.Result;
 using Microsoft.QualityManagement.Configuration.Template;
 using Microsoft.QualityManagement.Configuration.Template.Test;
 using Microsoft.QualityManagement.Document;
@@ -682,12 +683,281 @@ codeunit 139970 "Qlty. Tests - Insepctions"
         LibraryAssert.AreEqual(Page::"Qlty. Inspection List", PageManagement.GetConditionalListPageID(RecordRef), 'Should be inspections list page.');
     end;
 
+    [Test]
+    procedure FinishAcceptableWithSampleSize_PassQtyEqualsSampleSize()
+    var
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionResult: Record "Qlty. Inspection Result";
+    begin
+        // [SCENARIO] Finishing an inspection with an Acceptable result populates Pass Quantity from Sample Size.
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] An inspection with Source Quantity (Base) = 10 and Sample Size = 4
+        QltyInspectionUtility.CreateABasicTemplateAndInstanceOfAInspection(QltyInspectionHeader, QltyInspectionTemplateHdr);
+        CreateInspectionResultWithCategory(QltyInspectionResult, QltyInspectionResult."Result Category"::Acceptable);
+        QltyInspectionHeader."Source Quantity (Base)" := 10;
+        QltyInspectionHeader."Sample Size" := 4;
+        QltyInspectionHeader."Result Code" := QltyInspectionResult.Code;
+        QltyInspectionHeader.Modify(false);
+
+        // [WHEN] The inspection is set to Finished
+        QltyInspectionHeader.Validate(Status, QltyInspectionHeader.Status::Finished);
+
+        // [THEN] Pass Quantity equals Sample Size and Fail Quantity is zero
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual(4, QltyInspectionHeader."Pass Quantity", 'Pass Quantity should equal Sample Size.');
+        LibraryAssert.AreEqual(0, QltyInspectionHeader."Fail Quantity", 'Fail Quantity should be zero.');
+    end;
+
+    [Test]
+    procedure FinishNotAcceptableWithSampleSize_FailQtyEqualsSampleSize()
+    var
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionResult: Record "Qlty. Inspection Result";
+    begin
+        // [SCENARIO] Finishing an inspection with a Not acceptable result populates Fail Quantity from Sample Size.
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] An inspection with Source Quantity (Base) = 10, Sample Size = 4 and a Not acceptable result
+        QltyInspectionUtility.CreateABasicTemplateAndInstanceOfAInspection(QltyInspectionHeader, QltyInspectionTemplateHdr);
+        CreateInspectionResultWithCategory(QltyInspectionResult, QltyInspectionResult."Result Category"::"Not acceptable");
+        QltyInspectionHeader."Source Quantity (Base)" := 10;
+        QltyInspectionHeader."Sample Size" := 4;
+        QltyInspectionHeader."Result Code" := QltyInspectionResult.Code;
+        QltyInspectionHeader.Modify(false);
+
+        // [WHEN] The inspection is set to Finished
+        QltyInspectionHeader.Validate(Status, QltyInspectionHeader.Status::Finished);
+
+        // [THEN] Fail Quantity equals Sample Size and Pass Quantity is zero
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual(4, QltyInspectionHeader."Fail Quantity", 'Fail Quantity should equal Sample Size.');
+        LibraryAssert.AreEqual(0, QltyInspectionHeader."Pass Quantity", 'Pass Quantity should be zero.');
+    end;
+
+    [Test]
+    procedure FinishAcceptableNoSampleSize_PassQtyEqualsSourceQty()
+    var
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionResult: Record "Qlty. Inspection Result";
+    begin
+        // [SCENARIO] When Sample Size is zero, finishing falls back to Source Quantity (Base) for Pass Quantity.
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] An inspection with Source Quantity (Base) = 10, Sample Size = 0 and an Acceptable result
+        QltyInspectionUtility.CreateABasicTemplateAndInstanceOfAInspection(QltyInspectionHeader, QltyInspectionTemplateHdr);
+        CreateInspectionResultWithCategory(QltyInspectionResult, QltyInspectionResult."Result Category"::Acceptable);
+        QltyInspectionHeader."Source Quantity (Base)" := 10;
+        QltyInspectionHeader."Sample Size" := 0;
+        QltyInspectionHeader."Result Code" := QltyInspectionResult.Code;
+        QltyInspectionHeader.Modify(false);
+
+        // [WHEN] The inspection is set to Finished
+        QltyInspectionHeader.Validate(Status, QltyInspectionHeader.Status::Finished);
+
+        // [THEN] Pass Quantity equals Source Quantity (Base)
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual(10, QltyInspectionHeader."Pass Quantity", 'Pass Quantity should equal Source Quantity (Base).');
+        LibraryAssert.AreEqual(0, QltyInspectionHeader."Fail Quantity", 'Fail Quantity should be zero.');
+    end;
+
+    [Test]
+    procedure FinishNotAcceptableNoSampleSize_FailQtyEqualsSourceQty()
+    var
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionResult: Record "Qlty. Inspection Result";
+    begin
+        // [SCENARIO] When Sample Size is zero, finishing falls back to Source Quantity (Base) for Fail Quantity.
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] An inspection with Source Quantity (Base) = 10, Sample Size = 0 and a Not acceptable result
+        QltyInspectionUtility.CreateABasicTemplateAndInstanceOfAInspection(QltyInspectionHeader, QltyInspectionTemplateHdr);
+        CreateInspectionResultWithCategory(QltyInspectionResult, QltyInspectionResult."Result Category"::"Not acceptable");
+        QltyInspectionHeader."Source Quantity (Base)" := 10;
+        QltyInspectionHeader."Sample Size" := 0;
+        QltyInspectionHeader."Result Code" := QltyInspectionResult.Code;
+        QltyInspectionHeader.Modify(false);
+
+        // [WHEN] The inspection is set to Finished
+        QltyInspectionHeader.Validate(Status, QltyInspectionHeader.Status::Finished);
+
+        // [THEN] Fail Quantity equals Source Quantity (Base)
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual(10, QltyInspectionHeader."Fail Quantity", 'Fail Quantity should equal Source Quantity (Base).');
+        LibraryAssert.AreEqual(0, QltyInspectionHeader."Pass Quantity", 'Pass Quantity should be zero.');
+    end;
+
+    [Test]
+    procedure FinishUncategorizedResult_FailQtyPopulated()
+    var
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionResult: Record "Qlty. Inspection Result";
+    begin
+        // [SCENARIO] An Uncategorized result is treated as Not acceptable for auto-calculation purposes.
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] An inspection with Sample Size = 5 and an Uncategorized result
+        QltyInspectionUtility.CreateABasicTemplateAndInstanceOfAInspection(QltyInspectionHeader, QltyInspectionTemplateHdr);
+        CreateInspectionResultWithCategory(QltyInspectionResult, QltyInspectionResult."Result Category"::Uncategorized);
+        QltyInspectionHeader."Source Quantity (Base)" := 10;
+        QltyInspectionHeader."Sample Size" := 5;
+        QltyInspectionHeader."Result Code" := QltyInspectionResult.Code;
+        QltyInspectionHeader.Modify(false);
+
+        // [WHEN] The inspection is set to Finished
+        QltyInspectionHeader.Validate(Status, QltyInspectionHeader.Status::Finished);
+
+        // [THEN] Fail Quantity is populated, Pass Quantity stays zero
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual(5, QltyInspectionHeader."Fail Quantity", 'Fail Quantity should equal Sample Size for Uncategorized result.');
+        LibraryAssert.AreEqual(0, QltyInspectionHeader."Pass Quantity", 'Pass Quantity should be zero.');
+    end;
+
+    [Test]
+    procedure FinishWithEmptyResultCode_NoChange()
+    var
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+    begin
+        // [SCENARIO] When the inspection has no Result Code, Pass and Fail Quantities are left unchanged.
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] An inspection with Sample Size = 5 and no Result Code
+        QltyInspectionUtility.CreateABasicTemplateAndInstanceOfAInspection(QltyInspectionHeader, QltyInspectionTemplateHdr);
+        QltyInspectionHeader."Source Quantity (Base)" := 10;
+        QltyInspectionHeader."Sample Size" := 5;
+        QltyInspectionHeader."Result Code" := '';
+        QltyInspectionHeader.Modify(false);
+
+        // [WHEN] The inspection is set to Finished
+        QltyInspectionHeader.Validate(Status, QltyInspectionHeader.Status::Finished);
+
+        // [THEN] Pass and Fail Quantities remain zero
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual(0, QltyInspectionHeader."Pass Quantity", 'Pass Quantity should remain zero.');
+        LibraryAssert.AreEqual(0, QltyInspectionHeader."Fail Quantity", 'Fail Quantity should remain zero.');
+    end;
+
+    [Test]
+    procedure FinishOverwritesExistingManualValues()
+    var
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionResult: Record "Qlty. Inspection Result";
+    begin
+        // [SCENARIO] Pre-existing Pass/Fail values are overwritten by the auto-calculation when finishing.
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] An inspection with manually set Pass = 2, Fail = 1 and an Acceptable result
+        QltyInspectionUtility.CreateABasicTemplateAndInstanceOfAInspection(QltyInspectionHeader, QltyInspectionTemplateHdr);
+        CreateInspectionResultWithCategory(QltyInspectionResult, QltyInspectionResult."Result Category"::Acceptable);
+        QltyInspectionHeader."Source Quantity (Base)" := 10;
+        QltyInspectionHeader."Sample Size" := 5;
+        QltyInspectionHeader."Pass Quantity" := 2;
+        QltyInspectionHeader."Fail Quantity" := 1;
+        QltyInspectionHeader."Result Code" := QltyInspectionResult.Code;
+        QltyInspectionHeader.Modify(false);
+
+        // [WHEN] The inspection is set to Finished
+        QltyInspectionHeader.Validate(Status, QltyInspectionHeader.Status::Finished);
+
+        // [THEN] Pass Quantity equals Sample Size and Fail Quantity is cleared
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual(5, QltyInspectionHeader."Pass Quantity", 'Pass Quantity should be overwritten by Sample Size.');
+        LibraryAssert.AreEqual(0, QltyInspectionHeader."Fail Quantity", 'Fail Quantity should be cleared.');
+    end;
+
+    [Test]
+    procedure ReopenClearsPassQuantity()
+    var
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionResult: Record "Qlty. Inspection Result";
+    begin
+        // [SCENARIO] Reopening a finished inspection clears the previously calculated Pass Quantity.
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] A finished inspection with Pass Quantity populated by an Acceptable result
+        QltyInspectionUtility.CreateABasicTemplateAndInstanceOfAInspection(QltyInspectionHeader, QltyInspectionTemplateHdr);
+        CreateInspectionResultWithCategory(QltyInspectionResult, QltyInspectionResult."Result Category"::Acceptable);
+        QltyInspectionHeader."Source Quantity (Base)" := 10;
+        QltyInspectionHeader."Sample Size" := 4;
+        QltyInspectionHeader."Result Code" := QltyInspectionResult.Code;
+        QltyInspectionHeader.Modify(false);
+        QltyInspectionHeader.Validate(Status, QltyInspectionHeader.Status::Finished);
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual(4, QltyInspectionHeader."Pass Quantity", 'Pre-condition: Pass Quantity should be set.');
+
+        // [WHEN] The inspection is reopened
+        QltyInspectionHeader.Validate(Status, QltyInspectionHeader.Status::Open);
+
+        // [THEN] Both Pass and Fail Quantities are zero
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual(0, QltyInspectionHeader."Pass Quantity", 'Pass Quantity should be cleared on reopen.');
+        LibraryAssert.AreEqual(0, QltyInspectionHeader."Fail Quantity", 'Fail Quantity should remain zero on reopen.');
+    end;
+
+    [Test]
+    procedure ReopenClearsFailQuantity()
+    var
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionResult: Record "Qlty. Inspection Result";
+    begin
+        // [SCENARIO] Reopening a finished inspection clears the previously calculated Fail Quantity.
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] A finished inspection with Fail Quantity populated by a Not acceptable result
+        QltyInspectionUtility.CreateABasicTemplateAndInstanceOfAInspection(QltyInspectionHeader, QltyInspectionTemplateHdr);
+        CreateInspectionResultWithCategory(QltyInspectionResult, QltyInspectionResult."Result Category"::"Not acceptable");
+        QltyInspectionHeader."Source Quantity (Base)" := 10;
+        QltyInspectionHeader."Sample Size" := 4;
+        QltyInspectionHeader."Result Code" := QltyInspectionResult.Code;
+        QltyInspectionHeader.Modify(false);
+        QltyInspectionHeader.Validate(Status, QltyInspectionHeader.Status::Finished);
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual(4, QltyInspectionHeader."Fail Quantity", 'Pre-condition: Fail Quantity should be set.');
+
+        // [WHEN] The inspection is reopened
+        QltyInspectionHeader.Validate(Status, QltyInspectionHeader.Status::Open);
+
+        // [THEN] Both Pass and Fail Quantities are zero
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual(0, QltyInspectionHeader."Fail Quantity", 'Fail Quantity should be cleared on reopen.');
+        LibraryAssert.AreEqual(0, QltyInspectionHeader."Pass Quantity", 'Pass Quantity should remain zero on reopen.');
+    end;
+
     local procedure Initialize()
     begin
         if IsInitialized then
             exit;
         LibraryERMCountryData.CreateVATData();
         IsInitialized := true;
+    end;
+
+    local procedure CreateInspectionResultWithCategory(var QltyInspectionResult: Record "Qlty. Inspection Result"; ResultCategory: Enum "Qlty. Result Category")
+    var
+        ResultCode: Text;
+    begin
+        Clear(QltyInspectionResult);
+        QltyInspectionUtility.GenerateRandomCharacters(MaxStrLen(QltyInspectionResult.Code), ResultCode);
+        QltyInspectionResult.Code := CopyStr(ResultCode, 1, MaxStrLen(QltyInspectionResult.Code));
+        QltyInspectionResult."Result Category" := ResultCategory;
+        QltyInspectionResult.Insert();
     end;
 
     [ConfirmHandler]


### PR DESCRIPTION
## What & why

Changes:
1) Auto-calculate Pass/Fail Quantity
1. Auto-calculate Pass/Fail on Finish
Added CalculatePassFailQuantities() and call it from ProcessFinishInspection() before Modify:
- If Result Code is empty → no change.
- Quantity to apply = Sample Size (when > 0), otherwise Source Quantity (Base).
- If Result Category = Acceptable → set Pass Quantity, zero out Fail Quantity.
- Otherwise (Not acceptable / Uncategorized) → set Fail Quantity, zero out Pass Quantity.
- Always overwrites existing values; no setup toggle.
2. Clear Pass/Fail on Reopen
- Added ClearPassFailQuantities() and call it from ProcessReopenInspection() before Modify:
- Resets both Pass Quantity and Fail Quantity to 0 when status goes from Finished → Open.

2) Improved tooltips with actions limited to "Quality Admin & Supervisor" permission.

## Linked work

Fixes [AB#641526](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641526)
Fixes [AB#641527](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641527)

