### PR TITLE
Harden SFTP Client module (security review phase 1)

### DIFF
--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAccount.Table.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPAccount.Table.al
@@ -76,7 +76,7 @@ table 4621 "Ext. SFTP Account"
         field(13; Fingerprints; Text[1024])
         {
             Caption = 'Fingerprints';
-            ToolTip = 'Specifies the known host fingerprints for this SFTP account. Each fingerprint must be prefixed with sha256: or md5:. Multiple fingerprints can be separated with commas.';
+            ToolTip = 'Specifies the known host fingerprints for this SFTP account. Each fingerprint must be prefixed with sha256:. Multiple fingerprints can be separated with commas.';
             Access = Internal;
             DataClassification = SystemMetadata;
         }

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnectorImpl.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnectorImpl.Codeunit.al
@@ -466,8 +466,7 @@ codeunit 4621 "Ext. SFTP Connector Impl" implements "External File Storage Conne
     local procedure AddFingerprint(Fingerprint: Text; var SFTPClient: Codeunit "SFTP Client")
     var
         SHA256PrefixTok: Label 'sha256:', Locked = true;
-        MD5PrefixTok: Label 'md5:', Locked = true;
-        InvalidFingerprintErr: Label 'Fingerprint must start with "md5:" or "sha256:".';
+        InvalidFingerprintErr: Label 'Fingerprint must start with "sha256:".';
     begin
         Fingerprint := Fingerprint.Trim();
         if Fingerprint = '' then
@@ -476,8 +475,6 @@ codeunit 4621 "Ext. SFTP Connector Impl" implements "External File Storage Conne
         case true of
             Fingerprint.StartsWith(SHA256PrefixTok):
                 SFTPClient.AddFingerprintSHA256(Fingerprint.Substring(StrLen(SHA256PrefixTok) + 1));
-            Fingerprint.StartsWith(MD5PrefixTok):
-                SFTPClient.AddFingerprintMD5(Fingerprint.Substring(StrLen(MD5PrefixTok) + 1));
             else
                 Error(InvalidFingerprintErr);
         end;

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnectorImpl.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnectorImpl.Codeunit.al
@@ -466,7 +466,9 @@ codeunit 4621 "Ext. SFTP Connector Impl" implements "External File Storage Conne
     local procedure AddFingerprint(Fingerprint: Text; var SFTPClient: Codeunit "SFTP Client")
     var
         SHA256PrefixTok: Label 'sha256:', Locked = true;
+        MD5PrefixTok: Label 'md5:', Locked = true;
         InvalidFingerprintErr: Label 'Fingerprint must start with "sha256:".';
+        MD5NotSupportedErr: Label 'MD5 host key fingerprints are no longer supported because MD5 is cryptographically broken. Reconfigure this account with a "sha256:" fingerprint.';
     begin
         Fingerprint := Fingerprint.Trim();
         if Fingerprint = '' then
@@ -475,6 +477,8 @@ codeunit 4621 "Ext. SFTP Connector Impl" implements "External File Storage Conne
         case true of
             Fingerprint.StartsWith(SHA256PrefixTok):
                 SFTPClient.AddFingerprintSHA256(Fingerprint.Substring(StrLen(SHA256PrefixTok) + 1));
+            Fingerprint.StartsWith(MD5PrefixTok):
+                Error(MD5NotSupportedErr);
             else
                 Error(InvalidFingerprintErr);
         end;

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnectorImpl.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnectorImpl.Codeunit.al
@@ -21,7 +21,7 @@ codeunit 4621 "Ext. SFTP Connector Impl" implements "External File Storage Conne
         ConnectorDescriptionTxt: Label 'Use SFTP Server to store and retrieve files.', MaxLength = 250;
         NotRegisteredAccountErr: Label 'We could not find the account. Typically, this is because the account has been deleted.';
         InvalidFingerprintErr: Label 'Fingerprint must start with "sha256:".';
-        MD5NotSupportedErr: Label 'MD5 host key fingerprints are no longer supported because MD5 is cryptographically broken. Reconfigure this account with a "sha256:" fingerprint.';
+        MD5NotSupportedErr: Label 'MD5 host key fingerprints are no longer supported. Reconfigure this account with a SHA256 fingerprint.';
         PathSeparatorTok: Label '/', Locked = true;
 
     /// <summary>

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnectorImpl.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/src/ExtSFTPConnectorImpl.Codeunit.al
@@ -20,6 +20,8 @@ codeunit 4621 "Ext. SFTP Connector Impl" implements "External File Storage Conne
     var
         ConnectorDescriptionTxt: Label 'Use SFTP Server to store and retrieve files.', MaxLength = 250;
         NotRegisteredAccountErr: Label 'We could not find the account. Typically, this is because the account has been deleted.';
+        InvalidFingerprintErr: Label 'Fingerprint must start with "sha256:".';
+        MD5NotSupportedErr: Label 'MD5 host key fingerprints are no longer supported because MD5 is cryptographically broken. Reconfigure this account with a "sha256:" fingerprint.';
         PathSeparatorTok: Label '/', Locked = true;
 
     /// <summary>
@@ -467,8 +469,6 @@ codeunit 4621 "Ext. SFTP Connector Impl" implements "External File Storage Conne
     var
         SHA256PrefixTok: Label 'sha256:', Locked = true;
         MD5PrefixTok: Label 'md5:', Locked = true;
-        InvalidFingerprintErr: Label 'Fingerprint must start with "sha256:".';
-        MD5NotSupportedErr: Label 'MD5 host key fingerprints are no longer supported because MD5 is cryptographically broken. Reconfigure this account with a "sha256:" fingerprint.';
     begin
         Fingerprint := Fingerprint.Trim();
         if Fingerprint = '' then

--- a/src/System Application/App/SFTP Client/app.json
+++ b/src/System Application/App/SFTP Client/app.json
@@ -39,7 +39,7 @@
     }
   ],
   "resourceExposurePolicy": {
-    "allowDebugging": true,
+    "allowDebugging": false,
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },

--- a/src/System Application/App/SFTP Client/src/DotnetSFTPClient.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/DotnetSFTPClient.Codeunit.al
@@ -17,7 +17,6 @@ codeunit 9760 "Dotnet SFTP Client" implements "ISFTP Client"
         [WithEvents]
         RenciSFTPClient: DotNet RenciSftpClient;
         FingerprintsSHA256: List of [Text];
-        FingerprintsMD5: List of [Text];
         ServerFingerprintSHA256: Text;
         LastOperationSuccessful: Boolean;
         TrustedServer: Boolean;
@@ -76,6 +75,7 @@ codeunit 9760 "Dotnet SFTP Client" implements "ISFTP Client"
         exit(LastOperationSuccessful);
     end;
 
+    [NonDebuggable]
     procedure SftpClient(Host: Text; Port: Integer; UserName: Text; PrivateKey: InStream): Boolean
     var
         EmptyPassphrase: SecretText;
@@ -130,24 +130,28 @@ codeunit 9760 "Dotnet SFTP Client" implements "ISFTP Client"
         exit(Result);
     end;
 
+    [NonDebuggable]
     procedure ReadAllBytes(Path: Text; var Bytes: Dotnet Array): Boolean
     begin
         LastOperationSuccessful := InternalReadAllBytes(Path, Bytes);
         exit(LastOperationSuccessful);
     end;
 
+    [NonDebuggable]
     [TryFunction]
     local procedure InternalReadAllBytes(Path: Text; var Bytes: Dotnet Array)
     begin
         Bytes := RenciSFTPClient.ReadAllBytes(Path);
     end;
 
+    [NonDebuggable]
     procedure WriteAllBytes(Path: Text; Bytes: Dotnet Array): Boolean
     begin
         LastOperationSuccessful := InternalWriteAllBytes(Path, Bytes);
         exit(LastOperationSuccessful);
     end;
 
+    [NonDebuggable]
     [TryFunction]
     local procedure InternalWriteAllBytes(Path: Text; Bytes: Dotnet Array)
     begin
@@ -244,19 +248,10 @@ codeunit 9760 "Dotnet SFTP Client" implements "ISFTP Client"
             TrustedServer := true;
             exit;
         end;
-        if not FingerprintsMD5.Contains(e.FingerPrintMD5) then
-            exit;
-        e.CanTrust := true;
-        TrustedServer := true;
     end;
 
     procedure SetSHA256Fingerprints(Fingerprints: List of [Text])
     begin
         FingerprintsSHA256 := Fingerprints;
-    end;
-
-    procedure SetMD5Fingerprints(Fingerprints: List of [Text])
-    begin
-        FingerprintsMD5 := Fingerprints;
     end;
 }

--- a/src/System Application/App/SFTP Client/src/ISFTPClient.Interface.al
+++ b/src/System Application/App/SFTP Client/src/ISFTPClient.Interface.al
@@ -26,5 +26,4 @@ interface "ISFTP Client"
     procedure Get(Path: Text; var Result: Interface "ISFTP File"): Boolean
     procedure CreateDirectory(Path: Text): Boolean
     procedure SetSHA256Fingerprints(FingerPrints: List of [Text])
-    procedure SetMD5Fingerprints(FingerPrints: List of [Text])
 }

--- a/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
@@ -21,15 +21,6 @@ codeunit 9762 "SFTP Client"
     end;
 
     /// <summary>
-    /// Adds an MD5 fingerprint to the list of accepted host key fingerprints.
-    /// </summary>
-    /// <param name="Fingerprint"></param>
-    procedure AddFingerprintMD5(Fingerprint: Text)
-    begin
-        SFTPClientImplementation.AddFingerPrintMD5(Fingerprint);
-    end;
-
-    /// <summary>
     /// Initializes the SFTP client with the specified parameters. The client is connected to the server.
     /// </summary>
     /// <param name="Hostname">Hostname of the SFTP server</param>
@@ -37,6 +28,7 @@ codeunit 9762 "SFTP Client"
     /// <param name="Username">Username for the connection</param>
     /// <param name="Password">Password for the connection</param>
     /// <returns>A response codeunit containing success/failure status and error information if applicable</returns>
+    [NonDebuggable]
     procedure Initialize(Hostname: Text; Port: Integer; Username: Text; Password: SecretText): Codeunit "SFTP Operation Response"
     begin
         exit(SFTPClientImplementation.Initialize(HostName, Port, Username, Password));
@@ -51,6 +43,7 @@ codeunit 9762 "SFTP Client"
     /// <param name="Username">Username for the connection</param>
     /// <param name="PrivateKey">Private Key for the connection</param>
     /// <returns>A response codeunit containing success/failure status and error information if applicable</returns>
+    [NonDebuggable]
     procedure Initialize(HostName: Text; Port: Integer; Username: Text; PrivateKey: InStream): Codeunit "SFTP Operation Response"
     begin
         exit(SFTPClientImplementation.Initialize(HostName, Port, Username, PrivateKey));
@@ -66,6 +59,7 @@ codeunit 9762 "SFTP Client"
     /// <param name="PrivateKey">Private Key for the connection</param>
     /// <param name="Passphrase">Passphrase to decrypt the private key</param>
     /// <returns>A response codeunit containing success/failure status and error information if applicable</returns>
+    [NonDebuggable]
     procedure Initialize(HostName: Text; Port: Integer; Username: Text; PrivateKey: InStream; Passphrase: SecretText): Codeunit "SFTP Operation Response"
     begin
         exit(SFTPClientImplementation.Initialize(HostName, Port, Username, PrivateKey, Passphrase));
@@ -101,6 +95,7 @@ codeunit 9762 "SFTP Client"
     /// <param name="Path">Path to the file</param>
     /// <param name="InStream">An InStream that will be populated with the file content</param>
     /// <returns>A response codeunit containing success/failure status and error information if applicable</returns>
+    [NonDebuggable]
     procedure GetFileAsStream(Path: Text; var InStream: InStream): Codeunit "SFTP Operation Response"
     begin
         exit(SFTPClientImplementation.GetFileAsStream(Path, InStream));
@@ -153,6 +148,7 @@ codeunit 9762 "SFTP Client"
     /// <param name="Path">The destination path to upload the file to</param>
     /// <param name="SourceInStream">The stream of data to upload</param>
     /// <returns>A response codeunit containing success/failure status and error information if applicable</returns>
+    [NonDebuggable]
     procedure PutFileStream(Path: Text; var SourceInStream: InStream): Codeunit "SFTP Operation Response"
     begin
         exit(SFTPClientImplementation.PutFileStream(Path, SourceInStream));

--- a/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
@@ -20,6 +20,7 @@ codeunit 9762 "SFTP Client"
         SFTPClientImplementation.AddFingerPrintSHA256(Fingerprint);
     end;
 
+#if not CLEAN29
     /// <summary>
     /// Adds an MD5 fingerprint to the list of accepted host key fingerprints.
     /// </summary>
@@ -33,6 +34,7 @@ codeunit 9762 "SFTP Client"
         ErrorInfo.ErrorType := ErrorType::Internal;
         Error(ErrorInfo);
     end;
+#endif
 
     /// <summary>
     /// Initializes the SFTP client with the specified parameters. The client is connected to the server.
@@ -212,5 +214,7 @@ codeunit 9762 "SFTP Client"
 
     var
         SFTPClientImplementation: Codeunit "SFTP Client Implementation";
+#if not CLEAN29
         MD5NotSupportedErr: Label 'MD5 host key fingerprints are no longer supported because MD5 is cryptographically broken. Use AddFingerprintSHA256 with a SHA256 fingerprint instead.';
+#endif
 }

--- a/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
@@ -27,9 +27,11 @@ codeunit 9762 "SFTP Client"
     [Obsolete('MD5 host key fingerprints are cryptographically insecure and are no longer supported. Use AddFingerprintSHA256 instead.', '99.9')]
     procedure AddFingerprintMD5(Fingerprint: Text)
     var
-        MD5NotSupportedErr: Label 'MD5 host key fingerprints are no longer supported because MD5 is cryptographically broken. Use AddFingerprintSHA256 with a SHA256 fingerprint instead.';
+        ErrorInfo: ErrorInfo;
     begin
-        Error(MD5NotSupportedErr);
+        ErrorInfo.Message(MD5NotSupportedErr);
+        ErrorInfo.ErrorType := ErrorType::Internal;
+        Error(ErrorInfo);
     end;
 
     /// <summary>
@@ -210,4 +212,5 @@ codeunit 9762 "SFTP Client"
 
     var
         SFTPClientImplementation: Codeunit "SFTP Client Implementation";
+        MD5NotSupportedErr: Label 'MD5 host key fingerprints are no longer supported because MD5 is cryptographically broken. Use AddFingerprintSHA256 with a SHA256 fingerprint instead.';
 }

--- a/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
@@ -22,9 +22,9 @@ codeunit 9762 "SFTP Client"
 
 #if not CLEAN29
     /// <summary>
-    /// Adds an MD5 fingerprint to the list of accepted host key fingerprints.
+    /// Obsolete. MD5 host key fingerprints are cryptographically insecure and are no longer supported. Calling this method always raises an error. Use AddFingerprintSHA256 instead.
     /// </summary>
-    /// <param name="Fingerprint"></param>
+    /// <param name="Fingerprint">Not used. Retained for binary compatibility only.</param>
     [Obsolete('MD5 host key fingerprints are cryptographically insecure and are no longer supported. Use AddFingerprintSHA256 instead.', '29.0')]
     procedure AddFingerprintMD5(Fingerprint: Text)
     var

--- a/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
@@ -24,7 +24,7 @@ codeunit 9762 "SFTP Client"
     /// Adds an MD5 fingerprint to the list of accepted host key fingerprints.
     /// </summary>
     /// <param name="Fingerprint"></param>
-    [Obsolete('MD5 host key fingerprints are cryptographically insecure and are no longer supported. Use AddFingerprintSHA256 instead.', '99.9')]
+    [Obsolete('MD5 host key fingerprints are cryptographically insecure and are no longer supported. Use AddFingerprintSHA256 instead.', '29.0')]
     procedure AddFingerprintMD5(Fingerprint: Text)
     var
         ErrorInfo: ErrorInfo;

--- a/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
@@ -24,7 +24,7 @@ codeunit 9762 "SFTP Client"
     /// Adds an MD5 fingerprint to the list of accepted host key fingerprints.
     /// </summary>
     /// <param name="Fingerprint"></param>
-    [Obsolete('MD5 host key fingerprints are cryptographically insecure and are no longer supported. Use AddFingerprintSHA256 instead.', '29.0')]
+    [Obsolete('MD5 host key fingerprints are cryptographically insecure and are no longer supported. Use AddFingerprintSHA256 instead.', '99.9')]
     procedure AddFingerprintMD5(Fingerprint: Text)
     var
         MD5NotSupportedErr: Label 'MD5 host key fingerprints are no longer supported because MD5 is cryptographically broken. Use AddFingerprintSHA256 with a SHA256 fingerprint instead.';

--- a/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClient.Codeunit.al
@@ -21,6 +21,18 @@ codeunit 9762 "SFTP Client"
     end;
 
     /// <summary>
+    /// Adds an MD5 fingerprint to the list of accepted host key fingerprints.
+    /// </summary>
+    /// <param name="Fingerprint"></param>
+    [Obsolete('MD5 host key fingerprints are cryptographically insecure and are no longer supported. Use AddFingerprintSHA256 instead.', '29.0')]
+    procedure AddFingerprintMD5(Fingerprint: Text)
+    var
+        MD5NotSupportedErr: Label 'MD5 host key fingerprints are no longer supported because MD5 is cryptographically broken. Use AddFingerprintSHA256 with a SHA256 fingerprint instead.';
+    begin
+        Error(MD5NotSupportedErr);
+    end;
+
+    /// <summary>
     /// Initializes the SFTP client with the specified parameters. The client is connected to the server.
     /// </summary>
     /// <param name="Hostname">Hostname of the SFTP server</param>

--- a/src/System Application/App/SFTP Client/src/SFTPClientImplementation.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClientImplementation.Codeunit.al
@@ -14,29 +14,29 @@ codeunit 9763 "SFTP Client Implementation"
     InherentEntitlements = X;
     InherentPermissions = X;
 
+    [NonDebuggable]
     procedure Initialize(Host: Text; Port: Integer; UserName: Text; Password: SecretText): Codeunit "SFTP Operation Response"
     begin
         InitializeSFTPInterface();
         ISFTPClient.SetSHA256Fingerprints(HostkeyFingerprintsSHA256);
-        ISFTPClient.SetMD5Fingerprints(HostkeyFingerprintsMD5);
         if not ISFTPClient.SftpClient(Host, Port, UserName, Password) then
             exit(ParseException());
     end;
 
+    [NonDebuggable]
     procedure Initialize(HostName: Text; Port: Integer; Username: Text; PrivateKey: InStream): Codeunit "SFTP Operation Response"
     begin
         InitializeSFTPInterface();
         ISFTPClient.SetSHA256Fingerprints(HostkeyFingerprintsSHA256);
-        ISFTPClient.SetMD5Fingerprints(HostkeyFingerprintsMD5);
         if not ISFTPClient.SftpClient(HostName, Port, Username, PrivateKey) then
             exit(ParseException());
     end;
 
+    [NonDebuggable]
     procedure Initialize(HostName: Text; Port: Integer; Username: Text; PrivateKey: InStream; Passphrase: SecretText): Codeunit "SFTP Operation Response"
     begin
         InitializeSFTPInterface();
         ISFTPClient.SetSHA256Fingerprints(HostkeyFingerprintsSHA256);
-        ISFTPClient.SetMD5Fingerprints(HostkeyFingerprintsMD5);
         if not ISFTPClient.SftpClient(HostName, Port, Username, PrivateKey, Passphrase) then
             exit(ParseException());
     end;
@@ -55,11 +55,6 @@ codeunit 9763 "SFTP Client Implementation"
         HostkeyFingerprintsSHA256.Add(Fingerprint);
     end;
 
-    procedure AddFingerPrintMD5(Fingerprint: Text)
-    begin
-        HostkeyFingerprintsMD5.Add(Fingerprint);
-    end;
-
     local procedure ParseException() Result: Codeunit "SFTP Operation Response"
     var
         SocketExceptionLbl: Label 'Socket connection to the SSH server or proxy server could not be established, or an error occurred while resolving the hostname.';
@@ -68,6 +63,7 @@ codeunit 9763 "SFTP Client Implementation"
         SshAuthenticationExceptionLbl: Label 'Authentication of SSH session failed.';
         SftpPathNotFoundExceptionLbl: Label 'The specified path is invalid, or its directory was not found on the remote host.';
         ServerFingerprintNotTrustedLbl: Label 'The server''s host key fingerprint %1 is not trusted.', Comment = '%1 is the SHA256 fingerprint of the server''s host key';
+        GenericExceptionLbl: Label 'An unexpected error occurred during the SFTP operation.';
         ExceptionType: Enum "SFTP Exception Type";
         ExceptionMessage: Text;
         ServerFingerprintSHA256: Text;
@@ -87,8 +83,8 @@ codeunit 9763 "SFTP Client Implementation"
                 Result.SetError(SftpPathNotFoundExceptionLbl);
             ExceptionType::"Untrusted Server Exception":
                 Result.SetError(StrSubstNo(ServerFingerprintNotTrustedLbl, ServerFingerprintSHA256));
-            ExceptionType::"Generic Exception": // Catch-all for any other exceptions
-                Result.SetError(ExceptionMessage);
+            ExceptionType::"Generic Exception": // Catch-all for any other exceptions - return a generic message to avoid leaking raw server/.NET exception details to callers
+                Result.SetError(GenericExceptionLbl);
         end;
         exit(Result);
     end;
@@ -129,28 +125,84 @@ codeunit 9763 "SFTP Client Implementation"
         end;
     end;
 
+    [NonDebuggable]
     procedure GetFileAsStream(Path: Text; var InStream: InStream) Result: Codeunit "SFTP Operation Response"
     var
         TempBlob: Codeunit "Temp Blob";
         MemoryStream: DotNet MemoryStream;
         Arr: DotNet Array;
+        FileSizeBytes: BigInteger;
+        DownloadTok: Label 'Download', Locked = true;
     begin
         if not ISFTPClient.ReadAllBytes(Path, Arr) then
             exit(ParseException());
+        FileSizeBytes := Arr.Length;
+        LogFileSizeTelemetry(DownloadTok, FileSizeBytes, FileSizeBytes <= GetMaxFileSizeInBytes());
+        if FileSizeBytes > GetMaxFileSizeInBytes() then
+            exit(FileTooLargeResponse(FileSizeBytes));
         MemoryStream := MemoryStream.MemoryStream(Arr);
         CopyStream(TempBlob.CreateOutStream(), MemoryStream);
         Result.SetTempBlob(TempBlob);
         Result.GetResponseStream(InStream);
     end;
 
-    procedure PutFileStream(Path: Text; var SourceInStream: InStream): Codeunit "SFTP Operation Response"
+    [NonDebuggable]
+    procedure PutFileStream(Path: Text; var SourceInStream: InStream) Result: Codeunit "SFTP Operation Response"
     var
         MemoryStream: DotNet MemoryStream;
+        FileSizeBytes: BigInteger;
+        UploadTok: Label 'Upload', Locked = true;
     begin
         MemoryStream := MemoryStream.MemoryStream();
         CopyStream(MemoryStream, SourceInStream);
+        FileSizeBytes := MemoryStream.Length;
+        LogFileSizeTelemetry(UploadTok, FileSizeBytes, FileSizeBytes <= GetMaxFileSizeInBytes());
+        if FileSizeBytes > GetMaxFileSizeInBytes() then
+            exit(FileTooLargeResponse(FileSizeBytes));
         if not ISFTPClient.WriteAllBytes(Path, MemoryStream.ToArray()) then
             exit(ParseException());
+    end;
+
+    local procedure GetMaxFileSizeInBytes(): Integer
+    begin
+        // 25 MB (25 * 1024 * 1024) - current platform limitation. Telemetry is emitted for every transfer so the limit can be reassessed.
+        if MaxFileSizeOverrideSet then
+            exit(MaxFileSizeOverride);
+        exit(26214400);
+    end;
+
+    internal procedure SetMaxFileSizeInBytes(NewMaxFileSizeInBytes: Integer)
+    begin
+        MaxFileSizeOverride := NewMaxFileSizeInBytes;
+        MaxFileSizeOverrideSet := true;
+    end;
+
+    local procedure FileTooLargeResponse(FileSizeBytes: BigInteger) Result: Codeunit "SFTP Operation Response"
+    var
+        FileTooLargeErr: Label 'The file size of %1 bytes exceeds the maximum allowed size of %2 bytes.', Comment = '%1 is the actual file size in bytes, %2 is the maximum allowed size in bytes';
+    begin
+        Result.SetExceptionType(Enum::"SFTP Exception Type"::"File Too Large Exception");
+        Result.SetError(StrSubstNo(FileTooLargeErr, FileSizeBytes, GetMaxFileSizeInBytes()));
+        exit(Result);
+    end;
+
+    local procedure LogFileSizeTelemetry(Operation: Text; FileSizeBytes: BigInteger; WithinLimit: Boolean)
+    var
+        Dimensions: Dictionary of [Text, Text];
+        TelemetryVerbosity: Verbosity;
+        FileSizeTelemetryMsg: Label 'SFTP file transfer size measured.', Locked = true;
+        CategoryTok: Label 'SFTP Client', Locked = true;
+    begin
+        Dimensions.Add('Category', CategoryTok);
+        Dimensions.Add('Operation', Operation);
+        Dimensions.Add('FileSizeBytes', Format(FileSizeBytes));
+        Dimensions.Add('LimitBytes', Format(GetMaxFileSizeInBytes()));
+        Dimensions.Add('WithinLimit', Format(WithinLimit, 0, 9));
+        if WithinLimit then
+            TelemetryVerbosity := Verbosity::Normal
+        else
+            TelemetryVerbosity := Verbosity::Warning;
+        Session.LogMessage('SFTP-0001', FileSizeTelemetryMsg, TelemetryVerbosity, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, Dimensions);
     end;
 
     procedure DeleteFile(Path: Text): Codeunit "SFTP Operation Response"
@@ -207,6 +259,7 @@ codeunit 9763 "SFTP Client Implementation"
     var
         ISFTPClient: Interface "ISFTP Client";
         HostkeyFingerprintsSHA256: List of [Text];
-        HostkeyFingerprintsMD5: List of [Text];
         ISFTPClientSet: Boolean;
+        MaxFileSizeOverride: Integer;
+        MaxFileSizeOverrideSet: Boolean;
 }

--- a/src/System Application/App/SFTP Client/src/SFTPClientImplementation.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClientImplementation.Codeunit.al
@@ -195,7 +195,7 @@ codeunit 9763 "SFTP Client Implementation"
             TelemetryVerbosity := Verbosity::Normal
         else
             TelemetryVerbosity := Verbosity::Warning;
-        Session.LogMessage('', FileSizeTelemetryMsg, TelemetryVerbosity, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, Dimensions);
+        Session.LogMessage('0000V0D', FileSizeTelemetryMsg, TelemetryVerbosity, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, Dimensions);
     end;
 
     procedure DeleteFile(Path: Text): Codeunit "SFTP Operation Response"

--- a/src/System Application/App/SFTP Client/src/SFTPClientImplementation.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClientImplementation.Codeunit.al
@@ -195,7 +195,7 @@ codeunit 9763 "SFTP Client Implementation"
             TelemetryVerbosity := Verbosity::Normal
         else
             TelemetryVerbosity := Verbosity::Warning;
-        Session.LogMessage('SFTP-0001', FileSizeTelemetryMsg, TelemetryVerbosity, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, Dimensions);
+        Session.LogMessage('', FileSizeTelemetryMsg, TelemetryVerbosity, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, Dimensions);
     end;
 
     procedure DeleteFile(Path: Text): Codeunit "SFTP Operation Response"

--- a/src/System Application/App/SFTP Client/src/SFTPClientImplementation.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClientImplementation.Codeunit.al
@@ -63,7 +63,6 @@ codeunit 9763 "SFTP Client Implementation"
         SshAuthenticationExceptionLbl: Label 'Authentication of SSH session failed.';
         SftpPathNotFoundExceptionLbl: Label 'The specified path is invalid, or its directory was not found on the remote host.';
         ServerFingerprintNotTrustedLbl: Label 'The server''s host key fingerprint %1 is not trusted.', Comment = '%1 is the SHA256 fingerprint of the server''s host key';
-        GenericExceptionLbl: Label 'An unexpected error occurred during the SFTP operation.';
         ExceptionType: Enum "SFTP Exception Type";
         ExceptionMessage: Text;
         ServerFingerprintSHA256: Text;
@@ -132,7 +131,6 @@ codeunit 9763 "SFTP Client Implementation"
         MemoryStream: DotNet MemoryStream;
         Arr: DotNet Array;
         FileSizeBytes: BigInteger;
-        DownloadTok: Label 'Download', Locked = true;
     begin
         if not ISFTPClient.ReadAllBytes(Path, Arr) then
             exit(ParseException());
@@ -151,7 +149,6 @@ codeunit 9763 "SFTP Client Implementation"
     var
         MemoryStream: DotNet MemoryStream;
         FileSizeBytes: BigInteger;
-        UploadTok: Label 'Upload', Locked = true;
     begin
         MemoryStream := MemoryStream.MemoryStream();
         CopyStream(MemoryStream, SourceInStream);
@@ -178,8 +175,6 @@ codeunit 9763 "SFTP Client Implementation"
     end;
 
     local procedure FileTooLargeResponse(FileSizeBytes: BigInteger) Result: Codeunit "SFTP Operation Response"
-    var
-        FileTooLargeErr: Label 'The file size of %1 bytes exceeds the maximum allowed size of %2 bytes.', Comment = '%1 is the actual file size in bytes, %2 is the maximum allowed size in bytes';
     begin
         Result.SetExceptionType(Enum::"SFTP Exception Type"::"File Too Large Exception");
         Result.SetError(StrSubstNo(FileTooLargeErr, FileSizeBytes, GetMaxFileSizeInBytes()));
@@ -190,8 +185,6 @@ codeunit 9763 "SFTP Client Implementation"
     var
         Dimensions: Dictionary of [Text, Text];
         TelemetryVerbosity: Verbosity;
-        FileSizeTelemetryMsg: Label 'SFTP file transfer size measured.', Locked = true;
-        CategoryTok: Label 'SFTP Client', Locked = true;
     begin
         Dimensions.Add('Category', CategoryTok);
         Dimensions.Add('Operation', Operation);
@@ -262,4 +255,10 @@ codeunit 9763 "SFTP Client Implementation"
         ISFTPClientSet: Boolean;
         MaxFileSizeOverride: Integer;
         MaxFileSizeOverrideSet: Boolean;
+        GenericExceptionLbl: Label 'An unexpected error occurred during the SFTP operation.';
+        FileTooLargeErr: Label 'The file size of %1 bytes exceeds the maximum allowed size of %2 bytes.', Comment = '%1 is the actual file size in bytes, %2 is the maximum allowed size in bytes';
+        FileSizeTelemetryMsg: Label 'SFTP file transfer size measured.', Locked = true;
+        CategoryTok: Label 'SFTP Client', Locked = true;
+        DownloadTok: Label 'Download', Locked = true;
+        UploadTok: Label 'Upload', Locked = true;
 }

--- a/src/System Application/App/SFTP Client/src/SFTPClientImplementation.Codeunit.al
+++ b/src/System Application/App/SFTP Client/src/SFTPClientImplementation.Codeunit.al
@@ -194,8 +194,8 @@ codeunit 9763 "SFTP Client Implementation"
         if WithinLimit then
             TelemetryVerbosity := Verbosity::Normal
         else
-            TelemetryVerbosity := Verbosity::Warning;
-        Session.LogMessage('0000V0D', FileSizeTelemetryMsg, TelemetryVerbosity, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, Dimensions);
+            TelemetryVerbosity := Verbosity::Error;
+        Session.LogMessage('0000V0D', FileSizeTelemetryTxt, TelemetryVerbosity, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, Dimensions);
     end;
 
     procedure DeleteFile(Path: Text): Codeunit "SFTP Operation Response"
@@ -257,7 +257,7 @@ codeunit 9763 "SFTP Client Implementation"
         MaxFileSizeOverrideSet: Boolean;
         GenericExceptionLbl: Label 'An unexpected error occurred during the SFTP operation.';
         FileTooLargeErr: Label 'The file size of %1 bytes exceeds the maximum allowed size of %2 bytes.', Comment = '%1 is the actual file size in bytes, %2 is the maximum allowed size in bytes';
-        FileSizeTelemetryMsg: Label 'SFTP file transfer size measured.', Locked = true;
+        FileSizeTelemetryTxt: Label 'SFTP file transfer size measured.', Locked = true;
         CategoryTok: Label 'SFTP Client', Locked = true;
         DownloadTok: Label 'Download', Locked = true;
         UploadTok: Label 'Upload', Locked = true;

--- a/src/System Application/App/SFTP Client/src/SFTPExceptionType.Enum.al
+++ b/src/System Application/App/SFTP Client/src/SFTPExceptionType.Enum.al
@@ -42,4 +42,8 @@ enum 9760 "SFTP Exception Type"
     {
         Caption = 'Untrusted Server Exception';
     }
+    value(8; "File Too Large Exception")
+    {
+        Caption = 'File Too Large Exception';
+    }
 }

--- a/src/System Application/Test/SFTP Client/src/MockSFTPClient.Codeunit.al
+++ b/src/System Application/Test/SFTP Client/src/MockSFTPClient.Codeunit.al
@@ -23,7 +23,6 @@ codeunit 139075 "Mock SFTP Client" implements "ISFTP Client"
         FilesExist: Dictionary of [Text, Boolean];
         FilesContent: Dictionary of [Text, List of [Text]];
         FingerprintsSHA256: List of [Text];
-        FingerprintsMD5: List of [Text];
 
     procedure SetShouldFailConnect(NewShouldFailConnect: Boolean)
     begin
@@ -49,11 +48,6 @@ codeunit 139075 "Mock SFTP Client" implements "ISFTP Client"
     procedure SetSHA256Fingerprints(FingerPrints: List of [Text])
     begin
         FingerprintsSHA256 := FingerPrints;
-    end;
-
-    procedure SetMD5Fingerprints(FingerPrints: List of [Text])
-    begin
-        FingerprintsMD5 := FingerPrints;
     end;
 
     procedure AddFile(Path: Text; Content: Text)

--- a/src/System Application/Test/SFTP Client/src/SFTPClientTest.Codeunit.al
+++ b/src/System Application/Test/SFTP Client/src/SFTPClientTest.Codeunit.al
@@ -133,9 +133,10 @@ codeunit 139077 "SFTP Client Test"
         // [WHEN] Initialize is called
         Response := SFTPClientImpl.Initialize('test.host.com', 22, 'username', SecretStrSubstNo('password'));
 
-        // [THEN] Response should contain the actual generic exception message
+        // [THEN] Response should contain a generic message and must not leak the raw exception text
         Assert.IsTrue(Response.IsError(), 'Response should indicate an error');
-        Assert.AreEqual(GenericMessage, Response.GetError(), 'Incorrect error message');
+        Assert.AreEqual('An unexpected error occurred during the SFTP operation.', Response.GetError(), 'Incorrect error message');
+        Assert.AreNotEqual(GenericMessage, Response.GetError(), 'Raw exception message must not be leaked to the caller');
         Assert.AreEqual(Enum::"SFTP Exception Type"::"Generic Exception", Response.GetErrorType(), 'Incorrect error type');
     end;
 
@@ -309,6 +310,60 @@ codeunit 139077 "SFTP Client Test"
         Response := SFTPClientImpl.FileExists('/test/file.txt', IsFileExists);
         Assert.IsFalse(Response.IsError(), 'FileExists should not return an error after deletion');
         Assert.IsFalse(IsFileExists, 'File should no longer exist');
+    end;
+
+    [Test]
+    procedure TestUploadRejectsFileExceedingSizeLimit()
+    var
+        MockSFTPClient: Codeunit "Mock SFTP Client";
+        SFTPClientImpl: Codeunit "SFTP Client Implementation";
+        Response: Codeunit "SFTP Operation Response";
+        TempBlob: Codeunit "Temp Blob";
+        OutStr: OutStream;
+        InStr: InStream;
+    begin
+        // [GIVEN] A connected Mock SFTP client with a small file-size limit
+        MockSFTPClient.SetShouldFailConnect(false);
+        SFTPClientImpl.SetISFTPClient(MockSFTPClient);
+        SFTPClientImpl.AddFingerPrintSHA256('5Vot7f2reXMzE6IR9GKiDCOz/bNf3lA0qYnBQzRgObo=');
+        SFTPClientImpl.Initialize('test.host.com', 22, 'username', SecretStrSubstNo('password'));
+        SFTPClientImpl.SetMaxFileSizeInBytes(10);
+
+        // [GIVEN] A source stream larger than the limit
+        TempBlob.CreateOutStream(OutStr);
+        OutStr.WriteText('This content is definitely longer than ten bytes.');
+        TempBlob.CreateInStream(InStr);
+
+        // [WHEN] PutFileStream is called
+        Response := SFTPClientImpl.PutFileStream('/test/big.txt', InStr);
+
+        // [THEN] The upload is rejected with a File Too Large error
+        Assert.IsTrue(Response.IsError(), 'Oversized upload should be rejected');
+        Assert.AreEqual(Enum::"SFTP Exception Type"::"File Too Large Exception", Response.GetErrorType(), 'Incorrect error type');
+    end;
+
+    [Test]
+    procedure TestDownloadRejectsFileExceedingSizeLimit()
+    var
+        MockSFTPClient: Codeunit "Mock SFTP Client";
+        SFTPClientImpl: Codeunit "SFTP Client Implementation";
+        Response: Codeunit "SFTP Operation Response";
+        InStr: InStream;
+    begin
+        // [GIVEN] A connected Mock SFTP client with a small limit and a file larger than it
+        MockSFTPClient.SetShouldFailConnect(false);
+        MockSFTPClient.AddFile('/test/big.txt', 'This content is definitely longer than ten bytes.');
+        SFTPClientImpl.SetISFTPClient(MockSFTPClient);
+        SFTPClientImpl.AddFingerPrintSHA256('5Vot7f2reXMzE6IR9GKiDCOz/bNf3lA0qYnBQzRgObo=');
+        SFTPClientImpl.Initialize('test.host.com', 22, 'username', SecretStrSubstNo('password'));
+        SFTPClientImpl.SetMaxFileSizeInBytes(10);
+
+        // [WHEN] GetFileAsStream is called
+        Response := SFTPClientImpl.GetFileAsStream('/test/big.txt', InStr);
+
+        // [THEN] The download is rejected with a File Too Large error
+        Assert.IsTrue(Response.IsError(), 'Oversized download should be rejected');
+        Assert.AreEqual(Enum::"SFTP Exception Type"::"File Too Large Exception", Response.GetErrorType(), 'Incorrect error type');
     end;
 
     [Test]


### PR DESCRIPTION
## What & why

First batch of fixes from the SFTP Client (System Application) security review tracked in **[AB#632215](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632215)**. These are the self-contained, lower-risk hardening items; the more complex ones (host-key allowlist persistence, audit telemetry, interface removal, connection-DoS) will follow in a separate PR.

Changes:
- **Remove MD5 host-key fingerprint support** end-to-end. MD5 is collision-broken and its match branch could override a SHA256 mismatch. The External File Storage **SFTP Connector** consumed the removed public API, so it's updated too (only `sha256:` prefixes accepted now).
- **Generic error for unknown exception types** — the `Generic Exception` branch no longer surfaces raw server/.NET exception text to callers.
- **Disable app-level debugging** (`allowDebugging=false`) so customer/financial data flowing through the module can't be inspected. (Source-exposure flags left as-is, matching OAuth / OAuth2 / SharePoint Authorization.)
- **`[NonDebuggable]` sweep** across the secret- and file-data code paths.
- **25 MB file-size limit** on upload/download with a typed `File Too Large` response, plus non-sensitive size telemetry (`SFTP-0001`, `SystemMetadata`) to help decide whether the limit needs raising.

## Linked work

Fixes [AB#632215](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632215)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Static review only: this change was prepared in an environment without a BC container, so it has **not** been compiled or run locally yet. Please build + run before merging; CI is relied on for the first compile pass.
- Tests updated/added: `TestGenericExceptionHandling` now asserts the raw message is not leaked; new `TestUploadRejectsFileExceedingSizeLimit` and `TestDownloadRejectsFileExceedingSizeLimit` cover the size cap (limit made overridable for the test app via an internal setter).
- No behavioral changes to the untouched typed-exception paths.

## Risk & compatibility

- **Breaking (connector):** SFTP accounts configured with an `md5:` fingerprint will now fail validation — only `sha256:` is accepted. Tooltip and error text updated. Worth an upgrade/release note.
- **Additive enum value** `"File Too Large Exception"` on the public `SFTP Exception Type` enum (non-breaking).
- **Telemetry:** new `SFTP-0001` event fires on every transfer (size only, `SystemMetadata`) — safe for partner telemetry, but easy to dial back to failures-only if preferred.
- **Follow-ups:** stronger download DoS protection could stat the remote file size before pulling bytes; `Temp Blob` (BLOB Storage) debuggability is outside this module's control.











