### PR TITLE
[Shopify] Fix Product Sync deleting mapped variants on stale Updated At timestamp

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyVariantAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyVariantAPI.Codeunit.al
@@ -556,8 +556,13 @@ codeunit 30189 "Shpfy Variant API"
     begin
         Parameters.Add('VariantId', Format(ShopifyVariant.Id));
         JResponse := CommunicationMgt.ExecuteGraphQL(GraphQLType::Products_GetVariantById, Parameters);
-        if JsonHelper.GetJsonObject(JResponse.AsObject(), JData, 'data.productVariant') then
-            exit(UpdateShopifyVariantFields(ShopifyProduct, ShopifyVariant, ShopifyInventoryItem, JData));
+        // When the productVariant node is present, the variant still exists on Shopify, so report it as existing.
+        // UpdateShopifyVariantFields internally skips the field update when the local record is already up to date.
+        // Only a missing node (variant genuinely deleted on Shopify) returns false so the caller can delete the record.
+        if JsonHelper.GetJsonObject(JResponse.AsObject(), JData, 'data.productVariant') then begin
+            UpdateShopifyVariantFields(ShopifyProduct, ShopifyVariant, ShopifyInventoryItem, JData);
+            exit(true);
+        end;
     end;
 
     /// <summary> 
@@ -756,8 +761,7 @@ codeunit 30189 "Shpfy Variant API"
     /// <param name="ShopifyVariant">Parameter of type Record "Shopify Variant".</param>
     /// <param name="ShopifyInventoryItem">Parameter of type Record "Shopify Inventory Item".</param>
     /// <param name="JVariant">Parameter of type JsonObject.</param>
-    /// <returns>Return variable "Result" of type Boolean.</returns>
-    internal procedure UpdateShopifyVariantFields(ShopifyProduct: Record "Shpfy Product"; var ShopifyVariant: Record "Shpfy Variant"; var ShopifyInventoryItem: Record "Shpfy Inventory Item"; JVariant: JsonObject) Result: Boolean
+    internal procedure UpdateShopifyVariantFields(ShopifyProduct: Record "Shpfy Product"; var ShopifyVariant: Record "Shpfy Variant"; var ShopifyInventoryItem: Record "Shpfy Inventory Item"; JVariant: JsonObject)
     var
         RecordRef: RecordRef;
         UpdatedAt: DateTime;
@@ -768,9 +772,8 @@ codeunit 30189 "Shpfy Variant API"
     begin
         UpdatedAt := JsonHelper.GetValueAsDateTime(JVariant, 'updatedAt');
         if UpdatedAt < ShopifyVariant."Updated At" then
-            exit(false);
+            exit;
 
-        Result := true;
         ShopifyVariant."Updated At" := UpdatedAt;
         ShopifyVariant."Created At" := JsonHelper.GetValueAsDateTime(JVariant, 'createdAt');
         ShopifyVariant."Available For Sales" := JsonHelper.GetValueAsBoolean(JVariant, 'availableForSale');

--- a/src/Apps/W1/Shopify/Test/Products/ShpfyVariantAPITest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Products/ShpfyVariantAPITest.Codeunit.al
@@ -1,0 +1,145 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify.Test;
+
+using Microsoft.Integration.Shopify;
+using System.TestLibraries.Utilities;
+
+codeunit 139613 "Shpfy Variant API Test"
+{
+    Subtype = Test;
+    TestType = IntegrationTest;
+    TestPermissions = Disabled;
+    TestHttpRequestPolicy = BlockOutboundRequests;
+
+    var
+        Shop: Record "Shpfy Shop";
+        LibraryAssert: Codeunit "Library Assert";
+        LibraryRandom: Codeunit "Library - Random";
+        LibraryTestInitialize: Codeunit "Library - Test Initialize";
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+        IsInitialized: Boolean;
+        ProductId: BigInteger;
+        VariantId: BigInteger;
+        VariantResponseMode: Option Existing,Missing;
+        FutureUpdatedAt: DateTime;
+
+    [Test]
+    [HandlerFunctions('GetVariantHttpHandler')]
+    procedure UnitTestRetrieveShopifyVariantKeepsVariantWhenLocalUpdatedAtIsAhead()
+    var
+        ShopifyProduct: Record "Shpfy Product";
+        ShopifyVariant: Record "Shpfy Variant";
+        ShopifyInventoryItem: Record "Shpfy Inventory Item";
+        ProductInitTest: Codeunit "Shpfy Product Init Test";
+        VariantApi: Codeunit "Shpfy Variant API";
+        Result: Boolean;
+    begin
+        Initialize();
+
+        // [SCENARIO] When a variant's local "Updated At" is ahead of Shopify's updatedAt (e.g. after a bulk price
+        // [SCENARIO] export stamps CurrentDateTime), RetrieveShopifyVariant must still report the variant as existing
+        // [SCENARIO] so the caller does not delete it. The timestamp guard only skips the field update.
+
+        // [GIVEN] A standard Shopify product with a variant whose local "Updated At" is set into the future.
+        VariantResponseMode := VariantResponseMode::Existing;
+        ShopifyVariant := ProductInitTest.CreateStandardProduct(Shop);
+        ProductId := ShopifyVariant."Product Id";
+        VariantId := ShopifyVariant.Id;
+        FutureUpdatedAt := CurrentDateTime() + 86400000; // one day ahead of any Shopify updatedAt
+        ShopifyVariant."Updated At" := FutureUpdatedAt;
+        ShopifyVariant.Modify();
+        ShopifyProduct.Get(ProductId);
+
+        // [WHEN] Retrieve the variant while Shopify returns an older updatedAt.
+        VariantApi.SetShop(Shop);
+        Result := VariantApi.RetrieveShopifyVariant(ShopifyProduct, ShopifyVariant, ShopifyInventoryItem);
+
+        // [THEN] The variant is reported as existing (the caller must not delete it).
+        LibraryAssert.IsTrue(Result, 'RetrieveShopifyVariant should return true when the variant still exists on Shopify.');
+
+        // [THEN] The timestamp guard skipped the field update, so the local "Updated At" is untouched.
+        ShopifyVariant.Get(VariantId);
+        LibraryAssert.AreEqual(FutureUpdatedAt, ShopifyVariant."Updated At", 'The local "Updated At" should be preserved when the guard skips the update.');
+    end;
+
+    [Test]
+    [HandlerFunctions('GetVariantHttpHandler')]
+    procedure UnitTestRetrieveShopifyVariantReportsMissingWhenDeletedOnShopify()
+    var
+        ShopifyProduct: Record "Shpfy Product";
+        ShopifyVariant: Record "Shpfy Variant";
+        ShopifyInventoryItem: Record "Shpfy Inventory Item";
+        ProductInitTest: Codeunit "Shpfy Product Init Test";
+        VariantApi: Codeunit "Shpfy Variant API";
+        Result: Boolean;
+    begin
+        Initialize();
+
+        // [SCENARIO] When Shopify no longer returns the productVariant node, the variant is genuinely deleted and
+        // [SCENARIO] RetrieveShopifyVariant must return false so the caller can delete the local record.
+
+        // [GIVEN] A standard Shopify product with a variant.
+        VariantResponseMode := VariantResponseMode::Missing;
+        ShopifyVariant := ProductInitTest.CreateStandardProduct(Shop);
+        ProductId := ShopifyVariant."Product Id";
+        VariantId := ShopifyVariant.Id;
+        ShopifyProduct.Get(ProductId);
+
+        // [WHEN] Retrieve the variant while Shopify returns an empty productVariant node.
+        VariantApi.SetShop(Shop);
+        Result := VariantApi.RetrieveShopifyVariant(ShopifyProduct, ShopifyVariant, ShopifyInventoryItem);
+
+        // [THEN] The variant is reported as missing (the caller may delete it).
+        LibraryAssert.IsFalse(Result, 'RetrieveShopifyVariant should return false when the variant no longer exists on Shopify.');
+    end;
+
+    [HttpClientHandler]
+    internal procedure GetVariantHttpHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    var
+        VariantResponseTok: Label 'Products/ProductVariantDetailsResponse.txt', Locked = true;
+        MissingVariantResponseTok: Label '{"data":{"productVariant":null},"extensions":{}}', Locked = true;
+        ResultTxt: Text;
+    begin
+        if not InitializeTest.VerifyRequestUrl(Request.Path, Shop."Shopify URL") then
+            exit(true);
+
+        case VariantResponseMode of
+            VariantResponseMode::Existing:
+                begin
+                    ResultTxt := NavApp.GetResourceAsText(VariantResponseTok, TextEncoding::UTF8);
+                    ResultTxt := ResultTxt.Replace('{{ProductId}}', ProductId.ToText());
+                    ResultTxt := ResultTxt.Replace('{{VariantId}}', VariantId.ToText());
+                end;
+            VariantResponseMode::Missing:
+                ResultTxt := MissingVariantResponseTok;
+        end;
+        Response.Content.WriteFrom(ResultTxt);
+        exit(false);
+    end;
+
+    local procedure Initialize()
+    var
+        AccessToken: SecretText;
+    begin
+        LibraryTestInitialize.OnTestInitialize(Codeunit::"Shpfy Variant API Test");
+        if IsInitialized then
+            exit;
+
+        LibraryTestInitialize.OnBeforeTestSuiteInitialize(Codeunit::"Shpfy Variant API Test");
+
+        LibraryRandom.Init();
+        IsInitialized := true;
+        Commit();
+
+        Shop := InitializeTest.CreateShop();
+
+        AccessToken := LibraryRandom.RandText(20);
+        InitializeTest.RegisterAccessTokenForShop(Shop.GetStoreName(), AccessToken);
+
+        LibraryTestInitialize.OnAfterTestSuiteInitialize(Codeunit::"Shpfy Variant API Test");
+    end;
+}


### PR DESCRIPTION
Fixes [AB#641922](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641922)

## Summary

Product Sync (Shopify → BC) could incorrectly **delete** a mapped variant when a bulk price export had stamped the local "Updated At" with CurrentDateTime() before Shopify's asynchronous bulk operation completed.

The root cause is a conflation of two meanings in `RetrieveShopifyVariant`:

- The timestamp guard in `UpdateShopifyVariantFields` returns `false` to mean *"skip — the local record is already up to date"*.
- `RetrieveShopifyVariant` passed that `false` straight through, and its caller `ShpfyProductImport.SetProduct` interpreted `false` as *"variant no longer exists"* and called `ShopifyVariant.Delete()`.

During the window between a bulk price export stamping the local timestamp (`CurrentDateTime()`) and Shopify actually processing the queued mutation, a Shopify→BC sync sees `Shopify updatedAt < local Updated At`, the guard trips, and the variant is deleted. On the next sync it is re-created with a null `Item SystemId`, so for Default Title products the `Item No.` FlowField becomes blank.

## Fix

- `RetrieveShopifyVariant` now returns `true` whenever the `productVariant` node is present in the response (the variant still exists on Shopify), and `false` only when the node is genuinely absent (variant deleted on Shopify). The timestamp guard still skips the field update, but that skip no longer signals a deletion.
- `UpdateShopifyVariantFields` no longer returns a `Boolean` — its only caller ignored the value after the change.

## Test plan

Added `Shpfy Variant API Test` (codeunit 139613) with `[HttpClientHandler]`-based mocking:

- `UnitTestRetrieveShopifyVariantKeepsVariantWhenLocalUpdatedAtIsAhead` — local `Updated At` set ahead of Shopify's `updatedAt`; asserts the variant is reported as existing (not deleted) and the local timestamp is preserved (guard skipped the update).
- `UnitTestRetrieveShopifyVariantReportsMissingWhenDeletedOnShopify` — Shopify returns a null `productVariant` node; asserts the variant is reported as missing so the caller may delete it.



