### PR TITLE
Pull Request: Issue #9473 OnAfterIncreaseQty

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Tracking/InventoryProfileOffsetting.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/InventoryProfileOffsetting.Codeunit.al
@@ -1880,6 +1880,7 @@ codeunit 99000854 "Inventory Profile Offsetting"
         SupplyInvtProfile.Modify();
 
         OnAfterIncreaseQty(SupplyInvtProfile);
+
     end;
 
     local procedure InsertEmergencyOrderSupply(var SupplyInvtProfile: Record "Inventory Profile"; var DemandInvtProfile: Record "Inventory Profile"; var LastAvailableInventory: Decimal; var LastProjectedInventory: Decimal; PlanningStartDate: Date)
@@ -4973,11 +4974,6 @@ codeunit 99000854 "Inventory Profile Offsetting"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterIncreaseQty(var SupplyInvtProfile: Record "Inventory Profile")
-    begin
-    end;
-
-    [IntegrationEvent(false, false)]
     local procedure OnAfterAdjustPlanLine(var RequisitionLine: Record "Requisition Line"; var SupplyInventoryProfile: Record "Inventory Profile")
     begin
     end;
@@ -6114,6 +6110,11 @@ codeunit 99000854 "Inventory Profile Offsetting"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterCalcInventoryProfileRemainingQty(var InventoryProfile: Record "Inventory Profile"; DocumentNo: Code[20]; LineNo: Integer; var RemQty: Decimal)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterIncreaseQty(var SupplyInvtProfile: Record "Inventory Profile")
     begin
     end;
 }

--- a/src/Layers/W1/BaseApp/Inventory/Tracking/InventoryProfileOffsetting.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/InventoryProfileOffsetting.Codeunit.al
@@ -1878,6 +1878,8 @@ codeunit 99000854 "Inventory Profile Offsetting"
           SupplyInvtProfile."Remaining Quantity (Base)" -
           TempQty;
         SupplyInvtProfile.Modify();
+
+        OnAfterIncreaseQty(SupplyInvtProfile);
     end;
 
     local procedure InsertEmergencyOrderSupply(var SupplyInvtProfile: Record "Inventory Profile"; var DemandInvtProfile: Record "Inventory Profile"; var LastAvailableInventory: Decimal; var LastProjectedInventory: Decimal; PlanningStartDate: Date)
@@ -4968,6 +4970,11 @@ codeunit 99000854 "Inventory Profile Offsetting"
         Location.Get(LocationCode);
 
         exit(Location."Missing SKU Planning Policy" = Location."Missing SKU Planning Policy"::"Item Card");
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterIncreaseQty(var SupplyInvtProfile: Record "Inventory Profile")
+    begin
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/W1/BaseApp/Inventory/Tracking/InventoryProfileOffsetting.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/InventoryProfileOffsetting.Codeunit.al
@@ -1879,7 +1879,7 @@ codeunit 99000854 "Inventory Profile Offsetting"
           TempQty;
 
         OnIncreaseQtyOnBeforeSupplyInvtProfileModify(SupplyInvtProfile, NeededQty, RespectPlanningParm, TempSKU);
-        SupplyInvtProfile.Modify();     
+        SupplyInvtProfile.Modify();
     end;
 
     local procedure InsertEmergencyOrderSupply(var SupplyInvtProfile: Record "Inventory Profile"; var DemandInvtProfile: Record "Inventory Profile"; var LastAvailableInventory: Decimal; var LastProjectedInventory: Decimal; PlanningStartDate: Date)

--- a/src/Layers/W1/BaseApp/Inventory/Tracking/InventoryProfileOffsetting.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/InventoryProfileOffsetting.Codeunit.al
@@ -1877,10 +1877,9 @@ codeunit 99000854 "Inventory Profile Offsetting"
           SupplyInvtProfile."Quantity (Base)" +
           SupplyInvtProfile."Remaining Quantity (Base)" -
           TempQty;
-        SupplyInvtProfile.Modify();
 
-        OnAfterIncreaseQty(SupplyInvtProfile);
-
+        OnIncreaseQtyOnBeforeSupplyInvtProfileModify(SupplyInvtProfile, NeededQty, RespectPlanningParm, TempSKU);
+        SupplyInvtProfile.Modify();     
     end;
 
     local procedure InsertEmergencyOrderSupply(var SupplyInvtProfile: Record "Inventory Profile"; var DemandInvtProfile: Record "Inventory Profile"; var LastAvailableInventory: Decimal; var LastProjectedInventory: Decimal; PlanningStartDate: Date)
@@ -6114,7 +6113,7 @@ codeunit 99000854 "Inventory Profile Offsetting"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterIncreaseQty(var SupplyInvtProfile: Record "Inventory Profile")
+    local procedure OnIncreaseQtyOnBeforeSupplyInvtProfileModify(var SupplyInvtProfile: Record "Inventory Profile"; NeededQty: Decimal; RespectPlanningParm: Boolean; var TempSKU: Record "Stockkeeping Unit" temporary)
     begin
     end;
 }

--- a/src/Layers/W1/BaseApp/Inventory/Tracking/InventoryProfileOffsetting.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/InventoryProfileOffsetting.Codeunit.al
@@ -6113,7 +6113,7 @@ codeunit 99000854 "Inventory Profile Offsetting"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnIncreaseQtyOnBeforeSupplyInvtProfileModify(var SupplyInvtProfile: Record "Inventory Profile"; NeededQty: Decimal; RespectPlanningParm: Boolean; var TempSKU: Record "Stockkeeping Unit" temporary)
+    local procedure OnIncreaseQtyOnBeforeSupplyInvtProfileModify(var SupplyInventoryProfile: Record "Inventory Profile"; NeededQuantity: Decimal; RespectPlanningParameters: Boolean; var TempStockkeepingUnit: Record "Stockkeeping Unit" temporary)
     begin
     end;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #9473 

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [X] I built the affected app(s) locally with no new analyzer warnings.
- [X] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required ΓÇö be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

Fixes [AB#647952](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647952)
