### PR TITLE
[Shopify] Surface skipped records and sent JSONL for bulk price sync

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Bulk Operations/Codeunits/ShpfyBulkOperationMgt.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Bulk Operations/Codeunits/ShpfyBulkOperationMgt.Codeunit.al
@@ -53,7 +53,7 @@ codeunit 30270 "Shpfy Bulk Operation Mgt."
         BulkOperationId := BulkOperationAPI.CreateBulkOperationMutation(IBulkOperation.GetGraphQL(), Jsonl);
         if BulkOperationId = 0 then
             exit(false);
-        CreateBulkOperation(Shop, BulkOperationId, Type, IBulkOperation.GetName(), RequestData, BulkOperationType);
+        CreateBulkOperation(Shop, BulkOperationId, Type, IBulkOperation.GetName(), RequestData, BulkOperationType, Jsonl);
         if GuiAllowed then
             Message(BulkOperationCreatedLbl);
         exit(true);
@@ -92,7 +92,7 @@ codeunit 30270 "Shpfy Bulk Operation Mgt."
         end;
     end;
 
-    local procedure CreateBulkOperation(Shop: Record "Shpfy Shop"; BulkOperationId: BigInteger; Type: Option; Name: Text[250]; RequestData: JsonArray; BulkOperationType: Enum "Shpfy Bulk Operation Type")
+    local procedure CreateBulkOperation(Shop: Record "Shpfy Shop"; BulkOperationId: BigInteger; Type: Option; Name: Text[250]; RequestData: JsonArray; BulkOperationType: Enum "Shpfy Bulk Operation Type"; Jsonl: Text)
     var
         BulkOperation: Record "Shpfy Bulk Operation";
     begin
@@ -104,6 +104,8 @@ codeunit 30270 "Shpfy Bulk Operation Mgt."
         BulkOperation."Bulk Operation Type" := BulkOperationType;
         BulkOperation.Insert();
         BulkOperation.SetRequestData(RequestData);
+        if Shop."Logging Mode" = Enum::"Shpfy Logging Mode"::All then
+            BulkOperation.SetSentJsonl(Jsonl);
     end;
 
     internal procedure UpdateBulkOperationStatus(Shop: Record "Shpfy Shop"; SearchBulkOperationId: BigInteger; Type: Option; var BulkOperationStatus: Enum "Shpfy Bulk Operation Status")

--- a/src/Apps/W1/Shopify/App/src/Bulk Operations/Codeunits/ShpfyBulkUpdateProductPrice.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Bulk Operations/Codeunits/ShpfyBulkUpdateProductPrice.Codeunit.al
@@ -5,6 +5,7 @@
 
 namespace Microsoft.Integration.Shopify;
 
+using Microsoft.Inventory.Item;
 using System.Reflection;
 
 codeunit 30281 "Shpfy Bulk UpdateProductPrice" implements "Shpfy IBulk Operation"
@@ -13,6 +14,8 @@ codeunit 30281 "Shpfy Bulk UpdateProductPrice" implements "Shpfy IBulk Operation
 
     var
         NameLbl: Label 'Update product price';
+        PriceSyncRevertedWithErrorLbl: Label 'The product price update was reverted because Shopify returned an error: %1', Comment = '%1 = the error message returned by Shopify';
+        PriceSyncRevertedLbl: Label 'The product price update was reverted because Shopify did not confirm the update.';
 
     procedure GetGraphQL(): Text
     begin
@@ -51,54 +54,130 @@ codeunit 30281 "Shpfy Bulk UpdateProductPrice" implements "Shpfy IBulk Operation
         JVariants: JsonArray;
         JVariant: JsonToken;
         SuccessList: List of [BigInteger];
+        LineErrors: Dictionary of [BigInteger, Text];
+        LineNumber: BigInteger;
+        BaseLineNumber: BigInteger;
+        HasBaseLineNumber: Boolean;
+        IsSuccess: Boolean;
     begin
         if not Shop.Get(BulkOperation."Shop Code") then
             exit;
 
+        BaseLineNumber := 0;
         JsonlResult := BulkOperationMgt.GetBulkOperationResult(Shop, BulkOperation);
         if JsonlResult = '' then
             exit;
 
         Result := JsonlResult.Split(TypeHelper.LFSeparator());
         foreach Line in Result do
-            if JLine.ReadFrom(Line) then
+            if JLine.ReadFrom(Line) then begin
+                if JsonHelper.ContainsToken(JLine, '__lineNumber') then begin
+                    LineNumber := JsonHelper.GetValueAsBigInteger(JLine, '__lineNumber');
+                    if (not HasBaseLineNumber) or (LineNumber < BaseLineNumber) then begin
+                        BaseLineNumber := LineNumber;
+                        HasBaseLineNumber := true;
+                    end;
+                end;
+
+                IsSuccess := false;
                 if JsonHelper.ContainsToken(JLine, 'data.productVariantsBulkUpdate.productVariants') then begin
                     JVariants := JsonHelper.GetJsonArray(JLine, 'data.productVariantsBulkUpdate.productVariants');
                     if JVariants.Count = 1 then
                         if JVariants.Get(0, JVariant) then
-                            if JsonHelper.GetValueAsDateTime(JVariant, 'updatedAt') > 0DT then
+                            if JsonHelper.GetValueAsDateTime(JVariant, 'updatedAt') > 0DT then begin
                                 SuccessList.Add(CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JVariant, 'id')));
+                                IsSuccess := true;
+                            end;
                 end;
 
-        RevertRequests(BulkOperation, SuccessList);
+                if (not IsSuccess) and JsonHelper.ContainsToken(JLine, '__lineNumber') then
+                    LineErrors.Set(LineNumber, GetLineErrorMessage(JLine, JsonHelper));
+            end;
+
+        RevertRequests(BulkOperation, SuccessList, LineErrors, BaseLineNumber, Shop, true);
     end;
 
-    local procedure RevertRequests(var BulkOperation: Record "Shpfy Bulk Operation"; var SuccessList: List of [BigInteger])
+    local procedure RevertRequests(var BulkOperation: Record "Shpfy Bulk Operation"; var SuccessList: List of [BigInteger]; var LineErrors: Dictionary of [BigInteger, Text]; BaseLineNumber: BigInteger; Shop: Record "Shpfy Shop"; LogSkipped: Boolean)
     var
         ShopifyVariant: Record "Shpfy Variant";
+        SkippedRecord: Codeunit "Shpfy Skipped Record";
         JRequestData: JsonArray;
         JRequest: JsonToken;
         JVariant: JsonObject;
+        VariantId: BigInteger;
+        Index: Integer;
     begin
         JRequestData := BulkOperation.GetRequestData();
+        Index := 0;
         foreach JRequest in JRequestData do begin
             JVariant := JRequest.AsObject();
-            if not SuccessList.Contains(JVariant.GetBigInteger('id')) then
-                if ShopifyVariant.Get(JVariant.GetBigInteger('id')) then begin
+            VariantId := JVariant.GetBigInteger('id');
+            if not SuccessList.Contains(VariantId) then
+                if ShopifyVariant.Get(VariantId) then begin
                     ShopifyVariant.Price := JVariant.GetDecimal('price');
                     ShopifyVariant."Compare at Price" := JVariant.GetDecimal('compareAtPrice');
                     ShopifyVariant."Updated At" := JVariant.GetDateTime('updatedAt');
                     if JVariant.Contains('unitCost') then
                         ShopifyVariant."Unit Cost" := JVariant.GetDecimal('unitCost');
                     ShopifyVariant.Modify();
+
+                    if LogSkipped then
+                        SkippedRecord.LogSkippedRecord(ShopifyVariant.Id, GetBCRecordId(ShopifyVariant), CopyStr(GetSkippedReason(LineErrors, BaseLineNumber + Index), 1, 250), Shop);
                 end;
+            Index += 1;
         end;
     end;
 
     procedure RevertAllRequests(var BulkOperation: Record "Shpfy Bulk Operation")
     var
+        Shop: Record "Shpfy Shop";
         EmptyList: List of [BigInteger];
+        EmptyErrors: Dictionary of [BigInteger, Text];
     begin
-        RevertRequests(BulkOperation, EmptyList);
+        RevertRequests(BulkOperation, EmptyList, EmptyErrors, 0, Shop, false);
+    end;
+
+    local procedure GetLineErrorMessage(JLine: JsonObject; JsonHelper: Codeunit "Shpfy Json Helper") Messages: Text
+    var
+        JErrors: JsonArray;
+        JError: JsonToken;
+        ErrorMessage: Text;
+    begin
+        if JsonHelper.ContainsToken(JLine, 'data.productVariantsBulkUpdate.userErrors') then
+            JErrors := JsonHelper.GetJsonArray(JLine, 'data.productVariantsBulkUpdate.userErrors')
+        else
+            if JsonHelper.ContainsToken(JLine, 'errors') then
+                JErrors := JsonHelper.GetJsonArray(JLine, 'errors');
+
+        foreach JError in JErrors do begin
+            ErrorMessage := JsonHelper.GetValueAsText(JError, 'message');
+            if ErrorMessage <> '' then
+                if Messages = '' then
+                    Messages := ErrorMessage
+                else
+                    Messages += '; ' + ErrorMessage;
+        end;
+    end;
+
+    local procedure GetSkippedReason(var LineErrors: Dictionary of [BigInteger, Text]; LineNumber: BigInteger): Text
+    begin
+        if LineErrors.ContainsKey(LineNumber) then
+            if LineErrors.Get(LineNumber) <> '' then
+                exit(StrSubstNo(PriceSyncRevertedWithErrorLbl, LineErrors.Get(LineNumber)));
+        exit(PriceSyncRevertedLbl);
+    end;
+
+    local procedure GetBCRecordId(ShopifyVariant: Record "Shpfy Variant"): RecordId
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+    begin
+        // Resolve the skipped record back to the linked BC Item Variant (preferred) or Item, so the
+        // user sees which product failed. Falls back to the Shopify variant when no BC link exists.
+        if (not IsNullGuid(ShopifyVariant."Item Variant SystemId")) and ItemVariant.GetBySystemId(ShopifyVariant."Item Variant SystemId") then
+            exit(ItemVariant.RecordId());
+        if (not IsNullGuid(ShopifyVariant."Item SystemId")) and Item.GetBySystemId(ShopifyVariant."Item SystemId") then
+            exit(Item.RecordId());
+        exit(ShopifyVariant.RecordId());
     end;
 }

--- a/src/Apps/W1/Shopify/App/src/Bulk Operations/Codeunits/ShpfyBulkUpdateProductPrice.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Bulk Operations/Codeunits/ShpfyBulkUpdateProductPrice.Codeunit.al
@@ -174,8 +174,10 @@ codeunit 30281 "Shpfy Bulk UpdateProductPrice" implements "Shpfy IBulk Operation
     begin
         // Resolve the skipped record back to the linked BC Item Variant (preferred) or Item, so the
         // user sees which product failed. Falls back to the Shopify variant when no BC link exists.
+        ItemVariant.SetLoadFields();
         if (not IsNullGuid(ShopifyVariant."Item Variant SystemId")) and ItemVariant.GetBySystemId(ShopifyVariant."Item Variant SystemId") then
             exit(ItemVariant.RecordId());
+        Item.SetLoadFields();
         if (not IsNullGuid(ShopifyVariant."Item SystemId")) and Item.GetBySystemId(ShopifyVariant."Item SystemId") then
             exit(Item.RecordId());
         exit(ShopifyVariant.RecordId());

--- a/src/Apps/W1/Shopify/App/src/Bulk Operations/Pages/ShpfyBulkOperations.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Bulk Operations/Pages/ShpfyBulkOperations.Page.al
@@ -104,7 +104,6 @@ page 30152 "Shpfy Bulk Operations"
                 var
                     InStream: InStream;
                     FileName: Text;
-                    SentDataFileNameLbl: Label 'BulkOperation_%1.jsonl', Comment = '%1 = the bulk operation id', Locked = true;
                 begin
                     Rec.CalcFields("Sent JSONL");
                     if not Rec."Sent JSONL".HasValue then
@@ -168,6 +167,7 @@ page 30152 "Shpfy Bulk Operations"
         InProgressLbl: Label 'In Progress';
         ErrorLbl: Label 'Error';
         CompletedLbl: Label 'Completed';
+        SentDataFileNameLbl: Label 'BulkOperation_%1.jsonl', Comment = '%1 = the bulk operation id', Locked = true;
 
     trigger OnAfterGetRecord()
     begin

--- a/src/Apps/W1/Shopify/App/src/Bulk Operations/Pages/ShpfyBulkOperations.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Bulk Operations/Pages/ShpfyBulkOperations.Page.al
@@ -88,6 +88,32 @@ page 30152 "Shpfy Bulk Operations"
                     Message(BulkOperationMgt.GetBulkOperationResult(Shop, Rec));
                 end;
             }
+            action(GetSentData)
+            {
+                ApplicationArea = All;
+                Caption = 'Download Sent Data';
+                Enabled = HasSentJsonl;
+                Image = Export;
+                Promoted = true;
+                PromotedCategory = Process;
+                PromotedIsBig = true;
+                PromotedOnly = true;
+                ToolTip = 'Download the JSONL request that was sent to Shopify for this bulk operation.';
+
+                trigger OnAction();
+                var
+                    InStream: InStream;
+                    FileName: Text;
+                    SentDataFileNameLbl: Label 'BulkOperation_%1.jsonl', Comment = '%1 = the bulk operation id', Locked = true;
+                begin
+                    Rec.CalcFields("Sent JSONL");
+                    if not Rec."Sent JSONL".HasValue then
+                        exit;
+                    Rec."Sent JSONL".CreateInStream(InStream, TextEncoding::UTF8);
+                    FileName := StrSubstNo(SentDataFileNameLbl, Rec."Bulk Operation Id");
+                    DownloadFromStream(InStream, '', '', '', FileName);
+                end;
+            }
             action(Refresh)
             {
                 ApplicationArea = All;
@@ -137,6 +163,7 @@ page 30152 "Shpfy Bulk Operations"
 
     var
         HasDataUrl: Boolean;
+        HasSentJsonl: Boolean;
         CurrentStatus: Text;
         InProgressLbl: Label 'In Progress';
         ErrorLbl: Label 'Error';
@@ -145,6 +172,8 @@ page 30152 "Shpfy Bulk Operations"
     trigger OnAfterGetRecord()
     begin
         HasDataUrl := (Rec.Url <> '') or (Rec."Partial Data Url" <> '');
+        Rec.CalcFields("Sent JSONL");
+        HasSentJsonl := Rec."Sent JSONL".HasValue;
         if Rec.Status in [Rec.Status::Created, Rec.Status::Running, Rec.Status::Canceled] then
             CurrentStatus := InProgressLbl;
         if Rec.Status in [Rec.Status::Canceled, Rec.Status::Failed, Rec.Status::Expired] then

--- a/src/Apps/W1/Shopify/App/src/Bulk Operations/Tables/ShpfyBulkOperation.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Bulk Operations/Tables/ShpfyBulkOperation.Table.al
@@ -76,6 +76,11 @@ table 30148 "Shpfy Bulk Operation"
             Caption = 'Processed';
             DataClassification = SystemMetadata;
         }
+        field(13; "Sent JSONL"; Blob)
+        {
+            Caption = 'Sent JSONL';
+            DataClassification = SystemMetadata;
+        }
     }
 
     keys
@@ -127,5 +132,32 @@ table 30148 "Shpfy Bulk Operation"
             InStream.ReadText(RequestText);
             RequestData.ReadFrom(RequestText);
         end;
+    end;
+
+    internal procedure SetSentJsonl(Jsonl: Text)
+    var
+        OutStream: OutStream;
+    begin
+        Clear("Sent JSONL");
+        "Sent JSONL".CreateOutStream(OutStream, TextEncoding::UTF8);
+        OutStream.WriteText(Jsonl);
+        Modify();
+    end;
+
+    internal procedure GetSentJsonl() Jsonl: Text
+    var
+        InStream: InStream;
+        Line: Text;
+        JsonlBuilder: TextBuilder;
+    begin
+        CalcFields("Sent JSONL");
+        if not "Sent JSONL".HasValue then
+            exit('');
+        "Sent JSONL".CreateInStream(InStream, TextEncoding::UTF8);
+        while not InStream.EOS do begin
+            InStream.ReadText(Line);
+            JsonlBuilder.AppendLine(Line);
+        end;
+        exit(JsonlBuilder.ToText());
     end;
 }

--- a/src/Apps/W1/Shopify/Test/Bulk Operations/Codeunits/ShpfyBulkOperationsTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Bulk Operations/Codeunits/ShpfyBulkOperationsTest.Codeunit.al
@@ -6,6 +6,7 @@
 namespace Microsoft.Integration.Shopify.Test;
 
 using Microsoft.Integration.Shopify;
+using Microsoft.Inventory.Item;
 using System.TestLibraries.Utilities;
 
 codeunit 139633 "Shpfy Bulk Operations Test"
@@ -59,11 +60,13 @@ codeunit 139633 "Shpfy Bulk Operations Test"
     var
         BulkOperation: Record "Shpfy Bulk Operation";
         ShopifyVariant: Record "Shpfy Variant";
+        SkippedRecord: Record "Shpfy Skipped Record";
     begin
         BulkOperation.DeleteAll();
         BulkOperationRunning := false;
         BulkUploadFail := false;
         ShopifyVariant.DeleteAll();
+        SkippedRecord.DeleteAll();
         GraphQLResponses.Clear();
     end;
 
@@ -375,6 +378,159 @@ codeunit 139633 "Shpfy Bulk Operations Test"
         LibraryAssert.AreEqual(200, ShopifyVariant.Price, 'Variant price should not be reverted.');
         LibraryAssert.AreEqual(250, ShopifyVariant."Compare at Price", 'Variant compare at price should not be reverted.');
         LibraryAssert.AreEqual(75, ShopifyVariant."Unit Cost", 'Variant unit cost should be left untouched when legacy blob lacks unitCost.');
+        ClearSetup();
+    end;
+
+    [Test]
+    [HandlerFunctions('BulkOperationHttpHandler')]
+    procedure TestBulkOperationRevertFailedLogsSkippedRecords()
+    var
+        ShopifyVariant: Record "Shpfy Variant";
+        BulkOperation: Record "Shpfy Bulk Operation";
+        SkippedRecord: Record "Shpfy Skipped Record";
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        LibraryInventory: Codeunit "Library - Inventory";
+        BulkOperationType: Enum "Shpfy Bulk Operation Type";
+        ProductId: BigInteger;
+        VariantId: BigInteger;
+        VariantIds: List of [BigInteger];
+        Index: Integer;
+        RevertedWithUserErrorLbl: Label 'The product price update was reverted because Shopify returned an error: Product variant does not exist', Locked = true;
+        RevertedWithTopErrorLbl: Label 'The product price update was reverted because Shopify returned an error: This product is currently being modified. Please try again later.', Locked = true;
+    begin
+        // [SCENARIO] Bug 641615: when a bulk price sync reverts a variant because Shopify returned an
+        // error, a Shopify Skipped Record is created with the error details and the linked BC record so
+        // the user sees which item failed and why.
+
+        // [GIVEN] Four Shopify variants (1 and 4 succeed, 2 and 3 fail). The failed variants are linked
+        // to BC records: variant 2 to an Item, variant 3 to an Item Variant.
+        Initialize();
+        ClearSetup();
+        LibraryInventory.CreateItem(Item);
+        LibraryInventory.CreateItemVariant(ItemVariant, Item."No.");
+        for Index := 1 to 4 do begin
+            ProductId := Any.IntegerInRange(100000, 555555);
+            VariantId := Any.IntegerInRange(100000, 555555);
+            VariantIds.Add(VariantId);
+            ShopifyVariant.Init();
+            ShopifyVariant."Product Id" := ProductId;
+            ShopifyVariant.Id := VariantId;
+            ShopifyVariant.Price := 200;
+            ShopifyVariant."Compare at Price" := 250;
+            ShopifyVariant."Unit Cost" := 75;
+            case Index of
+                2:
+                    ShopifyVariant."Item SystemId" := Item.SystemId;
+                3:
+                    begin
+                        ShopifyVariant."Item SystemId" := Item.SystemId;
+                        ShopifyVariant."Item Variant SystemId" := ItemVariant.SystemId;
+                    end;
+            end;
+            ShopifyVariant.Insert();
+        end;
+        BulkOperationUrl := 'https://storage.googleapis.com/shopify-bulk-result/' + Any.AlphabeticText(20);
+        BulkOperation := CreateBulkOperation(BulkOperationId1, BulkOperationType::UpdateProductPrice, Shop.Code, BulkOperationUrl, GenerateRequestData(VariantIds, 100, 150, 50));
+
+        // [WHEN] Bulk operation is completed
+        BulkOperationIdCurrent := BulkOperationId1;
+        VariantId1 := VariantIds.Get(1);
+        VariantId2 := VariantIds.Get(4);
+        BulkOperation.Status := BulkOperation.Status::Completed;
+        BulkOperation.Modify(true);
+
+        // [THEN] A skipped record is logged for the item-linked failed variant, pointing at the BC Item
+        SkippedRecord.SetRange("Shopify Id", VariantIds.Get(2));
+        LibraryAssert.IsTrue(SkippedRecord.FindFirst(), 'Skipped record should be created for the first failed variant.');
+        LibraryAssert.AreEqual(RevertedWithUserErrorLbl, SkippedRecord."Skipped Reason", 'Skipped reason should contain the Shopify user error.');
+        LibraryAssert.AreEqual(Database::Item, SkippedRecord."Table ID", 'Skipped record should reference the BC Item table.');
+        LibraryAssert.AreEqual(Format(Item.RecordId()), Format(SkippedRecord."Record ID"), 'Skipped record should reference the BC Item record.');
+
+        // [THEN] A skipped record is logged for the variant-linked failed variant, pointing at the BC Item Variant
+        SkippedRecord.SetRange("Shopify Id", VariantIds.Get(3));
+        LibraryAssert.IsTrue(SkippedRecord.FindFirst(), 'Skipped record should be created for the second failed variant.');
+        LibraryAssert.AreEqual(RevertedWithTopErrorLbl, SkippedRecord."Skipped Reason", 'Skipped reason should contain the Shopify top-level error.');
+        LibraryAssert.AreEqual(Database::"Item Variant", SkippedRecord."Table ID", 'Skipped record should reference the BC Item Variant table.');
+        LibraryAssert.AreEqual(Format(ItemVariant.RecordId()), Format(SkippedRecord."Record ID"), 'Skipped record should reference the BC Item Variant record.');
+
+        // [THEN] No skipped record is logged for the variants that succeeded
+        SkippedRecord.SetRange("Shopify Id", VariantIds.Get(1));
+        LibraryAssert.IsTrue(SkippedRecord.IsEmpty(), 'No skipped record should be created for a variant that succeeded.');
+        SkippedRecord.SetRange("Shopify Id", VariantIds.Get(4));
+        LibraryAssert.IsTrue(SkippedRecord.IsEmpty(), 'No skipped record should be created for a variant that succeeded.');
+        ClearSetup();
+    end;
+
+    [Test]
+    [HandlerFunctions('BulkMessageHandler,BulkOperationHttpHandler')]
+    procedure TestSendBulkOperationStoresSentJsonl()
+    var
+        LoggingShop: Record "Shpfy Shop";
+        BulkOperation: Record "Shpfy Bulk Operation";
+        BulkOperationMgt: Codeunit "Shpfy Bulk Operation Mgt.";
+        BulkOperationType: Enum "Shpfy Bulk Operation Type";
+        IBulkOperation: Interface "Shpfy IBulk Operation";
+        tb: TextBuilder;
+        RequestData: JsonArray;
+        StoredJsonl: Text;
+    begin
+        // [SCENARIO] Bug 641615: when the shop's Logging Mode is All, the JSONL input sent to
+        // Shopify is stored on the bulk operation record so it can be downloaded for troubleshooting.
+        Initialize();
+        ClearSetup();
+
+        // [GIVEN] A shop with Logging Mode = All and a bulk operation input
+        LoggingShop := Shop;
+        LoggingShop."Logging Mode" := Enum::"Shpfy Logging Mode"::All;
+        BulkOperationIdCurrent := BulkOperationId1;
+        IBulkOperation := BulkOperationType::AddProduct;
+        tb.AppendLine(StrSubstNo(IBulkOperation.GetInput(), 'Sweet new snowboard 1', 'Snowboard', 'JadedPixel'));
+        tb.AppendLine(StrSubstNo(IBulkOperation.GetInput(), 'Sweet new snowboard 2', 'Snowboard', 'JadedPixel'));
+
+        // [WHEN] The bulk operation is sent
+        EnqueueGraphQLResponsesForSendBulkMutation();
+        BulkOperationMgt.SendBulkMutation(LoggingShop, BulkOperationType::AddProduct, tb.ToText(), RequestData);
+
+        // [THEN] The sent JSONL is stored on the bulk operation record
+        BulkOperation.Get(BulkOperationId1, Shop.Code, BulkOperation.Type::mutation);
+        StoredJsonl := BulkOperation.GetSentJsonl();
+        LibraryAssert.IsTrue(StoredJsonl.Contains('Sweet new snowboard 1'), 'Stored JSONL should contain the first sent line.');
+        LibraryAssert.IsTrue(StoredJsonl.Contains('Sweet new snowboard 2'), 'Stored JSONL should contain the second sent line.');
+        ClearSetup();
+    end;
+
+    [Test]
+    [HandlerFunctions('BulkMessageHandler,BulkOperationHttpHandler')]
+    procedure TestSendBulkOperationDoesNotStoreSentJsonlWhenNotLoggingAll()
+    var
+        LoggingShop: Record "Shpfy Shop";
+        BulkOperation: Record "Shpfy Bulk Operation";
+        BulkOperationMgt: Codeunit "Shpfy Bulk Operation Mgt.";
+        BulkOperationType: Enum "Shpfy Bulk Operation Type";
+        IBulkOperation: Interface "Shpfy IBulk Operation";
+        tb: TextBuilder;
+        RequestData: JsonArray;
+    begin
+        // [SCENARIO] Bug 641615: the sent JSONL is only stored when Logging Mode is All, so the
+        // bulk operation table does not grow with a payload blob on every price sync.
+        Initialize();
+        ClearSetup();
+
+        // [GIVEN] A shop with Logging Mode = Error Only and a bulk operation input
+        LoggingShop := Shop;
+        LoggingShop."Logging Mode" := Enum::"Shpfy Logging Mode"::"Error Only";
+        BulkOperationIdCurrent := BulkOperationId1;
+        IBulkOperation := BulkOperationType::AddProduct;
+        tb.AppendLine(StrSubstNo(IBulkOperation.GetInput(), 'Sweet new snowboard 1', 'Snowboard', 'JadedPixel'));
+
+        // [WHEN] The bulk operation is sent
+        EnqueueGraphQLResponsesForSendBulkMutation();
+        BulkOperationMgt.SendBulkMutation(LoggingShop, BulkOperationType::AddProduct, tb.ToText(), RequestData);
+
+        // [THEN] The sent JSONL is not stored on the bulk operation record
+        BulkOperation.Get(BulkOperationId1, Shop.Code, BulkOperation.Type::mutation);
+        LibraryAssert.AreEqual('', BulkOperation.GetSentJsonl(), 'Sent JSONL should not be stored when Logging Mode is not All.');
         ClearSetup();
     end;
 


### PR DESCRIPTION
Fixes [AB#641615](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641615)

## Problem

When a bulk price sync (`productVariantsBulkUpdate`) completes but Shopify returns a per-variant error — for example a product that was deleted on the Shopify side (`"Product does not exist"`) — the connector's `RevertFailedRequests` logic reverted the affected variant back to its old price **silently**. On the next Sync Prices run the same item is picked up again, producing an invisible infinite retry loop with no skipped-record entry, no log, and nothing in the UI to tell the user what failed.

## Changes

1. **Skipped record feedback on revert.** `Shpfy Bulk UpdateProductPrice.RevertFailedRequests` now parses the per-line `userErrors`/`errors` from the result JSONL and maps each result line back to its request-data entry via `__lineNumber` (base-agnostic: derived from the minimum observed line number, so it works whether Shopify numbers from 0 or 1). Every reverted variant gets a **Shopify Skipped Record** with the Shopify error message. The entry references the linked BC **Item Variant** (preferred) or **Item** — resolved from the Shopify variant's SystemIds — matching the existing `LogSkippedRecord` convention in `Shpfy Product Export`, so the user sees exactly which product failed and why. Logging respects the shop's Logging Mode (suppressed only when Disabled).

2. **Downloadable sent JSONL.** Added a `Sent JSONL` blob field (13) to table `Shpfy Bulk Operation` with `Set`/`GetSentJsonl` helpers. `Shpfy Bulk Operation Mgt.SendBulkMutation` now stores the JSONL request that was sent to Shopify — **only when Logging Mode = All**, to avoid growing the table with a payload blob on every price sync — and a new **Download Sent Data** action on the `Shopify Bulk Operations` page exposes it for troubleshooting.

## Test plan

Added to `Shpfy Bulk Operations Test`:

- `TestBulkOperationRevertFailedLogsSkippedRecords` — completes a bulk op where two of four variants fail; asserts a skipped record is logged for each failed variant with the correct Shopify error message, and that the entry's `Table ID`/`Record ID` resolve to the linked BC Item (item-level) and Item Variant (variant-level); asserts no skipped record for the successful variants.
- `TestSendBulkOperationStoresSentJsonl` — with Logging Mode = All, asserts the sent JSONL is stored on the bulk operation record.
- `TestSendBulkOperationDoesNotStoreSentJsonlWhenNotLoggingAll` — with Logging Mode = Error Only, asserts nothing is stored.



