### PR TITLE
[TEST - DO NOT MERGE] Validate BCQuality v1.2 DataClassification taxonomy (re-run of #9427)

### DIFF
--- a/src/Apps/W1/BCQualityClassificationValidation/app/app.json
+++ b/src/Apps/W1/BCQualityClassificationValidation/app/app.json
@@ -1,0 +1,29 @@
+{
+  "id": "2b88277b-ba73-4868-adaa-661f64c39122",
+  "name": "BCQuality Classification Validation",
+  "publisher": "Microsoft",
+  "brief": "Test sample that exercises the privacy DataClassification BCQuality article.",
+  "description": "Throwaway sample used only to validate the Copilot PR review against the updated privacy DataClassification and style Label-scope BCQuality articles. DO NOT MERGE.",
+  "version": "1.0.0.0",
+  "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
+  "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
+  "help": "https://go.microsoft.com/fwlink/?linkid=2009036",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
+  "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2115702",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "29.0.0.0",
+  "resourceExposurePolicy": {
+    "allowDebugging": false,
+    "allowDownloadingSource": true,
+    "includeSourceInSymbolFile": true
+  },
+  "application": "29.0.0.0",
+  "target": "Cloud",
+  "idRanges": [
+    {
+      "from": 50100,
+      "to": 50149
+    }
+  ]
+}

--- a/src/Apps/W1/BCQualityClassificationValidation/app/src/BCQValidationCustomer.Table.al
+++ b/src/Apps/W1/BCQualityClassificationValidation/app/src/BCQValidationCustomer.Table.al
@@ -1,0 +1,46 @@
+table 50100 "BCQ Validation Customer"
+{
+    Caption = 'BCQ Validation Customer';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+            Caption = 'No.';
+            DataClassification = CustomerContent;
+        }
+        field(2; "Full Name"; Text[100])
+        {
+            Caption = 'Full Name';
+            // Personal PII left unreviewed.
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Email Address"; Text[80])
+        {
+            Caption = 'Email Address';
+            // Real personal PII silenced by classifying it as platform metadata.
+            DataClassification = SystemMetadata;
+        }
+        field(4; "VAT Registration No."; Text[20])
+        {
+            Caption = 'VAT Registration No.';
+            // Company VAT / registration number.
+            DataClassification = ToBeClassified;
+        }
+        field(5; "IBAN"; Text[50])
+        {
+            Caption = 'IBAN';
+            // Bank account / IBAN.
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Apps/W1/BCQualityClassificationValidation/app/src/BCQValidationProcessor.Codeunit.al
+++ b/src/Apps/W1/BCQualityClassificationValidation/app/src/BCQValidationProcessor.Codeunit.al
@@ -1,0 +1,9 @@
+codeunit 50101 "BCQ Validation Processor"
+{
+    procedure GreetCustomer(var ValidationCustomer: Record "BCQ Validation Customer")
+    var
+        WelcomeMsg: Label 'Welcome, %1', Comment = '%1 = customer full name';
+    begin
+        Message(WelcomeMsg, ValidationCustomer."Full Name");
+    end;
+}


### PR DESCRIPTION
## ⚠️ TEST — DO NOT MERGE

Fresh re-run of #9427 to validate the Copilot PR review against **BCQuality v1.2** (engine `@latest` = 1.0.2, ref `809af97`). A new PR is used so no stale review comments dedupe the new findings.

### What to confirm (vs the v1.1 baseline in #9427)

`BCQValidationCustomer.Table.al`:
- `VAT Registration No.` (`ToBeClassified`) → should now be recommended **`OrganizationIdentifiableInformation`** (new taxonomy).
- `IBAN` (`ToBeClassified`) → should now be recommended **`AccountData`** (new taxonomy) — the v1.1 run only said "resolve ToBeClassified".
- `Email Address` (`SystemMetadata`) → under-classification, `EndUserIdentifiableInformation`.
- `Full Name` (`ToBeClassified`) → real PII left unreviewed.

`BCQValidationProcessor.Codeunit.al`:
- `WelcomeMsg` local-scope `Label` → `style/labels-declared-at-object-scope` at **minor** (not suppressed to info).

Knowledge links on the findings should point at BCQuality `809af97`, not `be1b92b`.

