### PR TITLE
Add [NonDebuggable] to Cryptography Management encrypt/decrypt procedures

### DIFF
--- a/src/System Application/App/Cryptography Management/src/CryptographyManagement.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/CryptographyManagement.Codeunit.al
@@ -25,6 +25,7 @@ codeunit 1266 "Cryptography Management"
     /// </summary>
     /// <param name="InputString">The value to encrypt.</param>
     /// <returns>Encrypted value.</returns>
+    [NonDebuggable]
     procedure EncryptText(InputString: Text[215]): Text
     begin
         exit(CryptographyManagementImpl.Encrypt(InputString));
@@ -35,6 +36,7 @@ codeunit 1266 "Cryptography Management"
     /// </summary>
     /// <param name="EncryptedString">The value to decrypt.</param>
     /// <returns>Plain text.</returns>
+    [NonDebuggable]
     procedure Decrypt(EncryptedString: Text): Text
     begin
         exit(CryptographyManagementImpl.Decrypt(EncryptedString));

--- a/src/System Application/App/Cryptography Management/src/CryptographyManagementImpl.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/CryptographyManagementImpl.Codeunit.al
@@ -31,6 +31,7 @@ codeunit 1279 "Cryptography Management Impl."
         EncryptionCheckFailErr: Label 'Encryption is either not enabled or the encryption key cannot be found.';
         EncryptionIsNotActivatedQst: Label 'Data encryption is not activated. It is recommended that you encrypt data. \Do you want to open the Data Encryption Management window?';
 
+    [NonDebuggable]
     procedure Encrypt(InputString: Text[215]): Text
     begin
         AssertEncryptionPossible();
@@ -39,6 +40,7 @@ codeunit 1279 "Cryptography Management Impl."
         exit(System.Encrypt(InputString));
     end;
 
+    [NonDebuggable]
     procedure Decrypt(EncryptedString: Text): Text
     begin
         AssertEncryptionPossible();


### PR DESCRIPTION
## Summary

The `EncryptText`/`Encrypt` and `Decrypt` procedures in the Cryptography Management system app (codeunit 1266 `Cryptography Management`) and its implementation (codeunit 1279 `Cryptography Management Impl.`) lacked the `[NonDebuggable]` flag.

Because both procedures return `Text` (not `SecretText`), the cleartext input and return values could be extracted using the AL debugger, even when the calling code is marked `[NonDebuggable]`. This compromised the confidentiality of encrypted and decrypted data.

## Fix

Added `[NonDebuggable]` to all four affected procedures:

- **CryptographyManagement.Codeunit.al** (1266 facade): `EncryptText`, `Decrypt`
- **CryptographyManagementImpl.Codeunit.al** (1279 impl): `Encrypt`, `Decrypt`

Attribute placement follows the existing System Application convention.

[AB#641977](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641977)


