### PR TITLE
[Extensibility Request] issue 30222: add handled event before RecreatePurchLines in Pay-to Vendor No. validation

### DIFF
--- a/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -317,8 +317,12 @@ table 38 "Purchase Header"
 
                 if (xRec."Buy-from Vendor No." = "Buy-from Vendor No.") and
                    (xRec."Pay-to Vendor No." <> "Pay-to Vendor No.")
-                then
-                    RecreatePurchLines(PayToVendorTxt);
+                then begin
+                    IsHandled := false;
+                    OnValidatePayToVendorNoOnBeforeRecreatePurchLines(Rec, xRec, IsHandled);
+                    if not IsHandled then
+                        RecreatePurchLines(PayToVendorTxt);
+                end;
 
                 if not SkipPayToContact then
                     UpdatePayToCont("Pay-to Vendor No.");
@@ -9156,6 +9160,11 @@ table 38 "Purchase Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidatePaytoVendorNoBeforeRecreateLines(var PurchaseHeader: Record "Purchase Header"; CallingFieldNo: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidatePayToVendorNoOnBeforeRecreatePurchLines(var PurchaseHeader: Record "Purchase Header"; xPurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/BE/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/BE/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -308,8 +308,12 @@ table 38 "Purchase Header"
 
                 if (xRec."Buy-from Vendor No." = "Buy-from Vendor No.") and
                    (xRec."Pay-to Vendor No." <> "Pay-to Vendor No.")
-                then
-                    RecreatePurchLines(PayToVendorTxt);
+                then begin
+                    IsHandled := false;
+                    OnValidatePayToVendorNoOnBeforeRecreatePurchLines(Rec, xRec, IsHandled);
+                    if not IsHandled then
+                        RecreatePurchLines(PayToVendorTxt);
+                end;
 
                 if not SkipPayToContact then
                     UpdatePayToCont("Pay-to Vendor No.");
@@ -8920,6 +8924,11 @@ table 38 "Purchase Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidatePaytoVendorNoBeforeRecreateLines(var PurchaseHeader: Record "Purchase Header"; CallingFieldNo: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidatePayToVendorNoOnBeforeRecreatePurchLines(var PurchaseHeader: Record "Purchase Header"; xPurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/CH/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/CH/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -309,8 +309,12 @@ table 38 "Purchase Header"
 
                 if (xRec."Buy-from Vendor No." = "Buy-from Vendor No.") and
                    (xRec."Pay-to Vendor No." <> "Pay-to Vendor No.")
-                then
-                    RecreatePurchLines(PayToVendorTxt);
+                then begin
+                    IsHandled := false;
+                    OnValidatePayToVendorNoOnBeforeRecreatePurchLines(Rec, xRec, IsHandled);
+                    if not IsHandled then
+                        RecreatePurchLines(PayToVendorTxt);
+                end;
 
                 if not SkipPayToContact then
                     UpdatePayToCont("Pay-to Vendor No.");
@@ -8975,6 +8979,11 @@ table 38 "Purchase Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidatePaytoVendorNoBeforeRecreateLines(var PurchaseHeader: Record "Purchase Header"; CallingFieldNo: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidatePayToVendorNoOnBeforeRecreatePurchLines(var PurchaseHeader: Record "Purchase Header"; xPurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -305,8 +305,12 @@ table 38 "Purchase Header"
 
                 if (xRec."Buy-from Vendor No." = "Buy-from Vendor No.") and
                    (xRec."Pay-to Vendor No." <> "Pay-to Vendor No.")
-                then
-                    RecreatePurchLines(PayToVendorTxt);
+                then begin
+                    IsHandled := false;
+                    OnValidatePayToVendorNoOnBeforeRecreatePurchLines(Rec, xRec, IsHandled);
+                    if not IsHandled then
+                        RecreatePurchLines(PayToVendorTxt);
+                end;
 
                 if not SkipPayToContact then
                     UpdatePayToCont("Pay-to Vendor No.");
@@ -8910,6 +8914,11 @@ table 38 "Purchase Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidatePaytoVendorNoBeforeRecreateLines(var PurchaseHeader: Record "Purchase Header"; CallingFieldNo: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidatePayToVendorNoOnBeforeRecreatePurchLines(var PurchaseHeader: Record "Purchase Header"; xPurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/ES/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -311,8 +311,12 @@ table 38 "Purchase Header"
 
                 if (xRec."Buy-from Vendor No." = "Buy-from Vendor No.") and
                    (xRec."Pay-to Vendor No." <> "Pay-to Vendor No.")
-                then
-                    RecreatePurchLines(PayToVendorTxt);
+                then begin
+                    IsHandled := false;
+                    OnValidatePayToVendorNoOnBeforeRecreatePurchLines(Rec, xRec, IsHandled);
+                    if not IsHandled then
+                        RecreatePurchLines(PayToVendorTxt);
+                end;
 
                 if not SkipPayToContact then
                     UpdatePayToCont("Pay-to Vendor No.");
@@ -9062,6 +9066,11 @@ table 38 "Purchase Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidatePaytoVendorNoBeforeRecreateLines(var PurchaseHeader: Record "Purchase Header"; CallingFieldNo: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidatePayToVendorNoOnBeforeRecreatePurchLines(var PurchaseHeader: Record "Purchase Header"; xPurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/FI/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/FI/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -304,8 +304,12 @@ table 38 "Purchase Header"
 
                 if (xRec."Buy-from Vendor No." = "Buy-from Vendor No.") and
                    (xRec."Pay-to Vendor No." <> "Pay-to Vendor No.")
-                then
-                    RecreatePurchLines(PayToVendorTxt);
+                then begin
+                    IsHandled := false;
+                    OnValidatePayToVendorNoOnBeforeRecreatePurchLines(Rec, xRec, IsHandled);
+                    if not IsHandled then
+                        RecreatePurchLines(PayToVendorTxt);
+                end;
 
                 if not SkipPayToContact then
                     UpdatePayToCont("Pay-to Vendor No.");
@@ -8953,6 +8957,11 @@ table 38 "Purchase Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidatePaytoVendorNoBeforeRecreateLines(var PurchaseHeader: Record "Purchase Header"; CallingFieldNo: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidatePayToVendorNoOnBeforeRecreatePurchLines(var PurchaseHeader: Record "Purchase Header"; xPurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/GB/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/GB/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -304,8 +304,12 @@ table 38 "Purchase Header"
 
                 if (xRec."Buy-from Vendor No." = "Buy-from Vendor No.") and
                    (xRec."Pay-to Vendor No." <> "Pay-to Vendor No.")
-                then
-                    RecreatePurchLines(PayToVendorTxt);
+                then begin
+                    IsHandled := false;
+                    OnValidatePayToVendorNoOnBeforeRecreatePurchLines(Rec, xRec, IsHandled);
+                    if not IsHandled then
+                        RecreatePurchLines(PayToVendorTxt);
+                end;
 
                 if not SkipPayToContact then
                     UpdatePayToCont("Pay-to Vendor No.");
@@ -8912,6 +8916,11 @@ table 38 "Purchase Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidatePaytoVendorNoBeforeRecreateLines(var PurchaseHeader: Record "Purchase Header"; CallingFieldNo: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidatePayToVendorNoOnBeforeRecreatePurchLines(var PurchaseHeader: Record "Purchase Header"; xPurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -342,8 +342,12 @@ table 38 "Purchase Header"
 
                 if (xRec."Buy-from Vendor No." = "Buy-from Vendor No.") and
                    (xRec."Pay-to Vendor No." <> "Pay-to Vendor No.")
-                then
-                    RecreatePurchLines(PayToVendorTxt);
+                then begin
+                    IsHandled := false;
+                    OnValidatePayToVendorNoOnBeforeRecreatePurchLines(Rec, xRec, IsHandled);
+                    if not IsHandled then
+                        RecreatePurchLines(PayToVendorTxt);
+                end;
 
                 if not SkipPayToContact then
                     UpdatePayToCont("Pay-to Vendor No.");
@@ -9543,6 +9547,11 @@ table 38 "Purchase Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidatePaytoVendorNoBeforeRecreateLines(var PurchaseHeader: Record "Purchase Header"; CallingFieldNo: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidatePayToVendorNoOnBeforeRecreatePurchLines(var PurchaseHeader: Record "Purchase Header"; xPurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NA/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/NA/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -305,8 +305,12 @@ table 38 "Purchase Header"
 
                 if (xRec."Buy-from Vendor No." = "Buy-from Vendor No.") and
                    (xRec."Pay-to Vendor No." <> "Pay-to Vendor No.")
-                then
-                    RecreatePurchLines(PayToVendorTxt);
+                then begin
+                    IsHandled := false;
+                    OnValidatePayToVendorNoOnBeforeRecreatePurchLines(Rec, xRec, IsHandled);
+                    if not IsHandled then
+                        RecreatePurchLines(PayToVendorTxt);
+                end;
 
                 if not SkipPayToContact then
                     UpdatePayToCont("Pay-to Vendor No.");
@@ -9101,6 +9105,11 @@ table 38 "Purchase Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidatePaytoVendorNoBeforeRecreateLines(var PurchaseHeader: Record "Purchase Header"; CallingFieldNo: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidatePayToVendorNoOnBeforeRecreatePurchLines(var PurchaseHeader: Record "Purchase Header"; xPurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NL/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/NL/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -308,8 +308,12 @@ table 38 "Purchase Header"
 
                 if (xRec."Buy-from Vendor No." = "Buy-from Vendor No.") and
                    (xRec."Pay-to Vendor No." <> "Pay-to Vendor No.")
-                then
-                    RecreatePurchLines(PayToVendorTxt);
+                then begin
+                    IsHandled := false;
+                    OnValidatePayToVendorNoOnBeforeRecreatePurchLines(Rec, xRec, IsHandled);
+                    if not IsHandled then
+                        RecreatePurchLines(PayToVendorTxt);
+                end;
 
                 if not SkipPayToContact then
                     UpdatePayToCont("Pay-to Vendor No.");
@@ -8931,6 +8935,11 @@ table 38 "Purchase Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidatePaytoVendorNoBeforeRecreateLines(var PurchaseHeader: Record "Purchase Header"; CallingFieldNo: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidatePayToVendorNoOnBeforeRecreatePurchLines(var PurchaseHeader: Record "Purchase Header"; xPurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NO/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/NO/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -307,8 +307,12 @@ table 38 "Purchase Header"
 
                 if (xRec."Buy-from Vendor No." = "Buy-from Vendor No.") and
                    (xRec."Pay-to Vendor No." <> "Pay-to Vendor No.")
-                then
-                    RecreatePurchLines(PayToVendorTxt);
+                then begin
+                    IsHandled := false;
+                    OnValidatePayToVendorNoOnBeforeRecreatePurchLines(Rec, xRec, IsHandled);
+                    if not IsHandled then
+                        RecreatePurchLines(PayToVendorTxt);
+                end;
 
                 if not SkipPayToContact then
                     UpdatePayToCont("Pay-to Vendor No.");
@@ -8936,6 +8940,11 @@ table 38 "Purchase Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidatePaytoVendorNoBeforeRecreateLines(var PurchaseHeader: Record "Purchase Header"; CallingFieldNo: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidatePayToVendorNoOnBeforeRecreatePurchLines(var PurchaseHeader: Record "Purchase Header"; xPurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -309,8 +309,12 @@ table 38 "Purchase Header"
 
                 if (xRec."Buy-from Vendor No." = "Buy-from Vendor No.") and
                    (xRec."Pay-to Vendor No." <> "Pay-to Vendor No.")
-                then
-                    RecreatePurchLines(PayToVendorTxt);
+                then begin
+                    IsHandled := false;
+                    OnValidatePayToVendorNoOnBeforeRecreatePurchLines(Rec, xRec, IsHandled);
+                    if not IsHandled then
+                        RecreatePurchLines(PayToVendorTxt);
+                end;
 
                 if not SkipPayToContact then
                     UpdatePayToCont("Pay-to Vendor No.");
@@ -9570,6 +9574,11 @@ table 38 "Purchase Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidatePaytoVendorNoBeforeRecreateLines(var PurchaseHeader: Record "Purchase Header"; CallingFieldNo: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidatePayToVendorNoOnBeforeRecreatePurchLines(var PurchaseHeader: Record "Purchase Header"; xPurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/SE/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/SE/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -304,8 +304,12 @@ table 38 "Purchase Header"
 
                 if (xRec."Buy-from Vendor No." = "Buy-from Vendor No.") and
                    (xRec."Pay-to Vendor No." <> "Pay-to Vendor No.")
-                then
-                    RecreatePurchLines(PayToVendorTxt);
+                then begin
+                    IsHandled := false;
+                    OnValidatePayToVendorNoOnBeforeRecreatePurchLines(Rec, xRec, IsHandled);
+                    if not IsHandled then
+                        RecreatePurchLines(PayToVendorTxt);
+                end;
 
                 if not SkipPayToContact then
                     UpdatePayToCont("Pay-to Vendor No.");
@@ -8909,6 +8913,11 @@ table 38 "Purchase Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidatePaytoVendorNoBeforeRecreateLines(var PurchaseHeader: Record "Purchase Header"; CallingFieldNo: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidatePayToVendorNoOnBeforeRecreatePurchLines(var PurchaseHeader: Record "Purchase Header"; xPurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -304,8 +304,12 @@ table 38 "Purchase Header"
 
                 if (xRec."Buy-from Vendor No." = "Buy-from Vendor No.") and
                    (xRec."Pay-to Vendor No." <> "Pay-to Vendor No.")
-                then
-                    RecreatePurchLines(PayToVendorTxt);
+                then begin
+                    IsHandled := false;
+                    OnValidatePayToVendorNoOnBeforeRecreatePurchLines(Rec, xRec, IsHandled);
+                    if not IsHandled then
+                        RecreatePurchLines(PayToVendorTxt);
+                end;
 
                 if not SkipPayToContact then
                     UpdatePayToCont("Pay-to Vendor No.");
@@ -8904,6 +8908,11 @@ table 38 "Purchase Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidatePaytoVendorNoBeforeRecreateLines(var PurchaseHeader: Record "Purchase Header"; CallingFieldNo: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidatePayToVendorNoOnBeforeRecreatePurchLines(var PurchaseHeader: Record "Purchase Header"; xPurchaseHeader: Record "Purchase Header"; var IsHandled: Boolean)
     begin
     end;
 


### PR DESCRIPTION
## Summary

The issue author needs a way to conditionally replace or bypass the standard `RecreatePurchLines` call that runs when the "Pay-to Vendor No." field is validated on a Purchase Header. Some custom purchase lines carry additional information that the standard line recreation would discard, so the extension must be able to run its own recreation logic instead. The existing extensibility points around this flow do not offer an `IsHandled` mechanism to skip the standard call, forcing partners to duplicate the entire validation trigger. This PR adds a handled integration event immediately before the `RecreatePurchLines` call so subscribers can take ownership of the recreation when needed.

Source issue repository: microsoft/AlAppExtensions; issue number: 30222

## Changes Made
- `OnValidatePayToVendorNoOnBeforeRecreatePurchLines` - new `IntegrationEvent` raised in the `OnValidate` trigger of field "Pay-to Vendor No." on table 38 "Purchase Header", immediately before `RecreatePurchLines(PayToVendorTxt)`. The event exposes `Rec`, `xRec`, and a `var IsHandled` flag (initialized to `false`); the standard `RecreatePurchLines` call now runs only when `IsHandled` remains `false`. Applied in the W1 base layer and propagated to the same-named table files in the APAC, BE, CH, DACH, ES, FI, GB, IT, NA, NL, NO, RU, and SE layers.

Fixes [AB#641640](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641640)



