### PR TITLE
Support VAT return reporting frequencies in Denmark

### DIFF
--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/app.json
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/app.json
@@ -34,5 +34,12 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
+  "internalsVisibleTo": [
+    {
+      "id": "64977288-facd-4b48-aaba-bc0e288edfb3",
+      "name": "Electronic VAT Declaration for Denmark Tests",
+      "publisher": "Microsoft"
+    }
+  ],
   "target": "OnPrem"
 }

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/ElecVATDeclAzKeyVault.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/ElecVATDeclAzKeyVault.Codeunit.al
@@ -59,6 +59,7 @@ codeunit 13668 "Elec. VAT Decl. Az. Key Vault"
         SecretValue: Text;
         Enabled: Boolean;
         ConfigurationStatus: Text;
+        CustomDimensions: Dictionary of [Text, Text];
     begin
         if not AzureKeyVault.GetAzureKeyVaultSecret(AKVReportingFrequencyEnabledTok, SecretValue) then begin
             Enabled := true;
@@ -71,9 +72,12 @@ codeunit 13668 "Elec. VAT Decl. Az. Key Vault"
                 ConfigurationStatus := 'Invalid';
             end;
 
+        CustomDimensions.Add('FeatureName', FeatureNameTxt);
+        CustomDimensions.Add('Enabled', Format(Enabled, 0, 9));
+        CustomDimensions.Add('ConfigurationStatus', ConfigurationStatus);
         Session.LogMessage(
             '0000M7M', ReportingFrequencyConfigurationReadTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher,
-            'FeatureName', FeatureNameTxt, 'Enabled', Format(Enabled, 0, 9), 'ConfigurationStatus', ConfigurationStatus);
+            CustomDimensions);
 
         exit(Enabled);
     end;

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/ElecVATDeclAzKeyVault.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/ElecVATDeclAzKeyVault.Codeunit.al
@@ -59,7 +59,6 @@ codeunit 13668 "Elec. VAT Decl. Az. Key Vault"
         SecretValue: Text;
         Enabled: Boolean;
         ConfigurationStatus: Text;
-        CustomDimensions: Dictionary of [Text, Text];
     begin
         if not AzureKeyVault.GetAzureKeyVaultSecret(AKVReportingFrequencyEnabledTok, SecretValue) then begin
             Enabled := true;
@@ -72,9 +71,9 @@ codeunit 13668 "Elec. VAT Decl. Az. Key Vault"
                 ConfigurationStatus := 'Invalid';
             end;
 
-        CustomDimensions.Add('Enabled', Format(Enabled, 0, 9));
-        CustomDimensions.Add('ConfigurationStatus', ConfigurationStatus);
-        FeatureTelemetry.LogUsage('0000M7M', FeatureNameTxt, ReportingFrequencyConfigurationReadTxt, CustomDimensions);
+        Session.LogMessage(
+            '0000M7M', ReportingFrequencyConfigurationReadTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher,
+            'FeatureName', FeatureNameTxt, 'Enabled', Format(Enabled, 0, 9), 'ConfigurationStatus', ConfigurationStatus);
 
         exit(Enabled);
     end;

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/ElecVATDeclAzKeyVault.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/ElecVATDeclAzKeyVault.Codeunit.al
@@ -19,6 +19,7 @@ codeunit 13668 "Elec. VAT Decl. Az. Key Vault"
         AKVGetStatusEndpointKeyTok: Label 'DKElecVAT-GetStatusEndpoint', Locked = true;
         AKVReportingFrequencyEnabledTok: Label 'DKElecVAT-ReportingFrequencyEnabled', Locked = true;
         AVKCompanyCertTok: Label 'DKElecVAT-CompanyCert', Locked = true;
+        ReportingFrequencyConfigurationReadTxt: Label 'Reporting frequency configuration read', Locked = true;
 
     [NonDebuggable]
     procedure GetClientCertificateBase64FromAKV() ClientCertificateBase64: Text
@@ -57,11 +58,23 @@ codeunit 13668 "Elec. VAT Decl. Az. Key Vault"
         AzureKeyVault: Codeunit "Azure Key Vault";
         SecretValue: Text;
         Enabled: Boolean;
+        ConfigurationStatus: Text;
+        CustomDimensions: Dictionary of [Text, Text];
     begin
-        if not AzureKeyVault.GetAzureKeyVaultSecret(AKVReportingFrequencyEnabledTok, SecretValue) then
-            exit(true);
-        if not Evaluate(Enabled, SecretValue.Trim()) then
-            exit(true);
+        if not AzureKeyVault.GetAzureKeyVaultSecret(AKVReportingFrequencyEnabledTok, SecretValue) then begin
+            Enabled := true;
+            ConfigurationStatus := 'Missing';
+        end else
+            if Evaluate(Enabled, SecretValue.Trim()) then
+                ConfigurationStatus := 'Valid'
+            else begin
+                Enabled := true;
+                ConfigurationStatus := 'Invalid';
+            end;
+
+        CustomDimensions.Add('Enabled', Format(Enabled, 0, 9));
+        CustomDimensions.Add('ConfigurationStatus', ConfigurationStatus);
+        FeatureTelemetry.LogUsage('0000M7M', FeatureNameTxt, ReportingFrequencyConfigurationReadTxt, CustomDimensions);
 
         exit(Enabled);
     end;

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/ElecVATDeclAzKeyVault.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/ElecVATDeclAzKeyVault.Codeunit.al
@@ -17,6 +17,7 @@ codeunit 13668 "Elec. VAT Decl. Az. Key Vault"
         AKVGetPeriodsEndpointKeyTok: Label 'DKElecVAT-EndpointGetPeriods', Locked = true;
         AKVSubmitDraftEndpointKeyTok: Label 'DKElecVAT-SubmitDraftEndpoint', Locked = true;
         AKVGetStatusEndpointKeyTok: Label 'DKElecVAT-GetStatusEndpoint', Locked = true;
+        AKVReportingFrequencyEnabledTok: Label 'DKElecVAT-ReportingFrequencyEnabled', Locked = true;
         AVKCompanyCertTok: Label 'DKElecVAT-CompanyCert', Locked = true;
 
     [NonDebuggable]
@@ -48,5 +49,20 @@ codeunit 13668 "Elec. VAT Decl. Az. Key Vault"
             FeatureTelemetry.LogError('0000M7K', FeatureNameTxt, '', StrSubstNo(CannotGetSecretFromKeyVaultErr, KeyName));
             Error(CannotGetSecretFromKeyVaultErr, KeyName);
         end;
+    end;
+
+    [NonDebuggable]
+    procedure IsReportingFrequencyEnabled(): Boolean
+    var
+        AzureKeyVault: Codeunit "Azure Key Vault";
+        SecretValue: Text;
+        Enabled: Boolean;
+    begin
+        if not AzureKeyVault.GetAzureKeyVaultSecret(AKVReportingFrequencyEnabledTok, SecretValue) then
+            exit(true);
+        if not Evaluate(Enabled, SecretValue.Trim()) then
+            exit(true);
+
+        exit(Enabled);
     end;
 }

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/ElecVATDeclAzKeyVault.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/ElecVATDeclAzKeyVault.Codeunit.al
@@ -56,10 +56,10 @@ codeunit 13668 "Elec. VAT Decl. Az. Key Vault"
     procedure IsReportingFrequencyEnabled(): Boolean
     var
         AzureKeyVault: Codeunit "Azure Key Vault";
-        SecretValue: Text;
-        Enabled: Boolean;
-        ConfigurationStatus: Text;
         CustomDimensions: Dictionary of [Text, Text];
+        SecretValue: Text;
+        ConfigurationStatus: Text;
+        Enabled: Boolean;
     begin
         if not AzureKeyVault.GetAzureKeyVaultSecret(AKVReportingFrequencyEnabledTok, SecretValue) then begin
             Enabled := true;
@@ -75,9 +75,14 @@ codeunit 13668 "Elec. VAT Decl. Az. Key Vault"
         CustomDimensions.Add('FeatureName', FeatureNameTxt);
         CustomDimensions.Add('Enabled', Format(Enabled, 0, 9));
         CustomDimensions.Add('ConfigurationStatus', ConfigurationStatus);
-        Session.LogMessage(
-            '0000M7M', ReportingFrequencyConfigurationReadTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher,
-            CustomDimensions);
+        if ConfigurationStatus = 'Invalid' then
+            Session.LogMessage(
+                '0000M7M', ReportingFrequencyConfigurationReadTxt, Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher,
+                CustomDimensions)
+        else
+            Session.LogMessage(
+                '0000M7M', ReportingFrequencyConfigurationReadTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher,
+                CustomDimensions);
 
         exit(Enabled);
     end;

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/ElecVATDeclAzKeyVault.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/ElecVATDeclAzKeyVault.Codeunit.al
@@ -20,6 +20,7 @@ codeunit 13668 "Elec. VAT Decl. Az. Key Vault"
         AKVReportingFrequencyEnabledTok: Label 'DKElecVAT-ReportingFrequencyEnabled', Locked = true;
         AVKCompanyCertTok: Label 'DKElecVAT-CompanyCert', Locked = true;
         ReportingFrequencyConfigurationReadTxt: Label 'Reporting frequency configuration read', Locked = true;
+        InvalidReportingFrequencyConfigurationTxt: Label 'Reporting frequency configuration is invalid', Locked = true;
 
     [NonDebuggable]
     procedure GetClientCertificateBase64FromAKV() ClientCertificateBase64: Text
@@ -72,17 +73,13 @@ codeunit 13668 "Elec. VAT Decl. Az. Key Vault"
                 ConfigurationStatus := 'Invalid';
             end;
 
-        CustomDimensions.Add('FeatureName', FeatureNameTxt);
         CustomDimensions.Add('Enabled', Format(Enabled, 0, 9));
         CustomDimensions.Add('ConfigurationStatus', ConfigurationStatus);
         if ConfigurationStatus = 'Invalid' then
-            Session.LogMessage(
-                '0000M7M', ReportingFrequencyConfigurationReadTxt, Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher,
-                CustomDimensions)
+            FeatureTelemetry.LogError(
+                '0000M7M', FeatureNameTxt, ReportingFrequencyConfigurationReadTxt, InvalidReportingFrequencyConfigurationTxt, '', CustomDimensions)
         else
-            Session.LogMessage(
-                '0000M7M', ReportingFrequencyConfigurationReadTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher,
-                CustomDimensions);
+            FeatureTelemetry.LogUsage('0000M7M', FeatureNameTxt, ReportingFrequencyConfigurationReadTxt, CustomDimensions);
 
         exit(Enabled);
     end;

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/VATReportFramework/ElecVATDeclGetPeriods.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/VATReportFramework/ElecVATDeclGetPeriods.Codeunit.al
@@ -9,6 +9,10 @@ codeunit 13610 "Elec. VAT Decl. Get Periods"
     var
         FeatureTelemetry: Codeunit "Feature Telemetry";
         PeriodsInsertedLbl: Label '%1 periods were received from server. %2 new periods were inserted.', Comment = '%1, %2: number of periods.';
+        DueDateNotFoundErr: Label 'The VAT return period received from SKAT does not contain a due date.';
+        FrequencyNotFoundErr: Label 'The VAT return period received from SKAT does not contain a reporting frequency.';
+        UnsupportedFrequencyErr: Label 'The reporting frequency %1 received from SKAT is not supported.', Comment = '%1: reporting frequency received from SKAT';
+        OverlappingPeriodErr: Label 'VAT return period %1 (%2 - %3) overlaps the period received from SKAT (%4 - %5). Delete the existing period if it is not linked to a VAT return, and then get VAT return periods again.', Comment = '%1: existing period number; %2, %3: existing start and end dates; %4, %5: received start and end dates';
         FeatureNameTxt: Label 'Electronic VAT Declaration DK', Locked = true;
         VATReturnPeriodsRcvdTxt: Label 'VAT Return Periods received.', Locked = true;
 
@@ -34,27 +38,73 @@ codeunit 13610 "Elec. VAT Decl. Get Periods"
     end;
 
     local procedure GetVATReturnPeriodsFromResponse(SKATResponse: Interface "Elec. VAT Decl. Response")
+    begin
+        GetVATReturnPeriodsFromResponseText(SKATResponse.GetResponseBodyAsText());
+    end;
+
+    procedure GetVATReturnPeriodsFromResponseText(ResponseText: Text)
+    var
+        ElecVATDeclAzKeyVault: Codeunit "Elec. VAT Decl. Az. Key Vault";
+    begin
+        GetVATReturnPeriodsFromResponseText(ResponseText, ElecVATDeclAzKeyVault.IsReportingFrequencyEnabled());
+    end;
+
+    procedure GetVATReturnPeriodsFromResponseText(ResponseText: Text; ReportingFrequencyEnabled: Boolean)
+    var
+        PeriodsInserted: Integer;
+        TotalPeriodsFetched: Integer;
+    begin
+        if ReportingFrequencyEnabled then
+            GetFrequencyAwareVATReturnPeriods(ResponseText, TotalPeriodsFetched, PeriodsInserted)
+        else
+            GetQuarterlyVATReturnPeriods(ResponseText, TotalPeriodsFetched, PeriodsInserted);
+
+        Message(PeriodsInsertedLbl, TotalPeriodsFetched, PeriodsInserted);
+    end;
+
+    local procedure GetFrequencyAwareVATReturnPeriods(ResponseText: Text; var TotalPeriodsFetched: Integer; var PeriodsInserted: Integer)
     var
         ElecVATDeclXml: Codeunit "Elec. VAT Decl. Xml";
-        ResponseText: Text;
+        DueDate: Date;
+        DueDateXmlNode: XmlNode;
+        FrequencyXmlNode: XmlNode;
+        PeriodXmlNode: XmlNode;
+        PeriodXmlNodeList: XmlNodeList;
+        ReportingFrequency: Enum "Elec. VAT Decl. Rep. Frequency";
+        i: Integer;
+    begin
+        PeriodXmlNodeList := ElecVATDeclXml.TryGetPeriodNodesFromResponseText(ResponseText);
+        TotalPeriodsFetched := PeriodXmlNodeList.Count();
+        for i := 1 to TotalPeriodsFetched do begin
+            PeriodXmlNodeList.Get(i, PeriodXmlNode);
+            if not ElecVATDeclXml.TryGetDueDateNodeFromPeriodNode(PeriodXmlNode, DueDateXmlNode) then
+                Error(DueDateNotFoundErr);
+            if not ElecVATDeclXml.TryGetFrequencyNodeFromPeriodNode(PeriodXmlNode, FrequencyXmlNode) then
+                Error(FrequencyNotFoundErr);
+            Evaluate(DueDate, DueDateXmlNode.AsXmlElement().InnerText());
+            ReportingFrequency := GetReportingFrequency(FrequencyXmlNode.AsXmlElement().InnerText());
+            if InsertVATReturnPeriod(DueDate, ReportingFrequency) then
+                PeriodsInserted += 1;
+        end;
+    end;
+
+    local procedure GetQuarterlyVATReturnPeriods(ResponseText: Text; var TotalPeriodsFetched: Integer; var PeriodsInserted: Integer)
+    var
+        ElecVATDeclXml: Codeunit "Elec. VAT Decl. Xml";
         DueDate: Date;
         DueDateXmlNode: XmlNode;
         DueDateXmlNodeList: XmlNodeList;
-        TotalPeriodsFetched: Integer;
-        PeriodsInserted: Integer;
     begin
-        ResponseText := SKATResponse.GetResponseBodyAsText();
         DueDateXmlNodeList := ElecVATDeclXml.TryGetDueDateNodesFromResponseText(ResponseText);
         TotalPeriodsFetched := DueDateXmlNodeList.Count();
         foreach DueDateXmlNode in DueDateXmlNodeList do begin
             Evaluate(DueDate, DueDateXmlNode.AsXmlElement().InnerText());
-            if InsertVATReturnPeriod(DueDate) then
+            if InsertLegacyVATReturnPeriod(DueDate) then
                 PeriodsInserted += 1;
         end;
-        Message(PeriodsInsertedLbl, TotalPeriodsFetched, PeriodsInserted);
     end;
 
-    local procedure InsertVATReturnPeriod(DueDate: Date) ActuallyInserted: Boolean
+    local procedure InsertLegacyVATReturnPeriod(DueDate: Date) ActuallyInserted: Boolean
     var
         VATReturnPeriod: Record "VAT Return Period";
         EndDate: Date;
@@ -71,5 +121,71 @@ codeunit 13610 "Elec. VAT Decl. Get Periods"
         VATReturnPeriod.Validate("Start Date", StartDate);
         VATReturnPeriod.Insert(true);
         ActuallyInserted := true;
+    end;
+
+    procedure GetReportingFrequency(FrequencyText: Text) ReportingFrequency: Enum "Elec. VAT Decl. Rep. Frequency"
+    var
+        NormalizedFrequency: Text;
+    begin
+        NormalizedFrequency := LowerCase(FrequencyText.Trim());
+        case true of
+            NormalizedFrequency.Contains('ned'):
+                exit(ReportingFrequency::Monthly);
+            NormalizedFrequency.Contains('alv'):
+                exit(ReportingFrequency::"Semi-Annual");
+            NormalizedFrequency.Contains('vartal'):
+                exit(ReportingFrequency::Quarterly);
+        end;
+        Error(UnsupportedFrequencyErr, FrequencyText);
+    end;
+
+    local procedure InsertVATReturnPeriod(DueDate: Date; ReportingFrequency: Enum "Elec. VAT Decl. Rep. Frequency") ActuallyInserted: Boolean
+    var
+        VATReturnPeriod: Record "VAT Return Period";
+        EndDate: Date;
+        StartDate: Date;
+    begin
+        EndDate := CalcPeriodEndDate(DueDate, ReportingFrequency);
+        StartDate := CalcPeriodStartDate(EndDate, ReportingFrequency);
+        VATReturnPeriod.SetRange("Start Date", StartDate);
+        VATReturnPeriod.SetRange("End Date", EndDate);
+        if not VATReturnPeriod.IsEmpty() then
+            exit;
+
+        VATReturnPeriod.Reset();
+        VATReturnPeriod.SetFilter("Start Date", '<=%1', EndDate);
+        VATReturnPeriod.SetFilter("End Date", '>=%1', StartDate);
+        if VATReturnPeriod.FindFirst() then
+            Error(OverlappingPeriodErr, VATReturnPeriod."No.", VATReturnPeriod."Start Date", VATReturnPeriod."End Date", StartDate, EndDate);
+
+        VATReturnPeriod.Validate("End Date", EndDate);
+        VATReturnPeriod.Validate("Due Date", DueDate);
+        VATReturnPeriod.Validate("Start Date", StartDate);
+        VATReturnPeriod.Insert(true);
+        ActuallyInserted := true;
+    end;
+
+    procedure CalcPeriodEndDate(DueDate: Date; ReportingFrequency: Enum "Elec. VAT Decl. Rep. Frequency"): Date
+    begin
+        case ReportingFrequency of
+            ReportingFrequency::Monthly:
+                exit(CalcDate('<-1M+CM>', DueDate));
+            ReportingFrequency::"Semi-Annual":
+                exit(CalcDate('<-6M+CM>', DueDate));
+            else
+                exit(CalcDate('<-3M+CM>', DueDate));
+        end;
+    end;
+
+    procedure CalcPeriodStartDate(EndDate: Date; ReportingFrequency: Enum "Elec. VAT Decl. Rep. Frequency"): Date
+    begin
+        case ReportingFrequency of
+            ReportingFrequency::Monthly:
+                exit(CalcDate('<-CM>', EndDate));
+            ReportingFrequency::"Semi-Annual":
+                exit(CalcDate('<-5M-CM>', EndDate));
+            else
+                exit(CalcDate('<-CQ>', EndDate));
+        end;
     end;
 }

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/VATReportFramework/ElecVATDeclGetPeriods.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/VATReportFramework/ElecVATDeclGetPeriods.Codeunit.al
@@ -170,10 +170,10 @@ codeunit 13610 "Elec. VAT Decl. Get Periods"
         case ReportingFrequency of
             ReportingFrequency::Monthly:
                 exit(CalcDate('<-1M+CM>', DueDate));
+            ReportingFrequency::Quarterly:
+                exit(CalcDate('<-3M+CM>', DueDate));
             ReportingFrequency::"Semi-Annual":
                 exit(CalcDate('<-6M+CM>', DueDate));
-            else
-                exit(CalcDate('<-3M+CM>', DueDate));
         end;
     end;
 
@@ -182,10 +182,10 @@ codeunit 13610 "Elec. VAT Decl. Get Periods"
         case ReportingFrequency of
             ReportingFrequency::Monthly:
                 exit(CalcDate('<-CM>', EndDate));
+            ReportingFrequency::Quarterly:
+                exit(CalcDate('<-CQ>', EndDate));
             ReportingFrequency::"Semi-Annual":
                 exit(CalcDate('<-5M-CM>', EndDate));
-            else
-                exit(CalcDate('<-CQ>', EndDate));
         end;
     end;
 }

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/VATReportFramework/ElecVATDeclGetPeriods.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/VATReportFramework/ElecVATDeclGetPeriods.Codeunit.al
@@ -10,6 +10,7 @@ codeunit 13610 "Elec. VAT Decl. Get Periods"
         FeatureTelemetry: Codeunit "Feature Telemetry";
         PeriodsInsertedLbl: Label '%1 periods were received from server. %2 new periods were inserted.', Comment = '%1, %2: number of periods.';
         DueDateNotFoundErr: Label 'The VAT return period received from SKAT does not contain a due date.';
+        InvalidDueDateErr: Label 'The VAT return period received from SKAT contains an invalid due date.';
         FrequencyNotFoundErr: Label 'The VAT return period received from SKAT does not contain a reporting frequency.';
         UnsupportedFrequencyErr: Label 'The reporting frequency %1 received from SKAT is not supported.', Comment = '%1: reporting frequency received from SKAT';
         OverlappingPeriodErr: Label 'VAT return period %1 (%2 - %3) overlaps the period received from SKAT (%4 - %5). Delete the existing period if it is not linked to a VAT return, and then get VAT return periods again.', Comment = '%1: existing period number; %2, %3: existing start and end dates; %4, %5: received start and end dates';
@@ -65,24 +66,38 @@ codeunit 13610 "Elec. VAT Decl. Get Periods"
     local procedure GetFrequencyAwareVATReturnPeriods(ResponseText: Text; var TotalPeriodsFetched: Integer; var PeriodsInserted: Integer)
     var
         ElecVATDeclXml: Codeunit "Elec. VAT Decl. Xml";
-        DueDate: Date;
-        DueDateXmlNode: XmlNode;
-        FrequencyXmlNode: XmlNode;
-        PeriodXmlNode: XmlNode;
         PeriodXmlNodeList: XmlNodeList;
         ReportingFrequency: Enum "Elec. VAT Decl. Rep. Frequency";
-        i: Integer;
     begin
         PeriodXmlNodeList := ElecVATDeclXml.TryGetPeriodNodesFromResponseText(ResponseText);
         TotalPeriodsFetched := PeriodXmlNodeList.Count();
-        for i := 1 to TotalPeriodsFetched do begin
+
+        InsertVATReturnPeriods(PeriodXmlNodeList, ReportingFrequency::Monthly, PeriodsInserted);
+        InsertVATReturnPeriods(PeriodXmlNodeList, ReportingFrequency::Quarterly, PeriodsInserted);
+        InsertVATReturnPeriods(PeriodXmlNodeList, ReportingFrequency::"Semi-Annual", PeriodsInserted);
+    end;
+
+    local procedure InsertVATReturnPeriods(PeriodXmlNodeList: XmlNodeList; ReportingFrequencyToInsert: Enum "Elec. VAT Decl. Rep. Frequency"; var PeriodsInserted: Integer)
+    var
+        ElecVATDeclXml: Codeunit "Elec. VAT Decl. Xml";
+        DueDateXmlNode: XmlNode;
+        FrequencyXmlNode: XmlNode;
+        PeriodXmlNode: XmlNode;
+        ReportingFrequency: Enum "Elec. VAT Decl. Rep. Frequency";
+        DueDate: Date;
+        i: Integer;
+    begin
+        for i := 1 to PeriodXmlNodeList.Count() do begin
             PeriodXmlNodeList.Get(i, PeriodXmlNode);
             if not ElecVATDeclXml.TryGetDueDateNodeFromPeriodNode(PeriodXmlNode, DueDateXmlNode) then
                 Error(DueDateNotFoundErr);
             if not ElecVATDeclXml.TryGetFrequencyNodeFromPeriodNode(PeriodXmlNode, FrequencyXmlNode) then
                 Error(FrequencyNotFoundErr);
-            Evaluate(DueDate, DueDateXmlNode.AsXmlElement().InnerText());
             ReportingFrequency := GetReportingFrequency(FrequencyXmlNode.AsXmlElement().InnerText());
+            if ReportingFrequency <> ReportingFrequencyToInsert then
+                continue;
+            if not Evaluate(DueDate, DueDateXmlNode.AsXmlElement().InnerText()) then
+                Error(InvalidDueDateErr);
             if InsertVATReturnPeriod(DueDate, ReportingFrequency) then
                 PeriodsInserted += 1;
         end;
@@ -98,7 +113,8 @@ codeunit 13610 "Elec. VAT Decl. Get Periods"
         DueDateXmlNodeList := ElecVATDeclXml.TryGetDueDateNodesFromResponseText(ResponseText);
         TotalPeriodsFetched := DueDateXmlNodeList.Count();
         foreach DueDateXmlNode in DueDateXmlNodeList do begin
-            Evaluate(DueDate, DueDateXmlNode.AsXmlElement().InnerText());
+            if not Evaluate(DueDate, DueDateXmlNode.AsXmlElement().InnerText()) then
+                Error(InvalidDueDateErr);
             if InsertLegacyVATReturnPeriod(DueDate) then
                 PeriodsInserted += 1;
         end;
@@ -111,7 +127,7 @@ codeunit 13610 "Elec. VAT Decl. Get Periods"
         StartDate: Date;
     begin
         EndDate := CalcDate('<-3M+CM>', DueDate);
-        StartDate := CalcDate('<-1Q+1D>', EndDate);
+        StartDate := CalcDate('<-CQ>', EndDate);
         VATReturnPeriod.SetRange("End Date", EndDate);
         if not VATReturnPeriod.IsEmpty() then
             exit;
@@ -155,8 +171,11 @@ codeunit 13610 "Elec. VAT Decl. Get Periods"
         VATReturnPeriod.Reset();
         VATReturnPeriod.SetFilter("Start Date", '<=%1', EndDate);
         VATReturnPeriod.SetFilter("End Date", '>=%1', StartDate);
-        if VATReturnPeriod.FindFirst() then
-            Error(OverlappingPeriodErr, VATReturnPeriod."No.", VATReturnPeriod."Start Date", VATReturnPeriod."End Date", StartDate, EndDate);
+        if VATReturnPeriod.FindSet() then
+            repeat
+                if (VATReturnPeriod."Start Date" < StartDate) or (VATReturnPeriod."End Date" > EndDate) then
+                    Error(OverlappingPeriodErr, VATReturnPeriod."No.", VATReturnPeriod."Start Date", VATReturnPeriod."End Date", StartDate, EndDate);
+            until VATReturnPeriod.Next() = 0;
 
         VATReturnPeriod.Validate("End Date", EndDate);
         VATReturnPeriod.Validate("Due Date", DueDate);

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/VATReportFramework/ElecVATDeclGetPeriods.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/VATReportFramework/ElecVATDeclGetPeriods.Codeunit.al
@@ -177,6 +177,7 @@ codeunit 13610 "Elec. VAT Decl. Get Periods"
                     Error(OverlappingPeriodErr, VATReturnPeriod."No.", VATReturnPeriod."Start Date", VATReturnPeriod."End Date", StartDate, EndDate);
             until VATReturnPeriod.Next() = 0;
 
+        Clear(VATReturnPeriod);
         VATReturnPeriod.Validate("End Date", EndDate);
         VATReturnPeriod.Validate("Due Date", DueDate);
         VATReturnPeriod.Validate("Start Date", StartDate);

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/VATReportFramework/ElecVATDeclRepFrequency.Enum.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/VATReportFramework/ElecVATDeclRepFrequency.Enum.al
@@ -1,0 +1,19 @@
+namespace Microsoft.Finance.VAT.Reporting;
+
+enum 13605 "Elec. VAT Decl. Rep. Frequency"
+{
+    Extensible = true;
+
+    value(0; Monthly)
+    {
+        Caption = 'Monthly';
+    }
+    value(1; Quarterly)
+    {
+        Caption = 'Quarterly';
+    }
+    value(2; "Semi-Annual")
+    {
+        Caption = 'Semi-Annual';
+    }
+}

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/VATReportFramework/ElecVATDeclRepFrequency.Enum.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/VATReportFramework/ElecVATDeclRepFrequency.Enum.al
@@ -2,7 +2,7 @@ namespace Microsoft.Finance.VAT.Reporting;
 
 enum 13605 "Elec. VAT Decl. Rep. Frequency"
 {
-    Extensible = true;
+    Extensible = false;
 
     value(0; Monthly)
     {

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/VATReportFramework/ElecVATDeclRepFrequency.Enum.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/VATReportFramework/ElecVATDeclRepFrequency.Enum.al
@@ -2,6 +2,7 @@ namespace Microsoft.Finance.VAT.Reporting;
 
 enum 13605 "Elec. VAT Decl. Rep. Frequency"
 {
+    Access = Internal;
     Extensible = false;
 
     value(0; Monthly)

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/XML/ElecVATDeclXml.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/src/Engine/XML/ElecVATDeclXml.Codeunit.al
@@ -17,7 +17,10 @@ codeunit 13618 "Elec. VAT Decl. Xml"
         DeeplinkXPathTok: Label '//%1:UrlIndicator', Locked = true;
         VATReturnStatusTok: Label '//%1:AdvisIdentifikator', Locked = true;
         ResponseTransactionIDXPathTok: Label '//%1:TransaktionIdentifier', Locked = true;
+        PeriodXPathTok: Label '//%1:AngivelseBetalingFristStruktur', Locked = true;
         DueDateXPathTok: Label '//%1:AngivelseFristKalenderBetalingDato', Locked = true;
+        PeriodDueDateXPathTok: Label './%1:AngivelseFristKalenderBetalingDato', Locked = true;
+        PeriodFrequencyXPathTok: Label './%1:AngivelseFrekvensNavn', Locked = true;
         Error200XPathTok: Label '//%1:FejlIdentifikator', Locked = true;
         EncodingTypeTok: Label 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary', Locked = true;
         X509TokenTypeTok: Label 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3', Locked = true;
@@ -130,6 +133,21 @@ codeunit 13618 "Elec. VAT Decl. Xml"
     procedure TryGetDueDateNodesFromResponseText(ResponseText: Text) DueDateNodes: XmlNodeList
     begin
         XmlDOMManagement.FindNodesWithNamespace(TextToXmlNode(ResponseText), StrSubstNo(DueDateXPathTok, PrefixTok), PrefixTok, GetSkatNamespace4(), DueDateNodes);
+    end;
+
+    procedure TryGetPeriodNodesFromResponseText(ResponseText: Text) PeriodNodes: XmlNodeList
+    begin
+        XmlDOMManagement.FindNodesWithNamespace(TextToXmlNode(ResponseText), StrSubstNo(PeriodXPathTok, PrefixTok), PrefixTok, GetSkatNamespace1(), PeriodNodes);
+    end;
+
+    procedure TryGetDueDateNodeFromPeriodNode(PeriodNode: XmlNode; var DueDateNode: XmlNode): Boolean
+    begin
+        exit(XmlDOMManagement.FindNodeWithNamespace(PeriodNode, StrSubstNo(PeriodDueDateXPathTok, PrefixTok), PrefixTok, GetSkatNamespace4(), DueDateNode));
+    end;
+
+    procedure TryGetFrequencyNodeFromPeriodNode(PeriodNode: XmlNode; var FrequencyNode: XmlNode): Boolean
+    begin
+        exit(XmlDOMManagement.FindNodeWithNamespace(PeriodNode, StrSubstNo(PeriodFrequencyXPathTok, PrefixTok), PrefixTok, GetSkatNamespace4(), FrequencyNode));
     end;
 
     procedure TryGetErrorNodeFromResponseText(ResponseText: Text; var ErrorNode: XmlNode) NodeFound: Boolean

--- a/src/Apps/DK/ElectronicVATDeclarationDK/test/app.json
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/test/app.json
@@ -51,5 +51,5 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "target": "Cloud"
+  "target": "OnPrem"
 }

--- a/src/Apps/DK/ElectronicVATDeclarationDK/test/src/ElecVATDeclTests.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/test/src/ElecVATDeclTests.Codeunit.al
@@ -168,6 +168,7 @@ codeunit 148015 "Elec. VAT Decl. Tests"
     end;
 
     [Test]
+    [Scope('OnPrem')]
     procedure ReportingFrequencyIsEnabledWhenKeyVaultFlagIsTrue()
     var
         ElecVATDeclAzKeyVault: Codeunit "Elec. VAT Decl. Az. Key Vault";
@@ -178,6 +179,7 @@ codeunit 148015 "Elec. VAT Decl. Tests"
     end;
 
     [Test]
+    [Scope('OnPrem')]
     procedure ReportingFrequencyIsDisabledWhenKeyVaultFlagIsFalse()
     var
         ElecVATDeclAzKeyVault: Codeunit "Elec. VAT Decl. Az. Key Vault";
@@ -188,6 +190,7 @@ codeunit 148015 "Elec. VAT Decl. Tests"
     end;
 
     [Test]
+    [Scope('OnPrem')]
     procedure ReportingFrequencyIsEnabledWhenKeyVaultFlagIsInvalid()
     var
         ElecVATDeclAzKeyVault: Codeunit "Elec. VAT Decl. Az. Key Vault";
@@ -198,6 +201,7 @@ codeunit 148015 "Elec. VAT Decl. Tests"
     end;
 
     [Test]
+    [Scope('OnPrem')]
     procedure ReportingFrequencyIsEnabledWhenKeyVaultFlagIsMissing()
     var
         ElecVATDeclAzKeyVault: Codeunit "Elec. VAT Decl. Az. Key Vault";
@@ -237,6 +241,7 @@ codeunit 148015 "Elec. VAT Decl. Tests"
             '<ns4:AngivelseFristKalenderBetalingDato>' + DueDate + '</ns4:AngivelseFristKalenderBetalingDato></ns1:AngivelseBetalingFristStruktur>');
     end;
 
+    [Scope('OnPrem')]
     local procedure SetReportingFrequencyKeyVaultFlag(FlagValue: Text)
     var
         LibraryAzureKVMockMgmt: Codeunit "Library - Azure KV Mock Mgmt.";

--- a/src/Apps/DK/ElectronicVATDeclarationDK/test/src/ElecVATDeclTests.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/test/src/ElecVATDeclTests.Codeunit.al
@@ -2,12 +2,202 @@ codeunit 148015 "Elec. VAT Decl. Tests"
 {
     Subtype = Test;
     TestPermissions = Disabled;
-    EventSubscriberInstance = Manual;
+
+    var
+        Assert: Codeunit Assert;
+        LibraryUtility: Codeunit "Library - Utility";
 
     trigger OnRun()
     begin
         // [FEATURE] [Electronic VAT Declaration for Denmark]
     end;
 
-    // Placeholder for future tests
+    [Test]
+    procedure QuarterlyPeriodStartsOnFirstDayOfQuarter()
+    var
+        ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
+        ReportingFrequency: Enum "Elec. VAT Decl. Rep. Frequency";
+        EndDate: Date;
+    begin
+        EndDate := ElecVATDeclGetPeriods.CalcPeriodEndDate(20260901D, ReportingFrequency::Quarterly);
+
+        Assert.AreEqual(20260630D, EndDate, 'The Q2 end date is incorrect.');
+        Assert.AreEqual(20260401D, ElecVATDeclGetPeriods.CalcPeriodStartDate(EndDate, ReportingFrequency::Quarterly), 'The Q2 start date is incorrect.');
+    end;
+
+    [Test]
+    procedure MonthlyPeriodUsesCalendarMonth()
+    var
+        ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
+        ReportingFrequency: Enum "Elec. VAT Decl. Rep. Frequency";
+        EndDate: Date;
+    begin
+        EndDate := ElecVATDeclGetPeriods.CalcPeriodEndDate(20260501D, ReportingFrequency::Monthly);
+
+        Assert.AreEqual(20260430D, EndDate, 'The monthly end date is incorrect.');
+        Assert.AreEqual(20260401D, ElecVATDeclGetPeriods.CalcPeriodStartDate(EndDate, ReportingFrequency::Monthly), 'The monthly start date is incorrect.');
+    end;
+
+    [Test]
+    procedure SemiAnnualPeriodUsesSixCalendarMonths()
+    var
+        ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
+        ReportingFrequency: Enum "Elec. VAT Decl. Rep. Frequency";
+        EndDate: Date;
+    begin
+        EndDate := ElecVATDeclGetPeriods.CalcPeriodEndDate(20261201D, ReportingFrequency::"Semi-Annual");
+
+        Assert.AreEqual(20260630D, EndDate, 'The semi-annual end date is incorrect.');
+        Assert.AreEqual(20260101D, ElecVATDeclGetPeriods.CalcPeriodStartDate(EndDate, ReportingFrequency::"Semi-Annual"), 'The semi-annual start date is incorrect.');
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler')]
+    procedure ResponsePeriodsKeepFrequencyAndDueDateAssociated()
+    var
+        VATReturnPeriod: Record "VAT Return Period";
+        ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
+        ResponseText: Text;
+    begin
+        Initialize();
+        ResponseText := GetResponseXml(
+            GetPeriodXml('Måned', '2026-05-01') +
+            GetPeriodXml('Halvår', '2026-12-01'));
+
+        ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText);
+
+        VATReturnPeriod.SetRange("Start Date", 20260401D);
+        VATReturnPeriod.SetRange("End Date", 20260430D);
+        VATReturnPeriod.SetRange("Due Date", 20260501D);
+        Assert.RecordIsNotEmpty(VATReturnPeriod);
+        VATReturnPeriod.SetRange("Start Date", 20260101D);
+        VATReturnPeriod.SetRange("End Date", 20260630D);
+        VATReturnPeriod.SetRange("Due Date", 20261201D);
+        Assert.RecordIsNotEmpty(VATReturnPeriod);
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler')]
+    procedure GettingSamePeriodsTwiceDoesNotInsertDuplicates()
+    var
+        VATReturnPeriod: Record "VAT Return Period";
+        ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
+        ResponseText: Text;
+    begin
+        Initialize();
+        ResponseText := GetResponseXml(GetPeriodXml('Kvartal', '2026-09-01'));
+
+        ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText);
+        ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText);
+
+        VATReturnPeriod.SetRange("Start Date", 20260401D);
+        VATReturnPeriod.SetRange("End Date", 20260630D);
+        Assert.RecordCount(VATReturnPeriod, 1);
+    end;
+
+    [Test]
+    procedure UnknownReportingFrequencyRaisesError()
+    var
+        ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
+    begin
+        asserterror ElecVATDeclGetPeriods.GetReportingFrequency('Ugentlig');
+
+        Assert.ExpectedError('is not supported');
+    end;
+
+    [Test]
+    procedure MissingReportingFrequencyRaisesError()
+    var
+        ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
+        ResponseText: Text;
+    begin
+        ResponseText := GetResponseXml(
+            '<ns1:AngivelseBetalingFristStruktur><ns4:AngivelseFristKalenderBetalingDato>2026-05-01</ns4:AngivelseFristKalenderBetalingDato></ns1:AngivelseBetalingFristStruktur>');
+
+        asserterror ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText);
+
+        Assert.ExpectedError('does not contain a reporting frequency');
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler')]
+    procedure DisabledReportingFrequencyCreatesQuarterlyPeriod()
+    var
+        VATReturnPeriod: Record "VAT Return Period";
+        ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
+        ResponseText: Text;
+    begin
+        Initialize();
+        ResponseText := GetResponseXml(
+            '<ns1:AngivelseBetalingFristStruktur><ns4:AngivelseFristKalenderBetalingDato>2026-09-01</ns4:AngivelseFristKalenderBetalingDato></ns1:AngivelseBetalingFristStruktur>');
+
+        ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText, false);
+
+        VATReturnPeriod.SetRange("Start Date", 20260401D);
+        VATReturnPeriod.SetRange("End Date", 20260630D);
+        VATReturnPeriod.SetRange("Due Date", 20260901D);
+        Assert.RecordIsNotEmpty(VATReturnPeriod);
+    end;
+
+    [Test]
+    procedure UnknownReportingFrequencyInResponseRaisesError()
+    var
+        ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
+    begin
+        asserterror ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(
+            GetResponseXml(GetPeriodXml('Ugentlig', '2026-05-01')));
+
+        Assert.ExpectedError('is not supported');
+    end;
+
+    [Test]
+    procedure ExistingIncorrectPeriodPreventsOverlappingInsert()
+    var
+        VATReturnPeriod: Record "VAT Return Period";
+        ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
+    begin
+        Initialize();
+        VATReturnPeriod.Validate("Start Date", 20260101D);
+        VATReturnPeriod.Validate("End Date", 20260331D);
+        VATReturnPeriod.Insert(true);
+
+        asserterror ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(
+            GetResponseXml(GetPeriodXml('Måned', '2026-04-01')));
+
+        Assert.ExpectedError('overlaps the period received from SKAT');
+    end;
+
+    local procedure Initialize()
+    var
+        NoSeries: Record "No. Series";
+        VATReportSetup: Record "VAT Report Setup";
+        VATReturnPeriod: Record "VAT Return Period";
+    begin
+        VATReturnPeriod.DeleteAll(true);
+        if not VATReportSetup.Get() then
+            VATReportSetup.Insert();
+        LibraryUtility.CreateNoSeries(NoSeries, true, false, false);
+        VATReportSetup.Validate("VAT Return Period No. Series", NoSeries.Code);
+        VATReportSetup.Modify();
+    end;
+
+    local procedure GetResponseXml(PeriodXml: Text): Text
+    begin
+        exit(
+            '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="urn:oio:skat:nemvirksomhed:ws:1.0.0" xmlns:ns4="urn:oio:skat:nemvirksomhed:1.0.0">' +
+            '<soapenv:Body><ns1:VirksomhedKalenderHent_O>' + PeriodXml + '</ns1:VirksomhedKalenderHent_O></soapenv:Body></soapenv:Envelope>');
+    end;
+
+    local procedure GetPeriodXml(Frequency: Text; DueDate: Text): Text
+    begin
+        exit(
+            '<ns1:AngivelseBetalingFristStruktur><ns4:AngivelseFrekvensNavn>' + Frequency + '</ns4:AngivelseFrekvensNavn>' +
+            '<ns4:AngivelseFristKalenderBetalingDato>' + DueDate + '</ns4:AngivelseFristKalenderBetalingDato></ns1:AngivelseBetalingFristStruktur>');
+    end;
+
+    [MessageHandler]
+    procedure MessageHandler(Message: Text[1024])
+    begin
+        Assert.IsTrue(Message.Contains('periods were received from server'), Message);
+    end;
 }

--- a/src/Apps/DK/ElectronicVATDeclarationDK/test/src/ElecVATDeclTests.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/test/src/ElecVATDeclTests.Codeunit.al
@@ -215,15 +215,13 @@ codeunit 148015 "Elec. VAT Decl. Tests"
 
     local procedure Initialize()
     var
-        NoSeries: Record "No. Series";
         VATReportSetup: Record "VAT Report Setup";
         VATReturnPeriod: Record "VAT Return Period";
     begin
         VATReturnPeriod.DeleteAll(true);
         if not VATReportSetup.Get() then
             VATReportSetup.Insert();
-        LibraryUtility.CreateNoSeries(NoSeries, true, false, false);
-        VATReportSetup.Validate("VAT Return Period No. Series", NoSeries.Code);
+        VATReportSetup.Validate("VAT Return Period No. Series", LibraryUtility.GetGlobalNoSeriesCode());
         VATReportSetup.Modify();
     end;
 

--- a/src/Apps/DK/ElectronicVATDeclarationDK/test/src/ElecVATDeclTests.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/test/src/ElecVATDeclTests.Codeunit.al
@@ -167,6 +167,48 @@ codeunit 148015 "Elec. VAT Decl. Tests"
         Assert.ExpectedError('overlaps the period received from SKAT');
     end;
 
+    [Test]
+    procedure ReportingFrequencyIsEnabledWhenKeyVaultFlagIsTrue()
+    var
+        ElecVATDeclAzKeyVault: Codeunit "Elec. VAT Decl. Az. Key Vault";
+    begin
+        SetReportingFrequencyKeyVaultFlag('true');
+
+        Assert.IsTrue(ElecVATDeclAzKeyVault.IsReportingFrequencyEnabled(), 'Reporting frequency must be enabled when the Key Vault flag is true.');
+    end;
+
+    [Test]
+    procedure ReportingFrequencyIsDisabledWhenKeyVaultFlagIsFalse()
+    var
+        ElecVATDeclAzKeyVault: Codeunit "Elec. VAT Decl. Az. Key Vault";
+    begin
+        SetReportingFrequencyKeyVaultFlag('false');
+
+        Assert.IsFalse(ElecVATDeclAzKeyVault.IsReportingFrequencyEnabled(), 'Reporting frequency must be disabled when the Key Vault flag is false.');
+    end;
+
+    [Test]
+    procedure ReportingFrequencyIsEnabledWhenKeyVaultFlagIsInvalid()
+    var
+        ElecVATDeclAzKeyVault: Codeunit "Elec. VAT Decl. Az. Key Vault";
+    begin
+        SetReportingFrequencyKeyVaultFlag('invalid');
+
+        Assert.IsTrue(ElecVATDeclAzKeyVault.IsReportingFrequencyEnabled(), 'Reporting frequency must default to enabled when the Key Vault flag is invalid.');
+    end;
+
+    [Test]
+    procedure ReportingFrequencyIsEnabledWhenKeyVaultFlagIsMissing()
+    var
+        ElecVATDeclAzKeyVault: Codeunit "Elec. VAT Decl. Az. Key Vault";
+        LibraryAzureKVMockMgmt: Codeunit "Library - Azure KV Mock Mgmt.";
+    begin
+        LibraryAzureKVMockMgmt.InitMockAzureKeyvaultSecretProvider();
+        LibraryAzureKVMockMgmt.UseAzureKeyvaultSecretProvider();
+
+        Assert.IsTrue(ElecVATDeclAzKeyVault.IsReportingFrequencyEnabled(), 'Reporting frequency must default to enabled when the Key Vault flag is missing.');
+    end;
+
     local procedure Initialize()
     var
         NoSeries: Record "No. Series";
@@ -193,6 +235,15 @@ codeunit 148015 "Elec. VAT Decl. Tests"
         exit(
             '<ns1:AngivelseBetalingFristStruktur><ns4:AngivelseFrekvensNavn>' + Frequency + '</ns4:AngivelseFrekvensNavn>' +
             '<ns4:AngivelseFristKalenderBetalingDato>' + DueDate + '</ns4:AngivelseFristKalenderBetalingDato></ns1:AngivelseBetalingFristStruktur>');
+    end;
+
+    local procedure SetReportingFrequencyKeyVaultFlag(FlagValue: Text)
+    var
+        LibraryAzureKVMockMgmt: Codeunit "Library - Azure KV Mock Mgmt.";
+    begin
+        LibraryAzureKVMockMgmt.InitMockAzureKeyvaultSecretProvider();
+        LibraryAzureKVMockMgmt.AddMockAzureKeyvaultSecretProviderMapping('DKElecVAT-ReportingFrequencyEnabled', FlagValue);
+        LibraryAzureKVMockMgmt.UseAzureKeyvaultSecretProvider();
     end;
 
     [MessageHandler]

--- a/src/Apps/DK/ElectronicVATDeclarationDK/test/src/ElecVATDeclTests.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/test/src/ElecVATDeclTests.Codeunit.al
@@ -64,7 +64,7 @@ codeunit 148015 "Elec. VAT Decl. Tests"
             GetPeriodXml('Måned', '2026-05-01') +
             GetPeriodXml('Halvår', '2026-12-01'));
 
-        ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText);
+        ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText, true);
 
         VATReturnPeriod.SetRange("Start Date", 20260401D);
         VATReturnPeriod.SetRange("End Date", 20260430D);
@@ -87,8 +87,8 @@ codeunit 148015 "Elec. VAT Decl. Tests"
         Initialize();
         ResponseText := GetResponseXml(GetPeriodXml('Kvartal', '2026-09-01'));
 
-        ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText);
-        ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText);
+        ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText, true);
+        ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText, true);
 
         VATReturnPeriod.SetRange("Start Date", 20260401D);
         VATReturnPeriod.SetRange("End Date", 20260630D);
@@ -114,7 +114,7 @@ codeunit 148015 "Elec. VAT Decl. Tests"
         ResponseText := GetResponseXml(
             '<ns1:AngivelseBetalingFristStruktur><ns4:AngivelseFristKalenderBetalingDato>2026-05-01</ns4:AngivelseFristKalenderBetalingDato></ns1:AngivelseBetalingFristStruktur>');
 
-        asserterror ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText);
+        asserterror ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText, true);
 
         Assert.ExpectedError('does not contain a reporting frequency');
     end;
@@ -145,7 +145,7 @@ codeunit 148015 "Elec. VAT Decl. Tests"
         ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
     begin
         asserterror ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(
-            GetResponseXml(GetPeriodXml('Ugentlig', '2026-05-01')));
+            GetResponseXml(GetPeriodXml('Ugentlig', '2026-05-01')), true);
 
         Assert.ExpectedError('is not supported');
     end;
@@ -162,7 +162,7 @@ codeunit 148015 "Elec. VAT Decl. Tests"
         VATReturnPeriod.Insert(true);
 
         asserterror ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(
-            GetResponseXml(GetPeriodXml('Måned', '2026-04-01')));
+            GetResponseXml(GetPeriodXml('Måned', '2026-04-01')), true);
 
         Assert.ExpectedError('overlaps the period received from SKAT');
     end;

--- a/src/Apps/DK/ElectronicVATDeclarationDK/test/src/ElecVATDeclTests.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/test/src/ElecVATDeclTests.Codeunit.al
@@ -226,6 +226,47 @@ codeunit 148015 "Elec. VAT Decl. Tests"
     end;
 
     [Test]
+    [HandlerFunctions('MessageHandler')]
+    [Scope('OnPrem')]
+    procedure KeyVaultEnabledFlagUsesReportingFrequencyFromResponse()
+    var
+        VATReturnPeriod: Record "VAT Return Period";
+        ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
+    begin
+        Initialize();
+        SetReportingFrequencyKeyVaultFlag('true');
+
+        ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(GetResponseXml(GetPeriodXml('Måned', '2026-05-01')));
+
+        VATReturnPeriod.SetRange("Start Date", 20260401D);
+        VATReturnPeriod.SetRange("End Date", 20260430D);
+        VATReturnPeriod.SetRange("Due Date", 20260501D);
+        Assert.RecordIsNotEmpty(VATReturnPeriod);
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler')]
+    [Scope('OnPrem')]
+    procedure KeyVaultDisabledFlagUsesLegacyQuarterlyPeriod()
+    var
+        VATReturnPeriod: Record "VAT Return Period";
+        ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
+        ResponseText: Text;
+    begin
+        Initialize();
+        SetReportingFrequencyKeyVaultFlag('false');
+        ResponseText := GetResponseXml(
+            '<ns1:AngivelseBetalingFristStruktur><ns4:AngivelseFristKalenderBetalingDato>2026-09-01</ns4:AngivelseFristKalenderBetalingDato></ns1:AngivelseBetalingFristStruktur>');
+
+        ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText);
+
+        VATReturnPeriod.SetRange("Start Date", 20260401D);
+        VATReturnPeriod.SetRange("End Date", 20260630D);
+        VATReturnPeriod.SetRange("Due Date", 20260901D);
+        Assert.RecordIsNotEmpty(VATReturnPeriod);
+    end;
+
+    [Test]
     [Scope('OnPrem')]
     procedure ReportingFrequencyIsEnabledWhenKeyVaultFlagIsInvalid()
     var

--- a/src/Apps/DK/ElectronicVATDeclarationDK/test/src/ElecVATDeclTests.Codeunit.al
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/test/src/ElecVATDeclTests.Codeunit.al
@@ -78,6 +78,31 @@ codeunit 148015 "Elec. VAT Decl. Tests"
 
     [Test]
     [HandlerFunctions('MessageHandler')]
+    procedure ResponsePeriodsAreIndependentOfFrequencyOrder()
+    var
+        VATReturnPeriod: Record "VAT Return Period";
+        ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
+        ResponseText: Text;
+    begin
+        Initialize();
+        ResponseText := GetResponseXml(
+            GetPeriodXml('Halvår', '2026-12-01') +
+            GetPeriodXml('Måned', '2026-05-01'));
+
+        ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText, true);
+
+        VATReturnPeriod.SetRange("Start Date", 20260401D);
+        VATReturnPeriod.SetRange("End Date", 20260430D);
+        VATReturnPeriod.SetRange("Due Date", 20260501D);
+        Assert.RecordIsNotEmpty(VATReturnPeriod);
+        VATReturnPeriod.SetRange("Start Date", 20260101D);
+        VATReturnPeriod.SetRange("End Date", 20260630D);
+        VATReturnPeriod.SetRange("Due Date", 20261201D);
+        Assert.RecordIsNotEmpty(VATReturnPeriod);
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler')]
     procedure GettingSamePeriodsTwiceDoesNotInsertDuplicates()
     var
         VATReturnPeriod: Record "VAT Return Period";
@@ -117,6 +142,17 @@ codeunit 148015 "Elec. VAT Decl. Tests"
         asserterror ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(ResponseText, true);
 
         Assert.ExpectedError('does not contain a reporting frequency');
+    end;
+
+    [Test]
+    procedure InvalidDueDateRaisesError()
+    var
+        ElecVATDeclGetPeriods: Codeunit "Elec. VAT Decl. Get Periods";
+    begin
+        asserterror ElecVATDeclGetPeriods.GetVATReturnPeriodsFromResponseText(
+            GetResponseXml(GetPeriodXml('Måned', 'not-a-date')), true);
+
+        Assert.ExpectedError('contains an invalid due date');
     end;
 
     [Test]

--- a/src/Apps/FI/FICore/test/app.json
+++ b/src/Apps/FI/FICore/test/app.json
@@ -23,6 +23,12 @@
       "name": "FI Core",
       "publisher": "Microsoft",
       "version": "29.0.0.0"
+    },
+    {
+      "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
+      "publisher": "Microsoft",
+      "name": "Library Variable Storage",
+      "version": "29.0.0.0"
     }
   ],
   "screenshots": [],

--- a/src/Apps/FI/FICore/test/app.json
+++ b/src/Apps/FI/FICore/test/app.json
@@ -23,12 +23,6 @@
       "name": "FI Core",
       "publisher": "Microsoft",
       "version": "29.0.0.0"
-    },
-    {
-      "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
-      "publisher": "Microsoft",
-      "name": "Library Variable Storage",
-      "version": "29.0.0.0"
     }
   ],
   "screenshots": [],


### PR DESCRIPTION
## Summary
- parse SKAT VAT return periods with their reporting frequency
- support monthly, quarterly, and semi-annual period calculations
- retain a feature-flagged legacy quarterly fallback
- prevent overlapping VAT return periods and add focused test coverage
- correct legacy Q2 boundaries and process nested response periods independently of frequency order
- reject invalid SKAT due dates and surface invalid feature-flag configuration as warning telemetry


Created the secret:
**DKElecVAT-ReportingFrequencyEnabled**

Fixes
[AB#644140](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644140)













