### PR TITLE
Add API Overview page (page 812)

### DIFF
--- a/src/Layers/W1/BaseApp/System/API/APIOverview.Page.al
+++ b/src/Layers/W1/BaseApp/System/API/APIOverview.Page.al
@@ -1,0 +1,172 @@
+namespace Microsoft.API;
+
+using System.Reflection;
+
+page 812 "API Overview"
+{
+    PageType = List;
+    ApplicationArea = Basic, Suite;
+    UsageCategory = Lists;
+    AdditionalSearchTerms = 'api,integration,endpoint,publisher';
+    SourceTable = "API Overview Buffer";
+    SourceTableTemporary = true;
+    Caption = 'API Overview';
+    Editable = false;
+    InsertAllowed = false;
+    ModifyAllowed = false;
+    DeleteAllowed = false;
+    Extensible = false;
+    AboutTitle = 'Explore APIs in your environment';
+    AboutText = 'This page lists all APIs available in this environment. Filter by publisher, group, or version, open an endpoint URL, and validate your integration setup.';
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Control1)
+            {
+                field(Description; Rec.Description)
+                {
+                    Caption = 'Name';
+                    ToolTip = 'Specifies the name of the API page or query.';
+                }
+                field("Object Type"; Rec."Object Type")
+                {
+                    Caption = 'Type';
+                    ToolTip = 'Specifies whether the API is implemented as an API page (supports read and write operations) or as an API query (read-only set of data).';
+                }
+                field("Object ID"; Rec."Object ID")
+                {
+                    Caption = 'ID';
+                    ToolTip = 'Specifies the object ID of the underlying API page or query. Use this when troubleshooting integrations together with a developer.';
+                }
+                field("API Publisher"; Rec."API Publisher")
+                {
+                    Caption = 'API Publisher';
+                    ToolTip = 'Specifies the publisher segment of the API URL. The publisher identifies who owns the API and is part of the route used by external systems.';
+                }
+                field("API Group"; Rec."API Group")
+                {
+                    Caption = 'API Group';
+                    ToolTip = 'Specifies the group segment of the API URL. Use the API group to scope integrations to a related set of endpoints.';
+                }
+                field("Entity Name"; Rec."Entity Name")
+                {
+                    Caption = 'Entity';
+                    ToolTip = 'Specifies the entity that the API exposes. The entity name appears in the API URL and helps identify the originating solution.';
+                }
+                field("API Version"; Rec."API Version")
+                {
+                    Caption = 'API Version';
+                    ToolTip = 'Specifies the version segment of the API URL. Choosing the right version ensures compatibility when integrating with external systems.';
+                }
+                field("API URL"; GetApiUrl(Rec))
+                {
+                    Caption = 'API URL';
+                    Editable = false;
+                    ExtendedDatatype = URL;
+                    ToolTip = 'Specifies the full URL of the API endpoint in this environment. Choose the link to open the endpoint, for example to inspect its metadata or test a request.';
+                }
+            }
+        }
+    }
+
+    views
+    {
+        view("API Pages")
+        {
+            Caption = 'API Pages';
+            Filters = where("Object Type" = const(Page));
+        }
+        view("API Queries")
+        {
+            Caption = 'API Queries';
+            Filters = where("Object Type" = const(Query));
+        }
+        view(APIv2)
+        {
+            Caption = 'API v2.0';
+            Filters = where("API Version" = const('v2.0'));
+        }
+        view(MicrosoftAPIs)
+        {
+            Caption = 'Microsoft APIs';
+            Filters = where("API Publisher" = const('microsoft'));
+        }
+        view(CustomAPIs)
+        {
+            Caption = 'Custom APIs';
+            Filters = where("API Publisher" = filter('<>''''&<>microsoft'));
+        }
+    }
+
+    trigger OnOpenPage()
+    begin
+        LoadAPIs();
+    end;
+
+    local procedure LoadAPIs()
+    var
+        TempAPILine: Record "API Overview Buffer" temporary;
+        PageMetadata: Record "Page Metadata";
+        QueryMetadata: Record "Query Metadata";
+        LineNo: Integer;
+        EntryNo: Integer;
+    begin
+        Rec.Reset();
+        Rec.DeleteAll();
+
+        PageMetadata.SetRange(PageType, PageMetadata.PageType::API);
+        if PageMetadata.FindSet() then
+            repeat
+                LineNo += 1;
+                TempAPILine.Init();
+                TempAPILine."Entry No." := LineNo;
+                TempAPILine."Object Type" := TempAPILine."Object Type"::Page;
+                TempAPILine."Object ID" := PageMetadata.ID;
+                TempAPILine.Description := PageMetadata.Name;
+                TempAPILine."Entity Name" := PageMetadata.EntityName;
+                TempAPILine."API Publisher" := PageMetadata.APIPublisher;
+                TempAPILine."API Group" := PageMetadata.APIGroup;
+                TempAPILine."API Version" := PageMetadata.APIVersion;
+                TempAPILine.Insert();
+            until PageMetadata.Next() = 0;
+
+        QueryMetadata.SetFilter(EntityName, '<>%1', '');
+        if QueryMetadata.FindSet() then
+            repeat
+                LineNo += 1;
+                TempAPILine.Init();
+                TempAPILine."Entry No." := LineNo;
+                TempAPILine."Object Type" := TempAPILine."Object Type"::Query;
+                TempAPILine."Object ID" := QueryMetadata.ID;
+                TempAPILine.Description := QueryMetadata.Name;
+                TempAPILine."Entity Name" := QueryMetadata.EntityName;
+                TempAPILine."API Publisher" := QueryMetadata.APIPublisher;
+                TempAPILine."API Group" := QueryMetadata.APIGroup;
+                TempAPILine."API Version" := QueryMetadata.APIVersion;
+                TempAPILine.Insert();
+            until QueryMetadata.Next() = 0;
+
+        TempAPILine.SetCurrentKey("API Publisher", "API Group", Description);
+        if TempAPILine.FindSet() then
+            repeat
+                EntryNo += 1;
+                Rec := TempAPILine;
+                Rec."Entry No." := EntryNo;
+                Rec.Insert();
+            until TempAPILine.Next() = 0;
+
+        if Rec.FindFirst() then;
+    end;
+
+    local procedure GetApiUrl(APIBuffer: Record "API Overview Buffer"): Text
+    begin
+        case APIBuffer."Object Type" of
+            APIBuffer."Object Type"::Page:
+                exit(GetUrl(ClientType::Api, CompanyName(), ObjectType::Page, APIBuffer."Object ID"));
+            APIBuffer."Object Type"::Query:
+                exit(GetUrl(ClientType::Api, CompanyName(), ObjectType::Query, APIBuffer."Object ID"));
+        end;
+    end;
+}

--- a/src/Layers/W1/BaseApp/System/API/APIOverviewBuffer.Table.al
+++ b/src/Layers/W1/BaseApp/System/API/APIOverviewBuffer.Table.al
@@ -1,0 +1,58 @@
+namespace Microsoft.API;
+
+table 812 "API Overview Buffer"
+{
+    Access = Internal;
+    DataClassification = SystemMetadata;
+    TableType = Temporary;
+
+    fields
+    {
+        field(1; "Entry No."; Integer)
+        {
+            Caption = 'Entry No.';
+        }
+        field(2; Description; Text[250])
+        {
+            Caption = 'Name';
+        }
+        field(3; "Object Type"; Option)
+        {
+            Caption = 'Type';
+            OptionMembers = ,Page,Query;
+            OptionCaption = ' ,Page,Query';
+        }
+        field(4; "Object ID"; Integer)
+        {
+            Caption = 'ID';
+            BlankZero = true;
+        }
+        field(5; "Entity Name"; Text[250])
+        {
+            Caption = 'Entity';
+        }
+        field(6; "API Publisher"; Text[40])
+        {
+            Caption = 'API Publisher';
+        }
+        field(7; "API Group"; Text[40])
+        {
+            Caption = 'API Group';
+        }
+        field(8; "API Version"; Text[250])
+        {
+            Caption = 'API Version';
+        }
+    }
+
+    keys
+    {
+        key(Key1; "Entry No.")
+        {
+            Clustered = true;
+        }
+        key(Key2; "API Publisher", "API Group", Description)
+        {
+        }
+    }
+}

--- a/src/Layers/W1/BaseApp/System/API/Upgrade/APIDataUpgradeCompanies.Page.al
+++ b/src/Layers/W1/BaseApp/System/API/Upgrade/APIDataUpgradeCompanies.Page.al
@@ -8,7 +8,7 @@ page 9998 "API Data Upgrade Companies"
     PageType = List;
     ApplicationArea = All;
     UsageCategory = Administration;
-    Caption = 'API upgrade overview';
+    Caption = 'API Upgrade Overview';
     SourceTable = Company;
     ModifyAllowed = false;
     InsertAllowed = false;

--- a/src/Layers/W1/Tests/Integration/APIOverviewTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Integration/APIOverviewTest.Codeunit.al
@@ -1,0 +1,147 @@
+codeunit 139103 "API Overview Test"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    trigger OnRun()
+    begin
+        // [FEATURE] [API Overview]
+    end;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TestAPIOverviewListsAPIPages()
+    var
+        APIOverview: TestPage "API Overview";
+        FoundPage: Boolean;
+    begin
+        // [SCENARIO] The API Overview page lists API pages from the environment
+        // [GIVEN] The API Overview page is opened
+        APIOverview.OpenView();
+
+        // [WHEN] Iterating the rows
+        // [THEN] At least one row with Type = Page is present
+        if APIOverview.First() then
+            repeat
+                if APIOverview."Object Type".Value() = 'Page' then begin
+                    FoundPage := true;
+                    break;
+                end;
+            until not APIOverview.Next();
+
+        APIOverview.Close();
+        Assert.IsTrue(FoundPage, 'Expected at least one API page in the API Overview');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TestAPIOverviewListsAPIQueries()
+    var
+        APIOverview: TestPage "API Overview";
+        FoundQuery: Boolean;
+    begin
+        // [SCENARIO] The API Overview page lists API queries from the environment
+        // [GIVEN] The API Overview page is opened
+        APIOverview.OpenView();
+
+        // [WHEN] Iterating the rows
+        // [THEN] At least one row with Type = Query is present
+        if APIOverview.First() then
+            repeat
+                if APIOverview."Object Type".Value() = 'Query' then begin
+                    FoundQuery := true;
+                    break;
+                end;
+            until not APIOverview.Next();
+
+        APIOverview.Close();
+        Assert.IsTrue(FoundQuery, 'Expected at least one API query in the API Overview');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TestAPIOverviewIncludesKnownAPIPage()
+    var
+        APIOverview: TestPage "API Overview";
+        Found: Boolean;
+    begin
+        // [SCENARIO] A well-known base-app API page is shown with the right publisher, group, version, entity name and URL
+        // [GIVEN] The API Overview page is opened
+        APIOverview.OpenView();
+
+        // [WHEN] Locating the Posted Sales Invoice API row
+        if APIOverview.First() then
+            repeat
+                if (APIOverview."Object Type".Value() = 'Page') and (APIOverview.Description.Value() = 'Posted Sales Invoice API') then begin
+                    Found := true;
+                    break;
+                end;
+            until not APIOverview.Next();
+
+        // [THEN] The row exposes the page's publisher, group, version, entity name and API URL
+        Assert.IsTrue(Found, 'Expected Posted Sales Invoice API in the API Overview');
+        Assert.AreEqual('microsoft', APIOverview."API Publisher".Value(), 'Unexpected API publisher for Posted Sales Invoice API');
+        Assert.AreEqual('automate', APIOverview."API Group".Value(), 'Unexpected API group for Posted Sales Invoice API');
+        Assert.AreEqual('v1.0', APIOverview."API Version".Value(), 'Unexpected API version for Posted Sales Invoice API');
+        Assert.AreEqual('postedSalesInvoice', APIOverview."Entity Name".Value(), 'Unexpected entity name for Posted Sales Invoice API');
+        Assert.IsTrue(APIOverview."API URL".Value().Contains('/api/microsoft/automate/v1.0/'), 'Unexpected API URL for Posted Sales Invoice API');
+        APIOverview.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TestAPIOverviewBuildsStandardApiUrl()
+    var
+        APIOverview: TestPage "API Overview";
+        Found: Boolean;
+    begin
+        // [SCENARIO] A standard v2.0 API page shows a URL that follows the /api/v2.0/ route
+        // [GIVEN] The API Overview page is opened
+        APIOverview.OpenView();
+
+        // [WHEN] Locating a standard v2.0 API page (blank publisher and group, version v2.0)
+        if APIOverview.First() then
+            repeat
+                if (APIOverview."Object Type".Value() = 'Page') and (APIOverview."API Publisher".Value() = '') and (APIOverview."API Group".Value() = '') and (APIOverview."API Version".Value() = 'v2.0') then begin
+                    Found := true;
+                    break;
+                end;
+            until not APIOverview.Next();
+
+        // [THEN] The URL follows the standard /api/v2.0/ route (no publisher or group segments)
+        Assert.IsTrue(Found, 'Expected at least one standard v2.0 API page');
+        Assert.IsTrue(APIOverview."API URL".Value().Contains('/api/v2.0/'), 'Standard API URL should contain the /api/v2.0/ route');
+        APIOverview.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TestAPIOverviewListsEveryAPIPage()
+    var
+        APIOverview: TestPage "API Overview";
+        PageMetadata: Record "Page Metadata";
+        APIPageCount: Integer;
+        DetailPageCount: Integer;
+    begin
+        // [SCENARIO] Every API page in metadata appears as a row in the flat list (no APIs are lost)
+        // [GIVEN] The API Overview page is opened
+        APIOverview.OpenView();
+
+        // [WHEN] Counting Page-type rows by walking the UI
+        if APIOverview.First() then
+            repeat
+                if APIOverview."Object Type".Value() = 'Page' then
+                    DetailPageCount += 1;
+            until not APIOverview.Next();
+
+        APIOverview.Close();
+
+        // [THEN] Count matches the underlying Page Metadata where PageType = API
+        PageMetadata.SetRange(PageType, PageMetadata.PageType::API);
+        APIPageCount := PageMetadata.Count();
+        Assert.AreEqual(APIPageCount, DetailPageCount, 'API Overview did not list every API page from Page Metadata');
+    end;
+}


### PR DESCRIPTION
## Summary

Adds a new admin-facing **API Overview** list page (Base Application, page `812`) that shows all APIs available in the environment — both API **pages** and API **queries** — across all publishers. This gives admins a single place to discover integration endpoints, open their URLs, and validate configuration before connecting external systems.

Fixes [AB#638459](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638459)

## What's included

- **Page 812 `API Overview`** (`src/Layers/W1/BaseApp/System/API/APIOverview.Page.al`)
  - Flat list of every `PageType = API` page and every query with an entity name, across all publishers.
  - Columns: Name, Type (Page/Query), ID, API Publisher, API Group, Entity, API Version, and **API URL**.
  - **API URL** is a clickable link (`ExtendedDatatype = URL`) built via `GetUrl(ClientType::Api, ...)` — the same mechanism the Web Services page uses — so it resolves to the real endpoint for the current environment and company.
  - Built-in views: **API Pages**, **API Queries**, **Microsoft APIs**, **Custom APIs** (publisher other than `microsoft`), and **API v2.0**.
  - `UsageCategory = Lists`, `ApplicationArea = Basic, Suite`, About-box text and admin-focused tooltips.
- **Table 812 `API Overview Buffer`** (`src/Layers/W1/BaseApp/System/API/APIOverviewBuffer.Table.al`)
  - Internal temporary buffer holding the rendered rows. Field lengths match the `Page Metadata` / `Query Metadata` source fields.
- **Codeunit 139103 `API Overview Test`** (`src/Layers/W1/Tests/Integration/APIOverviewTest.Codeunit.al`)
  - Verifies API pages and queries are listed, a known base-app API (`Posted Sales Invoice API`) appears with correct publisher/group/version/entity and URL, standard v2.0 APIs build the expected `/api/v2.0/` route, and every API page from metadata is listed.
- Minor: title-cased the caption of page 9998 `API Data Upgrade Companies`.

## Notes for reviewers

- The page intentionally shows the full API surface (all `PageType = API` pages and all queries with an entity name), not the narrower MCP-consumable subset.
- About-box copy is a draft pending PM approval and may be adjusted.



