### PR TITLE
Allow pull_request:linked-issue ownership source

### DIFF
--- a/.github/workflows/ownership-classification.yml
+++ b/.github/workflows/ownership-classification.yml
@@ -248,7 +248,8 @@ jobs:
             const confidenceValues = ['high', 'medium', 'low'];
             const sources = [
               'issue:path', 'issue:localization', 'issue:title-object',
-              'issue:title-phrase', 'issue:app-area', 'issue:body-object',
+              'issue:title-phrase', 'issue:title-keyword', 'issue:app-area',
+              'issue:body-object', 'issue:body-keyword',
               'issue:unresolved', 'pull_request:changed-files',
               'pull_request:ambiguous', 'pull_request:unresolved',
               'pull_request:incomplete-files',

--- a/.github/workflows/ownership-classification.yml
+++ b/.github/workflows/ownership-classification.yml
@@ -248,8 +248,7 @@ jobs:
             const confidenceValues = ['high', 'medium', 'low'];
             const sources = [
               'issue:path', 'issue:localization', 'issue:title-object',
-              'issue:title-phrase', 'issue:title-keyword', 'issue:app-area',
-              'issue:body-object', 'issue:body-keyword',
+              'issue:title-phrase', 'issue:app-area', 'issue:body-object',
               'issue:unresolved', 'pull_request:changed-files',
               'pull_request:ambiguous', 'pull_request:unresolved',
               'pull_request:incomplete-files',

--- a/.github/workflows/ownership-classification.yml
+++ b/.github/workflows/ownership-classification.yml
@@ -252,6 +252,7 @@ jobs:
               'issue:unresolved', 'pull_request:changed-files',
               'pull_request:ambiguous', 'pull_request:unresolved',
               'pull_request:incomplete-files',
+              'pull_request:linked-issue',
             ];
             const issue_number = Number(process.env.SUBJECT_NUMBER);
             const bytes = fs.readFileSync(process.env.RESULT_PATH);


### PR DESCRIPTION
## Symptom
The team-ownership classification workflow (`.github/workflows/ownership-classification.yml`) in microsoft/BCApps rejects correct classifications as malformed, failing with:

> The ownership result from BCAppsTriage was malformed, so no labels were changed.

This broke a real PR: microsoft/BCApps #9561 (base `releases/28.x`, linked issue #5383) was correctly classified as team `Integration` with `source: pull_request:linked-issue`, but the workflow threw the malformed error and applied no labels.

## Root cause
The `Validate and apply ownership result` step validates `result.ownership.source` against a hardcoded `sources` allowlist. A merged BCAppsTriage change (PR #40, linked-issue PR routing) added a new emitted source value `pull_request:linked-issue` — a PR whose team is adopted from its linked issue when the changed files are ambiguous. The BCApps allowlist was never updated, so any such result is rejected as malformed.

## Fix
Add `'pull_request:linked-issue'` to the `sources` allowlist, immediately after `'pull_request:incomplete-files'`. This restores parity with the classifier's `decision.js` source set in BCAppsTriage — the only emitted source value missing from the allowlist. The allowlist now contains all 12 valid source values.

Single-line change; no other edits.

Fixes [AB#642506](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642506)


