### PR TITLE
[Bug 642248] Header/Footer Theme Assignment: persist selected layout (missing Rec.Modify)

### DIFF
--- a/src/Layers/W1/BaseApp/Foundation/Reporting/HeaderFooterThemeAssignment.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/HeaderFooterThemeAssignment.Page.al
@@ -150,6 +150,7 @@ page 9667 "Header/Footer Theme Assignment"
             exit;
         Rec."Header Part Name" := CopyStr(Composite, 1, MaxStrLen(Rec."Header Part Name"));
         HeaderPartDisplay := LookupHelper.DecodeLayoutName(Composite);
+        Rec.Modify();
         CurrPage.Update(false);
     end;
 
@@ -161,6 +162,7 @@ page 9667 "Header/Footer Theme Assignment"
             exit;
         Rec."Theme Part Name" := CopyStr(Composite, 1, MaxStrLen(Rec."Theme Part Name"));
         ThemePartDisplay := LookupHelper.DecodeLayoutName(Composite);
+        Rec.Modify();
         CurrPage.Update(false);
     end;
 

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
@@ -411,7 +411,7 @@ page 9660 "Report Layouts"
 
             group(CompositeLayoutDetails)
             {
-                Caption = 'Composite Layout';
+                Caption = 'Composite layout';
                 Image = Document;
                 Visible = DocumentReportExperienceEnabled;
                 // The assignment page and lookup helper declare RIMD on Tenant Report Layout Cfg (indirect


### PR DESCRIPTION
## What & why

Fixes a data-persistence bug on the **Header/Footer Theme Assignment** page (9667).
Selecting a header part or theme part via the lookup set the value on `Rec`
(`Rec."Header Part Name"` / `Rec."Theme Part Name"`) and refreshed the page, but never
called `Rec.Modify()` — so the chosen layout was never written to the database and the
assignment was lost. This adds `Rec.Modify()` in both lookup handlers so the selection
persists. Also includes a minor caption casing fix on the **Report Layouts** page (9660):
`Composite Layout` → `Composite layout`.

## Linked work

[AB#642248](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642248)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

- Open **Header/Footer Theme Assignment** (page 9667), select a header part and a theme
  part via lookup, navigate away and back — the assignment now persists (previously it was lost).
- No automated tests added: change is a one-line `Modify()` fix on an existing page action; behavior
  is covered by manual verification above.

## Risk & compatibility

Low risk. No schema, API, or permission changes. Behavior change is limited to persisting a
selection that was previously being silently discarded on page 9667; the page already declares
the required write permissions on the underlying table. No upgrade or data migration impact.
The caption change on page 9660 is display-text only.

