### PR TITLE
Fix RSA private key PEM import

### DIFF
--- a/src/System Application/App/Cryptography Management/app.json
+++ b/src/System Application/App/Cryptography Management/app.json
@@ -42,6 +42,13 @@
       "version": "29.0.0.0"
     }
   ],
+  "internalsVisibleTo": [
+    {
+      "id": "96e34a7d-38cc-48a9-9348-d2194d67167d",
+      "name": "Cryptography Management Test",
+      "publisher": "Microsoft"
+    }
+  ],
   "screenshots": [],
   "platform": "29.0.0.0",
   "idRanges": [

--- a/src/System Application/App/Cryptography Management/src/RSAImpl.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/RSAImpl.Codeunit.al
@@ -168,10 +168,11 @@ codeunit 1476 "RSA Impl." implements "Signature Algorithm v2"
     procedure ToSecretXmlString(PrivateKey: SecretText; IncludePrivateParameters: Boolean): SecretText
     var
         RSAEncryptionHelper: DotNet RSAEncryptionHelper;
+        DotNetRSACryptoServiceProvider: DotNet RSACryptoServiceProvider;
     begin
-        RSA();
-        RSAEncryptionHelper.ImportFromPem(DotNetRSA, PrivateKey);
-        exit(ToSecretXmlString(IncludePrivateParameters));
+        DotNetRSACryptoServiceProvider := DotNetRSACryptoServiceProvider.RSACryptoServiceProvider();
+        RSAEncryptionHelper.ImportFromPem(DotNetRSACryptoServiceProvider, PrivateKey.Unwrap());
+        exit(DotNetRSACryptoServiceProvider.ToXmlString(IncludePrivateParameters));
     end;
 
     procedure ToSecretXmlString(IncludePrivateParameters: Boolean): SecretText

--- a/src/System Application/App/Cryptography Management/src/RSAImpl.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/RSAImpl.Codeunit.al
@@ -170,10 +170,10 @@ codeunit 1476 "RSA Impl." implements "Signature Algorithm v2"
         RSAEncryptionHelper: DotNet RSAEncryptionHelper;
     begin
         RSA();
-        RSAEncryptionHelper.ImportFromPem(DotNetRSA, PrivateKey.Unwrap());
+        RSAEncryptionHelper.ImportFromPem(DotNetRSA, PrivateKey);
         exit(ToSecretXmlString(IncludePrivateParameters));
     end;
-    
+
     procedure ToSecretXmlString(IncludePrivateParameters: Boolean): SecretText
     begin
         exit(DotNetRSA.ToXmlString(IncludePrivateParameters));

--- a/src/System Application/Test/Cryptography Management/src/RSATest.Codeunit.al
+++ b/src/System Application/Test/Cryptography Management/src/RSATest.Codeunit.al
@@ -55,15 +55,15 @@ codeunit 132617 "RSA Test"
     procedure ImportPrivateKeyFromPem()
     var
         RSA: Codeunit RSA;
+        RSAImpl: Codeunit "RSA Impl.";
         KeyXml: XmlDocument;
         Root: XmlElement;
         Node: XmlNode;
-        DotNetRSA: DotNet RSATest;
         PrivateKeyPem: SecretText;
         KeyXmlText: SecretText;
     begin
-        DotNetRSA := DotNetRSA.Create(2048);
-        PrivateKeyPem := SecretStrSubstNo('%1', DotNetRSA.ExportRSAPrivateKeyPem());
+        RSAImpl.InitializeRSA(2048);
+        PrivateKeyPem := RSAImpl.ExportRSAPrivateKeyPem();
 
         KeyXmlText := RSA.ToSecretXmlString(PrivateKeyPem, true);
 

--- a/src/System Application/Test/Cryptography Management/src/RSATest.Codeunit.al
+++ b/src/System Application/Test/Cryptography Management/src/RSATest.Codeunit.al
@@ -52,6 +52,26 @@ codeunit 132617 "RSA Test"
     end;
 
     [Test]
+    procedure ImportPrivateKeyFromPem()
+    var
+        RSA: Codeunit RSA;
+        KeyXml: XmlDocument;
+        Root: XmlElement;
+        Node: XmlNode;
+        PrivateKeyPem: SecretText;
+        KeyXmlText: SecretText;
+    begin
+        PrivateKeyPem := SecretStrSubstNo('-----BEGIN RSA PRIVATE KEY-----MIICXgIBAAKBgQDtxUm71hwHVfLImtOwbV5k4xLolqdJpVan+kZP0UA16oRdqeW0dBxxeNexesPsf3N5dE8hvCojpIxHxuoWf4ZS4sPwcXVnIz18NwfT+/UZ9hJ2hZoX/b4Ulo0Id7oqgvDAcNr1qvKztTLtw1CgxHiAOs3UksOmDPpkNt/Y8iMZVQIDAQABAoGBAJ7YqczSWsFP2zXHsdrxBhnyVeSLGVGrIrxwCF80lWgvt6R3Z51p4MKyD69jK9cownWGjYMlGSXcvVcKfcLwCUS2uWACl7EI93ojgKFpzXVwxBdneqvZVqtrZq13RsyiEuVk1UhgmiBlnburS+xtXBXpVsSVjqMnG/Erk+2/wJu1AkEA8N6PLramcbi8FQke+qFKGd3IUxC3MkATpX6JA++e7kz/o36CtWJ1BOt00HqVoeJ7e/pWXIp8k+DDlw/nwO756wJBAPy05eOKNS4CoV8q9TDzvPkWQebFQWh1TgLBRu3wkCXb5LpUutHbzk92p/5W7lHAO4AQ7Zb6e9FuMnOjMWlwKb8CQQCWXVllAADH3VsMhrUgIK/xldIIiNbUN8wL9AH0wxGkEc1EcyWFtgD3IUW7H8tpU8lii9R90LYUWqu/Ed7LQmQhAkEAk7CtwqQdnHxRD6utjSSGRxVpApQ6O/CC3T1UVO+Jb3bqYLPwU4IhO3PfjtgDhKfSnnBGSzytbKL4vXidAkBZRQJAeTNRxIni1ahNhiirada9UPj8RkF1EcUtxlwAckvPttvCGsQ+VWOe4DEyMneMvyFzgL0h+sHEu5l7qRGzlWf94Q==-----END RSA PRIVATE KEY-----');
+
+        KeyXmlText := RSA.ToSecretXmlString(PrivateKeyPem, true);
+
+        LibraryAssert.IsTrue(XmlDocument.ReadFrom(GetXmlString(KeyXmlText), KeyXml), 'RSA key is not valid xml data.');
+        LibraryAssert.IsTrue(KeyXml.GetRoot(Root), 'Could not get Root element of key.');
+        LibraryAssert.IsTrue(Root.SelectSingleNode('Modulus', Node), 'Could not find <Modulus> in key.');
+        LibraryAssert.IsTrue(Root.SelectSingleNode('DQ', Node), 'Could not find <DQ> in key.');
+    end;
+
+    [Test]
     procedure TestSignDataAndVerifyDataWithMD5AndPSS()
     begin
         LibraryAssert.IsTrue(SignAndVerifyData(enum::"Hash Algorithm"::MD5, enum::"RSA Signature Padding"::Pss), 'Failed to verify signed data');

--- a/src/System Application/Test/Cryptography Management/src/RSATest.Codeunit.al
+++ b/src/System Application/Test/Cryptography Management/src/RSATest.Codeunit.al
@@ -58,10 +58,12 @@ codeunit 132617 "RSA Test"
         KeyXml: XmlDocument;
         Root: XmlElement;
         Node: XmlNode;
+        DotNetRSA: DotNet RSATest;
         PrivateKeyPem: SecretText;
         KeyXmlText: SecretText;
     begin
-        PrivateKeyPem := SecretStrSubstNo('-----BEGIN RSA PRIVATE KEY-----MIICXgIBAAKBgQDtxUm71hwHVfLImtOwbV5k4xLolqdJpVan+kZP0UA16oRdqeW0dBxxeNexesPsf3N5dE8hvCojpIxHxuoWf4ZS4sPwcXVnIz18NwfT+/UZ9hJ2hZoX/b4Ulo0Id7oqgvDAcNr1qvKztTLtw1CgxHiAOs3UksOmDPpkNt/Y8iMZVQIDAQABAoGBAJ7YqczSWsFP2zXHsdrxBhnyVeSLGVGrIrxwCF80lWgvt6R3Z51p4MKyD69jK9cownWGjYMlGSXcvVcKfcLwCUS2uWACl7EI93ojgKFpzXVwxBdneqvZVqtrZq13RsyiEuVk1UhgmiBlnburS+xtXBXpVsSVjqMnG/Erk+2/wJu1AkEA8N6PLramcbi8FQke+qFKGd3IUxC3MkATpX6JA++e7kz/o36CtWJ1BOt00HqVoeJ7e/pWXIp8k+DDlw/nwO756wJBAPy05eOKNS4CoV8q9TDzvPkWQebFQWh1TgLBRu3wkCXb5LpUutHbzk92p/5W7lHAO4AQ7Zb6e9FuMnOjMWlwKb8CQQCWXVllAADH3VsMhrUgIK/xldIIiNbUN8wL9AH0wxGkEc1EcyWFtgD3IUW7H8tpU8lii9R90LYUWqu/Ed7LQmQhAkEAk7CtwqQdnHxRD6utjSSGRxVpApQ6O/CC3T1UVO+Jb3bqYLPwU4IhO3PfjtgDhKfSnnBGSzytbKL4vXidAkBZRQJAeTNRxIni1ahNhiirada9UPj8RkF1EcUtxlwAckvPttvCGsQ+VWOe4DEyMneMvyFzgL0h+sHEu5l7qRGzlWf94Q==-----END RSA PRIVATE KEY-----');
+        DotNetRSA := DotNetRSA.Create(2048);
+        PrivateKeyPem := SecretStrSubstNo('%1', DotNetRSA.ExportRSAPrivateKeyPem());
 
         KeyXmlText := RSA.ToSecretXmlString(PrivateKeyPem, true);
 

--- a/src/System Application/Test/Cryptography Management/src/dotnet.al
+++ b/src/System Application/Test/Cryptography Management/src/dotnet.al
@@ -9,9 +9,6 @@ dotnet
 {
     assembly("netstandard")
     {
-        type("System.Security.Cryptography.RSA"; RSATest)
-        {
-        }
         type("System.TimeZoneInfo"; TimeZoneInfoTest)
         {
         }

--- a/src/System Application/Test/Cryptography Management/src/dotnet.al
+++ b/src/System Application/Test/Cryptography Management/src/dotnet.al
@@ -9,6 +9,9 @@ dotnet
 {
     assembly("netstandard")
     {
+        type("System.Security.Cryptography.RSA"; RSATest)
+        {
+        }
         type("System.TimeZoneInfo"; TimeZoneInfoTest)
         {
         }


### PR DESCRIPTION
## What & why

Calling `RSA.ToSecretXmlString` with a PEM private key fails at runtime because `RSAEncryptionHelper.ImportFromPem` requires an `RSACryptoServiceProvider`, but the implementation passes the base `RSA` type. This change imports the PEM into the required CSP type and returns its XML representation.

## Linked work

Related to #866

Fixes [AB#619464](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/619464)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required - be specific: scenarios, commands, screenshots for UI changes)*

- Added `ImportPrivateKeyFromPem`, which generates a fresh RSA private key through the internal AL implementation, imports its PEM through the public RSA API, and verifies that the resulting XML contains public and private key parameters.
- Inspected the platform helper metadata to confirm the exact `ImportFromPem(RSACryptoServiceProvider, String)` contract.
- A local Business Central build and test run was not available because Docker is not installed in this environment.

## Risk & compatibility

Low risk. The public API is unchanged. PEM key material remains wrapped as `SecretText` outside the existing non-debuggable helper boundary. The test app receives friend access to reuse the module's internal PEM export helper without storing a key or introducing test-side .NET interop.



