### PR TITLE
[Extensibility Request] issue 30292: add temporary Warehouse Activity Line parameter to OnBeforeCreateWhseActivHeader

### DIFF
--- a/src/Layers/W1/BaseApp/Warehouse/Activity/CreatePick.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Warehouse/Activity/CreatePick.Codeunit.al
@@ -1634,7 +1634,7 @@ codeunit 7312 "Create Pick"
         IsHandled: Boolean;
     begin
         IsHandled := false;
-        OnBeforeCreateWhseActivHeader(CurrWarehouseActivityHeader, LocationCode, FirstWhseDocNo, LastWhseDocNo, NoOfSourceDoc, NoOfLines, WhseDocCreated, IsHandled);
+        OnBeforeCreateWhseActivHeader(CurrWarehouseActivityHeader, LocationCode, FirstWhseDocNo, LastWhseDocNo, NoOfSourceDoc, NoOfLines, WhseDocCreated, IsHandled, TempWarehouseActivityLine);
         if not IsHandled then begin
             CurrWarehouseActivityHeader.Init();
             CurrWarehouseActivityHeader."No." := '';
@@ -4880,7 +4880,7 @@ codeunit 7312 "Create Pick"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCreateWhseActivHeader(var CurrWarehouseActivityHeader: Record "Warehouse Activity Header"; LocationCode: Code[10]; var FirstWhseDocNo: Code[20]; var LastWhseDocNo: Code[20]; var NoOfSourceDoc: Integer; var NoOfLines: Integer; var WhseDocCreated: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCreateWhseActivHeader(var CurrWarehouseActivityHeader: Record "Warehouse Activity Header"; LocationCode: Code[10]; var FirstWhseDocNo: Code[20]; var LastWhseDocNo: Code[20]; var NoOfSourceDoc: Integer; var NoOfLines: Integer; var WhseDocCreated: Boolean; var IsHandled: Boolean; var TempWarehouseActivityLine: Record "Warehouse Activity Line" temporary)
     begin
     end;
 


### PR DESCRIPTION
## Summary
The issue author needs to add new order lines (Sales, Transfer, and Purchase Return Orders) to an existing warehouse pick. Doing so requires inspecting the temporary pick lines before a warehouse activity header is created, so a subscriber can decide whether a new header is needed or the lines should be redirected to an existing pick. The existing `OnBeforeCreateWhseActivHeader` event already exposes the handling and grouping state but not the temporary lines. This PR appends a temporary `Warehouse Activity Line` parameter to that event so subscribers can implement this scenario.

Source issue repository: microsoft/AlAppExtensions; issue number: 30292

## Changes Made
- `OnBeforeCreateWhseActivHeader` (codeunit 7312 "Create Pick") - added `var TempWarehouseActivityLine: Record "Warehouse Activity Line" temporary` as a new trailing parameter to the event publisher and its call in `CreateWhseActivHeader`, giving subscribers access to the temporary pick lines before the warehouse activity header is created.

Fixes [AB#641814](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641814)

