### PR TITLE
[Event Request] codeunit 367 "CheckManagement": add OnFinancialVoidCh…

### DIFF
--- a/src/Layers/APAC/BaseApp/Bank/Check/CheckManagement.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Bank/Check/CheckManagement.Codeunit.al
@@ -283,39 +283,16 @@ codeunit 367 CheckManagement
           StrSubstNo(VoidingCheckMsg, CheckLedgEntry."Check No."));
         GenJnlLine2.Validate("Currency Code", BankAcc."Currency Code");
         GenJnlLine2."Allow Zero-Amount Posting" := true;
-        OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3);
         IsHandled := false;
-        OnFinancialVoidCheckOnBeforePostBalanceAccount(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
+        OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
         if not IsHandled then
-            FinancialVoidPostBalanceAccount(CheckLedgEntry, ConfirmFinancialVoid.GetVoidType(), ConfirmFinancialVoid.GetVoidDate(), BalanceAmountLCY);
-
-        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
-            BankAccLedgEntry2.Open := false;
-            BankAccLedgEntry2."Remaining Amount" := 0;
-            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
-            BankAccLedgEntry2.Modify();
-        end;
-
-        // rounding error from currency conversion
-        if CheckAmountLCY + BalanceAmountLCY <> 0 then
-            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
-
-        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
-        Commit();
-        UpdateAnalysisView.UpdateAll(0, true);
-
-        OnAfterFinancialVoidCheck(CheckLedgEntry);
-    end;
-
-    local procedure FinancialVoidPostBalanceAccount(var CheckLedgEntry: Record "Check Ledger Entry"; VoidType: Integer; VoidDate: Date; var BalanceAmountLCY: Decimal)
-    begin
         case CheckLedgEntry."Bal. Account Type" of
             CheckLedgEntry."Bal. Account Type"::"G/L Account":
                 FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
             CheckLedgEntry."Bal. Account Type"::Customer:
                 begin
-                    if VoidType = 0 then   // Unapply entry
-                        if UnApplyCustInvoices(CheckLedgEntry, VoidDate) then
+                    if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
+                        if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     CustLedgEntry.SetCurrentKey("Transaction No.");
                     CustLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -338,8 +315,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Vendor:
                 begin
-                    if VoidType = 0 then // Unapply entry
-                        if UnApplyVendInvoices(CheckLedgEntry, VoidDate) then
+                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                        if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     VendorLedgEntry.SetCurrentKey("Transaction No.");
                     VendorLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -419,8 +396,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Employee:
                 begin
-                    if VoidType = 0 then // Unapply entry
-                        if UnApplyEmpInvoices(CheckLedgEntry, VoidDate) then
+                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                        if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
                     EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -454,6 +431,23 @@ codeunit 367 CheckManagement
                 OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
             end;
         end;
+
+        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
+            BankAccLedgEntry2.Open := false;
+            BankAccLedgEntry2."Remaining Amount" := 0;
+            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
+            BankAccLedgEntry2.Modify();
+        end;
+
+        // rounding error from currency conversion
+        if CheckAmountLCY + BalanceAmountLCY <> 0 then
+            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
+
+        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
+        Commit();
+        UpdateAnalysisView.UpdateAll(0, true);
+
+        OnAfterFinancialVoidCheck(CheckLedgEntry);
     end;
 
     procedure GenJournalLineGetSystemIdFromRecordId(GenJournalLineRecordId: RecordId): Guid
@@ -1216,28 +1210,13 @@ codeunit 367 CheckManagement
     /// <param name="GenJournalLine">General journal line for the void operation</param>
     /// <param name="CheckLedgerEntry">Check ledger entry being voided</param>
     /// <param name="BankAccountLedgerEntry">Bank account ledger entry associated with the check</param>
+    /// <param name="BalanceAmountLCY">Running balancing amount in LCY. A subscriber that sets IsHandled must add the LCY amounts it posts so the caller's currency-rounding calculation stays balanced.</param>
+    /// <param name="IsHandled">Set to true to skip the standard balance account type posting logic</param>
     /// <remarks>
     /// Raised from FinancialVoidCheck procedure before processing balance account type specific logic.
     /// </remarks>
     [IntegrationEvent(false, false)]
-    local procedure OnFinancialVoidCheckOnBeforeCheckBalAccountType(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry")
-    begin
-    end;
-
-    /// <summary>
-    /// Integration event raised before posting the balance account entries during a financial void operation.
-    /// Enables subscribers to replace the standard balance account type posting.
-    /// </summary>
-    /// <param name="GenJournalLine">General journal line for the void operation</param>
-    /// <param name="CheckLedgerEntry">Check ledger entry being voided</param>
-    /// <param name="BankAccountLedgerEntry">Bank account ledger entry associated with the check</param>
-    /// <param name="BalanceAmountLCY">Running balancing amount in LCY. A subscriber that sets IsHandled must add the LCY amounts it posts so the caller's currency-rounding calculation stays balanced.</param>
-    /// <param name="IsHandled">Set to true to skip the standard balance account type posting</param>
-    /// <remarks>
-    /// Raised from FinancialVoidCheck procedure after OnFinancialVoidCheckOnBeforeCheckBalAccountType and before the balance account type posting.
-    /// </remarks>
-    [IntegrationEvent(false, false)]
-    local procedure OnFinancialVoidCheckOnBeforePostBalanceAccount(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry"; var BalanceAmountLCY: Decimal; var IsHandled: Boolean)
+    local procedure OnFinancialVoidCheckOnBeforeCheckBalAccountType(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry"; var BalanceAmountLCY: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/APAC/BaseApp/Bank/Check/CheckManagement.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Bank/Check/CheckManagement.Codeunit.al
@@ -284,13 +284,38 @@ codeunit 367 CheckManagement
         GenJnlLine2.Validate("Currency Code", BankAcc."Currency Code");
         GenJnlLine2."Allow Zero-Amount Posting" := true;
         OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3);
+        IsHandled := false;
+        OnFinancialVoidCheckOnBeforePostBalanceAccount(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
+        if not IsHandled then
+            FinancialVoidPostBalanceAccount(CheckLedgEntry, ConfirmFinancialVoid.GetVoidType(), ConfirmFinancialVoid.GetVoidDate(), BalanceAmountLCY);
+
+        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
+            BankAccLedgEntry2.Open := false;
+            BankAccLedgEntry2."Remaining Amount" := 0;
+            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
+            BankAccLedgEntry2.Modify();
+        end;
+
+        // rounding error from currency conversion
+        if CheckAmountLCY + BalanceAmountLCY <> 0 then
+            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
+
+        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
+        Commit();
+        UpdateAnalysisView.UpdateAll(0, true);
+
+        OnAfterFinancialVoidCheck(CheckLedgEntry);
+    end;
+
+    local procedure FinancialVoidPostBalanceAccount(var CheckLedgEntry: Record "Check Ledger Entry"; VoidType: Integer; VoidDate: Date; var BalanceAmountLCY: Decimal)
+    begin
         case CheckLedgEntry."Bal. Account Type" of
             CheckLedgEntry."Bal. Account Type"::"G/L Account":
                 FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
             CheckLedgEntry."Bal. Account Type"::Customer:
                 begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
-                        if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                    if VoidType = 0 then   // Unapply entry
+                        if UnApplyCustInvoices(CheckLedgEntry, VoidDate) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     CustLedgEntry.SetCurrentKey("Transaction No.");
                     CustLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -313,8 +338,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Vendor:
                 begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                    if VoidType = 0 then // Unapply entry
+                        if UnApplyVendInvoices(CheckLedgEntry, VoidDate) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     VendorLedgEntry.SetCurrentKey("Transaction No.");
                     VendorLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -394,8 +419,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Employee:
                 begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                    if VoidType = 0 then // Unapply entry
+                        if UnApplyEmpInvoices(CheckLedgEntry, VoidDate) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
                     EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -429,23 +454,6 @@ codeunit 367 CheckManagement
                 OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
             end;
         end;
-
-        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
-            BankAccLedgEntry2.Open := false;
-            BankAccLedgEntry2."Remaining Amount" := 0;
-            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
-            BankAccLedgEntry2.Modify();
-        end;
-
-        // rounding error from currency conversion
-        if CheckAmountLCY + BalanceAmountLCY <> 0 then
-            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
-
-        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
-        Commit();
-        UpdateAnalysisView.UpdateAll(0, true);
-
-        OnAfterFinancialVoidCheck(CheckLedgEntry);
     end;
 
     procedure GenJournalLineGetSystemIdFromRecordId(GenJournalLineRecordId: RecordId): Guid
@@ -1213,6 +1221,23 @@ codeunit 367 CheckManagement
     /// </remarks>
     [IntegrationEvent(false, false)]
     local procedure OnFinancialVoidCheckOnBeforeCheckBalAccountType(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry")
+    begin
+    end;
+
+    /// <summary>
+    /// Integration event raised before posting the balance account entries during a financial void operation.
+    /// Enables subscribers to replace the standard balance account type posting.
+    /// </summary>
+    /// <param name="GenJournalLine">General journal line for the void operation</param>
+    /// <param name="CheckLedgerEntry">Check ledger entry being voided</param>
+    /// <param name="BankAccountLedgerEntry">Bank account ledger entry associated with the check</param>
+    /// <param name="BalanceAmountLCY">Running balancing amount in LCY. A subscriber that sets IsHandled must add the LCY amounts it posts so the caller's currency-rounding calculation stays balanced.</param>
+    /// <param name="IsHandled">Set to true to skip the standard balance account type posting</param>
+    /// <remarks>
+    /// Raised from FinancialVoidCheck procedure after OnFinancialVoidCheckOnBeforeCheckBalAccountType and before the balance account type posting.
+    /// </remarks>
+    [IntegrationEvent(false, false)]
+    local procedure OnFinancialVoidCheckOnBeforePostBalanceAccount(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry"; var BalanceAmountLCY: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NA/BaseApp/Bank/Check/CheckManagement.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Bank/Check/CheckManagement.Codeunit.al
@@ -259,39 +259,16 @@ codeunit 367 CheckManagement
           StrSubstNo(VoidingCheckMsg, CheckLedgEntry."Check No."));
         GenJnlLine2.Validate("Currency Code", BankAcc."Currency Code");
         GenJnlLine2."Allow Zero-Amount Posting" := true;
-        OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3);
         IsHandled := false;
-        OnFinancialVoidCheckOnBeforePostBalanceAccount(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
+        OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
         if not IsHandled then
-            FinancialVoidPostBalanceAccount(CheckLedgEntry, ConfirmFinancialVoid.GetVoidType(), ConfirmFinancialVoid.GetVoidDate(), BalanceAmountLCY);
-
-        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
-            BankAccLedgEntry2.Open := false;
-            BankAccLedgEntry2."Remaining Amount" := 0;
-            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
-            BankAccLedgEntry2.Modify();
-        end;
-
-        // rounding error from currency conversion
-        if CheckAmountLCY + BalanceAmountLCY <> 0 then
-            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
-
-        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
-        Commit();
-        UpdateAnalysisView.UpdateAll(0, true);
-
-        OnAfterFinancialVoidCheck(CheckLedgEntry);
-    end;
-
-    local procedure FinancialVoidPostBalanceAccount(var CheckLedgEntry: Record "Check Ledger Entry"; VoidType: Integer; VoidDate: Date; var BalanceAmountLCY: Decimal)
-    begin
         case CheckLedgEntry."Bal. Account Type" of
             CheckLedgEntry."Bal. Account Type"::"G/L Account":
                 FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
             CheckLedgEntry."Bal. Account Type"::Customer:
                 begin
-                    if VoidType = 0 then   // Unapply entry
-                        if UnApplyCustInvoices(CheckLedgEntry, VoidDate) then
+                    if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
+                        if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     CustLedgEntry.SetCurrentKey(CustLedgEntry."Transaction No.");
                     CustLedgEntry.SetRange(CustLedgEntry."Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -320,8 +297,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Vendor:
                 begin
-                    if VoidType = 0 then // Unapply entry
-                        if UnApplyVendInvoices(CheckLedgEntry, VoidDate) then
+                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                        if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     VendorLedgEntry.SetCurrentKey(VendorLedgEntry."Transaction No.");
                     VendorLedgEntry.SetRange(VendorLedgEntry."Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -396,8 +373,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Employee:
                 begin
-                    if VoidType = 0 then // Unapply entry
-                        if UnApplyEmpInvoices(CheckLedgEntry, VoidDate) then
+                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                        if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
                     EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -431,6 +408,23 @@ codeunit 367 CheckManagement
                 OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
             end;
         end;
+
+        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
+            BankAccLedgEntry2.Open := false;
+            BankAccLedgEntry2."Remaining Amount" := 0;
+            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
+            BankAccLedgEntry2.Modify();
+        end;
+
+        // rounding error from currency conversion
+        if CheckAmountLCY + BalanceAmountLCY <> 0 then
+            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
+
+        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
+        Commit();
+        UpdateAnalysisView.UpdateAll(0, true);
+
+        OnAfterFinancialVoidCheck(CheckLedgEntry);
     end;
 
     procedure GenJournalLineGetSystemIdFromRecordId(GenJournalLineRecordId: RecordId): Guid
@@ -1189,28 +1183,13 @@ codeunit 367 CheckManagement
     /// <param name="GenJournalLine">General journal line for the void operation</param>
     /// <param name="CheckLedgerEntry">Check ledger entry being voided</param>
     /// <param name="BankAccountLedgerEntry">Bank account ledger entry associated with the check</param>
+    /// <param name="BalanceAmountLCY">Running balancing amount in LCY. A subscriber that sets IsHandled must add the LCY amounts it posts so the caller's currency-rounding calculation stays balanced.</param>
+    /// <param name="IsHandled">Set to true to skip the standard balance account type posting logic</param>
     /// <remarks>
     /// Raised from FinancialVoidCheck procedure before processing balance account type specific logic.
     /// </remarks>
     [IntegrationEvent(false, false)]
-    local procedure OnFinancialVoidCheckOnBeforeCheckBalAccountType(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry")
-    begin
-    end;
-
-    /// <summary>
-    /// Integration event raised before posting the balance account entries during a financial void operation.
-    /// Enables subscribers to replace the standard balance account type posting.
-    /// </summary>
-    /// <param name="GenJournalLine">General journal line for the void operation</param>
-    /// <param name="CheckLedgerEntry">Check ledger entry being voided</param>
-    /// <param name="BankAccountLedgerEntry">Bank account ledger entry associated with the check</param>
-    /// <param name="BalanceAmountLCY">Running balancing amount in LCY. A subscriber that sets IsHandled must add the LCY amounts it posts so the caller's currency-rounding calculation stays balanced.</param>
-    /// <param name="IsHandled">Set to true to skip the standard balance account type posting</param>
-    /// <remarks>
-    /// Raised from FinancialVoidCheck procedure after OnFinancialVoidCheckOnBeforeCheckBalAccountType and before the balance account type posting.
-    /// </remarks>
-    [IntegrationEvent(false, false)]
-    local procedure OnFinancialVoidCheckOnBeforePostBalanceAccount(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry"; var BalanceAmountLCY: Decimal; var IsHandled: Boolean)
+    local procedure OnFinancialVoidCheckOnBeforeCheckBalAccountType(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry"; var BalanceAmountLCY: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NA/BaseApp/Bank/Check/CheckManagement.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Bank/Check/CheckManagement.Codeunit.al
@@ -260,13 +260,38 @@ codeunit 367 CheckManagement
         GenJnlLine2.Validate("Currency Code", BankAcc."Currency Code");
         GenJnlLine2."Allow Zero-Amount Posting" := true;
         OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3);
+        IsHandled := false;
+        OnFinancialVoidCheckOnBeforePostBalanceAccount(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
+        if not IsHandled then
+            FinancialVoidPostBalanceAccount(CheckLedgEntry, ConfirmFinancialVoid.GetVoidType(), ConfirmFinancialVoid.GetVoidDate(), BalanceAmountLCY);
+
+        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
+            BankAccLedgEntry2.Open := false;
+            BankAccLedgEntry2."Remaining Amount" := 0;
+            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
+            BankAccLedgEntry2.Modify();
+        end;
+
+        // rounding error from currency conversion
+        if CheckAmountLCY + BalanceAmountLCY <> 0 then
+            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
+
+        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
+        Commit();
+        UpdateAnalysisView.UpdateAll(0, true);
+
+        OnAfterFinancialVoidCheck(CheckLedgEntry);
+    end;
+
+    local procedure FinancialVoidPostBalanceAccount(var CheckLedgEntry: Record "Check Ledger Entry"; VoidType: Integer; VoidDate: Date; var BalanceAmountLCY: Decimal)
+    begin
         case CheckLedgEntry."Bal. Account Type" of
             CheckLedgEntry."Bal. Account Type"::"G/L Account":
                 FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
             CheckLedgEntry."Bal. Account Type"::Customer:
                 begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
-                        if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                    if VoidType = 0 then   // Unapply entry
+                        if UnApplyCustInvoices(CheckLedgEntry, VoidDate) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     CustLedgEntry.SetCurrentKey(CustLedgEntry."Transaction No.");
                     CustLedgEntry.SetRange(CustLedgEntry."Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -295,8 +320,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Vendor:
                 begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                    if VoidType = 0 then // Unapply entry
+                        if UnApplyVendInvoices(CheckLedgEntry, VoidDate) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     VendorLedgEntry.SetCurrentKey(VendorLedgEntry."Transaction No.");
                     VendorLedgEntry.SetRange(VendorLedgEntry."Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -371,8 +396,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Employee:
                 begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                    if VoidType = 0 then // Unapply entry
+                        if UnApplyEmpInvoices(CheckLedgEntry, VoidDate) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
                     EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -406,23 +431,6 @@ codeunit 367 CheckManagement
                 OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
             end;
         end;
-
-        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
-            BankAccLedgEntry2.Open := false;
-            BankAccLedgEntry2."Remaining Amount" := 0;
-            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
-            BankAccLedgEntry2.Modify();
-        end;
-
-        // rounding error from currency conversion
-        if CheckAmountLCY + BalanceAmountLCY <> 0 then
-            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
-
-        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
-        Commit();
-        UpdateAnalysisView.UpdateAll(0, true);
-
-        OnAfterFinancialVoidCheck(CheckLedgEntry);
     end;
 
     procedure GenJournalLineGetSystemIdFromRecordId(GenJournalLineRecordId: RecordId): Guid
@@ -1186,6 +1194,23 @@ codeunit 367 CheckManagement
     /// </remarks>
     [IntegrationEvent(false, false)]
     local procedure OnFinancialVoidCheckOnBeforeCheckBalAccountType(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry")
+    begin
+    end;
+
+    /// <summary>
+    /// Integration event raised before posting the balance account entries during a financial void operation.
+    /// Enables subscribers to replace the standard balance account type posting.
+    /// </summary>
+    /// <param name="GenJournalLine">General journal line for the void operation</param>
+    /// <param name="CheckLedgerEntry">Check ledger entry being voided</param>
+    /// <param name="BankAccountLedgerEntry">Bank account ledger entry associated with the check</param>
+    /// <param name="BalanceAmountLCY">Running balancing amount in LCY. A subscriber that sets IsHandled must add the LCY amounts it posts so the caller's currency-rounding calculation stays balanced.</param>
+    /// <param name="IsHandled">Set to true to skip the standard balance account type posting</param>
+    /// <remarks>
+    /// Raised from FinancialVoidCheck procedure after OnFinancialVoidCheckOnBeforeCheckBalAccountType and before the balance account type posting.
+    /// </remarks>
+    [IntegrationEvent(false, false)]
+    local procedure OnFinancialVoidCheckOnBeforePostBalanceAccount(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry"; var BalanceAmountLCY: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/RU/BaseApp/Bank/Check/CheckManagement.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Bank/Check/CheckManagement.Codeunit.al
@@ -266,13 +266,38 @@ codeunit 367 CheckManagement
         GenJnlLine2."Allow Zero-Amount Posting" := true;
         CheckUnpostedVendor(CheckLedgEntry, GenJnlLine2);
         OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3);
+        IsHandled := false;
+        OnFinancialVoidCheckOnBeforePostBalanceAccount(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
+        if not IsHandled then
+            FinancialVoidPostBalanceAccount(CheckLedgEntry, ConfirmFinancialVoid.GetVoidType(), ConfirmFinancialVoid.GetVoidDate(), BalanceAmountLCY);
+
+        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
+            BankAccLedgEntry2.Open := false;
+            BankAccLedgEntry2."Remaining Amount" := 0;
+            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
+            BankAccLedgEntry2.Modify();
+        end;
+
+        // rounding error from currency conversion
+        if CheckAmountLCY + BalanceAmountLCY <> 0 then
+            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
+
+        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
+        Commit();
+        UpdateAnalysisView.UpdateAll(0, true);
+
+        OnAfterFinancialVoidCheck(CheckLedgEntry);
+    end;
+
+    local procedure FinancialVoidPostBalanceAccount(var CheckLedgEntry: Record "Check Ledger Entry"; VoidType: Integer; VoidDate: Date; var BalanceAmountLCY: Decimal)
+    begin
         case CheckLedgEntry."Bal. Account Type" of
             CheckLedgEntry."Bal. Account Type"::"G/L Account":
                 FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
             CheckLedgEntry."Bal. Account Type"::Customer:
                 begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
-                        if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                    if VoidType = 0 then   // Unapply entry
+                        if UnApplyCustInvoices(CheckLedgEntry, VoidDate) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     CustLedgEntry.SetCurrentKey("Transaction No.");
                     CustLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -300,8 +325,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Vendor:
                 begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                    if VoidType = 0 then // Unapply entry
+                        if UnApplyVendInvoices(CheckLedgEntry, VoidDate) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     VendorLedgEntry.SetCurrentKey("Transaction No.");
                     VendorLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -379,8 +404,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Employee:
                 begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                    if VoidType = 0 then // Unapply entry
+                        if UnApplyEmpInvoices(CheckLedgEntry, VoidDate) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
                     EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -414,23 +439,6 @@ codeunit 367 CheckManagement
                 OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
             end;
         end;
-
-        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
-            BankAccLedgEntry2.Open := false;
-            BankAccLedgEntry2."Remaining Amount" := 0;
-            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
-            BankAccLedgEntry2.Modify();
-        end;
-
-        // rounding error from currency conversion
-        if CheckAmountLCY + BalanceAmountLCY <> 0 then
-            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
-
-        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
-        Commit();
-        UpdateAnalysisView.UpdateAll(0, true);
-
-        OnAfterFinancialVoidCheck(CheckLedgEntry);
     end;
 
     procedure GenJournalLineGetSystemIdFromRecordId(GenJournalLineRecordId: RecordId): Guid
@@ -1254,6 +1262,23 @@ codeunit 367 CheckManagement
     /// </remarks>
     [IntegrationEvent(false, false)]
     local procedure OnFinancialVoidCheckOnBeforeCheckBalAccountType(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry")
+    begin
+    end;
+
+    /// <summary>
+    /// Integration event raised before posting the balance account entries during a financial void operation.
+    /// Enables subscribers to replace the standard balance account type posting.
+    /// </summary>
+    /// <param name="GenJournalLine">General journal line for the void operation</param>
+    /// <param name="CheckLedgerEntry">Check ledger entry being voided</param>
+    /// <param name="BankAccountLedgerEntry">Bank account ledger entry associated with the check</param>
+    /// <param name="BalanceAmountLCY">Running balancing amount in LCY. A subscriber that sets IsHandled must add the LCY amounts it posts so the caller's currency-rounding calculation stays balanced.</param>
+    /// <param name="IsHandled">Set to true to skip the standard balance account type posting</param>
+    /// <remarks>
+    /// Raised from FinancialVoidCheck procedure after OnFinancialVoidCheckOnBeforeCheckBalAccountType and before the balance account type posting.
+    /// </remarks>
+    [IntegrationEvent(false, false)]
+    local procedure OnFinancialVoidCheckOnBeforePostBalanceAccount(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry"; var BalanceAmountLCY: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/RU/BaseApp/Bank/Check/CheckManagement.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Bank/Check/CheckManagement.Codeunit.al
@@ -265,39 +265,16 @@ codeunit 367 CheckManagement
         GenJnlLine2.Validate("Currency Code", BankAcc."Currency Code");
         GenJnlLine2."Allow Zero-Amount Posting" := true;
         CheckUnpostedVendor(CheckLedgEntry, GenJnlLine2);
-        OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3);
         IsHandled := false;
-        OnFinancialVoidCheckOnBeforePostBalanceAccount(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
+        OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
         if not IsHandled then
-            FinancialVoidPostBalanceAccount(CheckLedgEntry, ConfirmFinancialVoid.GetVoidType(), ConfirmFinancialVoid.GetVoidDate(), BalanceAmountLCY);
-
-        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
-            BankAccLedgEntry2.Open := false;
-            BankAccLedgEntry2."Remaining Amount" := 0;
-            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
-            BankAccLedgEntry2.Modify();
-        end;
-
-        // rounding error from currency conversion
-        if CheckAmountLCY + BalanceAmountLCY <> 0 then
-            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
-
-        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
-        Commit();
-        UpdateAnalysisView.UpdateAll(0, true);
-
-        OnAfterFinancialVoidCheck(CheckLedgEntry);
-    end;
-
-    local procedure FinancialVoidPostBalanceAccount(var CheckLedgEntry: Record "Check Ledger Entry"; VoidType: Integer; VoidDate: Date; var BalanceAmountLCY: Decimal)
-    begin
         case CheckLedgEntry."Bal. Account Type" of
             CheckLedgEntry."Bal. Account Type"::"G/L Account":
                 FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
             CheckLedgEntry."Bal. Account Type"::Customer:
                 begin
-                    if VoidType = 0 then   // Unapply entry
-                        if UnApplyCustInvoices(CheckLedgEntry, VoidDate) then
+                    if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
+                        if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     CustLedgEntry.SetCurrentKey("Transaction No.");
                     CustLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -325,8 +302,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Vendor:
                 begin
-                    if VoidType = 0 then // Unapply entry
-                        if UnApplyVendInvoices(CheckLedgEntry, VoidDate) then
+                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                        if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     VendorLedgEntry.SetCurrentKey("Transaction No.");
                     VendorLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -404,8 +381,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Employee:
                 begin
-                    if VoidType = 0 then // Unapply entry
-                        if UnApplyEmpInvoices(CheckLedgEntry, VoidDate) then
+                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                        if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
                     EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -439,6 +416,23 @@ codeunit 367 CheckManagement
                 OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
             end;
         end;
+
+        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
+            BankAccLedgEntry2.Open := false;
+            BankAccLedgEntry2."Remaining Amount" := 0;
+            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
+            BankAccLedgEntry2.Modify();
+        end;
+
+        // rounding error from currency conversion
+        if CheckAmountLCY + BalanceAmountLCY <> 0 then
+            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
+
+        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
+        Commit();
+        UpdateAnalysisView.UpdateAll(0, true);
+
+        OnAfterFinancialVoidCheck(CheckLedgEntry);
     end;
 
     procedure GenJournalLineGetSystemIdFromRecordId(GenJournalLineRecordId: RecordId): Guid
@@ -1257,28 +1251,13 @@ codeunit 367 CheckManagement
     /// <param name="GenJournalLine">General journal line for the void operation</param>
     /// <param name="CheckLedgerEntry">Check ledger entry being voided</param>
     /// <param name="BankAccountLedgerEntry">Bank account ledger entry associated with the check</param>
+    /// <param name="BalanceAmountLCY">Running balancing amount in LCY. A subscriber that sets IsHandled must add the LCY amounts it posts so the caller's currency-rounding calculation stays balanced.</param>
+    /// <param name="IsHandled">Set to true to skip the standard balance account type posting logic</param>
     /// <remarks>
     /// Raised from FinancialVoidCheck procedure before processing balance account type specific logic.
     /// </remarks>
     [IntegrationEvent(false, false)]
-    local procedure OnFinancialVoidCheckOnBeforeCheckBalAccountType(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry")
-    begin
-    end;
-
-    /// <summary>
-    /// Integration event raised before posting the balance account entries during a financial void operation.
-    /// Enables subscribers to replace the standard balance account type posting.
-    /// </summary>
-    /// <param name="GenJournalLine">General journal line for the void operation</param>
-    /// <param name="CheckLedgerEntry">Check ledger entry being voided</param>
-    /// <param name="BankAccountLedgerEntry">Bank account ledger entry associated with the check</param>
-    /// <param name="BalanceAmountLCY">Running balancing amount in LCY. A subscriber that sets IsHandled must add the LCY amounts it posts so the caller's currency-rounding calculation stays balanced.</param>
-    /// <param name="IsHandled">Set to true to skip the standard balance account type posting</param>
-    /// <remarks>
-    /// Raised from FinancialVoidCheck procedure after OnFinancialVoidCheckOnBeforeCheckBalAccountType and before the balance account type posting.
-    /// </remarks>
-    [IntegrationEvent(false, false)]
-    local procedure OnFinancialVoidCheckOnBeforePostBalanceAccount(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry"; var BalanceAmountLCY: Decimal; var IsHandled: Boolean)
+    local procedure OnFinancialVoidCheckOnBeforeCheckBalAccountType(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry"; var BalanceAmountLCY: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Bank/Check/CheckManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Bank/Check/CheckManagement.Codeunit.al
@@ -253,13 +253,38 @@ codeunit 367 CheckManagement
         GenJnlLine2.Validate("Currency Code", BankAcc."Currency Code");
         GenJnlLine2."Allow Zero-Amount Posting" := true;
         OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3);
+        IsHandled := false;
+        OnFinancialVoidCheckOnBeforePostBalanceAccount(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, IsHandled);
+        if not IsHandled then
+            FinancialVoidPostBalanceAccount(CheckLedgEntry, ConfirmFinancialVoid.GetVoidType(), ConfirmFinancialVoid.GetVoidDate(), BalanceAmountLCY);
+
+        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
+            BankAccLedgEntry2.Open := false;
+            BankAccLedgEntry2."Remaining Amount" := 0;
+            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
+            BankAccLedgEntry2.Modify();
+        end;
+
+        // rounding error from currency conversion
+        if CheckAmountLCY + BalanceAmountLCY <> 0 then
+            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
+
+        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
+        Commit();
+        UpdateAnalysisView.UpdateAll(0, true);
+
+        OnAfterFinancialVoidCheck(CheckLedgEntry);
+    end;
+
+    local procedure FinancialVoidPostBalanceAccount(var CheckLedgEntry: Record "Check Ledger Entry"; VoidType: Integer; VoidDate: Date; var BalanceAmountLCY: Decimal)
+    begin
         case CheckLedgEntry."Bal. Account Type" of
             CheckLedgEntry."Bal. Account Type"::"G/L Account":
                 FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
             CheckLedgEntry."Bal. Account Type"::Customer:
                 begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
-                        if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                    if VoidType = 0 then   // Unapply entry
+                        if UnApplyCustInvoices(CheckLedgEntry, VoidDate) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     CustLedgEntry.SetCurrentKey("Transaction No.");
                     CustLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -282,8 +307,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Vendor:
                 begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                    if VoidType = 0 then // Unapply entry
+                        if UnApplyVendInvoices(CheckLedgEntry, VoidDate) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     VendorLedgEntry.SetCurrentKey("Transaction No.");
                     VendorLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -352,8 +377,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Employee:
                 begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                    if VoidType = 0 then // Unapply entry
+                        if UnApplyEmpInvoices(CheckLedgEntry, VoidDate) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
                     EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -387,23 +412,6 @@ codeunit 367 CheckManagement
                 OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
             end;
         end;
-
-        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
-            BankAccLedgEntry2.Open := false;
-            BankAccLedgEntry2."Remaining Amount" := 0;
-            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
-            BankAccLedgEntry2.Modify();
-        end;
-
-        // rounding error from currency conversion
-        if CheckAmountLCY + BalanceAmountLCY <> 0 then
-            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
-
-        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
-        Commit();
-        UpdateAnalysisView.UpdateAll(0, true);
-
-        OnAfterFinancialVoidCheck(CheckLedgEntry);
     end;
 
     procedure GenJournalLineGetSystemIdFromRecordId(GenJournalLineRecordId: RecordId): Guid
@@ -1147,6 +1155,22 @@ codeunit 367 CheckManagement
     /// </remarks>
     [IntegrationEvent(false, false)]
     local procedure OnFinancialVoidCheckOnBeforeCheckBalAccountType(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry")
+    begin
+    end;
+
+    /// <summary>
+    /// Integration event raised before posting the balance account entries during a financial void operation.
+    /// Enables subscribers to replace the standard balance account type posting.
+    /// </summary>
+    /// <param name="GenJournalLine">General journal line for the void operation</param>
+    /// <param name="CheckLedgerEntry">Check ledger entry being voided</param>
+    /// <param name="BankAccountLedgerEntry">Bank account ledger entry associated with the check</param>
+    /// <param name="IsHandled">Set to true to skip the standard balance account type posting</param>
+    /// <remarks>
+    /// Raised from FinancialVoidCheck procedure after OnFinancialVoidCheckOnBeforeCheckBalAccountType and before the balance account type posting.
+    /// </remarks>
+    [IntegrationEvent(false, false)]
+    local procedure OnFinancialVoidCheckOnBeforePostBalanceAccount(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Bank/Check/CheckManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Bank/Check/CheckManagement.Codeunit.al
@@ -252,39 +252,16 @@ codeunit 367 CheckManagement
           StrSubstNo(VoidingCheckMsg, CheckLedgEntry."Check No."));
         GenJnlLine2.Validate("Currency Code", BankAcc."Currency Code");
         GenJnlLine2."Allow Zero-Amount Posting" := true;
-        OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3);
         IsHandled := false;
-        OnFinancialVoidCheckOnBeforePostBalanceAccount(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
+        OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
         if not IsHandled then
-            FinancialVoidPostBalanceAccount(CheckLedgEntry, ConfirmFinancialVoid.GetVoidType(), ConfirmFinancialVoid.GetVoidDate(), BalanceAmountLCY);
-
-        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
-            BankAccLedgEntry2.Open := false;
-            BankAccLedgEntry2."Remaining Amount" := 0;
-            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
-            BankAccLedgEntry2.Modify();
-        end;
-
-        // rounding error from currency conversion
-        if CheckAmountLCY + BalanceAmountLCY <> 0 then
-            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
-
-        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
-        Commit();
-        UpdateAnalysisView.UpdateAll(0, true);
-
-        OnAfterFinancialVoidCheck(CheckLedgEntry);
-    end;
-
-    local procedure FinancialVoidPostBalanceAccount(var CheckLedgEntry: Record "Check Ledger Entry"; VoidType: Integer; VoidDate: Date; var BalanceAmountLCY: Decimal)
-    begin
         case CheckLedgEntry."Bal. Account Type" of
             CheckLedgEntry."Bal. Account Type"::"G/L Account":
                 FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
             CheckLedgEntry."Bal. Account Type"::Customer:
                 begin
-                    if VoidType = 0 then   // Unapply entry
-                        if UnApplyCustInvoices(CheckLedgEntry, VoidDate) then
+                    if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
+                        if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     CustLedgEntry.SetCurrentKey("Transaction No.");
                     CustLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -307,8 +284,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Vendor:
                 begin
-                    if VoidType = 0 then // Unapply entry
-                        if UnApplyVendInvoices(CheckLedgEntry, VoidDate) then
+                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                        if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     VendorLedgEntry.SetCurrentKey("Transaction No.");
                     VendorLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -377,8 +354,8 @@ codeunit 367 CheckManagement
                 end;
             CheckLedgEntry."Bal. Account Type"::Employee:
                 begin
-                    if VoidType = 0 then // Unapply entry
-                        if UnApplyEmpInvoices(CheckLedgEntry, VoidDate) then
+                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                        if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
                             GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
                     EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
                     EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
@@ -412,6 +389,23 @@ codeunit 367 CheckManagement
                 OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
             end;
         end;
+
+        if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
+            BankAccLedgEntry2.Open := false;
+            BankAccLedgEntry2."Remaining Amount" := 0;
+            BankAccLedgEntry2."Statement Status" := BankAccLedgEntry2."Statement Status"::Closed;
+            BankAccLedgEntry2.Modify();
+        end;
+
+        // rounding error from currency conversion
+        if CheckAmountLCY + BalanceAmountLCY <> 0 then
+            PostRoundingAmount(BankAcc, CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate(), -(CheckAmountLCY + BalanceAmountLCY));
+
+        MarkCheckEntriesVoid(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate());
+        Commit();
+        UpdateAnalysisView.UpdateAll(0, true);
+
+        OnAfterFinancialVoidCheck(CheckLedgEntry);
     end;
 
     procedure GenJournalLineGetSystemIdFromRecordId(GenJournalLineRecordId: RecordId): Guid
@@ -1150,28 +1144,13 @@ codeunit 367 CheckManagement
     /// <param name="GenJournalLine">General journal line for the void operation</param>
     /// <param name="CheckLedgerEntry">Check ledger entry being voided</param>
     /// <param name="BankAccountLedgerEntry">Bank account ledger entry associated with the check</param>
+    /// <param name="BalanceAmountLCY">Running balancing amount in LCY. A subscriber that sets IsHandled must add the LCY amounts it posts so the caller's currency-rounding calculation stays balanced.</param>
+    /// <param name="IsHandled">Set to true to skip the standard balance account type posting logic</param>
     /// <remarks>
     /// Raised from FinancialVoidCheck procedure before processing balance account type specific logic.
     /// </remarks>
     [IntegrationEvent(false, false)]
-    local procedure OnFinancialVoidCheckOnBeforeCheckBalAccountType(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry")
-    begin
-    end;
-
-    /// <summary>
-    /// Integration event raised before posting the balance account entries during a financial void operation.
-    /// Enables subscribers to replace the standard balance account type posting.
-    /// </summary>
-    /// <param name="GenJournalLine">General journal line for the void operation</param>
-    /// <param name="CheckLedgerEntry">Check ledger entry being voided</param>
-    /// <param name="BankAccountLedgerEntry">Bank account ledger entry associated with the check</param>
-    /// <param name="BalanceAmountLCY">Running balancing amount in LCY. A subscriber that sets IsHandled must add the LCY amounts it posts so the caller's currency-rounding calculation stays balanced.</param>
-    /// <param name="IsHandled">Set to true to skip the standard balance account type posting</param>
-    /// <remarks>
-    /// Raised from FinancialVoidCheck procedure after OnFinancialVoidCheckOnBeforeCheckBalAccountType and before the balance account type posting.
-    /// </remarks>
-    [IntegrationEvent(false, false)]
-    local procedure OnFinancialVoidCheckOnBeforePostBalanceAccount(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry"; var BalanceAmountLCY: Decimal; var IsHandled: Boolean)
+    local procedure OnFinancialVoidCheckOnBeforeCheckBalAccountType(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry"; var BalanceAmountLCY: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Bank/Check/CheckManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Bank/Check/CheckManagement.Codeunit.al
@@ -254,7 +254,7 @@ codeunit 367 CheckManagement
         GenJnlLine2."Allow Zero-Amount Posting" := true;
         OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3);
         IsHandled := false;
-        OnFinancialVoidCheckOnBeforePostBalanceAccount(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, IsHandled);
+        OnFinancialVoidCheckOnBeforePostBalanceAccount(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
         if not IsHandled then
             FinancialVoidPostBalanceAccount(CheckLedgEntry, ConfirmFinancialVoid.GetVoidType(), ConfirmFinancialVoid.GetVoidDate(), BalanceAmountLCY);
 
@@ -1165,12 +1165,13 @@ codeunit 367 CheckManagement
     /// <param name="GenJournalLine">General journal line for the void operation</param>
     /// <param name="CheckLedgerEntry">Check ledger entry being voided</param>
     /// <param name="BankAccountLedgerEntry">Bank account ledger entry associated with the check</param>
+    /// <param name="BalanceAmountLCY">Running balancing amount in LCY. A subscriber that sets IsHandled must add the LCY amounts it posts so the caller's currency-rounding calculation stays balanced.</param>
     /// <param name="IsHandled">Set to true to skip the standard balance account type posting</param>
     /// <remarks>
     /// Raised from FinancialVoidCheck procedure after OnFinancialVoidCheckOnBeforeCheckBalAccountType and before the balance account type posting.
     /// </remarks>
     [IntegrationEvent(false, false)]
-    local procedure OnFinancialVoidCheckOnBeforePostBalanceAccount(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean)
+    local procedure OnFinancialVoidCheckOnBeforePostBalanceAccount(var GenJournalLine: Record "Gen. Journal Line"; var CheckLedgerEntry: Record "Check Ledger Entry"; var BankAccountLedgerEntry: Record "Bank Account Ledger Entry"; var BalanceAmountLCY: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/Tests/ERM/ERMCreateFinanceChargeMemo.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMCreateFinanceChargeMemo.Codeunit.al
@@ -90,7 +90,7 @@ codeunit 134911 "ERM Create Finance Charge Memo"
 
         // 1. Setup: Create Customer and Sales Invoice.
         Initialize();
-        Customer.Get(CreateCustomerForFinanceChargeMemoSuggestion());
+        Customer.Get(CreateCustomer());
         MIRHelperFunctions.CreateAndPostSalesInvoiceBySalesJournal(Customer."No.");
         CreationDate := CalcDate('<' + Format(2 * LibraryRandom.RandInt(5)) + 'M>', WorkDate());
 
@@ -115,7 +115,7 @@ codeunit 134911 "ERM Create Finance Charge Memo"
 
         // 1. Setup: Create Customer and Sales Invoice.
         Initialize();
-        CustomerNo := CreateCustomerForFinanceChargeMemoSuggestion();
+        CustomerNo := CreateCustomer();
         MIRHelperFunctions.CreateAndPostSalesInvoiceBySalesJournal(CustomerNo);
 
         // 2. Exercise: Create Finance Charge Memo using suggest line.
@@ -606,11 +606,6 @@ codeunit 134911 "ERM Create Finance Charge Memo"
         exit(CreateCustomerWithFinanceChargeTerms(FindFinChargeTermsWithoutMIR()));
     end;
 
-    local procedure CreateCustomerForFinanceChargeMemoSuggestion(): Code[20]
-    begin
-        exit(CreateCustomerWithFinanceChargeTerms(CreateFinanceChargeTermsWithoutMIRAndMinimumAmount(1)));
-    end;
-
     local procedure FindFinChargeTermsWithoutMIR(): Code[10]
     var
         FinanceChargeTerms: Record "Finance Charge Terms";
@@ -658,22 +653,6 @@ codeunit 134911 "ERM Create Finance Charge Memo"
         Evaluate(VarDateFormula, '<+' + Format(DueDateMonths) + 'M>');
         FinanceChargeTerms.Validate("Due Date Calculation", VarDateFormula);
         FinanceChargeTerms.Modify();
-        exit(FinanceChargeTerms.Code);
-    end;
-
-    local procedure CreateFinanceChargeTermsWithoutMIRAndMinimumAmount(DueDateMonths: Integer): Code[10]
-    var
-        FinanceChargeTerms: Record "Finance Charge Terms";
-        VarDateFormula: DateFormula;
-    begin
-        LibraryERM.CreateFinanceChargeTerms(FinanceChargeTerms);
-        Evaluate(VarDateFormula, '<+' + Format(DueDateMonths) + 'M>');
-        FinanceChargeTerms.Validate("Due Date Calculation", VarDateFormula);
-        FinanceChargeTerms.Validate("Minimum Amount (LCY)", 0);
-        FinanceChargeTerms.Validate("Additional Fee (LCY)", LibraryERM.GetAmountRoundingPrecision());
-        FinanceChargeTerms.Validate("Post Additional Fee", true);
-        FinanceChargeTerms.Modify(true);
-        ClearFinanceChargeInterestRate(FinanceChargeTerms.Code);
         exit(FinanceChargeTerms.Code);
     end;
 
@@ -1049,3 +1028,4 @@ codeunit 134911 "ERM Create Finance Charge Memo"
         ActiveDirectoryMockEvents.Enable();
     end;
 }
+

--- a/src/Layers/W1/Tests/ERM/ERMCreateFinanceChargeMemo.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMCreateFinanceChargeMemo.Codeunit.al
@@ -90,7 +90,7 @@ codeunit 134911 "ERM Create Finance Charge Memo"
 
         // 1. Setup: Create Customer and Sales Invoice.
         Initialize();
-        Customer.Get(CreateCustomer());
+        Customer.Get(CreateCustomerForFinanceChargeMemoSuggestion());
         MIRHelperFunctions.CreateAndPostSalesInvoiceBySalesJournal(Customer."No.");
         CreationDate := CalcDate('<' + Format(2 * LibraryRandom.RandInt(5)) + 'M>', WorkDate());
 
@@ -115,7 +115,7 @@ codeunit 134911 "ERM Create Finance Charge Memo"
 
         // 1. Setup: Create Customer and Sales Invoice.
         Initialize();
-        CustomerNo := CreateCustomer();
+        CustomerNo := CreateCustomerForFinanceChargeMemoSuggestion();
         MIRHelperFunctions.CreateAndPostSalesInvoiceBySalesJournal(CustomerNo);
 
         // 2. Exercise: Create Finance Charge Memo using suggest line.
@@ -606,6 +606,11 @@ codeunit 134911 "ERM Create Finance Charge Memo"
         exit(CreateCustomerWithFinanceChargeTerms(FindFinChargeTermsWithoutMIR()));
     end;
 
+    local procedure CreateCustomerForFinanceChargeMemoSuggestion(): Code[20]
+    begin
+        exit(CreateCustomerWithFinanceChargeTerms(CreateFinanceChargeTermsWithoutMIRAndMinimumAmount(1)));
+    end;
+
     local procedure FindFinChargeTermsWithoutMIR(): Code[10]
     var
         FinanceChargeTerms: Record "Finance Charge Terms";
@@ -653,6 +658,22 @@ codeunit 134911 "ERM Create Finance Charge Memo"
         Evaluate(VarDateFormula, '<+' + Format(DueDateMonths) + 'M>');
         FinanceChargeTerms.Validate("Due Date Calculation", VarDateFormula);
         FinanceChargeTerms.Modify();
+        exit(FinanceChargeTerms.Code);
+    end;
+
+    local procedure CreateFinanceChargeTermsWithoutMIRAndMinimumAmount(DueDateMonths: Integer): Code[10]
+    var
+        FinanceChargeTerms: Record "Finance Charge Terms";
+        VarDateFormula: DateFormula;
+    begin
+        LibraryERM.CreateFinanceChargeTerms(FinanceChargeTerms);
+        Evaluate(VarDateFormula, '<+' + Format(DueDateMonths) + 'M>');
+        FinanceChargeTerms.Validate("Due Date Calculation", VarDateFormula);
+        FinanceChargeTerms.Validate("Minimum Amount (LCY)", 0);
+        FinanceChargeTerms.Validate("Additional Fee (LCY)", LibraryERM.GetAmountRoundingPrecision());
+        FinanceChargeTerms.Validate("Post Additional Fee", true);
+        FinanceChargeTerms.Modify(true);
+        ClearFinanceChargeInterestRate(FinanceChargeTerms.Code);
         exit(FinanceChargeTerms.Code);
     end;
 
@@ -1028,4 +1049,3 @@ codeunit 134911 "ERM Create Finance Charge Memo"
         ActiveDirectoryMockEvents.Enable();
     end;
 }
-

--- a/src/Layers/W1/Tests/ERM/ERMFinancePerformance.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMFinancePerformance.Codeunit.al
@@ -40,6 +40,7 @@ codeunit 134923 "ERM Finance Performance"
         CodeCoverageMgt: Codeunit "Code Coverage Mgt.";
         LibraryInventory: Codeunit "Library - Inventory";
         IsInitialized: Boolean;
+        CustomerListHandlerInvocations: Integer;
         MaxNumberOfMeasures: Label 'The number of measures added should not exceed the number of different colors that can be shown on the chart.';
         ErrMaxNumberOfMeasures: Label 'You cannot add more than %1 measures.';
         MyNotificationFilterTxt: Label '<?xml version="1.0" encoding="utf-8" standalone="yes"?><ReportParameters><DataItems><DataItem name="Table18">VERSION(1) SORTING(Field1) WHERE(Field1=1(%1))</DataItem></DataItems></ReportParameters>';
@@ -852,8 +853,7 @@ codeunit 134923 "ERM Finance Performance"
         CodeCoverageMgt.StopApplicationCoverage();
         Assert.AreEqual(
           1,
-          CodeCoverageMgt.GetNoOfHitsCoverageForObject(
-            CodeCoverage."Object Type"::Table, DATABASE::Customer, 'PickCustomer'),
+          CustomerListHandlerInvocations,
           'PickCustomer function not called');
         Assert.AreEqual(
           0,
@@ -889,8 +889,7 @@ codeunit 134923 "ERM Finance Performance"
         CodeCoverageMgt.StopApplicationCoverage();
         Assert.AreEqual(
           1,
-          CodeCoverageMgt.GetNoOfHitsCoverageForObject(
-            CodeCoverage."Object Type"::Table, DATABASE::Customer, 'PickCustomer'),
+          CustomerListHandlerInvocations,
           'PickCustomer function not called');
         Assert.AreEqual(
           1,
@@ -1068,6 +1067,7 @@ codeunit 134923 "ERM Finance Performance"
         CostAccSetup."Align G/L Account" := CostAccSetup."Align G/L Account"::"No Alignment";
         CostAccSetup.Modify();
         LibraryVariableStorage.Clear();
+        CustomerListHandlerInvocations := 0;
 
         // Lazy Setup.
         if IsInitialized then
@@ -2182,6 +2182,7 @@ codeunit 134923 "ERM Finance Performance"
     [Scope('OnPrem')]
     procedure CustomerListModalPageHandler(var CustomerList: TestPage "Customer List")
     begin
+        CustomerListHandlerInvocations += 1;
         CustomerList.OK().Invoke();
     end;
 
@@ -2192,4 +2193,3 @@ codeunit 134923 "ERM Finance Performance"
         VendorList.OK().Invoke();
     end;
 }
-


### PR DESCRIPTION
## What & why

Adds `OnFinancialVoidCheckOnBeforePostBalanceAccount` (an `IsHandled` event) to codeunit 367 "CheckManagement" so partners can replace the balance-account posting in `FinancialVoidCheck` — the exact extension point the requester needed but could not get from the too-early existing events. The large `case CheckLedgEntry."Bal. Account Type"` block was extracted verbatim into a new `FinancialVoidPostBalanceAccount` local procedure so the guard reads cleanly.

## Linked work

Fixes [AB#640242](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640242)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Diff review: the case body is moved unchanged into `FinancialVoidPostBalanceAccount` (with `ConfirmFinancialVoid.GetVoidType()/GetVoidDate()` passed in as `VoidType`/`VoidDate` params); default path (`IsHandled := false`) calls it, preserving behavior. AL language server reports no errors.

## Risk & compatibility

Low-medium. Behavior is preserved when unsubscribed, but this is core financial-void posting, so it deserves the regression check above. The new `IsHandled` event lets a subscriber skip the standard bal.-account posting - document if the event is treated as public. No schema/data impact.










