### PR TITLE
[master] - Invalid SEPA export file format when SEPA Non-Euro Export enabled

### DIFF
--- a/src/Layers/BE/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/BE/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -103,7 +103,10 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    Cd := 'SEPA';
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        Cd := 'SEPA'
+                                    else
+                                        Cd := 'NURG';
                                 end;
                             }
                         }

--- a/src/Layers/BE/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/BE/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1861,6 +1861,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/CH/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/CH/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -110,7 +110,10 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    Cd := 'SEPA';
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        Cd := 'SEPA'
+                                    else
+                                        Cd := 'NURG';
                                 end;
                             }
 

--- a/src/Layers/CZ/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/CZ/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1861,6 +1861,34 @@
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/ES/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/ES/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -105,7 +105,10 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    Cd := 'SEPA';
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        Cd := 'SEPA'
+                                    else
+                                        Cd := 'NURG';
                                 end;
                             }
                         }

--- a/src/Layers/ES/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/ES/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1861,6 +1861,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/FR/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/FR/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -103,7 +103,10 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    Cd := 'SEPA';
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        Cd := 'SEPA'
+                                    else
+                                        Cd := 'NURG';
                                 end;
                             }
                         }

--- a/src/Layers/FR/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/FR/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1730,6 +1730,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/IT/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/IT/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -103,7 +103,10 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    Cd := 'SEPA';
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        Cd := 'SEPA'
+                                    else
+                                        Cd := 'NURG';
                                 end;
                             }
                         }

--- a/src/Layers/IT/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1862,6 +1862,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/NA/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1860,6 +1860,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -104,7 +104,10 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    Cd := 'SEPA';
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        Cd := 'SEPA'
+                                    else
+                                        Cd := 'NURG';
                                 end;
                             }
                         }

--- a/src/Layers/NO/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/NO/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -119,8 +119,11 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    SvcLvlCd := 'SEPA';
-                                end;
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        SvcLvlCd := 'SEPA'
+                                    else
+                                        SvcLvlCd := 'NURG';
+                               end;
                             }
                         }
                     }

--- a/src/Layers/NO/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/NO/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1802,6 +1802,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/RU/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1737,6 +1737,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/W1/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/W1/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -103,7 +103,10 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    Cd := 'SEPA';
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        Cd := 'SEPA'
+                                    else
+                                        Cd := 'NURG';
                                 end;
                             }
                         }

--- a/src/Layers/W1/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1861,6 +1861,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";


### PR DESCRIPTION
[Bug 641697](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/641697): [master][All-e]Invalid SEPA export file format when SEPA Non-Euro Export enabled - Copy

Fixes [AB#641697](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641697)



