### PR TITLE
[Extensibility Request] issue 30331: add event to adjust corrective credit memo confirmation text

### DIFF
--- a/src/Layers/APAC/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
@@ -210,6 +210,7 @@ codeunit 1303 "Correct Posted Sales Invoice"
     procedure CreateCreditMemoCopyDocument(var SalesInvoiceHeader: Record "Sales Invoice Header"; var SalesHeader: Record "Sales Header"): Boolean
     var
         SalesHdr: Record "Sales Header";
+        ConfirmQuestion: Text;
     begin
         OnBeforeCreateCreditMemoCopyDocument(SalesInvoiceHeader);
         TestNoFixedAssetInSalesInvoice(SalesInvoiceHeader);
@@ -221,9 +222,12 @@ codeunit 1303 "Correct Posted Sales Invoice"
         end;
         SalesHdr.SetRange("Document Type", SalesHdr."Document Type"::Order);
         SalesHdr.SetRange("No.", SalesInvoiceHeader."Order No.");
-        if not SalesHdr.IsEmpty then
-            if not Confirm(CreateCreditMemoQst) then
+        if not SalesHdr.IsEmpty then begin
+            ConfirmQuestion := CreateCreditMemoQst;
+            OnCreateCreditMemoCopyDocumentOnBeforeConfirm(SalesInvoiceHeader, SalesHdr, ConfirmQuestion);
+            if not Confirm(ConfirmQuestion) then
                 exit(false);
+        end;
 
         CreateCopyDocument(SalesInvoiceHeader, SalesHeader, SalesHeader."Document Type"::"Credit Memo", false);
 
@@ -1415,6 +1419,17 @@ codeunit 1303 "Correct Posted Sales Invoice"
     /// <param name="SalesInvoiceHeader">The posted sales invoice to copy from.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeCreateCreditMemoCopyDocument(var SalesInvoiceHeader: Record "Sales Invoice Header")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before confirming the creation of a corrective credit memo for an invoice posted from a sales order.
+    /// </summary>
+    /// <param name="SalesInvoiceHeader">The posted sales invoice being corrected.</param>
+    /// <param name="SalesHeader">The originating sales order the invoice was posted from.</param>
+    /// <param name="ConfirmQuestion">The confirmation text to be shown. Subscribers can modify it.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnCreateCreditMemoCopyDocumentOnBeforeConfirm(var SalesInvoiceHeader: Record "Sales Invoice Header"; var SalesHeader: Record "Sales Header"; var ConfirmQuestion: Text)
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
@@ -209,6 +209,7 @@ codeunit 1303 "Correct Posted Sales Invoice"
     procedure CreateCreditMemoCopyDocument(var SalesInvoiceHeader: Record "Sales Invoice Header"; var SalesHeader: Record "Sales Header"): Boolean
     var
         SalesHdr: Record "Sales Header";
+        ConfirmQuestion: Text;
     begin
         OnBeforeCreateCreditMemoCopyDocument(SalesInvoiceHeader);
         TestNoFixedAssetInSalesInvoice(SalesInvoiceHeader);
@@ -220,9 +221,12 @@ codeunit 1303 "Correct Posted Sales Invoice"
         end;
         SalesHdr.SetRange("Document Type", SalesHdr."Document Type"::Order);
         SalesHdr.SetRange("No.", SalesInvoiceHeader."Order No.");
-        if not SalesHdr.IsEmpty then
-            if not Confirm(CreateCreditMemoQst) then
+        if not SalesHdr.IsEmpty then begin
+            ConfirmQuestion := CreateCreditMemoQst;
+            OnCreateCreditMemoCopyDocumentOnBeforeConfirm(SalesInvoiceHeader, SalesHdr, ConfirmQuestion);
+            if not Confirm(ConfirmQuestion) then
                 exit(false);
+        end;
 
         CreateCopyDocument(SalesInvoiceHeader, SalesHeader, SalesHeader."Document Type"::"Credit Memo", false);
 
@@ -1393,6 +1397,17 @@ codeunit 1303 "Correct Posted Sales Invoice"
     /// <param name="SalesInvoiceHeader">The posted sales invoice to copy from.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeCreateCreditMemoCopyDocument(var SalesInvoiceHeader: Record "Sales Invoice Header")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before confirming the creation of a corrective credit memo for an invoice posted from a sales order.
+    /// </summary>
+    /// <param name="SalesInvoiceHeader">The posted sales invoice being corrected.</param>
+    /// <param name="SalesHeader">The originating sales order the invoice was posted from.</param>
+    /// <param name="ConfirmQuestion">The confirmation text to be shown. Subscribers can modify it.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnCreateCreditMemoCopyDocumentOnBeforeConfirm(var SalesInvoiceHeader: Record "Sales Invoice Header"; var SalesHeader: Record "Sales Header"; var ConfirmQuestion: Text)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
@@ -209,6 +209,7 @@ codeunit 1303 "Correct Posted Sales Invoice"
     procedure CreateCreditMemoCopyDocument(var SalesInvoiceHeader: Record "Sales Invoice Header"; var SalesHeader: Record "Sales Header"): Boolean
     var
         SalesHdr: Record "Sales Header";
+        ConfirmQuestion: Text;
     begin
         OnBeforeCreateCreditMemoCopyDocument(SalesInvoiceHeader);
         TestNoFixedAssetInSalesInvoice(SalesInvoiceHeader);
@@ -220,9 +221,12 @@ codeunit 1303 "Correct Posted Sales Invoice"
         end;
         SalesHdr.SetRange("Document Type", SalesHdr."Document Type"::Order);
         SalesHdr.SetRange("No.", SalesInvoiceHeader."Order No.");
-        if not SalesHdr.IsEmpty then
-            if not Confirm(CreateCreditMemoQst) then
+        if not SalesHdr.IsEmpty then begin
+            ConfirmQuestion := CreateCreditMemoQst;
+            OnCreateCreditMemoCopyDocumentOnBeforeConfirm(SalesInvoiceHeader, SalesHdr, ConfirmQuestion);
+            if not Confirm(ConfirmQuestion) then
                 exit(false);
+        end;
 
         CreateCopyDocument(SalesInvoiceHeader, SalesHeader, SalesHeader."Document Type"::"Credit Memo", false);
 
@@ -1393,6 +1397,17 @@ codeunit 1303 "Correct Posted Sales Invoice"
     /// <param name="SalesInvoiceHeader">The posted sales invoice to copy from.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeCreateCreditMemoCopyDocument(var SalesInvoiceHeader: Record "Sales Invoice Header")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before confirming the creation of a corrective credit memo for an invoice posted from a sales order.
+    /// </summary>
+    /// <param name="SalesInvoiceHeader">The posted sales invoice being corrected.</param>
+    /// <param name="SalesHeader">The originating sales order the invoice was posted from.</param>
+    /// <param name="ConfirmQuestion">The confirmation text to be shown. Subscribers can modify it.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnCreateCreditMemoCopyDocumentOnBeforeConfirm(var SalesInvoiceHeader: Record "Sales Invoice Header"; var SalesHeader: Record "Sales Header"; var ConfirmQuestion: Text)
     begin
     end;
 


### PR DESCRIPTION
## Summary
When a posted sales invoice was created from a sales order, correcting it shows a confirmation stating that the original order quantities will be reverted. With #29949, extensions can change what happens to those quantities, which makes the standard confirmation text inaccurate. The reporter needs a way to adjust that confirmation text so it reflects the extension's actual behavior. This PR adds an integration event immediately before the `Confirm` call so subscribers can modify the confirmation question.

Source issue repository: microsoft/AlAppExtensions; issue number: 30331

## Changes Made
- `CreateCreditMemoCopyDocument` - introduced a local `ConfirmQuestion` text seeded with `CreateCreditMemoQst` and raised the new event before `Confirm`, so the shown text can be adjusted; the same change was propagated to the APAC and ES layer counterparts.
- `OnCreateCreditMemoCopyDocumentOnBeforeConfirm` - new integration event exposing the posted invoice, the originating sales order, and the modifiable confirmation text.

Fixes [AB#641775](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641775)


