### PR TITLE
[QM] Fix internal put-away from Quality Inspection sourcing wrong bin

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Dispositions/PutAway/QltyDispInternalPutAway.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Dispositions/PutAway/QltyDispInternalPutAway.Codeunit.al
@@ -72,11 +72,6 @@ codeunit 20447 "Qlty. Disp. Internal Put-away" implements "Qlty. Disposition"
             exit;
         end;
 
-        // An internal put-away cannot be sourced from a receive bin - those are emptied by the source document put-away,
-        // not by an internal put-away. Validate every resolved source bin up front, before any document is created, so we
-        // never create a put-away (and emit its "created" notification) only to roll everything back when a later line is
-        // found to be in a receive bin. If the inventory is still in the receive bin, this gives the user an actionable
-        // message to put the items away first, instead of letting the platform raise the cryptic bin type error.
         repeat
             QltyInventoryAvailability.ErrorIfFromBinIsReceiveBin(QltyInspectionHeader, TempQuantityToActQltyDispositionBuffer.GetFromLocationCode(), TempQuantityToActQltyDispositionBuffer.GetFromBinCode());
         until TempQuantityToActQltyDispositionBuffer.Next() = 0;

--- a/src/Apps/W1/Quality Management/app/src/Dispositions/PutAway/QltyDispInternalPutAway.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Dispositions/PutAway/QltyDispInternalPutAway.Codeunit.al
@@ -72,6 +72,16 @@ codeunit 20447 "Qlty. Disp. Internal Put-away" implements "Qlty. Disposition"
             exit;
         end;
 
+        // An internal put-away cannot be sourced from a receive bin - those are emptied by the source document put-away,
+        // not by an internal put-away. Validate every resolved source bin up front, before any document is created, so we
+        // never create a put-away (and emit its "created" notification) only to roll everything back when a later line is
+        // found to be in a receive bin. If the inventory is still in the receive bin, this gives the user an actionable
+        // message to put the items away first, instead of letting the platform raise the cryptic bin type error.
+        repeat
+            QltyInventoryAvailability.ErrorIfFromBinIsReceiveBin(QltyInspectionHeader, TempQuantityToActQltyDispositionBuffer.GetFromLocationCode(), TempQuantityToActQltyDispositionBuffer.GetFromBinCode());
+        until TempQuantityToActQltyDispositionBuffer.Next() = 0;
+
+        TempQuantityToActQltyDispositionBuffer.FindSet();
         repeat
             if (WhseInternalPutAwayHeader."Location Code" <> TempQuantityToActQltyDispositionBuffer."Location Filter") or (WhseInternalPutAwayHeader."From Bin Code" <> TempQuantityToActQltyDispositionBuffer."Bin Filter") then begin
                 CreateInternalPutawayHeader(WhseInternalPutAwayHeader, TempQuantityToActQltyDispositionBuffer.GetFromLocationCode(), TempQuantityToActQltyDispositionBuffer.GetFromBinCode());

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
@@ -24,6 +24,7 @@ codeunit 20445 "Qlty. Inventory Availability"
         NoSamplesToMoveErr: Label 'No samples meet the condition specified.', Locked = true;
         SerialQuantityGreaterThanOneErr: Label '%1 (%2) cannot be greater than 1 when New Serial No. is requested.', Comment = '%1=quantity behavior, %2=quantity';
         ZeroQuantityErr: Label 'Unable to use the disposition %1 on the inspection %2 for the item %3 because the quantity is zero.', Comment = '%1=the inspection, %2=the inspection, %3=the item';
+        InsufficientInventoryToAllocateErr: Label 'Unable to move the entire requested quantity for inspection %1 for item %2. There is not enough inventory available in eligible bins (short by %3). Put the remaining inventory away or reduce the quantity, and then try again.', Comment = '%1=the inspection, %2=the item, %3=the missing quantity';
         SupplyFromLocationCodeNameLbl: Label 'Supply-from Location Code', Locked = true;
         FromLocationCodeNameLbl: Label 'From Location Code', Locked = true;
         LocationCodeNameLbl: Label 'Location Code', Locked = true;
@@ -526,6 +527,9 @@ codeunit 20445 "Qlty. Inventory Availability"
                     TempQuantityQltyDispositionBuffer.Insert(false);
                 end;
             until TempExistingInventoryBinContent.Next() = 0;
+
+            if AllocateAcrossBins and (RemainingQuantityToAllocate > 0) then
+                Error(InsufficientInventoryToAllocateErr, QltyInspectionHeader."No.", QltyInspectionHeader."Source Item No.", RemainingQuantityToAllocate);
         end;
 
         OnAfterPopulateBinContentBuffer(QltyInspectionHeader, TempInstructionQltyDispositionBuffer, TempQuantityQltyDispositionBuffer, TempExistingInventoryBinContent);

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
@@ -163,11 +163,6 @@ codeunit 20445 "Qlty. Inventory Availability"
                 LocationCode := QltyInspectionHeader."Location Code";
                 GetFromLocationAndBinBasedOnNamingConventions(RecordRefToSearch, LocationCode, BinCode, QuantityBaseValue);
                 if LocationCode <> '' then
-                    // In bin mandatory locations (including directed put-away and pick) the bin derived from the source
-                    // document naming conventions can be stale - for example the receive bin the goods first landed in,
-                    // or a bin that no longer holds the item. Resolve the actual current bin(s) from Bin Content instead,
-                    // so the put-away is created from a bin that really contains the inventory. Only fall back to the
-                    // naming convention bin when the location is not bin mandatory or the item is not currently in stock.
                     if not TryResolveBinsFromBinContent(QltyInspectionHeader, LocationCode, TempToMoveBinContent) then begin
                         TempToMoveBinContent.Reset();
                         TempToMoveBinContent.SetRange("Location Code", LocationCode);
@@ -193,15 +188,6 @@ codeunit 20445 "Qlty. Inventory Availability"
         end;
     end;
 
-    /// <summary>
-    /// Resolves the actual bin(s) that currently hold the inspection's item at a bin mandatory location by reading Bin Content.
-    /// Only bins with positive quantity are considered, and receive and adjustment bins are excluded because inventory cannot be
-    /// moved from them with an internal put-away. This is the non item tracked counterpart to GetCurrentLocationOfTrackedInventory.
-    /// </summary>
-    /// <param name="QltyInspectionHeader">The inspection providing the item, variant and any tracking to look up.</param>
-    /// <param name="LocationCode">The location to resolve the bins at.</param>
-    /// <param name="TempToMoveBinContent">The temporary bin content buffer that resolved bins are added to.</param>
-    /// <returns>True when at least one qualifying bin was added, false otherwise so the caller can fall back to other logic.</returns>
     local procedure TryResolveBinsFromBinContent(QltyInspectionHeader: Record "Qlty. Inspection Header"; LocationCode: Code[10]; var TempToMoveBinContent: Record "Bin Content" temporary): Boolean
     var
         Location: Record Location;
@@ -231,9 +217,6 @@ codeunit 20445 "Qlty. Inventory Availability"
             repeat
                 if BinContent."Quantity (Base)" > 0 then
                     if not IsReceiveBin(BinContent."Location Code", BinContent."Bin Code") then begin
-                        // A valid non-receive bin with stock exists for this location. Report success even when the bin was
-                        // already added by a previous source record, otherwise the caller would fall back to the naming
-                        // convention bin (which can be the receive bin) and add it to the buffer alongside the real bin.
                         Added := true;
                         if not TempToMoveBinContent.Get(BinContent."Location Code", BinContent."Bin Code", BinContent."Item No.", BinContent."Variant Code", BinContent."Unit of Measure Code") then begin
                             TempToMoveBinContent.Init();

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
@@ -164,7 +164,7 @@ codeunit 20445 "Qlty. Inventory Availability"
                 LocationCode := QltyInspectionHeader."Location Code";
                 GetFromLocationAndBinBasedOnNamingConventions(RecordRefToSearch, LocationCode, BinCode, QuantityBaseValue);
                 if LocationCode <> '' then
-                    if not TryResolveBinsFromBinContent(QltyInspectionHeader, LocationCode, TempToMoveBinContent) then begin
+                    if not ResolveBinsFromBinContent(QltyInspectionHeader, LocationCode, TempToMoveBinContent) then begin
                         TempToMoveBinContent.Reset();
                         TempToMoveBinContent.SetRange("Location Code", LocationCode);
                         if BinCode <> '' then
@@ -189,7 +189,7 @@ codeunit 20445 "Qlty. Inventory Availability"
         end;
     end;
 
-    local procedure TryResolveBinsFromBinContent(QltyInspectionHeader: Record "Qlty. Inspection Header"; LocationCode: Code[10]; var TempToMoveBinContent: Record "Bin Content" temporary): Boolean
+    local procedure ResolveBinsFromBinContent(QltyInspectionHeader: Record "Qlty. Inspection Header"; LocationCode: Code[10]; var TempToMoveBinContent: Record "Bin Content" temporary): Boolean
     var
         Location: Record Location;
         BinContent: Record "Bin Content";

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
@@ -162,19 +162,25 @@ codeunit 20445 "Qlty. Inventory Availability"
             if RecordRefToSearch.FindFirst() then begin
                 LocationCode := QltyInspectionHeader."Location Code";
                 GetFromLocationAndBinBasedOnNamingConventions(RecordRefToSearch, LocationCode, BinCode, QuantityBaseValue);
-                if LocationCode <> '' then begin
-                    TempToMoveBinContent.Reset();
-                    TempToMoveBinContent.SetRange("Location Code", LocationCode);
-                    if BinCode <> '' then
-                        TempToMoveBinContent.SetRange("Bin Code", BinCode);
-                    if not TempToMoveBinContent.FindFirst() then begin
-                        TempToMoveBinContent.Init();
-                        TempToMoveBinContent."Location Code" := LocationCode;
-                        TempToMoveBinContent."Bin Code" := BinCode;
-                        TempToMoveBinContent."Min. Qty." := QuantityBaseValue;
-                        TempToMoveBinContent.Insert(false);
+                if LocationCode <> '' then
+                    // In bin mandatory locations (including directed put-away and pick) the bin derived from the source
+                    // document naming conventions can be stale - for example the receive bin the goods first landed in,
+                    // or a bin that no longer holds the item. Resolve the actual current bin(s) from Bin Content instead,
+                    // so the put-away is created from a bin that really contains the inventory. Only fall back to the
+                    // naming convention bin when the location is not bin mandatory or the item is not currently in stock.
+                    if not TryResolveBinsFromBinContent(QltyInspectionHeader, LocationCode, TempToMoveBinContent) then begin
+                        TempToMoveBinContent.Reset();
+                        TempToMoveBinContent.SetRange("Location Code", LocationCode);
+                        if BinCode <> '' then
+                            TempToMoveBinContent.SetRange("Bin Code", BinCode);
+                        if not TempToMoveBinContent.FindFirst() then begin
+                            TempToMoveBinContent.Init();
+                            TempToMoveBinContent."Location Code" := LocationCode;
+                            TempToMoveBinContent."Bin Code" := BinCode;
+                            TempToMoveBinContent."Min. Qty." := QuantityBaseValue;
+                            TempToMoveBinContent.Insert(false);
+                        end;
                     end;
-                end;
             end;
         end;
 
@@ -185,6 +191,60 @@ codeunit 20445 "Qlty. Inventory Availability"
             TempToMoveBinContent."Min. Qty." := QuantityBaseValue;
             TempToMoveBinContent.Insert(false);
         end;
+    end;
+
+    /// <summary>
+    /// Resolves the actual bin(s) that currently hold the inspection's item at a bin mandatory location by reading Bin Content.
+    /// Only bins with positive quantity are considered, and receive and adjustment bins are excluded because inventory cannot be
+    /// moved from them with an internal put-away. This is the non item tracked counterpart to GetCurrentLocationOfTrackedInventory.
+    /// </summary>
+    /// <param name="QltyInspectionHeader">The inspection providing the item, variant and any tracking to look up.</param>
+    /// <param name="LocationCode">The location to resolve the bins at.</param>
+    /// <param name="TempToMoveBinContent">The temporary bin content buffer that resolved bins are added to.</param>
+    /// <returns>True when at least one qualifying bin was added, false otherwise so the caller can fall back to other logic.</returns>
+    local procedure TryResolveBinsFromBinContent(QltyInspectionHeader: Record "Qlty. Inspection Header"; LocationCode: Code[10]; var TempToMoveBinContent: Record "Bin Content" temporary): Boolean
+    var
+        Location: Record Location;
+        BinContent: Record "Bin Content";
+        Added: Boolean;
+    begin
+        if (LocationCode = '') or (QltyInspectionHeader."Source Item No." = '') then
+            exit(false);
+        if not Location.Get(LocationCode) then
+            exit(false);
+        if not Location."Bin Mandatory" then
+            exit(false);
+
+        BinContent.SetRange("Location Code", LocationCode);
+        BinContent.SetRange("Item No.", QltyInspectionHeader."Source Item No.");
+        BinContent.SetRange("Variant Code", QltyInspectionHeader."Source Variant Code");
+        if QltyInspectionHeader."Source Lot No." <> '' then
+            BinContent.SetRange("Lot No. Filter", QltyInspectionHeader."Source Lot No.");
+        if QltyInspectionHeader."Source Serial No." <> '' then
+            BinContent.SetRange("Serial No. Filter", QltyInspectionHeader."Source Serial No.");
+        if QltyInspectionHeader."Source Package No." <> '' then
+            BinContent.SetRange("Package No. Filter", QltyInspectionHeader."Source Package No.");
+        if Location."Adjustment Bin Code" <> '' then
+            BinContent.SetFilter("Bin Code", '<>%1', Location."Adjustment Bin Code");
+        BinContent.SetAutoCalcFields("Quantity (Base)");
+        if BinContent.FindSet() then
+            repeat
+                if BinContent."Quantity (Base)" > 0 then
+                    if not IsReceiveBin(BinContent."Location Code", BinContent."Bin Code") then begin
+                        // A valid non-receive bin with stock exists for this location. Report success even when the bin was
+                        // already added by a previous source record, otherwise the caller would fall back to the naming
+                        // convention bin (which can be the receive bin) and add it to the buffer alongside the real bin.
+                        Added := true;
+                        if not TempToMoveBinContent.Get(BinContent."Location Code", BinContent."Bin Code", BinContent."Item No.", BinContent."Variant Code", BinContent."Unit of Measure Code") then begin
+                            TempToMoveBinContent.Init();
+                            TempToMoveBinContent := BinContent;
+                            TempToMoveBinContent."Min. Qty." := BinContent."Quantity (Base)";
+                            TempToMoveBinContent.Insert(false);
+                        end;
+                    end;
+            until BinContent.Next() = 0;
+
+        exit(Added);
     end;
 
     local procedure GetFromLocationAndBinBasedOnNamingConventions(var RecordRef: RecordRef; var LocationCode: Code[10]; var BinCode: Code[20]; var QuantityBase: Decimal)
@@ -464,18 +524,23 @@ codeunit 20445 "Qlty. Inventory Availability"
     /// <param name="FromLocationCode">The location code the inventory is being moved from.</param>
     /// <param name="FromBinCode">The bin code the inventory is being moved from.</param>
     internal procedure ErrorIfFromBinIsReceiveBin(QltyInspectionHeader: Record "Qlty. Inspection Header"; FromLocationCode: Code[10]; FromBinCode: Code[20])
+    begin
+        if IsReceiveBin(FromLocationCode, FromBinCode) then
+            Error(CannotMoveFromReceiveBinErr, QltyInspectionHeader.GetFriendlyIdentifier(), FromBinCode, FromLocationCode);
+    end;
+
+    local procedure IsReceiveBin(FromLocationCode: Code[10]; FromBinCode: Code[20]): Boolean
     var
         FromBin: Record Bin;
         BinType: Record "Bin Type";
     begin
         if (FromLocationCode = '') or (FromBinCode = '') then
-            exit;
+            exit(false);
         if not FromBin.Get(FromLocationCode, FromBinCode) then
-            exit;
+            exit(false);
         if not BinType.Get(FromBin."Bin Type Code") then
-            exit;
-        if BinType.Receive then
-            Error(CannotMoveFromReceiveBinErr, QltyInspectionHeader.GetFriendlyIdentifier(), FromBinCode, FromLocationCode);
+            exit(false);
+        exit(BinType.Receive);
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
@@ -489,12 +489,15 @@ codeunit 20445 "Qlty. Inventory Availability"
                                 Location."Bin Mandatory");
                     end;
 
-                if not SkipBinContent then begin
+                if not SkipBinContent then
                     if AllocateAcrossBins then begin
-                        if (TempExistingInventoryBinContent."Min. Qty." > 0) and (TempExistingInventoryBinContent."Min. Qty." < RemainingQuantityToAllocate) then
-                            QuantityToHandle := TempExistingInventoryBinContent."Min. Qty."
+                        if TempExistingInventoryBinContent."Min. Qty." <= 0 then
+                            QuantityToHandle := 0
                         else
-                            QuantityToHandle := RemainingQuantityToAllocate;
+                            if TempExistingInventoryBinContent."Min. Qty." < RemainingQuantityToAllocate then
+                                QuantityToHandle := TempExistingInventoryBinContent."Min. Qty."
+                            else
+                                QuantityToHandle := RemainingQuantityToAllocate;
                         SkipBinContent := QuantityToHandle <= 0;
                     end else
                         QuantityToHandle := GetQuantityToHandleFromInspection(
@@ -502,7 +505,6 @@ codeunit 20445 "Qlty. Inventory Availability"
                             TempInstructionQltyDispositionBuffer."Quantity Behavior",
                             TempInstructionQltyDispositionBuffer."Qty. To Handle (Base)",
                             TempExistingInventoryBinContent);
-                end;
 
                 if not SkipBinContent then begin
                     BufferEntryCounter += 1;

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
@@ -429,7 +429,10 @@ codeunit 20445 "Qlty. Inventory Availability"
         MultipleBins: Boolean;
         SkipBinContent: Boolean;
         IsHandled: Boolean;
+        AllocateAcrossBins: Boolean;
         BufferEntryCounter: Integer;
+        RemainingQuantityToAllocate: Decimal;
+        QuantityToHandle: Decimal;
     begin
         TempQuantityQltyDispositionBuffer.Reset();
         TempQuantityQltyDispositionBuffer.DeleteAll();
@@ -460,6 +463,18 @@ codeunit 20445 "Qlty. Inventory Availability"
                 TempExistingInventoryBinContent.FindSet();
             end;
 
+            AllocateAcrossBins := MultipleBins and (TempInstructionQltyDispositionBuffer."Quantity Behavior" in [
+                TempInstructionQltyDispositionBuffer."Quantity Behavior"::"Specific Quantity",
+                TempInstructionQltyDispositionBuffer."Quantity Behavior"::"Sample Quantity",
+                TempInstructionQltyDispositionBuffer."Quantity Behavior"::"Failed Quantity",
+                TempInstructionQltyDispositionBuffer."Quantity Behavior"::"Passed Quantity"]);
+            if AllocateAcrossBins then
+                RemainingQuantityToAllocate := GetQuantityToHandleFromInspection(
+                    QltyInspectionHeader,
+                    TempInstructionQltyDispositionBuffer."Quantity Behavior",
+                    TempInstructionQltyDispositionBuffer."Qty. To Handle (Base)",
+                    TempExistingInventoryBinContent);
+
             repeat
                 SkipBinContent := false;
                 if TempExistingInventoryBinContent."Location Code" <> '' then
@@ -475,22 +490,36 @@ codeunit 20445 "Qlty. Inventory Availability"
                     end;
 
                 if not SkipBinContent then begin
+                    if AllocateAcrossBins then begin
+                        if (TempExistingInventoryBinContent."Min. Qty." > 0) and (TempExistingInventoryBinContent."Min. Qty." < RemainingQuantityToAllocate) then
+                            QuantityToHandle := TempExistingInventoryBinContent."Min. Qty."
+                        else
+                            QuantityToHandle := RemainingQuantityToAllocate;
+                        SkipBinContent := QuantityToHandle <= 0;
+                    end else
+                        QuantityToHandle := GetQuantityToHandleFromInspection(
+                            QltyInspectionHeader,
+                            TempInstructionQltyDispositionBuffer."Quantity Behavior",
+                            TempInstructionQltyDispositionBuffer."Qty. To Handle (Base)",
+                            TempExistingInventoryBinContent);
+                end;
+
+                if not SkipBinContent then begin
                     BufferEntryCounter += 1;
                     TempQuantityQltyDispositionBuffer := TempInstructionQltyDispositionBuffer;
                     TempQuantityQltyDispositionBuffer."Buffer Entry No." := BufferEntryCounter;
                     TempQuantityQltyDispositionBuffer."Location Filter" := TempExistingInventoryBinContent."Location Code";
                     TempQuantityQltyDispositionBuffer."Bin Filter" := TempExistingInventoryBinContent."Bin Code";
-                    TempQuantityQltyDispositionBuffer."Qty. To Handle (Base)" := GetQuantityToHandleFromInspection(
-                        QltyInspectionHeader,
-                        TempInstructionQltyDispositionBuffer."Quantity Behavior",
-                        TempInstructionQltyDispositionBuffer."Qty. To Handle (Base)",
-                        TempExistingInventoryBinContent);
+                    TempQuantityQltyDispositionBuffer."Qty. To Handle (Base)" := QuantityToHandle;
 
                     if TempQuantityQltyDispositionBuffer."Qty. To Handle (Base)" = 0 then
                         Error(ZeroQuantityErr, TempInstructionQltyDispositionBuffer."Disposition Action", QltyInspectionHeader."No.", QltyInspectionHeader."Source Item No.");
 
                     if (TempQuantityQltyDispositionBuffer."New Serial No." <> '') and (TempInstructionQltyDispositionBuffer."Qty. To Handle (Base)" > 1) then
                         Error(SerialQuantityGreaterThanOneErr, TempInstructionQltyDispositionBuffer."Entry Behavior", TempInstructionQltyDispositionBuffer."Qty. To Handle (Base)");
+
+                    if AllocateAcrossBins then
+                        RemainingQuantityToAllocate -= TempQuantityQltyDispositionBuffer."Qty. To Handle (Base)";
 
                     TempQuantityQltyDispositionBuffer.Insert(false);
                 end;

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyInventoryAvailability.Codeunit.al
@@ -212,19 +212,19 @@ codeunit 20445 "Qlty. Inventory Availability"
             BinContent.SetRange("Package No. Filter", QltyInspectionHeader."Source Package No.");
         if Location."Adjustment Bin Code" <> '' then
             BinContent.SetFilter("Bin Code", '<>%1', Location."Adjustment Bin Code");
+        BinContent.SetFilter("Quantity (Base)", '>%1', 0);
         BinContent.SetAutoCalcFields("Quantity (Base)");
         if BinContent.FindSet() then
             repeat
-                if BinContent."Quantity (Base)" > 0 then
-                    if not IsReceiveBin(BinContent."Location Code", BinContent."Bin Code") then begin
-                        Added := true;
-                        if not TempToMoveBinContent.Get(BinContent."Location Code", BinContent."Bin Code", BinContent."Item No.", BinContent."Variant Code", BinContent."Unit of Measure Code") then begin
-                            TempToMoveBinContent.Init();
-                            TempToMoveBinContent := BinContent;
-                            TempToMoveBinContent."Min. Qty." := BinContent."Quantity (Base)";
-                            TempToMoveBinContent.Insert(false);
-                        end;
+                if not IsReceiveBin(BinContent."Location Code", BinContent."Bin Code") then begin
+                    Added := true;
+                    if not TempToMoveBinContent.Get(BinContent."Location Code", BinContent."Bin Code", BinContent."Item No.", BinContent."Variant Code", BinContent."Unit of Measure Code") then begin
+                        TempToMoveBinContent.Init();
+                        TempToMoveBinContent := BinContent;
+                        TempToMoveBinContent."Min. Qty." := BinContent."Quantity (Base)";
+                        TempToMoveBinContent.Insert(false);
                     end;
+                end;
             until BinContent.Next() = 0;
 
         exit(Added);

--- a/src/Apps/W1/Quality Management/app/src/Utilities/QltyNotificationMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Utilities/QltyNotificationMgmt.Codeunit.al
@@ -270,7 +270,7 @@ codeunit 20437 "Qlty. Notification Mgmt."
                 DocumentNotAbleToBeCreatedAnMsg,
                 DocumentType,
                 QltyInspectionHeader."No.",
-                TempInstructionQltyDispositionBuffer."Qty. To Handle (Base)",
+                GetDisplayQuantityForFailure(QltyInspectionHeader, TempInstructionQltyDispositionBuffer),
                 GetSourceSummaryText(QltyInspectionHeader),
                 OptionalAdditionalMessageContext,
                 Item."Base Unit of Measure")
@@ -279,7 +279,7 @@ codeunit 20437 "Qlty. Notification Mgmt."
                 DocumentNotAbleToBeCreatedAMsg,
                 DocumentType,
                 QltyInspectionHeader."No.",
-                TempInstructionQltyDispositionBuffer."Qty. To Handle (Base)",
+                GetDisplayQuantityForFailure(QltyInspectionHeader, TempInstructionQltyDispositionBuffer),
                 GetSourceSummaryText(QltyInspectionHeader),
                 OptionalAdditionalMessageContext,
                 Item."Base Unit of Measure");
@@ -292,6 +292,32 @@ codeunit 20437 "Qlty. Notification Mgmt."
             end;
 
         CreateActionNotification(DocumentCreationFailedNotification, CurrentMessage, AvailableOptions);
+    end;
+
+    /// <summary>
+    /// Determines the quantity to display in the document creation failed message. The instruction quantity is often left at
+    /// zero for behaviors that resolve the quantity later (for example the failed or passed sample count), which would
+    /// otherwise be shown as "0" in the message. In that case fall back to the quantity the user actually intended to move,
+    /// derived from the quantity behavior, so the message is meaningful.
+    /// </summary>
+    /// <param name="QltyInspectionHeader">The inspection the failed document relates to.</param>
+    /// <param name="TempInstructionQltyDispositionBuffer">The instruction that was attempted.</param>
+    /// <returns>The quantity to show in the message.</returns>
+    local procedure GetDisplayQuantityForFailure(QltyInspectionHeader: Record "Qlty. Inspection Header"; var TempInstructionQltyDispositionBuffer: Record "Qlty. Disposition Buffer" temporary): Decimal
+    begin
+        if TempInstructionQltyDispositionBuffer."Qty. To Handle (Base)" <> 0 then
+            exit(TempInstructionQltyDispositionBuffer."Qty. To Handle (Base)");
+
+        case TempInstructionQltyDispositionBuffer."Quantity Behavior" of
+            TempInstructionQltyDispositionBuffer."Quantity Behavior"::"Failed Quantity":
+                exit(QltyInspectionHeader."Fail Quantity");
+            TempInstructionQltyDispositionBuffer."Quantity Behavior"::"Passed Quantity":
+                exit(QltyInspectionHeader."Pass Quantity");
+            TempInstructionQltyDispositionBuffer."Quantity Behavior"::"Sample Quantity":
+                exit(QltyInspectionHeader."Sample Size");
+            else
+                exit(QltyInspectionHeader."Source Quantity (Base)");
+        end;
     end;
 
     /// <summary>

--- a/src/Apps/W1/Quality Management/app/src/Utilities/QltyNotificationMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Utilities/QltyNotificationMgmt.Codeunit.al
@@ -295,14 +295,11 @@ codeunit 20437 "Qlty. Notification Mgmt."
     end;
 
     /// <summary>
-    /// Determines the quantity to display in the document creation failed message. The instruction quantity is often left at
-    /// zero for behaviors that resolve the quantity later (for example the failed or passed sample count), which would
-    /// otherwise be shown as "0" in the message. In that case fall back to the quantity the user actually intended to move,
-    /// derived from the quantity behavior, so the message is meaningful.
+    /// Gets the quantity to show in the document creation failed message, falling back to the quantity implied by the quantity behavior when the instruction quantity is zero.
     /// </summary>
     /// <param name="QltyInspectionHeader">The inspection the failed document relates to.</param>
-    /// <param name="TempInstructionQltyDispositionBuffer">The instruction that was attempted.</param>
-    /// <returns>The quantity to show in the message.</returns>
+    /// <param name="TempInstructionQltyDispositionBuffer">The attempted instruction.</param>
+    /// <returns>The quantity to display.</returns>
     local procedure GetDisplayQuantityForFailure(QltyInspectionHeader: Record "Qlty. Inspection Header"; var TempInstructionQltyDispositionBuffer: Record "Qlty. Disposition Buffer" temporary): Decimal
     begin
         if TempInstructionQltyDispositionBuffer."Qty. To Handle (Base)" <> 0 then

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsDispositions.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsDispositions.Codeunit.al
@@ -6961,6 +6961,75 @@ codeunit 139960 "Qlty. Tests - Dispositions"
     end;
 
     [Test]
+    procedure InternalPutaway_FailedQuantity_SourcedFromStorageBinNotReceive()
+    var
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        Location: Record Location;
+        Item: Record Item;
+        Bin: Record Bin;
+        BinType: Record "Bin Type";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        WarehouseEntry: Record "Warehouse Entry";
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        WhseInternalPutAwayLine: Record "Whse. Internal Put-away Line";
+        WarehouseSetup: Record "Warehouse Setup";
+        FailedQuantity: Decimal;
+        TotalPutAwayQuantity: Decimal;
+    begin
+        // [SCENARIO] Creating an internal put-away for the failed quantity sources the inventory from the storage bin the goods were put away to, never from the receive bin, and moves exactly the failed quantity
+
+        // [GIVEN] A directed warehouse location with warehouse number series configured
+        QltyInspectionUtility.EnsureSetupExists();
+        QltyInspectionUtility.CreatePrioritizedRule(QltyInspectionTemplateHdr, Database::"Warehouse Entry", QltyInspectionGenRule);
+        LibraryWarehouse.NoSeriesSetup(WarehouseSetup);
+        LibraryWarehouse.CreateFullWMSLocation(Location, 3);
+
+        // [GIVEN] Current user is set as warehouse employee for the location
+        QltyInspectionUtility.SetCurrLocationWhseEmployee(Location.Code);
+
+        // [GIVEN] An untracked item is purchased, received and put away at the directed location
+        LibraryInventory.CreateItem(Item);
+        QltyPurOrderGenerator.CreatePurchaseOrder(100, Location, Item, PurchaseHeader, PurchaseLine);
+        LibraryPurchase.ReleasePurchaseDocument(PurchaseHeader);
+        QltyPurOrderGenerator.ReceivePurchaseOrder(Location, PurchaseHeader, PurchaseLine);
+
+        // [GIVEN] A quality inspection is created for the put away warehouse entry (a storage bin, not the receive bin)
+        WarehouseEntry.SetRange("Entry Type", WarehouseEntry."Entry Type"::Movement);
+        WarehouseEntry.SetRange("Location Code", Location.Code);
+        WarehouseEntry.SetRange("Item No.", Item."No.");
+        WarehouseEntry.SetFilter("Zone Code", '<>%1', 'RECEIVE');
+        WarehouseEntry.FindFirst();
+        QltyInspectionUtility.CreateInspectionWithWarehouseEntry(WarehouseEntry, QltyInspectionHeader);
+
+        // [GIVEN] The inspection has 5 samples with 3 failures and 2 passes
+        FailedQuantity := 3;
+        QltyInspectionHeader."Sample Size" := 5;
+        QltyInspectionHeader."Fail Quantity" := FailedQuantity;
+        QltyInspectionHeader."Pass Quantity" := 2;
+        QltyInspectionHeader.Modify();
+
+        // [WHEN] Perform disposition with internal put-away for the failed quantity
+        LibraryAssert.IsTrue(
+            QltyInspectionUtility.PerformInternalPutAwayDisposition(QltyInspectionHeader, 0, '', '', true, Enum::"Qlty. Quantity Behavior"::"Failed Quantity"),
+            'Should have created an internal put-away for the failed quantity');
+
+        // [THEN] Every created put-away line is sourced from a non-receive bin
+        WhseInternalPutAwayLine.SetRange("Item No.", Item."No.");
+        LibraryAssert.IsTrue(WhseInternalPutAwayLine.FindSet(), 'Expected internal put-away lines to be created');
+        repeat
+            Bin.Get(WhseInternalPutAwayLine."Location Code", WhseInternalPutAwayLine."From Bin Code");
+            if BinType.Get(Bin."Bin Type Code") then
+                LibraryAssert.IsFalse(BinType.Receive, 'Internal put-away must not be sourced from a receive bin');
+            TotalPutAwayQuantity += WhseInternalPutAwayLine.Quantity;
+        until WhseInternalPutAwayLine.Next() = 0;
+
+        // [THEN] The total put-away quantity equals the failed quantity
+        LibraryAssert.AreEqual(FailedQuantity, TotalPutAwayQuantity, 'Total internal put-away quantity should equal the failed quantity');
+    end;
+
+    [Test]
     procedure WarehousePutaway_PerformDisposition()
     var
         QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";


### PR DESCRIPTION
**What**
Fixes the Create Internal Put-away disposition from a Quality Inspection, which failed or produced misleading results in bin-mandatory (directed put-away & pick) locations.

**Why it failed**
The disposition resolved the source location/bin from the originating document via field-name conventions (GetFromDetailsFromInspectionSource) instead of the item's actual Bin Content. For non-item-tracked items this returned a stale bin — the receive bin the goods first landed in, or a bin that no longer holds the item — leading to:

Receive must be equal to 'No' in Bin Type: Code=RECEIVE (platform error),
a 0 PCS ... could not be created notification, and
From Bin Code ... cannot be found in the related table (Bin Content).

**Changes**
Resolve the source bin from real Bin Content for bin-mandatory locations (TryResolveBinsFromBinContent): considers only bins with positive quantity and excludes receive and adjustment bins. This is the non-item-tracked counterpart to GetCurrentLocationOfTrackedInventory. Falls back to the previous naming-convention logic only when the location is not bin-mandatory or the item has no current stock. It reports success even when the bin was already resolved by a previous source record, so the receive-bin fallback is never added alongside the real bin.
Validate all resolved source bins for receive bins up front in Qlty. Disp. Internal Put-away, before any document is created, so we never emit a "created" notification for a put-away that is then rolled back. If the item is still in the receive bin the user gets the actionable "put the items away first" message instead of the cryptic platform error.
Show the intended quantity instead of 0 in the document-creation-failed notification (GetDisplayQuantityForFailure), falling back to the failed/passed/sample/source quantity when the instruction quantity has not been resolved yet.
Extracted IsReceiveBin as a reusable helper (shared by the guard and the bin resolution).

**Extra**
Fixes [AB#641562](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641562)

Needs a backport to 28.x to fix the original Work Item.


