### PR TITLE
[Extensibility Request] issue 30173: add integration events to Sales Line Discounts page

### DIFF
--- a/src/Layers/W1/BaseApp/Sales/Pricing/SalesLineDiscounts.Page.al
+++ b/src/Layers/W1/BaseApp/Sales/Pricing/SalesLineDiscounts.Page.al
@@ -431,6 +431,7 @@ page 7004 "Sales Line Discounts"
         else
             Rec.SetRange("Starting Date");
 
+        OnSetRecFiltersOnBeforeCurrPageUpdate(Rec, ItemTypeFilter);
         CurrPage.Update(false);
     end;
 
@@ -467,6 +468,8 @@ page 7004 "Sales Line Discounts"
                     if not ItemDiscGr.FindFirst() then
                         Clear(ItemDiscGr);
                 end;
+            else
+                OnGetFilterDescriptionCaseElse(Rec, ItemTypeFilter, SourceTableName, Item);
         end;
 
         SalesSrcTableName := '';
@@ -637,6 +640,28 @@ page 7004 "Sales Line Discounts"
     /// <param name="TypeFilter">The type filter integer value to set.</param>
     [IntegrationEvent(true, false)]
     local procedure OnGetTypeFilterCaseElse(var SalesLineDiscount: Record "Sales Line Discount"; var TypeFilter: Integer)
+    begin
+    end;
+
+    /// <summary>
+    /// Raises an event after the record filters have been applied and before the page is updated, allowing subscribers to apply additional filtering based on the current item type filter.
+    /// </summary>
+    /// <param name="SalesLineDiscount">The sales line discount record being filtered.</param>
+    /// <param name="ItemTypeFilter">The current item type filter value.</param>
+    [IntegrationEvent(true, false)]
+    local procedure OnSetRecFiltersOnBeforeCurrPageUpdate(var SalesLineDiscount: Record "Sales Line Discount"; ItemTypeFilter: Option Item,"Item Discount Group","None")
+    begin
+    end;
+
+    /// <summary>
+    /// Raises an event to resolve the filter description when the item type filter is not Item or Item Discount Group, allowing subscribers to provide a custom source table name and item filtering.
+    /// </summary>
+    /// <param name="SalesLineDiscount">The sales line discount record being described.</param>
+    /// <param name="ItemTypeFilter">The current item type filter value.</param>
+    /// <param name="SourceTableName">The source table name to display in the filter description.</param>
+    /// <param name="Item">The item record used to build the filter description.</param>
+    [IntegrationEvent(true, false)]
+    local procedure OnGetFilterDescriptionCaseElse(var SalesLineDiscount: Record "Sales Line Discount"; ItemTypeFilter: Option Item,"Item Discount Group","None"; var SourceTableName: Text; var Item: Record Item)
     begin
     end;
 }


### PR DESCRIPTION
## Summary
The author is building an extension on top of page 7004 "Sales Line Discounts" with additional fields backed by page-level global variables, and needs extensibility hooks that were not previously available. Specifically, they need to influence record filtering during filter setup (with access to the page/rec context) and to resolve the filter description for item type filter values the base application does not handle. This PR adds two integration events on the page so partners can extend these flows without modifying base code.

Source issue repository: microsoft/ALAppExtensions; issue number: 30173

## Changes Made
- `OnSetRecFiltersOnBeforeCurrPageUpdate` - new integration event raised in `SetRecFilters` after all record filters are applied and before `CurrPage.Update`, exposing the sales line discount record and the current item type filter so subscribers can apply additional filtering. Uses `IncludeSender = true` (matching existing events on the page) to give subscribers access to the page instance.
- `OnGetFilterDescriptionCaseElse` - new integration event raised from the `else` branch added to the `ItemTypeFilter` case in `GetFilterDescription`, letting subscribers supply a custom source table name and item filtering for item type filter values other than Item and Item Discount Group.
- The event parameters use the page's current `ItemTypeFilter` option type; the requested enum "Item Type Filter" is tracked separately (issue #30170) and does not yet exist in the codebase.

Fixes [AB#637953](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637953)


