### PR TITLE
[Shopify] Fix Get Catalogs tooltip to explain company dependency

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Catalogs/Pages/ShpfyCatalogs.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Catalogs/Pages/ShpfyCatalogs.Page.al
@@ -101,7 +101,7 @@ page 30159 "Shpfy Catalogs"
                 Promoted = true;
                 PromotedOnly = true;
                 PromotedCategory = Process;
-                ToolTip = 'Get catalogs from Shopify.';
+                ToolTip = 'Retrieve active B2B catalogs from Shopify for companies that have already been imported. If no companies are synced to this shop, no catalogs will be retrieved.';
 
                 trigger OnAction()
                 var


### PR DESCRIPTION
## Summary
Updates the `ToolTip` on the **Get Catalogs** action of the Shpfy Catalogs page so it explains the company dependency. The action only retrieves B2B catalogs for companies that have already been imported; if no companies are synced, no catalogs are returned. The previous tooltip (`Get catalogs from Shopify.`) gave no hint of this.

## Change
- `src/Apps/W1/Shopify/App/src/Catalogs/Pages/ShpfyCatalogs.Page.al` — updated the `GetCatalogs` action tooltip.

Fixes [AB#642040](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642040)



