### PR TITLE
[ALAppExtensions #30250] Matrix Management: reorder OnFormatRoundingFactor Signature

### DIFF
--- a/src/Layers/W1/BaseApp/Finance/Analysis/MatrixManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/Analysis/MatrixManagement.Codeunit.al
@@ -696,7 +696,7 @@ codeunit 9200 "Matrix Management"
                 OnFormatRoundingFactorOnElse(AmountDecimal, RoundingFactor);
         end;
 
-        OnFormatRoundingFactorOnAfterSetAmountDecimal(RoundingFactor, AmountDecimal);
+        OnFormatRoundingFactorOnAfterSetAmountDecimal(AmountDecimal, RoundingFactor);
 
         case NegativeAmountFormat of
             NegativeAmountFormat::"Minus Sign":
@@ -797,10 +797,10 @@ codeunit 9200 "Matrix Management"
     /// Integration event raised after the decimal format text has been set for the rounding factor and before the negative amount format is applied.
     /// Allows subscribers to change the decimal formatting based on the rounding factor.
     /// </summary>
-    /// <param name="RoundingFactor">Rounding factor being formatted.</param>
     /// <param name="AmountDecimal">Decimal format text, passed by reference so subscribers can change it.</param>
+    /// <param name="RoundingFactor">Rounding factor being formatted.</param>
     [IntegrationEvent(false, false)]
-    local procedure OnFormatRoundingFactorOnAfterSetAmountDecimal(RoundingFactor: Enum "Analysis Rounding Factor"; var AmountDecimal: Text)
+    local procedure OnFormatRoundingFactorOnAfterSetAmountDecimal(var AmountDecimal: Text; RoundingFactor: Enum "Analysis Rounding Factor")
     begin
     end;
 


### PR DESCRIPTION
## What & why

Reorders the parameters of the `OnAfterSetAmountDecimal` event so that `AmountDecimal` comes first, matching the parameter ordering used by the related events. This is a consistency/readability refactor, no behavior change.

## Linked work

Fixes [AB#639939](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639939)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Built the affected app locally — no errors, no new analyzer warnings.
- Pure parameter-order refactor of `OnAfterSetAmountDecimal` (and its subscribers/raisers updated to match); no runtime behavior change, so no functional test added.

## Risk & compatibility

- Low risk, but note this **changes the `OnAfterSetAmountDecimal` event signature** (parameter order). Any external subscriber to this event must update its parameter order to match — call out in release notes if the event is public.
- No table schema change, no data/upgrade impact.


