### PR TITLE
Test: tooltip-inheritance FP repro (cf #9315)

### DIFF
--- a/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/PINTANZSampleExt.TableExt.al
+++ b/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/PINTANZSampleExt.TableExt.al
@@ -1,0 +1,18 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Format;
+
+using Microsoft.Purchases.Vendor;
+
+tableextension 28009 "PINT A-NZ Sample Ext" extends Vendor
+{
+    fields
+    {
+        field(28008; "PINT ANZ Sample Note"; Text[50])
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+}

--- a/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/PINTANZVendorSample.Page.al
+++ b/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/PINTANZVendorSample.Page.al
@@ -37,6 +37,10 @@ page 28008 "PINT A-NZ Vendor Sample"
                 {
                     ApplicationArea = Basic, Suite;
                 }
+                field("PINT ANZ Sample Note"; Rec."PINT ANZ Sample Note")
+                {
+                    ApplicationArea = Basic, Suite;
+                }
             }
         }
     }

--- a/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/PINTANZVendorSample.Page.al
+++ b/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/PINTANZVendorSample.Page.al
@@ -1,0 +1,43 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Format;
+
+using Microsoft.Purchases.Vendor;
+
+page 28008 "PINT A-NZ Vendor Sample"
+{
+    PageType = List;
+    ApplicationArea = Basic, Suite;
+    UsageCategory = Lists;
+    SourceTable = Vendor;
+    Caption = 'PINT A-NZ Vendor Sample';
+    Editable = false;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(General)
+            {
+                field("No."; Rec."No.")
+                {
+                    ApplicationArea = Basic, Suite;
+                }
+                field(Name; Rec.Name)
+                {
+                    ApplicationArea = Basic, Suite;
+                }
+                field("Country/Region Code"; Rec."Country/Region Code")
+                {
+                    ApplicationArea = Basic, Suite;
+                }
+                field("VAT Registration No."; Rec."VAT Registration No.")
+                {
+                    ApplicationArea = Basic, Suite;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Purpose (test PR — do not merge)

Reproduces the tooltip false-positive scenario that was thumbed-down on #9315, to validate that the current review engine (`@latest` = 1.12.4, pinned to BCQuality v1.4) now suppresses it.

Adds a `List` page whose field controls are **bound to `Vendor` table fields** (`No.`, `Name`, `Country/Region Code`, `VAT Registration No.`) and **declare no explicit `ToolTip`**. Those table fields already carry ToolTips, so the page controls inherit them at runtime — a missing-`ToolTip` finding here is a false positive.

## Expected

- The review should **not** raise a missing-`ToolTip` finding on these bound fields (suppressed by `ui/bound-page-field-inherits-source-field-tooltip.md`, shipped in BCQuality v1.4 / #112).
- Each inline comment footer should now show `AL review agent v1.12.4`.


