### PR TITLE
[Extensibility Request] issue 30337: add OnCreateProdOrderLineOnBeforeCreateProdOrderLineFromItem event

### DIFF
--- a/src/Layers/W1/BaseApp/Manufacturing/Document/CreateProdOrderLines.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/CreateProdOrderLines.Codeunit.al
@@ -245,22 +245,22 @@ codeunit 99000787 "Create Prod. Order Lines"
         OnAfterCreateProdOrderLine(ProdOrder, VariantCode, ErrorOccured);
     end;
 
-    local procedure CreateProdOrderLineFromItem(ProdOrder: Record "Production Order"; VariantCode: Code[10]; var ErrorOccured: Boolean)
+    local procedure CreateProdOrderLineFromItem(var ProductionOrder: Record "Production Order"; VariantCode: Code[10]; var ErrorOccured: Boolean)
     begin
         OnCreateProdOrderLineOnBeforeInitProdOrderLine(InsertNew);
-        InitProdOrderLine(ProdOrder."Source No.", VariantCode, ProdOrder."Location Code");
-        ProdOrderLine.Description := ProdOrder.Description;
-        ProdOrderLine."Description 2" := ProdOrder."Description 2";
-        ProdOrderLine.Validate(Quantity, ProdOrder.Quantity);
+        InitProdOrderLine(ProductionOrder."Source No.", VariantCode, ProductionOrder."Location Code");
+        ProdOrderLine.Description := ProductionOrder.Description;
+        ProdOrderLine."Description 2" := ProductionOrder."Description 2";
+        ProdOrderLine.Validate(Quantity, ProductionOrder.Quantity);
         ProdOrderLine.UpdateDatetime();
         if SalesLineIsSet then
             CopyDimFromSalesLine(SalesLine, ProdOrderLine);
-        OnBeforeProdOrderLineInsert(ProdOrderLine, ProdOrder, SalesLineIsSet, SalesLine);
+        OnBeforeProdOrderLineInsert(ProdOrderLine, ProductionOrder, SalesLineIsSet, SalesLine);
         ProdOrderLine.Insert();
         if ProdOrderLine.HasErrorOccured() then
             ErrorOccured := true;
 
-        OnAfterProdOrderLineInsert(ProdOrder, ProdOrderLine, NextProdOrderLineNo);
+        OnAfterProdOrderLineInsert(ProductionOrder, ProdOrderLine, NextProdOrderLineNo);
     end;
 
     local procedure DeleteLinesForProductionOrder(ProductionOrder: Record "Production Order")
@@ -864,4 +864,3 @@ codeunit 99000787 "Create Prod. Order Lines"
     begin
     end;
 }
-

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/CreateProdOrderLines.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/CreateProdOrderLines.Codeunit.al
@@ -211,6 +211,7 @@ codeunit 99000787 "Create Prod. Order Lines"
     local procedure CreateProdOrderLine(ProdOrder: Record "Production Order"; VariantCode: Code[10]; var ErrorOccured: Boolean)
     var
         SalesHeader: Record "Sales Header";
+        IsHandled: Boolean;
     begin
         DeleteLinesForProductionOrder(ProdOrder);
 
@@ -221,20 +222,10 @@ codeunit 99000787 "Create Prod. Order Lines"
         case ProdOrder."Source Type" of
             ProdOrder."Source Type"::Item:
                 begin
-                    OnCreateProdOrderLineOnBeforeInitProdOrderLine(InsertNew);
-                    InitProdOrderLine(ProdOrder."Source No.", VariantCode, ProdOrder."Location Code");
-                    ProdOrderLine.Description := ProdOrder.Description;
-                    ProdOrderLine."Description 2" := ProdOrder."Description 2";
-                    ProdOrderLine.Validate(Quantity, ProdOrder.Quantity);
-                    ProdOrderLine.UpdateDatetime();
-                    if SalesLineIsSet then
-                        CopyDimFromSalesLine(SalesLine, ProdOrderLine);
-                    OnBeforeProdOrderLineInsert(ProdOrderLine, ProdOrder, SalesLineIsSet, SalesLine);
-                    ProdOrderLine.Insert();
-                    if ProdOrderLine.HasErrorOccured() then
-                        ErrorOccured := true;
-
-                    OnAfterProdOrderLineInsert(ProdOrder, ProdOrderLine, NextProdOrderLineNo);
+                    IsHandled := false;
+                    OnCreateProdOrderLineOnBeforeCreateProdOrderLineFromItem(IsHandled, ErrorOccured, ProdOrder, VariantCode);
+                    if not IsHandled then
+                        CreateProdOrderLineFromItem(ProdOrder, VariantCode, ErrorOccured);
                 end;
             ProdOrder."Source Type"::Family:
                 if not CopyFromFamily() then
@@ -252,6 +243,24 @@ codeunit 99000787 "Create Prod. Order Lines"
         end;
 
         OnAfterCreateProdOrderLine(ProdOrder, VariantCode, ErrorOccured);
+    end;
+
+    local procedure CreateProdOrderLineFromItem(ProdOrder: Record "Production Order"; VariantCode: Code[10]; var ErrorOccured: Boolean)
+    begin
+        OnCreateProdOrderLineOnBeforeInitProdOrderLine(InsertNew);
+        InitProdOrderLine(ProdOrder."Source No.", VariantCode, ProdOrder."Location Code");
+        ProdOrderLine.Description := ProdOrder.Description;
+        ProdOrderLine."Description 2" := ProdOrder."Description 2";
+        ProdOrderLine.Validate(Quantity, ProdOrder.Quantity);
+        ProdOrderLine.UpdateDatetime();
+        if SalesLineIsSet then
+            CopyDimFromSalesLine(SalesLine, ProdOrderLine);
+        OnBeforeProdOrderLineInsert(ProdOrderLine, ProdOrder, SalesLineIsSet, SalesLine);
+        ProdOrderLine.Insert();
+        if ProdOrderLine.HasErrorOccured() then
+            ErrorOccured := true;
+
+        OnAfterProdOrderLineInsert(ProdOrder, ProdOrderLine, NextProdOrderLineNo);
     end;
 
     local procedure DeleteLinesForProductionOrder(ProductionOrder: Record "Production Order")
@@ -832,6 +841,11 @@ codeunit 99000787 "Create Prod. Order Lines"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeIsReplSystemProdOrder(SalesLine: Record "Sales Line"; var ReplanSystemProdOrder: Boolean; var IsHandled: Boolean);
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCreateProdOrderLineOnBeforeCreateProdOrderLineFromItem(var IsHandled: Boolean; var ErrorOccured: Boolean; ProductionOrder: Record "Production Order"; VariantCode: Code[10])
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/CreateProdOrderLines.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/CreateProdOrderLines.Codeunit.al
@@ -845,7 +845,7 @@ codeunit 99000787 "Create Prod. Order Lines"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnCreateProdOrderLineOnBeforeCreateProdOrderLineFromItem(var IsHandled: Boolean; var ErrorOccured: Boolean; ProductionOrder: Record "Production Order"; VariantCode: Code[10])
+    local procedure OnCreateProdOrderLineOnBeforeCreateProdOrderLineFromItem(var IsHandled: Boolean; var ErrorOccured: Boolean; var ProductionOrder: Record "Production Order"; VariantCode: Code[10])
     begin
     end;
 


### PR DESCRIPTION
## Summary
The issue author needs to completely replace the standard `Source Type = Item` processing in `CreateProdOrderLine` under specific business conditions, executing their own production order line creation and controlling the resulting `ErrorOccured` outcome. None of the existing events (`OnCreateProdOrderLineOnBeforeInitProdOrderLine`, `OnBeforeProdOrderLineInsert`, `OnAfterProdOrderLineInsert`, `OnAfterCreateProdOrderLine`) can bypass the standard flow. This PR adds an `IsHandled`-based integration event that lets an extension take full ownership of the item-line creation and set `ErrorOccured`.

Source issue repository: microsoft/AlAppExtensions; issue number: 30337

## Changes Made
- `CreateProdOrderLine` (codeunit 99000787 "Create Prod. Order Lines") - extracted the standard `Source Type = Item` branch into a new local procedure `CreateProdOrderLineFromItem` and raised a new `OnCreateProdOrderLineOnBeforeCreateProdOrderLineFromItem` integration event with `var IsHandled` and `var ErrorOccured` before calling it, so subscribers can replace the standard item-line creation and report the outcome; when `IsHandled` stays false the original behavior and all existing events are preserved.
- `OnCreateProdOrderLineOnBeforeCreateProdOrderLineFromItem` - new `[IntegrationEvent(false, false)]` publisher exposing `IsHandled`, `ErrorOccured`, the `Production Order` record, and the variant code.

Fixes [AB#641918](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641918)





