### PR TITLE
[Subcontracting] Fixed purchase order not opening the list of transfer orders when > 1 were created

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchFactboxMgmt.Codeunit.al
@@ -419,6 +419,7 @@ codeunit 99001560 "Subc. Purch. Factbox Mgmt."
     procedure ShowTransferOrdersFromPurchaseOrder(PurchaseHeader: Record "Purchase Header"; IsReturn: Boolean)
     var
         TransferHeader: Record "Transfer Header";
+        PageManagement: Codeunit "Page Management";
     begin
 #if not CLEAN29
 #pragma warning disable AL0432
@@ -430,9 +431,9 @@ codeunit 99001560 "Subc. Purch. Factbox Mgmt."
         TransferHeader.SetRange("Subc. Return Order", IsReturn);
         if TransferHeader.Count() = 1 then begin
             TransferHeader.FindFirst();
-            Page.Run(Page::"Transfer Order", TransferHeader);
+            PageManagement.PageRun(TransferHeader);
         end else
-            Page.Run(Page::"Transfer Orders", TransferHeader);
+            PageManagement.PageRunList(TransferHeader);
     end;
 
     /// <summary>

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchFactboxMgmt.Codeunit.al
@@ -412,6 +412,30 @@ codeunit 99001560 "Subc. Purch. Factbox Mgmt."
     end;
 
     /// <summary>
+    /// Opens the subcontracting transfer order(s) linked to the given purchase order.
+    /// </summary>
+    /// <param name="PurchaseHeader">The purchase order to show the related subcontracting transfer orders for.</param>
+    /// <param name="IsReturn">When true, filters to return transfer orders; when false, filters to outbound transfer orders.</param>
+    procedure ShowTransferOrdersFromPurchaseOrder(PurchaseHeader: Record "Purchase Header"; IsReturn: Boolean)
+    var
+        TransferHeader: Record "Transfer Header";
+    begin
+#if not CLEAN29
+#pragma warning disable AL0432
+        if not SubcFeatureFlagHandler.IsSubcontractingEnabled() then
+#pragma warning restore AL0432
+            exit;
+#endif
+        TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
+        TransferHeader.SetRange("Subc. Return Order", IsReturn);
+        if TransferHeader.Count() = 1 then begin
+            TransferHeader.FindFirst();
+            Page.Run(Page::"Transfer Order", TransferHeader);
+        end else
+            Page.Run(Page::"Transfer Orders", TransferHeader);
+    end;
+
+    /// <summary>
     /// Returns the number of subcontractor prices matching the given purchase line.
     /// </summary>
     /// <param name="PurchaseLine">The purchase line to match subcontractor prices against.</param>

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
@@ -270,7 +270,7 @@ report 99001501 "Subc. Create Transf. Order"
         SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
     begin
         Commit(); // Used for following call of Transfer Pages
-        SubcPurchFactboxMgmt.ShowTransferOrdersAndReturnOrder("Purchase Line", true, false);
+        SubcPurchFactboxMgmt.ShowTransferOrdersFromPurchaseOrder("Purchase Header", false);
     end;
 
     local procedure GetTransferFromLocationForComponent(ProdOrderComponent: Record "Prod. Order Component"): Code[10]

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -358,6 +358,80 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
     end;
 
     [Test]
+    [HandlerFunctions('HandleMultipleTransferOrders')]
+    procedure MultipleWIPTransferOrdersFromPurchaseOrderOpenTransferOrdersPage()
+    var
+        Item: Record Item;
+        Location: array[2] of Record Location;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: array[2] of Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ReqWkshTemplate: Record "Req. Wksh. Template";
+        RequisitionLine: Record "Requisition Line";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
+        TransferHeader: Record "Transfer Header";
+        WorkCenter: array[2] of Record "Work Center";
+        SubcCalculateSubContracts: Report "Subc. Calculate Subcontracts";
+        CarryOutActionMsgReq: Report "Carry Out Action Msg. - Req.";
+        PurchaseHeaderPage: TestPage "Purchase Order";
+    begin
+        // [SCENARIO 641284] Creating WIP transfer orders for purchase lines from production orders at different locations opens all transfer orders.
+        Initialize();
+
+        // [GIVEN] A subcontracting item with WIP transfer enabled
+        SubcWarehouseLibrary.CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter, true);
+        SubcWarehouseLibrary.CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        SetTransferWIPItemOnRoutingLine(Item."Routing No.", WorkCenter[2]."No.", true);
+
+        // [GIVEN] Two released production orders for the item at different locations
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(Location[1]);
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(Location[2]);
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder[1], "Production Order Status"::Released,
+            ProductionOrder[1]."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5, Location[1].Code);
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder[2], "Production Order Status"::Released,
+            ProductionOrder[2]."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5, Location[2].Code);
+
+        // [GIVEN] One subcontracting purchase order containing a line for each production order
+        SubcontractingMgmtLibrary.CreateReqWkshTemplateAndName(ReqWkshTemplate, RequisitionWkshName);
+        RequisitionLine."Worksheet Template Name" := RequisitionWkshName."Worksheet Template Name";
+        RequisitionLine."Journal Batch Name" := RequisitionWkshName.Name;
+        WorkCenter[2].SetRecFilter();
+        SubcCalculateSubContracts.SetTableView(WorkCenter[2]);
+        SubcCalculateSubContracts.SetWkShLine(RequisitionLine);
+        SubcCalculateSubContracts.UseRequestPage(false);
+        SubcCalculateSubContracts.RunModal();
+
+        RequisitionLine.SetRange("Worksheet Template Name", RequisitionWkshName."Worksheet Template Name");
+        RequisitionLine.SetRange("Journal Batch Name", RequisitionWkshName.Name);
+        Assert.RecordCount(RequisitionLine, 2);
+        RequisitionLine.FindFirst();
+        CarryOutActionMsgReq.SetReqWkshLine(RequisitionLine);
+        CarryOutActionMsgReq.UseRequestPage(false);
+        CarryOutActionMsgReq.RunModal();
+
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange(Type, PurchaseLine.Type::Item);
+        PurchaseLine.SetRange("Work Center No.", WorkCenter[2]."No.");
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+        PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
+        Assert.RecordCount(PurchaseLine, 2);
+
+        // [WHEN] Create Transfer Order to Subcontractor is invoked from the purchase order
+        PurchaseHeaderPage.OpenView();
+        PurchaseHeaderPage.GoToRecord(PurchaseHeader);
+        PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [THEN] A transfer order was created for each production order location
+        TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
+        TransferHeader.SetRange("Subc. Return Order", false);
+        Assert.RecordCount(TransferHeader, 2);
+    end;
+
+    [Test]
     [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
     procedure WIPTransferOrderNotCreatedWhenFlagIsOff()
     var
@@ -1709,6 +1783,19 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
     procedure HandleTransferOrders(var TransfOrderPage: TestPage "Transfer Orders")
     begin
         TransfOrderPage.OK().Invoke();
+    end;
+
+    [PageHandler]
+    procedure HandleMultipleTransferOrders(var TransferOrders: TestPage "Transfer Orders")
+    var
+        NoOfTransferOrders: Integer;
+    begin
+        if TransferOrders.First() then
+            repeat
+                NoOfTransferOrders += 1;
+            until not TransferOrders.Next();
+        Assert.AreEqual(2, NoOfTransferOrders, 'The Transfer Orders page must show all transfer orders created for the purchase order.');
+        TransferOrders.OK().Invoke();
     end;
 
     [MessageHandler]

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -372,6 +372,7 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         RequisitionWkshName: Record "Requisition Wksh. Name";
         TransferHeader: Record "Transfer Header";
         WorkCenter: array[2] of Record "Work Center";
+        LibraryWarehouse: Codeunit "Library - Warehouse";
         SubcCalculateSubContracts: Report "Subc. Calculate Subcontracts";
         CarryOutActionMsgReq: Report "Carry Out Action Msg. - Req.";
         PurchaseHeaderPage: TestPage "Purchase Order";


### PR DESCRIPTION
**Summary**

1. Creating transfer orders for a subcontracting purchase order with multiple source locations opened only the last created transfer order.
2. The report passed the last processed purchase line, limiting the lookup to that line’s production order.
3. Added purchase-order-level transfer order navigation filtered by purchase order number and return status.
4. A single transfer order still opens the Transfer Order card; multiple orders now open the filtered Transfer Orders list.
5. Updated the creation report to use the purchase header instead of the last purchase line.
6. Added a regression test covering two production orders at different locations consolidated into one purchase order.


Fixes [AB#641284](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641284)






