### PR TITLE
[Extensibility Request] issue 30351: extend OnCheckExpirationDateOnBeforeAssignExpirationDate event

### DIFF
--- a/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -4245,7 +4245,7 @@ codeunit 22 "Item Jnl.-Post Line"
             ExpirationDateChecked := true;
         end;
         IsHandled := false;
-        OnCheckExpirationDateOnBeforeAssignExpirationDate(TempTrackingSpecification, ExistingExpirationDate, IsHandled);
+        OnCheckExpirationDateOnBeforeAssignExpirationDate(TempTrackingSpecification, ExistingExpirationDate, IsHandled, GlobalItemTrackingCode, ItemJnlLine2, SignFactor);
         if not IsHandled then
             if ItemJnlLine2."Entry Type" = ItemJnlLine2."Entry Type"::Transfer then
                 if TempTrackingSpecification."Expiration Date" = 0D then
@@ -8210,7 +8210,7 @@ codeunit 22 "Item Jnl.-Post Line"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnCheckExpirationDateOnBeforeAssignExpirationDate(var TempTrackingSpecification: Record "Tracking Specification" temporary; ExistingExpirationDate: Date; var IsHandled: Boolean)
+    local procedure OnCheckExpirationDateOnBeforeAssignExpirationDate(var TempTrackingSpecification: Record "Tracking Specification" temporary; ExistingExpirationDate: Date; var IsHandled: Boolean; GlobalItemTrackingCode: Record "Item Tracking Code"; ItemJnlLine2: Record "Item Journal Line"; SignFactor: Integer)
     begin
     end;
 

--- a/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -4217,7 +4217,7 @@ codeunit 22 "Item Jnl.-Post Line"
             ExpirationDateChecked := true;
         end;
         IsHandled := false;
-        OnCheckExpirationDateOnBeforeAssignExpirationDate(TempTrackingSpecification, ExistingExpirationDate, IsHandled);
+        OnCheckExpirationDateOnBeforeAssignExpirationDate(TempTrackingSpecification, ExistingExpirationDate, IsHandled, GlobalItemTrackingCode, ItemJnlLine2, SignFactor);
         if not IsHandled then
             if ItemJnlLine2."Entry Type" = ItemJnlLine2."Entry Type"::Transfer then
                 if TempTrackingSpecification."Expiration Date" = 0D then
@@ -8181,7 +8181,7 @@ codeunit 22 "Item Jnl.-Post Line"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnCheckExpirationDateOnBeforeAssignExpirationDate(var TempTrackingSpecification: Record "Tracking Specification" temporary; ExistingExpirationDate: Date; var IsHandled: Boolean)
+    local procedure OnCheckExpirationDateOnBeforeAssignExpirationDate(var TempTrackingSpecification: Record "Tracking Specification" temporary; ExistingExpirationDate: Date; var IsHandled: Boolean; GlobalItemTrackingCode: Record "Item Tracking Code"; ItemJnlLine2: Record "Item Journal Line"; SignFactor: Integer)
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -4226,7 +4226,7 @@ codeunit 22 "Item Jnl.-Post Line"
             ExpirationDateChecked := true;
         end;
         IsHandled := false;
-        OnCheckExpirationDateOnBeforeAssignExpirationDate(TempTrackingSpecification, ExistingExpirationDate, IsHandled);
+        OnCheckExpirationDateOnBeforeAssignExpirationDate(TempTrackingSpecification, ExistingExpirationDate, IsHandled, GlobalItemTrackingCode, ItemJnlLine2, SignFactor);
         if not IsHandled then
             if ItemJnlLine2."Entry Type" = ItemJnlLine2."Entry Type"::Transfer then
                 if TempTrackingSpecification."Expiration Date" = 0D then
@@ -8191,7 +8191,7 @@ codeunit 22 "Item Jnl.-Post Line"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnCheckExpirationDateOnBeforeAssignExpirationDate(var TempTrackingSpecification: Record "Tracking Specification" temporary; ExistingExpirationDate: Date; var IsHandled: Boolean)
+    local procedure OnCheckExpirationDateOnBeforeAssignExpirationDate(var TempTrackingSpecification: Record "Tracking Specification" temporary; ExistingExpirationDate: Date; var IsHandled: Boolean; GlobalItemTrackingCode: Record "Item Tracking Code"; ItemJnlLine2: Record "Item Journal Line"; SignFactor: Integer)
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -4244,7 +4244,7 @@ codeunit 22 "Item Jnl.-Post Line"
             ExpirationDateChecked := true;
         end;
         IsHandled := false;
-        OnCheckExpirationDateOnBeforeAssignExpirationDate(TempTrackingSpecification, ExistingExpirationDate, IsHandled);
+        OnCheckExpirationDateOnBeforeAssignExpirationDate(TempTrackingSpecification, ExistingExpirationDate, IsHandled, GlobalItemTrackingCode, ItemJnlLine2, SignFactor);
         if not IsHandled then
             if ItemJnlLine2."Entry Type" = ItemJnlLine2."Entry Type"::Transfer then
                 if TempTrackingSpecification."Expiration Date" = 0D then
@@ -8208,7 +8208,7 @@ codeunit 22 "Item Jnl.-Post Line"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnCheckExpirationDateOnBeforeAssignExpirationDate(var TempTrackingSpecification: Record "Tracking Specification" temporary; ExistingExpirationDate: Date; var IsHandled: Boolean)
+    local procedure OnCheckExpirationDateOnBeforeAssignExpirationDate(var TempTrackingSpecification: Record "Tracking Specification" temporary; ExistingExpirationDate: Date; var IsHandled: Boolean; GlobalItemTrackingCode: Record "Item Tracking Code"; ItemJnlLine2: Record "Item Journal Line"; SignFactor: Integer)
     begin
     end;
 

--- a/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -4256,7 +4256,7 @@ codeunit 22 "Item Jnl.-Post Line"
             ExpirationDateChecked := true;
         end;
         IsHandled := false;
-        OnCheckExpirationDateOnBeforeAssignExpirationDate(TempTrackingSpecification, ExistingExpirationDate, IsHandled);
+        OnCheckExpirationDateOnBeforeAssignExpirationDate(TempTrackingSpecification, ExistingExpirationDate, IsHandled, GlobalItemTrackingCode, ItemJnlLine2, SignFactor);
         if not IsHandled then
             if ItemJnlLine2."Entry Type" = ItemJnlLine2."Entry Type"::Transfer then
                 if TempTrackingSpecification."Expiration Date" = 0D then
@@ -8526,7 +8526,7 @@ codeunit 22 "Item Jnl.-Post Line"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnCheckExpirationDateOnBeforeAssignExpirationDate(var TempTrackingSpecification: Record "Tracking Specification" temporary; ExistingExpirationDate: Date; var IsHandled: Boolean)
+    local procedure OnCheckExpirationDateOnBeforeAssignExpirationDate(var TempTrackingSpecification: Record "Tracking Specification" temporary; ExistingExpirationDate: Date; var IsHandled: Boolean; GlobalItemTrackingCode: Record "Item Tracking Code"; ItemJnlLine2: Record "Item Journal Line"; SignFactor: Integer)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -4213,7 +4213,7 @@ codeunit 22 "Item Jnl.-Post Line"
             ExpirationDateChecked := true;
         end;
         IsHandled := false;
-        OnCheckExpirationDateOnBeforeAssignExpirationDate(TempTrackingSpecification, ExistingExpirationDate, IsHandled);
+        OnCheckExpirationDateOnBeforeAssignExpirationDate(TempTrackingSpecification, ExistingExpirationDate, IsHandled, GlobalItemTrackingCode, ItemJnlLine2, SignFactor);
         if not IsHandled then
             if ItemJnlLine2."Entry Type" = ItemJnlLine2."Entry Type"::Transfer then
                 if TempTrackingSpecification."Expiration Date" = 0D then
@@ -8177,7 +8177,7 @@ codeunit 22 "Item Jnl.-Post Line"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnCheckExpirationDateOnBeforeAssignExpirationDate(var TempTrackingSpecification: Record "Tracking Specification" temporary; ExistingExpirationDate: Date; var IsHandled: Boolean)
+    local procedure OnCheckExpirationDateOnBeforeAssignExpirationDate(var TempTrackingSpecification: Record "Tracking Specification" temporary; ExistingExpirationDate: Date; var IsHandled: Boolean; GlobalItemTrackingCode: Record "Item Tracking Code"; ItemJnlLine2: Record "Item Journal Line"; SignFactor: Integer)
     begin
     end;
 


### PR DESCRIPTION
## Summary
The issue author extends the standard item journal posting flow and needs to replicate the expiration-date assignment logic in a modified form. To do that reliably from a subscriber, they need access to the item tracking code, the item journal line, and the sign factor at the point where the expiration date is assigned. This PR appends those three values to the existing `OnCheckExpirationDateOnBeforeAssignExpirationDate` integration event so subscribers can drive the same logic through the existing `IsHandled` pattern.

Source issue repository: microsoft/AlAppExtensions; issue number: 30351

## Changes Made
- `OnCheckExpirationDateOnBeforeAssignExpirationDate` - appended `GlobalItemTrackingCode`, `ItemJnlLine2` and `SignFactor` parameters (after the existing `var IsHandled` parameter) to the integration event and passed them from `CheckExpirationDate` in codeunit 22 "Item Jnl.-Post Line"; the same change was propagated to the same-named files in the country layers that carry their own copy.

Fixes [AB#642240](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642240)



