### PR TITLE
28.x Add the ability in the Email Module to store Message Headers

### DIFF
--- a/src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al
+++ b/src/System Application/App/Email/src/Email/Inbox/EmailRetrievalFilters.Table.al
@@ -67,6 +67,10 @@ table 8885 "Email Retrieval Filters"
             InitValue = "Include";
             Caption = 'Category Filter Type';
         }
+        field(11; "Load Headers"; Boolean)
+        {
+            Caption = 'Load Headers';
+        }
     }
 
     keys

--- a/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessage.Codeunit.al
@@ -197,6 +197,61 @@ codeunit 8904 "Email Message"
         EmailMessageImpl.AppendToBody(Value);
     end;
 
+    /// <summary>
+    /// Adds a header to the currently loaded message. If a header with the same name is already
+    /// present, the new value is appended after a line feed character so the full sequence is
+    /// preserved -- useful for headers that legitimately repeat (e.g. <c>Received</c>).
+    /// </summary>
+    /// <param name="HeaderName">Header name (case-insensitive).</param>
+    /// <param name="HeaderValue">Header value to append.</param>
+    /// <remarks>Mutations are buffered in memory. Call <see cref="FlushHeaders"/> to persist them
+    /// before the codeunit instance goes out of scope or before navigating to another message via
+    /// <c>Get</c>; unflushed changes are discarded otherwise.</remarks>
+    procedure AddHeader(HeaderName: Text; HeaderValue: Text)
+    begin
+        EmailMessageImpl.AddHeader(HeaderName, HeaderValue);
+    end;
+
+    /// <summary>
+    /// Sets a header on the currently loaded message, replacing any existing value for the same
+    /// name. Use <see cref="AddHeader"/> when repeated headers should accumulate.
+    /// </summary>
+    /// <param name="HeaderName">Header name (case-insensitive).</param>
+    /// <param name="HeaderValue">Header value to store.</param>
+    /// <remarks>Mutations are buffered in memory. Call <see cref="FlushHeaders"/> to persist them
+    /// before the codeunit instance goes out of scope or before navigating to another message via
+    /// <c>Get</c>; unflushed changes are discarded otherwise.</remarks>
+    procedure SetHeader(HeaderName: Text; HeaderValue: Text)
+    begin
+        EmailMessageImpl.SetHeader(HeaderName, HeaderValue);
+    end;
+
+    /// <summary>
+    /// Reads a single header value from the currently loaded message. Lookups are case-insensitive
+    /// on the header name. Repeated headers are returned as one string with values joined by a
+    /// line feed character in the order they were added.
+    /// </summary>
+    /// <param name="HeaderName">Header name to look up (case-insensitive, whitespace-trimmed).</param>
+    /// <param name="Value">Returned value when the header is present; empty otherwise.</param>
+    /// <returns><c>true</c> when a value was found.</returns>
+    /// <remarks>Reads include any unflushed mutations issued via <see cref="AddHeader"/> or
+    /// <see cref="SetHeader"/> on this codeunit instance.</remarks>
+    procedure GetHeader(HeaderName: Text; var Value: Text): Boolean
+    begin
+        exit(EmailMessageImpl.GetHeader(HeaderName, Value));
+    end;
+
+    /// <summary>
+    /// Persists any pending header mutations to the database in a single write. Safe to call when
+    /// nothing is pending. Call this after any sequence of <see cref="AddHeader"/> /
+    /// <see cref="SetHeader"/> calls so the changes survive the codeunit instance going out of
+    /// scope or a subsequent navigation to another message.
+    /// </summary>
+    procedure FlushHeaders()
+    begin
+        EmailMessageImpl.FlushHeaders();
+    end;
+
     procedure GetExternalId(): Text[2048]
     begin
         exit(EmailMessageImpl.GetExternalId());

--- a/src/System Application/App/Email/src/Message/EmailMessage.Table.al
+++ b/src/System Application/App/Email/src/Message/EmailMessage.Table.al
@@ -52,6 +52,11 @@ table 8900 "Email Message"
             Access = Internal;
             DataClassification = CustomerContent;
         }
+        field(8; "Message Headers"; Blob)
+        {
+            Access = Internal;
+            DataClassification = CustomerContent;
+        }
     }
 
     keys

--- a/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/src/System Application/App/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -103,6 +103,7 @@ codeunit 8905 "Email Message Impl."
     begin
         Clear(GlobalEmailMessageAttachment);
         Clear(GlobalEmailMessage);
+        InvalidateHeadersCache();
 
         GlobalEmailMessage.Id := CreateGuid();
         GlobalEmailMessage.Insert();
@@ -221,6 +222,103 @@ codeunit 8905 "Email Message Impl."
     begin
         SetBodyHTMLFormattedValue(Value);
         Modify();
+    end;
+
+    procedure AddHeader(HeaderName: Text; HeaderValue: Text)
+    begin
+        StoreHeader(HeaderName, HeaderValue, true);
+    end;
+
+    procedure SetHeader(HeaderName: Text; HeaderValue: Text)
+    begin
+        StoreHeader(HeaderName, HeaderValue, false);
+    end;
+
+    procedure GetHeader(HeaderName: Text; var Value: Text): Boolean
+    var
+        HeaderToken: JsonToken;
+        NormalizedName: Text;
+    begin
+        Value := '';
+        NormalizedName := NormalizeHeaderName(HeaderName);
+        if NormalizedName = '' then
+            exit(false);
+        EnsureHeadersLoaded();
+        if not GlobalHeadersJson.Get(NormalizedName, HeaderToken) then
+            exit(false);
+        if not HeaderToken.IsValue() then
+            exit(false);
+        Value := HeaderToken.AsValue().AsText();
+        exit(true);
+    end;
+
+    procedure FlushHeaders()
+    var
+        HeadersOutStream: OutStream;
+        HeadersText: Text;
+    begin
+        if not GlobalHeadersDirty then
+            exit;
+        Clear(GlobalEmailMessage."Message Headers");
+        if GlobalHeadersJson.Keys().Count() > 0 then begin
+            GlobalHeadersJson.WriteTo(HeadersText);
+            GlobalEmailMessage."Message Headers".CreateOutStream(HeadersOutStream, TextEncoding::UTF8);
+            HeadersOutStream.WriteText(HeadersText);
+        end;
+        Modify();
+        GlobalHeadersDirty := false;
+    end;
+
+    local procedure StoreHeader(HeaderName: Text; HeaderValue: Text; AppendIfPresent: Boolean)
+    var
+        ExistingToken: JsonToken;
+        NormalizedName: Text;
+        LineFeed: Text[1];
+    begin
+        NormalizedName := NormalizeHeaderName(HeaderName);
+        if NormalizedName = '' then
+            exit;
+        EnsureHeadersLoaded();
+        if GlobalHeadersJson.Get(NormalizedName, ExistingToken) then
+            if AppendIfPresent then begin
+                LineFeed[1] := 10;
+                GlobalHeadersJson.Replace(NormalizedName, ExistingToken.AsValue().AsText() + LineFeed + HeaderValue);
+            end else
+                GlobalHeadersJson.Replace(NormalizedName, HeaderValue)
+        else
+            GlobalHeadersJson.Add(NormalizedName, HeaderValue);
+        GlobalHeadersDirty := true;
+    end;
+
+    local procedure NormalizeHeaderName(HeaderName: Text): Text
+    begin
+        exit(LowerCase(DelChr(HeaderName, '<>', ' ')));
+    end;
+
+    local procedure EnsureHeadersLoaded()
+    var
+        HeadersInStream: InStream;
+        HeadersText: Text;
+    begin
+        if GlobalHeadersLoaded then
+            exit;
+        Clear(GlobalHeadersJson);
+        GlobalEmailMessage.CalcFields("Message Headers");
+        if GlobalEmailMessage."Message Headers".HasValue() then begin
+            GlobalEmailMessage."Message Headers".CreateInStream(HeadersInStream, TextEncoding::UTF8);
+            HeadersInStream.ReadText(HeadersText);
+            if HeadersText <> '' then
+                if not GlobalHeadersJson.ReadFrom(HeadersText) then
+                    Clear(GlobalHeadersJson);
+        end;
+        GlobalHeadersLoaded := true;
+    end;
+
+    local procedure InvalidateHeadersCache()
+    begin
+        Clear(GlobalHeadersJson);
+        GlobalHeadersLoaded := false;
+        GlobalHeadersDirty := false;
     end;
 
     procedure IsRead(): Boolean
@@ -648,6 +746,7 @@ codeunit 8905 "Email Message Impl."
     procedure Get(MessageId: Guid): Boolean
     begin
         Clear(GlobalEmailMessageAttachment);
+        InvalidateHeadersCache();
 
         exit(GlobalEmailMessage.Get(MessageId));
     end;
@@ -1006,6 +1105,9 @@ codeunit 8905 "Email Message Impl."
         GlobalEmailMessageAttachment: Record "Email Message Attachment";
         TenantMedia: Record "Tenant Media";
         Telemetry: Codeunit Telemetry;
+        GlobalHeadersJson: JsonObject;
+        GlobalHeadersLoaded: Boolean;
+        GlobalHeadersDirty: Boolean;
         EmailCategoryLbl: Label 'Email', Locked = true;
         EmailMessageQueuedCannotModifyErr: Label 'Cannot edit the email because it has been queued to be sent.';
         EmailMessageSentCannotModifyErr: Label 'Cannot edit the message because it has already been sent.';

--- a/src/System Application/Test/Email/app.json
+++ b/src/System Application/Test/Email/app.json
@@ -117,7 +117,7 @@
     },
     {
       "from": 134705,
-      "to": 134706
+      "to": 134707
     }
   ],
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2134520",

--- a/src/System Application/Test/Email/src/EmailMessageHeadersTest.Codeunit.al
+++ b/src/System Application/Test/Email/src/EmailMessageHeadersTest.Codeunit.al
@@ -1,0 +1,116 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Test.Email;
+
+using System.Email;
+using System.TestLibraries.Security.AccessControl;
+using System.TestLibraries.Utilities;
+
+codeunit 134707 "Email Message Headers Test"
+{
+    Subtype = Test;
+    Permissions = tabledata "Email Message" = rm;
+
+    var
+        Assert: Codeunit "Library Assert";
+        PermissionsMock: Codeunit "Permissions Mock";
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure AddHeaderRoundTripsCaseInsensitivelyAfterFlush()
+    var
+        Message: Codeunit "Email Message";
+        Value: Text;
+    begin
+        PermissionsMock.Set('Email Edit');
+
+        Message.Create('to@test.com', 'subject', 'body');
+        Message.AddHeader('Authentication-Results', 'spf=pass');
+        Message.AddHeader('X-MS-Exchange-Organization-AuthAs', 'Internal');
+        Message.FlushHeaders();
+
+        Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
+        Assert.IsTrue(Message.GetHeader('authentication-results', Value), 'Header lookup should succeed case-insensitively');
+        Assert.AreEqual('spf=pass', Value, 'Authentication-Results header value mismatch');
+        Assert.IsTrue(Message.GetHeader('X-MS-EXCHANGE-ORGANIZATION-AUTHAS', Value), 'AuthAs header lookup should succeed case-insensitively');
+        Assert.AreEqual('Internal', Value, 'AuthAs header value mismatch');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure GetHeaderReturnsFalseWhenNoHeadersStored()
+    var
+        Message: Codeunit "Email Message";
+        Value: Text;
+    begin
+        PermissionsMock.Set('Email Edit');
+
+        Message.Create('to@test.com', 'subject', 'body');
+
+        Assert.IsFalse(Message.GetHeader('any-header', Value), 'Lookup on a message with no headers should return false');
+        Assert.AreEqual('', Value, 'Value should be empty when no headers stored');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure AddHeaderJoinsRepeatedValuesWithLineFeed()
+    var
+        Message: Codeunit "Email Message";
+        Value: Text;
+        LineFeed: Text[1];
+    begin
+        PermissionsMock.Set('Email Edit');
+        LineFeed[1] := 10;
+
+        Message.Create('to@test.com', 'subject', 'body');
+        Message.AddHeader('Received', 'from hop1');
+        Message.AddHeader('Received', 'from hop2');
+        Message.FlushHeaders();
+
+        Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
+        Assert.IsTrue(Message.GetHeader('Received', Value), 'Repeated header lookup should succeed');
+        Assert.AreEqual('from hop1' + LineFeed + 'from hop2', Value, 'Repeated AddHeader calls should join values with line feed in insertion order');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure SetHeaderReplacesExistingValue()
+    var
+        Message: Codeunit "Email Message";
+        Value: Text;
+    begin
+        PermissionsMock.Set('Email Edit');
+
+        Message.Create('to@test.com', 'subject', 'body');
+        Message.AddHeader('Received', 'from hop1');
+        Message.AddHeader('Received', 'from hop2');
+        Message.SetHeader('Received', 'canonical');
+        Message.FlushHeaders();
+
+        Assert.IsTrue(Message.Get(Message.GetId()), 'Message not found after reload');
+        Assert.IsTrue(Message.GetHeader('Received', Value), 'Header lookup after SetHeader should succeed');
+        Assert.AreEqual('canonical', Value, 'SetHeader should replace any previously joined values');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure UnflushedMutationsAreDiscardedOnGet()
+    var
+        Message: Codeunit "Email Message";
+        Value: Text;
+        MessageId: Guid;
+    begin
+        PermissionsMock.Set('Email Edit');
+
+        Message.Create('to@test.com', 'subject', 'body');
+        MessageId := Message.GetId();
+        Message.AddHeader('Authentication-Results', 'spf=pass');
+        // Intentionally no FlushHeaders -- pending mutations should be lost when we re-Get the message.
+
+        Assert.IsTrue(Message.Get(MessageId), 'Message not found after reload');
+        Assert.IsFalse(Message.GetHeader('Authentication-Results', Value), 'Unflushed mutations should not survive a Get');
+    end;
+}


### PR DESCRIPTION
Addresses
[AB#625413](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625413)

## What

Adding the ability in the Email Module to pass filters to be used at email retrieval for populating `Message Headers`, as well as primitives in the `Email Message` to manage them.

## Why

Part of the "skip review for trusted senders" slice. The headers will be used for determining authentication properties of the received email.

## Summary of the changes

- Adds a new BLOB field "Message Headers" that won't be populated by default.
- Adds a new field to the temporary "Filters" table to use as parameter in the email retrieval
- Exposes a surface for connectors to store the headers. It's up to connector to honor the contract on the parameter. Such surface is:
    - AddHeader: Sets (appending) the header specified
    - SetHeader: Sets (replacing) the header specified
- TryGetHeader: From the stored JSON, retrieves the header value requested.
- FlushHeaders: Instead of full round-trips persisting for each header on every call to `AddHeader`, the updates are done on the instance of the EmailMessage. Persistance happens when flushing.

### Other technical considerations

- Maintaining a cache of the headers JSON
- Only persisted when required (filters that default to false). Preliminar "smoke-analysis" reveals an increase of around 50% on DB size on emails if we were to store all the headers for all the emails. <img width="873" height="1455" alt="image"
src="https://github.com/user-attachments/assets/9eb787c5-8ae6-42e0-930b-2d34225b7636" />

## PTE for testing


[OutlookHeadersTester.zip](https://github.com/user-attachments/files/28313134/OutlookHeadersTester.zip)

Requires the changes in the [M365 API
app](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_git/NAV/pullrequest/247802)

Scenarios behave as expected:
- Retrieving email without the "Load headers" filter don't store anything in the headers blob:
<img width="3645" height="1638" alt="image"
src="https://github.com/user-attachments/assets/32ff25a1-b95b-42eb-bd3a-7ed745d78b21" />

- Retrieving them with the "Load headers" filter, stores them, and the proposed API allows retrieving them

<img width="3651" height="1620" alt="image"
src="https://github.com/user-attachments/assets/788c2a7a-98f9-4c55-9333-ee5539800311" />

---------

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

