### PR TITLE
[Projects] Register Job Assigned Resource tables for cloud migration

### DIFF
--- a/src/Layers/W1/Tests/NewObjectTests-Internal/CloudMigrationPropertyTest.Codeunit.al
+++ b/src/Layers/W1/Tests/NewObjectTests-Internal/CloudMigrationPropertyTest.Codeunit.al
@@ -98,6 +98,8 @@ codeunit 135160 "Cloud Migration Property Test"
         ListOfTablesToMigrate.Add(Database::"Job WIP Warning");
         ListOfTablesToMigrate.Add(Database::"Job");
         ListOfTablesToMigrate.Add(Database::"Job Archive");
+        ListOfTablesToMigrate.Add(Database::"Job Assigned Resource");
+        ListOfTablesToMigrate.Add(Database::"Job Assigned Resource Archive");
         ListOfTablesToMigrate.Add(Database::"Jobs Setup");
         ListOfTablesToMigrate.Add(Database::"Language");
         ListOfTablesToMigrate.Add(Database::"Last Used Chart");


### PR DESCRIPTION
## Summary
The new tables **Job Assigned Resource** (1008) and **Job Assigned Resource Archive** (5140), added in #9315, use the default `ReplicateData = true`. The internal `Cloud Migration Property Test` (codeunit 135160) enumerates every table with `ReplicateData = true` and asserts each is registered in its allowlist, so these two new tables caused the test to fail in the NAV internal gate:

> New tables have been found for cloud migration ... `Job Assigned Resource Archive;Job Assigned Resource;`

## Change
Add both tables to `GetTablesThatShouldBeCloudMigrated`. They hold `CustomerContent` assignment data that must migrate OnPrem->Cloud, exactly like `Job` and `Job Task`, so keeping `ReplicateData = true` (default) and registering them in the allowlist is the correct, consistent fix.

Fixes [AB#640497](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640497)




