### PR TITLE
[main] bug 633618 - Add VAT Statement Calc. Events CZL codeunit and integrate with VAT Statement Calculation CZL

### DIFF
--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/VATStatementCalcEventsCZL.Codeunit.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/VATStatementCalcEventsCZL.Codeunit.al
@@ -1,0 +1,48 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Finance.VAT.Reporting;
+
+using Microsoft.Finance.GeneralLedger.Ledger;
+using Microsoft.Finance.VAT.Ledger;
+
+/// <summary>
+/// Publishes integration events used to extend VAT statement calculation.
+/// </summary>
+codeunit 11775 "VAT Statement Calc. Events CZL"
+{
+    /// <summary>
+    /// Raised after filters are set on G/L entries and before opening the General Ledger Entries page from VAT statement line drill-down.
+    /// </summary>
+    /// <param name="GLEntry">The G/L Entry record with prepared filters that can be adjusted before the page is opened.</param>
+    /// <param name="VATStatementLine">The VAT statement line currently being processed.</param>
+    /// <param name="VATStmtCalcParametersCZL">The VAT statement calculation parameters for the current run.</param>
+    [IntegrationEvent(false, false)]
+    internal procedure OnRunGeneralLedgerEntriesOnAfterSetGLEntryFilters(var GLEntry: Record "G/L Entry"; VATStatementLine: Record "VAT Statement Line"; VATStmtCalcParametersCZL: Record "VAT Stmt. Calc. Parameters CZL")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised after filters are set on VAT entries and before opening the VAT Entries page from VAT statement line drill-down.
+    /// This event is raised only when VAT report number filtering is not used.
+    /// </summary>
+    /// <param name="VATEntry">The VAT Entry record with prepared filters that can be adjusted before the page is opened.</param>
+    /// <param name="VATStatementLine">The VAT statement line currently being processed.</param>
+    /// <param name="VATStmtCalcParametersCZL">The VAT statement calculation parameters for the current run.</param>
+    [IntegrationEvent(false, false)]
+    internal procedure OnRunVATEntriesOnAfterSetVATEntryFilters(var VATEntry: Record "VAT Entry"; VATStatementLine: Record "VAT Statement Line"; VATStmtCalcParametersCZL: Record "VAT Stmt. Calc. Parameters CZL")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised when drill-down encounters an unsupported VAT statement line type so subscribers can provide custom handling.
+    /// </summary>
+    /// <param name="VATStatementLine">The VAT statement line that requires custom handling.</param>
+    /// <param name="VATStmtCalcParametersCZL">The VAT statement calculation parameters for the current run.</param>
+    /// <param name="IsHandled">Set to true when the line type is handled by a subscriber to prevent the default error.</param>
+    [IntegrationEvent(false, false)]
+    internal procedure OnHandleAnotherLineType(VATStatementLine: Record "VAT Statement Line"; VATStmtCalcParametersCZL: Record "VAT Stmt. Calc. Parameters CZL"; var IsHandled: Boolean)
+    begin
+    end;
+}

--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/VATStatementCalculationCZL.Codeunit.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/VATStatementCalculationCZL.Codeunit.al
@@ -15,6 +15,7 @@ codeunit 11723 "VAT Statement Calculation CZL"
     var
         TempVATStatementLineBuffer: Record "VAT Statement Line" temporary;
         GlobalVATStatement: Report "VAT Statement";
+        VATStatementCalcEventsCZL: Codeunit "VAT Statement Calc. Events CZL";
         BufferingMode: Boolean;
         CircularRefErr: Label 'Formula cannot be calculated due to circular references.';
         DivideByZeroErr: Label 'Dividing by zero is not possible.';
@@ -167,7 +168,7 @@ codeunit 11723 "VAT Statement Calculation CZL"
         if VATStatementLine."VAT Prod. Posting Group" <> '' then
             GLEntry.SetRange("VAT Prod. Posting Group", VATStatementLine."VAT Prod. Posting Group");
         GLEntry.SetRange("VAT Reporting Date", VATStmtCalcParametersCZL."Start Date", VATStmtCalcParametersCZL."End Date");
-        OnRunGeneralLedgerEntriesOnAfterSetGLEntryFilters(GLEntry, VATStatementLine, VATStmtCalcParametersCZL);
+        VATStatementCalcEventsCZL.OnRunGeneralLedgerEntriesOnAfterSetGLEntryFilters(GLEntry, VATStatementLine, VATStmtCalcParametersCZL);
         Page.Run(Page::"General Ledger Entries", GLEntry);
     end;
 
@@ -190,7 +191,7 @@ codeunit 11723 "VAT Statement Calculation CZL"
                 VATEntry.SetCurrentKey(
                   Type, Closed, "Tax Jurisdiction Code", "Use Tax", "Posting Date");
             VATEntry.SetVATStmtCalcFilters(VATStatementLine, VATStmtCalcParametersCZL);
-            OnRunVATEntriesOnAfterSetVATEntryFilters(VATEntry, VATStatementLine, VATStmtCalcParametersCZL);
+            VATStatementCalcEventsCZL.OnRunVATEntriesOnAfterSetVATEntryFilters(VATEntry, VATStatementLine, VATStmtCalcParametersCZL);
 #if not CLEAN28
             VATStatementPreviewLineCZL.RaiseOnBeforeOpenPageVATEntryTotaling(VATEntry, VATStatementLine);
 #endif
@@ -219,7 +220,7 @@ codeunit 11723 "VAT Statement Calculation CZL"
         IsHandled: Boolean;
     begin
         IsHandled := false;
-        OnHandleAnotherLineType(VATStatementLine, VATStmtCalcParametersCZL, IsHandled);
+        VATStatementCalcEventsCZL.OnHandleAnotherLineType(VATStatementLine, VATStmtCalcParametersCZL, IsHandled);
 #if not CLEAN28
         VATStatementPreviewLineCZL.RaiseOnColumnValueDrillDownVATStatementLineTypeCase(VATStatementLine, IsHandled);
 #endif
@@ -380,20 +381,5 @@ codeunit 11723 "VAT Statement Calculation CZL"
         Amount := Amount * VATStatementLine.GetCalculateSign();
         if VATStmtCalcParametersCZL."Print in Integers" and VATStatementLine.Print then
             Amount := Round(Amount, 1, VATStmtCalcParametersCZL.GetRoundingDirection());
-    end;
-
-    [IntegrationEvent(false, false)]
-    local procedure OnRunGeneralLedgerEntriesOnAfterSetGLEntryFilters(var GLEntry: Record "G/L Entry"; VATStatementLine: Record "VAT Statement Line"; VATStmtCalcParametersCZL: Record "VAT Stmt. Calc. Parameters CZL")
-    begin
-    end;
-
-    [IntegrationEvent(false, false)]
-    local procedure OnRunVATEntriesOnAfterSetVATEntryFilters(var VATEntry: Record "VAT Entry"; VATStatementLine: Record "VAT Statement Line"; VATStmtCalcParametersCZL: Record "VAT Stmt. Calc. Parameters CZL")
-    begin
-    end;
-
-    [IntegrationEvent(false, false)]
-    local procedure OnHandleAnotherLineType(VATStatementLine: Record "VAT Statement Line"; VATStmtCalcParametersCZL: Record "VAT Stmt. Calc. Parameters CZL"; var IsHandled: Boolean)
-    begin
     end;
 }

--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/Pages/VATStatementPreviewLineCZL.Page.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/Pages/VATStatementPreviewLineCZL.Page.al
@@ -208,7 +208,7 @@ page 31136 "VAT Statement Preview Line CZL"
     begin
     end;
 #if not CLEAN28
-    [Obsolete('Replaced by OnRunVATEntriesOnAfterSetVATEntryFilters event in "VAT Statement Calculation CZL" codeunit.', '28.0')]
+    [Obsolete('Replaced by OnRunVATEntriesOnAfterSetVATEntryFilters event in "VAT Statement Calc. Events CZL" codeunit.', '28.0')]
     [IntegrationEvent(true, false)]
     local procedure OnBeforeOpenPageVATEntryTotaling(var VATEntry: Record "VAT Entry"; var VATStatementLine: Record "VAT Statement Line")
     begin
@@ -220,7 +220,7 @@ page 31136 "VAT Statement Preview Line CZL"
     begin
     end;
 #if not CLEAN28
-    [Obsolete('Replaced by OnHandleAnotherLineType event in "VAT Statement Calculation CZL" codeunit.', '28.0')]
+    [Obsolete('Replaced by OnHandleAnotherLineType event in "VAT Statement Calc. Events CZL" codeunit.', '28.0')]
     [IntegrationEvent(false, false)]
     local procedure OnColumnValueDrillDownVATStatementLineTypeCase(VATStatementLine: Record "VAT Statement Line"; var IsHandled: Boolean)
     begin

--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/Permissions/CZCorePackObjectsCZL.PermissionSet.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/Permissions/CZCorePackObjectsCZL.PermissionSet.al
@@ -147,6 +147,7 @@ permissionset 11732 "CZ Core Pack - Objects CZL"
                   codeunit "Workflow Response Handling CZL" = X,
                   codeunit "Purch. Inv. Header - Edit CZL" = X,
                   codeunit "VAT LCY Correction Mgt. CZL" = X,
+                  codeunit "VAT Statement Calc. Events CZL" = X,
                   page "Accountant CZ Role Center CZL" = X,
                   page "Acc. Sched.page.Drill-Down CZL" = X,
                   page "Acc. Sched. Res. Hdr. List CZL" = X,


### PR DESCRIPTION
## Describe the issue

Event OnBeforeOpenPageVATEntryTotaling is marked as obsolete with this message:

Method 'OnBeforeOpenPageVATEntryTotaling' is marked for removal. Reason: Replaced by OnRunVATEntriesOnAfterSetVATEntryFilters event in "VAT Statement Calculation CZL" codeunit.. Tag: 28.0.

This is problem because mentioned new event is in Codeunit that is set with Access=Internal. It means that we can't use new event. Codeunit should have access for other application or you have to use different object with event. This makes breaking change for us.

## Solution

Moved local events to separated codeunit "VAT Statement Calc. Events CZL"

## Linked work

Fixes [AB#633618](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633618)

