### PR TITLE
Make test company deletion best-effort in ImportTestDataInBcContainer

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -8,7 +8,7 @@
   "UsePsSession": false,
   "gitHubRunner": "windows-latest",
   "githubRunnerShell": "pwsh",
-  "artifact": "bcinsider/Sandbox/29.0.51936.0//latest",
+  "artifact": "bcinsider/Sandbox/29.0.52571.0//latest",
   "country": "base",
   "useProjectDependencies": true,
   "repoVersion": "29.0",

--- a/build/Packages.json
+++ b/build/Packages.json
@@ -9,7 +9,7 @@
     "_comment": "Used to fetch app baselines from BC artifacts"
   },
   "BCPlatform": {
-    "Version": "29.0.51074.0",
+    "Version": "29.0.52563.0",
     "Source": "BCPlatform",
     "_comment": "The BC platform version, fetched from the platform CDN"
   }

--- a/build/scripts/ImportTestDataInBcContainer.ps1
+++ b/build/scripts/ImportTestDataInBcContainer.ps1
@@ -855,11 +855,16 @@ function New-TestCompany() {
         [switch]$EvaluationCompany
     )
 
-    # Delete existing companies in the container
+    # Best-effort delete: a failed removal must not abort demo data generation as tests run in the freshly created company below. See AB#642236.
     $existingCompanies = Get-CompanyInBcContainer -containerName $ContainerName
     foreach ($company in $existingCompanies) {
         Write-Host "Deleting company $($company.CompanyName) in container $ContainerName"
-        Remove-CompanyInBcContainer -containerName $ContainerName -companyName $company.CompanyName
+        try {
+            Remove-CompanyInBcContainer -containerName $ContainerName -companyName $company.CompanyName
+        }
+        catch {
+            Write-Host "::warning::Failed to delete company '$($company.CompanyName)' in container $ContainerName. Continuing with test company creation. Error was: $($_.Exception.Message)"
+        }
     }
 
     Write-Host "Creating new test company in container $ContainerName"


### PR DESCRIPTION
## What & why

The DK unit/integration/legacy test jobs started failing at demo-data setup after the platform artifact bump (`29.0.51074.0` -> `29.0.52563.0`). `New-TestCompany` deletes existing companies before creating the fresh test company, and deleting DK's artifact company `CRONUS Danmark A/S` now throws:

```
The Company does not exist. Identification fields and values: Name='CRONUS Danmark A%2FS'
```

The root cause is a platform regression (tracked as [AB#642236](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642236)): the rewritten `Remove-NAVCompany` routes the delete through the V3 REST management API and URL-encodes the company name into the request path, so the `/` becomes `%2F` and the server never resolves it. Only company names containing `/` are affected, which is why DK is the only country that fails.

This change makes the pre-delete step best-effort: each `Remove-CompanyInBcContainer` call is wrapped in try/catch and a failed removal emits a `::warning::` instead of aborting the whole job. Tests still run in the freshly created company named from settings (e.g. `CRONUS International Ltd.` for DK Legacy), which never collides with the leftover artifact company, so skipping a delete does not affect test targeting. The trade-off is that an undeletable evaluation company may linger in the container.

This is a BCApps-side mitigation to unblock CI; the underlying platform bug still needs its own fix.

## Linked work

Fixes #

[AB#642236](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642236)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Change is limited to the CI test-data setup script (`build/scripts/ImportTestDataInBcContainer.ps1`). Verified from the failing run logs that the delete of `CRONUS Danmark A/S` is the sole cause of the DK job failures and occurs before any test runs; the try/catch lets setup proceed to company creation. No automated test is added because this is build-tooling error handling, not product behavior.

## Risk & compatibility

Low. Deletion is now non-fatal, so a genuine failure to remove a company will be surfaced as a warning rather than a hard failure. If cleanup is skipped, an extra (evaluation) company may remain in the container, but tests target the freshly created company by name and are unaffected. Once the platform regression ([AB#642236](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642236)) is fixed, deletion succeeds again and the catch is simply not exercised.


