### PR TITLE
Align Pay-to Name 2 editability with the other pay-to address fields on purchase documents

### DIFF
--- a/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
@@ -726,8 +726,8 @@ page 51 "Purchase Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseOrder.Page.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseOrder.Page.al
@@ -748,8 +748,8 @@ page 50 "Purchase Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/BE/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
+++ b/src/Layers/BE/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
@@ -731,8 +731,8 @@ page 51 "Purchase Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/CH/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
+++ b/src/Layers/CH/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
@@ -726,8 +726,8 @@ page 51 "Purchase Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/CH/BaseApp/Purchases/Document/PurchaseOrder.Page.al
+++ b/src/Layers/CH/BaseApp/Purchases/Document/PurchaseOrder.Page.al
@@ -748,8 +748,8 @@ page 50 "Purchase Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/CH/BaseApp/Purchases/Document/PurchaseQuote.Page.al
+++ b/src/Layers/CH/BaseApp/Purchases/Document/PurchaseQuote.Page.al
@@ -630,8 +630,8 @@ page 49 "Purchase Quote"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseOrder.Page.al
+++ b/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseOrder.Page.al
@@ -748,8 +748,8 @@ page 50 "Purchase Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/ES/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
+++ b/src/Layers/ES/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
@@ -737,8 +737,8 @@ page 51 "Purchase Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/ES/BaseApp/Purchases/Document/PurchaseOrder.Page.al
+++ b/src/Layers/ES/BaseApp/Purchases/Document/PurchaseOrder.Page.al
@@ -755,8 +755,8 @@ page 50 "Purchase Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/ES/BaseApp/Purchases/Document/PurchaseQuote.Page.al
+++ b/src/Layers/ES/BaseApp/Purchases/Document/PurchaseQuote.Page.al
@@ -639,8 +639,8 @@ page 49 "Purchase Quote"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/FI/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
+++ b/src/Layers/FI/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
@@ -726,8 +726,8 @@ page 51 "Purchase Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/FI/BaseApp/Purchases/Document/PurchaseOrder.Page.al
+++ b/src/Layers/FI/BaseApp/Purchases/Document/PurchaseOrder.Page.al
@@ -748,8 +748,8 @@ page 50 "Purchase Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/IT/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
@@ -735,8 +735,8 @@ page 51 "Purchase Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/IT/BaseApp/Purchases/Document/PurchaseOrder.Page.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/PurchaseOrder.Page.al
@@ -762,8 +762,8 @@ page 50 "Purchase Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/IT/BaseApp/Purchases/Document/PurchaseQuote.Page.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/PurchaseQuote.Page.al
@@ -633,8 +633,8 @@ page 49 "Purchase Quote"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NA/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
+++ b/src/Layers/NA/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
@@ -757,8 +757,8 @@ page 51 "Purchase Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NA/BaseApp/Purchases/Document/PurchaseOrder.Page.al
+++ b/src/Layers/NA/BaseApp/Purchases/Document/PurchaseOrder.Page.al
@@ -771,8 +771,8 @@ page 50 "Purchase Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NA/BaseApp/Purchases/Document/PurchaseQuote.Page.al
+++ b/src/Layers/NA/BaseApp/Purchases/Document/PurchaseQuote.Page.al
@@ -637,8 +637,8 @@ page 49 "Purchase Quote"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NL/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
+++ b/src/Layers/NL/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
@@ -737,8 +737,8 @@ page 51 "Purchase Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NL/BaseApp/Purchases/Document/PurchaseOrder.Page.al
+++ b/src/Layers/NL/BaseApp/Purchases/Document/PurchaseOrder.Page.al
@@ -759,8 +759,8 @@ page 50 "Purchase Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NL/BaseApp/Purchases/Document/PurchaseQuote.Page.al
+++ b/src/Layers/NL/BaseApp/Purchases/Document/PurchaseQuote.Page.al
@@ -639,8 +639,8 @@ page 49 "Purchase Quote"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NO/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
+++ b/src/Layers/NO/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
@@ -726,8 +726,8 @@ page 51 "Purchase Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/NO/BaseApp/Purchases/Document/PurchaseOrder.Page.al
+++ b/src/Layers/NO/BaseApp/Purchases/Document/PurchaseOrder.Page.al
@@ -748,8 +748,8 @@ page 50 "Purchase Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
@@ -742,8 +742,8 @@ page 51 "Purchase Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseOrder.Page.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseOrder.Page.al
@@ -760,8 +760,8 @@ page 50 "Purchase Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseQuote.Page.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseQuote.Page.al
@@ -634,8 +634,8 @@ page 49 "Purchase Quote"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchaseInvoice.Page.al
@@ -726,8 +726,8 @@ page 51 "Purchase Invoice"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchaseOrder.Page.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchaseOrder.Page.al
@@ -748,8 +748,8 @@ page 50 "Purchase Order"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchaseQuote.Page.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchaseQuote.Page.al
@@ -630,8 +630,8 @@ page 49 "Purchase Quote"
                         {
                             ApplicationArea = Basic, Suite;
                             Caption = 'Name 2';
-                            Editable = PayToOptions = PayToOptions::"Another Vendor";
-                            Enabled = PayToOptions = PayToOptions::"Another Vendor";
+                            Editable = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
+                            Enabled = (PayToOptions = PayToOptions::"Custom Address") or (Rec."Buy-from Vendor No." <> Rec."Pay-to Vendor No.");
                             Importance = Additional;
                             QuickEntry = false;
                             Visible = false;

--- a/src/Layers/W1/Tests/Misc/UTPageActionsControls.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/UTPageActionsControls.Codeunit.al
@@ -3530,7 +3530,8 @@ codeunit 134341 "UT Page Actions & Controls"
 
         // [THEN] Pay-to address fields are editable, and "Pay-to Name" field is not
         Assert.IsFalse(PurchaseQuotePage."Pay-to Name".Editable(), '');
-        Assert.IsTrue(PurchaseQuotePage."Pay-to Address".Editable() and
+        Assert.IsTrue(PurchaseQuotePage."Pay-to Name 2".Editable() and
+          PurchaseQuotePage."Pay-to Address".Editable() and
           PurchaseQuotePage."Pay-to Address 2".Editable() and
           PurchaseQuotePage."Pay-to City".Editable() and
           PurchaseQuotePage."Pay-to County".Editable() and
@@ -3561,7 +3562,8 @@ codeunit 134341 "UT Page Actions & Controls"
 
         // [THEN] Pay-to address fields are editable, and "Pay-to Name" field is not
         Assert.IsFalse(PurchaseOrderPage."Pay-to Name".Editable(), '');
-        Assert.IsTrue(PurchaseOrderPage."Pay-to Address".Editable() and
+        Assert.IsTrue(PurchaseOrderPage."Pay-to Name 2".Editable() and
+          PurchaseOrderPage."Pay-to Address".Editable() and
           PurchaseOrderPage."Pay-to Address 2".Editable() and
           PurchaseOrderPage."Pay-to City".Editable() and
           PurchaseOrderPage."Pay-to County".Editable() and
@@ -3592,7 +3594,8 @@ codeunit 134341 "UT Page Actions & Controls"
 
         // [THEN] Pay-to address fields are editable, and "Pay-to Name" field is not
         Assert.IsFalse(PurchaseInvoicePage."Pay-to Name".Editable(), '');
-        Assert.IsTrue(PurchaseInvoicePage."Pay-to Address".Editable() and
+        Assert.IsTrue(PurchaseInvoicePage."Pay-to Name 2".Editable() and
+          PurchaseInvoicePage."Pay-to Address".Editable() and
           PurchaseInvoicePage."Pay-to Address 2".Editable() and
           PurchaseInvoicePage."Pay-to City".Editable() and
           PurchaseInvoicePage."Pay-to County".Editable() and


### PR DESCRIPTION
## What & why

On the Purchase Quote, Purchase Order, and Purchase Invoice pages, "Pay-to Name 2" is only editable when the Pay-to option is "Another Vendor". Every other field in the pay-to address group (Address, Address 2, City, County, Post Code, Country/Region Code, Contact No., Contact) is editable when "Custom Address" is selected or when the pay-to vendor differs from the buy-from vendor. The field was missed when that editability logic was applied to the group. This is the purchase-side counterpart of #8312, fixed for sales in #9096.

This change gives "Pay-to Name 2" the same Editable and Enabled expression as the rest of the group on those three pages. The country layers that carry copies of these pages (APAC, BE, CH, DACH, ES, FI, IT, NA, NL, NO, RU) receive the identical two-property change, following the established practice of propagating W1 fixes to the localization layers.

## Linked work

Fixes #9097

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Extended the three existing pay-to editability tests (CustomAddressPayToOptionOnPurchaseQuotePage, ...PurchaseOrderPage, ...PurchaseInvoicePage in UTPageActionsControls.Codeunit.al) so they now also assert that "Pay-to Name 2" is editable when "Custom Address" is selected, alongside the sibling address fields they already cover.
- Verified that every page copy across the localization layers received the identical two-line change and nothing else (the diff is uniform, and byte order marks and line endings of the touched files are preserved).
- Confirmed on the Purchase Header table that "Pay-to Name 2" is a plain text field with no OnValidate logic and no table relation, so widening its page editability has no side effects beyond allowing input.
- I did not build the Base Application locally; the change is limited to two page control properties per page, replicating the exact expression already used by all sibling fields, and relies on the extended test coverage in CI.

## Risk & compatibility

- The Blanket Purchase Order, Purchase Credit Memo, and Purchase Return Order pages are intentionally not touched: they have no PayToOptions-based conditions on this field, mirroring the scoping decision on the sales-side issue.
- No breaking changes: no object signatures, events, or table schema are affected.


Fixes [AB#647959](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647959)

