### PR TITLE
Set shortLivedArtifactsRetentionDays to 3

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -162,6 +162,7 @@
     ]
   },
   "runNumberOffset": 60000,
+  "shortLivedArtifactsRetentionDays": 3,
   "incrementalBuilds": {
     "onPush": false,
     "onPull_Request": true,


### PR DESCRIPTION
## What & why

Increases `shortLivedArtifactsRetentionDays` from the default of 1 to 3 in `.github/AL-Go-Settings.json`.

The default 1-day retention on the short-lived `Apps`/`TestApps` build artifacts is shorter than a realistic re-run window. When a PR run is re-run more than a day after its build jobs produced those artifacts, the app binaries have already expired while the long-lived (30-day) `BuildOutput` metadata survives. AL-Go's dependency resolver then finds no current-run app artifacts locally and silently falls back to baseline `main` branch apps, so tests execute against stale baseline binaries and cannot catch newly added or changed tests. This produced a false-green run (Shopify test `UnitTestCalcPriceUsesCurrentWorkDate` from #9404 never ran in BCApps CI but failed downstream in NAV). Widening the window to 3 days makes the re-run case work correctly.

## Linked work

Fixes [AB#642371](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642371)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Settings-only change to CI artifact retention; no app code affected and no tests apply. Verified the JSON is valid and the new key is placed alongside the existing incremental-build settings.

## Risk & compatibility

Low risk. Only affects retention duration of short-lived CI artifacts (slightly higher storage usage). No product code, upgrade, or data impact.

