### PR TITLE
[FI] Obsolete unused 'Print on Invoice' VAT setting

### DIFF
--- a/src/Layers/FI/BaseApp/Finance/VAT/Setup/VATBusinessPostingGroup.Table.al
+++ b/src/Layers/FI/BaseApp/Finance/VAT/Setup/VATBusinessPostingGroup.Table.al
@@ -48,10 +48,22 @@ table 323 "VAT Business Posting Group"
             Caption = 'Last Modified Date Time';
             Editable = false;
         }
+#if not CLEANSCHEMA32
+#pragma warning disable AA0232
         field(13400; "Print on Invoice"; Boolean)
         {
             Caption = 'Print on Invoice';
+            ObsoleteReason = 'The Print VAT Information on Invoices functionality is discontinued and this setting is no longer used.';
+#if not CLEAN29
+            ObsoleteState = Pending;
+            ObsoleteTag = '29.0';
+#else
+            ObsoleteState = Removed;
+            ObsoleteTag = '32.0';
+#endif
         }
+#pragma warning restore AA0232
+#endif
     }
 
     keys

--- a/src/Layers/FI/BaseApp/Finance/VAT/Setup/VATBusinessPostingGroups.Page.al
+++ b/src/Layers/FI/BaseApp/Finance/VAT/Setup/VATBusinessPostingGroups.Page.al
@@ -36,11 +36,18 @@ page 470 "VAT Business Posting Groups"
                 {
                     ApplicationArea = Basic, Suite;
                 }
+#if not CLEAN29
+#pragma warning disable AL0432
                 field("Print on Invoice"; Rec."Print on Invoice")
                 {
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies if you want to include the Description on sales invoices and credit memos.';
+                    ObsoleteState = Pending;
+                    ObsoleteTag = '29.0';
+                    ObsoleteReason = 'The Print VAT Information on Invoices functionality is discontinued and this setting is no longer used.';
                 }
+#pragma warning restore AL0432
+#endif
             }
         }
         area(factboxes)

--- a/src/Layers/FI/BaseApp/Finance/VAT/Setup/VATProductPostingGroup.Table.al
+++ b/src/Layers/FI/BaseApp/Finance/VAT/Setup/VATProductPostingGroup.Table.al
@@ -47,10 +47,22 @@ table 324 "VAT Product Posting Group"
         {
             Caption = 'Last Modified DateTime';
         }
+#if not CLEANSCHEMA32
+#pragma warning disable AA0232
         field(13400; "Print on Invoice"; Boolean)
         {
             Caption = 'Print on Invoice';
+            ObsoleteReason = 'The Print VAT Information on Invoices functionality is discontinued and this setting is no longer used.';
+#if not CLEAN29
+            ObsoleteState = Pending;
+            ObsoleteTag = '29.0';
+#else
+            ObsoleteState = Removed;
+            ObsoleteTag = '32.0';
+#endif
         }
+#pragma warning restore AA0232
+#endif
     }
 
     keys

--- a/src/Layers/FI/BaseApp/Finance/VAT/Setup/VATProductPostingGroups.Page.al
+++ b/src/Layers/FI/BaseApp/Finance/VAT/Setup/VATProductPostingGroups.Page.al
@@ -38,11 +38,18 @@ page 471 "VAT Product Posting Groups"
                 {
                     ApplicationArea = Basic, Suite;
                 }
+#if not CLEAN29
+#pragma warning disable AL0432
                 field("Print on Invoice"; Rec."Print on Invoice")
                 {
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies if you want to include the Description on sales invoices and credit memos.';
+                    ObsoleteState = Pending;
+                    ObsoleteTag = '29.0';
+                    ObsoleteReason = 'The Print VAT Information on Invoices functionality is discontinued and this setting is no longer used.';
                 }
+#pragma warning restore AL0432
+#endif
             }
         }
         area(factboxes)

--- a/src/Layers/FI/Tests/Local/VATEXPReportTest.Codeunit.al
+++ b/src/Layers/FI/Tests/Local/VATEXPReportTest.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 codeunit 144017 "VATEXP Report Test"
 {
     Subtype = Test;
@@ -196,3 +198,5 @@ codeunit 144017 "VATEXP Report Test"
         exit(SalesInvHeaderNo)
     end;
 }
+#pragma warning restore AL0432
+#endif

--- a/src/Layers/W1/Tests/SCM/SCMCostingBatch.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMCostingBatch.Codeunit.al
@@ -1833,7 +1833,7 @@ codeunit 137402 "SCM Costing Batch"
         LibraryERMCountryData.CreateGeneralPostingSetupData();
         LibraryERMCountryData.UpdateGeneralPostingSetup();
         LibraryERMCountryData.UpdateJournalTemplMandatory(false);
-        RunAdjustCostItemEntries('');
+        LibraryCosting.AdjustCostItemEntries('', '');
         PostInvtCostToGL();
         LibrarySetupStorage.SaveSalesSetup();
         LibrarySetupStorage.SaveGeneralLedgerSetup();

--- a/src/Layers/W1/Tests/SCM/SCMCostingBatch.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMCostingBatch.Codeunit.al
@@ -1833,7 +1833,7 @@ codeunit 137402 "SCM Costing Batch"
         LibraryERMCountryData.CreateGeneralPostingSetupData();
         LibraryERMCountryData.UpdateGeneralPostingSetup();
         LibraryERMCountryData.UpdateJournalTemplMandatory(false);
-        LibraryCosting.AdjustCostItemEntries('', '');
+        RunAdjustCostItemEntries('');
         PostInvtCostToGL();
         LibrarySetupStorage.SaveSalesSetup();
         LibrarySetupStorage.SaveGeneralLedgerSetup();


### PR DESCRIPTION
## Summary

The FI **"Print on Invoice"** flag (field `13400`) on **VAT Business Posting Group** (323) and **VAT Product Posting Group** (324) is an **orphaned setup field** — it is defined on the two tables and surfaced on pages 470/471, but **nothing reads it**.

A full sweep of the `App/` tree confirms:
- No report (`.al` or `.rdlc`) or codeunit consumes the field.
- The only test — `VATEXP Report Test` (codeunit 144017) — runs the standard **Sales - Invoice** report and then uses `asserterror` to confirm the flag is **absent** from the output (code comment: *"No VatBusPostgroup information is available for this report"*).

The invoice-printing logic that once used it was dropped when the FI invoice reports were unified into W1, leaving the flag inert.

## Change

Obsolete the field **in place** using the standard `Pending (29.0)` → `Removed (32.0)` cycle, rather than delocalizing it into a new extension:

| File | Change |
|------|--------|
| VATBusinessPostingGroup.Table.al (323) | Field 13400 → `ObsoleteState = Pending`, guarded by `CLEANSCHEMA32` / `CLEAN29` |
| VATProductPostingGroup.Table.al (324) | Field 13400 → `ObsoleteState = Pending`, guarded by `CLEANSCHEMA32` / `CLEAN29` |
| VATBusinessPostingGroups.Page.al (470) | `Print on Invoice` control → `ObsoleteState = Pending`, guarded by `CLEAN29` |
| VATProductPostingGroups.Page.al (471) | `Print on Invoice` control → `ObsoleteState = Pending`, guarded by `CLEAN29` |
| VATEXPReportTest.Codeunit.al (144017) | Whole test guarded by `CLEAN29` — it exists only to exercise the flag and is removed together with it |

**No data migration / upgrade codeunit** is needed: the field carries no meaningful data and nothing consumes it.

## Verification

No behavioral change. Current (non-`CLEAN29`) builds keep the field/control/test (now marked deprecated); at `CLEAN29` they are removed and the column is dropped at `CLEANSCHEMA32`. Compile/test deferred to CI.

🤖 Generated with GitHub Copilot CLI

Fixes: [AB#622873](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622873)




