### PR TITLE
[Main]-Interest Document issued with non-taxable VAT does not generate non-taxable VAT entries in the Spanish localization

### DIFF
--- a/src/Layers/ES/BaseApp/Local/Finance/VAT/Calculation/NoTaxableMgt.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Local/Finance/VAT/Calculation/NoTaxableMgt.Codeunit.al
@@ -258,6 +258,33 @@ codeunit 10740 "No Taxable Mgt."
         exit(true);
     end;
 
+    local procedure CreateNoTaxableEntriesFinanceChargeMemo(GenJournalLine: Record "Gen. Journal Line"; TransactionNo: Integer): Boolean
+    var
+        Customer: Record Customer;
+        NoTaxableEntry: Record "No Taxable Entry";
+        TempSalesInvoiceLine: Record "Sales Invoice Line" temporary;
+        PostedLineRecordRef: RecordRef;
+    begin
+        if GenJournalLine."Document Type" <> GenJournalLine."Document Type"::"Finance Charge Memo" then
+            exit(false);
+        if not CopyVATGenJnlLineToTempSalesInvoiceLine(TempSalesInvoiceLine, GenJournalLine) then
+            exit(false);
+        if (GenJournalLine."Source Type" <> GenJournalLine."Source Type"::Customer) or (GenJournalLine."Source No." = '') then
+            exit(false);
+        if not Customer.Get(GenJournalLine."Source No.") then
+            exit(false);
+
+        GenJournalLine."Account No." := GenJournalLine."Source No.";
+        NoTaxableEntry.InitFromGenJnlLine(GenJournalLine);
+        NoTaxableEntry."Country/Region Code" := Customer."Country/Region Code";
+        NoTaxableEntry."VAT Registration No." := Customer."VAT Registration No.";
+        NoTaxableEntry."Transaction No." := TransactionNo;
+        PostedLineRecordRef.GetTable(TempSalesInvoiceLine);
+        InsertNoTaxableEntriesFromSalesLines(PostedLineRecordRef, NoTaxableEntry, -1);
+
+        exit(true);
+    end;
+
     [Scope('OnPrem')]
     procedure FindNoTaxableLinesPurchaseInvoice(var PurchInvLine: Record "Purch. Inv. Line"; VendorNo: Code[20]; DocumentNo: Code[20]; PostingDate: Date): Boolean
     begin
@@ -927,13 +954,15 @@ codeunit 10740 "No Taxable Mgt."
     local procedure InsertNoTaxableEntryOnPostCust(var GenJournalLine: Record "Gen. Journal Line"; Balancing: Boolean; var TempGLEntryBuf: Record "G/L Entry" temporary; var NextEntryNo: Integer; var NextTransactionNo: Integer)
     begin
         if not (GenJournalLine."Document Type" in
-                [GenJournalLine."Document Type"::Invoice, GenJournalLine."Document Type"::"Credit Memo"])
+                [GenJournalLine."Document Type"::Invoice, GenJournalLine."Document Type"::"Credit Memo", GenJournalLine."Document Type"::"Finance Charge Memo"])
         then
             exit;
 
         if CreateNoTaxableEntriesSalesInvoice(GenJournalLine, TempGLEntryBuf."Transaction No.") then
             exit;
         if CreateNoTaxableEntriesSalesCreditMemo(GenJournalLine, TempGLEntryBuf."Transaction No.") then
+            exit;
+        if CreateNoTaxableEntriesFinanceChargeMemo(GenJournalLine, TempGLEntryBuf."Transaction No.") then
             exit;
     end;
 

--- a/src/Layers/ES/Tests/Local/NoTaxableDocuments.Codeunit.al
+++ b/src/Layers/ES/Tests/Local/NoTaxableDocuments.Codeunit.al
@@ -1144,6 +1144,94 @@ codeunit 147515 "No Taxable Documents"
         Assert.IsFalse(NoTaxableEntry.IsEmpty(), NoTaxableEntryShouldBeCreatedErr);
     end;
 
+    [Test]
+    [HandlerFunctions('SuggestFinChargeMemoLinesRequestPageHandler')]
+    procedure NoTaxableEntryForIssuedFinanceChargeMemo()
+    var
+        Customer: Record Customer;
+        FinanceChargeMemoHeader: Record "Finance Charge Memo Header";
+        FinanceChargeTerms: Record "Finance Charge Terms";
+        IssuedFinChargeMemoHeader: Record "Issued Fin. Charge Memo Header";
+        NoTaxableEntry: Record "No Taxable Entry";
+        FinanceChargeDate: Date;
+        InvoiceDate: Date;
+    begin
+        // [SCENARIO 642269] No Taxable Entry is created when issuing a Finance Charge Memo whose interest account uses No Taxable VAT
+
+        // [GIVEN] Create a new Customer with VAT setup and Finance Charge Terms that post interest.
+        LibrarySII.CreateCustWithVATSetup(Customer);
+        CreateFinanceChargeTermsPostingInterest(FinanceChargeTerms);
+        Customer.Validate("Fin. Charge Terms Code", FinanceChargeTerms.Code);
+        Customer.Modify(true);
+
+        // [GIVEN] Interest account of the customer posting group uses a No Taxable VAT posting setup.
+        SetupNoTaxableInterestAccount(Customer);
+
+        // [GIVEN] An overdue posted sales invoice creating a customer balance.
+        InvoiceDate := WorkDate();
+        FinanceChargeDate := CalcDate('<+62D>', InvoiceDate);
+        CreateAndPostSalesInvoice(Customer, InvoiceDate);
+
+        // [GIVEN] A Finance Charge Memo with suggested interest lines.
+        CreateFinanceChargeMemoWithLines(FinanceChargeMemoHeader, Customer, FinanceChargeDate);
+
+        // [WHEN] Issue the Finance Charge Memo.
+        LibraryERM.IssueFinanceChargeMemo(FinanceChargeMemoHeader);
+
+        // [THEN] A No Taxable Entry is created for the issued finance charge memo interest.
+        IssuedFinChargeMemoHeader.SetRange("Customer No.", Customer."No.");
+        IssuedFinChargeMemoHeader.SetRange("Pre-Assigned No.", FinanceChargeMemoHeader."No.");
+        IssuedFinChargeMemoHeader.FindFirst();
+
+        FilterOnNoTaxableEntry(NoTaxableEntry, Customer."No.", IssuedFinChargeMemoHeader."No.");
+        Assert.IsFalse(NoTaxableEntry.IsEmpty(), NoTaxableEntryShouldBeCreatedErr);
+        NoTaxableEntry.FindFirst();
+        Assert.IsTrue(NoTaxableEntry.Base > 0, NoTaxableEntryShouldBeCreatedErr);
+    end;
+
+    [Test]
+    [HandlerFunctions('SuggestFinChargeMemoLinesRequestPageHandler')]
+    procedure NoTaxableEntryNotCreatedForIssuedFinanceChargeMemoWithTaxableInterest()
+    var
+        Customer: Record Customer;
+        FinanceChargeMemoHeader: Record "Finance Charge Memo Header";
+        FinanceChargeTerms: Record "Finance Charge Terms";
+        IssuedFinChargeMemoHeader: Record "Issued Fin. Charge Memo Header";
+        NoTaxableEntry: Record "No Taxable Entry";
+        FinanceChargeDate: Date;
+        InvoiceDate: Date;
+    begin
+        // [SCENARIO 642269] No Taxable Entry is not created when issuing a Finance Charge Memo whose interest account uses normal (taxable) VAT
+
+        // [GIVEN] Create a Customer with VAT setup and Finance Charge Terms that post interest.
+        LibrarySII.CreateCustWithVATSetup(Customer);
+        CreateFinanceChargeTermsPostingInterest(FinanceChargeTerms);
+        Customer.Validate("Fin. Charge Terms Code", FinanceChargeTerms.Code);
+        Customer.Modify(true);
+
+        // [GIVEN] Interest account of the customer posting group uses a normal (taxable) VAT posting setup.
+        SetupTaxableInterestAccount(Customer);
+
+        // [GIVEN] An overdue posted sales invoice creating a customer balance.
+        InvoiceDate := WorkDate();
+        FinanceChargeDate := CalcDate('<+62D>', InvoiceDate);
+        CreateAndPostSalesInvoice(Customer, InvoiceDate);
+
+        // [GIVEN] A Finance Charge Memo with suggested interest lines.
+        CreateFinanceChargeMemoWithLines(FinanceChargeMemoHeader, Customer, FinanceChargeDate);
+
+        // [WHEN] Issue the Finance Charge Memo.
+        LibraryERM.IssueFinanceChargeMemo(FinanceChargeMemoHeader);
+
+        // [THEN] No No Taxable Entry is created for the issued finance charge memo interest.
+        IssuedFinChargeMemoHeader.SetRange("Customer No.", Customer."No.");
+        IssuedFinChargeMemoHeader.SetRange("Pre-Assigned No.", FinanceChargeMemoHeader."No.");
+        IssuedFinChargeMemoHeader.FindFirst();
+
+        FilterOnNoTaxableEntry(NoTaxableEntry, Customer."No.", IssuedFinChargeMemoHeader."No.");
+        Assert.IsTrue(NoTaxableEntry.IsEmpty(), NoTaxableEntryShouldNotBeCreatedErr);
+    end;
+
     local procedure CreateGLAccountNoTaxableSale(): Code[20]
     var
         GLAccount: Record "G/L Account";
@@ -1341,6 +1429,141 @@ codeunit 147515 "No Taxable Documents"
         exit(ItemNo);
     end;
 
+    local procedure CreateFinanceChargeTermsPostingInterest(var FinanceChargeTerms: Record "Finance Charge Terms")
+    begin
+        LibraryERM.CreateFinanceChargeTerms(FinanceChargeTerms);
+        FinanceChargeTerms.Validate("Interest Calculation", FinanceChargeTerms."Interest Calculation"::"Open Entries");
+        FinanceChargeTerms.Validate("Interest Calculation Method", FinanceChargeTerms."Interest Calculation Method"::"Average Daily Balance");
+        FinanceChargeTerms.Validate("Interest Rate", 1.5);
+        FinanceChargeTerms.Validate("Interest Period (Days)", 30);
+        FinanceChargeTerms.Validate("Minimum Amount (LCY)", 10);
+        FinanceChargeTerms.Validate("Additional Fee (LCY)", 0);
+        Evaluate(FinanceChargeTerms."Grace Period", '<5D>');
+        Evaluate(FinanceChargeTerms."Due Date Calculation", '<1M>');
+        FinanceChargeTerms.Validate("Post Interest", true);
+
+        FinanceChargeTerms.Modify(true);
+    end;
+
+    local procedure SetupNoTaxableInterestAccount(Customer: Record Customer)
+    var
+        CustomerPostingGroup: Record "Customer Posting Group";
+        GeneralPostingSetup: Record "General Posting Setup";
+        GenProductPostingGroup: Record "Gen. Product Posting Group";
+        GLAccount: Record "G/L Account";
+        NoTaxableVATProdPostGroup: Code[20];
+    begin
+        // [GIVEN] No Taxable VAT posting setup for the customer's VAT Bus. Posting Group
+        NoTaxableVATProdPostGroup := LibrarySII.CreateSpecificNoTaxableVATSetup(Customer."VAT Bus. Posting Group", false, 0);
+
+        // [GIVEN] Gen. Prod. Posting Group defaulting to the No Taxable VAT Prod. Posting Group
+        LibraryERM.CreateGenProdPostingGroup(GenProductPostingGroup);
+        GenProductPostingGroup.Validate("Def. VAT Prod. Posting Group", NoTaxableVATProdPostGroup);
+        GenProductPostingGroup.Modify(true);
+        LibraryERM.CreateGeneralPostingSetup(GeneralPostingSetup, Customer."Gen. Bus. Posting Group", GenProductPostingGroup.Code);
+        GeneralPostingSetup.Validate("Sales Account", LibraryERM.CreateGLAccountNo());
+        GeneralPostingSetup.Modify(true);
+
+        // [GIVEN] Interest account using the No Taxable VAT setup
+        LibraryERM.CreateGLAccount(GLAccount);
+        GLAccount.Validate("Gen. Posting Type", GLAccount."Gen. Posting Type"::Sale);
+        GLAccount.Validate("Gen. Bus. Posting Group", Customer."Gen. Bus. Posting Group");
+        GLAccount.Validate("Gen. Prod. Posting Group", GenProductPostingGroup.Code);
+        GLAccount.Validate("VAT Bus. Posting Group", Customer."VAT Bus. Posting Group");
+        GLAccount.Validate("VAT Prod. Posting Group", NoTaxableVATProdPostGroup);
+        GLAccount.Modify(true);
+
+        CustomerPostingGroup.Get(Customer."Customer Posting Group");
+        CustomerPostingGroup.Validate("Interest Account", GLAccount."No.");
+        CustomerPostingGroup.Modify(true);
+    end;
+
+    local procedure SetupTaxableInterestAccount(Customer: Record Customer)
+    var
+        CustomerPostingGroup: Record "Customer Posting Group";
+        GeneralPostingSetup: Record "General Posting Setup";
+        GenProductPostingGroup: Record "Gen. Product Posting Group";
+        GLAccount: Record "G/L Account";
+        VATPostingSetup: Record "VAT Posting Setup";
+        VATProductPostingGroup: Record "VAT Product Posting Group";
+    begin
+        // [GIVEN] Normal (taxable) VAT posting setup for the customer's VAT Bus. Posting Group
+        LibraryERM.CreateVATProductPostingGroup(VATProductPostingGroup);
+        LibraryERM.CreateVATPostingSetup(VATPostingSetup, Customer."VAT Bus. Posting Group", VATProductPostingGroup.Code);
+        VATPostingSetup.Validate("VAT Calculation Type", VATPostingSetup."VAT Calculation Type"::"Normal VAT");
+        VATPostingSetup.Validate("VAT %", LibraryRandom.RandIntInRange(50, 70));
+        VATPostingSetup.Validate("VAT Identifier", VATPostingSetup."VAT Bus. Posting Group");
+        VATPostingSetup.Validate("Sales VAT Account", LibraryERM.CreateGLAccountNo());
+        VATPostingSetup.Validate("Purchase VAT Account", LibraryERM.CreateGLAccountNo());
+        VATPostingSetup.Modify(true);
+
+        // [GIVEN] Gen. Prod. Posting Group defaulting to the normal VAT Prod. Posting Group
+        LibraryERM.CreateGenProdPostingGroup(GenProductPostingGroup);
+        GenProductPostingGroup.Validate("Def. VAT Prod. Posting Group", VATProductPostingGroup.Code);
+        GenProductPostingGroup.Modify(true);
+        LibraryERM.CreateGeneralPostingSetup(GeneralPostingSetup, Customer."Gen. Bus. Posting Group", GenProductPostingGroup.Code);
+        GeneralPostingSetup.Validate("Sales Account", LibraryERM.CreateGLAccountNo());
+        GeneralPostingSetup.Modify(true);
+
+        // [GIVEN] Interest account using the normal VAT setup
+        LibraryERM.CreateGLAccount(GLAccount);
+        GLAccount.Validate("Gen. Posting Type", GLAccount."Gen. Posting Type"::Sale);
+        GLAccount.Validate("Gen. Bus. Posting Group", Customer."Gen. Bus. Posting Group");
+        GLAccount.Validate("Gen. Prod. Posting Group", GenProductPostingGroup.Code);
+        GLAccount.Validate("VAT Bus. Posting Group", Customer."VAT Bus. Posting Group");
+        GLAccount.Validate("VAT Prod. Posting Group", VATProductPostingGroup.Code);
+        GLAccount.Modify(true);
+
+        CustomerPostingGroup.Get(Customer."Customer Posting Group");
+        CustomerPostingGroup.Validate("Interest Account", GLAccount."No.");
+        CustomerPostingGroup.Modify(true);
+    end;
+
+    local procedure CreateAndPostSalesInvoice(Customer: Record Customer; PostingDate: Date)
+    var
+        GLAccount: Record "G/L Account";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        VATPostingSetup: Record "VAT Posting Setup";
+    begin
+        VATPostingSetup.Get(
+          Customer."VAT Bus. Posting Group", LibrarySII.CreateSpecificNoTaxableVATSetup(Customer."VAT Bus. Posting Group", false, 0));
+
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, Customer."No.");
+        SalesHeader.Validate("Posting Date", PostingDate);
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(
+          SalesLine, SalesHeader, SalesLine.Type::"G/L Account",
+          LibraryERM.CreateGLAccountWithVATPostingSetup(VATPostingSetup, GLAccount."Gen. Posting Type"::Sale), 1);
+        SalesLine.Validate("Unit Price", LibraryRandom.RandDecInRange(1000, 2000, 2));
+        SalesLine.Modify(true);
+        LibrarySales.PostSalesDocument(SalesHeader, true, true);
+    end;
+
+    local procedure CreateFinanceChargeMemoWithLines(var FinanceChargeMemoHeader: Record "Finance Charge Memo Header"; Customer: Record Customer; PostingDate: Date)
+    var
+        FinanceChargeMemoPage: TestPage "Finance Charge Memo";
+    begin
+        LibraryERM.CreateFinanceChargeMemoHeader(FinanceChargeMemoHeader, Customer."No.");
+        FinanceChargeMemoHeader.Validate("Posting Date", PostingDate);
+        FinanceChargeMemoHeader.Validate("Document Date", PostingDate);
+        FinanceChargeMemoHeader.Modify(true);
+        Commit();
+
+        FinanceChargeMemoPage.OpenEdit();
+        FinanceChargeMemoPage.Filter.SetFilter("No.", FinanceChargeMemoHeader."No.");
+        FinanceChargeMemoPage.SuggestFinChargeMemoLines.Invoke();
+        FinanceChargeMemoPage.Close();
+    end;
+
+    local procedure FilterOnNoTaxableEntry(var NoTaxableEntry: Record "No Taxable Entry"; CustomerNo: Code[20]; DocumentNo: Code[20])
+    begin
+        NoTaxableEntry.SetRange(Type, NoTaxableEntry.Type::Sale);
+        NoTaxableEntry.SetRange("Source No.", CustomerNo);
+        NoTaxableEntry.SetRange("Document Type", NoTaxableEntry."Document Type"::"Finance Charge Memo");
+        NoTaxableEntry.SetRange("Document No.", DocumentNo);
+    end;
+
     [ConfirmHandler]
     [Scope('OnPrem')]
     procedure ConfirmHandler(Question: Text[1024]; var Reply: Boolean)
@@ -1352,5 +1575,11 @@ codeunit 147515 "No Taxable Documents"
     [Scope('OnPrem')]
     procedure MessageHandler(Message: Text[1024])
     begin
+    end;
+
+    [RequestPageHandler]
+    procedure SuggestFinChargeMemoLinesRequestPageHandler(var SuggestFinChargeMemoLines: TestRequestPage "Suggest Fin. Charge Memo Lines")
+    begin
+        SuggestFinChargeMemoLines.OK().Invoke();
     end;
 }


### PR DESCRIPTION
Workitem :-[Bug 642269](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/642269): [master] [all-e]Interest Document issued with non-taxable VAT does not generate non-taxable VAT entries in the Spanish localization

Fixes [AB#642269](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642269)


