### PR TITLE
Obsolete E-Document Purchase Order Matching Copilot

### DIFF
--- a/src/Apps/W1/EDocument/App/Permissions/EDocCoreEdit.PermissionSet.al
+++ b/src/Apps/W1/EDocument/App/Permissions/EDocCoreEdit.PermissionSet.al
@@ -7,7 +7,9 @@ namespace Microsoft.eServices.EDocument;
 
 using Microsoft.eServices.EDocument.IO.Peppol;
 using Microsoft.EServices.EDocument.OrderMatch;
+#if not CLEAN29
 using Microsoft.eServices.EDocument.OrderMatch.Copilot;
+#endif
 using Microsoft.eServices.EDocument.Processing.Import;
 using Microsoft.eServices.EDocument.Processing.Import.Purchase;
 using Microsoft.EServices.EDocument.Processing.Import.Sales;
@@ -39,7 +41,9 @@ permissionset 6102 "E-Doc. Core - Edit"
         tabledata "E-Doc. Order Match" = IMD,
         tabledata "Service Participant" = IMD,
         tabledata "E-Doc. Import Parameters" = IMD,
+#if not CLEAN29
         tabledata "E-Doc. PO Match Prop. Buffer" = IMD,
+#endif
         tabledata "E-Document Header Mapping" = IMD,
         tabledata "E-Document Line Mapping" = IMD,
         tabledata "E-Document Purchase Header" = IMD,

--- a/src/Apps/W1/EDocument/App/Permissions/EDocCoreObjects.PermissionSet.al
+++ b/src/Apps/W1/EDocument/App/Permissions/EDocCoreObjects.PermissionSet.al
@@ -12,7 +12,9 @@ using Microsoft.eServices.EDocument.Integration.Send;
 using Microsoft.eServices.EDocument.IO;
 using Microsoft.eServices.EDocument.IO.Peppol;
 using Microsoft.EServices.EDocument.OrderMatch;
+#if not CLEAN29
 using Microsoft.EServices.EDocument.OrderMatch.Copilot;
+#endif
 using Microsoft.eServices.EDocument.Processing.Import;
 using Microsoft.eServices.EDocument.Processing.Import.Purchase;
 using Microsoft.EServices.EDocument.Processing.Import.Sales;
@@ -37,7 +39,9 @@ permissionset 6100 "E-Doc. Core - Objects"
         table "E-Doc. Service Supported Type" = X,
         table "E-Doc. Order Match" = X,
         table "E-Doc. Imported Line" = X,
+#if not CLEAN29
         table "E-Doc. PO Match Prop. Buffer" = X,
+#endif
         table "Service Participant" = X,
         table "E-Doc. Import Parameters" = X,
         table "E-Document Header Mapping" = X,
@@ -91,8 +95,10 @@ permissionset 6100 "E-Doc. Core - Objects"
         codeunit "Pre-Map Service Inv. Line" = X,
         codeunit "EDoc PEPPOL BIS 3.0" = X,
         codeunit "E-Doc. Line Matching" = X,
+#if not CLEAN29
         codeunit "E-Doc. PO AOAI Function" = X,
         codeunit "E-Doc. PO Copilot Matching" = X,
+#endif
         codeunit "E-Doc. Attachment Processor" = X,
         codeunit "Service Participant" = X,
         page "E-Doc. Changes Part" = X,
@@ -114,8 +120,10 @@ permissionset 6100 "E-Doc. Core - Objects"
         page "E-Doc. Purchase Order Sub" = X,
         page "E-Doc. Order Map. Activities" = X,
         page "E-Doc Service Supported Types" = X,
+#if not CLEAN29
         page "E-Doc. PO Copilot Prop" = X,
         page "E-Doc. PO Match Prop. Sub" = X,
+#endif
         page "E-Doc. Order Match Act." = X,
         page "E-Doc. Select PO Lines" = X,
         page "E-Doc. Select Receipt Lines" = X,

--- a/src/Apps/W1/EDocument/App/Permissions/EDocCoreRead.PermissionSet.al
+++ b/src/Apps/W1/EDocument/App/Permissions/EDocCoreRead.PermissionSet.al
@@ -6,7 +6,9 @@ namespace Microsoft.eServices.EDocument;
 
 using Microsoft.eServices.EDocument.IO.Peppol;
 using Microsoft.EServices.EDocument.OrderMatch;
+#if not CLEAN29
 using Microsoft.eServices.EDocument.OrderMatch.Copilot;
+#endif
 using Microsoft.eServices.EDocument.Processing;
 using Microsoft.eServices.EDocument.Processing.Import;
 using Microsoft.eServices.EDocument.Processing.Import.Purchase;
@@ -35,7 +37,9 @@ permissionset 6101 "E-Doc. Core - Read"
     #endregion Logging
         tabledata "E-Doc. Imported Line" = R,
         tabledata "E-Doc. Order Match" = R,
+#if not CLEAN29
         tabledata "E-Doc. PO Match Prop. Buffer" = R,
+#endif
     #region Service
         tabledata "E-Document Service" = R,
         tabledata "E-Doc. Service Data Exch. Def." = R,

--- a/src/Apps/W1/EDocument/App/Permissions/EDocCoreUser.PermissionSet.al
+++ b/src/Apps/W1/EDocument/App/Permissions/EDocCoreUser.PermissionSet.al
@@ -6,7 +6,9 @@ namespace Microsoft.eServices.EDocument;
 
 using Microsoft.eServices.EDocument.IO.Peppol;
 using Microsoft.eServices.EDocument.OrderMatch;
+#if not CLEAN29
 using Microsoft.eServices.EDocument.OrderMatch.Copilot;
+#endif
 using Microsoft.eServices.EDocument.Processing;
 using Microsoft.eServices.EDocument.Processing.Import;
 using Microsoft.eServices.EDocument.Processing.Import.Purchase;
@@ -41,7 +43,9 @@ permissionset 6105 "E-Doc. Core - User"
     #endregion Logging
         tabledata "E-Doc. Imported Line" = IMD,
         tabledata "E-Doc. Order Match" = IMD,
+#if not CLEAN29
         tabledata "E-Doc. PO Match Prop. Buffer" = IMD,
+#endif
         tabledata "Service Participant" = IMD,
     #region Purchase draft
         tabledata "E-Doc. Import Parameters" = IMD,

--- a/src/Apps/W1/EDocument/App/src/Document/EDocument.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Document/EDocument.Page.al
@@ -8,12 +8,16 @@ using Microsoft.Bank.Reconciliation;
 using Microsoft.eServices.EDocument.Integration.Receive;
 using Microsoft.eServices.EDocument.Integration.Send;
 using Microsoft.eServices.EDocument.OrderMatch;
+#if not CLEAN29
 using Microsoft.eServices.EDocument.OrderMatch.Copilot;
+#endif
 using Microsoft.eServices.EDocument.Processing.Import;
 using Microsoft.eServices.EDocument.Processing.Import.Purchase;
 using Microsoft.eServices.EDocument.Service;
 using Microsoft.Foundation.Attachment;
+#if not CLEAN29
 using System.Telemetry;
+#endif
 using System.Utilities;
 
 page 6121 "E-Document"
@@ -599,8 +603,10 @@ page 6121 "E-Document"
         EDocService: Record "E-Document Service";
         EDocServiceStatus2: Record "E-Document Service Status";
         EDocLog: Codeunit "E-Document Log";
+#if not CLEAN29
         FeatureTelemetry: Codeunit "Feature Telemetry";
         EDocPOCopilotMatching: Codeunit "E-Doc. PO Copilot Matching";
+#endif
     begin
         if not IsIncomingDoc then
             exit;
@@ -610,7 +616,9 @@ page 6121 "E-Document"
             EDocServiceStatus2.Get(Rec."Entry No", EDocService.Code);
             ShowMapToOrder := EDocServiceStatus2.Status = Enum::"E-Document Service Status"::"Order Linked";
             ShowRelink := true;
+#if not CLEAN29
             FeatureTelemetry.LogUptake('0000MMK', EDocPOCopilotMatching.FeatureName(), Enum::"Feature Uptake Status"::Discovered);
+#endif
         end;
     end;
 

--- a/src/Apps/W1/EDocument/App/src/Document/EDocument.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Document/EDocument.Page.al
@@ -8,16 +8,10 @@ using Microsoft.Bank.Reconciliation;
 using Microsoft.eServices.EDocument.Integration.Receive;
 using Microsoft.eServices.EDocument.Integration.Send;
 using Microsoft.eServices.EDocument.OrderMatch;
-#if not CLEAN29
-using Microsoft.eServices.EDocument.OrderMatch.Copilot;
-#endif
 using Microsoft.eServices.EDocument.Processing.Import;
 using Microsoft.eServices.EDocument.Processing.Import.Purchase;
 using Microsoft.eServices.EDocument.Service;
 using Microsoft.Foundation.Attachment;
-#if not CLEAN29
-using System.Telemetry;
-#endif
 using System.Utilities;
 
 page 6121 "E-Document"
@@ -464,7 +458,15 @@ page 6121 "E-Document"
         {
             group(Category_Process)
             {
-                actionref(MatchToOrderCE_Promoted; MatchToOrderCopilotEnabled) { }
+#if not CLEAN29
+                actionref(MatchToOrderCE_Promoted; MatchToOrderCopilotEnabled)
+                {
+                    Visible = false;
+                    ObsoleteState = Pending;
+                    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
+                    ObsoleteTag = '29.0';
+                }
+#endif
                 actionref(MatchToOrder_Promoted; MatchToOrder) { }
                 actionref(LinkOrder_Promoted; LinkOrder) { }
                 actionref(CreateDocument_Promoted; CreateDocument) { }
@@ -486,20 +488,18 @@ page 6121 "E-Document"
         }
         area(Prompting)
         {
+#if not CLEAN29
             action(MatchToOrderCopilotEnabled)
             {
                 Caption = 'Match Purchase Order';
                 ToolTip = 'Match E-document lines to Purchase Order.';
                 Image = SparkleFilled;
-                Visible = ShowMapToOrder;
-
-                trigger OnAction()
-                var
-                    EDocOrderMatch: Codeunit "E-Doc. Line Matching";
-                begin
-                    EDocOrderMatch.RunMatching(Rec, true);
-                end;
+                Visible = false;
+                ObsoleteState = Pending;
+                ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
+                ObsoleteTag = '29.0';
             }
+#endif
         }
     }
 
@@ -603,10 +603,6 @@ page 6121 "E-Document"
         EDocService: Record "E-Document Service";
         EDocServiceStatus2: Record "E-Document Service Status";
         EDocLog: Codeunit "E-Document Log";
-#if not CLEAN29
-        FeatureTelemetry: Codeunit "Feature Telemetry";
-        EDocPOCopilotMatching: Codeunit "E-Doc. PO Copilot Matching";
-#endif
     begin
         if not IsIncomingDoc then
             exit;
@@ -616,9 +612,6 @@ page 6121 "E-Document"
             EDocServiceStatus2.Get(Rec."Entry No", EDocService.Code);
             ShowMapToOrder := EDocServiceStatus2.Status = Enum::"E-Document Service Status"::"Order Linked";
             ShowRelink := true;
-#if not CLEAN29
-            FeatureTelemetry.LogUptake('0000MMK', EDocPOCopilotMatching.FeatureName(), Enum::"Feature Uptake Status"::Discovered);
-#endif
         end;
     end;
 

--- a/src/Apps/W1/EDocument/App/src/EDocumentInstall.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/EDocumentInstall.Codeunit.al
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.eServices.EDocument.IO;
 
+#if not CLEAN29
 using Microsoft.eServices.EDocument.OrderMatch.Copilot;
+#endif
 using System.IO;
 using System.Reflection;
 using System.Upgrade;
@@ -21,12 +23,14 @@ codeunit 6161 "E-Document Install"
         InsertDataExchV2();
     end;
 
+#if not CLEAN29
     trigger OnInstallAppPerDatabase()
     var
         EDocAIMatching: Codeunit "E-Doc. PO Copilot Matching";
     begin
         EDocAIMatching.RegisterAICapability();
     end;
+#endif
 
     internal procedure InsertDataExch()
     var

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchaseOrder.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchaseOrder.PageExt.al
@@ -66,29 +66,31 @@ pageextension 6132 "E-Doc. Purchase Order" extends "Purchase Order"
         }
         addlast(Prompting)
         {
+#if not CLEAN29
             action(MatchToOrderCopilotEnabled)
             {
                 Caption = 'Map E-Document Lines';
                 ToolTip = 'Map received E-Document to the Purchase Order';
                 ApplicationArea = All;
                 Image = SparkleFilled;
-                Visible = ShowMapToEDocument;
-
-                trigger OnAction()
-                var
-                    EDocument: Record "E-Document";
-                    EDocOrderMatch: Codeunit "E-Doc. Line Matching";
-                begin
-                    EDocument.GetBySystemId(Rec."E-Document Link");
-                    EDocOrderMatch.RunMatching(EDocument, true);
-                end;
+                Visible = false;
+                ObsoleteState = Pending;
+                ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
+                ObsoleteTag = '29.0';
             }
+#endif
         }
         addlast(Category_Process)
         {
+#if not CLEAN29
             actionref(MapEDocumentCE_Promoted; MatchToOrderCopilotEnabled)
             {
+                Visible = false;
+                ObsoleteState = Pending;
+                ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
+                ObsoleteTag = '29.0';
             }
+#endif
             actionref(MapEDocument_Promoted; MatchToOrder)
             {
             }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchaseOrderList.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchaseOrderList.PageExt.al
@@ -51,30 +51,32 @@ pageextension 6137 "E-Doc. Purchase Order List" extends "Purchase Order List"
         }
         addlast(Prompting)
         {
+#if not CLEAN29
             action(MatchToOrderCopilotEnabled)
             {
                 Caption = 'Map E-Document Lines';
                 ToolTip = 'Map received E-Document to the Purchase Order';
                 ApplicationArea = All;
                 Image = SparkleFilled;
-                Visible = ShowMapToEDocument;
-
-                trigger OnAction()
-                var
-                    EDocument: Record "E-Document";
-                    EDocOrderMatch: Codeunit "E-Doc. Line Matching";
-                begin
-                    EDocument.GetBySystemId(Rec."E-Document Link");
-                    EDocOrderMatch.RunMatching(EDocument, true);
-                end;
+                Visible = false;
+                ObsoleteState = Pending;
+                ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
+                ObsoleteTag = '29.0';
             }
+#endif
 
         }
         addlast(Category_Process)
         {
+#if not CLEAN29
             actionref(MapEDocumentCE_Promoted; MatchToOrderCopilotEnabled)
             {
+                Visible = false;
+                ObsoleteState = Pending;
+                ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
+                ObsoleteTag = '29.0';
             }
+#endif
             actionref(MapEDocument_Promoted; MatchToOrder)
             {
             }

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOAOAIFunction.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOAOAIFunction.Codeunit.al
@@ -6,7 +6,7 @@ codeunit 6167 "E-Doc. PO AOAI Function" implements "AOAI Function"
     InherentPermissions = X;
     InherentEntitlements = X;
     ObsoleteState = Pending;
-    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated.';
+    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
     ObsoleteTag = '29.0';
 
     [NonDebuggable]

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOAOAIFunction.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOAOAIFunction.Codeunit.al
@@ -1,9 +1,13 @@
+#if not CLEAN29
 #pragma warning disable AA0247
 codeunit 6167 "E-Doc. PO AOAI Function" implements "AOAI Function"
 {
     Access = Internal;
     InherentPermissions = X;
     InherentEntitlements = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated.';
+    ObsoleteTag = '29.0';
 
     [NonDebuggable]
     procedure GetPrompt() Prompt: JsonObject
@@ -89,3 +93,4 @@ codeunit 6167 "E-Doc. PO AOAI Function" implements "AOAI Function"
         MatchLineTxt: Label 'Matched to Purchase Order Line %1', Comment = '%1 = Number of the order line that the E-Document line is matched to';
         FailedToGetPromptSecretErr: Label 'Failed to get the prompt secret from Azure Key Vault', Locked = true;
 }
+#endif

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOCopilotMatching.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOCopilotMatching.Codeunit.al
@@ -16,7 +16,7 @@ codeunit 6163 "E-Doc. PO Copilot Matching"
     InherentPermissions = X;
     InherentEntitlements = X;
     ObsoleteState = Pending;
-    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated.';
+    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
     ObsoleteTag = '29.0';
 
     var

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOCopilotMatching.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOCopilotMatching.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 namespace Microsoft.eServices.EDocument.OrderMatch.Copilot;
 
 using Microsoft.eServices.EDocument;
@@ -14,6 +15,9 @@ codeunit 6163 "E-Doc. PO Copilot Matching"
     Access = Internal;
     InherentPermissions = X;
     InherentEntitlements = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated.';
+    ObsoleteTag = '29.0';
 
     var
         EDocAIMatchingFunction: Codeunit "E-Doc. PO AOAI Function";
@@ -329,3 +333,4 @@ codeunit 6163 "E-Doc. PO Copilot Matching"
         RegisterAICapability();
     end;
 }
+#endif

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOCopilotProp.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOCopilotProp.Page.al
@@ -20,7 +20,7 @@ page 6166 "E-Doc. PO Copilot Prop"
     InherentEntitlements = X;
     ContextSensitiveHelpPage = 'map-edocuments-with-copilot';
     ObsoleteState = Pending;
-    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated.';
+    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
     ObsoleteTag = '29.0';
 
     layout

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOCopilotProp.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOCopilotProp.Page.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 namespace Microsoft.eServices.EDocument.OrderMatch.Copilot;
 
 using Microsoft.eServices.EDocument;
@@ -18,6 +19,9 @@ page 6166 "E-Doc. PO Copilot Prop"
     InherentPermissions = X;
     InherentEntitlements = X;
     ContextSensitiveHelpPage = 'map-edocuments-with-copilot';
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated.';
+    ObsoleteTag = '29.0';
 
     layout
     {
@@ -332,3 +336,4 @@ page 6166 "E-Doc. PO Copilot Prop"
         CurrPage.ProposalDetails.Page.Load(TempAIProposalBuffer, TempLocalEDocOrderMatches);
     end;
 }
+#endif

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOMatchPropBuffer.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOMatchPropBuffer.Table.al
@@ -15,7 +15,7 @@ table 6163 "E-Doc. PO Match Prop. Buffer"
     InherentEntitlements = X;
     DataClassification = CustomerContent;
     ObsoleteState = Pending;
-    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated.';
+    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
     ObsoleteTag = '29.0';
 
 #pragma warning disable AA0473

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOMatchPropBuffer.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOMatchPropBuffer.Table.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 namespace Microsoft.EServices.EDocument.OrderMatch.Copilot;
 
 using Microsoft.eServices.EDocument;
@@ -13,6 +14,9 @@ table 6163 "E-Doc. PO Match Prop. Buffer"
     InherentPermissions = X;
     InherentEntitlements = X;
     DataClassification = CustomerContent;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated.';
+    ObsoleteTag = '29.0';
 
 #pragma warning disable AA0473
     fields
@@ -106,3 +110,4 @@ table 6163 "E-Doc. PO Match Prop. Buffer"
     end;
 
 }
+#endif

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOMatchPropSub.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOMatchPropSub.Page.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 namespace Microsoft.eServices.EDocument.OrderMatch.Copilot;
 
 using Microsoft.eServices.EDocument.OrderMatch;
@@ -15,6 +16,9 @@ page 6163 "E-Doc. PO Match Prop. Sub"
     InsertAllowed = false;
     InherentPermissions = X;
     InherentEntitlements = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated.';
+    ObsoleteTag = '29.0';
 
     layout
     {
@@ -119,3 +123,4 @@ page 6163 "E-Doc. PO Match Prop. Sub"
         TempEDocOrderMatches.Reset();
     end;
 }
+#endif

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOMatchPropSub.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/Copilot/EDocPOMatchPropSub.Page.al
@@ -17,7 +17,7 @@ page 6163 "E-Doc. PO Match Prop. Sub"
     InherentPermissions = X;
     InherentEntitlements = X;
     ObsoleteState = Pending;
-    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated.';
+    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
     ObsoleteTag = '29.0';
 
     layout

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/EDocLineMatching.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/EDocLineMatching.Codeunit.al
@@ -32,11 +32,6 @@ codeunit 6164 "E-Doc. Line Matching"
         PurchaseLineCreatedReceiveItemsMsg: Label 'The purchase line has been created. Please review the purchase order and receive items.';
 
     procedure RunMatching(var EDocument: Record "E-Document")
-    begin
-        RunMatching(EDocument, false);
-    end;
-
-    procedure RunMatching(var EDocument: Record "E-Document"; WithCopilot: Boolean)
     var
         EDocService: Record "E-Document Service";
         EDocServiceStatus: Record "E-Document Service Status";
@@ -50,7 +45,6 @@ codeunit 6164 "E-Doc. Line Matching"
         EDocServiceStatus.Get(EDocument."Entry No", EDocService.Code);
         EDocServiceStatus.TestField(Status, Enum::"E-Document Service Status"::"Order Linked");
         EDocOrderLineMatching.SetTempRecord(EDocument);
-        EDocOrderLineMatching.SetAutoRunCopilot(WithCopilot);
         EDocOrderLineMatching.Run();
     end;
 

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/EDocOrderLineMatching.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/EDocOrderLineMatching.Page.al
@@ -1,10 +1,14 @@
 namespace Microsoft.eServices.EDocument.OrderMatch;
 
 using Microsoft.eServices.EDocument;
+#if not CLEAN29
 using Microsoft.eServices.EDocument.OrderMatch.Copilot;
+#endif
 using Microsoft.Purchases.Document;
+#if not CLEAN29
 using System.AI;
 using System.Telemetry;
+#endif
 page 6167 "E-Doc. Order Line Matching"
 {
     Caption = 'Purchase Order Matching';
@@ -165,12 +169,16 @@ page 6167 "E-Doc. Order Line Matching"
         }
         area(Prompting)
         {
+#if not CLEAN29
             action(MatchCopilot)
             {
                 Caption = 'Match with Copilot';
                 ToolTip = 'Match e-document lines with the assistance of Copilot';
                 ApplicationArea = All;
                 Image = SparkleFilled;
+                ObsoleteState = Pending;
+                ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated.';
+                ObsoleteTag = '29.0';
 
                 trigger OnAction()
                 begin
@@ -178,6 +186,7 @@ page 6167 "E-Doc. Order Line Matching"
                     SetUserInteractions();
                 end;
             }
+#endif
         }
         area(Navigation)
         {
@@ -203,7 +212,14 @@ page 6167 "E-Doc. Order Line Matching"
             }
             group(Matching)
             {
-                actionref(MatchCopilot_Promoted; MatchCopilot) { }
+#if not CLEAN29
+                actionref(MatchCopilot_Promoted; MatchCopilot)
+                {
+                    ObsoleteState = Pending;
+                    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated.';
+                    ObsoleteTag = '29.0';
+                }
+#endif
                 actionref(MatchManual_Promoted; MatchManual) { }
                 actionref(MatchAuto_Promoted; MatchAutomatic) { }
                 actionref(RemoveMatch_Promoted; RemoveMatch) { }
@@ -218,17 +234,23 @@ page 6167 "E-Doc. Order Line Matching"
     }
 
     var
+#if not CLEAN29
         FeatureTelemetry: Codeunit "Feature Telemetry";
+#endif
         EDocMatchOrderLines: Codeunit "E-Doc. Line Matching";
         CostNotification: Notification;
         AutoRunCopilot: Boolean;
         LineCostVaryMatchMsg: Label 'Matched e-document lines (%1) has cost different from matched purchase order line. Please verify matches are correct.', Comment = '%1 - Line number';
+#if not CLEAN29
         NoMatchesFoundMsg: Label 'Copilot could not find any line matches. Please review manually';
+#endif
         GlobalDataCaptionExpressionTxt: Label 'Purchase Order %1', Comment = '%1 - Purchase order number';
 
     trigger OnAfterGetRecord()
+#if not CLEAN29
     var
         EDocOrderMatch: Record "E-Doc. Order Match";
+#endif
     begin
         CurrPage.OrderLines.Page.SetEDocumentBeingMatched(Rec);
         CurrPage.ImportedLines.Page.SetEDocumentBeingMatched(Rec);
@@ -236,12 +258,14 @@ page 6167 "E-Doc. Order Line Matching"
 
         OpenPurchaseHeader();
 
+#if not CLEAN29
         if AutoRunCopilot then begin
             AutoRunCopilot := false;
             EDocOrderMatch.SetRange("E-Document Entry No.", Rec."Entry No");
             if EDocOrderMatch.IsEmpty() then
                 MatchWithCopilot(false);
         end;
+#endif
     end;
 
     local procedure OpenPurchaseHeader()
@@ -313,6 +337,7 @@ page 6167 "E-Doc. Order Line Matching"
         end;
     end;
 
+#if not CLEAN29
     local procedure MatchWithCopilot(CheckToOverwrite: Boolean)
     var
         TempEDocImportedLines: Record "E-Doc. Imported Line" temporary;
@@ -342,6 +367,7 @@ page 6167 "E-Doc. Order Line Matching"
 
         CurrPage.Update();
     end;
+#endif
 
     local procedure SetUserInteractions()
     begin

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/EDocOrderLineMatching.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/EDocOrderLineMatching.Page.al
@@ -1,14 +1,7 @@
 namespace Microsoft.eServices.EDocument.OrderMatch;
 
 using Microsoft.eServices.EDocument;
-#if not CLEAN29
-using Microsoft.eServices.EDocument.OrderMatch.Copilot;
-#endif
 using Microsoft.Purchases.Document;
-#if not CLEAN29
-using System.AI;
-using System.Telemetry;
-#endif
 page 6167 "E-Doc. Order Line Matching"
 {
     Caption = 'Purchase Order Matching';
@@ -176,15 +169,10 @@ page 6167 "E-Doc. Order Line Matching"
                 ToolTip = 'Match e-document lines with the assistance of Copilot';
                 ApplicationArea = All;
                 Image = SparkleFilled;
+                Visible = false;
                 ObsoleteState = Pending;
-                ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated.';
+                ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
                 ObsoleteTag = '29.0';
-
-                trigger OnAction()
-                begin
-                    MatchWithCopilot(true);
-                    SetUserInteractions();
-                end;
             }
 #endif
         }
@@ -215,8 +203,9 @@ page 6167 "E-Doc. Order Line Matching"
 #if not CLEAN29
                 actionref(MatchCopilot_Promoted; MatchCopilot)
                 {
+                    Visible = false;
                     ObsoleteState = Pending;
-                    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated.';
+                    ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
                     ObsoleteTag = '29.0';
                 }
 #endif
@@ -234,38 +223,18 @@ page 6167 "E-Doc. Order Line Matching"
     }
 
     var
-#if not CLEAN29
-        FeatureTelemetry: Codeunit "Feature Telemetry";
-#endif
         EDocMatchOrderLines: Codeunit "E-Doc. Line Matching";
         CostNotification: Notification;
-        AutoRunCopilot: Boolean;
         LineCostVaryMatchMsg: Label 'Matched e-document lines (%1) has cost different from matched purchase order line. Please verify matches are correct.', Comment = '%1 - Line number';
-#if not CLEAN29
-        NoMatchesFoundMsg: Label 'Copilot could not find any line matches. Please review manually';
-#endif
         GlobalDataCaptionExpressionTxt: Label 'Purchase Order %1', Comment = '%1 - Purchase order number';
 
     trigger OnAfterGetRecord()
-#if not CLEAN29
-    var
-        EDocOrderMatch: Record "E-Doc. Order Match";
-#endif
     begin
         CurrPage.OrderLines.Page.SetEDocumentBeingMatched(Rec);
         CurrPage.ImportedLines.Page.SetEDocumentBeingMatched(Rec);
         CurrPage.OrderLines.Page.ResetQtyOnNonMatchedLines();
 
         OpenPurchaseHeader();
-
-#if not CLEAN29
-        if AutoRunCopilot then begin
-            AutoRunCopilot := false;
-            EDocOrderMatch.SetRange("E-Document Entry No.", Rec."Entry No");
-            if EDocOrderMatch.IsEmpty() then
-                MatchWithCopilot(false);
-        end;
-#endif
     end;
 
     local procedure OpenPurchaseHeader()
@@ -337,38 +306,6 @@ page 6167 "E-Doc. Order Line Matching"
         end;
     end;
 
-#if not CLEAN29
-    local procedure MatchWithCopilot(CheckToOverwrite: Boolean)
-    var
-        TempEDocImportedLines: Record "E-Doc. Imported Line" temporary;
-        TempPurchaseLines: Record "Purchase Line" temporary;
-        AzureOpenAI: Codeunit "Azure OpenAI";
-        AIMatchingImpl: Codeunit "E-Doc. PO Copilot Matching";
-        EDocOrderMatchAIProposal: Page "E-Doc. PO Copilot Prop";
-    begin
-        if not AzureOpenAI.IsEnabled(Enum::"Copilot Capability"::"E-Document Matching Assistance") then
-            exit;
-
-        FeatureTelemetry.LogUptake('0000MB0', AIMatchingImpl.FeatureName(), Enum::"Feature Uptake Status"::Discovered);
-        FeatureTelemetry.LogUptake('0000MB1', AIMatchingImpl.FeatureName(), Enum::"Feature Uptake Status"::"Set up");
-
-        CurrPage.ImportedLines.Page.GetRecords(TempEDocImportedLines);
-        CurrPage.OrderLines.Page.GetRecords(TempPurchaseLines);
-
-        if CheckToOverwrite then
-            EDocMatchOrderLines.AskToOverwrite(Rec, TempEDocImportedLines, TempPurchaseLines);
-        Commit();
-        EDocOrderMatchAIProposal.SetData(Rec, TempEDocImportedLines, TempPurchaseLines);
-        EDocOrderMatchAIProposal.SetGenerateMode();
-        EDocOrderMatchAIProposal.LookupMode(true);
-        if EDocOrderMatchAIProposal.RunModal() = Action::Cancel then
-            if ((not EDocOrderMatchAIProposal.WasCopilotMatchesFound()) and EDocOrderMatchAIProposal.IsCopilotRequestSuccessful()) then
-                Message(NoMatchesFoundMsg);
-
-        CurrPage.Update();
-    end;
-#endif
-
     local procedure SetUserInteractions()
     begin
         CurrPage.ImportedLines.Page.SetUserInteractions();
@@ -412,11 +349,6 @@ page 6167 "E-Doc. Order Line Matching"
         Rec.TransferFields(EDocument);
         Rec.SystemId := EDocument.SystemId;
         Rec.Insert(false);
-    end;
-
-    internal procedure SetAutoRunCopilot(CopilotToRun: Boolean)
-    begin
-        AutoRunCopilot := CopilotToRun;
     end;
 
 }

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/EDocOrderMatch.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/EDocOrderMatch.Table.al
@@ -1,7 +1,9 @@
 namespace Microsoft.eServices.EDocument.OrderMatch;
 
 using Microsoft.eServices.EDocument;
+#if not CLEAN29
 using Microsoft.eServices.EDocument.OrderMatch.Copilot;
+#endif
 using Microsoft.Purchases.Document;
 
 table 6164 "E-Doc. Order Match"
@@ -110,6 +112,7 @@ table 6164 "E-Doc. Order Match"
         ImportedLine.Get(Rec."E-Document Entry No.", Rec."E-Document Line No.");
     end;
 
+#if not CLEAN29
     procedure InsertMatch(var TempAIProposalBuffer: Record "E-Doc. PO Match Prop. Buffer" temporary; var TempEDocMatches: Record "E-Doc. Order Match" temporary)
     begin
         TempEDocMatches.Init();
@@ -125,6 +128,7 @@ table 6164 "E-Doc. Order Match"
         TempEDocMatches."PO Description" := TempAIProposalBuffer."PO Description";
         TempEDocMatches.Insert();
     end;
+#endif
 
 
 }

--- a/src/Apps/W1/EDocument/Test/src/Copilot/EDocCopilotPOAccuracy.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Copilot/EDocCopilotPOAccuracy.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 namespace Microsoft.Sales.Document.Test;
 
 using Microsoft.eServices.EDocument;
@@ -160,3 +161,4 @@ codeunit 133502 EDocCopilotPOAccuracy
 
     end;
 }
+#endif

--- a/src/Apps/W1/EDocument/Test/src/Copilot/EDocCopilotPOGeneralHarms.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Copilot/EDocCopilotPOGeneralHarms.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 namespace Microsoft.Sales.Document.Test;
 
 using Microsoft.eServices.EDocument;
@@ -118,3 +119,4 @@ codeunit 133528 EDocCopilotPOGeneralHarms
     end;
 
 }
+#endif

--- a/src/Apps/W1/EDocument/Test/src/Copilot/EDocCopilotPORedTeaming.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Copilot/EDocCopilotPORedTeaming.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 namespace Microsoft.Sales.Document.Test;
 
 using Microsoft.eServices.EDocument;
@@ -126,3 +127,4 @@ codeunit 133501 EDocCopilotPORedTeaming
     end;
 
 }
+#endif

--- a/src/Apps/W1/EDocument/Test/src/Copilot/EDocCopilotPOUPIAHarms.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Copilot/EDocCopilotPOUPIAHarms.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 namespace Microsoft.Sales.Document.Test;
 
 using Microsoft.eServices.EDocument;
@@ -119,3 +120,4 @@ codeunit 133527 EDocCopilotPOUPIAHarms
     end;
 
 }
+#endif


### PR DESCRIPTION
## Summary
Obsoletes the **E-Document Purchase Order Matching Copilot** feature following the Business Central Obsolete lifecycle.

The five Copilot-specific objects in `App/src/Processing/OrderMatching/Copilot/` are marked `ObsoleteState = Pending` with `ObsoleteReason` and `ObsoleteTag = '29.0'`:

| Object | ID |
|---|---|
| `E-Doc. PO Copilot Matching` (codeunit) | 6163 |
| `E-Doc. PO AOAI Function` (codeunit) | 6167 |
| `E-Doc. PO Copilot Prop` (page) | 6166 |
| `E-Doc. PO Match Prop. Sub` (page) | 6163 |
| `E-Doc. PO Match Prop. Buffer` (table) | 6163 |

This is the deprecation **warning window**: the objects remain functional and are stripped (`#if not CLEAN29` / `ObsoleteState = Removed`) in a later release. Existing internal callers keep compiling — `AL0432` (reference-to-pending) is a Warning in the app ruleset, which is the intended deprecation signal.

## Do we need to remove the Copilot capability on upgrade?
**No.** The `"E-Document Matching Assistance"` Copilot capability is **shared**: besides the obsoleted Copilot matching, it is still registered and required by the active `E-Doc. AI Tool Processor` import flow (`EDocAIToolProcessor.Setup()` calls `RegisterCapabilityIfNeeded()` and checks `IsCapabilityRegistered` / `IsCapabilityActive`). Unregistering it on upgrade would break that live feature, so no upgrade/removal code is added.

## Replaced by
The feature is superseded by the new **E-Document Purchase Draft** experience:

- **Purchase order line matching** is handled by `E-Doc. PO Matching` (codeunit 6196, `Processing/Import/Purchase/PurchaseOrderMatching/`), operating on the `E-Document Purchase Line` draft model.
- **AI-assisted line matching** moved to import time via `E-Doc. AI Tool Processor` (codeunit 6195) and its tools — historical matching, G/L account matching, deferral matching, and similar-description lookups. This is why the shared `"E-Document Matching Assistance"` Copilot capability remains registered.

## Notes
- The buffer table is `TableType = Temporary`, so there is no persisted-data migration concern.
- The shared capability enum value and `EDocAIToolProcessor` are intentionally left unchanged.

[AB#638024](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638024)


