### PR TITLE
[Extensibility Request] issue 30334: fix OnAfterCarryOutToReqWksh record order

### DIFF
--- a/src/Layers/NA/BaseApp/Inventory/Requisition/CarryOutAction.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Inventory/Requisition/CarryOutAction.Codeunit.al
@@ -217,7 +217,7 @@ codeunit 99000813 "Carry Out Action"
                 OnCarryOutToReqWkshOnAfterPlanningCompInsert(PlanningComponent2, PlanningComponent);
             until PlanningComponent.Next() = 0;
 
-        OnAfterCarryOutToReqWksh(RequisitionLine, RequisitionLine2, ReqWkshTempName, ReqJournalName, LineNo);
+        OnAfterCarryOutToReqWksh(RequisitionLine2, RequisitionLine, ReqWkshTempName, ReqJournalName, LineNo);
     end;
 
     procedure GetTransferOrdersToPrint(var TransferHeader: Record "Transfer Header")

--- a/src/Layers/NA/BaseApp/Inventory/Requisition/CarryOutAction.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Inventory/Requisition/CarryOutAction.Codeunit.al
@@ -217,7 +217,7 @@ codeunit 99000813 "Carry Out Action"
                 OnCarryOutToReqWkshOnAfterPlanningCompInsert(PlanningComponent2, PlanningComponent);
             until PlanningComponent.Next() = 0;
 
-        OnAfterCarryOutToReqWksh(RequisitionLine2, RequisitionLine, ReqWkshTempName, ReqJournalName, LineNo);
+        OnAfterCarryOutToReqWksh(RequisitionLine, RequisitionLine2, ReqWkshTempName, ReqJournalName, LineNo);
     end;
 
     procedure GetTransferOrdersToPrint(var TransferHeader: Record "Transfer Header")
@@ -748,7 +748,7 @@ codeunit 99000813 "Carry Out Action"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterCarryOutToReqWksh(var RequisitionLine: Record "Requisition Line"; RequisitionLine2: Record "Requisition Line"; ReqWkshTempName: Code[10]; ReqJournalName: Code[10]; LineNo: Integer)
+    local procedure OnAfterCarryOutToReqWksh(var RequisitionLine: Record "Requisition Line"; var RequisitionLine2: Record "Requisition Line"; ReqWkshTempName: Code[10]; ReqJournalName: Code[10]; LineNo: Integer)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Inventory/Requisition/CarryOutAction.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Requisition/CarryOutAction.Codeunit.al
@@ -217,7 +217,7 @@ codeunit 99000813 "Carry Out Action"
                 OnCarryOutToReqWkshOnAfterPlanningCompInsert(PlanningComponent2, PlanningComponent);
             until PlanningComponent.Next() = 0;
 
-        OnAfterCarryOutToReqWksh(RequisitionLine, RequisitionLine2, ReqWkshTempName, ReqJournalName, LineNo);
+        OnAfterCarryOutToReqWksh(RequisitionLine2, RequisitionLine, ReqWkshTempName, ReqJournalName, LineNo);
     end;
 
     procedure GetTransferOrdersToPrint(var TransferHeader: Record "Transfer Header")

--- a/src/Layers/W1/BaseApp/Inventory/Requisition/CarryOutAction.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Requisition/CarryOutAction.Codeunit.al
@@ -217,7 +217,7 @@ codeunit 99000813 "Carry Out Action"
                 OnCarryOutToReqWkshOnAfterPlanningCompInsert(PlanningComponent2, PlanningComponent);
             until PlanningComponent.Next() = 0;
 
-        OnAfterCarryOutToReqWksh(RequisitionLine2, RequisitionLine, ReqWkshTempName, ReqJournalName, LineNo);
+        OnAfterCarryOutToReqWksh(RequisitionLine, RequisitionLine2, ReqWkshTempName, ReqJournalName, LineNo);
     end;
 
     procedure GetTransferOrdersToPrint(var TransferHeader: Record "Transfer Header")
@@ -748,7 +748,7 @@ codeunit 99000813 "Carry Out Action"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterCarryOutToReqWksh(var RequisitionLine: Record "Requisition Line"; RequisitionLine2: Record "Requisition Line"; ReqWkshTempName: Code[10]; ReqJournalName: Code[10]; LineNo: Integer)
+    local procedure OnAfterCarryOutToReqWksh(var RequisitionLine: Record "Requisition Line"; var RequisitionLine2: Record "Requisition Line"; ReqWkshTempName: Code[10]; ReqJournalName: Code[10]; LineNo: Integer)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Manufacturing/Inventory/Requisition/MfgCarryOutAction.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Inventory/Requisition/MfgCarryOutAction.Codeunit.al
@@ -776,9 +776,9 @@ codeunit 99000818 "Mfg. Carry Out Action"
         ProdOrderCapacityNeed: Record "Prod. Order Capacity Need";
         ProdOrderCapacityNeed2: Record "Prod. Order Capacity Need";
     begin
-        PlanningRoutingLine.SetRange("Worksheet Template Name", RequisitionLine."Worksheet Template Name");
-        PlanningRoutingLine.SetRange("Worksheet Batch Name", RequisitionLine."Journal Batch Name");
-        PlanningRoutingLine.SetRange("Worksheet Line No.", RequisitionLine."Line No.");
+        PlanningRoutingLine.SetRange("Worksheet Template Name", RequisitionLine2."Worksheet Template Name");
+        PlanningRoutingLine.SetRange("Worksheet Batch Name", RequisitionLine2."Journal Batch Name");
+        PlanningRoutingLine.SetRange("Worksheet Line No.", RequisitionLine2."Line No.");
         if PlanningRoutingLine.Find('-') then
             repeat
                 PlanningRoutingLine2 := PlanningRoutingLine;
@@ -792,9 +792,9 @@ codeunit 99000818 "Mfg. Carry Out Action"
                 PlanningRoutingLine2.Insert();
             until PlanningRoutingLine.Next() = 0;
 
-        ProdOrderCapacityNeed.SetRange("Worksheet Template Name", RequisitionLine."Worksheet Template Name");
-        ProdOrderCapacityNeed.SetRange("Worksheet Batch Name", RequisitionLine."Journal Batch Name");
-        ProdOrderCapacityNeed.SetRange("Worksheet Line No.", RequisitionLine."Line No.");
+        ProdOrderCapacityNeed.SetRange("Worksheet Template Name", RequisitionLine2."Worksheet Template Name");
+        ProdOrderCapacityNeed.SetRange("Worksheet Batch Name", RequisitionLine2."Journal Batch Name");
+        ProdOrderCapacityNeed.SetRange("Worksheet Line No.", RequisitionLine2."Line No.");
         if ProdOrderCapacityNeed.Find('-') then
             repeat
                 ProdOrderCapacityNeed2 := ProdOrderCapacityNeed;

--- a/src/Layers/W1/BaseApp/Manufacturing/Inventory/Requisition/MfgCarryOutAction.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Inventory/Requisition/MfgCarryOutAction.Codeunit.al
@@ -776,9 +776,9 @@ codeunit 99000818 "Mfg. Carry Out Action"
         ProdOrderCapacityNeed: Record "Prod. Order Capacity Need";
         ProdOrderCapacityNeed2: Record "Prod. Order Capacity Need";
     begin
-        PlanningRoutingLine.SetRange("Worksheet Template Name", RequisitionLine2."Worksheet Template Name");
-        PlanningRoutingLine.SetRange("Worksheet Batch Name", RequisitionLine2."Journal Batch Name");
-        PlanningRoutingLine.SetRange("Worksheet Line No.", RequisitionLine2."Line No.");
+        PlanningRoutingLine.SetRange("Worksheet Template Name", RequisitionLine."Worksheet Template Name");
+        PlanningRoutingLine.SetRange("Worksheet Batch Name", RequisitionLine."Journal Batch Name");
+        PlanningRoutingLine.SetRange("Worksheet Line No.", RequisitionLine."Line No.");
         if PlanningRoutingLine.Find('-') then
             repeat
                 PlanningRoutingLine2 := PlanningRoutingLine;
@@ -792,9 +792,9 @@ codeunit 99000818 "Mfg. Carry Out Action"
                 PlanningRoutingLine2.Insert();
             until PlanningRoutingLine.Next() = 0;
 
-        ProdOrderCapacityNeed.SetRange("Worksheet Template Name", RequisitionLine2."Worksheet Template Name");
-        ProdOrderCapacityNeed.SetRange("Worksheet Batch Name", RequisitionLine2."Journal Batch Name");
-        ProdOrderCapacityNeed.SetRange("Worksheet Line No.", RequisitionLine2."Line No.");
+        ProdOrderCapacityNeed.SetRange("Worksheet Template Name", RequisitionLine."Worksheet Template Name");
+        ProdOrderCapacityNeed.SetRange("Worksheet Batch Name", RequisitionLine."Journal Batch Name");
+        ProdOrderCapacityNeed.SetRange("Worksheet Line No.", RequisitionLine."Line No.");
         if ProdOrderCapacityNeed.Find('-') then
             repeat
                 ProdOrderCapacityNeed2 := ProdOrderCapacityNeed;


### PR DESCRIPTION
## Summary
A subscriber to the `OnAfterCarryOutToReqWksh` integration event in codeunit 99000813 "Carry Out Action" needs to update the newly created target requisition line based on the source line it was copied from. The event's first parameter is passed by `var` precisely so subscribers can modify that record, but in version 28.1 the call was changed to pass the source line as the first argument and the target line by value, removing any way to persist changes to the target line. This regression blocks the reporter's process. This PR restores the previous argument order so the modifiable `var` parameter is once again the target requisition line.

Source issue repository: microsoft/ALAppExtensions; issue number: 30334

## Changes Made
- `Carry Out Action.CarryOutToReqWksh` - updated the `OnAfterCarryOutToReqWksh` call to pass the target requisition line as the (`var`) argument, so subscribers can modify and persist the target line; applied in both the W1 and NA layers.

Fixes [AB#641682](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641682)



