### PR TITLE
[Quality Management] [28.x] Enforce rules and restrictions with indirect and implicit permissions

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspecGenRuleMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspecGenRuleMgmt.Codeunit.al
@@ -15,6 +15,10 @@ using Microsoft.QualityManagement.Utilities;
 /// </summary>
 codeunit 20405 "Qlty. Inspec. Gen. Rule Mgmt."
 {
+    Permissions =
+        tabledata "Qlty. Inspection Gen. Rule" = r,
+        tabledata "Qlty. Inspect. Source Config." = r;
+
     var
         QltyConfigurationHelpers: Codeunit "Qlty. Configuration Helpers";
         QltyTraversal: Codeunit "Qlty. Traversal";

--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRule.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRule.Table.al
@@ -35,6 +35,8 @@ table 20404 "Qlty. Inspection Gen. Rule"
     DrillDownPageId = "Qlty. Inspection Gen. Rules";
     LookupPageId = "Qlty. Inspection Gen. Rules";
     DataClassification = CustomerContent;
+    Permissions = tabledata "Qlty. Management Setup" = r,
+                  tabledata "Qlty. Inspection Template Hdr." = r;
 
     fields
     {

--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRules.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRules.Page.al
@@ -19,6 +19,7 @@ page 20405 "Qlty. Inspection Gen. Rules"
     SourceTable = "Qlty. Inspection Gen. Rule";
     PopulateAllFields = true;
     SourceTableView = sorting("Sort Order", Intent);
+    AccessByPermission = tabledata "Qlty. Inspection Gen. Rule" = R;
     UsageCategory = Lists;
     ApplicationArea = QualityManagement;
     AboutTitle = 'About Quality Inspection Generation Rules';

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyIResultConditConf.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyIResultConditConf.Table.al
@@ -15,6 +15,7 @@ table 20412 "Qlty. I. Result Condit. Conf."
 {
     Caption = 'Quality Inspection Result Condition Configuration';
     DataClassification = CustomerContent;
+    Permissions = tabledata "Qlty. Inspection Result" = r;
 
     fields
     {

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResult.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResult.Table.al
@@ -21,6 +21,9 @@ table 20411 "Qlty. Inspection Result"
     LookupPageId = "Qlty. Inspection Result List";
     DrillDownPageId = "Qlty. Inspection Result List";
     DataClassification = CustomerContent;
+    Permissions = tabledata "Qlty. Inspection Header" = r,
+                  tabledata "Qlty. Inspection Line" = r,
+                  tabledata "Qlty. I. Result Condit. Conf." = rmd;
 
     fields
     {

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResultList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyInspectionResultList.Page.al
@@ -15,6 +15,7 @@ page 20416 "Qlty. Inspection Result List"
     SourceTable = "Qlty. Inspection Result";
     SourceTableView = sorting("Evaluation Sequence");
     CardPageId = "Qlty. Inspection Result Card";
+    AccessByPermission = tabledata "Qlty. Inspection Result" = R;
     PageType = List;
     ApplicationArea = QualityManagement;
     UsageCategory = Lists;

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultConditionMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultConditionMgmt.Codeunit.al
@@ -15,6 +15,13 @@ using System.Utilities;
 /// </summary>
 codeunit 20409 "Qlty. Result Condition Mgmt."
 {
+    Permissions =
+        tabledata "Qlty. Inspection Template Line" = r,
+        tabledata "Qlty. Inspection Result" = r,
+        tabledata "Qlty. Test" = r,
+        tabledata "Qlty. I. Result Condit. Conf." = rim,
+        tabledata "Qlty. Inspection Header" = r;
+
     var
         ConfirmManagement: Codeunit "Confirm Management";
         ChangedTestConditionsUpdateTemplatesQst: Label 'You have changed default conditions on the test %2, there are %1 template lines with earlier conditions for this result. Do you want to update the templates?', Comment = '%1=the amount of template lines that have other conditions, %2=the test name';

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultEvaluation.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultEvaluation.Codeunit.al
@@ -16,6 +16,11 @@ using System.Utilities;
 codeunit 20410 "Qlty. Result Evaluation"
 {
     TableNo = "Qlty. Inspection Line";
+    Permissions = tabledata "Qlty. Test" = r,
+                  tabledata "Qlty. Inspection Result" = r,
+                  tabledata "Qlty. Inspection Header" = rm,
+                  tabledata "Qlty. Inspection Line" = rim,
+                  tabledata "Qlty. I. Result Condit. Conf." = r;
 
     var
         IsDefaultNumberTok: Label '<>0', Locked = true;

--- a/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyTraversal.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyTraversal.Codeunit.al
@@ -4,14 +4,24 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.QualityManagement.Configuration.SourceConfiguration;
 
+using Microsoft.Assembly.History;
 using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Journal;
+using Microsoft.Inventory.Ledger;
+using Microsoft.Inventory.Tracking;
+using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Routing;
+using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 using Microsoft.QualityManagement.Document;
 using Microsoft.QualityManagement.Utilities;
 using Microsoft.Sales.Customer;
+using Microsoft.Sales.Document;
+using Microsoft.Warehouse.Document;
+using Microsoft.Warehouse.Journal;
+using Microsoft.Warehouse.Ledger;
 using System.Reflection;
 
 /// <summary>
@@ -19,6 +29,22 @@ using System.Reflection;
 /// </summary>
 codeunit 20408 "Qlty. Traversal"
 {
+    Permissions =
+        tabledata "Qlty. Inspect. Src. Fld. Conf." = r,
+        tabledata "Qlty. Inspect. Source Config." = r,
+        tabledata "Tracking Specification" = r,
+        tabledata "Warehouse Entry" = r,
+        tabledata "Warehouse Journal Line" = r,
+        tabledata "Warehouse Receipt Line" = r,
+        tabledata "Sales Line" = r,
+        tabledata "Purchase Line" = r,
+        tabledata "Prod. Order Line" = r,
+        tabledata "Prod. Order Routing Line" = r,
+        tabledata "Item Journal Line" = r,
+        tabledata "Item Ledger Entry" = r,
+        tabledata "Transfer Line" = r,
+        tabledata "Posted Assembly Header" = r;
+
     var
         QltyConfigurationHelpers: Codeunit "Qlty. Configuration Helpers";
         QltyMiscHelpers: Codeunit "Qlty. Misc Helpers";

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateHdr.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateHdr.Table.al
@@ -18,7 +18,9 @@ table 20402 "Qlty. Inspection Template Hdr."
     DrillDownPageId = "Qlty. Inspection Template List";
     LookupPageId = "Qlty. Inspection Template List";
     DataClassification = CustomerContent;
-    Permissions = tabledata "Qlty. Inspection Template Line" = d;
+    Permissions = tabledata "Qlty. Inspection Template Line" = d,
+                  tabledata "Qlty. Inspection Gen. Rule" = d,
+                  tabledata "Qlty. Inspection Line" = m;
 
     fields
     {

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/QltyInspectionTemplateList.Page.al
@@ -20,6 +20,7 @@ page 20404 "Qlty. Inspection Template List"
     Editable = false;
     PageType = List;
     SourceTable = "Qlty. Inspection Template Hdr.";
+    AccessByPermission = tabledata "Qlty. Inspection Template Hdr." = R;
     UsageCategory = Lists;
     ApplicationArea = QualityManagement;
     AdditionalSearchTerms = 'Standard operating procedures';

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestLookupValues.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestLookupValues.Page.al
@@ -14,6 +14,7 @@ page 20409 "Qlty. Test Lookup Values"
     PageType = List;
     SourceTable = "Qlty. Test Lookup Value";
     SourceTableView = sorting("Lookup Group Code", "Value");
+    AccessByPermission = tabledata "Qlty. Test Lookup Value" = R;
     UsageCategory = Administration;
     ApplicationArea = QualityManagement;
 

--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTests.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTests.Page.al
@@ -26,6 +26,7 @@ page 20401 "Qlty. Tests"
     PageType = List;
     SourceTable = "Qlty. Test";
     SourceTableView = sorting(Code);
+    AccessByPermission = tabledata "Qlty. Test" = R;
     UsageCategory = Administration;
     ApplicationArea = QualityManagement;
 

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionCreate.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionCreate.Codeunit.al
@@ -23,9 +23,12 @@ codeunit 20404 "Qlty. Inspection - Create"
     EventSubscriberInstance = Manual;
     InherentPermissions = X;
     Permissions =
-        tabledata "Qlty. Inspection Header" = Rim,
-        tabledata "Qlty. Inspection Line" = Rim,
-        tabledata "Qlty. I. Result Condit. Conf." = RIM;
+        tabledata "Qlty. Management Setup" = r,
+        tabledata "Qlty. Inspection Gen. Rule" = r,
+        tabledata "Qlty. Inspection Header" = rim,
+        tabledata "Qlty. Inspection Line" = rim,
+        tabledata "Qlty. I. Result Condit. Conf." = rim,
+        tabledata "Qlty. Inspection Template Line" = r;
 
     var
         QltyManagementSetup: Record "Qlty. Management Setup";
@@ -259,12 +262,6 @@ codeunit 20404 "Qlty. Inspection - Create"
         exit(InternalCreateInspectionWithSpecificTemplate(TargetRecordRef, IsManualCreation, OptionalSpecificTemplate, OptionalRec2Variant, OptionalRec3Variant, DummyRec4Variant, TempDummyQltyInspectionGenRule));
     end;
 
-    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Gen. Rule", 'R', InherentPermissionsScope::Both)]
-    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Header", 'RIM', InherentPermissionsScope::Both)]
-    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Line", 'RIM', InherentPermissionsScope::Both)]
-    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. I. Result Condit. Conf.", 'RIM', InherentPermissionsScope::Both)]
-    [InherentPermissions(PermissionObjectType::Codeunit, Codeunit::"Qlty. Permission Mgmt.", 'X', InherentPermissionsScope::Both)]
-    [InherentPermissions(PermissionObjectType::Codeunit, Codeunit::"Qlty. Start Workflow", 'X', InherentPermissionsScope::Both)]
     local procedure InternalCreateInspectionWithSpecificTemplate(TargetRecordRef: RecordRef; IsManualCreation: Boolean; OptionalSpecificTemplate: Code[20]; OptionalRec2Variant: Variant; OptionalRec3Variant: Variant; OptionalRec4Variant: Variant; var TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary) QltyInspectionCreateStatus: Enum "Qlty. Inspection Create Status"
     var
         TempQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary;
@@ -367,9 +364,10 @@ codeunit 20404 "Qlty. Inspection - Create"
                not PreventShowingGeneratedInspectionEvenIfConfigured and
                (QltyInspectionHeader."No." <> '')
             then
-                if IsManualCreation then
-                    Page.Run(Page::"Qlty. Inspection", QltyInspectionHeader)
-                else
+                if IsManualCreation then begin
+                    if not TryRunInspectionPage(Page::"Qlty. Inspection", QltyInspectionHeader) then
+                        QltyNotificationMgmt.NotifyInspectionCreated(QltyInspectionHeader);
+                end else
                     if IsNewlyCreatedInspection then
                         QltyNotificationMgmt.NotifyInspectionCreated(QltyInspectionHeader);
         end else begin
@@ -380,6 +378,21 @@ codeunit 20404 "Qlty. Inspection - Create"
         end;
 
         OnAfterCreateInspectionAfterDialog(TargetRecordRef, RecordRefToBufferTriggeringRecord, IsManualCreation, OptionalSpecificTemplate, TempQltyInspectionGenRule, QltyInspectionHeader, OptionalRec2Variant, OptionalRec3Variant);
+    end;
+
+    /// <summary>
+    /// Attempts to run the specified inspection page for the given inspection header.
+    /// Wrapped as a TryFunction because <c>Page.Run</c> will throw a permission error
+    /// when the current user is not permitted to read the underlying inspection records.
+    /// Callers should treat a false return as "page could not be shown" and fall back to a
+    /// non-interactive path such as a notification.
+    /// </summary>
+    /// <param name="PageId">The ID of the page to run (e.g. Page::"Qlty. Inspection" or Page::"Qlty. Inspection List").</param>
+    /// <param name="QltyInspectionHeader">The inspection header (or filtered set) to display on the page.</param>
+    [TryFunction]
+    local procedure TryRunInspectionPage(PageId: Integer; var QltyInspectionHeader: Record "Qlty. Inspection Header")
+    begin
+        Page.Run(PageId, QltyInspectionHeader);
     end;
 
     /// <summary>
@@ -910,15 +923,17 @@ codeunit 20404 "Qlty. Inspection - Create"
             if ToDisplayQltyInspectionIds.Count() = 1 then begin
                 CreatedQltyInspectionHeader.SetCurrentKey("No.", "Re-inspection No.");
                 CreatedQltyInspectionHeader.FindLast();
-                if IsManualCreation then
-                    Page.Run(Page::"Qlty. Inspection", CreatedQltyInspectionHeader)
-                else
+                if IsManualCreation then begin
+                    if not TryRunInspectionPage(Page::"Qlty. Inspection", CreatedQltyInspectionHeader) then
+                        QltyNotificationMgmt.NotifyInspectionCreated(CreatedQltyInspectionHeader);
+                end else
                     QltyNotificationMgmt.NotifyInspectionCreated(CreatedQltyInspectionHeader);
             end else begin
                 CreatedQltyInspectionHeader.FindSet();
-                if IsManualCreation then
-                    Page.Run(Page::"Qlty. Inspection List", CreatedQltyInspectionHeader)
-                else
+                if IsManualCreation then begin
+                    if not TryRunInspectionPage(Page::"Qlty. Inspection List", CreatedQltyInspectionHeader) then
+                        QltyNotificationMgmt.NotifyMultipleInspectionsCreated(CreatedQltyInspectionHeader);
+                end else
                     QltyNotificationMgmt.NotifyMultipleInspectionsCreated(CreatedQltyInspectionHeader);
             end;
         end;

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
@@ -35,8 +35,13 @@ table 20405 "Qlty. Inspection Header"
     DrillDownPageId = "Qlty. Inspection List";
     LookupPageId = "Qlty. Inspection List";
     DataClassification = CustomerContent;
-    Permissions = tabledata "Qlty. Inspection Line" = d,
-                  tabledata "Qlty. I. Result Condit. Conf." = d;
+    Permissions = tabledata "Qlty. Management Setup" = r,
+                  tabledata "Qlty. Inspection Result" = r,
+                  tabledata "Qlty. Inspection Template Hdr." = r,
+                  tabledata "Qlty. Inspection Template Line" = r,
+                  tabledata "Qlty. Inspection Header" = rm,
+                  tabledata "Qlty. Inspection Line" = rmd,
+                  tabledata "Qlty. I. Result Condit. Conf." = rd;
 
     fields
     {
@@ -636,7 +641,7 @@ table 20405 "Qlty. Inspection Header"
         ReopenInspectionQst: Label 'Are you sure you want to Reopen the inspection %1 on %2?', Comment = '%1=the inspection details, %2=the source details.';
         MoreRecentReinspectionErr: Label 'This inspection cannot be Reopened because there is a more recent Re-inspection. Please work with the most recent Re-inspection instead.';
         CreateReinspectionQst: Label 'Are you sure you want to create a Re-inspection?';
-        FinishBeforeReinspectionErr: Label 'An inspection must be finished before a Re-inspection can be made. This is done automatically, but you do not have permission to finish an inspection. Ask your administrator to add the ability to finish an inspection in the Quality Inspection Permissions page.';
+        FinishBeforeReinspectionErr: Label 'An inspection must be finished before a Re-inspection can be made. This is done automatically, but you do not have permission to finish an inspection.';
         PictureNameTok: Label '%1_%2_%3', Locked = true;
         FileExtensionTok: Label 'jpeg', Locked = true;
         CameraNotAvailableErr: Label 'The camera is not available. Make sure to use this with a device that has a camera supported by Business Central.';

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionLine.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionLine.Table.al
@@ -22,7 +22,12 @@ table 20406 "Qlty. Inspection Line"
     LookupPageId = "Qlty. Inspection Lines";
     DrillDownPageId = "Qlty. Inspection Lines";
     DataClassification = CustomerContent;
-    Permissions = tabledata "Qlty. I. Result Condit. Conf." = d;
+    Permissions = tabledata "Qlty. I. Result Condit. Conf." = rd,
+                  tabledata "Qlty. Test" = r,
+                  tabledata "Qlty. Inspection Result" = r,
+                  tabledata "Qlty. Inspection Template Line" = r,
+                  tabledata "Qlty. Inspection Header" = r,
+                  tabledata "Qlty. Inspection Line" = rm;
 
     fields
     {

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionLines.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionLines.Page.al
@@ -16,6 +16,7 @@ page 20413 "Qlty. Inspection Lines"
     PageType = List;
     SourceTable = "Qlty. Inspection Line";
     SourceTableView = sorting("Inspection No.", "Re-inspection No.", "Line No.") order(descending);
+    AccessByPermission = tabledata "Qlty. Inspection Line" = R;
     UsageCategory = Lists;
     ApplicationArea = QualityManagement;
 

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionList.Page.al
@@ -31,6 +31,7 @@ page 20408 "Qlty. Inspection List"
     PageType = List;
     SourceTable = "Qlty. Inspection Header";
     SourceTableView = sorting("No.", "Re-inspection No.") order(descending);
+    AccessByPermission = tabledata "Qlty. Inspection Header" = R;
     UsageCategory = Lists;
     ApplicationArea = QualityManagement;
     RefreshOnActivate = true;

--- a/src/Apps/W1/Quality Management/app/src/Integration/Assembly/QltyAssemblyIntegration.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Assembly/QltyAssemblyIntegration.Codeunit.al
@@ -20,6 +20,10 @@ using Microsoft.Warehouse.Journal;
 /// </summary>
 codeunit 20412 "Qlty. Assembly Integration"
 {
+    Permissions =
+        tabledata "Qlty. Inspection Gen. Rule" = r,
+        tabledata "Qlty. Inspection Header" = rm;
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Assembly-Post", 'OnAfterPost', '', true, true)]
     local procedure HandleOnAfterPost(var AssemblyHeader: Record "Assembly Header"; var AssemblyLine: Record "Assembly Line"; PostedAssemblyHeader: Record "Posted Assembly Header"; var ItemJnlPostLine: Codeunit "Item Jnl.-Post Line"; var ResJnlPostLine: Codeunit "Res. Jnl.-Post Line"; var WhseJnlRegisterLine: Codeunit "Whse. Jnl.-Register Line")
     var
@@ -35,9 +39,7 @@ codeunit 20412 "Qlty. Assembly Integration"
         HasInspection: Boolean;
         IsHandled: Boolean;
     begin
-        QltyInspectionGenRule.SetRange("Assembly Trigger", QltyInspectionGenRule."Assembly Trigger"::OnAssemblyOutputPost);
-        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
-        if QltyInspectionGenRule.IsEmpty() then
+        if not HasAssemblyOutputPostGenRule(QltyInspectionGenRule) then
             exit;
 
         MgtItemTrackingDocManagement.FindShptRcptEntries(TempSpecTrackingSpecification, Database::"Posted Assembly Header", 0, PostedAssemblyHeader."No.", '', 0, 0, '');
@@ -74,6 +76,14 @@ codeunit 20412 "Qlty. Assembly Integration"
             OnAfterAttemptCreateInspectionFromPostedAssembly(AssemblyHeader, PostedAssemblyHeader, TempSpecTrackingSpecification, QltyInspectionHeader);
         end;
         QltyBatchNotifHelper.EndBatch();
+    end;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Gen. Rule", 'R', InherentPermissionsScope::Permissions)]
+    local procedure HasAssemblyOutputPostGenRule(var QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule"): Boolean
+    begin
+        QltyInspectionGenRule.SetRange("Assembly Trigger", QltyInspectionGenRule."Assembly Trigger"::OnAssemblyOutputPost);
+        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
+        exit(not QltyInspectionGenRule.IsEmpty());
     end;
 
     /// <summary>

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyItemTrackingMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/QltyItemTrackingMgmt.Codeunit.al
@@ -162,6 +162,7 @@ codeunit 20439 "Qlty. Item Tracking Mgmt."
     /// </summary>
     /// <param name="ItemJnlTemplate"></param>
     /// <param name="PageTemplate"></param>
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Codeunit, Codeunit::ItemJnlManagement, 'OnTemplateSelectionSetFilter', '', true, true)]
     local procedure HandleOnTemplateSelectionSetFilter(var ItemJnlTemplate: Record "Item Journal Template"; var PageTemplate: Option)
     var
@@ -220,6 +221,7 @@ codeunit 20439 "Qlty. Item Tracking Mgmt."
     /// <param name="WarehouseJournalLine"></param>
     /// <param name="WhseJnlTemplate"></param>
     /// <param name="OpenFromBatch"></param>
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Table, Database::"Warehouse Journal Line", 'OnTemplateSelectionOnAfterSetFilters', '', true, true)]
     local procedure HandleOnTemplateSelectionOnAfterSetFilters(var WarehouseJournalLine: Record "Warehouse Journal Line"; var WhseJnlTemplate: Record "Warehouse Journal Template"; OpenFromBatch: Boolean)
     var

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/Tracking/QltyTrackingIntegration.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/Tracking/QltyTrackingIntegration.Codeunit.al
@@ -26,6 +26,9 @@ codeunit 20415 "Qlty. Tracking Integration"
         WarehouseEntryTypeBlockedErr: Label 'This warehouse transaction was blocked because the quality inspection %1 has the result of %2 for item %4 with tracking %5 %6 %7, which is configured to disallow the transaction "%3". You can change whether this transaction is allowed by navigating to Quality Inspection Results.', Comment = '%1=quality inspection, %2=result, %3=entry type being blocked, %4=item, %5=Lot No., %6=Serial No., %7=Package No.';
         NavigatePageSearchFiltersTok: Label 'NAVIGATEFILTERS', Locked = true;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::Microsoft.QualityManagement.Setup."Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
+    [InherentPermissions(PermissionObjectType::TableData, Database::Microsoft.QualityManagement.Configuration.Result."Qlty. Inspection Result", 'R', InherentPermissionsScope::Permissions)]
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Header", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Item Jnl.-Post Line", 'OnAfterCheckItemTrackingInformation', '', true, true)]
     local procedure HandleOnAfterCheckItemTrackingInformation(var ItemJnlLine2: Record "Item Journal Line"; var TrackingSpecification: Record "Tracking Specification"; ItemTrackingSetup: Record "Item Tracking Setup"; Item: Record Item)
     var
@@ -37,12 +40,8 @@ codeunit 20415 "Qlty. Tracking Integration"
         IsHandled: Boolean;
         TrackingDetails: Text;
     begin
-        case true of
-            not QltyInspectionHeader.ReadPermission(),
-            not QltyInspectionResult.ReadPermission(),
-            not QltyManagementSetup.GetSetupRecord():
-                exit;
-        end;
+        if not QltyManagementSetup.GetSetupRecord() then
+            exit;
 
         QltyInspectionHeader.SetRange("Source Item No.", ItemJnlLine2."Item No.");
         QltyInspectionHeader.SetRange("Source Variant Code", ItemJnlLine2."Variant Code");
@@ -176,6 +175,9 @@ codeunit 20415 "Qlty. Tracking Integration"
         CommonCheckWarehouseActivityLineIsAllowed(WarehouseActivityLine);
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::Microsoft.QualityManagement.Setup."Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
+    [InherentPermissions(PermissionObjectType::TableData, Database::Microsoft.QualityManagement.Configuration.Result."Qlty. Inspection Result", 'R', InherentPermissionsScope::Permissions)]
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Header", 'R', InherentPermissionsScope::Permissions)]
     local procedure CommonCheckWarehouseActivityLineIsAllowed(WarehouseActivityLine: Record "Warehouse Activity Line")
     var
         QltyManagementSetup: Record "Qlty. Management Setup";
@@ -185,12 +187,8 @@ codeunit 20415 "Qlty. Tracking Integration"
         IsFinished: Boolean;
         IsHandled: Boolean;
     begin
-        case true of
-            not QltyInspectionHeader.ReadPermission(),
-            not QltyInspectionResult.ReadPermission(),
-            not QltyManagementSetup.GetSetupRecord():
-                exit;
-        end;
+        if not QltyManagementSetup.GetSetupRecord() then
+            exit;
 
         QltyInspectionHeader.SetRange("Source Item No.", WarehouseActivityLine."Item No.");
         QltyInspectionHeader.SetRange("Source Variant Code", WarehouseActivityLine."Variant Code");

--- a/src/Apps/W1/Quality Management/app/src/Integration/Manufacturing/QltyManufacturIntegration.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Manufacturing/QltyManufacturIntegration.Codeunit.al
@@ -20,6 +20,11 @@ using Microsoft.QualityManagement.Utilities;
 /// </summary>
 codeunit 20407 "Qlty. Manufactur. Integration"
 {
+    Permissions =
+        tabledata "Qlty. Management Setup" = r,
+        tabledata "Qlty. Inspection Gen. Rule" = r,
+        tabledata "Qlty. Inspection Header" = r;
+
     var
         QltyTraversal: Codeunit "Qlty. Traversal";
 
@@ -32,6 +37,7 @@ codeunit 20407 "Qlty. Manufactur. Integration"
     /// <param name="ItemLedgerEntry"></param>
     /// <param name="ProdOrderLine"></param>
     /// <param name="ItemJournalLine"></param>
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Mfg. Item Jnl.-Post Line", 'OnAfterPostOutput', '', true, true)]
     local procedure HandleOnAfterPostOutput(var ItemLedgerEntry: Record "Item Ledger Entry"; var ProdOrderLine: Record "Prod. Order Line"; var ItemJournalLine: Record "Item Journal Line")
     var
@@ -79,12 +85,13 @@ codeunit 20407 "Qlty. Manufactur. Integration"
             if ProdOrderRoutingLine."Next Operation No." <> '' then
                 Clear(VerifiedItemLedgerEntry);
 
-        QltyInspectionGenRule.SetRange("Production Order Trigger", QltyInspectionGenRule."Production Order Trigger"::OnProductionOutputPost);
-        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
-        if not QltyInspectionGenRule.IsEmpty() then
-            AttemptCreateInspectionPosting(ProdOrderRoutingLine, VerifiedItemLedgerEntry, ProdOrderLine, ItemJournalLine, QltyInspectionGenRule);
+        if not HasProductionOutputPostGenRule(QltyInspectionGenRule) then
+            exit;
+
+        AttemptCreateInspectionPosting(ProdOrderRoutingLine, VerifiedItemLedgerEntry, ProdOrderLine, ItemJournalLine, QltyInspectionGenRule);
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Prod. Order Status Management", 'OnAfterChangeStatusOnProdOrder', '', true, true)]
     local procedure HandleOnAfterChangeStatusOnProdOrder(var ProdOrder: Record "Production Order"; var ToProdOrder: Record "Production Order"; NewStatus: Enum "Production Order Status"; NewPostingDate: Date; NewUpdateUnitCost: Boolean; var SuppressCommit: Boolean; xProductionOrder: Record "Production Order")
     var
@@ -105,12 +112,13 @@ codeunit 20407 "Qlty. Manufactur. Integration"
         if ToProdOrder.Status <> ToProdOrder.Status::Released then
             exit;
 
-        QltyInspectionGenRule.SetRange("Production Order Trigger", QltyInspectionGenRule."Production Order Trigger"::OnProductionOrderRelease);
-        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
-        if not QltyInspectionGenRule.IsEmpty() then
-            AttemptCreateInspectionReleased(ToProdOrder, QltyInspectionGenRule);
+        if not HasProductionOrderReleaseGenRule(QltyInspectionGenRule) then
+            exit;
+
+        AttemptCreateInspectionReleased(ToProdOrder, QltyInspectionGenRule);
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Prod. Order Status Management", 'OnAfterToProdOrderLineModify', '', true, true)]
     local procedure HandleOnAfterToProdOrderLineModify(var ToProdOrderLine: Record "Prod. Order Line"; var FromProdOrderLine: Record "Prod. Order Line"; var NewStatus: Option Quote,Planned,"Firm Planned",Released,Finished)
     var
@@ -125,6 +133,7 @@ codeunit 20407 "Qlty. Manufactur. Integration"
         UpdateReferencesForProductionOrderLine(FromProdOrderLine, ToProdOrderLine);
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Prod. Order Status Management", 'OnAfterToProdOrderRtngLineInsert', '', true, true)]
     local procedure HandleOnAfterToProdOrderRtngLineInsert(var ToProdOrderRoutingLine: Record "Prod. Order Routing Line"; var FromProdOrderRoutingLine: Record "Prod. Order Routing Line")
     var
@@ -139,6 +148,7 @@ codeunit 20407 "Qlty. Manufactur. Integration"
         UpdateReferencesForProductionOrderRoutingLine(FromProdOrderRoutingLine, ToProdOrderRoutingLine);
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Report, Report::"Refresh Production Order", 'OnAfterRefreshProdOrder', '', true, true)]
     local procedure HandleOnAfterRefreshProdOrder(var ProductionOrder: Record "Production Order"; ErrorOccured: Boolean)
     var
@@ -154,10 +164,10 @@ codeunit 20407 "Qlty. Manufactur. Integration"
         if not QltyManagementSetup.GetSetupRecord() then
             exit;
 
-        QltyInspectionGenRule.SetRange("Production Order Trigger", QltyInspectionGenRule."Production Order Trigger"::OnReleasedProductionOrderRefresh);
-        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
-        if not QltyInspectionGenRule.IsEmpty() then
-            AttemptCreateInspectionReleased(ProductionOrder, QltyInspectionGenRule);
+        if not HasReleasedProductionOrderRefreshGenRule(QltyInspectionGenRule) then
+            exit;
+
+        AttemptCreateInspectionReleased(ProductionOrder, QltyInspectionGenRule);
     end;
 
     /// <summary>
@@ -165,7 +175,7 @@ codeunit 20407 "Qlty. Manufactur. Integration"
     /// </summary>
     /// <param name="OldProductionOrder"></param>
     /// <param name="NewProductionOrder"></param>
-    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Header", 'rm')]
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Header", 'RM')]
     local procedure UpdateReferencesForProductionOrder(OldProductionOrder: Record "Production Order"; NewProductionOrder: Record "Production Order")
     var
         QltyInspectionHeader: Record "Qlty. Inspection Header";
@@ -203,7 +213,7 @@ codeunit 20407 "Qlty. Manufactur. Integration"
     /// </summary>
     /// <param name="OldProdOrderLine"></param>
     /// <param name="NewProdOrderLine"></param>
-    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Header", 'rm')]
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Header", 'RM')]
     local procedure UpdateReferencesForProductionOrderLine(OldProdOrderLine: Record "Prod. Order Line"; NewProdOrderLine: Record "Prod. Order Line")
     var
         QltyInspectionHeader: Record "Qlty. Inspection Header";
@@ -241,7 +251,7 @@ codeunit 20407 "Qlty. Manufactur. Integration"
     /// </summary>
     /// <param name="OldProdOrderRoutingLine"></param>
     /// <param name="NewProdOrderRoutingLine"></param>
-    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Header", 'rm')]
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Header", 'RM')]
     local procedure UpdateReferencesForProductionOrderRoutingLine(OldProdOrderRoutingLine: Record "Prod. Order Routing Line"; NewProdOrderRoutingLine: Record "Prod. Order Routing Line")
     var
         QltyInspectionHeader: Record "Qlty. Inspection Header";
@@ -484,6 +494,33 @@ codeunit 20407 "Qlty. Manufactur. Integration"
             QltyInspectionCreate.GetCreatedInspection(QltyInspectionHeader);
 
         OnAfterProductionAttemptCreateAutomaticInspection(ProdOrderRoutingLine, ItemLedgerEntry, ProdOrderLine, ItemJournalLine);
+    end;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Gen. Rule", 'R', InherentPermissionsScope::Permissions)]
+    local procedure HasProductionOutputPostGenRule(var QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule"): Boolean
+    begin
+        QltyInspectionGenRule.Reset();
+        QltyInspectionGenRule.SetRange("Production Order Trigger", QltyInspectionGenRule."Production Order Trigger"::OnProductionOutputPost);
+        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
+        exit(not QltyInspectionGenRule.IsEmpty());
+    end;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Gen. Rule", 'R', InherentPermissionsScope::Permissions)]
+    local procedure HasProductionOrderReleaseGenRule(var QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule"): Boolean
+    begin
+        QltyInspectionGenRule.Reset();
+        QltyInspectionGenRule.SetRange("Production Order Trigger", QltyInspectionGenRule."Production Order Trigger"::OnProductionOrderRelease);
+        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
+        exit(not QltyInspectionGenRule.IsEmpty());
+    end;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Gen. Rule", 'R', InherentPermissionsScope::Permissions)]
+    local procedure HasReleasedProductionOrderRefreshGenRule(var QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule"): Boolean
+    begin
+        QltyInspectionGenRule.Reset();
+        QltyInspectionGenRule.SetRange("Production Order Trigger", QltyInspectionGenRule."Production Order Trigger"::OnReleasedProductionOrderRefresh);
+        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
+        exit(not QltyInspectionGenRule.IsEmpty());
     end;
 
     /// <summary>

--- a/src/Apps/W1/Quality Management/app/src/Integration/Receiving/QltyReceivingIntegration.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Receiving/QltyReceivingIntegration.Codeunit.al
@@ -26,11 +26,17 @@ using Microsoft.Warehouse.Journal;
 
 codeunit 20411 "Qlty. Receiving Integration"
 {
+    Permissions =
+        tabledata "Qlty. Management Setup" = r,
+        tabledata "Qlty. Inspection Gen. Rule" = r,
+        tabledata "Qlty. Inspection Header" = r;
+
     var
         QltyManagementSetup: Record "Qlty. Management Setup";
         ApplicableReceivingQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
         QltyBatchNotifHelper: Codeunit "Qlty. Batch Notif. Helper";
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Purch.-Post", 'OnAfterPurchRcptLineInsert', '', true, true)]
     local procedure HandleOnAfterPurchRcptLineInsert(PurchaseLine: Record "Purchase Line"; var PurchRcptLine: Record "Purch. Rcpt. Line"; ItemLedgShptEntryNo: Integer; WhseShip: Boolean; WhseReceive: Boolean; CommitIsSupressed: Boolean; PurchInvHeader: Record "Purch. Inv. Header"; var TempTrackingSpecification: Record "Tracking Specification" temporary; PurchRcptHeader: Record "Purch. Rcpt. Header"; TempWhseRcptHeader: Record "Warehouse Receipt Header"; xPurchLine: Record "Purchase Line"; var TempPurchLineGlobal: Record "Purchase Line" temporary)
     var
@@ -47,11 +53,9 @@ codeunit 20411 "Qlty. Receiving Integration"
         if not QltyManagementSetup.GetSetupRecord() then
             exit;
 
-        ApplicableReceivingQltyInspectionGenRule.Reset();
-        ApplicableReceivingQltyInspectionGenRule.SetRange("Purchase Order Trigger", ApplicableReceivingQltyInspectionGenRule."Purchase Order Trigger"::OnPurchaseOrderPostReceive);
-        ApplicableReceivingQltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', ApplicableReceivingQltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", ApplicableReceivingQltyInspectionGenRule."Activation Trigger"::"Automatic only");
-        if ApplicableReceivingQltyInspectionGenRule.IsEmpty() then
+        if not HasPurchaseOrderPostReceiveGenRule(ApplicableReceivingQltyInspectionGenRule) then
             exit;
+
         if PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.") then;
 
         TempTrackingSpecification.SetFilter("Quantity Handled (Base)", '<>0');
@@ -90,6 +94,7 @@ codeunit 20411 "Qlty. Receiving Integration"
         TempTrackingSpecification.SetRange("Buffer Status");
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Whse.-Post Receipt", 'OnPostWhseJnlLineOnBeforeWhseJnlRegisterLineRun', '', true, true)]
     local procedure HandleOnPostWhseJnlLineOnBeforeWhseJnlRegisterLineRun(var WarehouseJournalLine: Record "Warehouse Journal Line"; PostedWhseReceiptHeader: Record "Posted Whse. Receipt Header")
     begin
@@ -99,16 +104,15 @@ codeunit 20411 "Qlty. Receiving Integration"
         if not QltyManagementSetup.GetSetupRecord() then
             exit;
 
-        ApplicableReceivingQltyInspectionGenRule.Reset();
-        ApplicableReceivingQltyInspectionGenRule.SetRange("Warehouse Receipt Trigger", ApplicableReceivingQltyInspectionGenRule."Warehouse Receipt Trigger"::OnWarehouseReceiptPost);
-        ApplicableReceivingQltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', ApplicableReceivingQltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", ApplicableReceivingQltyInspectionGenRule."Activation Trigger"::"Automatic only");
-        if not ApplicableReceivingQltyInspectionGenRule.IsEmpty() then begin
-            QltyBatchNotifHelper.BeginBatch();
-            AttemptCreateInspectionWithWhseJournalLine(WarehouseJournalLine, PostedWhseReceiptHeader);
-            QltyBatchNotifHelper.EndBatch();
-        end;
+        if not HasWarehouseReceiptPostGenRule(ApplicableReceivingQltyInspectionGenRule) then
+            exit;
+
+        QltyBatchNotifHelper.BeginBatch();
+        AttemptCreateInspectionWithWhseJournalLine(WarehouseJournalLine, PostedWhseReceiptHeader);
+        QltyBatchNotifHelper.EndBatch();
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Purchases Warehouse Mgt.", 'OnAfterCreateRcptLineFromPurchLine', '', true, true)]
     local procedure HandleOnAfterCreateRcptLineFromPurchLine(var WarehouseReceiptLine: Record "Warehouse Receipt Line"; WarehouseReceiptHeader: Record "Warehouse Receipt Header"; PurchaseLine: Record "Purchase Line")
     var
@@ -120,17 +124,16 @@ codeunit 20411 "Qlty. Receiving Integration"
         if not QltyManagementSetup.GetSetupRecord() then
             exit;
 
-        ApplicableReceivingQltyInspectionGenRule.Reset();
-        ApplicableReceivingQltyInspectionGenRule.SetRange("Warehouse Receipt Trigger", ApplicableReceivingQltyInspectionGenRule."Warehouse Receipt Trigger"::OnWarehouseReceiptCreate);
-        ApplicableReceivingQltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', ApplicableReceivingQltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", ApplicableReceivingQltyInspectionGenRule."Activation Trigger"::"Automatic only");
-        if not ApplicableReceivingQltyInspectionGenRule.IsEmpty() then begin
-            OptionalSource := PurchaseLine;
-            QltyBatchNotifHelper.BeginBatch();
-            AttemptCreateInspectionWithReceiptLine(WarehouseReceiptLine, WarehouseReceiptHeader, OptionalSource);
-            QltyBatchNotifHelper.EndBatch();
-        end;
+        if not HasWarehouseReceiptCreateGenRule(ApplicableReceivingQltyInspectionGenRule) then
+            exit;
+
+        OptionalSource := PurchaseLine;
+        QltyBatchNotifHelper.BeginBatch();
+        AttemptCreateInspectionWithReceiptLine(WarehouseReceiptLine, WarehouseReceiptHeader, OptionalSource);
+        QltyBatchNotifHelper.EndBatch();
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Post", 'OnBeforePostItemTrackingLine', '', true, true)]
     local procedure HandleOnBeforePostItemTrackingLine(SalesHeader: Record "Sales Header"; SalesLine: Record "Sales Line"; var TempItemLedgEntryNotInvoiced: Record "Item Ledger Entry" temporary; HasATOShippedNotInvoiced: Boolean; var IsHandled: Boolean; var ItemLedgShptEntryNo: Integer; var RemQtyToBeInvoiced: Decimal; var RemQtyToBeInvoicedBase: Decimal; SalesInvoiceHeader: Record "Sales Invoice Header"; SalesCrMemoHeader: Record "Sales Cr.Memo Header")
     var
@@ -152,9 +155,8 @@ codeunit 20411 "Qlty. Receiving Integration"
         if not QltyManagementSetup.GetSetupRecord() then
             exit;
 
-        QltyInspectionGenRule.SetRange("Sales Return Trigger", QltyInspectionGenRule."Sales Return Trigger"::OnSalesReturnOrderPostReceive);
-        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
-        if not QltyInspectionGenRule.IsEmpty() then begin
+        if HasSalesReturnOrderPostReceiveGenRule(QltyInspectionGenRule) then begin
+
             SourceVariant := SalesLine;
             QltyWarehouseIntegration.CollectSourceItemTracking(SourceVariant, TempTrackingSpecification);
             IsHandled := false;
@@ -185,6 +187,7 @@ codeunit 20411 "Qlty. Receiving Integration"
         OnAfterSalesReturnCreateInspectionWithSalesLine(SalesHeader, SalesLine, TempItemLedgEntryNotInvoiced, TempTrackingSpecification, HasInspection, QltyInspectionHeader);
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"TransferOrder-Post Transfer", 'OnAfterInsertDirectTransLine', '', true, true)]
     local procedure HandleOnAfterInsertDirectTransLine(var DirectTransLine: Record "Direct Trans. Line"; DirectTransHeader: Record "Direct Trans. Header"; TransLine: Record "Transfer Line")
     var
@@ -196,16 +199,15 @@ codeunit 20411 "Qlty. Receiving Integration"
         if not QltyManagementSetup.GetSetupRecord() then
             exit;
 
-        ApplicableReceivingQltyInspectionGenRule.Reset();
-        ApplicableReceivingQltyInspectionGenRule.SetRange("Transfer Order Trigger", ApplicableReceivingQltyInspectionGenRule."Transfer Order Trigger"::OnTransferOrderPostReceive);
-        ApplicableReceivingQltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', ApplicableReceivingQltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", ApplicableReceivingQltyInspectionGenRule."Activation Trigger"::"Automatic only");
-        if not ApplicableReceivingQltyInspectionGenRule.IsEmpty() then begin
-            QltyBatchNotifHelper.BeginBatch();
-            AttemptCreateInspectionWithReceiveTransferLine(TransLine, UnusedTransTransferReceiptHeader, DirectTransHeader);
-            QltyBatchNotifHelper.EndBatch();
-        end;
+        if not HasTransferOrderPostReceiveGenRule(ApplicableReceivingQltyInspectionGenRule) then
+            exit;
+
+        QltyBatchNotifHelper.BeginBatch();
+        AttemptCreateInspectionWithReceiveTransferLine(TransLine, UnusedTransTransferReceiptHeader, DirectTransHeader);
+        QltyBatchNotifHelper.EndBatch();
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"TransferOrder-Post Receipt", 'OnAfterInsertTransRcptLine', '', true, true)]
     local procedure HandleOnAfterInsertTransRcptLine(var TransRcptLine: Record "Transfer Receipt Line"; TransLine: Record "Transfer Line"; CommitIsSuppressed: Boolean; TransferReceiptHeader: Record "Transfer Receipt Header")
     var
@@ -217,16 +219,15 @@ codeunit 20411 "Qlty. Receiving Integration"
         if not QltyManagementSetup.GetSetupRecord() then
             exit;
 
-        ApplicableReceivingQltyInspectionGenRule.Reset();
-        ApplicableReceivingQltyInspectionGenRule.SetRange("Transfer Order Trigger", ApplicableReceivingQltyInspectionGenRule."Transfer Order Trigger"::OnTransferOrderPostReceive);
-        ApplicableReceivingQltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', ApplicableReceivingQltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", ApplicableReceivingQltyInspectionGenRule."Activation Trigger"::"Automatic only");
-        if not ApplicableReceivingQltyInspectionGenRule.IsEmpty() then begin
-            QltyBatchNotifHelper.BeginBatch();
-            AttemptCreateInspectionWithReceiveTransferLine(TransLine, TransferReceiptHeader, UnusedDirectTransHeader);
-            QltyBatchNotifHelper.EndBatch();
-        end;
+        if not HasTransferOrderPostReceiveGenRule(ApplicableReceivingQltyInspectionGenRule) then
+            exit;
+
+        QltyBatchNotifHelper.BeginBatch();
+        AttemptCreateInspectionWithReceiveTransferLine(TransLine, TransferReceiptHeader, UnusedDirectTransHeader);
+        QltyBatchNotifHelper.EndBatch();
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Release Purchase Document", 'OnAfterReleasePurchaseDoc', '', true, true)]
     local procedure HandleOnAfterReleasePurchDoc(var PurchaseHeader: Record "Purchase Header"; PreviewMode: Boolean; var LinesWereModified: Boolean; SkipWhseRequestOperations: Boolean)
     var
@@ -241,10 +242,7 @@ codeunit 20411 "Qlty. Receiving Integration"
         if not QltyManagementSetup.GetSetupRecord() then
             exit;
 
-        ApplicableReceivingQltyInspectionGenRule.Reset();
-        ApplicableReceivingQltyInspectionGenRule.SetRange("Purchase Order Trigger", ApplicableReceivingQltyInspectionGenRule."Purchase Order Trigger"::OnPurchaseOrderRelease);
-        ApplicableReceivingQltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', ApplicableReceivingQltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", ApplicableReceivingQltyInspectionGenRule."Activation Trigger"::"Automatic only");
-        if ApplicableReceivingQltyInspectionGenRule.IsEmpty() then
+        if not HasPurchaseOrderReleaseGenRule(ApplicableReceivingQltyInspectionGenRule) then
             exit;
 
         QltyBatchNotifHelper.BeginBatch();
@@ -447,6 +445,60 @@ codeunit 20411 "Qlty. Receiving Integration"
         GenJnlPostPreview: Codeunit "Gen. Jnl.-Post Preview";
     begin
         IsInPreviewPostingMode := GenJnlPostPreview.IsActive();
+    end;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Gen. Rule", 'R', InherentPermissionsScope::Permissions)]
+    local procedure HasPurchaseOrderPostReceiveGenRule(var QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule"): Boolean
+    begin
+        QltyInspectionGenRule.Reset();
+        QltyInspectionGenRule.SetRange("Purchase Order Trigger", QltyInspectionGenRule."Purchase Order Trigger"::OnPurchaseOrderPostReceive);
+        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
+        exit(not QltyInspectionGenRule.IsEmpty());
+    end;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Gen. Rule", 'R', InherentPermissionsScope::Permissions)]
+    local procedure HasWarehouseReceiptPostGenRule(var QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule"): Boolean
+    begin
+        QltyInspectionGenRule.Reset();
+        QltyInspectionGenRule.SetRange("Warehouse Receipt Trigger", QltyInspectionGenRule."Warehouse Receipt Trigger"::OnWarehouseReceiptPost);
+        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
+        exit(not QltyInspectionGenRule.IsEmpty());
+    end;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Gen. Rule", 'R', InherentPermissionsScope::Permissions)]
+    local procedure HasWarehouseReceiptCreateGenRule(var QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule"): Boolean
+    begin
+        QltyInspectionGenRule.Reset();
+        QltyInspectionGenRule.SetRange("Warehouse Receipt Trigger", QltyInspectionGenRule."Warehouse Receipt Trigger"::OnWarehouseReceiptCreate);
+        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
+        exit(not QltyInspectionGenRule.IsEmpty());
+    end;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Gen. Rule", 'R', InherentPermissionsScope::Permissions)]
+    local procedure HasSalesReturnOrderPostReceiveGenRule(var QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule"): Boolean
+    begin
+        QltyInspectionGenRule.Reset();
+        QltyInspectionGenRule.SetRange("Sales Return Trigger", QltyInspectionGenRule."Sales Return Trigger"::OnSalesReturnOrderPostReceive);
+        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
+        exit(not QltyInspectionGenRule.IsEmpty());
+    end;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Gen. Rule", 'R', InherentPermissionsScope::Permissions)]
+    local procedure HasTransferOrderPostReceiveGenRule(var QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule"): Boolean
+    begin
+        QltyInspectionGenRule.Reset();
+        QltyInspectionGenRule.SetRange("Transfer Order Trigger", QltyInspectionGenRule."Transfer Order Trigger"::OnTransferOrderPostReceive);
+        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
+        exit(not QltyInspectionGenRule.IsEmpty());
+    end;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Gen. Rule", 'R', InherentPermissionsScope::Permissions)]
+    local procedure HasPurchaseOrderReleaseGenRule(var QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule"): Boolean
+    begin
+        QltyInspectionGenRule.Reset();
+        QltyInspectionGenRule.SetRange("Purchase Order Trigger", QltyInspectionGenRule."Purchase Order Trigger"::OnPurchaseOrderRelease);
+        QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
+        exit(not QltyInspectionGenRule.IsEmpty());
     end;
 
     /// <summary>

--- a/src/Apps/W1/Quality Management/app/src/Integration/Warehouse/QltyWarehouseIntegration.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Warehouse/QltyWarehouseIntegration.Codeunit.al
@@ -17,6 +17,12 @@ using Microsoft.Warehouse.Ledger;
 
 codeunit 20438 "Qlty. Warehouse Integration"
 {
+    Permissions =
+        tabledata "Qlty. Management Setup" = r,
+        tabledata "Qlty. Inspection Gen. Rule" = r,
+        tabledata "Qlty. Inspection Header" = r;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Whse. Jnl.-Register Line", 'OnAfterInsertWhseEntry', '', true, true)]
     local procedure HandleOnAfterInsertWhseEntry(var WarehouseEntry: Record "Warehouse Entry"; var WarehouseJournalLine: Record "Warehouse Journal Line")
     var
@@ -29,10 +35,18 @@ codeunit 20438 "Qlty. Warehouse Integration"
         if not QltyManagementSetup.GetSetupRecord() then
             exit;
 
+        if not HasWhseMovementRegisterGenRule(QltyInspectionGenRule) then
+            exit;
+
+        AttemptCreateInspectionWithWhseJournalLine(WarehouseEntry, WarehouseJournalLine, QltyInspectionGenRule);
+    end;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Qlty. Inspection Gen. Rule", 'R', InherentPermissionsScope::Permissions)]
+    local procedure HasWhseMovementRegisterGenRule(var QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule"): Boolean
+    begin
         QltyInspectionGenRule.SetRange("Warehouse Movement Trigger", QltyInspectionGenRule."Warehouse Movement Trigger"::OnWhseMovementRegister);
         QltyInspectionGenRule.SetFilter("Activation Trigger", '%1|%2', QltyInspectionGenRule."Activation Trigger"::"Manual or Automatic", QltyInspectionGenRule."Activation Trigger"::"Automatic only");
-        if not QltyInspectionGenRule.IsEmpty() then
-            AttemptCreateInspectionWithWhseJournalLine(WarehouseEntry, WarehouseJournalLine, QltyInspectionGenRule);
+        exit(not QltyInspectionGenRule.IsEmpty());
     end;
 
     local procedure AttemptCreateInspectionWithWhseJournalLine(var WarehouseEntry: Record "Warehouse Entry"; var WarehouseJournalLine: Record "Warehouse Journal Line"; var QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule")

--- a/src/Apps/W1/Quality Management/app/src/Permissions/QltyMgmtICreate.PermissionSet.al
+++ b/src/Apps/W1/Quality Management/app/src/Permissions/QltyMgmtICreate.PermissionSet.al
@@ -1,0 +1,72 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.QualityManagement.Permissions;
+
+using Microsoft.Assembly.History;
+using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Journal;
+using Microsoft.Inventory.Ledger;
+using Microsoft.Inventory.Tracking;
+using Microsoft.Inventory.Transfer;
+using Microsoft.Manufacturing.Document;
+using Microsoft.Purchases.Document;
+using Microsoft.QualityManagement.Configuration.GenerationRule;
+using Microsoft.QualityManagement.Configuration.Result;
+using Microsoft.QualityManagement.Configuration.SourceConfiguration;
+using Microsoft.QualityManagement.Configuration.Template;
+using Microsoft.QualityManagement.Configuration.Template.Test;
+using Microsoft.QualityManagement.Document;
+using Microsoft.QualityManagement.Setup;
+using Microsoft.Sales.Document;
+using Microsoft.Warehouse.Document;
+using Microsoft.Warehouse.Journal;
+using Microsoft.Warehouse.Ledger;
+
+/// <summary>
+/// Grants the minimum permissions required to initiate quality inspections from
+/// automatic procedures triggered by other operations (for example, production order
+/// completion, purchase receipts, warehouse activities, and similar background
+/// scenarios), as well as from manual actions invoked by the user in the UI
+/// (for example, the "Create Quality Inspection" action on documents and lines).
+/// Setup and configuration data is exposed as read-only, while inspection
+/// records can be created and updated, so that Quality Management data is only
+/// modified through Quality Management code paths and not by direct user interaction.
+/// </summary>
+permissionset 20407 "QltyMgmt - I. Create"
+{
+    Caption = 'Quality Inspection - Create';
+    Access = Public;
+    Assignable = true;
+
+    IncludedPermissionSets = "QltyMgmt - Objects";
+
+    Permissions =
+        tabledata "Qlty. Management Setup" = r,
+        tabledata "Qlty. Inspection Gen. Rule" = r,
+        tabledata "Qlty. Inspection Result" = r,
+        tabledata "Qlty. Test" = r,
+        tabledata "Qlty. Test Lookup Value" = r,
+        tabledata "Qlty. Inspection Template Hdr." = r,
+        tabledata "Qlty. Inspection Template Line" = r,
+        tabledata "Qlty. Inspect. Source Config." = r,
+        tabledata "Qlty. Inspect. Src. Fld. Conf." = r,
+        tabledata "Qlty. Inspection Header" = rIm,
+        tabledata "Qlty. Inspection Line" = rIm,
+        tabledata "Qlty. I. Result Condit. Conf." = rIm,
+        tabledata Item = r,
+        tabledata "Reservation Entry" = r,
+        tabledata "Tracking Specification" = r,
+        tabledata "Warehouse Entry" = r,
+        tabledata "Warehouse Journal Line" = r,
+        tabledata "Warehouse Receipt Line" = r,
+        tabledata "Sales Line" = r,
+        tabledata "Purchase Line" = r,
+        tabledata "Prod. Order Line" = r,
+        tabledata "Prod. Order Routing Line" = r,
+        tabledata "Item Journal Line" = r,
+        tabledata "Item Ledger Entry" = r,
+        tabledata "Transfer Line" = r,
+        tabledata "Posted Assembly Header" = r;
+}

--- a/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Page.al
@@ -20,6 +20,7 @@ page 20400 "Qlty. Management Setup"
     DeleteAllowed = false;
     InsertAllowed = false;
     SourceTable = "Qlty. Management Setup";
+    AccessByPermission = tabledata "Qlty. Management Setup" = R;
     UsageCategory = Administration;
     ApplicationArea = QualityManagement;
     AboutTitle = 'About Quality Management Setup';

--- a/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Table.al
@@ -27,6 +27,7 @@ table 20400 "Qlty. Management Setup"
     Caption = 'Quality Management Setup';
     DrillDownPageId = "Qlty. Management Setup";
     DataClassification = CustomerContent;
+    Permissions = tabledata "Qlty. Management Setup" = r;
 
     fields
     {
@@ -525,9 +526,6 @@ table 20400 "Qlty. Management Setup"
 
     internal procedure GetSetupRecord(): Boolean
     begin
-        if not Rec.ReadPermission() then
-            exit(false);
-
         exit(Rec.Get());
     end;
 

--- a/src/Apps/W1/Quality Management/app/src/Setup/SetupGuide/QltyGuidedExperience.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/SetupGuide/QltyGuidedExperience.Codeunit.al
@@ -71,7 +71,7 @@ codeunit 20419 "Qlty. Guided Experience"
         if not (Session.CurrentClientType() in [ClientType::Web, ClientType::Windows, ClientType::Desktop]) then
             exit;
 
-        if not (QltyManagementSetup.ReadPermission and QltyManagementSetup.WritePermission) then
+        if not (QltyManagementSetup.ReadPermission() and QltyManagementSetup.WritePermission()) then
             exit;
 
         if not Company.Get(CompanyName()) then

--- a/src/Apps/W1/Quality Management/app/src/Utilities/QltyMiscHelpers.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Utilities/QltyMiscHelpers.Codeunit.al
@@ -12,6 +12,8 @@ using System.Security.AccessControl;
 
 codeunit 20599 "Qlty. Misc Helpers"
 {
+    Permissions = tabledata "Qlty. Test Lookup Value" = r;
+
     var
         DateKeywordTxt: Label 'Date';
         YesNoKeyword1Txt: Label 'Does the';

--- a/src/Apps/W1/Quality Management/app/src/Utilities/QltyNotificationMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Utilities/QltyNotificationMgmt.Codeunit.al
@@ -18,6 +18,7 @@ using System.Reflection;
 codeunit 20437 "Qlty. Notification Mgmt."
 {
     Access = Internal;
+    Permissions = tabledata "Qlty. Inspection Header" = r;
 
     var
         AssignToSelfLbl: Label 'Assign to myself';


### PR DESCRIPTION
## What & why
Implement InherentPermissions so users without Quality Management permissions would not silently skip mandatory Quality Inspection creation or transaction restrictions.

Automatic Quality Inspection creation is now handled like this:
1. If there is no Quality Inspection Setup or there is no Generation Rule triggered on specific event, Quality Management code is skipped, and user does not need any Quality Management permission set. InherentPermissions for these two tables are used.

2. However, if there is trigger, then user has to have Quality Management permissions. Otherwise, user gets standard permission error, such as this:
<img width="561" height="266" alt="image" src="https://github.com/user-attachments/assets/0981f1db-fd75-43c1-9c0a-151181eeec92" />

3. Minimum is new permission set "QltyMgmt - I. Create"/'Quality Inspection - Create' which grants indirect permissions for creating inspections, without accessing or processing them further.
- This permission set grants permission to run creation inspection manually as well, via "Create Quality Inspection" actions. But, due to AccessByPermission, View actions are hidden if user has just that Quality Management permission set.

## Linked work
Fixes [AB#641763](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641763)

