### PR TITLE
[Main]- When issuing a prepayment invoice with an invoice discount applied, the prepayment amount does not take into account the total amount including tax.

### DIFF
--- a/build/scripts/GitHub/GitHubPullRequest.class.psm1
+++ b/build/scripts/GitHub/GitHubPullRequest.class.psm1
@@ -140,6 +140,6 @@ class GitHubPullRequest {
             return
         }
         $milestoneNumber = $githubMilestone.number
-        gh api "/repos/$($this.Repository)/issues/$($this.PRNumber)" -H ([GitHubAPI]::AcceptJsonHeader) -H ([GitHubAPI]::GitHubAPIHeader) -F milestone=$milestoneNumber | ConvertFrom-Json
+        gh api --method PATCH "/repos/$($this.Repository)/issues/$($this.PRNumber)" -H ([GitHubAPI]::AcceptJsonHeader) -H ([GitHubAPI]::GitHubAPIHeader) -F milestone=$milestoneNumber | Out-Null
     }
 }

--- a/src/Layers/CA/Tests/Local/ERMSalesPrepmtIncludeTax.Codeunit.al
+++ b/src/Layers/CA/Tests/Local/ERMSalesPrepmtIncludeTax.Codeunit.al
@@ -14,6 +14,7 @@
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryRandom: Codeunit "Library - Random";
         Assert: Codeunit Assert;
+        PrepmtAmountMustIncludeTaxErr: Label 'Posted prepayment amount on the Sales Prepayments Account must include tax.';
 
     [Test]
     [Scope('OnPrem')]
@@ -491,6 +492,57 @@
           CustomerPostingGroup."Receivables Account", GeneralPostingSetup."Sales Prepayments Account", PrepmtAmount / 2);
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure PrepmtInvoiceInclTaxWithInvoiceDiscount()
+    var
+        Customer: Record Customer;
+        GeneralPostingSetup: Record "General Posting Setup";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        TaxArea: Record "Tax Area";
+        TaxDetail: Record "Tax Detail";
+        TaxGroup: Record "Tax Group";
+        TaxPct: Decimal;
+        ExpectedPrepmtInclTax: Decimal;
+    begin
+        // [SCENARIO 638146] Posted prepayment invoice amount includes sales tax when "Prepmt. Include Tax" = TRUE and an invoice discount is applied.
+
+        // [GIVEN] Tax Details for tax jurisdiction with 5 %.
+        LibraryERM.CreateTaxArea(TaxArea);
+        LibraryERM.CreateTaxGroup(TaxGroup);
+        TaxPct := 5;
+        CreateTaxAreaSetupWithValues(TaxDetail, TaxArea.Code, TaxGroup.Code, TaxPct);
+
+        // [GIVEN] Customer with a 10 % invoice discount.
+        Customer.Get(CreateCustomerWithTaxArea(TaxArea.Code));
+        CreateInvoiceDiscountForCustomer(Customer."No.", 10);
+
+        // [GIVEN] Sales Order with "Prepmt. Include Tax" = TRUE and "Prepayment %" = 100.
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, Customer."No.");
+        SalesHeader.Validate("Prepayment %", 100);
+        SalesHeader.Validate("Prices Including VAT", false);
+        SalesHeader.Validate("Compress Prepayment", true);
+        SalesHeader.Validate("Prepmt. Include Tax", true);
+        SalesHeader.Modify(true);
+
+        // [GIVEN] Sales Line with Unit Price = 289.60 and Quantity = 10 => Line Amount 2896, Inv. Discount 289.60, Net Amount 2606.40.
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, CreateItemWithTaxGroup(TaxGroup.Code), 10);
+        SalesLine.Validate("Unit Price", 289.6);
+        SalesLine.Modify(true);
+        CalcSalesInvoiceDiscount(SalesLine);
+        GeneralPostingSetup.Get(SalesLine."Gen. Bus. Posting Group", SalesLine."Gen. Prod. Posting Group");
+
+        // [WHEN] Post the prepayment invoice.
+        PostSalesPrepmtInvoice(SalesHeader);
+
+        // [THEN] The posted prepayment G/L Entry for the Sales Prepayments Account equals the discounted total including tax = (2896 - 289.60) * 1.05 = 2736.72.
+        SalesHeader.Get(SalesHeader."Document Type", SalesHeader."No.");
+        SalesHeader.CalcFields("Amount Including VAT");
+        ExpectedPrepmtInclTax := Round(SalesHeader."Amount Including VAT" * SalesHeader."Prepayment %" / 100);
+        VerifyPrepmtGLEntryAmount(SalesHeader."Last Prepayment No.", GeneralPostingSetup."Sales Prepayments Account", -ExpectedPrepmtInclTax);
+    end;
+
     local procedure PrepareSOwithPostedPrepmtInv(var SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line"; NoOfLines: Integer; TaxAreaCode: Code[20]; ItemNo: Code[20]; PrepmtInclTax: Boolean)
     var
         i: Integer;
@@ -780,6 +832,34 @@
         GLEntry.SetFilter("G/L Account No.", GLAccFilter);
         GLEntry.CalcSums(Amount);
         GLEntry.TestField(Amount, ExpAmount);
+    end;
+
+    local procedure CreateInvoiceDiscountForCustomer(CustomerNo: Code[20]; DiscountPct: Decimal)
+    var
+        CustInvoiceDisc: Record "Cust. Invoice Disc.";
+    begin
+        CustInvoiceDisc.Init();
+        CustInvoiceDisc.Validate(Code, CustomerNo);
+        CustInvoiceDisc.Validate("Minimum Amount", 0);
+        CustInvoiceDisc.Insert(true);
+        CustInvoiceDisc.Validate("Discount %", DiscountPct);
+        CustInvoiceDisc.Modify(true);
+    end;
+
+    local procedure CalcSalesInvoiceDiscount(var SalesLine: Record "Sales Line")
+    begin
+        CODEUNIT.Run(CODEUNIT::"Sales-Calc. Discount", SalesLine);
+        SalesLine.Find();
+    end;
+
+    local procedure VerifyPrepmtGLEntryAmount(DocumentNo: Code[20]; PrepaymentAcc: Code[20]; ExpAmount: Decimal)
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        GLEntry.SetRange("Document No.", DocumentNo);
+        GLEntry.SetRange("G/L Account No.", PrepaymentAcc);
+        GLEntry.CalcSums(Amount);
+        Assert.AreEqual(ExpAmount, GLEntry.Amount, PrepmtAmountMustIncludeTaxErr);
     end;
 }
 

--- a/src/Layers/NA/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -700,7 +700,7 @@ codeunit 442 "Sales-Post Prepayments"
                     TempSalesLine.Insert();
                 end;
             until SalesLine.Next() = 0;
-UpdateDifferenceAmount(SalesHeader, TotalPrepmtInvLineBuffer, TempPrepmtInvLineBuf, HasInvoiceDiscount);
+        UpdateDifferenceAmount(SalesHeader, TotalPrepmtInvLineBuffer, TempPrepmtInvLineBuf, HasInvoiceDiscount);
 
         if SalesSetup."Invoice Rounding" then
             if InsertInvoiceRounding(
@@ -2083,8 +2083,11 @@ UpdateDifferenceAmount(SalesHeader, TotalPrepmtInvLineBuffer, TempPrepmtInvLineB
     begin
         if HasInvoiceDiscount and (SalesHeader."Prepayment %" <> 0) then begin
             Currency.Initialize(SalesHeader."Currency Code");
-            SalesHeader.CalcFields(Amount);
-            PrepmtAmt := Round(SalesHeader.Amount * SalesHeader."Prepayment %" / 100, Currency."Amount Rounding Precision");
+            SalesHeader.CalcFields(Amount, "Amount Including VAT");
+            if SalesHeader."Prepmt. Include Tax" then
+                PrepmtAmt := Round(SalesHeader."Amount Including VAT" * SalesHeader."Prepayment %" / 100, Currency."Amount Rounding Precision")
+            else
+                PrepmtAmt := Round(SalesHeader.Amount * SalesHeader."Prepayment %" / 100, Currency."Amount Rounding Precision");
             if TotalPrepmtInvLineBuffer.Amount > PrepmtAmt then begin
                 DifferenceAmt := TotalPrepmtInvLineBuffer.Amount - PrepmtAmt;
 

--- a/src/Layers/US/Tests/Local/ERMSalesPrepmtIncludeTax.Codeunit.al
+++ b/src/Layers/US/Tests/Local/ERMSalesPrepmtIncludeTax.Codeunit.al
@@ -14,6 +14,7 @@
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryRandom: Codeunit "Library - Random";
         Assert: Codeunit Assert;
+        PrepmtAmountMustIncludeTaxErr: Label 'Posted prepayment amount on the Sales Prepayments Account must include tax.';
 
     [Test]
     [Scope('OnPrem')]
@@ -491,6 +492,57 @@
           CustomerPostingGroup."Receivables Account", GeneralPostingSetup."Sales Prepayments Account", PrepmtAmount / 2);
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure PrepmtInvoiceInclTaxWithInvoiceDiscount()
+    var
+        Customer: Record Customer;
+        GeneralPostingSetup: Record "General Posting Setup";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        TaxArea: Record "Tax Area";
+        TaxDetail: Record "Tax Detail";
+        TaxGroup: Record "Tax Group";
+        TaxPct: Decimal;
+        ExpectedPrepmtInclTax: Decimal;
+    begin
+        // [SCENARIO 638146] Posted prepayment invoice amount includes sales tax when "Prepmt. Include Tax" = TRUE and an invoice discount is applied.
+
+        // [GIVEN] Tax Details for tax jurisdiction with 5 %.
+        LibraryERM.CreateTaxArea(TaxArea);
+        LibraryERM.CreateTaxGroup(TaxGroup);
+        TaxPct := 5;
+        CreateTaxAreaSetupWithValues(TaxDetail, TaxArea.Code, TaxGroup.Code, TaxPct);
+
+        // [GIVEN] Customer with a 10 % invoice discount.
+        Customer.Get(CreateCustomerWithTaxArea(TaxArea.Code));
+        CreateInvoiceDiscountForCustomer(Customer."No.", 10);
+
+        // [GIVEN] Sales Order with "Prepmt. Include Tax" = TRUE and "Prepayment %" = 100.
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, Customer."No.");
+        SalesHeader.Validate("Prepayment %", 100);
+        SalesHeader.Validate("Prices Including VAT", false);
+        SalesHeader.Validate("Compress Prepayment", true);
+        SalesHeader.Validate("Prepmt. Include Tax", true);
+        SalesHeader.Modify(true);
+
+        // [GIVEN] Sales Line with Unit Price = 289.60 and Quantity = 10 => Line Amount 2896, Inv. Discount 289.60, Net Amount 2606.40.
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, CreateItemWithTaxGroup(TaxGroup.Code), 10);
+        SalesLine.Validate("Unit Price", 289.6);
+        SalesLine.Modify(true);
+        CalcSalesInvoiceDiscount(SalesLine);
+        GeneralPostingSetup.Get(SalesLine."Gen. Bus. Posting Group", SalesLine."Gen. Prod. Posting Group");
+
+        // [WHEN] Post the prepayment invoice.
+        PostSalesPrepmtInvoice(SalesHeader);
+
+        // [THEN] The posted prepayment G/L Entry for the Sales Prepayments Account equals the discounted total including tax = (2896 - 289.60) * 1.05 = 2736.72.
+        SalesHeader.Get(SalesHeader."Document Type", SalesHeader."No.");
+        SalesHeader.CalcFields("Amount Including VAT");
+        ExpectedPrepmtInclTax := Round(SalesHeader."Amount Including VAT" * SalesHeader."Prepayment %" / 100);
+        VerifyPrepmtGLEntryAmount(SalesHeader."Last Prepayment No.", GeneralPostingSetup."Sales Prepayments Account", -ExpectedPrepmtInclTax);
+    end;
+
     local procedure PrepareSOwithPostedPrepmtInv(var SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line"; NoOfLines: Integer; TaxAreaCode: Code[20]; ItemNo: Code[20]; PrepmtInclTax: Boolean)
     var
         i: Integer;
@@ -780,6 +832,34 @@
         GLEntry.SetFilter("G/L Account No.", GLAccFilter);
         GLEntry.CalcSums(Amount);
         GLEntry.TestField(Amount, ExpAmount);
+    end;
+
+    local procedure CreateInvoiceDiscountForCustomer(CustomerNo: Code[20]; DiscountPct: Decimal)
+    var
+        CustInvoiceDisc: Record "Cust. Invoice Disc.";
+    begin
+        CustInvoiceDisc.Init();
+        CustInvoiceDisc.Validate(Code, CustomerNo);
+        CustInvoiceDisc.Validate("Minimum Amount", 0);
+        CustInvoiceDisc.Insert(true);
+        CustInvoiceDisc.Validate("Discount %", DiscountPct);
+        CustInvoiceDisc.Modify(true);
+    end;
+
+    local procedure CalcSalesInvoiceDiscount(var SalesLine: Record "Sales Line")
+    begin
+        CODEUNIT.Run(CODEUNIT::"Sales-Calc. Discount", SalesLine);
+        SalesLine.Find();
+    end;
+
+    local procedure VerifyPrepmtGLEntryAmount(DocumentNo: Code[20]; PrepaymentAcc: Code[20]; ExpAmount: Decimal)
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        GLEntry.SetRange("Document No.", DocumentNo);
+        GLEntry.SetRange("G/L Account No.", PrepaymentAcc);
+        GLEntry.CalcSums(Amount);
+        Assert.AreEqual(ExpAmount, GLEntry.Amount, PrepmtAmountMustIncludeTaxErr);
     end;
 }
 


### PR DESCRIPTION
[Bug 641621](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/641621): [All-E][Main]When issuing a prepayment invoice with an invoice discount applied, the prepayment amount does not take into account the total amount including tax.

[AB#641621](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641621)

Issue: When posting a sales prepayment invoice with "Prepmt. Include Tax" = TRUE on an order that has an invoice discount applied, the posted prepayment amount incorrectly excludes sales tax. Removing the invoice discount produced the correct tax-inclusive prepayment, but adding a discount stripped the tax from the posted prepayment amount.

Cause: In the UpdateDifferenceAmount procedure in [SalesPostPrepayments.Codeunit.al](vscode-file://vscode-app/c:/Users/v-dhavalmore/AppData/Local/Programs/Microsoft%20VS%20Code/fcf604774b/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (which only runs when HasInvoiceDiscount is true), the reconciliation target was computed as SalesHeader.Amount * "Prepayment %" / 100 — i.e. the net, tax-excluded amount. The routine then subtracted the resulting difference (effectively the tax) from both Amount and "Amount Incl. VAT" of the prepayment buffer, removing the tax that the proportional PrepmtAmount calculation had correctly included.

Solution: Modified UpdateDifferenceAmount so that when SalesHeader."Prepmt. Include Tax" is true it uses SalesHeader."Amount Including VAT" * "Prepayment %" / 100 (the tax-inclusive amount) as the reconciliation target, matching the tax-inclusive values held in the prepayment buffer. This preserves the tax in the posted prepayment for the invoice-discount path, while the non-include-tax path and no-discount scenarios remain unchanged.


