### PR TITLE
Fix Payables Agent permission error opening E-Document

### DIFF
--- a/src/Apps/W1/PayablesAgent/app/PayablesAgent.Codeunit.al
+++ b/src/Apps/W1/PayablesAgent/app/PayablesAgent.Codeunit.al
@@ -22,7 +22,7 @@ codeunit 3303 "Payables Agent" implements IAgentMetadata, IAgentFactory
     InherentEntitlements = X;
     InherentPermissions = X;
     Subtype = Install;
-    Permissions = tabledata "Payables Agent Setup" = R, tabledata User = R;
+    Permissions = tabledata "Payables Agent Setup" = R, tabledata User = R, tabledata Agent = R, tabledata "Agent Task Message" = R;
 
     trigger OnInstallAppPerDatabase()
     begin


### PR DESCRIPTION
Elevate the Agent Task Message (2000000263) table read via the Permissions property on codeunit 3303 so resolving the current session's E-Document no longer throws NavPermissionException regardless of the assigned permission set.

Fixes [AB#641543](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641543)



