### PR TITLE
[master]-[ES][Cartera Bills] Applying a foreign-currency payment to a bill that leads to gain-loss entry cannot be reversed

### DIFF
--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4433,7 +4433,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
               GenJnlLine, TempDimPostingBuffer, AdjAmount, SaveEntryNo, GetCustomerReceivablesAccount(GenJnlLine, CustPostingGr));
 
         OnPostDtldCustLedgEntriesOnAfterCreateGLEntriesForTotalAmounts(TempGLEntryBuf, GlobalGLEntry, NextTransactionNo);
-        PostReceivableDocs(GenJnlLine, CustPostingGr);
+        PostReceivableDocs(GenJnlLine, CustPostingGr, SaveEntryNo);
 
         DtldCVLedgEntryBuf.DeleteAll();
     end;
@@ -8466,25 +8466,39 @@ codeunit 12 "Gen. Jnl.-Post Line"
         exit;
     end;
 
-    local procedure PostReceivableDocs(GenJnlLine: Record "Gen. Journal Line"; CustPostingGr: Record "Customer Posting Group")
+    local procedure PostReceivableDocs(GenJnlLine: Record "Gen. Journal Line"; CustPostingGr: Record "Customer Posting Group"; var SaveEntryNo: Integer)
     var
+        GLEntry: Record "G/L Entry";
+        NeedsSaveEntryNoFix: Boolean;
         DocAmountAddCurr: Decimal;
         GLAccNo: Code[20];
     begin
-        if (DocAmountLCY <> 0) or (DiscDocAmountLCY <> 0) or (CollDocAmountLCY <> 0) or (RejDocAmountLCY <> 0) or
-           (DiscRiskFactAmountLCY <> 0) or (DiscUnriskFactAmountLCY <> 0) or (CollFactAmountLCY <> 0)
-        then
-            if NextEntryNo2 = NextEntryNo then
-                NextEntryNo := NextEntryNo - 1;
+        NeedsSaveEntryNoFix := (SaveEntryNo <> 0) and (NextEntryNo2 <> NextEntryNo);
+        if not NeedsSaveEntryNoFix then
+            if (DocAmountLCY <> 0) or (DiscDocAmountLCY <> 0) or (CollDocAmountLCY <> 0) or (RejDocAmountLCY <> 0) or
+               (DiscRiskFactAmountLCY <> 0) or (DiscUnriskFactAmountLCY <> 0) or (CollFactAmountLCY <> 0)
+            then
+                if NextEntryNo2 = NextEntryNo then
+                    NextEntryNo := NextEntryNo - 1;
         if DocAmountLCY <> 0 then begin
             if GenJnlLine."Currency Code" = AddCurrency.Code then
                 DocAmountAddCurr := GenJnlLine.Amount
             else
                 DocAmountAddCurr := DocAmtCalcAddCurrency(GenJnlLine, DocAmountLCY);
             GLAccNo := GetGLAccountForReceivableDocs(GenJnlLine, CustPostingGr, DocAmountLCY, CollDocAmountLCY);
-            CreateGLEntryBalAcc(
-              GenJnlLine, GLAccNo, DocAmountLCY, DocAmountAddCurr,
-              GenJnlLine."Bal. Account Type", GenJnlLine."Bal. Account No.");
+            if NeedsSaveEntryNoFix then begin
+                DocAmountAddCurr := DocAmountAddCurr - GenJnlLine."VAT Amount";
+                InitGLEntry(GenJnlLine, GLEntry, GLAccNo, DocAmountLCY, DocAmountAddCurr, true, true,
+                  CalcAmountSrcCurr(GenJnlLine, DocAmountLCY));
+                GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
+                GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";
+                UpdateGLEntryNo(GLEntry."Entry No.", SaveEntryNo);
+                InsertGLEntry(GenJnlLine, GLEntry, true);
+                OnMoveGenJournalLine(GenJnlLine, GLEntry.RecordId);
+            end else
+                CreateGLEntryBalAcc(
+                  GenJnlLine, GLAccNo, DocAmountLCY, DocAmountAddCurr,
+                  GenJnlLine."Bal. Account Type", GenJnlLine."Bal. Account No.");
         end;
         if DiscDocAmountLCY <> 0 then begin
             CustPostingGr.TestField("Discted. Bills Acc.");
@@ -8840,7 +8854,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                                     IsOK := true;
                     end;
             else
-                if CustLedgEntryInserted2 or (ReceivableAccAmtLCY <> 0) or (ReceivableAccAmtAddCurr <> 0)
+                if CustLedgEntryInserted2 or (ReceivableAccAmtLCY < 0) or (ReceivableAccAmtAddCurr < 0)
                    and (AddCurrencyCode <> '')
                 then
                     if (not FromBillSettlement) or (ReceivableAccAmtLCY < 0) or (ReceivableAccAmtAddCurr < 0) then


### PR DESCRIPTION
[Bug 640419](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/640419): [All-E][ES][Cartera Bills] Applying a foreign-currency payment to a bill that leads to gain-loss entry cannot be reversed

Fixes [AB#640419](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640419)

