### PR TITLE
[Extensibility Request] issue 30349: add OnBeforeCheckTrackingIfRequired event to Item Journal Line

### DIFF
--- a/src/Layers/APAC/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
+++ b/src/Layers/APAC/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
@@ -3665,6 +3665,7 @@ table 83 "Item Journal Line"
     /// <param name="ItemTrackingSetup">Item tracking setup to use.</param>
     procedure CheckTrackingIfRequired(ItemTrackingSetup: Record "Item Tracking Setup")
     begin
+        OnBeforeCheckTrackingIfRequired(Rec, ItemTrackingSetup);
         if ItemTrackingSetup."Serial No. Required" then
             TestField("Serial No.");
         if ItemTrackingSetup."Lot No. Required" then
@@ -4943,6 +4944,11 @@ table 83 "Item Journal Line"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
     begin
     end;
 

--- a/src/Layers/CH/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
+++ b/src/Layers/CH/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
@@ -3707,6 +3707,7 @@ table 83 "Item Journal Line"
     /// <param name="ItemTrackingSetup">Item tracking setup to use.</param>
     procedure CheckTrackingIfRequired(ItemTrackingSetup: Record "Item Tracking Setup")
     begin
+        OnBeforeCheckTrackingIfRequired(Rec, ItemTrackingSetup);
         if ItemTrackingSetup."Serial No. Required" then
             TestField("Serial No.");
         if ItemTrackingSetup."Lot No. Required" then
@@ -4985,6 +4986,11 @@ table 83 "Item Journal Line"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
+++ b/src/Layers/ES/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
@@ -3675,6 +3675,7 @@ table 83 "Item Journal Line"
     /// <param name="ItemTrackingSetup">Item tracking setup to use.</param>
     procedure CheckTrackingIfRequired(ItemTrackingSetup: Record "Item Tracking Setup")
     begin
+        OnBeforeCheckTrackingIfRequired(Rec, ItemTrackingSetup);
         if ItemTrackingSetup."Serial No. Required" then
             TestField("Serial No.");
         if ItemTrackingSetup."Lot No. Required" then
@@ -4953,6 +4954,11 @@ table 83 "Item Journal Line"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
     begin
     end;
 

--- a/src/Layers/FR/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
+++ b/src/Layers/FR/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
@@ -3669,6 +3669,7 @@ table 83 "Item Journal Line"
     /// <param name="ItemTrackingSetup">Item tracking setup to use.</param>
     procedure CheckTrackingIfRequired(ItemTrackingSetup: Record "Item Tracking Setup")
     begin
+        OnBeforeCheckTrackingIfRequired(Rec, ItemTrackingSetup);
         if ItemTrackingSetup."Serial No. Required" then
             TestField("Serial No.");
         if ItemTrackingSetup."Lot No. Required" then
@@ -4947,6 +4948,11 @@ table 83 "Item Journal Line"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
     begin
     end;
 

--- a/src/Layers/GB/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
+++ b/src/Layers/GB/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
@@ -3669,6 +3669,7 @@ table 83 "Item Journal Line"
     /// <param name="ItemTrackingSetup">Item tracking setup to use.</param>
     procedure CheckTrackingIfRequired(ItemTrackingSetup: Record "Item Tracking Setup")
     begin
+        OnBeforeCheckTrackingIfRequired(Rec, ItemTrackingSetup);
         if ItemTrackingSetup."Serial No. Required" then
             TestField("Serial No.");
         if ItemTrackingSetup."Lot No. Required" then
@@ -4947,6 +4948,11 @@ table 83 "Item Journal Line"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
+++ b/src/Layers/IT/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
@@ -3739,6 +3739,7 @@ table 83 "Item Journal Line"
     /// <param name="ItemTrackingSetup">Item tracking setup to use.</param>
     procedure CheckTrackingIfRequired(ItemTrackingSetup: Record "Item Tracking Setup")
     begin
+        OnBeforeCheckTrackingIfRequired(Rec, ItemTrackingSetup);
         if ItemTrackingSetup."Serial No. Required" then
             TestField("Serial No.");
         if ItemTrackingSetup."Lot No. Required" then
@@ -5017,6 +5018,11 @@ table 83 "Item Journal Line"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
     begin
     end;
 

--- a/src/Layers/RU/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
+++ b/src/Layers/RU/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
@@ -3876,6 +3876,7 @@ table 83 "Item Journal Line"
     /// <param name="ItemTrackingSetup">Item tracking setup to use.</param>
     procedure CheckTrackingIfRequired(ItemTrackingSetup: Record "Item Tracking Setup")
     begin
+        OnBeforeCheckTrackingIfRequired(Rec, ItemTrackingSetup);
         if ItemTrackingSetup."Serial No. Required" then
             TestField("Serial No.");
         if ItemTrackingSetup."Lot No. Required" then
@@ -5154,6 +5155,11 @@ table 83 "Item Journal Line"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
+++ b/src/Layers/W1/BaseApp/Inventory/Journal/ItemJournalLine.Table.al
@@ -3659,6 +3659,7 @@ table 83 "Item Journal Line"
     /// <param name="ItemTrackingSetup">Item tracking setup to use.</param>
     procedure CheckTrackingIfRequired(ItemTrackingSetup: Record "Item Tracking Setup")
     begin
+        OnBeforeCheckTrackingIfRequired(Rec, ItemTrackingSetup);
         if ItemTrackingSetup."Serial No. Required" then
             TestField("Serial No.");
         if ItemTrackingSetup."Lot No. Required" then
@@ -4937,6 +4938,11 @@ table 83 "Item Journal Line"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckTrackingIfRequired(ItemJournalLine: Record "Item Journal Line"; ItemTrackingSetup: Record "Item Tracking Setup");
     begin
     end;
 


### PR DESCRIPTION
## Summary
The reporter needs clearer, user-facing error messages when item tracking (Serial/Lot No.) is missing during document posting. The standard `CheckTrackingIfRequired` validation reports errors against the temporary "Item Journal Line" record, so users cannot tell which document line or item is affected. This PR adds an integration event at the start of `CheckTrackingIfRequired` so extensions can run their own validation and raise a more meaningful error before the standard checks.

Source issue repository: microsoft/AlAppExtensions; issue number: 30349

## Changes Made
- `CheckTrackingIfRequired` (table 83 "Item Journal Line") - raise a new `OnBeforeCheckTrackingIfRequired` integration event at the start of the procedure so subscribers can perform custom item-tracking validation before the standard `TestField` checks; the same change is propagated to the country layer counterparts (APAC, CH, ES, FR, GB, IT, RU).

Fixes [AB#642241](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642241)



