### PR TITLE
Fix Incoming Documents default processed filter

### DIFF
--- a/src/Layers/W1/BaseApp/eServices/EDocument/IncomingDocuments.Page.al
+++ b/src/Layers/W1/BaseApp/eServices/EDocument/IncomingDocuments.Page.al
@@ -800,10 +800,9 @@ page 190 "Incoming Documents"
         UpdateOCRSetupVisibility();
 
         Rec.FilterGroup(0);
-        if Rec.GetFilter(Processed) = '' then begin
-            Rec.SetRange(Processed, false);
-            ShowAllDocsIsEnable := false;
-        end else
+        if Rec.GetFilter(Processed) = '' then
+            SetProcessedDocumentsVisibility(false)
+        else
             ShowAllDocsIsEnable := Rec.GetFilter(Processed) <> Format(false);
     end;
 

--- a/src/Layers/W1/BaseApp/eServices/EDocument/IncomingDocuments.Page.al
+++ b/src/Layers/W1/BaseApp/eServices/EDocument/IncomingDocuments.Page.al
@@ -801,9 +801,7 @@ page 190 "Incoming Documents"
 
         Rec.FilterGroup(0);
         if Rec.GetFilter(Processed) = '' then
-            SetProcessedDocumentsVisibility(false)
-        else
-            ShowAllDocsIsEnable := Rec.GetFilter(Processed) <> Format(false);
+            SetProcessedDocumentsVisibility(false);
     end;
 
     var

--- a/src/Layers/W1/BaseApp/eServices/EDocument/IncomingDocuments.Page.al
+++ b/src/Layers/W1/BaseApp/eServices/EDocument/IncomingDocuments.Page.al
@@ -800,8 +800,11 @@ page 190 "Incoming Documents"
         UpdateOCRSetupVisibility();
 
         Rec.FilterGroup(0);
-        if Rec.GetFilter(Processed) <> '' then
-            SetProcessedDocumentsVisibility(Rec.GetFilter(Processed) = Format(true));
+        if Rec.GetFilter(Processed) = '' then begin
+            Rec.SetRange(Processed, false);
+            ShowAllDocsIsEnable := false;
+        end else
+            ShowAllDocsIsEnable := Rec.GetFilter(Processed) <> Format(false);
     end;
 
     var
@@ -937,4 +940,3 @@ page 190 "Incoming Documents"
     begin
     end;
 }
-

--- a/src/Layers/W1/Tests/ERM/ERMIncomingDocuments.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMIncomingDocuments.Codeunit.al
@@ -1881,6 +1881,30 @@ codeunit 134400 "ERM Incoming Documents"
     end;
 
     [Test]
+    [HandlerFunctions('IncomingDocumentsProcessedFilterHandler')]
+    [Scope('OnPrem')]
+    procedure TestIncomingDocsDefaultToUnprocessed()
+    begin
+        VerifyIncomingDocumentsProcessedFilter('', false);
+    end;
+
+    [Test]
+    [HandlerFunctions('IncomingDocumentsProcessedFilterHandler')]
+    [Scope('OnPrem')]
+    procedure TestIncomingDocsPreserveProcessedFilter()
+    begin
+        VerifyIncomingDocumentsProcessedFilter(Format(true), true);
+    end;
+
+    [Test]
+    [HandlerFunctions('IncomingDocumentsProcessedFilterHandler')]
+    [Scope('OnPrem')]
+    procedure TestIncomingDocsPreserveUnprocessedFilter()
+    begin
+        VerifyIncomingDocumentsProcessedFilter(Format(false), false);
+    end;
+
+    [Test]
     [Scope('OnPrem')]
     procedure TestIncomingDocsShouldShowAllDocsOnShowAllAction()
     var
@@ -2179,6 +2203,22 @@ codeunit 134400 "ERM Incoming Documents"
         IncomingDocuments.GotoRecord(IncomingDocumentRec);
         Assert.AreEqual(DataExchangeTypeHasValue, IncomingDocuments.CreateGenJnlLine.Enabled(), 'Editable value unexpected.');
         Assert.AreEqual(DataExchangeTypeHasValue, IncomingDocuments.CreateDocument.Enabled(), 'Editable value unexpected.');
+    end;
+
+    local procedure VerifyIncomingDocumentsProcessedFilter(ProcessedFilter: Text; ExpectedProcessed: Boolean)
+    var
+        IncomingDocument: Record "Incoming Document";
+    begin
+        IncomingDocument.DeleteAll();
+        CreateIncomingDocument(IncomingDocument, 'Processed Document', true);
+        CreateIncomingDocument(IncomingDocument, 'Unprocessed Document', false);
+
+        IncomingDocument.Reset();
+        if ProcessedFilter <> '' then
+            IncomingDocument.SetFilter(Processed, ProcessedFilter);
+
+        LibraryVariableStorage.Enqueue(ExpectedProcessed);
+        Page.RunModal(Page::"Incoming Documents", IncomingDocument);
     end;
 
     local procedure GetIncomeStatementAcc(): Code[20]
@@ -2732,6 +2772,15 @@ codeunit 134400 "ERM Incoming Documents"
         IncomingDocuments.OK().Invoke();
     end;
 
+    [ModalPageHandler]
+    [Scope('OnPrem')]
+    procedure IncomingDocumentsProcessedFilterHandler(var IncomingDocuments: TestPage "Incoming Documents")
+    begin
+        IncomingDocuments.Processed.AssertEquals(LibraryVariableStorage.DequeueBoolean());
+        Assert.IsFalse(IncomingDocuments.Next(), 'Expected the page to contain one incoming document.');
+        IncomingDocuments.OK().Invoke();
+    end;
+
     [PageHandler]
     [Scope('OnPrem')]
     procedure IncomingDocumentCardHandler(var IncomingDocumentCard: TestPage "Incoming Document")
@@ -2870,4 +2919,3 @@ codeunit 134400 "ERM Incoming Documents"
         Assert.AreEqual(1, TempBlobList.Count(), NoOfAttachmentsSameErr);
     end;
 }
-

--- a/src/Layers/W1/Tests/ERM/ERMIncomingDocuments.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMIncomingDocuments.Codeunit.al
@@ -2778,6 +2778,8 @@ codeunit 134400 "ERM Incoming Documents"
     begin
         IncomingDocuments.Processed.AssertEquals(LibraryVariableStorage.DequeueBoolean());
         Assert.IsFalse(IncomingDocuments.Next(), 'Expected the page to contain one incoming document.');
+        Assert.IsTrue(IncomingDocuments.ShowAll.Enabled(), 'Expected Show All to be enabled for a filtered view.');
+        Assert.IsFalse(IncomingDocuments.ShowUnprocessed.Enabled(), 'Expected Show Unprocessed to be disabled for a filtered view.');
         IncomingDocuments.OK().Invoke();
     end;
 

--- a/src/Layers/W1/Tests/ERM/ERMIncomingDocuments.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMIncomingDocuments.Codeunit.al
@@ -2217,8 +2217,10 @@ codeunit 134400 "ERM Incoming Documents"
         if ProcessedFilter <> '' then
             IncomingDocument.SetFilter(Processed, ProcessedFilter);
 
+        LibraryVariableStorage.Clear();
         LibraryVariableStorage.Enqueue(ExpectedProcessed);
         Page.RunModal(Page::"Incoming Documents", IncomingDocument);
+        LibraryVariableStorage.AssertEmpty();
     end;
 
     local procedure GetIncomeStatementAcc(): Code[20]


### PR DESCRIPTION
## What & why

Incoming Documents no longer defaulted to unprocessed records when opened without a filter, and an explicit `Processed = true` filter could be cleared. Restore the default `Processed = false` view while preserving explicitly supplied `true` and `false` filters.

Regression tests cover all three filter scenarios.

## Linked work
Fixes [AB#637747](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637747)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required - be specific: scenarios, commands, screenshots for UI changes)*

- Added regression coverage verifying that an unfiltered page defaults to unprocessed documents.
- Added regression coverage verifying that explicit `Processed = true` and `Processed = false` filters are preserved.
- Local execution was not completed because this workspace has no Business Central container or required AL package cache.

## Risk & compatibility

Low risk. The change only affects initial page filter handling and retains existing Show All/Show Unprocessed action behavior. No data, permissions, or upgrade impact.






