### PR TITLE
[Extensibility Request] issue 30336: add OnValidateNoOnBeforeModifyCapNeedEntries event in Prod. Order Routing Line

### DIFF
--- a/src/Layers/IT/BaseApp/Manufacturing/Document/ProdOrderRoutingLine.Table.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/Document/ProdOrderRoutingLine.Table.al
@@ -2176,7 +2176,7 @@ table 5409 "Prod. Order Routing Line"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnValidateNoOnBeforeModifyCapNeedEntries(var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var xProdOrderRoutingLine: Record "Prod. Order Routing Line")
+    local procedure OnValidateNoOnBeforeModifyCapNeedEntries(var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; xProdOrderRoutingLine: Record "Prod. Order Routing Line")
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Manufacturing/Document/ProdOrderRoutingLine.Table.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/Document/ProdOrderRoutingLine.Table.al
@@ -164,6 +164,7 @@ table 5409 "Prod. Order Routing Line"
                             MachineCtrTransferFields();
                         end;
                 end;
+                OnValidateNoOnBeforeModifyCapNeedEntries(Rec, xRec);
                 ModifyCapNeedEntries();
 
                 GetProdOrderLine();
@@ -2171,6 +2172,11 @@ table 5409 "Prod. Order Routing Line"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidateRoutingStatusOnBeforeConfirm(var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidateNoOnBeforeModifyCapNeedEntries(var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var xProdOrderRoutingLine: Record "Prod. Order Routing Line")
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/ProdOrderRoutingLine.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/ProdOrderRoutingLine.Table.al
@@ -138,6 +138,7 @@ table 5409 "Prod. Order Routing Line"
                             MachineCtrTransferFields();
                         end;
                 end;
+                OnValidateNoOnBeforeModifyCapNeedEntries(Rec, xRec);
                 ModifyCapNeedEntries();
 
                 GetProdOrderLine();
@@ -1954,6 +1955,11 @@ table 5409 "Prod. Order Routing Line"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidateRoutingStatusOnBeforeConfirm(var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidateNoOnBeforeModifyCapNeedEntries(var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var xProdOrderRoutingLine: Record "Prod. Order Routing Line")
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/ProdOrderRoutingLine.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/ProdOrderRoutingLine.Table.al
@@ -1959,7 +1959,7 @@ table 5409 "Prod. Order Routing Line"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnValidateNoOnBeforeModifyCapNeedEntries(var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var xProdOrderRoutingLine: Record "Prod. Order Routing Line")
+    local procedure OnValidateNoOnBeforeModifyCapNeedEntries(var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; xProdOrderRoutingLine: Record "Prod. Order Routing Line")
     begin
     end;
 


### PR DESCRIPTION
## Summary
The issue author is building a customization on table 5409 "Prod. Order Routing Line" that must run after the standard Work Center / Machine Center transfer logic populates the routing line, but before capacity need entries are updated. They need access to both `Rec` and `xRec` to compare the previous and current routing line state at that exact point, which no existing event provides. This PR adds an integration event at that precise location so extensions can subscribe without duplicating validation logic.

Source issue repository: microsoft/AlAppExtensions; issue number: 30336

## Changes Made
- `Prod. Order Routing Line` (table 5409) - Added integration event `OnValidateNoOnBeforeModifyCapNeedEntries(Rec, xRec)` in the `OnValidate` trigger of field `No.`, raised after `WorkCenterTransferFields()`/`MachineCtrTransferFields()` and immediately before `ModifyCapNeedEntries()`; new publisher declared alongside the other integration events. The same change is mirrored in the IT layer counterpart.

Fixes [AB#641735](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641735)




