### PR TITLE
[Master] - Bug 641055: Sustainability - Fix Scope 3 installation multiplier

### DIFF
--- a/src/Apps/W1/Sustainability/app/src/Purchase/SustainabilityPurchLine.TableExt.al
+++ b/src/Apps/W1/Sustainability/app/src/Purchase/SustainabilityPurchLine.TableExt.al
@@ -25,6 +25,7 @@ tableextension 6211 "Sustainability Purch. Line" extends "Purchase Line"
             trigger OnValidate()
             var
                 SustainabilityAccount: Record "Sustainability Account";
+                SustainabilityAccountCategory: Record "Sustain. Account Category";
             begin
                 Rec.TestStatusOpen();
                 if Rec."Sust. Account No." <> xRec."Sust. Account No." then
@@ -44,6 +45,9 @@ tableextension 6211 "Sustainability Purch. Line" extends "Purchase Line"
                     Rec.Validate("Sust. Account Category", SustainabilityAccount.Category);
                     Rec.Validate("Sust. Account Subcategory", SustainabilityAccount.Subcategory);
                     UpdateDefaultEmissionOnPurchLine(Rec);
+                    if SustainabilityAccountCategory.Get(SustainabilityAccount.Category) then
+                        if SustainabilityAccountCategory."Calculation Foundation" = SustainabilityAccountCategory."Calculation Foundation"::Distance then
+                            Rec.Validate("Installation Multiplier", 1);
                 end;
 
                 CreateDimFromDefaultDim(FieldNo(Rec."Sust. Account No."));


### PR DESCRIPTION
Workitem Bug 641055: [Sustainability] Scope 3 Distance: Installation Multiplier defaults to 1 in Journal but 0 in Purchase Order/Invoice, giving 0 emissions

Fixes [AB#641055](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641055)

Issue: On Purchase Order/Invoice lines using a distance‑based Scope 3 sustainability account, "Installation Multiplier" defaulted to 0. Because distance emissions are calculated as Distance × Emission Factor × Installation Multiplier, the result was always 0 — even with a valid distance and emission factor. The Sustainability Journal behaved correctly because its "Installation Multiplier" field has InitValue = 1, so the two entry points produced inconsistent emissions.

Cause: The purchase line "Installation Multiplier" field had no default value (0), and nothing set it when a sustainability account was assigned. Unlike the journal line, there was no InitValue = 1 equivalent for purchase documents.

Solution: In the "Sust. Account No." OnValidate trigger on the Purchase Line, when the assigned account's category uses Calculation Foundation = Distance, default "Installation Multiplier" to 1 (matching the journal's behavior). The default is intentionally scoped to Distance‑based accounts only, so Fuel/Electricity, Custom, and per‑unit item emission lines keep "Installation Multiplier" = 0 and continue to pass the TestField("Installation Multiplier", 0) validation.


