### PR TITLE
[ALAppExtensions #30229][Event Request] table 12113 "Tmp Withholding Contribution"

### DIFF
--- a/src/Layers/IT/BaseApp/Local/Finance/WithholdingTax/TmpWithholdingContribution.Table.al
+++ b/src/Layers/IT/BaseApp/Local/Finance/WithholdingTax/TmpWithholdingContribution.Table.al
@@ -444,16 +444,16 @@ table 12113 "Tmp Withholding Contribution"
             Error(NegativeTaxableBaseErr);
     end;
 
-    local procedure AssignWithholdingTaxValues(WithholdCodeLine: Record "Withhold Code Line")
+    local procedure AssignWithholdingTaxValues(WithholdCodeLineToAssign: Record "Withhold Code Line")
     begin
         "Withholding Account" := WithholdCode."Withholding Taxes Payable Acc.";
-        "Withholding Tax %" := WithholdCodeLine."Withholding Tax %";
-        "Non Taxable %" := 100 - WithholdCodeLine."Taxable Base %";
+        "Withholding Tax %" := WithholdCodeLineToAssign."Withholding Tax %";
+        "Non Taxable %" := 100 - WithholdCodeLineToAssign."Taxable Base %";
         "Taxable Base" := Round(((
                                   "Total Amount" -
                                   "Base - Excluded Amount" -
                                   "Non Taxable Amount By Treaty") *
-                                 WithholdCodeLine."Taxable Base %") / 100);
+                                 WithholdCodeLineToAssign."Taxable Base %") / 100);
         "Non Taxable Amount" := "Total Amount" -
           "Base - Excluded Amount" -
           "Non Taxable Amount By Treaty" -
@@ -628,7 +628,7 @@ table 12113 "Tmp Withholding Contribution"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnCalculateWithholdingTaxOnBeforeAssignWithholdingTaxValues(var IsHandled: Boolean; WithholdCodeLine: Record "Withhold Code Line"; var TmpWithholdingContribution: Record "Tmp Withholding Contribution")
+    local procedure OnCalculateWithholdingTaxOnBeforeAssignWithholdingTaxValues(var IsHandled: Boolean; WithholdCodeLineToAssign: Record "Withhold Code Line"; var TmpWithholdingContribution: Record "Tmp Withholding Contribution")
     begin
     end;
 }

--- a/src/Layers/IT/BaseApp/Local/Finance/WithholdingTax/TmpWithholdingContribution.Table.al
+++ b/src/Layers/IT/BaseApp/Local/Finance/WithholdingTax/TmpWithholdingContribution.Table.al
@@ -425,12 +425,27 @@ table 12113 "Tmp Withholding Contribution"
     end;
 
     procedure CalculateWithholdingTax()
+    var
+        IsHandled: Boolean;
     begin
         WithholdCode.Get("Withholding Tax Code");
 
         WithholdingSocSec.WithholdLineFilter(WithholdCodeLine, "Withholding Tax Code",
           "Payment Date");
 
+        IsHandled := false;
+        OnCalculateWithholdingTaxOnBeforeAssignWithholdingTaxValues(IsHandled, WithholdCodeLine, Rec);
+        if not IsHandled then
+            AssignWithholdingTaxValues(WithholdCodeLine);
+
+        OnCalculateWithholdingTaxOnAfterAssignWithholdingTaxAmount(Rec);
+
+        if "Taxable Base" < 0 then
+            Error(NegativeTaxableBaseErr);
+    end;
+
+    local procedure AssignWithholdingTaxValues(WithholdCodeLine: Record "Withhold Code Line")
+    begin
         "Withholding Account" := WithholdCode."Withholding Taxes Payable Acc.";
         "Withholding Tax %" := WithholdCodeLine."Withholding Tax %";
         "Non Taxable %" := 100 - WithholdCodeLine."Taxable Base %";
@@ -445,10 +460,6 @@ table 12113 "Tmp Withholding Contribution"
           "Taxable Base";
 
         "Withholding Tax Amount" := Round("Taxable Base" * "Withholding Tax %" / 100);
-        OnCalculateWithholdingTaxOnAfterAssignWithholdingTaxAmount(Rec);
-
-        if "Taxable Base" < 0 then
-            Error(NegativeTaxableBaseErr);
     end;
 
     [Scope('OnPrem')]
@@ -613,6 +624,11 @@ table 12113 "Tmp Withholding Contribution"
 
     [IntegrationEvent(false, false)]
     local procedure OnCalculateWithholdingTaxOnAfterAssignWithholdingTaxAmount(var TmpWithholdingContribution: Record "Tmp Withholding Contribution")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCalculateWithholdingTaxOnBeforeAssignWithholdingTaxValues(var IsHandled: Boolean; WithholdCodeLine: Record "Withhold Code Line"; var TmpWithholdingContribution: Record "Tmp Withholding Contribution")
     begin
     end;
 }


### PR DESCRIPTION
## What & why

Adds `OnCalculateWithholdingTaxOnBeforeAssignWithholdingTaxValues` (an `IsHandled` event) to table 12113 "Tmp Withholding Contribution" and extracts the standard field assignments in `CalculateWithholdingTax()` into a new `AssignWithholdingTaxValues` local procedure (the reviewer-requested pattern, instead of wrapping an inline block). The negative-taxable-base check stays outside the handled block so it always runs, regardless of who computes the values.

## Linked work

Fixes [AB#641342](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641342)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Diff review: assignment logic moved verbatim into `AssignWithholdingTaxValues`; the `IsHandled` event precedes it; `Error(NegativeTaxableBaseErr)` remains after the guarded block. Default path is behavior-preserving.
- No tests added: extract-method plus opt-in override; standard result and the negative-base validation are unchanged.

## Risk & compatibility

Low. `IsHandled` guards the calculation only; the negative-base validation is intentionally kept outside it so it cannot be bypassed. No existing event signatures changed, no schema/data impact.



