### PR TITLE
[Extensibility Request] issue 30330: add OnCancelInvoiceOnBeforeConfirm event

### DIFF
--- a/src/Layers/W1/BaseApp/Sales/History/CancelPstdSalesInvYesNo.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/History/CancelPstdSalesInvYesNo.Codeunit.al
@@ -37,12 +37,15 @@ codeunit 1323 "Cancel PstdSalesInv (Yes/No)"
         CorrectPostedSalesInvoice: Codeunit "Correct Posted Sales Invoice";
         PageManagement: Codeunit "Page Management";
         IsHandled: Boolean;
+        ConfirmQuestion: Text;
     begin
         IsHandled := false;
         OnCancelInvoiceOnBeforeTestCorrectInvoiceIsAllowed(SalesInvoiceHeader, IsHandled);
         if not IsHandled then
             CorrectPostedSalesInvoice.TestCorrectInvoiceIsAllowed(SalesInvoiceHeader, true);
-        if Confirm(GetCancelPostedInvoiceQst(SalesInvoiceHeader)) then
+        ConfirmQuestion := GetCancelPostedInvoiceQst(SalesInvoiceHeader);
+        OnCancelInvoiceOnBeforeConfirm(SalesInvoiceHeader, ConfirmQuestion);
+        if Confirm(ConfirmQuestion) then
             if CorrectPostedSalesInvoice.CancelPostedInvoice(SalesInvoiceHeader) then
                 if Confirm(OpenPostedCreditMemoQst) then begin
                     CancelledDocument.FindSalesCancelledInvoice(SalesInvoiceHeader."No.");
@@ -62,6 +65,11 @@ codeunit 1323 "Cancel PstdSalesInv (Yes/No)"
         if SalesInvoiceHeader."Order No." <> '' then
             exit(CancelPostedInvoiceFromOrderQst);
         exit(CancelPostedInvoiceQst);
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCancelInvoiceOnBeforeConfirm(var SalesInvoiceHeader: Record "Sales Invoice Header"; var ConfirmQuestion: Text)
+    begin
     end;
 
     [IntegrationEvent(false, false)]


### PR DESCRIPTION
## Summary
When a posted sales invoice is corrected or cancelled, an extension can now change what happens to the originating sales order's quantities (via #29949, shipped in 28.2). However, the confirmation dialog shown before cancelling still states that the original quantities will be restored, which becomes inaccurate when that behavior is overridden. The reporter needs a hook to adjust the confirmation text so it matches the actual behavior. This PR adds an integration event that lets extensions override the confirmation question before it is shown.

Source issue repository: microsoft/AlAppExtensions; issue number: 30330

## Changes Made
- `Cancel PstdSalesInv (Yes/No)` (codeunit 1323), `CancelInvoice` - resolve the confirmation text into a `ConfirmQuestion` variable and raise the new `OnCancelInvoiceOnBeforeConfirm` integration event before the `Confirm` call, allowing subscribers to adjust the message; added the event publisher.

Fixes [AB#641733](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641733)



