### PR TITLE
[Payables Agent] set Document Date and Due Date on Incomming Document when Draft is created

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/ImportEDocumentProcess.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/ImportEDocumentProcess.Codeunit.al
@@ -157,6 +157,14 @@ codeunit 6104 "Import E-Document Process"
 
             OnFoundVendorNo(EDocument, VendNo);
         end;
+
+        if EDocumentPurchaseHeader.Get(EDocument."Entry No") then begin
+            if EDocumentPurchaseHeader."Document Date" <> 0D then
+                EDocument."Document Date" := EDocumentPurchaseHeader."Document Date";
+            if EDocumentPurchaseHeader."Due Date" <> 0D then
+                EDocument."Due Date" := EDocumentPurchaseHeader."Due Date";
+        end;
+
         EDocument.Modify();
     end;
 


### PR DESCRIPTION
## What & why

When an inbound E-Document is imported, the Prepare draft step already fills in the vendor name and number from the E-Document Purchase Header. But it was not filling in the **Document Date** and **Due Date**.

Because of this, once a document reached the **Draft ready** status, the Document Date and Due Date columns showed up empty on the **Inbound E-Documents** list, even though those values were already present on the E-Document Purchase Header.

This fix copies the Document Date and Due Date from the E-Document Purchase Header onto the E-Document during the Prepare draft step. It only copies them when they actually have a value, so an existing date is never replaced with a blank one. This is the same approach already used for the vendor name and number. Now both dates show correctly on the Inbound E-Documents list once the document reaches Draft ready.

## Linked work

Fixes [AB#642321](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642321)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

I imported an inbound purchase E-Document and processed it until it reached the Draft ready status. The Document Date and Due Date then showed up correctly on the Inbound E-Documents list and matched the values on the E-Document Purchase Header.

I also checked the case where the E-Document Purchase Header has no date set. In that case the existing values on the E-Document were left as they were and did not get overwritten with a blank date.

I confirmed that the vendor name and number still resolve the same way as before.

## Risk & compatibility

Low risk. The change only fills in two extra fields, Document Date and Due Date, during the existing Prepare draft step, and it does so only when a value is present. There are no schema changes, no permission changes, and no impact on the Version 1.0 import path.

