### PR TITLE
Incident 51000001074180 : [BC-IN] GST Component code alignment issue in Pay GST Calculation details.

### DIFF
--- a/src/Apps/IN/INGST/app/GSTReturnSettlement/src/codeunit/GSTSettlement.Codeunit.al
+++ b/src/Apps/IN/INGST/app/GSTReturnSettlement/src/codeunit/GSTSettlement.Codeunit.al
@@ -781,6 +781,7 @@ codeunit 18318 "GST Settlement"
     var
         GSTPaymentBuffer: Record "GST Payment Buffer";
     begin
+        GSTPaymentBuffer.SetCurrentKey("GST Registration No.", "Document No.", "Sequence No.");
         GSTPaymentBuffer.SetRange("GST Registration No.", GSTINNo);
         GSTPaymentBuffer.SetRange("Document No.", DocumentNo);
         if GSTPaymentBuffer.FindSet() then
@@ -3058,6 +3059,7 @@ codeunit 18318 "GST Settlement"
             GSTPaymentBufferDetails.DeleteAll();
 
         GSTPaymentBuffer.Reset();
+        GSTPaymentBuffer.SetCurrentKey("GST Registration No.", "Document No.", "Sequence No.");
         GSTPaymentBuffer.SetRange("GST Registration No.", GSTINNo);
         GSTPaymentBuffer.SetRange("Document No.", DocumentNo);
         if GSTPaymentBuffer.FindSet() then

--- a/src/Apps/IN/INGST/app/GSTReturnSettlement/src/page/PayGSTCalculationDetails.page.al
+++ b/src/Apps/IN/INGST/app/GSTReturnSettlement/src/page/PayGSTCalculationDetails.page.al
@@ -13,7 +13,7 @@ page 18324 "Pay GST Calculation Details"
     ModifyAllowed = false;
     PageType = List;
     SourceTable = "GST Payment Buffer Details";
-    SourceTableView = sorting("GST Registration No.", "Document No.", "GST Component Code", "Line No.") order(ascending);
+    SourceTableView = sorting("GST Registration No.", "Document No.", "Line No.") order(ascending);
 
     layout
     {

--- a/src/Apps/IN/INGST/app/GSTReturnSettlement/src/table/GSTPaymentBufferDetails.table.al
+++ b/src/Apps/IN/INGST/app/GSTReturnSettlement/src/table/GSTPaymentBufferDetails.table.al
@@ -126,6 +126,9 @@ table 18322 "GST Payment Buffer Details"
         {
             Clustered = true;
         }
+        key(LineOrder; "GST Registration No.", "Document No.", "Line No.")
+        {
+        }
     }
 
     fieldgroups


### PR DESCRIPTION
[Bug 642154](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/642154): [Main]-Incident 51000001074180 : [BC-IN] GST Component code alignment issue in Pay GST Calculation details.

[[[AB#642154](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642154)]

**Issue:**
GST Settlement calculated credit set-off in the wrong sequence. With multiple liability components (IGST, CGST, SGST), the Pay GST Calculation Details showed incorrect `Credit Utilized` / `Surplus Credit` because components were processed alphabetically (CGST, IGST, SGST) instead of the configured Return & Reco Component sequence (IGST, CGST, SGST).

**Cause:**
Both settlement loops in Codeunit 18318 `GST Settlement` (`UpdateCreditAmount` and `ValidateCreditUtilizedAmt`) iterated `GST Payment Buffer` without a `SetCurrentKey`, defaulting to the clustered `GST Component Code` key instead of the `Sequence No.` key.

**Solution:**
- **Codeunit 18318 `GST Settlement`**: Added `SetCurrentKey("GST Registration No.", "Document No.", "Sequence No.")` before `FindSet()` in both procedures. `GST Claim Setoff` priority logic untouched.
- **Table 18322 `GST Payment Buffer Details`**: Added non-clustered `LineOrder` key for display sorting (primary key unchanged).
- **Page 18324 `Pay GST Calculation Details`**: Changed `SourceTableView` to sort by `Line No.` so rows display in sequence order.

No breaking changes — only iteration/display order corrected; calculation and posting logic unchanged.

Summary: 
Process GST Payment Buffer in Return & Reco Component Sequence No. order instead of clustered GST Component Code order during settlement calculation.

- GSTSettlement.Codeunit: add SetCurrentKey on Sequence No. in UpdateCreditAmount and ValidateCreditUtilizedAmt
- GST Payment Buffer Details table: add non-clustered LineOrder key for display sorting
- Pay GST Calculation Details page: sort by Line No. to show components in sequence order

GST Claim Setoff priority logic and primary keys unchanged.


