### PR TITLE
[Shopify] Add Compare-at Price field to Shopify Variants page for personalization

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Pages/ShpfyVariants.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Pages/ShpfyVariants.Page.al
@@ -109,6 +109,12 @@ page 30127 "Shpfy Variants"
                     ApplicationArea = All;
                     ToolTip = 'Specifies the price of a product variant.';
                 }
+                field(CompareAtPrice; Rec."Compare at Price")
+                {
+                    ApplicationArea = All;
+                    Visible = false;
+                    ToolTip = 'Specifies the original price of the product variant in Shopify before a discount. Shopify displays it alongside the current price to show the price reduction.';
+                }
                 field(Barcode; Rec.Barcode)
                 {
                     ApplicationArea = All;


### PR DESCRIPTION
On the **Shopify Products** page, the **Shopify Variants** part did not expose the **Compare at Price** field for personalization. The field exists in table **Shpfy Variant (30129)** (field 7) but had no corresponding field control on page **Shpfy Variants (30127)**, so users could not add it via personalization or review the Shopify compare-at price for variants.

### Fix
Added a `Compare at Price` field control to page 30127 ""Shpfy Variants"", placed after the `Price` field. It is `Visible = false` so it does not change the default layout for existing users, but is available to add through personalization. Uses the tooltip suggested in the work item.

Fixes [AB#642131](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642131)


