### PR TITLE
Fix Run PS Tests: stub Get-BcContainerAppInfo so Pester can mock it

### DIFF
--- a/build/scripts/tests/ParallelTestExecution.Test.ps1
+++ b/build/scripts/tests/ParallelTestExecution.Test.ps1
@@ -11,6 +11,7 @@ Describe "ParallelTestExecution app-name resolution" {
         $script:createdBcContainerAppInfoStub = $false
         if (-not (Get-Command Get-BcContainerAppInfo -ErrorAction SilentlyContinue)) {
             function global:Get-BcContainerAppInfo {
+                [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Parameters exist only so the stub matches the mocked BcContainerHelper cmdlet signature; the body never runs.')]
                 param(
                     [string]$containerName,
                     [string]$tenant,

--- a/build/scripts/tests/ParallelTestExecution.Test.ps1
+++ b/build/scripts/tests/ParallelTestExecution.Test.ps1
@@ -4,6 +4,25 @@ Import-Module (Join-Path $PSScriptRoot '../ParallelTestExecution.psm1') -Force
 
 Describe "ParallelTestExecution app-name resolution" {
     BeforeAll {
+        # Get-BcContainerAppInfo comes from BcContainerHelper, which is present when the module
+        # runs inside a BC container but is NOT loaded in the "Run PS Tests" runner. Pester cannot
+        # mock a command that does not exist, so define a no-op stub (guarded so we never shadow the
+        # real cmdlet) declaring the parameters the module passes, letting the mock bind correctly.
+        $script:createdBcContainerAppInfoStub = $false
+        if (-not (Get-Command Get-BcContainerAppInfo -ErrorAction SilentlyContinue)) {
+            function global:Get-BcContainerAppInfo {
+                param(
+                    [string]$containerName,
+                    [string]$tenant,
+                    [switch]$tenantSpecificProperties
+                )
+                # This body must never run: it exists only so Pester can resolve and mock the
+                # command. Every module call to it in these tests is intercepted by Pester's mock.
+                throw "Get-BcContainerAppInfo stub should never be called; a Pester mock must intercept it."
+            }
+            $script:createdBcContainerAppInfoStub = $true
+        }
+
         # Create real app.json files on disk so Get-AppNameFromMetadata can read them.
         $script:tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("patest_" + [System.Guid]::NewGuid().ToString('N'))
         New-Item -ItemType Directory -Path $script:tempRoot -Force | Out-Null
@@ -24,6 +43,9 @@ Describe "ParallelTestExecution app-name resolution" {
     }
 
     AfterAll {
+        if ($script:createdBcContainerAppInfoStub -and (Test-Path 'function:global:Get-BcContainerAppInfo')) {
+            Remove-Item 'function:global:Get-BcContainerAppInfo' -Force -ErrorAction SilentlyContinue
+        }
         if (Test-Path $script:tempRoot) { Remove-Item $script:tempRoot -Recurse -Force -ErrorAction SilentlyContinue }
     }
 

--- a/build/scripts/tests/ParallelTestExecution.Test.ps1
+++ b/build/scripts/tests/ParallelTestExecution.Test.ps1
@@ -11,12 +11,14 @@ Describe "ParallelTestExecution app-name resolution" {
         $script:createdBcContainerAppInfoStub = $false
         if (-not (Get-Command Get-BcContainerAppInfo -ErrorAction SilentlyContinue)) {
             function global:Get-BcContainerAppInfo {
-                [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Parameters exist only so the stub matches the mocked BcContainerHelper cmdlet signature; the body never runs.')]
                 param(
                     [string]$containerName,
                     [string]$tenant,
                     [switch]$tenantSpecificProperties
                 )
+                # The parameters exist only so the stub matches the mocked BcContainerHelper cmdlet
+                # signature; reference them so PSScriptAnalyzer does not flag them as unused.
+                $null = $containerName, $tenant, $tenantSpecificProperties
                 # This body must never run: it exists only so Pester can resolve and mock the
                 # command. Every module call to it in these tests is intercepted by Pester's mock.
                 throw "Get-BcContainerAppInfo stub should never be called; a Pester mock must intercept it."


### PR DESCRIPTION
## What & why

The `Run PS Tests` job started failing with:

```
CommandNotFoundException: Could not find Command Get-BcContainerAppInfo
```

`build/scripts/tests/ParallelTestExecution.Test.ps1` (added alongside the test-dispatch fix in #9059) mocks `Get-BcContainerAppInfo`, which is a **BcContainerHelper** cmdlet. That module is loaded when the build runs inside a BC container, but it is **not** present in the `Run PS Tests` runner. Pester 5 cannot mock a command that does not exist, so the mock setup threw and the job failed. This was not caught before merge because locally BcContainerHelper is usually loaded, so the mock resolved against the real cmdlet.

## Linked work

<!-- No approved product issue: this is a CI/test-only fix for a break introduced by #9059. -->

Fixes #

Related to #9059 (introduced the test), supersedes #9174 (which fixed the same failure via a production module wrapper).

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- This is a PowerShell test-only change; there is no BC app to build or run.
- Reproduced the exact CI condition locally by running Pester with module autoloading disabled so `Get-BcContainerAppInfo` is absent (`Get-Command` returns nothing). Before the fix the mock setup threw `CommandNotFoundException`; after the fix all 5 tests pass.
- The stub body intentionally `throw`s to document that it must never execute; the tests passing proves every module call is intercepted by Pester's mock, not the stub.

## Risk & compatibility

- Change is confined to a single Pester test file; no production build script or module is touched (this is the key difference from #9174, which added a wrapper to the shipped `ParallelTestExecution.psm1`).
- The stub is only defined when the real cmdlet is absent (i.e. the PS test runner) and is removed in `AfterAll`, so it never shadows the real BcContainerHelper cmdlet in a container and does not leak into other test files.
- No behavioral change to `ParallelTestExecution.psm1` or the test-dispatch logic.



