### PR TITLE
636017 Move Item Price List and Res. Price List report action tooltip…

### DIFF
--- a/src/Layers/APAC/BaseApp/Inventory/Item/ItemList.Page.al
+++ b/src/Layers/APAC/BaseApp/Inventory/Item/ItemList.Page.al
@@ -1071,7 +1071,6 @@ page 31 "Item List"
                     Image = "Report";
                     Visible = ExtendedPriceEnabled;
                     RunObject = Report "Item Price List";
-                    ToolTip = 'View, print, or save a list of your items and their prices, for example, to send to customers. You can create the list for specific customers, campaigns, currencies, or other criteria.';
                 }
                 action("Inventory Cost and Price List")
                 {

--- a/src/Layers/GB/BaseApp/Inventory/Item/ItemList.Page.al
+++ b/src/Layers/GB/BaseApp/Inventory/Item/ItemList.Page.al
@@ -1080,7 +1080,6 @@ page 31 "Item List"
                     Image = "Report";
                     Visible = ExtendedPriceEnabled;
                     RunObject = Report "Item Price List";
-                    ToolTip = 'View, print, or save a list of your items and their prices, for example, to send to customers. You can create the list for specific customers, campaigns, currencies, or other criteria.';
                 }
                 action("Inventory Cost and Price List")
                 {

--- a/src/Layers/IT/BaseApp/Inventory/Item/ItemList.Page.al
+++ b/src/Layers/IT/BaseApp/Inventory/Item/ItemList.Page.al
@@ -1070,7 +1070,6 @@ page 31 "Item List"
                     Image = "Report";
                     Visible = ExtendedPriceEnabled;
                     RunObject = Report "Item Price List";
-                    ToolTip = 'View, print, or save a list of your items and their prices, for example, to send to customers. You can create the list for specific customers, campaigns, currencies, or other criteria.';
                 }
                 action("Inventory Cost and Price List")
                 {

--- a/src/Layers/NA/BaseApp/Inventory/Item/ItemList.Page.al
+++ b/src/Layers/NA/BaseApp/Inventory/Item/ItemList.Page.al
@@ -1076,7 +1076,6 @@ page 31 "Item List"
                     Image = "Report";
                     Visible = ExtendedPriceEnabled;
                     RunObject = Report "Item Price List";
-                    ToolTip = 'View, print, or save a list of your items and their prices, for example, to send to customers. You can create the list for specific customers, campaigns, currencies, or other criteria.';
                 }
                 action("Inventory Cost and Price List")
                 {

--- a/src/Layers/NA/BaseApp/Projects/Resources/Resource/ResourceList.Page.al
+++ b/src/Layers/NA/BaseApp/Projects/Resources/Resource/ResourceList.Page.al
@@ -545,7 +545,6 @@ page 77 "Resource List"
                 Image = "Report";
                 Visible = ExtendedPriceEnabled;
                 RunObject = Report "Res. Price List";
-                ToolTip = 'Specifies a list of unit prices for the selected resources. By default, a unit price is based on the price in the Resource Prices window. If there is no valid alternative price, then the unit price from the resource card is used. The report can be used by the company''s salespeople or sent to customers.';
             }
             action("Resource Register")
             {

--- a/src/Layers/RU/BaseApp/Inventory/Item/ItemList.Page.al
+++ b/src/Layers/RU/BaseApp/Inventory/Item/ItemList.Page.al
@@ -1070,7 +1070,6 @@ page 31 "Item List"
                     Image = "Report";
                     Visible = ExtendedPriceEnabled;
                     RunObject = Report "Item Price List";
-                    ToolTip = 'View, print, or save a list of your items and their prices, for example, to send to customers. You can create the list for specific customers, campaigns, currencies, or other criteria.';
                 }
                 action("Inventory Cost and Price List")
                 {

--- a/src/Layers/W1/BaseApp/Inventory/Item/ItemList.Page.al
+++ b/src/Layers/W1/BaseApp/Inventory/Item/ItemList.Page.al
@@ -1070,7 +1070,6 @@ page 31 "Item List"
                     Image = "Report";
                     Visible = ExtendedPriceEnabled;
                     RunObject = Report "Item Price List";
-                    ToolTip = 'View, print, or save a list of your items and their prices, for example, to send to customers. You can create the list for specific customers, campaigns, currencies, or other criteria.';
                 }
                 action("Inventory Cost and Price List")
                 {

--- a/src/Layers/W1/BaseApp/Pricing/Reports/ItemPriceList.Report.al
+++ b/src/Layers/W1/BaseApp/Pricing/Reports/ItemPriceList.Report.al
@@ -24,6 +24,7 @@ report 7050 "Item Price List"
 {
     ApplicationArea = Basic, Suite;
     Caption = 'Item Price List';
+    ToolTip = 'View, print, or save a list of your items and their prices, for example, to send to customers. You can create the list for specific customers, campaigns, currencies, or other criteria.';
     PreviewMode = PrintLayout;
     UsageCategory = ReportsAndAnalysis;
     DefaultRenderingLayout = RDLCLayout;

--- a/src/Layers/W1/BaseApp/Pricing/Reports/ResPriceList.Report.al
+++ b/src/Layers/W1/BaseApp/Pricing/Reports/ResPriceList.Report.al
@@ -21,6 +21,7 @@ report 7054 "Res. Price List"
 {
     ApplicationArea = Jobs;
     Caption = 'Resource Price List';
+    ToolTip = 'Specifies a list of unit prices for the selected resources. By default, a unit price is based on the price in the Resource Prices window. If there is no valid alternative price, then the unit price from the resource card is used. The report can be used by the company''s salespeople or sent to customers.';
     PreviewMode = PrintLayout;
     UsageCategory = ReportsAndAnalysis;
     DefaultRenderingLayout = RDLCLayout;

--- a/src/Layers/W1/BaseApp/Projects/Resources/Resource/ResourceList.Page.al
+++ b/src/Layers/W1/BaseApp/Projects/Resources/Resource/ResourceList.Page.al
@@ -544,7 +544,6 @@ page 77 "Resource List"
                 Image = "Report";
                 Visible = ExtendedPriceEnabled;
                 RunObject = Report "Res. Price List";
-                ToolTip = 'Specifies a list of unit prices for the selected resources. By default, a unit price is based on the price in the Resource Prices window. If there is no valid alternative price, then the unit price from the resource card is used. The report can be used by the company''s salespeople or sent to customers.';
             }
             action("Resource Register")
             {


### PR DESCRIPTION
## What & why

Moves the report action ToolTips for **report 7050 "Item Price List"** and **report 7054 "Res. Price List"** off the page actions that run them and onto the report objects themselves. The tooltip is now defined once on the report and applies wherever the report is invoked, and the now-duplicate `ToolTip` is removed from the page actions.

This is part of the "move report action tooltips to report objects" cleanup (CP0529-331 / slice 636017), and the first area landed after the move to GitHub.

- W1: report-level `ToolTip` added to `ItemPriceList.Report.al` and `ResPriceList.Report.al`; duplicate removed from the `Item Price List` action on `Inventory/Item/ItemList.Page.al` and the `Res. Price List` action on `Projects/Resources/Resource/ResourceList.Page.al`.
- Country layers: same page-action removal in the forks that carry it — `ItemList` in APAC/GB/IT/NA/RU and `ResourceList` in NA. The two reports have no country forks, so no report-side changes there.

## Linked work

Fixes [AB#636017](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636017)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Metadata-only change (`ToolTip` property). Diff verified to be tooltip-only across all 10 files (2 report additions, 8 page-action removals), with BOM/EOL preserved. The tooltip text moved to each report is byte-identical to what previously showed on the page action, so the end-user tooltip is unchanged — it is now sourced from the report object.

No tests added: `ToolTip` is a design-time metadata property with no runtime behavior to assert; there is no existing tooltip test harness for these objects.

## Risk & compatibility

Low. No code, schema, table, or behavior change — only the `ToolTip` design property moves from page action to report. No upgrade/data impact, no permission/telemetry impact, no breaking change. Same cleanup pattern already merged for Warehouse, Manufacturing, Service, Sales and Inventory.




