### PR TITLE
Support multi company setup External SharePoint account

### DIFF
--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccount.Table.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccount.Table.al
@@ -112,7 +112,7 @@ table 4580 "Ext. SharePoint Account"
         ClearCertificateAuthentication();
     end;
 
-    local procedure ClearCertificateAuthentication()
+    internal procedure ClearCertificateAuthentication()
     begin
         if not IsNullGuid(Rec."Certificate Key") then begin
             TryDeleteIsolatedStorageValue(Rec."Certificate Key");
@@ -142,7 +142,7 @@ table 4580 "Ext. SharePoint Account"
     end;
 #pragma warning restore AS0022
 
-    local procedure ClearClientSecretAuthentication()
+    internal procedure ClearClientSecretAuthentication()
     begin
         if not IsNullGuid(Rec."Client Secret Key") then begin
             TryDeleteIsolatedStorageValue(Rec."Client Secret Key");

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccountWizard.Page.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccountWizard.Page.al
@@ -6,6 +6,7 @@
 namespace System.ExternalFileStorage;
 
 using System.Environment;
+using Microsoft.Foundation.Company;
 
 /// <summary>
 /// Displays an account that is being registered via the SharePoint connector.
@@ -38,111 +39,175 @@ page 4581 "Ext. SharePoint Account Wizard"
                 }
             }
 
-            field(NameField; Rec.Name)
+            group(Step1)
             {
-                Caption = 'Account Name';
-                NotBlank = true;
-                ShowMandatory = true;
-                ToolTip = 'Specifies a descriptive name for this SharePoint storage account connection.';
+                Caption = 'Account Details';
+                Visible = Step = Step::AccountDetails;
 
-                trigger OnValidate()
-                begin
-                    IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
-                end;
-            }
 
-            field("Tenant Id"; Rec."Tenant Id")
-            {
-                ShowMandatory = true;
-                ToolTip = 'Specifies the Microsoft Entra ID Tenant ID (Directory ID) where your SharePoint site and app registration are located.';
-
-                trigger OnValidate()
-                begin
-                    IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
-                end;
-            }
-
-            field("Client Id"; Rec."Client Id")
-            {
-                ShowMandatory = true;
-                ToolTip = 'Specifies the Client ID (Application ID) of the App Registration in Microsoft Entra ID.';
-
-                trigger OnValidate()
-                begin
-                    IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
-                end;
-            }
-
-            field("Authentication Type"; Rec."Authentication Type")
-            {
-                ToolTip = 'Specifies the authentication flow used for this SharePoint account. Client Secret uses User grant flow, which means that the user must sign in when using this account. Certificate uses Client credentials flow, which means that the user does not need to sign in when using this account.';
-                trigger OnValidate()
-                begin
-                    UpdateAuthTypeVisibility();
-                    IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
-                end;
-            }
-            group(SharePointClientSecretCredentials)
-            {
-                ShowCaption = false;
-                Visible = ClientSecretVisible;
-
-                field(ClientSecretField; ClientSecret)
+                field(NameField; Rec.Name)
                 {
-                    Caption = 'Client Secret';
-                    ExtendedDatatype = Masked;
+                    Caption = 'Account Name';
+                    NotBlank = true;
                     ShowMandatory = true;
-                    ToolTip = 'Specifies the Client Secret value from the App Registration in Microsoft Entra ID. This value is used to authenticate the connection to SharePoint.';
-                }
-            }
+                    ToolTip = 'Specifies a descriptive name for this SharePoint storage account connection.';
 
-            group(SharePointCertificateCredentials)
-            {
-                ShowCaption = false;
-                Visible = CertificateVisible;
-
-                field(CertificateUploadStatus; CertificateStatusText)
-                {
-                    Caption = 'Certificate';
-                    Editable = false;
-                    ShowMandatory = true;
-                    ToolTip = 'Specifies the certificate file used for authentication. Click here to upload a certificate file (.pfx, .cer, or .crt).';
-
-                    trigger OnDrillDown()
+                    trigger OnValidate()
                     begin
-                        Certificate := Rec.UploadCertificateFile();
-                        UpdateCertificateStatus();
                         IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
                     end;
                 }
 
-                field(CertificatePasswordField; CertificatePassword)
+                field("Tenant Id"; Rec."Tenant Id")
                 {
-                    Caption = 'Certificate Password';
-                    ExtendedDatatype = Masked;
-                    ShowMandatory = false;
-                    ToolTip = 'Specifies the password used to protect the private key in the certificate. Leave empty if the certificate is not password-protected.';
+                    ShowMandatory = true;
+                    ToolTip = 'Specifies the Microsoft Entra ID Tenant ID (Directory ID) where your SharePoint site and app registration are located.';
+
+                    trigger OnValidate()
+                    begin
+                        IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
+                    end;
+                }
+
+                field("Client Id"; Rec."Client Id")
+                {
+                    ShowMandatory = true;
+                    ToolTip = 'Specifies the Client ID (Application ID) of the App Registration in Microsoft Entra ID.';
+
+                    trigger OnValidate()
+                    begin
+                        IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
+                    end;
+                }
+
+                field("Authentication Type"; Rec."Authentication Type")
+                {
+                    ToolTip = 'Specifies the authentication flow used for this SharePoint account. Client Secret uses User grant flow, which means that the user must sign in when using this account. Certificate uses Client credentials flow, which means that the user does not need to sign in when using this account.';
+                    trigger OnValidate()
+                    begin
+                        UpdateAuthTypeVisibility();
+                        IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
+                    end;
+                }
+                group(SharePointClientSecretCredentials)
+                {
+                    ShowCaption = false;
+                    Visible = ClientSecretVisible;
+
+                    field(ClientSecretField; ClientSecret)
+                    {
+                        Caption = 'Client Secret';
+                        ExtendedDatatype = Masked;
+                        ShowMandatory = true;
+                        ToolTip = 'Specifies the Client Secret value from the App Registration in Microsoft Entra ID. This value is used to authenticate the connection to SharePoint.';
+                    }
+                }
+
+                group(SharePointCertificateCredentials)
+                {
+                    ShowCaption = false;
+                    Visible = CertificateVisible;
+
+                    field(CertificateUploadStatus; CertificateStatusText)
+                    {
+                        Caption = 'Certificate';
+                        Editable = false;
+                        ShowMandatory = true;
+                        ToolTip = 'Specifies the certificate file used for authentication. Click here to upload a certificate file (.pfx, .cer, or .crt).';
+
+                        trigger OnDrillDown()
+                        begin
+                            Certificate := Rec.UploadCertificateFile();
+                            UpdateCertificateStatus();
+                            IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
+                        end;
+                    }
+
+                    field(CertificatePasswordField; CertificatePassword)
+                    {
+                        Caption = 'Certificate Password';
+                        ExtendedDatatype = Masked;
+                        ShowMandatory = false;
+                        ToolTip = 'Specifies the password used to protect the private key in the certificate. Leave empty if the certificate is not password-protected.';
+                    }
+                }
+                field("SharePoint Url"; Rec."SharePoint Url")
+                {
+                    Caption = 'SharePoint Name';
+                    ShowMandatory = true;
+
+                    trigger OnValidate()
+                    begin
+                        IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
+                    end;
+                }
+
+                field("Base Relative Folder Path"; Rec."Base Relative Folder Path")
+                {
+                    ShowMandatory = true;
+
+                    trigger OnValidate()
+                    begin
+                        IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
+                    end;
                 }
             }
-            field("SharePoint Url"; Rec."SharePoint Url")
+            group(Step2)
             {
-                Caption = 'SharePoint Name';
-                ShowMandatory = true;
+                Caption = 'Company Selection';
+                Visible = Step = Step::CompanySelection;
 
-                trigger OnValidate()
-                begin
-                    IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
-                end;
-            }
+                group(CompanyFilterGroup)
+                {
+                    ShowCaption = false;
+                    field(MultipleCompaniesField; MultipleCompanies)
+                    {
+                        Caption = 'Multiple Companies';
+                        ToolTip = 'Specifies whether the file account should be created in multiple companies.';
 
-            field("Base Relative Folder Path"; Rec."Base Relative Folder Path")
-            {
-                ShowMandatory = true;
+                        trigger OnValidate()
+                        begin
+                            UpdateFinishEnabled();
+                        end;
+                    }
+                    field(CompanyFilterField; CompanyFilter)
+                    {
+                        Caption = 'Company Filter';
+                        Editable = MultipleCompanies;
+                        ToolTip = 'Specifies a filter to select companies. Use standard BC filter syntax (e.g. "CRONUS*" or "Company A|Company B").';
 
-                trigger OnValidate()
-                begin
-                    IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
-                end;
+                        trigger OnValidate()
+                        begin
+                            UpdateFinishEnabled();
+                        end;
+
+                        trigger OnLookup(var Text: Text): Boolean
+                        var
+                            Company: Record Company;
+                        begin
+                            if Page.RunModal(Page::Companies, Company) = Action::LookupOK then begin
+                                if Text <> '' then
+                                    Text := Text + '|' + Company.Name
+                                else
+                                    Text := Company.Name;
+                                exit(true);
+                            end;
+                        end;
+                    }
+                    field(DefaultField; SetAsDefault)
+                    {
+                        Caption = 'Set as default';
+                        Editable = MultipleCompanies;
+                        ToolTip = 'Specifies the the account for all scenarios.';
+                    }
+
+                    field(MatchingCompaniesField; MatchingCompaniesCount)
+                    {
+                        Caption = 'Matching Companies';
+                        Editable = false;
+                        ToolTip = 'Shows the number of companies that match the current filter.';
+                    }
+                }
             }
         }
     }
@@ -170,6 +235,25 @@ page 4581 "Ext. SharePoint Account Wizard"
                 Image = NextRecord;
                 InFooterBar = true;
                 ToolTip = 'Move to next step.';
+                Visible = Step < Step::CompanySelection;
+
+                trigger OnAction()
+                var
+                    SecretToPass: SecretText;
+                begin
+                    Step += 1;
+                    if Step = Step::CompanySelection then
+                        UpdateFinishEnabled();
+                end;
+            }
+            action(FinishAction)
+            {
+                Caption = 'Finish';
+                Enabled = IsFinishEnabled;
+                Image = Approve;
+                InFooterBar = true;
+                ToolTip = 'Create the file account in all selected companies.';
+                Visible = Step = Step::CompanySelection;
 
                 trigger OnAction()
                 var
@@ -182,7 +266,10 @@ page 4581 "Ext. SharePoint Account Wizard"
                             SecretToPass := Certificate;
                     end;
 
-                    SharePointConnectorImpl.CreateAccount(Rec, SecretToPass, CertificatePassword, SharePointAccount);
+                    if not MultipleCompanies then
+                        SharePointConnectorImpl.CreateAccount(Rec, SecretToPass, CertificatePassword, SharePointAccount)
+                    else
+                        CreateAccountInCompanies(Rec, SecretToPass, CertificatePassword);
                     CurrPage.Close();
                 end;
             }
@@ -203,6 +290,12 @@ page 4581 "Ext. SharePoint Account Wizard"
         TopBannerVisible: Boolean;
         ClientSecretVisible: Boolean;
         CertificateVisible: Boolean;
+        MultipleCompanies: Boolean;
+        CompanyFilter: Text;
+        MatchingCompaniesCount: Integer;
+        SetAsDefault: Boolean;
+        Step: Option AccountDetails,CompanySelection;
+        IsFinishEnabled: Boolean;
 
     trigger OnOpenPage()
     var
@@ -246,5 +339,90 @@ page 4581 "Ext. SharePoint Account Wizard"
             CertificateStatusText := NoCertificateUploadedLbl
         else
             CertificateStatusText := CertificateUploadedLbl;
+    end;
+
+    local procedure UpdateFinishEnabled()
+    var
+        Company: Record Company;
+    begin
+        if not MultipleCompanies then begin
+            MatchingCompaniesCount := 0;
+            IsFinishEnabled := true;
+            exit;
+        end;
+        Company.Reset();
+        if CompanyFilter <> '' then
+            Company.SetFilter(Name, CompanyFilter);
+        MatchingCompaniesCount := Company.Count();
+        IsFinishEnabled := MatchingCompaniesCount > 0;
+    end;
+
+    local procedure CreateAccountInCompanies(var AccountToCopy: Record "Ext. SharePoint Account"; ClientSecretOrCertificate: SecretText; CertificatePassword: SecretText)
+    var
+        Company: Record Company;
+        ExtSharePointAccount: Record "Ext. SharePoint Account";
+        ExtSharePointCreateAccount: Codeunit "Ext. SharePoint Create Account";
+        SessionId: Integer;
+        AccountCurrentCompanyCreated: Boolean;
+        I: Integer;
+    begin
+        AccountToCopy.Id := CreateGuid();
+
+        if CompanyFilter <> '' then
+            Company.SetFilter(Name, CompanyFilter);
+
+        if Company.FindSet() then begin
+            StoreSecretsForSession(AccountToCopy);
+            Commit();
+            repeat
+                if StartSession(SessionId, Codeunit::"Ext. SharePoint Create Account", Company.Name, AccountToCopy) then begin
+                    while IsSessionActive(SessionId) do
+                        Sleep(200);
+                    if Company.Name = CompanyName() then
+                        AccountCurrentCompanyCreated := true;
+                end;
+            until Company.Next() = 0;
+            RemoveSecretsFromSession(AccountToCopy);
+        end;
+
+        if AccountCurrentCompanyCreated then begin
+            ExtSharePointAccount.SetRange(Name, AccountToCopy.Name);
+            if ExtSharePointAccount.FindFirst() then begin
+                SharePointAccount."Account Id" := ExtSharePointAccount.Id;
+                SharePointAccount.Name := ExtSharePointAccount.Name;
+                SharePointAccount.Connector := Enum::"Ext. File Storage Connector"::"SharePoint";
+            end;
+        end;
+    end;
+
+    local procedure StoreSecretsForSession(AccountToCopy: Record "Ext. SharePoint Account")
+    var
+        ExtSharePointCreateAccount: Codeunit "Ext. SharePoint Create Account";
+        SecretToStore: SecretText;
+    begin
+        case AccountToCopy."Authentication Type" of
+            Enum::"Ext. SharePoint Auth Type"::"Client Secret":
+                begin
+                    SecretToStore := ClientSecret;
+                    IsolatedStorage.Set(ExtSharePointCreateAccount.GetSecretKeyToken(AccountToCopy.Id), SecretToStore, DataScope::Module);
+                end;
+            Enum::"Ext. SharePoint Auth Type"::Certificate:
+                begin
+                    IsolatedStorage.Set(ExtSharePointCreateAccount.GetSecretKeyToken(AccountToCopy.Id), Certificate, DataScope::Module);
+                    SecretToStore := CertificatePassword;
+                    IsolatedStorage.Set(ExtSharePointCreateAccount.GetCertPwdKeyToken(AccountToCopy.Id), SecretToStore, DataScope::Module);
+                end;
+        end;
+        IsolatedStorage.Set(ExtSharePointCreateAccount.GetSetAsDefaultKeyToken(AccountToCopy.Id), SetAsDefault ? '1' : '0', DataScope::Module);
+    end;
+
+    local procedure RemoveSecretsFromSession(AccountToCopy: Record "Ext. SharePoint Account")
+    var
+        ExtSharePointCreateAccount: Codeunit "Ext. SharePoint Create Account";
+    begin
+        if IsolatedStorage.Delete(ExtSharePointCreateAccount.GetSecretKeyToken(AccountToCopy.Id), DataScope::Module) then;
+        if AccountToCopy."Authentication Type" = Enum::"Ext. SharePoint Auth Type"::Certificate then
+            if IsolatedStorage.Delete(ExtSharePointCreateAccount.GetCertPwdKeyToken(AccountToCopy.Id), DataScope::Module) then;
+        if IsolatedStorage.Delete(ExtSharePointCreateAccount.GetSetAsDefaultKeyToken(AccountToCopy.Id), DataScope::Module) then;
     end;
 }

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccountWizard.Page.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccountWizard.Page.al
@@ -151,6 +151,11 @@ page 4581 "Ext. SharePoint Account Wizard"
                         IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
                     end;
                 }
+                field(MultipleCompaniesField; MultipleCompanies)
+                {
+                    Caption = 'Multiple Companies';
+                    ToolTip = 'Specifies whether the file account should be created in multiple companies.';
+                }
             }
             group(Step2)
             {
@@ -160,16 +165,6 @@ page 4581 "Ext. SharePoint Account Wizard"
                 group(CompanyFilterGroup)
                 {
                     ShowCaption = false;
-                    field(MultipleCompaniesField; MultipleCompanies)
-                    {
-                        Caption = 'Multiple Companies';
-                        ToolTip = 'Specifies whether the file account should be created in multiple companies.';
-
-                        trigger OnValidate()
-                        begin
-                            UpdateFinishEnabled();
-                        end;
-                    }
                     field(CompanyFilterField; CompanyFilter)
                     {
                         Caption = 'Company Filter';
@@ -178,7 +173,7 @@ page 4581 "Ext. SharePoint Account Wizard"
 
                         trigger OnValidate()
                         begin
-                            UpdateFinishEnabled();
+                            IsNextEnabled := GetMatchingCompaniesCount() > 0;
                         end;
 
                         trigger OnLookup(var Text: Text): Boolean
@@ -201,10 +196,9 @@ page 4581 "Ext. SharePoint Account Wizard"
                         ToolTip = 'Specifies the the account for all scenarios.';
                     }
 
-                    field(MatchingCompaniesField; MatchingCompaniesCount)
+                    field(MatchingCompaniesField; GetMatchingCompaniesCount())
                     {
                         Caption = 'Matching Companies';
-                        Editable = false;
                         ToolTip = 'Shows the number of companies that match the current filter.';
                     }
                 }
@@ -225,7 +219,10 @@ page 4581 "Ext. SharePoint Account Wizard"
 
                 trigger OnAction()
                 begin
-                    CurrPage.Close();
+                    if Step = Step::AccountDetails then
+                        CurrPage.Close()
+                    else
+                        Step -= 1;
                 end;
             }
             action(Next)
@@ -235,42 +232,27 @@ page 4581 "Ext. SharePoint Account Wizard"
                 Image = NextRecord;
                 InFooterBar = true;
                 ToolTip = 'Move to next step.';
-                Visible = Step < Step::CompanySelection;
 
                 trigger OnAction()
                 var
                     SecretToPass: SecretText;
                 begin
-                    Step += 1;
-                    if Step = Step::CompanySelection then
-                        UpdateFinishEnabled();
-                end;
-            }
-            action(FinishAction)
-            {
-                Caption = 'Finish';
-                Enabled = IsFinishEnabled;
-                Image = Approve;
-                InFooterBar = true;
-                ToolTip = 'Create the file account in all selected companies.';
-                Visible = Step = Step::CompanySelection;
-
-                trigger OnAction()
-                var
-                    SecretToPass: SecretText;
-                begin
-                    case Rec."Authentication Type" of
-                        Enum::"Ext. SharePoint Auth Type"::"Client Secret":
-                            SecretToPass := ClientSecret;
-                        Enum::"Ext. SharePoint Auth Type"::Certificate:
-                            SecretToPass := Certificate;
+                    if (Step = Step::AccountDetails) and not MultipleCompanies then begin
+                        SharePointConnectorImpl.CreateAccount(Rec, SecretToPass, CertificatePassword, SharePointAccount);
+                        CurrPage.Close();
                     end;
-
-                    if not MultipleCompanies then
-                        SharePointConnectorImpl.CreateAccount(Rec, SecretToPass, CertificatePassword, SharePointAccount)
-                    else
+                    if Step = Step::CompanySelection then begin
+                        case Rec."Authentication Type" of
+                            Enum::"Ext. SharePoint Auth Type"::"Client Secret":
+                                SecretToPass := ClientSecret;
+                            Enum::"Ext. SharePoint Auth Type"::Certificate:
+                                SecretToPass := Certificate;
+                        end;
                         CreateAccountInCompanies(Rec, SecretToPass, CertificatePassword);
-                    CurrPage.Close();
+                        CurrPage.Close();
+                    end;
+                    IsNextEnabled := GetMatchingCompaniesCount > 0;
+                    Step += 1;
                 end;
             }
         }
@@ -292,10 +274,8 @@ page 4581 "Ext. SharePoint Account Wizard"
         CertificateVisible: Boolean;
         MultipleCompanies: Boolean;
         CompanyFilter: Text;
-        MatchingCompaniesCount: Integer;
         SetAsDefault: Boolean;
         Step: Option AccountDetails,CompanySelection;
-        IsFinishEnabled: Boolean;
 
     trigger OnOpenPage()
     var
@@ -341,20 +321,14 @@ page 4581 "Ext. SharePoint Account Wizard"
             CertificateStatusText := CertificateUploadedLbl;
     end;
 
-    local procedure UpdateFinishEnabled()
+    local procedure GetMatchingCompaniesCount(): Integer
     var
         Company: Record Company;
     begin
-        if not MultipleCompanies then begin
-            MatchingCompaniesCount := 0;
-            IsFinishEnabled := true;
-            exit;
-        end;
         Company.Reset();
         if CompanyFilter <> '' then
             Company.SetFilter(Name, CompanyFilter);
-        MatchingCompaniesCount := Company.Count();
-        IsFinishEnabled := MatchingCompaniesCount > 0;
+        exit(Company.Count());
     end;
 
     local procedure CreateAccountInCompanies(var AccountToCopy: Record "Ext. SharePoint Account"; ClientSecretOrCertificate: SecretText; CertificatePassword: SecretText)

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccountWizard.Page.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccountWizard.Page.al
@@ -237,17 +237,17 @@ page 4581 "Ext. SharePoint Account Wizard"
                 var
                     SecretToPass: SecretText;
                 begin
+                    case Rec."Authentication Type" of
+                        Enum::"Ext. SharePoint Auth Type"::"Client Secret":
+                            SecretToPass := ClientSecret;
+                        Enum::"Ext. SharePoint Auth Type"::Certificate:
+                            SecretToPass := Certificate;
+                    end;
                     if (Step = Step::AccountDetails) and not MultipleCompanies then begin
                         SharePointConnectorImpl.CreateAccount(Rec, SecretToPass, CertificatePassword, SharePointAccount);
                         CurrPage.Close();
                     end;
                     if Step = Step::CompanySelection then begin
-                        case Rec."Authentication Type" of
-                            Enum::"Ext. SharePoint Auth Type"::"Client Secret":
-                                SecretToPass := ClientSecret;
-                            Enum::"Ext. SharePoint Auth Type"::Certificate:
-                                SecretToPass := Certificate;
-                        end;
                         CreateAccountInCompanies(Rec, SecretToPass, CertificatePassword);
                         CurrPage.Close();
                     end;
@@ -336,6 +336,7 @@ page 4581 "Ext. SharePoint Account Wizard"
         Company: Record Company;
         ExtSharePointAccount: Record "Ext. SharePoint Account";
         ExtSharePointCreateAccount: Codeunit "Ext. SharePoint Create Account";
+        FailedCompanies: List of [Text];
         SessionId: Integer;
         AccountCurrentCompanyCreated: Boolean;
         I: Integer;
@@ -354,12 +355,18 @@ page 4581 "Ext. SharePoint Account Wizard"
                         Sleep(200);
                     if Company.Name = CompanyName() then
                         AccountCurrentCompanyCreated := true;
+                    ExtSharePointAccount.ChangeCompany(Company.Name);
+                    ExtSharePointAccount.SetRange(Name, AccountToCopy.Name);
+                    if ExtSharePointAccount.IsEmpty() then
+                        FailedCompanies.Add(Company.Name);
                 end;
             until Company.Next() = 0;
             RemoveSecretsFromSession(AccountToCopy);
         end;
 
         if AccountCurrentCompanyCreated then begin
+            ExtSharePointAccount.Reset();
+            ExtSharePointAccount.ChangeCompany(CompanyName());
             ExtSharePointAccount.SetRange(Name, AccountToCopy.Name);
             if ExtSharePointAccount.FindFirst() then begin
                 SharePointAccount."Account Id" := ExtSharePointAccount.Id;
@@ -367,6 +374,9 @@ page 4581 "Ext. SharePoint Account Wizard"
                 SharePointAccount.Connector := Enum::"Ext. File Storage Connector"::"SharePoint";
             end;
         end;
+
+        if FailedCompanies.Count() > 0 then
+            ShowFailedCompanies(FailedCompanies);
     end;
 
     local procedure StoreSecretsForSession(AccountToCopy: Record "Ext. SharePoint Account")
@@ -398,5 +408,20 @@ page 4581 "Ext. SharePoint Account Wizard"
         if AccountToCopy."Authentication Type" = Enum::"Ext. SharePoint Auth Type"::Certificate then
             if IsolatedStorage.Delete(ExtSharePointCreateAccount.GetCertPwdKeyToken(AccountToCopy.Id), DataScope::Module) then;
         if IsolatedStorage.Delete(ExtSharePointCreateAccount.GetSetAsDefaultKeyToken(AccountToCopy.Id), DataScope::Module) then;
+    end;
+
+    local procedure ShowFailedCompanies(FailedCompanies: List of [Text])
+    var
+        FailedCompaniesMsg: Label 'The SharePoint account could not be created in the following companies:\%1', Comment = '%1 - Formatted list of company names';
+        FailedCompaniesBuilder: TextBuilder;
+        FailedCompany: Text;
+    begin
+        foreach FailedCompany in FailedCompanies do begin
+            if FailedCompaniesBuilder.Length() > 0 then
+                FailedCompaniesBuilder.AppendLine();
+            FailedCompaniesBuilder.Append(FailedCompany);
+        end;
+        if GuiAllowed() then
+            Message(FailedCompaniesMsg, FailedCompaniesBuilder.ToText());
     end;
 }

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccountWizard.Page.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccountWizard.Page.al
@@ -339,8 +339,10 @@ page 4581 "Ext. SharePoint Account Wizard"
         FailedCompanies: List of [Text];
         SessionId: Integer;
         AccountCurrentCompanyCreated: Boolean;
+        StartOfProcess: DateTime;
     begin
         AccountToCopy.Id := CreateGuid();
+        StartOfProcess := CurrentDateTime();
 
         if CompanyFilter <> '' then
             Company.SetFilter(Name, CompanyFilter);
@@ -356,6 +358,7 @@ page 4581 "Ext. SharePoint Account Wizard"
                         AccountCurrentCompanyCreated := true;
                     ExtSharePointAccount.ChangeCompany(Company.Name);
                     ExtSharePointAccount.SetRange(Name, AccountToCopy.Name);
+                    ExtSharePointAccount.SetFilter(SystemCreatedAt, '>%1', StartOfProcess);
                     if ExtSharePointAccount.IsEmpty() then
                         FailedCompanies.Add(Company.Name);
                 end;

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccountWizard.Page.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccountWizard.Page.al
@@ -339,7 +339,6 @@ page 4581 "Ext. SharePoint Account Wizard"
         FailedCompanies: List of [Text];
         SessionId: Integer;
         AccountCurrentCompanyCreated: Boolean;
-        I: Integer;
     begin
         AccountToCopy.Id := CreateGuid();
 

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccountWizard.Page.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccountWizard.Page.al
@@ -235,7 +235,9 @@ page 4581 "Ext. SharePoint Account Wizard"
 
                 trigger OnAction()
                 var
+                    ExtSharePointAccount: Record "Ext. SharePoint Account";
                     SecretToPass: SecretText;
+                    AccountExistsLbl: Label 'An account with the same name already exists. Do you want to update it?', Locked = true;
                 begin
                     case Rec."Authentication Type" of
                         Enum::"Ext. SharePoint Auth Type"::"Client Secret":
@@ -244,7 +246,14 @@ page 4581 "Ext. SharePoint Account Wizard"
                             SecretToPass := Certificate;
                     end;
                     if (Step = Step::AccountDetails) and not MultipleCompanies then begin
-                        SharePointConnectorImpl.CreateAccount(Rec, SecretToPass, CertificatePassword, SharePointAccount);
+                        ExtSharePointAccount.SetRange(Name, Rec.Name);
+                        if not ExtSharePointAccount.FindFirst() then
+                            SharePointConnectorImpl.CreateAccount(Rec, SecretToPass, CertificatePassword, SharePointAccount)
+                        else
+                            if Confirm(AccountExistsLbl, false) then
+                                SharePointConnectorImpl.ModifyAccount(ExtSharePointAccount, Rec, SecretToPass, CertificatePassword, SharePointAccount)
+                            else
+                                exit;
                         CurrPage.Close();
                     end;
                     if Step = Step::CompanySelection then begin
@@ -358,7 +367,7 @@ page 4581 "Ext. SharePoint Account Wizard"
                         AccountCurrentCompanyCreated := true;
                     ExtSharePointAccount.ChangeCompany(Company.Name);
                     ExtSharePointAccount.SetRange(Name, AccountToCopy.Name);
-                    ExtSharePointAccount.SetFilter(SystemCreatedAt, '>%1', StartOfProcess);
+                    ExtSharePointAccount.SetFilter(SystemModifiedAt, '>%1', StartOfProcess);
                     if ExtSharePointAccount.IsEmpty() then
                         FailedCompanies.Add(Company.Name);
                 end;

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointConnectorImpl.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointConnectorImpl.Codeunit.al
@@ -385,6 +385,12 @@ codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage
 
     internal procedure ModifyAccount(var AccountToModify: Record "Ext. SharePoint Account"; AccountWithNewValues: Record "Ext. SharePoint Account"; ClientSecretOrCertificate: SecretText; CertificatePassword: SecretText; var TempFileAccount: Record "File Account" temporary)
     begin
+        case AccountToModify."Authentication Type" of
+            Enum::"Ext. SharePoint Auth Type"::"Client Secret":
+                AccountToModify.ClearClientSecretAuthentication();
+            Enum::"Ext. SharePoint Auth Type"::Certificate:
+                AccountToModify.ClearCertificateAuthentication();
+        end;
         AccountToModify.TransferFields(AccountWithNewValues, false);
         case AccountToModify."Authentication Type" of
             Enum::"Ext. SharePoint Auth Type"::"Client Secret":

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointConnectorImpl.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointConnectorImpl.Codeunit.al
@@ -383,6 +383,26 @@ codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage
         TempFileAccount.Connector := Enum::"Ext. File Storage Connector"::"SharePoint";
     end;
 
+    internal procedure ModifyAccount(var AccountToModify: Record "Ext. SharePoint Account"; AccountWithNewValues: Record "Ext. SharePoint Account"; ClientSecretOrCertificate: SecretText; CertificatePassword: SecretText; var TempFileAccount: Record "File Account" temporary)
+    begin
+        AccountToModify.TransferFields(AccountWithNewValues, false);
+        case AccountToModify."Authentication Type" of
+            Enum::"Ext. SharePoint Auth Type"::"Client Secret":
+                AccountToModify.SetClientSecret(ClientSecretOrCertificate);
+            Enum::"Ext. SharePoint Auth Type"::Certificate:
+                begin
+                    AccountToModify.SetCertificate(ClientSecretOrCertificate);
+                    AccountToModify.SetCertificatePassword(CertificatePassword);
+                end;
+        end;
+
+        AccountToModify.Modify();
+
+        TempFileAccount."Account Id" := AccountToModify.Id;
+        TempFileAccount.Name := AccountToModify.Name;
+        TempFileAccount.Connector := Enum::"Ext. File Storage Connector"::"SharePoint";
+    end;
+
     local procedure InitSharePointClient(var AccountId: Guid; var SharePointClient: Codeunit "SharePoint Client")
     var
         SharePointAccount: Record "Ext. SharePoint Account";

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointCreateAccount.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointCreateAccount.Codeunit.al
@@ -1,0 +1,63 @@
+namespace System.ExternalFileStorage;
+
+codeunit 4581 "Ext. SharePoint Create Account"
+{
+    Access = Internal;
+    InherentEntitlements = X;
+    InherentPermissions = X;
+    Permissions = tabledata "Ext. SharePoint Account" = r;
+    TableNo = "Ext. SharePoint Account";
+
+    trigger OnRun()
+    var
+        ExtSharePointAccount: Record "Ext. SharePoint Account";
+        TempFileAccount: Record "File Account" temporary;
+        SharePointConnectorImpl: Codeunit "Ext. SharePoint Connector Impl";
+        SecretToPass: SecretText;
+        CertificatePassword: SecretText;
+        SetAsDefaultTxt: Text;
+    begin
+        if not IsolatedStorage.Get(GetSecretKeyToken(Rec.Id), DataScope::Module, SecretToPass) then
+            exit;
+
+        ExtSharePointAccount.SetRange(Name, Rec.Name);
+        if ExtSharePointAccount.FindFirst() then
+            SharePointConnectorImpl.DeleteAccount(ExtSharePointAccount.Id);
+
+        if IsolatedStorage.Get(GetCertPwdKeyToken(Rec.Id), DataScope::Module, CertificatePassword) then;
+
+        SharePointConnectorImpl.CreateAccount(Rec, SecretToPass, CertificatePassword, TempFileAccount);
+        if IsolatedStorage.Get(GetSetAsDefaultKeyToken(Rec.Id), DataScope::Module, SetAsDefaultTxt) then
+            if SetAsDefaultTxt = '1' then
+                MakeDefault(TempFileAccount);
+    end;
+
+    internal procedure MakeDefault(TempFileAccount: Record "File Account" temporary)
+    var
+        FileScenarioCU: Codeunit "File Scenario";
+    begin
+        // Cannot call codeunit "File Account Impl.", procedure IsUserFileAdmin due to it's protection level
+        FileScenarioCU.SetDefaultFileAccount(TempFileAccount);
+    end;
+
+    internal procedure GetSecretKeyToken(AccountId: Guid): Text
+    var
+        SecretKeyTokLbl: Label 'EFS_Secret_%1', Locked = true;
+    begin
+        exit(StrSubstNo(SecretKeyTokLbl, AccountId));
+    end;
+
+    internal procedure GetCertPwdKeyToken(AccountId: Guid): Text
+    var
+        CertPwdKeyTokLbl: Label 'EFS_CertPwd_%1', Locked = true;
+    begin
+        exit(StrSubstNo(CertPwdKeyTokLbl, AccountId));
+    end;
+
+    internal procedure GetSetAsDefaultKeyToken(AccountId: Guid): Text
+    var
+        SetAsDefaultKeyTokLbl: Label 'EFS_SetAsDefault_%1', Locked = true;
+    begin
+        exit(StrSubstNo(SetAsDefaultKeyTokLbl, AccountId));
+    end;
+}

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointCreateAccount.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointCreateAccount.Codeunit.al
@@ -19,14 +19,14 @@ codeunit 4581 "Ext. SharePoint Create Account"
     begin
         if not IsolatedStorage.Get(GetSecretKeyToken(Rec.Id), DataScope::Module, SecretToPass) then
             exit;
-
-        ExtSharePointAccount.SetRange(Name, Rec.Name);
-        if ExtSharePointAccount.FindFirst() then
-            SharePointConnectorImpl.DeleteAccount(ExtSharePointAccount.Id);
-
         if IsolatedStorage.Get(GetCertPwdKeyToken(Rec.Id), DataScope::Module, CertificatePassword) then;
 
-        SharePointConnectorImpl.CreateAccount(Rec, SecretToPass, CertificatePassword, TempFileAccount);
+        ExtSharePointAccount.SetRange(Name, Rec.Name);
+        if not ExtSharePointAccount.FindFirst() then
+            SharePointConnectorImpl.CreateAccount(Rec, SecretToPass, CertificatePassword, TempFileAccount)
+        else
+            SharePointConnectorImpl.ModifyAccount(ExtSharePointAccount, Rec, SecretToPass, CertificatePassword, TempFileAccount);
+
         if IsolatedStorage.Get(GetSetAsDefaultKeyToken(Rec.Id), DataScope::Module, SetAsDefaultTxt) then
             if SetAsDefaultTxt = '1' then
                 MakeDefault(TempFileAccount);


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

Creating a SharePoint file account is currently per company. Most of our customers use one SharePoint account per database. Most databases contain 30 companies or more. Manually creating these file accounts per company is a burden. This PR will fix that.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #9596

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*
In the "Ext. SharePoint Account Wizard"-page enabled "Multiple Companies" and thereby created file account in multiple companies.
Tested this with and without the "Company Filter" and with and without "Set as default" set.

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

Due to the protection level the permission check if a user has rights to set the newly created file account is default is done with calling "File Account Impl.".IsUserFileAdmin().

When multi company is activated, an exiting SharePoint file account will be removed before it will be added again.
