### PR TITLE
[Main]-"Factura Duplicada" error message appears under SII History if you use the same Vendor Invoice No. for the same Vendor (VAT Registration No.) in different documents in the Spanish version.

### DIFF
--- a/src/Layers/ES/BaseApp/Local/SII/Purchases/Document/SIIPurchaseSubscribers.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Local/SII/Purchases/Document/SIIPurchaseSubscribers.Codeunit.al
@@ -8,9 +8,15 @@ using Microsoft.Finance.GeneralLedger.Journal;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
 using Microsoft.Purchases.Payables;
+using Microsoft.Purchases.Vendor;
+using Microsoft.Utilities;
+using System.Environment.Configuration;
 
 codeunit 7000126 "SII Purchase Subscribers"
 {
+    var
+        SIIDuplicateExtDocNoTxt: Label 'A posted %1 with external document number %2 already exists for vendor %3. Because SII is enabled, the Spanish Tax Authority may reject this document as a duplicate (Factura Duplicada).', Comment = '%1 = Vendor Ledger Entry Document Type; %2 = External Document No.; %3 = Vendor No.';
+        ShowSIIDuplicateVendLedgEntryTxt: Label 'Show the posted document';
     [EventSubscriber(ObjectType::Table, Database::"Purchase Header", 'OnAfterValidateEvent', 'Pay-to Vendor No.', false, false)]
     local procedure PurchHeaderOnAfterValidatePayToVendorNo(var Rec: Record "Purchase Header")
     var
@@ -34,6 +40,94 @@ codeunit 7000126 "SII Purchase Subscribers"
         SIISchemeCodeMgt: Codeunit "SII Scheme Code Mgt.";
     begin
         SIISchemeCodeMgt.UpdatePurchSpecialSchemeCodeInPurchLine(Rec);
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"Purchase Header", 'OnAfterValidateEvent', 'Vendor Invoice No.', false, false)]
+    local procedure PurchHeaderOnAfterValidateVendorInvoiceNo(var Rec: Record "Purchase Header")
+    begin
+        NotifyIfSIIDuplicateExternalDocNo(Rec, Rec."Vendor Invoice No.");
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"Purchase Header", 'OnAfterValidateEvent', 'Vendor Cr. Memo No.', false, false)]
+    local procedure PurchHeaderOnAfterValidateVendorCrMemoNo(var Rec: Record "Purchase Header")
+    begin
+        NotifyIfSIIDuplicateExternalDocNo(Rec, Rec."Vendor Cr. Memo No.");
+    end;
+
+    local procedure NotifyIfSIIDuplicateExternalDocNo(PurchaseHeader: Record "Purchase Header"; ExternalDocNo: Code[35])
+    var
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        SIIManagement: Codeunit "SII Management";
+    begin
+        // Only relevant when SII is active. The per-user notification toggle is evaluated (and
+        // seeded when missing) inside SendSIIDuplicateExtDocNoNotification, mirroring the standard flow.
+        if ExternalDocNo = '' then
+            exit;
+        if PurchaseHeader."Pay-to Vendor No." = '' then
+            exit;
+        if not SIIManagement.IsSIISetupEnabled() then
+            exit;
+
+        // The standard OnValidate already warns for the SAME document type.
+        // SII adds the cross-type case (Invoice vs. Credit Memo), which shares the same IDFactura for AEAT.
+        if FindPostedDocWithSameExtDocNoDifferentType(PurchaseHeader, ExternalDocNo, VendorLedgerEntry) then
+            SendSIIDuplicateExtDocNoNotification(PurchaseHeader, VendorLedgerEntry);
+    end;
+
+    local procedure FindPostedDocWithSameExtDocNoDifferentType(PurchaseHeader: Record "Purchase Header"; ExternalDocNo: Code[35]; var VendorLedgerEntry: Record "Vendor Ledger Entry"): Boolean
+    var
+        VendorMgt: Codeunit "Vendor Mgt.";
+    begin
+        VendorLedgerEntry.Reset();
+        VendorLedgerEntry.SetCurrentKey("External Document No.");
+        // Reuse the standard filter so 'Same Ext. Doc. No. in Diff. FY' (ES) is honored via OnAfterSetFilterForExternalDocNo.
+        VendorMgt.SetFilterForExternalDocNo(
+            VendorLedgerEntry, GetOppositeGenJnlDocType(PurchaseHeader), ExternalDocNo,
+            PurchaseHeader."Pay-to Vendor No.", PurchaseHeader."Document Date");
+        VendorLedgerEntry.SetRange("Do Not Send To SII", false);
+        exit(VendorLedgerEntry.FindFirst());
+    end;
+
+    local procedure GetOppositeGenJnlDocType(PurchaseHeader: Record "Purchase Header"): Enum "Gen. Journal Document Type"
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+    begin
+        // Invoice/Order -> look for posted Credit Memos; Credit Memo/Return Order -> look for posted Invoices.
+        case PurchaseHeader."Document Type" of
+            PurchaseHeader."Document Type"::"Credit Memo",
+            PurchaseHeader."Document Type"::"Return Order":
+                exit(GenJournalLine."Document Type"::Invoice);
+            else
+                exit(GenJournalLine."Document Type"::"Credit Memo");
+        end;
+    end;
+
+    local procedure SendSIIDuplicateExtDocNoNotification(PurchaseHeader: Record "Purchase Header"; VendorLedgerEntry: Record "Vendor Ledger Entry")
+    var
+        MyNotifications: Record "My Notifications";
+        InstructionMgt: Codeunit "Instruction Mgt.";
+        NotificationLifecycleMgt: Codeunit "Notification Lifecycle Mgt.";
+        SIIDuplicateNotification: Notification;
+    begin
+        // Mirror the standard "already exists" notification guard: default-on when not yet seeded,
+        // then create the missing My Notifications record before the final enable check.
+        if not MyNotifications.IsEnabled(PurchaseHeader.GetShowExternalDocAlreadyExistNotificationId()) then
+            exit;
+        InstructionMgt.CreateMissingMyNotificationsWithDefaultState(PurchaseHeader.GetShowExternalDocAlreadyExistNotificationId());
+        if not PurchaseHeader.IsDocAlreadyExistNotificationEnabled() then
+            exit;
+
+        // Reuse the standard notification id + action so it shares one slot and respects the same user toggle.
+        SIIDuplicateNotification.Id := PurchaseHeader.GetShowExternalDocAlreadyExistNotificationId();
+        SIIDuplicateNotification.Message :=
+            StrSubstNo(SIIDuplicateExtDocNoTxt, VendorLedgerEntry."Document Type", VendorLedgerEntry."External Document No.", PurchaseHeader."Pay-to Vendor No.");
+        SIIDuplicateNotification.Scope := NotificationScope::LocalScope;
+        SIIDuplicateNotification.AddAction(ShowSIIDuplicateVendLedgEntryTxt, Codeunit::"Document Notifications", 'ShowVendorLedgerEntry');
+        SIIDuplicateNotification.SetData(PurchaseHeader.FieldName("Document Type"), Format(PurchaseHeader."Document Type"));
+        SIIDuplicateNotification.SetData(PurchaseHeader.FieldName("No."), PurchaseHeader."No.");
+        SIIDuplicateNotification.SetData(VendorLedgerEntry.FieldName("Entry No."), Format(VendorLedgerEntry."Entry No."));
+        NotificationLifecycleMgt.SendNotificationWithAdditionalContext(
+            SIIDuplicateNotification, PurchaseHeader.RecordId(), PurchaseHeader.GetShowExternalDocAlreadyExistNotificationId());
     end;
 
     [EventSubscriber(ObjectType::Table, Database::"Vendor Ledger Entry", 'OnAfterCopyVendLedgerEntryFromGenJnlLine', '', false, false)]

--- a/src/Layers/ES/Tests/Local/SIIDocumentsUI.Codeunit.al
+++ b/src/Layers/ES/Tests/Local/SIIDocumentsUI.Codeunit.al
@@ -18,7 +18,15 @@ codeunit 147521 "SII Documents - UI"
         LibraryService: Codeunit "Library - Service";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibrarySII: Codeunit "Library - SII";
+        LibraryERM: Codeunit "Library - ERM";
+        LibraryRandom: Codeunit "Library - Random";
+        LibraryUtility: Codeunit "Library - Utility";
+        LibraryVariableStorage: Codeunit "Library - Variable Storage";
+        NotificationLifecycleMgt: Codeunit "Notification Lifecycle Mgt.";
         IsInitialized: Boolean;
+        FacturaDuplicadaFragmentTxt: Label 'Factura Duplicada', Locked = true;
+        ExactlyOneNotificationErr: Label 'Exactly one notification is expected.';
+        SIIDuplicateNotificationErr: Label 'The SII duplicate notification message is expected.';
 
     [Test]
     [Scope('OnPrem')]
@@ -473,6 +481,69 @@ codeunit 147521 "SII Documents - UI"
         PurchaseHeaderVerify.TestField("Invoice Type", PurchaseHeaderVerify."Invoice Type"::"F5 Imports (DUA)");
     end;
 
+    [Test]
+    [HandlerFunctions('SIIDuplicateExtDocNoNotificationHandler')]
+    [Scope('OnPrem')]
+    procedure SIIDuplicateExtDocNoNotifiedOnPurchCrMemoWhenPostedInvoiceExists()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        VendorNo: Code[20];
+        ExtDocNo: Code[35];
+    begin
+        // [FEATURE] [Credit Memo] [Purchase] [Notification] [AI Test]
+        // [SCENARIO 639518] With SII enabled, validating an external document number on a purchase credit memo that already
+        // exists on a posted purchase invoice of the same vendor raises the SII duplicate notification.
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for vendor "V" with external document number "X"
+        VendorNo := LibraryPurchase.CreateVendorNo();
+        ExtDocNo := LibraryUtility.GenerateRandomText(MaxStrLen(ExtDocNo));
+        PostPurchDocWithExtDocNo(PurchaseHeader."Document Type"::Invoice, VendorNo, ExtDocNo);
+
+        // [WHEN] A purchase credit memo for vendor "V" gets "Vendor Cr. Memo No." = "X"
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::"Credit Memo", VendorNo);
+        PurchaseHeader.Validate("Vendor Cr. Memo No.", ExtDocNo);
+
+        // [THEN] The SII duplicate ("Factura Duplicada") notification is raised
+        Assert.AreEqual(1, LibraryVariableStorage.Length(), ExactlyOneNotificationErr);
+        Assert.IsTrue(
+            StrPos(LibraryVariableStorage.DequeueText(), FacturaDuplicadaFragmentTxt) > 0,
+            SIIDuplicateNotificationErr);
+
+        LibraryVariableStorage.AssertEmpty();
+        NotificationLifecycleMgt.RecallAllNotifications();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure SIINoDuplicateNotificationWhenSIIDisabled()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        VendorNo: Code[20];
+        ExtDocNo: Code[35];
+    begin
+        // [FEATURE] [Credit Memo] [Purchase] [Notification] [AI Test]
+        // [SCENARIO 639518] With SII enabled, validating an external document number on a purchase credit memo that already
+        // exists on a posted purchase invoice of the same vendor raises the SII duplicate notification.
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for vendor "V" with external document number "X"
+        VendorNo := LibraryPurchase.CreateVendorNo();
+        ExtDocNo := LibraryUtility.GenerateRandomText(MaxStrLen(ExtDocNo));
+        PostPurchDocWithExtDocNo(PurchaseHeader."Document Type"::Invoice, VendorNo, ExtDocNo);
+
+        // [GIVEN] SII is disabled
+        LibrarySII.InitSetup(false, false);
+
+        // [WHEN] A purchase credit memo for vendor "V" gets "Vendor Cr. Memo No." = "X"
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::"Credit Memo", VendorNo);
+        PurchaseHeader.Validate("Vendor Cr. Memo No.", ExtDocNo);
+
+        // [THEN] No SII duplicate notification is raised
+        LibraryVariableStorage.AssertEmpty();
+        NotificationLifecycleMgt.RecallAllNotifications();
+    end;
+
     local procedure Initialize()
     begin
         LibrarySetupStorage.Restore();
@@ -499,6 +570,31 @@ codeunit 147521 "SII Documents - UI"
     local procedure CreateServiceHeader(var ServiceHeader: Record "Service Header"; DocumentType: Enum "Service Document Type")
     begin
         LibraryService.CreateServiceHeader(ServiceHeader, DocumentType, '');
+    end;
+
+    local procedure PostPurchDocWithExtDocNo(DocumentType: Enum "Purchase Document Type"; VendorNo: Code[20]; ExtDocNo: Code[35])
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+    begin
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, DocumentType, VendorNo);
+        if DocumentType = PurchaseHeader."Document Type"::"Credit Memo" then
+            PurchaseHeader.Validate("Vendor Cr. Memo No.", ExtDocNo)
+        else
+            PurchaseHeader.Validate("Vendor Invoice No.", ExtDocNo);
+        PurchaseHeader.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(
+            PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account",
+            LibraryERM.CreateGLAccountWithPurchSetup(), LibraryRandom.RandInt(100));
+        PurchaseLine.Validate("Direct Unit Cost", LibraryRandom.RandDec(100, 2));
+        PurchaseLine.Modify(true);
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+    end;
+
+    [SendNotificationHandler]
+    procedure SIIDuplicateExtDocNoNotificationHandler(var Notification: Notification): Boolean
+    begin
+        LibraryVariableStorage.Enqueue(Notification.Message);
     end;
 }
 


### PR DESCRIPTION
[Bug 642238](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/642238): [master] [All-e]"Factura Duplicada" error message appears under SII History if you use the same Vendor Invoice No. for the same Vendor (VAT Registration No.) in different documents in the Spanish version.

[AB#642238](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642238)

**Issue**: In the Spanish version, when a purchase document reuses the same External Document No. (Vendor Invoice No. / Vendor Cr. Memo No.) that was already used on a posted document of the opposite type for the same vendor, no warning is shown. Because SII builds the IDFactura key from vendor VAT Reg. No. + External Document No. + Document Date (ignoring invoice vs. credit-memo type), AEAT later rejects the second document as "Factura Duplicada", and the error only surfaces in SII History after posting.

**Cause**: The standard ShowExternalDocAlreadyExistNotification on Purchase Header only warns when a posted document of the same document type already exists with that External Document No. It never detects the cross-type case (Invoice vs. Credit Memo), which SII nonetheless treats as the same IDFactura, so the duplicate goes unnoticed at entry time.

**Solution**: Added SII-gated subscribers in [SIIPurchaseSubscribers.Codeunit.al](vscode-file://vscode-app/c:/Users/v-dhavalmore/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on the OnAfterValidate of "Vendor Invoice No." and "Vendor Cr. Memo No.". When SII is enabled, they look for a posted Vendor Ledger Entry of the opposite document type with the same External Document No., vendor, and date (reusing VendorMgt.SetFilterForExternalDocNo, honoring "Same Ext. Doc. No. in Diff. FY", and skipping "Do Not Send To SII" entries) and raise a non-blocking notification warning of a possible "Factura Duplicada", sharing the standard notification's user toggle.



