### PR TITLE
[Shopify] Create BC customer on order import when Shopify customer has no default address

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCustByEmailPhone.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCustByEmailPhone.Codeunit.al
@@ -53,14 +53,18 @@ codeunit 30113 "Shpfy Cust. By Email/Phone" implements "Shpfy ICustomer Mapping"
             if AllowCreate then begin
                 CustomerAddress.SetRange("Customer Id", CustomerId);
                 CustomerAddress.SetRange(Default, true);
-                if CustomerAddress.FindFirst() then begin
-                    CreateCustomer.SetShop(ShopCode);
-                    CreateCustomer.SetTemplateCode(TemplateCode);
-                    CustomerAddress.SetRecFilter();
-                    CreateCustomer.Run(CustomerAddress);
-                    ShopifyCustomer.CalcFields("Customer No.");
-                    exit(ShopifyCustomer."Customer No.");
+                if not CustomerAddress.FindFirst() then begin
+                    CustomerAddress.SetRange(Default);
+                    if not CustomerAddress.FindFirst() then
+                        exit('');
                 end;
+                CreateCustomer.SetShop(ShopCode);
+                CreateCustomer.SetTemplateCode(TemplateCode);
+                CustomerAddress.SetRecFilter();
+                CreateCustomer.Run(CustomerAddress);
+                ShopifyCustomer.Get(CustomerId);
+                ShopifyCustomer.CalcFields("Customer No.");
+                exit(ShopifyCustomer."Customer No.");
             end;
 
         end else begin

--- a/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyUpdateCustomer.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyUpdateCustomer.Codeunit.al
@@ -49,12 +49,15 @@ codeunit 30124 "Shpfy Update Customer"
     var
         CustomerAddress: Record "Shpfy Customer Address";
         CustContUpdate: Codeunit "CustCont-Update";
-        NoDefaltAddressErr: Label 'No default address found for Shopify customer id: %1', Comment = '%1 = Shopify customer id';
+        NoAddressErr: Label 'No address found for Shopify customer id: %1', Comment = '%1 = Shopify customer id';
     begin
         CustomerAddress.SetRange("Customer Id", ShopifyCustomer.Id);
         CustomerAddress.SetRange(Default, true);
-        if not CustomerAddress.FindFirst() then
-            Error(NoDefaltAddressErr, ShopifyCustomer.Id);
+        if not CustomerAddress.FindFirst() then begin
+            CustomerAddress.SetRange(Default);
+            if not CustomerAddress.FindFirst() then
+                Error(NoAddressErr, ShopifyCustomer.Id);
+        end;
 
         FillInCustomerFields(Customer, ShopifyShop, ShopifyCustomer, CustomerAddress);
         Customer.Modify();

--- a/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyUpdateCustomer.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyUpdateCustomer.Codeunit.al
@@ -25,6 +25,7 @@ codeunit 30124 "Shpfy Update Customer"
         Shop: Record "Shpfy Shop";
         CustomerEvents: Codeunit "Shpfy Customer Events";
         NoLocationErr: Label 'No location was found for Shopify company id: %1', Comment = 'Shopify should not be translated. %1 = Shopify company id';
+        NoAddressErr: Label 'No address found for Shopify customer id: %1', Comment = '%1 = Shopify customer id';
 
     trigger OnRun()
     var
@@ -49,7 +50,6 @@ codeunit 30124 "Shpfy Update Customer"
     var
         CustomerAddress: Record "Shpfy Customer Address";
         CustContUpdate: Codeunit "CustCont-Update";
-        NoAddressErr: Label 'No address found for Shopify customer id: %1', Comment = '%1 = Shopify customer id';
     begin
         CustomerAddress.SetRange("Customer Id", ShopifyCustomer.Id);
         CustomerAddress.SetRange(Default, true);

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCreateCustomerTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCreateCustomerTest.Codeunit.al
@@ -95,6 +95,39 @@ codeunit 139565 "Shpfy Create Customer Test"
         LibraryAssert.AreEqual(ResultCode, ShopifyCustomer."Customer No.", 'The Shopify customer should be linked to the created BC customer.');
     end;
 
+    [Test]
+    procedure UnitTestUpdateCustomerWithoutDefaultAddressDoesNotError()
+    var
+        Customer: Record Customer;
+        ShopifyCustomer: Record "Shpfy Customer";
+        ShopifyCustomerAddress: Record "Shpfy Customer Address";
+        UpdateCustomer: Codeunit "Shpfy Update Customer";
+    begin
+        // [SCENARIO] Updating a linked BC customer from a Shopify customer that has no default address
+        // (Shopify defaultAddress = null) falls back to an available address instead of erroring.
+        Initialize();
+
+        // [GIVEN] A BC customer linked to a Shopify customer
+        Customer.Init();
+        Customer."No." := CopyStr(Any.AlphanumericText(10), 1, MaxStrLen(Customer."No."));
+        Customer.Insert(true);
+        CustomerInitTest.CreateShopifyCustomer(ShopifyCustomer);
+        ShopifyCustomer."Customer SystemId" := Customer.SystemId;
+        ShopifyCustomer.Modify();
+
+        // [GIVEN] The Shopify customer has an address that is not marked as default
+        ShopifyCustomerAddress := CustomerInitTest.CreateShopifyCustomerAddress(ShopifyCustomer);
+        ShopifyCustomerAddress.TestField(Default, false);
+
+        // [WHEN] The customer is updated from Shopify
+        UpdateCustomer.SetShop(Shop);
+        UpdateCustomer.Run(ShopifyCustomer);
+
+        // [THEN] No error is raised and the customer address is filled from the available (non-default) address
+        Customer.Get(Customer."No.");
+        LibraryAssert.AreEqual(ShopifyCustomerAddress."Address 1", Customer.Address, 'Customer address should be updated from the available address.');
+    end;
+
     local procedure Initialize()
     var
         AccessToken: SecretText;

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCreateCustomerTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCreateCustomerTest.Codeunit.al
@@ -58,6 +58,43 @@ codeunit 139565 "Shpfy Create Customer Test"
             LibraryAssert.AssertRecordNotFound();
     end;
 
+    [Test]
+    procedure UnitTestMapCustomerWithoutDefaultAddressStillCreatesCustomer()
+    var
+        Customer: Record Customer;
+        CustomerTempl: Record "Customer Templ.";
+        ShopifyCustomer: Record "Shpfy Customer";
+        ShopifyCustomerAddress: Record "Shpfy Customer Address";
+        ICustomerMapping: Interface "Shpfy ICustomer Mapping";
+        JCustomerInfo: JsonObject;
+        CustomerId: BigInteger;
+        ResultCode: Code[20];
+    begin
+        // [SCENARIO] A staged Shopify customer that is not yet linked to a BC customer and whose address is not flagged
+        // as default (Shopify defaultAddress = null) still gets a BC customer created when mapping allows creation.
+        Initialize();
+        if not CustomerTempl.FindFirst() then
+            exit;
+
+        // [GIVEN] A staged Shopify customer without a linked BC customer
+        CustomerId := CustomerInitTest.CreateShopifyCustomer(ShopifyCustomer);
+        // [GIVEN] The customer has an address that is not marked as default
+        ShopifyCustomerAddress := CustomerInitTest.CreateShopifyCustomerAddress(ShopifyCustomer);
+        ShopifyCustomerAddress.TestField(Default, false);
+
+        // [WHEN] Mapping the customer by email/phone with customer creation allowed
+        ICustomerMapping := "Shpfy Customer Mapping"::"By EMail/Phone";
+        JCustomerInfo := CustomerInitTest.CreateJsonCustomerInfo(Shop."Name Source", Shop."Name 2 Source");
+        ResultCode := ICustomerMapping.DoMapping(CustomerId, JCustomerInfo, Shop.Code, CustomerTempl.Code, true);
+
+        // [THEN] A BC customer is created, linked to the Shopify customer, even though no default address existed
+        LibraryAssert.AreNotEqual('', ResultCode, 'A customer should be created when the customer has no default address.');
+        LibraryAssert.IsTrue(Customer.Get(ResultCode), 'The mapped BC customer should exist.');
+        ShopifyCustomer.Get(CustomerId);
+        ShopifyCustomer.CalcFields("Customer No.");
+        LibraryAssert.AreEqual(ResultCode, ShopifyCustomer."Customer No.", 'The Shopify customer should be linked to the created BC customer.');
+    end;
+
     local procedure Initialize()
     var
         AccessToken: SecretText;


### PR DESCRIPTION
## What & why

During Shopify order import and customer sync, the connector handled a Shopify customer with **no default address** (Shopify `defaultAddress = null` — e.g. an address with Company populated but not flagged default) inconsistently across three code paths that all filter on `SetRange(Default, true)`:

| Codeunit | Old behavior on no default address |
|---|---|
| 30117 `Shpfy Customer Import` | ✅ already fell back to any available address |
| 30113 `Shpfy Cust. By Email/Phone` | ❌ returned blank → order silently mapped to the shop's **Default Customer** (no BC customer created) |
| 30124 `Shpfy Update Customer` | ❌ hard `Error("No default address found...")` → aborted sync / order import for an already-linked customer |

The 30113 gap is the direct cause of ICM 51000001096512 (customer not created on order import). The 30124 gap is a latent, related failure of the same root cause. When Shopify returns `defaultAddress = null`, `ShpfyCustomerAPI` flags every address `Default = false`, so the default-only lookups find nothing.

This change makes all three paths consistent:
- **CU 30113** – fall back to the first available address when no default exists; re-read the Shopify customer (`Get(CustomerId)`) before returning so the `Customer No.` FlowField reflects the newly linked customer (otherwise the customer is created but `DoMapping` still returns blank and the order maps to the default customer).
- **CU 30124** – fall back to the first available address instead of erroring; only error when the customer has **no address at all**. The misspelled label `NoDefaltAddressErr` ("No default address found") is renamed to `NoAddressErr` ("No address found") to match the corrected semantics.

## Linked work

Fixes [AB#641625](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641625)

<!-- Internal ADO work item; originates from ICM 51000001096512. -->

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Built the Shopify Connector (App) and Test apps locally via AL — 0 errors, no new warnings. Added two regression tests in codeunit 139565:
- `UnitTestMapCustomerWithoutDefaultAddressStillCreatesCustomer` — stages a Shopify customer with a non-default address, maps `By EMail/Phone` with `AllowCreate = true`, asserts a BC customer is created **and** linked (`Customer No.` = result).
- `UnitTestUpdateCustomerWithoutDefaultAddressDoesNotError` — links a BC customer to a Shopify customer with a non-default address, runs `Shpfy Update Customer`, asserts it no longer errors and fills fields from that address.

Both tests **pass with the fix** and **fail without it** (30113 returns blank; 30124 errors with "No default address found..."), confirming they are genuine regression guards. All 4 tests in codeunit 139565 pass.

## Risk & compatibility

Low. Behavior is unchanged when a default address exists. The new paths only affect the previously-broken no-default-address case: CU 30113 now creates/links a customer instead of returning blank; CU 30124 now updates from an available address instead of erroring. The renamed label (`NoAddressErr`) is user-facing and translatable — translations regenerate on build. No schema, permission, or upgrade impact.




