### PR TITLE
[Shopify] Add Unlisted product status

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Enums/ShpfyProductStatus.Enum.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Enums/ShpfyProductStatus.Enum.al
@@ -25,5 +25,9 @@ enum 30130 "Shpfy Product Status"
     {
         Caption = 'Draft';
     }
+    value(3; Unlisted)
+    {
+        Caption = 'Unlisted';
+    }
 
 }


### PR DESCRIPTION
## What & why

Shopify added the `UNLISTED` value to its GraphQL [`ProductStatus`](https://shopify.dev/docs/api/admin-graphql/latest/enums/ProductStatus) enum (visible from API version 2025-10 onward). The Shopify Connector talks to API version 2026-07, but the `"Shpfy Product Status"` enum (30130) only knew about `Active`, `Archived`, and `Draft`. As a result, `ShpfyProductAPI.ConvertToProductStatus` could not map the `UNLISTED` string and silently fell back to `Active`, misrepresenting unlisted products on import.

This adds the `Unlisted` value to the enum. Because the value name matches the cleaned Shopify string, both directions now work with no further code changes: import maps `UNLISTED` → `Unlisted`, and export uppercases the enum name back to `UNLISTED`.

## Linked work

Fixes [AB#642074](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642074)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Built the Shopify Connector app locally via the AL tooling — package generated with no errors and no new analyzer warnings.
- Published the app to a local on-prem NST and exercised the import path (`UpdateShopifyProductFields`) with a product payload carrying `"status":"UNLISTED"`; the resulting `Shpfy Product` record was mapped to `Unlisted` instead of the previous `Active` fallback.
- No test added: the change is a purely additive enum value, and the text↔enum mapping is deterministic (the cleaned Shopify string matches the enum value name by construction), so a dedicated test would mostly exercise framework string-matching rather than connector logic.

## Risk & compatibility

Low. The change only adds a new enum value; existing `Active`/`Archived`/`Draft` handling is unchanged, and the enum is `Extensible = false`. Products that were incorrectly stored as `Active` because they are `UNLISTED` in Shopify will be corrected to `Unlisted` on the next sync.



