### PR TITLE
[Shopify] Fix unhandled duplicate-contact confirm in customer creation tests

### DIFF
--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCreateCustomerTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCreateCustomerTest.Codeunit.al
@@ -5,8 +5,8 @@
 
 namespace Microsoft.Integration.Shopify.Test;
 
-using Microsoft.Integration.Shopify;
 using Microsoft.CRM.Setup;
+using Microsoft.Integration.Shopify;
 using Microsoft.Sales.Customer;
 using System.TestLibraries.Utilities;
 

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCreateCustomerTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCreateCustomerTest.Codeunit.al
@@ -6,6 +6,7 @@
 namespace Microsoft.Integration.Shopify.Test;
 
 using Microsoft.Integration.Shopify;
+using Microsoft.CRM.Setup;
 using Microsoft.Sales.Customer;
 using System.TestLibraries.Utilities;
 
@@ -130,6 +131,7 @@ codeunit 139565 "Shpfy Create Customer Test"
 
     local procedure Initialize()
     var
+        MarketingSetup: Record "Marketing Setup";
         AccessToken: SecretText;
     begin
         if IsInitialized then
@@ -141,6 +143,17 @@ codeunit 139565 "Shpfy Create Customer Test"
         Shop.Modify(false);
         AccessToken := Any.AlphanumericText(20);
         InitializeTest.RegisterAccessTokenForShop(Shop.GetStoreName(), AccessToken);
+
+        // Disable duplicate-contact auto-search so creating/updating a customer (which cascades to
+        // contact creation) does not raise an interactive "Duplicate Contacts were found" confirm
+        // dialog during automated integration tests, where GuiAllowed is true and some localizations'
+        // demo data enables this setting.
+        if MarketingSetup.Get() then begin
+            MarketingSetup."Autosearch for Duplicates" := false;
+            MarketingSetup."Maintain Dupl. Search Strings" := false;
+            MarketingSetup.Modify(false);
+        end;
+
         Commit();
     end;
 


### PR DESCRIPTION
Fixes [AB#641993](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641993)

### Summary

Two Shopify Connector integration tests in `Shpfy Create Customer Test` (`UnitTestMapCustomerWithoutDefaultAddressStillCreatesCustomer` and `UnitTestUpdateCustomerWithoutDefaultAddressDoesNotError`) broke the BCApps→NAV uptake in the `RunALIntegrationTests_IN_Extensions` bucket with:

> `Unhandled UI: Confirm Duplicate Contacts were found. Would you like to process these?`

### Root cause

Creating or updating a BC customer cascades to contact creation (`CustCont-Update.OnModify` → `Contact.CheckDuplicates` → `DuplicateManagement.LaunchDuplicateForm`), which raises a `Confirm` dialog. That dialog only appears when **`GuiAllowed`** (true for integration tests, but false during real Shopify order import — so production is unaffected) **and** Marketing Setup `"Autosearch for Duplicates"` is enabled with a matching duplicate contact. The India localization demo data enables autosearch, so the dialog pops up and the automated harness cannot answer it. This is a test-only artifact.

### Fix

Disable `"Autosearch for Duplicates"` / `"Maintain Dupl. Search Strings"` in the codeunit's `Initialize()` so the duplicate confirm never fires, deterministically, in any localization.

A `[ConfirmHandler]` was intentionally not used: the dialog only fires when a duplicate index exists (localization-dependent), which would risk "handler not executed" failures in buckets without a match.

### Test plan

- Only test code is changed; production code is untouched.
- Local `al_getdiagnostics` on the modified file: 0 errors.
- The two failing customer-creation tests no longer trigger the interactive confirm dialog.


