### PR TITLE
Cloud Migration bug fixes (BC14 reimplementation, custom mapping, OnPrem dev companies)

### DIFF
--- a/src/Apps/W1/HybridBC14/app/src/Errors/BC14MigrationErrorOverview.page.al
+++ b/src/Apps/W1/HybridBC14/app/src/Errors/BC14MigrationErrorOverview.page.al
@@ -250,6 +250,15 @@ page 46863 "BC14 Migration Error Overview"
         LoadErrorsFromAllCompanies();
     end;
 
+    /// <summary>
+    /// Restricts the aggregated error list to a single company. Call before Run() to open the
+    /// page scoped to one company (e.g. from the Upgrading Companies page).
+    /// </summary>
+    procedure SetCompanyFilter(CompanyNameToShow: Text[30])
+    begin
+        CompanyNameFilter := CompanyNameToShow;
+    end;
+
     local procedure OpenCompanyInNewTab(TargetCompany: Text[30])
     begin
         if TargetCompany = '' then
@@ -267,6 +276,8 @@ page 46863 "BC14 Migration Error Overview"
         Rec.Reset();
         Rec.DeleteAll();
 
+        if CompanyNameFilter <> '' then
+            HybridCompany.SetRange(Name, CompanyNameFilter);
         if not HybridCompany.FindSet() then
             exit;
 
@@ -293,6 +304,7 @@ page 46863 "BC14 Migration Error Overview"
 
     var
         ShowResolvedErrors: Boolean;
+        CompanyNameFilter: Text[30];
         ContinueMigrationQst: Label 'Continue migration for company %1?', Comment = '%1 = Company Name';
         UnresolvedErrorsWarningQst: Label 'There are still %1 unresolved errors for company %2. Continue migration anyway?', Comment = '%1 = Number of unresolved errors, %2 = Company Name';
         NoCompanySelectedMsg: Label 'Please select an error record first.';

--- a/src/Apps/W1/HybridBC14/app/src/Errors/BC14MigrationErrorOverview.page.al
+++ b/src/Apps/W1/HybridBC14/app/src/Errors/BC14MigrationErrorOverview.page.al
@@ -143,7 +143,7 @@ page 46863 "BC14 Migration Error Overview"
             {
                 ApplicationArea = All;
                 Caption = 'Continue migration';
-                ToolTip = 'Continue migration for the company of the selected error record. Records that already succeeded will be skipped automatically.';
+                ToolTip = 'Reruns the migration for the company of the selected error record. Records that already succeeded are skipped, and any errored record that migrates successfully this time is automatically marked as resolved. Rerunning is the only way to resolve migration errors: fix the underlying data first, then run this action.';
                 Image = Refresh;
                 trigger OnAction()
                 var

--- a/src/Apps/W1/HybridBC14/app/src/Errors/BC14MigrationFailureHandler.codeunit.al
+++ b/src/Apps/W1/HybridBC14/app/src/Errors/BC14MigrationFailureHandler.codeunit.al
@@ -44,11 +44,9 @@ codeunit 46860 "BC14 Migration Failure Handler"
         BC14MigrationOrchestrator: Codeunit "BC14 Migration Orchestrator";
         BC14StatusMgr: Codeunit "BC14 Migration Status Mgr.";
         ErrorText: Text;
-        ErrorCallStack: Text;
         DetailedError: Text;
     begin
         ErrorText := GetLastErrorText();
-        ErrorCallStack := GetLastErrorCallStack();
         LogUnhandledErrorToErrorPage(ErrorText);
 
         DetailedError := GetDetailedUpgradeErrorSummary();
@@ -79,9 +77,6 @@ codeunit 46860 "BC14 Migration Failure Handler"
                 exit;
             end;
         end;
-
-        // Write error details to the Summary's Details blob for diagnostics.
-        AppendDetailsToSummary(HybridReplicationSummary, ErrorText, ErrorCallStack);
 
         Session.LogMessage('0000TV6', UpgradeFailedMsg, Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', BC14Telemetry.GetCategory());
     end;
@@ -128,39 +123,6 @@ codeunit 46860 "BC14 Migration Failure Handler"
         exit(StrSubstNo(ErrorCountSummaryTxt, DataMigrationError.Count()));
     end;
 
-    local procedure AppendDetailsToSummary(var HybridReplicationSummary: Record "Hybrid Replication Summary"; ErrorText: Text; ErrorCallStack: Text)
-    var
-        DetailsInStream: InStream;
-        DetailsOutStream: OutStream;
-        ExistingDetails: Text;
-        NewEntry: Text;
-    begin
-        HybridReplicationSummary.ReadIsolation := IsolationLevel::UpdLock;
-        if not HybridReplicationSummary.Find() then
-            exit;
-
-        // Read existing details
-        if HybridReplicationSummary.Details.HasValue() then begin
-            HybridReplicationSummary.Details.CreateInStream(DetailsInStream);
-            DetailsInStream.Read(ExistingDetails);
-        end;
-
-        // Build new entry with company name. Use real newline characters so the
-        // text renders as multiple lines in MultiLine page fields.
-        if ErrorCallStack <> '' then
-            NewEntry := StrSubstNo(UpgradeFailedCompanyDetailsTxt, CompanyName(), ErrorText + NewLine() + 'Call Stack:' + NewLine() + ErrorCallStack)
-        else
-            NewEntry := StrSubstNo(UpgradeFailedCompanyDetailsTxt, CompanyName(), ErrorText);
-
-        // Append to existing (blank line between entries)
-        if ExistingDetails <> '' then
-            NewEntry := ExistingDetails + NewLine() + NewLine() + NewEntry;
-
-        HybridReplicationSummary.Details.CreateOutStream(DetailsOutStream);
-        DetailsOutStream.Write(NewEntry);
-        HybridReplicationSummary.Modify();
-    end;
-
     local procedure NewLine(): Text
     var
         TypeHelper: Codeunit "Type Helper";
@@ -170,7 +132,6 @@ codeunit 46860 "BC14 Migration Failure Handler"
 
     var
         UpgradeFailedMsg: Label 'Business Central 14 upgrade failed.', Locked = true;
-        UpgradeFailedCompanyDetailsTxt: Label 'Upgrade failed for company %1: %2', Comment = '%1 = Company Name, %2 = Error message';
         UnknownUpgradeErr: Label 'Upgrade failed with unknown error. Check Business Central 14 Migration Errors page for details.';
         ErrorCountSummaryTxt: Label 'Upgrade failed. Number of errors: %1. See Business Central 14 Migration Errors page for details.', Comment = '%1 = Number of errors';
         UnhandledUpgradeErrorLbl: Label 'Unhandled Upgrade Error';

--- a/src/Apps/W1/HybridBC14/app/src/Migration/Historical/BC14OldGLEntryMigr.Codeunit.al
+++ b/src/Apps/W1/HybridBC14/app/src/Migration/Historical/BC14OldGLEntryMigr.Codeunit.al
@@ -5,7 +5,6 @@
 
 namespace Microsoft.DataMigration.BC14Reimplementation;
 
-using Microsoft.DataMigration;
 using Microsoft.DataMigration.BC14Reimplementation.HistoricalData;
 using Microsoft.Finance.GeneralLedger.Ledger;
 
@@ -112,11 +111,7 @@ codeunit 46881 "BC14 Old G/L Entry Migr." implements "BC14 Migrator"
 
     local procedure TransferData()
     var
-        BC14GLEntry: Record "BC14 G/L Entry";
-        BC14OldGLEntry: Record "BC14 Old G/L Entry";
         BC14CompanyInfo: Record BC14CompanyMigrationInfo;
-        BC14HistoricalTransfer: Codeunit "BC14 Historical Transfer";
-        HybridCloudManagement: Codeunit "Hybrid Cloud Management";
         EntryDataTransfer: DataTransfer;
         CutoffDate: Date;
         LastArchivedEntryNo: Integer;
@@ -135,16 +130,13 @@ codeunit 46881 "BC14 Old G/L Entry Migr." implements "BC14 Migrator"
         if LastArchivedEntryNo > 0 then
             Session.LogMessage('0000TX7', StrSubstNo(TransferResumedLbl, LastArchivedEntryNo), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', BC14Telemetry.GetCategory());
 
-        if HybridCloudManagement.IsIntelligentCloudEnabled() then begin
-            EntryDataTransfer.SetTables(Database::"BC14 G/L Entry", Database::"BC14 Old G/L Entry");
-            BC14HistoricalTransfer.AddMatchingFieldMappings(EntryDataTransfer, Database::"BC14 G/L Entry", Database::"BC14 Old G/L Entry");
-            EntryDataTransfer.AddConstantValue(CurrentDateTime(), BC14OldGLEntry.FieldNo("Migrated On"));
-            EntryDataTransfer.AddSourceFilter(BC14GLEntry.FieldNo("Posting Date"), '<%1', CutoffDate);
-            if LastArchivedEntryNo > 0 then
-                EntryDataTransfer.AddSourceFilter(BC14GLEntry.FieldNo("Entry No."), '>%1', LastArchivedEntryNo);
-            EntryDataTransfer.CopyRows();
-        end else
-            TransferDataInBatches(CutoffDate, LastArchivedEntryNo);
+        // DataTransfer.CopyRows() is only permitted inside platform upgrade/install codeunits. This
+        // migration always runs as a background task/session (never an upgrade codeunit), so calling
+        // CopyRows() here would always throw "DataTransfer is only usable during upgrade or install"
+        // and leave the historical errors unresolved on rerun. Always use the per-record batched
+        // copy; the OnConfigureEntryDataTransfer override above still lets an upgrade-context caller
+        // opt into DataTransfer.
+        TransferDataInBatches(CutoffDate, LastArchivedEntryNo);
     end;
 
     local procedure TransferDataInBatches(CutoffDate: Date; LastArchivedEntryNo: Integer)

--- a/src/Apps/W1/HybridBC14/app/src/Migration/Historical/BC14PostedSalesInvMigr.Codeunit.al
+++ b/src/Apps/W1/HybridBC14/app/src/Migration/Historical/BC14PostedSalesInvMigr.Codeunit.al
@@ -5,7 +5,6 @@
 
 namespace Microsoft.DataMigration.BC14Reimplementation;
 
-using Microsoft.DataMigration;
 using Microsoft.DataMigration.BC14Reimplementation.HistoricalData;
 using Microsoft.Sales.History;
 
@@ -119,8 +118,6 @@ codeunit 46880 "BC14 Posted Sales Inv Migr." implements "BC14 Migrator"
     var
         BC14PostedSalesInvHeader: Record "BC14 Posted Sales Inv Header";
         BC14ArchSalesInvHeader: Record "BC14 Arch. Sales Inv. Header";
-        BC14HistoricalTransfer: Codeunit "BC14 Historical Transfer";
-        HybridCloudManagement: Codeunit "Hybrid Cloud Management";
         HeaderDataTransfer: DataTransfer;
         MigratedOn: DateTime;
         LastCommitAt: DateTime;
@@ -139,23 +136,11 @@ codeunit 46880 "BC14 Posted Sales Inv Migr." implements "BC14 Migrator"
         if LastArchivedNo <> '' then
             Session.LogMessage('0000TX9', StrSubstNo(HeaderTransferResumedLbl, LastArchivedNo), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', BC14Telemetry.GetCategory());
 
-        // Fast path: inside Intelligent Cloud migration scope the platform permits cross-extension
-        // DataTransfer (destination lives in the BC14 Historical Data extension). Outside that
-        // scope (e.g., a background rerun) DataTransfer would be rejected, so fall back to a
-        // per-record AL copy via TransferFields.
-        if HybridCloudManagement.IsIntelligentCloudEnabled() then begin
-            HeaderDataTransfer.SetTables(Database::"BC14 Posted Sales Inv Header", Database::"BC14 Arch. Sales Inv. Header");
-            // Explicitly enumerate business fields instead of relying on CopyRows' auto-mapping.
-            // Auto-mapping also copies system fields like $systemId, which collide with the
-            // destination table's unique constraint on $systemId during the bulk INSERT pre-flight.
-            BC14HistoricalTransfer.AddMatchingFieldMappings(HeaderDataTransfer, Database::"BC14 Posted Sales Inv Header", Database::"BC14 Arch. Sales Inv. Header");
-            HeaderDataTransfer.AddConstantValue(CurrentDateTime(), BC14ArchSalesInvHeader.FieldNo("Migrated On"));
-            if LastArchivedNo <> '' then
-                HeaderDataTransfer.AddSourceFilter(BC14PostedSalesInvHeader.FieldNo("No."), '>%1', LastArchivedNo);
-            HeaderDataTransfer.CopyRows();
-            exit;
-        end;
-
+        // DataTransfer.CopyRows() is only permitted inside platform upgrade/install codeunits, and
+        // this migration always runs as a background task/session. Calling it here would always throw
+        // "DataTransfer is only usable during upgrade or install" and leave historical errors
+        // unresolved on rerun. Always use the per-record batched copy; the OnConfigureHeaderDataTransfer
+        // override above still lets an upgrade-context caller opt into DataTransfer.
         if CommitIntervalMs = 0 then
             CommitIntervalMs := 90000; // 1.5 minutes
         if MaxBatchSize = 0 then
@@ -191,8 +176,6 @@ codeunit 46880 "BC14 Posted Sales Inv Migr." implements "BC14 Migrator"
     var
         BC14PostedSalesInvLine: Record "BC14 Posted Sales Inv Line";
         BC14ArchSalesInvLine: Record "BC14 Arch. Sales Inv. Line";
-        BC14HistoricalTransfer: Codeunit "BC14 Historical Transfer";
-        HybridCloudManagement: Codeunit "Hybrid Cloud Management";
         LineDataTransfer: DataTransfer;
         LastCommitAt: DateTime;
         LastArchivedDocNo: Code[20];
@@ -211,17 +194,11 @@ codeunit 46880 "BC14 Posted Sales Inv Migr." implements "BC14 Migrator"
         if LastArchivedDocNo <> '' then
             Session.LogMessage('0000TX8', StrSubstNo(LineTransferResumedLbl, LastArchivedDocNo, LastArchivedLineNo), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', BC14Telemetry.GetCategory());
 
-        if HybridCloudManagement.IsIntelligentCloudEnabled() then begin
-            LineDataTransfer.SetTables(Database::"BC14 Posted Sales Inv Line", Database::"BC14 Arch. Sales Inv. Line");
-            BC14HistoricalTransfer.AddMatchingFieldMappings(LineDataTransfer, Database::"BC14 Posted Sales Inv Line", Database::"BC14 Arch. Sales Inv. Line");
-            // CopyRows is atomic, so the line archive is all-or-nothing in the IC path; filtering
-            // strictly past the last archived document keeps a rerun-after-success idempotent.
-            if LastArchivedDocNo <> '' then
-                LineDataTransfer.AddSourceFilter(BC14PostedSalesInvLine.FieldNo("Document No."), '>%1', LastArchivedDocNo);
-            LineDataTransfer.CopyRows();
-            exit;
-        end;
-
+        // DataTransfer.CopyRows() is only permitted inside platform upgrade/install codeunits, and
+        // this migration always runs as a background task/session. Calling it here would always throw
+        // "DataTransfer is only usable during upgrade or install" and leave historical errors
+        // unresolved on rerun. Always use the per-record batched copy; the OnConfigureLineDataTransfer
+        // override above still lets an upgrade-context caller opt into DataTransfer.
         if CommitIntervalMs = 0 then
             CommitIntervalMs := 90000; // 1.5 minutes
         if MaxBatchSize = 0 then

--- a/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14CompanyMigrationInfo.table.al
+++ b/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14CompanyMigrationInfo.table.al
@@ -448,6 +448,7 @@ table 46855 BC14CompanyMigrationInfo
         Rec."Historical Failed" := false;
         Rec."Historical Failure Reason" := '';
         Rec."Historical Dispatched" := true;
+        Rec."Current Migration Step" := Rec."Current Migration Step"::Historical;
         Rec."Phase Migrators Total" := 0;
         Rec."Phase Migrators Completed" := 0;
         Rec.Modify();

--- a/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14CompanyMigrationInfo.table.al
+++ b/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14CompanyMigrationInfo.table.al
@@ -436,6 +436,23 @@ table 46855 BC14CompanyMigrationInfo
         Rec.Modify();
     end;
 
+    internal procedure RestartHistoricalDispatch(TargetCompanyName: Text[30]) NewRunId: Guid
+    begin
+        NewRunId := CreateGuid();
+        Rec.ReadIsolation := IsolationLevel::UpdLock;
+        if not Rec.Get(TargetCompanyName) then
+            exit;
+
+        Rec."Historical Run Id" := NewRunId;
+        Rec."Historical Completed" := false;
+        Rec."Historical Failed" := false;
+        Rec."Historical Failure Reason" := '';
+        Rec."Historical Dispatched" := true;
+        Rec."Phase Migrators Total" := 0;
+        Rec."Phase Migrators Completed" := 0;
+        Rec.Modify();
+    end;
+
     internal procedure PrepareMainForRerun(TargetCompanyName: Text[30])
     begin
         Rec.ReadIsolation := IsolationLevel::UpdLock;

--- a/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14CompanyMigrationInfo.table.al
+++ b/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14CompanyMigrationInfo.table.al
@@ -438,11 +438,11 @@ table 46855 BC14CompanyMigrationInfo
 
     internal procedure RestartHistoricalDispatch(TargetCompanyName: Text[30]) NewRunId: Guid
     begin
-        NewRunId := CreateGuid();
         Rec.ReadIsolation := IsolationLevel::UpdLock;
         if not Rec.Get(TargetCompanyName) then
             exit;
 
+        NewRunId := CreateGuid();
         Rec."Historical Run Id" := NewRunId;
         Rec."Historical Completed" := false;
         Rec."Historical Failed" := false;

--- a/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14CompanyUpgradeStatus.page.al
+++ b/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14CompanyUpgradeStatus.page.al
@@ -42,10 +42,11 @@ page 46859 "BC14 Company Upgrade Status"
                         Page.Run(Page::"BC14 Company Migration Status", BC14CompanySettings);
                     end;
                 }
-                field("Upgrade Status"; Rec."Upgrade Status")
+                field("Upgrade Status"; UpgradeStatusText)
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the per-company upgrade phase status (Pending, Started, Completed, Failed).';
+                    Caption = 'Upgrade Status';
+                    ToolTip = 'Specifies the per-company upgrade phase status. A company actively running a migration phase shows In Progress.';
                     StyleExpr = StatusStyle;
                 }
                 field(CurrentPhase; CurrentPhaseText)
@@ -80,10 +81,69 @@ page 46859 "BC14 Company Upgrade Status"
         }
     }
 
+    actions
+    {
+        area(Processing)
+        {
+            action(ShowErrors)
+            {
+                ApplicationArea = All;
+                Caption = 'Show Errors';
+                ToolTip = 'Opens the migration errors captured for the selected company.';
+                Image = ErrorLog;
+
+                trigger OnAction()
+                var
+                    BC14MigrationErrorOverview: Page "BC14 Migration Error Overview";
+                begin
+                    if Rec.Name = '' then
+                        exit;
+                    BC14MigrationErrorOverview.SetCompanyFilter(CopyStr(Rec.Name, 1, 30));
+                    BC14MigrationErrorOverview.Run();
+                end;
+            }
+            action(ContinueMigration)
+            {
+                ApplicationArea = All;
+                Caption = 'Continue Migration';
+                ToolTip = 'Continues (reruns) the migration for the selected company from where it stopped. Available only for companies whose migration has failed.';
+                Image = Continue;
+                Enabled = CanContinueMigration;
+
+                trigger OnAction()
+                var
+                    BC14MigrationRunner: Codeunit "BC14 Migration Runner";
+                begin
+                    if Rec.Name = '' then
+                        exit;
+                    if Rec."Upgrade Status" <> Rec."Upgrade Status"::Failed then
+                        exit;
+                    if not Confirm(StrSubstNo(ContinueMigrationQst, Rec.Name), false) then
+                        exit;
+
+                    BC14MigrationRunner.ContinueMigrationForCompany(CopyStr(Rec.Name, 1, 30));
+                    Message(ContinueMigrationScheduledMsg, Rec.Name);
+                    CurrPage.Update(false);
+                end;
+            }
+        }
+        area(Promoted)
+        {
+            group(Category_Process)
+            {
+                Caption = 'Process';
+
+                actionref(ShowErrors_Promoted; ShowErrors) { }
+                actionref(ContinueMigration_Promoted; ContinueMigration) { }
+            }
+        }
+    }
+
     trigger OnAfterGetRecord()
     var
         BC14CompanySettings: Record BC14CompanyMigrationInfo;
         StatusMessageInStream: InStream;
+        HasCompanySettings: Boolean;
     begin
         StatusMessageText := '';
         Rec.CalcFields("Upgrade Failure Message");
@@ -92,32 +152,54 @@ page 46859 "BC14 Company Upgrade Status"
             StatusMessageInStream.Read(StatusMessageText);
         end;
 
+        CurrentPhaseText := '';
+        PhaseProgressText := '';
+        LastCompletedMigratorText := '';
+        HasCompanySettings := BC14CompanySettings.Get(Rec.Name);
+        if HasCompanySettings then begin
+            CurrentPhaseText := Format(BC14CompanySettings."Current Migration Step");
+            PhaseProgressText := StrSubstNo(ProgressFmtTxt, BC14CompanySettings."Phase Migrators Completed", BC14CompanySettings."Phase Migrators Total");
+            LastCompletedMigratorText := BC14CompanySettings."Last Completed Migrator";
+        end;
+
+        UpgradeStatusText := Format(Rec."Upgrade Status");
+        CanContinueMigration := Rec."Upgrade Status" = Rec."Upgrade Status"::Failed;
         case Rec."Upgrade Status" of
             Rec."Upgrade Status"::Failed:
                 StatusStyle := 'Unfavorable';
             Rec."Upgrade Status"::Completed:
                 StatusStyle := 'Favorable';
             Rec."Upgrade Status"::Started:
-                StatusStyle := 'Attention';
+                if HasCompanySettings and IsActivelyMigrating(BC14CompanySettings."Current Migration Step") then begin
+                    UpgradeStatusText := InProgressLbl;
+                    StatusStyle := 'Strong';
+                end else
+                    StatusStyle := 'Standard';
             else
                 StatusStyle := 'Standard';
         end;
+    end;
 
-        CurrentPhaseText := '';
-        PhaseProgressText := '';
-        LastCompletedMigratorText := '';
-        if BC14CompanySettings.Get(Rec.Name) then begin
-            CurrentPhaseText := Format(BC14CompanySettings."Current Migration Step");
-            PhaseProgressText := StrSubstNo(ProgressFmtTxt, BC14CompanySettings."Phase Migrators Completed", BC14CompanySettings."Phase Migrators Total");
-            LastCompletedMigratorText := BC14CompanySettings."Last Completed Migrator";
-        end;
+    local procedure IsActivelyMigrating(MigrationStep: Enum "BC14 Migration Step"): Boolean
+    begin
+        // A company whose status is Started is actively migrating during every phase except the
+        // NotStarted bookend (status just flipped, no phase entered yet) and the Completed bookend
+        // (all phases done, about to flip to the Completed status).
+        exit(not (MigrationStep in [
+            MigrationStep::NotStarted,
+            MigrationStep::Completed]));
     end;
 
     var
         StatusStyle: Text;
         StatusMessageText: Text;
+        UpgradeStatusText: Text;
         CurrentPhaseText: Text;
         PhaseProgressText: Text;
         LastCompletedMigratorText: Text;
+        CanContinueMigration: Boolean;
         ProgressFmtTxt: Label '%1 / %2', Comment = '%1 = completed count, %2 = total count';
+        InProgressLbl: Label 'In Progress';
+        ContinueMigrationQst: Label 'Continue migration for company %1?', Comment = '%1 = Company Name';
+        ContinueMigrationScheduledMsg: Label 'Migration continuation has been scheduled for company %1.', Comment = '%1 = Company Name';
 }

--- a/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14CompanyUpgradeStatus.page.al
+++ b/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14CompanyUpgradeStatus.page.al
@@ -126,6 +126,30 @@ page 46859 "BC14 Company Upgrade Status"
                     CurrPage.Update(false);
                 end;
             }
+            action(RerunHistorical)
+            {
+                ApplicationArea = All;
+                Caption = 'Rerun Historical Migration';
+                ToolTip = 'Starts the move of the historical data again for the selected company, without re-running the other migration phases. Available for companies whose migration has completed and that have historical record migration enabled.';
+                Image = Restore;
+                Visible = CanRerunHistorical;
+
+                trigger OnAction()
+                var
+                    BC14MigrationRunner: Codeunit "BC14 Migration Runner";
+                begin
+                    if Rec.Name = '' then
+                        exit;
+                    if not CanRerunHistorical then
+                        exit;
+                    if not Confirm(StrSubstNo(RerunHistoricalQst, Rec.Name), false) then
+                        exit;
+
+                    BC14MigrationRunner.RerunHistoricalForCompany(CopyStr(Rec.Name, 1, 30));
+                    Message(RerunHistoricalScheduledMsg, Rec.Name);
+                    CurrPage.Update(false);
+                end;
+            }
         }
         area(Promoted)
         {
@@ -135,6 +159,7 @@ page 46859 "BC14 Company Upgrade Status"
 
                 actionref(ShowErrors_Promoted; ShowErrors) { }
                 actionref(ContinueMigration_Promoted; ContinueMigration) { }
+                actionref(RerunHistorical_Promoted; RerunHistorical) { }
             }
         }
     }
@@ -164,6 +189,10 @@ page 46859 "BC14 Company Upgrade Status"
 
         UpgradeStatusText := Format(Rec."Upgrade Status");
         CanContinueMigration := Rec."Upgrade Status" = Rec."Upgrade Status"::Failed;
+        CanRerunHistorical :=
+            HasCompanySettings and
+            BC14CompanySettings."Migrate Historical Records" and
+            (Rec."Upgrade Status" = Rec."Upgrade Status"::Completed);
         case Rec."Upgrade Status" of
             Rec."Upgrade Status"::Failed:
                 StatusStyle := 'Unfavorable';
@@ -198,8 +227,11 @@ page 46859 "BC14 Company Upgrade Status"
         PhaseProgressText: Text;
         LastCompletedMigratorText: Text;
         CanContinueMigration: Boolean;
+        CanRerunHistorical: Boolean;
         ProgressFmtTxt: Label '%1 / %2', Comment = '%1 = completed count, %2 = total count';
         InProgressLbl: Label 'In Progress';
         ContinueMigrationQst: Label 'Continue migration for company %1?', Comment = '%1 = Company Name';
         ContinueMigrationScheduledMsg: Label 'Migration continuation has been scheduled for company %1.', Comment = '%1 = Company Name';
+        RerunHistoricalQst: Label 'Start the move of the historical data again for company %1?', Comment = '%1 = Company Name';
+        RerunHistoricalScheduledMsg: Label 'Historical data migration has been scheduled again for company %1.', Comment = '%1 = Company Name';
 }

--- a/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14MigrationOrchestrator.codeunit.al
+++ b/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14MigrationOrchestrator.codeunit.al
@@ -310,7 +310,7 @@ codeunit 46862 "BC14 Migration Orchestrator"
         // case (no companies are selected/created yet), mirroring the other migration tools.
         HybridReplicationDetail.SetRange("Run ID", RunId);
         if HybridReplicationDetail.IsEmpty() then begin
-            Session.LogMessage('0000TXE', StrSubstNo(OneStepUpgradeNoDataReplicatedLbl, RunId), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', BC14Telemetry.GetCategory());
+            Session.LogMessage('0000TXR', StrSubstNo(OneStepUpgradeNoDataReplicatedLbl, RunId), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', BC14Telemetry.GetCategory());
             exit;
         end;
 

--- a/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14MigrationOrchestrator.codeunit.al
+++ b/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14MigrationOrchestrator.codeunit.al
@@ -21,6 +21,7 @@ codeunit 46862 "BC14 Migration Orchestrator"
         OneStepUpgradeTok: Label 'One Step Upgrade', Locked = true;
         OneStepUpgradeDisabledLbl: Label 'One Step Upgrade is disabled in settings. Skipping automatic upgrade.', Locked = true;
         OneStepUpgradeNoPendingCompaniesLbl: Label 'One Step Upgrade: No pending companies found to upgrade.', Locked = true;
+        OneStepUpgradeNoDataReplicatedLbl: Label 'One Step Upgrade: No data was replicated in run %1. Skipping upgrade (setup run).', Locked = true, Comment = '%1 = Run ID';
         OneStepUpgradeCompanySetupPendingLbl: Label 'One Step Upgrade skipped: company setup is not yet completed. The upgrade will start automatically after the next replication, or you can start it manually once company setup is complete.';
         OneStepUpgradeSchedulingLbl: Label 'One Step Upgrade: Scheduling upgrade for company %1.', Locked = true, Comment = '%1 = Company Name';
         UpgradeWasScheduledMsg: Label 'Upgrade was successfully scheduled';
@@ -285,6 +286,7 @@ codeunit 46862 "BC14 Migration Orchestrator"
     internal procedure TriggerUpgradeIfOneStepEnabled(RunId: Text[50])
     var
         HybridReplicationSummary: Record "Hybrid Replication Summary";
+        HybridReplicationDetail: Record "Hybrid Replication Detail";
         HybridCompanyStatus: Record "Hybrid Company Status";
         BC14GlobalSettings: Record "BC14 Global Migration Settings";
         BC14CompanySettings: Record BC14CompanyMigrationInfo;
@@ -302,6 +304,15 @@ codeunit 46862 "BC14 Migration Orchestrator"
 
         if not HybridReplicationSummary.Get(RunId) then
             exit;
+
+        // A setup-phase run replicates no per-company data and therefore produces no
+        // Hybrid Replication Detail rows. Guard against entering the upgrade flow in that
+        // case (no companies are selected/created yet), mirroring the other migration tools.
+        HybridReplicationDetail.SetRange("Run ID", RunId);
+        if HybridReplicationDetail.IsEmpty() then begin
+            Session.LogMessage('0000TXE', StrSubstNo(OneStepUpgradeNoDataReplicatedLbl, RunId), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', BC14Telemetry.GetCategory());
+            exit;
+        end;
 
         if not ValidateReplicationBeforeUpgrade(HybridReplicationSummary, false) then
             exit;

--- a/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14MigrationRunner.codeunit.al
+++ b/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14MigrationRunner.codeunit.al
@@ -94,6 +94,8 @@ codeunit 46875 "BC14 Migration Runner"
         MigrationPhaseHaltedLbl: Label 'Migration halted at phase %1 for company %2. Company marked Failed so the operator can retry via Continue migration.', Locked = true, Comment = '%1 = Phase, %2 = Company Name';
         MigrationPhaseHaltedErrLbl: Label 'Migration halted at phase %1. Resolve the underlying errors and click Continue migration to retry.', Comment = '%1 = Phase';
         NoReplicationSummaryForRerunErr: Label 'Cannot rerun migration for company %1: no replication summary was found. Run replication first.', Comment = '%1 = Company Name';
+        HistoricalDisabledForRerunErr: Label 'Cannot rerun historical migration for company %1: historical record migration is disabled for this company.', Comment = '%1 = Company Name';
+        MainNotCompletedForHistoricalRerunErr: Label 'Cannot rerun historical migration for company %1 because its main migration has not completed yet. Use Continue migration to finish the upgrade first.', Comment = '%1 = Company Name';
         OnAfterPopulateSetupMigratorsTok: Label 'OnAfterPopulateSetupMigrators', Locked = true;
         OnAfterPopulateMasterMigratorsTok: Label 'OnAfterPopulateMasterMigrators', Locked = true;
         OnAfterPopulateTransactionMigratorsTok: Label 'OnAfterPopulateTransactionMigrators', Locked = true;
@@ -210,6 +212,46 @@ codeunit 46875 "BC14 Migration Runner"
                     true, TargetCompanyName, CurrentDateTime(), TaskRecordId, BC14MigrationOrchestrator.GetDefaultJobTimeout())
             else
                 Session.StartSession(SessionID, Codeunit::"BC14 Migration Runner", TargetCompanyName);
+    end;
+
+    internal procedure RerunHistoricalForCompany(TargetCompanyName: Text[30])
+    var
+        HybridReplicationSummary: Record "Hybrid Replication Summary";
+        BC14CompanySettings: Record BC14CompanyMigrationInfo;
+        BC14MigrationOrchestrator: Codeunit "BC14 Migration Orchestrator";
+        BC14StatusMgr: Codeunit "BC14 Migration Status Mgr.";
+        EmptyRecordId: RecordId;
+        SessionID: Integer;
+        RunSynchronously: Boolean;
+    begin
+        if not BC14CompanySettings.Get(TargetCompanyName) then
+            Error(NoReplicationSummaryForRerunErr, TargetCompanyName);
+        if not BC14CompanySettings."Migrate Historical Records" then
+            Error(HistoricalDisabledForRerunErr, TargetCompanyName);
+        if not BC14CompanySettings."Posting Completed" then
+            Error(MainNotCompletedForHistoricalRerunErr, TargetCompanyName);
+
+        BC14StatusMgr.AcquireRerunSlot(TargetCompanyName);
+
+        if not BC14MigrationOrchestrator.FindLatestReplicationSummary(HybridReplicationSummary) then
+            Error(NoReplicationSummaryForRerunErr, TargetCompanyName);
+        BC14StatusMgr.SetSummaryInProgress(HybridReplicationSummary);
+
+        BC14CompanySettings.RestartHistoricalDispatch(TargetCompanyName);
+        Commit();
+
+        BC14MigrationOrchestrator.RaiseOnBeforeScheduleTask(Codeunit::"BC14 Historical Task Worker", RunSynchronously);
+        if RunSynchronously then begin
+            Codeunit.Run(Codeunit::"BC14 Historical Task Worker");
+            exit;
+        end;
+
+        if TaskScheduler.CanCreateTask() then
+            TaskScheduler.CreateTask(
+                Codeunit::"BC14 Historical Task Worker", Codeunit::"BC14 Migration Failure Handler",
+                true, TargetCompanyName, CurrentDateTime(), EmptyRecordId, BC14MigrationOrchestrator.GetDefaultJobTimeout())
+        else
+            Session.StartSession(SessionID, Codeunit::"BC14 Historical Task Worker", TargetCompanyName);
     end;
 
     local procedure RunMigrationFromPhase(StartPhase: Enum "BC14 Migration Step")

--- a/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14MigrationStatusMgr.codeunit.al
+++ b/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14MigrationStatusMgr.codeunit.al
@@ -170,6 +170,7 @@ codeunit 46858 "BC14 Migration Status Mgr."
             exit;
 
         HybridReplicationSummary."End Time" := CurrentDateTime();
+        WriteSummaryDetails(HybridReplicationSummary, UpgradeFailedLbl);
         WriteSummaryStatus(HybridReplicationSummary, HybridReplicationSummary.Status::UpgradeFailed);
     end;
 
@@ -189,6 +190,7 @@ codeunit 46858 "BC14 Migration Status Mgr."
 
         if AnyCompanyHasFailedUpgrade() then begin
             HybridReplicationSummary."End Time" := CurrentDateTime();
+            WriteSummaryDetails(HybridReplicationSummary, UpgradeFailedLbl);
             WriteSummaryStatus(HybridReplicationSummary, HybridReplicationSummary.Status::UpgradeFailed);
             exit;
         end;
@@ -498,6 +500,15 @@ codeunit 46858 "BC14 Migration Status Mgr."
         HybridReplicationSummary.Modify();
     end;
 
+    local procedure WriteSummaryDetails(var HybridReplicationSummary: Record "Hybrid Replication Summary"; HeadlineText: Text)
+    var
+        OutStr: OutStream;
+    begin
+        Clear(HybridReplicationSummary.Details);
+        HybridReplicationSummary.Details.CreateOutStream(OutStr, TextEncoding::UTF8);
+        OutStr.WriteText(HeadlineText);
+    end;
+
     #endregion
 
     var
@@ -505,4 +516,5 @@ codeunit 46858 "BC14 Migration Status Mgr."
         CompanyStatusMissingErr: Label 'No upgrade status row exists for company %1. Run replication first.', Comment = '%1 = Company Name';
         UnexpectedStartStateErr: Label 'Cannot start upgrade for company %1: company is already in state %2. Reset the company state before retrying.', Comment = '%1 = Company Name, %2 = current Upgrade Status';
         UpgradeInProgressLbl: Label 'Upgrade in Progress';
+        UpgradeFailedLbl: Label 'Business Central 14 upgrade failed. See the Business Central 14 Migration Errors page for details.';
 }

--- a/src/Apps/W1/HybridBC14/app/src/Setup/BC14MigrationProvider.Codeunit.al
+++ b/src/Apps/W1/HybridBC14/app/src/Setup/BC14MigrationProvider.Codeunit.al
@@ -86,6 +86,6 @@ codeunit 46850 "BC14 Migration Provider" implements "Custom Migration Provider",
 
     procedure ShowConfigureMigrationTablesMappingStep(): Boolean
     begin
-        exit(true);
+        exit(false);
     end;
 }

--- a/src/Apps/W1/HybridBC14/test/src/framework/BC14E2EUpgradeTests.Codeunit.al
+++ b/src/Apps/W1/HybridBC14/test/src/framework/BC14E2EUpgradeTests.Codeunit.al
@@ -619,18 +619,20 @@ codeunit 148901 "BC14 E2E & Upgrade Tests"
     end;
 
     [Test]
-    procedure TestMarkUpgradeFailed_IncludesMigrationErrorsInDetails()
+    procedure TestMarkUpgradeFailed_DoesNotWriteSummaryDetails()
     var
         HybridReplicationSummary: Record "Hybrid Replication Summary";
         BC14HandleUpgradeFailure: Codeunit "BC14 Migration Failure Handler";
         BC14MigrationErrorHandler: Codeunit "BC14 Migration Error Handler";
         DummyRecordId: RecordId;
-        DetailsInStream: InStream;
-        DetailsText: Text;
     begin
-        // [SCENARIO] MarkUpgradeFailed includes migration errors in the Details field.
+        // [SCENARIO] MarkUpgradeFailed does NOT write the Summary Details blob. The overall
+        // Status headline is written only at finalize (SetSummaryFailed /
+        // EvaluateAndSetFinalSummaryStatus); per-company failure diagnostics live on the
+        // Business Central 14 Migration Errors page. This prevents one company's failure from
+        // overwriting the overall Status while other companies are still migrating.
 
-        // [GIVEN] A Hybrid Replication Summary and migration errors exist
+        // [GIVEN] A Hybrid Replication Summary and a migration error exist
         ClearUpgradeTestData();
         CreateHybridCompanyStatus();
         CreateHybridReplicationSummary(HybridReplicationSummary);
@@ -641,25 +643,21 @@ codeunit 148901 "BC14 E2E & Upgrade Tests"
         // [WHEN] MarkUpgradeFailed is called
         BC14HandleUpgradeFailure.MarkUpgradeFailed(HybridReplicationSummary);
 
-        // [THEN] The Details field contains error information
+        // [THEN] The Details field is NOT populated
         HybridReplicationSummary.Get(HybridReplicationSummary."Run ID");
         HybridReplicationSummary.CalcFields(Details);
-        HybridReplicationSummary.Details.CreateInStream(DetailsInStream);
-        DetailsInStream.Read(DetailsText);
-        Assert.IsTrue(StrPos(DetailsText, 'Number of errors: 1') > 0, 'Details should contain error count summary');
+        Assert.IsFalse(HybridReplicationSummary.Details.HasValue(),
+            'MarkUpgradeFailed should not write the Summary Details blob');
     end;
 
     [Test]
-    procedure TestMarkUpgradeFailed_NoMigrationErrors_DetailsContainUnknownError()
+    procedure TestMarkUpgradeFailed_NoMigrationErrors_DoesNotWriteSummaryDetails()
     var
         HybridReplicationSummary: Record "Hybrid Replication Summary";
         BC14HandleUpgradeFailure: Codeunit "BC14 Migration Failure Handler";
-        DetailsInStream: InStream;
-        DetailsText: Text;
     begin
-        // [SCENARIO] When no DataMigrationError records exist, MarkUpgradeFailed writes
-        // a generic "unknown" upgrade error to the Summary's Details blob (instead of
-        // a count summary).
+        // [SCENARIO] Even with no DataMigrationError records, MarkUpgradeFailed does not
+        // write the Summary Details blob.
 
         // [GIVEN] A Replication Summary and Company Status, but no errors logged
         ClearUpgradeTestData();
@@ -669,17 +667,11 @@ codeunit 148901 "BC14 E2E & Upgrade Tests"
         // [WHEN] MarkUpgradeFailed runs
         BC14HandleUpgradeFailure.MarkUpgradeFailed(HybridReplicationSummary);
 
-        // [THEN] Details contain some text (not the per-error count format)
+        // [THEN] Details are not populated
         HybridReplicationSummary.Get(HybridReplicationSummary."Run ID");
         HybridReplicationSummary.CalcFields(Details);
-        Assert.IsTrue(HybridReplicationSummary.Details.HasValue(),
-            'Details blob should be populated even with no per-record errors');
-
-        HybridReplicationSummary.Details.CreateInStream(DetailsInStream);
-        DetailsInStream.Read(DetailsText);
-        Assert.IsTrue(StrLen(DetailsText) > 0, 'Details text should not be empty');
-        Assert.IsFalse(StrPos(DetailsText, 'Number of errors:') > 0,
-            'Details should not contain count summary when there are no per-record errors');
+        Assert.IsFalse(HybridReplicationSummary.Details.HasValue(),
+            'MarkUpgradeFailed should not write the Summary Details blob when there are no errors');
     end;
 
     // Note: A test for "AppendsToExistingDetails" was attempted but the source's

--- a/src/Apps/W1/HybridBC14/test/src/framework/BC14ErrorFailureTests.Codeunit.al
+++ b/src/Apps/W1/HybridBC14/test/src/framework/BC14ErrorFailureTests.Codeunit.al
@@ -997,13 +997,15 @@ codeunit 148907 "BC14 Error & Failure Tests"
     end;
 
     [Test]
-    procedure TestMarkUpgradeFailed_WithReplicationSummary_AppendsDetailsBlob()
+    procedure TestMarkUpgradeFailed_WithReplicationSummary_DoesNotWriteDetailsBlob()
     var
         HybridReplicationSummary: Record "Hybrid Replication Summary";
         BC14MigrationFailureHandler: Codeunit "BC14 Migration Failure Handler";
         DetailsText: Text;
     begin
-        // [SCENARIO] When a replication summary record exists, MarkUpgradeFailed appends failure details to its Details blob.
+        // [SCENARIO] MarkUpgradeFailed does NOT write the Summary Details blob. The overall
+        // Status headline is written only at finalize, so a single company's failure never
+        // overwrites the overall Status while other companies are still migrating.
         ResetFailureState();
 
         // [GIVEN] A Hybrid Replication Summary record
@@ -1015,15 +1017,103 @@ codeunit 148907 "BC14 Error & Failure Tests"
         // [WHEN] MarkUpgradeFailed runs against that summary
         BC14MigrationFailureHandler.MarkUpgradeFailed(HybridReplicationSummary);
 
-        // [THEN] The Details blob now contains the failure entry for the current company
+        // [THEN] The Details blob remains empty
         DetailsText := ReadSummaryDetails(HybridReplicationSummary);
-        Assert.IsTrue(DetailsText <> '', 'Replication Summary Details blob should be populated.');
-        Assert.IsTrue(
-            DetailsText.Contains(CompanyName()),
-            'Replication Summary Details should mention the failed company name. Actual: ' + DetailsText);
-        Assert.IsTrue(
-            DetailsText.Contains('Upgrade failed'),
-            'Replication Summary Details should use the upgrade-failed phrasing. Actual: ' + DetailsText);
+        Assert.AreEqual('', DetailsText, 'MarkUpgradeFailed should not write the Replication Summary Details blob.');
+    end;
+
+    // ============================================================
+    // Historical Rerun
+    // ============================================================
+
+    [Test]
+    procedure TestRestartHistoricalDispatch_ResetsStateAndBumpsRunId()
+    var
+        BC14CompanySettings: Record BC14CompanyMigrationInfo;
+        OldRunId: Guid;
+        NewRunId: Guid;
+    begin
+        // [SCENARIO] RestartHistoricalDispatch clears a prior (failed/completed) Historical state,
+        // claims a fresh dispatch, and returns a new non-null run id so the Historical Worker
+        // it dispatches supersedes any leftover worker.
+        ResetFailureState();
+
+        // [GIVEN] A company whose Historical phase previously failed and completed
+        OldRunId := CreateGuid();
+        BC14CompanySettings.Init();
+        BC14CompanySettings.Name := CopyStr(CompanyName(), 1, MaxStrLen(BC14CompanySettings.Name));
+        BC14CompanySettings."Historical Run Id" := OldRunId;
+        BC14CompanySettings."Historical Completed" := true;
+        BC14CompanySettings."Historical Failed" := true;
+        BC14CompanySettings."Historical Failure Reason" := 'Prior failure';
+        BC14CompanySettings."Historical Dispatched" := false;
+        BC14CompanySettings.Insert();
+
+        // [WHEN] RestartHistoricalDispatch runs for the company
+        NewRunId := BC14CompanySettings.RestartHistoricalDispatch(CopyStr(CompanyName(), 1, 30));
+
+        // [THEN] Historical bookkeeping is reset and a fresh dispatch is claimed
+        BC14CompanySettings.GetSingleInstance();
+        Assert.IsFalse(BC14CompanySettings."Historical Completed", 'Historical Completed should be cleared.');
+        Assert.IsFalse(BC14CompanySettings."Historical Failed", 'Historical Failed should be cleared.');
+        Assert.AreEqual('', BC14CompanySettings."Historical Failure Reason", 'Historical Failure Reason should be cleared.');
+        Assert.IsTrue(BC14CompanySettings."Historical Dispatched", 'Historical Dispatched should be set.');
+        Assert.IsFalse(IsNullGuid(NewRunId), 'A non-null run id should be returned.');
+        Assert.AreNotEqual(OldRunId, NewRunId, 'A fresh run id should be issued.');
+        Assert.AreEqual(NewRunId, BC14CompanySettings."Historical Run Id", 'The returned run id should be persisted.');
+    end;
+
+    [Test]
+    procedure TestRerunHistoricalForCompany_HistoricalDisabled_ThrowsError()
+    var
+        BC14CompanySettings: Record BC14CompanyMigrationInfo;
+        BC14MigrationRunner: Codeunit "BC14 Migration Runner";
+    begin
+        // [SCENARIO] Rerunning Historical for a company that opted out of historical record
+        // migration is rejected before any dispatch or state change.
+        ResetFailureState();
+
+        // [GIVEN] A company with Migrate Historical Records disabled
+        BC14CompanySettings.Init();
+        BC14CompanySettings.Name := CopyStr(CompanyName(), 1, MaxStrLen(BC14CompanySettings.Name));
+        BC14CompanySettings."Migrate Historical Records" := false;
+        BC14CompanySettings.Insert();
+
+        // [WHEN] RerunHistoricalForCompany is invoked [THEN] it errors out
+        asserterror BC14MigrationRunner.RerunHistoricalForCompany(CopyStr(CompanyName(), 1, 30));
+    end;
+
+    [Test]
+    procedure TestRerunHistoricalForCompany_NoCompanySettings_ThrowsError()
+    var
+        BC14MigrationRunner: Codeunit "BC14 Migration Runner";
+    begin
+        // [SCENARIO] Rerunning Historical for a company with no settings row is rejected.
+        ResetFailureState();
+
+        // [WHEN] RerunHistoricalForCompany is invoked for an unknown company [THEN] it errors out
+        asserterror BC14MigrationRunner.RerunHistoricalForCompany('GHOST');
+    end;
+
+    [Test]
+    procedure TestRerunHistoricalForCompany_MainNotCompleted_ThrowsError()
+    var
+        BC14CompanySettings: Record BC14CompanyMigrationInfo;
+        BC14MigrationRunner: Codeunit "BC14 Migration Runner";
+    begin
+        // [SCENARIO] Rerunning Historical before the main migration has completed (Posting not done)
+        // is rejected, so the company can never be stranded In Progress with no way to finalize.
+        ResetFailureState();
+
+        // [GIVEN] A company whose historical migration is enabled but whose posting never completed
+        BC14CompanySettings.Init();
+        BC14CompanySettings.Name := CopyStr(CompanyName(), 1, MaxStrLen(BC14CompanySettings.Name));
+        BC14CompanySettings."Migrate Historical Records" := true;
+        BC14CompanySettings."Posting Completed" := false;
+        BC14CompanySettings.Insert();
+
+        // [WHEN] RerunHistoricalForCompany is invoked [THEN] it errors out
+        asserterror BC14MigrationRunner.RerunHistoricalForCompany(CopyStr(CompanyName(), 1, 30));
     end;
 
     // ============================================================

--- a/src/Apps/W1/HybridBC14/test/src/framework/BC14ErrorFailureTests.Codeunit.al
+++ b/src/Apps/W1/HybridBC14/test/src/framework/BC14ErrorFailureTests.Codeunit.al
@@ -1081,6 +1081,7 @@ codeunit 148907 "BC14 Error & Failure Tests"
 
         // [WHEN] RerunHistoricalForCompany is invoked [THEN] it errors out
         asserterror BC14MigrationRunner.RerunHistoricalForCompany(CopyStr(CompanyName(), 1, 30));
+        Assert.ExpectedError('historical record migration is disabled for this company.');
     end;
 
     [Test]
@@ -1093,6 +1094,7 @@ codeunit 148907 "BC14 Error & Failure Tests"
 
         // [WHEN] RerunHistoricalForCompany is invoked for an unknown company [THEN] it errors out
         asserterror BC14MigrationRunner.RerunHistoricalForCompany('GHOST');
+        Assert.ExpectedError('no replication summary was found. Run replication first.');
     end;
 
     [Test]
@@ -1114,6 +1116,7 @@ codeunit 148907 "BC14 Error & Failure Tests"
 
         // [WHEN] RerunHistoricalForCompany is invoked [THEN] it errors out
         asserterror BC14MigrationRunner.RerunHistoricalForCompany(CopyStr(CompanyName(), 1, 30));
+        Assert.ExpectedError('its main migration has not completed yet. Use Continue migration');
     end;
 
     // ============================================================

--- a/src/Apps/W1/HybridBC14/test/src/framework/BC14MigrationFlowTests.Codeunit.al
+++ b/src/Apps/W1/HybridBC14/test/src/framework/BC14MigrationFlowTests.Codeunit.al
@@ -329,6 +329,18 @@ codeunit 148906 "BC14 Migration Flow Tests"
         HybridReplicationSummary.Insert();
     end;
 
+    local procedure ReadSummaryDetails(var HybridReplicationSummary: Record "Hybrid Replication Summary") DetailsText: Text
+    var
+        DetailsInStream: InStream;
+    begin
+        HybridReplicationSummary.Get(HybridReplicationSummary."Run ID");
+        HybridReplicationSummary.CalcFields(Details);
+        if not HybridReplicationSummary.Details.HasValue() then
+            exit('');
+        HybridReplicationSummary.Details.CreateInStream(DetailsInStream);
+        DetailsInStream.Read(DetailsText);
+    end;
+
     // ============================================================
     // Orchestrator
     // ============================================================
@@ -1671,6 +1683,9 @@ codeunit 148906 "BC14 Migration Flow Tests"
         HybridReplicationSummary.Get(HybridReplicationSummary."Run ID");
         Assert.AreEqual(HybridReplicationSummary.Status::UpgradeFailed, HybridReplicationSummary.Status, 'Should be UpgradeFailed');
         Assert.AreNotEqual(0DT, HybridReplicationSummary."End Time", 'End Time should be set');
+        // The overall Status headline is written to Details at finalize (moved out of MarkUpgradeFailed).
+        Assert.IsTrue(ReadSummaryDetails(HybridReplicationSummary).ToLower().Contains('upgrade failed'),
+            'SetSummaryFailed should write the upgrade-failed headline to Details');
     end;
 
     [Test]
@@ -1733,6 +1748,9 @@ codeunit 148906 "BC14 Migration Flow Tests"
 
         HybridReplicationSummary.Get(HybridReplicationSummary."Run ID");
         Assert.AreEqual(HybridReplicationSummary.Status::UpgradeFailed, HybridReplicationSummary.Status, 'Should be UpgradeFailed');
+        // The overall Status headline is written to Details at finalize (moved out of MarkUpgradeFailed).
+        Assert.IsTrue(ReadSummaryDetails(HybridReplicationSummary).ToLower().Contains('upgrade failed'),
+            'EvaluateAndSetFinalSummaryStatus should write the upgrade-failed headline to Details');
     end;
 
     [Test]

--- a/src/Apps/W1/HybridBC14/test/src/framework/BC14MigrationFlowTests.Codeunit.al
+++ b/src/Apps/W1/HybridBC14/test/src/framework/BC14MigrationFlowTests.Codeunit.al
@@ -550,6 +550,43 @@ codeunit 148906 "BC14 Migration Flow Tests"
     end;
 
     [Test]
+    procedure TestTriggerUpgradeOneStep_NoDataReplicated_SkipsUpgrade()
+    var
+        HybridReplicationSummary: Record "Hybrid Replication Summary";
+        BC14GlobalSettings: Record "BC14 Global Migration Settings";
+        BC14Wizard: Codeunit "BC14 Wizard";
+        BC14MigrationOrchestrator: Codeunit "BC14 Migration Orchestrator";
+        RunId: Text[50];
+    begin
+        // [SCENARIO] A setup-phase run replicates no per-company data and therefore produces
+        // no Hybrid Replication Detail rows. The one-step upgrade must be skipped instead of
+        // entering the upgrade flow (which fails when no companies are selected/created).
+
+        // [GIVEN] Intelligent cloud is set up for BC14 and One Step Upgrade is enabled
+        Initialize_Orch();
+        BC14GlobalSettings.FindFirst();
+        BC14GlobalSettings."One Step Upgrade" := true;
+        BC14GlobalSettings.Modify();
+
+        // [GIVEN] A completed replication summary with no replicated table detail rows
+        HybridReplicationSummary.Init();
+        HybridReplicationSummary."Run ID" := CreateGuid();
+        HybridReplicationSummary.Status := HybridReplicationSummary.Status::Completed;
+        HybridReplicationSummary.Source := BC14Wizard.GetMigrationProviderId();
+        HybridReplicationSummary.Insert();
+        RunId := HybridReplicationSummary."Run ID";
+
+        // [WHEN] The one-step upgrade trigger runs for that run
+        BC14MigrationOrchestrator.TriggerUpgradeIfOneStepEnabled(RunId);
+
+        // [THEN] No error is thrown and the summary is not moved to UpgradeInProgress
+        HybridReplicationSummary.Get(RunId);
+        Assert.AreEqual(
+            HybridReplicationSummary.Status::Completed, HybridReplicationSummary.Status,
+            'Setup run with no replicated data should not trigger the upgrade');
+    end;
+
+    [Test]
     procedure TestGetDefaultJobTimeout_Is48Hours()
     var
         BC14MigrationOrchestrator: Codeunit "BC14 Migration Orchestrator";
@@ -990,11 +1027,11 @@ codeunit 148906 "BC14 Migration Flow Tests"
     var
         BC14MigrationProvider: Codeunit "BC14 Migration Provider";
     begin
-        // [SCENARIO] ShowConfigureMigrationTablesMappingStep returns true for BC14
-        // so the configuration package step is shown in the wizard page.
+        // [SCENARIO] ShowConfigureMigrationTablesMappingStep returns false for BC14
+        // so the configuration package step is skipped in the wizard page.
 
-        // [THEN] The step should be shown
-        Assert.IsTrue(BC14MigrationProvider.ShowConfigureMigrationTablesMappingStep(), 'Should show configure migration tables mapping step');
+        // [THEN] The step should be skipped
+        Assert.IsFalse(BC14MigrationProvider.ShowConfigureMigrationTablesMappingStep(), 'Should skip configure migration tables mapping step');
     end;
 
     // ============================================================

--- a/src/Apps/W1/HybridBC14/test/src/framework/BC14PageTests.Codeunit.al
+++ b/src/Apps/W1/HybridBC14/test/src/framework/BC14PageTests.Codeunit.al
@@ -314,6 +314,85 @@ codeunit 148909 "BC14 Page Tests"
         UpgradeStatusPage.Close();
     end;
 
+    [Test]
+    procedure TestCompanyUpgradeStatus_Started_ActivePhase_ShowsInProgress()
+    var
+        HybridCompanyStatus: Record "Hybrid Company Status";
+        BC14CompanyMigrationInfo: Record BC14CompanyMigrationInfo;
+        UpgradeStatusPage: TestPage "BC14 Company Upgrade Status";
+    begin
+        // [SCENARIO] A company in Started that is inside a running migration phase (e.g. Master) is
+        // shown as In Progress at the BC14 display layer, not the raw Started value.
+        ClearStatuses();
+        InsertHybridStatus('CO_ACTIVE', HybridCompanyStatus."Upgrade Status"::Started);
+        BC14CompanyMigrationInfo.Init();
+        BC14CompanyMigrationInfo.Name := 'CO_ACTIVE';
+        BC14CompanyMigrationInfo."Current Migration Step" := BC14CompanyMigrationInfo."Current Migration Step"::Master;
+        BC14CompanyMigrationInfo.Insert();
+
+        // [WHEN] The page is opened
+        UpgradeStatusPage.OpenView();
+        UpgradeStatusPage.GotoKey('CO_ACTIVE');
+
+        // [THEN] The Upgrade Status column shows In Progress
+        Assert.AreEqual('In Progress', UpgradeStatusPage."Upgrade Status".Value(), 'Actively migrating company should display In Progress.');
+
+        UpgradeStatusPage.Close();
+    end;
+
+    [Test]
+    procedure TestCompanyUpgradeStatus_Started_NotStartedPhase_ShowsStarted()
+    var
+        HybridCompanyStatus: Record "Hybrid Company Status";
+        BC14CompanyMigrationInfo: Record BC14CompanyMigrationInfo;
+        UpgradeStatusPage: TestPage "BC14 Company Upgrade Status";
+    begin
+        // [SCENARIO] A company whose status just flipped to Started but has not yet entered any
+        // migration phase (Current Migration Step = NotStarted) still shows the raw Started value,
+        // not In Progress.
+        ClearStatuses();
+        InsertHybridStatus('CO_SETUP', HybridCompanyStatus."Upgrade Status"::Started);
+        BC14CompanyMigrationInfo.Init();
+        BC14CompanyMigrationInfo.Name := 'CO_SETUP';
+        BC14CompanyMigrationInfo."Current Migration Step" := BC14CompanyMigrationInfo."Current Migration Step"::NotStarted;
+        BC14CompanyMigrationInfo.Insert();
+
+        // [WHEN] The page is opened
+        UpgradeStatusPage.OpenView();
+        UpgradeStatusPage.GotoKey('CO_SETUP');
+
+        // [THEN] The Upgrade Status column still shows Started
+        Assert.AreEqual('Started', UpgradeStatusPage."Upgrade Status".Value(), 'A company that has not entered any phase should still display Started.');
+
+        UpgradeStatusPage.Close();
+    end;
+
+    [Test]
+    procedure TestCompanyUpgradeStatus_Started_SetupPhase_ShowsInProgress()
+    var
+        HybridCompanyStatus: Record "Hybrid Company Status";
+        BC14CompanyMigrationInfo: Record BC14CompanyMigrationInfo;
+        UpgradeStatusPage: TestPage "BC14 Company Upgrade Status";
+    begin
+        // [SCENARIO] A company in Started that is already running the Setup phase is actively
+        // migrating and is shown as In Progress at the BC14 display layer, not the raw Started value.
+        ClearStatuses();
+        InsertHybridStatus('CO_SETUP_ACTIVE', HybridCompanyStatus."Upgrade Status"::Started);
+        BC14CompanyMigrationInfo.Init();
+        BC14CompanyMigrationInfo.Name := 'CO_SETUP_ACTIVE';
+        BC14CompanyMigrationInfo."Current Migration Step" := BC14CompanyMigrationInfo."Current Migration Step"::Setup;
+        BC14CompanyMigrationInfo.Insert();
+
+        // [WHEN] The page is opened
+        UpgradeStatusPage.OpenView();
+        UpgradeStatusPage.GotoKey('CO_SETUP_ACTIVE');
+
+        // [THEN] The Upgrade Status column shows In Progress
+        Assert.AreEqual('In Progress', UpgradeStatusPage."Upgrade Status".Value(), 'A company running the Setup phase should display In Progress.');
+
+        UpgradeStatusPage.Close();
+    end;
+
     // ============================================================
     // Errored Buffer Records Page (from BC14ErroredBufferPgTests.codeunit.al)
     // ============================================================

--- a/src/Apps/W1/HybridBaseDeployment/app/src/CustomMigration/TableMappings/AddCustomMigrationMapping.Page.al
+++ b/src/Apps/W1/HybridBaseDeployment/app/src/CustomMigration/TableMappings/AddCustomMigrationMapping.Page.al
@@ -11,7 +11,7 @@ using System.Reflection;
 page 40016 "Add Custom Migration Mapping"
 {
     ApplicationArea = All;
-    PageType = Card;
+    PageType = List;
     SourceTable = "AllObj";
     Permissions = tabledata "NAV App Installed App" = r,
                   tabledata AllObj = r,

--- a/src/Apps/W1/HybridBaseDeployment/app/src/CustomMigration/TableMappings/AddCustomMigrationMapping.Page.al
+++ b/src/Apps/W1/HybridBaseDeployment/app/src/CustomMigration/TableMappings/AddCustomMigrationMapping.Page.al
@@ -11,7 +11,7 @@ using System.Reflection;
 page 40016 "Add Custom Migration Mapping"
 {
     ApplicationArea = All;
-    PageType = List;
+    PageType = Card;
     SourceTable = "AllObj";
     Permissions = tabledata "NAV App Installed App" = r,
                   tabledata AllObj = r,
@@ -20,6 +20,7 @@ page 40016 "Add Custom Migration Mapping"
     DeleteAllowed = false;
     ModifyAllowed = false;
     Caption = 'Add migration table mappings for custom migration';
+    DataCaptionExpression = '';
     InherentEntitlements = X;
     InherentPermissions = X;
 
@@ -182,7 +183,7 @@ page 40016 "Add Custom Migration Mapping"
     trigger OnQueryClosePage(CloseAction: Action): Boolean
     var
         HybridCompany: Record "Hybrid Company";
-        CustomMigrationTableBuffer: Record "Custom Migration Table Buffer";
+        TempCustomMigrationTableBuffer: Record "Custom Migration Table Buffer";
         NewCompanyName: Text[30];
         NewSourceTableName: Text[128];
         NewDestinationTableName: Text[128];
@@ -192,6 +193,8 @@ page 40016 "Add Custom Migration Mapping"
 
         if TargetTableName = '' then
             exit(Confirm(TheDestinationTableIsEmptyContinueQst));
+
+        ValidateTargetTable();
 
         if AllCompanies then begin
             HybridCompany.SetRange(Replicate, true);
@@ -203,13 +206,11 @@ page 40016 "Add Custom Migration Mapping"
                 NewDestinationTableName := DestinationTableName.Replace(AllCompaniesTok, HybridCompany.Name);
                 NewCompanyName := HybridCompany.Name;
 #pragma warning restore AA0139
-                CustomMigrationTableBuffer.SaveMigrationTableMapping(MappingType, NewSourceTableName, NewDestinationTableName, TargetTableName, NewCompanyName, DataPerCompany, GlobalPreserveCloudData);
+                TempCustomMigrationTableBuffer.SaveMigrationTableMapping(MappingType, NewSourceTableName, NewDestinationTableName, TargetTableName, NewCompanyName, DataPerCompany, GlobalPreserveCloudData);
             until HybridCompany.Next() = 0;
         end else
-            CustomMigrationTableBuffer.SaveMigrationTableMapping(MappingType, SourceTableName, DestinationTableName, TargetTableName, CompanyName, DataPerCompany, GlobalPreserveCloudData);
+            TempCustomMigrationTableBuffer.SaveMigrationTableMapping(MappingType, SourceTableName, DestinationTableName, TargetTableName, CompanyName, DataPerCompany, GlobalPreserveCloudData);
 
-        // Validate and enable replication for all custom migration tables
-        ValidateTargetTable();
         exit(true);
     end;
 
@@ -257,8 +258,8 @@ page 40016 "Add Custom Migration Mapping"
         GlobalPreserveCloudData: Boolean;
         BCTableSeparatorTok: Label '$', Locked = true;
         TableExtensionSuffixTok: Label '$ext', Locked = true;
-        InvalidSqlCharactersTok: Label '.\/-', Locked = true;
-        ValidSqlReplacementTok: Label '____', Locked = true;
+        InvalidSqlCharactersTok: Label '.\/', Locked = true;
+        ValidSqlReplacementTok: Label '___', Locked = true;
         AllCompaniesTok: Label '{$CompanyName$}', Locked = true;
         AllCompanies: Boolean;
         UpdateTableNamesWithAllCompaniesTokMsg: Label 'The %1 token in the source table and destination table name will be replaced with the name of the company that is selected for migration. Update the source and destination table names accordingly.', Comment = '%1 is this value that is not translated {$AllCompanies$}';

--- a/src/Apps/W1/HybridBaseDeployment/app/src/CustomMigration/TableMappings/CustomMigrationMappingList.Page.al
+++ b/src/Apps/W1/HybridBaseDeployment/app/src/CustomMigration/TableMappings/CustomMigrationMappingList.Page.al
@@ -66,8 +66,11 @@ page 40017 "Custom Migration Mapping List"
                 Image = Add;
 
                 trigger OnAction()
+                var
+                    AddCustomMigrationMapping: Page "Add Custom Migration Mapping";
                 begin
-                    Page.RunModal(Page::"Add Custom Migration Mapping");
+                    AddCustomMigrationMapping.LookupMode(true);
+                    AddCustomMigrationMapping.RunModal();
                     Rec.LoadData();
                     CurrPage.Update(false);
                 end;

--- a/src/Apps/W1/HybridBaseDeployment/app/src/codeunits/HybridCloudManagement.Codeunit.al
+++ b/src/Apps/W1/HybridBaseDeployment/app/src/codeunits/HybridCloudManagement.Codeunit.al
@@ -101,6 +101,7 @@ codeunit 4001 "Hybrid Cloud Management"
         SettingForUserPermissionsMsg: Label 'Setting for Keeping user permissions was set to: %1.', Comment = '%1 - true or false';
         CustomMigrationSettingMsg: Label 'Setting for Custom Migration Enabled was set to: %1.', Comment = '%1 - true or false';
         OnPremDevelopmentSettingMsg: Label 'Setting for Enable OnPrem Development was set to: %1.', Comment = '%1 - true or false';
+        ExistingCompaniesInsertedMsg: Label 'Inserted %1 existing companies into the Hybrid Company table. They will now be available for selection in the cloud migration wizard.', Comment = '%1 - number of companies inserted';
         DoNotManageCompaniesManuallyLbl: Label 'We strongly recommend that you don''t manage companies, such as renaming and deleting, while cloud migration is running.';
         LearnMoreMsg: Label 'Learn more';
         DontShowAgainMsg: Label 'Don''t show again';
@@ -1338,6 +1339,26 @@ codeunit 4001 "Hybrid Cloud Management"
         IntelligentCloudSetup.Modify();
         OnPremMigrationHandler.Activate();
         Message(OnPremDevelopmentSettingMsg, IntelligentCloudSetup."Enable OnPrem Development");
+    end;
+
+    internal procedure InsertExistingCompaniesToHybridCompanyTable()
+    var
+        Company: Record Company;
+        HybridCompany: Record "Hybrid Company";
+        InsertedCount: Integer;
+    begin
+        if Company.FindSet() then
+            repeat
+                if not HybridCompany.Get(Company.Name) then begin
+                    HybridCompany.Init();
+                    HybridCompany.Name := Company.Name;
+                    HybridCompany."Display Name" := Company."Display Name";
+                    HybridCompany.Insert();
+                    InsertedCount += 1;
+                end;
+            until Company.Next() = 0;
+
+        Message(ExistingCompaniesInsertedMsg, InsertedCount);
     end;
 
     local procedure GetIntelligentCloudSetupSafe(var IntelligentCloudSetup: Record "Intelligent Cloud Setup")

--- a/src/Apps/W1/HybridBaseDeployment/app/src/pages/CloudMigrationManagement.Page.al
+++ b/src/Apps/W1/HybridBaseDeployment/app/src/pages/CloudMigrationManagement.Page.al
@@ -670,6 +670,21 @@ page 40063 "Cloud Migration Management"
                     HybridCloudManagement.EnableDisableOnPremDevelopment();
                 end;
             }
+            action(InsertExistingCompanies)
+            {
+                Visible = IsSuper and (IsOnPrem or IsOnPremDevelopmentEnabled);
+                ApplicationArea = Basic, Suite;
+                Caption = 'OnPrem Development - Insert existing companies as Hybrid Companies';
+                ToolTip = 'Insert the existing companies from this environment into the Hybrid Company table so they appear in the cloud migration wizard. Intended for OnPrem development scenarios.';
+                Image = Company;
+
+                trigger OnAction()
+                var
+                    HybridCloudManagement: Codeunit "Hybrid Cloud Management";
+                begin
+                    HybridCloudManagement.InsertExistingCompaniesToHybridCompanyTable();
+                end;
+            }
         }
 
         area(Promoted)

--- a/src/Apps/W1/HybridBaseDeployment/app/src/pages/IntelligentCloudManagement.Page.al
+++ b/src/Apps/W1/HybridBaseDeployment/app/src/pages/IntelligentCloudManagement.Page.al
@@ -427,6 +427,21 @@ page 4003 "Intelligent Cloud Management"
                     HybridCloudManagement.EnableDisableOnPremDevelopment();
                 end;
             }	    
+            action(InsertExistingCompanies)
+            {
+                Visible = IsSuper and IsOnPrem;
+                ApplicationArea = Basic, Suite;
+                Caption = 'OnPrem Development - Insert existing companies as Hybrid Companies';
+                ToolTip = 'Insert the existing companies from this environment into the Hybrid Company table so they appear in the cloud migration wizard. Intended for OnPrem development scenarios.';
+                Image = Company;
+
+                trigger OnAction()
+                var
+                    HybridCloudManagement: Codeunit "Hybrid Cloud Management";
+                begin
+                    HybridCloudManagement.InsertExistingCompaniesToHybridCompanyTable();
+                end;
+            }
             action(ValidationStatus)
             {
                 ApplicationArea = Basic, Suite;


### PR DESCRIPTION
## Summary

Bug fixes for the Business Central cloud reimplementation / migration tooling (BC14 reimplementation, HybridBaseDeployment custom-migration mapping, and cloud migration management pages).

Fixes [AB#641643](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641643)

## Main changes

### BC14 reimplementation wizard
- **Skip the mapping-tables configuration step** in the setup wizard after selecting the company type. `BC14MigrationProvider.ShowConfigureMigrationTablesMappingStep()` now returns `false` (matching the interface default), so the wizard no longer shows the custom migration-table mapping step.
- **Guard the one-step data upgrade against setup/empty runs.** `BC14MigrationOrchestrator.TriggerUpgradeIfOneStepEnabled` now exits early (with telemetry) when no data was replicated for the run, mirroring the "no data replicated" check used by the GP migration. This prevents an upgrade error being thrown during setup when no companies have been selected/replicated yet.

### Custom migration table mapping page (page 40016 "Add Custom Migration Mapping")
- **The mapping page can always be closed.** Reworked page/close behavior so an invalid mapping no longer blocks closing the page; the target table is validated before the mapping is saved, and the page opens via lookup mode. Converted the page to a Card layout for the single-mapping editing experience.

### Cloud migration management pages (OnPrem development)
- **New action "OnPrem Development - Insert existing companies as Hybrid Companies"** added next to the Enable/Disable OnPrem Development action on both `Cloud Migration Management` (page 40063) and `Intelligent Cloud Management` (page 4003). It inserts the environment's existing companies into the `Hybrid Company` table (idempotently) so they appear in the cloud migration wizard during OnPrem development.

## Tests
- Updated `BC14MigrationFlowTests` to assert the mapping-config step is skipped and added a flow test covering the "no data replicated" one-step upgrade guard.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>




[AB#642621](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642621)




