### PR TITLE
Unbind Contoso demo data subscriptions when module generation fails

### DIFF
--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoTool/ContosoDemoTool.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoTool/ContosoDemoTool.Codeunit.al
@@ -172,6 +172,7 @@ codeunit 5193 "Contoso Demo Tool"
         ContosoDemoDataModule: Record "Contoso Demo Data Module";
         Module: Enum "Contoso Demo Data Module";
         ModuleProvider: Interface "Contoso Demo Data Module";
+        GeneratingDemoDataErrorText: Text;
     begin
         foreach Module in SortedModulesList do begin
 
@@ -183,30 +184,42 @@ codeunit 5193 "Contoso Demo Tool"
 
                 OnBeforeGeneratingDemoData(Module, ContosoDemoDataLevel);
 
-                case ContosoDemoDataLevel of
-                    Enum::"Contoso Demo Data Level"::"Setup Data":
-                        begin
-                            ModuleProvider.CreateSetupData();
-                            ContosoDemoDataModule.Validate("Data Level", ContosoDemoDataLevel);
-                            ContosoDemoDataModule.Modify(true);
-                        end;
-                    Enum::"Contoso Demo Data Level"::"Master Data":
-                        ModuleProvider.CreateMasterData();
-                    Enum::"Contoso Demo Data Level"::"Transactional Data":
-                        ModuleProvider.CreateTransactionalData();
-                    Enum::"Contoso Demo Data Level"::"Historical Data":
-                        begin
-                            ModuleProvider.CreateHistoricalData();
-                            ContosoDemoDataModule.Validate("Data Level", Enum::"Contoso Demo Data Level"::All);
-                            ContosoDemoDataModule.Modify(true);
-                        end;
+                if TryGenerateModuleDemoData(ModuleProvider, ContosoDemoDataModule, ContosoDemoDataLevel) then begin
+                    OnAfterGeneratingDemoData(Module, ContosoDemoDataLevel);
+
+                    Session.LogMessage('0000OL7', StrSubstNo(EndGeneratingDemoDataMsg, ContosoDemoDataModule.Module, ContosoDemoDataLevel), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', ContosoCoffeeDemoDatasetFeatureNameTok);
+                end else begin
+                    // Release any subscriptions bound in OnBeforeGeneratingDemoData before surfacing the error,
+                    // otherwise they stay bound and every subsequent generation fails to bind them again.
+                    GeneratingDemoDataErrorText := GetLastErrorText();
+                    OnAfterGeneratingDemoData(Module, ContosoDemoDataLevel);
+                    Error('%1', GeneratingDemoDataErrorText);
                 end;
-
-                OnAfterGeneratingDemoData(Module, ContosoDemoDataLevel);
-
-                Session.LogMessage('0000OL7', StrSubstNo(EndGeneratingDemoDataMsg, ContosoDemoDataModule.Module, ContosoDemoDataLevel), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', ContosoCoffeeDemoDatasetFeatureNameTok);
             end;
 
+        end;
+    end;
+
+    [TryFunction]
+    local procedure TryGenerateModuleDemoData(ModuleProvider: Interface "Contoso Demo Data Module"; var ContosoDemoDataModule: Record "Contoso Demo Data Module"; ContosoDemoDataLevel: Enum "Contoso Demo Data Level")
+    begin
+        case ContosoDemoDataLevel of
+            Enum::"Contoso Demo Data Level"::"Setup Data":
+                begin
+                    ModuleProvider.CreateSetupData();
+                    ContosoDemoDataModule.Validate("Data Level", ContosoDemoDataLevel);
+                    ContosoDemoDataModule.Modify(true);
+                end;
+            Enum::"Contoso Demo Data Level"::"Master Data":
+                ModuleProvider.CreateMasterData();
+            Enum::"Contoso Demo Data Level"::"Transactional Data":
+                ModuleProvider.CreateTransactionalData();
+            Enum::"Contoso Demo Data Level"::"Historical Data":
+                begin
+                    ModuleProvider.CreateHistoricalData();
+                    ContosoDemoDataModule.Validate("Data Level", Enum::"Contoso Demo Data Level"::All);
+                    ContosoDemoDataModule.Modify(true);
+                end;
         end;
     end;
 

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolBindingTest.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolBindingTest.Codeunit.al
@@ -1,0 +1,37 @@
+namespace Microsoft.Test.DemoTool;
+
+using Microsoft.DemoTool;
+
+codeunit 148141 "DemoTool Binding Test"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure BoundCodeunitsAreReleasedWhenGenerationFails()
+    var
+        ContosoDemoDataModule: Record "Contoso Demo Data Module";
+        ContosoDemoTool: Codeunit "Contoso Demo Tool";
+        ContosoBindLeakSubscriber: Codeunit "Contoso Bind Leak Subscriber";
+    begin
+        // [SCENARIO 641669] A failure during demo data generation must not leave manually bound codeunits bound,
+        // otherwise the next generation attempt fails with "The binding of codeunit ... has already been bound."
+        ContosoDemoTool.RefreshModules();
+
+        // [GIVEN] A localization-like subscriber that binds a codeunit in OnBeforeGeneratingDemoData and unbinds it in OnAfterGeneratingDemoData
+        BindSubscription(ContosoBindLeakSubscriber);
+
+        // [GIVEN] The module fails while its demo data is being generated
+        ContosoBindLeakSubscriber.SetFailOnGenerate(true);
+
+        // [WHEN] Generating demo data for the module fails
+        ContosoDemoDataModule.SetRange(Module, Enum::"Contoso Demo Data Module"::"Contoso Bind Leak");
+        asserterror ContosoDemoTool.CreateDemoData(ContosoDemoDataModule, Enum::"Contoso Demo Data Level"::"Setup Data");
+
+        // [THEN] Retrying generation succeeds instead of failing with a binding error, because the bound codeunit was released
+        ContosoBindLeakSubscriber.SetFailOnGenerate(false);
+        ContosoDemoDataModule.SetRange(Module, Enum::"Contoso Demo Data Module"::"Contoso Bind Leak");
+        ContosoDemoTool.CreateDemoData(ContosoDemoDataModule, Enum::"Contoso Demo Data Level"::"Setup Data");
+
+        UnbindSubscription(ContosoBindLeakSubscriber);
+    end;
+}

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/TestImplementations/ContosoBindLeakHelper.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/TestImplementations/ContosoBindLeakHelper.Codeunit.al
@@ -1,0 +1,14 @@
+namespace Microsoft.Test.DemoTool;
+
+using Microsoft.DemoTool;
+
+codeunit 148142 "Contoso Bind Leak Helper"
+{
+    // Manually bindable codeunit used to reproduce the demo data binding leak.
+    EventSubscriberInstance = Manual;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Contoso Demo Tool", 'OnAfterGeneratingDemoData', '', false, false)]
+    local procedure OnAfterGeneratingDemoData(Module: Enum "Contoso Demo Data Module"; ContosoDemoDataLevel: Enum "Contoso Demo Data Level")
+    begin
+    end;
+}

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/TestImplementations/ContosoBindLeakModule.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/TestImplementations/ContosoBindLeakModule.Codeunit.al
@@ -1,0 +1,42 @@
+namespace Microsoft.Test.DemoTool;
+
+using Microsoft.DemoTool;
+
+codeunit 148140 "Contoso Bind Leak Module" implements "Contoso Demo Data Module"
+{
+    var
+        GenerateFailedErr: Label 'Contoso Bind Leak Module generation failed on purpose.';
+
+    procedure RunConfigurationPage();
+    begin
+
+    end;
+
+    procedure GetDependencies(): List of [enum "Contoso Demo Data Module"]
+    begin
+
+    end;
+
+    procedure CreateSetupData();
+    var
+        ContosoBindLeakSubscriber: Codeunit "Contoso Bind Leak Subscriber";
+    begin
+        if ContosoBindLeakSubscriber.GetFailOnGenerate() then
+            Error(GenerateFailedErr);
+    end;
+
+    procedure CreateMasterData();
+    begin
+
+    end;
+
+    procedure CreateTransactionalData();
+    begin
+
+    end;
+
+    procedure CreateHistoricalData();
+    begin
+
+    end;
+}

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/TestImplementations/ContosoBindLeakSubscriber.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/TestImplementations/ContosoBindLeakSubscriber.Codeunit.al
@@ -1,0 +1,46 @@
+namespace Microsoft.Test.DemoTool;
+
+using Microsoft.DemoTool;
+
+codeunit 148143 "Contoso Bind Leak Subscriber"
+{
+    // Mimics a localization codeunit: it manually binds a subscription in OnBeforeGeneratingDemoData
+    // and releases it in OnAfterGeneratingDemoData.
+    SingleInstance = true;
+    EventSubscriberInstance = Manual;
+
+    var
+        FailOnGenerate: Boolean;
+
+    procedure SetFailOnGenerate(NewFailOnGenerate: Boolean)
+    begin
+        FailOnGenerate := NewFailOnGenerate;
+    end;
+
+    procedure GetFailOnGenerate(): Boolean
+    begin
+        exit(FailOnGenerate);
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Contoso Demo Tool", 'OnBeforeGeneratingDemoData', '', false, false)]
+    local procedure OnBeforeGeneratingDemoData(Module: Enum "Contoso Demo Data Module"; ContosoDemoDataLevel: Enum "Contoso Demo Data Level")
+    var
+        ContosoBindLeakHelper: Codeunit "Contoso Bind Leak Helper";
+    begin
+        if Module <> Enum::"Contoso Demo Data Module"::"Contoso Bind Leak" then
+            exit;
+
+        BindSubscription(ContosoBindLeakHelper);
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Contoso Demo Tool", 'OnAfterGeneratingDemoData', '', false, false)]
+    local procedure OnAfterGeneratingDemoData(Module: Enum "Contoso Demo Data Module"; ContosoDemoDataLevel: Enum "Contoso Demo Data Level")
+    var
+        ContosoBindLeakHelper: Codeunit "Contoso Bind Leak Helper";
+    begin
+        if Module <> Enum::"Contoso Demo Data Module"::"Contoso Bind Leak" then
+            exit;
+
+        UnbindSubscription(ContosoBindLeakHelper);
+    end;
+}

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/TestImplementations/ContosoTest.EnumExt.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/TestImplementations/ContosoTest.EnumExt.al
@@ -16,4 +16,8 @@ enumextension 148000 "Contoso Test" extends "Contoso Demo Data Module"
     {
         Implementation = "Contoso Demo Data Module" = "Contoso Test Module 3";
     }
+    value(148004; "Contoso Bind Leak")
+    {
+        Implementation = "Contoso Demo Data Module" = "Contoso Bind Leak Module";
+    }
 }


### PR DESCRIPTION
## What & why

`Contoso Demo Tool`.`GenerateDemoData` (codeunit 5193) fired `OnBeforeGeneratingDemoData` (where localizations `BindSubscription`) and `OnAfterGeneratingDemoData` (where they `UnbindSubscription`) around each module's data creation. An error in between skipped the unbind, so the session-scoped manual bindings leaked and every later "Generate" failed with `The binding of codeunit 11489 was unsuccessful. The codeunit has already been bound.` — until the client was restarted.

This wraps per-module generation in a `[TryFunction]`; on failure it still raises `OnAfterGeneratingDemoData` (releasing bindings) and then re-surfaces the original error. Single change at the W1 orchestration point, so it covers every localization.

- **`ContosoDemoTool.Codeunit.al`**: extracted the level `case` into `TryGenerateModuleDemoData`. Success path unchanged; failure path captures `GetLastErrorText()`, runs `OnAfterGeneratingDemoData`, then re-raises via `Error('%1', ...)`.
- **Test app**: `DemoToolBindingTest` reproduces the leak (bind in `OnBefore` / unbind in `OnAfter` via a helper, a deliberately-failing module); a first generation fails, a retry must not hit the binding error. Scaffolding (`ContosoBindLeak{Module,Helper,Subscriber}`, enum value `148004`) is inert unless the manual subscriber is bound and its fail flag set.

```al
if TryGenerateModuleDemoData(ModuleProvider, ContosoDemoDataModule, ContosoDemoDataLevel) then begin
    OnAfterGeneratingDemoData(Module, ContosoDemoDataLevel);
    Session.LogMessage('0000OL7', ...);
end else begin
    GeneratingDemoDataErrorText := GetLastErrorText();
    OnAfterGeneratingDemoData(Module, ContosoDemoDataLevel); // release bound subscriptions
    Error('%1', GeneratingDemoDataErrorText);
end;
```

## Linked work

[AB#641669](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641669)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Added `DemoToolBindingTest.BoundCodeunitsAreReleasedWhenGenerationFails`: asserts the first generation errors, then a retry succeeds instead of failing with "already been bound". This fails against the pre-fix code and passes after.
- AL build/publish/run-tests could not be executed in this session (no BC container/symbols provisioned); the fix and test were validated by static review and AL-semantics analysis. **Needs a local build + test run before merge.**

## Risk & compatibility

- Behavioral change: `OnAfterGeneratingDemoData` now also fires on the error path (for cleanup). Existing localization subscribers create localized data via error-trapping `Codeunit.Run` and otherwise only `UnbindSubscription`, and the re-raised `Error` rolls back the whole transaction — so net data effect on failure is unchanged (only the leaked binding is now released). Third-party subscribers that assume `OnAfter` implies success, or that `Commit` on this event, should be aware.
- No schema, permission, or public API changes.

---
Promoted from microsoft/BCAppsBugFix#55: https://github.com/microsoft/BCAppsBugFix/pull/55

Fixes [AB#641669](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641669)


