### PR TITLE
Lock Code labels on default Transformation Rule records

### DIFF
--- a/src/Layers/W1/BaseApp/System/DataExchange/TransformationRule.Table.al
+++ b/src/Layers/W1/BaseApp/System/DataExchange/TransformationRule.Table.al
@@ -286,31 +286,31 @@ table 1237 "Transformation Rule"
     end;
 
     var
-        UNIXTIMESTAMPTxt: Label 'UNIXTIMESTAMP', Comment = 'Assigned to Transformation.Code field for Unix Timestamp';
+        UNIXTIMESTAMPTxt: Label 'UNIXTIMESTAMP', Locked = true, Comment = 'Assigned to Transformation.Code field for Unix Timestamp';
         UNIXTimeStampDescTxt: Label 'Transforming UNIX timestamp to text format.';
-        UPPERCASETxt: Label 'UPPERCASE', Comment = 'Assigned to Transformation.Code field for Upper case';
+        UPPERCASETxt: Label 'UPPERCASE', Locked = true, Comment = 'Assigned to Transformation.Code field for Upper case';
         UpperCaseDescTxt: Label 'Upper Case Text';
-        LOWERCASETxt: Label 'LOWERCASE', Comment = 'Assigned to Transformation.Code field for Lower case';
+        LOWERCASETxt: Label 'LOWERCASE', Locked = true, Comment = 'Assigned to Transformation.Code field for Lower case';
         LowerCaseDescTxt: Label 'Lower Case Text';
-        TITLECASETxt: Label 'TITLECASE', Comment = 'Assigned to Transformation.Code field for Title case';
+        TITLECASETxt: Label 'TITLECASE', Locked = true, Comment = 'Assigned to Transformation.Code field for Title case';
         TitleCaseDescTxt: Label 'Title Case Text';
-        TRIMTxt: Label 'TRIM', Comment = 'Assigned to Transformation.Code field for Trim';
+        TRIMTxt: Label 'TRIM', Locked = true, Comment = 'Assigned to Transformation.Code field for Trim';
         TrimDescTxt: Label 'Trim Text';
-        FOURTH_TO_SIXTH_CHARTxt: Label 'FOURTH_TO_SIXTH_CHAR', Comment = 'Assigned to Transformation.Code field for getting the 4th to 6th characters in a string';
+        FOURTH_TO_SIXTH_CHARTxt: Label 'FOURTH_TO_SIXTH_CHAR', Locked = true, Comment = 'Assigned to Transformation.Code field for getting the 4th to 6th characters in a string';
         FourthToSixthCharactersDescTxt: Label 'Fourth to Sixth Characters Text';
-        YYYYMMDDDateTxt: Label 'YYYYMMDD_DATE', Comment = 'Assigned to Transformation.Code field for converting dates from yyyyMMdd format';
+        YYYYMMDDDateTxt: Label 'YYYYMMDD_DATE', Locked = true, Comment = 'Assigned to Transformation.Code field for converting dates from yyyyMMdd format';
         YYYYMMDDDateDescTxt: Label 'yyyyMMdd Date Text';
-        YYYYMMDDHHMMSSTxt: Label 'YYYYMMDDHHMMSS_FMT', Comment = 'Assigned to Transformation.Code field for converting dates from yyyyMMdd format';
+        YYYYMMDDHHMMSSTxt: Label 'YYYYMMDDHHMMSS_FMT', Locked = true, Comment = 'Assigned to Transformation.Code field for converting dates from yyyyMMdd format';
         YYYYMMDDHHMMSSDescTxt: Label 'yyyyMMddHHmmss Date/Time Format';
-        ALPHANUMERIC_ONLYTxt: Label 'ALPHANUMERIC_ONLY', Comment = 'Assigned to Transformation.Code field for getting only the Alphanumeric characters in a string';
+        ALPHANUMERIC_ONLYTxt: Label 'ALPHANUMERIC_ONLY', Locked = true, Comment = 'Assigned to Transformation.Code field for getting only the Alphanumeric characters in a string';
         AlphaNumericDescTxt: Label 'Alphanumeric Text Only';
-        DKNUMBERFORMATTxt: Label 'DK_DECIMAL_FORMAT', Comment = 'Assigned to Transformation.Code field for getting decimal formatting rule for Danish numbers';
+        DKNUMBERFORMATTxt: Label 'DK_DECIMAL_FORMAT', Locked = true, Comment = 'Assigned to Transformation.Code field for getting decimal formatting rule for Danish numbers';
         DKNUMBERFORMATDescTxt: Label 'Danish Decimal Format';
-        USDATEFORMATTxt: Label 'US_DATE_FORMAT', Comment = 'Assigned to Transformation.Code field for getting date formatting rule from U.S. dates';
+        USDATEFORMATTxt: Label 'US_DATE_FORMAT', Locked = true, Comment = 'Assigned to Transformation.Code field for getting date formatting rule from U.S. dates';
         USDATEFORMATDescTxt: Label 'U.S. Date Format';
-        USDATETIMEFORMATTxt: Label 'US_DATETIME_FORMAT', Comment = 'Assigned to Transformation.Code field for getting date formatting rule from U.S. dates';
+        USDATETIMEFORMATTxt: Label 'US_DATETIME_FORMAT', Locked = true, Comment = 'Assigned to Transformation.Code field for getting date formatting rule from U.S. dates';
         USDATETIMEFORMATDescTxt: Label 'U.S. Date/Time Format';
-        DeleteNOTPROVIDEDTxt: Label 'DELETE_NOTPROVIDED', Comment = 'NOTPROVIDED should stay in english because it is a constant value. DELETE should be translated.';
+        DeleteNOTPROVIDEDTxt: Label 'DELETE_NOTPROVIDED', Locked = true, Comment = 'NOTPROVIDED should stay in english because it is a constant value. DELETE should be translated.';
         DeleteNOTPROVIDEDDescriptionTxt: Label 'Delete NOTPROVIDED value', Comment = 'NOTPROVIDED should stay in english because it is a constant value. ''Delete'' and ''value'' should be translated.';
 #if not CLEAN28
         AppendSpaceTxt: Label 'ADDSPCEND', Locked = true;


### PR DESCRIPTION
Fixes #9192

## What & why

The default Transformation Rule records created by `CreateDefaultTransformations()` use
`Label` declarations for the `Code` field without `Locked = true`. Since `Code` is this
table's primary key and is referenced by other objects/configurations as a fixed
identifier, translating it causes the same logical rule (e.g. "Uppercase") to have a
different `Code` value depending on the environment's installation/UI language or an
installed translation/language extension — breaking portability of configurations
between differently-localized environments.

This PR adds `Locked = true` to the 12 Code-producing labels, following the same pattern
already used for `AppendSpaceTxt` in this file. The `...DescTxt` labels used for
`Description` are left translatable, since only the Description should be localized.

## Linked work

Fixes #9192

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Built the Base Application module locally with the change applied — no new analyzer
  warnings introduced.
- Installed a translation/language extension targeting these labels and confirmed that,
  after the fix, the Code-producing labels (UPPERCASETxt, LOWERCASETxt, TITLECASETxt,
  TRIMTxt, etc.) can no longer be overridden by the translation — Locked = true correctly
  keeps the Code value fixed, while the corresponding Description labels remain
  translatable as before.
- No automated tests added: this is a metadata-only change (Locked = true on existing
  Label declarations) with no new branching logic to cover.

## Risk & compatibility

Environments where these default Transformation Rule records were already inserted with
a translated (non-English) Code — prior to this fix — will not have their existing rows
renamed. Since `InsertRec` only inserts a rule if `Get(NewCode)` does not find it, an
upgrade/reinstall that re-runs `CreateDefaultTransformations()` on such an environment
would insert a new row with the English Locked Code alongside the existing
translated-Code row, rather than replacing it. Maintainers may want to consider whether
an upgrade codeunit is needed to clean up/rename pre-existing translated rows, or whether
this is acceptable as-is since the old rows would simply become unused duplicates.
