### PR TITLE
[Master] - Bug 641222: Sustainability - Show CO2e per unit on Item Journal line

### DIFF
--- a/src/Apps/W1/Sustainability/app/src/Journal/SustItemJournal.PageExt.al
+++ b/src/Apps/W1/Sustainability/app/src/Journal/SustItemJournal.PageExt.al
@@ -22,6 +22,12 @@ pageextension 6288 "Sust. Item Journal" extends "Item Journal"
         }
         addafter("Unit Cost")
         {
+            field("CO2e per Unit"; Rec."CO2e per Unit")
+            {
+                Visible = SustainabilityVisible;
+                ApplicationArea = Basic, Suite;
+                ToolTip = 'Specifies the value of the CO2e per Unit field.';
+            }
             field("Total CO2e"; Rec."Total CO2e")
             {
                 Visible = SustainabilityVisible;


### PR DESCRIPTION
Workitem Bug 641222: [Sustainability] Item Journal line shows only Total CO2e; CO2e per Unit is not visible/editable without Page Inspector

Fixes [AB#641222](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641222)

Issue: On the Item Journal, only "Total CO2e" was shown on the line. The "CO2e per Unit" value could not be seen or edited from the page — users had to open Page Inspector to view/change it, making per‑unit emission entry impractical.

Cause: The "CO2e per Unit" field (field 6217 on the Item Journal Line) existed on the table and was fully functional (with its own OnValidate that recalculates Total CO2e), but it was never added to the "Sust. Item Journal" page extension layout. Only "Total CO2e" had a control.

Solution: Added a "CO2e per Unit" field control to the "Sust. Item Journal" page extension, placed just before "Total CO2e". It reuses the existing SustainabilityVisible visibility toggle and Basic, Suite application area, so it appears (and is editable) only when value chain tracking is enabled — consistent with the other sustainability fields. Editing it now drives the existing Total CO2e recalculation directly from the journal, with no need for Page Inspector.

