### PR TITLE
Extend Contoso Mfg shop calendar range to cover next-year due dates

### DIFF
--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Manufacturing/2.Master Data/CreateMfgCapacity.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Manufacturing/2.Master Data/CreateMfgCapacity.Codeunit.al
@@ -118,11 +118,11 @@ codeunit 4775 "Create Mfg Capacity"
         ContosoManufacturing.InsertWorkCenter(WorkCenter500(), SubcontractorTok, WorkCenterGroup5(), 0, MfgCapUnitOfMeasure.Minutes(), 100, ShopCalendarOneShift(), 1, CommonPostingGroup.Retail(), MfgVendor.SubcontractorVendor(), true);
 
 
-        CalcMachineCenterCalendar.InitializeRequest(ContosoUtilities.AdjustDate(19020101D), ContosoUtilities.AdjustDate(19031231D));
+        CalcMachineCenterCalendar.InitializeRequest(ContosoUtilities.AdjustDate(19020101D), ContosoUtilities.AdjustDate(19041231D));
         CalcMachineCenterCalendar.UseRequestPage(false);
         CalcMachineCenterCalendar.RunModal();
 
-        CalculateWorkCenterCalendar.InitializeRequest(ContosoUtilities.AdjustDate(19020101D), ContosoUtilities.AdjustDate(19031231D));
+        CalculateWorkCenterCalendar.InitializeRequest(ContosoUtilities.AdjustDate(19020101D), ContosoUtilities.AdjustDate(19041231D));
         CalculateWorkCenterCalendar.UseRequestPage(false);
         CalculateWorkCenterCalendar.RunModal();
     end;


### PR DESCRIPTION
## Problem
Contoso Coffee Manufacturing demo data generated work/machine center shop calendar entries only for **CurrentYear-1 .. CurrentYear**. A released production order with a due date in the **next** calendar year (e.g. 6/1/2027 with a 2026 work date) had backward scheduling fail **silently**, clamping Starting/Ending Date-Time to 12/31/CurrentYear because no calendar entries existed beyond that date.

## Root cause
In `CreateMfgCapacity.Codeunit.al` the calendar-calculation reports were initialized with a fixed end date `AdjustDate(19031231D)`. With `"Starting Year" = Today.Year - 1` and `AdjustDate`'s `Year := baseYear + StartingYear - 1994` mapping, base year 1903 resolves to CurrentYear, so the generated window ended at 12/31/CurrentYear.

## Fix
Extend the end date by one base year (`AdjustDate(19031231D)` -> `AdjustDate(19041231D)`) for both `Calc. Machine Center Calendar` and `Calculate Work Center Calendar`. The window becomes **CurrentYear-1 .. CurrentYear+1**, so next-year due dates schedule against real calendar entries. Start date unchanged.

## Validation
- Language-server diagnostics on the changed file: no errors.
- Diff limited to two date literals in identical, already-valid `AdjustDate` call sites.
- Suggested functional check: regenerate Contoso Manufacturing demo data, create a released prod. order for Item 1000 with a due date in CurrentYear+1, Refresh with Scheduling Direction = Back, and confirm Starting/Ending Date-Time land near the due date instead of 12/31/CurrentYear.

## Risk
Minimal — demo-data only; adds one extra year of calendar entries per work/machine center.

Fixes [AB#639691](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639691)


