### PR TITLE
[QM] Fix internal put-away from Quality Inspection sourcing wrong bin

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Dispositions/PutAway/QltyDispInternalPutAway.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Dispositions/PutAway/QltyDispInternalPutAway.Codeunit.al
@@ -72,6 +72,16 @@ codeunit 20447 "Qlty. Disp. Internal Put-away" implements "Qlty. Disposition"
             exit;
         end;
 
+        // An internal put-away cannot be sourced from a receive bin - those are emptied by the source document put-away,
+        // not by an internal put-away. Validate every resolved source bin up front, before any document is created, so we
+        // never create a put-away (and emit its "created" notification) only to roll everything back when a later line is
+        // found to be in a receive bin. If the inventory is still in the receive bin, this gives the user an actionable
+        // message to put the items away first, instead of letting the platform raise the cryptic bin type error.
+        repeat
+            QltyInventoryAvailability.ErrorIfFromBinIsReceiveBin(QltyInspectionHeader, TempQuantityToActQltyDispositionBuffer.GetFromLocationCode(), TempQuantityToActQltyDispositionBuffer.GetFromBinCode());
+        until TempQuantityToActQltyDispositionBuffer.Next() = 0;
+
+        TempQuantityToActQltyDispositionBuffer.FindSet();
         repeat
             if (WhseInternalPutAwayHeader."Location Code" <> TempQuantityToActQltyDispositionBuffer."Location Filter") or (WhseInternalPutAwayHeader."From Bin Code" <> TempQuantityToActQltyDispositionBuffer."Bin Filter") then begin
                 CreateInternalPutawayHeader(WhseInternalPutAwayHeader, TempQuantityToActQltyDispositionBuffer.GetFromLocationCode(), TempQuantityToActQltyDispositionBuffer.GetFromBinCode());

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
@@ -162,19 +162,25 @@ codeunit 20445 "Qlty. Inventory Availability"
             if RecordRefToSearch.FindFirst() then begin
                 LocationCode := QltyInspectionHeader."Location Code";
                 GetFromLocationAndBinBasedOnNamingConventions(RecordRefToSearch, LocationCode, BinCode, QuantityBaseValue);
-                if LocationCode <> '' then begin
-                    TempToMoveBinContent.Reset();
-                    TempToMoveBinContent.SetRange("Location Code", LocationCode);
-                    if BinCode <> '' then
-                        TempToMoveBinContent.SetRange("Bin Code", BinCode);
-                    if not TempToMoveBinContent.FindFirst() then begin
-                        TempToMoveBinContent.Init();
-                        TempToMoveBinContent."Location Code" := LocationCode;
-                        TempToMoveBinContent."Bin Code" := BinCode;
-                        TempToMoveBinContent."Min. Qty." := QuantityBaseValue;
-                        TempToMoveBinContent.Insert(false);
+                if LocationCode <> '' then
+                    // In bin mandatory locations (including directed put-away and pick) the bin derived from the source
+                    // document naming conventions can be stale - for example the receive bin the goods first landed in,
+                    // or a bin that no longer holds the item. Resolve the actual current bin(s) from Bin Content instead,
+                    // so the put-away is created from a bin that really contains the inventory. Only fall back to the
+                    // naming convention bin when the location is not bin mandatory or the item is not currently in stock.
+                    if not TryResolveBinsFromBinContent(QltyInspectionHeader, LocationCode, TempToMoveBinContent) then begin
+                        TempToMoveBinContent.Reset();
+                        TempToMoveBinContent.SetRange("Location Code", LocationCode);
+                        if BinCode <> '' then
+                            TempToMoveBinContent.SetRange("Bin Code", BinCode);
+                        if not TempToMoveBinContent.FindFirst() then begin
+                            TempToMoveBinContent.Init();
+                            TempToMoveBinContent."Location Code" := LocationCode;
+                            TempToMoveBinContent."Bin Code" := BinCode;
+                            TempToMoveBinContent."Min. Qty." := QuantityBaseValue;
+                            TempToMoveBinContent.Insert(false);
+                        end;
                     end;
-                end;
             end;
         end;
 
@@ -185,6 +191,60 @@ codeunit 20445 "Qlty. Inventory Availability"
             TempToMoveBinContent."Min. Qty." := QuantityBaseValue;
             TempToMoveBinContent.Insert(false);
         end;
+    end;
+
+    /// <summary>
+    /// Resolves the actual bin(s) that currently hold the inspection's item at a bin mandatory location by reading Bin Content.
+    /// Only bins with positive quantity are considered, and receive and adjustment bins are excluded because inventory cannot be
+    /// moved from them with an internal put-away. This is the non item tracked counterpart to GetCurrentLocationOfTrackedInventory.
+    /// </summary>
+    /// <param name="QltyInspectionHeader">The inspection providing the item, variant and any tracking to look up.</param>
+    /// <param name="LocationCode">The location to resolve the bins at.</param>
+    /// <param name="TempToMoveBinContent">The temporary bin content buffer that resolved bins are added to.</param>
+    /// <returns>True when at least one qualifying bin was added, false otherwise so the caller can fall back to other logic.</returns>
+    local procedure TryResolveBinsFromBinContent(QltyInspectionHeader: Record "Qlty. Inspection Header"; LocationCode: Code[10]; var TempToMoveBinContent: Record "Bin Content" temporary): Boolean
+    var
+        Location: Record Location;
+        BinContent: Record "Bin Content";
+        Added: Boolean;
+    begin
+        if (LocationCode = '') or (QltyInspectionHeader."Source Item No." = '') then
+            exit(false);
+        if not Location.Get(LocationCode) then
+            exit(false);
+        if not Location."Bin Mandatory" then
+            exit(false);
+
+        BinContent.SetRange("Location Code", LocationCode);
+        BinContent.SetRange("Item No.", QltyInspectionHeader."Source Item No.");
+        BinContent.SetRange("Variant Code", QltyInspectionHeader."Source Variant Code");
+        if QltyInspectionHeader."Source Lot No." <> '' then
+            BinContent.SetRange("Lot No. Filter", QltyInspectionHeader."Source Lot No.");
+        if QltyInspectionHeader."Source Serial No." <> '' then
+            BinContent.SetRange("Serial No. Filter", QltyInspectionHeader."Source Serial No.");
+        if QltyInspectionHeader."Source Package No." <> '' then
+            BinContent.SetRange("Package No. Filter", QltyInspectionHeader."Source Package No.");
+        if Location."Adjustment Bin Code" <> '' then
+            BinContent.SetFilter("Bin Code", '<>%1', Location."Adjustment Bin Code");
+        BinContent.SetAutoCalcFields("Quantity (Base)");
+        if BinContent.FindSet() then
+            repeat
+                if BinContent."Quantity (Base)" > 0 then
+                    if not IsReceiveBin(BinContent."Location Code", BinContent."Bin Code") then begin
+                        // A valid non-receive bin with stock exists for this location. Report success even when the bin was
+                        // already added by a previous source record, otherwise the caller would fall back to the naming
+                        // convention bin (which can be the receive bin) and add it to the buffer alongside the real bin.
+                        Added := true;
+                        if not TempToMoveBinContent.Get(BinContent."Location Code", BinContent."Bin Code", BinContent."Item No.", BinContent."Variant Code", BinContent."Unit of Measure Code") then begin
+                            TempToMoveBinContent.Init();
+                            TempToMoveBinContent := BinContent;
+                            TempToMoveBinContent."Min. Qty." := BinContent."Quantity (Base)";
+                            TempToMoveBinContent.Insert(false);
+                        end;
+                    end;
+            until BinContent.Next() = 0;
+
+        exit(Added);
     end;
 
     local procedure GetFromLocationAndBinBasedOnNamingConventions(var RecordRef: RecordRef; var LocationCode: Code[10]; var BinCode: Code[20]; var QuantityBase: Decimal)
@@ -464,18 +524,23 @@ codeunit 20445 "Qlty. Inventory Availability"
     /// <param name="FromLocationCode">The location code the inventory is being moved from.</param>
     /// <param name="FromBinCode">The bin code the inventory is being moved from.</param>
     internal procedure ErrorIfFromBinIsReceiveBin(QltyInspectionHeader: Record "Qlty. Inspection Header"; FromLocationCode: Code[10]; FromBinCode: Code[20])
+    begin
+        if IsReceiveBin(FromLocationCode, FromBinCode) then
+            Error(CannotMoveFromReceiveBinErr, QltyInspectionHeader.GetFriendlyIdentifier(), FromBinCode, FromLocationCode);
+    end;
+
+    local procedure IsReceiveBin(FromLocationCode: Code[10]; FromBinCode: Code[20]): Boolean
     var
         FromBin: Record Bin;
         BinType: Record "Bin Type";
     begin
         if (FromLocationCode = '') or (FromBinCode = '') then
-            exit;
+            exit(false);
         if not FromBin.Get(FromLocationCode, FromBinCode) then
-            exit;
+            exit(false);
         if not BinType.Get(FromBin."Bin Type Code") then
-            exit;
-        if BinType.Receive then
-            Error(CannotMoveFromReceiveBinErr, QltyInspectionHeader.GetFriendlyIdentifier(), FromBinCode, FromLocationCode);
+            exit(false);
+        exit(BinType.Receive);
     end;
 
     [IntegrationEvent(false, false)]


### PR DESCRIPTION
Resolve the source bin for the Create Internal Put-away disposition from the item's actual Bin Content in bin mandatory locations, instead of guessing it from the source document naming conventions which returned stale receive bins or bins without content.

Also validate all resolved source bins for receive bins up front before creating any document, so we no longer emit a 'created' notification for a put-away that is then rolled back.

Fixes [AB#641562](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641562)

Needs a backport to 28.x to fix the original Work Item.





