### PR TITLE
Update BCArtifact to 29.0.52664.0 & unblock platform uptake with AL1430 ruleset exception

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -8,7 +8,7 @@
   "UsePsSession": false,
   "gitHubRunner": "windows-latest",
   "githubRunnerShell": "pwsh",
-  "artifact": "bcinsider/Sandbox/29.0.51936.0//latest",
+  "artifact": "bcinsider/Sandbox/29.0.52664.0//latest",
   "country": "base",
   "useProjectDependencies": true,
   "repoVersion": "29.0",

--- a/build/Packages.json
+++ b/build/Packages.json
@@ -9,7 +9,7 @@
     "_comment": "Used to fetch app baselines from BC artifacts"
   },
   "BCPlatform": {
-    "Version": "29.0.51074.0",
+    "Version": "29.0.52663.0",
     "Source": "BCPlatform",
     "_comment": "The BC platform version, fetched from the platform CDN"
   }

--- a/src/rulesets/ruleset.json
+++ b/src/rulesets/ruleset.json
@@ -93,6 +93,11 @@
         "id":  "AW0017",
         "action":  "Warning",
         "justification": "MaskType is not yet implemented for repeater controls, but it does not break the UI. It is informational that the value will not be visible in the repeater."
-    }
+    },
+    {
+        "id": "AL1430",
+        "action": "Warning",
+        "justification": "TODO(#642602) - Recent bugfix uncovered violations that need to be addressed."
+    },
   ]
 }


### PR DESCRIPTION
This PR contains the following changes:

Update BCArtifact version. New value: 29.0.52664.0
Update platform version. New value: 29.0.52663.0

Ruleset exception for AL1430.

[AB#642468](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642468)
[AB#539394](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/539394)


