### PR TITLE
636017 Move Manufacturing report action tooltips to report objects

### DIFF
--- a/src/Layers/IT/BaseApp/Manufacturing/Document/ReleasedProductionOrder.Page.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/Document/ReleasedProductionOrder.Page.al
@@ -691,7 +691,6 @@ page 99000831 "Released Production Order"
                 //The property 'PromotedCategory' can only be set if the property 'Promoted' is set to 'true'
                 //PromotedCategory = "Report";
                 RunObject = Report "Subcontractor - Dispatch List";
-                ToolTip = 'View the list of material to be sent to manufacturing subcontractors.';
             }
         }
         area(Promoted)

--- a/src/Layers/IT/BaseApp/Manufacturing/RoleCenters/ProductionPlannerRoleCenter.Page.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/RoleCenters/ProductionPlannerRoleCenter.Page.al
@@ -156,7 +156,6 @@ page 9010 "Production Planner Role Center"
                     Caption = 'Capacity Task List';
                     Image = "Report";
                     RunObject = Report "Capacity Task List";
-                    ToolTip = 'View the production orders that are waiting to be processed at the work centers and machine centers. Printouts are made for the capacity of the work center or machine center). The report includes information such as starting and ending time, date per production order and input quantity.';
                 }
                 action("Subcontractor - Dispatch List")
                 {
@@ -164,7 +163,6 @@ page 9010 "Production Planner Role Center"
                     Caption = 'Subcontractor - Dispatch List';
                     Image = "Report";
                     RunObject = Report "Subcontractor - Dispatch List";
-                    ToolTip = 'View the list of material to be sent to manufacturing subcontractors.';
                 }
             }
             group(Production)
@@ -176,7 +174,6 @@ page 9010 "Production Planner Role Center"
                     Caption = 'Production Order - &Shortage List';
                     Image = "Report";
                     RunObject = Report "Prod. Order - Shortage List";
-                    ToolTip = 'View a list of the missing quantity per production order. The report shows how the inventory development is planned from today until the set day - for example whether orders are still open.';
                 }
                 action("D&etailed Calculation")
                 {
@@ -204,7 +201,6 @@ page 9010 "Production Planner Role Center"
                     Caption = 'Production Order Statistics';
                     Image = "Report";
                     RunObject = report "Production Order Statistics";
-                    ToolTip = 'View statistical information, such as the value of posted entries, for the record.';
                 }
                 action("Sta&tus")
                 {
@@ -220,7 +216,6 @@ page 9010 "Production Planner Role Center"
                     Caption = 'Inventory &Valuation WIP';
                     Image = "Report";
                     RunObject = Report "Inventory Valuation - WIP";
-                    ToolTip = 'View inventory valuation for selected production orders in your WIP inventory. The report also shows information about the value of consumption, capacity usage and output in WIP.';
                 }
                 action("Prod. Order - &Job Card")
                 {

--- a/src/Layers/IT/BaseApp/Manufacturing/RoleCenters/ShopSupervisorMfgFoundation.Page.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/RoleCenters/ShopSupervisorMfgFoundation.Page.al
@@ -80,7 +80,6 @@ page 9011 "Shop Supervisor Mfg Foundation"
                 Caption = 'Production Order - &Shortage List';
                 Image = "Report";
                 RunObject = Report "Prod. Order - Shortage List";
-                ToolTip = 'View a list of the missing quantity per production order. The report shows how the inventory development is planned from today until the set day - for example whether orders are still open.';
             }
             action("Subcontractor - Dis&patch List")
             {
@@ -116,7 +115,6 @@ page 9011 "Shop Supervisor Mfg Foundation"
                 Caption = 'Production Order Statistics';
                 Image = "Report";
                 RunObject = report "Production Order Statistics";
-                ToolTip = 'View statistical information, such as the value of posted entries, for the record.';
             }
             action("S&tatus")
             {
@@ -139,7 +137,6 @@ page 9011 "Shop Supervisor Mfg Foundation"
                 Caption = 'Inventory Valuation &WIP';
                 Image = "Report";
                 RunObject = Report "Inventory Valuation - WIP";
-                ToolTip = 'View inventory valuation for selected production orders in your WIP inventory. The report also shows information about the value of consumption, capacity usage and output in WIP. The printed report only shows invoiced amounts, that is, the cost of entries that have been posted as invoiced.';
             }
         }
         area(embedding)

--- a/src/Layers/IT/BaseApp/Manufacturing/RoleCenters/ShopSupervisorRoleCenter.Page.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/RoleCenters/ShopSupervisorRoleCenter.Page.al
@@ -111,7 +111,6 @@ page 9012 "Shop Supervisor Role Center"
                 Caption = 'Capacity Tas&k List';
                 Image = "Report";
                 RunObject = Report "Capacity Task List";
-                ToolTip = 'View the production orders that are waiting to be processed at the work centers and machine centers. Printouts are made for the capacity of the work center or machine center. The report includes information such as starting and ending time, date per production order and input quantity.';
             }
             action("Subcontractor - Dis&patch List")
             {
@@ -147,7 +146,6 @@ page 9012 "Shop Supervisor Role Center"
                 Caption = 'Production Order Statistics';
                 Image = "Report";
                 RunObject = report "Production Order Statistics";
-                ToolTip = 'View statistical information, such as the value of posted entries, for the record.';
             }
             action("S&tatus")
             {

--- a/src/Layers/IT/BaseApp/Manufacturing/WorkCenter/WorkCenterCard.Page.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/WorkCenter/WorkCenterCard.Page.al
@@ -361,7 +361,6 @@ page 99000754 "Work Center Card"
                 //The property 'PromotedCategory' can only be set if the property 'Promoted' is set to 'true'
                 //PromotedCategory = "Report";
                 RunObject = Report "Subcontractor - Dispatch List";
-                ToolTip = 'View the list of material to be sent to manufacturing subcontractors.';
             }
         }
         area(Promoted)

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/FinishedProductionOrders.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/FinishedProductionOrders.Page.al
@@ -331,7 +331,6 @@ page 9327 "Finished Production Orders"
                 Caption = 'Production Order Statistics';
                 Image = "Report";
                 RunObject = Report "Production Order Statistics";
-                ToolTip = 'View statistical information about the production order''s direct material and capacity costs and overhead as well as its capacity need in the time unit of measure.';
             }
         }
         area(Processing)

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/FirmPlannedProdOrder.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/FirmPlannedProdOrder.Page.al
@@ -437,7 +437,6 @@ page 99000829 "Firm Planned Prod. Order"
                 //The property 'PromotedCategory' can only be set if the property 'Promoted' is set to 'true'
                 //PromotedCategory = "Report";
                 RunObject = Report "Subcontractor - Dispatch List";
-                ToolTip = 'View the list of material to be sent to manufacturing subcontractors.';
             }
         }
         area(Promoted)

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/FirmPlannedProdOrders.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/FirmPlannedProdOrders.Page.al
@@ -367,7 +367,6 @@ page 9325 "Firm Planned Prod. Orders"
                 //The property 'PromotedCategory' can only be set if the property 'Promoted' is set to 'true'
                 //PromotedCategory = "Report";
                 RunObject = Report "Production Order Statistics";
-                ToolTip = 'View statistical information about the production order''s direct material and capacity costs and overhead as well as its capacity need in the time unit of measure.';
             }
         }
         area(Promoted)

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/PlannedProductionOrder.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/PlannedProductionOrder.Page.al
@@ -394,7 +394,6 @@ page 99000813 "Planned Production Order"
                 Caption = 'Subcontractor - Dispatch List';
                 Image = "Report";
                 RunObject = Report "Subcontractor - Dispatch List";
-                ToolTip = 'View the list of material to be sent to manufacturing subcontractors.';
             }
         }
         area(Promoted)

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/ReleasedProductionOrder.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/ReleasedProductionOrder.Page.al
@@ -675,7 +675,6 @@ page 99000831 "Released Production Order"
                 //The property 'PromotedCategory' can only be set if the property 'Promoted' is set to 'true'
                 //PromotedCategory = "Report";
                 RunObject = Report "Subcontractor - Dispatch List";
-                ToolTip = 'View the list of material to be sent to manufacturing subcontractors.';
             }
         }
         area(Promoted)

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/ReleasedProductionOrders.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/ReleasedProductionOrders.Page.al
@@ -424,7 +424,6 @@ page 9326 "Released Production Orders"
                 Caption = 'Production Order Statistics';
                 Image = "Report";
                 RunObject = Report "Production Order Statistics";
-                ToolTip = 'View statistical information about the production order''s direct material and capacity costs and overhead as well as its capacity need in the time unit of measure.';
             }
         }
         area(Promoted)

--- a/src/Layers/W1/BaseApp/Manufacturing/Finance/RoleCenters/MfgFinanceManagerRC.PageExt.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Finance/RoleCenters/MfgFinanceManagerRC.PageExt.al
@@ -37,7 +37,6 @@ pageextension 99000780 "Mfg. Finance Manager RC" extends "Finance Manager Role C
                 ApplicationArea = Manufacturing;
                 Caption = 'Production Order - WIP';
                 RunObject = report "Inventory Valuation - WIP";
-                Tooltip = 'Run the Production Order - WIP report.';
             }
         }
     }

--- a/src/Layers/W1/BaseApp/Manufacturing/Inventory/Item/MfgItemList.PageExt.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Inventory/Item/MfgItemList.PageExt.al
@@ -102,7 +102,6 @@ pageextension 99000751 "Mfg. Item List" extends "Item List"
                     Caption = 'Where-Used (Top Level)';
                     Image = "Report";
                     RunObject = Report Microsoft.Manufacturing.Reports."Where-Used (Top Level)";
-                    ToolTip = 'View where and in what quantities the item is used in the product structure. The report only shows information for the top-level item. For example, if item "A" is used to produce item "B", and item "B" is used to produce item "C", the report will show item B if you run this report for item A. If you run this report for item B, then item C will be shown as where-used.';
                 }
                 action("Quantity Explosion of BOM")
                 {
@@ -110,7 +109,6 @@ pageextension 99000751 "Mfg. Item List" extends "Item List"
                     Caption = 'Quantity Explosion of BOM';
                     Image = "Report";
                     RunObject = Report Microsoft.Manufacturing.Reports."Quantity Explosion of BOM";
-                    ToolTip = 'View an indented BOM listing for the item or items that you specify in the filters. The production BOM is completely exploded for all levels.';
                 }
             }
             group(Costing)
@@ -123,7 +121,6 @@ pageextension 99000751 "Mfg. Item List" extends "Item List"
                     Caption = 'Inventory Valuation - WIP';
                     Image = "Report";
                     RunObject = Report "Inventory Valuation - WIP";
-                    ToolTip = 'View inventory valuation for selected production orders in your WIP inventory. The report also shows information about the value of consumption, capacity usage and output in WIP. The printed report only shows invoiced amounts, that is, the cost of entries that have been posted as invoiced.';
                 }
                 action("Cost Shares Breakdown")
                 {

--- a/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMList.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMList.Page.al
@@ -200,7 +200,6 @@ page 99000787 "Production BOM List"
                 Caption = 'Where-Used (Top Level)';
                 Image = "Report";
                 RunObject = Report "Where-Used (Top Level)";
-                ToolTip = 'View where and in what quantities the item is used in the product structure. The report only shows information for the top-level item. For example, if item "A" is used to produce item "B", and item "B" is used to produce item "C", the report will show item B if you run this report for item A. If you run this report for item B, then item C will be shown as where-used.';
             }
             action("Quantity Explosion of BOM")
             {
@@ -208,7 +207,6 @@ page 99000787 "Production BOM List"
                 Caption = 'Quantity Explosion of BOM';
                 Image = "Report";
                 RunObject = Report "Quantity Explosion of BOM";
-                ToolTip = 'View an indented BOM listing for the item or items that you specify in the filters. The production BOM is completely exploded for all levels.';
             }
 #if not CLEAN27
             action("Compare List")

--- a/src/Layers/W1/BaseApp/Manufacturing/Reports/CapacityTaskList.Report.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Reports/CapacityTaskList.Report.al
@@ -13,6 +13,7 @@ report 99000780 "Capacity Task List"
     DefaultRenderingLayout = ExcelLayout;
     ApplicationArea = Manufacturing;
     Caption = 'Capacity Task List';
+    ToolTip = 'View the production orders that are waiting to be processed at the work centers and machine centers. Printouts are made for the capacity of the work center or machine center). The report includes information such as starting and ending time, date per production order and input quantity.';
     UsageCategory = ReportsAndAnalysis;
     WordMergeDataItem = "Prod. Order Routing Line Group";
 

--- a/src/Layers/W1/BaseApp/Manufacturing/Reports/CapacityTaskList.Report.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Reports/CapacityTaskList.Report.al
@@ -13,7 +13,7 @@ report 99000780 "Capacity Task List"
     DefaultRenderingLayout = ExcelLayout;
     ApplicationArea = Manufacturing;
     Caption = 'Capacity Task List';
-    ToolTip = 'View the production orders that are waiting to be processed at the work centers and machine centers. Printouts are made for the capacity of the work center or machine center). The report includes information such as starting and ending time, date per production order and input quantity.';
+    ToolTip = 'View the production orders that are waiting to be processed at the work centers and machine centers. Printouts are made for the capacity of the work center or machine center. The report includes information such as starting and ending time, date per production order and input quantity.';
     UsageCategory = ReportsAndAnalysis;
     WordMergeDataItem = "Prod. Order Routing Line Group";
 

--- a/src/Layers/W1/BaseApp/Manufacturing/Reports/InventoryValuationWIP.Report.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Reports/InventoryValuationWIP.Report.al
@@ -12,6 +12,7 @@ report 5802 "Inventory Valuation - WIP"
 {
     ApplicationArea = Manufacturing;
     Caption = 'Production Order - WIP';
+    ToolTip = 'View inventory valuation for selected production orders in your WIP inventory. The report also shows information about the value of consumption, capacity usage and output in WIP. The printed report only shows invoiced amounts, that is, the cost of entries that have been posted as invoiced.';
     UsageCategory = ReportsAndAnalysis;
     DefaultRenderingLayout = Excel;
 

--- a/src/Layers/W1/BaseApp/Manufacturing/Reports/ProdOrderShortageList.Report.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Reports/ProdOrderShortageList.Report.al
@@ -12,6 +12,7 @@ report 99000788 "Prod. Order - Shortage List"
     DefaultRenderingLayout = Excel;
     ApplicationArea = Manufacturing;
     Caption = 'Prod. Order - Shortage List';
+    ToolTip = 'View a list of the missing quantity per production order. The report shows how the inventory development is planned from today until the set day - for example whether orders are still open.';
     UsageCategory = ReportsAndAnalysis;
 
     dataset

--- a/src/Layers/W1/BaseApp/Manufacturing/Reports/ProductionOrderStatistics.Report.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Reports/ProductionOrderStatistics.Report.al
@@ -14,6 +14,7 @@ report 99000791 "Production Order Statistics"
     AdditionalSearchTerms = 'material cost,capacity cost,material overhead';
     ApplicationArea = Manufacturing;
     Caption = 'Production Order Statistics';
+    ToolTip = 'View statistical information about the production order''s direct material and capacity costs and overhead as well as its capacity need in the time unit of measure.';
     UsageCategory = ReportsAndAnalysis;
     DefaultRenderingLayout = ProdOrderStatisticsExcel;
 

--- a/src/Layers/W1/BaseApp/Manufacturing/Reports/QuantityExplosionofBOM.Report.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Reports/QuantityExplosionofBOM.Report.al
@@ -14,6 +14,7 @@ report 99000753 "Quantity Explosion of BOM"
     DefaultRenderingLayout = ExcelLayout;
     ApplicationArea = Manufacturing;
     Caption = 'Quantity Explosion of BOM';
+    ToolTip = 'View an indented BOM listing for the item or items that you specify in the filters. The production BOM is completely exploded for all levels.';
     UsageCategory = ReportsAndAnalysis;
 
     dataset

--- a/src/Layers/W1/BaseApp/Manufacturing/Reports/SubcontractorDispatchList.Report.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Reports/SubcontractorDispatchList.Report.al
@@ -14,6 +14,7 @@ report 99000789 "Subcontractor - Dispatch List"
     DefaultRenderingLayout = ExcelLayout;
     ApplicationArea = Manufacturing;
     Caption = 'Subcontractor - Dispatch List';
+    ToolTip = 'View the list of material to be sent to manufacturing subcontractors.';
     UsageCategory = ReportsAndAnalysis;
 
     dataset

--- a/src/Layers/W1/BaseApp/Manufacturing/Reports/WhereUsedTopLevel.Report.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Reports/WhereUsedTopLevel.Report.al
@@ -12,6 +12,7 @@ report 99000757 "Where-Used (Top Level)"
 {
     ApplicationArea = Manufacturing;
     Caption = 'Where-Used (Top Level)';
+    ToolTip = 'View where and in what quantities the item is used in the product structure. The report only shows information for the top-level item. For example, if item "A" is used to produce item "B", and item "B" is used to produce item "C", the report will show item B if you run this report for item A. If you run this report for item B, then item C will be shown as where-used.';
     UsageCategory = ReportsAndAnalysis;
     DefaultRenderingLayout = WhereUsedTopLevelExcel;
 

--- a/src/Layers/W1/BaseApp/Manufacturing/RoleCenters/MachineOperatorRoleCenter.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/RoleCenters/MachineOperatorRoleCenter.Page.al
@@ -71,7 +71,6 @@ page 9013 "Machine Operator Role Center"
                 Caption = '&Capacity Task List';
                 Image = "Report";
                 RunObject = Report "Capacity Task List";
-                ToolTip = 'View the production orders that are waiting to be processed at the work centers and machine centers. Printouts are made for the capacity of the work center or machine center). The report includes information such as starting and ending time, date per production order and input quantity.';
             }
             action("Prod. Order - &Job Card")
             {

--- a/src/Layers/W1/BaseApp/Manufacturing/RoleCenters/ProductionPlannerRoleCenter.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/RoleCenters/ProductionPlannerRoleCenter.Page.al
@@ -156,7 +156,6 @@ page 9010 "Production Planner Role Center"
                     Caption = 'Capacity Task List';
                     Image = "Report";
                     RunObject = Report "Capacity Task List";
-                    ToolTip = 'View the production orders that are waiting to be processed at the work centers and machine centers. Printouts are made for the capacity of the work center or machine center). The report includes information such as starting and ending time, date per production order and input quantity.';
                 }
                 action("Subcontractor - Dispatch List")
                 {
@@ -164,7 +163,6 @@ page 9010 "Production Planner Role Center"
                     Caption = 'Subcontractor - Dispatch List';
                     Image = "Report";
                     RunObject = Report "Subcontractor - Dispatch List";
-                    ToolTip = 'View the list of material to be sent to manufacturing subcontractors.';
                 }
             }
             group(Production)
@@ -176,7 +174,6 @@ page 9010 "Production Planner Role Center"
                     Caption = 'Production Order - &Shortage List';
                     Image = "Report";
                     RunObject = Report "Prod. Order - Shortage List";
-                    ToolTip = 'View a list of the missing quantity per production order. The report shows how the inventory development is planned from today until the set day - for example whether orders are still open.';
                 }
                 action("D&etailed Calculation")
                 {
@@ -204,7 +201,6 @@ page 9010 "Production Planner Role Center"
                     Caption = 'Production Order Statistics';
                     Image = "Report";
                     RunObject = report "Production Order Statistics";
-                    ToolTip = 'View statistical information, such as the value of posted entries, for the record.';
                 }
                 action("Sta&tus")
                 {
@@ -220,7 +216,6 @@ page 9010 "Production Planner Role Center"
                     Caption = 'Inventory &Valuation WIP';
                     Image = "Report";
                     RunObject = Report "Inventory Valuation - WIP";
-                    ToolTip = 'View inventory valuation for selected production orders in your WIP inventory. The report also shows information about the value of consumption, capacity usage and output in WIP.';
                 }
                 action("Prod. Order - &Job Card")
                 {

--- a/src/Layers/W1/BaseApp/Manufacturing/RoleCenters/ShopSuperbasicActivities.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/RoleCenters/ShopSuperbasicActivities.Page.al
@@ -55,7 +55,6 @@ page 9044 "Shop Super. basic Activities"
                         ApplicationArea = Manufacturing;
                         Caption = 'View Production Order - Shortage List';
                         RunObject = Report "Prod. Order - Shortage List";
-                        ToolTip = 'View a list of the missing quantity per production order. You are shown how the inventory development is planned from today until the set day - for example whether orders are still open.';
                     }
                     action("Change Production Order Status")
                     {

--- a/src/Layers/W1/BaseApp/Manufacturing/RoleCenters/ShopSupervisorMfgFoundation.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/RoleCenters/ShopSupervisorMfgFoundation.Page.al
@@ -80,7 +80,6 @@ page 9011 "Shop Supervisor Mfg Foundation"
                 Caption = 'Production Order - &Shortage List';
                 Image = "Report";
                 RunObject = Report "Prod. Order - Shortage List";
-                ToolTip = 'View a list of the missing quantity per production order. The report shows how the inventory development is planned from today until the set day - for example whether orders are still open.';
             }
             action("Subcontractor - Dis&patch List")
             {
@@ -88,7 +87,6 @@ page 9011 "Shop Supervisor Mfg Foundation"
                 Caption = 'Subcontractor - Dis&patch List';
                 Image = "Report";
                 RunObject = Report "Subcontractor - Dispatch List";
-                ToolTip = 'View the list of material to be sent to manufacturing subcontractors.';
             }
             separator(Action42)
             {
@@ -112,7 +110,6 @@ page 9011 "Shop Supervisor Mfg Foundation"
                 Caption = 'Production Order Statistics';
                 Image = "Report";
                 RunObject = report "Production Order Statistics";
-                ToolTip = 'View statistical information, such as the value of posted entries, for the record.';
             }
             action("S&tatus")
             {
@@ -135,7 +132,6 @@ page 9011 "Shop Supervisor Mfg Foundation"
                 Caption = 'Inventory Valuation &WIP';
                 Image = "Report";
                 RunObject = Report "Inventory Valuation - WIP";
-                ToolTip = 'View inventory valuation for selected production orders in your WIP inventory. The report also shows information about the value of consumption, capacity usage and output in WIP. The printed report only shows invoiced amounts, that is, the cost of entries that have been posted as invoiced.';
             }
         }
         area(embedding)

--- a/src/Layers/W1/BaseApp/Manufacturing/RoleCenters/ShopSupervisorRoleCenter.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/RoleCenters/ShopSupervisorRoleCenter.Page.al
@@ -111,7 +111,6 @@ page 9012 "Shop Supervisor Role Center"
                 Caption = 'Capacity Tas&k List';
                 Image = "Report";
                 RunObject = Report "Capacity Task List";
-                ToolTip = 'View the production orders that are waiting to be processed at the work centers and machine centers. Printouts are made for the capacity of the work center or machine center. The report includes information such as starting and ending time, date per production order and input quantity.';
             }
             action("Subcontractor - Dis&patch List")
             {
@@ -119,7 +118,6 @@ page 9012 "Shop Supervisor Role Center"
                 Caption = 'Subcontractor - Dis&patch List';
                 Image = "Report";
                 RunObject = Report "Subcontractor - Dispatch List";
-                ToolTip = 'View the list of material to be sent to manufacturing subcontractors.';
             }
             separator(Action42)
             {
@@ -143,7 +141,6 @@ page 9012 "Shop Supervisor Role Center"
                 Caption = 'Production Order Statistics';
                 Image = "Report";
                 RunObject = report "Production Order Statistics";
-                ToolTip = 'View statistical information, such as the value of posted entries, for the record.';
             }
             action("S&tatus")
             {

--- a/src/Layers/W1/BaseApp/Manufacturing/WorkCenter/WorkCenterCard.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/WorkCenter/WorkCenterCard.Page.al
@@ -337,7 +337,6 @@ page 99000754 "Work Center Card"
                 //The property 'PromotedCategory' can only be set if the property 'Promoted' is set to 'true'
                 //PromotedCategory = "Report";
                 RunObject = Report "Subcontractor - Dispatch List";
-                ToolTip = 'View the list of material to be sent to manufacturing subcontractors.';
             }
         }
         area(Promoted)


### PR DESCRIPTION
## What & why

Moves the report action ToolTips for **7 Manufacturing reports** off the page actions that run them and onto the report objects themselves. The tooltip is now defined once on the report and applies wherever the report is invoked — the page action inherits it via the 2025 release wave 1 feature *"Running objects in actions defaults to UI descriptors on target object"* — and the now-duplicate `ToolTip` is removed from the page actions.

Reports moved: Capacity Task List, Inventory Valuation - WIP, Prod. Order - Shortage List, Production Order Statistics, Quantity Explosion of BOM, Subcontractor - Dispatch List, Where-Used (Top Level).

This **completes the Manufacturing area** — the pre-migration ADO pass was partial (IT-only, 4 files) and, via a since-fixed tooling bug, skipped reports that have obsolete dataset columns. `classify` now reports Manufacturing = 0 remaining.

## Scope

- **W1** (`src/Layers/W1/BaseApp/Manufacturing`): 22 files — 7 report-level ToolTip adds + 27 duplicate action ToolTip removals across 15 pages/role centers.
- **Country**: the IT layer is the only fork of these pages — 5 IT forks updated (12 removals). No other country forks exist.

Metadata-only, tooltip-only diff; BOM/EOL preserved.

Fixes [AB#636017](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636017)




