### PR TITLE
[Main]-[BC-IN] Purchase invoice with a deferral schedule and Non-availment GST is not functioning correctly

### DIFF
--- a/src/Apps/IN/INTaxBase/app/src/codeunit/TaxBaseSubscribers.Codeunit.al
+++ b/src/Apps/IN/INTaxBase/app/src/codeunit/TaxBaseSubscribers.Codeunit.al
@@ -285,7 +285,29 @@ codeunit 18544 "Tax Base Subscribers"
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Deferral Utilities", 'OnBeforeCheckDeferralConditionForGenJournal', '', false, false)]
     local procedure OnBeforeCheckDeferralConditionForGenJournal(var GenJournalLine: Record "Gen. Journal Line"; var IsHandled: Boolean)
     begin
-        IsHandled := true;
+        // Allow Deferral Code with Sales/Purchases source code for IN Tax Engine posting lines and India vouchers.
+        IsHandled :=
+            GenJournalLine."System-Created Entry" or
+            IsIndiaVoucherJournalLine(GenJournalLine);
+    end;
+
+    local procedure IsIndiaVoucherJournalLine(GenJournalLine: Record "Gen. Journal Line"): Boolean
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+    begin
+        if GenJournalLine."Journal Template Name" = '' then
+            exit(false);
+
+        if not GenJournalTemplate.Get(GenJournalLine."Journal Template Name") then
+            exit(false);
+
+        exit(GenJournalTemplate.Type in [
+            GenJournalTemplate.Type::"Cash Receipt Voucher",
+            GenJournalTemplate.Type::"Cash Payment Voucher",
+            GenJournalTemplate.Type::"Bank Receipt Voucher",
+            GenJournalTemplate.Type::"Bank Payment Voucher",
+            GenJournalTemplate.Type::"Contra Voucher",
+            GenJournalTemplate.Type::"Journal Voucher"]);
     end;
 
     local procedure CallTaxEngineForPurchaseLines(var PurchaseHeader: Record "Purchase Header")


### PR DESCRIPTION
[Bug 641225](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/641225): Incident 21000001049308 : [BC-IN] Purchase invoice with a deferral schedule and Non-availment GST is not functioning correctly

[AB#641225](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640621)

**Issue:** A purchase invoice with Non-availment GST does not get posted when a Default Deferral Template is configured on the G/L Account Card.

**Cause:** The base application's CheckDeferralConditionForGenJournal validation in codeunit Deferral Utilities raises an error for the general journal line, which blocks the posting.

**Solution:** Subscribed to the OnBeforeCheckDeferralConditionForGenJournal event in codeunit Gen. Jnl.-Post Handler to handle this validation for the IN Localization in the Tax Engine application. This change also resolves the related Journal Voucher posting issue caused by the same validation.

