### PR TITLE
[Master] - 'Greater Than' Withholding Tax Calculation Rule is not applied correctly in Withholding Tax Posting Setup.

### DIFF
--- a/src/Apps/W1/WithholdingTax/Test/src/ERMWithholdingTaxTestsI.Codeunit.al
+++ b/src/Apps/W1/WithholdingTax/Test/src/ERMWithholdingTaxTestsI.Codeunit.al
@@ -16,6 +16,7 @@ using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.NoSeries;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Payables;
+using Microsoft.Purchases.Setup;
 using Microsoft.Purchases.Vendor;
 using Microsoft.WithholdingTax;
 
@@ -1844,6 +1845,66 @@ codeunit 148321 "ERM Withholding Tax Tests I"
         UnapplyVendorLedgerEntryAmount('');  // Currency as blank.
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmHandler')]
+    procedure GreaterThanRuleBelowThresholdCreatesWHTEntryOnPurchaseInvoice()
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+        WHTPostingSetup: Record "Withholding Tax Posting Setup";
+        DocumentNo: Code[20];
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 641041] "Greater than" Calculation Rule generates a WHT Entry when the invoice amount is below the minimum invoice amount.
+        Initialize();
+
+        // [GIVEN] WHT enabled and a WHT Posting Setup with Calculation Rule "Greater than" and Minimum Invoice Amount 200.
+        UpdateGeneralLedgerSetup(true, false);
+        UpdateWHTCertificateNosOnPurchSetup();
+        LibraryERM.FindVATPostingSetup(VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Normal VAT");
+        CreateWHTPostingSetupWithCalcRule(WHTPostingSetup, WHTPostingSetup."Wthldg. Tax Calculation Rule"::"Greater than", 200);
+
+        // [WHEN] A purchase invoice for 120 (below the minimum) is posted.
+        DocumentNo :=
+          CreateAndPostPurchaseDocumentWithWHTAndAmount(
+            WHTPostingSetup, "Purchase Document Type"::Invoice,
+            CreateVendorWithPostingGroup(VATPostingSetup."VAT Bus. Posting Group", WHTPostingSetup."Wthldg. Tax Bus. Post. Group"),
+            CreateGLAccount(VATPostingSetup."VAT Prod. Posting Group", WHTPostingSetup."Wthldg. Tax Prod. Post. Group"), 120);
+
+        // [THEN] A WHT Entry is created for the posted invoice.
+        VerifyWHTEntryExists(DocumentNo);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmHandler')]
+    procedure GreaterThanRuleAboveThresholdDoesNotCreateWHTEntryOnPurchaseInvoice()
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+        WHTPostingSetup: Record "Withholding Tax Posting Setup";
+        DocumentNo: Code[20];
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 641041] "Greater than" Calculation Rule does not generate a WHT Entry when the invoice amount is above the minimum invoice amount.
+        Initialize();
+
+        // [GIVEN] WHT enabled and a WHT Posting Setup with Calculation Rule "Greater than" and Minimum Invoice Amount 200.
+        UpdateGeneralLedgerSetup(true, false);
+        UpdateWHTCertificateNosOnPurchSetup();
+        LibraryERM.FindVATPostingSetup(VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Normal VAT");
+        CreateWHTPostingSetupWithCalcRule(WHTPostingSetup, WHTPostingSetup."Wthldg. Tax Calculation Rule"::"Greater than", 200);
+
+        // [WHEN] A purchase invoice for 300 (above the minimum) is posted.
+        DocumentNo :=
+          CreateAndPostPurchaseDocumentWithWHTAndAmount(
+            WHTPostingSetup, "Purchase Document Type"::Invoice,
+            CreateVendorWithPostingGroup(VATPostingSetup."VAT Bus. Posting Group", WHTPostingSetup."Wthldg. Tax Bus. Post. Group"),
+            CreateGLAccount(VATPostingSetup."VAT Prod. Posting Group", WHTPostingSetup."Wthldg. Tax Prod. Post. Group"), 300);
+
+        // [THEN] No WHT Entry is created for the posted invoice.
+        VerifyWHTEntryDoesNotExist(DocumentNo);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -2720,6 +2781,49 @@ codeunit 148321 "ERM Withholding Tax Tests I"
         Vendor.Validate("Wthldg. Tax Bus. Post. Group", WHTBusPostingGroup);
         Vendor.Modify(true);
         exit(Vendor."No.");
+    end;
+
+    local procedure CreateWHTPostingSetupWithCalcRule(var WHTPostingSetup: Record "Withholding Tax Posting Setup"; CalculationRule: Option; MinInvoiceAmount: Decimal)
+    var
+        WHTBusinessPostingGroup: Record "Wthldg. Tax Bus. Post. Group";
+        WHTProductPostingGroup: Record "Wthldg. Tax Prod. Post. Group";
+        WHTRevenueTypes: Record "Withholding Tax Revenue Types";
+    begin
+        LibraryWithholdingTax.CreateWHTBusinessPostingGroup(WHTBusinessPostingGroup);
+        LibraryWithholdingTax.CreateWHTProductPostingGroup(WHTProductPostingGroup);
+        CreateWHTPostingSetupWithRealizedWHTType(
+          WHTPostingSetup, WHTBusinessPostingGroup.Code, WHTProductPostingGroup.Code,
+          WHTPostingSetup."Realized Withholding Tax Type"::Invoice, LibraryRandom.RandIntInRange(10, 20));
+        LibraryWithholdingTax.CreateWHTRevenueTypes(WHTRevenueTypes);
+        WHTPostingSetup.Validate("Revenue Type", WHTRevenueTypes.Code);
+        WHTPostingSetup.Validate("Wthldg. Tax Calculation Rule", CalculationRule);
+        WHTPostingSetup.Validate("Wthldg. Tax Min. Inv. Amount", MinInvoiceAmount);
+        WHTPostingSetup.Modify(true);
+    end;
+
+    local procedure VerifyWHTEntryExists(DocumentNo: Code[20])
+    var
+        WHTEntry: Record "Withholding Tax Entry";
+    begin
+        WHTEntry.SetRange("Document No.", DocumentNo);
+        Assert.RecordIsNotEmpty(WHTEntry);
+    end;
+
+    local procedure VerifyWHTEntryDoesNotExist(DocumentNo: Code[20])
+    var
+        WHTEntry: Record "Withholding Tax Entry";
+    begin
+        WHTEntry.SetRange("Document No.", DocumentNo);
+        Assert.RecordIsEmpty(WHTEntry);
+    end;
+
+    local procedure UpdateWHTCertificateNosOnPurchSetup()
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
+    begin
+        PurchasesPayablesSetup.Get();
+        PurchasesPayablesSetup.Validate("Wthldg. Tax Certificate Nos.", LibraryERM.CreateNoSeriesCode());
+        PurchasesPayablesSetup.Modify(true);
     end;
 
     [ModalPageHandler]

--- a/src/Apps/W1/WithholdingTax/app/src/Purchase/Transaction/WithholdingTaxJnlSubscriber.Codeunit.al
+++ b/src/Apps/W1/WithholdingTax/app/src/Purchase/Transaction/WithholdingTaxJnlSubscriber.Codeunit.al
@@ -292,7 +292,7 @@ codeunit 6786 "Withholding Tax Jnl Subscriber"
              GenJnlLine."Wthldg. Tax Prod. Post. Group")
         then
             if WithholdingPostingSetup."Realized Withholding Tax Type" = WithholdingPostingSetup."Realized Withholding Tax Type"::Earliest then
-                if Abs(GenJnlLine.Amount) < WithholdingPostingSetup."Wthldg. Tax Min. Inv. Amount" then
+                if not WithholdingTaxMgmt.ShouldCreateWithholdingTax(GenJnlLine.Amount, WithholdingPostingSetup) then
                     WithholdingAmountLCY := 0;
     end;
 
@@ -433,7 +433,7 @@ codeunit 6786 "Withholding Tax Jnl Subscriber"
 
         if WithholdingPostingSetup.Get(GenJnlLine."Wthldg. Tax Bus. Post. Group", GenJnlLine."Wthldg. Tax Prod. Post. Group") then
             if WithholdingPostingSetup."Realized Withholding Tax Type" = WithholdingPostingSetup."Realized Withholding Tax Type"::Earliest then
-                if GenJnlLine.Amount < WithholdingPostingSetup."Wthldg. Tax Min. Inv. Amount" then
+                if not WithholdingTaxMgmt.ShouldCreateWithholdingTax(GenJnlLine.Amount, WithholdingPostingSetup) then
                     WHTAmountLCY := 0;
     end;
 
@@ -670,12 +670,13 @@ codeunit 6786 "Withholding Tax Jnl Subscriber"
     local procedure IsAboveWithholdingMinInvAmount(GenJnlLine: Record "Gen. Journal Line"): Boolean
     var
         WithholdingPostingSetup: Record "Withholding Tax Posting Setup";
+        WithholdingTaxMgmt: Codeunit "Withholding Tax Mgmt.";
     begin
         if not (GenJnlLine."Document Type" in [GenJnlLine."Document Type"::Invoice, GenJnlLine."Document Type"::"Credit Memo"]) then
             exit(true);
 
         if WithholdingPostingSetup.Get(GenJnlLine."Wthldg. Tax Bus. Post. Group", GenJnlLine."Wthldg. Tax Prod. Post. Group") then
-            exit(Abs(GenJnlLine.Amount) >= WithholdingPostingSetup."Wthldg. Tax Min. Inv. Amount");
+            exit(WithholdingTaxMgmt.ShouldCreateWithholdingTax(GenJnlLine.Amount, WithholdingPostingSetup));
 
         exit(false);
     end;
@@ -852,7 +853,7 @@ codeunit 6786 "Withholding Tax Jnl Subscriber"
 
         if WithholdingPostingSetup.Get(GenJnlLine."Wthldg. Tax Bus. Post. Group", GenJnlLine."Wthldg. Tax Prod. Post. Group") then
             if WithholdingPostingSetup."Realized Withholding Tax Type" = WithholdingPostingSetup."Realized Withholding Tax Type"::Earliest then
-                if Abs(GenJnlLine.Amount) < WithholdingPostingSetup."Wthldg. Tax Min. Inv. Amount" then
+                if not WithholdingTaxMgmt.ShouldCreateWithholdingTax(GenJnlLine.Amount, WithholdingPostingSetup) then
                     WithholdingAmountLCY := 0;
     end;
 

--- a/src/Apps/W1/WithholdingTax/app/src/Purchase/Transaction/WithholdingTaxMgmt.Codeunit.al
+++ b/src/Apps/W1/WithholdingTax/app/src/Purchase/Transaction/WithholdingTaxMgmt.Codeunit.al
@@ -609,6 +609,11 @@ codeunit 6785 "Withholding Tax Mgmt."
         exit(false);
     end;
 
+    procedure ShouldCreateWithholdingTax(InvoiceAmount: Decimal; WithholdingPostingSetup: Record "Withholding Tax Posting Setup"): Boolean
+    begin
+        exit(not CheckWithholdingCalculationRule(InvoiceAmount, WithholdingPostingSetup));
+    end;
+
     procedure InsertWithholdingTax(TransType: Option Purchase,Sale) EntryNo: Integer
     var
         WithholdingTaxEntry: Record "Withholding Tax Entry";
@@ -1909,7 +1914,7 @@ codeunit 6785 "Withholding Tax Mgmt."
                 end;
 
                 if WithholdingPostingSetup."Realized Withholding Tax Type" = WithholdingPostingSetup."Realized Withholding Tax Type"::Earliest then
-                    if Abs(WithholdingTaxEntry.Base) < WithholdingPostingSetup."Wthldg. Tax Min. Inv. Amount" then
+                    if not ShouldCreateWithholdingTax(WithholdingTaxEntry.Base, WithholdingPostingSetup) then
                         exit;
 
                 WithholdingTaxEntry.Insert();
@@ -3513,7 +3518,7 @@ codeunit 6785 "Withholding Tax Mgmt."
 
         if WithholdingPostingSetup.Get(GenJnlLine."Wthldg. Tax Bus. Post. Group", GenJnlLine."Wthldg. Tax Prod. Post. Group") then
             if WithholdingPostingSetup."Realized Withholding Tax Type" = WithholdingPostingSetup."Realized Withholding Tax Type"::Earliest then
-                if WithholdingTaxBase < WithholdingPostingSetup."Wthldg. Tax Min. Inv. Amount" then
+                if not ShouldCreateWithholdingTax(WithholdingTaxBase, WithholdingPostingSetup) then
                     WithholdingTaxAmount := 0;
     end;
 

--- a/src/Apps/W1/WithholdingTax/app/src/Purchase/Transaction/WthldgTaxPurchSubscribers.Codeunit.al
+++ b/src/Apps/W1/WithholdingTax/app/src/Purchase/Transaction/WthldgTaxPurchSubscribers.Codeunit.al
@@ -425,7 +425,7 @@ codeunit 6784 "Wthldg Tax Purch. Subscribers"
         if PurchHeader."Document Type" in [PurchHeader."Document Type"::Order, PurchHeader."Document Type"::Invoice] then begin
             PurchInvHeader.Get(GenJnlLineDocNo);
 
-            if TotalInvAmount >= WithholdingPostingSetup."Wthldg. Tax Min. Inv. Amount" then
+            if WithholdingTaxMgmt.ShouldCreateWithholdingTax(TotalInvAmount, WithholdingPostingSetup) then
                 WithholdingTaxMgmt.InsertVendInvoiceWithholdingTax(PurchInvHeader);
 
             WithholdingTaxEntry.Reset();


### PR DESCRIPTION
[Bug 642326](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/642326): [master] [All-e]'Greater Than' Withholding Tax Calculation Rule is not applied correctly in Withholding Tax Posting Setup.

[AB#642326](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642326)

**Issue**: When a Withholding Tax Posting Setup uses a "Wthldg. Tax Calculation Rule" other than "Less than" (e.g. "Greater than", "Greater than or equal to", "Equal to"), the withholding tax was calculated/zeroed incorrectly against the "Wthldg. Tax Min. Inv. Amount". WHT was created (or suppressed) based on the wrong comparison, so amounts that should have been excluded got taxed and vice-versa.

**Cause**: Multiple threshold checks across Withholding Tax Jnl Subscriber, Withholding Tax Mgmt., and Wthldg Tax Purch. Subscribers hard-coded the comparison as Abs(Amount) < WithholdingPostingSetup."Wthldg. Tax Min. Inv. Amount". This assumed a "Less than" rule and completely ignored the configured "Wthldg. Tax Calculation Rule" enum, so the other rule options (Greater than, etc.) were never honored.

**Solution**: Added a reusable ShouldCreateWithholdingTax(Amount, WithholdingPostingSetup) procedure in Withholding Tax Mgmt. that returns not CheckWithholdingCalculationRule(...), so the decision respects the actual configured "Wthldg. Tax Calculation Rule" (Less than / ≤ / Equal / Greater than / ≥). Replaced all hard-coded Abs(Amount) < Min Inv. Amount checks in the three transaction codeunits with this rule-aware call, ensuring consistent, correct WHT creation and zeroing for every calculation rule.

