### PR TITLE
Features/616423/backport uninstalled extensions notification 28.x

### DIFF
--- a/src/System Application/App/Extension Management/src/DeleteOrphanedExtensionData.Page.al
+++ b/src/System Application/App/Extension Management/src/DeleteOrphanedExtensionData.Page.al
@@ -64,6 +64,12 @@ page 2514 "Delete Orphaned Extension Data"
                     Caption = 'Published As';
                     ToolTip = 'Specifies whether the extension is published as a per-tenant, development, or a global extension.';
                 }
+                field("Is Reviewed"; Rec."Is Reviewed")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Reviewed';
+                    ToolTip = 'Specifies whether the orphaned extension data has been reviewed.';
+                }
 
                 label(Spacer)
                 {
@@ -86,6 +92,9 @@ page 2514 "Delete Orphaned Extension Data"
         area(Promoted)
         {
             actionref(PromptedDelete; DeleteData)
+            {
+            }
+            actionref(PromotedMarkAsReviewed; MarkAsReviewed)
             {
             }
         }
@@ -113,8 +122,26 @@ page 2514 "Delete Orphaned Extension Data"
                             Clear(Rec);
                             Rec.SetView(FilterCache);
                             Rec.SetFilter(Rec.Status, '<>Installed');
+                            UpdateHasUnreviewedExtensions();
                             CurrPage.Update(false);
                         end;
+                    end;
+                }
+                action(MarkAsReviewed)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Mark All as Reviewed';
+                    Enabled = HasUnreviewedExtensions;
+                    Image = Approve;
+                    ToolTip = 'Mark all orphaned extension data as reviewed. This acknowledges the data has been seen and is kept intentionally.';
+
+                    trigger OnAction()
+                    var
+                        ExtensionDatabaseManagement: Codeunit "Extension Database Management";
+                    begin
+                        ExtensionDatabaseManagement.MarkAllOrphanedExtensionDataAsReviewed();
+                        UpdateHasUnreviewedExtensions();
+                        CurrPage.Update(false);
                     end;
                 }
             }
@@ -128,6 +155,7 @@ page 2514 "Delete Orphaned Extension Data"
 
     trigger OnOpenPage()
     begin
+        UpdateHasUnreviewedExtensions();
         CurrPage.Update(false);
         DetermineEnvironmentConfigurations();
     end;
@@ -135,6 +163,7 @@ page 2514 "Delete Orphaned Extension Data"
     var
         ExtensionInstallationImpl: Codeunit "Extension Installation Impl";
         VersionDisplay: Text;
+        HasUnreviewedExtensions: Boolean;
         IsSaaS: Boolean;
         VersionFormatTxt: Label 'v. %1', Comment = 'v=version abbr, %1=Version string';
         ClearExtensionSchemaOrphanMsg: Label 'The %1 extension data was deleted.', Comment = '%1=The extension which data was deleted';
@@ -158,6 +187,15 @@ page 2514 "Delete Orphaned Extension Data"
     begin
         // Getting the version display text and adding a '- NotInstalled' if in SaaS for PerTenant extensions
         exit(StrSubstNo(VersionFormatTxt, Rec."Schema Version"));
+    end;
+
+    local procedure UpdateHasUnreviewedExtensions()
+    var
+        ExtensionDatabaseSnapshot: Record "Extension Database Snapshot";
+    begin
+        ExtensionDatabaseSnapshot.SetFilter(Status, '<>%1', ExtensionDatabaseSnapshot.Status::Installed);
+        ExtensionDatabaseSnapshot.SetFilter("Is Reviewed", '%1', false);
+        HasUnreviewedExtensions := not ExtensionDatabaseSnapshot.IsEmpty();
     end;
 }
 

--- a/src/System Application/App/Extension Management/src/ExtensionManagement.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionManagement.Page.al
@@ -32,7 +32,8 @@ page 2500 "Extension Management"
                             "Tenant Visible" = const(true));
     UsageCategory = Administration;
     ContextSensitiveHelpPage = 'ui-extensions';
-    Permissions = tabledata "Published Application" = r;
+    Permissions = tabledata "Published Application" = r,
+                  tabledata "Extension Database Snapshot" = r;
 
     layout
     {
@@ -381,6 +382,30 @@ page 2500 "Extension Management"
         ActionsEnabled := false;
 
         HelpActionVisible := false;
+        ShowUninstalledExtensionsNotification();
+    end;
+
+    local procedure ShowUninstalledExtensionsNotification()
+    var
+        Uninstalled: Record "Extension Database Snapshot";
+        Notif: Notification;
+    begin
+        if not Uninstalled.ReadPermission() then
+            exit;
+
+        Notif.Id := OrphanedDataNotificationIdTok;
+        Notif.Scope := NotificationScope::LocalScope;
+
+        Notif.Recall();
+
+        Uninstalled.SetFilter(Status, '<>%1', Uninstalled.Status::Installed);
+        Uninstalled.SetFilter("Is Reviewed", '%1', false);
+        if not Uninstalled.IsEmpty() then begin
+            Notif.Message(UninstalledExtensionsMsg);
+            Notif.AddAction(ShowOrphanedDataLbl, Codeunit::"Extension Operation Impl", 'HandleOrphanedDataNotification');
+            Notif.AddAction(MarkAllAsReviewedLbl, Codeunit::"Extension Operation Impl", 'MarkOrphanedDataAsReviewed');
+            Notif.Send();
+        end;
     end;
 
     var
@@ -403,6 +428,10 @@ page 2500 "Extension Management"
         InfoStyle: Boolean;
         HelpActionVisible: Boolean;
         IsSourceSpecificationAvailable: Boolean;
+        UninstalledExtensionsMsg: Label 'There''s orphaned data from uninstalled extensions. Use the Delete Orphaned Extension Data page to review it.';
+        ShowOrphanedDataLbl: Label 'Show Data';
+        MarkAllAsReviewedLbl: Label 'Mark All as Reviewed';
+        OrphanedDataNotificationIdTok: Label 'b1c5a678-2e3f-4d91-a6b0-9f8e7d6c5b4a', Locked = true;
 
     protected procedure IsSaasEnvironment(): boolean
     begin

--- a/src/System Application/App/Extension Management/src/ExtensionManagement.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionManagement.Page.al
@@ -387,24 +387,21 @@ page 2500 "Extension Management"
 
     local procedure ShowUninstalledExtensionsNotification()
     var
-        Uninstalled: Record "Extension Database Snapshot";
-        Notif: Notification;
+        ExtensionDatabaseSnapshot: Record "Extension Database Snapshot";
+        OrphanedDataNotification: Notification;
     begin
-        if not Uninstalled.ReadPermission() then
-            exit;
+        OrphanedDataNotification.Id := OrphanedDataNotificationIdTok;
+        OrphanedDataNotification.Scope := NotificationScope::LocalScope;
 
-        Notif.Id := OrphanedDataNotificationIdTok;
-        Notif.Scope := NotificationScope::LocalScope;
+        OrphanedDataNotification.Recall();
 
-        Notif.Recall();
-
-        Uninstalled.SetFilter(Status, '<>%1', Uninstalled.Status::Installed);
-        Uninstalled.SetFilter("Is Reviewed", '%1', false);
-        if not Uninstalled.IsEmpty() then begin
-            Notif.Message(UninstalledExtensionsMsg);
-            Notif.AddAction(ShowOrphanedDataLbl, Codeunit::"Extension Operation Impl", 'HandleOrphanedDataNotification');
-            Notif.AddAction(MarkAllAsReviewedLbl, Codeunit::"Extension Operation Impl", 'MarkOrphanedDataAsReviewed');
-            Notif.Send();
+        ExtensionDatabaseSnapshot.SetFilter(Status, '<>%1', ExtensionDatabaseSnapshot.Status::Installed);
+        ExtensionDatabaseSnapshot.SetFilter("Is Reviewed", '%1', false);
+        if not ExtensionDatabaseSnapshot.IsEmpty() then begin
+            OrphanedDataNotification.Message(UninstalledExtensionsMsg);
+            OrphanedDataNotification.AddAction(ShowOrphanedDataLbl, Codeunit::"Extension Operation Impl", 'HandleOrphanedDataNotification');
+            OrphanedDataNotification.AddAction(MarkAllAsReviewedLbl, Codeunit::"Extension Operation Impl", 'MarkOrphanedDataAsReviewed');
+            OrphanedDataNotification.Send();
         end;
     end;
 

--- a/src/System Application/App/Extension Management/src/ExtensionOperationImpl.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionOperationImpl.Codeunit.al
@@ -436,6 +436,19 @@ codeunit 2503 "Extension Operation Impl"
         end;
     end;
 
+    procedure HandleOrphanedDataNotification(Notif: Notification)
+    begin
+        Page.Run(Page::"Delete Orphaned Extension Data");
+    end;
+
+    procedure MarkOrphanedDataAsReviewed(Notif: Notification)
+    var
+        ExtensionDatabaseManagement: Codeunit "Extension Database Management";
+    begin
+        ExtensionDatabaseManagement.MarkAllOrphanedExtensionDataAsReviewed();
+        Notif.Recall();
+    end;
+
     internal procedure GetAppName(AppId: Guid; OperationId: Guid) AppName: Text
     begin
         AppName := GetAppName(AppId);


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

Backports the "uninstalled extensions notification" feature to the 28.x release (cherry-picks of #7350 and #7937 from main).

When the Extension Management page is opened, a notification is now shown if there are extensions that have been uninstalled but still have synchronized data. The notification's "Show Extensions" action opens the new "Delete Orphaned Extension Data" page, where users can review and clean up the leftover data.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#633514](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633514)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

Verified with local testing:
- Uninstalling an extension shows the notification on the **Extension Management** page; **Show Data** opens the **Delete Orphaned Extension Data** page.
- **Mark All as Reviewed** works from both the notification and the page.
- Reinstalling then uninstalling a previously reviewed extension resets it to unreviewed instead of keeping it reviewed.

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

The orphaned-data check now reads the **Extension Database Snapshot** record in two pages (`ExtensionManagement.Page.al`, `DeleteOrphanedExtensionData.Page.al`); indirect read permission (`tabledata "Extension Database Snapshot" = r`) was added to the Extension Management page for its new `OnOpenPage` read, while the Delete Orphaned Extension Data page already had it.

