### PR TITLE
[TEST - do not merge] Fake app to validate BC PR review agent recall across all domains

### DIFF
--- a/src/Apps/W1/ContosoWidgetMgmt/App/AppSourceCop.json
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/AppSourceCop.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/AL/master/schemas/appsourcecop.schema.json",
+  "mandatoryAffixes": [ "CWM" ]
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/Permissions/WidgetFullAccess.PermissionSet.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/Permissions/WidgetFullAccess.PermissionSet.al
@@ -1,0 +1,7 @@
+permissionset 50060 "CWM Widget Full Access"
+{
+    Caption = 'Widget - Full Access';
+    Assignable = true;
+
+    Permissions = tabledata * = RIMD;
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/app.json
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/app.json
@@ -1,0 +1,26 @@
+{
+  "id": "6f2c1e4a-8b3d-4c9e-a1f7-2d5b9c0e7a34",
+  "name": "Contoso Widget Management",
+  "publisher": "Contoso",
+  "brief": "Manage widgets and their loyalty program.",
+  "description": "Sample app used to validate the BC PR review agent. Contains deliberately planted code issues across all review domains.",
+  "version": "1.0.0.0",
+  "application": "26.0.0.0",
+  "platform": "26.0.0.0",
+  "idRanges": [
+    {
+      "from": 50000,
+      "to": 50149
+    }
+  ],
+  "target": "Cloud",
+  "resourceExposurePolicy": {
+    "allowDebugging": false,
+    "allowDownloadingSource": false,
+    "includeSourceInSymbolFile": false
+  },
+  "runtime": "13.0",
+  "features": [
+    "NoImplicitWith"
+  ]
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/CustomerLoyaltyExt.TableExt.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/CustomerLoyaltyExt.TableExt.al
@@ -1,0 +1,14 @@
+// Anti-pattern: the field added to the standard Customer table carries no
+// affix, so it collides with any other app that adds "Loyalty Points" to
+// Customer (AS0011).
+tableextension 50004 "Customer Loyalty Ext" extends Customer
+{
+    fields
+    {
+        field(50004; "Loyalty Points"; Integer)
+        {
+            Caption = 'Loyalty Points';
+            DataClassification = CustomerContent;
+        }
+    }
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/LoyaltyTier.Table.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/LoyaltyTier.Table.al
@@ -1,0 +1,31 @@
+// Own object deliberately declared without the app's mandatory affix (CWM).
+// Any other app that also defines a "Loyalty Tier" table collides with this one.
+table 50003 "Loyalty Tier"
+{
+    Caption = 'Loyalty Tier';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[20])
+        {
+            Caption = 'Code';
+        }
+        field(10; Description; Text[100])
+        {
+            Caption = 'Description';
+        }
+        field(20; "Minimum Points"; Integer)
+        {
+            Caption = 'Minimum Points';
+        }
+    }
+
+    keys
+    {
+        key(PK; "Code")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/Widget.Table.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/Widget.Table.al
@@ -1,0 +1,66 @@
+table 50000 "CWM Widget"
+{
+    Caption = 'Widget';
+    DataClassification = CustomerContent;
+    LookupPageId = "CWM Widget List";
+    DrillDownPageId = "CWM Widget List";
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+            Caption = 'No.';
+
+            trigger OnValidate()
+            begin
+                if "No." = xRec."No." then
+                    exit;
+                WidgetSetup.Get();
+                NoSeriesMgt.TestManual(WidgetSetup."Widget Nos.");
+                "No. Series" := '';
+            end;
+        }
+        field(2; Description; Text[100])
+        {
+            Caption = 'Description';
+        }
+        field(3; "Contact Email"; Text[80])
+        {
+            Caption = 'Contact Email';
+            DataClassification = SystemMetadata;
+            ExtendedDatatype = EMail;
+        }
+        field(4; "Linked Customer No."; Code[20])
+        {
+            Caption = 'Linked Customer No.';
+            TableRelation = Customer."No.";
+            ValidateTableRelation = false;
+        }
+        field(10; "No. Series"; Code[20])
+        {
+            Caption = 'No. Series';
+            Editable = false;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+
+    var
+        WidgetSetup: Record "CWM Widget Setup";
+        NoSeriesMgt: Codeunit NoSeriesManagement;
+
+    trigger OnInsert()
+    begin
+        if "No." = '' then begin
+            WidgetSetup.Get();
+            WidgetSetup.TestField("Widget Nos.");
+            NoSeriesMgt.InitSeries(WidgetSetup."Widget Nos.", xRec."No. Series", 0D, "No.", "No. Series");
+        end;
+    end;
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetApi.Page.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetApi.Page.al
@@ -1,0 +1,34 @@
+// APIVersion is omitted, so the endpoint defaults to beta instead of publishing
+// an intended explicit stable contract.
+page 50070 "CWM Widget API"
+{
+    PageType = API;
+    APIPublisher = 'contoso';
+    APIGroup = 'widgets';
+    EntityName = 'widget';
+    EntitySetName = 'widgets';
+    SourceTable = "CWM Widget";
+    DelayedInsert = true;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(records)
+            {
+                field(number; Rec."No.")
+                {
+                    Caption = 'number';
+                }
+                field(description; Rec.Description)
+                {
+                    Caption = 'description';
+                }
+                field(contactEmail; Rec."Contact Email")
+                {
+                    Caption = 'contactEmail';
+                }
+            }
+        }
+    }
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetApiClient.Codeunit.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetApiClient.Codeunit.al
@@ -1,0 +1,28 @@
+codeunit 50022 "CWM Api Client"
+{
+    procedure SyncWidgets()
+    var
+        ApiKey: Text;
+        BearerToken: Text;
+        Client: HttpClient;
+        Response: HttpResponseMessage;
+        Headers: HttpHeaders;
+    begin
+        ApiKey := GetApiKey();
+        BearerToken := GetAccessToken();
+        Headers := Client.DefaultRequestHeaders();
+        Headers.Add('Authorization', 'Bearer ' + BearerToken);
+        Headers.Add('X-Api-Key', ApiKey);
+        Client.Get('https://api.contoso.com/widgets', Response);
+    end;
+
+    local procedure GetApiKey(): Text
+    begin
+        exit('');
+    end;
+
+    local procedure GetAccessToken(): Text
+    begin
+        exit('');
+    end;
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetCard.Page.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetCard.Page.al
@@ -1,0 +1,32 @@
+page 50011 "CWM Widget Card"
+{
+    PageType = Card;
+    ApplicationArea = All;
+    UsageCategory = None;
+    SourceTable = "CWM Widget";
+    Caption = 'Widget Card';
+
+    layout
+    {
+        area(Content)
+        {
+            group(General)
+            {
+                field("No."; Rec."No.")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the number of the widget.';
+                }
+                field(Description; Rec.Description)
+                {
+                    ApplicationArea = All;
+                    ToolTip = '';
+                }
+                field("Contact Email"; Rec."Contact Email")
+                {
+                    ToolTip = 'Specifies the contact email for the widget.';
+                }
+            }
+        }
+    }
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetList.Page.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetList.Page.al
@@ -1,0 +1,34 @@
+page 50010 "CWM Widget List"
+{
+    PageType = List;
+    ApplicationArea = All;
+    UsageCategory = Lists;
+    SourceTable = "CWM Widget";
+    Caption = 'Widgets';
+    CardPageId = "CWM Widget Card";
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(General)
+            {
+                field("No."; Rec."No.")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the number of the widget.';
+                }
+                field(Description; Rec.Description)
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the description of the widget.';
+                }
+                field("Linked Customer No."; Rec."Linked Customer No.")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the customer linked to the widget.';
+                }
+            }
+        }
+    }
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetLog.Page.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetLog.Page.al
@@ -1,0 +1,45 @@
+page 50012 "CWM Widget Log"
+{
+    PageType = List;
+    ApplicationArea = All;
+    UsageCategory = History;
+    SourceTable = "CWM Widget Log Entry";
+    Caption = 'Widget Log Entries';
+    Editable = false;
+
+    // Historical log page that opens oldest-first: no descending default sort.
+    layout
+    {
+        area(Content)
+        {
+            repeater(General)
+            {
+                field("Entry No."; Rec."Entry No.")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the number of the log entry.';
+                }
+                field("Widget No."; Rec."Widget No.")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the widget the log entry relates to.';
+                }
+                field("Logged At"; Rec."Logged At")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies when the log entry was created.';
+                }
+                field(Status; Rec.Status)
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the status of the log entry.';
+                }
+                field(Message; Rec.Message)
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the log message.';
+                }
+            }
+        }
+    }
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetLogEntry.Table.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetLogEntry.Table.al
@@ -1,0 +1,40 @@
+table 50002 "CWM Widget Log Entry"
+{
+    Caption = 'Widget Log Entry';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Entry No."; Integer)
+        {
+            Caption = 'Entry No.';
+            AutoIncrement = true;
+        }
+        field(2; "Widget No."; Code[20])
+        {
+            Caption = 'Widget No.';
+            TableRelation = "CWM Widget"."No.";
+        }
+        field(3; "Logged At"; DateTime)
+        {
+            Caption = 'Logged At';
+        }
+        field(4; Status; Option)
+        {
+            Caption = 'Status';
+            OptionMembers = Success,Failure;
+        }
+        field(5; Message; Text[250])
+        {
+            Caption = 'Message';
+        }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetMgt.Codeunit.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetMgt.Codeunit.al
@@ -1,0 +1,57 @@
+codeunit 50020 "CWM Widget Mgt"
+{
+    procedure NormalizeWidgetDescriptions()
+    var
+        Widget: Record "CWM Widget";
+    begin
+        if Widget.FindSet(true) then
+            repeat
+                Widget.Description := UpperCase(Widget.Description);
+                Widget.Modify();
+                Commit();
+            until Widget.Next() = 0;
+    end;
+
+    procedure HasLogEntries(WidgetNo: Code[20]): Boolean
+    var
+        WidgetLogEntry: Record "CWM Widget Log Entry";
+    begin
+        WidgetLogEntry.SetRange("Widget No.", WidgetNo);
+        if WidgetLogEntry.Count() > 0 then
+            exit(true);
+        if WidgetLogEntry.FindFirst() then
+            exit(true);
+        exit(false);
+    end;
+
+    procedure ProcessWidgets(var Widget: Record "CWM Widget")
+    begin
+        if Widget.FindSet() then
+            repeat
+                OnProcessWidget(Widget);
+                Widget.Description := UpperCase(Widget.Description);
+                Widget.Modify(true);
+            until Widget.Next() = 0;
+    end;
+
+    procedure PostWidget(var Widget: Record "CWM Widget")
+    begin
+        Widget.FieldError("Contact Email", 'must be filled in');
+
+        if Widget."Linked Customer No." = '' then
+            Error('Linked customer is required.');
+    end;
+
+    procedure CheckWidgetExists(WidgetNo: Code[20])
+    var
+        Widget: Record "CWM Widget";
+    begin
+        if not Widget.Get(WidgetNo) then
+            Error('Widget ' + WidgetNo + ' does not exist.');
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnProcessWidget(var Widget: Record "CWM Widget")
+    begin
+    end;
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetOrderProcessor.Codeunit.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetOrderProcessor.Codeunit.al
@@ -1,0 +1,26 @@
+codeunit 50026 "CWM Widget Order Processor"
+{
+    // Anti-pattern: every helper is public by default, exposing implementation
+    // detail as a de-facto API. Each becomes a contract that cannot be changed
+    // without risking breakage for consumers that bound to it.
+    procedure ProcessOrder(WidgetNo: Code[20])
+    begin
+        ValidateOrder(WidgetNo);
+        PostOrder(WidgetNo);
+    end;
+
+    procedure ValidateOrder(WidgetNo: Code[20])
+    begin
+        if WidgetNo = '' then
+            Error('Widget number is required.');
+    end;
+
+    procedure PostOrder(WidgetNo: Code[20])
+    begin
+    end;
+
+    procedure CalculateInternalScore(WidgetNo: Code[20]): Decimal
+    begin
+        exit(0);
+    end;
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetQueryReader.Codeunit.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetQueryReader.Codeunit.al
@@ -1,0 +1,16 @@
+codeunit 50024 "CWM Widget Query Reader"
+{
+    procedure ReadWidgetsForCustomer(CustomerNoFilter: Code[20])
+    var
+        WidgetSales: Query "CWM Widget Sales";
+    begin
+        WidgetSales.Open();
+        WidgetSales.SetRange(LinkedCustomerNo, CustomerNoFilter);
+        while WidgetSales.Read() do
+            ProcessRow(WidgetSales.WidgetNo);
+    end;
+
+    local procedure ProcessRow(WidgetNo: Code[20])
+    begin
+    end;
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetSales.Query.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetSales.Query.al
@@ -1,0 +1,14 @@
+query 50050 "CWM Widget Sales"
+{
+    QueryType = Normal;
+
+    elements
+    {
+        dataitem(Widget; "CWM Widget")
+        {
+            column(WidgetNo; "No.") { }
+            column(WidgetDescription; Description) { }
+            column(LinkedCustomerNo; "Linked Customer No.") { }
+        }
+    }
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetSetup.Table.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetSetup.Table.al
@@ -1,0 +1,26 @@
+table 50001 "CWM Widget Setup"
+{
+    Caption = 'Widget Setup';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Primary Key"; Code[10])
+        {
+            Caption = 'Primary Key';
+        }
+        field(2; "Widget Nos."; Code[20])
+        {
+            Caption = 'Widget Nos.';
+            TableRelation = "No. Series";
+        }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetShippingCharge.Codeunit.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetShippingCharge.Codeunit.al
@@ -1,0 +1,35 @@
+codeunit 50021 "CWM Shipping Charge"
+{
+    // Anti-pattern: every call site must 'case' over the enum. Each new shipping
+    // method forces a synchronized edit to each of these blocks instead of a
+    // single new interface implementation.
+    procedure GetRate(Method: Enum "CWM Shipping Method"; Weight: Decimal): Decimal
+    begin
+        case Method of
+            Method::Standard:
+                exit(Weight * 1.5);
+            Method::Express:
+                exit((Weight * 1.5) + 25);
+        end;
+    end;
+
+    procedure GetDeliveryDays(Method: Enum "CWM Shipping Method"): Integer
+    begin
+        case Method of
+            Method::Standard:
+                exit(5);
+            Method::Express:
+                exit(1);
+        end;
+    end;
+
+    procedure GetCarrierName(Method: Enum "CWM Shipping Method"): Text
+    begin
+        case Method of
+            Method::Standard:
+                exit('Ground');
+            Method::Express:
+                exit('Air');
+        end;
+    end;
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetShippingMethod.Enum.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetShippingMethod.Enum.al
@@ -1,0 +1,7 @@
+enum 50040 "CWM Shipping Method"
+{
+    Extensible = true;
+
+    value(0; Standard) { Caption = 'Standard'; }
+    value(1; Express) { Caption = 'Express'; }
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetTelemetry.Codeunit.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetTelemetry.Codeunit.al
@@ -1,0 +1,24 @@
+codeunit 50023 "CWM Widget Telemetry"
+{
+    procedure LogWidgetProcessed(WidgetNo: Code[20])
+    begin
+        Session.LogMessage(
+            '0000',
+            'Widget record processed',
+            Verbosity::Normal,
+            DataClassification::SystemMetadata,
+            TelemetryScope::All,
+            'Category', 'ContosoWidget');
+    end;
+
+    procedure LogWidgetPosted(WidgetNo: Code[20])
+    begin
+        Session.LogMessage(
+            '0000',
+            'Widget posted',
+            Verbosity::Normal,
+            DataClassification::SystemMetadata,
+            TelemetryScope::All,
+            'Category', 'ContosoWidget');
+    end;
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetTest.Codeunit.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetTest.Codeunit.al
@@ -1,0 +1,19 @@
+codeunit 50080 "CWM Widget Test"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure BlankContactEmailIsRejected()
+    var
+        Widget: Record "CWM Widget";
+        WidgetMgt: Codeunit "CWM Widget Mgt";
+    begin
+        Widget.Init();
+        Widget."No." := 'W-001';
+        Widget."Contact Email" := '';
+
+        // Bare asserterror: passes if ANY error is raised, so it never proves
+        // the blank contact-email guard is the thing that fired.
+        asserterror WidgetMgt.PostWidget(Widget);
+    end;
+}

--- a/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetUpgrade.Codeunit.al
+++ b/src/Apps/W1/ContosoWidgetMgmt/App/src/WidgetUpgrade.Codeunit.al
@@ -1,0 +1,30 @@
+codeunit 50025 "CWM Widget Upgrade"
+{
+    Subtype = Upgrade;
+
+    trigger OnUpgradePerCompany()
+    var
+        AppInfo: ModuleInfo;
+    begin
+        NavApp.GetCurrentModuleInfo(AppInfo);
+
+        // Version-coupled branching breaks when a tenant skips a version.
+        if AppInfo.DataVersion().Major > 14 then
+            exit;
+
+        if AppInfo.DataVersion().Major < 14 then
+            UpgradeContactEmail()
+        else if AppInfo.DataVersion().Major < 17 then
+            UpgradeLoyaltyPoints()
+        else
+            exit;
+    end;
+
+    local procedure UpgradeContactEmail()
+    begin
+    end;
+
+    local procedure UpgradeLoyaltyPoints()
+    begin
+    end;
+}


### PR DESCRIPTION
## ⚠️ Test PR — do not merge

This PR adds a **self-contained sample app** (`src/Apps/W1/ContosoWidgetMgmt`) whose
only purpose is to **validate the BC PR review agent** now that BCQuality's expanded
knowledge corpus is live. Every object contains a deliberately planted, knowledge-backed
AL issue. The goal is to check whether the review agent flags each planted issue, with
**all 16 review domains covered**.

It is expected to fail the normal CICD build. It will be closed once the review agent
has run and its recall has been scored.

### Planted issues (scoring key)

| # | Domain | Where | Planted anti-pattern | BCQuality article |
|---|--------|-------|----------------------|-------------------|
| 1 | appsource | `LoyaltyTier.Table.al` + `CustomerLoyaltyExt.TableExt.al` | Own table + Customer field with **no mandatory affix** (AppSourceCop declares `CWM`) | object-affixes-prevent-collisions |
| 2 | breaking-changes | `WidgetOrderProcessor.Codeunit.al` | All helpers **public by default**, no access modifiers | choose-access-modifiers-deliberately |
| 3 | data-modeling | `Widget.Table.al` | Uses **obsolete `NoSeriesManagement`** (InitSeries/TestManual) | use-no-series-codeunit-not-noseriesmanagement |
| 4 | error-handling | `WidgetMgt.Codeunit.al` | **Unconditional `FieldError`** as a check (dead code after it) | fielderror-vs-testfield |
| 5 | events | `WidgetMgt.Codeunit.al` | **IntegrationEvent published inside a loop** | do-not-publish-events-inside-loops |
| 6 | interfaces | `WidgetShippingCharge.Codeunit.al` | **`case` over enum** in multiple procedures instead of interface dispatch | prefer-interface-over-case-branching |
| 7 | performance | `WidgetMgt.Codeunit.al` | **`Commit()` inside a `repeat..until` loop** | avoid-commit-inside-loops |
| 8 | performance | `WidgetMgt.Codeunit.al` | **`Count() > 0`** for existence instead of `not IsEmpty()` | use-isempty-for-existence-check |
| 9 | privacy | `Widget.Table.al` | PII email field classified **`SystemMetadata`** | data-classification-required-on-pii-fields |
| 10 | query | `WidgetQueryReader.Codeunit.al` | **`SetRange` after `Query.Open()`** | set-query-filters-before-open |
| 11 | security | `WidgetApiClient.Codeunit.al` | Credentials held in **plain `Text`** not `SecretText` | secrettext-for-credentials |
| 12 | security | `Widget.Table.al` | **`ValidateTableRelation = false`** on user-editable FK | validatetablerelation-false-on-user-input |
| 13 | security | `WidgetFullAccess.PermissionSet.al` | **`tabledata * = RIMD`** wildcard grant | permission-set-avoid-wildcard-grants |
| 14 | style | `WidgetCard.Page.al` | Page field with **empty `ToolTip`** | tooltip-required-on-page-fields |
| 15 | style | `WidgetCard.Page.al` | Page control **missing `ApplicationArea`** | applicationarea-required-on-page-controls |
| 16 | style | `WidgetMgt.Codeunit.al` | `Error` via **string concatenation** not Label+placeholders | error-passes-parameters-directly-not-strsubstno |
| 17 | telemetry | `WidgetTelemetry.Codeunit.al` | **Placeholder/non-unique event id `'0000'`** | telemetry-event-id-stable-unique |
| 18 | testing | `WidgetTest.Codeunit.al` | **Bare `asserterror`** without ExpectedError/code | asserterror-needs-expectederror-and-code |
| 19 | ui | `WidgetLog.Page.al` | History list opens **oldest-first**, no descending sort | default-descending-sort-on-historical-pages |
| 20 | upgrade | `WidgetUpgrade.Codeunit.al` | Upgrade branches on **`DataVersion().Major`** not upgrade tags | use-upgrade-tags-not-version-checks |
| 21 | web-services | `WidgetApi.Page.al` | API page **omits `APIVersion`** (defaults to beta) | set-required-api-page-properties |

_All 16 domains represented: appsource, breaking-changes, data-modeling, error-handling,
events, interfaces, performance, privacy, query, security, style, telemetry, testing, ui,
upgrade, web-services._

