### PR TITLE
Removing the allowed environment types from published apps

### DIFF
--- a/build/projects.json
+++ b/build/projects.json
@@ -24,10 +24,7 @@
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
-      "repositoryUrl": "https://github.com/microsoft/BCApps",
-      "allowedEnvironmentTypes": [
-        "Sandbox"
-      ]
+      "repositoryUrl": "https://github.com/microsoft/BCApps"
     },
     "Library Assert": {
       "isMultiCountry": true,
@@ -36,10 +33,7 @@
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
-      "repositoryUrl": "https://github.com/microsoft/BCApps",
-      "allowedEnvironmentTypes": [
-        "Sandbox"
-      ]
+      "repositoryUrl": "https://github.com/microsoft/BCApps"
     },
     "Library Variable Storage": {
       "isMultiCountry": true,
@@ -48,10 +42,7 @@
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
-      "repositoryUrl": "https://github.com/microsoft/BCApps",
-      "allowedEnvironmentTypes": [
-        "Sandbox"
-      ]
+      "repositoryUrl": "https://github.com/microsoft/BCApps"
     },
     "Prevent Metadata Updates": {
       "isMultiCountry": true,
@@ -79,10 +70,7 @@
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
-      "repositoryUrl": "https://github.com/microsoft/BCApps",
-      "allowedEnvironmentTypes": [
-        "Sandbox"
-      ]
+      "repositoryUrl": "https://github.com/microsoft/BCApps"
     },
     "Performance Toolkit": {
       "isMultiCountry": true,


### PR DESCRIPTION
Porting https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_git/NAV/pullrequest/250067 to BCApps.

Removes the `allowedEnvironmentTypes: ["Sandbox"]` restriction from the published test-framework apps (Any, Library Assert, Library Variable Storage, Test Runner) in `build/projects.json`, allowing them to be deployed to all environment types.

Fixes [AB#640801](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640801)

