### PR TITLE
[master] Overdue Balance (LCY) filters do not behave as expected if you open the Customer Card from a document or journal.

### DIFF
--- a/src/Layers/APAC/BaseApp/Sales/Customer/CustomerCard.Page.al
+++ b/src/Layers/APAC/BaseApp/Sales/Customer/CustomerCard.Page.al
@@ -2459,6 +2459,9 @@ page 21 "Customer Card"
         ActivateFields();
         SetCreditLimitStyle();
 
+        if Rec.GetFilter("Date Filter") = '' then
+            Rec.SetRange("Date Filter", 0D, WorkDate());
+
         if CRMIntegrationEnabled or CDSIntegrationEnabled then begin
             CRMIsCoupledToRecord := CRMCouplingManagement.IsRecordCoupledToCRM(Rec.RecordId);
             if Rec."No." <> xRec."No." then

--- a/src/Layers/BE/BaseApp/Sales/Customer/CustomerCard.Page.al
+++ b/src/Layers/BE/BaseApp/Sales/Customer/CustomerCard.Page.al
@@ -2413,6 +2413,9 @@ page 21 "Customer Card"
         ActivateFields();
         SetCreditLimitStyle();
 
+        if Rec.GetFilter("Date Filter") = '' then
+            Rec.SetRange("Date Filter", 0D, WorkDate());
+
         if CRMIntegrationEnabled or CDSIntegrationEnabled then begin
             CRMIsCoupledToRecord := CRMCouplingManagement.IsRecordCoupledToCRM(Rec.RecordId);
             if Rec."No." <> xRec."No." then

--- a/src/Layers/ES/BaseApp/Sales/Customer/CustomerCard.Page.al
+++ b/src/Layers/ES/BaseApp/Sales/Customer/CustomerCard.Page.al
@@ -2451,6 +2451,9 @@ page 21 "Customer Card"
         ActivateFields();
         SetCreditLimitStyle();
 
+        if Rec.GetFilter("Date Filter") = '' then
+            Rec.SetRange("Date Filter", 0D, WorkDate());
+
         if CRMIntegrationEnabled or CDSIntegrationEnabled then begin
             CRMIsCoupledToRecord := CRMCouplingManagement.IsRecordCoupledToCRM(Rec.RecordId);
             if Rec."No." <> xRec."No." then

--- a/src/Layers/FR/BaseApp/Sales/Customer/CustomerCard.Page.al
+++ b/src/Layers/FR/BaseApp/Sales/Customer/CustomerCard.Page.al
@@ -2457,6 +2457,9 @@ page 21 "Customer Card"
         ActivateFields();
         SetCreditLimitStyle();
 
+        if Rec.GetFilter("Date Filter") = '' then
+            Rec.SetRange("Date Filter", 0D, WorkDate());
+
         if CRMIntegrationEnabled or CDSIntegrationEnabled then begin
             CRMIsCoupledToRecord := CRMCouplingManagement.IsRecordCoupledToCRM(Rec.RecordId);
             if Rec."No." <> xRec."No." then

--- a/src/Layers/GB/BaseApp/Sales/Customer/CustomerCard.Page.al
+++ b/src/Layers/GB/BaseApp/Sales/Customer/CustomerCard.Page.al
@@ -2447,6 +2447,9 @@ page 21 "Customer Card"
         ActivateFields();
         SetCreditLimitStyle();
 
+        if Rec.GetFilter("Date Filter") = '' then
+            Rec.SetRange("Date Filter", 0D, WorkDate());
+
         if CRMIntegrationEnabled or CDSIntegrationEnabled then begin
             CRMIsCoupledToRecord := CRMCouplingManagement.IsRecordCoupledToCRM(Rec.RecordId);
             if Rec."No." <> xRec."No." then

--- a/src/Layers/IT/BaseApp/Sales/Customer/CustomerCard.Page.al
+++ b/src/Layers/IT/BaseApp/Sales/Customer/CustomerCard.Page.al
@@ -2541,6 +2541,9 @@ page 21 "Customer Card"
         ActivateFields();
         SetCreditLimitStyle();
 
+        if Rec.GetFilter("Date Filter") = '' then
+            Rec.SetRange("Date Filter", 0D, WorkDate());
+
         if CRMIntegrationEnabled or CDSIntegrationEnabled then begin
             CRMIsCoupledToRecord := CRMCouplingManagement.IsRecordCoupledToCRM(Rec.RecordId);
             if Rec."No." <> xRec."No." then

--- a/src/Layers/NA/BaseApp/Sales/Customer/CustomerCard.Page.al
+++ b/src/Layers/NA/BaseApp/Sales/Customer/CustomerCard.Page.al
@@ -2558,6 +2558,9 @@ page 21 "Customer Card"
         ActivateFields();
         SetCreditLimitStyle();
 
+        if Rec.GetFilter("Date Filter") = '' then
+            Rec.SetRange("Date Filter", 0D, WorkDate());
+
         if CRMIntegrationEnabled or CDSIntegrationEnabled then begin
             CRMIsCoupledToRecord := CRMCouplingManagement.IsRecordCoupledToCRM(Rec.RecordId);
             if Rec."No." <> xRec."No." then

--- a/src/Layers/NL/BaseApp/Sales/Customer/CustomerCard.Page.al
+++ b/src/Layers/NL/BaseApp/Sales/Customer/CustomerCard.Page.al
@@ -2403,6 +2403,9 @@ page 21 "Customer Card"
         ActivateFields();
         SetCreditLimitStyle();
 
+        if Rec.GetFilter("Date Filter") = '' then
+            Rec.SetRange("Date Filter", 0D, WorkDate());
+
         if CRMIntegrationEnabled or CDSIntegrationEnabled then begin
             CRMIsCoupledToRecord := CRMCouplingManagement.IsRecordCoupledToCRM(Rec.RecordId);
             if Rec."No." <> xRec."No." then

--- a/src/Layers/NO/BaseApp/Sales/Customer/CustomerCard.Page.al
+++ b/src/Layers/NO/BaseApp/Sales/Customer/CustomerCard.Page.al
@@ -2419,6 +2419,9 @@ page 21 "Customer Card"
         ActivateFields();
         SetCreditLimitStyle();
 
+        if Rec.GetFilter("Date Filter") = '' then
+            Rec.SetRange("Date Filter", 0D, WorkDate());
+
         if CRMIntegrationEnabled or CDSIntegrationEnabled then begin
             CRMIsCoupledToRecord := CRMCouplingManagement.IsRecordCoupledToCRM(Rec.RecordId);
             if Rec."No." <> xRec."No." then

--- a/src/Layers/RU/BaseApp/Sales/Customer/CustomerCard.Page.al
+++ b/src/Layers/RU/BaseApp/Sales/Customer/CustomerCard.Page.al
@@ -2529,6 +2529,9 @@ page 21 "Customer Card"
         ActivateFields();
         SetCreditLimitStyle();
 
+        if Rec.GetFilter("Date Filter") = '' then
+            Rec.SetRange("Date Filter", 0D, WorkDate());
+
         if CRMIntegrationEnabled or CDSIntegrationEnabled then begin
             CRMIsCoupledToRecord := CRMCouplingManagement.IsRecordCoupledToCRM(Rec.RecordId);
             if Rec."No." <> xRec."No." then

--- a/src/Layers/W1/BaseApp/Sales/Customer/CustomerCard.Page.al
+++ b/src/Layers/W1/BaseApp/Sales/Customer/CustomerCard.Page.al
@@ -2389,6 +2389,9 @@ page 21 "Customer Card"
         ActivateFields();
         SetCreditLimitStyle();
 
+        if Rec.GetFilter("Date Filter") = '' then
+            Rec.SetRange("Date Filter", 0D, WorkDate());
+
         if CRMIntegrationEnabled or CDSIntegrationEnabled then begin
             CRMIsCoupledToRecord := CRMCouplingManagement.IsRecordCoupledToCRM(Rec.RecordId);
             if Rec."No." <> xRec."No." then

--- a/src/Layers/W1/Tests/ERM/ERMCustomerStatistics.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMCustomerStatistics.Codeunit.al
@@ -1119,6 +1119,76 @@ codeunit 134389 "ERM Customer Statistics"
         Assert.AreEqual(CustomerStatistics.GetTotalAmountLCY.AsDecimal(), Customer.GetTotalAmountLCY(), CustomerCardFactboxTotalErr);
     end;
 
+    [Test]
+    procedure OverdueBalanceLCYOnCustomerCardWhenOpenedWithoutDateFilter()
+    var
+        Customer: Record Customer;
+        SalesHeader: Record "Sales Header";
+        OverdueCustLedgEntry: Record "Cust. Ledger Entry";
+        FutureCustLedgEntry: Record "Cust. Ledger Entry";
+        SalesInvoice: TestPage "Sales Invoice";
+        CustomerCard: TestPage "Customer Card";
+        OverdueAmountLCY: Decimal;
+        FutureAmountLCY: Decimal;
+    begin
+        // [SCENARIO 640988] "Overdue Balance (LCY)" on the Customer Card shows only overdue entries when the card is opened from a document (the card is reached without an explicit Date Filter).
+        Initialize();
+
+        // [GIVEN] Create Customer with an overdue entry and a not-yet-due entry.
+        LibrarySales.CreateCustomer(Customer);
+        OverdueAmountLCY := LibraryRandom.RandDecInRange(100, 200, 2);
+        FutureAmountLCY := LibraryRandom.RandDecInRange(300, 400, 2);
+        MockCustLedgerEntryWithDueDateAndAmountLCY(OverdueCustLedgEntry, Customer."No.", CalcDate('<-1D>', WorkDate()), OverdueAmountLCY);
+        MockCustLedgerEntryWithDueDateAndAmountLCY(FutureCustLedgEntry, Customer."No.", CalcDate('<1D>', WorkDate()), FutureAmountLCY);
+
+        // [GIVEN] Create a sales invoice for the customer.
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, Customer."No.");
+
+        // [WHEN] Open the Customer Card from the sales document (navigating through the customer part, which passes an empty Date Filter to the card).
+        SalesInvoice.OpenView();
+        SalesInvoice.GotoRecord(SalesHeader);
+        CustomerCard.Trap();
+        SalesInvoice.Control1902018507."No.".DrillDown();
+
+        // [THEN] Verify "Balance Due (LCY)" on the Customer Card shows only the overdue amount.
+        Assert.AreEqual(OverdueAmountLCY, CustomerCard."Balance Due (LCY)".AsDecimal(), OverDueBalanceErr);
+
+        CustomerCard.Close();
+        SalesInvoice.Close();
+    end;
+
+    [Test]
+    procedure DrillDownOnBalanceDueFromCardWithoutDateFilterFiltersOverdueEntries()
+    var
+        Customer: Record Customer;
+        OverdueCustLedgEntry: Record "Cust. Ledger Entry";
+        FutureCustLedgEntry: Record "Cust. Ledger Entry";
+        CustomerCard: TestPage "Customer Card";
+        CustomerLedgerEntries: TestPage "Customer Ledger Entries";
+    begin
+        // [SCENARIO 640988] Drill Down on "Balance Due (LCY)" from the Customer Card applies a Due Date filter and shows only overdue entries.
+        Initialize();
+
+        // [GIVEN] Create customer with an overdue open entry and a not-yet-due open entry.
+        LibrarySales.CreateCustomer(Customer);
+        MockCustLedgerEntryWithDueDateAndAmountLCY(OverdueCustLedgEntry, Customer."No.", CalcDate('<-1D>', WorkDate()), LibraryRandom.RandDecInRange(100, 200, 2));
+        MockCustLedgerEntryWithDueDateAndAmountLCY(FutureCustLedgEntry, Customer."No.", CalcDate('<1D>', WorkDate()), LibraryRandom.RandDecInRange(300, 400, 2));
+
+        // [WHEN] Open the Customer Card and drill down on "Balance Due (LCY)".
+        CustomerCard.OpenView();
+        CustomerCard.GotoRecord(Customer);
+        CustomerLedgerEntries.Trap();
+        CustomerCard."Balance Due (LCY)".DrillDown();
+
+        // [THEN] Verify Due Date filter is applied on the Customer Ledger Entries page, showing only the overdue entry.
+        Assert.AreNotEqual('', CustomerLedgerEntries.FILTER.GetFilter("Due Date"), 'Due Date filter should be applied on the drill down.');
+        CustomerLedgerEntries.First();
+        Assert.AreEqual(OverdueCustLedgEntry."Entry No.", CustomerLedgerEntries."Entry No.".AsInteger(), '');
+        Assert.IsFalse(CustomerLedgerEntries.Next(), '');
+        CustomerLedgerEntries.Close();
+        CustomerCard.Close();
+    end;
+
     local procedure Initialize()
     var
         Currency: Record Currency;
@@ -1293,6 +1363,19 @@ codeunit 134389 "ERM Customer Statistics"
         DetailedCustLedgEntry."Cust. Ledger Entry No." := CustLedgEntryNo;
         DetailedCustLedgEntry."Document Type" := DetailedCustLedgEntry."Document Type"::Payment;
         DetailedCustLedgEntry.Insert();
+    end;
+
+    local procedure MockCustLedgerEntryWithDueDateAndAmountLCY(var CustLedgEntry: Record "Cust. Ledger Entry"; CustNo: Code[20]; DueDate: Date; AmountLCY: Decimal)
+    var
+        DetailedCustLedgEntry: Record "Detailed Cust. Ledg. Entry";
+    begin
+        CreateCustLedgerEntryWithDueDate(CustLedgEntry, CustNo, DueDate);
+        CreatePaymentDetailedCustLedgerEntryForCustLedgerEntry(DetailedCustLedgEntry, CustLedgEntry."Entry No.");
+        DetailedCustLedgEntry.Validate("Initial Entry Due Date", CustLedgEntry."Due Date");
+        DetailedCustLedgEntry.Validate("Customer No.", CustLedgEntry."Customer No.");
+        DetailedCustLedgEntry.Validate(Amount, AmountLCY);
+        DetailedCustLedgEntry.Validate("Amount (LCY)", AmountLCY);
+        DetailedCustLedgEntry.Modify(true);
     end;
 
     local procedure MockDetailedCustLedgerEntryWithDueDate(var DetailedCustLedgEntry: Record "Detailed Cust. Ledg. Entry"; CustLedgerEntry: Record "Cust. Ledger Entry")


### PR DESCRIPTION
**Issue:** "Overdue Balance (LCY)" on the Customer Card shows the total balance (e.g. 145) instead of the overdue amount (45), and its drill-down misses the Due Date filter, when the card is opened from a document or journal.

**Cause:** The Customer Card defaulted its Date Filter only in OnOpenPage, which isn't reliably applied when the card is reached from a document/journal (empty Date Filter propagated), so the Balance Due (LCY) flowfield summed all entries and the drill-down skipped the due-date filter.

**Solution:** Also default Date Filter to 0D..WorkDate() in the card's OnAfterGetCurrRecordFunc (mirroring the Vendor Card), so the overdue calculation and drill-down filters are correct regardless of how the card is opened.

Workitem: [Bug 640988](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/640988): [master] [all-e]Overdue Balance (LCY) filters do not behave as expected if you open the Customer Card from a document or journal.

Fixes [AB#640988](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640988)
