### PR TITLE
Route early preview feedback to the correct OCV area

### DIFF
--- a/src/System Application/App/Guided Experience/src/Early Access Preview/EarlyAccessPreviewFeatures.Page.al
+++ b/src/System Application/App/Guided Experience/src/Early Access Preview/EarlyAccessPreviewFeatures.Page.al
@@ -101,7 +101,7 @@ page 1965 "Early Access Preview Features"
                 var
                     Feedback: Codeunit "Microsoft User Feedback";
                 begin
-                    Feedback.RequestFeedback('Early Access Preview');
+                    Feedback.RequestFeedback('Early Access Preview', EarlyAccessPreviewFeatureAreaTok, EarlyAccessPreviewFeatureAreaDisplayNameTok);
                 end;
             }
             action(ProvideFeatureFeedback)
@@ -115,7 +115,7 @@ page 1965 "Early Access Preview Features"
                 var
                     Feedback: Codeunit "Microsoft User Feedback";
                 begin
-                    Feedback.RequestFeedback(Rec.Title);
+                    Feedback.RequestFeedback(Rec.Title, EarlyAccessPreviewFeatureAreaTok, EarlyAccessPreviewFeatureAreaDisplayNameTok);
                 end;
             }
             action(ViewHelp)
@@ -200,6 +200,7 @@ page 1965 "Early Access Preview Features"
         HasVideoUrl: Boolean;
         HasHelpUrl: Boolean;
         VideoFieldText: Text;
+        EarlyAccessPreviewFeatureAreaTok: Label 'EarlyAccessPreview', Locked = true;
+        EarlyAccessPreviewFeatureAreaDisplayNameTok: Label 'Early Access Preview', Locked = true;
         WatchVideoLbl: Label 'Watch Video';
 }
-


### PR DESCRIPTION
## What & why

Early Access Preview feedback was submitted without OCV area metadata, causing it to appear in the general feedback area. This change routes both release-level and feature-level feedback to the `EarlyAccessPreview` area.

## Linked work
Fixes [AB#634022](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/634022)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

- Verified both feedback actions call the area-aware overload with `EarlyAccessPreview` and `Early Access Preview` metadata.
- Ran `git diff --check` successfully.
- No automated test was added because the change only supplies static routing metadata to the platform feedback API.

## Risk & compatibility

None. The feedback prompts and feature names are unchanged; only OCV routing metadata is added.


