### PR TITLE
[ALAppExtensions #30294][Event Change Request] Report 12121 "G/L Book - Print" - "OnPreDataItemOnAfterSetGLBookEntryFilters"

### DIFF
--- a/src/Layers/IT/BaseApp/Local/Finance/GeneralLedger/Reports/GLBookPrint.Report.al
+++ b/src/Layers/IT/BaseApp/Local/Finance/GeneralLedger/Reports/GLBookPrint.Report.al
@@ -344,6 +344,7 @@ report 12121 "G/L Book - Print"
                 GLBookEntry.SetRange("Progressive No.", 0);
                 GLBookEntry.SetFilter("Official Date", '<%1', StartDate);
                 GLBookEntry.SetFilter(Amount, '<>0');
+                OnPreDataItemOnAfterSetGLBookEntryFilters(GLBookEntry, "GL Book Entry");
 
                 if GLBookEntry.FindFirst() and
                    (ReportType <> ReportType::"Test Print")
@@ -751,6 +752,11 @@ report 12121 "G/L Book - Print"
                 if PurchCrMemoHeader.Get("GL Book Entry"."Document No.") then
                     Descr := PurchCrMemoHeader."Pay-to Name";
         end;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnPreDataItemOnAfterSetGLBookEntryFilters(var CheckGLBookEntry: Record "GL Book Entry"; var GLBookEntry: Record "GL Book Entry")
+    begin
     end;
 }
 

--- a/src/Layers/IT/BaseApp/Local/Finance/GeneralLedger/Reports/GLBookPrint.Report.al
+++ b/src/Layers/IT/BaseApp/Local/Finance/GeneralLedger/Reports/GLBookPrint.Report.al
@@ -755,7 +755,7 @@ report 12121 "G/L Book - Print"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnPreDataItemOnAfterSetGLBookEntryFilters(var CheckGLBookEntry: Record "GL Book Entry"; var GLBookEntry: Record "GL Book Entry")
+    local procedure OnPreDataItemOnAfterSetGLBookEntryFilters(var CheckGLBookEntry: Record "GL Book Entry"; var SourceGLBookEntry: Record "GL Book Entry")
     begin
     end;
 }


### PR DESCRIPTION
## What & why

Adds a new `OnPreDataItemOnAfterSetGLBookEntryFilters` integration event to report 12121 "G/L Book - Print". It is raised in `OnPreDataItem()` right after the standard `GLBookEntry` filters are set and before the `FindFirst()` gap check raises its error, so partners can add their own filter to `GLBookEntry` before that validation runs. Additive publisher only - no behavior change when unsubscribed.

## Linked work

Fixes [AB#640953](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640953)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Diff review: one event-raise call plus one `[IntegrationEvent]` publisher; control flow is unchanged when no subscriber is present.
- No tests added: a new integration-event publisher introduces no runtime behavior on its own.

## Risk & compatibility

Very low. New publisher only; no existing event signatures changed, no schema change, no data/upgrade impact.


