### PR TITLE
[Main]- Description field in the contact history is showing the number of the original unregistered reminder instead of the registered reminder number when using the reminder automation setup.

### DIFF
--- a/src/Layers/APAC/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/APAC/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -865,7 +865,7 @@ report 117 Reminder
                 repeat
                     SegManagement.LogDocument(
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
-                      '', '', "Issued Reminder Header"."Posting Description", '');
+                      '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
     end;
 

--- a/src/Layers/BE/BaseApp/Sales/Reminder/IssuedReminderHeader.Table.al
+++ b/src/Layers/BE/BaseApp/Sales/Reminder/IssuedReminderHeader.Table.al
@@ -818,4 +818,21 @@ table 297 "Issued Reminder Header"
     internal procedure OnGetReportParameters(var LogInteraction: Boolean; var ShowNotDueAmounts: Boolean; var ShowMIRLines: Boolean; ReportID: Integer; var Handled: Boolean)
     begin
     end;
+
+    /// <summary>
+    /// Returns the description to use when logging an interaction for this issued reminder.
+    /// When the posting description still holds the default text derived from the pre-assigned
+    /// (unissued) reminder number, it is replaced with the same text based on the issued reminder
+    /// number so the Contact History references the registered reminder. Customized posting
+    /// descriptions are preserved.
+    /// </summary>
+    /// <returns>The interaction log description text.</returns>
+    internal procedure GetLogInteractionDescription(): Text[100]
+    var
+        ReminderHeader: Record "Reminder Header";
+    begin
+        if ("Pre-Assigned No." <> '') and ("Posting Description" = ReminderHeader.GetDefaultPostingDescription("Pre-Assigned No.")) then
+            exit(ReminderHeader.GetDefaultPostingDescription("No."));
+        exit("Posting Description");
+    end;
 }

--- a/src/Layers/BE/BaseApp/Sales/Reminder/ReminderHeader.Table.al
+++ b/src/Layers/BE/BaseApp/Sales/Reminder/ReminderHeader.Table.al
@@ -52,7 +52,7 @@ table 295 "Reminder Header"
                     NoSeries.TestManual(GetNoSeriesCode());
                     "No. Series" := '';
                 end;
-                "Posting Description" := StrSubstNo(ReminderNoLbl, "No.");
+                "Posting Description" := GetDefaultPostingDescription("No.");
             end;
         }
         /// <summary>
@@ -754,7 +754,7 @@ table 295 "Reminder Header"
     begin
         SalesSetup.Get();
         SetReminderNo();
-        "Posting Description" := StrSubstNo(ReminderNoLbl, "No.");
+        "Posting Description" := GetDefaultPostingDescription("No.");
 
         OnInsertOnBeforeInitNoSeries(Rec, xRec, IsHandled);
         if not IsHandled then
@@ -811,6 +811,16 @@ table 295 "Reminder Header"
         GapInNumberSeriesIfDeleteTxt: Label 'Deleting this document will cause a gap in the number series for reminders. ';
         CreateEmptyReminderTxt: Label 'An empty reminder %1 will be created to fill this gap in the number series.\\', Comment = '%1 = Reminder No.';
         UnexpectedLineTypeErr: Label 'Unexpected line type %1 in reminder %2', Comment = '%1 = Line Type, %2 = Reminder No.';
+
+    /// <summary>
+    /// Returns the default posting description text for the given reminder number.
+    /// </summary>
+    /// <param name="ReminderNo">The reminder number to embed in the posting description.</param>
+    /// <returns>The default posting description text.</returns>
+    internal procedure GetDefaultPostingDescription(ReminderNo: Code[20]): Text[100]
+    begin
+        exit(StrSubstNo(ReminderNoLbl, ReminderNo));
+    end;
 
     /// <summary>
     /// Opens a dialog to assist with selecting a number from related number series.

--- a/src/Layers/DACH/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/DACH/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -920,7 +920,7 @@ report 117 Reminder
                 repeat
                     SegManagement.LogDocument(
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
-                      '', '', "Issued Reminder Header"."Posting Description", '');
+                      '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
     end;
 

--- a/src/Layers/ES/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/ES/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -1028,7 +1028,7 @@ report 117 Reminder
                 repeat
                     SegManagement.LogDocument(
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
-                      '', '', "Issued Reminder Header"."Posting Description", '');
+                      '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
     end;
 

--- a/src/Layers/FI/BaseApp/Sales/Reminder/IssuedReminderHeader.Table.al
+++ b/src/Layers/FI/BaseApp/Sales/Reminder/IssuedReminderHeader.Table.al
@@ -810,4 +810,21 @@ table 297 "Issued Reminder Header"
     internal procedure OnGetReportParameters(var LogInteraction: Boolean; var ShowNotDueAmounts: Boolean; var ShowMIRLines: Boolean; ReportID: Integer; var Handled: Boolean)
     begin
     end;
+
+    /// <summary>
+    /// Returns the description to use when logging an interaction for this issued reminder.
+    /// When the posting description still holds the default text derived from the pre-assigned
+    /// (unissued) reminder number, it is replaced with the same text based on the issued reminder
+    /// number so the Contact History references the registered reminder. Customized posting
+    /// descriptions are preserved.
+    /// </summary>
+    /// <returns>The interaction log description text.</returns>
+    internal procedure GetLogInteractionDescription(): Text[100]
+    var
+        ReminderHeader: Record "Reminder Header";
+    begin
+        if ("Pre-Assigned No." <> '') and ("Posting Description" = ReminderHeader.GetDefaultPostingDescription("Pre-Assigned No.")) then
+            exit(ReminderHeader.GetDefaultPostingDescription("No."));
+        exit("Posting Description");
+    end;
 }

--- a/src/Layers/FI/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/FI/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -931,7 +931,7 @@ report 117 Reminder
                 repeat
                     SegManagement.LogDocument(
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
-                      '', '', "Issued Reminder Header"."Posting Description", '');
+                      '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
     end;
 

--- a/src/Layers/FR/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/FR/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -947,7 +947,7 @@ report 117 Reminder
                 repeat
                     SegManagement.LogDocument(
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
-                      '', '', "Issued Reminder Header"."Posting Description", '');
+                      '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
     end;
 

--- a/src/Layers/GB/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/GB/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -1153,7 +1153,7 @@ report 117 Reminder
                 repeat
                     SegManagement.LogDocument(
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
-                      '', '', "Issued Reminder Header"."Posting Description", '');
+                      '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
     end;
 

--- a/src/Layers/GB/Tests/ERM/ReminderAutomationTests.Codeunit.al
+++ b/src/Layers/GB/Tests/ERM/ReminderAutomationTests.Codeunit.al
@@ -1077,6 +1077,74 @@ codeunit 134979 "Reminder Automation Tests"
         Assert.AreEqual(1, TempBlobList.Count(), NoOfAttachmentsSameErr);
     end;
 
+    [HandlerFunctions('NewReminderActionModalPageHandler,CreateRemindersSetupModalPageHandler,IssueRemindersSetupModalPageHandler,SendRemindersSetupLogInteractionModalPageHandler,SelectRemTermsAutomationHandler')]
+    [Test]
+    procedure TestReminderAutomationLogsInteractionWithIssuedReminderNumber()
+    var
+        Contact: Record Contact;
+        Customer: Record Customer;
+        InteractionLogEntry: Record "Interaction Log Entry";
+        IssuedReminderHeader: Record "Issued Reminder Header";
+        JobQueueEntry: Record "Job Queue Entry";
+        ReminderActionGroup: Record "Reminder Action Group";
+        ReminderTerms: Record "Reminder Terms";
+        SendEmailMock: Codeunit "Send Email Mock";
+        ReminderAutomationJob: Codeunit "Reminders Automation Job";
+        ReminderAutomationCard: TestPage "Reminder Automation Card";
+        NumberOfOverdueEntries: Integer;
+    begin
+        // [FEATURE] [Reminder Automation] [Interaction] [AI test]
+        // [SCENARIO 639904] When Reminder Automation issues and sends reminders with Log Interaction enabled,
+        // the Contact History Description references the Issued Reminder number, not the original unissued reminder number.
+        Initialize();
+
+        // [GIVEN] An interaction template is set up for the "Sales Rmdr." document type
+        SetupSalesRmdrInteractionTemplate();
+
+        // [GIVEN] A customer that is linked to a contact and has reminder terms with overdue entries
+        CreateReminderTermsWithLevels(ReminderTerms, GetDefaultDueDatePeriodForReminderLevel(), Any.IntegerInRange(2, 5));
+        NumberOfOverdueEntries := Any.IntegerInRange(2, 5);
+        CreateCustomerWithContactAndOverdueEntries(Customer, Contact, ReminderTerms, NumberOfOverdueEntries);
+
+        // [GIVEN] A reminder automation group with create, issue and send (log interaction) actions
+        CreateReminderAutomationGroupViaUI(ReminderAutomationCard, ReminderTerms);
+        CreateReminderAction(ReminderAutomationCard, Enum::"Reminder Action"::"Create Reminder");
+        CreateReminderAction(ReminderAutomationCard, Enum::"Reminder Action"::"Issue Reminder");
+        CreateReminderAction(ReminderAutomationCard, Enum::"Reminder Action"::"Send Reminder");
+        ReminderActionGroup.Get(ReminderAutomationCard.Code.Value());
+
+        // [WHEN] The reminder automation runs (create + issue + send by email with log interaction)
+        BindSubscription(SendEmailMock);
+        SendEmailMock.AddSupportedScenario(Enum::"Email Scenario"::Reminder);
+        JobQueueEntry := CreateTestJobQueueEntry(ReminderActionGroup);
+        ReminderAutomationJob.Run(JobQueueEntry);
+        UnbindSubscription(SendEmailMock);
+
+        // [THEN] The job completed and an issued reminder was created with a number different from its pre-assigned (original) number
+        VerifyJobWasSuccesfull(ReminderActionGroup);
+        IssuedReminderHeader.SetRange("Customer No.", Customer."No.");
+        Assert.IsTrue(IssuedReminderHeader.FindFirst(), NoIssuedReminderCreatedErr);
+        Assert.AreNotEqual(
+          IssuedReminderHeader."Pre-Assigned No.", IssuedReminderHeader."No.",
+          IssuedReminderNoMustDifferErr);
+
+        // [THEN] An interaction log entry is created for the issued reminder and linked to the customer's contact
+        InteractionLogEntry.SetRange("Document Type", InteractionLogEntry."Document Type"::"Sales Rmdr.");
+        InteractionLogEntry.SetRange("Document No.", IssuedReminderHeader."No.");
+        Assert.IsTrue(InteractionLogEntry.FindLast(), NoInteractionLogEntryCreatedErr);
+        InteractionLogEntry.TestField("Contact No.", Contact."No.");
+
+        // [THEN] The Description references the Issued Reminder number, not the original (pre-assigned) reminder number
+        Assert.AreEqual(
+          StrSubstNo(ReminderPostingDescriptionLbl, IssuedReminderHeader."No."), InteractionLogEntry.Description,
+          InteractionDescriptionMustReferenceIssuedNoErr);
+        Assert.AreNotEqual(
+          StrSubstNo(ReminderPostingDescriptionLbl, IssuedReminderHeader."Pre-Assigned No."), InteractionLogEntry.Description,
+          InteractionDescriptionMustNotReferenceOriginalNoErr);
+
+        NotificationLifecycleMgt.RecallAllNotifications();
+    end;
+
     [ModalPageHandler()]
     procedure IssueRemindersSetupModalPageHandlerWithFilterSaveCheck(var IssueRemindersSetupPage: TestPage "Issue Reminders Setup")
     var
@@ -1613,6 +1681,53 @@ codeunit 134979 "Reminder Automation Tests"
         FeatureKey.Modify(true);
     end;
 
+    local procedure CreateCustomerWithContactAndOverdueEntries(var Customer: Record Customer; var Contact: Record Contact; var ReminderTerms: Record "Reminder Terms"; NumberOfEntries: Integer)
+    var
+        Item: Record Item;
+        ReminderLevel: Record "Reminder Level";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        PostingDate: Date;
+        I: Integer;
+    begin
+        ReminderLevel.SetRange("Reminder Terms Code", ReminderTerms.Code);
+        ReminderLevel.FindFirst();
+
+        // Create a customer that is linked to a contact through a business relation, so the logged interaction is tied to the contact
+        LibraryMarketing.CreateContactWithCustomer(Contact, Customer);
+        Customer.Validate("Reminder Terms Code", ReminderTerms.Code);
+        Customer.Modify(true);
+
+        PostingDate := WorkDate() + (WorkDate() - CalcDate(ReminderLevel."Due Date Calculation", WorkDate()));
+        PostingDate := CalcDate('<-5M>', PostingDate);
+
+        for I := 1 to NumberOfEntries do begin
+            LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, Customer."No.");
+            SalesHeader.Validate("Posting Date", PostingDate);
+            SalesHeader.Validate("Due Date", PostingDate);
+            SalesHeader.Validate("Document Date", PostingDate);
+            SalesHeader.Modify(true);
+            LibraryInventory.CreateItemWithUnitPriceAndUnitCost(
+              Item, Any.DecimalInRange(1, 100, 2), Any.DecimalInRange(1, 100, 2));
+            LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, Item."No.", Any.IntegerInRange(1, 10));
+            LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        end;
+    end;
+
+    local procedure SetupSalesRmdrInteractionTemplate()
+    var
+        InteractionTemplateSetup: Record "Interaction Template Setup";
+        InteractionTemplate: Record "Interaction Template";
+    begin
+        if not InteractionTemplateSetup.Get() then begin
+            InteractionTemplateSetup.Init();
+            InteractionTemplateSetup.Insert();
+        end;
+        LibraryMarketing.CreateInteractionTemplate(InteractionTemplate);
+        InteractionTemplateSetup.Validate("Sales Rmdr.", InteractionTemplate.Code);
+        InteractionTemplateSetup.Modify(true);
+    end;
+
     [StrMenuHandler]
     [Scope('OnPrem')]
     procedure CancelMailSendingStrMenuHandler(Options: Text; var Choice: Integer; Instruction: Text)
@@ -1683,6 +1798,15 @@ codeunit 134979 "Reminder Automation Tests"
         Assert.IsTrue(CreateReminderSetup.GetCustomerSelectionDisplayText() <> '', FiltersAreNotSavedErr);
     end;
 
+    [ModalPageHandler()]
+    procedure SendRemindersSetupLogInteractionModalPageHandler(var SendRemindersSetup: TestPage "Send Reminders Setup")
+    begin
+        SendRemindersSetup.SendByEmail.SetValue(true);
+        SendRemindersSetup.Print.SetValue(false);
+        SendRemindersSetup.LogInteraction.SetValue(true);
+        SendRemindersSetup.OK().Invoke();
+    end;
+
     [FilterPageHandler]
     procedure CreateReminderSetupPageCustomerFilterHandler(var CustomerRecordRef: RecordRef): Boolean
     var
@@ -1721,13 +1845,21 @@ codeunit 134979 "Reminder Automation Tests"
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryErm: Codeunit "Library - ERM";
         LibraryRandom: Codeunit "Library - Random";
+        LibraryMarketing: Codeunit "Library - Marketing";
+        NotificationLifecycleMgt: Codeunit "Notification Lifecycle Mgt.";
         Assert: Codeunit Assert;
         Any: Codeunit Any;
         IsInitialized: Boolean;
+        ReminderPostingDescriptionLbl: Label 'Reminder %1', Comment = '%1 = Reminder No.';
         FiltersAreNotSavedErr: Label 'Filters are not saved';
         EmailRelatedRecordNotFoundErr: Label 'Email related record not found';
         ReminderLevelNotFoundErr: Label 'No Reminder Level found for the created Reminder Terms';
         LanguageDoesNotMatchErr: Label 'Attachment language does not match global language';
         NoAttachmentsErr: Label 'The email has no attachments.';
         NoOfAttachmentsSameErr: Label 'The number of attachments must be the same.';
+        NoIssuedReminderCreatedErr: Label 'No issued reminder was created for the customer.';
+        IssuedReminderNoMustDifferErr: Label 'The issued reminder number must differ from the pre-assigned (original) reminder number.';
+        NoInteractionLogEntryCreatedErr: Label 'No interaction log entry was created for the issued reminder.';
+        InteractionDescriptionMustReferenceIssuedNoErr: Label 'Interaction Description must reference the issued reminder number.';
+        InteractionDescriptionMustNotReferenceOriginalNoErr: Label 'Interaction Description must not reference the original unissued reminder number.';
 }

--- a/src/Layers/IT/Tests/ERM/ReminderAutomationTests.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM/ReminderAutomationTests.Codeunit.al
@@ -1077,6 +1077,74 @@ codeunit 134979 "Reminder Automation Tests"
         Assert.AreEqual(1, TempBlobList.Count(), NoOfAttachmentsSameErr);
     end;
 
+    [HandlerFunctions('NewReminderActionModalPageHandler,CreateRemindersSetupModalPageHandler,IssueRemindersSetupModalPageHandler,SendRemindersSetupLogInteractionModalPageHandler,SelectRemTermsAutomationHandler')]
+    [Test]
+    procedure TestReminderAutomationLogsInteractionWithIssuedReminderNumber()
+    var
+        Contact: Record Contact;
+        Customer: Record Customer;
+        InteractionLogEntry: Record "Interaction Log Entry";
+        IssuedReminderHeader: Record "Issued Reminder Header";
+        JobQueueEntry: Record "Job Queue Entry";
+        ReminderActionGroup: Record "Reminder Action Group";
+        ReminderTerms: Record "Reminder Terms";
+        SendEmailMock: Codeunit "Send Email Mock";
+        ReminderAutomationJob: Codeunit "Reminders Automation Job";
+        ReminderAutomationCard: TestPage "Reminder Automation Card";
+        NumberOfOverdueEntries: Integer;
+    begin
+        // [FEATURE] [Reminder Automation] [Interaction] [AI test]
+        // [SCENARIO 639904] When Reminder Automation issues and sends reminders with Log Interaction enabled,
+        // the Contact History Description references the Issued Reminder number, not the original unissued reminder number.
+        Initialize();
+
+        // [GIVEN] An interaction template is set up for the "Sales Rmdr." document type
+        SetupSalesRmdrInteractionTemplate();
+
+        // [GIVEN] A customer that is linked to a contact and has reminder terms with overdue entries
+        CreateReminderTermsWithLevels(ReminderTerms, GetDefaultDueDatePeriodForReminderLevel(), Any.IntegerInRange(2, 5));
+        NumberOfOverdueEntries := Any.IntegerInRange(2, 5);
+        CreateCustomerWithContactAndOverdueEntries(Customer, Contact, ReminderTerms, NumberOfOverdueEntries);
+
+        // [GIVEN] A reminder automation group with create, issue and send (log interaction) actions
+        CreateReminderAutomationGroupViaUI(ReminderAutomationCard, ReminderTerms);
+        CreateReminderAction(ReminderAutomationCard, Enum::"Reminder Action"::"Create Reminder");
+        CreateReminderAction(ReminderAutomationCard, Enum::"Reminder Action"::"Issue Reminder");
+        CreateReminderAction(ReminderAutomationCard, Enum::"Reminder Action"::"Send Reminder");
+        ReminderActionGroup.Get(ReminderAutomationCard.Code.Value());
+
+        // [WHEN] The reminder automation runs (create + issue + send by email with log interaction)
+        BindSubscription(SendEmailMock);
+        SendEmailMock.AddSupportedScenario(Enum::"Email Scenario"::Reminder);
+        JobQueueEntry := CreateTestJobQueueEntry(ReminderActionGroup);
+        ReminderAutomationJob.Run(JobQueueEntry);
+        UnbindSubscription(SendEmailMock);
+
+        // [THEN] The job completed and an issued reminder was created with a number different from its pre-assigned (original) number
+        VerifyJobWasSuccesfull(ReminderActionGroup);
+        IssuedReminderHeader.SetRange("Customer No.", Customer."No.");
+        Assert.IsTrue(IssuedReminderHeader.FindFirst(), NoIssuedReminderCreatedErr);
+        Assert.AreNotEqual(
+          IssuedReminderHeader."Pre-Assigned No.", IssuedReminderHeader."No.",
+          IssuedReminderNoMustDifferErr);
+
+        // [THEN] An interaction log entry is created for the issued reminder and linked to the customer's contact
+        InteractionLogEntry.SetRange("Document Type", InteractionLogEntry."Document Type"::"Sales Rmdr.");
+        InteractionLogEntry.SetRange("Document No.", IssuedReminderHeader."No.");
+        Assert.IsTrue(InteractionLogEntry.FindLast(), NoInteractionLogEntryCreatedErr);
+        InteractionLogEntry.TestField("Contact No.", Contact."No.");
+
+        // [THEN] The Description references the Issued Reminder number, not the original (pre-assigned) reminder number
+        Assert.AreEqual(
+          StrSubstNo(ReminderPostingDescriptionLbl, IssuedReminderHeader."No."), InteractionLogEntry.Description,
+          InteractionDescriptionMustReferenceIssuedNoErr);
+        Assert.AreNotEqual(
+          StrSubstNo(ReminderPostingDescriptionLbl, IssuedReminderHeader."Pre-Assigned No."), InteractionLogEntry.Description,
+          InteractionDescriptionMustNotReferenceOriginalNoErr);
+
+        NotificationLifecycleMgt.RecallAllNotifications();
+    end;
+
     [ModalPageHandler()]
     procedure IssueRemindersSetupModalPageHandlerWithFilterSaveCheck(var IssueRemindersSetupPage: TestPage "Issue Reminders Setup")
     var
@@ -1614,6 +1682,53 @@ codeunit 134979 "Reminder Automation Tests"
         FeatureKey.Modify(true);
     end;
 
+    local procedure CreateCustomerWithContactAndOverdueEntries(var Customer: Record Customer; var Contact: Record Contact; var ReminderTerms: Record "Reminder Terms"; NumberOfEntries: Integer)
+    var
+        Item: Record Item;
+        ReminderLevel: Record "Reminder Level";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        PostingDate: Date;
+        I: Integer;
+    begin
+        ReminderLevel.SetRange("Reminder Terms Code", ReminderTerms.Code);
+        ReminderLevel.FindFirst();
+
+        // Create a customer that is linked to a contact through a business relation, so the logged interaction is tied to the contact
+        LibraryMarketing.CreateContactWithCustomer(Contact, Customer);
+        Customer.Validate("Reminder Terms Code", ReminderTerms.Code);
+        Customer.Modify(true);
+
+        PostingDate := WorkDate() + (WorkDate() - CalcDate(ReminderLevel."Due Date Calculation", WorkDate()));
+        PostingDate := CalcDate('<-5M>', PostingDate);
+
+        for I := 1 to NumberOfEntries do begin
+            LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, Customer."No.");
+            SalesHeader.Validate("Posting Date", PostingDate);
+            SalesHeader.Validate("Due Date", PostingDate);
+            SalesHeader.Validate("Document Date", PostingDate);
+            SalesHeader.Modify(true);
+            LibraryInventory.CreateItemWithUnitPriceAndUnitCost(
+              Item, Any.DecimalInRange(1, 100, 2), Any.DecimalInRange(1, 100, 2));
+            LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, Item."No.", Any.IntegerInRange(1, 10));
+            LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        end;
+    end;
+
+    local procedure SetupSalesRmdrInteractionTemplate()
+    var
+        InteractionTemplateSetup: Record "Interaction Template Setup";
+        InteractionTemplate: Record "Interaction Template";
+    begin
+        if not InteractionTemplateSetup.Get() then begin
+            InteractionTemplateSetup.Init();
+            InteractionTemplateSetup.Insert();
+        end;
+        LibraryMarketing.CreateInteractionTemplate(InteractionTemplate);
+        InteractionTemplateSetup.Validate("Sales Rmdr.", InteractionTemplate.Code);
+        InteractionTemplateSetup.Modify(true);
+    end;
+
     [StrMenuHandler]
     [Scope('OnPrem')]
     procedure CancelMailSendingStrMenuHandler(Options: Text; var Choice: Integer; Instruction: Text)
@@ -1684,6 +1799,15 @@ codeunit 134979 "Reminder Automation Tests"
         Assert.IsTrue(CreateReminderSetup.GetCustomerSelectionDisplayText() <> '', FiltersAreNotSavedErr);
     end;
 
+    [ModalPageHandler()]
+    procedure SendRemindersSetupLogInteractionModalPageHandler(var SendRemindersSetup: TestPage "Send Reminders Setup")
+    begin
+        SendRemindersSetup.SendByEmail.SetValue(true);
+        SendRemindersSetup.Print.SetValue(false);
+        SendRemindersSetup.LogInteraction.SetValue(true);
+        SendRemindersSetup.OK().Invoke();
+    end;
+
     [FilterPageHandler]
     procedure CreateReminderSetupPageCustomerFilterHandler(var CustomerRecordRef: RecordRef): Boolean
     var
@@ -1722,13 +1846,21 @@ codeunit 134979 "Reminder Automation Tests"
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryErm: Codeunit "Library - ERM";
         LibraryRandom: Codeunit "Library - Random";
+        LibraryMarketing: Codeunit "Library - Marketing";
+        NotificationLifecycleMgt: Codeunit "Notification Lifecycle Mgt.";
         Assert: Codeunit Assert;
         Any: Codeunit Any;
         IsInitialized: Boolean;
+        ReminderPostingDescriptionLbl: Label 'Reminder %1', Comment = '%1 = Reminder No.';
         FiltersAreNotSavedErr: Label 'Filters are not saved';
         EmailRelatedRecordNotFoundErr: Label 'Email related record not found';
         ReminderLevelNotFoundErr: Label 'No Reminder Level found for the created Reminder Terms';
         LanguageDoesNotMatchErr: Label 'Attachment language does not match global language';
         NoAttachmentsErr: Label 'The email has no attachments.';
         NoOfAttachmentsSameErr: Label 'The number of attachments must be the same.';
+        NoIssuedReminderCreatedErr: Label 'No issued reminder was created for the customer.';
+        IssuedReminderNoMustDifferErr: Label 'The issued reminder number must differ from the pre-assigned (original) reminder number.';
+        NoInteractionLogEntryCreatedErr: Label 'No interaction log entry was created for the issued reminder.';
+        InteractionDescriptionMustReferenceIssuedNoErr: Label 'Interaction Description must reference the issued reminder number.';
+        InteractionDescriptionMustNotReferenceOriginalNoErr: Label 'Interaction Description must not reference the original unissued reminder number.';
 }

--- a/src/Layers/NA/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/NA/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -874,7 +874,7 @@ report 117 Reminder
                 repeat
                     SegManagement.LogDocument(
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
-                      '', '', "Issued Reminder Header"."Posting Description", '');
+                      '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
     end;
 

--- a/src/Layers/NA/Tests/ERM/ReminderAutomationTests.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM/ReminderAutomationTests.Codeunit.al
@@ -937,6 +937,74 @@ codeunit 134979 "Reminder Automation Tests"
         Assert.AreEqual(1, TempBlobList.Count(), NoOfAttachmentsSameErr);
     end;
 
+    [HandlerFunctions('NewReminderActionModalPageHandler,CreateRemindersSetupModalPageHandler,IssueRemindersSetupModalPageHandler,SendRemindersSetupLogInteractionModalPageHandler,SelectRemTermsAutomationHandler')]
+    [Test]
+    procedure TestReminderAutomationLogsInteractionWithIssuedReminderNumber()
+    var
+        Contact: Record Contact;
+        Customer: Record Customer;
+        InteractionLogEntry: Record "Interaction Log Entry";
+        IssuedReminderHeader: Record "Issued Reminder Header";
+        JobQueueEntry: Record "Job Queue Entry";
+        ReminderActionGroup: Record "Reminder Action Group";
+        ReminderTerms: Record "Reminder Terms";
+        SendEmailMock: Codeunit "Send Email Mock";
+        ReminderAutomationJob: Codeunit "Reminders Automation Job";
+        ReminderAutomationCard: TestPage "Reminder Automation Card";
+        NumberOfOverdueEntries: Integer;
+    begin
+        // [FEATURE] [Reminder Automation] [Interaction] [AI test]
+        // [SCENARIO 639904] When Reminder Automation issues and sends reminders with Log Interaction enabled,
+        // the Contact History Description references the Issued Reminder number, not the original unissued reminder number.
+        Initialize();
+
+        // [GIVEN] An interaction template is set up for the "Sales Rmdr." document type
+        SetupSalesRmdrInteractionTemplate();
+
+        // [GIVEN] A customer that is linked to a contact and has reminder terms with overdue entries
+        CreateReminderTermsWithLevels(ReminderTerms, GetDefaultDueDatePeriodForReminderLevel(), Any.IntegerInRange(2, 5));
+        NumberOfOverdueEntries := Any.IntegerInRange(2, 5);
+        CreateCustomerWithContactAndOverdueEntries(Customer, Contact, ReminderTerms, NumberOfOverdueEntries);
+
+        // [GIVEN] A reminder automation group with create, issue and send (log interaction) actions
+        CreateReminderAutomationGroupViaUI(ReminderAutomationCard, ReminderTerms);
+        CreateReminderAction(ReminderAutomationCard, Enum::"Reminder Action"::"Create Reminder");
+        CreateReminderAction(ReminderAutomationCard, Enum::"Reminder Action"::"Issue Reminder");
+        CreateReminderAction(ReminderAutomationCard, Enum::"Reminder Action"::"Send Reminder");
+        ReminderActionGroup.Get(ReminderAutomationCard.Code.Value());
+
+        // [WHEN] The reminder automation runs (create + issue + send by email with log interaction)
+        BindSubscription(SendEmailMock);
+        SendEmailMock.AddSupportedScenario(Enum::"Email Scenario"::Reminder);
+        JobQueueEntry := CreateTestJobQueueEntry(ReminderActionGroup);
+        ReminderAutomationJob.Run(JobQueueEntry);
+        UnbindSubscription(SendEmailMock);
+
+        // [THEN] The job completed and an issued reminder was created with a number different from its pre-assigned (original) number
+        VerifyJobWasSuccesfull(ReminderActionGroup);
+        IssuedReminderHeader.SetRange("Customer No.", Customer."No.");
+        Assert.IsTrue(IssuedReminderHeader.FindFirst(), NoIssuedReminderCreatedErr);
+        Assert.AreNotEqual(
+          IssuedReminderHeader."Pre-Assigned No.", IssuedReminderHeader."No.",
+          IssuedReminderNoMustDifferErr);
+
+        // [THEN] An interaction log entry is created for the issued reminder and linked to the customer's contact
+        InteractionLogEntry.SetRange("Document Type", InteractionLogEntry."Document Type"::"Sales Rmdr.");
+        InteractionLogEntry.SetRange("Document No.", IssuedReminderHeader."No.");
+        Assert.IsTrue(InteractionLogEntry.FindLast(), NoInteractionLogEntryCreatedErr);
+        InteractionLogEntry.TestField("Contact No.", Contact."No.");
+
+        // [THEN] The Description references the Issued Reminder number, not the original (pre-assigned) reminder number
+        Assert.AreEqual(
+          StrSubstNo(ReminderPostingDescriptionLbl, IssuedReminderHeader."No."), InteractionLogEntry.Description,
+          InteractionDescriptionMustReferenceIssuedNoErr);
+        Assert.AreNotEqual(
+          StrSubstNo(ReminderPostingDescriptionLbl, IssuedReminderHeader."Pre-Assigned No."), InteractionLogEntry.Description,
+          InteractionDescriptionMustNotReferenceOriginalNoErr);
+
+        NotificationLifecycleMgt.RecallAllNotifications();
+    end;
+
     [ModalPageHandler()]
     procedure IssueRemindersSetupModalPageHandlerWithFilterSaveCheck(var IssueRemindersSetupPage: TestPage "Issue Reminders Setup")
     var
@@ -1472,6 +1540,53 @@ codeunit 134979 "Reminder Automation Tests"
         FeatureKey.Modify(true);
     end;
 
+    local procedure CreateCustomerWithContactAndOverdueEntries(var Customer: Record Customer; var Contact: Record Contact; var ReminderTerms: Record "Reminder Terms"; NumberOfEntries: Integer)
+    var
+        Item: Record Item;
+        ReminderLevel: Record "Reminder Level";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        PostingDate: Date;
+        I: Integer;
+    begin
+        ReminderLevel.SetRange("Reminder Terms Code", ReminderTerms.Code);
+        ReminderLevel.FindFirst();
+
+        // Create a customer that is linked to a contact through a business relation, so the logged interaction is tied to the contact
+        LibraryMarketing.CreateContactWithCustomer(Contact, Customer);
+        Customer.Validate("Reminder Terms Code", ReminderTerms.Code);
+        Customer.Modify(true);
+
+        PostingDate := WorkDate() + (WorkDate() - CalcDate(ReminderLevel."Due Date Calculation", WorkDate()));
+        PostingDate := CalcDate('<-5M>', PostingDate);
+
+        for I := 1 to NumberOfEntries do begin
+            LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, Customer."No.");
+            SalesHeader.Validate("Posting Date", PostingDate);
+            SalesHeader.Validate("Due Date", PostingDate);
+            SalesHeader.Validate("Document Date", PostingDate);
+            SalesHeader.Modify(true);
+            LibraryInventory.CreateItemWithUnitPriceAndUnitCost(
+              Item, Any.DecimalInRange(1, 100, 2), Any.DecimalInRange(1, 100, 2));
+            LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, Item."No.", Any.IntegerInRange(1, 10));
+            LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        end;
+    end;
+
+    local procedure SetupSalesRmdrInteractionTemplate()
+    var
+        InteractionTemplateSetup: Record "Interaction Template Setup";
+        InteractionTemplate: Record "Interaction Template";
+    begin
+        if not InteractionTemplateSetup.Get() then begin
+            InteractionTemplateSetup.Init();
+            InteractionTemplateSetup.Insert();
+        end;
+        LibraryMarketing.CreateInteractionTemplate(InteractionTemplate);
+        InteractionTemplateSetup.Validate("Sales Rmdr.", InteractionTemplate.Code);
+        InteractionTemplateSetup.Modify(true);
+    end;
+
     [StrMenuHandler]
     [Scope('OnPrem')]
     procedure CancelMailSendingStrMenuHandler(Options: Text; var Choice: Integer; Instruction: Text)
@@ -1542,6 +1657,15 @@ codeunit 134979 "Reminder Automation Tests"
         Assert.IsTrue(CreateReminderSetup.GetCustomerSelectionDisplayText() <> '', FiltersAreNotSavedErr);
     end;
 
+    [ModalPageHandler()]
+    procedure SendRemindersSetupLogInteractionModalPageHandler(var SendRemindersSetup: TestPage "Send Reminders Setup")
+    begin
+        SendRemindersSetup.SendByEmail.SetValue(true);
+        SendRemindersSetup.Print.SetValue(false);
+        SendRemindersSetup.LogInteraction.SetValue(true);
+        SendRemindersSetup.OK().Invoke();
+    end;
+
     [FilterPageHandler]
     procedure CreateReminderSetupPageCustomerFilterHandler(var CustomerRecordRef: RecordRef): Boolean
     var
@@ -1580,13 +1704,21 @@ codeunit 134979 "Reminder Automation Tests"
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryErm: Codeunit "Library - ERM";
         LibraryRandom: Codeunit "Library - Random";
+        LibraryMarketing: Codeunit "Library - Marketing";
+        NotificationLifecycleMgt: Codeunit "Notification Lifecycle Mgt.";
         Assert: Codeunit Assert;
         Any: Codeunit Any;
         IsInitialized: Boolean;
+        ReminderPostingDescriptionLbl: Label 'Reminder %1', Comment = '%1 = Reminder No.';
         FiltersAreNotSavedErr: Label 'Filters are not saved';
         EmailRelatedRecordNotFoundErr: Label 'Email related record not found';
         ReminderLevelNotFoundErr: Label 'No Reminder Level found for the created Reminder Terms';
         LanguageDoesNotMatchErr: Label 'Attachment language does not match global language';
         NoAttachmentsErr: Label 'The email has no attachments.';
         NoOfAttachmentsSameErr: Label 'The number of attachments must be the same.';
+        NoIssuedReminderCreatedErr: Label 'No issued reminder was created for the customer.';
+        IssuedReminderNoMustDifferErr: Label 'The issued reminder number must differ from the pre-assigned (original) reminder number.';
+        NoInteractionLogEntryCreatedErr: Label 'No interaction log entry was created for the issued reminder.';
+        InteractionDescriptionMustReferenceIssuedNoErr: Label 'Interaction Description must reference the issued reminder number.';
+        InteractionDescriptionMustNotReferenceOriginalNoErr: Label 'Interaction Description must not reference the original unissued reminder number.';
 }

--- a/src/Layers/NO/BaseApp/Sales/Reminder/IssuedReminderHeader.Table.al
+++ b/src/Layers/NO/BaseApp/Sales/Reminder/IssuedReminderHeader.Table.al
@@ -871,4 +871,21 @@ table 297 "Issued Reminder Header"
     internal procedure OnGetReportParameters(var LogInteraction: Boolean; var ShowNotDueAmounts: Boolean; var ShowMIRLines: Boolean; ReportID: Integer; var Handled: Boolean)
     begin
     end;
+
+    /// <summary>
+    /// Returns the description to use when logging an interaction for this issued reminder.
+    /// When the posting description still holds the default text derived from the pre-assigned
+    /// (unissued) reminder number, it is replaced with the same text based on the issued reminder
+    /// number so the Contact History references the registered reminder. Customized posting
+    /// descriptions are preserved.
+    /// </summary>
+    /// <returns>The interaction log description text.</returns>
+    internal procedure GetLogInteractionDescription(): Text[100]
+    var
+        ReminderHeader: Record "Reminder Header";
+    begin
+        if ("Pre-Assigned No." <> '') and ("Posting Description" = ReminderHeader.GetDefaultPostingDescription("Pre-Assigned No.")) then
+            exit(ReminderHeader.GetDefaultPostingDescription("No."));
+        exit("Posting Description");
+    end;
 }

--- a/src/Layers/NO/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/NO/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -934,7 +934,7 @@ report 117 Reminder
                 repeat
                     SegManagement.LogDocument(
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
-                      '', '', "Issued Reminder Header"."Posting Description", '');
+                      '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
     end;
 

--- a/src/Layers/NO/BaseApp/Sales/Reminder/ReminderHeader.Table.al
+++ b/src/Layers/NO/BaseApp/Sales/Reminder/ReminderHeader.Table.al
@@ -55,7 +55,7 @@ table 295 "Reminder Header"
                     NoSeries.TestManual(GetNoSeriesCode());
                     "No. Series" := '';
                 end;
-                "Posting Description" := StrSubstNo(ReminderNoLbl, "No.");
+                "Posting Description" := GetDefaultPostingDescription("No.");
             end;
         }
         /// <summary>
@@ -811,7 +811,7 @@ table 295 "Reminder Header"
     begin
         SalesSetup.Get();
         SetReminderNo();
-        "Posting Description" := StrSubstNo(ReminderNoLbl, "No.");
+        "Posting Description" := GetDefaultPostingDescription("No.");
 
         OnInsertOnBeforeInitNoSeries(Rec, xRec, IsHandled);
         if not IsHandled then
@@ -874,6 +874,16 @@ table 295 "Reminder Header"
         GapInNumberSeriesIfDeleteTxt: Label 'Deleting this document will cause a gap in the number series for reminders. ';
         CreateEmptyReminderTxt: Label 'An empty reminder %1 will be created to fill this gap in the number series.\\', Comment = '%1 = Reminder No.';
         UnexpectedLineTypeErr: Label 'Unexpected line type %1 in reminder %2', Comment = '%1 = Line Type, %2 = Reminder No.';
+
+    /// <summary>
+    /// Returns the default posting description text for the given reminder number.
+    /// </summary>
+    /// <param name="ReminderNo">The reminder number to embed in the posting description.</param>
+    /// <returns>The default posting description text.</returns>
+    internal procedure GetDefaultPostingDescription(ReminderNo: Code[20]): Text[100]
+    begin
+        exit(StrSubstNo(ReminderNoLbl, ReminderNo));
+    end;
 
     /// <summary>
     /// Opens a dialog to assist with selecting a number from related number series.

--- a/src/Layers/W1/BaseApp/Sales/Reminder/IssuedReminderHeader.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/IssuedReminderHeader.Table.al
@@ -806,4 +806,21 @@ table 297 "Issued Reminder Header"
     internal procedure OnGetReportParameters(var LogInteraction: Boolean; var ShowNotDueAmounts: Boolean; var ShowMIRLines: Boolean; ReportID: Integer; var Handled: Boolean)
     begin
     end;
+
+    /// <summary>
+    /// Returns the description to use when logging an interaction for this issued reminder.
+    /// When the posting description still holds the default text derived from the pre-assigned
+    /// (unissued) reminder number, it is replaced with the same text based on the issued reminder
+    /// number so the Contact History references the registered reminder. Customized posting
+    /// descriptions are preserved.
+    /// </summary>
+    /// <returns>The interaction log description text.</returns>
+    internal procedure GetLogInteractionDescription(): Text[100]
+    var
+        ReminderHeader: Record "Reminder Header";
+    begin
+        if ("Pre-Assigned No." <> '') and ("Posting Description" = ReminderHeader.GetDefaultPostingDescription("Pre-Assigned No.")) then
+            exit(ReminderHeader.GetDefaultPostingDescription("No."));
+        exit("Posting Description");
+    end;
 }

--- a/src/Layers/W1/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -919,7 +919,7 @@ report 117 Reminder
                 repeat
                     SegManagement.LogDocument(
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
-                      '', '', "Issued Reminder Header"."Posting Description", '');
+                      '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
     end;
 

--- a/src/Layers/W1/BaseApp/Sales/Reminder/ReminderHeader.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/ReminderHeader.Table.al
@@ -52,7 +52,7 @@ table 295 "Reminder Header"
                     NoSeries.TestManual(GetNoSeriesCode());
                     "No. Series" := '';
                 end;
-                "Posting Description" := StrSubstNo(ReminderNoLbl, "No.");
+                "Posting Description" := GetDefaultPostingDescription("No.");
             end;
         }
         /// <summary>
@@ -749,7 +749,7 @@ table 295 "Reminder Header"
     begin
         SalesSetup.Get();
         SetReminderNo();
-        "Posting Description" := StrSubstNo(ReminderNoLbl, "No.");
+        "Posting Description" := GetDefaultPostingDescription("No.");
 
         OnInsertOnBeforeInitNoSeries(Rec, xRec, IsHandled);
         if not IsHandled then
@@ -806,6 +806,16 @@ table 295 "Reminder Header"
         GapInNumberSeriesIfDeleteTxt: Label 'Deleting this document will cause a gap in the number series for reminders. ';
         CreateEmptyReminderTxt: Label 'An empty reminder %1 will be created to fill this gap in the number series.\\', Comment = '%1 = Reminder No.';
         UnexpectedLineTypeErr: Label 'Unexpected line type %1 in reminder %2', Comment = '%1 = Line Type, %2 = Reminder No.';
+
+    /// <summary>
+    /// Returns the default posting description text for the given reminder number.
+    /// </summary>
+    /// <param name="ReminderNo">The reminder number to embed in the posting description.</param>
+    /// <returns>The default posting description text.</returns>
+    internal procedure GetDefaultPostingDescription(ReminderNo: Code[20]): Text[100]
+    begin
+        exit(StrSubstNo(ReminderNoLbl, ReminderNo));
+    end;
 
     /// <summary>
     /// Opens a dialog to assist with selecting a number from related number series.

--- a/src/Layers/W1/Tests/ERM/ReminderAutomationTests.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ReminderAutomationTests.Codeunit.al
@@ -1077,6 +1077,74 @@ codeunit 134979 "Reminder Automation Tests"
         Assert.AreEqual(1, TempBlobList.Count(), NoOfAttachmentsSameErr);
     end;
 
+    [HandlerFunctions('NewReminderActionModalPageHandler,CreateRemindersSetupModalPageHandler,IssueRemindersSetupModalPageHandler,SendRemindersSetupLogInteractionModalPageHandler,SelectRemTermsAutomationHandler')]
+    [Test]
+    procedure TestReminderAutomationLogsInteractionWithIssuedReminderNumber()
+    var
+        Contact: Record Contact;
+        Customer: Record Customer;
+        InteractionLogEntry: Record "Interaction Log Entry";
+        IssuedReminderHeader: Record "Issued Reminder Header";
+        JobQueueEntry: Record "Job Queue Entry";
+        ReminderActionGroup: Record "Reminder Action Group";
+        ReminderTerms: Record "Reminder Terms";
+        SendEmailMock: Codeunit "Send Email Mock";
+        ReminderAutomationJob: Codeunit "Reminders Automation Job";
+        ReminderAutomationCard: TestPage "Reminder Automation Card";
+        NumberOfOverdueEntries: Integer;
+    begin
+        // [FEATURE] [Reminder Automation] [Interaction] [AI test]
+        // [SCENARIO 639904] When Reminder Automation issues and sends reminders with Log Interaction enabled,
+        // the Contact History Description references the Issued Reminder number, not the original unissued reminder number.
+        Initialize();
+
+        // [GIVEN] An interaction template is set up for the "Sales Rmdr." document type
+        SetupSalesRmdrInteractionTemplate();
+
+        // [GIVEN] A customer that is linked to a contact and has reminder terms with overdue entries
+        CreateReminderTermsWithLevels(ReminderTerms, GetDefaultDueDatePeriodForReminderLevel(), Any.IntegerInRange(2, 5));
+        NumberOfOverdueEntries := Any.IntegerInRange(2, 5);
+        CreateCustomerWithContactAndOverdueEntries(Customer, Contact, ReminderTerms, NumberOfOverdueEntries);
+
+        // [GIVEN] A reminder automation group with create, issue and send (log interaction) actions
+        CreateReminderAutomationGroupViaUI(ReminderAutomationCard, ReminderTerms);
+        CreateReminderAction(ReminderAutomationCard, Enum::"Reminder Action"::"Create Reminder");
+        CreateReminderAction(ReminderAutomationCard, Enum::"Reminder Action"::"Issue Reminder");
+        CreateReminderAction(ReminderAutomationCard, Enum::"Reminder Action"::"Send Reminder");
+        ReminderActionGroup.Get(ReminderAutomationCard.Code.Value());
+
+        // [WHEN] The reminder automation runs (create + issue + send by email with log interaction)
+        BindSubscription(SendEmailMock);
+        SendEmailMock.AddSupportedScenario(Enum::"Email Scenario"::Reminder);
+        JobQueueEntry := CreateTestJobQueueEntry(ReminderActionGroup);
+        ReminderAutomationJob.Run(JobQueueEntry);
+        UnbindSubscription(SendEmailMock);
+
+        // [THEN] The job completed and an issued reminder was created with a number different from its pre-assigned (original) number
+        VerifyJobWasSuccesfull(ReminderActionGroup);
+        IssuedReminderHeader.SetRange("Customer No.", Customer."No.");
+        Assert.IsTrue(IssuedReminderHeader.FindFirst(), NoIssuedReminderCreatedErr);
+        Assert.AreNotEqual(
+          IssuedReminderHeader."Pre-Assigned No.", IssuedReminderHeader."No.",
+          IssuedReminderNoMustDifferErr);
+
+        // [THEN] An interaction log entry is created for the issued reminder and linked to the customer's contact
+        InteractionLogEntry.SetRange("Document Type", InteractionLogEntry."Document Type"::"Sales Rmdr.");
+        InteractionLogEntry.SetRange("Document No.", IssuedReminderHeader."No.");
+        Assert.IsTrue(InteractionLogEntry.FindLast(), NoInteractionLogEntryCreatedErr);
+        InteractionLogEntry.TestField("Contact No.", Contact."No.");
+
+        // [THEN] The Description references the Issued Reminder number, not the original (pre-assigned) reminder number
+        Assert.AreEqual(
+          StrSubstNo(ReminderPostingDescriptionLbl, IssuedReminderHeader."No."), InteractionLogEntry.Description,
+          InteractionDescriptionMustReferenceIssuedNoErr);
+        Assert.AreNotEqual(
+          StrSubstNo(ReminderPostingDescriptionLbl, IssuedReminderHeader."Pre-Assigned No."), InteractionLogEntry.Description,
+          InteractionDescriptionMustNotReferenceOriginalNoErr);
+
+        NotificationLifecycleMgt.RecallAllNotifications();
+    end;
+
     [ModalPageHandler()]
     procedure IssueRemindersSetupModalPageHandlerWithFilterSaveCheck(var IssueRemindersSetupPage: TestPage "Issue Reminders Setup")
     var
@@ -1613,6 +1681,53 @@ codeunit 134979 "Reminder Automation Tests"
         FeatureKey.Modify(true);
     end;
 
+    local procedure CreateCustomerWithContactAndOverdueEntries(var Customer: Record Customer; var Contact: Record Contact; var ReminderTerms: Record "Reminder Terms"; NumberOfEntries: Integer)
+    var
+        Item: Record Item;
+        ReminderLevel: Record "Reminder Level";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        PostingDate: Date;
+        I: Integer;
+    begin
+        ReminderLevel.SetRange("Reminder Terms Code", ReminderTerms.Code);
+        ReminderLevel.FindFirst();
+
+        // Create a customer that is linked to a contact through a business relation, so the logged interaction is tied to the contact
+        LibraryMarketing.CreateContactWithCustomer(Contact, Customer);
+        Customer.Validate("Reminder Terms Code", ReminderTerms.Code);
+        Customer.Modify(true);
+
+        PostingDate := WorkDate() + (WorkDate() - CalcDate(ReminderLevel."Due Date Calculation", WorkDate()));
+        PostingDate := CalcDate('<-5M>', PostingDate);
+
+        for I := 1 to NumberOfEntries do begin
+            LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, Customer."No.");
+            SalesHeader.Validate("Posting Date", PostingDate);
+            SalesHeader.Validate("Due Date", PostingDate);
+            SalesHeader.Validate("Document Date", PostingDate);
+            SalesHeader.Modify(true);
+            LibraryInventory.CreateItemWithUnitPriceAndUnitCost(
+              Item, Any.DecimalInRange(1, 100, 2), Any.DecimalInRange(1, 100, 2));
+            LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, Item."No.", Any.IntegerInRange(1, 10));
+            LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        end;
+    end;
+
+    local procedure SetupSalesRmdrInteractionTemplate()
+    var
+        InteractionTemplateSetup: Record "Interaction Template Setup";
+        InteractionTemplate: Record "Interaction Template";
+    begin
+        if not InteractionTemplateSetup.Get() then begin
+            InteractionTemplateSetup.Init();
+            InteractionTemplateSetup.Insert();
+        end;
+        LibraryMarketing.CreateInteractionTemplate(InteractionTemplate);
+        InteractionTemplateSetup.Validate("Sales Rmdr.", InteractionTemplate.Code);
+        InteractionTemplateSetup.Modify(true);
+    end;
+
     [StrMenuHandler]
     [Scope('OnPrem')]
     procedure CancelMailSendingStrMenuHandler(Options: Text; var Choice: Integer; Instruction: Text)
@@ -1683,6 +1798,15 @@ codeunit 134979 "Reminder Automation Tests"
         Assert.IsTrue(CreateReminderSetup.GetCustomerSelectionDisplayText() <> '', FiltersAreNotSavedErr);
     end;
 
+    [ModalPageHandler()]
+    procedure SendRemindersSetupLogInteractionModalPageHandler(var SendRemindersSetup: TestPage "Send Reminders Setup")
+    begin
+        SendRemindersSetup.SendByEmail.SetValue(true);
+        SendRemindersSetup.Print.SetValue(false);
+        SendRemindersSetup.LogInteraction.SetValue(true);
+        SendRemindersSetup.OK().Invoke();
+    end;
+
     [FilterPageHandler]
     procedure CreateReminderSetupPageCustomerFilterHandler(var CustomerRecordRef: RecordRef): Boolean
     var
@@ -1721,13 +1845,21 @@ codeunit 134979 "Reminder Automation Tests"
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryErm: Codeunit "Library - ERM";
         LibraryRandom: Codeunit "Library - Random";
+        LibraryMarketing: Codeunit "Library - Marketing";
+        NotificationLifecycleMgt: Codeunit "Notification Lifecycle Mgt.";
         Assert: Codeunit Assert;
         Any: Codeunit Any;
         IsInitialized: Boolean;
+        ReminderPostingDescriptionLbl: Label 'Reminder %1', Comment = '%1 = Reminder No.';
         FiltersAreNotSavedErr: Label 'Filters are not saved';
         EmailRelatedRecordNotFoundErr: Label 'Email related record not found';
         ReminderLevelNotFoundErr: Label 'No Reminder Level found for the created Reminder Terms';
         LanguageDoesNotMatchErr: Label 'Attachment language does not match global language';
         NoAttachmentsErr: Label 'The email has no attachments.';
         NoOfAttachmentsSameErr: Label 'The number of attachments must be the same.';
+        NoIssuedReminderCreatedErr: Label 'No issued reminder was created for the customer.';
+        IssuedReminderNoMustDifferErr: Label 'The issued reminder number must differ from the pre-assigned (original) reminder number.';
+        NoInteractionLogEntryCreatedErr: Label 'No interaction log entry was created for the issued reminder.';
+        InteractionDescriptionMustReferenceIssuedNoErr: Label 'Interaction Description must reference the issued reminder number.';
+        InteractionDescriptionMustNotReferenceOriginalNoErr: Label 'Interaction Description must not reference the original unissued reminder number.';
 }


### PR DESCRIPTION
[Bug 641874](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/641874): [all-e][Main]Description field in the contact history is showing the number of the original unregistered reminder instead of the registered reminder number when using the reminder automation setup.

[AB#641874](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641874)

**Issue**: In Reminder Automation, the Description shown in Contact History displays the number of the original unregistered reminder instead of the newly registered reminder number, resulting in incorrect history information.

**Cause**: The contact history description was built using a reference/number from the pre-registration reminder flow, and that value was not updated to the final registered reminder document number before logging history.

**Solution**: Updated the reminder automation/contact history logic to populate Description with the registered reminder number (final posted document) so history shows the correct reference after reminder registration.






