### PR TITLE
[Extensibility Request] issue 30346: make InsertPostValueEntryToGL public in Item Jnl.-Post Line

### DIFF
--- a/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -5312,7 +5312,7 @@ codeunit 22 "Item Jnl.-Post Line"
         exit((ItemJnlLine."Value Entry Type" = ItemJnlLine."Value Entry Type"::Revaluation) and (ItemJnlLine.Quantity <> 0));
     end;
 
-    local procedure InsertPostValueEntryToGL(ValueEntry: Record "Value Entry")
+    procedure InsertPostValueEntryToGL(ValueEntry: Record "Value Entry")
     var
         PostValueEntryToGL: Record "Post Value Entry to G/L";
     begin

--- a/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -5284,7 +5284,7 @@ codeunit 22 "Item Jnl.-Post Line"
         exit((ItemJnlLine."Value Entry Type" = ItemJnlLine."Value Entry Type"::Revaluation) and (ItemJnlLine.Quantity <> 0));
     end;
 
-    local procedure InsertPostValueEntryToGL(ValueEntry: Record "Value Entry")
+    procedure InsertPostValueEntryToGL(ValueEntry: Record "Value Entry")
     var
         PostValueEntryToGL: Record "Post Value Entry to G/L";
     begin

--- a/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -5293,7 +5293,7 @@ codeunit 22 "Item Jnl.-Post Line"
         exit((ItemJnlLine."Value Entry Type" = ItemJnlLine."Value Entry Type"::Revaluation) and (ItemJnlLine.Quantity <> 0));
     end;
 
-    local procedure InsertPostValueEntryToGL(ValueEntry: Record "Value Entry")
+    procedure InsertPostValueEntryToGL(ValueEntry: Record "Value Entry")
     var
         PostValueEntryToGL: Record "Post Value Entry to G/L";
     begin

--- a/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -5311,7 +5311,7 @@ codeunit 22 "Item Jnl.-Post Line"
         exit((ItemJnlLine."Value Entry Type" = ItemJnlLine."Value Entry Type"::Revaluation) and (ItemJnlLine.Quantity <> 0));
     end;
 
-    local procedure InsertPostValueEntryToGL(ValueEntry: Record "Value Entry")
+    procedure InsertPostValueEntryToGL(ValueEntry: Record "Value Entry")
     var
         PostValueEntryToGL: Record "Post Value Entry to G/L";
     begin

--- a/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -5327,7 +5327,7 @@ codeunit 22 "Item Jnl.-Post Line"
         exit((ItemJnlLine."Value Entry Type" = ItemJnlLine."Value Entry Type"::Revaluation) and (ItemJnlLine.Quantity <> 0));
     end;
 
-    local procedure InsertPostValueEntryToGL(ValueEntry: Record "Value Entry")
+    procedure InsertPostValueEntryToGL(ValueEntry: Record "Value Entry")
     var
         PostValueEntryToGL: Record "Post Value Entry to G/L";
     begin

--- a/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -5280,7 +5280,7 @@ codeunit 22 "Item Jnl.-Post Line"
         exit((ItemJnlLine."Value Entry Type" = ItemJnlLine."Value Entry Type"::Revaluation) and (ItemJnlLine.Quantity <> 0));
     end;
 
-    local procedure InsertPostValueEntryToGL(ValueEntry: Record "Value Entry")
+    procedure InsertPostValueEntryToGL(ValueEntry: Record "Value Entry")
     var
         PostValueEntryToGL: Record "Post Value Entry to G/L";
     begin


### PR DESCRIPTION
## Summary
An extension author wants to post additional variances and reuse the standard General Ledger posting logic that already lives in codeunit 22 `Item Jnl.-Post Line`. They already call the public `PostInventoryToGL` procedure, but `InsertPostValueEntryToGL` was declared `local` and therefore unreachable from extensions. This PR exposes that procedure so extensions can invoke the standard posting flow.

Source issue repository: microsoft/AlAppExtensions; issue number: 30346

## Changes Made
- `InsertPostValueEntryToGL` (codeunit 22 `Item Jnl.-Post Line`) - changed from a `local procedure` to a public `procedure` so extensions can call the standard value-entry-to-G/L posting logic. Applied in the W1 base layer and mirrored to the same-named counterparts in the APAC, CH, ES, IT, and RU layers.

Fixes [AB#642120](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642120)




