### PR TITLE
Hide Provide feedback action on E-Document Purchase Draft when user-i…

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseDraft.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseDraft.Page.al
@@ -10,6 +10,7 @@ using Microsoft.Foundation.Attachment;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Setup;
 using Microsoft.Purchases.Vendor;
+using System.Environment.Configuration;
 using System.Feedback;
 using System.Telemetry;
 using System.Text;
@@ -418,6 +419,7 @@ page 6181 "E-Document Purchase Draft"
                     Caption = 'Provide feedback';
                     ToolTip = 'Provide feedback on the Payables Agent experience.';
                     Image = Comment;
+                    Visible = FeedbackActionVisible;
 
                     trigger OnAction()
                     begin
@@ -530,6 +532,7 @@ page 6181 "E-Document Purchase Draft"
         PageEditable := IsEditable();
         IsCreditMemo := Rec."Document Type" = Enum::"E-Document Type"::"Purchase Credit Memo";
         GlobalEDocumentNotification.RefreshAndShowPendingDraftNotifications(Rec."Entry No");
+        FeedbackActionVisible := IsUserInitiatedFeedbackEnabled();
         if PurchasesPayablesSetup.Get() then
             ApplyVATDiffEnabled := PurchasesPayablesSetup."Apply VAT Diff. For Purch EDoc";
 
@@ -733,6 +736,13 @@ page 6181 "E-Document Purchase Draft"
         EDocumentErrorHelper.ThrowIfHasErrors(Rec);
     end;
 
+    local procedure IsUserInitiatedFeedbackEnabled(): Boolean
+    var
+        TenantFeedbackSettings: Codeunit "Tenant Feedback Settings";
+    begin
+        exit(TenantFeedbackSettings.GetUserInitiatedFeedbackEnabled());
+    end;
+
     local procedure ProvideFeedback()
     var
         EDocumentDataStorage: Record "E-Doc. Data Storage";
@@ -743,6 +753,9 @@ page 6181 "E-Document Purchase Draft"
         InStream: InStream;
         ContextFiles, ContextProperties : Dictionary of [Text, Text];
     begin
+        if not IsUserInitiatedFeedbackEnabled() then
+            exit;
+
         if EDocDraftFeedback.RunModal() = Action::Yes then begin
             if EDocumentDataStorage.Get(Rec."Unstructured Data Entry No.") then begin
                 EDocumentDataStorage.GetTempBlob().CreateInStream(InStream);
@@ -794,5 +807,6 @@ page 6181 "E-Document Purchase Draft"
         ResetDraftQst: Label 'All the changes that you may have made on the document draft will be lost. Do you want to continue?';
         PageEditable, HasPDFSource, IsCreditMemo : Boolean;
         ApplyVATDiffEnabled: Boolean;
+        FeedbackActionVisible: Boolean;
         AppliedVATAmountDiff: Decimal;
 }


### PR DESCRIPTION
## What & why

Hides the **Provide feedback** action on E-Document Purchase Draft (page 6181) when a tenant
admin has disabled user feedback in PPAC. Previously the button showed and opened a dialog
that did nothing after confirm. Now `OnOpenPage` reads
`Tenant Feedback Settings.GetUserInitiatedFeedbackEnabled()` and gates the action's
`Visible`, with a defensive guard in `ProvideFeedback()`.

## Linked work

Fixes [AB#636003](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636003)

## How I validated this

- [x] Read the full diff - only the intended 14-line change.
- [x] Built E-Document Core locally, no new warnings.
- [x] Ran in BC: feedback on - action visible, feedback off - hidden.
- [ ] No test added - visibility depends on PPAC, not mockable here.

## Risk & compatibility

Low, UI-only. No schema/permission/upgrade impact.


