### PR TITLE
[Shopify] Fix Sync Prices using stale WorkDate from SingleInstance cache

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductPriceCalc.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductPriceCalc.Codeunit.al
@@ -166,7 +166,7 @@ codeunit 30182 "Shpfy Product Price Calc."
     /// <param name="ShopifyShop">Parameter of type Record "Shopify Shop".</param>
     internal procedure SetShop(ShopifyShop: Record "Shpfy Shop")
     begin
-        if (Shop.Code <> ShopifyShop.Code) or (Shop.SystemModifiedAt < ShopifyShop.SystemModifiedAt) then begin
+        if (Shop.Code <> ShopifyShop.Code) or (Shop.SystemModifiedAt < ShopifyShop.SystemModifiedAt) or (TempSalesHeader."Document Date" <> WorkDate()) then begin
             Shop := ShopifyShop;
             SetParameters(Shop);
             Clear(TempSalesHeader);

--- a/src/Apps/W1/Shopify/Test/Products/ShpfyProductInitTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Products/ShpfyProductInitTest.Codeunit.al
@@ -275,6 +275,41 @@ codeunit 139603 "Shpfy Product Init Test"
         PriceListHeader.Modify();
     end;
 
+    internal procedure CreateDatedAllCustDiscPriceList(ItemNo: Code[20]; DiscUpToBoundary: Decimal; DiscFromBoundary: Decimal; BoundaryDate: Date)
+    var
+        PriceListHeader: Record "Price List Header";
+        PriceListLine: Record "Price List Line";
+    begin
+        LibraryPriceCalculation.CreatePriceHeader(PriceListHeader, PriceListHeader."Price Type"::Sale, PriceListHeader."Source Type"::"All Customers", '');
+
+        // Discount that applies up to and including the boundary date.
+        PriceListLine.Init();
+        PriceListLine.Validate("Price List Code", PriceListHeader.Code);
+        PriceListLine.Validate("Asset Type", PriceListLine."Asset Type"::Item);
+        PriceListLine.Validate("Asset No.", ItemNo);
+        PriceListLine.Validate("Price Type", PriceListLine."Price Type"::Sale);
+        PriceListLine.Validate("Amount Type", PriceListLine."Amount Type"::Discount);
+        PriceListLine.Validate("Source Type", PriceListLine."Source Type"::"All Customers");
+        PriceListLine.Validate("Ending Date", BoundaryDate);
+        PriceListLine.Validate("Line Discount %", DiscUpToBoundary);
+        PriceListLine.Insert(true);
+
+        // Discount that applies from the day after the boundary date onwards.
+        PriceListLine.Init();
+        PriceListLine.Validate("Price List Code", PriceListHeader.Code);
+        PriceListLine.Validate("Asset Type", PriceListLine."Asset Type"::Item);
+        PriceListLine.Validate("Asset No.", ItemNo);
+        PriceListLine.Validate("Price Type", PriceListLine."Price Type"::Sale);
+        PriceListLine.Validate("Amount Type", PriceListLine."Amount Type"::Discount);
+        PriceListLine.Validate("Source Type", PriceListLine."Source Type"::"All Customers");
+        PriceListLine.Validate("Starting Date", BoundaryDate + 1);
+        PriceListLine.Validate("Line Discount %", DiscFromBoundary);
+        PriceListLine.Insert(true);
+
+        PriceListHeader.Validate(Status, PriceListHeader.Status::Active);
+        PriceListHeader.Modify();
+    end;
+
     internal procedure CreateAllCustomerPriceList(Code: Code[10]; ItemNo: Code[20]; Price: Decimal; DiscountPerc: Decimal)
     var
         PriceListLine: Record "Price List Line";

--- a/src/Apps/W1/Shopify/Test/Products/ShpfyProductPriceCalcTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Products/ShpfyProductPriceCalcTest.Codeunit.al
@@ -149,6 +149,67 @@ codeunit 139605 "Shpfy Product Price Calc. Test"
         LibraryAssert.AreNearlyEqual(InitPrice * (1 - InitDiscountPerc / 100), Price, 0.01, 'Discount Price');
     end;
 
+    [Test]
+    [HandlerFunctions('ActivateConfirmHandler')]
+    procedure UnitTestCalcPriceUsesCurrentWorkDate()
+    var
+        Shop: Record "Shpfy Shop";
+        Item: Record Item;
+        PriceCalculationSetup: Record "Price Calculation Setup";
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+        ProductInitTest: Codeunit "Shpfy Product Init Test";
+        ProductPriceCalculation: Codeunit "Shpfy Product Price Calc.";
+        InitUnitCost: Decimal;
+        InitPrice: Decimal;
+        DiscUpToBoundary: Decimal;
+        DiscFromBoundary: Decimal;
+        UnitCost: Decimal;
+        PriceBeforeBoundary: Decimal;
+        PriceFromBoundary: Decimal;
+        ComparePrice: Decimal;
+        OriginalWorkDate: Date;
+        BoundaryDate: Date;
+    begin
+        // [SCENARIO] Bug 642194: changing the Work Date mid-session must recalculate prices even though the Shop record has not been modified.
+        // [SCENARIO] The price calculation codeunit is SingleInstance and caches a temp Sales Header with Document Date = WorkDate(). A stale cache must not keep applying the previous Work Date's discount.
+
+        // [INIT] Initialization startup data.
+        LibraryPriceCalculation.EnableExtendedPriceCalculation();
+        LibraryPriceCalculation.AddSetup(PriceCalculationSetup, "Price Calculation Method"::"Lowest Price", "Price Type"::Sale, "Price Asset Type"::Item, "Price Calculation Handler"::"Business Central (Version 16.0)", true);
+        Shop := InitializeTest.CreateShop();
+        Shop."Allow Line Disc." := true;
+        Shop.Modify();
+        InitUnitCost := Any.DecimalInRange(10, 100, 1);
+        InitPrice := Any.DecimalInRange(2 * InitUnitCost, 4 * InitUnitCost, 1);
+        DiscUpToBoundary := 50;
+        DiscFromBoundary := 20;
+        Item := ProductInitTest.CreateItem(Shop."Item Templ. Code", InitUnitCost, InitPrice);
+
+        // [GIVEN] Two "All Customers" discount price list lines for the item: 50% up to the boundary date, 20% from the day after the boundary date.
+        BoundaryDate := DMY2Date(1, 1, 2027);
+        ProductInitTest.CreateDatedAllCustDiscPriceList(Item."No.", DiscUpToBoundary, DiscFromBoundary, BoundaryDate);
+
+        OriginalWorkDate := WorkDate();
+
+        // [WHEN] The Work Date is after the boundary date and the price is calculated for the shop.
+        WorkDate(BoundaryDate + 180);
+        ProductPriceCalculation.SetShop(Shop);
+        ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, PriceFromBoundary, ComparePrice);
+
+        // [WHEN] The Work Date is moved before the boundary date and the price is calculated again WITHOUT modifying the shop.
+        WorkDate(BoundaryDate - 30);
+        ProductPriceCalculation.SetShop(Shop);
+        ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, PriceBeforeBoundary, ComparePrice);
+
+        // [THEN] Restore the Work Date before asserting so a failure does not leak into other tests.
+        WorkDate(OriginalWorkDate);
+
+        // [THEN] The first calculation applied the 20% discount valid from the boundary date onwards.
+        LibraryAssert.AreNearlyEqual(InitPrice * (1 - DiscFromBoundary / 100), PriceFromBoundary, 0.01, 'Price for Work Date after the boundary date');
+        // [THEN] The second calculation applied the 50% discount valid up to the boundary date (would still be 20% with a stale WorkDate cache).
+        LibraryAssert.AreNearlyEqual(InitPrice * (1 - DiscUpToBoundary / 100), PriceBeforeBoundary, 0.01, 'Price for Work Date before the boundary date');
+    end;
+
     [ConfirmHandler]
     procedure ActivateConfirmHandler(Question: Text[1024]; var Reply: Boolean)
     begin


### PR DESCRIPTION
## Summary

Codeunit `Shpfy Product Price Calc.` (30182) is `SingleInstance` and caches a temporary Sales Header whose `Document Date`/`Order Date` is captured from `WorkDate()` in `CreateTempSalesHeader()`. The `SetShop()` guard only rebuilt the cached header when the shop code or `SystemModifiedAt` changed, so changing the Work Date mid-session had no effect on price calculation until the Shop record was modified (e.g. toggling an unrelated setting) or the session was restarted.

As a result, running **Sync Prices** after changing the Work Date could apply the discount valid for the *previous* Work Date.

## Fix

- Add a `WorkDate()` check to the `SetShop()` guard so the cached temp Sales Header is rebuilt whenever the Work Date changes.
- `SetShopAndCatalog()` already recreates the header unconditionally on every call, so it is unaffected and left as-is.

## Test plan

- Added regression test `UnitTestCalcPriceUsesCurrentWorkDate` (with helper `CreateDatedAllCustDiscPriceList`) that sets up two date-bounded "All Customers" discount price list lines (50% up to the boundary date, 20% after), calculates the price at a Work Date after the boundary, then moves the Work Date before the boundary and recalculates **without** modifying the Shop record. It asserts the correct (50%) discount is applied for the new Work Date; before the fix the stale cache would keep applying the 20% discount.
- Shopify App and Test projects build with 0 errors.

Fixes [AB#642194](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642194)



