### PR TITLE
[FS Integration] SVCITEM-CUSTASSET mapping ignores "Convert to Customer Asset" flag — every Service Item synced to FS unconditionally

### DIFF
--- a/src/Apps/W1/FieldServiceIntegration/app/src/Codeunits/FSIntTableSubscriber.Codeunit.al
+++ b/src/Apps/W1/FieldServiceIntegration/app/src/Codeunits/FSIntTableSubscriber.Codeunit.al
@@ -2700,6 +2700,9 @@ codeunit 6610 "FS Int. Table Subscriber"
             exit;
 
         SourceRecordRef.SetTable(ServiceItem);
+        if CRMIntegrationRecord.FindByRecordID(ServiceItem.RecordId) then
+            exit;
+
         if ServiceItem."Item No." = '' then
             exit;
 

--- a/src/Apps/W1/FieldServiceIntegration/app/src/Codeunits/FSIntTableSubscriber.Codeunit.al
+++ b/src/Apps/W1/FieldServiceIntegration/app/src/Codeunits/FSIntTableSubscriber.Codeunit.al
@@ -2706,9 +2706,6 @@ codeunit 6610 "FS Int. Table Subscriber"
         if CRMIntegrationRecord.FindByRecordID(ServiceItem.RecordId) then
             exit;
 
-        if ServiceItem."Item No." = '' then
-            exit;
-
         if not Item.Get(ServiceItem."Item No.") then
             exit;
 

--- a/src/Apps/W1/FieldServiceIntegration/app/src/Codeunits/FSIntTableSubscriber.Codeunit.al
+++ b/src/Apps/W1/FieldServiceIntegration/app/src/Codeunits/FSIntTableSubscriber.Codeunit.al
@@ -2518,6 +2518,8 @@ codeunit 6610 "FS Int. Table Subscriber"
                 IgnoreArchievedServiceOrdersOnQueryPostFilterIgnoreRecord(SourceRecordRef, IgnoreRecord);
             Database::"FS Work Order":
                 IgnoreArchievedCRMWorkOrdersOnQueryPostFilterIgnoreRecord(SourceRecordRef, IgnoreRecord);
+            Database::"Service Item":
+                IgnoreServiceItemsByConvertToCustomerAssetFlag(SourceRecordRef, IgnoreRecord);
         end;
 
         if FSConnectionSetup.IsEnabled() then
@@ -2681,6 +2683,37 @@ codeunit 6610 "FS Int. Table Subscriber"
         if CRMIntegrationRecord.FindByCRMID(WorkOrderId) then
             if CRMIntegrationRecord."Archived Service Order" then
                 IgnoreRecord := true;
+    end;
+
+    internal procedure IgnoreServiceItemsByConvertToCustomerAssetFlag(SourceRecordRef: RecordRef; var IgnoreRecord: Boolean)
+    var
+        FSConnectionSetup: Record "FS Connection Setup";
+        ServiceItem: Record "Service Item";
+        Item: Record Item;
+        CRMIntegrationRecord: Record "CRM Integration Record";
+        CRMProduct: Record "CRM Product";
+    begin
+        if not FSConnectionSetup.IsEnabled() then
+            exit;
+
+        if IgnoreRecord then
+            exit;
+
+        SourceRecordRef.SetTable(ServiceItem);
+        if ServiceItem."Item No." = '' then
+            exit;
+
+        if not Item.Get(ServiceItem."Item No.") then
+            exit;
+
+        if not CRMIntegrationRecord.FindByRecordID(Item.RecordId) then
+            exit;
+
+        if not CRMProduct.Get(CRMIntegrationRecord."CRM ID") then
+            exit;
+
+        if not CRMProduct.ConvertToCustomerAsset then
+            IgnoreRecord := true;
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Integration Table Synch.", 'OnAfterInitSynchJob', '', true, true)]

--- a/src/Apps/W1/FieldServiceIntegration/app/src/Codeunits/FSIntTableSubscriber.Codeunit.al
+++ b/src/Apps/W1/FieldServiceIntegration/app/src/Codeunits/FSIntTableSubscriber.Codeunit.al
@@ -2700,6 +2700,9 @@ codeunit 6610 "FS Int. Table Subscriber"
             exit;
 
         SourceRecordRef.SetTable(ServiceItem);
+        if ServiceItem."Item No." = '' then
+            exit;
+
         if CRMIntegrationRecord.FindByRecordID(ServiceItem.RecordId) then
             exit;
 

--- a/src/Apps/W1/FieldServiceIntegration/app/src/Table Extensions/FSCRMProduct.TableExt.al
+++ b/src/Apps/W1/FieldServiceIntegration/app/src/Table Extensions/FSCRMProduct.TableExt.al
@@ -21,5 +21,13 @@ tableextension 6617 "FS CRM Product" extends "CRM Product"
             OptionMembers = Inventory,Service,"Non-Inventory";
             DataClassification = SystemMetadata;
         }
+        field(12001; ConvertToCustomerAsset; Boolean)
+        {
+            Caption = 'Convert to Customer Asset';
+            Description = 'Indicates whether the product should generate a customer asset.';
+            ExternalName = 'msdyn_converttocustomerasset';
+            ExternalType = 'Boolean';
+            DataClassification = SystemMetadata;
+        }
     }
 }

--- a/src/Apps/W1/FieldServiceIntegration/test library/src/FSIntegrationTestLibrary.Codeunit.al
+++ b/src/Apps/W1/FieldServiceIntegration/test library/src/FSIntegrationTestLibrary.Codeunit.al
@@ -79,6 +79,13 @@ codeunit 139205 "FS Integration Test Library"
         FSIntTableSubscriber.IgnoreArchievedCRMWorkOrdersOnQueryPostFilterIgnoreRecord(SourceRecordRef, IgnoreRecord);
     end;
 
+    procedure IgnoreServiceItemsByConvertToCustomerAssetFlag(SourceRecordRef: RecordRef; var IgnoreRecord: Boolean)
+    var
+        FSIntTableSubscriber: Codeunit "FS Int. Table Subscriber";
+    begin
+        FSIntTableSubscriber.IgnoreServiceItemsByConvertToCustomerAssetFlag(SourceRecordRef, IgnoreRecord);
+    end;
+
     procedure MarkArchivedServiceOrder(ServiceHeader: Record "Service Header")
     var
         FSIntTableSubscriber: Codeunit "FS Int. Table Subscriber";

--- a/src/Apps/W1/FieldServiceIntegration/test/src/FSIntegrationTest.Codeunit.al
+++ b/src/Apps/W1/FieldServiceIntegration/test/src/FSIntegrationTest.Codeunit.al
@@ -23,6 +23,7 @@ using Microsoft.Purchases.Vendor;
 using Microsoft.Sales.Customer;
 using Microsoft.Service.Archive;
 using Microsoft.Service.Document;
+using Microsoft.Service.Item;
 using Microsoft.Service.Setup;
 using Microsoft.Service.Test;
 using Microsoft.TestLibraries.DynamicsFieldService;
@@ -1570,6 +1571,112 @@ codeunit 139204 "FS Integration Test"
         // [THEN] Verify that Quantity Consumed is not written into Work Order record.
         WorkOrderProduct.Get(CRMIntegrationRecord."CRM ID");
         Assert.AreEqual(0, WorkOrderProduct.QuantityConsumed, 'Quantity Consumed should not be written into Work Order record for Posting Preview action.');
+    end;
+
+    [Test]
+    procedure IgnoreServiceItemWhenConvertToCustomerAssetIsFalse()
+    var
+        Item: Record Item;
+        TempServiceItem: Record "Service Item" temporary;
+        CRMProduct: Record "CRM Product";
+        CRMIntegrationRecord: Record "CRM Integration Record";
+        RecordRef: RecordRef;
+        IgnoreRecord: Boolean;
+        ProductId: Guid;
+    begin
+        // [FEATURE] [Service Item Mapping]
+        // [SCENARIO] Service Item is skipped when linked CRM Product has Convert to Customer Asset = No.
+        Initialize();
+        InitSetup(true, '');
+
+        Item.Get(CreateItem());
+        TempServiceItem."Item No." := Item."No.";
+        RecordRef.GetTable(TempServiceItem);
+
+        ProductId := CreateGuid();
+        CRMProduct.ProductId := ProductId;
+        CRMProduct.ConvertToCustomerAsset := false;
+        CRMProduct.Insert(false);
+
+        CRMIntegrationRecord.CoupleCRMIDToRecordID(ProductId, Item.RecordId());
+
+        FSIntegrationTestLibrary.IgnoreServiceItemsByConvertToCustomerAssetFlag(RecordRef, IgnoreRecord);
+
+        Assert.IsTrue(IgnoreRecord, 'Service Item should be ignored when Convert to Customer Asset is false.');
+    end;
+
+    [Test]
+    procedure DoNotIgnoreServiceItemWhenConvertToCustomerAssetIsTrue()
+    var
+        Item: Record Item;
+        TempServiceItem: Record "Service Item" temporary;
+        CRMProduct: Record "CRM Product";
+        CRMIntegrationRecord: Record "CRM Integration Record";
+        RecordRef: RecordRef;
+        IgnoreRecord: Boolean;
+        ProductId: Guid;
+    begin
+        // [FEATURE] [Service Item Mapping]
+        // [SCENARIO] Service Item is not skipped when linked CRM Product has Convert to Customer Asset = Yes.
+        Initialize();
+        InitSetup(true, '');
+
+        Item.Get(CreateItem());
+        TempServiceItem."Item No." := Item."No.";
+        RecordRef.GetTable(TempServiceItem);
+
+        ProductId := CreateGuid();
+        CRMProduct.ProductId := ProductId;
+        CRMProduct.ConvertToCustomerAsset := true;
+        CRMProduct.Insert(false);
+
+        CRMIntegrationRecord.CoupleCRMIDToRecordID(ProductId, Item.RecordId());
+
+        FSIntegrationTestLibrary.IgnoreServiceItemsByConvertToCustomerAssetFlag(RecordRef, IgnoreRecord);
+
+        Assert.IsFalse(IgnoreRecord, 'Service Item should not be ignored when Convert to Customer Asset is true.');
+    end;
+
+    [Test]
+    procedure DoNotIgnoreServiceItemWhenItemNoIsBlank()
+    var
+        TempServiceItem: Record "Service Item" temporary;
+        RecordRef: RecordRef;
+        IgnoreRecord: Boolean;
+    begin
+        // [FEATURE] [Service Item Mapping]
+        // [SCENARIO] Service Item with blank Item No. is not skipped by this filter.
+        Initialize();
+        InitSetup(true, '');
+
+        TempServiceItem."Item No." := '';
+        RecordRef.GetTable(TempServiceItem);
+
+        FSIntegrationTestLibrary.IgnoreServiceItemsByConvertToCustomerAssetFlag(RecordRef, IgnoreRecord);
+
+        Assert.IsFalse(IgnoreRecord, 'Service Item with blank Item No. should not be ignored by this filter.');
+    end;
+
+    [Test]
+    procedure DoNotIgnoreServiceItemWhenItemIsNotCoupled()
+    var
+        Item: Record Item;
+        TempServiceItem: Record "Service Item" temporary;
+        RecordRef: RecordRef;
+        IgnoreRecord: Boolean;
+    begin
+        // [FEATURE] [Service Item Mapping]
+        // [SCENARIO] Service Item with uncoupled Item is not skipped by this filter.
+        Initialize();
+        InitSetup(true, '');
+
+        Item.Get(CreateItem());
+        TempServiceItem."Item No." := Item."No.";
+        RecordRef.GetTable(TempServiceItem);
+
+        FSIntegrationTestLibrary.IgnoreServiceItemsByConvertToCustomerAssetFlag(RecordRef, IgnoreRecord);
+
+        Assert.IsFalse(IgnoreRecord, 'Service Item with uncoupled Item should not be ignored by this filter.');
     end;
 
     local procedure Initialize()


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

**Summary**
This change fixes a gap in Field Service Integration where Service Items were synced to Field Service Customer Assets without honoring the Dataverse Product setting Convert to Customer Asset.

**Problem**
SVCITEM-CUSTASSET synchronization pushed all eligible Service Items, even when the linked Dataverse Product had Convert to Customer Asset set to No.

**Root Cause**
1. Field Service Integration did not expose the Dataverse Product field msdyn_converttocustomerasset.
2. Service Item records had no per-record post-filter logic in OnQueryPostFilterIgnoreRecord.

**Behavior After Fix**
For SVCITEM-CUSTASSET candidates:

1. Resolve Service Item -> Item.
2. Resolve Item -> coupled CRM Product.
3. If ConvertToCustomerAsset is false, skip record.
4. If lookup data is missing, do not force skip.

Product type is intentionally not evaluated. Convert to Customer Asset is the deciding signal.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#640250](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/640250/?view=edit)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

Added automated coverage for the Service Item to Customer Asset sync filter:

- `IgnoreServiceItemWhenConvertToCustomerAssetIsFalse` verifies that a Service Item is ignored when its related Item is coupled to a Field Service product where `ConvertToCustomerAsset = false`.
- `DoNotIgnoreServiceItemWhenConvertToCustomerAssetIsTrue` verifies that a Service Item is not ignored when the coupled Field Service product allows conversion to Customer Asset.
- `DoNotIgnoreServiceItemWhenItemNoIsBlank` verifies that Service Items without an Item No. are not blocked by the new product flag logic.
- `DoNotIgnoreServiceItemWhenItemIsNotCoupled` verifies that Service Items are not ignored when the related Item is not coupled to a Field Service product.

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

To avoid disrupting existing customers, already-coupled Service Item / Customer Asset pairs are grandfathered. If a Service Item is already coupled to a Field Service Customer Asset, synchronization continues even when the related Field Service product has `ConvertToCustomerAsset = false`.

The new `ConvertToCustomerAsset` check is enforced only for Service Items that are not yet coupled. This prevents new Customer Asset synchronization from being created for products that should not generate customer assets, while preserving existing integrations and avoiding unexpected sync stops after upgrade.

This means there can be temporary mixed behavior between legacy coupled records and newly evaluated records, but the behavior is intentional to minimize customer impact.






