### PR TITLE
Bug 642180: DE report 11015 Export Business Data fails when scheduled via Job Queue: Client callbacks are not supported

### DIFF
--- a/src/Layers/DACH/BaseApp/Local/Finance/AuditFileExport/ExportBusinessData.Report.al
+++ b/src/Layers/DACH/BaseApp/Local/Finance/AuditFileExport/ExportBusinessData.Report.al
@@ -920,9 +920,6 @@ report 11015 "Export Business Data"
         TempBlobZipArchive.CreateInStream(ZipArchiveInStream);
         ZipFileName := DataExportRecordDefinition."Data Exp. Rec. Type Code" + '.zip';
 
-        // When the report runs in the background (e.g. scheduled via Job Queue) there is no client
-        // to receive a file download callback. Save the result to the Report Inbox instead so the
-        // user can download it from there.
         if not GuiAllowed() then begin
             SaveZipToReportInbox(ZipArchiveInStream, DataExportRecordDefinition);
             exit;

--- a/src/Layers/DACH/BaseApp/Local/Finance/AuditFileExport/ExportBusinessData.Report.al
+++ b/src/Layers/DACH/BaseApp/Local/Finance/AuditFileExport/ExportBusinessData.Report.al
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Finance.AuditFileExport;
 
+using Microsoft.EServices.EDocument;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Period;
 using System;
@@ -918,11 +919,36 @@ report 11015 "Export Business Data"
     begin
         TempBlobZipArchive.CreateInStream(ZipArchiveInStream);
         ZipFileName := DataExportRecordDefinition."Data Exp. Rec. Type Code" + '.zip';
+
+        // When the report runs in the background (e.g. scheduled via Job Queue) there is no client
+        // to receive a file download callback. Save the result to the Report Inbox instead so the
+        // user can download it from there.
+        if not GuiAllowed() then begin
+            SaveZipToReportInbox(ZipArchiveInStream, DataExportRecordDefinition);
+            exit;
+        end;
+
         if ClientFileName <> '' then begin
             ZipFileNameOnServer := FileMgt.InstreamExportToServerFile(ZipArchiveInStream, '.zip');
             FileMgt.DownloadHandler(ZipFileNameOnServer, '', '', '', ClientFileName);
         end else
             FileMgt.DownloadFromStreamHandler(ZipArchiveInStream, '', '', '', ZipFileName);
+    end;
+
+    local procedure SaveZipToReportInbox(ZipArchiveInStream: InStream; DataExportRecordDefinition: Record "Data Export Record Definition")
+    var
+        ReportInbox: Record "Report Inbox";
+        ReportOutputOutStream: OutStream;
+    begin
+        ReportInbox.Init();
+        ReportInbox."User ID" := CopyStr(UserId(), 1, MaxStrLen(ReportInbox."User ID"));
+        ReportInbox."Report ID" := Report::"Export Business Data";
+        ReportInbox.Description := CopyStr(DataExportRecordDefinition."Data Exp. Rec. Type Code", 1, MaxStrLen(ReportInbox.Description));
+        ReportInbox."Output Type" := ReportInbox."Output Type"::Zip;
+        ReportInbox."Created Date-Time" := RoundDateTime(CurrentDateTime(), 60000);
+        ReportInbox."Report Output".CreateOutStream(ReportOutputOutStream);
+        CopyStream(ReportOutputOutStream, ZipArchiveInStream);
+        ReportInbox.Insert(true);
     end;
 
     [Scope('OnPrem')]


### PR DESCRIPTION
**ISSUE:**
The DE report "Export Business Data" (11015) fails when it is scheduled to run via a Job Queue Entry, ending with "Client callbacks are not supported... attempted to issue a client callback to download a file (CodeUnit 419 File Management)".

**CAUSE:**
The report is processing-only and delivers its result by pushing the ZIP straight to the client (a client callback). A Job Queue runs in a background session with no client, so the callback throws and nothing is produced.

**SOLUTION:**
When the report runs in the background (no GUI), the generated ZIP is now stored in the Report Inbox instead of being pushed to the client, so the user can download it from there - the same way scheduled layout reports behave. Running the report interactively still downloads the ZIP directly as before.

**TESTS:**
Tested manually both new and old ways of export, works as expected

Fixes [AB#642180](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642180)


