### PR TITLE
Preserve existing users' custom Role Center on plan re-sync (Bug 641534)

### DIFF
--- a/src/Layers/W1/BaseApp/Modules/System/PermissionSets/PermissionManager.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Modules/System/PermissionSets/PermissionManager.Codeunit.al
@@ -172,6 +172,10 @@ codeunit 9002 "Permission Manager"
             UserPersonalization.Validate(Scope, AllProfile.Scope);
             UserPersonalization.Insert();
         end else
+            // Only overwrite an existing user's role center in CRONUS evaluation companies (demo experience).
+            // For real (non-evaluation) companies the user may have chosen a custom role center, which must
+            // not be reset during a plan re-sync (regression from PR 213237). IsAllProfileFiltered is only
+            // set for the CRONUS evaluation case below.
             if IsAllProfileFiltered then begin
                 UserPersonalization.Validate("Profile ID", AllProfile."Profile ID");
                 UserPersonalization.Validate("App ID", AllProfile."App ID");
@@ -225,12 +229,12 @@ codeunit 9002 "Permission Manager"
         if Company."Evaluation Company" then begin
             if Company.Name.ToLower().StartsWith('cronus') then begin
                 AllProfile.SetRange("Profile ID", 'Business Manager Evaluation');
-                IsFiltered := true;
+                IsFiltered := true; // CRONUS evaluation: overwrite existing users' role center for the demo experience
             end;
-        end else begin
+        end else
+            // Real (non-evaluation) company: new users still get the 'Business Manager' role center, but
+            // IsFiltered is intentionally left false so existing users' customized role centers are preserved.
             AllProfile.SetRange("Profile ID", 'Business Manager');
-            IsFiltered := true;
-        end;
     end;
 
     local procedure GetCharRepresentationOfPermission(PermissionOption: Integer): Text[1]

--- a/src/Layers/W1/Tests/SINGLESERVER/UserAccessinSaaSTests.Codeunit.al
+++ b/src/Layers/W1/Tests/SINGLESERVER/UserAccessinSaaSTests.Codeunit.al
@@ -180,6 +180,58 @@ codeunit 139460 "User Access in SaaS Tests"
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
     [Scope('OnPrem')]
+    procedure TestUpdateUserAccessForSaaSDoesNotOverwriteExistingRoleCenter()
+    var
+        User: Record User;
+        UserPersonalization: Record "User Personalization";
+        AllProfile: Record "All Profile";
+        Company: Record Company;
+        LibraryPermissions: Codeunit "Library - Permissions";
+        AzureADPlanTestLibrary: Codeunit "Azure AD Plan Test Library";
+        PlanID: Guid;
+        CustomProfileID: Code[30];
+    begin
+        // [SCENARIO] An existing user who already picked a custom Role Center must keep it
+        // when the user access is re-synced from Microsoft 365 (regression from PR 213237).
+        Initialize();
+
+        // [GIVEN] A real (non-evaluation) company
+        Company.Get(CompanyName());
+        Company."Evaluation Company" := false;
+        Company.Modify();
+
+        // [GIVEN] SaaS with an existing user assigned to a Business Manager plan (Role Center 9022)
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(true);
+        LibraryPermissions.CreateUser(User, UserEuropeDcst1FullTok, true);
+
+        PlanID := AzureADPlanTestLibrary.CreatePlan('TestPlan');
+        AzureADPlanTestLibrary.ChangePlanRoleCenterID(PlanID, 9022);
+        AzureADPlanTestLibrary.AssignUserToPlan(User."User Security ID", PlanID, true);
+
+        // [GIVEN] The user already personalized a custom Role Center (not Business Manager)
+        AllProfile.SetFilter("Profile ID", '<>%1&<>%2', 'Business Manager', 'Business Manager Evaluation');
+        AllProfile.SetRange(Enabled, true);
+        AllProfile.FindFirst();
+        CustomProfileID := AllProfile."Profile ID";
+        UserPersonalization.Validate("User SID", User."User Security ID");
+        UserPersonalization.Validate("App ID", AllProfile."App ID");
+        UserPersonalization.Validate("Profile ID", AllProfile."Profile ID");
+        UserPersonalization.Validate(Scope, AllProfile.Scope);
+        UserPersonalization.Insert(true);
+
+        // [WHEN] UpdateUserAccessForSaaS is called (e.g. Retrieve Users / plan re-sync)
+        PermissionManager.UpdateUserAccessForSaaS(User."User Security ID");
+
+        // [THEN] The user's custom Role Center is preserved and NOT overwritten to Business Manager
+        UserPersonalization.Get(User."User Security ID");
+        Assert.AreEqual(
+          CustomProfileID, UserPersonalization."Profile ID",
+          'Existing user custom Role Center must not be overwritten during plan re-sync.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    [Scope('OnPrem')]
     procedure TestUpdateUserAccessForSaaSWithInvalidRoleCenter()
     var
         User: Record User;


### PR DESCRIPTION
## Problem

After a plan re-sync (for example running **Retrieve Users**, or opening a same-tenant copy-acc sandbox), **all** existing users' previously customized Role Centers are silently reset to **Business Manager** (Bedrijfsmanager). Customers reported every user in the environment being affected, with no customization involved.

## Root cause

`Permission Manager.AssignDefaultRoleCenterToUser` has a long-standing branch (from 2019) that overwrites an existing user's `User Personalization` profile when `IsAllProfileFiltered` is true. Originally that flag was set only for CRONUS evaluation companies (demo experience). PR 213237 ("Pick 'Business Manager' role for users created via Update from MS action") renamed the helper to `FilterProfileToBusinessManager` and made it set `IsFiltered := true` for **all non-evaluation** companies as well. That unintentionally activated the overwrite branch for real customers: any plan re-sync (`OnUpdateUserAccessForSaaS` raised from `AzureADPlanImpl.AddNewlyAssignedUserPlans`) now reset every existing user's custom Role Center.

## Fix (conservative)

Keep PR 213237's intended behaviour - **new** non-evaluation users still get the `Business Manager` Role Center (via the `Insert` branch, which uses the filtered profile). Only stop flagging non-evaluation companies for the *overwrite* path, so **existing** users keep their customized Role Center. CRONUS evaluation/demo behaviour is unchanged (existing users are still aligned to the evaluation role center).

The only functional change is removing `IsFiltered := true;` from the non-evaluation branch of `FilterProfileToBusinessManager`.

## Changes

- `src/Layers/W1/BaseApp/Modules/System/PermissionSets/PermissionManager.Codeunit.al`
- `src/Layers/W1/Tests/SINGLESERVER/UserAccessinSaaSTests.Codeunit.al` - regression test `TestUpdateUserAccessForSaaSDoesNotOverwriteExistingRoleCenter` (real/non-eval company, existing user with a custom Role Center is preserved after `UpdateUserAccessForSaaS`).

## Risk

Low. New-user role assignment is unchanged; CRONUS eval behaviour is unchanged. Only the overwrite of existing real-customer users is removed.

Fixes Bug 641534.


