### PR TITLE
637301 Report layout override lifecycle

### DIFF
--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
@@ -40,6 +40,7 @@ page 9661 "Report Layout Edit Dialog"
                 ApplicationArea = Basic, Suite;
                 NotBlank = true;
                 ShowMandatory = true;
+                Editable = LayoutNameEditable;
                 Caption = 'Layout Name';
                 ToolTip = 'Specifies the name of the layout.';
 
@@ -74,16 +75,21 @@ page 9661 "Report Layout Edit Dialog"
 
                 trigger OnValidate()
                 begin
-                    if (CreateCopy) then
+                    // In override mode (extension layout) the user always chooses global vs company
+                    // scope, whether they override in place or opt into a copy.
+                    if OverrideMode then
                         AvailableInAllCompaniesEditable := true
                     else
-                        if (IsLayoutOwnedByCurrentCompany) then begin
-                            AvailableInAllCompaniesEditable := true;
-                            AvailableInAllCompanies := false;
-                        end else begin
-                            AvailableInAllCompaniesEditable := false;
-                            AvailableInAllCompanies := true;
-                        end;
+                        if (CreateCopy) then
+                            AvailableInAllCompaniesEditable := true
+                        else
+                            if (IsLayoutOwnedByCurrentCompany) then begin
+                                AvailableInAllCompaniesEditable := true;
+                                AvailableInAllCompanies := false;
+                            end else begin
+                                AvailableInAllCompaniesEditable := false;
+                                AvailableInAllCompanies := true;
+                            end;
                 end;
             }
             field(AvailableInAllCompanies; AvailableInAllCompanies)
@@ -98,7 +104,7 @@ page 9661 "Report Layout Edit Dialog"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Mark layout as obsolete';
                 ToolTip = 'Specifies whether the layout is obsolete.';
-                Editable = true;
+                Editable = IsObsoleteEditable;
             }
         }
     }
@@ -119,6 +125,9 @@ page 9661 "Report Layout Edit Dialog"
         AvailableInAllCompaniesEditable: Boolean;
         IsLayoutOwnedByCurrentCompany: Boolean;
         IsObsolete: Boolean;
+        LayoutNameEditable: Boolean;
+        IsObsoleteEditable: Boolean;
+        OverrideMode: Boolean;
 
     internal procedure SelectedLayoutDescription(): Text[250]
     begin
@@ -153,10 +162,20 @@ page 9661 "Report Layout Edit Dialog"
         OldLayoutName := ReportLayoutList."Caption";
         NewLayoutName := OldLayoutName;
         IsObsolete := ReportLayoutList.IsObsolete;
+        LayoutNameEditable := true;
+        IsObsoleteEditable := true;
+        OverrideMode := false;
 
         if not ReportLayoutList."User Defined" then begin
-            CreateCopy := true;
-            CreateCopyEditable := false;
+            // Override mode: edit the extension layout's Description / IsObsolete via a
+            // Tenant Report Layout Override record. The name/identity is fixed, and IsObsolete is
+            // one-way (a layout already obsolete in metadata cannot be un-obsoleted). Copy remains
+            // available as an opt-in escape hatch to fork the layout content into a user layout.
+            OverrideMode := true;
+            CreateCopy := false;
+            CreateCopyEditable := true;
+            LayoutNameEditable := false;
+            IsObsoleteEditable := not ReportLayoutList.IsObsolete;
             AvailableInAllCompaniesEditable := true;
             AvailableInAllCompanies := true;
 

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
@@ -79,9 +79,16 @@ page 9661 "Report Layout Edit Dialog"
                     // the Layout Name so the forked copy can be given a distinct name, and unlocks the
                     // layout-availability field — the copy is a normal tenant layout, so its company
                     // scope is chosen there (not by the override-scope control).
+                    // The two scope toggles are mutually exclusive: a copy writes a tenant layout and
+                    // NO override, so the override-scope control must not stay live (it would do
+                    // nothing); conversely an in-place override does not create a layout, so the
+                    // availability field stays read-only there.
                     if OverrideMode then begin
                         LayoutNameEditable := CreateCopy;
                         AvailableInAllCompaniesEditable := CreateCopy;
+                        OverrideForAllCompaniesEditable := not CreateCopy;
+                        if CreateCopy then
+                            OverrideForAllCompanies := false;
                     end else
                         if (CreateCopy) then
                             AvailableInAllCompaniesEditable := true
@@ -112,9 +119,9 @@ page 9661 "Report Layout Edit Dialog"
             {
                 ApplicationArea = Basic, Suite;
                 Caption = 'Override for all companies';
-                ToolTip = 'Specifies whether this override applies to all companies (global) or only the current company. The layout itself stays available everywhere; this controls only the scope of the override.';
+                ToolTip = 'Specifies whether this override applies to all companies (global) or only the current company. The layout itself stays available everywhere; this controls only the scope of the override. Not used when you save the changes to a copy — a copy is a new layout, and its availability is set above.';
                 Visible = OverrideMode;
-                Editable = OverrideMode;
+                Editable = OverrideForAllCompaniesEditable;
             }
             field(IsObsolete; IsObsolete)
             {
@@ -146,6 +153,7 @@ page 9661 "Report Layout Edit Dialog"
         IsObsoleteEditable: Boolean;
         OverrideMode: Boolean;
         OverrideForAllCompanies: Boolean;
+        OverrideForAllCompaniesEditable: Boolean;
 
     internal procedure SelectedLayoutDescription(): Text[250]
     begin
@@ -202,8 +210,9 @@ page 9661 "Report Layout Edit Dialog"
             // Override scope uses its own control and defaults to the CURRENT company (ask-first
             // before global) — NOT the "Available in All Companies" layout-availability field.
             OverrideForAllCompanies := false;
+            OverrideForAllCompaniesEditable := true;
             // Keep the shipped default for the copy escape hatch: a copy of an extension layout is
-            // created for all companies unless the user says otherwise (field shown once Copy is ticked).
+            // created for all companies unless the user says otherwise (unlocked once Copy is ticked).
             AvailableInAllCompanies := true;
             AvailableInAllCompaniesEditable := false;
 

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
@@ -86,9 +86,6 @@ page 9661 "Report Layout Edit Dialog"
                     if OverrideMode then begin
                         LayoutNameEditable := CreateCopy;
                         AvailableInAllCompaniesEditable := CreateCopy;
-                        OverrideForAllCompaniesEditable := not CreateCopy;
-                        if CreateCopy then
-                            OverrideForAllCompanies := false;
                     end else
                         if (CreateCopy) then
                             AvailableInAllCompaniesEditable := true
@@ -107,21 +104,11 @@ page 9661 "Report Layout Edit Dialog"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Available in All Companies';
                 ToolTip = 'Specifies whether the layout should be available in all companies or just the current company.';
-                // Always visible: `Visible` is evaluated when the page initialises and is NOT
-                // re-evaluated when a variable changes, so it cannot be revealed by ticking Copy.
-                // Editability carries the meaning instead — for an extension layout this field states
-                // the (true) fact that the layout is available everywhere and is read-only until the
-                // user opts into a copy, whose company scope it then controls. The *override* scope is
-                // a separate control, so the two meanings stay distinct.
+                // For an extension layout this states the (true) fact that the layout is available
+                // everywhere; it is read-only until the user opts into a copy, whose company scope it
+                // then controls. Editing an extension layout in place never changes availability — it
+                // writes an override for the CURRENT company only, with no scope choice to make.
                 Editable = AvailableInAllCompaniesEditable;
-            }
-            field(OverrideForAllCompanies; OverrideForAllCompanies)
-            {
-                ApplicationArea = Basic, Suite;
-                Caption = 'Override for all companies';
-                ToolTip = 'Specifies whether this override applies to all companies (global) or only the current company. The layout itself stays available everywhere; this controls only the scope of the override. Not used when you save the changes to a copy — a copy is a new layout, and its availability is set above.';
-                Visible = OverrideMode;
-                Editable = OverrideForAllCompaniesEditable;
             }
             field(IsObsolete; IsObsolete)
             {
@@ -152,8 +139,6 @@ page 9661 "Report Layout Edit Dialog"
         LayoutNameEditable: Boolean;
         IsObsoleteEditable: Boolean;
         OverrideMode: Boolean;
-        OverrideForAllCompanies: Boolean;
-        OverrideForAllCompaniesEditable: Boolean;
 
     internal procedure SelectedLayoutDescription(): Text[250]
     begin
@@ -168,11 +153,6 @@ page 9661 "Report Layout Edit Dialog"
     internal procedure SelectedAvailableInAllCompanies(): Boolean
     begin
         exit(AvailableInAllCompanies);
-    end;
-
-    internal procedure SelectedOverrideForAllCompanies(): Boolean
-    begin
-        exit(OverrideForAllCompanies);
     end;
 
     internal procedure SelectedIsObsolete(): Boolean
@@ -207,10 +187,9 @@ page 9661 "Report Layout Edit Dialog"
             CreateCopyEditable := true;
             LayoutNameEditable := false;
             IsObsoleteEditable := not ReportLayoutList.IsObsolete;
-            // Override scope uses its own control and defaults to the CURRENT company (ask-first
-            // before global) — NOT the "Available in All Companies" layout-availability field.
-            OverrideForAllCompanies := false;
-            OverrideForAllCompaniesEditable := true;
+            // No scope choice is offered here: an in-place edit of an extension layout always writes a
+            // CURRENT-COMPANY override. Tenant-wide (global) overrides are a governance act — see the
+            // task notes — and are deliberately kept out of this dialog.
             // Keep the shipped default for the copy escape hatch: a copy of an extension layout is
             // created for all companies unless the user says otherwise (unlocked once Copy is ticked).
             AvailableInAllCompanies := true;

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
@@ -75,10 +75,10 @@ page 9661 "Report Layout Edit Dialog"
 
                 trigger OnValidate()
                 begin
-                    // In override mode (extension layout) the user always chooses global vs company
-                    // scope, whether they override in place or opt into a copy.
+                    // In override mode (extension layout) checking "Save Changes to a Copy" re-enables
+                    // the Layout Name so the forked copy can be given a distinct name.
                     if OverrideMode then
-                        AvailableInAllCompaniesEditable := true
+                        LayoutNameEditable := CreateCopy
                     else
                         if (CreateCopy) then
                             AvailableInAllCompaniesEditable := true
@@ -98,6 +98,15 @@ page 9661 "Report Layout Edit Dialog"
                 Caption = 'Available in All Companies';
                 ToolTip = 'Specifies whether the layout should be available in all companies or just the current company.';
                 Editable = AvailableInAllCompaniesEditable;
+                Visible = not OverrideMode;
+            }
+            field(OverrideForAllCompanies; OverrideForAllCompanies)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Override for all companies';
+                ToolTip = 'Specifies whether this override applies to all companies (global) or only the current company. The layout itself stays available everywhere; this controls only the scope of the override.';
+                Visible = OverrideMode;
+                Editable = OverrideMode;
             }
             field(IsObsolete; IsObsolete)
             {
@@ -128,6 +137,7 @@ page 9661 "Report Layout Edit Dialog"
         LayoutNameEditable: Boolean;
         IsObsoleteEditable: Boolean;
         OverrideMode: Boolean;
+        OverrideForAllCompanies: Boolean;
 
     internal procedure SelectedLayoutDescription(): Text[250]
     begin
@@ -142,6 +152,11 @@ page 9661 "Report Layout Edit Dialog"
     internal procedure SelectedAvailableInAllCompanies(): Boolean
     begin
         exit(AvailableInAllCompanies);
+    end;
+
+    internal procedure SelectedOverrideForAllCompanies(): Boolean
+    begin
+        exit(OverrideForAllCompanies);
     end;
 
     internal procedure SelectedIsObsolete(): Boolean
@@ -176,8 +191,9 @@ page 9661 "Report Layout Edit Dialog"
             CreateCopyEditable := true;
             LayoutNameEditable := false;
             IsObsoleteEditable := not ReportLayoutList.IsObsolete;
-            AvailableInAllCompaniesEditable := true;
-            AvailableInAllCompanies := true;
+            // Override scope uses its own control and defaults to the CURRENT company (ask-first
+            // before global) — NOT the "Available in All Companies" layout-availability field.
+            OverrideForAllCompanies := false;
 
         end else begin
             CreateCopy := false;

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
@@ -76,13 +76,12 @@ page 9661 "Report Layout Edit Dialog"
                 trigger OnValidate()
                 begin
                     // In override mode (extension layout) checking "Save Changes to a Copy" re-enables
-                    // the Layout Name so the forked copy can be given a distinct name, and exposes the
+                    // the Layout Name so the forked copy can be given a distinct name, and unlocks the
                     // layout-availability field — the copy is a normal tenant layout, so its company
                     // scope is chosen there (not by the override-scope control).
                     if OverrideMode then begin
                         LayoutNameEditable := CreateCopy;
                         AvailableInAllCompaniesEditable := CreateCopy;
-                        CurrPage.Update(false);
                     end else
                         if (CreateCopy) then
                             AvailableInAllCompaniesEditable := true
@@ -101,10 +100,13 @@ page 9661 "Report Layout Edit Dialog"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Available in All Companies';
                 ToolTip = 'Specifies whether the layout should be available in all companies or just the current company.';
+                // Always visible: `Visible` is evaluated when the page initialises and is NOT
+                // re-evaluated when a variable changes, so it cannot be revealed by ticking Copy.
+                // Editability carries the meaning instead — for an extension layout this field states
+                // the (true) fact that the layout is available everywhere and is read-only until the
+                // user opts into a copy, whose company scope it then controls. The *override* scope is
+                // a separate control, so the two meanings stay distinct.
                 Editable = AvailableInAllCompaniesEditable;
-                // Hidden while overriding an extension layout (the layout is already available
-                // everywhere); shown again when the user opts into a copy, which IS a tenant layout.
-                Visible = (not OverrideMode) or CreateCopy;
             }
             field(OverrideForAllCompanies; OverrideForAllCompanies)
             {

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
@@ -104,10 +104,8 @@ page 9661 "Report Layout Edit Dialog"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Available in All Companies';
                 ToolTip = 'Specifies whether the layout should be available in all companies or just the current company.';
-                // For an extension layout this states the (true) fact that the layout is available
-                // everywhere; it is read-only until the user opts into a copy, whose company scope it
-                // then controls. Editing an extension layout in place never changes availability — it
-                // writes an override for the CURRENT company only, with no scope choice to make.
+                // States the layout's availability, not the override scope. For an extension layout it
+                // is a read-only fact until the user opts into a copy, whose company scope it then sets.
                 Editable = AvailableInAllCompaniesEditable;
             }
             field(IsObsolete; IsObsolete)
@@ -182,19 +180,19 @@ page 9661 "Report Layout Edit Dialog"
             // Tenant Report Layout Override record. The name/identity is fixed, and IsObsolete is
             // one-way (a layout already obsolete in metadata cannot be un-obsoleted). Copy remains
             // available as an opt-in escape hatch to fork the layout content into a user layout.
+            // No override-scope choice is offered: an in-place edit always writes a CURRENT-COMPANY
+            // override, because a tenant-wide (global) override is a governance act and is
+            // deliberately kept out of the everyday edit dialog.
             OverrideMode := true;
             CreateCopy := false;
             CreateCopyEditable := true;
             LayoutNameEditable := false;
             IsObsoleteEditable := not ReportLayoutList.IsObsolete;
-            // No scope choice is offered here: an in-place edit of an extension layout always writes a
-            // CURRENT-COMPANY override. Tenant-wide (global) overrides are a governance act — see the
-            // task notes — and are deliberately kept out of this dialog.
-            // Keep the shipped default for the copy escape hatch: a copy of an extension layout is
-            // created for all companies unless the user says otherwise (unlocked once Copy is ticked).
+
+            // Availability describes the copy, not the override: keep the shipped default (a copy of an
+            // extension layout is created for all companies) and unlock it only once Copy is ticked.
             AvailableInAllCompanies := true;
             AvailableInAllCompaniesEditable := false;
-
         end else begin
             CreateCopy := false;
             CreateCopyEditable := true;

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
@@ -159,6 +159,19 @@ page 9661 "Report Layout Edit Dialog"
         exit(OverrideForAllCompanies);
     end;
 
+    /// <summary>
+    /// Re-seeds the dialog when it is reopened after the user declined an all-companies override, so
+    /// their entries survive and only the scope is reset. Does not re-run SetupDialog (which would
+    /// discard the edits).
+    /// </summary>
+    internal procedure SetOverrideValues(NewDescription: Text[250]; NewIsObsolete: Boolean; ScopeIsGlobal: Boolean)
+    begin
+        Description := NewDescription;
+        if IsObsoleteEditable then
+            IsObsolete := NewIsObsolete;
+        OverrideForAllCompanies := ScopeIsGlobal;
+    end;
+
     internal procedure SelectedIsObsolete(): Boolean
     begin
         exit(IsObsolete);

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
@@ -76,10 +76,14 @@ page 9661 "Report Layout Edit Dialog"
                 trigger OnValidate()
                 begin
                     // In override mode (extension layout) checking "Save Changes to a Copy" re-enables
-                    // the Layout Name so the forked copy can be given a distinct name.
-                    if OverrideMode then
-                        LayoutNameEditable := CreateCopy
-                    else
+                    // the Layout Name so the forked copy can be given a distinct name, and exposes the
+                    // layout-availability field — the copy is a normal tenant layout, so its company
+                    // scope is chosen there (not by the override-scope control).
+                    if OverrideMode then begin
+                        LayoutNameEditable := CreateCopy;
+                        AvailableInAllCompaniesEditable := CreateCopy;
+                        CurrPage.Update(false);
+                    end else
                         if (CreateCopy) then
                             AvailableInAllCompaniesEditable := true
                         else
@@ -98,7 +102,9 @@ page 9661 "Report Layout Edit Dialog"
                 Caption = 'Available in All Companies';
                 ToolTip = 'Specifies whether the layout should be available in all companies or just the current company.';
                 Editable = AvailableInAllCompaniesEditable;
-                Visible = not OverrideMode;
+                // Hidden while overriding an extension layout (the layout is already available
+                // everywhere); shown again when the user opts into a copy, which IS a tenant layout.
+                Visible = (not OverrideMode) or CreateCopy;
             }
             field(OverrideForAllCompanies; OverrideForAllCompanies)
             {
@@ -159,19 +165,6 @@ page 9661 "Report Layout Edit Dialog"
         exit(OverrideForAllCompanies);
     end;
 
-    /// <summary>
-    /// Re-seeds the dialog when it is reopened after the user declined an all-companies override, so
-    /// their entries survive and only the scope is reset. Does not re-run SetupDialog (which would
-    /// discard the edits).
-    /// </summary>
-    internal procedure SetOverrideValues(NewDescription: Text[250]; NewIsObsolete: Boolean; ScopeIsGlobal: Boolean)
-    begin
-        Description := NewDescription;
-        if IsObsoleteEditable then
-            IsObsolete := NewIsObsolete;
-        OverrideForAllCompanies := ScopeIsGlobal;
-    end;
-
     internal procedure SelectedIsObsolete(): Boolean
     begin
         exit(IsObsolete);
@@ -207,6 +200,10 @@ page 9661 "Report Layout Edit Dialog"
             // Override scope uses its own control and defaults to the CURRENT company (ask-first
             // before global) — NOT the "Available in All Companies" layout-availability field.
             OverrideForAllCompanies := false;
+            // Keep the shipped default for the copy escape hatch: a copy of an extension layout is
+            // created for all companies unless the user says otherwise (field shown once Copy is ticked).
+            AvailableInAllCompanies := true;
+            AvailableInAllCompaniesEditable := false;
 
         end else begin
             CreateCopy := false;

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
@@ -75,10 +75,16 @@ page 9661 "Report Layout Edit Dialog"
 
                 trigger OnValidate()
                 begin
-                    // A copy is a normal tenant layout, so it needs its own name and company scope.
                     if OverrideMode then begin
                         LayoutNameEditable := CreateCopy;
                         AvailableInAllCompaniesEditable := CreateCopy;
+                        IsObsoleteEditable := CreateCopy or (not ObsoleteInMetadata);
+                        if not CreateCopy then begin
+                            // Back to an in-place override: restore the values it will actually write,
+                            // so a locked field never displays something the write contradicts.
+                            AvailableInAllCompanies := true;
+                            IsObsolete := ObsoleteInMetadata;
+                        end;
                     end else
                         if CreateCopy then
                             AvailableInAllCompaniesEditable := true
@@ -128,6 +134,7 @@ page 9661 "Report Layout Edit Dialog"
         LayoutNameEditable: Boolean;
         IsObsoleteEditable: Boolean;
         OverrideMode: Boolean;
+        ObsoleteInMetadata: Boolean;
 
     internal procedure SelectedLayoutDescription(): Text[250]
     begin
@@ -167,14 +174,13 @@ page 9661 "Report Layout Edit Dialog"
         OverrideMode := false;
 
         if not ReportLayoutList."User Defined" then begin
-            // Extension layout: the name is fixed and IsObsolete is one-way, so neither can be re-edited.
             OverrideMode := true;
+            ObsoleteInMetadata := ReportLayoutList.IsObsolete;
             CreateCopy := false;
             CreateCopyEditable := true;
             LayoutNameEditable := false;
-            IsObsoleteEditable := not ReportLayoutList.IsObsolete;
+            IsObsoleteEditable := not ObsoleteInMetadata;
 
-            // Read-only Yes: the override scope for an in-place edit. Ticking Copy unlocks it.
             AvailableInAllCompanies := true;
             AvailableInAllCompaniesEditable := false;
         end else begin

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
@@ -77,12 +77,10 @@ page 9661 "Report Layout Edit Dialog"
                 begin
                     // In override mode (extension layout) checking "Save Changes to a Copy" re-enables
                     // the Layout Name so the forked copy can be given a distinct name, and unlocks the
-                    // layout-availability field — the copy is a normal tenant layout, so its company
-                    // scope is chosen there (not by the override-scope control).
-                    // The two scope toggles are mutually exclusive: a copy writes a tenant layout and
-                    // NO override, so the override-scope control must not stay live (it would do
-                    // nothing); conversely an in-place override does not create a layout, so the
-                    // availability field stays read-only there.
+                    // availability field, because a copy is a normal tenant layout that needs its own
+                    // company scope chosen.
+                    // Unticked, the field stays read-only Yes: an in-place edit writes an all-companies
+                    // override and offers no alternative, so there is nothing to choose.
                     if OverrideMode then begin
                         LayoutNameEditable := CreateCopy;
                         AvailableInAllCompaniesEditable := CreateCopy;
@@ -104,8 +102,10 @@ page 9661 "Report Layout Edit Dialog"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Available in All Companies';
                 ToolTip = 'Specifies whether the layout should be available in all companies or just the current company.';
-                // States the layout's availability, not the override scope. For an extension layout it
-                // is a read-only fact until the user opts into a copy, whose company scope it then sets.
+                // For an in-place edit of an extension layout this states the scope the override is
+                // written at — all companies — and is read-only, because that is the only scope the
+                // everyday path offers. Opting into a copy makes it editable, where it sets the
+                // company scope of the new tenant layout instead.
                 Editable = AvailableInAllCompaniesEditable;
             }
             field(IsObsolete; IsObsolete)
@@ -180,17 +180,17 @@ page 9661 "Report Layout Edit Dialog"
             // Tenant Report Layout Override record. The name/identity is fixed, and IsObsolete is
             // one-way (a layout already obsolete in metadata cannot be un-obsoleted). Copy remains
             // available as an opt-in escape hatch to fork the layout content into a user layout.
-            // No override-scope choice is offered: an in-place edit always writes a CURRENT-COMPANY
-            // override, because a tenant-wide (global) override is a governance act and is
-            // deliberately kept out of the everyday edit dialog.
+            // No override-scope choice is offered: an in-place edit always writes an ALL-COMPANIES
+            // override, because an extension layout is the same layout in every company and the
+            // override records metadata about it rather than changing the layout itself.
             OverrideMode := true;
             CreateCopy := false;
             CreateCopyEditable := true;
             LayoutNameEditable := false;
             IsObsoleteEditable := not ReportLayoutList.IsObsolete;
 
-            // Availability describes the copy, not the override: keep the shipped default (a copy of an
-            // extension layout is created for all companies) and unlock it only once Copy is ticked.
+            // Read-only Yes: for an in-place edit this is the override scope, and it is not negotiable
+            // here. Ticking Copy unlocks it, where it then sets the company scope of the new copy.
             AvailableInAllCompanies := true;
             AvailableInAllCompaniesEditable := false;
         end else begin

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutEditDialog.page.al
@@ -75,20 +75,15 @@ page 9661 "Report Layout Edit Dialog"
 
                 trigger OnValidate()
                 begin
-                    // In override mode (extension layout) checking "Save Changes to a Copy" re-enables
-                    // the Layout Name so the forked copy can be given a distinct name, and unlocks the
-                    // availability field, because a copy is a normal tenant layout that needs its own
-                    // company scope chosen.
-                    // Unticked, the field stays read-only Yes: an in-place edit writes an all-companies
-                    // override and offers no alternative, so there is nothing to choose.
+                    // A copy is a normal tenant layout, so it needs its own name and company scope.
                     if OverrideMode then begin
                         LayoutNameEditable := CreateCopy;
                         AvailableInAllCompaniesEditable := CreateCopy;
                     end else
-                        if (CreateCopy) then
+                        if CreateCopy then
                             AvailableInAllCompaniesEditable := true
                         else
-                            if (IsLayoutOwnedByCurrentCompany) then begin
+                            if IsLayoutOwnedByCurrentCompany then begin
                                 AvailableInAllCompaniesEditable := true;
                                 AvailableInAllCompanies := false;
                             end else begin
@@ -102,10 +97,6 @@ page 9661 "Report Layout Edit Dialog"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Available in All Companies';
                 ToolTip = 'Specifies whether the layout should be available in all companies or just the current company.';
-                // For an in-place edit of an extension layout this states the scope the override is
-                // written at — all companies — and is read-only, because that is the only scope the
-                // everyday path offers. Opting into a copy makes it editable, where it sets the
-                // company scope of the new tenant layout instead.
                 Editable = AvailableInAllCompaniesEditable;
             }
             field(IsObsolete; IsObsolete)
@@ -176,21 +167,14 @@ page 9661 "Report Layout Edit Dialog"
         OverrideMode := false;
 
         if not ReportLayoutList."User Defined" then begin
-            // Override mode: edit the extension layout's Description / IsObsolete via a
-            // Tenant Report Layout Override record. The name/identity is fixed, and IsObsolete is
-            // one-way (a layout already obsolete in metadata cannot be un-obsoleted). Copy remains
-            // available as an opt-in escape hatch to fork the layout content into a user layout.
-            // No override-scope choice is offered: an in-place edit always writes an ALL-COMPANIES
-            // override, because an extension layout is the same layout in every company and the
-            // override records metadata about it rather than changing the layout itself.
+            // Extension layout: the name is fixed and IsObsolete is one-way, so neither can be re-edited.
             OverrideMode := true;
             CreateCopy := false;
             CreateCopyEditable := true;
             LayoutNameEditable := false;
             IsObsoleteEditable := not ReportLayoutList.IsObsolete;
 
-            // Read-only Yes: for an in-place edit this is the override scope, and it is not negotiable
-            // here. Ticking Copy unlocks it, where it then sets the company scope of the new copy.
+            // Read-only Yes: the override scope for an in-place edit. Ticking Copy unlocks it.
             AvailableInAllCompanies := true;
             AvailableInAllCompaniesEditable := false;
         end else begin

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
@@ -476,11 +476,16 @@ page 9660 "Report Layouts"
                 }
             }
 
+            // Status changes apply to both user-defined layouts (updated in place in Tenant Report
+            // Layout) and extension-installed layouts (written to Tenant Report Layout Override). The
+            // platform's BaseSystemPermissionSet grants both tables together, so gating on
+            // Tenant Report Layout = M correctly represents "may manage layout status" and matches the
+            // page's own Tenant Report Layout permission.
             action(SetApproved)
             {
                 ApplicationArea = Basic, Suite;
                 Caption = 'Set Approved';
-                ToolTip = 'Mark the selected user-defined layouts as approved. Only approved layouts are available for selection on report request pages.';
+                ToolTip = 'Mark the selected layouts as approved. Only approved layouts are available for selection on report request pages.';
                 Image = Approve;
                 Enabled = CanModifyStatus;
                 AccessByPermission = tabledata "Tenant Report Layout" = M;
@@ -494,7 +499,7 @@ page 9660 "Report Layouts"
             {
                 ApplicationArea = Basic, Suite;
                 Caption = 'Set Draft';
-                ToolTip = 'Mark the selected user-defined layouts as draft. Draft layouts are not available for selection on report request pages.';
+                ToolTip = 'Mark the selected layouts as draft. Draft layouts are not available for selection on report request pages.';
                 Image = OpenWorksheet;
                 Enabled = CanModifyStatus;
                 AccessByPermission = tabledata "Tenant Report Layout" = M;
@@ -508,7 +513,7 @@ page 9660 "Report Layouts"
             {
                 ApplicationArea = Basic, Suite;
                 Caption = 'Set Pending Approval';
-                ToolTip = 'Mark the selected user-defined layouts as pending approval. Pending layouts are not available for selection on report request pages.';
+                ToolTip = 'Mark the selected layouts as pending approval. Pending layouts are not available for selection on report request pages.';
                 Image = AddWatch;
                 Enabled = CanModifyStatus;
                 AccessByPermission = tabledata "Tenant Report Layout" = M;
@@ -522,7 +527,7 @@ page 9660 "Report Layouts"
             {
                 ApplicationArea = Basic, Suite;
                 Caption = 'Set Retired';
-                ToolTip = 'Mark the selected user-defined layouts as retired. Retired layouts are not available for selection on report request pages.';
+                ToolTip = 'Mark the selected layouts as retired. Retired layouts are not available for selection on report request pages.';
                 Image = Archive;
                 Enabled = CanModifyStatus;
                 AccessByPermission = tabledata "Tenant Report Layout" = M;

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
@@ -728,9 +728,9 @@ page 9660 "Report Layouts"
         IsMultiSelect := SelectedReportLayoutList.Count() > 1;
         ShareOptionsVisible := DocumentSharing.ShareEnabled(Enum::"Document Sharing Source"::System);
         ShareOptionsEnabled := LayoutIsSelected and (not IsMultiSelect) and Rec."User Defined" and (Rec."Layout Format" <> Rec."Layout Format"::RDLC);
-        SelectedReportLayoutList.SetRange("User Defined", true);
-        CanModifyStatus := LayoutIsSelected and not SelectedReportLayoutList.IsEmpty();
-        SelectedReportLayoutList.SetRange("User Defined");
+        // Both user-defined and extension-installed layouts can have their status changed: user-defined
+        // layouts are updated in place, extension layouts via a Tenant Report Layout Override record.
+        CanModifyStatus := LayoutIsSelected;
         UpdateUserDisplayName();
     end;
 

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
@@ -236,11 +236,10 @@ page 9660 "Report Layouts"
                 var
                     NewEditedLayoutName: Text;
                 begin
-                    if not Rec."User Defined" then begin
-                        if Dialog.Confirm(EditInfoExtensionLayoutTxt, false) then
-                            ReportLayoutsImpl.EditReportLayout(Rec, NewEditedLayoutName);
-                    end else
-                        ReportLayoutsImpl.EditReportLayout(Rec, NewEditedLayoutName);
+                    // Both user-defined and extension-installed layouts can be edited here. For an
+                    // extension layout the dialog writes a Tenant Report Layout Override record
+                    // (Description / IsObsolete) instead of copying the layout.
+                    ReportLayoutsImpl.EditReportLayout(Rec, NewEditedLayoutName);
                     SetFocusedRecord(Rec."Report ID", NewEditedLayoutName);
                 end;
             }
@@ -776,7 +775,6 @@ page 9660 "Report Layouts"
         DocumentReportExperienceEnabled: Boolean;
         WordLayoutSelected: Boolean;
         ModifyNonUserLayoutErr: Label 'Only user-defined layouts can be modified or removed.';
-        EditInfoExtensionLayoutTxt: Label 'It is not possible to modify the layout info for this layout because it is provided by an extension. Do you want to edit a copy of the layout instead ?';
         ReplaceConfirmationTxt: Label 'This action will replace the layout file of the currently selected layout "%1". Do you want to continue ?', Comment = '%1 = LayoutName';
         LayoutStatusChangedMsg: Label '%1 layout(s) set to %2.', Comment = '%1 = Number of layouts updated, %2 = Status name';
         DeletePartWithReferencesQst: Label 'Layout part "%1" is referenced in the Tenant Report Layout Configuration. Deleting it will clear those references and may result in reports rendering without the expected header/footer or theme. Do you want to continue?', Comment = '%1 = Layout Name';

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
@@ -726,7 +726,6 @@ page 9660 "Report Layouts"
         IsMultiSelect := SelectedReportLayoutList.Count() > 1;
         ShareOptionsVisible := DocumentSharing.ShareEnabled(Enum::"Document Sharing Source"::System);
         ShareOptionsEnabled := LayoutIsSelected and (not IsMultiSelect) and Rec."User Defined" and (Rec."Layout Format" <> Rec."Layout Format"::RDLC);
-        // Extension layouts can now have their status changed too, via an override record.
         CanModifyStatus := LayoutIsSelected;
         UpdateUserDisplayName();
     end;

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
@@ -236,9 +236,6 @@ page 9660 "Report Layouts"
                 var
                     NewEditedLayoutName: Text;
                 begin
-                    // Both user-defined and extension-installed layouts can be edited here. For an
-                    // extension layout the dialog writes a Tenant Report Layout Override record
-                    // (Description / IsObsolete) instead of copying the layout.
                     ReportLayoutsImpl.EditReportLayout(Rec, NewEditedLayoutName);
                     SetFocusedRecord(Rec."Report ID", NewEditedLayoutName);
                 end;
@@ -476,11 +473,8 @@ page 9660 "Report Layouts"
                 }
             }
 
-            // Status changes apply to both user-defined layouts (updated in place in Tenant Report
-            // Layout) and extension-installed layouts (written to Tenant Report Layout Override). The
-            // platform's BaseSystemPermissionSet grants both tables together, so gating on
-            // Tenant Report Layout = M correctly represents "may manage layout status" and matches the
-            // page's own Tenant Report Layout permission.
+            // BaseSystemPermissionSet grants Tenant Report Layout and its override table together, so
+            // gating on Tenant Report Layout = M covers both.
             action(SetApproved)
             {
                 ApplicationArea = Basic, Suite;
@@ -732,8 +726,7 @@ page 9660 "Report Layouts"
         IsMultiSelect := SelectedReportLayoutList.Count() > 1;
         ShareOptionsVisible := DocumentSharing.ShareEnabled(Enum::"Document Sharing Source"::System);
         ShareOptionsEnabled := LayoutIsSelected and (not IsMultiSelect) and Rec."User Defined" and (Rec."Layout Format" <> Rec."Layout Format"::RDLC);
-        // Both user-defined and extension-installed layouts can have their status changed: user-defined
-        // layouts are updated in place, extension layouts via a Tenant Report Layout Override record.
+        // Extension layouts can now have their status changed too, via an override record.
         CanModifyStatus := LayoutIsSelected;
         UpdateUserDisplayName();
     end;

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -44,6 +44,8 @@ codeunit 9660 "Report Layouts Impl."
         EmptyLayoutNameTxt: Label 'A layout name must be specified.';
         CannotUpdateLayoutTxt: Label 'The Layout could not be updated for export. The exported file will contain the original layout.';
         LayoutAlreadyExistsErr: Label 'A layout named "%1" already exists.', Comment = '%1 = Layout Name';
+        MixedScopeErr: Label 'The selected layouts have different scopes. Some apply to all companies and some only to the current company. Select layouts of a single scope and try again.';
+        GlobalScopeConfirmQst: Label 'One or more of the selected layouts apply to all companies. Changing the status will affect all companies, not only the current one. Do you want to continue?';
 
     internal procedure SetSelectedCompany(NewCompanyName: Text)
     begin
@@ -66,8 +68,10 @@ codeunit 9660 "Report Layouts Impl."
     begin
         if not ReportLayoutList."User Defined" then begin
             // Extension-installed layout: override the status rather than copying the layout.
-            // Company-specific by default (see CP0529-338 open question Q1 on scope).
-            UpsertLayoutOverride(ReportLayoutList, false, false, '', true, NewStatus, false, false);
+            // A layout that already has a global override is updated globally; otherwise the status
+            // override is company-specific (see CP0529-338 Q1). Mixed-scope selections and the
+            // global confirmation are handled by SetLayoutStatusBatch before this point.
+            UpsertLayoutOverride(ReportLayoutList, LayoutStatusIsGlobalScope(ReportLayoutList), false, '', true, NewStatus, false, false);
             exit(true);
         end;
 
@@ -77,6 +81,21 @@ codeunit 9660 "Report Layouts Impl."
             exit(true);
         end;
         exit(false);
+    end;
+
+    /// <summary>
+    /// Determines whether a status change to an extension-installed layout applies globally.
+    /// A company-specific override for the current company takes precedence (company scope); otherwise
+    /// an existing global override means the layout is global-scope. A layout with no override defaults
+    /// to company scope.
+    /// </summary>
+    local procedure LayoutStatusIsGlobalScope(ReportLayoutList: Record "Report Layout List"): Boolean
+    var
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+    begin
+        if TenantReportLayoutOverride.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", SelectedCompany) then
+            exit(false);
+        exit(TenantReportLayoutOverride.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''));
     end;
 
     /// <summary>
@@ -140,9 +159,33 @@ codeunit 9660 "Report Layouts Impl."
     var
         CustomDimensions: Dictionary of [Text, Text];
         UpdateCount: Integer;
+        HasGlobalScope: Boolean;
+        HasCompanyScope: Boolean;
     begin
         if not ReportLayoutList.FindSet() then
             exit(0);
+
+        // First pass: classify the scope of the extension-installed layouts in the selection.
+        // User-defined layouts update in place and are not part of the scope decision.
+        repeat
+            if not ReportLayoutList."User Defined" then
+                if LayoutStatusIsGlobalScope(ReportLayoutList) then
+                    HasGlobalScope := true
+                else
+                    HasCompanyScope := true;
+        until ReportLayoutList.Next() = 0;
+
+        // Keep each run to a single scope so the effect is unambiguous.
+        if HasGlobalScope and HasCompanyScope then
+            Error(MixedScopeErr);
+
+        // A global-scope change affects every company, so make the user confirm it explicitly.
+        if HasGlobalScope then
+            if not Confirm(GlobalScopeConfirmQst, false) then
+                exit(0);
+
+        // Second pass: apply the status change.
+        ReportLayoutList.FindSet();
         repeat
             if SetLayoutStatus(ReportLayoutList, NewStatus) then
                 UpdateCount += 1;

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -672,6 +672,21 @@ codeunit 9660 "Report Layouts Impl."
             AvailableInAllCompanies := ReportLayoutEditDialog.SelectedAvailableInAllCompanies();
             NewIsObsolete := ReportLayoutEditDialog.SelectedIsObsolete();
 
+            // Extension-installed layout, edited in place (not copied): write an override for the
+            // mutable properties (Description, IsObsolete) instead of copying the layout. The layout
+            // name/identity cannot change here, so NewLayoutName is not used.
+            if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then begin
+                UpsertLayoutOverride(SelectedReportLayoutList, AvailableInAllCompanies, true, NewDescription, false, Enum::"Report Layout Status"::Draft, true, NewIsObsolete);
+                NewEditedLayoutName := SelectedReportLayoutList.Name;
+
+                CustomDimensions.Add('ReportId', Format(SelectedReportLayoutList."Report ID"));
+                CustomDimensions.Add('LayoutName', SelectedReportLayoutList.Name);
+                CustomDimensions.Add('NewLayoutDescription', NewDescription);
+                AddReportLayoutDimensionsAction('EditOverride', CustomDimensions);
+                Log('0000N0H', 'Report layout properties overridden by user', CustomDimensions);
+                exit;
+            end;
+
             // Check if a layout having NewLayoutName already exists
             if TenantReportLayout.Get(SelectedReportLayoutList."Report ID", NewLayoutName, EmptyGuid) then
                 if CreateCopy or (SelectedReportLayoutList.Name <> NewLayoutName) then

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -21,7 +21,8 @@ codeunit 9660 "Report Layouts Impl."
 {
     Access = Internal;
     Permissions = tabledata "Tenant Report Layout" = rimd,
-                  tabledata "Tenant Report Layout Selection" = rimd;
+                  tabledata "Tenant Report Layout Selection" = rimd,
+                  tabledata "Tenant Report Layout Override" = rimd;
 
     var
         TenantReportLayoutSelection: Record "Tenant Report Layout Selection";
@@ -50,19 +51,25 @@ codeunit 9660 "Report Layouts Impl."
     end;
 
     /// <summary>
-    /// Sets the status for a user-defined layout.
-    /// Only user-defined layouts have entries in "Tenant Report Layout" (table 2000000232).
-    /// Extension-defined layouts reside in the read-only App database and cannot be modified.
+    /// Sets the status for a layout.
+    /// User-defined layouts are updated in place in "Tenant Report Layout" (table 2000000232).
+    /// Extension-installed layouts reside in the read-only App database; their status is set by
+    /// writing an override record in "Tenant Report Layout Override" (table 2000000248) instead of
+    /// copying the layout into the tenant table.
     /// </summary>
     /// <param name="ReportLayoutList">The layout record from the virtual table</param>
     /// <param name="NewStatus">The new status to set</param>
-    /// <returns>True if the status was updated, false if the layout is not user-defined or not found</returns>
+    /// <returns>True if the status was updated, false if the user-defined layout was not found</returns>
     internal procedure SetLayoutStatus(ReportLayoutList: Record "Report Layout List"; NewStatus: Enum "Report Layout Status"): Boolean
     var
         TenantReportLayout: Record "Tenant Report Layout";
     begin
-        if not ReportLayoutList."User Defined" then
-            exit(false);
+        if not ReportLayoutList."User Defined" then begin
+            // Extension-installed layout: override the status rather than copying the layout.
+            // Company-specific by default (see CP0529-338 open question Q1 on scope).
+            UpsertLayoutOverride(ReportLayoutList, false, false, '', true, NewStatus, false, false);
+            exit(true);
+        end;
 
         if TenantReportLayout.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", EmptyGuid) then begin
             TenantReportLayout."Layout Status" := NewStatus;
@@ -70,6 +77,56 @@ codeunit 9660 "Report Layouts Impl."
             exit(true);
         end;
         exit(false);
+    end;
+
+    /// <summary>
+    /// Creates or updates a "Tenant Report Layout Override" record for an extension-installed layout.
+    /// Only the fields flagged by the corresponding Apply* parameter are written, together with their
+    /// "Override *" flag; unset fields pass through from the layout metadata unchanged. "IsObsolete" is
+    /// one-way: it can only ever be set to true and never clears a layout that is obsolete in metadata.
+    /// </summary>
+    /// <param name="ReportLayoutList">The (extension-installed) layout row from the virtual table</param>
+    /// <param name="MakeGlobal">True writes a global override (empty Company Name); false writes one scoped to the selected company</param>
+    local procedure UpsertLayoutOverride(ReportLayoutList: Record "Report Layout List"; MakeGlobal: Boolean; ApplyDescription: Boolean; NewDescription: Text[250]; ApplyStatus: Boolean; NewStatus: Enum "Report Layout Status"; ApplyObsolete: Boolean; NewIsObsolete: Boolean)
+    var
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        OverrideCompanyName: Text[30];
+        OverrideExists: Boolean;
+    begin
+        if MakeGlobal then
+            OverrideCompanyName := ''
+        else
+            OverrideCompanyName := SelectedCompany;
+
+        OverrideExists := TenantReportLayoutOverride.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", OverrideCompanyName);
+        if not OverrideExists then begin
+            TenantReportLayoutOverride.Init();
+            TenantReportLayoutOverride."Report ID" := ReportLayoutList."Report ID";
+            TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
+            TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
+            TenantReportLayoutOverride."Company Name" := OverrideCompanyName;
+        end;
+
+        if ApplyDescription then begin
+            TenantReportLayoutOverride.Description := NewDescription;
+            TenantReportLayoutOverride."Override Description" := true;
+        end;
+
+        if ApplyStatus then begin
+            TenantReportLayoutOverride."Layout Status" := NewStatus;
+            TenantReportLayoutOverride."Override Layout Status" := true;
+        end;
+
+        // One-way: only ever mark obsolete; never write false over a metadata-obsolete layout.
+        if ApplyObsolete and NewIsObsolete then begin
+            TenantReportLayoutOverride.IsObsolete := true;
+            TenantReportLayoutOverride."Override IsObsolete" := true;
+        end;
+
+        if OverrideExists then
+            TenantReportLayoutOverride.Modify(true)
+        else
+            TenantReportLayoutOverride.Insert(true);
     end;
 
     /// <summary>

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -95,17 +95,25 @@ codeunit 9660 "Report Layouts Impl."
 
     /// <summary>
     /// Determines whether a status change to an extension-installed layout applies globally.
-    /// A company-specific override for the current company takes precedence (company scope); otherwise
-    /// an existing global override means the layout is global-scope. A layout with no override defaults
-    /// to company scope.
+    /// "Tenant Report Layout Override" is field-granular, so scope must be resolved from the field that
+    /// is about to change: only a row that actually sets "Override Layout Status" tells us where the
+    /// effective status comes from. A current-company status override wins (company scope); otherwise a
+    /// global status override means global scope. A layout whose status is not overridden anywhere
+    /// defaults to company scope, so a description-only or obsolete-only row on either side never drags
+    /// the status change into the wrong scope.
     /// </summary>
     local procedure LayoutStatusIsGlobalScope(ReportLayoutList: Record "Report Layout List"): Boolean
     var
         TenantReportLayoutOverride: Record "Tenant Report Layout Override";
     begin
         if TenantReportLayoutOverride.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", SelectedCompany) then
-            exit(false);
-        exit(TenantReportLayoutOverride.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''));
+            if TenantReportLayoutOverride."Override Layout Status" then
+                exit(false);
+
+        if TenantReportLayoutOverride.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", '') then
+            exit(TenantReportLayoutOverride."Override Layout Status");
+
+        exit(false);
     end;
 
     /// <summary>

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -84,6 +84,16 @@ codeunit 9660 "Report Layouts Impl."
     end;
 
     /// <summary>
+    /// Renders the override scope for telemetry as a stable, non-localized token.
+    /// </summary>
+    local procedure ScopeDimension(IsGlobal: Boolean): Text
+    begin
+        if IsGlobal then
+            exit('AllCompanies');
+        exit('CurrentCompany');
+    end;
+
+    /// <summary>
     /// Determines whether a status change to an extension-installed layout applies globally.
     /// A company-specific override for the current company takes precedence (company scope); otherwise
     /// an existing global override means the layout is global-scope. A layout with no override defaults
@@ -740,13 +750,20 @@ codeunit 9660 "Report Layouts Impl."
             if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then begin
                 UpsertLayoutOverride(SelectedReportLayoutList, AvailableInAllCompanies, ApplyDescription, NewDescription, false, Enum::"Report Layout Status"::Draft, ApplyObsolete, NewIsObsolete);
 
-                // TODO (Slice 4 C/D): telemetry disabled while testing. The previous Log reused event
-                // id '0000N0H' (dimension-schema clash with the Edit path) and shipped the free-text
-                // description (PII). Re-enable with a dedicated event id and no content dimension.
-                // CustomDimensions.Add('ReportId', Format(SelectedReportLayoutList."Report ID"));
-                // CustomDimensions.Add('LayoutName', SelectedReportLayoutList.Name);
-                // AddReportLayoutDimensionsAction('EditOverride', CustomDimensions);
-                // Log('0000N0H', 'Report layout properties overridden by user', CustomDimensions);
+                // Telemetry for the override path uses its OWN event id '0000RTQ', freshly allocated
+                // from the number series. It is deliberately not the Edit path's '0000N0H': that event
+                // carries a different custom-dimension schema (Old/New layout name and description),
+                // and reusing it here would change the meaning of an id existing queries already
+                // consume. The dimensions below are metadata only — the layout description is
+                // user-entered free text and is reported as a changed/not-changed flag rather than
+                // its content.
+                CustomDimensions.Add('ReportId', Format(SelectedReportLayoutList."Report ID"));
+                CustomDimensions.Add('LayoutName', SelectedReportLayoutList.Name);
+                CustomDimensions.Add('DescriptionChanged', Format(ApplyDescription));
+                CustomDimensions.Add('ObsoleteSet', Format(ApplyObsolete));
+                CustomDimensions.Add('OverrideScope', ScopeDimension(AvailableInAllCompanies));
+                AddReportLayoutDimensionsAction('EditOverride', CustomDimensions);
+                Log('0000RTQ', 'Report layout properties overridden by user', CustomDimensions);
                 exit;
             end;
 

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -46,8 +46,6 @@ codeunit 9660 "Report Layouts Impl."
         LayoutAlreadyExistsErr: Label 'A layout named "%1" already exists.', Comment = '%1 = Layout Name';
         MixedScopeErr: Label 'The selected layouts have different scopes. Some apply to all companies and some only to the current company. Select layouts of a single scope and try again.';
         GlobalScopeConfirmQst: Label 'One or more of the selected layouts apply to all companies. Changing the status will affect all companies, not only the current one. Do you want to continue?';
-        GlobalOverrideConfirmQst: Label 'This override will apply to all companies, not only the current one. Do you want to continue?\\Choose No to discard the changes without applying them. To apply them to the current company only, reopen Edit info and leave "Override for all companies" clear.';
-        NoChangesAppliedMsg: Label 'No changes were applied. To change this layout for the current company only, reopen Edit info and leave "Override for all companies" clear.';
 
     internal procedure SetSelectedCompany(NewCompanyName: Text)
     begin
@@ -721,12 +719,12 @@ codeunit 9660 "Report Layouts Impl."
             AvailableInAllCompanies := ReportLayoutEditDialog.SelectedAvailableInAllCompanies();
             NewIsObsolete := ReportLayoutEditDialog.SelectedIsObsolete();
 
-            // For an extension layout edited IN PLACE the scope comes from the dedicated "Override for
-            // all companies" control. A copy is an ordinary tenant layout, so its company scope keeps
-            // coming from "Available in All Companies" (read above) — the override control must not
-            // decide where the copy lives.
+            // An extension layout edited IN PLACE always overrides for the CURRENT company: the
+            // tenant-wide (global) decision is a governance act and is not offered here. A copy is an
+            // ordinary tenant layout, so its company scope keeps coming from "Available in All
+            // Companies" (read above).
             if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then
-                AvailableInAllCompanies := ReportLayoutEditDialog.SelectedOverrideForAllCompanies();
+                AvailableInAllCompanies := false;
 
             // Extension-installed layout, edited in place (not copied): write an override for only the
             // properties the user actually changed (a no-op OK writes nothing). IsObsolete is one-way.
@@ -737,17 +735,6 @@ codeunit 9660 "Report Layouts Impl."
                 ApplyObsolete := NewIsObsolete and (not SelectedReportLayoutList.IsObsolete);
                 if not (ApplyDescription or ApplyObsolete) then
                     exit;
-                // Declining the all-companies scope abandons the edit — say so explicitly, so the user
-                // isn't left wondering whether the change was applied to this company at least.
-                // (Reopening the dialog with the entries preserved is not possible here: an AL Page
-                // variable cannot be run twice without Clear(), which would discard those entries.)
-                // Nested ifs on purpose: AL does not short-circuit `and`, so combining these would
-                // call Confirm even for a company-scoped edit.
-                if AvailableInAllCompanies then
-                    if not Confirm(GlobalOverrideConfirmQst, false) then begin
-                        Message(NoChangesAppliedMsg);
-                        exit;
-                    end;
             end;
 
             if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then begin

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -68,8 +68,8 @@ codeunit 9660 "Report Layouts Impl."
     begin
         if not ReportLayoutList."User Defined" then begin
             // Extension-installed layout: override the status rather than copying the layout.
-            // A layout that already has a global override is updated globally; otherwise the status
-            // override is company-specific (see CP0529-338 Q1). Mixed-scope selections and the
+            // A layout whose status is already overridden globally is updated globally; otherwise the
+            // status override is company-specific (see CP0529-338 Q1). Mixed-scope selections and the
             // global confirmation are handled by SetLayoutStatusBatch before this point.
             UpsertLayoutOverride(ReportLayoutList, LayoutStatusIsGlobalScope(ReportLayoutList), false, '', true, NewStatus, false, false);
             exit(true);
@@ -172,7 +172,8 @@ codeunit 9660 "Report Layouts Impl."
     /// </summary>
     /// <param name="ReportLayoutList">Record set with selected layouts (filtered/marked)</param>
     /// <param name="NewStatus">The new status to set</param>
-    /// <returns>Number of layouts updated (excludes extension-defined layouts)</returns>
+    /// <returns>Number of layouts updated — user-defined layouts in place, extension-installed layouts
+    /// through a "Tenant Report Layout Override" record</returns>
     internal procedure SetLayoutStatusBatch(var ReportLayoutList: Record "Report Layout List"; NewStatus: Enum "Report Layout Status"): Integer
     var
         CustomDimensions: Dictionary of [Text, Text];
@@ -737,34 +738,31 @@ codeunit 9660 "Report Layouts Impl."
             AvailableInAllCompanies := ReportLayoutEditDialog.SelectedAvailableInAllCompanies();
             NewIsObsolete := ReportLayoutEditDialog.SelectedIsObsolete();
 
-            // An extension layout edited IN PLACE always overrides for the CURRENT company: the
-            // tenant-wide (global) decision is a governance act and is not offered here. A copy is an
-            // ordinary tenant layout, so its company scope keeps coming from "Available in All
-            // Companies" (read above).
-            if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then
+            // Extension-installed layout, edited in place (not copied): write an override record rather
+            // than copying the layout. Only the properties the user actually changed are written, so
+            // pressing OK without editing anything writes nothing at all; IsObsolete is one-way.
+            if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then begin
+                // Such an edit always overrides for the CURRENT company: the tenant-wide (global)
+                // decision is a governance act and is deliberately not offered in the everyday edit
+                // dialog. A copy is an ordinary tenant layout, so its company scope keeps coming from
+                // "Available in All Companies" and is handled further below.
                 AvailableInAllCompanies := false;
 
-            // Extension-installed layout, edited in place (not copied): write an override for only the
-            // properties the user actually changed (a no-op OK writes nothing). IsObsolete is one-way.
-            // Ask first before an all-companies (global) override.
-            if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then begin
                 NewEditedLayoutName := SelectedReportLayoutList.Name;
                 ApplyDescription := NewDescription <> SelectedReportLayoutList."Description";
                 ApplyObsolete := NewIsObsolete and (not SelectedReportLayoutList.IsObsolete);
                 if not (ApplyDescription or ApplyObsolete) then
                     exit;
-            end;
 
-            if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then begin
                 UpsertLayoutOverride(SelectedReportLayoutList, AvailableInAllCompanies, ApplyDescription, NewDescription, false, Enum::"Report Layout Status"::Draft, ApplyObsolete, NewIsObsolete);
 
-                // Telemetry for the override path uses its OWN event id '0000RTQ', freshly allocated
-                // from the number series. It is deliberately not the Edit path's '0000N0H': that event
-                // carries a different custom-dimension schema (Old/New layout name and description),
-                // and reusing it here would change the meaning of an id existing queries already
-                // consume. The dimensions below are metadata only — the layout description is
-                // user-entered free text and is reported as a changed/not-changed flag rather than
-                // its content.
+                // Telemetry for the override path uses its OWN event id, freshly allocated from the
+                // number series rather than reusing the one the user-defined Edit path logs under:
+                // that event carries a different custom-dimension schema (Old/New layout name and
+                // description), and reusing it here would change the meaning of an id existing
+                // queries already consume. The dimensions below are metadata only — the layout
+                // description is user-entered free text and is reported as a changed/not-changed
+                // flag rather than its content.
                 CustomDimensions.Add('ReportId', Format(SelectedReportLayoutList."Report ID"));
                 CustomDimensions.Add('LayoutName', SelectedReportLayoutList.Name);
                 CustomDimensions.Add('DescriptionChanged', Format(ApplyDescription));

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -46,7 +46,8 @@ codeunit 9660 "Report Layouts Impl."
         LayoutAlreadyExistsErr: Label 'A layout named "%1" already exists.', Comment = '%1 = Layout Name';
         MixedScopeErr: Label 'The selected layouts have different scopes. Some apply to all companies and some only to the current company. Select layouts of a single scope and try again.';
         GlobalScopeConfirmQst: Label 'One or more of the selected layouts apply to all companies. Changing the status will affect all companies, not only the current one. Do you want to continue?';
-        GlobalOverrideConfirmQst: Label 'This override will apply to all companies, not only the current one. Do you want to continue?\\Choose No to go back to the dialog with your changes, where you can apply them to the current company only.';
+        GlobalOverrideConfirmQst: Label 'This override will apply to all companies, not only the current one. Do you want to continue?\\Choose No to discard the changes without applying them. To apply them to the current company only, reopen Edit info and leave "Override for all companies" clear.';
+        NoChangesAppliedMsg: Label 'No changes were applied. To change this layout for the current company only, reopen Edit info and leave "Override for all companies" clear.';
 
     internal procedure SetSelectedCompany(NewCompanyName: Text)
     begin
@@ -701,7 +702,6 @@ codeunit 9660 "Report Layouts Impl."
         NewIsObsolete: Boolean;
         ApplyDescription: Boolean;
         ApplyObsolete: Boolean;
-        ReopenForScope: Boolean;
         CustomDimensions: Dictionary of [Text, Text];
     begin
         if SelectedReportLayoutList."User Defined" then begin
@@ -711,8 +711,7 @@ codeunit 9660 "Report Layouts Impl."
             CompanyName := SelectedCompany;
 
         ReportLayoutEditDialog.SetupDialog(SelectedReportLayoutList, SelectedCompany);
-        repeat
-            ReopenForScope := false;
+        begin
             if ReportLayoutEditDialog.RunModal() <> Action::OK then
                 exit;
 
@@ -722,9 +721,11 @@ codeunit 9660 "Report Layouts Impl."
             AvailableInAllCompanies := ReportLayoutEditDialog.SelectedAvailableInAllCompanies();
             NewIsObsolete := ReportLayoutEditDialog.SelectedIsObsolete();
 
-            // For an extension layout the override scope comes from the dedicated "Override for all
-            // companies" control, not the (layout-availability) "Available in All Companies" field.
-            if not SelectedReportLayoutList."User Defined" then
+            // For an extension layout edited IN PLACE the scope comes from the dedicated "Override for
+            // all companies" control. A copy is an ordinary tenant layout, so its company scope keeps
+            // coming from "Available in All Companies" (read above) — the override control must not
+            // decide where the copy lives.
+            if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then
                 AvailableInAllCompanies := ReportLayoutEditDialog.SelectedOverrideForAllCompanies();
 
             // Extension-installed layout, edited in place (not copied): write an override for only the
@@ -736,22 +737,19 @@ codeunit 9660 "Report Layouts Impl."
                 ApplyObsolete := NewIsObsolete and (not SelectedReportLayoutList.IsObsolete);
                 if not (ApplyDescription or ApplyObsolete) then
                     exit;
-                // Declining the all-companies scope must NOT throw away what the user typed: reopen the
-                // dialog with their values, scope reset to the current company, so they can save it
-                // company-scoped (or cancel deliberately).
+                // Declining the all-companies scope abandons the edit — say so explicitly, so the user
+                // isn't left wondering whether the change was applied to this company at least.
+                // (Reopening the dialog with the entries preserved is not possible here: an AL Page
+                // variable cannot be run twice without Clear(), which would discard those entries.)
                 // Nested ifs on purpose: AL does not short-circuit `and`, so combining these would
                 // call Confirm even for a company-scoped edit.
                 if AvailableInAllCompanies then
                     if not Confirm(GlobalOverrideConfirmQst, false) then begin
-                        ReportLayoutEditDialog.SetOverrideValues(NewDescription, NewIsObsolete, false);
-                        ReopenForScope := true;
+                        Message(NoChangesAppliedMsg);
+                        exit;
                     end;
             end;
-        until not ReopenForScope;
 
-        // The dialog values are settled at this point (scope question answered). Block kept so the
-        // paths below — override write, copy, in-place user-defined edit — stay as they were.
-        begin
             if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then begin
                 UpsertLayoutOverride(SelectedReportLayoutList, AvailableInAllCompanies, ApplyDescription, NewDescription, false, Enum::"Report Layout Status"::Draft, ApplyObsolete, NewIsObsolete);
 

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -739,10 +739,13 @@ codeunit 9660 "Report Layouts Impl."
                 // Declining the all-companies scope must NOT throw away what the user typed: reopen the
                 // dialog with their values, scope reset to the current company, so they can save it
                 // company-scoped (or cancel deliberately).
-                if AvailableInAllCompanies and (not Confirm(GlobalOverrideConfirmQst, false)) then begin
-                    ReportLayoutEditDialog.SetOverrideValues(NewDescription, NewIsObsolete, false);
-                    ReopenForScope := true;
-                end;
+                // Nested ifs on purpose: AL does not short-circuit `and`, so combining these would
+                // call Confirm even for a company-scoped edit.
+                if AvailableInAllCompanies then
+                    if not Confirm(GlobalOverrideConfirmQst, false) then begin
+                        ReportLayoutEditDialog.SetOverrideValues(NewDescription, NewIsObsolete, false);
+                        ReopenForScope := true;
+                    end;
             end;
         until not ReopenForScope;
 

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -46,6 +46,7 @@ codeunit 9660 "Report Layouts Impl."
         LayoutAlreadyExistsErr: Label 'A layout named "%1" already exists.', Comment = '%1 = Layout Name';
         MixedScopeErr: Label 'The selected layouts have different scopes. Some apply to all companies and some only to the current company. Select layouts of a single scope and try again.';
         GlobalScopeConfirmQst: Label 'One or more of the selected layouts apply to all companies. Changing the status will affect all companies, not only the current one. Do you want to continue?';
+        GlobalOverrideConfirmQst: Label 'This override will apply to all companies, not only the current one. Do you want to continue?';
 
     internal procedure SetSelectedCompany(NewCompanyName: Text)
     begin
@@ -698,6 +699,8 @@ codeunit 9660 "Report Layouts Impl."
         AllCompaniesTxt: Label '';
         AvailableInAllCompanies: Boolean;
         NewIsObsolete: Boolean;
+        ApplyDescription: Boolean;
+        ApplyObsolete: Boolean;
         CustomDimensions: Dictionary of [Text, Text];
     begin
         if SelectedReportLayoutList."User Defined" then begin
@@ -715,18 +718,32 @@ codeunit 9660 "Report Layouts Impl."
             AvailableInAllCompanies := ReportLayoutEditDialog.SelectedAvailableInAllCompanies();
             NewIsObsolete := ReportLayoutEditDialog.SelectedIsObsolete();
 
-            // Extension-installed layout, edited in place (not copied): write an override for the
-            // mutable properties (Description, IsObsolete) instead of copying the layout. The layout
-            // name/identity cannot change here, so NewLayoutName is not used.
-            if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then begin
-                UpsertLayoutOverride(SelectedReportLayoutList, AvailableInAllCompanies, true, NewDescription, false, Enum::"Report Layout Status"::Draft, true, NewIsObsolete);
-                NewEditedLayoutName := SelectedReportLayoutList.Name;
+            // For an extension layout the override scope comes from the dedicated "Override for all
+            // companies" control, not the (layout-availability) "Available in All Companies" field.
+            if not SelectedReportLayoutList."User Defined" then
+                AvailableInAllCompanies := ReportLayoutEditDialog.SelectedOverrideForAllCompanies();
 
-                CustomDimensions.Add('ReportId', Format(SelectedReportLayoutList."Report ID"));
-                CustomDimensions.Add('LayoutName', SelectedReportLayoutList.Name);
-                CustomDimensions.Add('NewLayoutDescription', NewDescription);
-                AddReportLayoutDimensionsAction('EditOverride', CustomDimensions);
-                Log('0000N0H', 'Report layout properties overridden by user', CustomDimensions);
+            // Extension-installed layout, edited in place (not copied): write an override for only the
+            // properties the user actually changed (a no-op OK writes nothing). IsObsolete is one-way.
+            // Ask first before an all-companies (global) override.
+            if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then begin
+                NewEditedLayoutName := SelectedReportLayoutList.Name;
+                ApplyDescription := NewDescription <> SelectedReportLayoutList."Description";
+                ApplyObsolete := NewIsObsolete and (not SelectedReportLayoutList.IsObsolete);
+                if not (ApplyDescription or ApplyObsolete) then
+                    exit;
+                if AvailableInAllCompanies then
+                    if not Confirm(GlobalOverrideConfirmQst, false) then
+                        exit;
+                UpsertLayoutOverride(SelectedReportLayoutList, AvailableInAllCompanies, ApplyDescription, NewDescription, false, Enum::"Report Layout Status"::Draft, ApplyObsolete, NewIsObsolete);
+
+                // TODO (Slice 4 C/D): telemetry disabled while testing. The previous Log reused event
+                // id '0000N0H' (dimension-schema clash with the Edit path) and shipped the free-text
+                // description (PII). Re-enable with a dedicated event id and no content dimension.
+                // CustomDimensions.Add('ReportId', Format(SelectedReportLayoutList."Report ID"));
+                // CustomDimensions.Add('LayoutName', SelectedReportLayoutList.Name);
+                // AddReportLayoutDimensionsAction('EditOverride', CustomDimensions);
+                // Log('0000N0H', 'Report layout properties overridden by user', CustomDimensions);
                 exit;
             end;
 

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -46,7 +46,7 @@ codeunit 9660 "Report Layouts Impl."
         LayoutAlreadyExistsErr: Label 'A layout named "%1" already exists.', Comment = '%1 = Layout Name';
         MixedScopeErr: Label 'The selected layouts have different scopes. Some apply to all companies and some only to the current company. Select layouts of a single scope and try again.';
         GlobalScopeConfirmQst: Label 'One or more of the selected layouts apply to all companies. Changing the status will affect all companies, not only the current one. Do you want to continue?';
-        GlobalOverrideConfirmQst: Label 'This override will apply to all companies, not only the current one. Do you want to continue?';
+        GlobalOverrideConfirmQst: Label 'This override will apply to all companies, not only the current one. Do you want to continue?\\Choose No to go back to the dialog with your changes, where you can apply them to the current company only.';
 
     internal procedure SetSelectedCompany(NewCompanyName: Text)
     begin
@@ -701,6 +701,7 @@ codeunit 9660 "Report Layouts Impl."
         NewIsObsolete: Boolean;
         ApplyDescription: Boolean;
         ApplyObsolete: Boolean;
+        ReopenForScope: Boolean;
         CustomDimensions: Dictionary of [Text, Text];
     begin
         if SelectedReportLayoutList."User Defined" then begin
@@ -710,7 +711,10 @@ codeunit 9660 "Report Layouts Impl."
             CompanyName := SelectedCompany;
 
         ReportLayoutEditDialog.SetupDialog(SelectedReportLayoutList, SelectedCompany);
-        if ReportLayoutEditDialog.RunModal() = Action::OK then begin
+        repeat
+            ReopenForScope := false;
+            if ReportLayoutEditDialog.RunModal() <> Action::OK then
+                exit;
 
             NewDescription := ReportLayoutEditDialog.SelectedLayoutDescription();
             NewLayoutName := ReportLayoutEditDialog.SelectedLayoutName();
@@ -732,9 +736,20 @@ codeunit 9660 "Report Layouts Impl."
                 ApplyObsolete := NewIsObsolete and (not SelectedReportLayoutList.IsObsolete);
                 if not (ApplyDescription or ApplyObsolete) then
                     exit;
-                if AvailableInAllCompanies then
-                    if not Confirm(GlobalOverrideConfirmQst, false) then
-                        exit;
+                // Declining the all-companies scope must NOT throw away what the user typed: reopen the
+                // dialog with their values, scope reset to the current company, so they can save it
+                // company-scoped (or cancel deliberately).
+                if AvailableInAllCompanies and (not Confirm(GlobalOverrideConfirmQst, false)) then begin
+                    ReportLayoutEditDialog.SetOverrideValues(NewDescription, NewIsObsolete, false);
+                    ReopenForScope := true;
+                end;
+            end;
+        until not ReopenForScope;
+
+        // The dialog values are settled at this point (scope question answered). Block kept so the
+        // paths below — override write, copy, in-place user-defined edit — stay as they were.
+        begin
+            if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then begin
                 UpsertLayoutOverride(SelectedReportLayoutList, AvailableInAllCompanies, ApplyDescription, NewDescription, false, Enum::"Report Layout Status"::Draft, ApplyObsolete, NewIsObsolete);
 
                 // TODO (Slice 4 C/D): telemetry disabled while testing. The previous Log reused event

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -71,8 +71,6 @@ codeunit 9660 "Report Layouts Impl."
         TenantReportLayout: Record "Tenant Report Layout";
     begin
         if not ReportLayoutList."User Defined" then begin
-            // Extension layouts live in the read-only App database, so the status is overridden here
-            // rather than written. Mixed-scope selections are rejected by SetLayoutStatusBatch first.
             UpsertLayoutOverride(ReportLayoutList, LayoutStatusIsGlobalScope(ReportLayoutList), false, '', true, NewStatus, false, false);
             exit(true);
         end;
@@ -98,10 +96,6 @@ codeunit 9660 "Report Layouts Impl."
         exit(true);
     end;
 
-    /// <summary>
-    /// Creates or updates a "Tenant Report Layout Override". Only fields flagged by their Apply*
-    /// parameter are written; MakeGlobal writes an empty Company Name. IsObsolete is one-way.
-    /// </summary>
     local procedure UpsertLayoutOverride(ReportLayoutList: Record "Report Layout List"; MakeGlobal: Boolean; ApplyDescription: Boolean; NewDescription: Text[250]; ApplyStatus: Boolean; NewStatus: Enum "Report Layout Status"; ApplyObsolete: Boolean; NewIsObsolete: Boolean)
     var
         TenantReportLayoutOverride: Record "Tenant Report Layout Override";
@@ -171,11 +165,9 @@ codeunit 9660 "Report Layouts Impl."
                     HasCompanyScope := true;
         until ReportLayoutList.Next() = 0;
 
-        // Keep each run to a single scope so the effect is unambiguous.
         if HasGlobalScope and HasCompanyScope then
             Error(MixedScopeErr);
 
-        // Second pass: apply the status change.
         ReportLayoutList.FindSet();
         repeat
             if SetLayoutStatus(ReportLayoutList, NewStatus) then
@@ -710,8 +702,6 @@ codeunit 9660 "Report Layouts Impl."
             AvailableInAllCompanies := ReportLayoutEditDialog.SelectedAvailableInAllCompanies();
             NewIsObsolete := ReportLayoutEditDialog.SelectedIsObsolete();
 
-            // In-place edit of an extension layout: write an override, and only for what changed, so
-            // pressing OK without editing writes nothing. IsObsolete is one-way.
             if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then begin
                 // All companies, which is what the read-only Yes in the dialog states.
                 AvailableInAllCompanies := true;
@@ -724,8 +714,6 @@ codeunit 9660 "Report Layouts Impl."
 
                 UpsertLayoutOverride(SelectedReportLayoutList, AvailableInAllCompanies, ApplyDescription, NewDescription, false, Enum::"Report Layout Status"::Draft, ApplyObsolete, NewIsObsolete);
 
-                // Own event id: the user-defined Edit path logs a different custom-dimension schema
-                // under 0000N0H, and reusing it would change the meaning of an id existing queries read.
                 CustomDimensions.Add('ReportId', Format(SelectedReportLayoutList."Report ID"));
                 CustomDimensions.Add('LayoutName', SelectedReportLayoutList.Name);
                 CustomDimensions.Add('DescriptionChanged', Format(ApplyDescription));

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -45,7 +45,6 @@ codeunit 9660 "Report Layouts Impl."
         CannotUpdateLayoutTxt: Label 'The Layout could not be updated for export. The exported file will contain the original layout.';
         LayoutAlreadyExistsErr: Label 'A layout named "%1" already exists.', Comment = '%1 = Layout Name';
         MixedScopeErr: Label 'The selected layouts have different scopes. Some apply to all companies and some only to the current company. Select layouts of a single scope and try again.';
-        GlobalScopeConfirmQst: Label 'One or more of the selected layouts apply to all companies. Changing the status will affect all companies, not only the current one. Do you want to continue?';
 
     internal procedure SetSelectedCompany(NewCompanyName: Text)
     begin
@@ -68,9 +67,9 @@ codeunit 9660 "Report Layouts Impl."
     begin
         if not ReportLayoutList."User Defined" then begin
             // Extension-installed layout: override the status rather than copying the layout.
-            // A layout whose status is already overridden globally is updated globally; otherwise the
-            // status override is company-specific (see CP0529-338 Q1). Mixed-scope selections and the
-            // global confirmation are handled by SetLayoutStatusBatch before this point.
+            // The override is written for all companies unless this company already has a status
+            // override of its own (see CP0529-338 Q1). Mixed-scope selections are rejected by
+            // SetLayoutStatusBatch before this point.
             UpsertLayoutOverride(ReportLayoutList, LayoutStatusIsGlobalScope(ReportLayoutList), false, '', true, NewStatus, false, false);
             exit(true);
         end;
@@ -95,25 +94,25 @@ codeunit 9660 "Report Layouts Impl."
 
     /// <summary>
     /// Determines whether a status change to an extension-installed layout applies globally.
-    /// "Tenant Report Layout Override" is field-granular, so scope must be resolved from the field that
-    /// is about to change: only a row that actually sets "Override Layout Status" tells us where the
-    /// effective status comes from. A current-company status override wins (company scope); otherwise a
-    /// global status override means global scope. A layout whose status is not overridden anywhere
-    /// defaults to company scope, so a description-only or obsolete-only row on either side never drags
-    /// the status change into the wrong scope.
+    /// Status changes are tenant-wide by default: a layout installed by an extension is the same layout
+    /// in every company, so its lifecycle state normally is too.
+    /// "Tenant Report Layout Override" is field-granular, so an existing exception has to be recognised
+    /// from the field that is about to change, not from the mere existence of a row: only a row that sets
+    /// "Override Layout Status" for the current company keeps the change company-scoped. A
+    /// description-only or obsolete-only row therefore never drags the status change out of global scope.
     /// </summary>
     local procedure LayoutStatusIsGlobalScope(ReportLayoutList: Record "Report Layout List"): Boolean
     var
         TenantReportLayoutOverride: Record "Tenant Report Layout Override";
     begin
+        // A company-specific status override, where one already exists, keeps the change in that company.
+        // Such a row can no longer be created from the UI, but it may come from an earlier version or from
+        // a vendor's install codeunit, and it is what a future company-scoped option would build on.
         if TenantReportLayoutOverride.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", SelectedCompany) then
             if TenantReportLayoutOverride."Override Layout Status" then
                 exit(false);
 
-        if TenantReportLayoutOverride.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", '') then
-            exit(TenantReportLayoutOverride."Override Layout Status");
-
-        exit(false);
+        exit(true);
     end;
 
     /// <summary>
@@ -123,7 +122,7 @@ codeunit 9660 "Report Layouts Impl."
     /// one-way: it can only ever be set to true and never clears a layout that is obsolete in metadata.
     /// </summary>
     /// <param name="ReportLayoutList">The (extension-installed) layout row from the virtual table</param>
-    /// <param name="MakeGlobal">True writes a global override (empty Company Name); false writes one scoped to the selected company</param>
+    /// <param name="MakeGlobal">True writes a global override (empty Company Name) — the default for an in-place edit; false writes one scoped to the selected company</param>
     local procedure UpsertLayoutOverride(ReportLayoutList: Record "Report Layout List"; MakeGlobal: Boolean; ApplyDescription: Boolean; NewDescription: Text[250]; ApplyStatus: Boolean; NewStatus: Enum "Report Layout Status"; ApplyObsolete: Boolean; NewIsObsolete: Boolean)
     var
         TenantReportLayoutOverride: Record "Tenant Report Layout Override";
@@ -198,10 +197,9 @@ codeunit 9660 "Report Layouts Impl."
         if HasGlobalScope and HasCompanyScope then
             Error(MixedScopeErr);
 
-        // A global-scope change affects every company, so make the user confirm it explicitly.
-        if HasGlobalScope then
-            if not Confirm(GlobalScopeConfirmQst, false) then
-                exit(0);
+        // No confirmation for the all-companies case: a status change is metadata about the layout's
+        // lifecycle, not a change to the layout itself, and it is tenant-wide by default. Prompting on
+        // the normal path would train users to dismiss the dialog without reading it.
 
         // Second pass: apply the status change.
         ReportLayoutList.FindSet();
@@ -742,11 +740,13 @@ codeunit 9660 "Report Layouts Impl."
             // than copying the layout. Only the properties the user actually changed are written, so
             // pressing OK without editing anything writes nothing at all; IsObsolete is one-way.
             if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then begin
-                // Such an edit always overrides for the CURRENT company: the tenant-wide (global)
-                // decision is a governance act and is deliberately not offered in the everyday edit
-                // dialog. A copy is an ordinary tenant layout, so its company scope keeps coming from
-                // "Available in All Companies" and is handled further below.
-                AvailableInAllCompanies := false;
+                // Such an edit overrides for ALL companies. An extension layout is the same layout
+                // everywhere, so its description and lifecycle state normally are too, and the override
+                // records metadata about the layout rather than changing the layout itself. This is why
+                // "Available in All Companies" is shown as a read-only Yes for an in-place edit: it
+                // states the scope the override will be written at. A copy is an ordinary tenant layout,
+                // so it takes its own company scope from that field, handled further below.
+                AvailableInAllCompanies := true;
 
                 NewEditedLayoutName := SelectedReportLayoutList.Name;
                 ApplyDescription := NewDescription <> SelectedReportLayoutList."Description";

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -51,28 +51,17 @@ codeunit 9660 "Report Layouts Impl."
         SelectedCompany := CopyStr(NewCompanyName, 1, MaxStrLen(SelectedCompany));
     end;
 
-    /// <summary>
-    /// The company an override applies to, for the scope-sensitive paths below.
-    /// Falls back to the running company when a caller has not called SetSelectedCompany:
-    /// "Report Theme and Header/Footer" reaches SetLayoutStatusBatch without setting it, and a blank
-    /// value would silently probe the GLOBAL row instead of this company's — misclassifying scope and,
-    /// in a batch spanning an already-overridden layout and a fresh one, raising the mixed-scope error
-    /// when both are in fact global. Resolving here rather than mutating the field keeps this
-    /// independent of call order, so a future caller cannot reintroduce the same gap.
-    /// </summary>
     local procedure OverrideCompany(): Text[30]
     begin
+        // Falls back: "Report Theme and Header/Footer" calls SetLayoutStatusBatch without SetSelectedCompany.
         if SelectedCompany <> '' then
             exit(SelectedCompany);
         exit(CopyStr(CompanyName(), 1, MaxStrLen(SelectedCompany)));
     end;
 
     /// <summary>
-    /// Sets the status for a layout.
-    /// User-defined layouts are updated in place in "Tenant Report Layout" (table 2000000232).
-    /// Extension-installed layouts reside in the read-only App database; their status is set by
-    /// writing an override record in "Tenant Report Layout Override" (table 2000000248) instead of
-    /// copying the layout into the tenant table.
+    /// Sets the status for a layout. Extension-installed layouts live in the read-only App database,
+    /// so their status is written as an override record rather than by copying the layout.
     /// </summary>
     /// <param name="ReportLayoutList">The layout record from the virtual table</param>
     /// <param name="NewStatus">The new status to set</param>
@@ -82,10 +71,8 @@ codeunit 9660 "Report Layouts Impl."
         TenantReportLayout: Record "Tenant Report Layout";
     begin
         if not ReportLayoutList."User Defined" then begin
-            // Extension-installed layout: override the status rather than copying the layout.
-            // The override is written for all companies unless this company already has a status
-            // override of its own (see CP0529-338 Q1). Mixed-scope selections are rejected by
-            // SetLayoutStatusBatch before this point.
+            // Extension layouts live in the read-only App database, so the status is overridden here
+            // rather than written. Mixed-scope selections are rejected by SetLayoutStatusBatch first.
             UpsertLayoutOverride(ReportLayoutList, LayoutStatusIsGlobalScope(ReportLayoutList), false, '', true, NewStatus, false, false);
             exit(true);
         end;
@@ -98,32 +85,12 @@ codeunit 9660 "Report Layouts Impl."
         exit(false);
     end;
 
-    /// <summary>
-    /// Renders the override scope for telemetry as a stable, non-localized token.
-    /// </summary>
-    local procedure ScopeDimension(IsGlobal: Boolean): Text
-    begin
-        if IsGlobal then
-            exit('AllCompanies');
-        exit('CurrentCompany');
-    end;
-
-    /// <summary>
-    /// Determines whether a status change to an extension-installed layout applies globally.
-    /// Status changes are tenant-wide by default: a layout installed by an extension is the same layout
-    /// in every company, so its lifecycle state normally is too.
-    /// "Tenant Report Layout Override" is field-granular, so an existing exception has to be recognised
-    /// from the field that is about to change, not from the mere existence of a row: only a row that sets
-    /// "Override Layout Status" for the current company keeps the change company-scoped. A
-    /// description-only or obsolete-only row therefore never drags the status change out of global scope.
-    /// </summary>
     local procedure LayoutStatusIsGlobalScope(ReportLayoutList: Record "Report Layout List"): Boolean
     var
         TenantReportLayoutOverride: Record "Tenant Report Layout Override";
     begin
-        // A company-specific status override, where one already exists, keeps the change in that company.
-        // Such a row can no longer be created from the UI, but it may come from an earlier version or from
-        // a vendor's install codeunit, and it is what a future company-scoped option would build on.
+        // Field-granular: only an "Override Layout Status" row makes the change company-scoped, and the
+        // UI no longer writes one - these come from an earlier version or a vendor install codeunit.
         if TenantReportLayoutOverride.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", OverrideCompany()) then
             if TenantReportLayoutOverride."Override Layout Status" then
                 exit(false);
@@ -132,13 +99,9 @@ codeunit 9660 "Report Layouts Impl."
     end;
 
     /// <summary>
-    /// Creates or updates a "Tenant Report Layout Override" record for an extension-installed layout.
-    /// Only the fields flagged by the corresponding Apply* parameter are written, together with their
-    /// "Override *" flag; unset fields pass through from the layout metadata unchanged. "IsObsolete" is
-    /// one-way: it can only ever be set to true and never clears a layout that is obsolete in metadata.
+    /// Creates or updates a "Tenant Report Layout Override". Only fields flagged by their Apply*
+    /// parameter are written; MakeGlobal writes an empty Company Name. IsObsolete is one-way.
     /// </summary>
-    /// <param name="ReportLayoutList">The (extension-installed) layout row from the virtual table</param>
-    /// <param name="MakeGlobal">True writes a global override (empty Company Name) — the default for an in-place edit; false writes one scoped to the selected company</param>
     local procedure UpsertLayoutOverride(ReportLayoutList: Record "Report Layout List"; MakeGlobal: Boolean; ApplyDescription: Boolean; NewDescription: Text[250]; ApplyStatus: Boolean; NewStatus: Enum "Report Layout Status"; ApplyObsolete: Boolean; NewIsObsolete: Boolean)
     var
         TenantReportLayoutOverride: Record "Tenant Report Layout Override";
@@ -199,8 +162,7 @@ codeunit 9660 "Report Layouts Impl."
         if not ReportLayoutList.FindSet() then
             exit(0);
 
-        // First pass: classify the scope of the extension-installed layouts in the selection.
-        // User-defined layouts update in place and are not part of the scope decision.
+        // First pass: classify scope. User-defined layouts update in place and do not affect it.
         repeat
             if not ReportLayoutList."User Defined" then
                 if LayoutStatusIsGlobalScope(ReportLayoutList) then
@@ -212,10 +174,6 @@ codeunit 9660 "Report Layouts Impl."
         // Keep each run to a single scope so the effect is unambiguous.
         if HasGlobalScope and HasCompanyScope then
             Error(MixedScopeErr);
-
-        // No confirmation for the all-companies case: a status change is metadata about the layout's
-        // lifecycle, not a change to the layout itself, and it is tenant-wide by default. Prompting on
-        // the normal path would train users to dismiss the dialog without reading it.
 
         // Second pass: apply the status change.
         ReportLayoutList.FindSet();
@@ -752,16 +710,10 @@ codeunit 9660 "Report Layouts Impl."
             AvailableInAllCompanies := ReportLayoutEditDialog.SelectedAvailableInAllCompanies();
             NewIsObsolete := ReportLayoutEditDialog.SelectedIsObsolete();
 
-            // Extension-installed layout, edited in place (not copied): write an override record rather
-            // than copying the layout. Only the properties the user actually changed are written, so
-            // pressing OK without editing anything writes nothing at all; IsObsolete is one-way.
+            // In-place edit of an extension layout: write an override, and only for what changed, so
+            // pressing OK without editing writes nothing. IsObsolete is one-way.
             if (not SelectedReportLayoutList."User Defined") and (not CreateCopy) then begin
-                // Such an edit overrides for ALL companies. An extension layout is the same layout
-                // everywhere, so its description and lifecycle state normally are too, and the override
-                // records metadata about the layout rather than changing the layout itself. This is why
-                // "Available in All Companies" is shown as a read-only Yes for an in-place edit: it
-                // states the scope the override will be written at. A copy is an ordinary tenant layout,
-                // so it takes its own company scope from that field, handled further below.
+                // All companies, which is what the read-only Yes in the dialog states.
                 AvailableInAllCompanies := true;
 
                 NewEditedLayoutName := SelectedReportLayoutList.Name;
@@ -772,18 +724,13 @@ codeunit 9660 "Report Layouts Impl."
 
                 UpsertLayoutOverride(SelectedReportLayoutList, AvailableInAllCompanies, ApplyDescription, NewDescription, false, Enum::"Report Layout Status"::Draft, ApplyObsolete, NewIsObsolete);
 
-                // Telemetry for the override path uses its OWN event id, freshly allocated from the
-                // number series rather than reusing the one the user-defined Edit path logs under:
-                // that event carries a different custom-dimension schema (Old/New layout name and
-                // description), and reusing it here would change the meaning of an id existing
-                // queries already consume. The dimensions below are metadata only — the layout
-                // description is user-entered free text and is reported as a changed/not-changed
-                // flag rather than its content.
+                // Own event id: the user-defined Edit path logs a different custom-dimension schema
+                // under 0000N0H, and reusing it would change the meaning of an id existing queries read.
                 CustomDimensions.Add('ReportId', Format(SelectedReportLayoutList."Report ID"));
                 CustomDimensions.Add('LayoutName', SelectedReportLayoutList.Name);
                 CustomDimensions.Add('DescriptionChanged', Format(ApplyDescription));
                 CustomDimensions.Add('ObsoleteSet', Format(ApplyObsolete));
-                CustomDimensions.Add('OverrideScope', ScopeDimension(AvailableInAllCompanies));
+                CustomDimensions.Add('OverrideScope', 'AllCompanies');
                 AddReportLayoutDimensionsAction('EditOverride', CustomDimensions);
                 Log('0000RTQ', 'Report layout properties overridden by user', CustomDimensions);
                 exit;

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -52,6 +52,22 @@ codeunit 9660 "Report Layouts Impl."
     end;
 
     /// <summary>
+    /// The company an override applies to, for the scope-sensitive paths below.
+    /// Falls back to the running company when a caller has not called SetSelectedCompany:
+    /// "Report Theme and Header/Footer" reaches SetLayoutStatusBatch without setting it, and a blank
+    /// value would silently probe the GLOBAL row instead of this company's — misclassifying scope and,
+    /// in a batch spanning an already-overridden layout and a fresh one, raising the mixed-scope error
+    /// when both are in fact global. Resolving here rather than mutating the field keeps this
+    /// independent of call order, so a future caller cannot reintroduce the same gap.
+    /// </summary>
+    local procedure OverrideCompany(): Text[30]
+    begin
+        if SelectedCompany <> '' then
+            exit(SelectedCompany);
+        exit(CopyStr(CompanyName(), 1, MaxStrLen(SelectedCompany)));
+    end;
+
+    /// <summary>
     /// Sets the status for a layout.
     /// User-defined layouts are updated in place in "Tenant Report Layout" (table 2000000232).
     /// Extension-installed layouts reside in the read-only App database; their status is set by
@@ -108,7 +124,7 @@ codeunit 9660 "Report Layouts Impl."
         // A company-specific status override, where one already exists, keeps the change in that company.
         // Such a row can no longer be created from the UI, but it may come from an earlier version or from
         // a vendor's install codeunit, and it is what a future company-scoped option would build on.
-        if TenantReportLayoutOverride.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", SelectedCompany) then
+        if TenantReportLayoutOverride.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", OverrideCompany()) then
             if TenantReportLayoutOverride."Override Layout Status" then
                 exit(false);
 
@@ -132,7 +148,7 @@ codeunit 9660 "Report Layouts Impl."
         if MakeGlobal then
             OverrideCompanyName := ''
         else
-            OverrideCompanyName := SelectedCompany;
+            OverrideCompanyName := OverrideCompany();
 
         OverrideExists := TenantReportLayoutOverride.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", OverrideCompanyName);
         if not OverrideExists then begin

--- a/src/Layers/W1/Tests/Report/Layouts/TestReportLayoutsReport2.rdl
+++ b/src/Layers/W1/Tests/Report/Layouts/TestReportLayoutsReport2.rdl
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Report xmlns="http://schemas.microsoft.com/sqlserver/reporting/2016/01/reportdefinition" xmlns:rd="http://schemas.microsoft.com/SQLServer/reporting/reportdesigner">
+  <AutoRefresh>0</AutoRefresh>
+  <DataSources>
+    <DataSource Name="DataSource">
+      <ConnectionProperties>
+        <DataProvider>SQL</DataProvider>
+        <ConnectString />
+      </ConnectionProperties>
+      <rd:SecurityType>None</rd:SecurityType>
+    </DataSource>
+  </DataSources>
+  <ReportSections>
+    <ReportSection>
+      <Body>
+        <Height>2in</Height>
+        <Style />
+      </Body>
+      <Width>6.5in</Width>
+      <Page>
+        <Style />
+      </Page>
+    </ReportSection>
+  </ReportSections>
+  <Code>Public Function BlankZero(ByVal Value As Decimal)
+    if Value = 0 then
+        Return ""
+    end if
+    Return Value
+End Function
+
+Public Function BlankPos(ByVal Value As Decimal)
+    if Value &gt; 0 then
+        Return ""
+    end if
+    Return Value
+End Function
+
+Public Function BlankZeroAndPos(ByVal Value As Decimal)
+    if Value &gt;= 0 then
+        Return ""
+    end if
+    Return Value
+End Function
+
+Public Function BlankNeg(ByVal Value As Decimal)
+    if Value &lt; 0 then
+        Return ""
+    end if
+    Return Value
+End Function
+
+Public Function BlankNegAndZero(ByVal Value As Decimal)
+    if Value &lt;= 0 then
+        Return ""
+    end if
+    Return Value
+End Function
+</Code>
+  <Language>=User!Language</Language>
+  <ConsumeContainerWhitespace>true</ConsumeContainerWhitespace>
+  <rd:ReportUnitType>Inch</rd:ReportUnitType>
+  <rd:ReportID>0eeb6585-38ae-40f1-885b-8d50088d51b4</rd:ReportID>
+  <DataSets>
+    <DataSet Name="DataSet_Result">
+      <Fields>
+        <Field Name="ColumnName">
+          <DataField>ColumnName</DataField>
+        </Field>
+      </Fields>
+      <Query>
+        <DataSourceName>DataSource</DataSourceName>
+        <CommandText />
+      </Query>
+    </DataSet>
+  </DataSets>
+</Report>

--- a/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
@@ -712,6 +712,92 @@ codeunit 139595 "Report Layouts Test"
     begin
     end;
 
+    [Test]
+    [HandlerFunctions('EditExtensionOverrideGlobalDescHandler')]
+    procedure TestEditExtensionLayoutWritesGlobalDescriptionOverride()
+    var
+        TenantReportLayout: Record "Tenant Report Layout";
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsPage: TestPage "Report Layouts";
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] Editing an extension-installed layout's description writes a global
+        // Tenant Report Layout Override record instead of copying the layout.
+        EnsureNewLayoutsAreCleaned();
+
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
+
+        // Act - Edit info (override mode), global scope
+        ReportLayoutsPage.OpenView();
+        ReportLayoutsPage.GoToRecord(ReportLayoutList);
+        ReportLayoutsPage.EditLayout.Invoke();
+        ReportLayoutsPage.Close();
+
+        // Assert - a global description override exists, no tenant copy
+        Assert.IsTrue(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+            'A global override record should have been created.');
+        Assert.IsTrue(TenantReportLayoutOverride."Override Description", 'The Override Description flag should be set.');
+        Assert.AreEqual(EditedLayoutNameTxt, TenantReportLayoutOverride.Description, 'The override should carry the edited description.');
+
+        TenantReportLayout.SetRange("Report ID", 139595);
+        Assert.IsTrue(TenantReportLayout.IsEmpty(), 'No copy should have been created in Tenant Report Layout.');
+    end;
+
+    [Test]
+    [HandlerFunctions('EditExtensionOverrideCompanyObsoleteHandler')]
+    procedure TestEditExtensionLayoutWritesCompanyObsoleteOverride()
+    var
+        TenantReportLayout: Record "Tenant Report Layout";
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsPage: TestPage "Report Layouts";
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] Marking an extension-installed layout obsolete for the current company writes a
+        // company-specific override (one-way IsObsolete) instead of copying the layout.
+        EnsureNewLayoutsAreCleaned();
+
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
+
+        // Act - Edit info (override mode), company scope, mark obsolete
+        ReportLayoutsPage.OpenView();
+        ReportLayoutsPage.GoToRecord(ReportLayoutList);
+        ReportLayoutsPage.EditLayout.Invoke();
+        ReportLayoutsPage.Close();
+
+        // Assert - a company-specific obsolete override exists, no tenant copy
+        Assert.IsTrue(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
+            'A company-specific override record should have been created.');
+        Assert.IsTrue(TenantReportLayoutOverride."Override IsObsolete", 'The Override IsObsolete flag should be set.');
+        Assert.IsTrue(TenantReportLayoutOverride.IsObsolete, 'The override should mark the layout obsolete.');
+
+        TenantReportLayout.SetRange("Report ID", 139595);
+        Assert.IsTrue(TenantReportLayout.IsEmpty(), 'No copy should have been created in Tenant Report Layout.');
+    end;
+
+    [ModalPageHandler]
+    procedure EditExtensionOverrideGlobalDescHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
+    begin
+        ReportLayoutEditDialog.Description.SetValue(EditedLayoutNameTxt);
+        ReportLayoutEditDialog.AvailableInAllCompanies.SetValue(true);
+        ReportLayoutEditDialog.OK().Invoke();
+    end;
+
+    [ModalPageHandler]
+    procedure EditExtensionOverrideCompanyObsoleteHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
+    begin
+        ReportLayoutEditDialog.AvailableInAllCompanies.SetValue(false);
+        ReportLayoutEditDialog.IsObsolete.SetValue(true);
+        ReportLayoutEditDialog.OK().Invoke();
+    end;
+
     var
         Assert: Codeunit Assert;
         TempBlob: Codeunit "Temp Blob";

--- a/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
@@ -760,6 +760,47 @@ codeunit 139595 "Report Layouts Test"
     end;
 
     [Test]
+    procedure TestMixedScopeBatchStatusIsRejected()
+    var
+        ReportLayoutList: Record "Report Layout List";
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutsImpl: Codeunit "Report Layouts Impl.";
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] A batch status change spanning mixed scopes (one global, one company-default
+        // extension layout) is rejected, keeping each run to a single unambiguous scope.
+        // Driven through the internal impl codeunit (Tests-Report is in BaseApp internalsVisibleTo)
+        // because a TestPage cannot multi-select records for CurrPage.SetSelectionFilter.
+        EnsureNewLayoutsAreCleaned();
+
+        // Report 139595 ships two extension layouts; make the first global-scope, leave the second
+        // at company-default scope.
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.AreEqual(2, ReportLayoutList.Count(), 'The test report should ship two extension layouts.');
+        ReportLayoutList.FindFirst();
+
+        TenantReportLayoutOverride.Init();
+        TenantReportLayoutOverride."Report ID" := 139595;
+        TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
+        TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
+        TenantReportLayoutOverride."Company Name" := '';
+        TenantReportLayoutOverride."Layout Status" := Enum::"Report Layout Status"::Draft;
+        TenantReportLayoutOverride."Override Layout Status" := true;
+        TenantReportLayoutOverride.Insert(true);
+
+        // Act - batch over BOTH extension layouts (mixed scope)
+        ReportLayoutList.Reset();
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        ReportLayoutsImpl.SetSelectedCompany(CompanyName());
+        asserterror ReportLayoutsImpl.SetLayoutStatusBatch(ReportLayoutList, Enum::"Report Layout Status"::Approved);
+
+        // Assert - rejected with the mixed-scope error
+        Assert.ExpectedError('different scopes');
+    end;
+
+    [Test]
     [HandlerFunctions('EditExtensionOverrideGlobalDescHandler')]
     procedure TestEditExtensionLayoutWritesGlobalDescriptionOverride()
     var

--- a/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
@@ -713,6 +713,53 @@ codeunit 139595 "Report Layouts Test"
     end;
 
     [Test]
+    [HandlerFunctions('ConfirmHandler,StatusChangedMessageHandler')]
+    procedure TestSetGlobalScopeExtensionLayoutStatusConfirmsAndUpdatesGlobal()
+    var
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsPage: TestPage "Report Layouts";
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] Changing the status of an extension layout that already has a GLOBAL override
+        // prompts for confirmation and updates the global override, not a company-specific one.
+        EnsureNewLayoutsAreCleaned();
+
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
+
+        // Establish global scope by seeding a global override for the layout.
+        TenantReportLayoutOverride.Init();
+        TenantReportLayoutOverride."Report ID" := 139595;
+        TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
+        TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
+        TenantReportLayoutOverride."Company Name" := '';
+        TenantReportLayoutOverride.Description := EditedLayoutNameTxt;
+        TenantReportLayoutOverride."Override Description" := true;
+        TenantReportLayoutOverride.Insert(true);
+
+        // Act - Set status to Approved; scope is global, so a confirmation is expected (ConfirmHandler = Yes)
+        ReportLayoutsPage.OpenView();
+        ReportLayoutsPage.GoToRecord(ReportLayoutList);
+        ReportLayoutsPage.SetApproved.Invoke();
+        ReportLayoutsPage.Close();
+
+        // Assert - the GLOBAL override carries the Approved status; no company-specific override was created
+        Assert.IsTrue(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+            'The global override should still exist.');
+        Assert.IsTrue(TenantReportLayoutOverride."Override Layout Status", 'Override Layout Status should be set on the global override.');
+        Assert.AreEqual(
+            Enum::"Report Layout Status"::Approved,
+            TenantReportLayoutOverride."Layout Status",
+            'The global override should carry the Approved status.');
+        Assert.IsFalse(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
+            'No company-specific override should have been created for a global-scope layout.');
+    end;
+
+    [Test]
     [HandlerFunctions('EditExtensionOverrideGlobalDescHandler')]
     procedure TestEditExtensionLayoutWritesGlobalDescriptionOverride()
     var

--- a/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
@@ -492,9 +492,13 @@ codeunit 139595 "Report Layouts Test"
     local procedure EnsureNewLayoutsAreCleaned()
     var
         TenantReportLayout: Record "Tenant Report Layout";
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
     begin
         TenantReportLayout.SetRange("Report ID", 139595);
         TenantReportLayout.DeleteAll();
+
+        TenantReportLayoutOverride.SetRange("Report ID", 139595);
+        TenantReportLayoutOverride.DeleteAll();
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Report Layouts Impl.", 'OnBeforeUpload', '', false, false)]
@@ -657,6 +661,50 @@ codeunit 139595 "Report Layouts Test"
             Enum::"Report Layout Status"::Draft,
             TenantReportLayout."Layout Status",
             'Layout status should be Draft after cycling back.');
+    end;
+
+    [Test]
+    [HandlerFunctions('StatusChangedMessageHandler')]
+    procedure TestSetExtensionLayoutStatusWritesOverride()
+    var
+        TenantReportLayout: Record "Tenant Report Layout";
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsPage: TestPage "Report Layouts";
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] Setting the status of an extension-installed layout writes a Tenant Report Layout
+        // Override record instead of copying the layout into the tenant table.
+
+        // Init - remove any tenant layouts/overrides for the test report
+        EnsureNewLayoutsAreCleaned();
+
+        // The test report (139595) ships an RDLC layout via its rendering section, so it surfaces in
+        // Report Layout List as an extension-installed layout (User Defined = false).
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
+
+        // Act - Set status to Approved via the page action
+        ReportLayoutsPage.OpenView();
+        ReportLayoutsPage.GoToRecord(ReportLayoutList);
+        Assert.IsTrue(ReportLayoutsPage.SetApproved.Enabled(), 'Set Approved should be enabled for extension layouts.');
+        ReportLayoutsPage.SetApproved.Invoke();
+        ReportLayoutsPage.Close();
+
+        // Assert - a company-specific override carries the Approved status...
+        Assert.IsTrue(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
+            'An override record should have been created for the extension layout.');
+        Assert.IsTrue(TenantReportLayoutOverride."Override Layout Status", 'The Override Layout Status flag should be set.');
+        Assert.AreEqual(
+            Enum::"Report Layout Status"::Approved,
+            TenantReportLayoutOverride."Layout Status",
+            'The override should carry the Approved status.');
+
+        // ...and no copy was made into the tenant table.
+        TenantReportLayout.SetRange("Report ID", 139595);
+        Assert.IsTrue(TenantReportLayout.IsEmpty(), 'No copy should have been created in Tenant Report Layout.');
     end;
 
     [MessageHandler]

--- a/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
@@ -920,17 +920,16 @@ codeunit 139595 "Report Layouts Test"
     end;
 
     [Test]
-    [HandlerFunctions('EditExtensionOverrideDeclineGlobalHandler,ConfirmHandlerNo')]
-    procedure TestEditExtensionLayoutDeclineGlobalKeepsEditsAndSavesCompanyScope()
+    [HandlerFunctions('EditExtensionOverrideDeclineGlobalHandler,ConfirmHandlerNo,MessageHandler')]
+    procedure TestEditExtensionLayoutDeclineGlobalWritesNothing()
     var
         TenantReportLayoutOverride: Record "Tenant Report Layout Override";
         ReportLayoutList: Record "Report Layout List";
         ReportLayoutsPage: TestPage "Report Layouts";
     begin
         // [FEATURE] [AI TEST]
-        // [SCENARIO] Declining the all-companies confirmation reopens the dialog with the user's
-        // entries preserved and the scope reset to the current company, so the edit can still be
-        // saved company-scoped instead of being silently discarded (Slice 4, step-4 finding).
+        // [SCENARIO] Declining the all-companies confirmation applies nothing (not globally and not
+        // for the current company) and tells the user so — no silent partial write.
         EnsureNewLayoutsAreCleaned();
         EditDialogPass := 0;
 
@@ -938,39 +937,72 @@ codeunit 139595 "Report Layouts Test"
         ReportLayoutList.SetRange("User Defined", false);
         Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
 
-        // Act - pass 1 sets a description + global scope; the declined confirm reopens the dialog,
-        // where pass 2 verifies the state and accepts the (now company-scoped) edit.
+        // Act - type a description, ask for an all-companies override, then decline the confirmation
         ReportLayoutsPage.OpenView();
         ReportLayoutsPage.GoToRecord(ReportLayoutList);
         ReportLayoutsPage.EditLayout.Invoke();
         ReportLayoutsPage.Close();
 
-        Assert.AreEqual(2, EditDialogPass, 'The dialog should have been reopened after declining the global scope.');
+        Assert.AreEqual(1, EditDialogPass, 'The edit dialog should have been shown exactly once.');
 
-        // Assert - the edit landed as a COMPANY-scoped override, and no global override was created
+        // Assert - nothing was written at either scope
+        TenantReportLayoutOverride.SetRange("Report ID", 139595);
+        Assert.IsTrue(TenantReportLayoutOverride.IsEmpty(), 'Declining the all-companies scope must not write any override.');
+    end;
+
+    [Test]
+    [HandlerFunctions('EditExtensionCopyAllCompaniesHandler')]
+    procedure TestCopyOfExtensionLayoutKeepsAllCompaniesScope()
+    var
+        TenantReportLayout: Record "Tenant Report Layout";
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsPage: TestPage "Report Layouts";
+        EmptyGuid: Guid;
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] Copying an extension layout ("Save Changes to a Copy") creates an ordinary tenant
+        // layout whose company scope comes from "Available in All Companies" (default: all companies),
+        // NOT from the override-scope control — and writes no override record.
+        EnsureNewLayoutsAreCleaned();
+
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
+
+        // Act - Edit info -> tick "Save Changes to a Copy", rename, leave availability at its default
+        ReportLayoutsPage.OpenView();
+        ReportLayoutsPage.GoToRecord(ReportLayoutList);
+        ReportLayoutsPage.EditLayout.Invoke();
+        ReportLayoutsPage.Close();
+
+        // Assert - the copy exists as a GLOBAL tenant layout (Company Name empty), and no override
         Assert.IsTrue(
-            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
-            'The declined global edit should have been saved as a company-specific override.');
-        Assert.IsTrue(TenantReportLayoutOverride."Override Description", 'Override Description should be set.');
-        Assert.AreEqual(EditedLayoutNameTxt, TenantReportLayoutOverride.Description, 'The typed description should have survived the reopen.');
-        Assert.IsFalse(
-            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
-            'No global override should exist after declining the all-companies scope.');
+            TenantReportLayout.Get(139595, EditedLayoutNameTxt, EmptyGuid),
+            'The copy should exist in Tenant Report Layout under its new name.');
+        Assert.AreEqual('', TenantReportLayout."Company Name", 'The copy should be available in all companies by default.');
+
+        TenantReportLayoutOverride.SetRange("Report ID", 139595);
+        Assert.IsTrue(TenantReportLayoutOverride.IsEmpty(), 'Copying must not write an override record.');
+    end;
+
+    [ModalPageHandler]
+    procedure EditExtensionCopyAllCompaniesHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
+    begin
+        // Ticking Copy must expose an editable Layout Name and the availability field (Slice 4 B + 4c).
+        ReportLayoutEditDialog.CreateCopy.SetValue(true);
+        ReportLayoutEditDialog.LayoutName.SetValue(EditedLayoutNameTxt);
+        Assert.AreEqual('Yes', ReportLayoutEditDialog.AvailableInAllCompanies.Value, 'A copy should default to all companies.');
+        ReportLayoutEditDialog.OK().Invoke();
     end;
 
     [ModalPageHandler]
     procedure EditExtensionOverrideDeclineGlobalHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
     begin
+        // Type a description and ask for an all-companies override; ConfirmHandlerNo then declines it.
         EditDialogPass += 1;
-        if EditDialogPass = 1 then begin
-            // First pass: type a description and ask for an all-companies override.
-            ReportLayoutEditDialog.Description.SetValue(EditedLayoutNameTxt);
-            ReportLayoutEditDialog.OverrideForAllCompanies.SetValue(true);
-        end else begin
-            // Reopened after declining: the entries must be preserved and the scope reset to company.
-            Assert.AreEqual(EditedLayoutNameTxt, ReportLayoutEditDialog.Description.Value, 'The description should be preserved on reopen.');
-            Assert.AreEqual('No', ReportLayoutEditDialog.OverrideForAllCompanies.Value, 'The scope should be reset to the current company on reopen.');
-        end;
+        ReportLayoutEditDialog.Description.SetValue(EditedLayoutNameTxt);
+        ReportLayoutEditDialog.OverrideForAllCompanies.SetValue(true);
         ReportLayoutEditDialog.OK().Invoke();
     end;
 

--- a/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
@@ -721,22 +721,24 @@ codeunit 139595 "Report Layouts Test"
         ReportLayoutsPage: TestPage "Report Layouts";
     begin
         // [FEATURE] [AI TEST]
-        // [SCENARIO] Changing the status of an extension layout that already has a GLOBAL override
-        // prompts for confirmation and updates the global override, not a company-specific one.
+        // [SCENARIO] Changing the status of an extension layout whose STATUS is already overridden
+        // globally prompts for confirmation and updates the global override, not a company-specific one.
         EnsureNewLayoutsAreCleaned();
 
         ReportLayoutList.SetRange("Report ID", 139595);
         ReportLayoutList.SetRange("User Defined", false);
         Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
 
-        // Establish global scope by seeding a global override for the layout.
+        // Establish global scope FOR THE STATUS FIELD. The override table is field-granular, so scope is
+        // resolved from "Override Layout Status" - seeding a description-only row would not make the
+        // status global-scope (see TestGlobalDescriptionOnlyOverrideKeepsStatusCompanyScoped).
         TenantReportLayoutOverride.Init();
         TenantReportLayoutOverride."Report ID" := 139595;
         TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
         TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
         TenantReportLayoutOverride."Company Name" := '';
-        TenantReportLayoutOverride.Description := EditedLayoutNameTxt;
-        TenantReportLayoutOverride."Override Description" := true;
+        TenantReportLayoutOverride."Layout Status" := Enum::"Report Layout Status"::Draft;
+        TenantReportLayoutOverride."Override Layout Status" := true;
         TenantReportLayoutOverride.Insert(true);
 
         // Act - Set status to Approved; scope is global, so a confirmation is expected (ConfirmHandler = Yes)
@@ -757,6 +759,123 @@ codeunit 139595 "Report Layouts Test"
         Assert.IsFalse(
             TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
             'No company-specific override should have been created for a global-scope layout.');
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler,StatusChangedMessageHandler')]
+    procedure TestCompanyDescriptionOnlyOverrideDoesNotForkGlobalStatus()
+    var
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsPage: TestPage "Report Layouts";
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] The override table is field-granular. A company-specific row that overrides only the
+        // DESCRIPTION must not make a status change company-scoped while the effective status still comes
+        // from a global status override - that would silently fork layout status per company and skip the
+        // all-companies confirmation. Scope is resolved from "Override Layout Status", so the change is
+        // recognised as global: it confirms and updates the global row.
+        EnsureNewLayoutsAreCleaned();
+
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
+
+        // Global row owns the STATUS...
+        TenantReportLayoutOverride.Init();
+        TenantReportLayoutOverride."Report ID" := 139595;
+        TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
+        TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
+        TenantReportLayoutOverride."Company Name" := '';
+        TenantReportLayoutOverride."Layout Status" := Enum::"Report Layout Status"::Draft;
+        TenantReportLayoutOverride."Override Layout Status" := true;
+        TenantReportLayoutOverride.Insert(true);
+
+        // ...while a company row owns only the DESCRIPTION.
+        TenantReportLayoutOverride.Init();
+        TenantReportLayoutOverride."Report ID" := 139595;
+        TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
+        TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
+        TenantReportLayoutOverride."Company Name" := CompanyName();
+        TenantReportLayoutOverride.Description := EditedLayoutNameTxt;
+        TenantReportLayoutOverride."Override Description" := true;
+        TenantReportLayoutOverride.Insert(true);
+
+        // Act - Set status to Approved; scope is global, so a confirmation is expected (ConfirmHandler = Yes)
+        ReportLayoutsPage.OpenView();
+        ReportLayoutsPage.GoToRecord(ReportLayoutList);
+        ReportLayoutsPage.SetApproved.Invoke();
+        ReportLayoutsPage.Close();
+
+        // Assert - the GLOBAL row took the new status...
+        Assert.IsTrue(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+            'The global override should still exist.');
+        Assert.AreEqual(
+            Enum::"Report Layout Status"::Approved,
+            TenantReportLayoutOverride."Layout Status",
+            'The global override should have taken the Approved status.');
+
+        // ...and the company row still overrides only the description, with no forked status.
+        Assert.IsTrue(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
+            'The company-specific description override should still exist.');
+        Assert.IsFalse(
+            TenantReportLayoutOverride."Override Layout Status",
+            'The status must not be forked into the company-specific override.');
+    end;
+
+    [Test]
+    [HandlerFunctions('StatusChangedMessageHandler')]
+    procedure TestGlobalDescriptionOnlyOverrideKeepsStatusCompanyScoped()
+    var
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsPage: TestPage "Report Layouts";
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] The mirror case: a GLOBAL row that overrides only the description must not drag a
+        // status change tenant-wide. The status is not overridden anywhere, so the change stays
+        // company-scoped and no all-companies confirmation is raised (no ConfirmHandler is registered,
+        // so an unexpected Confirm would fail this test).
+        EnsureNewLayoutsAreCleaned();
+
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
+
+        TenantReportLayoutOverride.Init();
+        TenantReportLayoutOverride."Report ID" := 139595;
+        TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
+        TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
+        TenantReportLayoutOverride."Company Name" := '';
+        TenantReportLayoutOverride.Description := EditedLayoutNameTxt;
+        TenantReportLayoutOverride."Override Description" := true;
+        TenantReportLayoutOverride.Insert(true);
+
+        // Act - Set status to Approved; scope is company, so no confirmation should be raised
+        ReportLayoutsPage.OpenView();
+        ReportLayoutsPage.GoToRecord(ReportLayoutList);
+        ReportLayoutsPage.SetApproved.Invoke();
+        ReportLayoutsPage.Close();
+
+        // Assert - a company-specific override carries the status...
+        Assert.IsTrue(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
+            'A company-specific override should have been created for the status change.');
+        Assert.IsTrue(TenantReportLayoutOverride."Override Layout Status", 'The Override Layout Status flag should be set.');
+        Assert.AreEqual(
+            Enum::"Report Layout Status"::Approved,
+            TenantReportLayoutOverride."Layout Status",
+            'The company override should carry the Approved status.');
+
+        // ...and the global description-only row was left untouched.
+        Assert.IsTrue(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+            'The global description override should still exist.');
+        Assert.IsFalse(
+            TenantReportLayoutOverride."Override Layout Status",
+            'The global override must not have gained a status override.');
     end;
 
     [Test]

--- a/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
@@ -801,8 +801,8 @@ codeunit 139595 "Report Layouts Test"
     end;
 
     [Test]
-    [HandlerFunctions('EditExtensionOverrideGlobalDescHandler,ConfirmHandler')]
-    procedure TestEditExtensionLayoutWritesGlobalDescriptionOverride()
+    [HandlerFunctions('EditExtensionOverrideDescHandler')]
+    procedure TestEditExtensionLayoutWritesCompanyDescriptionOverride()
     var
         TenantReportLayout: Record "Tenant Report Layout";
         TenantReportLayoutOverride: Record "Tenant Report Layout Override";
@@ -810,26 +810,30 @@ codeunit 139595 "Report Layouts Test"
         ReportLayoutsPage: TestPage "Report Layouts";
     begin
         // [FEATURE] [AI TEST]
-        // [SCENARIO] Editing an extension-installed layout's description writes a global
-        // Tenant Report Layout Override record instead of copying the layout.
+        // [SCENARIO] Editing an extension-installed layout's description writes a CURRENT-COMPANY
+        // Tenant Report Layout Override record instead of copying the layout. The dialog offers no
+        // scope choice — tenant-wide overrides are a governance act, not an everyday edit.
         EnsureNewLayoutsAreCleaned();
 
         ReportLayoutList.SetRange("Report ID", 139595);
         ReportLayoutList.SetRange("User Defined", false);
         Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
 
-        // Act - Edit info (override mode), global scope
+        // Act - Edit info (override mode)
         ReportLayoutsPage.OpenView();
         ReportLayoutsPage.GoToRecord(ReportLayoutList);
         ReportLayoutsPage.EditLayout.Invoke();
         ReportLayoutsPage.Close();
 
-        // Assert - a global description override exists, no tenant copy
+        // Assert - a COMPANY-scoped description override exists (and no global one), no tenant copy
         Assert.IsTrue(
-            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
-            'A global override record should have been created.');
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
+            'A company-specific override record should have been created.');
         Assert.IsTrue(TenantReportLayoutOverride."Override Description", 'The Override Description flag should be set.');
         Assert.AreEqual(EditedLayoutNameTxt, TenantReportLayoutOverride.Description, 'The override should carry the edited description.');
+        Assert.IsFalse(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+            'An everyday edit must never create a global override.');
 
         TenantReportLayout.SetRange("Report ID", 139595);
         Assert.IsTrue(TenantReportLayout.IsEmpty(), 'No copy should have been created in Tenant Report Layout.');
@@ -897,17 +901,15 @@ codeunit 139595 "Report Layouts Test"
     end;
 
     [ModalPageHandler]
-    procedure EditExtensionOverrideGlobalDescHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
+    procedure EditExtensionOverrideDescHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
     begin
         ReportLayoutEditDialog.Description.SetValue(EditedLayoutNameTxt);
-        ReportLayoutEditDialog.OverrideForAllCompanies.SetValue(true);
         ReportLayoutEditDialog.OK().Invoke();
     end;
 
     [ModalPageHandler]
     procedure EditExtensionOverrideCompanyObsoleteHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
     begin
-        ReportLayoutEditDialog.OverrideForAllCompanies.SetValue(false);
         ReportLayoutEditDialog.IsObsolete.SetValue(true);
         ReportLayoutEditDialog.OK().Invoke();
     end;
@@ -919,36 +921,6 @@ codeunit 139595 "Report Layouts Test"
         ReportLayoutEditDialog.OK().Invoke();
     end;
 
-    [Test]
-    [HandlerFunctions('EditExtensionOverrideDeclineGlobalHandler,ConfirmHandlerNo,MessageHandler')]
-    procedure TestEditExtensionLayoutDeclineGlobalWritesNothing()
-    var
-        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
-        ReportLayoutList: Record "Report Layout List";
-        ReportLayoutsPage: TestPage "Report Layouts";
-    begin
-        // [FEATURE] [AI TEST]
-        // [SCENARIO] Declining the all-companies confirmation applies nothing (not globally and not
-        // for the current company) and tells the user so — no silent partial write.
-        EnsureNewLayoutsAreCleaned();
-        EditDialogPass := 0;
-
-        ReportLayoutList.SetRange("Report ID", 139595);
-        ReportLayoutList.SetRange("User Defined", false);
-        Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
-
-        // Act - type a description, ask for an all-companies override, then decline the confirmation
-        ReportLayoutsPage.OpenView();
-        ReportLayoutsPage.GoToRecord(ReportLayoutList);
-        ReportLayoutsPage.EditLayout.Invoke();
-        ReportLayoutsPage.Close();
-
-        Assert.AreEqual(1, EditDialogPass, 'The edit dialog should have been shown exactly once.');
-
-        // Assert - nothing was written at either scope
-        TenantReportLayoutOverride.SetRange("Report ID", 139595);
-        Assert.IsTrue(TenantReportLayoutOverride.IsEmpty(), 'Declining the all-companies scope must not write any override.');
-    end;
 
     [Test]
     [HandlerFunctions('EditExtensionCopyAllCompaniesHandler')]
@@ -996,26 +968,10 @@ codeunit 139595 "Report Layouts Test"
         ReportLayoutEditDialog.OK().Invoke();
     end;
 
-    [ModalPageHandler]
-    procedure EditExtensionOverrideDeclineGlobalHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
-    begin
-        // Type a description and ask for an all-companies override; ConfirmHandlerNo then declines it.
-        EditDialogPass += 1;
-        ReportLayoutEditDialog.Description.SetValue(EditedLayoutNameTxt);
-        ReportLayoutEditDialog.OverrideForAllCompanies.SetValue(true);
-        ReportLayoutEditDialog.OK().Invoke();
-    end;
-
-    [ConfirmHandler]
-    procedure ConfirmHandlerNo(Question: Text[1024]; var Reply: Boolean)
-    begin
-        Reply := false;
-    end;
 
     var
         Assert: Codeunit Assert;
         TempBlob: Codeunit "Temp Blob";
-        EditDialogPass: Integer;
         NewLayoutNameTxt: Label 'NewLayout';
         EditedLayoutNameTxt: Label 'EditedLayout';
         SampleTextTxt: Label 'ATAKLOA, TINWTABSBATF.';

--- a/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
@@ -919,9 +919,71 @@ codeunit 139595 "Report Layouts Test"
         ReportLayoutEditDialog.OK().Invoke();
     end;
 
+    [Test]
+    [HandlerFunctions('EditExtensionOverrideDeclineGlobalHandler,ConfirmHandlerNo')]
+    procedure TestEditExtensionLayoutDeclineGlobalKeepsEditsAndSavesCompanyScope()
+    var
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsPage: TestPage "Report Layouts";
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] Declining the all-companies confirmation reopens the dialog with the user's
+        // entries preserved and the scope reset to the current company, so the edit can still be
+        // saved company-scoped instead of being silently discarded (Slice 4, step-4 finding).
+        EnsureNewLayoutsAreCleaned();
+        EditDialogPass := 0;
+
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
+
+        // Act - pass 1 sets a description + global scope; the declined confirm reopens the dialog,
+        // where pass 2 verifies the state and accepts the (now company-scoped) edit.
+        ReportLayoutsPage.OpenView();
+        ReportLayoutsPage.GoToRecord(ReportLayoutList);
+        ReportLayoutsPage.EditLayout.Invoke();
+        ReportLayoutsPage.Close();
+
+        Assert.AreEqual(2, EditDialogPass, 'The dialog should have been reopened after declining the global scope.');
+
+        // Assert - the edit landed as a COMPANY-scoped override, and no global override was created
+        Assert.IsTrue(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
+            'The declined global edit should have been saved as a company-specific override.');
+        Assert.IsTrue(TenantReportLayoutOverride."Override Description", 'Override Description should be set.');
+        Assert.AreEqual(EditedLayoutNameTxt, TenantReportLayoutOverride.Description, 'The typed description should have survived the reopen.');
+        Assert.IsFalse(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+            'No global override should exist after declining the all-companies scope.');
+    end;
+
+    [ModalPageHandler]
+    procedure EditExtensionOverrideDeclineGlobalHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
+    begin
+        EditDialogPass += 1;
+        if EditDialogPass = 1 then begin
+            // First pass: type a description and ask for an all-companies override.
+            ReportLayoutEditDialog.Description.SetValue(EditedLayoutNameTxt);
+            ReportLayoutEditDialog.OverrideForAllCompanies.SetValue(true);
+        end else begin
+            // Reopened after declining: the entries must be preserved and the scope reset to company.
+            Assert.AreEqual(EditedLayoutNameTxt, ReportLayoutEditDialog.Description.Value, 'The description should be preserved on reopen.');
+            Assert.AreEqual('No', ReportLayoutEditDialog.OverrideForAllCompanies.Value, 'The scope should be reset to the current company on reopen.');
+        end;
+        ReportLayoutEditDialog.OK().Invoke();
+    end;
+
+    [ConfirmHandler]
+    procedure ConfirmHandlerNo(Question: Text[1024]; var Reply: Boolean)
+    begin
+        Reply := false;
+    end;
+
     var
         Assert: Codeunit Assert;
         TempBlob: Codeunit "Temp Blob";
+        EditDialogPass: Integer;
         NewLayoutNameTxt: Label 'NewLayout';
         EditedLayoutNameTxt: Label 'EditedLayout';
         SampleTextTxt: Label 'ATAKLOA, TINWTABSBATF.';

--- a/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
@@ -801,7 +801,7 @@ codeunit 139595 "Report Layouts Test"
     end;
 
     [Test]
-    [HandlerFunctions('EditExtensionOverrideGlobalDescHandler')]
+    [HandlerFunctions('EditExtensionOverrideGlobalDescHandler,ConfirmHandler')]
     procedure TestEditExtensionLayoutWritesGlobalDescriptionOverride()
     var
         TenantReportLayout: Record "Tenant Report Layout";
@@ -870,19 +870,52 @@ codeunit 139595 "Report Layouts Test"
         Assert.IsTrue(TenantReportLayout.IsEmpty(), 'No copy should have been created in Tenant Report Layout.');
     end;
 
+    [Test]
+    [HandlerFunctions('EditExtensionOverrideNoOpHandler')]
+    procedure TestEditExtensionLayoutNoOpWritesNoOverride()
+    var
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsPage: TestPage "Report Layouts";
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] Edit info on an extension layout + OK with no changes writes NO override
+        // (Slice 4 A — no silent global override for a no-op edit).
+        EnsureNewLayoutsAreCleaned();
+
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
+
+        ReportLayoutsPage.OpenView();
+        ReportLayoutsPage.GoToRecord(ReportLayoutList);
+        ReportLayoutsPage.EditLayout.Invoke();
+        ReportLayoutsPage.Close();
+
+        TenantReportLayoutOverride.SetRange("Report ID", 139595);
+        Assert.IsTrue(TenantReportLayoutOverride.IsEmpty(), 'A no-op edit must not create any override.');
+    end;
+
     [ModalPageHandler]
     procedure EditExtensionOverrideGlobalDescHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
     begin
         ReportLayoutEditDialog.Description.SetValue(EditedLayoutNameTxt);
-        ReportLayoutEditDialog.AvailableInAllCompanies.SetValue(true);
+        ReportLayoutEditDialog.OverrideForAllCompanies.SetValue(true);
         ReportLayoutEditDialog.OK().Invoke();
     end;
 
     [ModalPageHandler]
     procedure EditExtensionOverrideCompanyObsoleteHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
     begin
-        ReportLayoutEditDialog.AvailableInAllCompanies.SetValue(false);
+        ReportLayoutEditDialog.OverrideForAllCompanies.SetValue(false);
         ReportLayoutEditDialog.IsObsolete.SetValue(true);
+        ReportLayoutEditDialog.OK().Invoke();
+    end;
+
+    [ModalPageHandler]
+    procedure EditExtensionOverrideNoOpHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
+    begin
+        // Change nothing, just confirm — should write no override (Slice 4 A).
         ReportLayoutEditDialog.OK().Invoke();
     end;
 

--- a/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
@@ -935,14 +935,16 @@ codeunit 139595 "Report Layouts Test"
         ReportLayoutsImpl: Codeunit "Report Layouts Impl.";
     begin
         // [FEATURE] [AI TEST]
-        // [SCENARIO] A batch status change spanning mixed scopes (one global, one company-default
-        // extension layout) is rejected, keeping each run to a single unambiguous scope.
+        // [SCENARIO] A batch status change spanning mixed scopes is rejected, keeping each run to a
+        // single unambiguous scope.
         // Driven through the internal impl codeunit (Tests-Report is in BaseApp internalsVisibleTo)
         // because a TestPage cannot multi-select records for CurrPage.SetSelectionFilter.
         EnsureNewLayoutsAreCleaned();
 
-        // Report 139595 ships two extension layouts; make the first global-scope, leave the second
-        // at company-default scope.
+        // Report 139595 ships two extension layouts. All-companies is now the DEFAULT scope, so mixing
+        // requires giving one layout a COMPANY-SPECIFIC status override; the untouched second layout
+        // resolves to global. (Seeding a global override on one would no longer create a mix — both
+        // sides would be global.)
         ReportLayoutList.SetRange("Report ID", 139595);
         ReportLayoutList.SetRange("User Defined", false);
         Assert.AreEqual(2, ReportLayoutList.Count(), 'The test report should ship two extension layouts.');
@@ -952,7 +954,7 @@ codeunit 139595 "Report Layouts Test"
         TenantReportLayoutOverride."Report ID" := 139595;
         TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
         TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
-        TenantReportLayoutOverride."Company Name" := '';
+        TenantReportLayoutOverride."Company Name" := CompanyName();
         TenantReportLayoutOverride."Layout Status" := Enum::"Report Layout Status"::Draft;
         TenantReportLayoutOverride."Override Layout Status" := true;
         TenantReportLayoutOverride.Insert(true);
@@ -966,6 +968,90 @@ codeunit 139595 "Report Layouts Test"
 
         // Assert - rejected with the mixed-scope error
         Assert.ExpectedError('different scopes');
+    end;
+
+    [Test]
+    procedure TestBatchStatusOverAllGlobalLayoutsUpdatesEveryOne()
+    var
+        ReportLayoutList: Record "Report Layout List";
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutsImpl: Codeunit "Report Layouts Impl.";
+        UpdateCount: Integer;
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] The success path of a multi-layout batch run: two fresh extension layouts both
+        // resolve to all-companies scope, so the run is single-scope and applies to both. No
+        // confirmation is raised — no ConfirmHandler is registered, so a prompt would fail this test,
+        // which is what pins the removal of the former all-companies confirmation.
+        // Driven through the internal impl codeunit because a TestPage cannot multi-select.
+        EnsureNewLayoutsAreCleaned();
+
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.AreEqual(2, ReportLayoutList.Count(), 'The test report should ship two extension layouts.');
+
+        // Act - batch over BOTH layouts, neither of which has any override yet
+        ReportLayoutsImpl.SetSelectedCompany(CompanyName());
+        UpdateCount := ReportLayoutsImpl.SetLayoutStatusBatch(ReportLayoutList, Enum::"Report Layout Status"::Retired);
+
+        // Assert - both were updated...
+        Assert.AreEqual(2, UpdateCount, 'Both extension layouts should have been updated.');
+
+        // ...each through a GLOBAL override, with no company-specific rows anywhere.
+        ReportLayoutList.FindSet();
+        repeat
+            Assert.IsTrue(
+                TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+                StrSubstNo('A global override should exist for layout %1.', ReportLayoutList."Name"));
+            Assert.AreEqual(
+                Enum::"Report Layout Status"::Retired,
+                TenantReportLayoutOverride."Layout Status",
+                StrSubstNo('The global override for %1 should carry the Retired status.', ReportLayoutList."Name"));
+            Assert.IsFalse(
+                TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
+                StrSubstNo('No company-specific override should exist for layout %1.', ReportLayoutList."Name"));
+        until ReportLayoutList.Next() = 0;
+    end;
+
+    [Test]
+    [HandlerFunctions('EditExtensionAssertObsoleteLockedHandler')]
+    procedure TestObsoleteExtensionLayoutCannotBeUnObsoleted()
+    var
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsPage: TestPage "Report Layouts";
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] IsObsolete is ONE-WAY. Once a layout resolves to obsolete, the edit dialog must not
+        // offer a way back: the field is locked, so retiring cannot be undone through the UI. This is
+        // the guarantee the design leans on when treating obsoleting as a grave act.
+        EnsureNewLayoutsAreCleaned();
+
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
+
+        // Make the layout obsolete via a global override, the way the everyday edit path would.
+        TenantReportLayoutOverride.Init();
+        TenantReportLayoutOverride."Report ID" := 139595;
+        TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
+        TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
+        TenantReportLayoutOverride."Company Name" := '';
+        TenantReportLayoutOverride.IsObsolete := true;
+        TenantReportLayoutOverride."Override IsObsolete" := true;
+        TenantReportLayoutOverride.Insert(true);
+
+        // Act - reopen Edit info; the handler asserts the obsolete field is locked
+        ReportLayoutsPage.OpenView();
+        ReportLayoutsPage.GoToRecord(ReportLayoutList);
+        ReportLayoutsPage.EditLayout.Invoke();
+        ReportLayoutsPage.Close();
+
+        // Assert - still obsolete; nothing cleared it
+        Assert.IsTrue(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+            'The global obsolete override should still exist.');
+        Assert.IsTrue(TenantReportLayoutOverride.IsObsolete, 'The layout must still be obsolete.');
     end;
 
     [Test]
@@ -1079,6 +1165,17 @@ codeunit 139595 "Report Layouts Test"
     procedure EditExtensionOverrideObsoleteHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
     begin
         ReportLayoutEditDialog.IsObsolete.SetValue(true);
+        ReportLayoutEditDialog.OK().Invoke();
+    end;
+
+    [ModalPageHandler]
+    procedure EditExtensionAssertObsoleteLockedHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
+    begin
+        // One-way IsObsolete: on a layout that already resolves to obsolete the field must be locked,
+        // so there is no route back through the dialog.
+        Assert.IsFalse(
+            ReportLayoutEditDialog.IsObsolete.Editable(),
+            'Mark layout as obsolete must be locked once the layout is already obsolete.');
         ReportLayoutEditDialog.OK().Invoke();
     end;
 

--- a/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
@@ -499,6 +499,9 @@ codeunit 139595 "Report Layouts Test"
 
         TenantReportLayoutOverride.SetRange("Report ID", 139595);
         TenantReportLayoutOverride.DeleteAll();
+
+        // A test failing between Enqueue and Dequeue would otherwise leak into the next one.
+        LibraryVariableStorage.Clear();
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Report Layouts Impl.", 'OnBeforeUpload', '', false, false)]
@@ -1106,6 +1109,7 @@ codeunit 139595 "Report Layouts Test"
             TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
             'The global obsolete override should still exist.');
         Assert.IsTrue(TenantReportLayoutOverride.IsObsolete, 'The layout must still be obsolete.');
+        LibraryVariableStorage.AssertEmpty();
     end;
 
     [Test]
@@ -1273,6 +1277,110 @@ codeunit 139595 "Report Layouts Test"
 
         TenantReportLayoutOverride.SetRange("Report ID", 139595);
         Assert.IsTrue(TenantReportLayoutOverride.IsEmpty(), 'Copying must not write an override record.');
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('EditExtensionToggleCopyOffHandler')]
+    procedure TestUntickingCopyRestoresAllCompaniesScope()
+    var
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsPage: TestPage "Report Layouts";
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] Ticking "Save Changes to a Copy", choosing company-only, then unticking it must put
+        // the scope back to all companies. Otherwise the field shows a read-only No while the in-place
+        // edit writes an all-companies override - the dialog would contradict what is written.
+        EnsureNewLayoutsAreCleaned();
+
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
+
+        // Act - tick Copy, select company-only, untick Copy, then edit the description and save
+        ReportLayoutsPage.OpenView();
+        ReportLayoutsPage.GoToRecord(ReportLayoutList);
+        ReportLayoutsPage.EditLayout.Invoke();
+        ReportLayoutsPage.Close();
+
+        // Assert - the dialog showed Yes again, and the override it wrote is global
+        Assert.AreEqual(
+            'Yes', LibraryVariableStorage.DequeueText(),
+            'Unticking Save Changes to a Copy must restore the all-companies scope shown in the dialog.');
+        Assert.IsTrue(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+            'A global override should have been written.');
+        Assert.IsFalse(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
+            'No company-specific override should exist.');
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [ModalPageHandler]
+    procedure EditExtensionToggleCopyOffHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
+    begin
+        ReportLayoutEditDialog.CreateCopy.SetValue(true);
+        ReportLayoutEditDialog.AvailableInAllCompanies.SetValue(false);
+        ReportLayoutEditDialog.CreateCopy.SetValue(false);
+        LibraryVariableStorage.Enqueue(ReportLayoutEditDialog.AvailableInAllCompanies.Value);
+        ReportLayoutEditDialog.Description.SetValue(EditedLayoutNameTxt);
+        ReportLayoutEditDialog.OK().Invoke();
+    end;
+
+    [Test]
+    [HandlerFunctions('CopyObsoleteExtensionLayoutHandler')]
+    procedure TestCopyOfObsoleteExtensionLayoutCanClearObsolete()
+    var
+        TenantReportLayout: Record "Tenant Report Layout";
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsPage: TestPage "Report Layouts";
+        EmptyGuid: Guid;
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] The one-way obsolete lock belongs to the in-place override path only. Taking a copy
+        // of an obsolete extension layout must re-enable the field, because the copy is an ordinary
+        // tenant layout - otherwise the copy is stuck obsolete and the old copy flow regresses.
+        EnsureNewLayoutsAreCleaned();
+
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
+
+        // Make the layout resolve to obsolete, the way the everyday edit path would
+        TenantReportLayoutOverride.Init();
+        TenantReportLayoutOverride."Report ID" := 139595;
+        TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
+        TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
+        TenantReportLayoutOverride."Company Name" := '';
+        TenantReportLayoutOverride.IsObsolete := true;
+        TenantReportLayoutOverride."Override IsObsolete" := true;
+        TenantReportLayoutOverride.Insert(true);
+
+        // Act - Edit info -> tick Copy; the handler records whether the obsolete field became editable
+        ReportLayoutsPage.OpenView();
+        ReportLayoutsPage.GoToRecord(ReportLayoutList);
+        ReportLayoutsPage.EditLayout.Invoke();
+        ReportLayoutsPage.Close();
+
+        // Assert - copy mode unlocked the field, and the copy exists
+        Assert.IsTrue(
+            LibraryVariableStorage.DequeueBoolean(),
+            'Mark layout as obsolete must be editable again once Save Changes to a Copy is selected.');
+        Assert.IsTrue(
+            TenantReportLayout.Get(139595, EditedLayoutNameTxt, EmptyGuid),
+            'The copy should exist in Tenant Report Layout under its new name.');
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [ModalPageHandler]
+    procedure CopyObsoleteExtensionLayoutHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
+    begin
+        ReportLayoutEditDialog.CreateCopy.SetValue(true);
+        LibraryVariableStorage.Enqueue(ReportLayoutEditDialog.IsObsolete.Editable());
+        ReportLayoutEditDialog.LayoutName.SetValue(EditedLayoutNameTxt);
+        ReportLayoutEditDialog.OK().Invoke();
     end;
 
     [ModalPageHandler]

--- a/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
@@ -673,8 +673,8 @@ codeunit 139595 "Report Layouts Test"
         ReportLayoutsPage: TestPage "Report Layouts";
     begin
         // [FEATURE] [AI TEST]
-        // [SCENARIO] Setting the status of an extension-installed layout writes a Tenant Report Layout
-        // Override record instead of copying the layout into the tenant table.
+        // [SCENARIO] Setting the status of an extension-installed layout writes an ALL-COMPANIES
+        // Tenant Report Layout Override record instead of copying the layout into the tenant table.
 
         // Init - remove any tenant layouts/overrides for the test report
         EnsureNewLayoutsAreCleaned();
@@ -692,15 +692,18 @@ codeunit 139595 "Report Layouts Test"
         ReportLayoutsPage.SetApproved.Invoke();
         ReportLayoutsPage.Close();
 
-        // Assert - a company-specific override carries the Approved status...
+        // Assert - a global override carries the Approved status...
         Assert.IsTrue(
-            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
-            'An override record should have been created for the extension layout.');
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+            'A global override record should have been created for the extension layout.');
         Assert.IsTrue(TenantReportLayoutOverride."Override Layout Status", 'The Override Layout Status flag should be set.');
         Assert.AreEqual(
             Enum::"Report Layout Status"::Approved,
             TenantReportLayoutOverride."Layout Status",
             'The override should carry the Approved status.');
+        Assert.IsFalse(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
+            'No company-specific override should have been created.');
 
         // ...and no copy was made into the tenant table.
         TenantReportLayout.SetRange("Report ID", 139595);
@@ -713,8 +716,8 @@ codeunit 139595 "Report Layouts Test"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandler,StatusChangedMessageHandler')]
-    procedure TestSetGlobalScopeExtensionLayoutStatusConfirmsAndUpdatesGlobal()
+    [HandlerFunctions('StatusChangedMessageHandler')]
+    procedure TestSetGlobalScopeExtensionLayoutStatusUpdatesGlobal()
     var
         TenantReportLayoutOverride: Record "Tenant Report Layout Override";
         ReportLayoutList: Record "Report Layout List";
@@ -722,7 +725,9 @@ codeunit 139595 "Report Layouts Test"
     begin
         // [FEATURE] [AI TEST]
         // [SCENARIO] Changing the status of an extension layout whose STATUS is already overridden
-        // globally prompts for confirmation and updates the global override, not a company-specific one.
+        // globally updates that global override rather than creating a company-specific one. No
+        // confirmation is raised — all-companies is the normal scope, so no ConfirmHandler is
+        // registered and an unexpected prompt would fail this test.
         EnsureNewLayoutsAreCleaned();
 
         ReportLayoutList.SetRange("Report ID", 139595);
@@ -741,7 +746,7 @@ codeunit 139595 "Report Layouts Test"
         TenantReportLayoutOverride."Override Layout Status" := true;
         TenantReportLayoutOverride.Insert(true);
 
-        // Act - Set status to Approved; scope is global, so a confirmation is expected (ConfirmHandler = Yes)
+        // Act - Set status to Approved; scope is global and no confirmation should be raised
         ReportLayoutsPage.OpenView();
         ReportLayoutsPage.GoToRecord(ReportLayoutList);
         ReportLayoutsPage.SetApproved.Invoke();
@@ -762,7 +767,7 @@ codeunit 139595 "Report Layouts Test"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandler,StatusChangedMessageHandler')]
+    [HandlerFunctions('StatusChangedMessageHandler')]
     procedure TestCompanyDescriptionOnlyOverrideDoesNotForkGlobalStatus()
     var
         TenantReportLayoutOverride: Record "Tenant Report Layout Override";
@@ -771,10 +776,9 @@ codeunit 139595 "Report Layouts Test"
     begin
         // [FEATURE] [AI TEST]
         // [SCENARIO] The override table is field-granular. A company-specific row that overrides only the
-        // DESCRIPTION must not make a status change company-scoped while the effective status still comes
-        // from a global status override - that would silently fork layout status per company and skip the
-        // all-companies confirmation. Scope is resolved from "Override Layout Status", so the change is
-        // recognised as global: it confirms and updates the global row.
+        // DESCRIPTION must not make a status change company-scoped - that would silently fork layout
+        // status per company. Scope is resolved from "Override Layout Status", so the change stays
+        // all-companies and updates the global row.
         EnsureNewLayoutsAreCleaned();
 
         ReportLayoutList.SetRange("Report ID", 139595);
@@ -801,7 +805,7 @@ codeunit 139595 "Report Layouts Test"
         TenantReportLayoutOverride."Override Description" := true;
         TenantReportLayoutOverride.Insert(true);
 
-        // Act - Set status to Approved; scope is global, so a confirmation is expected (ConfirmHandler = Yes)
+        // Act - Set status to Approved; scope stays all-companies and no confirmation should be raised
         ReportLayoutsPage.OpenView();
         ReportLayoutsPage.GoToRecord(ReportLayoutList);
         ReportLayoutsPage.SetApproved.Invoke();
@@ -827,17 +831,16 @@ codeunit 139595 "Report Layouts Test"
 
     [Test]
     [HandlerFunctions('StatusChangedMessageHandler')]
-    procedure TestGlobalDescriptionOnlyOverrideKeepsStatusCompanyScoped()
+    procedure TestGlobalDescriptionOnlyOverrideTakesStatusGlobally()
     var
         TenantReportLayoutOverride: Record "Tenant Report Layout Override";
         ReportLayoutList: Record "Report Layout List";
         ReportLayoutsPage: TestPage "Report Layouts";
     begin
         // [FEATURE] [AI TEST]
-        // [SCENARIO] The mirror case: a GLOBAL row that overrides only the description must not drag a
-        // status change tenant-wide. The status is not overridden anywhere, so the change stays
-        // company-scoped and no all-companies confirmation is raised (no ConfirmHandler is registered,
-        // so an unexpected Confirm would fail this test).
+        // [SCENARIO] A GLOBAL row that overrides only the description gains the status override on the
+        // same row rather than causing a second row to be created. No confirmation is raised
+        // (no ConfirmHandler is registered, so an unexpected Confirm would fail this test).
         EnsureNewLayoutsAreCleaned();
 
         ReportLayoutList.SetRange("Report ID", 139595);
@@ -853,29 +856,75 @@ codeunit 139595 "Report Layouts Test"
         TenantReportLayoutOverride."Override Description" := true;
         TenantReportLayoutOverride.Insert(true);
 
-        // Act - Set status to Approved; scope is company, so no confirmation should be raised
+        // Act - Set status to Approved; all-companies is the default scope, no confirmation expected
         ReportLayoutsPage.OpenView();
         ReportLayoutsPage.GoToRecord(ReportLayoutList);
         ReportLayoutsPage.SetApproved.Invoke();
         ReportLayoutsPage.Close();
 
-        // Assert - a company-specific override carries the status...
+        // Assert - the existing GLOBAL row now carries both overrides...
         Assert.IsTrue(
-            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
-            'A company-specific override should have been created for the status change.');
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+            'The global override should still exist.');
         Assert.IsTrue(TenantReportLayoutOverride."Override Layout Status", 'The Override Layout Status flag should be set.');
         Assert.AreEqual(
             Enum::"Report Layout Status"::Approved,
             TenantReportLayoutOverride."Layout Status",
-            'The company override should carry the Approved status.');
+            'The global override should carry the Approved status.');
+        Assert.IsTrue(TenantReportLayoutOverride."Override Description", 'The existing description override must be preserved.');
 
-        // ...and the global description-only row was left untouched.
-        Assert.IsTrue(
-            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
-            'The global description override should still exist.');
+        // ...and no company-specific row was created.
         Assert.IsFalse(
-            TenantReportLayoutOverride."Override Layout Status",
-            'The global override must not have gained a status override.');
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
+            'No company-specific override should have been created.');
+    end;
+
+    [Test]
+    [HandlerFunctions('StatusChangedMessageHandler')]
+    procedure TestCompanyStatusOverrideKeepsStatusCompanyScoped()
+    var
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsPage: TestPage "Report Layouts";
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] Company precedence survives the move to all-companies-by-default: where this company
+        // ALREADY has a status override, a further status change stays in that company and does not leak
+        // into a global row. Such rows can no longer be created from the UI, but they may come from an
+        // earlier version or a vendor's install codeunit — and this is the branch a future
+        // company-scoped option would build on.
+        EnsureNewLayoutsAreCleaned();
+
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
+
+        TenantReportLayoutOverride.Init();
+        TenantReportLayoutOverride."Report ID" := 139595;
+        TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
+        TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
+        TenantReportLayoutOverride."Company Name" := CompanyName();
+        TenantReportLayoutOverride."Layout Status" := Enum::"Report Layout Status"::Draft;
+        TenantReportLayoutOverride."Override Layout Status" := true;
+        TenantReportLayoutOverride.Insert(true);
+
+        // Act
+        ReportLayoutsPage.OpenView();
+        ReportLayoutsPage.GoToRecord(ReportLayoutList);
+        ReportLayoutsPage.SetApproved.Invoke();
+        ReportLayoutsPage.Close();
+
+        // Assert - the COMPANY row took the new status, and nothing went global
+        Assert.IsTrue(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
+            'The company-specific override should still exist.');
+        Assert.AreEqual(
+            Enum::"Report Layout Status"::Approved,
+            TenantReportLayoutOverride."Layout Status",
+            'The company override should have taken the Approved status.');
+        Assert.IsFalse(
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+            'No global override should have been created when this company already owns the status.');
     end;
 
     [Test]
@@ -921,7 +970,7 @@ codeunit 139595 "Report Layouts Test"
 
     [Test]
     [HandlerFunctions('EditExtensionOverrideDescHandler')]
-    procedure TestEditExtensionLayoutWritesCompanyDescriptionOverride()
+    procedure TestEditExtensionLayoutWritesGlobalDescriptionOverride()
     var
         TenantReportLayout: Record "Tenant Report Layout";
         TenantReportLayoutOverride: Record "Tenant Report Layout Override";
@@ -929,9 +978,9 @@ codeunit 139595 "Report Layouts Test"
         ReportLayoutsPage: TestPage "Report Layouts";
     begin
         // [FEATURE] [AI TEST]
-        // [SCENARIO] Editing an extension-installed layout's description writes a CURRENT-COMPANY
-        // Tenant Report Layout Override record instead of copying the layout. The dialog offers no
-        // scope choice — tenant-wide overrides are a governance act, not an everyday edit.
+        // [SCENARIO] Editing an extension-installed layout's description writes an ALL-COMPANIES
+        // Tenant Report Layout Override record instead of copying the layout. An extension layout is the
+        // same layout in every company, so its description is overridden tenant-wide by default.
         EnsureNewLayoutsAreCleaned();
 
         ReportLayoutList.SetRange("Report ID", 139595);
@@ -944,23 +993,23 @@ codeunit 139595 "Report Layouts Test"
         ReportLayoutsPage.EditLayout.Invoke();
         ReportLayoutsPage.Close();
 
-        // Assert - a COMPANY-scoped description override exists (and no global one), no tenant copy
+        // Assert - a GLOBAL description override exists (and no company-specific one), no tenant copy
         Assert.IsTrue(
-            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
-            'A company-specific override record should have been created.');
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+            'A global override record should have been created.');
         Assert.IsTrue(TenantReportLayoutOverride."Override Description", 'The Override Description flag should be set.');
         Assert.AreEqual(EditedLayoutNameTxt, TenantReportLayoutOverride.Description, 'The override should carry the edited description.');
         Assert.IsFalse(
-            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
-            'An everyday edit must never create a global override.');
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
+            'An everyday edit must not create a company-specific override.');
 
         TenantReportLayout.SetRange("Report ID", 139595);
         Assert.IsTrue(TenantReportLayout.IsEmpty(), 'No copy should have been created in Tenant Report Layout.');
     end;
 
     [Test]
-    [HandlerFunctions('EditExtensionOverrideCompanyObsoleteHandler')]
-    procedure TestEditExtensionLayoutWritesCompanyObsoleteOverride()
+    [HandlerFunctions('EditExtensionOverrideObsoleteHandler')]
+    procedure TestEditExtensionLayoutWritesGlobalObsoleteOverride()
     var
         TenantReportLayout: Record "Tenant Report Layout";
         TenantReportLayoutOverride: Record "Tenant Report Layout Override";
@@ -968,24 +1017,24 @@ codeunit 139595 "Report Layouts Test"
         ReportLayoutsPage: TestPage "Report Layouts";
     begin
         // [FEATURE] [AI TEST]
-        // [SCENARIO] Marking an extension-installed layout obsolete for the current company writes a
-        // company-specific override (one-way IsObsolete) instead of copying the layout.
+        // [SCENARIO] Marking an extension-installed layout obsolete writes an ALL-COMPANIES override
+        // (one-way IsObsolete) instead of copying the layout.
         EnsureNewLayoutsAreCleaned();
 
         ReportLayoutList.SetRange("Report ID", 139595);
         ReportLayoutList.SetRange("User Defined", false);
         Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
 
-        // Act - Edit info (override mode), company scope, mark obsolete
+        // Act - Edit info (override mode), mark obsolete
         ReportLayoutsPage.OpenView();
         ReportLayoutsPage.GoToRecord(ReportLayoutList);
         ReportLayoutsPage.EditLayout.Invoke();
         ReportLayoutsPage.Close();
 
-        // Assert - a company-specific obsolete override exists, no tenant copy
+        // Assert - a global obsolete override exists, no tenant copy
         Assert.IsTrue(
-            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
-            'A company-specific override record should have been created.');
+            TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+            'A global override record should have been created.');
         Assert.IsTrue(TenantReportLayoutOverride."Override IsObsolete", 'The Override IsObsolete flag should be set.');
         Assert.IsTrue(TenantReportLayoutOverride.IsObsolete, 'The override should mark the layout obsolete.');
 
@@ -1027,7 +1076,7 @@ codeunit 139595 "Report Layouts Test"
     end;
 
     [ModalPageHandler]
-    procedure EditExtensionOverrideCompanyObsoleteHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
+    procedure EditExtensionOverrideObsoleteHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
     begin
         ReportLayoutEditDialog.IsObsolete.SetValue(true);
         ReportLayoutEditDialog.OK().Invoke();

--- a/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
@@ -734,9 +734,8 @@ codeunit 139595 "Report Layouts Test"
         ReportLayoutList.SetRange("User Defined", false);
         Assert.IsTrue(ReportLayoutList.FindFirst(), 'The extension-installed test layout should be present.');
 
-        // Establish global scope FOR THE STATUS FIELD. The override table is field-granular, so scope is
-        // resolved from "Override Layout Status" - seeding a description-only row would not make the
-        // status global-scope (see TestGlobalDescriptionOnlyOverrideKeepsStatusCompanyScoped).
+        // Seed the STATUS field specifically: the table is field-granular, so scope is resolved from
+        // "Override Layout Status" and a description-only row would not establish it.
         TenantReportLayoutOverride.Init();
         TenantReportLayoutOverride."Report ID" := 139595;
         TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
@@ -800,7 +799,7 @@ codeunit 139595 "Report Layouts Test"
         TenantReportLayoutOverride."Report ID" := 139595;
         TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
         TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
-        TenantReportLayoutOverride."Company Name" := CompanyName();
+        TenantReportLayoutOverride."Company Name" := CopyStr(CompanyName(), 1, MaxStrLen(TenantReportLayoutOverride."Company Name"));
         TenantReportLayoutOverride.Description := EditedLayoutNameTxt;
         TenantReportLayoutOverride."Override Description" := true;
         TenantReportLayoutOverride.Insert(true);
@@ -903,7 +902,7 @@ codeunit 139595 "Report Layouts Test"
         TenantReportLayoutOverride."Report ID" := 139595;
         TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
         TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
-        TenantReportLayoutOverride."Company Name" := CompanyName();
+        TenantReportLayoutOverride."Company Name" := CopyStr(CompanyName(), 1, MaxStrLen(TenantReportLayoutOverride."Company Name"));
         TenantReportLayoutOverride."Layout Status" := Enum::"Report Layout Status"::Draft;
         TenantReportLayoutOverride."Override Layout Status" := true;
         TenantReportLayoutOverride.Insert(true);
@@ -954,7 +953,7 @@ codeunit 139595 "Report Layouts Test"
         TenantReportLayoutOverride."Report ID" := 139595;
         TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
         TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
-        TenantReportLayoutOverride."Company Name" := CompanyName();
+        TenantReportLayoutOverride."Company Name" := CopyStr(CompanyName(), 1, MaxStrLen(TenantReportLayoutOverride."Company Name"));
         TenantReportLayoutOverride."Layout Status" := Enum::"Report Layout Status"::Draft;
         TenantReportLayoutOverride."Override Layout Status" := true;
         TenantReportLayoutOverride.Insert(true);
@@ -1014,11 +1013,11 @@ codeunit 139595 "Report Layouts Test"
         repeat
             Assert.IsTrue(
                 TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
-                StrSubstNo('A global override should exist for layout %1.', ReportLayoutList."Name"));
+                StrSubstNo(GlobalOverrideMissingErr, ReportLayoutList."Name"));
             Assert.AreEqual(
                 Enum::"Report Layout Status"::Approved,
                 TenantReportLayoutOverride."Layout Status",
-                StrSubstNo('The global override for %1 should carry the Approved status.', ReportLayoutList."Name"));
+                StrSubstNo(GlobalOverrideApprovedErr, ReportLayoutList."Name"));
         until ReportLayoutList.Next() = 0;
     end;
 
@@ -1054,14 +1053,14 @@ codeunit 139595 "Report Layouts Test"
         repeat
             Assert.IsTrue(
                 TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
-                StrSubstNo('A global override should exist for layout %1.', ReportLayoutList."Name"));
+                StrSubstNo(GlobalOverrideMissingErr, ReportLayoutList."Name"));
             Assert.AreEqual(
                 Enum::"Report Layout Status"::Retired,
                 TenantReportLayoutOverride."Layout Status",
-                StrSubstNo('The global override for %1 should carry the Retired status.', ReportLayoutList."Name"));
+                StrSubstNo(GlobalOverrideRetiredErr, ReportLayoutList."Name"));
             Assert.IsFalse(
                 TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", CompanyName()),
-                StrSubstNo('No company-specific override should exist for layout %1.', ReportLayoutList."Name"));
+                StrSubstNo(CompanyOverrideUnexpectedErr, ReportLayoutList."Name"));
         until ReportLayoutList.Next() = 0;
     end;
 
@@ -1093,13 +1092,16 @@ codeunit 139595 "Report Layouts Test"
         TenantReportLayoutOverride."Override IsObsolete" := true;
         TenantReportLayoutOverride.Insert(true);
 
-        // Act - reopen Edit info; the handler asserts the obsolete field is locked
+        // Act - reopen Edit info; the handler records whether the obsolete field was editable
         ReportLayoutsPage.OpenView();
         ReportLayoutsPage.GoToRecord(ReportLayoutList);
         ReportLayoutsPage.EditLayout.Invoke();
         ReportLayoutsPage.Close();
 
-        // Assert - still obsolete; nothing cleared it
+        // Assert - the field was locked, and the layout is still obsolete
+        Assert.IsFalse(
+            LibraryVariableStorage.DequeueBoolean(),
+            'Mark layout as obsolete must be locked once the layout is already obsolete.');
         Assert.IsTrue(
             TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
             'The global obsolete override should still exist.');
@@ -1190,7 +1192,7 @@ codeunit 139595 "Report Layouts Test"
     begin
         // [FEATURE] [AI TEST]
         // [SCENARIO] Edit info on an extension layout + OK with no changes writes NO override
-        // (Slice 4 A — no silent global override for a no-op edit).
+        // (no silent global override for a no-op edit).
         EnsureNewLayoutsAreCleaned();
 
         ReportLayoutList.SetRange("Report ID", 139595);
@@ -1223,18 +1225,15 @@ codeunit 139595 "Report Layouts Test"
     [ModalPageHandler]
     procedure EditExtensionAssertObsoleteLockedHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
     begin
-        // One-way IsObsolete: on a layout that already resolves to obsolete the field must be locked,
-        // so there is no route back through the dialog.
-        Assert.IsFalse(
-            ReportLayoutEditDialog.IsObsolete.Editable(),
-            'Mark layout as obsolete must be locked once the layout is already obsolete.');
+        // Record only. The test asserts, so a mismatch cannot be swallowed by the calling UI operation.
+        LibraryVariableStorage.Enqueue(ReportLayoutEditDialog.IsObsolete.Editable());
         ReportLayoutEditDialog.OK().Invoke();
     end;
 
     [ModalPageHandler]
     procedure EditExtensionOverrideNoOpHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
     begin
-        // Change nothing, just confirm — should write no override (Slice 4 A).
+        // Change nothing, just confirm — should write no override.
         ReportLayoutEditDialog.OK().Invoke();
     end;
 
@@ -1265,7 +1264,8 @@ codeunit 139595 "Report Layouts Test"
         ReportLayoutsPage.EditLayout.Invoke();
         ReportLayoutsPage.Close();
 
-        // Assert - the copy exists as a GLOBAL tenant layout (Company Name empty), and no override
+        // Assert - the dialog defaulted to all companies, the copy is a GLOBAL tenant layout, no override
+        Assert.AreEqual('Yes', LibraryVariableStorage.DequeueText(), 'A copy should default to all companies.');
         Assert.IsTrue(
             TenantReportLayout.Get(139595, EditedLayoutNameTxt, EmptyGuid),
             'The copy should exist in Tenant Report Layout under its new name.');
@@ -1278,10 +1278,10 @@ codeunit 139595 "Report Layouts Test"
     [ModalPageHandler]
     procedure EditExtensionCopyAllCompaniesHandler(var ReportLayoutEditDialog: TestPage "Report Layout Edit Dialog")
     begin
-        // Ticking Copy must expose an editable Layout Name and the availability field (Slice 4 B + 4c).
         ReportLayoutEditDialog.CreateCopy.SetValue(true);
         ReportLayoutEditDialog.LayoutName.SetValue(EditedLayoutNameTxt);
-        Assert.AreEqual('Yes', ReportLayoutEditDialog.AvailableInAllCompanies.Value, 'A copy should default to all companies.');
+        // Record only; the test asserts it.
+        LibraryVariableStorage.Enqueue(ReportLayoutEditDialog.AvailableInAllCompanies.Value);
         ReportLayoutEditDialog.OK().Invoke();
     end;
 
@@ -1289,9 +1289,14 @@ codeunit 139595 "Report Layouts Test"
     var
         Assert: Codeunit Assert;
         TempBlob: Codeunit "Temp Blob";
+        LibraryVariableStorage: Codeunit "Library - Variable Storage";
         NewLayoutNameTxt: Label 'NewLayout';
         EditedLayoutNameTxt: Label 'EditedLayout';
         SampleTextTxt: Label 'ATAKLOA, TINWTABSBATF.';
         AlternateLayoutTextTxt: Label 'IWATSTGIFLBOTG.';
+        GlobalOverrideMissingErr: Label 'A global override should exist for layout %1.', Comment = '%1 = layout name';
+        GlobalOverrideApprovedErr: Label 'The global override for %1 should carry the Approved status.', Comment = '%1 = layout name';
+        GlobalOverrideRetiredErr: Label 'The global override for %1 should carry the Retired status.', Comment = '%1 = layout name';
+        CompanyOverrideUnexpectedErr: Label 'No company-specific override should exist for layout %1.', Comment = '%1 = layout name';
         InsertedLayoutContextTxt: Text;
 }

--- a/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportLayoutsTest.Codeunit.al
@@ -971,6 +971,58 @@ codeunit 139595 "Report Layouts Test"
     end;
 
     [Test]
+    procedure TestBatchStatusResolvesScopeWithoutSetSelectedCompany()
+    var
+        ReportLayoutList: Record "Report Layout List";
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+        ReportLayoutsImpl: Codeunit "Report Layouts Impl.";
+        UpdateCount: Integer;
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO] Scope resolution must not depend on a caller having called SetSelectedCompany first.
+        // "Report Theme and Header/Footer" reaches SetLayoutStatusBatch without calling it, and a blank
+        // company would make the company-row lookup probe the GLOBAL row instead: an already-overridden
+        // layout would then classify as company scope while a fresh one classified as global, and this
+        // batch would fail with the mixed-scope error even though both are global.
+        // Note this test deliberately does NOT call SetSelectedCompany.
+        EnsureNewLayoutsAreCleaned();
+
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        Assert.AreEqual(2, ReportLayoutList.Count(), 'The test report should ship two extension layouts.');
+        ReportLayoutList.FindFirst();
+
+        // One layout already carries a GLOBAL status override; the other has none. Both are global scope.
+        TenantReportLayoutOverride.Init();
+        TenantReportLayoutOverride."Report ID" := 139595;
+        TenantReportLayoutOverride."Name" := ReportLayoutList."Name";
+        TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
+        TenantReportLayoutOverride."Company Name" := '';
+        TenantReportLayoutOverride."Layout Status" := Enum::"Report Layout Status"::Draft;
+        TenantReportLayoutOverride."Override Layout Status" := true;
+        TenantReportLayoutOverride.Insert(true);
+
+        // Act - batch over BOTH, with SelectedCompany never set
+        ReportLayoutList.Reset();
+        ReportLayoutList.SetRange("Report ID", 139595);
+        ReportLayoutList.SetRange("User Defined", false);
+        UpdateCount := ReportLayoutsImpl.SetLayoutStatusBatch(ReportLayoutList, Enum::"Report Layout Status"::Approved);
+
+        // Assert - no spurious mixed-scope error, and both layouts updated globally
+        Assert.AreEqual(2, UpdateCount, 'Both layouts should have been updated; a blank company must not split the scope.');
+        ReportLayoutList.FindSet();
+        repeat
+            Assert.IsTrue(
+                TenantReportLayoutOverride.Get(139595, ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", ''),
+                StrSubstNo('A global override should exist for layout %1.', ReportLayoutList."Name"));
+            Assert.AreEqual(
+                Enum::"Report Layout Status"::Approved,
+                TenantReportLayoutOverride."Layout Status",
+                StrSubstNo('The global override for %1 should carry the Approved status.', ReportLayoutList."Name"));
+        until ReportLayoutList.Next() = 0;
+    end;
+
+    [Test]
     procedure TestBatchStatusOverAllGlobalLayoutsUpdatesEveryOne()
     var
         ReportLayoutList: Record "Report Layout List";

--- a/src/Layers/W1/Tests/Report/Reports/TestReportLayoutsReport.Report.al
+++ b/src/Layers/W1/Tests/Report/Reports/TestReportLayoutsReport.Report.al
@@ -27,5 +27,12 @@ report 139595 TestReportLayoutsReport
             Type = RDLC;
             LayoutFile = 'Layouts/TestReportLayoutsReport.rdl';
         }
+        // Second extension-installed layout so tests can exercise multi-layout scenarios
+        // (e.g. mixed global/company scope in a batch status change - CP0529-338).
+        layout(MYLAYOUT2)
+        {
+            Type = RDLC;
+            LayoutFile = 'Layouts/TestReportLayoutsReport.rdl';
+        }
     }
 }

--- a/src/Layers/W1/Tests/Report/Reports/TestReportLayoutsReport.Report.al
+++ b/src/Layers/W1/Tests/Report/Reports/TestReportLayoutsReport.Report.al
@@ -29,10 +29,11 @@ report 139595 TestReportLayoutsReport
         }
         // Second extension-installed layout so tests can exercise multi-layout scenarios
         // (e.g. mixed global/company scope in a batch status change - CP0529-338).
+        // Uses its own layout file: a layout file must not be shared between layouts (AL0835).
         layout(MYLAYOUT2)
         {
             Type = RDLC;
-            LayoutFile = 'Layouts/TestReportLayoutsReport.rdl';
+            LayoutFile = 'Layouts/TestReportLayoutsReport2.rdl';
         }
     }
 }


### PR DESCRIPTION
## Summary
Application-side implementation of CP0529-338: lifecycle/property changes to an **extension-installed** report layout now write a `Tenant Report Layout Override` record instead of copying the layout into `Tenant Report Layout` (which left the original visible with its default values).

- **Layout Status** (Set Approved/Draft/Pending/Retired) on an extension layout writes an override for **all companies**. An extension layout is the same layout in every company, and the override records metadata about its lifecycle rather than changing the layout itself, so tenant-wide is the default rather than a special case.
- **Edit info** overrides **Description** and **IsObsolete** (one-way — a layout already obsolete in metadata cannot be un-obsoleted), also for all companies. There is no scope control in the dialog; *Available in All Companies* is shown read-only and states the scope the override is written at. "Save Changes to a Copy" is kept as an opt-in escape hatch: ticking it makes the layout name, the copy's own company scope **and the obsolete flag** editable, because the copy is an ordinary tenant layout; unticking it restores the values the in-place override will actually write, so a read-only field never displays something the write contradicts.
- **Company precedence is preserved.** Where a company already has a status override of its own, a further status change stays in that company. Such rows can no longer be created from the UI but may exist from an earlier version or a vendor's install codeunit. A batch run must still be single-scope — a mix is rejected — so one run is never ambiguous.
- **Only fields the user actually changed are written.** Opening *Edit info* and pressing OK without editing anything creates no override record at all.
- **User-defined layouts are unchanged** (in-place update in `Tenant Report Layout`).

The update path is chosen by `Report Layout List."User Defined"`: `true` → in-place update; `false` → upsert a `Tenant Report Layout Override` record. Scope is resolved **per field** — from the `Override Layout Status` flag rather than from the mere existence of a row — so a description-only or obsolete-only row never drags a status change into the wrong scope.

Telemetry for the override path uses its own allocated event id `0000RTQ` with metadata-only dimensions; the layout description is reported as a changed/not-changed flag, never as content.

## Tests
`Report Layouts Test` (codeunit 139595) — **33 tests**, covering the all-companies default for both the status and edit paths, company precedence where a company already owns the status, field-granular scope resolution in both directions, no-op edits writing nothing, one-way `IsObsolete`, the copy escape hatch, both the success and mixed-scope-rejection paths of a multi-layout batch run, and the pre-existing user-defined regression suite. A second shipped layout (`MYLAYOUT2`) was added to the test report so multi-layout scope scenarios are exercisable.

Two of those cover the dialog transitions raised in review: unticking *Save Changes to a Copy* after selecting company-only must restore the all-companies scope, and taking a copy of an obsolete extension layout must re-enable the obsolete field so the copy is not stuck obsolete.

Modal handlers **record** what they observe and the test asserts it after the dialog closes, rather than asserting inside the handler where a failure can be swallowed by the calling UI operation. `LibraryVariableStorage` is cleared at the start of every test and asserted empty at the end, so a leaked value cannot cascade and each dialog is proven to have fired exactly once.

The tests that cover the all-companies paths deliberately register **no `ConfirmHandler`**, so an unexpected prompt fails them — that is what pins the removal of the former confirmation.

Scope behaviour is additionally checked by hand across two companies, using a helper extension that surfaces the override scope the product page does not display.

## Notes for reviewers
- The all-companies **confirmation** that an earlier revision raised on the status path has been removed. Once tenant-wide is the normal scope, prompting on the everyday path trains users to dismiss the dialog without reading it; the change is layout metadata, not layout content. The mixed-scope rejection is kept.
- `AccessByPermission = tabledata "Tenant Report Layout" = M` is deliberate: `BaseSystemPermissionSet` grants the tenant layout and override tables together, so it correctly represents "may manage layout status" and matches the page's own permission.
- A dedicated permission for tenant-wide writes was considered and **deliberately not introduced here** — it would touch every layout object and belongs to a permission design owned by the application team; a request to revisit that model is being raised with them separately.
- Deferred with the reasoning recorded on the relevant threads, and carried in the work item: improving the mixed-scope error to name the split (belongs with per-layout scope visibility), a pre-existing company-scoped row taking precedence in its own company, `StatusChangedMessageHandler` not inspecting the message it consumes (pre-existing), and the parameter shape of `UpsertLayoutOverride` (changes again with the company-scoped option).

[AB#637301](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637301)

