### PR TITLE
Copy record links to posted Phys. Invt. Order and Recording headers

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Counting/Document/PhysInvtOrderPost.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Counting/Document/PhysInvtOrderPost.Codeunit.al
@@ -22,6 +22,7 @@ using Microsoft.Inventory.Setup;
 using Microsoft.Inventory.Tracking;
 using Microsoft.Utilities;
 using Microsoft.Warehouse.Journal;
+using System.Utilities;
 
 codeunit 5884 "Phys. Invt. Order-Post"
 {
@@ -356,6 +357,7 @@ codeunit 5884 "Phys. Invt. Order-Post"
 
     local procedure InsertPostedHeader(PhysInvtOrderHeader: Record "Phys. Invt. Order Header")
     var
+        RecordLinkManagement: Codeunit "Record Link Management";
         IsHandled: Boolean;
     begin
         OnBeforeInsertPostedHeader(PhysInvtOrderHeader);
@@ -377,8 +379,10 @@ codeunit 5884 "Phys. Invt. Order-Post"
         PstdPhysInvtOrderHdr."User ID" := CopyStr(UserId(), 1, MaxStrLen(PstdPhysInvtOrderHdr."User ID"));
         IsHandled := false;
         OnInsertPostedHeaderOnBeforeInsert(PhysInvtOrderHeader, PstdPhysInvtOrderHdr, IsHandled);
-        if not IsHandled then
+        if not IsHandled then begin
             PstdPhysInvtOrderHdr.Insert();
+            RecordLinkManagement.CopyLinks(PhysInvtOrderHeader, PstdPhysInvtOrderHdr);
+        end;
     end;
 
     local procedure InsertPostedLine(PstdPhysInvtOrderHdr: Record "Pstd. Phys. Invt. Order Hdr"; PhysInvtOrderLine: Record "Phys. Invt. Order Line")
@@ -408,6 +412,7 @@ codeunit 5884 "Phys. Invt. Order-Post"
     var
         PstdPhysInvtRecordHdr: Record "Pstd. Phys. Invt. Record Hdr";
         PstdPhysInvtRecordLine: Record "Pstd. Phys. Invt. Record Line";
+        RecordLinkManagement: Codeunit "Record Link Management";
         IsHandled: Boolean;
     begin
         PhysInvtRecordHeader.Reset();
@@ -420,8 +425,10 @@ codeunit 5884 "Phys. Invt. Order-Post"
 
                 IsHandled := false;
                 OnInsertPostedRecordingsOnBeforeInsertHdr(PhysInvtRecordHeader, PstdPhysInvtRecordHdr, IsHandled);
-                if not IsHandled then
+                if not IsHandled then begin
                     PstdPhysInvtRecordHdr.Insert();
+                    RecordLinkManagement.CopyLinks(PhysInvtRecordHeader, PstdPhysInvtRecordHdr);
+                end;
 
                 PhysInvtRecordLine.Reset();
                 PhysInvtRecordLine.SetRange("Order No.", PhysInvtRecordHeader."Order No.");

--- a/src/Layers/W1/Tests/Physical Inventory/PhysInvtItemTracking.Codeunit.al
+++ b/src/Layers/W1/Tests/Physical Inventory/PhysInvtItemTracking.Codeunit.al
@@ -970,6 +970,49 @@ codeunit 137460 "Phys. Invt. Item Tracking"
         Assert.AreEqual(0, PhysInvtOrderLine.Count, StrSubstNo(ItemNotBeIncludedErr, NonInventoryItem.Type));
     end;
 
+    [Test]
+    [HandlerFunctions('CalcPhysOrderLinesRequestPageHandler,CalculateQuantityExpectedStrMenuHandler,ConfirmHandlerTRUE,MessageHandler')]
+    [Scope('OnPrem')]
+    procedure CopyLinksOnPostingPhysInvtOrder()
+    var
+        Item: Record Item;
+        Location: Record Location;
+        PhysInvtOrderHeader: Record "Phys. Invt. Order Header";
+        PhysInvtRecordHeader: Record "Phys. Invt. Record Header";
+        PstdPhysInvtOrderHdr: Record "Pstd. Phys. Invt. Order Hdr";
+        PstdPhysInvtRecordHdr: Record "Pstd. Phys. Invt. Record Hdr";
+        OrderLink: Text[250];
+        RecordingLink: Text[250];
+    begin
+        // [FEATURE] [Record Link]
+        // [SCENARIO] Record Links on Phys. Invt. Order Header and Phys. Invt. Recording Header are copied to their posted counterparts when the order is posted.
+        Initialize();
+
+        // [GIVEN] Phys. Invt. Order with one finished Recording
+        CreatePhysInventoryOrderWithFinishedRecording(PhysInvtOrderHeader, Item, Location, 5, 5);
+
+        // [GIVEN] Record Link is added to the Phys. Invt. Order Header
+        OrderLink := CreateRecordLink(PhysInvtOrderHeader);
+
+        // [GIVEN] Record Link is added to the Phys. Invt. Recording Header
+        PhysInvtRecordHeader.SetRange("Order No.", PhysInvtOrderHeader."No.");
+        PhysInvtRecordHeader.FindFirst();
+        RecordingLink := CreateRecordLink(PhysInvtRecordHeader);
+
+        // [WHEN] Phys. Invt. Order is finished and posted
+        FinishAndPostPhysInventoryOrder(PhysInvtOrderHeader);
+
+        // [THEN] Record Link is copied to Posted Phys. Invt. Order Header
+        PstdPhysInvtOrderHdr.SetRange("Pre-Assigned No.", PhysInvtOrderHeader."No.");
+        PstdPhysInvtOrderHdr.FindFirst();
+        VerifyRecordLinkUrl(PstdPhysInvtOrderHdr.RecordId, OrderLink);
+
+        // [THEN] Record Link is copied to Posted Phys. Invt. Recording Header
+        PstdPhysInvtRecordHdr.SetRange("Order No.", PstdPhysInvtOrderHdr."No.");
+        PstdPhysInvtRecordHdr.FindFirst();
+        VerifyRecordLinkUrl(PstdPhysInvtRecordHdr.RecordId, RecordingLink);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -1489,6 +1532,27 @@ codeunit 137460 "Phys. Invt. Item Tracking"
         LibraryReportValidation: Codeunit "Library - Report Validation";
     begin
         LibraryReportValidation.DeleteObjectOptions(CurrentSaveValuesId);
+    end;
+
+    local procedure CreateRecordLink(SourceRecord: Variant): Text[250]
+    var
+        RecordLink: Record "Record Link";
+        RecRef: RecordRef;
+    begin
+        RecRef.GetTable(SourceRecord);
+        RecRef.AddLink(LibraryUtility.GenerateGUID());
+        RecordLink.SetRange("Record ID", RecRef.RecordId);
+        RecordLink.FindFirst();
+        exit(RecordLink.URL1);
+    end;
+
+    local procedure VerifyRecordLinkUrl(RecID: RecordId; ExpectedUrl: Text)
+    var
+        RecordLink: Record "Record Link";
+    begin
+        RecordLink.SetRange("Record ID", RecID);
+        RecordLink.FindFirst();
+        RecordLink.TestField(URL1, ExpectedUrl);
     end;
 
     local procedure CreateItemWithLotTrackingAndPhysInventory(


### PR DESCRIPTION
## What & why

Record links (the standard Notes and Links factboxes) attached to a Phys. Invt. Order Header or a Phys. Invt. Recording Header were lost on posting: codeunit 5884 "Phys. Invt. Order-Post" never called `"Record Link Management".CopyLinks`, unlike the sales, purchase, and warehouse posting flows, which all carry record links over to their posted history tables.

This change copies the links in the two places where the posted headers are inserted: `RecordLinkManagement.CopyLinks(PhysInvtOrderHeader, PstdPhysInvtOrderHdr)` after the insert in `InsertPostedHeader()`, and `RecordLinkManagement.CopyLinks(PhysInvtRecordHeader, PstdPhysInvtRecordHdr)` after each recording header insert in `InsertPostedRecordings()`. Both calls sit inside the existing `if not IsHandled then` blocks, so subscribers that replace the standard insert keep full control. A regression test posts an order with a note on both the order and the recording and verifies the links arrive on the posted documents.

This is a re-submission of microsoft/BusinessCentralApps#1900 (pilot repository, retired). The fix and the test were reviewed there; the regression test was added at the reviewer's request. The pilot PR was closed unmerged by the repository retirement.

## Linked work

Fixes #9099

Original pilot review: microsoft/BusinessCentralApps#1900 (fixing microsoft/BusinessCentralApps#1610).

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Verified against current main that neither `InsertPostedHeader()` nor `InsertPostedRecordings()` references `CopyLinks` or `Record Link Management` anywhere in the codeunit, so the defect is still present.
- New test `CopyLinksOnPostingPhysInvtOrder` in PhysInvtItemTracking.Codeunit.al mirrors the existing `DropShipmentCopyLinksOnPostingReceiptShipment` pattern: it attaches a record link to both the Phys. Invt. Order Header and the Phys. Invt. Recording Header, posts the order, and asserts both posted headers carry the link. The test was reviewed in the pilot PR.
- Verified codeunit 5884 has no country layer copies (W1 only), so no localization propagation is needed.
- `using System.Utilities;` is inserted in alphabetical position for the `Record Link Management` reference.
- I did not build the Base Application locally; the change is two additive calls plus a test and relies on CI for compilation and the test run.

## Risk & compatibility

- Additive behavior only: posting output is unchanged except that record links now appear on the posted documents, matching every other posting flow.
- The copy runs inside the existing `IsHandled` gates right after the standard inserts, so event subscribers that take over the insert are unaffected.
- No schema, permission, or signature changes.


Fixes [AB#647958](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647958)

