### PR TITLE
Preserve shared external blob when deleting a Document Attachment referenced by another row

### DIFF
--- a/src/Apps/W1/External Storage - Document Attachments/Test/src/DAExtStorageImplTests.Codeunit.al
+++ b/src/Apps/W1/External Storage - Document Attachments/Test/src/DAExtStorageImplTests.Codeunit.al
@@ -492,6 +492,50 @@ codeunit 136820 "DA Ext. Storage Impl. Tests"
             'External connector DeleteFile should not be invoked when Delete from External Storage is disabled');
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmYesHandler')]
+    procedure RecordDeleteKeepsSharedBlobReferencedByAnotherAttachment()
+    var
+        DocumentAttachment: Record "Document Attachment";
+        OtherDocumentAttachment: Record "Document Attachment";
+        DAExternalStorageImpl: Codeunit "DA External Storage Impl.";
+        ExternalFilePath: Text;
+    begin
+        // [SCENARIO] When another Document Attachment still references the same external file (for example the
+        // copy created on the posted document during posting), deleting one row must NOT delete the shared blob.
+        // Regression test for the posting failure "Document Attachment does not exist" (AB#640968).
+        Initialize();
+        SetupFileScenarioWithTestConnector();
+        EnableFeatureWithDelete();
+
+        // [GIVEN] An externally-stored attachment
+        CreateDocumentAttachmentWithContent(DocumentAttachment);
+        DAExternalStorageImpl.UploadToExternalStorage(DocumentAttachment);
+        DocumentAttachment.SetRecFilter();
+        DocumentAttachment.FindFirst();
+        ExternalFilePath := DocumentAttachment."External File Path";
+        Assert.AreNotEqual('', ExternalFilePath, 'Precondition: upload should set the External File Path');
+
+        // [GIVEN] A second attachment (for example the posted-document copy) that references the same external file
+        OtherDocumentAttachment.Init();
+        OtherDocumentAttachment.ID := Any.IntegerInRange(100000, 199999);
+        OtherDocumentAttachment."Table ID" := Database::"Document Attachment";
+        OtherDocumentAttachment."No." := CopyStr(Any.AlphanumericText(20), 1, 20);
+        OtherDocumentAttachment."File Name" := DocumentAttachment."File Name";
+        OtherDocumentAttachment."File Extension" := DocumentAttachment."File Extension";
+        OtherDocumentAttachment."Stored Externally" := true;
+        OtherDocumentAttachment."Stored Internally" := false;
+        OtherDocumentAttachment."External File Path" := ExternalFilePath;
+        OtherDocumentAttachment.Insert(false);
+
+        // [WHEN] The first Document Attachment row is deleted (fires OnAfterDeleteEvent)
+        DocumentAttachment.Delete(true);
+
+        // [THEN] The subscriber must NOT delete the shared blob, because another attachment still references it
+        Assert.AreNotEqual(ExternalFilePath, FileConnectorMock.GetLastDeletedPath(),
+            'External connector DeleteFile should not be invoked while another attachment references the same External File Path');
+    end;
+
     #endregion
 
     #region MIME Type Tests

--- a/src/Apps/W1/External Storage - Document Attachments/app/app.json
+++ b/src/Apps/W1/External Storage - Document Attachments/app/app.json
@@ -2,7 +2,7 @@
   "id": "5f2e93a0-6083-4718-b05a-7ac89be5644d",
   "name": "External Storage - Document Attachments",
   "publisher": "Microsoft",
-  "version": "29.0.0.0",
+  "version": "29.1.0.0",
   "brief": "External Storage processor for Business Central document attachments",
   "description": "Processes document attachments from Business Central and stores them in configured External Storage connectors (Azure Blob, File Share, SharePoint)",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",

--- a/src/Apps/W1/External Storage - Document Attachments/app/src/DocumentAttachmentIntegration/DAExternalStorageImpl.Codeunit.al
+++ b/src/Apps/W1/External Storage - Document Attachments/app/src/DocumentAttachmentIntegration/DAExternalStorageImpl.Codeunit.al
@@ -844,7 +844,29 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
         if IsFileFromAnotherEnvironmentOrCompany(DocumentAttachment) then
             exit(false);
 
+        // The external blob is shared with other attachments (for example, the copy created on the
+        // posted document during posting) - deleting it would break those still-live references.
+        if IsExternalFileStillReferenced(DocumentAttachment) then
+            exit(false);
+
         exit(true);
+    end;
+
+    /// <summary>
+    /// Checks whether any other Document Attachment record still references the same external file.
+    /// </summary>
+    /// <param name="DocumentAttachment">The document attachment record whose external file is being evaluated.</param>
+    /// <returns>True if another externally-stored attachment references the same external file path; otherwise false.</returns>
+    local procedure IsExternalFileStillReferenced(DocumentAttachment: Record "Document Attachment"): Boolean
+    var
+        OtherDocumentAttachment: Record "Document Attachment";
+    begin
+        if DocumentAttachment."External File Path" = '' then
+            exit(false);
+
+        OtherDocumentAttachment.SetRange("Stored Externally", true);
+        OtherDocumentAttachment.SetRange("External File Path", DocumentAttachment."External File Path");
+        exit(not OtherDocumentAttachment.IsEmpty());
     end;
 
     /// <summary>


### PR DESCRIPTION
## What & why

Posting a Purchase Invoice with attachments copied from a Purchase Order (via the *External Storage – Document Attachments* extension) failed with **"Document Attachment does not exist"** and rolled back the whole transaction.

During posting, base CU 1173 `Document Attachment Mgmt.CopyAttachmentsForPostedDocs` copies the externally-stored attachment onto the posted document using the **same** `External File Path` — two rows now point at one shared blob. Posting then deletes the original unposted row, and CU 8751 `DA External Storage Impl.`'s `OnAfterDeleteEvent` deleted the shared blob even though the posted copy still referenced it. The delete path is generic, so Sales flows are equally exposed.

- **`DAExternalStorageImpl.Codeunit.al`** — new `IsExternalFileStillReferenced()` helper plus a guard in `IsEligibleForExternalFileDeletionOnRecordDelete` that skips the blob delete when any other externally-stored `Document Attachment` references the same `External File Path`. Fixes Purchase and Sales at once since the guard sits on the shared delete path.
- **`DAExtStorageImplTests.Codeunit.al`** — regression test `RecordDeleteKeepsSharedBlobReferencedByAnotherAttachment` (CU 136820).
- **`app.json`** — version 29.0.0.0 → 29.1.0.0.

```al
// Files from another environment/company are managed by their owning environment
if IsFileFromAnotherEnvironmentOrCompany(DocumentAttachment) then
    exit(false);

// The external blob is shared with other attachments (for example, the copy created on the
// posted document during posting) - deleting it would break those still-live references.
if IsExternalFileStillReferenced(DocumentAttachment) then
    exit(false);
```

## Linked work

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Full AL build + publish + test run against container `bcapps-29002931484`, CU 136820: **28/28 pass**.
- Baseline check: with the guard removed, `RecordDeleteKeepsSharedBlobReferencedByAnotherAttachment` fails (shared blob deleted / `DeleteFile` invoked on the still-referenced path); with the guard active it passes.
- Existing single-reference, Skip-Delete-On-Copy, foreign-environment, and feature-disabled deletion tests remain green.

## Risk & compatibility

Low. Change is confined to one app; no schema, platform, or permission impact. Only the automatic `OnAfterDelete` blob-deletion path changes — it now retains a blob while any other externally-stored attachment references the same path. Single-reference deletion behavior is unchanged. Trade-off: a blob is retained until its last referencing row is removed (avoids the more severe orphaned-reference/posting-rollback failure).

---
Promoted from microsoft/BCAppsBugFix#57: https://github.com/microsoft/BCAppsBugFix/pull/57
