### PR TITLE
Fixes #9144 - External File Attachment - Migrating files fails

### DIFF
--- a/src/Apps/W1/External Storage - Document Attachments/Test/src/DAExtStorageImplTests.Codeunit.al
+++ b/src/Apps/W1/External Storage - Document Attachments/Test/src/DAExtStorageImplTests.Codeunit.al
@@ -122,6 +122,7 @@ codeunit 136820 "DA Ext. Storage Impl. Tests"
     var
         DocumentAttachment: Record "Document Attachment";
         DAExternalStorageImpl: Codeunit "DA External Storage Impl.";
+        MediaReferenceCounts: Dictionary of [Guid, Integer];
         Result: Boolean;
     begin
         // [SCENARIO] Delete from internal should succeed after file is uploaded externally
@@ -135,8 +136,11 @@ codeunit 136820 "DA Ext. Storage Impl. Tests"
         DocumentAttachment.SetRecFilter();
         DocumentAttachment.FindFirst();
 
+        // [GIVEN] A reference count map reflecting the current single reference to the media
+        DAExternalStorageImpl.BuildMediaReferenceCounts(MediaReferenceCounts);
+
         // [WHEN] Delete from internal is attempted
-        Result := DAExternalStorageImpl.DeleteFromInternalStorage(DocumentAttachment);
+        Result := DAExternalStorageImpl.DeleteFromInternalStorage(DocumentAttachment, MediaReferenceCounts);
 
         // [THEN] Delete should succeed
         Assert.IsTrue(Result, 'Delete from internal should succeed');
@@ -324,6 +328,7 @@ codeunit 136820 "DA Ext. Storage Impl. Tests"
     var
         DocumentAttachment: Record "Document Attachment";
         DAExternalStorageImpl: Codeunit "DA External Storage Impl.";
+        MediaReferenceCounts: Dictionary of [Guid, Integer];
         Result: Boolean;
     begin
         // [SCENARIO] Delete from internal storage should succeed for externally stored docs
@@ -334,8 +339,11 @@ codeunit 136820 "DA Ext. Storage Impl. Tests"
         DocumentAttachment."Stored Externally" := true;
         DocumentAttachment.Modify();
 
+        // [GIVEN] A reference count map reflecting the current single reference to the media
+        DAExternalStorageImpl.BuildMediaReferenceCounts(MediaReferenceCounts);
+
         // [WHEN] Delete from internal is attempted
-        Result := DAExternalStorageImpl.DeleteFromInternalStorage(DocumentAttachment);
+        Result := DAExternalStorageImpl.DeleteFromInternalStorage(DocumentAttachment, MediaReferenceCounts);
 
         // [THEN] Delete should succeed
         Assert.IsTrue(Result, 'Delete from internal should succeed');
@@ -351,6 +359,7 @@ codeunit 136820 "DA Ext. Storage Impl. Tests"
     var
         DocumentAttachment: Record "Document Attachment";
         DAExternalStorageImpl: Codeunit "DA External Storage Impl.";
+        MediaReferenceCounts: Dictionary of [Guid, Integer];
         Result: Boolean;
     begin
         // [SCENARIO] Delete from internal should fail for non-external document
@@ -360,7 +369,7 @@ codeunit 136820 "DA Ext. Storage Impl. Tests"
         CreateDocumentAttachmentWithContent(DocumentAttachment);
 
         // [WHEN] Delete from internal is attempted
-        Result := DAExternalStorageImpl.DeleteFromInternalStorage(DocumentAttachment);
+        Result := DAExternalStorageImpl.DeleteFromInternalStorage(DocumentAttachment, MediaReferenceCounts);
 
         // [THEN] Delete should fail
         Assert.IsFalse(Result, 'Delete from internal should fail for non-external document');

--- a/src/Apps/W1/External Storage - Document Attachments/app/src/AutomaticSync/DAExternalStorageSync.Report.al
+++ b/src/Apps/W1/External Storage - Document Attachments/app/src/AutomaticSync/DAExternalStorageSync.Report.al
@@ -41,6 +41,14 @@ report 8752 "DA External Storage Sync"
                 ProcessedCount := 0;
                 FailedCount := 0;
 
+                // Multiple Document Attachment records can reference the same Tenant Media
+                // record (e.g. an original and its posted-document counterpart). Build a
+                // reference count once up front so the shared record is only physically
+                // deleted after the last referencing attachment has been migrated.
+                if SyncDirection = SyncDirection::"To External Storage" then
+                    ExternalStorageImpl.BuildMediaReferenceCounts(MediaReferenceCounts);
+
+
                 if GuiAllowed() then
                     Dialog.Open(ProcessingMsg, TotalCount);
             end;
@@ -61,7 +69,7 @@ report 8752 "DA External Storage Sync"
                         begin
                             SyncSuccess := ExternalStorageImpl.UploadToExternalStorage(DocumentAttachment);
                             if SyncSuccess and (Operation = Operation::Move) then begin
-                                DeleteSuccess := ExternalStorageImpl.DeleteFromInternalStorage(DocumentAttachment);
+                                DeleteSuccess := ExternalStorageImpl.DeleteFromInternalStorage(DocumentAttachment, MediaReferenceCounts);
                                 if not DeleteSuccess then
                                     FailedCount += 1;
                             end;
@@ -143,6 +151,7 @@ report 8752 "DA External Storage Sync"
     var
         ExternalStorageImpl: Codeunit "DA External Storage Impl.";
         Dialog: Dialog;
+        MediaReferenceCounts: Dictionary of [Guid, Integer];
         FailedCount: Integer;
         MaxRecordsToProcess: Integer;
         ProcessedCount: Integer;

--- a/src/Apps/W1/External Storage - Document Attachments/app/src/DocumentAttachmentIntegration/DAExternalStorageImpl.Codeunit.al
+++ b/src/Apps/W1/External Storage - Document Attachments/app/src/DocumentAttachmentIntegration/DAExternalStorageImpl.Codeunit.al
@@ -420,9 +420,11 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
     /// </summary>
     /// <param name="DocumentAttachment">The document attachment record to delete from internal storage.</param>
     /// <returns>True if deletion was successful, false otherwise.</returns>
-    procedure DeleteFromInternalStorage(var DocumentAttachment: Record "Document Attachment"): Boolean
+    procedure DeleteFromInternalStorage(var DocumentAttachment: Record "Document Attachment"; var MediaReferenceCounts: Dictionary of [Guid, Integer]): Boolean
     var
         TenantMedia: Record "Tenant Media";
+        MediaId: Guid;
+        RemainingReferences: Integer;
     begin
         // Validate input parameters
         if not DocumentAttachment."Document Reference ID".HasValue() then
@@ -432,16 +434,63 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
         if not DocumentAttachment."Stored Externally" then
             exit(false);
 
+        MediaId := DocumentAttachment."Document Reference ID".MediaId();
+        if not TenantMedia.Get(MediaId) then
+            exit(false);
+
+        // Multiple Document Attachment records can point to the same Tenant Media record
+        // (e.g. a posted document's attachment frequently shares its "Document Reference ID"
+        // with the attachment on the original document). Only remove the shared Tenant Media
+        // record once this is the last Document Attachment still referencing it - otherwise the
+        // other attachment(s) would lose access to their file content.
+        //
+        // Media fields cannot be filtered or passed as parameters (SetRange isn't supported on
+        // them), so reference counts are tracked in a Guid-keyed map built once up front by
+        // BuildMediaReferenceCounts, rather than re-scanning the table on every call.
+        if MediaReferenceCounts.Get(MediaId, RemainingReferences) then begin
+            RemainingReferences -= 1;
+            MediaReferenceCounts.Set(MediaId, RemainingReferences);
+        end else
+            // Not in the map (e.g. caller didn't pre-build it) - fall back to treating this as
+            // the only reference so behavior degrades to "delete immediately", same as before.
+            RemainingReferences := 0;
+
         // Delete from Tenant Media
-        if TenantMedia.Get(DocumentAttachment."Document Reference ID".MediaId()) then begin
+        if RemainingReferences <= 0 then
             TenantMedia.Delete();
 
-            // Mark Document Attachment as Not Stored Internally
-            DocumentAttachment.MarkAsDeletedInternally();
-            exit(true);
-        end;
+        // This attachment's own reference to internal storage is cleared either way.
+        DocumentAttachment.MarkAsDeletedInternally();
+        exit(true);
+    end;
 
-        exit(false);
+    /// <summary>
+    /// Scans Document Attachment once and counts, per Tenant Media (by MediaId), how many
+    /// Document Attachment records currently reference it. Call this once before a batch of
+    /// DeleteFromInternalStorage calls (e.g. from a report's OnPreDataItem) and reuse the same
+    /// dictionary instance for every call in that batch, since Media fields can't be filtered
+    /// directly and re-scanning per record would not scale.
+    /// </summary>
+    /// <param name="MediaReferenceCounts">The dictionary to populate with MediaId -&gt; reference count.</param>
+    procedure BuildMediaReferenceCounts(var MediaReferenceCounts: Dictionary of [Guid, Integer])
+    var
+        DocumentAttachment: Record "Document Attachment";
+        MediaId: Guid;
+        CurrentCount: Integer;
+    begin
+        Clear(MediaReferenceCounts);
+
+        DocumentAttachment.SetLoadFields("Document Reference ID");
+        if DocumentAttachment.FindSet() then
+            repeat
+                if DocumentAttachment."Document Reference ID".HasValue() then begin
+                    MediaId := DocumentAttachment."Document Reference ID".MediaId();
+                    if MediaReferenceCounts.Get(MediaId, CurrentCount) then
+                        MediaReferenceCounts.Set(MediaId, CurrentCount + 1)
+                    else
+                        MediaReferenceCounts.Add(MediaId, 1);
+                end;
+            until DocumentAttachment.Next() = 0;
     end;
 
     /// <summary>

--- a/src/Apps/W1/External Storage - Document Attachments/app/src/DocumentAttachmentIntegration/DocumentAttachmentExternal.Page.al
+++ b/src/Apps/W1/External Storage - Document Attachments/app/src/DocumentAttachmentIntegration/DocumentAttachmentExternal.Page.al
@@ -220,6 +220,7 @@ page 8751 "Document Attachment - External"
                 var
                     DocumentAttachment: Record "Document Attachment";
                     ExternalStorageImpl: Codeunit "DA External Storage Impl.";
+                    MediaReferenceCounts: Dictionary of [Guid, Integer];
                     SuccessCount: Integer;
                     FailedCount: Integer;
                 begin
@@ -231,6 +232,12 @@ page 8751 "Document Attachment - External"
                     DocumentAttachment.SetRange("Stored Internally", true);
                     SuccessCount := 0;
                     FailedCount := 0;
+
+                    // Multiple Document Attachment records can share the same Tenant Media
+                    // record; build a reference count once so it's only physically deleted
+                    // after the last referencing attachment in the selection is processed.
+                    ExternalStorageImpl.BuildMediaReferenceCounts(MediaReferenceCounts, MediaReferenceCounts);
+
                     if DocumentAttachment.FindSet() then
                         repeat
                             if ExternalStorageImpl.DeleteFromInternalStorage(DocumentAttachment) then


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->
Fixes a bug in the "DA External Storage Sync" migration (report 8752) where the shared Tenant Media record behind multiple Document Attachment rows could be deleted after the first attachment was migrated, causing subsequent attachments referencing the same media to fail.

DeleteFromInternalStorage now takes a pre-built Guid → reference count map and only physically deletes a Tenant Media record once its count reaches zero, i.e. once every Document Attachment referencing it has been migrated. The map is built with a single pass over Document Attachment (BuildMediaReferenceCounts) before each batch runs, rather than re-querying per record — Media fields can't be filtered or passed as parameters directly, so this avoids an O(n²) scan while staying correct across partial runs and Maximum Records to Process limits.


## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #9144 

## How I validated this

- [Y] I read the full diff and it contains only changes I intended.
- [Y] I built the affected app(s) locally with no new analyzer warnings.
- [Y] I ran the change in Business Central and confirmed it behaves as expected.
- [Y]I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

I started with a fresh Cronus company. With External file storage disabled.
I attached some documents to an un-posted invoice and posted it. Verified that the new attachments on the posted invoice and the posted receipt were sharing the same Tenant Media Record. 
I then enabled External File storage and ran the Sync with Destination to external storage and action of Move.
Let the report run.
The report ran without an failed files.
Checked that all attachments migrated correctly and that nothing was left un migrated.
Existing test updated to include the new MediaReferenceCounts Dictionary.

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

This change only affects the migration of document attachments from internal to external storage.


