### PR TITLE
Bug 642230: [28.x][Community reported] Data Search - Show all records is missing an event call to make it consistent with the initial search

### DIFF
--- a/src/Apps/W1/DataSearch/App/DataSearchResultRecords.page.al
+++ b/src/Apps/W1/DataSearch/App/DataSearchResultRecords.page.al
@@ -16,7 +16,7 @@ page 2682 "Data Search Result Records"
     InherentEntitlements = X;
     InherentPermissions = X;
     AnalysisModeEnabled = false;
-    
+
     layout
     {
         area(content)
@@ -378,6 +378,7 @@ page 2682 "Data Search Result Records"
     internal procedure SetSourceRecRef(var RecRef: RecordRef; TableSubtype: Integer; SearchString: Text; NewPageCaption: Text)
     var
         DataSearchInTable: Codeunit "Data Search in Table";
+        DataSearchEvents: Codeunit "Data Search Events";
         FldRef: FieldRef;
     begin
         if RecRef.Number = 0 then
@@ -389,6 +390,7 @@ page 2682 "Data Search Result Records"
         FldRef := SourceRecRef.Field(SourceRecRef.SystemModifiedAtNo);
         SourceRecRef.SetView(StrSubstNo(SetViewLbl, FldRef.Name));
         DataSearchInTable.SetFiltersOnRecRef(SourceRecRef, TableSubtype, SearchString);
+        DataSearchEvents.OnBeforeSearchTable(SourceRecRef);
         TableCaptionTxt := NewPageCaption;
     end;
 


### PR DESCRIPTION
Fixes [AB#642230](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642230)

Backport from main. Added event raise from before showing the full resultset, so we filter the same way as in the search itself.



