### PR TITLE
[TEST - please ignore] Team-labeler routing test (expected: Finance)

### DIFF
--- a/src/Layers/W1/BaseApp/CashFlow/ZZZ_TEST_TeamLabeler_DELETE_ME.md
+++ b/src/Layers/W1/BaseApp/CashFlow/ZZZ_TEST_TeamLabeler_DELETE_ME.md
@@ -1,0 +1,6 @@
+# TEST FILE - please ignore
+
+This file exists only to smoke-test the automatic team-labeler and will be
+deleted / the PR closed shortly. It touches the CashFlow (Finance) area.
+
+Expected routing: Finance.


### PR DESCRIPTION
> **This is a TEST pull request** created to verify the automatic team-labeler.
> It only adds a throwaway markdown file under a Finance area and will be closed
> without merging. Please ignore.

Verifying that ownership routing lands on **Finance** based on the changed file path
(`src/Layers/W1/BaseApp/CashFlow/...`).

Expected routing: **Finance**.

_Automated team-labeler smoke test — safe to close, do not merge._
