### PR TITLE
[Shopify] Add Companies to Shopify navigation menu

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Page Extensions/ShpfyBusinessManagerRC.PageExt.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Page Extensions/ShpfyBusinessManagerRC.PageExt.al
@@ -29,7 +29,7 @@ pageextension 30101 "Shpfy Business Manager RC" extends "Business Manager Role C
             group(Shpfy)
             {
                 Caption = 'Shopify';
-                ToolTip = 'Manage Shopify Shops, customers, products, orders, gift cards, transactions and payouts.';
+                ToolTip = 'Manage Shopify Shops, customers, companies, products, orders, gift cards, transactions and payouts.';
 
                 action(ShpfyShops)
                 {
@@ -46,6 +46,14 @@ pageextension 30101 "Shpfy Business Manager RC" extends "Business Manager Role C
                     Image = CustomerList;
                     RunObject = page "Shpfy Customers";
                     ToolTip = 'View or edit detailed information for the customers that you trade with through Shopify.';
+                }
+                action(ShpfyCompanies)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Companies';
+                    Image = Company;
+                    RunObject = page "Shpfy Companies";
+                    ToolTip = 'View or edit detailed information for the companies that you trade with through Shopify.';
                 }
                 action(ShpfyProducts)
                 {

--- a/src/Apps/W1/Shopify/App/src/Base/Page Extensions/ShpfyOrderProcessorRC.PageExt.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Page Extensions/ShpfyOrderProcessorRC.PageExt.al
@@ -30,7 +30,7 @@ pageextension 30102 "Shpfy Order Processor RC" extends "Order Processor Role Cen
             group(Shpfy)
             {
                 Caption = 'Shopify';
-                ToolTip = 'Manage Shopify Shops, customers, products, orders, gift cards, transactions and payouts.';
+                ToolTip = 'Manage Shopify Shops, customers, companies, products, orders, gift cards, transactions and payouts.';
 
                 action("ShpfyShopify Shops")
                 {
@@ -47,6 +47,14 @@ pageextension 30102 "Shpfy Order Processor RC" extends "Order Processor Role Cen
                     Image = CustomerList;
                     RunObject = page "Shpfy Customers";
                     ToolTip = 'View or edit detailed information for the customers that you trade with through Shopify.';
+                }
+                action("ShpfyShopify Companies")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Companies';
+                    Image = Company;
+                    RunObject = page "Shpfy Companies";
+                    ToolTip = 'View or edit detailed information for the companies that you trade with through Shopify.';
                 }
                 action("ShpfyShopify Products")
                 {

--- a/src/Apps/W1/Shopify/App/src/Base/Page Extensions/ShpfySalesRelMgrRC.PageExt.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Page Extensions/ShpfySalesRelMgrRC.PageExt.al
@@ -19,7 +19,7 @@ pageextension 30104 "Shpfy Sales & Rel. Mgr. RC" extends "Sales & Relationship M
             group(Shpfy)
             {
                 Caption = 'Shopify';
-                ToolTip = 'Manage Shopify Shops, customers, products, orders, gift cards, transactions and payouts.';
+                ToolTip = 'Manage Shopify Shops, customers, companies, products, orders, gift cards, transactions and payouts.';
 
                 action(ShpfyShops)
                 {
@@ -36,6 +36,14 @@ pageextension 30104 "Shpfy Sales & Rel. Mgr. RC" extends "Sales & Relationship M
                     Image = CustomerList;
                     RunObject = page "Shpfy Customers";
                     ToolTip = 'View or edit detailed information for the customers that you trade with through Shopify.';
+                }
+                action(ShpfyCompanies)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Companies';
+                    Image = Company;
+                    RunObject = page "Shpfy Companies";
+                    ToolTip = 'View or edit detailed information for the companies that you trade with through Shopify.';
                 }
                 action(ShpfyProducts)
                 {


### PR DESCRIPTION
## Summary

"Shopify Companies" was missing from the Shopify navigation menu, forcing users to search for it manually. Companies are now available for general use (not only B2B), so the Companies list should be directly accessible alongside Customers, Products, Orders, etc.

This adds a **Companies** action (placed right after **Customers**) to the Shopify group in all three role centers that surface the Shopify menu:

- `Shpfy Business Manager RC` (extends Business Manager Role Center)
- `Shpfy Order Processor RC` (extends Order Processor Role Center)
- `Shpfy Sales & Rel. Mgr. RC` (extends Sales & Relationship Mgr. RC)

Each action opens page `Shpfy Companies` (30156) using `Image = Company`, matching the existing Companies action on the Shop Card. The group tooltips were also updated to mention companies.

Fixes [AB#642036](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642036)


