### PR TITLE
[Master] - Bug 641049: Sustainability - Validate item tracking for specific carbon tracking

### DIFF
--- a/src/Apps/W1/Sustainability/app/src/Certificate/SustItem.TableExt.al
+++ b/src/Apps/W1/Sustainability/app/src/Certificate/SustItem.TableExt.al
@@ -1,6 +1,7 @@
 namespace Microsoft.Sustainability.Certificate;
 
 using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Tracking;
 using Microsoft.Sustainability.Account;
 using Microsoft.Sustainability.Codes;
 using Microsoft.Sustainability.EPR;
@@ -269,12 +270,19 @@ tableextension 6220 "Sust. Item" extends Item
             Caption = 'Carbon Tracking Method';
             ToolTip = 'Specifies the Carbon Tracking Method for this item.';
             DataClassification = CustomerContent;
+
+            trigger OnValidate()
+            begin
+                if Rec."Carbon Tracking Method" = Rec."Carbon Tracking Method"::Specific then
+                    CheckItemTrackingForSpecificCarbonTracking();
+            end;
         }
     }
 
     var
         SustainabilitySetup: Record "Sustainability Setup";
         AtLeastOneNonZeroEmissionValueErr: Label '%1, %2, %3 cannot all be zero. Please provide at least one non-zero value.', Comment = '%1, %2 , %3 = Field Caption';
+        SpecificCarbonTrackingNeedsItemTrackingErr: Label 'The %1 %2 requires an %3 with serial or lot specific tracking so that per-unit emissions can be resolved.', Comment = '%1 = Carbon Tracking Method field caption, %2 = Carbon Tracking Method value, %3 = Item Tracking Code field caption';
 
     local procedure UpdateCertificateInformation()
     var
@@ -312,5 +320,20 @@ tableextension 6220 "Sust. Item" extends Item
         Item.Validate("Default N2O Emission", 0);
         Item.Validate("Default CH4 Emission", 0);
         Item.Validate("Default CO2 Emission", 0);
+    end;
+
+    local procedure CheckItemTrackingForSpecificCarbonTracking()
+    var
+        ItemTrackingCode: Record "Item Tracking Code";
+    begin
+        if (Rec."Item Tracking Code" <> '') and ItemTrackingCode.Get(Rec."Item Tracking Code") then
+            if ItemTrackingCode."SN Specific Tracking" or ItemTrackingCode."Lot Specific Tracking" then
+                exit;
+
+        Error(
+            SpecificCarbonTrackingNeedsItemTrackingErr,
+            Rec.FieldCaption("Carbon Tracking Method"),
+            Format(Rec."Carbon Tracking Method"::Specific),
+            Rec.FieldCaption("Item Tracking Code"));
     end;
 }

--- a/src/Apps/W1/Sustainability/test/src/LibrarySustainability.Codeunit.al
+++ b/src/Apps/W1/Sustainability/test/src/LibrarySustainability.Codeunit.al
@@ -504,7 +504,9 @@ codeunit 148182 "Library - Sustainability"
 
     procedure CreateItemWithSpecificCarbonTrackingMethod(var Item: Record Item)
     begin
-        LibraryInventory.CreateItem(Item);
+        // Specific carbon tracking requires an item tracking code with serial or lot specific tracking,
+        // so create a lot-tracked item before setting the Carbon Tracking Method to Specific.
+        LibraryItemTracking.CreateLotItem(Item);
         Item.Validate("Carbon Tracking Method", Item."Carbon Tracking Method"::Specific);
         Item.Modify();
     end;

--- a/src/Apps/W1/Sustainability/test/src/SustCertificateTest.Codeunit.al
+++ b/src/Apps/W1/Sustainability/test/src/SustCertificateTest.Codeunit.al
@@ -12,6 +12,7 @@ using Microsoft.Inventory.BOM;
 using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Journal;
 using Microsoft.Inventory.Location;
+using Microsoft.Inventory.Tracking;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
@@ -59,6 +60,7 @@ codeunit 148187 "Sust. Certificate Test"
         LibrarySales: Codeunit "Library - Sales";
         LibraryWarehouse: Codeunit "Library - Warehouse";
         LibraryJob: Codeunit "Library - Job";
+        LibraryItemTracking: Codeunit "Library - Item Tracking";
         AccountCodeLbl: Label 'AccountCode%1', Locked = true, Comment = '%1 = Number';
         CategoryCodeLbl: Label 'CategoryCode%1', Locked = true, Comment = '%1 = Number';
         SubcategoryCodeLbl: Label 'SubcategoryCode%1', Locked = true, Comment = '%1 = Number';
@@ -82,6 +84,7 @@ codeunit 148187 "Sust. Certificate Test"
         RecyclabilityPercentageMaxValueErr: Label 'The value must be less than or equal to %1. Value: %2.', Comment = '%1 = Maximum Value, %2 = Field Value';
         EmissionUOMCannotBeChangedErr: Label 'The value for %1 cannot be modified because there are existing sustainability ledger entries that use the unit of measure %2.', Comment = '%1 = Field Caption, %2 = Unit of Measure Code';
         FieldShouldNotBeEditableErr: Label '%1 should not be editable in Page %2', Comment = '%1 = Field Caption, %2 = Page Caption';
+        SpecificCarbonTrackingNeedsItemTrackingErr: Label 'The %1 %2 requires an %3 with serial or lot specific tracking so that per-unit emissions can be resolved.', Comment = '%1 = Carbon Tracking Method field caption, %2 = Carbon Tracking Method value, %3 = Item Tracking Code field caption';
 
     [Test]
     procedure VerifyHasValueFieldShouldThrowErrorWhenValueIsUpdated()
@@ -7253,6 +7256,122 @@ codeunit 148187 "Sust. Certificate Test"
         Assert.IsFalse(
             ServiceOrderSubform."Total CO2e".Visible(),
             StrSubstNo(FieldShouldNotBeVisibleErr, ServiceOrderSubform."Total CO2e".Caption(), ServiceOrderSubform.Caption()));
+    end;
+
+    [Test]
+    procedure VerifyCarbonTrackingMethodSpecificThrowsErrorWhenItemHasNoItemTrackingCode()
+    var
+        Item: Record Item;
+    begin
+        // [SCENARIO 641049] Verify "Carbon Tracking Method" Specific throws an error When Item has no Item Tracking Code.
+        LibrarySustainability.CleanUpBeforeTesting();
+
+        // [GIVEN] Create an Item without an Item Tracking Code.
+        LibraryInventory.CreateItem(Item);
+
+        // [WHEN] Update "Carbon Tracking Method" to Specific in an Item.
+        asserterror Item.Validate("Carbon Tracking Method", Item."Carbon Tracking Method"::Specific);
+
+        // [VERIFY] Verify "Carbon Tracking Method" Specific throws an error When Item has no Item Tracking Code.
+        Assert.ExpectedError(
+            StrSubstNo(
+                SpecificCarbonTrackingNeedsItemTrackingErr,
+                Item.FieldCaption("Carbon Tracking Method"),
+                Format(Item."Carbon Tracking Method"::Specific),
+                Item.FieldCaption("Item Tracking Code")));
+    end;
+
+    [Test]
+    procedure VerifyCarbonTrackingMethodSpecificThrowsErrorWhenItemTrackingCodeHasNoSerialOrLotTracking()
+    var
+        Item: Record Item;
+        ItemTrackingCode: Record "Item Tracking Code";
+    begin
+        // [SCENARIO 641049] Verify "Carbon Tracking Method" Specific throws an error When Item Tracking Code has no serial or lot specific tracking.
+        LibrarySustainability.CleanUpBeforeTesting();
+
+        // [GIVEN] Create an Item Tracking Code without serial or lot specific tracking.
+        LibraryItemTracking.CreateItemTrackingCode(ItemTrackingCode, false, false);
+
+        // [GIVEN] Create an Item with the Item Tracking Code.
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Item Tracking Code", ItemTrackingCode.Code);
+        Item.Modify(true);
+
+        // [WHEN] Update "Carbon Tracking Method" to Specific in an Item.
+        asserterror Item.Validate("Carbon Tracking Method", Item."Carbon Tracking Method"::Specific);
+
+        // [VERIFY] Verify "Carbon Tracking Method" Specific throws an error When Item Tracking Code has no serial or lot specific tracking.
+        Assert.ExpectedError(
+            StrSubstNo(
+                SpecificCarbonTrackingNeedsItemTrackingErr,
+                Item.FieldCaption("Carbon Tracking Method"),
+                Format(Item."Carbon Tracking Method"::Specific),
+                Item.FieldCaption("Item Tracking Code")));
+    end;
+
+    [Test]
+    procedure VerifyCarbonTrackingMethodSpecificIsAllowedWhenItemTrackingCodeHasLotTracking()
+    var
+        Item: Record Item;
+        ItemTrackingCode: Record "Item Tracking Code";
+    begin
+        // [SCENARIO 641049] Verify "Carbon Tracking Method" Specific is allowed When Item Tracking Code has lot specific tracking.
+        LibrarySustainability.CleanUpBeforeTesting();
+
+        // [GIVEN] Create an Item Tracking Code with lot specific tracking.
+        LibraryItemTracking.CreateItemTrackingCode(ItemTrackingCode, false, true);
+
+        // [GIVEN] Create an Item with the Item Tracking Code.
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Item Tracking Code", ItemTrackingCode.Code);
+        Item.Modify(true);
+
+        // [WHEN] Update "Carbon Tracking Method" to Specific in an Item.
+        Item.Validate("Carbon Tracking Method", Item."Carbon Tracking Method"::Specific);
+        Item.Modify(true);
+
+        // [VERIFY] Verify "Carbon Tracking Method" Specific is allowed When Item Tracking Code has lot specific tracking.
+        Assert.AreEqual(
+            Item."Carbon Tracking Method"::Specific,
+            Item."Carbon Tracking Method",
+            StrSubstNo(
+                ValueMustBeEqualErr,
+                Item.FieldCaption("Carbon Tracking Method"),
+                Format(Item."Carbon Tracking Method"::Specific),
+                Item.TableCaption()));
+    end;
+
+    [Test]
+    procedure VerifyCarbonTrackingMethodSpecificIsAllowedWhenItemTrackingCodeHasSerialTracking()
+    var
+        Item: Record Item;
+        ItemTrackingCode: Record "Item Tracking Code";
+    begin
+        // [SCENARIO 641049] Verify "Carbon Tracking Method" Specific is allowed When Item Tracking Code has serial specific tracking.
+        LibrarySustainability.CleanUpBeforeTesting();
+
+        // [GIVEN] Create an Item Tracking Code with serial specific tracking.
+        LibraryItemTracking.CreateItemTrackingCode(ItemTrackingCode, true, false);
+
+        // [GIVEN] Create an Item with the Item Tracking Code.
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Item Tracking Code", ItemTrackingCode.Code);
+        Item.Modify(true);
+
+        // [WHEN] Update "Carbon Tracking Method" to Specific in an Item.
+        Item.Validate("Carbon Tracking Method", Item."Carbon Tracking Method"::Specific);
+        Item.Modify(true);
+
+        // [VERIFY] Verify "Carbon Tracking Method" Specific is allowed When Item Tracking Code has serial specific tracking.
+        Assert.AreEqual(
+            Item."Carbon Tracking Method"::Specific,
+            Item."Carbon Tracking Method",
+            StrSubstNo(
+                ValueMustBeEqualErr,
+                Item.FieldCaption("Carbon Tracking Method"),
+                Format(Item."Carbon Tracking Method"::Specific),
+                Item.TableCaption()));
     end;
 
     local procedure CreateSustainabilityAccount(var AccountCode: Code[20]; var CategoryCode: Code[20]; var SubcategoryCode: Code[20]; i: Integer): Record "Sustainability Account"

--- a/src/Apps/W1/Sustainability/test/src/SustValueEntryTest.Codeunit.al
+++ b/src/Apps/W1/Sustainability/test/src/SustValueEntryTest.Codeunit.al
@@ -3828,9 +3828,9 @@ codeunit 148190 "Sust. Value Entry Test"
         PurchaseHeader."Buy-from Country/Region Code" := CountryRegion.Code;
         PurchaseHeader.Modify();
 
-        // [GIVEN] Create a Purchase Line of Item with Specific Carbon Tracking Method
-        LibrarySustainability.CreateItemWithSpecificCarbonTrackingMethod(Item);
-        CreatePurchaseLineWithEmissionValue(PurchaseLine, PurchaseHeader, Item."No.", '', '', LibraryRandom.RandIntInRange(10, 10), EmissionCO2[1], EmissionCH4[1], EmissionN2O[1], AccountCode);
+        // [GIVEN] Create a lot-tracked Item with Specific Carbon Tracking Method.
+        LibrarySustainability.UpdateCarbonTrackingMethod(Item, Item."Carbon Tracking Method"::Specific);
+        CreatePurchaseLineWithEmissionValue(PurchaseLine, PurchaseHeader, Item."No.", Item."Item Tracking Code", LibraryUtility.GenerateGUID(), LibraryRandom.RandIntInRange(10, 10), EmissionCO2[1], EmissionCH4[1], EmissionN2O[1], AccountCode);
 
         // [GIVEN] Save Expected CO2e
         for Index := 1 to ArrayLen(ExpectedCO2eEmission) do
@@ -4045,7 +4045,7 @@ codeunit 148190 "Sust. Value Entry Test"
         CreateSustainabilityAccount(AccountCode[3], CategoryCode, SubcategoryCode, LibraryRandom.RandIntInRange(3, 3));
 
         // [GIVEN] Update "Default Sust. Account","CO2e per Unit" in Production Item.
-        LibraryInventory.CreateItem(ProdItem);
+        LibraryItemTracking.CreateLotItem(ProdItem);
         LibrarySustainability.UpdateCarbonTrackingMethod(ProdItem, ProdItem."Carbon Tracking Method"::Specific);
         ProdItem.Validate("Default Sust. Account", AccountCode[3]);
         ProdItem.Validate("CO2e per Unit", LibraryRandom.RandInt(100));
@@ -4065,6 +4065,9 @@ codeunit 148190 "Sust. Value Entry Test"
         // [GIVEN] Create and Refresh Production Order.
         CreateAndRefreshProductionOrder(ProductionOrder, ProductionOrder.Status::Released, ProdItem."No.", LibraryRandom.RandIntInRange(10, 10));
         SetTrackingForProdOrderComponents(ProductionOrder, CompItem, LotNo[2]);
+
+        // [GIVEN] Assign a lot to the production output line (ProdItem uses Specific carbon tracking which requires item tracking).
+        SetTrackingForProdOrderOutput(ProductionOrder, ProdItem, LibraryUtility.GenerateGUID());
 
         // [GIVEN] Find Prod Order Routing Line.
         ProductionOrderRoutingLine.SetRange(Status, ProductionOrder.Status);
@@ -4633,6 +4636,15 @@ codeunit 148190 "Sust. Value Entry Test"
         ProdOrderComponent.SetRange("Item No.", CompItem."No.");
         if ProdOrderComponent.FindFirst() then
             LibraryManufacturing.CreateProdOrderCompItemTracking(ReservationEntry, ProdOrderComponent, '', LotNo, ProdOrderComponent."Expected Qty. (Base)");
+    end;
+
+    local procedure SetTrackingForProdOrderOutput(var ProductionOrder: Record "Production Order"; ProdItem: Record Item; LotNo: Code[50])
+    var
+        ProdOrderLine: Record "Prod. Order Line";
+        ReservationEntry: Record "Reservation Entry";
+    begin
+        FindProdOrderLine(ProdOrderLine, ProductionOrder, ProdItem."No.");
+        LibraryManufacturing.CreateProdOrderItemTracking(ReservationEntry, ProdOrderLine, '', LotNo, ProdOrderLine.Quantity);
     end;
 
     local procedure DefineEmissionArrays(var EmissionCO2: array[2] of Decimal; var EmissionCH4: array[2] of Decimal; var EmissionN2O: array[2] of Decimal)

--- a/src/Apps/W1/Sustainability/test/src/SustValueEntryTest.Codeunit.al
+++ b/src/Apps/W1/Sustainability/test/src/SustValueEntryTest.Codeunit.al
@@ -3829,6 +3829,7 @@ codeunit 148190 "Sust. Value Entry Test"
         PurchaseHeader.Modify();
 
         // [GIVEN] Create a lot-tracked Item with Specific Carbon Tracking Method.
+        LibraryItemTracking.CreateLotItem(Item);
         LibrarySustainability.UpdateCarbonTrackingMethod(Item, Item."Carbon Tracking Method"::Specific);
         CreatePurchaseLineWithEmissionValue(PurchaseLine, PurchaseHeader, Item."No.", Item."Item Tracking Code", LibraryUtility.GenerateGUID(), LibraryRandom.RandIntInRange(10, 10), EmissionCO2[1], EmissionCH4[1], EmissionN2O[1], AccountCode);
 


### PR DESCRIPTION
Workitem Bug 641049: [Sustainability] No warning/validation to enable Item Tracking when Carbon Tracking Method = Specific

Fixes [AB#641049](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641049)

**Issue:** On the Item card, setting "Carbon Tracking Method" = Specific was allowed even when the item had no Item Tracking Code (or one without serial/lot-specific tracking). No warning was shown, so per-unit emissions could not be resolved and the setup was silently invalid.

**Cause:** The "Carbon Tracking Method" field had no OnValidate check tying the Specific value to the presence of serial- or lot-specific item tracking.

**Solution:** In the "Carbon Tracking Method" OnValidate trigger, when the value is Specific, validate that the item's Item Tracking Code exists and has SN- or Lot-specific tracking enabled; otherwise raise a clear error so the correct tracking must be configured first.



