### PR TITLE
Add workflow to expand telemetry tags from PR command

### DIFF
--- a/.github/workflows/ExpandTelemetryTagsFromPRComment.yaml
+++ b/.github/workflows/ExpandTelemetryTagsFromPRComment.yaml
@@ -1,0 +1,294 @@
+name: "Expand Telemetry Tags"
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pullRequestNumber:
+        description: "Pull request number to process"
+        required: true
+        type: number
+
+permissions:
+  actions: read
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+defaults:
+  run:
+    shell: pwsh
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+
+concurrency:
+  group: telemetry-tags-${{ github.event_name == 'issue_comment' && github.event.issue.number || inputs.pullRequestNumber }}
+  cancel-in-progress: false
+
+jobs:
+  ExpandTelemetryTags:
+    if: >
+      github.repository_owner == 'microsoft' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.issue.pull_request &&
+          startsWith(github.event.comment.body, '/telemetry-tags')
+        )
+      )
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v9.1
+        with:
+          shell: powershell
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Initialize the workflow
+        id: init
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v9.1
+        with:
+          shell: powershell
+
+      - name: Resolve context
+        id: context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_PR_NUMBER: ${{ github.event.issue.number }}
+          INPUT_PR_NUMBER: ${{ inputs.pullRequestNumber }}
+          COMMENT_AUTHOR: ${{ github.event_name == 'issue_comment' && github.event.comment.user.login || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          if ($env:EVENT_NAME -eq "workflow_dispatch") {
+            $prNumber = [int]$env:INPUT_PR_NUMBER
+            $authorized = $true
+          }
+          else {
+            $prNumber = [int]$env:ISSUE_PR_NUMBER
+            $authorized = $false
+            try {
+              $perm = gh api "repos/$($env:REPOSITORY)/collaborators/$($env:COMMENT_AUTHOR)/permission" | ConvertFrom-Json
+              $authorized = @("admin", "maintain", "write") -contains $perm.permission
+            }
+            catch {
+              $authorized = $false
+            }
+          }
+
+          $pr = gh api "repos/$($env:REPOSITORY)/pulls/$prNumber" | ConvertFrom-Json
+          $canPush = $pr.head.repo.full_name -eq $env:REPOSITORY
+
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "prNumber=$prNumber"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "authorized=$authorized"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "headRepo=$($pr.head.repo.full_name)"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "headRef=$($pr.head.ref)"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "headSha=$($pr.head.sha)"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "canPush=$canPush"
+
+      - name: Acknowledge unauthorized command
+        if: github.event_name == 'issue_comment' && steps.context.outputs.authorized != 'True'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $message = @"
+          Sorry @${{ github.event.comment.user.login }}, only maintainers with write access can run `/telemetry-tags`.
+          "@
+          gh api "repos/${{ github.repository }}/issues/${{ steps.context.outputs.prNumber }}/comments" --method POST -f body="$message" | Out-Null
+
+      - name: Checkout PR head
+        if: steps.context.outputs.authorized == 'True'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ steps.context.outputs.headRepo }}
+          ref: ${{ steps.context.outputs.headRef }}
+          path: pr
+
+      - name: Expand telemetry tags
+        if: steps.context.outputs.authorized == 'True'
+        id: expand
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.context.outputs.prNumber }}
+          REPOSITORY: ${{ github.repository }}
+          PR_PATH: ${{ github.workspace }}\pr
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          function Expand-TelemetryTags() {
+              param
+              (
+                  [Parameter(Mandatory=$true)]
+                  [string[]] $SourceFilePaths
+              )
+
+              if (-not $SourceFilePaths) {
+                  return
+              }
+
+              $traceTagTool = Join-Path $env:PkgMicrosoft_BusinessCentral_SharedInfrastructure_EnlistmentScripts "lib\net45\TraceTagTool\TraceTagTool.psm1"
+              if (-not (Test-Path -Path $traceTagTool)) {
+                  throw "TraceTagTool module not found at '$traceTagTool'."
+              }
+
+              Import-Module $traceTagTool -Force
+              $tagsToBeUpdated = Expand-TraceTags -SourceFilePaths $SourceFilePaths
+              if($tagsToBeUpdated -eq 0) {
+                  Write-Host "No telemetry tags need to be updated."
+                  return
+              }
+
+              Write-Warning "Telemetry tags have been updated."
+          }
+
+          try {
+            $files = @(gh api --paginate "repos/$($env:REPOSITORY)/pulls/$($env:PR_NUMBER)/files?per_page=100" --jq ".[] | .filename")
+            $alFiles = @()
+            foreach ($file in $files) {
+              if ($file -and $file.ToLower().EndsWith(".al")) {
+                $fullPath = Join-Path $env:PR_PATH $file
+                if (Test-Path -Path $fullPath) {
+                  $alFiles += $fullPath
+                }
+              }
+            }
+
+            if (-not $alFiles -or $alFiles.Count -eq 0) {
+              Add-Content -Path $env:GITHUB_OUTPUT -Value "status=no_files"
+              Add-Content -Path $env:GITHUB_OUTPUT -Value "changed=false"
+              exit 0
+            }
+
+            Expand-TelemetryTags -SourceFilePaths $alFiles
+            $changed = @(git -C $env:PR_PATH status --porcelain -- '*.al')
+            if ($changed.Count -gt 0) {
+              Add-Content -Path $env:GITHUB_OUTPUT -Value "status=updated"
+              Add-Content -Path $env:GITHUB_OUTPUT -Value "changed=true"
+            }
+            else {
+              Add-Content -Path $env:GITHUB_OUTPUT -Value "status=up_to_date"
+              Add-Content -Path $env:GITHUB_OUTPUT -Value "changed=false"
+            }
+          }
+          catch {
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "status=error"
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "changed=false"
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "errorMessage=$($_.Exception.Message)"
+            Write-Warning $_
+          }
+
+      - name: Commit and push updates
+        if: steps.context.outputs.authorized == 'True' && steps.expand.outputs.changed == 'true' && steps.context.outputs.canPush == 'true'
+        id: push
+        continue-on-error: true
+        env:
+          PR_PATH: ${{ github.workspace }}\pr
+          HEAD_REF: ${{ steps.context.outputs.headRef }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          try {
+            git -C $env:PR_PATH config user.name "github-actions[bot]"
+            git -C $env:PR_PATH config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git -C $env:PR_PATH add -- '*.al'
+            git -C $env:PR_PATH diff --cached --quiet
+            if ($LASTEXITCODE -eq 0) {
+              Add-Content -Path $env:GITHUB_OUTPUT -Value "pushed=false"
+              Add-Content -Path $env:GITHUB_OUTPUT -Value "pushMessage=No staged changes after telemetry expansion."
+              exit 0
+            }
+
+            git -C $env:PR_PATH commit -m "chore: expand telemetry tags"
+            git -C $env:PR_PATH push origin "HEAD:$($env:HEAD_REF)"
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "pushed=true"
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "pushMessage=Telemetry tag updates were pushed to the PR branch."
+          }
+          catch {
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "pushed=false"
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "pushMessage=$($_.Exception.Message)"
+            Write-Warning $_
+          }
+
+      - name: Create patch artifact when push is unavailable
+        if: steps.context.outputs.authorized == 'True' && steps.expand.outputs.changed == 'true' && (steps.context.outputs.canPush != 'true' || steps.push.outputs.pushed != 'true')
+        id: patch
+        env:
+          PR_PATH: ${{ github.workspace }}\pr
+        run: |
+          $patchPath = Join-Path $env:RUNNER_TEMP "telemetry-tags-${{ steps.context.outputs.prNumber }}.patch"
+          git -C $env:PR_PATH diff -- '*.al' | Out-File -Encoding utf8 -FilePath $patchPath
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "patchPath=$patchPath"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "artifactName=telemetry-tags-pr-${{ steps.context.outputs.prNumber }}"
+
+      - name: Upload patch artifact
+        if: steps.patch.outputs.patchPath != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        env:
+          ACTIONS_RUNNER_DISABLE_NODE_MAGLEV: 1
+        with:
+          name: ${{ steps.patch.outputs.artifactName }}
+          path: ${{ steps.patch.outputs.patchPath }}
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Comment result on PR
+        if: steps.context.outputs.authorized == 'True'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $status = "${{ steps.expand.outputs.status }}"
+          $comment = ""
+
+          switch ($status) {
+            "no_files" {
+              $comment = "Telemetry tag check completed: no `.al` files were changed in this PR."
+            }
+            "up_to_date" {
+              $comment = "Telemetry tag check completed: all telemetry tags are already up to date ✅"
+            }
+            "updated" {
+              if ("${{ steps.push.outputs.pushed }}" -eq "true") {
+                $comment = "Telemetry tags were updated and pushed to `${{ steps.context.outputs.headRef }}` ✅"
+              }
+              else {
+                $comment = @"
+                Telemetry tags were updated, but I couldn't push to the PR branch from this workflow.
+
+                A patch artifact was uploaded: `${{ steps.patch.outputs.artifactName }}`.
+                Please download and apply it locally, then commit and push.
+                "@
+              }
+            }
+            "error" {
+              $comment = @"
+              Telemetry tag workflow ran, but expansion failed:
+
+              `${{ steps.expand.outputs.errorMessage }}`
+              "@
+            }
+            Default {
+              $comment = "Telemetry tag workflow finished with status: `$status`."
+            }
+          }
+
+          gh api "repos/${{ github.repository }}/issues/${{ steps.context.outputs.prNumber }}/comments" --method POST -f body="$comment" | Out-Null
+
+      - name: Finalize the workflow
+        if: always()
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v9.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          shell: powershell
+          telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          currentJobContext: ${{ toJson(job) }}

--- a/.github/workflows/ExpandTelemetryTagsFromPRComment.yaml
+++ b/.github/workflows/ExpandTelemetryTagsFromPRComment.yaml
@@ -14,8 +14,7 @@ permissions:
   actions: read
   contents: write
   issues: write
-  pull-requests: write
-  id-token: write
+  pull-requests: read
 
 defaults:
   run:
@@ -37,7 +36,7 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         (
           github.event.issue.pull_request &&
-          startsWith(github.event.comment.body, '/telemetry-tags')
+          github.event.comment.body == '/telemetry-tags'
         )
       )
     runs-on: windows-latest
@@ -110,7 +109,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ steps.context.outputs.headRepo }}
-          ref: ${{ steps.context.outputs.headRef }}
+          ref: ${{ steps.context.outputs.headSha }}
           path: pr
 
       - name: Expand telemetry tags
@@ -230,7 +229,9 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "artifactName=telemetry-tags-pr-${{ steps.context.outputs.prNumber }}"
 
       - name: Upload patch artifact
+        id: uploadPatch
         if: steps.patch.outputs.patchPath != ''
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         env:
           ACTIONS_RUNNER_DISABLE_NODE_MAGLEV: 1
@@ -261,14 +262,23 @@ jobs:
                 $comment = "Telemetry tags were updated and pushed to `${{ steps.context.outputs.headRef }}` ✅"
               }
               else {
-                $comment = @"
-                Telemetry tags were updated, but I couldn't push to the PR branch from this workflow.
+                                if ("${{ steps.uploadPatch.outcome }}" -eq "success") {
+                                  $comment = @"
+                                  Telemetry tags were updated, but I couldn't push to the PR branch from this workflow.
 
-                A patch artifact was uploaded: `${{ steps.patch.outputs.artifactName }}`.
-                Please download and apply it locally, then commit and push.
+                                  A patch artifact was uploaded: `${{ steps.patch.outputs.artifactName }}`.
+                                  Please download and apply it locally, then commit and push.
                 "@
-              }
-            }
+                                }
+                                else {
+                                  $comment = @"
+                                  Telemetry tags were updated, but I couldn't push to the PR branch and patch artifact upload failed.
+
+                                  Please run `/telemetry-tags` again or update tags locally and push.
+                "@
+                                }
+                              }
+                            }
             "error" {
               $comment = @"
               Telemetry tag workflow ran, but expansion failed:


### PR DESCRIPTION
## Summary
- add new workflow to trigger telemetry tag expansion from /telemetry-tags PR comments
- support manual workflow_dispatch with PR number
- push updates when possible and fall back to patch artifact + PR comment for fork PRs

## Validation
- YAML parse smoke test passed locally
- Trigger and job presence validated in workflow file


