### PR TITLE
[master] Contact No. Lookup on Sales Quote returns All Customers instead of related Contacts after Updating to v28.2 - regression.

### DIFF
--- a/src/Layers/APAC/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/APAC/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -9710,7 +9710,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/BE/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/BE/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -9571,7 +9571,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/CH/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/CH/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -9600,7 +9600,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/CZ/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/CZ/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -9541,7 +9541,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/ES/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/ES/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -9667,7 +9667,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/FI/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/FI/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -9541,7 +9541,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/FR/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/FR/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -9545,7 +9545,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/GB/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/GB/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -9541,7 +9541,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/IT/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/IT/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -10284,7 +10284,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/NA/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/NA/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -9855,7 +9855,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/NL/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/NL/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -9567,7 +9567,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/NO/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/NO/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -9632,7 +9632,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/RU/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/RU/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -10060,7 +10060,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/SE/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/SE/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -9570,7 +9570,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/W1/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -9541,7 +9541,7 @@ table 36 "Sales Header"
             exit(Result);
 
         Contact.FilterGroup(2);
-        if ("Sell-to Customer No." <> '') and ("Document Type" <> "Document Type"::Quote) then
+        if "Sell-to Customer No." <> '' then
             if Contact.Get("Sell-to Contact No.") then
                 Contact.SetRange("Company No.", Contact."Company No.")
             else

--- a/src/Layers/W1/Tests/Marketing/TestContactLookup.Codeunit.al
+++ b/src/Layers/W1/Tests/Marketing/TestContactLookup.Codeunit.al
@@ -561,6 +561,35 @@ codeunit 134837 "Test Contact Lookup"
         SalesQuote."Sell-to Contact No.".AssertEquals(Contact."No.");
     end;
 
+    [Test]
+    [HandlerFunctions('ContactListModalPageHandler')]
+    procedure SellToContactLookupOnSalesQuoteWithCustomerTest()
+    var
+        Customer: Record Customer;
+        SalesHeader: Record "Sales Header";
+        SalesQuote: TestPage "Sales Quote";
+    begin
+        // [FEATURE] [Sales Quote]
+        // [SCENARIO 641671] When "Sell-to Customer No." is set in a Sales Quote then on contact look up the contact list is filtered by the customer's contact "Company No." instead of showing all contacts.
+        Initialize();
+
+        // [GIVEN] Create Customer with a Contact.
+        LibrarySmallBusiness.CreateCustomer(Customer);
+        Customer.Validate(Contact, StrSubstNo('%1 %2', LibraryUtility.GenerateRandomText(10), LibraryUtility.GenerateRandomText(10)));
+
+        // [GIVEN] Create a Sales Quote for the created customer.
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Quote, Customer."No.");
+        SalesQuote.OpenEdit();
+        SalesQuote.GotoRecord(SalesHeader);
+
+        // [WHEN] Look up contact list from "Sell-to Contact".
+        LibraryVariableStorage.Enqueue(Customer."Primary Contact No.");
+        SalesQuote."Sell-to Contact".Lookup();
+
+        // [THEN] Verify the contact list is filtered by the "Company No." of the customer's contact.
+        // Verification in ContactListModalPageHandler
+    end;
+
     local procedure Initialize()
     var
         ObjectOptions: Record "Object Options";

--- a/src/Layers/W1/Tests/Marketing/TestContactLookup.Codeunit.al
+++ b/src/Layers/W1/Tests/Marketing/TestContactLookup.Codeunit.al
@@ -570,7 +570,7 @@ codeunit 134837 "Test Contact Lookup"
         SalesQuote: TestPage "Sales Quote";
     begin
         // [FEATURE] [Sales Quote]
-        // [SCENARIO 641671] When "Sell-to Customer No." is set in a Sales Quote then on contact look up the contact list is filtered by the customer's contact "Company No." instead of showing all contacts.
+        // [SCENARIO 642199] When "Sell-to Customer No." is set in a Sales Quote then on "Sell-to Contact No." look up the contact list is filtered by the customer's contact "Company No." instead of showing all contacts.
         Initialize();
 
         // [GIVEN] Create Customer with a Contact.
@@ -582,9 +582,9 @@ codeunit 134837 "Test Contact Lookup"
         SalesQuote.OpenEdit();
         SalesQuote.GotoRecord(SalesHeader);
 
-        // [WHEN] Look up contact list from "Sell-to Contact".
+        // [WHEN] Look up contact list from "Sell-to Contact No.".
         LibraryVariableStorage.Enqueue(Customer."Primary Contact No.");
-        SalesQuote."Sell-to Contact".Lookup();
+        SalesQuote."Sell-to Contact No.".Lookup();
 
         // [THEN] Verify the contact list is filtered by the "Company No." of the customer's contact.
         // Verification in ContactListModalPageHandler


### PR DESCRIPTION
Workitem: [Bug 642199](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/642199): [master] [ALL-E] Contact No. Lookup on Sales Quote returns All Customers instead of related Contacts after Updating to v28.2 - regression.

Fixes [AB#642199](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642199)

**Issue:** On a Sales Quote, the Contact No. field lookup showed all contacts (customers and vendors) instead of only the selected customer's contacts (regression in v28.2; other documents worked fine).

**Cause:** In SelltoContactLookup() the filter condition included ("Document Type" <> "Document Type"::Quote), which skipped the contact-relation filtering entirely for quote documents.

**Solution:** Removed the Quote exclusion so quotes apply the same customer-based contact filter as other documents, while the "Sell-to Customer No." <> '' guard preserves the quote-for-a-prospect flow.



