### PR TITLE
[Shopify] Preserve manually set Sell-to Customer No. when Bill-to mapping fails

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyOrderMapping.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyOrderMapping.Codeunit.al
@@ -95,15 +95,17 @@ codeunit 30163 "Shpfy Order Mapping"
         if OrderHeader."Bill-to Customer No." = '' then begin
             OrderEvents.OnBeforeMapCustomer(OrderHeader, IsHandled);
             if not IsHandled then begin
-                JCustomer.Add('Name', OrderHeader."Sell-to Customer Name");
-                JCustomer.Add('Name2', OrderHeader."Sell-to Customer Name 2");
-                JCustomer.Add('Address', OrderHeader."Sell-to Address");
-                JCustomer.Add('Address2', OrderHeader."Sell-to Address 2");
-                JCustomer.Add('PostCode', OrderHeader."Sell-to Post Code");
-                JCustomer.Add('City', OrderHeader."Sell-to City");
-                JCustomer.Add('County', OrderHeader."Sell-to County");
-                JCustomer.Add('CountryCode', OrderHeader."Sell-to Country/Region Code");
-                OrderHeader."Sell-to Customer No." := CustomerMapping.DoMapping(OrderHeader."Customer Id", JCustomer, OrderHeader."Shop Code", CustomerTemplateCode, AllowCreateCustomer);
+                if OrderHeader."Sell-to Customer No." = '' then begin
+                    JCustomer.Add('Name', OrderHeader."Sell-to Customer Name");
+                    JCustomer.Add('Name2', OrderHeader."Sell-to Customer Name 2");
+                    JCustomer.Add('Address', OrderHeader."Sell-to Address");
+                    JCustomer.Add('Address2', OrderHeader."Sell-to Address 2");
+                    JCustomer.Add('PostCode', OrderHeader."Sell-to Post Code");
+                    JCustomer.Add('City', OrderHeader."Sell-to City");
+                    JCustomer.Add('County', OrderHeader."Sell-to County");
+                    JCustomer.Add('CountryCode', OrderHeader."Sell-to Country/Region Code");
+                    OrderHeader."Sell-to Customer No." := CustomerMapping.DoMapping(OrderHeader."Customer Id", JCustomer, OrderHeader."Shop Code", CustomerTemplateCode, AllowCreateCustomer);
+                end;
 
                 Clear(JCustomer);
                 JCustomer.Add('Name', OrderHeader."Bill-to Name");
@@ -120,6 +122,8 @@ codeunit 30163 "Shpfy Order Mapping"
 
                 if OrderHeader."Sell-to Customer No." = '' then
                     OrderHeader."Sell-to Customer No." := OrderHeader."Bill-to Customer No.";
+                if OrderHeader."Bill-to Customer No." = '' then
+                    OrderHeader."Bill-to Customer No." := OrderHeader."Sell-to Customer No.";
 
                 if OrderHeader."Bill-to Customer No." <> Shop."Default Customer No." then
                     OrderHeader."Bill-to Contact No." := FindContactNo(OrderHeader."Bill-to Contact Name", OrderHeader."Bill-to Customer No.");

--- a/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrderTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrderTest.Codeunit.al
@@ -233,6 +233,48 @@ codeunit 139609 "Shpfy Order Test"
         OrderHeader.Validate("Sell-to Contact No.", '');
     end;
 
+    [Test]
+    procedure TestManualSellToPreservedWhenBillToMappingFails()
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        Shop: Record "Shpfy Shop";
+        Customer: Record Customer;
+        OrderMapping: Codeunit "Shpfy Order Mapping";
+        CommunicationMgt: Codeunit "Shpfy Communication Mgt.";
+        Result: Boolean;
+    begin
+        // [SCENARIO] Bug 642033: A manually set Sell-to Customer No. must not be cleared when the Bill-to customer cannot be mapped.
+        Initialize();
+
+        // [GIVEN] A shop that does not import/create customers and has no default customer
+        Codeunit.Run(Codeunit::"Shpfy Initialize Test");
+        Shop := CommunicationMgt.GetShopRecord();
+        Shop."Customer Import From Shopify" := Shop."Customer Import From Shopify"::None;
+        Shop."Default Customer No." := '';
+        Shop.Modify(false);
+        CommunicationMgt.SetShop(Shop);
+
+        // [GIVEN] A Shopify order with a manually selected Sell-to customer and no Bill-to mapping
+        LibrarySales.CreateCustomer(Customer);
+        CreateShopifyOrderHeader(OrderHeader);
+        OrderHeader."Shop Code" := Shop.Code;
+        OrderHeader.B2B := false;
+        OrderHeader."Sell-to Customer No." := Customer."No.";
+        OrderHeader."Bill-to Customer No." := '';
+        OrderHeader.Modify();
+
+        // [WHEN] Mapping the order (as done by the Create Sales Document action)
+        Result := OrderMapping.DoMapping(OrderHeader);
+
+        // [THEN] The mapping succeeds
+        LibraryAssert.IsTrue(Result, 'Mapping should succeed when Sell-to is set manually');
+
+        // [THEN] The manual Sell-to selection is preserved and Bill-to falls back to it
+        OrderHeader.Get(OrderHeader."Shopify Order Id");
+        LibraryAssert.AreEqual(Customer."No.", OrderHeader."Sell-to Customer No.", 'Manual Sell-to Customer No. must be preserved');
+        LibraryAssert.AreEqual(Customer."No.", OrderHeader."Bill-to Customer No.", 'Bill-to Customer No. should fall back to Sell-to');
+    end;
+
     local procedure CreateShopifyOrderHeader(var OrderHeader: Record "Shpfy Order Header")
     begin
         OrderHeader.Init();


### PR DESCRIPTION
## What & why

Fixes a Shopify Connector bug: when a user manually set **Sell-to Customer No.** on a Shopify order but left **Bill-to Customer No.** unmapped, the **Create Sales Document** action overwrote the manual Sell-to selection with the (blank) customer-mapping result and failed with *"Not everything can be mapped."*, losing the user's selection.

**Root cause:** In `Shpfy Order Mapping`.`MapHeaderFields`, when *Bill-to Customer No.* was empty the code entered the mapping block and unconditionally re-mapped *Sell-to Customer No.*. With no mapping configured for the Shopify customer, the mapping returned blank and cleared the manual selection. There was also no fallback to derive *Bill-to* from *Sell-to* (only the reverse existed).

**Fix:**
- Only run the Sell-to customer mapping when *Sell-to Customer No.* is still blank, preserving a manually chosen customer.
- Add a symmetric fallback so *Bill-to Customer No.* is derived from *Sell-to Customer No.* when Bill-to remains blank, allowing the document to be created.

## Linked work

Fixes [AB#642033](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642033)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Built the Shopify Connector app locally with the AL compiler: 0 errors, no new analyzer warnings.
- Added `TestManualSellToPreservedWhenBillToMappingFails` in `Shpfy Order Test` (139609) reproducing the scenario (manual Sell-to, empty Bill-to, no default customer / no mapping). It asserts `DoMapping` succeeds, the manual Sell-to is preserved, and Bill-to falls back to it. The test compiles against symbols; runtime execution was deferred.

## Risk & compatibility

Low. The Sell-to mapping now runs only when Sell-to is blank, so automated order imports (where Sell-to Customer No. starts blank) are unchanged. The new Bill-to-from-Sell-to fallback only fires when Bill-to would otherwise remain blank. Scope is limited to the non-B2B customer path (`MapHeaderFields`); the B2B path (`MapB2BHeaderFields`) is unchanged.





