### PR TITLE
Improve Contoso App

### DIFF
--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Analytics/3.Transactions/CreateExtendedPurchDocument.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Analytics/3.Transactions/CreateExtendedPurchDocument.Codeunit.al
@@ -151,5 +151,5 @@ codeunit 5688 "Create Extended Purch Document"
     end;
 
     var
-        AnalyticsReferenceTok: Label 'ANALYTICS', MaxLength = 35;
+        AnalyticsReferenceTok: Label 'ANALYTICS', MaxLength = 35, Locked = true;
 }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Bank/1.Setup Data/CreateBankAccPostingGrp.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Bank/1.Setup Data/CreateBankAccPostingGrp.Codeunit.al
@@ -45,8 +45,8 @@ codeunit 5293 "Create Bank Acc. Posting Grp"
     end;
 
     var
-        CashTok: Label 'CASH', MaxLength = 20;
-        CheckingTok: Label 'CHECKING', MaxLength = 20;
-        OperatingTok: Label 'OPERATING', MaxLength = 20;
-        SavingsTok: Label 'SAVINGS', MaxLength = 20;
+        CashTok: Label 'CASH', MaxLength = 20, Locked = true;
+        CheckingTok: Label 'CHECKING', MaxLength = 20, Locked = true;
+        OperatingTok: Label 'OPERATING', MaxLength = 20, Locked = true;
+        SavingsTok: Label 'SAVINGS', MaxLength = 20, Locked = true;
 }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Finance/2.Master data/CreateAddReportingCurrency.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Finance/2.Master data/CreateAddReportingCurrency.Codeunit.al
@@ -56,6 +56,7 @@ codeunit 5627 "Create Add. Reporting Currency"
         CreateGLAccount: Codeunit "Create G/L Account";
         IsHandled: Boolean;
     begin
+        IsHandled := false;
         OnBeforeGetResidualCurrencyAccounts(FXGainsAccount, FXLossesAccount, IsHandled);
         if IsHandled then
             exit;

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Finance/FinanceModuleSetup.Table.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Finance/FinanceModuleSetup.Table.al
@@ -26,26 +26,31 @@ table 4772 "Finance Module Setup"
         }
         field(2; "VAT Prod. Post Grp. Standard"; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Standard VAT Product Posting Group';
             TableRelation = "VAT Product Posting Group";
         }
         field(3; "VAT Prod. Post Grp. Reduced"; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Reduced VAT Product Posting Group';
             TableRelation = "VAT Product Posting Group";
         }
         field(4; "VAT Prod. Post Grp. NO VAT"; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'No VAT Product Posting Group';
             TableRelation = "VAT Product Posting Group";
         }
         field(5; "Yearly License All. GLAcc No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Yearly License Allocation G/L Account No.';
             TableRelation = "G/L Account";
         }
         field(6; "Deferral Account No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Deferral Account No.';
         }
     }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/FixedAsset/FAModuleSetup.Table.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/FixedAsset/FAModuleSetup.Table.al
@@ -25,6 +25,7 @@ table 4767 "FA Module Setup"
         }
         field(2; "Default Depreciation Book"; Code[10])
         {
+            DataClassification = CustomerContent;
             Caption = 'Default Depreciation Book';
             TableRelation = "Depreciation Book";
         }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/HumanResources/HumanResourcesModuleSetup.Table.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/HumanResources/HumanResourcesModuleSetup.Table.al
@@ -25,6 +25,7 @@ table 4770 "Human Resources Module Setup"
         }
         field(4; "Employee Posting Group"; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Employee Posting Group';
             TableRelation = "Employee Posting Group";
         }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Jobs/JobsModuleSetup.Page.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Jobs/JobsModuleSetup.Page.al
@@ -39,7 +39,7 @@ page 4764 "Jobs Module Setup"
                 }
                 field("Item 4 No."; Rec."Item Supply No.")
                 {
-                    ToolTip = 'Specifies s item number to use for the scenarios.';
+                    ToolTip = 'Specifies the supply item number to use for the scenarios.';
                 }
                 field("Resource L1 No."; Rec."Resource Installer No.")
                 {

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Jobs/JobsModuleSetup.Table.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Jobs/JobsModuleSetup.Table.al
@@ -31,41 +31,49 @@ table 4771 "Jobs Module Setup"
         }
         field(2; "Customer No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Customer No.';
             TableRelation = Customer;
         }
         field(3; "Item Machine No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Item Machine No.';
             TableRelation = Item;
         }
         field(4; "Item Consumable No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Item Consumable No.';
             TableRelation = Item;
         }
         field(5; "Item Supply No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Item Supply No.';
             TableRelation = Item;
         }
         field(6; "Item Service No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Item Service No.';
             TableRelation = Item;
         }
         field(7; "Resource Installer No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Resource No.';
             TableRelation = Resource;
         }
         field(8; "Job Posting Group"; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Job Posting Group';
             TableRelation = "Job Posting Group";
         }
         field(9; "Job Location"; Code[10])
         {
+            DataClassification = CustomerContent;
             Caption = 'Project Location';
             TableRelation = Location where("Use As In-Transit" = const(false));
         }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Service/ServiceModuleSetup.Table.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Service/ServiceModuleSetup.Table.al
@@ -29,36 +29,43 @@ table 4765 "Service Module Setup"
         }
         field(2; "Customer No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Customer No.';
             TableRelation = Customer;
         }
         field(3; "Item 1 No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Item 1 No.';
             TableRelation = Item where(Type = const(Inventory));
         }
         field(4; "Service Item 1 No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Service Item 1 No.';
             TableRelation = Item where(Type = const(Service));
         }
         field(5; "Service Item 2 No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Service Item 2 No.';
             TableRelation = Item where(Type = const(Service));
         }
         field(6; "Resource 1 No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Resource 1 No.';
             TableRelation = Resource;
         }
         field(7; "Resource 2 No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Resource 2 No.';
             TableRelation = Resource;
         }
         field(8; "Service Location"; Code[10])
         {
+            DataClassification = CustomerContent;
             Caption = 'Service Location';
             TableRelation = Location where("Use As In-Transit" = const(false));
         }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Warehousing/WarehouseModuleSetup.Table.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Warehousing/WarehouseModuleSetup.Table.al
@@ -29,46 +29,55 @@ table 4764 "Warehouse Module Setup"
         }
         field(2; "Customer No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Customer No.';
             TableRelation = Customer;
         }
         field(3; "Vendor No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Vendor No.';
             TableRelation = Vendor;
         }
         field(4; "Item 1 No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Item 1 No.';
             TableRelation = Item where(Type = const(Inventory));
         }
         field(5; "Item 2 No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Item 2 No.';
             TableRelation = Item where(Type = const(Inventory));
         }
         field(6; "Item 3 No."; Code[20])
         {
+            DataClassification = CustomerContent;
             Caption = 'Item 3 No.';
             TableRelation = Item where(Type = const(Inventory));
         }
         field(7; "Location Bin"; Code[10])
         {
+            DataClassification = CustomerContent;
             Caption = 'Location Bin';
             TableRelation = Location where("Use As In-Transit" = const(false));
         }
         field(8; "Location Adv Logistics"; Code[10])
         {
+            DataClassification = CustomerContent;
             Caption = 'Location Advanced';
             TableRelation = Location where("Use As In-Transit" = const(false));
         }
         field(9; "Location Directed Pick"; Code[10])
         {
+            DataClassification = CustomerContent;
             Caption = 'Location Directed Pick and Put-away';
             TableRelation = Location where("Use As In-Transit" = const(false));
         }
         field(10; "Location In-Transit"; Code[10])
         {
+            DataClassification = CustomerContent;
             Caption = 'Location In-Transit';
             TableRelation = Location where("Use As In-Transit" = const(true));
         }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/eServices/EServiceDemoDataSetup.Page.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/eServices/EServiceDemoDataSetup.Page.al
@@ -27,4 +27,9 @@ page 5296 "EService Demo Data Setup"
             }
         }
     }
+
+    trigger OnOpenPage()
+    begin
+        Rec.InitRecord();
+    end;
 }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/eServices/EServiceDemoDataSetup.Table.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/eServices/EServiceDemoDataSetup.Table.al
@@ -24,6 +24,7 @@ table 5296 "EService Demo Data Setup"
         }
         field(2; "Invoice Field Name"; Text[100])
         {
+            DataClassification = CustomerContent;
             Caption = 'Invoice File Name';
             ToolTip = 'Specifies the Invoice File Name for the Incoming Document.';
         }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoTool/ContosoCoffeeDemoDataSetup.Table.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoTool/ContosoCoffeeDemoDataSetup.Table.al
@@ -26,33 +26,39 @@ table 4768 "Contoso Coffee Demo Data Setup"
         }
         field(2; "Starting Year"; Integer)
         {
+            DataClassification = CustomerContent;
             Caption = 'Starting Year';
         }
         field(3; "Company Type"; Option)
         {
+            DataClassification = CustomerContent;
             OptionMembers = VAT,"Sales Tax";
             Caption = 'Company Type';
         }
         field(4; "Country/Region Code"; Code[10])
         {
+            DataClassification = CustomerContent;
             TableRelation = "Country/Region";
             Caption = 'Country/Region Code';
             InitValue = 'GB';
         }
         field(5; "Price Factor"; Decimal)
         {
+            DataClassification = CustomerContent;
             AutoFormatType = 0;
             InitValue = 1;
             Caption = 'Price Factor';
         }
         field(6; "Rounding Precision"; Decimal)
         {
+            DataClassification = CustomerContent;
             AutoFormatType = 0;
             Caption = 'Rounding Precision';
             InitValue = 0.01;
         }
         field(7; "Language ID"; Integer)
         {
+            DataClassification = CustomerContent;
             Caption = 'Language ID';
             Editable = false;
             InitValue = 0;
@@ -60,6 +66,7 @@ table 4768 "Contoso Coffee Demo Data Setup"
         }
         field(8; "Starting Date"; Date)
         {
+            DataClassification = CustomerContent;
             Caption = 'Starting Date';
         }
     }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoTool/ContosoDemoDataModule.Table.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoTool/ContosoDemoDataModule.Table.al
@@ -20,22 +20,27 @@ table 5161 "Contoso Demo Data Module"
     {
         field(1; Module; Enum "Contoso Demo Data Module")
         {
+            DataClassification = SystemMetadata;
             Caption = 'Module';
         }
         field(2; Name; Text[100])
         {
+            DataClassification = SystemMetadata;
             Caption = 'Name';
         }
         field(3; "Data Level"; Enum "Contoso Demo Data Level")
         {
+            DataClassification = SystemMetadata;
             Caption = 'Data Level';
         }
         field(4; Install; Boolean)
         {
+            DataClassification = SystemMetadata;
             Caption = 'Install';
         }
         field(5; "Is Setup Company"; Boolean)
         {
+            DataClassification = SystemMetadata;
             Caption = 'Setup Company';
         }
     }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoTool/ContosoModuleDependency.Table.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoTool/ContosoModuleDependency.Table.al
@@ -19,10 +19,12 @@ table 5169 "Contoso Module Dependency"
     {
         field(1; Name; Enum "Contoso Demo Data Module")
         {
+            DataClassification = SystemMetadata;
             TableRelation = "Contoso Demo Data Module";
         }
         field(2; DependsOn; Enum "Contoso Demo Data Module")
         {
+            DataClassification = SystemMetadata;
             TableRelation = "Contoso Demo Data Module";
         }
     }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/Permissions/ContosoDemoRead.PermissionSet.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/Permissions/ContosoDemoRead.PermissionSet.al
@@ -8,7 +8,7 @@ permissionset 4766 "Contoso Demo - Read"
 {
     Access = Public;
     Assignable = true;
-    Caption = 'Contoso Demo - Edit';
+    Caption = 'Contoso Demo - Read';
 
     IncludedPermissionSets = "Contoso Demo - Objects";
 


### PR DESCRIPTION
Improve Contoso App.

Addresses code-review findings in the Contoso Coffee demo dataset:
- Field-level `DataClassification` on setup-table fields (per-field AS0016).
- `Locked = true` on Tok-suffixed code Labels.
- `OnOpenPage` -> `InitRecord()` on EService Demo Data Setup.
- Correct `Contoso Demo - Read` permission-set caption.
- Reset `IsHandled` before `OnBeforeGetResidualCurrencyAccounts`.
- Fix truncated tooltip on Jobs setup "Item 4 No.".

