### PR TITLE
[Extensibility Request] issue 30239: add OnBeforeOnRunOnCheckWarehouse event in Mfg. Item Jnl. Check Line

### DIFF
--- a/src/Layers/IT/BaseApp/Manufacturing/Inventory/Journal/MfgItemJnlCheckLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/Inventory/Journal/MfgItemJnlCheckLine.Codeunit.al
@@ -35,6 +35,11 @@ codeunit 99000760 "Mfg. Item Jnl. Check Line"
         IsHandled: Boolean;
         ShouldCheckItemNo: Boolean;
     begin
+        IsHandled := false;
+        OnBeforeOnRunOnCheckWarehouse(ItemJournalLine, CalledFromAdjustment, CalledFromInvtPutawayPick, IsHandled);
+        if IsHandled then
+            exit;
+
         if (ItemJournalLine."Entry Type" in [ItemJournalLine."Entry Type"::Consumption, ItemJournalLine."Entry Type"::Output]) and
            not (ItemJournalLine."Value Entry Type" = ItemJournalLine."Value Entry Type"::Revaluation) and
            not ItemJournalLine.OnlyStopTime()
@@ -305,6 +310,11 @@ codeunit 99000760 "Mfg. Item Jnl. Check Line"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeCheckWarehouseLastOutputOperation(var ItemJournalLine: Record "Item Journal Line"; var Result: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeOnRunOnCheckWarehouse(var ItemJournalLine: Record "Item Journal Line"; CalledFromAdjustment: Boolean; CalledFromInvtPutawayPick: Boolean; var IsHandled: Boolean)
     begin
     end;
 }

--- a/src/Layers/W1/BaseApp/Manufacturing/Inventory/Journal/MfgItemJnlCheckLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Inventory/Journal/MfgItemJnlCheckLine.Codeunit.al
@@ -32,6 +32,11 @@ codeunit 99000760 "Mfg. Item Jnl. Check Line"
         IsHandled: Boolean;
         ShouldCheckItemNo: Boolean;
     begin
+        IsHandled := false;
+        OnBeforeOnRunOnCheckWarehouse(ItemJournalLine, CalledFromAdjustment, CalledFromInvtPutawayPick, IsHandled);
+        if IsHandled then
+            exit;
+
         if (ItemJournalLine."Entry Type" in [ItemJournalLine."Entry Type"::Consumption, ItemJournalLine."Entry Type"::Output]) and
            not (ItemJournalLine."Value Entry Type" = ItemJournalLine."Value Entry Type"::Revaluation) and
            not ItemJournalLine.OnlyStopTime()
@@ -271,6 +276,11 @@ codeunit 99000760 "Mfg. Item Jnl. Check Line"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeCheckWarehouseLastOutputOperation(var ItemJournalLine: Record "Item Journal Line"; var Result: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeOnRunOnCheckWarehouse(var ItemJournalLine: Record "Item Journal Line"; CalledFromAdjustment: Boolean; CalledFromInvtPutawayPick: Boolean; var IsHandled: Boolean)
     begin
     end;
 }


### PR DESCRIPTION
## Summary
The manufacturing warehouse validation in codeunit 99000760 "Mfg. Item Jnl. Check Line" runs unconditionally as a subscriber to "Item Jnl.-Check Line".OnRunOnCheckWarehouse, which prevents extensions from posting Consumption/Output transactions that intentionally need to bypass this validation. To enable this scenario while preserving standard behavior for everyone else, this PR adds a new IsHandled publisher event at the start of that subscriber so an extension can conditionally skip the manufacturing checks for its own transactions.

Source issue repository: microsoft/AlAppExtensions; issue number: 30239

## Changes Made
- `OnRunOnCheckWarehouse` - initializes `IsHandled` to `false` and raises the new event at the beginning of the procedure, exiting early when a subscriber handles it; mirrored to the IT layer counterpart.
- `OnBeforeOnRunOnCheckWarehouse` - new `[IntegrationEvent(false, false)]` publisher exposing `ItemJournalLine`, `CalledFromAdjustment`, `CalledFromInvtPutawayPick`, and `var IsHandled` so extensions can bypass the standard validation when required.

Fixes [AB#642012](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642012)


