### PR TITLE
[main]-Invalid SEPA export file format when SEPA Non-Euro Export enabled

### DIFF
--- a/src/Layers/BE/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/BE/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -6,6 +6,7 @@ namespace Microsoft.Bank.DirectDebit;
 
 using Microsoft.Bank.Payment;
 using Microsoft.Finance.GeneralLedger.Journal;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Company;
 using System.Telemetry;
 
@@ -102,8 +103,14 @@ xmlport 1001 "SEPA CT pain.001.001.09"
                             {
 
                                 trigger OnBeforePassVariable()
+                                var
+                                    GeneralLedgerSetup: Record "General Ledger Setup";
                                 begin
-                                    Cd := 'SEPA';
+                                    GeneralLedgerSetup.Get();
+                                    if GeneralLedgerSetup."SEPA Non-Euro Export" then
+                                        Cd := 'NURG'
+                                    else
+                                        Cd := 'SEPA';
                                 end;
                             }
                         }

--- a/src/Layers/BE/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/BE/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1693,6 +1693,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     end;
 
     [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "SEPA" when a Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled and a Euro payment exists.
+        LibraryERM.SetAllowNonEuroExport(false);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "SEPA".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'SEPA');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "NURG" when a non-Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled and a payment exists.
+        LibraryERM.SetAllowNonEuroExport(true);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "NURG".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'NURG');
+    end;
+
+    [Test]
     [Scope('OnPrem')]
     procedure ValidatePaymentJnlExportErrorTextHasNoErrorEntriesWhenJournalLineDeleted()
     var
@@ -2361,6 +2405,20 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
             end;
         end;
         Assert.AreEqual(ExpectedNoOfCdtTrfTxInf, NoOfCdtTrfTxInf, 'Wrong number of DrctDbtTxInf nodes.');
+    end;
+
+    local procedure VerifySvcLvlCodeIfPresent(var TempBlob: Codeunit "Temp Blob"; ExpectedSvcLvlCode: Text)
+    var
+        SvcLvlCodeNodeList: DotNet XmlNodeList;
+        SvcLvlCdXPathTok: Label '//PmtInf/PmtTpInf/SvcLvl/Cd', Locked = true;
+    begin
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.GetNodeList(SvcLvlCdXPathTok, SvcLvlCodeNodeList);
+        // Some country layers (for example CH) intentionally omit the SvcLvl node for non-local exports.
+        if IsNull(SvcLvlCodeNodeList) then
+            exit;
+        if SvcLvlCodeNodeList.Count() > 0 then
+            LibraryXPathXMLReader.VerifyNodeValueByXPath(SvcLvlCdXPathTok, ExpectedSvcLvlCode);
     end;
 
     local procedure VerifyPaymentJnlExportErr(GenJnlLine: Record "Gen. Journal Line"; ErrText: Text)

--- a/src/Layers/CH/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/CH/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -7,6 +7,7 @@ namespace Microsoft.Bank.DirectDebit;
 using Microsoft.Bank;
 using Microsoft.Bank.Payment;
 using Microsoft.Finance.GeneralLedger.Journal;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Company;
 using System.Telemetry;
 
@@ -109,8 +110,14 @@ xmlport 1001 "SEPA CT pain.001.001.09"
                             {
 
                                 trigger OnBeforePassVariable()
+                                var
+                                    GeneralLedgerSetup: Record "General Ledger Setup";
                                 begin
-                                    Cd := 'SEPA';
+                                    GeneralLedgerSetup.Get();
+                                    if GeneralLedgerSetup."SEPA Non-Euro Export" then
+                                        Cd := 'NURG'
+                                    else
+                                        Cd := 'SEPA';
                                 end;
                             }
 

--- a/src/Layers/CZ/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/CZ/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1693,6 +1693,50 @@
     end;
 
     [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "SEPA" when a Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled and a Euro payment exists.
+        LibraryERM.SetAllowNonEuroExport(false);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "SEPA".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'SEPA');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "NURG" when a non-Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled and a payment exists.
+        LibraryERM.SetAllowNonEuroExport(true);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "NURG".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'NURG');
+    end;
+
+    [Test]
     [Scope('OnPrem')]
     procedure ValidatePaymentJnlExportErrorTextHasNoErrorEntriesWhenJournalLineDeleted()
     var
@@ -2363,6 +2407,20 @@
             end;
         end;
         Assert.AreEqual(ExpectedNoOfCdtTrfTxInf, NoOfCdtTrfTxInf, 'Wrong number of DrctDbtTxInf nodes.');
+    end;
+
+    local procedure VerifySvcLvlCodeIfPresent(var TempBlob: Codeunit "Temp Blob"; ExpectedSvcLvlCode: Text)
+    var
+        SvcLvlCodeNodeList: DotNet XmlNodeList;
+        SvcLvlCdXPathTok: Label '//PmtInf/PmtTpInf/SvcLvl/Cd', Locked = true;
+    begin
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.GetNodeList(SvcLvlCdXPathTok, SvcLvlCodeNodeList);
+        // Some country layers (for example CH) intentionally omit the SvcLvl node for non-local exports.
+        if IsNull(SvcLvlCodeNodeList) then
+            exit;
+        if SvcLvlCodeNodeList.Count() > 0 then
+            LibraryXPathXMLReader.VerifyNodeValueByXPath(SvcLvlCdXPathTok, ExpectedSvcLvlCode);
     end;
 
     local procedure VerifyPaymentJnlExportErr(GenJnlLine: Record "Gen. Journal Line"; ErrText: Text)

--- a/src/Layers/ES/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/ES/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -6,6 +6,7 @@ namespace Microsoft.Bank.DirectDebit;
 
 using Microsoft.Bank.Payment;
 using Microsoft.Finance.GeneralLedger.Journal;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Company;
 using Microsoft.Sales.Receivables;
 using System.Telemetry;
@@ -104,8 +105,14 @@ xmlport 1001 "SEPA CT pain.001.001.09"
                             {
 
                                 trigger OnBeforePassVariable()
+                                var
+                                    GeneralLedgerSetup: Record "General Ledger Setup";
                                 begin
-                                    Cd := 'SEPA';
+                                    GeneralLedgerSetup.Get();
+                                    if GeneralLedgerSetup."SEPA Non-Euro Export" then
+                                        Cd := 'NURG'
+                                    else
+                                        Cd := 'SEPA';
                                 end;
                             }
                         }

--- a/src/Layers/ES/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/ES/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1693,6 +1693,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     end;
 
     [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "SEPA" when a Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled and a Euro payment exists.
+        LibraryERM.SetAllowNonEuroExport(false);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "SEPA".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'SEPA');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "NURG" when a non-Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled and a payment exists.
+        LibraryERM.SetAllowNonEuroExport(true);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "NURG".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'NURG');
+    end;
+
+    [Test]
     [Scope('OnPrem')]
     procedure ValidatePaymentJnlExportErrorTextHasNoErrorEntriesWhenJournalLineDeleted()
     var
@@ -2366,6 +2410,20 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
             end;
         end;
         Assert.AreEqual(ExpectedNoOfCdtTrfTxInf, NoOfCdtTrfTxInf, 'Wrong number of DrctDbtTxInf nodes.');
+    end;
+
+    local procedure VerifySvcLvlCodeIfPresent(var TempBlob: Codeunit "Temp Blob"; ExpectedSvcLvlCode: Text)
+    var
+        SvcLvlCodeNodeList: DotNet XmlNodeList;
+        SvcLvlCdXPathTok: Label '//PmtInf/PmtTpInf/SvcLvl/Cd', Locked = true;
+    begin
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.GetNodeList(SvcLvlCdXPathTok, SvcLvlCodeNodeList);
+        // Some country layers (for example CH) intentionally omit the SvcLvl node for non-local exports.
+        if IsNull(SvcLvlCodeNodeList) then
+            exit;
+        if SvcLvlCodeNodeList.Count() > 0 then
+            LibraryXPathXMLReader.VerifyNodeValueByXPath(SvcLvlCdXPathTok, ExpectedSvcLvlCode);
     end;
 
     local procedure VerifyPaymentJnlExportErr(GenJnlLine: Record "Gen. Journal Line"; ErrText: Text)

--- a/src/Layers/FR/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/FR/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -6,6 +6,7 @@ namespace Microsoft.Bank.DirectDebit;
 
 using Microsoft.Bank.Payment;
 using Microsoft.Finance.GeneralLedger.Journal;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Company;
 using System.Telemetry;
 
@@ -102,8 +103,14 @@ xmlport 1001 "SEPA CT pain.001.001.09"
                             {
 
                                 trigger OnBeforePassVariable()
+                                var
+                                    GeneralLedgerSetup: Record "General Ledger Setup";
                                 begin
-                                    Cd := 'SEPA';
+                                    GeneralLedgerSetup.Get();
+                                    if GeneralLedgerSetup."SEPA Non-Euro Export" then
+                                        Cd := 'NURG'
+                                    else
+                                        Cd := 'SEPA';
                                 end;
                             }
                         }

--- a/src/Layers/FR/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/FR/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1562,6 +1562,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     end;
 
     [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "SEPA" when a Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled and a Euro payment exists.
+        LibraryERM.SetAllowNonEuroExport(false);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "SEPA".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'SEPA');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "NURG" when a non-Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled and a payment exists.
+        LibraryERM.SetAllowNonEuroExport(true);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "NURG".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'NURG');
+    end;
+
+    [Test]
     [Scope('OnPrem')]
     procedure ValidatePaymentJnlExportErrorTextHasNoErrorEntriesWhenJournalLineDeleted()
     var
@@ -2206,6 +2250,20 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
             end;
         end;
         Assert.AreEqual(ExpectedNoOfCdtTrfTxInf, NoOfCdtTrfTxInf, 'Wrong number of DrctDbtTxInf nodes.');
+    end;
+
+    local procedure VerifySvcLvlCodeIfPresent(var TempBlob: Codeunit "Temp Blob"; ExpectedSvcLvlCode: Text)
+    var
+        SvcLvlCodeNodeList: DotNet XmlNodeList;
+        SvcLvlCdXPathTok: Label '//PmtInf/PmtTpInf/SvcLvl/Cd', Locked = true;
+    begin
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.GetNodeList(SvcLvlCdXPathTok, SvcLvlCodeNodeList);
+        // Some country layers (for example CH) intentionally omit the SvcLvl node for non-local exports.
+        if IsNull(SvcLvlCodeNodeList) then
+            exit;
+        if SvcLvlCodeNodeList.Count() > 0 then
+            LibraryXPathXMLReader.VerifyNodeValueByXPath(SvcLvlCdXPathTok, ExpectedSvcLvlCode);
     end;
 
     local procedure VerifyPaymentJnlExportErr(GenJnlLine: Record "Gen. Journal Line"; ErrText: Text)

--- a/src/Layers/IT/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/IT/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -6,6 +6,7 @@ namespace Microsoft.Bank.DirectDebit;
 
 using Microsoft.Bank.Payment;
 using Microsoft.Finance.GeneralLedger.Journal;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Company;
 using System.Telemetry;
 
@@ -102,8 +103,14 @@ xmlport 1001 "SEPA CT pain.001.001.09"
                             {
 
                                 trigger OnBeforePassVariable()
+                                var
+                                    GeneralLedgerSetup: Record "General Ledger Setup";
                                 begin
-                                    Cd := 'SEPA';
+                                    GeneralLedgerSetup.Get();
+                                    if GeneralLedgerSetup."SEPA Non-Euro Export" then
+                                        Cd := 'NURG'
+                                    else
+                                        Cd := 'SEPA';
                                 end;
                             }
                         }

--- a/src/Layers/IT/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1694,6 +1694,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     end;
 
     [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "SEPA" when a Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled and a Euro payment exists.
+        LibraryERM.SetAllowNonEuroExport(false);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "SEPA".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'SEPA');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "NURG" when a non-Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled and a payment exists.
+        LibraryERM.SetAllowNonEuroExport(true);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "NURG".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'NURG');
+    end;
+
+    [Test]
     [Scope('OnPrem')]
     procedure ValidatePaymentJnlExportErrorTextHasNoErrorEntriesWhenJournalLineDeleted()
     var
@@ -2362,6 +2406,20 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
             end;
         end;
         Assert.AreEqual(ExpectedNoOfCdtTrfTxInf, NoOfCdtTrfTxInf, 'Wrong number of DrctDbtTxInf nodes.');
+    end;
+
+    local procedure VerifySvcLvlCodeIfPresent(var TempBlob: Codeunit "Temp Blob"; ExpectedSvcLvlCode: Text)
+    var
+        SvcLvlCodeNodeList: DotNet XmlNodeList;
+        SvcLvlCdXPathTok: Label '//PmtInf/PmtTpInf/SvcLvl/Cd', Locked = true;
+    begin
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.GetNodeList(SvcLvlCdXPathTok, SvcLvlCodeNodeList);
+        // Some country layers (for example CH) intentionally omit the SvcLvl node for non-local exports.
+        if IsNull(SvcLvlCodeNodeList) then
+            exit;
+        if SvcLvlCodeNodeList.Count() > 0 then
+            LibraryXPathXMLReader.VerifyNodeValueByXPath(SvcLvlCdXPathTok, ExpectedSvcLvlCode);
     end;
 
     local procedure VerifyPaymentJnlExportErr(GenJnlLine: Record "Gen. Journal Line"; ErrText: Text)

--- a/src/Layers/NA/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1692,6 +1692,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     end;
 
     [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "SEPA" when a Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled and a Euro payment exists.
+        LibraryERM.SetAllowNonEuroExport(false);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "SEPA".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'SEPA');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "NURG" when a non-Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled and a payment exists.
+        LibraryERM.SetAllowNonEuroExport(true);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "NURG".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'NURG');
+    end;
+
+    [Test]
     [Scope('OnPrem')]
     procedure ValidatePaymentJnlExportErrorTextHasNoErrorEntriesWhenJournalLineDeleted()
     var
@@ -2361,6 +2405,20 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
             end;
         end;
         Assert.AreEqual(ExpectedNoOfCdtTrfTxInf, NoOfCdtTrfTxInf, 'Wrong number of DrctDbtTxInf nodes.');
+    end;
+
+    local procedure VerifySvcLvlCodeIfPresent(var TempBlob: Codeunit "Temp Blob"; ExpectedSvcLvlCode: Text)
+    var
+        SvcLvlCodeNodeList: DotNet XmlNodeList;
+        SvcLvlCdXPathTok: Label '//PmtInf/PmtTpInf/SvcLvl/Cd', Locked = true;
+    begin
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.GetNodeList(SvcLvlCdXPathTok, SvcLvlCodeNodeList);
+        // Some country layers (for example CH) intentionally omit the SvcLvl node for non-local exports.
+        if IsNull(SvcLvlCodeNodeList) then
+            exit;
+        if SvcLvlCodeNodeList.Count() > 0 then
+            LibraryXPathXMLReader.VerifyNodeValueByXPath(SvcLvlCdXPathTok, ExpectedSvcLvlCode);
     end;
 
     local procedure VerifyPaymentJnlExportErr(GenJnlLine: Record "Gen. Journal Line"; ErrText: Text)

--- a/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -6,6 +6,7 @@ namespace Microsoft.Bank.DirectDebit;
 
 using Microsoft.Bank.Payment;
 using Microsoft.Finance.GeneralLedger.Journal;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Company;
 using System.Telemetry;
 
@@ -103,8 +104,14 @@ xmlport 1001 "SEPA CT pain.001.001.09"
                             {
 
                                 trigger OnBeforePassVariable()
+                                var
+                                    GeneralLedgerSetup: Record "General Ledger Setup";
                                 begin
-                                    Cd := 'SEPA';
+                                    GeneralLedgerSetup.Get();
+                                    if GeneralLedgerSetup."SEPA Non-Euro Export" then
+                                        Cd := 'NURG'
+                                    else
+                                        Cd := 'SEPA';
                                 end;
                             }
                         }

--- a/src/Layers/NO/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/NO/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -6,6 +6,7 @@ namespace Microsoft.Bank.DirectDebit;
 
 using Microsoft.Bank.Payment;
 using Microsoft.Finance.GeneralLedger.Journal;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Company;
 using Microsoft.Purchases.Payables;
 using Microsoft.Utilities;
@@ -118,8 +119,14 @@ xmlport 1001 "SEPA CT pain.001.001.09"
                                 XmlName = 'Cd';
 
                                 trigger OnBeforePassVariable()
+                                var
+                                    GeneralLedgerSetup: Record "General Ledger Setup";
                                 begin
-                                    SvcLvlCd := 'SEPA';
+                                    GeneralLedgerSetup.Get();
+                                    if GeneralLedgerSetup."SEPA Non-Euro Export" then
+                                        SvcLvlCd := 'NURG'
+                                    else
+                                        SvcLvlCd := 'SEPA';
                                 end;
                             }
                         }

--- a/src/Layers/NO/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/NO/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1634,6 +1634,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     end;
 
     [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "SEPA" when a Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled and a Euro payment exists.
+        LibraryERM.SetAllowNonEuroExport(false);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "SEPA".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'SEPA');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "NURG" when a non-Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled and a payment exists.
+        LibraryERM.SetAllowNonEuroExport(true);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "NURG".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'NURG');
+    end;
+
+    [Test]
     [Scope('OnPrem')]
     procedure ValidatePaymentJnlExportErrorTextHasNoErrorEntriesWhenJournalLineDeleted()
     var
@@ -2329,6 +2373,20 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
             end;
         end;
         Assert.AreEqual(ExpectedNoOfCdtTrfTxInf, NoOfCdtTrfTxInf, 'Wrong number of DrctDbtTxInf nodes.');
+    end;
+
+    local procedure VerifySvcLvlCodeIfPresent(var TempBlob: Codeunit "Temp Blob"; ExpectedSvcLvlCode: Text)
+    var
+        SvcLvlCodeNodeList: DotNet XmlNodeList;
+        SvcLvlCdXPathTok: Label '//PmtInf/PmtTpInf/SvcLvl/Cd', Locked = true;
+    begin
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.GetNodeList(SvcLvlCdXPathTok, SvcLvlCodeNodeList);
+        // Some country layers (for example CH) intentionally omit the SvcLvl node for non-local exports.
+        if IsNull(SvcLvlCodeNodeList) then
+            exit;
+        if SvcLvlCodeNodeList.Count() > 0 then
+            LibraryXPathXMLReader.VerifyNodeValueByXPath(SvcLvlCdXPathTok, ExpectedSvcLvlCode);
     end;
 
     local procedure VerifyPaymentJnlExportErr(GenJnlLine: Record "Gen. Journal Line"; ErrText: Text)

--- a/src/Layers/RU/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1569,6 +1569,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     end;
 
     [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "SEPA" when a Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled and a Euro payment exists.
+        LibraryERM.SetAllowNonEuroExport(false);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "SEPA".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'SEPA');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "NURG" when a non-Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled and a payment exists.
+        LibraryERM.SetAllowNonEuroExport(true);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "NURG".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'NURG');
+    end;
+
+    [Test]
     [Scope('OnPrem')]
     procedure ValidatePaymentJnlExportErrorTextHasNoErrorEntriesWhenJournalLineDeleted()
     var
@@ -2197,6 +2241,20 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
             end;
         end;
         Assert.AreEqual(ExpectedNoOfCdtTrfTxInf, NoOfCdtTrfTxInf, 'Wrong number of DrctDbtTxInf nodes.');
+    end;
+
+    local procedure VerifySvcLvlCodeIfPresent(var TempBlob: Codeunit "Temp Blob"; ExpectedSvcLvlCode: Text)
+    var
+        SvcLvlCodeNodeList: DotNet XmlNodeList;
+        SvcLvlCdXPathTok: Label '//PmtInf/PmtTpInf/SvcLvl/Cd', Locked = true;
+    begin
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.GetNodeList(SvcLvlCdXPathTok, SvcLvlCodeNodeList);
+        // Some country layers (for example CH) intentionally omit the SvcLvl node for non-local exports.
+        if IsNull(SvcLvlCodeNodeList) then
+            exit;
+        if SvcLvlCodeNodeList.Count() > 0 then
+            LibraryXPathXMLReader.VerifyNodeValueByXPath(SvcLvlCdXPathTok, ExpectedSvcLvlCode);
     end;
 
     local procedure VerifyPaymentJnlExportErr(GenJnlLine: Record "Gen. Journal Line"; ErrText: Text)

--- a/src/Layers/W1/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
+++ b/src/Layers/W1/BaseApp/Bank/DirectDebit/SEPACTpain00100109.XmlPort.al
@@ -6,6 +6,7 @@ namespace Microsoft.Bank.DirectDebit;
 
 using Microsoft.Bank.Payment;
 using Microsoft.Finance.GeneralLedger.Journal;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Company;
 using System.Telemetry;
 
@@ -102,8 +103,14 @@ xmlport 1001 "SEPA CT pain.001.001.09"
                             {
 
                                 trigger OnBeforePassVariable()
+                                var
+                                    GeneralLedgerSetup: Record "General Ledger Setup";
                                 begin
-                                    Cd := 'SEPA';
+                                    GeneralLedgerSetup.Get();
+                                    if GeneralLedgerSetup."SEPA Non-Euro Export" then
+                                        Cd := 'NURG'
+                                    else
+                                        Cd := 'SEPA';
                                 end;
                             }
                         }

--- a/src/Layers/W1/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMTestSEPACreditTransfers.Codeunit.al
@@ -1693,6 +1693,50 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
     end;
 
     [Test]
+    procedure SvcLvlCodeIsSepaForEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "SEPA" when a Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is disabled and a Euro payment exists.
+        LibraryERM.SetAllowNonEuroExport(false);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "SEPA".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'SEPA');
+    end;
+
+    [Test]
+    procedure SvcLvlCodeIsNurgForNonEuroPayment()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+    begin
+        // [SCENARIO 641065] The service level code "PmtTpInf/SvcLvl/Cd" is "NURG" when a non-Euro payment is exported.
+        Init();
+
+        // [GIVEN] "SEPA Non-Euro Export" is enabled and a payment exists.
+        LibraryERM.SetAllowNonEuroExport(true);
+        CreateGenJnlLine(GenJournalLine);
+
+        // [WHEN] Export the payment using the SEPA CT xmlport.
+        TempBlob.CreateOutStream(BlobOutStream);
+        Xmlport.Export(BankAccount.GetPaymentExportXMLPortID(), BlobOutStream, GenJournalLine);
+
+        // [THEN] When the "SvcLvl/Cd" node is present, its value is "NURG".
+        VerifySvcLvlCodeIfPresent(TempBlob, 'NURG');
+    end;
+
+    [Test]
     [Scope('OnPrem')]
     procedure ValidatePaymentJnlExportErrorTextHasNoErrorEntriesWhenJournalLineDeleted()
     var
@@ -2361,6 +2405,20 @@ codeunit 134403 "ERM Test SEPA Credit Transfers"
             end;
         end;
         Assert.AreEqual(ExpectedNoOfCdtTrfTxInf, NoOfCdtTrfTxInf, 'Wrong number of DrctDbtTxInf nodes.');
+    end;
+
+    local procedure VerifySvcLvlCodeIfPresent(var TempBlob: Codeunit "Temp Blob"; ExpectedSvcLvlCode: Text)
+    var
+        SvcLvlCodeNodeList: DotNet XmlNodeList;
+        SvcLvlCdXPathTok: Label '//PmtInf/PmtTpInf/SvcLvl/Cd', Locked = true;
+    begin
+        LibraryXPathXMLReader.InitializeWithBlob(TempBlob, NamespaceTxt);
+        LibraryXPathXMLReader.GetNodeList(SvcLvlCdXPathTok, SvcLvlCodeNodeList);
+        // Some country layers (for example CH) intentionally omit the SvcLvl node for non-local exports.
+        if IsNull(SvcLvlCodeNodeList) then
+            exit;
+        if SvcLvlCodeNodeList.Count() > 0 then
+            LibraryXPathXMLReader.VerifyNodeValueByXPath(SvcLvlCdXPathTok, ExpectedSvcLvlCode);
     end;
 
     local procedure VerifyPaymentJnlExportErr(GenJnlLine: Record "Gen. Journal Line"; ErrText: Text)


### PR DESCRIPTION
[Bug 641697](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/641697): [master][All-e]Invalid SEPA export file format when SEPA Non-Euro Export enabled

Fixes [AB#641697](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641697)


