### PR TITLE
[TEST - DO NOT MERGE] Validate BCQuality DataClassification + Label-scope articles

### DIFF
--- a/src/Apps/W1/BCQualityClassificationValidation/app/app.json
+++ b/src/Apps/W1/BCQualityClassificationValidation/app/app.json
@@ -1,0 +1,29 @@
+{
+  "id": "2b88277b-ba73-4868-adaa-661f64c39122",
+  "name": "BCQuality Classification Validation",
+  "publisher": "Microsoft",
+  "brief": "Test sample that exercises the privacy DataClassification BCQuality article.",
+  "description": "Throwaway sample used only to validate the Copilot PR review against the updated privacy DataClassification and style Label-scope BCQuality articles. DO NOT MERGE.",
+  "version": "1.0.0.0",
+  "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
+  "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
+  "help": "https://go.microsoft.com/fwlink/?linkid=2009036",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
+  "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2115702",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "29.0.0.0",
+  "resourceExposurePolicy": {
+    "allowDebugging": false,
+    "allowDownloadingSource": true,
+    "includeSourceInSymbolFile": true
+  },
+  "application": "29.0.0.0",
+  "target": "Cloud",
+  "idRanges": [
+    {
+      "from": 50100,
+      "to": 50149
+    }
+  ]
+}

--- a/src/Apps/W1/BCQualityClassificationValidation/app/src/BCQValidationCustomer.Table.al
+++ b/src/Apps/W1/BCQualityClassificationValidation/app/src/BCQValidationCustomer.Table.al
@@ -1,0 +1,46 @@
+table 50100 "BCQ Validation Customer"
+{
+    Caption = 'BCQ Validation Customer';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+            Caption = 'No.';
+            DataClassification = CustomerContent;
+        }
+        field(2; "Full Name"; Text[100])
+        {
+            Caption = 'Full Name';
+            // Personal PII left unreviewed.
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Email Address"; Text[80])
+        {
+            Caption = 'Email Address';
+            // Real personal PII silenced by classifying it as platform metadata.
+            DataClassification = SystemMetadata;
+        }
+        field(4; "VAT Registration No."; Text[20])
+        {
+            Caption = 'VAT Registration No.';
+            // Company VAT / registration number.
+            DataClassification = ToBeClassified;
+        }
+        field(5; "IBAN"; Text[50])
+        {
+            Caption = 'IBAN';
+            // Bank account / IBAN.
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Apps/W1/BCQualityClassificationValidation/app/src/BCQValidationProcessor.Codeunit.al
+++ b/src/Apps/W1/BCQualityClassificationValidation/app/src/BCQValidationProcessor.Codeunit.al
@@ -1,0 +1,9 @@
+codeunit 50101 "BCQ Validation Processor"
+{
+    procedure GreetCustomer(var ValidationCustomer: Record "BCQ Validation Customer")
+    var
+        WelcomeMsg: Label 'Welcome, %1', Comment = '%1 = customer full name';
+    begin
+        Message(WelcomeMsg, ValidationCustomer."Full Name");
+    end;
+}


### PR DESCRIPTION
## ⚠️ TEST — DO NOT MERGE

Throwaway sample created only to **validate the Copilot PR-review agent** against two recently updated BCQuality articles. Close after the review has been inspected.

### What it seeds

`BCQValidationCustomer.Table.al` deliberately mis-classifies PII fields to exercise `privacy/data-classification-required-on-pii-fields`:

| Field | DataClassification | Expected finding |
|---|---|---|
| `Full Name` | `ToBeClassified` | Real personal PII left unreviewed → should be `EndUserIdentifiableInformation` / `CustomerContent` |
| `Email Address` | `SystemMetadata` | Real PII silenced as platform metadata → under-classification |
| `VAT Registration No.` | `ToBeClassified` | Company registration/VAT number → should be **`OrganizationIdentifiableInformation`** (new taxonomy) |
| `IBAN` | `ToBeClassified` | Bank account/IBAN → should be **`AccountData`** (new taxonomy) |

`BCQValidationProcessor.Codeunit.al` declares `WelcomeMsg` as a **local (procedure-scope) Label** to exercise `style/labels-declared-at-object-scope` — validating that it still surfaces at **minor** (not suppressed to info) after the severity-calibration change.

### How to validate

Run the review with `bcquality_ref` pointing at the updated BCQuality content, then confirm:
1. The DataClassification findings use the corrected "default is `ToBeClassified`" wording.
2. The VAT field is recommended `OrganizationIdentifiableInformation` and the IBAN field `AccountData`.
3. The local-scope Label finding is posted at minor severity.


