### PR TITLE
Fix flaky ERM Sales/Purchase Tax II value-entry rounding test

### DIFF
--- a/src/DisabledTests/Tests-Local/Tests-Local.DisabledTest.json
+++ b/src/DisabledTests/Tests-Local/Tests-Local.DisabledTest.json
@@ -1420,11 +1420,6 @@
     "method": "PrintOrderConfirmationW1Report"
   },
   {
-    "codeunitId": 142051,
-    "codeunitName": "ERM Sales/Purchase Tax II",
-    "method": "VerifyValueAfterPostPurchaseOrderWithChargeItemAssgnmt"
-  },
-  {
     "codeunitId": 142052,
     "codeunitName": "ERM Payables/Receivables",
     "method": "ApplyEntriesForCustPartialPaymentAgainstInvoiceAndCrMemo"

--- a/src/Layers/CA/Tests/Local/ERMSalesPurchaseTaxII.Codeunit.al
+++ b/src/Layers/CA/Tests/Local/ERMSalesPurchaseTaxII.Codeunit.al
@@ -6147,7 +6147,8 @@ codeunit 142051 "ERM Sales/Purchase Tax II"
         ValueEntry.SetRange("Document Type", ValueEntry."Document Type"::"Purchase Invoice");
         ValueEntry.SetRange("Document No.", DocumentNo);
         ValueEntry.CalcSums("Cost Amount (Actual)");
-        Assert.AreEqual(ExpectedAmount, ValueEntry."Cost Amount (Actual)", WrongValueEntryAmountErr);
+        Assert.AreNearlyEqual(
+          ExpectedAmount, ValueEntry."Cost Amount (Actual)", LibraryERM.GetAmountRoundingPrecision(), WrongValueEntryAmountErr);
     end;
 
     local procedure VerifyUnitCostWithTaxInJobLedgEntry(PurchLine: Record "Purchase Line"; DocNo: Code[20])

--- a/src/Layers/US/Tests/Local/ERMSalesPurchaseTaxII.Codeunit.al
+++ b/src/Layers/US/Tests/Local/ERMSalesPurchaseTaxII.Codeunit.al
@@ -6096,7 +6096,8 @@
         ValueEntry.SetRange("Document Type", ValueEntry."Document Type"::"Purchase Invoice");
         ValueEntry.SetRange("Document No.", DocumentNo);
         ValueEntry.CalcSums("Cost Amount (Actual)");
-        Assert.AreEqual(ExpectedAmount, ValueEntry."Cost Amount (Actual)", WrongValueEntryAmountErr);
+        Assert.AreNearlyEqual(
+          ExpectedAmount, ValueEntry."Cost Amount (Actual)", LibraryERM.GetAmountRoundingPrecision(), WrongValueEntryAmountErr);
     end;
 
     local procedure VerifyUnitCostWithTaxInJobLedgEntry(PurchLine: Record "Purchase Line"; DocNo: Code[20])


### PR DESCRIPTION
## Problem
The Tests-Local test `142051 ""ERM Sales/Purchase Tax II"".VerifyValueAfterPostPurchaseOrderWithChargeItemAssgnmt` fails intermittently on SNAP with `Assert.AreEqual failed ... Value Entry Amount is wrong.` (a 1-cent difference). It is currently on the `Tests-Local` disabled list.

## Root cause
`VerifyValueEntriesCostAmount` asserts the summed `Cost Amount (Actual)` with **strict equality**. The expected value rounds the expensed use tax **once on the total charge** (`ChargeAmount + Round(ChargeAmount * TaxPct / 100)`), but posting distributes the item charge **equally across two item lines** and rounds the expensed tax **per value entry**. Because `sum(Round(tax_i)) != Round(sum(tax_i))` by up to one rounding unit for some randomized inputs, the strict comparison fails intermittently. The per-line rounding is correct product behavior; the exact-equality assertion is the defect.

## Fix
- Replace `Assert.AreEqual` with `Assert.AreNearlyEqual(..., LibraryERM.GetAmountRoundingPrecision(), ...)` in `VerifyValueEntriesCostAmount` (US and CA local layers). The max divergence with two lines is bounded by one rounding unit, so this is deterministic, not merely less flaky. Both symbols are already used elsewhere in these codeunits.
- Re-enable the fixed test by removing its entry from `src/DisabledTests/Tests-Local/Tests-Local.DisabledTest.json`.

## Scope / notes
- Affects US and CA local test codeunits only (identical helper).
- `releases/28.x` note: this app has not yet moved to the BCApps GitHub release branch (`src/Layers` is not present there), so the identical change must be ported in the NAV/ADO enlistment for the release line; it cannot be committed from the GitHub enlistment.

## Validation
Static: no compiler/analyzer errors on the two edited codeunits; `AreNearlyEqual` / `GetAmountRoundingPrecision` already declared and used in-file; disabled-test JSON re-validated after edit. Full compile + re-enabled-test run across random seeds is the remaining CI validation step (no local symbols/container in this environment).

Fixes [AB#637055](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637055)



