### PR TITLE
Improve error message when demo data container has no apps to install

### DIFF
--- a/build/scripts/ImportTestDataInBcContainer.ps1
+++ b/build/scripts/ImportTestDataInBcContainer.ps1
@@ -622,8 +622,13 @@ function Install-AllApps() {
 
     # Install all published-but-not-installed apps in dependency order
     Write-Host "Installing all published apps..."
-    $publishedApps = Get-BcContainerAppInfo -containerName $ContainerName -tenantSpecificProperties -sort DependenciesFirst
-    $uninstalledApps = $publishedApps | Where-Object { $_.IsPublished -and -not $_.IsInstalled }
+    $publishedApps = @(Get-BcContainerAppInfo -containerName $ContainerName -tenantSpecificProperties -sort DependenciesFirst)
+
+    if ($publishedApps.Count -eq 0) {
+        throw "No apps found in container '$ContainerName'. The build/publish step produced no apps to install. This usually means dependency resolution downloaded no apps - e.g. a branch name containing glob metacharacters (such as ']') can break artifact matching in AL-Go's DownloadProjectDependencies."
+    }
+
+    $uninstalledApps = @($publishedApps | Where-Object { $_.IsPublished -and -not $_.IsInstalled })
 
     if ($uninstalledApps.Count -eq 0) {
         Write-Host "All apps already installed"
@@ -677,7 +682,7 @@ function Install-BaseAppsForDemoTool() {
 
     # Install only those apps (in dependency order)
     $publishedApps = Get-BcContainerAppInfo -containerName $ContainerName -tenantSpecificProperties -sort DependenciesFirst
-    $appsToInstall = $publishedApps | Where-Object { $_.IsPublished -and -not $_.IsInstalled -and ($baseAppNames -contains $_.Name) }
+    $appsToInstall = @($publishedApps | Where-Object { $_.IsPublished -and -not $_.IsInstalled -and ($baseAppNames -contains $_.Name) })
 
     Write-Host "Installing $($appsToInstall.Count) base apps"
     foreach ($app in $appsToInstall) {


### PR DESCRIPTION
## What & why

CI test jobs were failing during demo data generation with the opaque error `An error occurred during demo data generation: The property 'Count' cannot be found on this object`, which gave no hint at the real problem and wiped out ~105 jobs across a single run.

Root cause: in `Install-AllApps`, `Get-BcContainerAppInfo | Where-Object {...}` returns `$null` (not an empty array) when the filter matches nothing. Under the pipeline's StrictMode, reading `.Count` on `$null` throws that cryptic message. The underlying trigger is that the container had zero published apps, so the filter had nothing to match.

This change does not try to fix why a container can end up empty (that is a separate dependency-resolution issue being addressed in AL-Go). It makes the failure legible and robust:

- Wrap the collections in `@()` so `.Count` is always valid, in both `Install-AllApps` and the sibling `Install-BaseAppsForDemoTool` (same latent pattern).
- Throw a clear, actionable error when the container has no published apps at all, pointing at the real cause instead of failing later with an opaque message.

## Linked work

Fixes #

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Reproduced the mechanism directly in PowerShell: `@(1,2,3) | Where-Object { $_ -gt 10 }` returns `$null`, and under `Set-StrictMode -Version Latest` reading `.Count` on it throws the exact error seen in CI; with `@()` wrapping it returns `0` correctly.
- Confirmed against the failing CI jobs (multiple PR runs on 2026-07-09) that the container had zero published apps (`Installing apps took 0 seconds`, 0 apps published) at the point `Install-AllApps` ran, matching the empty-collection path.
- No AL tests added: this is a PowerShell build-script change with no AL test coverage in the repo. The new `throw` path converts a silent failure into a clear one.

## Risk & compatibility

Low. Behavior is unchanged on the healthy path (apps present). The only new behavior is a clearer error message on an already-failing path (empty container), plus defensive `@()` wrapping that cannot change results for non-empty collections. No upgrade, data, or permission impact.


