### PR TITLE
636017 Move report action tooltips to report objects (small areas)

### DIFF
--- a/src/Layers/FR/BaseApp/Foundation/Period/AccountingPeriods.Page.al
+++ b/src/Layers/FR/BaseApp/Foundation/Period/AccountingPeriods.Page.al
@@ -161,7 +161,6 @@ page 100 "Accounting Periods"
                 Ellipsis = true;
                 Image = CreateYear;
                 RunObject = Report "Create Fiscal Year";
-                ToolTip = 'Open a new fiscal year and define its accounting periods so you can start posting documents.';
             }
             action("C&lose Year")
             {

--- a/src/Layers/FR/BaseApp/Foundation/Period/CreateFiscalYear.Report.al
+++ b/src/Layers/FR/BaseApp/Foundation/Period/CreateFiscalYear.Report.al
@@ -10,6 +10,7 @@ using System.Utilities;
 report 93 "Create Fiscal Year"
 {
     Caption = 'Create Fiscal Year';
+    ToolTip = 'Open a new fiscal year and define its accounting periods so you can start posting documents.';
     ProcessingOnly = true;
 
     dataset

--- a/src/Layers/NA/BaseApp/Projects/RoleCenters/JobProjectManagerRC.Page.al
+++ b/src/Layers/NA/BaseApp/Projects/RoleCenters/JobProjectManagerRC.Page.al
@@ -665,7 +665,6 @@ page 9015 "Job Project Manager RC"
                         Caption = 'Employee - Staff Absences';
                         Image = "Report";
                         RunObject = Report "Employee - Staff Absences";
-                        ToolTip = 'View a list of employee absences by date. The list includes the cause of each employee absence.';
                     }
                     action("Employee - Absences by Causes")
                     {
@@ -673,7 +672,6 @@ page 9015 "Job Project Manager RC"
                         Caption = 'Employee - Absences by Causes';
                         Image = "Report";
                         RunObject = Report "Employee - Absences by Causes";
-                        ToolTip = 'View a list of all your employee absences categorized by absence code.';
                     }
                 }
             }

--- a/src/Layers/NO/BaseApp/Foundation/Period/AccountingPeriods.Page.al
+++ b/src/Layers/NO/BaseApp/Foundation/Period/AccountingPeriods.Page.al
@@ -110,7 +110,6 @@ page 100 "Accounting Periods"
                 Ellipsis = true;
                 Image = CreateYear;
                 RunObject = Report "Create Fiscal Year";
-                ToolTip = 'Open a new fiscal year and define its accounting periods so you can start posting documents.';
             }
             action("C&lose Year")
             {

--- a/src/Layers/W1/BaseApp/Assembly/Inventory/Item/AsmItemList.PageExt.al
+++ b/src/Layers/W1/BaseApp/Assembly/Inventory/Item/AsmItemList.PageExt.al
@@ -18,7 +18,6 @@ pageextension 905 "Asm. Item List" extends "Item List"
                 Caption = 'Assemble to Order - Sales';
                 Image = "Report";
                 RunObject = Report "Assemble to Order - Sales";
-                ToolTip = 'View key sales figures for assembly components that may be sold either as part of assembly items in assemble-to-order sales or as separate items directly from inventory. Use this report to analyze the quantity, cost, sales, and profit figures of assembly components to support decisions, such as whether to price a kit differently or to stop or start using a particular item in assemblies.';
             }
         }
     }

--- a/src/Layers/W1/BaseApp/Assembly/Reports/AssembletoOrderSales.Report.al
+++ b/src/Layers/W1/BaseApp/Assembly/Reports/AssembletoOrderSales.Report.al
@@ -15,6 +15,7 @@ report 915 "Assemble to Order - Sales"
     AdditionalSearchTerms = 'kit to order,kit sale';
     ApplicationArea = Assembly;
     Caption = 'Assemble to Order - Sales';
+    ToolTip = 'View key sales figures for assembly components that may be sold either as part of assembly items in assemble-to-order sales or as separate items directly from inventory. Use this report to analyze the quantity, cost, sales, and profit figures of assembly components to support decisions, such as whether to price a kit differently or to stop or start using a particular item in assemblies.';
     UsageCategory = ReportsAndAnalysis;
     DefaultRenderingLayout = RDLCLayout;
 

--- a/src/Layers/W1/BaseApp/Foundation/Period/AccountingPeriods.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Period/AccountingPeriods.Page.al
@@ -101,7 +101,6 @@ page 100 "Accounting Periods"
                 Ellipsis = true;
                 Image = CreateYear;
                 RunObject = Report "Create Fiscal Year";
-                ToolTip = 'Open a new fiscal year and define its accounting periods so you can start posting documents.';
             }
             action("C&lose Year")
             {

--- a/src/Layers/W1/BaseApp/Foundation/Period/CreateFiscalYear.Report.al
+++ b/src/Layers/W1/BaseApp/Foundation/Period/CreateFiscalYear.Report.al
@@ -10,6 +10,7 @@ using System.Utilities;
 report 93 "Create Fiscal Year"
 {
     Caption = 'Create Fiscal Year';
+    ToolTip = 'Open a new fiscal year and define its accounting periods so you can start posting documents.';
     ProcessingOnly = true;
 
     dataset

--- a/src/Layers/W1/BaseApp/HumanResources/Reports/EmployeeAbsencesbyCauses.Report.al
+++ b/src/Layers/W1/BaseApp/HumanResources/Reports/EmployeeAbsencesbyCauses.Report.al
@@ -14,6 +14,7 @@ report 5205 "Employee - Absences by Causes"
     RDLCLayout = './HumanResources/Reports/EmployeeAbsencesbyCauses.rdlc';
     ApplicationArea = BasicHR;
     Caption = 'Employee Absences by Causes';
+    ToolTip = 'View a list of all your employee absences categorized by absence code.';
     UsageCategory = ReportsAndAnalysis;
 
     dataset

--- a/src/Layers/W1/BaseApp/HumanResources/Reports/EmployeeStaffAbsences.Report.al
+++ b/src/Layers/W1/BaseApp/HumanResources/Reports/EmployeeStaffAbsences.Report.al
@@ -13,6 +13,7 @@ report 5204 "Employee - Staff Absences"
     RDLCLayout = './HumanResources/Reports/EmployeeStaffAbsences.rdlc';
     ApplicationArea = BasicHR;
     Caption = 'Staff Absences';
+    ToolTip = 'View a list of employee absences by date. The list includes the cause of each employee absence.';
     UsageCategory = ReportsAndAnalysis;
 
     dataset

--- a/src/Layers/W1/BaseApp/Modules/Foundation/UserTask/UserTaskList.Page.al
+++ b/src/Layers/W1/BaseApp/Modules/Foundation/UserTask/UserTaskList.Page.al
@@ -135,7 +135,6 @@ page 1170 "User Task List"
                 Caption = 'Delete User Tasks';
                 Image = Delete;
                 RunObject = Report "User Task Utility";
-                ToolTip = 'Find and delete user tasks.';
             }
         }
         area(Promoted)

--- a/src/Layers/W1/BaseApp/Modules/Foundation/UserTask/UserTaskUtility.Report.al
+++ b/src/Layers/W1/BaseApp/Modules/Foundation/UserTask/UserTaskUtility.Report.al
@@ -7,6 +7,7 @@ namespace Microsoft.Foundation.Task;
 report 1170 "User Task Utility"
 {
     Caption = 'User Task Utility';
+    ToolTip = 'Find and delete user tasks.';
     ProcessingOnly = true;
 
     dataset

--- a/src/Layers/W1/BaseApp/Projects/RoleCenters/JobProjectManagerRC.Page.al
+++ b/src/Layers/W1/BaseApp/Projects/RoleCenters/JobProjectManagerRC.Page.al
@@ -623,7 +623,6 @@ page 9015 "Job Project Manager RC"
                         Caption = 'Employee - Staff Absences';
                         Image = "Report";
                         RunObject = Report "Employee - Staff Absences";
-                        ToolTip = 'View a list of employee absences by date. The list includes the cause of each employee absence.';
                     }
                     action("Employee - Absences by Causes")
                     {
@@ -631,7 +630,6 @@ page 9015 "Job Project Manager RC"
                         Caption = 'Employee - Absences by Causes';
                         Image = "Report";
                         RunObject = Report "Employee - Absences by Causes";
-                        ToolTip = 'View a list of all your employee absences categorized by absence code.';
                     }
                 }
             }


### PR DESCRIPTION
## What & why

Moves the report action ToolTips onto the report objects themselves for the remaining **small areas** (HumanResources, Foundation, Assembly, Modules), bundled into one PR. The tooltip is now defined once on the report and applies wherever the report is invoked — the page action inherits it via the 2025 release wave 1 feature *"Running objects in actions defaults to UI descriptors on target object"* — and the now-duplicate `ToolTip` is removed from the page actions.

Reports moved (5): Employee - Absences by Causes, Employee - Staff Absences (HumanResources), Create Fiscal Year (Foundation), Assemble to Order - Sales (Assembly), User Task Utility (Modules).

This clears the last remaining actionable reports — `classify` now reports all four areas = 0 remaining.

## Scope

- **W1** (`src/Layers/W1/BaseApp`): 9 files — 5 report-level ToolTip adds + 4 duplicate action ToolTip removals across 4 pages (incl. a cross-namespace ref on the Projects JobProjectManager role center).
- **Country**: 4 forks — FR Create Fiscal Year report add; FR + NO Foundation AccountingPeriods and NA Projects JobProjectManagerRC removals.

Metadata-only, tooltip-only diff; BOM/EOL preserved.

Fixes [AB#636017](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636017)




