### PR TITLE
[28.1] Fix agent setup field lookup casing (backport #8941)

### DIFF
--- a/src/System Application/App/Agent/Setup/AgentImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Setup/AgentImpl.Codeunit.al
@@ -533,7 +533,7 @@ codeunit 4301 "Agent Impl."
         SetupPageRecordRef.Open(PageMetadata.SourceTable, PageMetadata.SourceTableTemporary);
 
         FieldMetadata.SetRange(TableNo, PageMetadata.SourceTable);
-        FieldMetadata.SetRange(FieldName, UserSecurityIdTok);
+        FieldMetadata.SetFilter(FieldName, StrSubstNo('@%1', UserSecurityIdTok));
         if not FieldMetadata.FindFirst() then
             Error(SetupPageSourceTableMissingFieldErr, SetupPageId, UserSecurityIdTok);
 


### PR DESCRIPTION
## What & why

Backport of #8941 to `releases/28.1`.

Resolve an error that prevented an agent''s setup page from opening due to a field name casing mismatch. `Agent Impl.OpenSetupPageId` looked up the setup table''s `User Security ID` field with a case-sensitive `SetRange`, so a setup table whose field name uses a different casing failed the lookup and the setup page could not open. The lookup now uses a case-insensitive `SetFilter`.

Cherry-picked from commit 36e8b432 (PR #8941).

## Linked work

Fixes [AB#642096](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642096)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.

Backport-only PR -- the change is identical to the already-reviewed and merged #8941 (one line in `AgentImpl.Codeunit.al`: `SetRange` -> case-insensitive `SetFilter`).

## Risk & compatibility

Minimal: single-line change to a field-metadata lookup filter. No schema, data, permission, or API impact.

