### PR TITLE
[Subcontracting] (Bug 641903) [28.x]: Production Order actions in ILE page not clickable for transfer lines

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/General/SubcILEntries.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/General/SubcILEntries.PageExt.al
@@ -49,7 +49,7 @@ pageextension 99001501 "Subc. ILEntries" extends "Item Ledger Entries"
                 {
                     ApplicationArea = Subcontracting;
                     Caption = 'Production Order';
-                    Enabled = (Rec."Order Type" = Rec."Order Type"::Production) and (Rec."Order No." <> '');
+                    Enabled = ((Rec."Order Type" = Rec."Order Type"::Production) and (Rec."Order No." <> '')) or (Rec."Subc. Prod. Order No." <> '');
                     Image = Production;
                     ToolTip = 'View the related production order.';
                     trigger OnAction()
@@ -61,7 +61,7 @@ pageextension 99001501 "Subc. ILEntries" extends "Item Ledger Entries"
                 {
                     ApplicationArea = Subcontracting;
                     Caption = 'Production Order Routing';
-                    Enabled = (Rec."Order Type" = Rec."Order Type"::Production) and (Rec."Order No." <> '');
+                    Enabled = ((Rec."Order Type" = Rec."Order Type"::Production) and (Rec."Order No." <> '')) or (Rec."Subc. Prod. Order No." <> '');
                     Image = Route;
                     ToolTip = 'View the related production order routing.';
                     trigger OnAction()
@@ -73,7 +73,7 @@ pageextension 99001501 "Subc. ILEntries" extends "Item Ledger Entries"
                 {
                     ApplicationArea = Subcontracting;
                     Caption = 'Production Order Components';
-                    Enabled = (Rec."Order Type" = Rec."Order Type"::Production) and (Rec."Order No." <> '');
+                    Enabled = ((Rec."Order Type" = Rec."Order Type"::Production) and (Rec."Order No." <> '')) or (Rec."Subc. Prod. Order No." <> '');
                     Image = Components;
                     ToolTip = 'View the related production order components.';
                     trigger OnAction()

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOFactboxMgmt.Codeunit.al
@@ -273,8 +273,13 @@ codeunit 99001559 "Subc. ProdO. Factbox Mgmt."
             Database::"Item Ledger Entry":
                 begin
                     ResultRecordRef.SetTable(ItemLedgerEntry);
-                    ProdOrderNo := ItemLedgerEntry."Order No.";
-                    ProdOrderLineNo := ItemLedgerEntry."Order Line No.";
+                    if (ItemLedgerEntry."Order Type" = ItemLedgerEntry."Order Type"::Production) and (ItemLedgerEntry."Order No." <> '') then begin
+                        ProdOrderNo := ItemLedgerEntry."Order No.";
+                        ProdOrderLineNo := ItemLedgerEntry."Order Line No.";
+                    end else begin
+                        ProdOrderNo := ItemLedgerEntry."Subc. Prod. Order No.";
+                        ProdOrderLineNo := ItemLedgerEntry."Subc. Prod. Order Line No.";
+                    end;
                     OperationNo := ItemLedgerEntry."Subc. Operation No.";
                     RoutingNo := GetRoutingNoFromProdOrderRoutingLine(ProdOrderNo, ProdOrderLineNo, OperationNo);
                 end;

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingUITest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingUITest.Codeunit.al
@@ -843,6 +843,46 @@ codeunit 139990 "Subc. Subcontracting UI Test"
         RoutingLine.Insert(true);
     end;
 
+    [Test]
+    procedure ItemLedgerEntriesSubcProdActionsEnabledForTransferViaSubcProdOrder()
+    var
+        ItemLedgerEntry: Record "Item Ledger Entry";
+        ItemLedgerEntries: TestPage "Item Ledger Entries";
+    begin
+        // [SCENARIO 641405] Subcontracting production actions on Item Ledger Entries are enabled for a Transfer-type entry
+        // [SCENARIO 641405] whose production order is referenced only through the Subc. Prod. Order fields (the base Order No. holds the transfer order).
+        Initialize();
+
+        // [GIVEN] A Transfer-type Item Ledger Entry whose base Order fields point at a transfer order,
+        //         while the production order is only referenced through the Subc. Prod. Order fields
+        ItemLedgerEntry.Init();
+        ItemLedgerEntry."Entry No." := GetNextItemLedgerEntryNo();
+        ItemLedgerEntry."Item No." := 'TEST-ITEM';
+        ItemLedgerEntry."Entry Type" := ItemLedgerEntry."Entry Type"::Transfer;
+        ItemLedgerEntry."Order Type" := ItemLedgerEntry."Order Type"::Transfer;
+        ItemLedgerEntry."Order No." := 'TRANSFER-001';
+        ItemLedgerEntry."Order Line No." := 10000;
+        ItemLedgerEntry."Subc. Prod. Order No." := 'PO-SUBC-001';
+        ItemLedgerEntry."Subc. Prod. Order Line No." := 10000;
+        ItemLedgerEntry.Insert();
+
+        // [WHEN] The Item Ledger Entries page is opened for that entry
+        ItemLedgerEntries.OpenView();
+        ItemLedgerEntries.GoToRecord(ItemLedgerEntry);
+
+        // [THEN] The Production Order action is enabled
+        Assert.IsTrue(ItemLedgerEntries."Production Order".Enabled(), ILEProdActionsNotEnabledErr);
+        // [THEN] The Production Order Routing action is enabled
+        Assert.IsTrue(ItemLedgerEntries."Production Order Routing".Enabled(), ILEProdActionsNotEnabledErr);
+        // [THEN] The Production Order Components action is enabled
+        Assert.IsTrue(ItemLedgerEntries."Production Order Components".Enabled(), ILEProdActionsNotEnabledErr);
+
+        ItemLedgerEntries.Close();
+
+        // Cleanup
+        ItemLedgerEntry.Delete();
+    end;
+
     local procedure GetNextItemLedgerEntryNo(): Integer
     var
         ItemLedgerEntry: Record "Item Ledger Entry";


### PR DESCRIPTION
**Backport**

Fixes [AB#641903](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641903)

The Production Order / Routing / Components actions on the Item Ledger Entries page were ``Enabled`` only when the base ``"Order Type" = Production`` and ``"Order No." <> '``, and ``SetProdOrderInformationByVariant`` read the production order from the base ``"Order No."`` for ILEs. For a subcontracting **Transfer**-type ILE the base Order No. holds the transfer order and the production order is in ``"Subc. Prod. Order No."``, so the actions stayed greyed out. Enable the actions when ``"Subc. Prod. Order No."`` is set, and resolve the production order from the Subc. Prod. Order fields when the base Order fields do not point at a production order. Adds a test.





