### PR TITLE
[Extensibility Request] issue 30339: add OnAfterCalcAvailableQtyBase event to Whse. Worksheet Line

### DIFF
--- a/src/Layers/W1/BaseApp/Warehouse/Worksheet/WhseWorksheetLine.Table.al
+++ b/src/Layers/W1/BaseApp/Warehouse/Worksheet/WhseWorksheetLine.Table.al
@@ -783,6 +783,8 @@ table 7326 "Whse. Worksheet Line"
 
             AvailableQty := AvailQtyBase - QtyAssgndOnWkshBase + AssignedQtyOnReservedLines();
         end;
+
+        OnAfterCalcAvailableQtyBase(Rec, AvailableQty);
     end;
 
     procedure CalcReservedNotFromILEQty(QtyBaseAvailToPick: Decimal; var QtyToPick: Decimal; var QtyToPickBase: Decimal)
@@ -1712,6 +1714,11 @@ table 7326 "Whse. Worksheet Line"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeCalcAvailableQtyBase(var WhseWorksheetLine: Record "Whse. Worksheet Line"; var AvailableQty: Decimal; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterCalcAvailableQtyBase(var WhseWorksheetLine: Record "Whse. Worksheet Line"; var AvailableQty: Decimal)
     begin
     end;
 


### PR DESCRIPTION
## Summary
The issue reports that extensions cannot adjust the final available quantity computed by `CalcAvailableQtyBase()` in table 7326 "Whse. Worksheet Line". The existing `OnBeforeCalcAvailableQtyBase` event only supports fully replacing the calculation, and the underlying `CalcTotalAvailQtyToPickForDirectedPutAwayPick` helper is marked Internal, so scenarios such as stock ring-fencing cannot reuse the standard logic and then tweak the result. This PR adds an integration event at the end of the procedure so subscribers can adjust the calculated `AvailableQty` after the standard calculation runs.

Source issue repository: microsoft/AlAppExtensions; issue number: 30339

## Changes Made
- `Whse. Worksheet Line.CalcAvailableQtyBase` - raise a new `OnAfterCalcAvailableQtyBase(Rec, AvailableQty)` integration event at the end of the procedure so extensions can adjust the final calculated available quantity without reimplementing the standard logic.
- `OnAfterCalcAvailableQtyBase` - added the integration event publisher alongside the existing `OnBeforeCalcAvailableQtyBase` publisher.

Fixes [AB#641774](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641774)


