### PR TITLE
[Test] Validate reorder-namespace apply-suggestion (scrambled using order)

### DIFF
--- a/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/PINTANZImport.Codeunit.al
+++ b/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/PINTANZImport.Codeunit.al
@@ -4,12 +4,12 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.eServices.EDocument.Format;
 
-using Microsoft.eServices.EDocument;
-using Microsoft.eServices.EDocument.Service.Participant;
-using Microsoft.Finance.GeneralLedger.Setup;
-using Microsoft.Purchases.Vendor;
-using System.IO;
 using System.Utilities;
+using Microsoft.Purchases.Vendor;
+using Microsoft.eServices.EDocument;
+using System.IO;
+using Microsoft.Finance.GeneralLedger.Setup;
+using Microsoft.eServices.EDocument.Service.Participant;
 
 codeunit 28007 "PINT A-NZ Import"
 {

--- a/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/PINTANZReviewSample.Codeunit.al
+++ b/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/PINTANZReviewSample.Codeunit.al
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Format;
+
+using Microsoft.Purchases.Vendor;
+
+codeunit 28008 "PINT A-NZ Review Sample"
+{
+    Access = Internal;
+
+    procedure HasAnyVendor(): Boolean
+    var
+        Vendor: Record Vendor;
+    begin
+        exit(Vendor.Count() > 0);
+    end;
+
+    procedure EnsurePositive(Amount: Decimal)
+    begin
+        if Amount < 0 then
+            Error('Amount must be positive.');
+    end;
+}


### PR DESCRIPTION
## Purpose (test PR — do not merge)

Validation PR for the Copilot PR-review agent. It intentionally introduces a **scrambled `using` (namespace) order** in one codeunit so the reviewer emits a "reorder namespace / sort using directives" finding with a one-click ```suggestion``` block.

## What to check

1. **Apply-suggestion correctness (reorder namespace):** the agent should flag the out-of-order `using` list in `PINTANZImport.Codeunit.al` and offer a one-click suggestion that restores the correct sorted order. Verify clicking **Apply suggestion** produces a clean, compiling `using` block with no duplicated or dropped lines.
2. **Comment style:** eyeball the rendered review comment. (Note: the engine is pinned via `@latest`, which tracks the newest engine *release*; the comment-style fix in BC-ALAgents#32 only takes effect once that PR is merged and released.)

## Change

- `src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/PINTANZImport.Codeunit.al` — reordered the six `using` directives into a deliberately non-alphabetical order. No functional/compilation impact (`using` order does not affect compilation).


