### PR TITLE
[Extensibility Request] issue 30264: add and extend events in CalcBestDirectUnitCost

### DIFF
--- a/src/Layers/W1/BaseApp/Purchases/Pricing/PurchPriceCalcMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/Pricing/PurchPriceCalcMgt.Codeunit.al
@@ -298,6 +298,7 @@ codeunit 7010 "Purch. Price Calc. Mgt."
         BestPurchPrice: Record "Purchase Price";
         BestPurchPriceFound: Boolean;
         IsHandled: Boolean;
+        InMinQty: Boolean;
     begin
         IsHandled := false;
         OnBeforeCalcBestDirectUnitCost(PurchPrice, BestPurchPrice, BestPurchPriceFound, IsHandled, SKU, Item);
@@ -307,7 +308,9 @@ codeunit 7010 "Purch. Price Calc. Mgt."
         FoundPurchPrice := PurchPrice.Find('-');
         if FoundPurchPrice then
             repeat
-                if IsInMinQty(PurchPrice."Unit of Measure Code", PurchPrice."Minimum Quantity") then begin
+                InMinQty := IsInMinQty(PurchPrice."Unit of Measure Code", PurchPrice."Minimum Quantity");
+                OnCalcBestDirectUnitCostOnAfterIsInMinQty(PurchPrice, QtyPerUOM, Qty, InMinQty);
+                if InMinQty then begin
                     OnCalcBestDirectUnitCostOnBeforeConvertPriceToVAT(PurchPrice);
                     ConvertPriceToVAT(
                       Vend."Prices Including VAT", Item."VAT Prod. Posting Group",
@@ -315,22 +318,25 @@ codeunit 7010 "Purch. Price Calc. Mgt."
                     ConvertPriceToUoM(PurchPrice."Unit of Measure Code", PurchPrice."Direct Unit Cost");
                     ConvertPriceLCYToFCY(PurchPrice."Currency Code", PurchPrice."Direct Unit Cost");
 
-                    case true of
-                        ((BestPurchPrice."Currency Code" = '') and (PurchPrice."Currency Code" <> '')) or
-                        ((BestPurchPrice."Variant Code" = '') and (PurchPrice."Variant Code" <> '')):
-                            begin
-                                BestPurchPrice := PurchPrice;
-                                BestPurchPriceFound := true;
-                            end;
-                        ((BestPurchPrice."Currency Code" = '') or (PurchPrice."Currency Code" <> '')) and
-                      ((BestPurchPrice."Variant Code" = '') or (PurchPrice."Variant Code" <> '')):
-                            if (BestPurchPrice."Direct Unit Cost" = 0) or
-                               (CalcLineAmount(BestPurchPrice) > CalcLineAmount(PurchPrice))
-                            then begin
-                                BestPurchPrice := PurchPrice;
-                                BestPurchPriceFound := true;
-                            end;
-                    end;
+                    IsHandled := false;
+                    OnCalcBestDirectUnitCostOnBeforeCaseStatement(PurchPrice, BestPurchPrice, BestPurchPriceFound, IsHandled, LineDiscPerCent);
+                    if not IsHandled then
+                        case true of
+                            ((BestPurchPrice."Currency Code" = '') and (PurchPrice."Currency Code" <> '')) or
+                            ((BestPurchPrice."Variant Code" = '') and (PurchPrice."Variant Code" <> '')):
+                                begin
+                                    BestPurchPrice := PurchPrice;
+                                    BestPurchPriceFound := true;
+                                end;
+                            ((BestPurchPrice."Currency Code" = '') or (PurchPrice."Currency Code" <> '')) and
+                          ((BestPurchPrice."Variant Code" = '') or (PurchPrice."Variant Code" <> '')):
+                                if (BestPurchPrice."Direct Unit Cost" = 0) or
+                                   (CalcLineAmount(BestPurchPrice) > CalcLineAmount(PurchPrice))
+                                then begin
+                                    BestPurchPrice := PurchPrice;
+                                    BestPurchPriceFound := true;
+                                end;
+                        end;
                 end;
             until PurchPrice.Next() = 0;
         IsHandled := false;
@@ -341,7 +347,7 @@ codeunit 7010 "Purch. Price Calc. Mgt."
         // No price found in agreement
         if not BestPurchPriceFound then begin
             IsHandled := false;
-            OnCalcBestDirectUnitCostOnBeforeNoPriceFound(BestPurchPrice, Item, IsHandled);
+            OnCalcBestDirectUnitCostOnBeforeNoPriceFound(BestPurchPrice, Item, IsHandled, PriceInSKU, SKU);
             if not IsHandled then begin
                 PriceInSKU := PriceInSKU and (SKU."Last Direct Cost" <> 0);
                 if PriceInSKU then
@@ -1120,7 +1126,17 @@ codeunit 7010 "Purch. Price Calc. Mgt."
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnCalcBestDirectUnitCostOnBeforeNoPriceFound(var PurchasePrice: Record "Purchase Price"; Item: Record Item; var IsHandled: Boolean)
+    local procedure OnCalcBestDirectUnitCostOnBeforeNoPriceFound(var PurchasePrice: Record "Purchase Price"; Item: Record Item; var IsHandled: Boolean; var PriceInSKU: Boolean; var StockkeepingUnit: Record "Stockkeeping Unit")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCalcBestDirectUnitCostOnAfterIsInMinQty(var PurchasePrice: Record "Purchase Price"; QtyPerUOM: Decimal; Qty: Decimal; var InMinQty: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCalcBestDirectUnitCostOnBeforeCaseStatement(var PurchasePrice: Record "Purchase Price"; var BestPurchasePrice: Record "Purchase Price"; var BestPurchPriceFound: Boolean; var IsHandled: Boolean; LineDiscPerCent: Decimal)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Purchases/Pricing/PurchPriceCalcMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/Pricing/PurchPriceCalcMgt.Codeunit.al
@@ -1131,7 +1131,7 @@ codeunit 7010 "Purch. Price Calc. Mgt."
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnCalcBestDirectUnitCostOnAfterIsInMinQty(var PurchasePrice: Record "Purchase Price"; QtyPerUOM: Decimal; Qty: Decimal; var InMinQty: Boolean)
+    local procedure OnCalcBestDirectUnitCostOnAfterIsInMinQty(var PurchasePrice: Record "Purchase Price"; QuantityPerUnitOfMeasure: Decimal; Quantity: Decimal; var InMinQty: Boolean)
     begin
     end;
 


### PR DESCRIPTION
## Summary
The author needs to customize purchase price selection in `CalcBestDirectUnitCost` (codeunit 7010 "Purch. Price Calc. Mgt.") on a per-price-record basis - deciding which quantity the minimum-quantity check compares against, applying a different best-price selection rule, and intercepting the no-price fallback cost. The existing events do not expose the required in-scope state (the current `Purchase Price` record, the current best price, or `PriceInSKU`/`SKU`) at the right points, forcing subscribers to re-implement whole loops. This PR adds two new integration events inside the selection loop and extends one existing event so subscribers can override these decisions without duplicating internal logic.

Source issue repository: microsoft/AlAppExtensions; issue number: 30264

## Changes Made
- `OnCalcBestDirectUnitCostOnAfterIsInMinQty` - new integration event raised right after the `IsInMinQty` call in the loop, exposing the `PurchasePrice` record, `QtyPerUOM`, `Qty`, and the min-quantity `var Boolean` result so subscribers can override which quantity the minimum is checked against per price record. The `IsInMinQty` result is now stored in a new local `InMinQty` variable that drives the loop.
- `OnCalcBestDirectUnitCostOnBeforeCaseStatement` - new integration event raised after the price conversions and before the `case true of` selection block, exposing `PurchasePrice`, `BestPurchasePrice`, `BestPurchPriceFound`, a `var IsHandled` skip flag, and `LineDiscPerCent` so subscribers can replace the best-price selection rule; the standard `case` block runs only when `IsHandled` is `false`.
- `OnCalcBestDirectUnitCostOnBeforeNoPriceFound` - extended with `var PriceInSKU: Boolean` and `var StockkeepingUnit: Record "Stockkeeping Unit"` appended to the signature so subscribers can intercept the no-price fallback with full knowledge of the SKU state; the call site now passes `PriceInSKU` and `SKU`.

Fixes [AB#641452](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641452)





