### PR TITLE
[Shopify] Add Unlisted to Status for Created Products and update status tooltip

### DIFF
--- a/src/Apps/W1/Shopify/App/src/PermissionSets/ShpfyObjects.PermissionSet.al
+++ b/src/Apps/W1/Shopify/App/src/PermissionSets/ShpfyObjects.PermissionSet.al
@@ -135,6 +135,7 @@ permissionset 30104 "Shpfy - Objects"
         codeunit "Shpfy Create Transl. Product" = X,
         codeunit "Shpfy CreateProdStatusActive" = X,
         codeunit "Shpfy CreateProdStatusDraft" = X,
+        codeunit "Shpfy CreateProdStatusUnlisted" = X,
         codeunit "Shpfy Cust. By Bill-to" = X,
         codeunit "Shpfy Cust. By Default Cust." = X,
         codeunit "Shpfy Cust. By Email/Phone" = X,

--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyCreateProdStatusUnlisted.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyCreateProdStatusUnlisted.Codeunit.al
@@ -1,0 +1,26 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify;
+
+using Microsoft.Inventory.Item;
+
+/// <summary>
+/// Codeunit Shpfy CreateProdStatusUnlisted (ID 30205) implements Interface Shopify.ICreateProductStatusValue.
+/// </summary>
+codeunit 30205 "Shpfy CreateProdStatusUnlisted" implements "Shpfy ICreateProductStatusValue"
+{
+    Access = Internal;
+
+    /// <summary>
+    /// GetStatus.
+    /// </summary>
+    /// <param name="Item">Record Item.</param>
+    /// <returns>Return value of type enum "Shopify Product Status".</returns>
+    internal procedure GetStatus(Item: Record Item): enum "Shpfy Product Status";
+    begin
+        exit(Enum::"Shpfy Product Status"::Unlisted);
+    end;
+}

--- a/src/Apps/W1/Shopify/App/src/Products/Enums/ShpfyCrProdStatusValue.Enum.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Enums/ShpfyCrProdStatusValue.Enum.al
@@ -24,4 +24,9 @@ enum 30129 "Shpfy Cr. Prod. Status Value" implements "Shpfy ICreateProductStatus
         Caption = 'Draft';
         Implementation = "Shpfy ICreateProductStatusValue" = "Shpfy CreateProdStatusDraft";
     }
+    value(2; Unlisted)
+    {
+        Caption = 'Unlisted';
+        Implementation = "Shpfy ICreateProductStatusValue" = "Shpfy CreateProdStatusUnlisted";
+    }
 }

--- a/src/Apps/W1/Shopify/App/src/Products/Pages/ShpfyProducts.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Pages/ShpfyProducts.Page.al
@@ -45,7 +45,7 @@ page 30126 "Shpfy Products"
                 field(Status; Rec.Status)
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the status of the product in Shopify. Valid values are: active, archived, draft. If you change this, this will immediately send to Shopify.';
+                    ToolTip = 'Specifies the status of the product in Shopify. Valid values are: active, archived, draft, unlisted. If you change this, this will immediately send to Shopify.';
 
                     trigger OnValidate()
                     var


### PR DESCRIPTION
Addresses reactivation feedback on bug 642074.

PR #9321 added the `Unlisted` value to the `Shpfy Product Status` enum, but Andrei noted two remaining gaps that this PR fixes:

1. **Status tooltip** — `ShpfyProducts.Page.al` Status field tooltip listed only `active, archived, draft`. Now includes `unlisted`.
2. **"Status for Created Products" picker** — the `Shpfy Cr. Prod. Status Value` enum (shown on the Shop Card) only offered Active/Draft. Added an `Unlisted` value, backed by a new `Shpfy CreateProdStatusUnlisted` codeunit implementing `ICreateProductStatusValue`, and registered it in the `Shpfy - Objects` permission set.

The documentation update (`synchronize-items.md`) noted in the work item is owned by Andrei and lives outside this repo, so it is not part of this PR.

Fixes [AB#642074](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642074)



