### PR TITLE
[Extensibility Request] issue 30329: override confirmation text in CancelPostedInvoiceAndOpenSalesOrder

### DIFF
--- a/src/Layers/W1/BaseApp/Sales/History/CorrectPstdSalesInvYesNo.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/History/CorrectPstdSalesInvYesNo.Codeunit.al
@@ -82,8 +82,11 @@ codeunit 1322 "Correct PstdSalesInv (Yes/No)"
         ConfirmManagement: Codeunit "Confirm Management";
         CorrectPostedSalesInvoice: Codeunit "Correct Posted Sales Invoice";
         IsHandled: Boolean;
+        ConfirmQuestion: Text;
     begin
-        if ConfirmManagement.GetResponse(CorrectPostedInvoiceFromSingleOrderQst, false) then begin
+        ConfirmQuestion := CorrectPostedInvoiceFromSingleOrderQst;
+        OnCancelPostedInvoiceAndOpenSalesOrderOnBeforeConfirm(SalesInvoiceHeader, SalesHeader, ConfirmQuestion);
+        if ConfirmManagement.GetResponse(ConfirmQuestion, false) then begin
             if not CorrectPostedSalesInvoice.CancelPostedInvoice(SalesInvoiceHeader) then
                 exit(false);
 
@@ -131,6 +134,11 @@ codeunit 1322 "Correct PstdSalesInv (Yes/No)"
 
     [IntegrationEvent(false, false)]
     local procedure OnCorrectInvoiceOnBeforeOpenSalesOrderPage(var SalesHeader: Record "Sales Header"; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCancelPostedInvoiceAndOpenSalesOrderOnBeforeConfirm(var SalesInvoiceHeader: Record "Sales Invoice Header"; var SalesHeader: Record "Sales Header"; var ConfirmQuestion: Text)
     begin
     end;
 }


### PR DESCRIPTION
## Summary
Following #29949 (shipped in 28.2), an extension can change what happens to the originating sales order's quantities when a posted sales invoice is corrected or cancelled. When that behavior is changed, the standard confirmation text shown before the action becomes inaccurate because it still states the original quantities will be reverted. This PR adds an integration event so an extension can override the confirmation question text before it is shown, without duplicating the procedure's logic.

Source issue repository: microsoft/AlAppExtensions; issue number: 30329

## Changes Made
- `CancelPostedInvoiceAndOpenSalesOrder` (codeunit "Correct PstdSalesInv (Yes/No)") - the confirmation text is now stored in a local `ConfirmQuestion` variable and the new `OnCancelPostedInvoiceAndOpenSalesOrderOnBeforeConfirm` integration event is raised before `ConfirmManagement.GetResponse`, allowing subscribers to override the question text.
- `OnCancelPostedInvoiceAndOpenSalesOrderOnBeforeConfirm` - new integration event publisher exposing the sales invoice header, sales header, and a `var ConfirmQuestion: Text` parameter.

Fixes [AB#641734](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641734)


