### PR TITLE
[ALAppExtensions #30221][Event Request] table 12137 "Purch. Withh. Contribution"

### DIFF
--- a/src/Layers/IT/BaseApp/Local/Finance/WithholdingTax/PurchWithhContribution.Table.al
+++ b/src/Layers/IT/BaseApp/Local/Finance/WithholdingTax/PurchWithhContribution.Table.al
@@ -463,6 +463,7 @@ table 12137 "Purch. Withh. Contribution"
     var
         Assoggettato: Decimal;
         Gap: Decimal;
+        IsHandled: Boolean;
     begin
         if "Payment Date" <> 0D then begin
             SocSecBracketLine.SetSocSecLineFilters(
@@ -488,11 +489,14 @@ table 12137 "Purch. Withh. Contribution"
 
         Vend.CalcFields("Soc. Sec. Company Base");
 
-        Assoggettato := Vend."Soc. Sec. Company Base" + Vend."Soc. Sec. 3 Parties Base" +
-          SocSecBracketLine.GetCompContribRemGrossAmtForVendorInPeriod(
-            Vend."No.",
-            CalcDate('<-CY>', "Date Related"),
-            CalcDate('<CY>', "Date Related"));
+        IsHandled := false;
+        OnValorizzaINPSOnBeforeCalcAssoggettato(Assoggettato, Vend, PurchHeader, IsHandled);
+        if not IsHandled then
+            Assoggettato := Vend."Soc. Sec. Company Base" + Vend."Soc. Sec. 3 Parties Base" +
+              SocSecBracketLine.GetCompContribRemGrossAmtForVendorInPeriod(
+                Vend."No.",
+                CalcDate('<-CY>', "Date Related"),
+                CalcDate('<CY>', "Date Related"));
 
         if SocSecCodeLine.Amount - Assoggettato > GrossAmount then
             "Gross Amount" := GrossAmount
@@ -648,6 +652,7 @@ table 12137 "Purch. Withh. Contribution"
             PurchWithhContribution."Social Security Code" := Vend."Social Security Code";
             PurchWithhContribution."INAIL Code" := Vend."INAIL Code";
             PurchWithhContribution.Validate("Currency Code", Vend."Currency Code");
+            OnCreateRecordOnBeforeInsertPurchWithhContribution(PurchWithhContribution, PurchaseHeader, Vend);
             PurchWithhContribution.Insert(true);
         end;
     end;
@@ -687,6 +692,16 @@ table 12137 "Purch. Withh. Contribution"
 
     [IntegrationEvent(false, false)]
     local procedure OnValorizzaRitenuteOnBeforeValidateWithholdingTaxAmount(var PurchWithhContribution: Record "Purch. Withh. Contribution")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValorizzaINPSOnBeforeCalcAssoggettato(var Assoggettato: Decimal; Vendor: Record Vendor; PurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCreateRecordOnBeforeInsertPurchWithhContribution(var PurchWithhContribution: Record "Purch. Withh. Contribution"; PurchaseHeader: Record "Purchase Header"; Vendor: Record Vendor)
     begin
     end;
 }


### PR DESCRIPTION
## What & why

Adds two integration events to table 12137 "Purch. Withh. Contribution": `OnValorizzaINPSOnBeforeCalcAssoggettato` (an `IsHandled`-guarded hook letting partners replace the `Assoggettato` calculation in `ValorizzaINPS`) and `OnCreateRecordOnBeforeInsertPurchWithhContribution` (raised before `Insert(true)` so custom fields can be populated). `IsHandled` defaults to `false`, so the standard calculation runs unchanged unless a subscriber opts to override it.

## Linked work

Fixes [AB#640605](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640605)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Diff review: `IsHandled` local plus guarded `Assoggettato` calc, pre-insert event, and two publishers. Default path (`IsHandled := false`) runs the original calculation verbatim.
- No tests added: default behavior is unchanged; the events only enable opt-in overrides.

## Risk & compatibility

Low. `IsHandled` guards a calculation (default result preserved), not an integrity/validation check. No existing event signatures changed, no schema/data impact.

