### PR TITLE
removed access internal  to edocument mailing

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/EDocumentEmailing.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocumentEmailing.Codeunit.al
@@ -14,7 +14,6 @@ using System.Utilities;
 
 codeunit 6188 "E-Document Emailing"
 {
-    Access = Internal;
     InherentEntitlements = X;
     InherentPermissions = X;
 


### PR DESCRIPTION
Removed access internal in Codeunit "E-Document Emailing"

Fixes #8566 

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

