### PR TITLE
[28.x] Add [NonDebuggable] to Cryptography Management encrypt/decrypt procedures

### DIFF
--- a/src/System Application/App/Cryptography Management/src/CryptographyManagement.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/CryptographyManagement.Codeunit.al
@@ -25,6 +25,7 @@ codeunit 1266 "Cryptography Management"
     /// </summary>
     /// <param name="InputString">The value to encrypt.</param>
     /// <returns>Encrypted value.</returns>
+    [NonDebuggable]
     procedure EncryptText(InputString: Text[215]): Text
     begin
         exit(CryptographyManagementImpl.Encrypt(InputString));
@@ -35,6 +36,7 @@ codeunit 1266 "Cryptography Management"
     /// </summary>
     /// <param name="EncryptedString">The value to decrypt.</param>
     /// <returns>Plain text.</returns>
+    [NonDebuggable]
     procedure Decrypt(EncryptedString: Text): Text
     begin
         exit(CryptographyManagementImpl.Decrypt(EncryptedString));

--- a/src/System Application/App/Cryptography Management/src/CryptographyManagementImpl.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/CryptographyManagementImpl.Codeunit.al
@@ -31,6 +31,7 @@ codeunit 1279 "Cryptography Management Impl."
         EncryptionCheckFailErr: Label 'Encryption is either not enabled or the encryption key cannot be found.';
         EncryptionIsNotActivatedQst: Label 'Data encryption is not activated. It is recommended that you encrypt data. \Do you want to open the Data Encryption Management window?';
 
+    [NonDebuggable]
     procedure Encrypt(InputString: Text[215]): Text
     begin
         AssertEncryptionPossible();
@@ -39,6 +40,7 @@ codeunit 1279 "Cryptography Management Impl."
         exit(System.Encrypt(InputString));
     end;
 
+    [NonDebuggable]
     procedure Decrypt(EncryptedString: Text): Text
     begin
         AssertEncryptionPossible();


### PR DESCRIPTION
## Summary

Backport of #9291 to `releases/28.x`.

The `EncryptText`/`Encrypt` and `Decrypt` procedures in the Cryptography Management system app (codeunit 1266 / codeunit 1279) lacked the `[NonDebuggable]` flag. Because both take/return plain `Text` (not `SecretText`), cleartext input and decrypted output could be extracted with an attached debugger. This backport adds `[NonDebuggable]` to all four procedures.

MSRC/Autoclave assessed the original issue as P1.

## Fix

Added `[NonDebuggable]` to:
- **CryptographyManagement.Codeunit.al** (1266): `EncryptText`, `Decrypt`
- **CryptographyManagementImpl.Codeunit.al** (1279): `Encrypt`, `Decrypt`

Cherry-picked cleanly from main (PR #9291).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes [AB#642029](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642029)
