### PR TITLE
[releases/28.1] [NAV] Track failed BCApps validation (AUTODETECTED) - Shopify test updated

### DIFF
--- a/src/Apps/W1/Shopify/Test/Base/ShpfyInitializeTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Base/ShpfyInitializeTest.Codeunit.al
@@ -47,6 +47,7 @@ codeunit 139561 "Shpfy Initialize Test"
 
     internal procedure CreateShop(): Record "Shpfy Shop"
     var
+        GeneralPostingSetup: Record "General Posting Setup";
         RefundGLAccount: Record "G/L Account";
         Shop: Record "Shpfy Shop";
         VATPostingSetup: Record "VAT Posting Setup";
@@ -64,6 +65,8 @@ codeunit 139561 "Shpfy Initialize Test"
                 exit(Shop);
 
         Code := CopyStr(Any.AlphabeticText(MaxStrLen(Code)), 1, MaxStrLen(Code));
+
+        LibraryERM.CreateGeneralPostingSetupInvt(GeneralPostingSetup);
 
         LibraryERM.CreateVATPostingSetupWithAccounts(VATPostingSetup,
            VATPostingSetup."VAT Calculation Type"::"Normal VAT", LibraryRandom.RandDecInDecimalRange(10, 25, 0));

--- a/src/Apps/W1/Shopify/Test/Base/ShpfyInitializeTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Base/ShpfyInitializeTest.Codeunit.al
@@ -15,7 +15,9 @@ using Microsoft.Foundation.Enums;
 using Microsoft.Foundation.NoSeries;
 using Microsoft.Integration.Shopify;
 using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Setup;
 using Microsoft.Sales.Customer;
+using Microsoft.Sales.Setup;
 using System.TestLibraries.Utilities;
 
 /// <summary>
@@ -34,6 +36,7 @@ codeunit 139561 "Shpfy Initialize Test"
         CommunicationMgt: Codeunit "Shpfy Communication Mgt.";
         LibraryERM: Codeunit "Library - ERM";
         LibraryRandom: Codeunit "Library - Random";
+        LibraryUtility: Codeunit "Library - Utility";
         ShopifyAccessToken: Text;
 #pragma warning disable AA0240
         DummyCustomerEmailLbl: Label 'dummy@customer.com';
@@ -48,7 +51,9 @@ codeunit 139561 "Shpfy Initialize Test"
     internal procedure CreateShop(): Record "Shpfy Shop"
     var
         GeneralPostingSetup: Record "General Posting Setup";
+        InventorySetup: Record "Inventory Setup";
         RefundGLAccount: Record "G/L Account";
+        SalesReceivablesSetup: Record "Sales & Receivables Setup";
         Shop: Record "Shpfy Shop";
         VATPostingSetup: Record "VAT Posting Setup";
         ShpfyInitializeTest: Codeunit "Shpfy Initialize Test";
@@ -98,6 +103,10 @@ codeunit 139561 "Shpfy Initialize Test"
         Commit();
         CommunicationMgt.SetShop(Shop);
         CommunicationMgt.SetTestInProgress(true);
+        LibraryUtility.UpdateSetupNoSeriesCode(
+            DATABASE::"Sales & Receivables Setup", SalesReceivablesSetup.FieldNo("Customer Nos."));
+        LibraryUtility.UpdateSetupNoSeriesCode(
+            DATABASE::"Inventory Setup", InventorySetup.FieldNo("Item Nos."));
         CreateDummyCustomer(CustomerTemplateCode);
         CreateDummyItem(ItemTemplateCode);
         if not TempShop.Get(Code) then begin


### PR DESCRIPTION
Cherry-pick of Shopify test updates for releases/28.1

Fixes
[AB#642190](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642190)



