### PR TITLE
Enforce permissions when reviewing orphaned extension data

### DIFF
--- a/src/System Application/App/Extension Management/src/DeleteOrphanedExtensionData.Page.al
+++ b/src/System Application/App/Extension Management/src/DeleteOrphanedExtensionData.Page.al
@@ -137,9 +137,9 @@ page 2514 "Delete Orphaned Extension Data"
 
                     trigger OnAction()
                     var
-                        ExtensionDatabaseManagement: Codeunit "Extension Database Management";
+                        ExtensionOperationImpl: Codeunit "Extension Operation Impl";
                     begin
-                        ExtensionDatabaseManagement.MarkAllOrphanedExtensionDataAsReviewed();
+                        ExtensionOperationImpl.MarkAllOrphanedExtensionDataAsReviewed();
                         UpdateHasUnreviewedExtensions();
                         CurrPage.Update(false);
                     end;
@@ -198,5 +198,4 @@ page 2514 "Delete Orphaned Extension Data"
         HasUnreviewedExtensions := not ExtensionDatabaseSnapshot.IsEmpty();
     end;
 }
-
 

--- a/src/System Application/App/Extension Management/src/ExtensionOperationImpl.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionOperationImpl.Codeunit.al
@@ -442,11 +442,17 @@ codeunit 2503 "Extension Operation Impl"
     end;
 
     procedure MarkOrphanedDataAsReviewed(Notif: Notification)
+    begin
+        MarkAllOrphanedExtensionDataAsReviewed();
+        Notif.Recall();
+    end;
+
+    internal procedure MarkAllOrphanedExtensionDataAsReviewed()
     var
         ExtensionDatabaseManagement: Codeunit "Extension Database Management";
     begin
+        CheckPermissions();
         ExtensionDatabaseManagement.MarkAllOrphanedExtensionDataAsReviewed();
-        Notif.Recall();
     end;
 
     internal procedure GetAppName(AppId: Guid; OperationId: Guid) AppName: Text
@@ -457,4 +463,3 @@ codeunit 2503 "Extension Operation Impl"
             AppName := GetDeployOperationAppName(OperationId);
     end;
 }
-


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

Ensure marking orphaned extension data as reviewed consistently calls CheckPermissions() from both the notification and page actions.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#633514](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633514)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

No tests added; both entry points now share the same implementation.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

- Installed and uninstalled an extension; verified the orphaned-data notification appeared.
- Marked data as reviewed from both the notification and the Delete Orphaned Extension Data page; verified the reviewed status was updated.
- Reinstalled and uninstalled the extension; verified the reviewed status was reset.

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

Permission enforcement is stricter on OpenPage.



