### PR TITLE
[master]-Invalid SEPA export file format when SEPA Non-Euro Export enabled

### DIFF
--- a/src/Layers/BE/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/BE/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -103,7 +103,10 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    Cd := 'SEPA';
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        Cd := 'SEPA'
+                                    else
+                                        Cd := 'NURG';
                                 end;
                             }
                         }

--- a/src/Layers/BE/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/BE/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1861,6 +1861,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/BE/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/BE/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1865,6 +1865,7 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     procedure SvcLvlCodeIsNurgForNonEuroPayment()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
+        Currency: Record Currency;
         GenJournalLine: Record "Gen. Journal Line";
         TempBlob: Codeunit "Temp Blob";
         BlobOutStream: OutStream;
@@ -1877,16 +1878,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
         GeneralLedgerSetup.Modify();
 
-        // [GIVEN] A payment journal line for vendor "V".
+        // [GIVEN] A payment journal line for vendor "V" in a non-euro currency "C".
+        LibraryERM.CreateCurrency(Currency);
+        LibraryERM.CreateRandomExchangeRate(Currency.Code);
+        CreateGenJnlLine(GenJournalLine);
+        GenJournalLine.Validate("Currency Code", Currency.Code);
+        GenJournalLine.Modify(true);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
+        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a euro payment in SEPA format with charge bearer "SLEV" keeps "SEPA" in the "SvcLvl/Cd" tag.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled in General Ledger Setup, so charge bearer is "SLEV".
+        // [GIVEN] A euro payment journal line for vendor "V".
         CreateGenJnlLine(GenJournalLine);
 
         // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        // [THEN] The payment is exported with charge bearer "SLEV".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
-        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SLEV');
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "SEPA".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'SEPA');
     end;
 
     local procedure Init()

--- a/src/Layers/BE/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/BE/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1889,10 +1889,9 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        // [THEN] The payment is exported with charge bearer "SHAR".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
-        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
 
         // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');

--- a/src/Layers/CH/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/CH/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -110,7 +110,10 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    Cd := 'SEPA';
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        Cd := 'SEPA'
+                                    else
+                                        Cd := 'NURG';
                                 end;
                             }
 

--- a/src/Layers/CZ/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/CZ/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1889,10 +1889,9 @@
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        // [THEN] The payment is exported with charge bearer "SHAR".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
-        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
 
         // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');

--- a/src/Layers/CZ/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/CZ/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1865,6 +1865,7 @@
     procedure SvcLvlCodeIsNurgForNonEuroPayment()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
+        Currency: Record Currency;
         GenJournalLine: Record "Gen. Journal Line";
         TempBlob: Codeunit "Temp Blob";
         BlobOutStream: OutStream;
@@ -1877,16 +1878,50 @@
         GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
         GeneralLedgerSetup.Modify();
 
-        // [GIVEN] A payment journal line for vendor "V".
+        // [GIVEN] A payment journal line for vendor "V" in a non-euro currency "C".
+        LibraryERM.CreateCurrency(Currency);
+        LibraryERM.CreateRandomExchangeRate(Currency.Code);
+        CreateGenJnlLine(GenJournalLine);
+        GenJournalLine.Validate("Currency Code", Currency.Code);
+        GenJournalLine.Modify(true);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
+        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a euro payment in SEPA format with charge bearer "SLEV" keeps "SEPA" in the "SvcLvl/Cd" tag.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled in General Ledger Setup, so charge bearer is "SLEV".
+        // [GIVEN] A euro payment journal line for vendor "V".
         CreateGenJnlLine(GenJournalLine);
 
         // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        // [THEN] The payment is exported with charge bearer "SLEV".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
-        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SLEV');
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "SEPA".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'SEPA');
     end;
 
     local procedure Init()

--- a/src/Layers/CZ/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/CZ/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1861,6 +1861,34 @@
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/ES/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/ES/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -105,7 +105,10 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    Cd := 'SEPA';
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        Cd := 'SEPA'
+                                    else
+                                        Cd := 'NURG';
                                 end;
                             }
                         }

--- a/src/Layers/ES/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/ES/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1861,6 +1861,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/ES/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/ES/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1865,6 +1865,7 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     procedure SvcLvlCodeIsNurgForNonEuroPayment()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
+        Currency: Record Currency;
         GenJournalLine: Record "Gen. Journal Line";
         TempBlob: Codeunit "Temp Blob";
         BlobOutStream: OutStream;
@@ -1877,16 +1878,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
         GeneralLedgerSetup.Modify();
 
-        // [GIVEN] A payment journal line for vendor "V".
+        // [GIVEN] A payment journal line for vendor "V" in a non-euro currency "C".
+        LibraryERM.CreateCurrency(Currency);
+        LibraryERM.CreateRandomExchangeRate(Currency.Code);
+        CreateGenJnlLine(GenJournalLine);
+        GenJournalLine.Validate("Currency Code", Currency.Code);
+        GenJournalLine.Modify(true);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
+        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a euro payment in SEPA format with charge bearer "SLEV" keeps "SEPA" in the "SvcLvl/Cd" tag.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled in General Ledger Setup, so charge bearer is "SLEV".
+        // [GIVEN] A euro payment journal line for vendor "V".
         CreateGenJnlLine(GenJournalLine);
 
         // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        // [THEN] The payment is exported with charge bearer "SLEV".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
-        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SLEV');
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "SEPA".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'SEPA');
     end;
 
     local procedure Init()

--- a/src/Layers/ES/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/ES/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1889,10 +1889,9 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        // [THEN] The payment is exported with charge bearer "SHAR".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
-        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
 
         // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');

--- a/src/Layers/FR/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/FR/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -103,7 +103,10 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    Cd := 'SEPA';
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        Cd := 'SEPA'
+                                    else
+                                        Cd := 'NURG';
                                 end;
                             }
                         }

--- a/src/Layers/FR/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/FR/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1734,6 +1734,7 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     procedure SvcLvlCodeIsNurgForNonEuroPayment()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
+        Currency: Record Currency;
         GenJournalLine: Record "Gen. Journal Line";
         TempBlob: Codeunit "Temp Blob";
         BlobOutStream: OutStream;
@@ -1746,16 +1747,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
         GeneralLedgerSetup.Modify();
 
-        // [GIVEN] A payment journal line for vendor "V".
+        // [GIVEN] A payment journal line for vendor "V" in a non-euro currency "C".
+        LibraryERM.CreateCurrency(Currency);
+        LibraryERM.CreateRandomExchangeRate(Currency.Code);
+        CreateGenJnlLine(GenJournalLine);
+        GenJournalLine.Validate("Currency Code", Currency.Code);
+        GenJournalLine.Modify(true);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
+        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a euro payment in SEPA format with charge bearer "SLEV" keeps "SEPA" in the "SvcLvl/Cd" tag.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled in General Ledger Setup, so charge bearer is "SLEV".
+        // [GIVEN] A euro payment journal line for vendor "V".
         CreateGenJnlLine(GenJournalLine);
 
         // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        // [THEN] The payment is exported with charge bearer "SLEV".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
-        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SLEV');
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "SEPA".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'SEPA');
     end;
 
     local procedure Init()

--- a/src/Layers/FR/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/FR/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1758,10 +1758,9 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        // [THEN] The payment is exported with charge bearer "SHAR".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
-        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
 
         // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');

--- a/src/Layers/FR/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/FR/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1730,6 +1730,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/IT/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/IT/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -103,7 +103,10 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    Cd := 'SEPA';
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        Cd := 'SEPA'
+                                    else
+                                        Cd := 'NURG';
                                 end;
                             }
                         }

--- a/src/Layers/IT/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1866,6 +1866,7 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     procedure SvcLvlCodeIsNurgForNonEuroPayment()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
+        Currency: Record Currency;
         GenJournalLine: Record "Gen. Journal Line";
         TempBlob: Codeunit "Temp Blob";
         BlobOutStream: OutStream;
@@ -1878,16 +1879,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
         GeneralLedgerSetup.Modify();
 
-        // [GIVEN] A payment journal line for vendor "V".
+        // [GIVEN] A payment journal line for vendor "V" in a non-euro currency "C".
+        LibraryERM.CreateCurrency(Currency);
+        LibraryERM.CreateRandomExchangeRate(Currency.Code);
+        CreateGenJnlLine(GenJournalLine);
+        GenJournalLine.Validate("Currency Code", Currency.Code);
+        GenJournalLine.Modify(true);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
+        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a euro payment in SEPA format with charge bearer "SLEV" keeps "SEPA" in the "SvcLvl/Cd" tag.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled in General Ledger Setup, so charge bearer is "SLEV".
+        // [GIVEN] A euro payment journal line for vendor "V".
         CreateGenJnlLine(GenJournalLine);
 
         // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        // [THEN] The payment is exported with charge bearer "SLEV".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
-        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SLEV');
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "SEPA".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'SEPA');
     end;
 
     local procedure Init()

--- a/src/Layers/IT/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1862,6 +1862,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/IT/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1890,10 +1890,9 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        // [THEN] The payment is exported with charge bearer "SHAR".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
-        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
 
         // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');

--- a/src/Layers/NA/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1860,6 +1860,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/NA/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1888,10 +1888,9 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        // [THEN] The payment is exported with charge bearer "SHAR".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
-        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
 
         // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');

--- a/src/Layers/NA/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1864,6 +1864,7 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     procedure SvcLvlCodeIsNurgForNonEuroPayment()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
+        Currency: Record Currency;
         GenJournalLine: Record "Gen. Journal Line";
         TempBlob: Codeunit "Temp Blob";
         BlobOutStream: OutStream;
@@ -1876,16 +1877,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
         GeneralLedgerSetup.Modify();
 
-        // [GIVEN] A payment journal line for vendor "V".
+        // [GIVEN] A payment journal line for vendor "V" in a non-euro currency "C".
+        LibraryERM.CreateCurrency(Currency);
+        LibraryERM.CreateRandomExchangeRate(Currency.Code);
+        CreateGenJnlLine(GenJournalLine);
+        GenJournalLine.Validate("Currency Code", Currency.Code);
+        GenJournalLine.Modify(true);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
+        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a euro payment in SEPA format with charge bearer "SLEV" keeps "SEPA" in the "SvcLvl/Cd" tag.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled in General Ledger Setup, so charge bearer is "SLEV".
+        // [GIVEN] A euro payment journal line for vendor "V".
         CreateGenJnlLine(GenJournalLine);
 
         // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        // [THEN] The payment is exported with charge bearer "SLEV".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
-        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SLEV');
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "SEPA".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'SEPA');
     end;
 
     local procedure Init()

--- a/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -104,7 +104,10 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    Cd := 'SEPA';
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        Cd := 'SEPA'
+                                    else
+                                        Cd := 'NURG';
                                 end;
                             }
                         }

--- a/src/Layers/NO/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/NO/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -119,8 +119,11 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    SvcLvlCd := 'SEPA';
-                                end;
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        SvcLvlCd := 'SEPA'
+                                    else
+                                        SvcLvlCd := 'NURG';
+                               end;
                             }
                         }
                     }

--- a/src/Layers/NO/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/NO/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1830,10 +1830,9 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        // [THEN] The payment is exported with charge bearer "SHAR".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
-        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
 
         // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');

--- a/src/Layers/NO/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/NO/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1806,6 +1806,7 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     procedure SvcLvlCodeIsNurgForNonEuroPayment()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
+        Currency: Record Currency;
         GenJournalLine: Record "Gen. Journal Line";
         TempBlob: Codeunit "Temp Blob";
         BlobOutStream: OutStream;
@@ -1818,16 +1819,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
         GeneralLedgerSetup.Modify();
 
-        // [GIVEN] A payment journal line for vendor "V".
+        // [GIVEN] A payment journal line for vendor "V" in a non-euro currency "C".
+        LibraryERM.CreateCurrency(Currency);
+        LibraryERM.CreateRandomExchangeRate(Currency.Code);
+        CreateGenJnlLine(GenJournalLine);
+        GenJournalLine.Validate("Currency Code", Currency.Code);
+        GenJournalLine.Modify(true);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
+        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a euro payment in SEPA format with charge bearer "SLEV" keeps "SEPA" in the "SvcLvl/Cd" tag.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled in General Ledger Setup, so charge bearer is "SLEV".
+        // [GIVEN] A euro payment journal line for vendor "V".
         CreateGenJnlLine(GenJournalLine);
 
         // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        // [THEN] The payment is exported with charge bearer "SLEV".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
-        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SLEV');
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "SEPA".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'SEPA');
     end;
 
     local procedure Init()

--- a/src/Layers/NO/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/NO/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1802,6 +1802,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/RU/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1737,6 +1737,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/RU/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1765,10 +1765,9 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        // [THEN] The payment is exported with charge bearer "SHAR".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
-        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
 
         // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');

--- a/src/Layers/RU/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1741,6 +1741,7 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     procedure SvcLvlCodeIsNurgForNonEuroPayment()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
+        Currency: Record Currency;
         GenJournalLine: Record "Gen. Journal Line";
         TempBlob: Codeunit "Temp Blob";
         BlobOutStream: OutStream;
@@ -1753,16 +1754,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
         GeneralLedgerSetup.Modify();
 
-        // [GIVEN] A payment journal line for vendor "V".
+        // [GIVEN] A payment journal line for vendor "V" in a non-euro currency "C".
+        LibraryERM.CreateCurrency(Currency);
+        LibraryERM.CreateRandomExchangeRate(Currency.Code);
+        CreateGenJnlLine(GenJournalLine);
+        GenJournalLine.Validate("Currency Code", Currency.Code);
+        GenJournalLine.Modify(true);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
+        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a euro payment in SEPA format with charge bearer "SLEV" keeps "SEPA" in the "SvcLvl/Cd" tag.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled in General Ledger Setup, so charge bearer is "SLEV".
+        // [GIVEN] A euro payment journal line for vendor "V".
         CreateGenJnlLine(GenJournalLine);
 
         // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        // [THEN] The payment is exported with charge bearer "SLEV".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
-        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SLEV');
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "SEPA".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'SEPA');
     end;
 
     local procedure Init()

--- a/src/Layers/W1/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/W1/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -103,7 +103,10 @@ xmlport 1001 "SEPA CT pain.001.001.09"
 
                                 trigger OnBeforePassVariable()
                                 begin
-                                    Cd := 'SEPA';
+                                    if PaymentExportDataGroup."SEPA Charge Bearer Text" = 'SLEV' then
+                                        Cd := 'SEPA'
+                                    else
+                                        Cd := 'NURG';
                                 end;
                             }
                         }

--- a/src/Layers/W1/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1861,6 +1861,34 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         UnbindSubscription(ERMTestSEPACreditTransfers);
     end;
 
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a non-euro payment in SEPA format with charge bearer "SHAR" writes "NURG" into the "SvcLvl/Cd" tag instead of the invalid "SEPA".
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled in General Ledger Setup, so charge bearer is "SHAR".
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
+        GeneralLedgerSetup.Modify();
+
+        // [GIVEN] A payment journal line for vendor "V".
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
     local procedure Init()
     var
         NoSeries: Record "No. Series";

--- a/src/Layers/W1/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1865,6 +1865,7 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     procedure SvcLvlCodeIsNurgForNonEuroPayment()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
+        Currency: Record Currency;
         GenJournalLine: Record "Gen. Journal Line";
         TempBlob: Codeunit "Temp Blob";
         BlobOutStream: OutStream;
@@ -1877,16 +1878,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         GeneralLedgerSetup.Validate("SEPA Non-Euro Export", true);
         GeneralLedgerSetup.Modify();
 
-        // [GIVEN] A payment journal line for vendor "V".
+        // [GIVEN] A payment journal line for vendor "V" in a non-euro currency "C".
+        LibraryERM.CreateCurrency(Currency);
+        LibraryERM.CreateRandomExchangeRate(Currency.Code);
+        CreateGenJnlLine(GenJournalLine);
+        GenJournalLine.Validate("Currency Code", Currency.Code);
+        GenJournalLine.Modify(true);
+
+        // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
+        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] Exporting a euro payment in SEPA format with charge bearer "SLEV" keeps "SEPA" in the "SvcLvl/Cd" tag.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled in General Ledger Setup, so charge bearer is "SLEV".
+        // [GIVEN] A euro payment journal line for vendor "V".
         CreateGenJnlLine(GenJournalLine);
 
         // [WHEN] Export the journal line using XmlPort "SEPA CT pain.001.001.09".
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
+        // [THEN] The payment is exported with charge bearer "SLEV".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
-        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SLEV');
+
+        // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "SEPA".
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'SEPA');
     end;
 
     local procedure Init()

--- a/src/Layers/W1/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1889,10 +1889,9 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
         TempBlob.CreateOutStream(BlobOutStream);
         Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
 
-        // [THEN] The payment is exported with charge bearer "SHAR" and the instructed amount in currency "C".
+        // [THEN] The payment is exported with charge bearer "SHAR".
         LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/ChrgBr', 'SHAR');
-        LibraryXPathXMLReader.VerifyAttributeValue('InstdAmt', 'Ccy', Currency.Code);
 
         // [THEN] The "PmtTpInf/SvcLvl/Cd" tag has value "NURG".
         LibraryXPathXMLReader.VerifyNodeValueByXPath('//PmtInf/PmtTpInf/SvcLvl/Cd', 'NURG');


### PR DESCRIPTION
[Bug 641697](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/641697): [master][All-e]Invalid SEPA export file format when SEPA Non-Euro Export enabled

Fixes [AB#641697](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641697)




