### PR TITLE
Fix Aged Accounts Receivable (Report 120) performance on large ledger history

### DIFF
--- a/src/Layers/ES/BaseApp/Sales/Reports/AgedAccountsReceivable.Report.al
+++ b/src/Layers/ES/BaseApp/Sales/Reports/AgedAccountsReceivable.Report.al
@@ -438,6 +438,7 @@ report 120 "Aged Accounts Receivable"
                                     CurrReport.Break();
 
                             CustLedgEntryEndingDate := TempCustLedgEntry;
+                            DetailedCustomerLedgerEntry.SetLoadFields("Entry Type", "Posting Date", Amount, "Amount (LCY)");
                             DetailedCustomerLedgerEntry.SetRange("Cust. Ledger Entry No.", CustLedgEntryEndingDate."Entry No.");
                             DetailedCustomerLedgerEntry.SetFilter("Excluded from calculation", '%1', false);
                             OnTempCustLedgEntryGetRecordOnAfterSetDetailedEntryFilters(DetailedCustomerLedgerEntry);

--- a/src/Layers/NA/BaseApp/Sales/Reports/AgedAccountsReceivable.Report.al
+++ b/src/Layers/NA/BaseApp/Sales/Reports/AgedAccountsReceivable.Report.al
@@ -436,6 +436,7 @@ report 120 "Aged Accounts Receivable"
                                     CurrReport.Break();
 
                             CustLedgEntryEndingDate := TempCustLedgEntry;
+                            DetailedCustomerLedgerEntry.SetLoadFields("Entry Type", "Posting Date", Amount, "Amount (LCY)");
                             DetailedCustomerLedgerEntry.SetRange("Cust. Ledger Entry No.", CustLedgEntryEndingDate."Entry No.");
                             OnTempCustLedgEntryGetRecordOnAfterSetDetailedEntryFilters(DetailedCustomerLedgerEntry);
                             if DetailedCustomerLedgerEntry.FindSet(false) then

--- a/src/Layers/W1/BaseApp/Sales/Reports/AgedAccountsReceivable.Report.al
+++ b/src/Layers/W1/BaseApp/Sales/Reports/AgedAccountsReceivable.Report.al
@@ -438,6 +438,7 @@ report 120 "Aged Accounts Receivable"
                                     CurrReport.Break();
 
                             CustLedgEntryEndingDate := TempCustLedgEntry;
+                            DetailedCustomerLedgerEntry.SetLoadFields("Entry Type", "Posting Date", Amount, "Amount (LCY)");
                             DetailedCustomerLedgerEntry.SetRange("Cust. Ledger Entry No.", CustLedgEntryEndingDate."Entry No.");
                             OnTempCustLedgEntryGetRecordOnAfterSetDetailedEntryFilters(DetailedCustomerLedgerEntry);
                             if DetailedCustomerLedgerEntry.FindSet(false) then


### PR DESCRIPTION
## Why

The standard **Aged Accounts Receivable** report (Report 120, Base Application) does not complete on databases holding 2-3 years of Customer Ledger history — the UI hangs on "Working on it… Rows generated". A CPU profile (~334s, ~99% in SQL) traced ~22-35% of the time to the per-row Detailed Cust. Ledg. Entry loop, which issued a full-record `FindSet` for every temporary ledger entry. This N+1 pattern scales with total Detailed Cust. Ledg. Entry history rather than with the size of the open receivables population, even though aging is a point-in-time snapshot anchored to a single "Aged As Of" date.

## Summary

- **Added** `SetLoadFields` on the Detailed Cust. Ledg. Entry loop in Report 120 so only the four columns the loop consumes (`Entry Type`, `Posting Date`, `Amount`, `Amount (LCY)`) are read, cutting per-row SQL cost — `Cust. Ledger Entry No.` is only a filter and needs no load.
- **Propagated** the identical change from the W1 base layer to the ES and NA base layers via Miapp to keep localizations in sync.

Work item: [AB#640854](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640854)


