### PR TITLE
[ALAppExtensions #30313]codeunit 441 "Prepayment Mgt."  OnBeforeReleaseSalesDocument

### DIFF
--- a/src/Layers/W1/BaseApp/Finance/ReceivablesPayables/PrepaymentMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/ReceivablesPayables/PrepaymentMgt.Codeunit.al
@@ -342,6 +342,7 @@ codeunit 441 "Prepayment Mgt."
     begin
         SalesHeader.SetRange("Document Type", SalesHeader."Document Type"::Order);
         SalesHeader.SetRange(Status, SalesHeader.Status::"Pending Prepayment");
+        OnBeforeUpdatePendingPrepaymentSales(SalesHeader);
         if SalesHeader.FindSet(true) then
             repeat
                 if not PrepaymentMgt.TestSalesPayment(SalesHeader) then begin
@@ -350,6 +351,7 @@ codeunit 441 "Prepayment Mgt."
                         Session.LogMessage('0000254', StrSubstNo(StatusOfSalesOrderIsChangedTxt, Format(SalesHeader."No.")), Verbosity::Normal, DataClassification::CustomerContent, TelemetryScope::ExtensionPublisher, 'Category', UpdateSalesOrderStatusTxt);
                 end;
             until SalesHeader.Next() = 0;
+        OnAfterUpdatePendingPrepaymentSales(SalesHeader);
     end;
 
     /// <summary>
@@ -424,6 +426,24 @@ codeunit 441 "Prepayment Mgt."
             UpdateFrequency::Weekly:
                 exit(60 * 24 * 7);
         end;
+    end;
+
+    /// <summary>
+    /// Integration event raised before pending prepayment sales orders are processed for release.
+    /// </summary>
+    /// <param name="SalesHeader">Sales document header filtered to pending prepayment orders</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeUpdatePendingPrepaymentSales(var SalesHeader: Record "Sales Header")
+    begin
+    end;
+
+    /// <summary>
+    /// Integration event raised after pending prepayment sales orders have been processed for release.
+    /// </summary>
+    /// <param name="SalesHeader">Sales document header used while processing pending prepayment orders</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterUpdatePendingPrepaymentSales(var SalesHeader: Record "Sales Header")
+    begin
     end;
 
     /// <summary>


### PR DESCRIPTION
## What & why

Adds `OnBeforeUpdatePendingPrepaymentSales` and `OnAfterUpdatePendingPrepaymentSales` integration events around the sales loop in `UpdatePendingPrepaymentSales()` of codeunit 441 "Prepayment Mgt.". This gives partners a signal specific to the prepayment-driven release flow (before/after processing) that the generic `Release Sales Document` events do not distinguish. Additive publishers with XML-doc comments matching the codeunit's existing style.

## Linked work

Fixes [AB#641536](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641536)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Diff review: two event-raise calls wrapping the existing loop plus two documented publishers; the loop itself is untouched.
- No tests added: additive integration-event publishers with no behavior change when unsubscribed.
- 
## Risk & compatibility

Very low. New publishers only; no existing event signatures changed, no schema/data impact.

