### PR TITLE
[28.x] Add Microsoft Graph API Support to SharePoint Connector

### DIFF
--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/app.json
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/app.json
@@ -24,7 +24,7 @@
   "idRanges": [
     {
       "from": 4580,
-      "to": 4589
+      "to": 4610
     }
   ],
   "resourceExposurePolicy": {

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccount.Page.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccount.Page.al
@@ -97,10 +97,18 @@ page 4580 "Ext. SharePoint Account"
                 }
             }
             field(Disabled; Rec.Disabled) { }
+            field("Use legacy REST API"; Rec."Use legacy REST API")
+            {
+                trigger OnValidate()
+                begin
+                    Message(CheckBasePathMsg);
+                end;
+            }
         }
     }
 
     var
+        CheckBasePathMsg: Label 'The API type has been changed. Please verify that the Base Relative Folder Path is still correct for the selected API type.';
         PageEditable: Boolean;
         ClientSecretVisible: Boolean;
         CertificateVisible: Boolean;

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccount.Table.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccount.Table.al
@@ -34,7 +34,7 @@ table 4580 "Ext. SharePoint Account"
         field(5; "Base Relative Folder Path"; Text[2048])
         {
             Caption = 'Base Relative Folder Path';
-            ToolTip = 'Specifies the folder path relative to the site collection. Start with the document library or folder name (e.g., Shared Documents/Reports). This path can be copied from the URL of the folder in SharePoint after the site collection (e.g., /Shared Documents/Reports from https://mysharepoint.sharepoint.com/sites/ProjectX/Shared%20Documents/Reports).';
+            ToolTip = 'Specifies the base folder path. For SharePoint REST API: Use the full server-relative path including the site (e.g., /sites/ProjectX/Shared Documents/Reports). For Microsoft Graph API: Use only the path relative to the document library (e.g., Reports). When using Graph API, the path should not include the site or document library root, only the folders within the library.';
         }
         field(6; "Tenant Id"; Guid)
         {
@@ -50,7 +50,9 @@ table 4580 "Ext. SharePoint Account"
         }
         field(8; "Client Secret Key"; Guid)
         {
+            Caption = 'Client Secret Key';
             Access = Internal;
+            AllowInCustomizations = Never;
             DataClassification = SystemMetadata;
         }
         field(9; Disabled; Boolean)
@@ -61,18 +63,28 @@ table 4580 "Ext. SharePoint Account"
         field(10; "Authentication Type"; Enum "Ext. SharePoint Auth Type")
         {
             Caption = 'Authentication Type';
-            ToolTip = 'Specifies the authentication flow used for this SharePoint account. Client Secret uses User grant flow, which means that the user must sign in when using this account. Certificate uses Client credentials flow, which means that the user does not need to sign in when using this account.';
+            ToolTip = 'Specifies the authentication method used for this SharePoint account. When using the legacy REST API, Client Secret uses the Authorization Code (user grant) flow, which requires an interactive sign-in, while Certificate uses the Client Credentials (app-only) flow, which does not require a user sign-in. When using Microsoft Graph API, both Client Secret and Certificate always use the Client Credentials (app-only) flow, so no interactive sign-in is required regardless of the selected type.';
             InitValue = "Client Secret";
         }
         field(11; "Certificate Key"; Guid)
         {
+            Caption = 'Certificate Key';
             Access = Internal;
+            AllowInCustomizations = Never;
             DataClassification = SystemMetadata;
         }
         field(12; "Certificate Password Key"; Guid)
         {
+            Caption = 'Certificate Password Key';
             Access = Internal;
+            AllowInCustomizations = Never;
             DataClassification = SystemMetadata;
+        }
+        field(13; "Use legacy REST API"; Boolean)
+        {
+            Caption = 'Use legacy REST API';
+            DataClassification = SystemMetadata;
+            ToolTip = 'Specifies whether to use Microsoft Graph API or SharePoint REST API. Microsoft Graph API supports downloading files larger than 150 MB through chunked transfers. Note: Requires Microsoft Graph permissions (Sites.ReadWrite.All) configured in your app registration instead of SharePoint permissions.';
         }
     }
 

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccountWizard.Page.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointAccountWizard.Page.al
@@ -43,7 +43,6 @@ page 4581 "Ext. SharePoint Account Wizard"
                 Caption = 'Account Name';
                 NotBlank = true;
                 ShowMandatory = true;
-                ToolTip = 'Specifies a descriptive name for this SharePoint storage account connection.';
 
                 trigger OnValidate()
                 begin
@@ -54,7 +53,6 @@ page 4581 "Ext. SharePoint Account Wizard"
             field("Tenant Id"; Rec."Tenant Id")
             {
                 ShowMandatory = true;
-                ToolTip = 'Specifies the Microsoft Entra ID Tenant ID (Directory ID) where your SharePoint site and app registration are located.';
 
                 trigger OnValidate()
                 begin
@@ -65,7 +63,6 @@ page 4581 "Ext. SharePoint Account Wizard"
             field("Client Id"; Rec."Client Id")
             {
                 ShowMandatory = true;
-                ToolTip = 'Specifies the Client ID (Application ID) of the App Registration in Microsoft Entra ID.';
 
                 trigger OnValidate()
                 begin
@@ -75,7 +72,6 @@ page 4581 "Ext. SharePoint Account Wizard"
 
             field("Authentication Type"; Rec."Authentication Type")
             {
-                ToolTip = 'Specifies the authentication flow used for this SharePoint account. Client Secret uses User grant flow, which means that the user must sign in when using this account. Certificate uses Client credentials flow, which means that the user does not need to sign in when using this account.';
                 trigger OnValidate()
                 begin
                     UpdateAuthTypeVisibility();
@@ -133,6 +129,9 @@ page 4581 "Ext. SharePoint Account Wizard"
                 begin
                     IsNextEnabled := SharePointConnectorImpl.IsAccountValid(Rec);
                 end;
+            }
+            field("Use legacy REST API"; Rec."Use legacy REST API")
+            {
             }
 
             field("Base Relative Folder Path"; Rec."Base Relative Folder Path")

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointConnectorImpl.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointConnectorImpl.Codeunit.al
@@ -6,9 +6,9 @@
 namespace System.ExternalFileStorage;
 
 using System.DataAdministration;
+using System.Integration.Graph.Authorization;
 using System.Integration.Sharepoint;
 using System.Text;
-using System.Utilities;
 
 codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage Connector"
 {
@@ -18,8 +18,12 @@ codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage
     Permissions = tabledata "Ext. SharePoint Account" = rimd;
 
     var
+        RestHelper: Codeunit "Ext. SharePoint REST Helper";
+        GraphHelper: Codeunit "Ext. SharePoint Graph Helper";
         ConnectorDescriptionTxt: Label 'Use SharePoint to store and retrieve files.', MaxLength = 250;
         NotRegisteredAccountErr: Label 'We could not find the account. Typically, this is because the account has been deleted.';
+
+    #region File Operations
 
     /// <summary>
     /// Gets a List of Files stored on the provided account.
@@ -30,28 +34,13 @@ codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage
     /// <param name="TempFileAccountContent">A list with all files stored in the path.</param>
     procedure ListFiles(AccountId: Guid; Path: Text; FilePaginationData: Codeunit "File Pagination Data"; var TempFileAccountContent: Record "File Account Content" temporary)
     var
-        SharePointFile: Record "SharePoint File";
-        SharePointClient: Codeunit "SharePoint Client";
-        OrginalPath: Text;
+        SharePointAccount: Record "Ext. SharePoint Account";
     begin
-        OrginalPath := Path;
-        InitPath(AccountId, Path);
-        InitSharePointClient(AccountId, SharePointClient);
-        if not SharePointClient.GetFolderFilesByServerRelativeUrl(Path, SharePointFile) then
-            ShowError(SharePointClient);
-
-        FilePaginationData.SetEndOfListing(true);
-
-        if not SharePointFile.FindSet() then
-            exit;
-
-        repeat
-            TempFileAccountContent.Init();
-            TempFileAccountContent.Name := SharePointFile.Name;
-            TempFileAccountContent.Type := TempFileAccountContent.Type::"File";
-            TempFileAccountContent."Parent Directory" := CopyStr(OrginalPath, 1, MaxStrLen(TempFileAccountContent."Parent Directory"));
-            TempFileAccountContent.Insert();
-        until SharePointFile.Next() = 0;
+        SharePointAccount.Get(AccountId);
+        if SharePointAccount."Use legacy REST API" then
+            RestHelper.ListFiles(SharePointAccount, Path, FilePaginationData, TempFileAccountContent)
+        else
+            GraphHelper.ListFiles(SharePointAccount, Path, FilePaginationData, TempFileAccountContent);
     end;
 
     /// <summary>
@@ -59,22 +48,16 @@ codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage
     /// </summary>
     /// <param name="AccountId">The file account ID which is used to get the file.</param>
     /// <param name="Path">The file path inside the file account.</param>
-    /// <param name="Stream">The Stream were the file is read to.</param>
+    /// <param name="Stream">The Stream where the file is read to.</param>
     procedure GetFile(AccountId: Guid; Path: Text; Stream: InStream)
     var
-        SharePointClient: Codeunit "SharePoint Client";
-        Content: HttpContent;
-        TempBlobStream: InStream;
+        SharePointAccount: Record "Ext. SharePoint Account";
     begin
-        InitPath(AccountId, Path);
-        InitSharePointClient(AccountId, SharePointClient);
-
-        if not SharePointClient.DownloadFileContentByServerRelativeUrl(Path, TempBlobStream) then
-            ShowError(SharePointClient);
-
-        // Platform fix: For some reason the Stream from DownloadFileContentByServerRelativeUrl dies after leaving the interface
-        Content.WriteFrom(TempBlobStream);
-        Content.ReadAs(Stream);
+        SharePointAccount.Get(AccountId);
+        if SharePointAccount."Use legacy REST API" then
+            RestHelper.GetFile(SharePointAccount, Path, Stream)
+        else
+            GraphHelper.GetFile(SharePointAccount, Path, Stream);
     end;
 
     /// <summary>
@@ -82,52 +65,50 @@ codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage
     /// </summary>
     /// <param name="AccountId">The file account ID which is used to send out the file.</param>
     /// <param name="Path">The file path inside the file account.</param>
-    /// <param name="Stream">The Stream were the file is read from.</param>
+    /// <param name="Stream">The Stream where the file is read from.</param>
     procedure CreateFile(AccountId: Guid; Path: Text; Stream: InStream)
     var
-        SharePointFile: Record "SharePoint File";
-        SharePointClient: Codeunit "SharePoint Client";
-        ParentPath, FileName : Text;
+        SharePointAccount: Record "Ext. SharePoint Account";
     begin
-        InitPath(AccountId, Path);
-        InitSharePointClient(AccountId, SharePointClient);
-        SplitPath(Path, ParentPath, FileName);
-        if SharePointClient.AddFileToFolder(ParentPath, FileName, Stream, SharePointFile, false) then
-            exit;
-
-        ShowError(SharePointClient);
+        SharePointAccount.Get(AccountId);
+        if SharePointAccount."Use legacy REST API" then
+            RestHelper.CreateFile(SharePointAccount, Path, Stream)
+        else
+            GraphHelper.CreateFile(SharePointAccount, Path, Stream);
     end;
 
     /// <summary>
-    /// Copies as file inside the provided account.
+    /// Copies a file inside the provided account.
     /// </summary>
     /// <param name="AccountId">The file account ID which is used to send out the file.</param>
     /// <param name="SourcePath">The source file path.</param>
     /// <param name="TargetPath">The target file path.</param>
     procedure CopyFile(AccountId: Guid; SourcePath: Text; TargetPath: Text)
     var
-        TempBlob: Codeunit "Temp Blob";
-        Stream: InStream;
+        SharePointAccount: Record "Ext. SharePoint Account";
     begin
-        TempBlob.CreateInStream(Stream);
-
-        GetFile(AccountId, SourcePath, Stream);
-        CreateFile(AccountId, TargetPath, Stream);
+        SharePointAccount.Get(AccountId);
+        if SharePointAccount."Use legacy REST API" then
+            RestHelper.CopyFile(SharePointAccount, SourcePath, TargetPath)
+        else
+            GraphHelper.CopyFile(SharePointAccount, SourcePath, TargetPath);
     end;
 
     /// <summary>
-    /// Move as file inside the provided account.
+    /// Moves a file inside the provided account.
     /// </summary>
     /// <param name="AccountId">The file account ID which is used to send out the file.</param>
     /// <param name="SourcePath">The source file path.</param>
     /// <param name="TargetPath">The target file path.</param>
     procedure MoveFile(AccountId: Guid; SourcePath: Text; TargetPath: Text)
     var
-        Stream: InStream;
+        SharePointAccount: Record "Ext. SharePoint Account";
     begin
-        GetFile(AccountId, SourcePath, Stream);
-        CreateFile(AccountId, TargetPath, Stream);
-        DeleteFile(AccountId, SourcePath);
+        SharePointAccount.Get(AccountId);
+        if SharePointAccount."Use legacy REST API" then
+            RestHelper.MoveFile(SharePointAccount, SourcePath, TargetPath)
+        else
+            GraphHelper.MoveFile(SharePointAccount, SourcePath, TargetPath);
     end;
 
     /// <summary>
@@ -138,33 +119,29 @@ codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage
     /// <returns>Returns true if the file exists</returns>
     procedure FileExists(AccountId: Guid; Path: Text): Boolean
     var
-        SharePointFile: Record "SharePoint File";
-        SharePointClient: Codeunit "SharePoint Client";
+        SharePointAccount: Record "Ext. SharePoint Account";
     begin
-        InitPath(AccountId, Path);
-        InitSharePointClient(AccountId, SharePointClient);
-        if not SharePointClient.GetFolderFilesByServerRelativeUrl(GetParentPath(Path), SharePointFile) then
-            ShowError(SharePointClient);
-
-        SharePointFile.SetRange(Name, GetFileName(Path));
-        exit(not SharePointFile.IsEmpty());
+        SharePointAccount.Get(AccountId);
+        if SharePointAccount."Use legacy REST API" then
+            exit(RestHelper.FileExists(SharePointAccount, Path))
+        else
+            exit(GraphHelper.FileExists(SharePointAccount, Path));
     end;
 
     /// <summary>
-    /// Deletes a file exists on the provided account.
+    /// Deletes a file on the provided account.
     /// </summary>
     /// <param name="AccountId">The file account ID which is used to send out the file.</param>
     /// <param name="Path">The file path inside the file account.</param>
     procedure DeleteFile(AccountId: Guid; Path: Text)
     var
-        SharePointClient: Codeunit "SharePoint Client";
+        SharePointAccount: Record "Ext. SharePoint Account";
     begin
-        InitPath(AccountId, Path);
-        InitSharePointClient(AccountId, SharePointClient);
-        if SharePointClient.DeleteFileByServerRelativeUrl(Path) then
-            exit;
-
-        ShowError(SharePointClient);
+        SharePointAccount.Get(AccountId);
+        if SharePointAccount."Use legacy REST API" then
+            RestHelper.DeleteFile(SharePointAccount, Path)
+        else
+            GraphHelper.DeleteFile(SharePointAccount, Path);
     end;
 
     /// <summary>
@@ -176,28 +153,13 @@ codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage
     /// <param name="Files">A list with all directories stored in the path.</param>
     procedure ListDirectories(AccountId: Guid; Path: Text; FilePaginationData: Codeunit "File Pagination Data"; var TempFileAccountContent: Record "File Account Content" temporary)
     var
-        SharePointFolder: Record "SharePoint Folder";
-        SharePointClient: Codeunit "SharePoint Client";
-        OrginalPath: Text;
+        SharePointAccount: Record "Ext. SharePoint Account";
     begin
-        OrginalPath := Path;
-        InitPath(AccountId, Path);
-        InitSharePointClient(AccountId, SharePointClient);
-        if not SharePointClient.GetSubFoldersByServerRelativeUrl(Path, SharePointFolder) then
-            ShowError(SharePointClient);
-
-        FilePaginationData.SetEndOfListing(true);
-
-        if not SharePointFolder.FindSet() then
-            exit;
-
-        repeat
-            TempFileAccountContent.Init();
-            TempFileAccountContent.Name := SharePointFolder.Name;
-            TempFileAccountContent.Type := TempFileAccountContent.Type::Directory;
-            TempFileAccountContent."Parent Directory" := CopyStr(OrginalPath, 1, MaxStrLen(TempFileAccountContent."Parent Directory"));
-            TempFileAccountContent.Insert();
-        until SharePointFolder.Next() = 0;
+        SharePointAccount.Get(AccountId);
+        if SharePointAccount."Use legacy REST API" then
+            RestHelper.ListDirectories(SharePointAccount, Path, FilePaginationData, TempFileAccountContent)
+        else
+            GraphHelper.ListDirectories(SharePointAccount, Path, FilePaginationData, TempFileAccountContent);
     end;
 
     /// <summary>
@@ -207,15 +169,13 @@ codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage
     /// <param name="Path">The directory path inside the file account.</param>
     procedure CreateDirectory(AccountId: Guid; Path: Text)
     var
-        SharePointFolder: Record "SharePoint Folder";
-        SharePointClient: Codeunit "SharePoint Client";
+        SharePointAccount: Record "Ext. SharePoint Account";
     begin
-        InitPath(AccountId, Path);
-        InitSharePointClient(AccountId, SharePointClient);
-        if SharePointClient.CreateFolder(Path, SharePointFolder) then
-            exit;
-
-        ShowError(SharePointClient);
+        SharePointAccount.Get(AccountId);
+        if SharePointAccount."Use legacy REST API" then
+            RestHelper.CreateDirectory(SharePointAccount, Path)
+        else
+            GraphHelper.CreateDirectory(SharePointAccount, Path);
     end;
 
     /// <summary>
@@ -226,33 +186,32 @@ codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage
     /// <returns>Returns true if the directory exists</returns>
     procedure DirectoryExists(AccountId: Guid; Path: Text) Result: Boolean
     var
-        SharePointClient: Codeunit "SharePoint Client";
+        SharePointAccount: Record "Ext. SharePoint Account";
     begin
-        InitPath(AccountId, Path);
-        InitSharePointClient(AccountId, SharePointClient);
-
-        Result := SharePointClient.FolderExistsByServerRelativeUrl(Path);
-
-        if not SharePointClient.GetDiagnostics().IsSuccessStatusCode() then
-            ShowError(SharePointClient);
+        SharePointAccount.Get(AccountId);
+        if SharePointAccount."Use legacy REST API" then
+            exit(RestHelper.DirectoryExists(SharePointAccount, Path))
+        else
+            exit(GraphHelper.DirectoryExists(SharePointAccount, Path));
     end;
 
     /// <summary>
-    /// Deletes a directory exists on the provided account.
+    /// Deletes a directory on the provided account.
     /// </summary>
     /// <param name="AccountId">The file account ID which is used to send out the file.</param>
     /// <param name="Path">The directory path inside the file account.</param>
     procedure DeleteDirectory(AccountId: Guid; Path: Text)
     var
-        SharePointClient: Codeunit "SharePoint Client";
+        SharePointAccount: Record "Ext. SharePoint Account";
     begin
-        InitPath(AccountId, Path);
-        InitSharePointClient(AccountId, SharePointClient);
-        if SharePointClient.DeleteFolderByServerRelativeUrl(Path) then
-            exit;
-
-        ShowError(SharePointClient);
+        SharePointAccount.Get(AccountId);
+        if SharePointAccount."Use legacy REST API" then
+            RestHelper.DeleteDirectory(SharePointAccount, Path)
+        else
+            GraphHelper.DeleteDirectory(SharePointAccount, Path);
     end;
+
+    #endregion
 
     /// <summary>
     /// Gets the registered accounts for the SharePoint connector.
@@ -383,118 +342,14 @@ codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage
         TempFileAccount.Connector := Enum::"Ext. File Storage Connector"::"SharePoint";
     end;
 
-    local procedure InitSharePointClient(var AccountId: Guid; var SharePointClient: Codeunit "SharePoint Client")
-    var
-        SharePointAccount: Record "Ext. SharePoint Account";
-        SharePointAuth: Codeunit "SharePoint Auth.";
-        SharePointAuthorization: Interface "SharePoint Authorization";
-        Scopes: List of [Text];
-        AccountDisabledErr: Label 'The account "%1" is disabled.', Comment = '%1 - Account Name';
+    /// <summary>
+    /// Injects mock authorizations into both helpers so tests can exercise the dispatching
+    /// between the Graph and REST stacks without acquiring real tokens.
+    /// </summary>
+    internal procedure SetAuthorizationsForTest(GraphAuthorization: Interface "Graph Authorization"; SharePointAuthorization: Interface "SharePoint Authorization")
     begin
-        SharePointAccount.Get(AccountId);
-        if SharePointAccount.Disabled then
-            Error(AccountDisabledErr, SharePointAccount.Name);
-
-        Scopes.Add('00000003-0000-0ff1-ce00-000000000000/.default');
-
-        case SharePointAccount."Authentication Type" of
-            Enum::"Ext. SharePoint Auth Type"::"Client Secret":
-                SharePointAuthorization := SharePointAuth.CreateAuthorizationCode(
-                    Format(SharePointAccount."Tenant Id", 0, 4),
-                    Format(SharePointAccount."Client Id", 0, 4),
-                    SharePointAccount.GetClientSecret(SharePointAccount."Client Secret Key"),
-                    Scopes);
-            Enum::"Ext. SharePoint Auth Type"::Certificate:
-                SharePointAuthorization := SharePointAuth.CreateClientCredentials(
-                    Format(SharePointAccount."Tenant Id", 0, 4),
-                    Format(SharePointAccount."Client Id", 0, 4),
-                    SharePointAccount.GetCertificate(SharePointAccount."Certificate Key"),
-                    SharePointAccount.GetCertificatePassword(SharePointAccount."Certificate Password Key"),
-                    Scopes);
-        end;
-
-        SharePointClient.Initialize(SharePointAccount."SharePoint Url", SharePointAuthorization);
-    end;
-
-    local procedure PathSeparator(): Text
-    begin
-        exit('/');
-    end;
-
-    local procedure ShowError(var SharePointClient: Codeunit "SharePoint Client")
-    var
-        ErrorOccuredErr: Label 'An error occured.\%1', Comment = '%1 - Error message from sharepoint';
-    begin
-        Error(ErrorOccuredErr, SharePointClient.GetDiagnostics().GetErrorMessage());
-    end;
-
-    local procedure GetParentPath(Path: Text) ParentPath: Text
-    begin
-        if (Path.TrimEnd(PathSeparator()).Contains(PathSeparator())) then
-            ParentPath := Path.TrimEnd(PathSeparator()).Substring(1, Path.LastIndexOf(PathSeparator()));
-    end;
-
-    local procedure GetFileName(Path: Text) FileName: Text
-    begin
-        if (Path.TrimEnd(PathSeparator()).Contains(PathSeparator())) then
-            FileName := Path.TrimEnd(PathSeparator()).Substring(Path.LastIndexOf(PathSeparator()) + 1);
-    end;
-
-    local procedure InitPath(AccountId: Guid; var Path: Text)
-    var
-        SharePointAccount: Record "Ext. SharePoint Account";
-        SitePath: Text;
-    begin
-        SharePointAccount.Get(AccountId);
-
-        // Extract site path from SharePoint URL
-        SitePath := GetSitePathFromUrl(SharePointAccount."SharePoint Url");
-
-        // Combine base folder path with the file path
-        Path := CombinePath(SharePointAccount."Base Relative Folder Path", Path);
-
-        // Ensure path starts with forward slash
-        if not Path.StartsWith('/') then
-            Path := '/' + Path;
-
-        // Prepend site path if it exists and path doesn't already include it
-        if (SitePath <> '') and (not Path.StartsWith(SitePath)) then
-            Path := SitePath + Path;
-    end;
-
-    local procedure GetSitePathFromUrl(SharePointUrl: Text): Text
-    var
-        Uri: Codeunit Uri;
-        PathSegment: Text;
-    begin
-        Uri.Init(SharePointUrl);
-        PathSegment := Uri.GetAbsolutePath();
-
-        // Remove trailing slash if present
-        if PathSegment.EndsWith('/') then
-            PathSegment := PathSegment.TrimEnd('/');
-
-        exit(PathSegment);
-    end;
-
-    local procedure CombinePath(Parent: Text; Child: Text): Text
-    begin
-        if Parent = '' then
-            exit(Child);
-
-        if Child = '' then
-            exit(Parent);
-
-        if not Parent.EndsWith(PathSeparator()) then
-            Parent += PathSeparator();
-
-        exit(Parent + Child);
-    end;
-
-    local procedure SplitPath(Path: Text; var ParentPath: Text; var FileName: Text)
-    begin
-        ParentPath := Path.TrimEnd(PathSeparator()).Substring(1, Path.LastIndexOf(PathSeparator()));
-        FileName := Path.TrimEnd(PathSeparator()).Substring(Path.LastIndexOf(PathSeparator()) + 1);
+        GraphHelper.SetAuthorizationForTest(GraphAuthorization);
+        RestHelper.SetAuthorizationForTest(SharePointAuthorization);
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Environment Cleanup", OnClearCompanyConfig, '', false, false)]

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointGraphHelper.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointGraphHelper.Codeunit.al
@@ -1,0 +1,387 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.ExternalFileStorage;
+
+using System.Integration.Graph.Authorization;
+using System.Integration.Sharepoint;
+using System.Utilities;
+
+/// <summary>
+/// Helper implementation for SharePoint file operations using Microsoft Graph API.
+/// This codeunit contains the actual Graph API logic, called by the main connector based on account settings.
+/// </summary>
+codeunit 4610 "Ext. SharePoint Graph Helper"
+{
+    Access = Internal;
+    InherentEntitlements = X;
+    InherentPermissions = X;
+    Permissions = tabledata "Ext. SharePoint Account" = r;
+
+
+    var
+        SharePointGraphClient: Codeunit "SharePoint Graph Client";
+        TestGraphAuthorization: Interface "Graph Authorization";
+        UseTestGraphAuthorization: Boolean;
+        ErrorOccurredErr: Label 'An error occurred.\%1', Comment = '%1 - Error message from Graph API';
+
+    #region File Operations
+
+    internal procedure ListFiles(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; FilePaginationData: Codeunit "File Pagination Data"; var TempFileAccountContent: Record "File Account Content" temporary)
+    var
+        TempGraphDriveItem: Record "SharePoint Graph Drive Item";
+        Response: Codeunit "SharePoint Graph Response";
+        OriginalPath: Text;
+    begin
+        OriginalPath := Path;
+        InitPath(SharePointAccount, Path);
+        InitializeGraphClient(SharePointAccount);
+
+        // List children in the directory
+        Path := Path.TrimEnd('/');
+        if Path = '' then
+            Path := '/';
+
+        Response := SharePointGraphClient.GetItemsByPath(Path, TempGraphDriveItem);
+
+        if not Response.IsSuccessful() then
+            ShowError(Response);
+
+        FilePaginationData.SetEndOfListing(true);
+
+        if not TempGraphDriveItem.FindSet() then
+            exit;
+
+        repeat
+            // Only include files (not folders)
+            if not TempGraphDriveItem.IsFolder then begin
+                TempFileAccountContent.Init();
+                TempFileAccountContent.Name := TempGraphDriveItem.Name;
+                TempFileAccountContent.Type := TempFileAccountContent.Type::"File";
+                TempFileAccountContent."Parent Directory" := CopyStr(OriginalPath, 1, MaxStrLen(TempFileAccountContent."Parent Directory"));
+                TempFileAccountContent.Insert();
+            end;
+        until TempGraphDriveItem.Next() = 0;
+    end;
+
+    internal procedure GetFile(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; Stream: InStream)
+    var
+        TempBlob: Codeunit "Temp Blob";
+        Response: Codeunit "SharePoint Graph Response";
+        Content: HttpContent;
+    begin
+        InitPath(SharePointAccount, Path);
+        InitializeGraphClient(SharePointAccount);
+
+        // Use chunked download for all files to handle >150MB files
+        Response := SharePointGraphClient.DownloadLargeFileByPath(Path, TempBlob);
+
+        if not Response.IsSuccessful() then
+            ShowError(Response);
+
+        // TempBlob is cleared after the procedure. HttpContent "hack" keeps the data.
+        Content.WriteFrom(TempBlob.CreateInStream());
+        Content.ReadAs(Stream);
+    end;
+
+    internal procedure CreateFile(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; Stream: InStream)
+    var
+        TempGraphDriveItem: Record "SharePoint Graph Drive Item";
+        Response: Codeunit "SharePoint Graph Response";
+        FileName: Text;
+        FolderPath: Text;
+        MaxSimpleUploadSize: Integer;
+    begin
+        InitPath(SharePointAccount, Path);
+        InitializeGraphClient(SharePointAccount);
+
+        // Split path into folder and filename
+        SplitPath(Path, FolderPath, FileName);
+
+        // Use simple upload for files under 4MB, chunked upload for larger files
+        // Graph API supports simple upload up to 4MB
+        MaxSimpleUploadSize := 4 * 1024 * 1024; // 4 MB
+
+        if Stream.Length <= MaxSimpleUploadSize then
+            Response := SharePointGraphClient.UploadFile(FolderPath, FileName, Stream, TempGraphDriveItem)
+        else
+            Response := SharePointGraphClient.UploadLargeFile(FolderPath, FileName, Stream, TempGraphDriveItem);
+
+        if not Response.IsSuccessful() then
+            ShowError(Response);
+    end;
+
+    internal procedure CopyFile(SharePointAccount: Record "Ext. SharePoint Account"; SourcePath: Text; TargetPath: Text)
+    var
+        Response: Codeunit "SharePoint Graph Response";
+        FileName: Text;
+        TargetFolderPath: Text;
+    begin
+        InitPath(SharePointAccount, SourcePath);
+        InitPath(SharePointAccount, TargetPath);
+        InitializeGraphClient(SharePointAccount);
+
+        // Split destination path into folder and filename
+        SplitPath(TargetPath, TargetFolderPath, FileName);
+
+        // Use native Graph API copy operation
+        Response := SharePointGraphClient.CopyItemByPath(SourcePath, TargetFolderPath, FileName);
+
+        if not Response.IsSuccessful() then
+            ShowError(Response);
+    end;
+
+    internal procedure MoveFile(SharePointAccount: Record "Ext. SharePoint Account"; SourcePath: Text; TargetPath: Text)
+    var
+        Response: Codeunit "SharePoint Graph Response";
+        FileName: Text;
+        TargetFolderPath: Text;
+    begin
+        InitPath(SharePointAccount, SourcePath);
+        InitPath(SharePointAccount, TargetPath);
+        InitializeGraphClient(SharePointAccount);
+
+        // Split destination path into folder and filename
+        SplitPath(TargetPath, TargetFolderPath, FileName);
+
+        // Use native Graph API move operation
+        Response := SharePointGraphClient.MoveItemByPath(SourcePath, TargetFolderPath, FileName);
+
+        if not Response.IsSuccessful() then
+            ShowError(Response);
+    end;
+
+    internal procedure FileExists(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text): Boolean
+    var
+        Response: Codeunit "SharePoint Graph Response";
+        Exists: Boolean;
+    begin
+        InitPath(SharePointAccount, Path);
+        InitializeGraphClient(SharePointAccount);
+
+        Response := SharePointGraphClient.ItemExistsByPath(Path, Exists);
+
+        if not Response.IsSuccessful() then
+            ShowError(Response);
+
+        exit(Exists);
+    end;
+
+    internal procedure DeleteFile(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text)
+    var
+        Response: Codeunit "SharePoint Graph Response";
+    begin
+        InitPath(SharePointAccount, Path);
+        InitializeGraphClient(SharePointAccount);
+
+        Response := SharePointGraphClient.DeleteItemByPath(Path);
+
+        if not Response.IsSuccessful() then
+            ShowError(Response);
+    end;
+
+    #endregion
+
+    #region Directory Operations
+
+    internal procedure ListDirectories(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; FilePaginationData: Codeunit "File Pagination Data"; var TempFileAccountContent: Record "File Account Content" temporary)
+    var
+        TempGraphDriveItem: Record "SharePoint Graph Drive Item";
+        Response: Codeunit "SharePoint Graph Response";
+        OriginalPath: Text;
+    begin
+        OriginalPath := Path;
+        InitPath(SharePointAccount, Path);
+        InitializeGraphClient(SharePointAccount);
+
+        // List children in the directory
+        Path := Path.TrimEnd('/');
+        if Path = '' then
+            Path := '/';
+
+        Response := SharePointGraphClient.GetItemsByPath(Path, TempGraphDriveItem);
+
+        if not Response.IsSuccessful() then
+            ShowError(Response);
+
+        FilePaginationData.SetEndOfListing(true);
+
+        if not TempGraphDriveItem.FindSet() then
+            exit;
+
+        repeat
+            // Only include folders
+            if TempGraphDriveItem.IsFolder then begin
+                TempFileAccountContent.Init();
+                TempFileAccountContent.Name := TempGraphDriveItem.Name;
+                TempFileAccountContent.Type := TempFileAccountContent.Type::Directory;
+                TempFileAccountContent."Parent Directory" := CopyStr(OriginalPath, 1, MaxStrLen(TempFileAccountContent."Parent Directory"));
+                TempFileAccountContent.Insert();
+            end;
+        until TempGraphDriveItem.Next() = 0;
+    end;
+
+    internal procedure CreateDirectory(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text)
+    var
+        TempGraphDriveItem: Record "SharePoint Graph Drive Item";
+        Response: Codeunit "SharePoint Graph Response";
+        ParentPath: Text;
+        FolderName: Text;
+    begin
+        InitPath(SharePointAccount, Path);
+        InitializeGraphClient(SharePointAccount);
+
+        // Split path into parent path and folder name
+        SplitPath(Path, ParentPath, FolderName);
+
+        Response := SharePointGraphClient.CreateFolder(ParentPath, FolderName, TempGraphDriveItem);
+
+        if not Response.IsSuccessful() then
+            ShowError(Response);
+    end;
+
+    internal procedure DirectoryExists(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text): Boolean
+    var
+        Response: Codeunit "SharePoint Graph Response";
+        Exists: Boolean;
+    begin
+        InitPath(SharePointAccount, Path);
+        InitializeGraphClient(SharePointAccount);
+
+        Response := SharePointGraphClient.ItemExistsByPath(Path, Exists);
+
+        if not Response.IsSuccessful() then
+            ShowError(Response);
+
+        exit(Exists);
+    end;
+
+    internal procedure DeleteDirectory(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text)
+    var
+        Response: Codeunit "SharePoint Graph Response";
+    begin
+        InitPath(SharePointAccount, Path);
+        InitializeGraphClient(SharePointAccount);
+
+        Response := SharePointGraphClient.DeleteItemByPath(Path);
+
+        if not Response.IsSuccessful() then
+            ShowError(Response);
+    end;
+
+    #endregion
+
+    #region Helper Methods
+
+    local procedure InitializeGraphClient(SharePointAccount: Record "Ext. SharePoint Account")
+    var
+        GraphAuthorization: Codeunit "Graph Authorization";
+        GraphAuthInterface: Interface "Graph Authorization";
+        ClientSecret: SecretText;
+        Certificate: SecretText;
+        CertificatePassword: SecretText;
+        Scopes: List of [Text];
+        AccountDisabledErr: Label 'The account "%1" is disabled.', Comment = '%1 - Account Name';
+    begin
+        // Get and validate account
+        if SharePointAccount.Disabled then
+            Error(AccountDisabledErr, SharePointAccount.Name);
+
+        // Add required SharePoint scopes
+        Scopes.Add('https://graph.microsoft.com/.default');
+
+        // Create authorization based on authentication type.
+        // Tests inject a mock authorization because acquiring a token requires a real Entra ID app registration.
+        if UseTestGraphAuthorization then
+            GraphAuthInterface := TestGraphAuthorization
+        else
+            case SharePointAccount."Authentication Type" of
+                SharePointAccount."Authentication Type"::"Client Secret":
+                    begin
+                        ClientSecret := SharePointAccount.GetClientSecret(SharePointAccount."Client Secret Key");
+                        GraphAuthInterface := GraphAuthorization.CreateAuthorizationWithClientCredentials(
+                            Format(SharePointAccount."Tenant Id", 0, 4),
+                            Format(SharePointAccount."Client Id", 0, 4),
+                            ClientSecret,
+                            Scopes);
+                    end;
+                SharePointAccount."Authentication Type"::Certificate:
+                    begin
+                        Certificate := SharePointAccount.GetCertificate(SharePointAccount."Certificate Key");
+                        CertificatePassword := SharePointAccount.GetCertificatePassword(SharePointAccount."Certificate Password Key");
+                        GraphAuthInterface := GraphAuthorization.CreateAuthorizationWithClientCredentials(
+                            Format(SharePointAccount."Tenant Id", 0, 4),
+                            Format(SharePointAccount."Client Id", 0, 4),
+                            Certificate,
+                            CertificatePassword,
+                            Scopes);
+                    end;
+            end;
+
+        // Initialize SharePoint Graph Client with Site URL and authorization
+        SharePointGraphClient.Initialize(SharePointAccount."SharePoint Url", GraphAuthInterface);
+    end;
+
+    /// <summary>
+    /// Injects a mock authorization so tests can exercise the Graph API flow without acquiring a real token.
+    /// Token acquisition goes through the platform OAuth stack and cannot be intercepted by test HTTP handlers.
+    /// </summary>
+    internal procedure SetAuthorizationForTest(NewGraphAuthorization: Interface "Graph Authorization")
+    begin
+        TestGraphAuthorization := NewGraphAuthorization;
+        UseTestGraphAuthorization := true;
+    end;
+
+    local procedure ShowError(Response: Codeunit "SharePoint Graph Response")
+    begin
+        Error(ErrorOccurredErr, Response.GetError());
+    end;
+
+    local procedure SplitPath(FullPath: Text; var FolderPath: Text; var ItemName: Text)
+    var
+        LastSlashPos: Integer;
+    begin
+        // Find the last slash to split path
+        LastSlashPos := FullPath.LastIndexOf('/');
+
+        if LastSlashPos = 0 then begin
+            // No slash found - item is in root
+            FolderPath := '/';
+            ItemName := FullPath;
+        end else begin
+            FolderPath := CopyStr(FullPath, 1, LastSlashPos - 1);
+            ItemName := CopyStr(FullPath, LastSlashPos + 1);
+
+            if FolderPath = '' then
+                FolderPath := '/';
+        end;
+    end;
+
+    local procedure PathSeparator(): Text
+    begin
+        exit('/');
+    end;
+
+    local procedure InitPath(SharePointAccount: Record "Ext. SharePoint Account"; var Path: Text)
+    begin
+        Path := CombinePath(SharePointAccount."Base Relative Folder Path", Path);
+    end;
+
+    local procedure CombinePath(Parent: Text; Child: Text): Text
+    begin
+        if Parent = '' then
+            exit(Child);
+
+        if Child = '' then
+            exit(Parent);
+
+        if not Parent.EndsWith(PathSeparator()) then
+            Parent += PathSeparator();
+
+        exit(Parent + Child);
+    end;
+
+    #endregion
+}

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointGraphHelper.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointGraphHelper.Codeunit.al
@@ -31,7 +31,7 @@ codeunit 4610 "Ext. SharePoint Graph Helper"
 
     internal procedure ListFiles(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; FilePaginationData: Codeunit "File Pagination Data"; var TempFileAccountContent: Record "File Account Content" temporary)
     var
-        TempGraphDriveItem: Record "SharePoint Graph Drive Item";
+        GraphDriveItem: Record "SharePoint Graph Drive Item";
         Response: Codeunit "SharePoint Graph Response";
         OriginalPath: Text;
     begin
@@ -44,26 +44,26 @@ codeunit 4610 "Ext. SharePoint Graph Helper"
         if Path = '' then
             Path := '/';
 
-        Response := SharePointGraphClient.GetItemsByPath(Path, TempGraphDriveItem);
+        Response := SharePointGraphClient.GetItemsByPath(Path, GraphDriveItem);
 
         if not Response.IsSuccessful() then
             ShowError(Response);
 
         FilePaginationData.SetEndOfListing(true);
 
-        if not TempGraphDriveItem.FindSet() then
+        if not GraphDriveItem.FindSet() then
             exit;
 
         repeat
             // Only include files (not folders)
-            if not TempGraphDriveItem.IsFolder then begin
+            if not GraphDriveItem.IsFolder then begin
                 TempFileAccountContent.Init();
-                TempFileAccountContent.Name := TempGraphDriveItem.Name;
+                TempFileAccountContent.Name := GraphDriveItem.Name;
                 TempFileAccountContent.Type := TempFileAccountContent.Type::"File";
                 TempFileAccountContent."Parent Directory" := CopyStr(OriginalPath, 1, MaxStrLen(TempFileAccountContent."Parent Directory"));
                 TempFileAccountContent.Insert();
             end;
-        until TempGraphDriveItem.Next() = 0;
+        until GraphDriveItem.Next() = 0;
     end;
 
     internal procedure GetFile(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; Stream: InStream)
@@ -88,7 +88,7 @@ codeunit 4610 "Ext. SharePoint Graph Helper"
 
     internal procedure CreateFile(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; Stream: InStream)
     var
-        TempGraphDriveItem: Record "SharePoint Graph Drive Item";
+        GraphDriveItem: Record "SharePoint Graph Drive Item";
         Response: Codeunit "SharePoint Graph Response";
         FileName: Text;
         FolderPath: Text;
@@ -105,9 +105,9 @@ codeunit 4610 "Ext. SharePoint Graph Helper"
         MaxSimpleUploadSize := 4 * 1024 * 1024; // 4 MB
 
         if Stream.Length <= MaxSimpleUploadSize then
-            Response := SharePointGraphClient.UploadFile(FolderPath, FileName, Stream, TempGraphDriveItem)
+            Response := SharePointGraphClient.UploadFile(FolderPath, FileName, Stream, GraphDriveItem)
         else
-            Response := SharePointGraphClient.UploadLargeFile(FolderPath, FileName, Stream, TempGraphDriveItem);
+            Response := SharePointGraphClient.UploadLargeFile(FolderPath, FileName, Stream, GraphDriveItem);
 
         if not Response.IsSuccessful() then
             ShowError(Response);
@@ -188,7 +188,7 @@ codeunit 4610 "Ext. SharePoint Graph Helper"
 
     internal procedure ListDirectories(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; FilePaginationData: Codeunit "File Pagination Data"; var TempFileAccountContent: Record "File Account Content" temporary)
     var
-        TempGraphDriveItem: Record "SharePoint Graph Drive Item";
+        GraphDriveItem: Record "SharePoint Graph Drive Item";
         Response: Codeunit "SharePoint Graph Response";
         OriginalPath: Text;
     begin
@@ -201,31 +201,31 @@ codeunit 4610 "Ext. SharePoint Graph Helper"
         if Path = '' then
             Path := '/';
 
-        Response := SharePointGraphClient.GetItemsByPath(Path, TempGraphDriveItem);
+        Response := SharePointGraphClient.GetItemsByPath(Path, GraphDriveItem);
 
         if not Response.IsSuccessful() then
             ShowError(Response);
 
         FilePaginationData.SetEndOfListing(true);
 
-        if not TempGraphDriveItem.FindSet() then
+        if not GraphDriveItem.FindSet() then
             exit;
 
         repeat
             // Only include folders
-            if TempGraphDriveItem.IsFolder then begin
+            if GraphDriveItem.IsFolder then begin
                 TempFileAccountContent.Init();
-                TempFileAccountContent.Name := TempGraphDriveItem.Name;
+                TempFileAccountContent.Name := GraphDriveItem.Name;
                 TempFileAccountContent.Type := TempFileAccountContent.Type::Directory;
                 TempFileAccountContent."Parent Directory" := CopyStr(OriginalPath, 1, MaxStrLen(TempFileAccountContent."Parent Directory"));
                 TempFileAccountContent.Insert();
             end;
-        until TempGraphDriveItem.Next() = 0;
+        until GraphDriveItem.Next() = 0;
     end;
 
     internal procedure CreateDirectory(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text)
     var
-        TempGraphDriveItem: Record "SharePoint Graph Drive Item";
+        GraphDriveItem: Record "SharePoint Graph Drive Item";
         Response: Codeunit "SharePoint Graph Response";
         ParentPath: Text;
         FolderName: Text;
@@ -236,7 +236,7 @@ codeunit 4610 "Ext. SharePoint Graph Helper"
         // Split path into parent path and folder name
         SplitPath(Path, ParentPath, FolderName);
 
-        Response := SharePointGraphClient.CreateFolder(ParentPath, FolderName, TempGraphDriveItem);
+        Response := SharePointGraphClient.CreateFolder(ParentPath, FolderName, GraphDriveItem);
 
         if not Response.IsSuccessful() then
             ShowError(Response);

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointRestHelper.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointRestHelper.Codeunit.al
@@ -27,28 +27,28 @@ codeunit 4609 "Ext. SharePoint REST Helper"
 
     internal procedure ListFiles(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; FilePaginationData: Codeunit "File Pagination Data"; var TempFileAccountContent: Record "File Account Content" temporary)
     var
-        TempSharePointFile: Record "SharePoint File";
+        SharePointFile: Record "SharePoint File";
         SharePointClient: Codeunit "SharePoint Client";
         OriginalPath: Text;
     begin
         OriginalPath := Path;
         InitPath(SharePointAccount, Path);
         InitSharePointClient(SharePointAccount, SharePointClient);
-        if not SharePointClient.GetFolderFilesByServerRelativeUrl(Path, TempSharePointFile) then
+        if not SharePointClient.GetFolderFilesByServerRelativeUrl(Path, SharePointFile) then
             ShowError(SharePointClient);
 
         FilePaginationData.SetEndOfListing(true);
 
-        if not TempSharePointFile.FindSet() then
+        if not SharePointFile.FindSet() then
             exit;
 
         repeat
             TempFileAccountContent.Init();
-            TempFileAccountContent.Name := TempSharePointFile.Name;
+            TempFileAccountContent.Name := SharePointFile.Name;
             TempFileAccountContent.Type := TempFileAccountContent.Type::"File";
             TempFileAccountContent."Parent Directory" := CopyStr(OriginalPath, 1, MaxStrLen(TempFileAccountContent."Parent Directory"));
             TempFileAccountContent.Insert();
-        until TempSharePointFile.Next() = 0;
+        until SharePointFile.Next() = 0;
     end;
 
     internal procedure GetFile(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; Stream: InStream)
@@ -70,14 +70,14 @@ codeunit 4609 "Ext. SharePoint REST Helper"
 
     internal procedure CreateFile(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; Stream: InStream)
     var
-        TempSharePointFile: Record "SharePoint File";
+        SharePointFile: Record "SharePoint File";
         SharePointClient: Codeunit "SharePoint Client";
         ParentPath, FileName : Text;
     begin
         InitPath(SharePointAccount, Path);
         InitSharePointClient(SharePointAccount, SharePointClient);
         SplitPath(Path, ParentPath, FileName);
-        if SharePointClient.AddFileToFolder(ParentPath, FileName, Stream, TempSharePointFile, false) then
+        if SharePointClient.AddFileToFolder(ParentPath, FileName, Stream, SharePointFile, false) then
             exit;
 
         ShowError(SharePointClient);
@@ -102,16 +102,16 @@ codeunit 4609 "Ext. SharePoint REST Helper"
 
     internal procedure FileExists(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text): Boolean
     var
-        TempSharePointFile: Record "SharePoint File";
+        SharePointFile: Record "SharePoint File";
         SharePointClient: Codeunit "SharePoint Client";
     begin
         InitPath(SharePointAccount, Path);
         InitSharePointClient(SharePointAccount, SharePointClient);
-        if not SharePointClient.GetFolderFilesByServerRelativeUrl(GetParentPath(Path), TempSharePointFile) then
+        if not SharePointClient.GetFolderFilesByServerRelativeUrl(GetParentPath(Path), SharePointFile) then
             ShowError(SharePointClient);
 
-        TempSharePointFile.SetRange(Name, GetFileName(Path));
-        exit(not TempSharePointFile.IsEmpty());
+        SharePointFile.SetRange(Name, GetFileName(Path));
+        exit(not SharePointFile.IsEmpty());
     end;
 
     internal procedure DeleteFile(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text)
@@ -132,38 +132,38 @@ codeunit 4609 "Ext. SharePoint REST Helper"
 
     internal procedure ListDirectories(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; FilePaginationData: Codeunit "File Pagination Data"; var TempFileAccountContent: Record "File Account Content" temporary)
     var
-        TempSharePointFolder: Record "SharePoint Folder";
+        SharePointFolder: Record "SharePoint Folder";
         SharePointClient: Codeunit "SharePoint Client";
         OriginalPath: Text;
     begin
         OriginalPath := Path;
         InitPath(SharePointAccount, Path);
         InitSharePointClient(SharePointAccount, SharePointClient);
-        if not SharePointClient.GetSubFoldersByServerRelativeUrl(Path, TempSharePointFolder) then
+        if not SharePointClient.GetSubFoldersByServerRelativeUrl(Path, SharePointFolder) then
             ShowError(SharePointClient);
 
         FilePaginationData.SetEndOfListing(true);
 
-        if not TempSharePointFolder.FindSet() then
+        if not SharePointFolder.FindSet() then
             exit;
 
         repeat
             TempFileAccountContent.Init();
-            TempFileAccountContent.Name := TempSharePointFolder.Name;
+            TempFileAccountContent.Name := SharePointFolder.Name;
             TempFileAccountContent.Type := TempFileAccountContent.Type::Directory;
             TempFileAccountContent."Parent Directory" := CopyStr(OriginalPath, 1, MaxStrLen(TempFileAccountContent."Parent Directory"));
             TempFileAccountContent.Insert();
-        until TempSharePointFolder.Next() = 0;
+        until SharePointFolder.Next() = 0;
     end;
 
     internal procedure CreateDirectory(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text)
     var
-        TempSharePointFolder: Record "SharePoint Folder";
+        SharePointFolder: Record "SharePoint Folder";
         SharePointClient: Codeunit "SharePoint Client";
     begin
         InitPath(SharePointAccount, Path);
         InitSharePointClient(SharePointAccount, SharePointClient);
-        if SharePointClient.CreateFolder(Path, TempSharePointFolder) then
+        if SharePointClient.CreateFolder(Path, SharePointFolder) then
             exit;
 
         ShowError(SharePointClient);

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointRestHelper.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointRestHelper.Codeunit.al
@@ -1,0 +1,325 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.ExternalFileStorage;
+
+using System.Integration.Sharepoint;
+using System.Utilities;
+
+/// <summary>
+/// Helper implementation for SharePoint file operations using SharePoint REST API.
+/// This codeunit contains the actual REST API logic, called by the main connector based on account settings.
+/// </summary>
+codeunit 4609 "Ext. SharePoint REST Helper"
+{
+    Access = Internal;
+    InherentEntitlements = X;
+    InherentPermissions = X;
+    Permissions = tabledata "Ext. SharePoint Account" = r;
+
+    var
+        TestSharePointAuthorization: Interface "SharePoint Authorization";
+        UseTestSharePointAuthorization: Boolean;
+
+    #region File Operations
+
+    internal procedure ListFiles(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; FilePaginationData: Codeunit "File Pagination Data"; var TempFileAccountContent: Record "File Account Content" temporary)
+    var
+        TempSharePointFile: Record "SharePoint File";
+        SharePointClient: Codeunit "SharePoint Client";
+        OriginalPath: Text;
+    begin
+        OriginalPath := Path;
+        InitPath(SharePointAccount, Path);
+        InitSharePointClient(SharePointAccount, SharePointClient);
+        if not SharePointClient.GetFolderFilesByServerRelativeUrl(Path, TempSharePointFile) then
+            ShowError(SharePointClient);
+
+        FilePaginationData.SetEndOfListing(true);
+
+        if not TempSharePointFile.FindSet() then
+            exit;
+
+        repeat
+            TempFileAccountContent.Init();
+            TempFileAccountContent.Name := TempSharePointFile.Name;
+            TempFileAccountContent.Type := TempFileAccountContent.Type::"File";
+            TempFileAccountContent."Parent Directory" := CopyStr(OriginalPath, 1, MaxStrLen(TempFileAccountContent."Parent Directory"));
+            TempFileAccountContent.Insert();
+        until TempSharePointFile.Next() = 0;
+    end;
+
+    internal procedure GetFile(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; Stream: InStream)
+    var
+        SharePointClient: Codeunit "SharePoint Client";
+        Content: HttpContent;
+        TempBlobStream: InStream;
+    begin
+        InitPath(SharePointAccount, Path);
+        InitSharePointClient(SharePointAccount, SharePointClient);
+
+        if not SharePointClient.DownloadFileContentByServerRelativeUrl(Path, TempBlobStream) then
+            ShowError(SharePointClient);
+
+        // Platform fix: For some reason the Stream from DownloadFileContentByServerRelativeUrl dies after leaving the interface
+        Content.WriteFrom(TempBlobStream);
+        Content.ReadAs(Stream);
+    end;
+
+    internal procedure CreateFile(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; Stream: InStream)
+    var
+        TempSharePointFile: Record "SharePoint File";
+        SharePointClient: Codeunit "SharePoint Client";
+        ParentPath, FileName : Text;
+    begin
+        InitPath(SharePointAccount, Path);
+        InitSharePointClient(SharePointAccount, SharePointClient);
+        SplitPath(Path, ParentPath, FileName);
+        if SharePointClient.AddFileToFolder(ParentPath, FileName, Stream, TempSharePointFile, false) then
+            exit;
+
+        ShowError(SharePointClient);
+    end;
+
+    internal procedure CopyFile(SharePointAccount: Record "Ext. SharePoint Account"; SourcePath: Text; TargetPath: Text)
+    var
+        Stream: InStream;
+    begin
+        GetFile(SharePointAccount, SourcePath, Stream);
+        CreateFile(SharePointAccount, TargetPath, Stream);
+    end;
+
+    internal procedure MoveFile(SharePointAccount: Record "Ext. SharePoint Account"; SourcePath: Text; TargetPath: Text)
+    var
+        Stream: InStream;
+    begin
+        GetFile(SharePointAccount, SourcePath, Stream);
+        CreateFile(SharePointAccount, TargetPath, Stream);
+        DeleteFile(SharePointAccount, SourcePath);
+    end;
+
+    internal procedure FileExists(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text): Boolean
+    var
+        TempSharePointFile: Record "SharePoint File";
+        SharePointClient: Codeunit "SharePoint Client";
+    begin
+        InitPath(SharePointAccount, Path);
+        InitSharePointClient(SharePointAccount, SharePointClient);
+        if not SharePointClient.GetFolderFilesByServerRelativeUrl(GetParentPath(Path), TempSharePointFile) then
+            ShowError(SharePointClient);
+
+        TempSharePointFile.SetRange(Name, GetFileName(Path));
+        exit(not TempSharePointFile.IsEmpty());
+    end;
+
+    internal procedure DeleteFile(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text)
+    var
+        SharePointClient: Codeunit "SharePoint Client";
+    begin
+        InitPath(SharePointAccount, Path);
+        InitSharePointClient(SharePointAccount, SharePointClient);
+        if SharePointClient.DeleteFileByServerRelativeUrl(Path) then
+            exit;
+
+        ShowError(SharePointClient);
+    end;
+
+    #endregion
+
+    #region Directory Operations
+
+    internal procedure ListDirectories(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text; FilePaginationData: Codeunit "File Pagination Data"; var TempFileAccountContent: Record "File Account Content" temporary)
+    var
+        TempSharePointFolder: Record "SharePoint Folder";
+        SharePointClient: Codeunit "SharePoint Client";
+        OriginalPath: Text;
+    begin
+        OriginalPath := Path;
+        InitPath(SharePointAccount, Path);
+        InitSharePointClient(SharePointAccount, SharePointClient);
+        if not SharePointClient.GetSubFoldersByServerRelativeUrl(Path, TempSharePointFolder) then
+            ShowError(SharePointClient);
+
+        FilePaginationData.SetEndOfListing(true);
+
+        if not TempSharePointFolder.FindSet() then
+            exit;
+
+        repeat
+            TempFileAccountContent.Init();
+            TempFileAccountContent.Name := TempSharePointFolder.Name;
+            TempFileAccountContent.Type := TempFileAccountContent.Type::Directory;
+            TempFileAccountContent."Parent Directory" := CopyStr(OriginalPath, 1, MaxStrLen(TempFileAccountContent."Parent Directory"));
+            TempFileAccountContent.Insert();
+        until TempSharePointFolder.Next() = 0;
+    end;
+
+    internal procedure CreateDirectory(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text)
+    var
+        TempSharePointFolder: Record "SharePoint Folder";
+        SharePointClient: Codeunit "SharePoint Client";
+    begin
+        InitPath(SharePointAccount, Path);
+        InitSharePointClient(SharePointAccount, SharePointClient);
+        if SharePointClient.CreateFolder(Path, TempSharePointFolder) then
+            exit;
+
+        ShowError(SharePointClient);
+    end;
+
+    internal procedure DirectoryExists(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text) Result: Boolean
+    var
+        SharePointClient: Codeunit "SharePoint Client";
+    begin
+        InitPath(SharePointAccount, Path);
+        InitSharePointClient(SharePointAccount, SharePointClient);
+
+        Result := SharePointClient.FolderExistsByServerRelativeUrl(Path);
+
+        if not SharePointClient.GetDiagnostics().IsSuccessStatusCode() then
+            ShowError(SharePointClient);
+    end;
+
+    internal procedure DeleteDirectory(SharePointAccount: Record "Ext. SharePoint Account"; Path: Text)
+    var
+        SharePointClient: Codeunit "SharePoint Client";
+    begin
+        InitPath(SharePointAccount, Path);
+        InitSharePointClient(SharePointAccount, SharePointClient);
+        if SharePointClient.DeleteFolderByServerRelativeUrl(Path) then
+            exit;
+
+        ShowError(SharePointClient);
+    end;
+
+    #endregion
+
+    #region Helper Methods
+
+    local procedure InitSharePointClient(SharePointAccount: Record "Ext. SharePoint Account"; var SharePointClient: Codeunit "SharePoint Client")
+    var
+        SharePointAuth: Codeunit "SharePoint Auth.";
+        SharePointAuthorization: Interface "SharePoint Authorization";
+        Scopes: List of [Text];
+        AccountDisabledErr: Label 'The account "%1" is disabled.', Comment = '%1 - Account Name';
+    begin
+        if SharePointAccount.Disabled then
+            Error(AccountDisabledErr, SharePointAccount.Name);
+
+        Scopes.Add('00000003-0000-0ff1-ce00-000000000000/.default');
+
+        // Tests inject a mock authorization because acquiring a token requires a real Entra ID app registration.
+        if UseTestSharePointAuthorization then
+            SharePointAuthorization := TestSharePointAuthorization
+        else
+            case SharePointAccount."Authentication Type" of
+                Enum::"Ext. SharePoint Auth Type"::"Client Secret":
+                    SharePointAuthorization := SharePointAuth.CreateAuthorizationCode(
+                        Format(SharePointAccount."Tenant Id", 0, 4),
+                        Format(SharePointAccount."Client Id", 0, 4),
+                        SharePointAccount.GetClientSecret(SharePointAccount."Client Secret Key"),
+                        Scopes);
+                Enum::"Ext. SharePoint Auth Type"::Certificate:
+                    SharePointAuthorization := SharePointAuth.CreateClientCredentials(
+                        Format(SharePointAccount."Tenant Id", 0, 4),
+                        Format(SharePointAccount."Client Id", 0, 4),
+                        SharePointAccount.GetCertificate(SharePointAccount."Certificate Key"),
+                        SharePointAccount.GetCertificatePassword(SharePointAccount."Certificate Password Key"),
+                        Scopes);
+            end;
+
+        SharePointClient.Initialize(SharePointAccount."SharePoint Url", SharePointAuthorization);
+    end;
+
+    /// <summary>
+    /// Injects a mock authorization so tests can exercise the REST API flow without acquiring a real token.
+    /// Token acquisition goes through the platform OAuth stack and cannot be intercepted by test HTTP handlers.
+    /// </summary>
+    internal procedure SetAuthorizationForTest(NewSharePointAuthorization: Interface "SharePoint Authorization")
+    begin
+        TestSharePointAuthorization := NewSharePointAuthorization;
+        UseTestSharePointAuthorization := true;
+    end;
+
+    local procedure PathSeparator(): Text
+    begin
+        exit('/');
+    end;
+
+    local procedure ShowError(var SharePointClient: Codeunit "SharePoint Client")
+    var
+        ErrorOccurredErr: Label 'An error occurred.\%1', Comment = '%1 - Error message from SharePoint';
+    begin
+        Error(ErrorOccurredErr, SharePointClient.GetDiagnostics().GetErrorMessage());
+    end;
+
+    local procedure GetParentPath(Path: Text) ParentPath: Text
+    begin
+        if (Path.TrimEnd(PathSeparator()).Contains(PathSeparator())) then
+            ParentPath := Path.TrimEnd(PathSeparator()).Substring(1, Path.LastIndexOf(PathSeparator()));
+    end;
+
+    local procedure GetFileName(Path: Text) FileName: Text
+    begin
+        if (Path.TrimEnd(PathSeparator()).Contains(PathSeparator())) then
+            FileName := Path.TrimEnd(PathSeparator()).Substring(Path.LastIndexOf(PathSeparator()) + 1);
+    end;
+
+    local procedure InitPath(SharePointAccount: Record "Ext. SharePoint Account"; var Path: Text)
+    var
+        SitePath: Text;
+    begin
+        // Extract site path from SharePoint URL
+        SitePath := GetSitePathFromUrl(SharePointAccount."SharePoint Url");
+
+        // Combine base folder path with the file path
+        Path := CombinePath(SharePointAccount."Base Relative Folder Path", Path);
+
+        // Ensure path starts with forward slash
+        if not Path.StartsWith('/') then
+            Path := '/' + Path;
+
+        // Prepend site path if it exists and path doesn't already include it
+        if (SitePath <> '') and (not Path.StartsWith(SitePath)) then
+            Path := SitePath + Path;
+    end;
+
+    local procedure GetSitePathFromUrl(SharePointUrl: Text): Text
+    var
+        Uri: Codeunit Uri;
+        PathSegment: Text;
+    begin
+        Uri.Init(SharePointUrl);
+        PathSegment := Uri.GetAbsolutePath();
+
+        // Remove trailing slash if present
+        if PathSegment.EndsWith('/') then
+            PathSegment := PathSegment.TrimEnd('/');
+
+        exit(PathSegment);
+    end;
+
+    local procedure CombinePath(Parent: Text; Child: Text): Text
+    begin
+        if Parent = '' then
+            exit(Child);
+
+        if Child = '' then
+            exit(Parent);
+
+        if not Parent.EndsWith(PathSeparator()) then
+            Parent += PathSeparator();
+
+        exit(Parent + Child);
+    end;
+
+    local procedure SplitPath(Path: Text; var ParentPath: Text; var FileName: Text)
+    begin
+        ParentPath := Path.TrimEnd(PathSeparator()).Substring(1, Path.LastIndexOf(PathSeparator()));
+        FileName := Path.TrimEnd(PathSeparator()).Substring(Path.LastIndexOf(PathSeparator()) + 1);
+    end;
+
+    #endregion
+}

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointUpgrade.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/src/ExtSharePointUpgrade.Codeunit.al
@@ -1,0 +1,51 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.ExternalFileStorage;
+
+using System.Upgrade;
+
+codeunit 4608 "Ext. SharePoint Upgrade"
+{
+    Access = Internal;
+    InherentEntitlements = X;
+    InherentPermissions = X;
+    Subtype = Upgrade;
+    Permissions = tabledata "Ext. SharePoint Account" = rm;
+
+    trigger OnUpgradePerCompany()
+    var
+        UpgradeTag: Codeunit "Upgrade Tag";
+    begin
+        if UpgradeTag.HasUpgradeTag(GetUseLegacyRestAPIUpgradeTag()) then
+            exit;
+
+        SetUseLegacyRestAPIForExistingAccounts();
+
+        UpgradeTag.SetUpgradeTag(GetUseLegacyRestAPIUpgradeTag());
+    end;
+
+    internal procedure SetUseLegacyRestAPIForExistingAccounts()
+    var
+        ExtSharePointAccount: Record "Ext. SharePoint Account";
+    begin
+        ExtSharePointAccount.SetRange("Use legacy REST API", false);
+        if ExtSharePointAccount.IsEmpty() then
+            exit;
+
+        ExtSharePointAccount.ModifyAll("Use legacy REST API", true);
+    end;
+
+    internal procedure GetUseLegacyRestAPIUpgradeTag(): Code[250]
+    begin
+        exit('MS-5833-SharePointUseLegacyRestAPI-20260313');
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Upgrade Tag", 'OnGetPerCompanyUpgradeTags', '', false, false)]
+    local procedure RegisterPerCompanyUpgradeTags(var PerCompanyUpgradeTags: List of [Code[250]])
+    begin
+        PerCompanyUpgradeTags.Add(GetUseLegacyRestAPIUpgradeTag());
+    end;
+}

--- a/src/Apps/W1/External File Storage - SharePoint Connector/Test/src/ExtSPAccountTableTest.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/Test/src/ExtSPAccountTableTest.Codeunit.al
@@ -1,0 +1,144 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Test.ExternalFileStorage;
+
+using System.ExternalFileStorage;
+using System.TestLibraries.Utilities;
+
+codeunit 144583 "Ext. SP Account Table Test"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "Library Assert";
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestDefaultAuthTypeIsClientSecret()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] A new account record is inserted
+        Account.Init();
+        Account.Id := CreateGuid();
+        Account.Insert();
+
+        // [THEN] Authentication Type defaults to Client Secret
+        Assert.AreEqual(
+            Enum::"Ext. SharePoint Auth Type"::"Client Secret",
+            Account."Authentication Type",
+            'Default authentication type should be Client Secret');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestDefaultUseLegacyRestAPIIsFalse()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] A new account record is inserted
+        Account.Init();
+        Account.Id := CreateGuid();
+        Account.Insert();
+
+        // [THEN] Use legacy REST API defaults to false (Graph is the new default)
+        Assert.IsFalse(Account."Use legacy REST API", 'Use legacy REST API should default to false');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestSetClientSecretClearsCertificateKeys()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] An account with a certificate and certificate password already set
+        Account.Init();
+        Account.Id := CreateGuid();
+        Account.Insert();
+        Account.SetCertificate(SecretStrSubstNo('cert-data'));
+        Account.SetCertificatePassword(SecretStrSubstNo('cert-password'));
+
+        Assert.IsFalse(IsNullGuid(Account."Certificate Key"), 'Certificate Key should be set after SetCertificate');
+        Assert.IsFalse(IsNullGuid(Account."Certificate Password Key"), 'Certificate Password Key should be set after SetCertificatePassword');
+
+        // [WHEN] SetClientSecret is called
+        Account.SetClientSecret(SecretStrSubstNo('secret-value'));
+
+        // [THEN] Both certificate keys are cleared — only one authentication method can be active
+        Assert.IsTrue(IsNullGuid(Account."Certificate Key"), 'Certificate Key should be cleared after SetClientSecret');
+        Assert.IsTrue(IsNullGuid(Account."Certificate Password Key"), 'Certificate Password Key should be cleared after SetClientSecret');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestSetCertificateClearsClientSecretKey()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] An account with a client secret already set
+        Account.Init();
+        Account.Id := CreateGuid();
+        Account.Insert();
+        Account.SetClientSecret(SecretStrSubstNo('secret-value'));
+
+        Assert.IsFalse(IsNullGuid(Account."Client Secret Key"), 'Client Secret Key should be set after SetClientSecret');
+
+        // [WHEN] SetCertificate is called
+        Account.SetCertificate(SecretStrSubstNo('cert-data'));
+
+        // [THEN] The client secret key is cleared
+        Assert.IsTrue(IsNullGuid(Account."Client Secret Key"), 'Client Secret Key should be cleared after SetCertificate');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestClientSecretRoundTrip()
+    var
+        Account: Record "Ext. SharePoint Account";
+        Retrieved: SecretText;
+        ExpectedTxt: Text;
+    begin
+        // [GIVEN] An account
+        Account.Init();
+        Account.Id := CreateGuid();
+        Account.Insert();
+
+        // [WHEN] A client secret is stored and retrieved
+        ExpectedTxt := 'my-secret-value';
+        Account.SetClientSecret(SecretStrSubstNo(ExpectedTxt));
+        Retrieved := Account.GetClientSecret(Account."Client Secret Key");
+
+        // [THEN] The retrieved value matches
+#pragma warning disable AL0796
+        Assert.AreEqual(ExpectedTxt, Retrieved.Unwrap(), 'Retrieved client secret should match stored value');
+#pragma warning restore AL0796
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestCertificateRoundTrip()
+    var
+        Account: Record "Ext. SharePoint Account";
+        Retrieved: SecretText;
+        ExpectedTxt: Text;
+    begin
+        // [GIVEN] An account
+        Account.Init();
+        Account.Id := CreateGuid();
+        Account.Insert();
+
+        // [WHEN] A certificate is stored and retrieved
+        ExpectedTxt := 'base64-cert-data';
+        Account.SetCertificate(SecretStrSubstNo(ExpectedTxt));
+        Retrieved := Account.GetCertificate(Account."Certificate Key");
+
+        // [THEN] The retrieved value matches
+#pragma warning disable AL0796
+        Assert.AreEqual(ExpectedTxt, Retrieved.Unwrap(), 'Retrieved certificate should match stored value');
+#pragma warning restore AL0796
+    end;
+}

--- a/src/Apps/W1/External File Storage - SharePoint Connector/Test/src/ExtSPGraphHelperTest.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/Test/src/ExtSPGraphHelperTest.Codeunit.al
@@ -1,0 +1,601 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Test.ExternalFileStorage;
+
+using System.ExternalFileStorage;
+using System.Test.Integration.Sharepoint;
+using System.TestLibraries.Utilities;
+using System.Utilities;
+
+/// <summary>
+/// Tests the Graph helper using platform-level HTTP mocking ([HttpClientHandler]).
+/// A mock "Graph Authorization" is injected because token acquisition goes through the
+/// platform OAuth stack and cannot be intercepted by test HTTP handlers.
+/// </summary>
+codeunit 144585 "Ext. SP Graph Helper Test"
+{
+    Subtype = Test;
+    TestHttpRequestPolicy = BlockOutboundRequests;
+    TestPermissions = Disabled;
+
+    var
+        GraphHelper: Codeunit "Ext. SharePoint Graph Helper";
+        GraphAuthMock: Codeunit "SharePoint Graph Auth Mock";
+        Assert: Codeunit "Library Assert";
+        LastPath: Text;
+        LastMethod: HttpRequestType;
+        ReturnNotFound: Boolean;
+        ReturnServerError: Boolean;
+        UploadSessionCreated: Boolean;
+        ChunkUploadCount: Integer;
+        SharePointUrlLbl: Label 'https://contoso.sharepoint.com/sites/test', Locked = true;
+
+    #region File Operations
+
+    [Test]
+    [HandlerFunctions('ListItemsHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestListFilesReturnsOnlyFiles()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempContent: Record "File Account Content" temporary;
+        Pagination: Codeunit "File Pagination Data";
+    begin
+        // [GIVEN] Mock returns 1 folder + 2 files
+        Initialize(Account);
+
+        // [WHEN]
+        GraphHelper.ListFiles(Account, '', Pagination, TempContent);
+
+        // [THEN] Only the 2 files are in the result, with the right names and type
+        Assert.RecordCount(TempContent, 2);
+        TempContent.SetRange(Type, TempContent.Type::"File");
+        Assert.RecordCount(TempContent, 2);
+        TempContent.SetRange(Name, 'Report.pdf');
+        Assert.RecordCount(TempContent, 1);
+        TempContent.SetRange(Name, 'Budget.xlsx');
+        Assert.RecordCount(TempContent, 1);
+    end;
+
+    [Test]
+    [HandlerFunctions('ListItemsHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestListDirectoriesReturnsOnlyFolders()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempContent: Record "File Account Content" temporary;
+        Pagination: Codeunit "File Pagination Data";
+    begin
+        // [GIVEN] Same mixed response
+        Initialize(Account);
+
+        // [WHEN]
+        GraphHelper.ListDirectories(Account, '', Pagination, TempContent);
+
+        // [THEN] Only the 1 folder
+        Assert.RecordCount(TempContent, 1);
+        TempContent.FindFirst();
+        Assert.AreEqual('Subfolder', TempContent.Name, 'Folder name should match');
+        Assert.AreEqual(TempContent.Type::Directory, TempContent.Type, 'Should be Directory type');
+    end;
+
+    [Test]
+    [HandlerFunctions('ListItemsHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestListFilesAppliesBaseRelativeFolderPath()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempContent: Record "File Account Content" temporary;
+        Pagination: Codeunit "File Pagination Data";
+    begin
+        // [GIVEN] An account with a base relative folder path
+        Initialize(Account);
+        Account."Base Relative Folder Path" := 'Docs/Base';
+
+        // [WHEN] Listing a subfolder
+        GraphHelper.ListFiles(Account, 'Sub', Pagination, TempContent);
+
+        // [THEN] The request path combines base path and subfolder
+        Assert.IsTrue(LastPath.Contains('Docs/Base/Sub'), 'Request should target the combined path. Actual: ' + LastPath);
+
+        // [THEN] The parent directory reflects the original (relative) path, not the combined one
+        TempContent.FindFirst();
+        Assert.AreEqual('Sub', TempContent."Parent Directory", 'Parent Directory should be the original path');
+    end;
+
+    [Test]
+    [HandlerFunctions('ListItemsHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestBasePathWithTrailingSlashDoesNotDoubleSlash()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempContent: Record "File Account Content" temporary;
+        Pagination: Codeunit "File Pagination Data";
+    begin
+        // [GIVEN] A base path ending with a slash
+        Initialize(Account);
+        Account."Base Relative Folder Path" := 'Docs/Base/';
+
+        // [WHEN]
+        GraphHelper.ListFiles(Account, 'Sub', Pagination, TempContent);
+
+        // [THEN] The combined path has no double slash
+        Assert.IsTrue(LastPath.Contains('Docs/Base/Sub'), 'Request should target the combined path. Actual: ' + LastPath);
+        Assert.IsFalse(LastPath.Contains('Base//Sub'), 'Combined path must not contain a double slash. Actual: ' + LastPath);
+    end;
+
+    [Test]
+    [HandlerFunctions('GetFileHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestGetFileDownloadsContent()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempBlob: Codeunit "Temp Blob";
+        InStream: InStream;
+        FileContent: Text;
+    begin
+        // [GIVEN] Mock provides file metadata (size=5) then chunk body 'HELLO'
+        Initialize(Account);
+        TempBlob.CreateInStream(InStream);
+
+        // [WHEN]
+        GraphHelper.GetFile(Account, 'file.txt', InStream);
+
+        // [THEN] The downloaded content survives the stream hand-over
+        InStream.ReadText(FileContent);
+        Assert.AreEqual('HELLO', FileContent, 'Downloaded file content should match the mocked response');
+    end;
+
+    [Test]
+    [HandlerFunctions('SimpleSuccessHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestCreateFileUsesSimpleUploadForSmallFiles()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempBlob: Codeunit "Temp Blob";
+        InStream: InStream;
+        OutStream: OutStream;
+    begin
+        // [GIVEN] A file under the 4 MB simple-upload limit
+        Initialize(Account);
+        TempBlob.CreateOutStream(OutStream);
+        OutStream.WriteText('hello');
+        TempBlob.CreateInStream(InStream);
+
+        // [WHEN]
+        GraphHelper.CreateFile(Account, 'folder/test.txt', InStream);
+
+        // [THEN] The file is PUT directly to the content endpoint (no upload session)
+        Assert.IsTrue(LastPath.Contains('folder/test.txt:/content'), 'Small files should use the simple :/content upload. Actual: ' + LastPath);
+        Assert.IsFalse(LastPath.Contains('createUploadSession'), 'Small files should not create an upload session');
+    end;
+
+    [Test]
+    [HandlerFunctions('SimpleSuccessHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestCreateFileInRootSplitsPath()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempBlob: Codeunit "Temp Blob";
+        InStream: InStream;
+        OutStream: OutStream;
+    begin
+        // [GIVEN] A file path without any folder
+        Initialize(Account);
+        TempBlob.CreateOutStream(OutStream);
+        OutStream.WriteText('hello');
+        TempBlob.CreateInStream(InStream);
+
+        // [WHEN]
+        GraphHelper.CreateFile(Account, 'rootfile.txt', InStream);
+
+        // [THEN] The file lands in the drive root
+        Assert.IsTrue(LastPath.Contains('rootfile.txt:/content'), 'Root files should upload to the drive root. Actual: ' + LastPath);
+    end;
+
+    [Test]
+    [HandlerFunctions('LargeUploadHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestCreateLargeFileUsesUploadSession()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempBlob: Codeunit "Temp Blob";
+        InStream: InStream;
+        OutStream: OutStream;
+        OneKbTxt: Text;
+        Index: Integer;
+    begin
+        // [GIVEN] A file over the 4 MB simple-upload limit
+        Initialize(Account);
+        TempBlob.CreateOutStream(OutStream);
+        OneKbTxt := PadStr('', 1024, 'A');
+        for Index := 1 to 4097 do // 4097 KB > 4 MB
+            OutStream.WriteText(OneKbTxt);
+        TempBlob.CreateInStream(InStream);
+
+        // [WHEN]
+        GraphHelper.CreateFile(Account, 'folder/big.txt', InStream);
+
+        // [THEN] The chunked upload session flow is used
+        Assert.IsTrue(UploadSessionCreated, 'Files over 4 MB should create an upload session');
+        Assert.IsTrue(ChunkUploadCount >= 1, 'At least one chunk should be uploaded to the session URL');
+    end;
+
+    [Test]
+    [HandlerFunctions('CopyFileHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestCopyFileUsesNativeGraphCopy()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] Mock supplies target folder item, source item, copy response
+        Initialize(Account);
+
+        // [WHEN]
+        GraphHelper.CopyFile(Account, 'source.txt', 'TargetFolder/source.txt');
+
+        // [THEN] The last request path contains '/copy' — native Graph copy, not Get+Create
+        Assert.IsTrue(LastPath.Contains('/copy'), 'CopyFile should use the native Graph /copy endpoint');
+    end;
+
+    [Test]
+    [HandlerFunctions('MoveFileHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestMoveFileUsesGraphPatch()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN]
+        Initialize(Account);
+
+        // [WHEN]
+        GraphHelper.MoveFile(Account, 'source.txt', 'TargetFolder/source.txt');
+
+        // [THEN] Last request was PATCH
+        Assert.IsTrue(LastMethod = HttpRequestType::PATCH, 'MoveFile should use a PATCH request');
+    end;
+
+    [Test]
+    [HandlerFunctions('ItemExistsHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestFileExistsTrueOn200()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] The item request succeeds (200)
+        Initialize(Account);
+
+        // [WHEN] / [THEN]
+        Assert.IsTrue(GraphHelper.FileExists(Account, 'file.txt'), 'FileExists should return true on 200');
+    end;
+
+    [Test]
+    [HandlerFunctions('ItemExistsHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestFileExistsFalseOn404()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] The item request returns 404
+        Initialize(Account);
+        ReturnNotFound := true;
+
+        // [WHEN] / [THEN] 404 means "does not exist" — no error
+        Assert.IsFalse(GraphHelper.FileExists(Account, 'missing.txt'), 'FileExists should return false on 404');
+    end;
+
+    [Test]
+    [HandlerFunctions('ItemExistsHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestFileExistsFailsOnServerError()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] The item request fails with 500 (throttling, auth, outage, ...)
+        Initialize(Account);
+        ReturnServerError := true;
+
+        // [WHEN] / [THEN] FileExists raises an error instead of reporting "does not exist"
+        asserterror GraphHelper.FileExists(Account, 'file.txt');
+        Assert.IsTrue(GetLastErrorText().Contains('An error occurred.'), 'A server error must surface as an error, not as a negative exists-check');
+    end;
+
+    [Test]
+    [HandlerFunctions('SimpleSuccessHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestDeleteFileSendsDeleteRequest()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN]
+        Initialize(Account);
+
+        // [WHEN] Deleting a file
+        GraphHelper.DeleteFile(Account, 'file.txt');
+
+        // [THEN] A DELETE request targeted the file
+        Assert.IsTrue(LastMethod = HttpRequestType::DELETE, 'DeleteFile should send a DELETE request');
+        Assert.IsTrue(LastPath.Contains('file.txt'), 'The DELETE request should target the file. Actual: ' + LastPath);
+    end;
+
+    #endregion
+
+    #region Directory Operations
+
+    [Test]
+    [HandlerFunctions('SimpleSuccessHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestCreateDirectorySendsPostRequest()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN]
+        Initialize(Account);
+
+        // [WHEN] Creating a directory
+        GraphHelper.CreateDirectory(Account, 'NewFolder');
+
+        // [THEN] The folder was created via a POST request
+        Assert.IsTrue(LastMethod = HttpRequestType::POST, 'CreateDirectory should send a POST request');
+    end;
+
+    [Test]
+    [HandlerFunctions('ItemExistsHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestDirectoryExistsTrueOn200()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] The item request succeeds (200)
+        Initialize(Account);
+
+        // [WHEN] / [THEN]
+        Assert.IsTrue(GraphHelper.DirectoryExists(Account, 'MyFolder'), 'DirectoryExists should return true on 200');
+    end;
+
+    [Test]
+    [HandlerFunctions('ItemExistsHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestDirectoryExistsFalseOn404()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] The item request returns 404
+        Initialize(Account);
+        ReturnNotFound := true;
+
+        // [WHEN] / [THEN] 404 means "does not exist" — no error
+        Assert.IsFalse(GraphHelper.DirectoryExists(Account, 'MissingFolder'), 'DirectoryExists should return false on 404');
+    end;
+
+    [Test]
+    [HandlerFunctions('SimpleSuccessHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestDeleteDirectorySendsDeleteRequest()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN]
+        Initialize(Account);
+
+        // [WHEN] Deleting a directory
+        GraphHelper.DeleteDirectory(Account, 'OldFolder');
+
+        // [THEN] A DELETE request targeted the folder
+        Assert.IsTrue(LastMethod = HttpRequestType::DELETE, 'DeleteDirectory should send a DELETE request');
+        Assert.IsTrue(LastPath.Contains('OldFolder'), 'The DELETE request should target the folder. Actual: ' + LastPath);
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestDisabledAccountThrowsError()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempContent: Record "File Account Content" temporary;
+        Pagination: Codeunit "File Pagination Data";
+    begin
+        // [GIVEN] A disabled account
+        Initialize(Account);
+        Account.Disabled := true;
+
+        // [WHEN] / [THEN] Any operation fails before any HTTP traffic
+        asserterror GraphHelper.ListFiles(Account, '', Pagination, TempContent);
+        Assert.IsTrue(GetLastErrorText().Contains('is disabled'), 'A disabled account should raise the disabled-account error');
+    end;
+
+    #endregion
+
+    #region HTTP Handlers
+
+    [HttpClientHandler]
+    procedure ListItemsHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        LastPath := Request.Path;
+        LastMethod := Request.RequestType;
+        if TryHandleDiscovery(Request, Response) then
+            exit;
+
+        // items listing
+        Response.Content.WriteFrom('{"value":[' +
+            '{"id":"1","name":"Subfolder","folder":{"childCount":0}},' +
+            '{"id":"2","name":"Report.pdf","file":{"mimeType":"application/pdf"},"size":1000},' +
+            '{"id":"3","name":"Budget.xlsx","file":{"mimeType":"application/vnd.ms-excel"},"size":2000}' +
+            ']}');
+    end;
+
+    [HttpClientHandler]
+    procedure GetFileHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        LastPath := Request.Path;
+        LastMethod := Request.RequestType;
+        if TryHandleDiscovery(Request, Response) then
+            exit;
+
+        if Request.Path.Contains(':/content') then
+            // chunk download — return small body
+            Response.Content.WriteFrom('HELLO')
+        else
+            // GetDriveItemByPath for file size
+            Response.Content.WriteFrom('{"id":"f1","name":"file.txt","file":{"mimeType":"text/plain"},"size":5}');
+    end;
+
+    [HttpClientHandler]
+    procedure SimpleSuccessHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        LastPath := Request.Path;
+        LastMethod := Request.RequestType;
+        if TryHandleDiscovery(Request, Response) then
+            exit;
+
+        Response.Content.WriteFrom('{"id":"result-id","name":"item"}');
+    end;
+
+    [HttpClientHandler]
+    procedure LargeUploadHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        LastPath := Request.Path;
+        LastMethod := Request.RequestType;
+        if TryHandleDiscovery(Request, Response) then
+            exit;
+
+        case true of
+            Request.Path.Contains('createUploadSession'):
+                begin
+                    UploadSessionCreated := true;
+                    // Upload URL host must be a trusted Microsoft host to pass validation
+                    Response.Content.WriteFrom('{"uploadUrl":"https://contoso.sharepoint.com/upload-session/test-session"}');
+                end;
+            Request.Path.Contains('upload-session'):
+                begin
+                    ChunkUploadCount += 1;
+                    // Every chunk response carries the item so the final chunk completes the upload
+                    Response.Content.WriteFrom('{"id":"large-item-id","name":"big.txt","size":4195328,"file":{"mimeType":"application/octet-stream"}}');
+                end;
+            else
+                Response.Content.WriteFrom('{"id":"result-id","name":"item"}');
+        end;
+    end;
+
+    [HttpClientHandler]
+    procedure CopyFileHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        LastPath := Request.Path;
+        LastMethod := Request.RequestType;
+        if TryHandleDiscovery(Request, Response) then
+            exit;
+
+        if Request.Path.Contains('/copy') then
+            Response.Content.WriteFrom('{}')
+        else
+            // GetDriveItemByPath calls for target and source
+            Response.Content.WriteFrom('{"id":"item-id","name":"item","folder":{"childCount":0}}');
+    end;
+
+    [HttpClientHandler]
+    procedure MoveFileHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        LastPath := Request.Path;
+        LastMethod := Request.RequestType;
+        if TryHandleDiscovery(Request, Response) then
+            exit;
+
+        if Request.RequestType = HttpRequestType::PATCH then
+            Response.Content.WriteFrom('{}')
+        else
+            // GetDriveItemByPath for source and target
+            Response.Content.WriteFrom('{"id":"item-id","name":"item","folder":{"childCount":0}}');
+    end;
+
+    [HttpClientHandler]
+    procedure ItemExistsHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        LastPath := Request.Path;
+        LastMethod := Request.RequestType;
+        if TryHandleDiscovery(Request, Response) then
+            exit;
+
+        case true of
+            ReturnServerError:
+                begin
+                    Response.HttpStatusCode := 500;
+                    Response.Content.WriteFrom('{"error":{"code":"generalException","message":"Something went wrong"}}');
+                end;
+            ReturnNotFound:
+                begin
+                    Response.HttpStatusCode := 404;
+                    Response.Content.WriteFrom('{"error":{"code":"itemNotFound","message":"Item not found"}}');
+                end;
+            else
+                Response.Content.WriteFrom('{"id":"f1","name":"file.txt","file":{},"size":10}');
+        end;
+    end;
+
+    #endregion
+
+    #region Handler Helpers
+
+    local procedure TryHandleDiscovery(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        if IsSiteDiscovery(Request) then begin
+            Response.Content.WriteFrom('{"id":"test-site-id"}');
+            exit(true);
+        end;
+        if IsDriveDiscovery(Request) then begin
+            Response.Content.WriteFrom('{"id":"test-drive-id"}');
+            exit(true);
+        end;
+        exit(false);
+    end;
+
+    local procedure IsSiteDiscovery(Request: TestHttpRequestMessage): Boolean
+    begin
+        // Site discovery: graph.microsoft.com/v1.0/sites/hostname:/path:
+        // No /drive, no /root, no /items
+        exit(
+            Request.Path.Contains('graph.microsoft.com') and
+            Request.Path.Contains('/sites/') and
+            not Request.Path.Contains('/drive') and
+            not Request.Path.Contains('/items') and
+            not Request.Path.Contains('/root'));
+    end;
+
+    local procedure IsDriveDiscovery(Request: TestHttpRequestMessage): Boolean
+    begin
+        // Drive discovery: graph.microsoft.com/v1.0/sites/{siteId}/drive?select=id
+        exit(
+            Request.Path.Contains('graph.microsoft.com') and
+            Request.Path.Contains('/drive') and
+            not Request.Path.Contains('/drives/') and
+            not Request.Path.Contains('/root'));
+    end;
+
+    #endregion
+
+    #region Setup
+
+    local procedure Initialize(var Account: Record "Ext. SharePoint Account")
+    begin
+        Clear(GraphHelper);
+        GraphHelper.SetAuthorizationForTest(GraphAuthMock);
+
+        LastPath := '';
+        ReturnNotFound := false;
+        ReturnServerError := false;
+        UploadSessionCreated := false;
+        ChunkUploadCount := 0;
+
+        Account.Init();
+        Account.Id := CreateGuid();
+        Account."SharePoint Url" := SharePointUrlLbl;
+        Account."Tenant Id" := CreateGuid();
+        Account."Client Id" := CreateGuid();
+        Account."Authentication Type" := Enum::"Ext. SharePoint Auth Type"::"Client Secret";
+        Account."Use legacy REST API" := false;
+        Account.Insert();
+    end;
+
+    #endregion
+}

--- a/src/Apps/W1/External File Storage - SharePoint Connector/Test/src/ExtSPRestHelperTest.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/Test/src/ExtSPRestHelperTest.Codeunit.al
@@ -1,0 +1,537 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Test.ExternalFileStorage;
+
+using System.ExternalFileStorage;
+using System.TestLibraries.Integration.Sharepoint;
+using System.TestLibraries.Utilities;
+using System.Utilities;
+
+/// <summary>
+/// Tests the REST helper using platform-level HTTP mocking ([HttpClientHandler]).
+/// A dummy "SharePoint Authorization" is injected because token acquisition goes through the
+/// platform OAuth stack and cannot be intercepted by test HTTP handlers.
+/// Every handler records the requests it sees (verb, URL, download/add/delete legs) so tests
+/// can assert what the helper actually asked SharePoint to do, not just that no error occurred.
+/// </summary>
+codeunit 144586 "Ext. SP REST Helper Test"
+{
+    Subtype = Test;
+    TestHttpRequestPolicy = BlockOutboundRequests;
+    TestPermissions = Disabled;
+
+    var
+        RestHelper: Codeunit "Ext. SharePoint REST Helper";
+        DummySharePointAuthorization: Codeunit "Dummy SharePoint Authorization";
+        Assert: Codeunit "Library Assert";
+        LastPath: Text;
+        LastMethod: HttpRequestType;
+        DownloadPath: Text;
+        FileAddPath: Text;
+        DeletePath: Text;
+        ReturnFolderExists: Boolean;
+        ReturnFileExists: Boolean;
+        SharePointUrlLbl: Label 'https://contoso.sharepoint.com/sites/test', Locked = true;
+
+    #region File Operations
+
+    [Test]
+    [HandlerFunctions('ListFilesHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestListFilesReturnsFiles()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempContent: Record "File Account Content" temporary;
+        Pagination: Codeunit "File Pagination Data";
+    begin
+        // [GIVEN] The folder listing returns 2 files
+        Initialize(Account);
+
+        // [WHEN] Listing files
+        RestHelper.ListFiles(Account, '', Pagination, TempContent);
+
+        // [THEN] Both files are returned with the right names
+        Assert.RecordCount(TempContent, 2);
+        TempContent.SetRange(Type, TempContent.Type::"File");
+        Assert.RecordCount(TempContent, 2);
+        TempContent.SetRange(Name, 'document.pdf');
+        Assert.RecordCount(TempContent, 1);
+        TempContent.SetRange(Name, 'budget.xlsx');
+        Assert.RecordCount(TempContent, 1);
+    end;
+
+    [Test]
+    [HandlerFunctions('GetFileHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestGetFileDownloadsContent()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempBlob: Codeunit "Temp Blob";
+        InStream: InStream;
+        FileContent: Text;
+    begin
+        // [GIVEN] The download endpoint returns 'Hello World'
+        Initialize(Account);
+        TempBlob.CreateInStream(InStream);
+
+        // [WHEN] Getting the file
+        RestHelper.GetFile(Account, 'file.txt', InStream);
+
+        // [THEN] The downloaded content survives the stream hand-over
+        InStream.ReadText(FileContent);
+        Assert.AreEqual('Hello World', FileContent, 'Downloaded file content should match the mocked response');
+    end;
+
+    [Test]
+    [HandlerFunctions('CreateFileHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestCreateFileUploadsToFolder()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempBlob: Codeunit "Temp Blob";
+        InStream: InStream;
+        OutStream: OutStream;
+    begin
+        // [GIVEN] A file to upload
+        Initialize(Account);
+        TempBlob.CreateOutStream(OutStream);
+        OutStream.WriteText('content');
+        TempBlob.CreateInStream(InStream);
+
+        // [WHEN] Creating the file
+        RestHelper.CreateFile(Account, 'file.txt', InStream);
+
+        // [THEN] The file was uploaded via the Files/add endpoint under its own name
+        Assert.IsTrue(FileAddPath.Contains('/Files/add(url='), 'CreateFile should upload via the Files/add endpoint. Actual: ' + FileAddPath);
+        Assert.IsTrue(FileAddPath.Contains('file.txt'), 'The upload should target the requested file name. Actual: ' + FileAddPath);
+    end;
+
+    [Test]
+    [HandlerFunctions('CopyFileHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestCopyFileDownloadsSourceAndCreatesTargetWithoutDelete()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] The REST stack has no native copy: CopyFile = GetFile + CreateFile
+        Initialize(Account);
+
+        // [WHEN] Copying source.txt to dest.txt
+        RestHelper.CopyFile(Account, 'source.txt', 'dest.txt');
+
+        // [THEN] The source was downloaded and the target created
+        Assert.IsTrue(DownloadPath.Contains('source.txt'), 'CopyFile should download the source file. Actual: ' + DownloadPath);
+        Assert.IsTrue(FileAddPath.Contains('dest.txt'), 'CopyFile should create the target file. Actual: ' + FileAddPath);
+
+        // [THEN] The source was NOT deleted — that is what distinguishes copy from move
+        Assert.AreEqual('', DeletePath, 'CopyFile must not delete the source file');
+    end;
+
+    [Test]
+    [HandlerFunctions('MoveFileHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestMoveFileCreatesTargetAndDeletesSource()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] The REST stack has no native move: MoveFile = GetFile + CreateFile + DeleteFile
+        Initialize(Account);
+
+        // [WHEN] Moving source.txt to dest.txt
+        RestHelper.MoveFile(Account, 'source.txt', 'dest.txt');
+
+        // [THEN] The source was downloaded, the target created, and the source deleted
+        Assert.IsTrue(DownloadPath.Contains('source.txt'), 'MoveFile should download the source file. Actual: ' + DownloadPath);
+        Assert.IsTrue(FileAddPath.Contains('dest.txt'), 'MoveFile should create the target file. Actual: ' + FileAddPath);
+        Assert.IsTrue(DeletePath.Contains('source.txt'), 'MoveFile must delete the source file. Actual: ' + DeletePath);
+    end;
+
+    [Test]
+    [HandlerFunctions('FileExistsHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestFileExistsTrue()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] The parent folder listing contains the file
+        Initialize(Account);
+        ReturnFileExists := true;
+
+        // [WHEN] / [THEN]
+        Assert.IsTrue(RestHelper.FileExists(Account, 'file.txt'), 'FileExists should return true');
+    end;
+
+    [Test]
+    [HandlerFunctions('FileExistsHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestFileExistsFalse()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] The parent folder listing does not contain the file
+        Initialize(Account);
+        ReturnFileExists := false;
+
+        // [WHEN] / [THEN]
+        Assert.IsFalse(RestHelper.FileExists(Account, 'file.txt'), 'FileExists should return false');
+    end;
+
+    [Test]
+    [HandlerFunctions('DeleteHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestDeleteFileSendsDeleteRequest()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN]
+        Initialize(Account);
+
+        // [WHEN] Deleting a file
+        RestHelper.DeleteFile(Account, 'file.txt');
+
+        // [THEN] A DELETE request targeted the file
+        Assert.IsTrue(DeletePath.Contains('file.txt'), 'DeleteFile should send a DELETE request for the file. Actual: ' + DeletePath);
+    end;
+
+    #endregion
+
+    #region Directory Operations
+
+    [Test]
+    [HandlerFunctions('ListDirectoriesHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestListDirectoriesReturnsFolders()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempContent: Record "File Account Content" temporary;
+        Pagination: Codeunit "File Pagination Data";
+    begin
+        // [GIVEN] The folder listing returns 1 subfolder
+        Initialize(Account);
+
+        // [WHEN] Listing directories
+        RestHelper.ListDirectories(Account, '', Pagination, TempContent);
+
+        // [THEN] The folder is returned with the right name and type
+        Assert.RecordCount(TempContent, 1);
+        TempContent.FindFirst();
+        Assert.AreEqual('Subfolder', TempContent.Name, 'Folder name should match');
+        Assert.AreEqual(TempContent.Type::Directory, TempContent.Type, 'Type should be Directory');
+    end;
+
+    [Test]
+    [HandlerFunctions('CreateDirectoryHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestCreateDirectoryPostsToFoldersEndpoint()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN]
+        Initialize(Account);
+
+        // [WHEN] Creating a directory
+        RestHelper.CreateDirectory(Account, 'NewFolder');
+
+        // [THEN] A POST went to the folders endpoint
+        Assert.IsTrue(LastPath.Contains('/Web/folders'), 'CreateDirectory should POST to the folders endpoint. Actual: ' + LastPath);
+        Assert.IsTrue(LastMethod = HttpRequestType::POST, 'CreateDirectory should send a POST request');
+    end;
+
+    [Test]
+    [HandlerFunctions('DirectoryExistsHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestDirectoryExistsTrue()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] The folder exists on the server
+        Initialize(Account);
+        ReturnFolderExists := true;
+
+        // [WHEN] / [THEN]
+        Assert.IsTrue(RestHelper.DirectoryExists(Account, 'MyFolder'), 'DirectoryExists should return true');
+    end;
+
+    [Test]
+    [HandlerFunctions('DirectoryExistsHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestDirectoryExistsFalse()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] The folder does not exist on the server
+        Initialize(Account);
+        ReturnFolderExists := false;
+
+        // [WHEN] / [THEN]
+        Assert.IsFalse(RestHelper.DirectoryExists(Account, 'MissingFolder'), 'DirectoryExists should return false');
+    end;
+
+    [Test]
+    [HandlerFunctions('DeleteHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestDeleteDirectorySendsDeleteRequest()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN]
+        Initialize(Account);
+
+        // [WHEN] Deleting a directory
+        RestHelper.DeleteDirectory(Account, 'OldFolder');
+
+        // [THEN] A DELETE request targeted the folder
+        Assert.IsTrue(DeletePath.Contains('OldFolder'), 'DeleteDirectory should send a DELETE request for the folder. Actual: ' + DeletePath);
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestDisabledAccountThrowsError()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempContent: Record "File Account Content" temporary;
+        Pagination: Codeunit "File Pagination Data";
+    begin
+        // [GIVEN] A disabled account
+        Initialize(Account);
+        Account.Disabled := true;
+
+        // [WHEN] / [THEN] Any operation fails before any HTTP traffic
+        asserterror RestHelper.ListFiles(Account, '', Pagination, TempContent);
+        Assert.IsTrue(GetLastErrorText().Contains('is disabled'), 'A disabled account should raise the disabled-account error');
+    end;
+
+    #endregion
+
+    #region HTTP Handlers
+
+    [HttpClientHandler]
+    procedure ListFilesHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        TrackRequest(Request);
+        case true of
+            IsContextInfo(Request):
+                WriteContextInfoResponse(Response);
+            Request.Path.Contains('/Files') and (Request.RequestType = HttpRequestType::GET):
+                Response.Content.WriteFrom(GetFilesJson());
+            else
+                Response.Content.WriteFrom('{}');
+        end;
+    end;
+
+    [HttpClientHandler]
+    procedure GetFileHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        TrackRequest(Request);
+        case true of
+            IsFileDownload(Request):
+                Response.Content.WriteFrom('Hello World');
+            else
+                Response.Content.WriteFrom('{}');
+        end;
+    end;
+
+    [HttpClientHandler]
+    procedure CreateFileHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        TrackRequest(Request);
+        case true of
+            IsContextInfo(Request):
+                WriteContextInfoResponse(Response);
+            Request.Path.Contains('/Files/add(url='):
+                Response.Content.WriteFrom(GetFileItemJson('file.txt'));
+            else
+                Response.Content.WriteFrom('{}');
+        end;
+    end;
+
+    [HttpClientHandler]
+    procedure CopyFileHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        TrackRequest(Request);
+        case true of
+            IsContextInfo(Request):
+                WriteContextInfoResponse(Response);
+            IsFileDownload(Request):
+                Response.Content.WriteFrom('file content');
+            Request.Path.Contains('/Files/add(url='):
+                Response.Content.WriteFrom(GetFileItemJson('dest.txt'));
+            else
+                Response.Content.WriteFrom('{}');
+        end;
+    end;
+
+    [HttpClientHandler]
+    procedure MoveFileHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        TrackRequest(Request);
+        case true of
+            IsContextInfo(Request):
+                WriteContextInfoResponse(Response);
+            IsFileDownload(Request):
+                Response.Content.WriteFrom('file content');
+            Request.Path.Contains('/Files/add(url='):
+                Response.Content.WriteFrom(GetFileItemJson('dest.txt'));
+            Request.RequestType = HttpRequestType::DELETE:
+                Response.Content.WriteFrom('{}');
+            else
+                Response.Content.WriteFrom('{}');
+        end;
+    end;
+
+    [HttpClientHandler]
+    procedure FileExistsHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        TrackRequest(Request);
+        case true of
+            Request.Path.Contains('/Files') and (Request.RequestType = HttpRequestType::GET):
+                // FileExists lists the parent folder and filters by name, so the positive
+                // response must contain the file name the test asks for ('file.txt').
+                if ReturnFileExists then
+                    Response.Content.WriteFrom('{"odata.metadata":"","value":[' +
+                        '{"odata.type":"SP.File","UniqueId":"44444444-4444-4444-4444-444444444444","Name":"file.txt","ServerRelativeUrl":"/sites/test/file.txt","Length":"100"}' +
+                        ']}')
+                else
+                    Response.Content.WriteFrom('{"odata.metadata":"","value":[]}');
+            else
+                Response.Content.WriteFrom('{}');
+        end;
+    end;
+
+    [HttpClientHandler]
+    procedure DeleteHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        TrackRequest(Request);
+        case true of
+            IsContextInfo(Request):
+                WriteContextInfoResponse(Response);
+            else
+                Response.Content.WriteFrom('{}');
+        end;
+    end;
+
+    [HttpClientHandler]
+    procedure ListDirectoriesHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        TrackRequest(Request);
+        case true of
+            Request.Path.Contains('/Folders') and (Request.RequestType = HttpRequestType::GET):
+                Response.Content.WriteFrom(GetFoldersJson());
+            else
+                Response.Content.WriteFrom('{}');
+        end;
+    end;
+
+    [HttpClientHandler]
+    procedure CreateDirectoryHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        TrackRequest(Request);
+        case true of
+            IsContextInfo(Request):
+                WriteContextInfoResponse(Response);
+            Request.Path.Contains('/_api/Web/folders') and (Request.RequestType = HttpRequestType::POST):
+                Response.Content.WriteFrom('{"d":{"__metadata":{"type":"SP.Folder"},"Name":"NewFolder","Exists":true}}');
+            else
+                Response.Content.WriteFrom('{}');
+        end;
+    end;
+
+    [HttpClientHandler]
+    procedure DirectoryExistsHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        TrackRequest(Request);
+        case true of
+            Request.Path.Contains('/Exists'):
+                if ReturnFolderExists then
+                    Response.Content.WriteFrom('{"value":true}')
+                else
+                    Response.Content.WriteFrom('{"value":false}');
+            else
+                Response.Content.WriteFrom('{}');
+        end;
+    end;
+
+    #endregion
+
+    #region Handler Helpers
+
+    local procedure TrackRequest(Request: TestHttpRequestMessage)
+    begin
+        LastPath := Request.Path;
+        LastMethod := Request.RequestType;
+        if Request.RequestType = HttpRequestType::DELETE then
+            DeletePath := Request.Path;
+        if IsFileDownload(Request) then
+            DownloadPath := Request.Path;
+        if Request.Path.Contains('/Files/add(url=') then
+            FileAddPath := Request.Path;
+    end;
+
+    local procedure IsContextInfo(Request: TestHttpRequestMessage): Boolean
+    begin
+        exit(Request.Path.Contains('contextinfo') and (Request.RequestType = HttpRequestType::POST));
+    end;
+
+    local procedure IsFileDownload(Request: TestHttpRequestMessage): Boolean
+    begin
+        // The URI builder escapes '$value' to '%24value' when building the download URL
+        exit((Request.Path.Contains('/$value') or Request.Path.Contains('%24value')) and (Request.RequestType = HttpRequestType::GET));
+    end;
+
+    local procedure WriteContextInfoResponse(var Response: TestHttpResponseMessage)
+    begin
+        Response.Content.WriteFrom('{"d":{"GetContextWebInformation":{"FormDigestValue":"fake-digest","FormDigestTimeoutSeconds":1800,"LibraryVersion":"16.0.0.0","SiteFullUrl":"https://contoso.sharepoint.com/sites/test","WebFullUrl":"https://contoso.sharepoint.com/sites/test"}}}');
+    end;
+
+    local procedure GetFilesJson(): Text
+    begin
+        // UniqueId is the primary key of the "SharePoint File" buffer — every entry needs a distinct value
+        exit('{"odata.metadata":"","value":[' +
+            '{"odata.type":"SP.File","UniqueId":"11111111-1111-1111-1111-111111111111","Name":"document.pdf","ServerRelativeUrl":"/sites/test/document.pdf","Length":"1024"},' +
+            '{"odata.type":"SP.File","UniqueId":"22222222-2222-2222-2222-222222222222","Name":"budget.xlsx","ServerRelativeUrl":"/sites/test/budget.xlsx","Length":"2048"}' +
+            ']}');
+    end;
+
+    local procedure GetFoldersJson(): Text
+    begin
+        exit('{"odata.metadata":"","value":[' +
+            '{"odata.type":"SP.Folder","UniqueId":"33333333-3333-3333-3333-333333333333","Name":"Subfolder","ServerRelativeUrl":"/sites/test/Subfolder","ItemCount":0}' +
+            ']}');
+    end;
+
+    local procedure GetFileItemJson(FileName: Text): Text
+    begin
+        exit('{"d":{"__metadata":{"type":"SP.File"},"Name":"' + FileName + '","ServerRelativeUrl":"/sites/test/' + FileName + '"}}');
+    end;
+
+    #endregion
+
+    #region Setup
+
+    local procedure Initialize(var Account: Record "Ext. SharePoint Account")
+    begin
+        Clear(RestHelper);
+        RestHelper.SetAuthorizationForTest(DummySharePointAuthorization);
+
+        LastPath := '';
+        DownloadPath := '';
+        FileAddPath := '';
+        DeletePath := '';
+        ReturnFileExists := false;
+        ReturnFolderExists := false;
+
+        Account.Init();
+        Account.Id := CreateGuid();
+        Account."SharePoint Url" := SharePointUrlLbl;
+        Account."Tenant Id" := CreateGuid();
+        Account."Client Id" := CreateGuid();
+        Account."Authentication Type" := Enum::"Ext. SharePoint Auth Type"::"Client Secret";
+        Account."Use legacy REST API" := true;
+        Account.Insert();
+    end;
+
+    #endregion
+}

--- a/src/Apps/W1/External File Storage - SharePoint Connector/Test/src/ExtSharePointDispatchTest.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/Test/src/ExtSharePointDispatchTest.Codeunit.al
@@ -1,0 +1,232 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Test.ExternalFileStorage;
+
+using System.ExternalFileStorage;
+using System.Test.Integration.Sharepoint;
+using System.TestLibraries.Integration.Sharepoint;
+using System.TestLibraries.Utilities;
+
+/// <summary>
+/// Verifies that "Ext. SharePoint Connector Impl" dispatches to the right helper (REST or Graph)
+/// based on the account's "Use legacy REST API" flag. All calls go through the connector — not the
+/// helpers directly — so the dispatching logic itself is what gets tested. The [HttpClientHandler]
+/// records which API family every outbound request hits: Graph calls go to graph.microsoft.com,
+/// REST calls go to /_api/.
+/// </summary>
+codeunit 144587 "Ext. SharePoint Dispatch Test"
+{
+    Subtype = Test;
+    TestHttpRequestPolicy = BlockOutboundRequests;
+    TestPermissions = Disabled;
+
+    var
+        ConnectorImpl: Codeunit "Ext. SharePoint Connector Impl";
+        GraphAuthMock: Codeunit "SharePoint Graph Auth Mock";
+        DummySharePointAuthorization: Codeunit "Dummy SharePoint Authorization";
+        Assert: Codeunit "Library Assert";
+        HitGraphApi: Boolean;
+        HitRestApi: Boolean;
+        SharePointUrlLbl: Label 'https://contoso.sharepoint.com/sites/test', Locked = true;
+
+    #region Tests
+
+    [Test]
+    [HandlerFunctions('DispatchHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestConnectorDispatchesListFilesToGraphWhenLegacyRestIsFalse()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempContent: Record "File Account Content" temporary;
+        Pagination: Codeunit "File Pagination Data";
+    begin
+        // [GIVEN] An account with Use legacy REST API = false
+        Initialize(Account, false);
+
+        // [WHEN] Listing files through the connector
+        ConnectorImpl.ListFiles(Account.Id, '', Pagination, TempContent);
+
+        // [THEN] Traffic went to Graph only
+        Assert.IsTrue(HitGraphApi, 'The connector should dispatch to the Graph helper');
+        Assert.IsFalse(HitRestApi, 'The connector should not call the REST API');
+    end;
+
+    [Test]
+    [HandlerFunctions('DispatchHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestConnectorDispatchesListFilesToRestWhenLegacyRestIsTrue()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempContent: Record "File Account Content" temporary;
+        Pagination: Codeunit "File Pagination Data";
+    begin
+        // [GIVEN] An account with Use legacy REST API = true
+        Initialize(Account, true);
+
+        // [WHEN] Listing files through the connector
+        ConnectorImpl.ListFiles(Account.Id, '', Pagination, TempContent);
+
+        // [THEN] Traffic went to the REST API only
+        Assert.IsTrue(HitRestApi, 'The connector should dispatch to the REST helper');
+        Assert.IsFalse(HitGraphApi, 'The connector should not call the Graph API');
+    end;
+
+    [Test]
+    [HandlerFunctions('DispatchHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestConnectorDispatchesListDirectoriesToGraphWhenLegacyRestIsFalse()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempContent: Record "File Account Content" temporary;
+        Pagination: Codeunit "File Pagination Data";
+    begin
+        // [GIVEN] An account with Use legacy REST API = false
+        Initialize(Account, false);
+
+        // [WHEN] Listing directories through the connector
+        ConnectorImpl.ListDirectories(Account.Id, '', Pagination, TempContent);
+
+        // [THEN] Traffic went to Graph only
+        Assert.IsTrue(HitGraphApi, 'The connector should dispatch directory listing to the Graph helper');
+        Assert.IsFalse(HitRestApi, 'The connector should not call the REST API');
+    end;
+
+    [Test]
+    [HandlerFunctions('DispatchHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestConnectorDispatchesListDirectoriesToRestWhenLegacyRestIsTrue()
+    var
+        Account: Record "Ext. SharePoint Account";
+        TempContent: Record "File Account Content" temporary;
+        Pagination: Codeunit "File Pagination Data";
+    begin
+        // [GIVEN] An account with Use legacy REST API = true
+        Initialize(Account, true);
+
+        // [WHEN] Listing directories through the connector
+        ConnectorImpl.ListDirectories(Account.Id, '', Pagination, TempContent);
+
+        // [THEN] Traffic went to the REST API only
+        Assert.IsTrue(HitRestApi, 'The connector should dispatch directory listing to the REST helper');
+        Assert.IsFalse(HitGraphApi, 'The connector should not call the Graph API');
+    end;
+
+    [Test]
+    [HandlerFunctions('DispatchHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestConnectorDispatchesFileExistsToGraphWhenLegacyRestIsFalse()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] An account with Use legacy REST API = false
+        Initialize(Account, false);
+
+        // [WHEN] Checking file existence through the connector
+        ConnectorImpl.FileExists(Account.Id, 'file.txt');
+
+        // [THEN] Traffic went to Graph only
+        Assert.IsTrue(HitGraphApi, 'The connector should dispatch FileExists to the Graph helper');
+        Assert.IsFalse(HitRestApi, 'The connector should not call the REST API');
+    end;
+
+    [Test]
+    [HandlerFunctions('DispatchHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestConnectorDispatchesFileExistsToRestWhenLegacyRestIsTrue()
+    var
+        Account: Record "Ext. SharePoint Account";
+    begin
+        // [GIVEN] An account with Use legacy REST API = true
+        Initialize(Account, true);
+
+        // [WHEN] Checking file existence through the connector
+        ConnectorImpl.FileExists(Account.Id, 'file.txt');
+
+        // [THEN] Traffic went to the REST API only
+        Assert.IsTrue(HitRestApi, 'The connector should dispatch FileExists to the REST helper');
+        Assert.IsFalse(HitGraphApi, 'The connector should not call the Graph API');
+    end;
+
+    #endregion
+
+    #region HTTP Handler
+
+    [HttpClientHandler]
+    procedure DispatchHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        case true of
+            Request.Path.Contains('graph.microsoft.com'):
+                begin
+                    HitGraphApi := true;
+                    RespondAsGraph(Request, Response);
+                end;
+            Request.Path.Contains('/_api/'):
+                begin
+                    HitRestApi := true;
+                    RespondAsRest(Request, Response);
+                end;
+            else
+                Response.Content.WriteFrom('{}');
+        end;
+    end;
+
+    local procedure RespondAsGraph(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage)
+    begin
+        case true of
+            // Site discovery: /sites/hostname:/path: (no /drive, no /root)
+            Request.Path.Contains('/sites/') and
+                not Request.Path.Contains('/drive') and
+                not Request.Path.Contains('/root'):
+                Response.Content.WriteFrom('{"id":"test-site-id"}');
+            // Drive discovery: /sites/{siteId}/drive
+            Request.Path.Contains('/drive') and
+                not Request.Path.Contains('/drives/') and
+                not Request.Path.Contains('/root'):
+                Response.Content.WriteFrom('{"id":"test-drive-id"}');
+            else
+                // Listing / item request
+                Response.Content.WriteFrom('{"value":[{"id":"1","name":"file.txt","file":{},"size":10}],"id":"1","name":"file.txt","file":{},"size":10}');
+        end;
+    end;
+
+    local procedure RespondAsRest(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage)
+    begin
+        case true of
+            Request.Path.Contains('contextinfo') and (Request.RequestType = HttpRequestType::POST):
+                Response.Content.WriteFrom('{"d":{"GetContextWebInformation":{"FormDigestValue":"fake-digest","FormDigestTimeoutSeconds":1800,"LibraryVersion":"16.0.0.0","SiteFullUrl":"https://contoso.sharepoint.com/sites/test","WebFullUrl":"https://contoso.sharepoint.com/sites/test"}}}');
+            Request.Path.Contains('/Files') and (Request.RequestType = HttpRequestType::GET):
+                Response.Content.WriteFrom('{"odata.metadata":"","value":[{"odata.type":"SP.File","UniqueId":"11111111-1111-1111-1111-111111111111","Name":"file.txt","ServerRelativeUrl":"/sites/test/file.txt","Length":"100"}]}');
+            Request.Path.Contains('/Folders') and (Request.RequestType = HttpRequestType::GET):
+                Response.Content.WriteFrom('{"odata.metadata":"","value":[{"odata.type":"SP.Folder","UniqueId":"22222222-2222-2222-2222-222222222222","Name":"SubFolder","ServerRelativeUrl":"/sites/test/SubFolder","ItemCount":0}]}');
+            else
+                Response.Content.WriteFrom('{}');
+        end;
+    end;
+
+    #endregion
+
+    #region Setup
+
+    local procedure Initialize(var Account: Record "Ext. SharePoint Account"; UseLegacyRestAPI: Boolean)
+    begin
+        Clear(ConnectorImpl);
+        ConnectorImpl.SetAuthorizationsForTest(GraphAuthMock, DummySharePointAuthorization);
+
+        HitGraphApi := false;
+        HitRestApi := false;
+
+        Account.Init();
+        Account.Id := CreateGuid();
+        Account."SharePoint Url" := SharePointUrlLbl;
+        Account."Tenant Id" := CreateGuid();
+        Account."Client Id" := CreateGuid();
+        Account."Authentication Type" := Enum::"Ext. SharePoint Auth Type"::"Client Secret";
+        Account."Use legacy REST API" := UseLegacyRestAPI;
+        Account.Insert();
+    end;
+
+    #endregion
+}

--- a/src/Apps/W1/External File Storage - SharePoint Connector/Test/src/ExtSharePointUpgradeTest.Codeunit.al
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/Test/src/ExtSharePointUpgradeTest.Codeunit.al
@@ -1,0 +1,73 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.Test.ExternalFileStorage;
+
+using System.ExternalFileStorage;
+using System.TestLibraries.Utilities;
+
+codeunit 144584 "Ext. SharePoint Upgrade Test"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "Library Assert";
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestUpgradeSetsUseLegacyRestAPIOnExistingAccounts()
+    var
+        ExtSharePointAccount: Record "Ext. SharePoint Account";
+        ExtSharePointUpgrade: Codeunit "Ext. SharePoint Upgrade";
+        FirstAccountId: Guid;
+        SecondAccountId: Guid;
+    begin
+        // [GIVEN] Accounts created before the flag existed (Use legacy REST API = false)
+        ExtSharePointAccount.DeleteAll();
+        FirstAccountId := CreateAccount(false);
+        SecondAccountId := CreateAccount(false);
+
+        // [WHEN] The upgrade routine runs
+        ExtSharePointUpgrade.SetUseLegacyRestAPIForExistingAccounts();
+
+        // [THEN] Existing accounts keep using the REST API so their behavior does not silently change
+        ExtSharePointAccount.Get(FirstAccountId);
+        Assert.IsTrue(ExtSharePointAccount."Use legacy REST API", 'Existing accounts must be switched to the legacy REST API on upgrade');
+        ExtSharePointAccount.Get(SecondAccountId);
+        Assert.IsTrue(ExtSharePointAccount."Use legacy REST API", 'All existing accounts must be switched, not just the first one');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestUpgradeIsNoOpWhenNoAccountsNeedUpdating()
+    var
+        ExtSharePointAccount: Record "Ext. SharePoint Account";
+        ExtSharePointUpgrade: Codeunit "Ext. SharePoint Upgrade";
+        AccountId: Guid;
+    begin
+        // [GIVEN] Only accounts that already use the legacy REST API
+        ExtSharePointAccount.DeleteAll();
+        AccountId := CreateAccount(true);
+
+        // [WHEN] The upgrade routine runs
+        ExtSharePointUpgrade.SetUseLegacyRestAPIForExistingAccounts();
+
+        // [THEN] The account is untouched
+        ExtSharePointAccount.Get(AccountId);
+        Assert.IsTrue(ExtSharePointAccount."Use legacy REST API", 'Accounts already on the legacy REST API must stay on it');
+    end;
+
+    local procedure CreateAccount(UseLegacyRestAPI: Boolean): Guid
+    var
+        ExtSharePointAccount: Record "Ext. SharePoint Account";
+    begin
+        ExtSharePointAccount.Init();
+        ExtSharePointAccount.Id := CreateGuid();
+        ExtSharePointAccount."Use legacy REST API" := UseLegacyRestAPI;
+        ExtSharePointAccount.Insert();
+        exit(ExtSharePointAccount.Id);
+    end;
+}


### PR DESCRIPTION
## Backport

Backports #5833 to the `releases/28.x` branch.

Cherry-picked the squash merge commit `30b880e0` onto `releases/28.x`. One conflict in `ExtSharePointConnectorImpl.Codeunit.al` was resolved by taking the PR's dispatch-based implementation — the only divergence on 28.x was a cosmetic `TempSharePointFile`→`SharePointFile` variable rename in method bodies that the PR deletes entirely.

## Original summary

Adds Microsoft Graph API support as an alternative to the existing SharePoint REST API, with a backward-compatible `Use legacy REST API` toggle. Graph API supports downloading files larger than 150 MB via chunked transfers, which the SharePoint REST API cannot.

- **New field** `Use legacy REST API` on `Ext. SharePoint Account` table/page to select the API stack
- **Refactored** `Ext. SharePoint Connector Impl` to dispatch operations to REST vs Graph based on the flag
- **New codeunits**: `Ext. SharePoint Graph Helper`, `Ext. SharePoint REST Helper`, `Ext. SharePoint Upgrade` (existing accounts default to legacy REST on upgrade so nobody silently switches stacks)
- Extended the app `idRanges` to 4610
- Added unit tests for the account table, graph helper, REST helper, dispatch routing, and upgrade

## Backport verification

- System Application SharePoint Graph module (dependency #3655) is already present on 28.x; all `SharePoint Graph Client` methods called by the helper exist with matching signatures.
- The certificate `SetParameters` fix referenced by the original PR is already present on 28.x's `GraphAuthClientCredentials` (it was not part of the squash diff).

Fixes #5383
Fixes [AB#612932](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/612932)
