### PR TITLE
Make service-invoked System Application facades callable by any user (Privacy Notice + Page Summary Provider)

### DIFF
--- a/src/System Application/App/Page Summary Provider/src/PageSummaryProvider.Codeunit.al
+++ b/src/System Application/App/Page Summary Provider/src/PageSummaryProvider.Codeunit.al
@@ -12,6 +12,8 @@ namespace System.Integration;
 codeunit 2718 "Page Summary Provider"
 {
     Access = Public;
+    InherentEntitlements = X;
+    InherentPermissions = X;
 
     #region OData API functions
     /// <summary>

--- a/src/System Application/App/Privacy Notice/src/PrivacyNotice.Codeunit.al
+++ b/src/System Application/App/Privacy Notice/src/PrivacyNotice.Codeunit.al
@@ -11,6 +11,8 @@ namespace System.Privacy;
 codeunit 1563 "Privacy Notice"
 {
     Access = Public;
+    InherentEntitlements = X;
+    InherentPermissions = X;
 
     /// <summary>
     /// Creates a privacy notice.


### PR DESCRIPTION
**Work item:** [AB#641612](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641612)

## Summary

Two System Application public **facade** codeunits are reachable from system-trigger subscribers in low-permission (web-service / OData / MCP / Copilot / agent) sessions, but declare only `Access = Public` — no `InherentEntitlements` / `InherentPermissions` — even though the impl codeunits they delegate to declare both. Entering such a facade requires the calling user to hold Execute permission on it; regular (non-SUPER) users don't, so they hit `NavPermissionException` (`18023703`). This makes them callable by any authenticated user by declaring the inherent grants, matching their impls.

| Facade (fixed) | Impl (already inherent `X`) | Reached from |
| --- | --- | --- |
| CU 1563 `Privacy Notice` | CU 1565 `Privacy Notice Impl.` | `Copilot Capability Impl.IsCapabilityActive` -> privacy notice, via `System Action Triggers.GetCopilotCapabilityStatus`/`GetCopilotCapabilityInfo` |
| CU 2718 `Page Summary Provider` | CU 2717 `Page Summary Provider Impl.` | `Agent Task Impl` subscriber to `System Action Triggers.GetPageSummary`; also directly OData/web-service exposed |

## Problem (Privacy Notice)

Non-admin users hit `NavPermissionException 18023703` ("CodeUnit 1563 Privacy Notice Execute: System Application") when the platform evaluates a Copilot capability:

```
Codeunit 7774 "Copilot Capability Impl".IsCapabilityActive
  -> Codeunit 1563 "Privacy Notice".GetPrivacyNoticeApprovalState   <-- fails entering here
     -> Codeunit 1565 "Privacy Notice Impl.".CheckPrivacyNoticeApprovalState
```

It surfaced via the platform MCP feature gate, which evaluates a Copilot capability for every MCP request.

## Root cause

Along each chain, both the caller/subscriber and the impl declare inherent execute, but the **public facade in the middle does not**:

| Codeunit | InherentEntitlements / InherentPermissions |
| --- | --- |
| 7774 `Copilot Capability Impl` (caller) | `X` / `X` |
| **1563 `Privacy Notice`** (facade) | **neither — only `Access = Public`** |
| 1565 `Privacy Notice Impl.` (delegate) | `X` / `X` |
| Agent Task Impl (subscriber) | `X` / `X` |
| **2718 `Page Summary Provider`** (facade) | **neither — only `Access = Public`** |
| 2717 `Page Summary Provider Impl.` (delegate) | `X` / `X` |

The facade is the only link that doesn't grant itself inherent execute, so entering any of its methods requires the calling user's assigned permission sets to grant Execute on it. Built-in/SUPER users bypass this; other users (including Entra tenant admins without SUPER) do not.

## Fix

Add `InherentEntitlements = X; InherentPermissions = X;` to CU 1563 and CU 2718, aligning them with their impls. This only grants Execute on the codeunit object; actual table access remains bounded by the impls' declared tabledata permissions, and Privacy Notice admin detection (`Privacy Notice Approval` `WritePermission()`) is unaffected.

## Telemetry confirmation (Privacy Notice)

Production trace (Copilot Chat over MCP, `WebServiceClient` session), platform permission-check diagnostic at the failure:

```
Entitlements for object CodeUnit 1563: Execute. Role permissions: None. User enabled: True Expired: False License type: Full AuthenticationMethod: AccessControlService IsTenantAdmin: True IsSystemSession: False.
(NavPermissionException) 18023703 ... (CodeUnit 1563 Privacy Notice Execute: System Application)
```

Decoding (`PermissionSetBase.CreatePermissionCheckFailureTelemetryMessage`):
- **Role permissions: None** — assigned permission sets grant no Execute on CU 1563.
- **Entitlements: Execute** — the license *allows* Execute, but an entitlement is a cap, not a grant.
- No inherent permission on the facade -> nothing supplies Execute -> denied.

Note this repro was an `IsTenantAdmin: True` user: an Entra tenant admin without the BC SUPER permission set still fails. `InherentPermissions = X` supplies the object's own Execute so no assigned permission set is required.

## Audit scope (per review feedback)

Following the request to check other System Application system-trigger subscribers: enumerated subscribers to `System Action Triggers` (and related system-trigger codeunits) and traced their call paths. The only additional same-shape instance found is CU 2718 (fixed here). `GetCopilotCapabilityInfo` shares the CU 1563 path and is covered by that fix. One medium/tabledata note (agent feedback tables) and a few interactive-only facades were reviewed and not treated as failures in low-permission contexts; details available on request.

## Notes

- Not built locally (property-only additions mirroring sibling codeunits); relying on CI.
- No API surface / signature change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>




