### PR TITLE
[28.x][Payables Agent] Users can personalize-in the Name column on the draft page

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocPurchaseDraftSubform.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocPurchaseDraftSubform.Page.al
@@ -72,6 +72,14 @@ page 6183 "E-Doc. Purchase Draft Subform"
                     Lookup = true;
                     ShowMandatory = true;
                 }
+                field("Name"; MatchedEntityName)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Name';
+                    ToolTip = 'Specifies the name of the matched item, G/L account, or other entity for this line. This value is read-only and reflects the matched record, not the extracted invoice description.';
+                    Editable = false;
+                    Visible = false;
+                }
                 field("VAT Prod. Posting Group"; Rec."[BC] VAT Prod. Posting Group")
                 {
                     ApplicationArea = All;
@@ -338,7 +346,7 @@ page 6183 "E-Doc. Purchase Draft Subform"
         EDocumentPOMatchWarnings: Record "E-Doc PO Match Warning";
         EDocPurchaseHistMapping: Codeunit "E-Doc. Purchase Hist. Mapping";
         EDocPOMatching: Codeunit "E-Doc. PO Matching";
-        AdditionalColumns, OrderMatchedCaption, MatchWarningsCaption, MatchWarningsStyleExpr : Text;
+        AdditionalColumns, OrderMatchedCaption, MatchWarningsCaption, MatchWarningsStyleExpr, MatchedEntityName : Text;
         LineAmount: Decimal;
         DimVisible1, DimVisible2, HasAdditionalColumns, IsEDocumentMatchedToAnyPOLine, IsLineMatchedToOrderLine, IsLineMatchedToReceiptLine, HasEDocumentOrderMatchWarnings, VATProdPostGroupIsVisible : Boolean;
         HistoryCantBeRetrievedErr: Label 'The purchase invoice that matched historically with this line can''t be opened.';
@@ -364,6 +372,7 @@ page 6183 "E-Doc. Purchase Draft Subform"
     begin
         if EDocumentPurchaseLine.Get(Rec."E-Document Entry No.", Rec."Line No.") then;
         AdditionalColumns := Rec.AdditionalColumnsDisplayText();
+        MatchedEntityName := Rec.GetMatchedEntityName();
         SetHasAdditionalColumns();
         UpdateCalculatedAmounts(false);
         IsLineMatchedToOrderLine := EDocPOMatching.IsEDocumentLineMatchedToAnyPOLine(EDocumentPurchaseLine);

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseLine.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseLine.Table.al
@@ -288,23 +288,41 @@ table 6101 "E-Document Purchase Line"
 
         case Rec."[BC] Purchase Line Type" of
             "Purchase Line Type"::Item:
-                if Item.Get(Rec."[BC] Purchase Type No.") then
-                    EntityName := Item.Description;
+                begin
+                    Item.SetLoadFields(Description);
+                    if Item.Get(Rec."[BC] Purchase Type No.") then
+                        EntityName := Item.Description;
+                end;
             "Purchase Line Type"::"G/L Account":
-                if GLAccount.Get(Rec."[BC] Purchase Type No.") then
-                    EntityName := GLAccount.Name;
+                begin
+                    GLAccount.SetLoadFields(Name);
+                    if GLAccount.Get(Rec."[BC] Purchase Type No.") then
+                        EntityName := GLAccount.Name;
+                end;
             "Purchase Line Type"::"Allocation Account":
-                if AllocationAccount.Get(Rec."[BC] Purchase Type No.") then
-                    EntityName := AllocationAccount.Name;
+                begin
+                    AllocationAccount.SetLoadFields(Name);
+                    if AllocationAccount.Get(Rec."[BC] Purchase Type No.") then
+                        EntityName := AllocationAccount.Name;
+                end;
             "Purchase Line Type"::"Fixed Asset":
-                if FixedAsset.Get(Rec."[BC] Purchase Type No.") then
-                    EntityName := FixedAsset.Description;
+                begin
+                    FixedAsset.SetLoadFields(Description);
+                    if FixedAsset.Get(Rec."[BC] Purchase Type No.") then
+                        EntityName := FixedAsset.Description;
+                end;
             "Purchase Line Type"::Resource:
-                if Resource.Get(Rec."[BC] Purchase Type No.") then
-                    EntityName := Resource.Name;
+                begin
+                    Resource.SetLoadFields(Name);
+                    if Resource.Get(Rec."[BC] Purchase Type No.") then
+                        EntityName := Resource.Name;
+                end;
             "Purchase Line Type"::"Charge (Item)":
-                if ItemCharge.Get(Rec."[BC] Purchase Type No.") then
-                    EntityName := ItemCharge.Description;
+                begin
+                    ItemCharge.SetLoadFields(Description);
+                    if ItemCharge.Get(Rec."[BC] Purchase Type No.") then
+                        EntityName := ItemCharge.Description;
+                end;
         end;
 
         OnAfterGetMatchedEntityName(Rec, EntityName);

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseLine.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseLine.Table.al
@@ -264,6 +264,17 @@ table 6101 "E-Document Purchase Line"
         DimMgt: Codeunit DimensionManagement;
 
     local procedure SetDescriptionFromLineTypeNo()
+    begin
+        if Rec.Description <> '' then
+            exit;
+        Rec.Description := GetMatchedEntityName();
+    end;
+
+    /// <summary>
+    /// Returns the name of the entity (Item, G/L Account, Resource, etc.) that this line is matched to,
+    /// resolved from the "[BC] Purchase Line Type" and "[BC] Purchase Type No." fields
+    /// </summary>
+    internal procedure GetMatchedEntityName() EntityName: Text[100]
     var
         Item: Record Item;
         GLAccount: Record "G/L Account";
@@ -272,29 +283,36 @@ table 6101 "E-Document Purchase Line"
         Resource: Record Resource;
         ItemCharge: Record "Item Charge";
     begin
-        if Rec.Description <> '' then
-            exit;
+        if Rec."[BC] Purchase Type No." = '' then
+            exit('');
 
         case Rec."[BC] Purchase Line Type" of
             "Purchase Line Type"::Item:
                 if Item.Get(Rec."[BC] Purchase Type No.") then
-                    Rec.Description := Item.Description;
+                    EntityName := Item.Description;
             "Purchase Line Type"::"G/L Account":
                 if GLAccount.Get(Rec."[BC] Purchase Type No.") then
-                    Rec.Description := GLAccount.Name;
+                    EntityName := GLAccount.Name;
             "Purchase Line Type"::"Allocation Account":
                 if AllocationAccount.Get(Rec."[BC] Purchase Type No.") then
-                    Rec.Description := AllocationAccount.Name;
+                    EntityName := AllocationAccount.Name;
             "Purchase Line Type"::"Fixed Asset":
                 if FixedAsset.Get(Rec."[BC] Purchase Type No.") then
-                    Rec.Description := FixedAsset.Description;
+                    EntityName := FixedAsset.Description;
             "Purchase Line Type"::Resource:
                 if Resource.Get(Rec."[BC] Purchase Type No.") then
-                    Rec.Description := Resource.Name;
+                    EntityName := Resource.Name;
             "Purchase Line Type"::"Charge (Item)":
                 if ItemCharge.Get(Rec."[BC] Purchase Type No.") then
-                    Rec.Description := ItemCharge.Description;
+                    EntityName := ItemCharge.Description;
         end;
+
+        OnAfterGetMatchedEntityName(Rec, EntityName);
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterGetMatchedEntityName(EDocumentPurchaseLine: Record "E-Document Purchase Line"; var EntityName: Text[100])
+    begin
     end;
 
     local procedure POMatchingValidation()


### PR DESCRIPTION
## What & why

This change adds a read-only Name column to the E-Document purchase draft lines subform (page 6183 E-Doc. Purchase Draft Subform). The column shows the name of the matched entity such as Item, G/L Account, or Resource, so reviewers can confirm a line was matched to the right record. It stays hidden by default and users personalize it into view. The value reflects the matched record rather than the extracted invoice description and cannot be edited.

## Linked work

Fixes [AB#641589](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641589)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

What I tested and the outcome

- Built E-Document Core locally with no errors and no new analyzer warnings.
- Published to a local sandbox and opened the Purchase Document Draft page.
- Personalized the Name column into the Lines part and confirmed it shows the matched entity name, stays read-only, and updates when Type or No. change.
- Confirmed the column is blank for lines with no match and that it reflects the matched record rather than the edited Description.
- No automated tests added yet. The change is a small refactor of the existing SetDescriptionFromLineTypeNo behavior. I can add a codeunit test asserting GetMatchedEntityName returns the right value per line type if reviewers prefer.

## Risk & compatibility

- Low risk. No table schema change and no new stored fields.
- The Name value binds to a page variable computed in OnAfterGetRecord, so there is no data upgrade impact.
- Existing description defaulting behaves the same because it now calls the shared GetMatchedEntityName helper.
- The new OnAfterGetMatchedEntityName integration event is additive for connector apps.





