### PR TITLE
[Shopify] Disambiguate Shopify timestamp field captions and tooltips

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Companies/Tables/ShpfyCompany.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Companies/Tables/ShpfyCompany.Table.al
@@ -37,13 +37,13 @@ table 30150 "Shpfy Company"
         }
         field(4; "Created At"; DateTime)
         {
-            Caption = 'Created At';
+            Caption = 'Created At (Shopify)';
             DataClassification = CustomerContent;
         }
 
         field(5; "Updated At"; DateTime)
         {
-            Caption = 'Updated At';
+            Caption = 'Updated At (Shopify)';
             DataClassification = CustomerContent;
         }
         field(6; "Last Updated by BC"; DateTime)

--- a/src/Apps/W1/Shopify/App/src/Customers/Tables/ShpfyCustomer.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Customers/Tables/ShpfyCustomer.Table.al
@@ -94,13 +94,13 @@ table 30105 "Shpfy Customer"
 
         field(13; "Created At"; DateTime)
         {
-            Caption = 'Created At';
+            Caption = 'Created At (Shopify)';
             DataClassification = CustomerContent;
         }
 
         field(14; "Updated At"; DateTime)
         {
-            Caption = 'Updated At';
+            Caption = 'Updated At (Shopify)';
             DataClassification = CustomerContent;
         }
         field(15; "Last Updated by BC"; DateTime)

--- a/src/Apps/W1/Shopify/App/src/Gift Cards/Pages/ShpfyGiftCardTransactions.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Gift Cards/Pages/ShpfyGiftCardTransactions.Page.al
@@ -74,7 +74,7 @@ page 30111 "Shpfy Gift Card Transactions"
                 field("Created At"; Rec."Created At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the date and time at which the transaction is processed.';
+                    ToolTip = 'Specifies the date and time when the transaction was created in Shopify.';
                 }
                 field(Authorization; Rec.Authorization)
                 {

--- a/src/Apps/W1/Shopify/App/src/Order Fulfillments/Pages/ShpfyOrderFulfillment.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order Fulfillments/Pages/ShpfyOrderFulfillment.Page.al
@@ -45,12 +45,12 @@ page 30153 "Shpfy Order Fulfillment"
                 field(CreatedAt; Rec."Created At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the date and time when the fulfillment was created.';
+                    ToolTip = 'Specifies the date and time when the fulfillment was created in Shopify.';
                 }
                 field(UpdatedAt; Rec."Updated At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the date and time when the fulfillment was last modified.';
+                    ToolTip = 'Specifies the date and time when the fulfillment was last modified in Shopify.';
                 }
                 field(TrackingNumber; Rec."Tracking Number")
                 {

--- a/src/Apps/W1/Shopify/App/src/Order Fulfillments/Pages/ShpfyOrderFulfillments.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order Fulfillments/Pages/ShpfyOrderFulfillments.Page.al
@@ -49,12 +49,12 @@ page 30112 "Shpfy Order Fulfillments"
                 field(CreatedAt; Rec."Created At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the date and time when the fulfillment was created.';
+                    ToolTip = 'Specifies the date and time when the fulfillment was created in Shopify.';
                 }
                 field(UpdatedAt; Rec."Updated At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the date and time when the fulfillment was last modified.';
+                    ToolTip = 'Specifies the date and time when the fulfillment was last modified in Shopify.';
                 }
                 field(TrackingNumber; Rec."Tracking Number")
                 {

--- a/src/Apps/W1/Shopify/App/src/Order Fulfillments/Tables/ShpfyFulFillmentOrderHeader.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order Fulfillments/Tables/ShpfyFulFillmentOrderHeader.Table.al
@@ -44,7 +44,7 @@ table 30143 "Shpfy FulFillment Order Header"
         }
         field(7; "Updated At"; DateTime)
         {
-            Caption = 'Updated At';
+            Caption = 'Updated At (Shopify)';
             DataClassification = SystemMetadata;
         }
         field(8; "Shopify Order No."; Text[50])

--- a/src/Apps/W1/Shopify/App/src/Order Fulfillments/Tables/ShpfyOrderFulfillment.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order Fulfillments/Tables/ShpfyOrderFulfillment.Table.al
@@ -28,12 +28,12 @@ table 30111 "Shpfy Order Fulfillment"
         }
         field(3; "Created At"; DateTime)
         {
-            Caption = 'Created At';
+            Caption = 'Created At (Shopify)';
             DataClassification = SystemMetadata;
         }
         field(4; "Updated At"; DateTime)
         {
-            Caption = 'Updated At';
+            Caption = 'Updated At (Shopify)';
             DataClassification = SystemMetadata;
         }
         field(5; "Tracking Number"; Text[30])

--- a/src/Apps/W1/Shopify/App/src/Order Refunds/Pages/ShpfyRefund.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/Pages/ShpfyRefund.Page.al
@@ -38,7 +38,7 @@ page 30145 "Shpfy Refund"
                 field("Updated At"; Rec."Updated At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the date and time when the refund was update in Shopify.';
+                    ToolTip = 'Specifies the date and time when the refund was updated in Shopify.';
                     Visible = false;
                 }
                 field("Sell-to Customer No."; Rec."Sell-to Customer No.")

--- a/src/Apps/W1/Shopify/App/src/Order Refunds/Pages/ShpfyRefunds.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/Pages/ShpfyRefunds.Page.al
@@ -41,7 +41,7 @@ page 30147 "Shpfy Refunds"
                 field("Updated At"; Rec."Updated At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the date and time when the refund was update in Shopify';
+                    ToolTip = 'Specifies the date and time when the refund was updated in Shopify.';
                     Visible = false;
                 }
                 field("Sell-to Customer No."; Rec."Sell-to Customer No.")

--- a/src/Apps/W1/Shopify/App/src/Order Refunds/Tables/ShpfyRefundHeader.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/Tables/ShpfyRefundHeader.Table.al
@@ -30,13 +30,13 @@ table 30142 "Shpfy Refund Header"
         }
         field(3; "Created At"; DateTime)
         {
-            Caption = 'Created At';
+            Caption = 'Created At (Shopify)';
             DataClassification = SystemMetadata;
             Editable = false;
         }
         field(4; "Updated At"; DateTime)
         {
-            Caption = 'Updated At';
+            Caption = 'Updated At (Shopify)';
             DataClassification = SystemMetadata;
             Editable = false;
         }

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrder.Page.al
@@ -185,7 +185,7 @@ page 30113 "Shpfy Order"
                     ApplicationArea = All;
                     Editable = false;
                     Importance = Additional;
-                    ToolTip = 'Specifies the date and time when the order was last modified.';
+                    ToolTip = 'Specifies the date and time when the order was last modified in Shopify.';
                 }
                 field(CancelledAt; Rec."Cancelled At")
                 {

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrders.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrders.Page.al
@@ -113,7 +113,7 @@ page 30115 "Shpfy Orders"
                 field(CreatedAt; Rec."Created At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the date and time when the order was created.';
+                    ToolTip = 'Specifies the date and time when the order was created in Shopify.';
                 }
                 field(Confirmed; Rec.Confirmed)
                 {

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrdersToImport.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrdersToImport.Page.al
@@ -118,7 +118,7 @@ page 30121 "Shpfy Orders to Import"
                 field(UpdatedAt; Rec."Updated At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the date and time when the order was last modified.';
+                    ToolTip = 'Specifies the date and time when the order was last modified in Shopify.';
                 }
                 field(Test; Rec.Test)
                 {

--- a/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderHeader.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderHeader.Table.al
@@ -394,7 +394,7 @@ table 30118 "Shpfy Order Header"
         }
         field(82; "Closed At"; DateTime)
         {
-            Caption = 'Closed At';
+            Caption = 'Closed At (Shopify)';
             DataClassification = SystemMetadata;
             Editable = false;
         }
@@ -410,7 +410,7 @@ table 30118 "Shpfy Order Header"
         }
         field(87; "Processed At"; DateTime)
         {
-            Caption = 'Processed At';
+            Caption = 'Processed At (Shopify)';
             DataClassification = SystemMetadata;
         }
         field(89; "Shopify Order No."; Text[50])
@@ -426,7 +426,7 @@ table 30118 "Shpfy Order Header"
         }
         field(91; "Created At"; DateTime)
         {
-            Caption = 'Created At';
+            Caption = 'Created At (Shopify)';
             DataClassification = SystemMetadata;
         }
         field(92; "Source Name"; Code[20])
@@ -437,7 +437,7 @@ table 30118 "Shpfy Order Header"
         }
         field(93; "Updated At"; DateTime)
         {
-            Caption = 'Updated At';
+            Caption = 'Updated At (Shopify)';
             DataClassification = SystemMetadata;
         }
         field(94; "Shipping Charges Amount"; Decimal)

--- a/src/Apps/W1/Shopify/App/src/Payments/Pages/ShpfyPaymentTransactions.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Payments/Pages/ShpfyPaymentTransactions.Page.al
@@ -26,7 +26,7 @@ page 30124 "Shpfy Payment Transactions"
                 field(ProcessedAt; Rec."Processed At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the date and time at which the transaction is processed.';
+                    ToolTip = 'Specifies the date and time when the transaction was processed in Shopify.';
                 }
                 field(Type; Rec.Type)
                 {

--- a/src/Apps/W1/Shopify/App/src/Payments/Tables/ShpfyPaymentTransaction.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Payments/Tables/ShpfyPaymentTransaction.Table.al
@@ -88,7 +88,7 @@ table 30124 "Shpfy Payment Transaction"
         }
         field(13; "Processed At"; DateTime)
         {
-            Caption = 'Processed At';
+            Caption = 'Processed At (Shopify)';
             DataClassification = CustomerContent;
         }
         field(101; "Shop Code"; Code[20])

--- a/src/Apps/W1/Shopify/App/src/Products/Pages/ShpfyProducts.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Pages/ShpfyProducts.Page.al
@@ -139,12 +139,12 @@ page 30126 "Shpfy Products"
                 field(CreatedAt; Rec."Created At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies when the product was created.';
+                    ToolTip = 'Specifies when the product was created in Shopify.';
                 }
                 field(UpdatedAt; Rec."Updated At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies when the product was updated.';
+                    ToolTip = 'Specifies when the product was updated in Shopify.';
                 }
                 field(ProductType; Rec."Product Type")
                 {

--- a/src/Apps/W1/Shopify/App/src/Products/Pages/ShpfyVariants.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Pages/ShpfyVariants.Page.al
@@ -127,12 +127,12 @@ page 30127 "Shpfy Variants"
                 field(CreatedAt; Rec."Created At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the date and time when the product variant was created.';
+                    ToolTip = 'Specifies the date and time when the product variant was created in Shopify.';
                 }
                 field(UpdatedAt; Rec."Updated At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the date and time when the product variant was last modified.';
+                    ToolTip = 'Specifies the date and time when the product variant was last modified in Shopify.';
                 }
                 field(InventoryPolicy; Rec."Inventory Policy")
                 {

--- a/src/Apps/W1/Shopify/App/src/Products/Tables/ShpfyInventoryItem.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Tables/ShpfyInventoryItem.Table.al
@@ -75,7 +75,7 @@ table 30126 "Shpfy Inventory Item"
         }
         field(12; "Updated At"; DateTime)
         {
-            Caption = 'Updated At';
+            Caption = 'Updated At (Shopify)';
             DataClassification = CustomerContent;
         }
     }

--- a/src/Apps/W1/Shopify/App/src/Products/Tables/ShpfyProduct.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Tables/ShpfyProduct.Table.al
@@ -26,13 +26,13 @@ table 30127 "Shpfy Product"
         }
         field(2; "Created At"; DateTime)
         {
-            Caption = 'Created At';
+            Caption = 'Created At (Shopify)';
             DataClassification = CustomerContent;
             Editable = false;
         }
         field(3; "Updated At"; DateTime)
         {
-            Caption = 'Updated At';
+            Caption = 'Updated At (Shopify)';
             DataClassification = CustomerContent;
             Editable = false;
         }

--- a/src/Apps/W1/Shopify/App/src/Products/Tables/ShpfyVariant.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Tables/ShpfyVariant.Table.al
@@ -29,12 +29,12 @@ table 30129 "Shpfy Variant"
         }
         field(3; "Created At"; DateTime)
         {
-            Caption = 'CreatedAt';
+            Caption = 'Created At (Shopify)';
             DataClassification = CustomerContent;
         }
         field(4; "Updated At"; DateTime)
         {
-            Caption = 'Updated At';
+            Caption = 'Updated At (Shopify)';
             DataClassification = CustomerContent;
         }
         field(5; "Available For Sales"; Boolean)

--- a/src/Apps/W1/Shopify/App/src/Transactions/Pages/ShpfyOrderTransactions.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Transactions/Pages/ShpfyOrderTransactions.Page.al
@@ -83,7 +83,7 @@ page 30131 "Shpfy Order Transactions"
                 field(CreatedAt; Rec."Created At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the date and time at which the transaction is processed.';
+                    ToolTip = 'Specifies the date and time when the transaction was created in Shopify.';
                 }
                 field(Authorization; Rec.Authorization)
                 {

--- a/src/Apps/W1/Shopify/App/src/Transactions/Pages/ShpfyTransactions.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Transactions/Pages/ShpfyTransactions.Page.al
@@ -35,7 +35,7 @@ page 30134 "Shpfy Transactions"
                 field(CreatedAt; Rec."Created At")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the date and time at which the transaction is processed.';
+                    ToolTip = 'Specifies the date and time when the transaction was created in Shopify.';
                 }
                 field(Type; Rec.Type)
                 {

--- a/src/Apps/W1/Shopify/App/src/Transactions/Tables/ShpfyOrderTransaction.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Transactions/Tables/ShpfyOrderTransaction.Table.al
@@ -66,7 +66,7 @@ table 30133 "Shpfy Order Transaction"
         }
         field(8; "Created At"; DateTime)
         {
-            Caption = 'Created At';
+            Caption = 'Created At (Shopify)';
             DataClassification = SystemMetadata;
             Editable = false;
         }


### PR DESCRIPTION
## What & why

Shopify-sourced timestamp fields (`createdAt`, `updatedAt`, etc.) were stored with generic captions like **"Created At"** / **"Updated At"**, which are easily confused with the BC platform's `SystemCreatedAt` / `SystemModifiedAt` auditing fields (visible in search, personalization, and extension development).

This PR extends the disambiguation pattern already used in **Shpfy Orders To Import** to the rest of the connector:

- Adds a **`(Shopify)`** suffix to **20 timestamp field captions across 11 tables** (Company, Customer, Product, Variant, Inventory Item, Order Header, Order Fulfillment, Fulfillment Order Header, Refund Header, Payment Transaction, Order Transaction).
- Fixes the **`CreatedAt`** (missing space) caption bug on **Shpfy Variant**.
- Standardizes the related **page tooltips** to mention **"in Shopify"** for a clear data source, fixes the **"was update"** typo on the refund tooltips, and corrects the misleading **"…is processed"** wording on the Order Transaction **"Created At"** tooltip.

Text/caption-only change — no schema, logic, or API changes.

## Linked work

Fixes [AB#641693](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641693)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Compiled the **Shopify Connector** app locally (AL compiler) — **0 errors, no new warnings**.
- Verified via search that all 20 target captions now carry the `(Shopify)` suffix and that no timestamp tooltip in scope is left without "in Shopify".
- No tests added: this is a caption/tooltip text-only change with no behavioral impact; there is no test coverage for on-screen caption/tooltip strings.

## Risk & compatibility

- **Display-only.** Field IDs, field names, data, and API/OData behavior are unchanged, so there is no upgrade or breaking-change impact.
- Non-English translations for the affected captions/tooltips will show as outdated until the translation pipeline regenerates them — expected and handled by the normal localization flow.



