### PR TITLE
Fix untrappable JSON error in E-Document ADI import (Bug 640122)

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Helpers/EDocumentJsonHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Helpers/EDocumentJsonHelper.Codeunit.al
@@ -8,14 +8,20 @@ codeunit 6121 "EDocument Json Helper"
 {
     Access = Internal;
 
+    var
+        MalformedAdiResponseTxt: label 'ADI response is missing the expected ''%1'' property; returning an empty object.', Locked = true;
+        TelemetryCategoryTxt: label 'E-Document Matching Assistance', Locked = true;
+
     internal procedure GetHeaderFields(SourceJsonObject: JsonObject): JsonObject
     var
         JsonToken: JsonToken;
         ContentObject, EmptyObject : JsonObject;
     begin
         ContentObject := GetInnerObject(SourceJsonObject);
-        if not ContentObject.Get('fields', JsonToken) then
+        if not ContentObject.Get('fields', JsonToken) then begin
+            Session.LogMessage('', StrSubstNo(MalformedAdiResponseTxt, 'fields'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
             exit(EmptyObject);
+        end;
         exit(JsonToken.AsObject());
     end;
 
@@ -34,14 +40,20 @@ codeunit 6121 "EDocument Json Helper"
         JsonToken: JsonToken;
         OutputsObject, InnerObject, EmptyObject : JsonObject;
     begin
-        if not SourceJsonObject.Get('outputs', JsonToken) then
+        if not SourceJsonObject.Get('outputs', JsonToken) then begin
+            Session.LogMessage('', StrSubstNo(MalformedAdiResponseTxt, 'outputs'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
             exit(EmptyObject);
+        end;
         OutputsObject := JsonToken.AsObject();
-        if not OutputsObject.Get('1', JsonToken) then
+        if not OutputsObject.Get('1', JsonToken) then begin
+            Session.LogMessage('', StrSubstNo(MalformedAdiResponseTxt, '1'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
             exit(EmptyObject);
+        end;
         InnerObject := JsonToken.AsObject();
-        if not InnerObject.Get('result', JsonToken) then
+        if not InnerObject.Get('result', JsonToken) then begin
+            Session.LogMessage('', StrSubstNo(MalformedAdiResponseTxt, 'result'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
             exit(EmptyObject);
+        end;
         exit(JsonToken.AsObject());
     end;
 

--- a/src/Apps/W1/EDocument/App/src/Helpers/EDocumentJsonHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Helpers/EDocumentJsonHelper.Codeunit.al
@@ -11,10 +11,11 @@ codeunit 6121 "EDocument Json Helper"
     internal procedure GetHeaderFields(SourceJsonObject: JsonObject): JsonObject
     var
         JsonToken: JsonToken;
-        ContentObject: JsonObject;
+        ContentObject, EmptyObject : JsonObject;
     begin
         ContentObject := GetInnerObject(SourceJsonObject);
-        ContentObject.Get('fields', JsonToken);
+        if not ContentObject.Get('fields', JsonToken) then
+            exit(EmptyObject);
         exit(JsonToken.AsObject());
     end;
 
@@ -31,13 +32,16 @@ codeunit 6121 "EDocument Json Helper"
     internal procedure GetInnerObject(SourceJsonObject: JsonObject): JsonObject
     var
         JsonToken: JsonToken;
-        OutputsObject, InnerObject : JsonObject;
+        OutputsObject, InnerObject, EmptyObject : JsonObject;
     begin
-        SourceJsonObject.Get('outputs', JsonToken);
+        if not SourceJsonObject.Get('outputs', JsonToken) then
+            exit(EmptyObject);
         OutputsObject := JsonToken.AsObject();
-        OutputsObject.Get('1', JsonToken);
+        if not OutputsObject.Get('1', JsonToken) then
+            exit(EmptyObject);
         InnerObject := JsonToken.AsObject();
-        InnerObject.Get('result', JsonToken);
+        if not InnerObject.Get('result', JsonToken) then
+            exit(EmptyObject);
         exit(JsonToken.AsObject());
     end;
 

--- a/src/Apps/W1/EDocument/App/src/Helpers/EDocumentJsonHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Helpers/EDocumentJsonHelper.Codeunit.al
@@ -19,7 +19,7 @@ codeunit 6121 "EDocument Json Helper"
     begin
         ContentObject := GetInnerObject(SourceJsonObject);
         if not ContentObject.Get('fields', JsonToken) then begin
-            Session.LogMessage('', StrSubstNo(MalformedAdiResponseTxt, 'fields'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
+            Session.LogMessage('0000UK1', StrSubstNo(MalformedAdiResponseTxt, 'fields'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
             exit(EmptyObject);
         end;
         exit(JsonToken.AsObject());
@@ -41,17 +41,17 @@ codeunit 6121 "EDocument Json Helper"
         OutputsObject, InnerObject, EmptyObject : JsonObject;
     begin
         if not SourceJsonObject.Get('outputs', JsonToken) then begin
-            Session.LogMessage('', StrSubstNo(MalformedAdiResponseTxt, 'outputs'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
+            Session.LogMessage('0000UK2', StrSubstNo(MalformedAdiResponseTxt, 'outputs'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
             exit(EmptyObject);
         end;
         OutputsObject := JsonToken.AsObject();
         if not OutputsObject.Get('1', JsonToken) then begin
-            Session.LogMessage('', StrSubstNo(MalformedAdiResponseTxt, '1'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
+            Session.LogMessage('0000UK3', StrSubstNo(MalformedAdiResponseTxt, '1'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
             exit(EmptyObject);
         end;
         InnerObject := JsonToken.AsObject();
         if not InnerObject.Get('result', JsonToken) then begin
-            Session.LogMessage('', StrSubstNo(MalformedAdiResponseTxt, 'result'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
+            Session.LogMessage('0000UK4', StrSubstNo(MalformedAdiResponseTxt, 'result'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
             exit(EmptyObject);
         end;
         exit(JsonToken.AsObject());


### PR DESCRIPTION
## Why

The E-Document Matching Assistance (ADI) import path in `EDocument Json Helper` read properties from the ADI response using `JsonObject.Get(...)` without checking the boolean return value. When the Azure Document Intelligence response was malformed or missing an expected property (`outputs`, `1`, `result`, or `fields`), the subsequent `JsonToken.AsObject()` call operated on an uninitialized token, raising an untrappable runtime error that crashed the import instead of degrading gracefully.

## Summary

- **Fixed** the untrappable JSON error by guarding every `Get` call in `GetInnerObject` and `GetHeaderFields`; when an expected property is absent the helper now returns an empty `JsonObject` instead of dereferencing an uninitialized token.
- **Added** telemetry (`0000UK1`-`0000UK4`, Warning) under the "E-Document Matching Assistance" category so malformed ADI responses are diagnosable, with a locked label naming the missing property.

[AB#640122](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640122)
