### PR TITLE
[master] NORWAY - Test Report (ID 2) cannot be run and throw validation errors about field reference that is not more included in the dataset of the Norway version

### DIFF
--- a/src/Layers/NO/BaseApp/Finance/GeneralLedger/Reports/GeneralJournalTest.rdlc
+++ b/src/Layers/NO/BaseApp/Finance/GeneralLedger/Reports/GeneralJournalTest.rdlc
@@ -2308,7 +2308,7 @@
                                               <Paragraph>
                                                 <TextRuns>
                                                   <TextRun>
-                                                    <Value EvaluationMode="Auto">=First(Fields!VATCaption_GenJnlLine.Value)</Value>
+                                                    <Value EvaluationMode="Auto">=First(Fields!VATNumberCaption_GenJnlLine.Value)</Value>
                                                     <Style>
                                                       <FontFamily>Segoe UI Semibold</FontFamily>
                                                       <FontSize>7pt</FontSize>
@@ -2550,7 +2550,7 @@
                                               <Paragraph>
                                                 <TextRuns>
                                                   <TextRun>
-                                                    <Value EvaluationMode="Auto">=First(Fields!BalVATCodeCaption_GenJnlLine.Value)</Value>
+                                                    <Value EvaluationMode="Auto">=First(Fields!BalVATNumberCaption_GenJnlLine.Value)</Value>
                                                     <Style>
                                                       <FontFamily>Segoe UI Semibold</FontFamily>
                                                       <FontSize>7pt</FontSize>
@@ -2939,7 +2939,7 @@
                                               <Paragraph>
                                                 <TextRuns>
                                                   <TextRun>
-                                                    <Value EvaluationMode="Auto">=Fields!VATCode_GenJnlLine.Value</Value>
+                                                    <Value EvaluationMode="Auto">=Fields!VATNumber_GenJnlLine.Value</Value>
                                                     <Style>
                                                       <FontFamily>Segoe UI</FontFamily>
                                                       <FontSize>7pt</FontSize>
@@ -3187,7 +3187,7 @@
                                               <Paragraph>
                                                 <TextRuns>
                                                   <TextRun>
-                                                    <Value EvaluationMode="Auto">=Fields!BalVATCode_GenJnlLine.Value</Value>
+                                                    <Value EvaluationMode="Auto">=Fields!BalVATNumber_GenJnlLine.Value</Value>
                                                     <Style>
                                                       <FontFamily>Segoe UI</FontFamily>
                                                       <FontSize>7pt</FontSize>


### PR DESCRIPTION
**Issue:** Report fails validation/rendering on missing dataset fields. 
**Cause:** NO layout referenced old field names (VATCaption/BalVATCodeCaption/VATCode/BalVATCode_GenJnlLine) after they were renamed to VATNumber.... 
**Solution:** Updated the 4 references to the new field names so the layout matches the dataset.

Workitem: [Bug 642372](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/642372): [master][all-e]NORWAY - Test Report (ID 2) cannot be run and throw validation errors about field reference that is not more included in the dataset of the Norway version

Fixes [AB#642372](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642372)


