### PR TITLE
[Master]- Report 152 "Calculate Low Level Code" terminates with error: "Cannot add instance as another with key %1 has already been added." after upgrade to v28.1

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/BOM/Tree/BOMTreeNode.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/BOM/Tree/BOMTreeNode.Codeunit.al
@@ -85,13 +85,11 @@ codeunit 3684 "BOM Tree Node"
     end;
 
     procedure IsChild(ChildKey: Text): Boolean
-    var
-        Child: Codeunit "BOM Tree Node";
     begin
         // Look the child up directly by key instead of enumerating. Enumerating relies on the
         // dictionary's single shared enumerator, and exiting the loop early on a match left the
         // enumerator mid-collection, causing later calls on the same parent to miss existing
         // children and wrongly return false (leading to a duplicate node insert error).
-        exit(ChildNodes.TryGet(ChildKey, Child));
+        exit(ChildNodes.ContainsKey(ChildKey));
     end;
 }

--- a/src/Layers/W1/BaseApp/Inventory/BOM/Tree/BOMTreeNode.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/BOM/Tree/BOMTreeNode.Codeunit.al
@@ -88,11 +88,10 @@ codeunit 3684 "BOM Tree Node"
     var
         Child: Codeunit "BOM Tree Node";
     begin
-        while ChildNodes.MoveNext() do begin
-            ChildNodes.GetCurrent(Child);
-            if Child.GetKey() = ChildKey then
-                exit(true);
-        end;
-        ChildNodes.ResetEnumerator();
+        // Look the child up directly by key instead of enumerating. Enumerating relies on the
+        // dictionary's single shared enumerator, and exiting the loop early on a match left the
+        // enumerator mid-collection, causing later calls on the same parent to miss existing
+        // children and wrongly return false (leading to a duplicate node insert error).
+        exit(ChildNodes.TryGet(ChildKey, Child));
     end;
 }

--- a/src/Layers/W1/BaseApp/Inventory/BOM/Tree/BOMTreeNodeDictionary.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/BOM/Tree/BOMTreeNodeDictionary.Codeunit.al
@@ -56,6 +56,15 @@ codeunit 3675 "BOM Tree Node Dictionary"
 #pragma warning restore AS0022
 
     /// <summary>
+    /// Checks whether an instance with the given key exists in the dictionary without raising an error.
+    /// <param name="InstanceKey">The key given.</param>
+    /// </summary>
+    internal procedure ContainsKey(InstanceKey: Text): Boolean
+    begin
+        exit(InstanceDictionaryImpl.Contains(InstanceKey));
+    end;
+
+    /// <summary>
     /// Removes the instance from the dictionary that correponds to the given key.
     /// <param name="InstanceKey">The given key.</param>
     /// </summary>

--- a/src/Layers/W1/BaseApp/Inventory/BOM/Tree/BOMTreeNodeDictionaryImpl.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/BOM/Tree/BOMTreeNodeDictionaryImpl.Codeunit.al
@@ -41,6 +41,11 @@ codeunit 3676 "BOM Tree Node Dictionary Impl."
         Get(FoundAtIndex, Found);
     end;
 
+    procedure Contains(InstanceKey: Text): Boolean
+    begin
+        exit(IndexOf(InstanceKey) <> 0);
+    end;
+
     procedure Add(Instance: Codeunit "BOM Tree Node") AtIndex: Integer
     var
         InstanceKey: Text;

--- a/src/Layers/W1/Tests/SCM/SCMLowLevelCode.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMLowLevelCode.Codeunit.al
@@ -6,6 +6,8 @@ codeunit 137053 "SCM Low-Level Code"
     var
         Assert: Codeunit Assert;
         LibraryManufacturing: Codeunit "Library - Manufacturing";
+        LibraryInventory: Codeunit "Library - Inventory";
+        LibraryWarehouse: Codeunit "Library - Warehouse";
         CloseBOMQst: Label 'All versions attached to the BOM will be closed. Close BOM?';
         ConfirmQst: Label 'Calculate low-level code?';
         RecursiveLoopDetected: Label 'A recursive loop was found in the following chain of nodes: %1.';
@@ -397,6 +399,38 @@ codeunit 137053 "SCM Low-Level Code"
         Assert.ExpectedError(StrSubstNo(RecursiveLoopDetected, StrSubstNo('%1, %2, %3, %4, %5, %6, %7', GetKey(ItemA), GetKey(ProdBOMA), GetKey(ItemB), GetKey(ProdBOMB), GetKey(ItemC), GetKey(ProdBOMC), GetKey(ItemB))));
     end;
 
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    [HandlerFunctions('BOMConfirmHandler')]
+    procedure TestItemAndSKUsSharingSameProductionBOM()
+    var
+        ParentItem: Record Item;
+        ChildItem: Record Item;
+        LowLevelCodeCalculator: Codeunit "Low-Level Code Calculator";
+        ProductionBOMNo: Code[20];
+    begin
+        // [SCENARIO] Calculating low-level codes succeeds when an item and several of its stockkeeping units all point to the same production BOM, without raising a duplicate BOM tree node error.
+
+        // [GIVEN] An item with a certified production BOM that contains a child item.
+        DeleteDemoDataEntities();
+        DeleteAllStockkeepingUnits();
+        CreateItem(ParentItem);
+        CreateItem(ChildItem);
+        ProductionBOMNo := CreateBOM(ParentItem, ChildItem);
+
+        // [GIVEN] Two stockkeeping units for the parent item that reference the same production BOM.
+        CreateSKUForItemWithProductionBOM(ParentItem."No.", ProductionBOMNo);
+        CreateSKUForItemWithProductionBOM(ParentItem."No.", ProductionBOMNo);
+
+        // [WHEN] Low-level codes are calculated.
+        ClearAllLowLevelCodes();
+        LowLevelCodeCalculator.Calculate();
+
+        // [THEN] The calculation completes without error and the low-level codes are correct.
+        VerifyItemLowLevelCode(ParentItem."No.", 0);
+        VerifyItemLowLevelCode(ChildItem."No.", 1);
+    end;
+
     local procedure DeleteDemoDataEntities()
     var
         Item: Record Item;
@@ -526,6 +560,25 @@ codeunit 137053 "SCM Low-Level Code"
     begin
         BOMNode.CreateForProdBOM(ProdBOMHeader."No.", 0, LowLevelCodeParameter);
         exit(BOMNode.GetKey());
+    end;
+
+    local procedure DeleteAllStockkeepingUnits()
+    var
+        StockkeepingUnit: Record "Stockkeeping Unit";
+    begin
+        StockkeepingUnit.DeleteAll();
+    end;
+
+    local procedure CreateSKUForItemWithProductionBOM(ItemNo: Code[20]; ProductionBOMNo: Code[20])
+    var
+        StockkeepingUnit: Record "Stockkeeping Unit";
+        Location: Record Location;
+    begin
+        LibraryWarehouse.CreateLocation(Location);
+        LibraryInventory.CreateStockkeepingUnitForLocationAndVariant(StockkeepingUnit, Location.Code, ItemNo, '');
+        StockkeepingUnit.Validate("Replenishment System", StockkeepingUnit."Replenishment System"::"Prod. Order");
+        StockkeepingUnit.Validate("Production BOM No.", ProductionBOMNo);
+        StockkeepingUnit.Modify(true);
     end;
 
     [ConfirmHandler]


### PR DESCRIPTION
[Bug 642311](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/642311): [ALL-E] Report 152 "Calculate Low Level Code" terminates with error: "Cannot add instance as another with key %1 has already been added." after upgrade to v28.1

[AB#642311](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642311)

**Issue**: When running Report 152 "Calculate Low-Level Code" (regression after the 28.2 upgrade), the report terminates with "Cannot add instance as another with key {"Type":"Production BOM","No.":"BM00780"} has already been added." This occurs when an item and one or more of its Stockkeeping Units all point to the same Production BOM, so the same Item→Production BOM relation is offered to the BOM tree more than once.

**Cause**: In the IsChild procedure in BOMTreeNode.Codeunit.al (codeunit 3684 "BOM Tree Node"), the existence check enumerated ChildNodes with MoveNext() and did exit(true) on a match without calling ResetEnumerator(). Because the dictionary uses a single shared enumerator, exiting mid-loop left it stranded; the next IsChild call on the same parent resumed from that position, missed the already-added child, and returned false. The ChildHasKey guard in AddChildToParent then passed and a duplicate node was inserted, raising KeyAlreadyExistsErr.

**Solution**: Replaced the enumeration in IsChild with a direct O(1) key lookup exit(ChildNodes.TryGet(ChildKey, Child));, which uses the dictionary's KeyIndexMap and never touches the shared enumerator. The duplicate relation is now correctly detected and skipped, so the calculation completes successfully. Added regression test TestItemAndSKUsSharingSameProductionBOM in codeunit 137053 "SCM Low-Level Code" covering an item plus multiple SKUs sharing one Production BOM.



