### PR TITLE
Reset workflow templates no longer removes steps from active workflows

### DIFF
--- a/src/Layers/W1/BaseApp/System/Workflow/WorkflowSetup.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/Workflow/WorkflowSetup.Codeunit.al
@@ -261,16 +261,21 @@ codeunit 1502 "Workflow Setup"
     begin
         Workflow.SetRange(Template, true);
         Workflow.SetFilter(Code, '%1', GetWorkflowTemplateToken() + '*');
-        Workflow.DeleteAll();
-
-        WorkflowStep.SetFilter("Workflow Code", '%1', GetWorkflowTemplateToken() + '*');
-        if WorkflowStep.FindSet() then begin
+        if Workflow.FindSet() then
             repeat
-                WorkflowStepArgument.SetRange(ID, WorkflowStep.Argument);
-                WorkflowStepArgument.DeleteAll();
-            until WorkflowStep.Next() = 0;
-            WorkflowStep.DeleteAll();
-        end;
+                // Only delete the steps that belong to the template itself. Workflows created from a
+                // template keep the template token prefix in their code (e.g. MS-XYZ-01) but are not
+                // templates, so filtering steps by the token wildcard would also delete their steps.
+                WorkflowStep.SetRange("Workflow Code", Workflow.Code);
+                if WorkflowStep.FindSet() then begin
+                    repeat
+                        WorkflowStepArgument.SetRange(ID, WorkflowStep.Argument);
+                        WorkflowStepArgument.DeleteAll();
+                    until WorkflowStep.Next() = 0;
+                    WorkflowStep.DeleteAll();
+                end;
+            until Workflow.Next() = 0;
+        Workflow.DeleteAll();
 
         InitWorkflow();
     end;

--- a/src/Layers/W1/BaseApp/System/Workflow/WorkflowTemplates.Page.al
+++ b/src/Layers/W1/BaseApp/System/Workflow/WorkflowTemplates.Page.al
@@ -85,12 +85,14 @@ page 1505 "Workflow Templates"
                 Caption = 'Reset Microsoft Templates';
                 Visible = not IsLookupMode;
                 Image = ResetStatus;
-                ToolTip = 'Recreate all Microsoft templates';
+                ToolTip = 'Delete and recreate the built-in Microsoft workflow templates. This affects only the templates, not the workflows that were created from them.';
 
                 trigger OnAction()
                 var
                     WorkflowSetup: Codeunit "Workflow Setup";
                 begin
+                    if not Confirm(ResetTemplatesQst) then
+                        exit;
                     WorkflowSetup.ResetWorkflowTemplates();
                     Initialize();
                 end;
@@ -151,6 +153,7 @@ page 1505 "Workflow Templates"
     var
         WorkflowSetup: Codeunit "Workflow Setup";
         QueryClosePageLookupErr: Label 'Select a workflow template to continue, or choose Cancel to close the page.';
+        ResetTemplatesQst: Label 'This will delete and recreate all Microsoft workflow templates. Do you want to continue?';
         DescriptionStyle: Text;
 
     protected var

--- a/src/Layers/W1/Tests/Workflow/CopyWorkflowTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Workflow/CopyWorkflowTests.Codeunit.al
@@ -14,6 +14,8 @@ codeunit 134306 "Copy Workflow Tests"
         AmountCondXmlTemplateTxt: Label '<?xml version="1.0" standalone="yes"?><ReportParameters name="Purch. Inv. Event Conditions" id="1502"><DataItems><DataItem name="Purchase Header">SORTING(Document Type,No.) WHERE(Amount=FILTER(%1))</DataItem><DataItem name="Purchase Line">SORTING(Document Type,Document No.,Line No.)</DataItem></DataItems></ReportParameters>', Locked = true;
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
+        LibraryVariableStorage: Codeunit "Library - Variable Storage";
+        ResetTemplatesConfirmQst: Label 'delete and recreate all Microsoft workflow templates', Locked = true;
 
     [Test]
     [Scope('OnPrem')]
@@ -351,7 +353,7 @@ codeunit 134306 "Copy Workflow Tests"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerYes')]
+    [HandlerFunctions('ConfirmHandler')]
     [Scope('OnPrem')]
     procedure TestResetTemplatesKeepsStepsOfWorkflowCreatedFromTemplate()
     var
@@ -379,6 +381,8 @@ codeunit 134306 "Copy Workflow Tests"
         CreateTwoStepWorkflowWithCode(WorkflowFromTemplate, WorkflowFromTemplateCode);
 
         // [WHEN] The user runs Reset Microsoft Templates and confirms.
+        LibraryVariableStorage.Enqueue(ResetTemplatesConfirmQst);
+        LibraryVariableStorage.Enqueue(true);
         WorkflowTemplatesPage.OpenView();
         WorkflowTemplatesPage."Reset Templates".Invoke();
 
@@ -386,10 +390,11 @@ codeunit 134306 "Copy Workflow Tests"
         Assert.IsTrue(WorkflowFromTemplate.Get(WorkflowFromTemplateCode), 'The workflow created from the template must not be deleted.');
         WorkflowStep.SetRange("Workflow Code", WorkflowFromTemplateCode);
         Assert.IsFalse(WorkflowStep.IsEmpty(), 'The steps of the workflow created from the template must not be deleted.');
+        LibraryVariableStorage.AssertEmpty();
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerNo')]
+    [HandlerFunctions('ConfirmHandler')]
     [Scope('OnPrem')]
     procedure TestResetTemplatesIsSkippedWhenConfirmationDeclined()
     var
@@ -409,15 +414,19 @@ codeunit 134306 "Copy Workflow Tests"
         TemplateWorkflow.Modify(true);
 
         // [WHEN] The user runs Reset Microsoft Templates but declines the confirmation.
+        LibraryVariableStorage.Enqueue(ResetTemplatesConfirmQst);
+        LibraryVariableStorage.Enqueue(false);
         WorkflowTemplatesPage.OpenView();
         WorkflowTemplatesPage."Reset Templates".Invoke();
 
         // [THEN] Nothing is reset: the template still exists.
         Assert.IsTrue(TemplateWorkflow.Get(TemplateCode), 'The templates must not be reset when the confirmation is declined.');
+        LibraryVariableStorage.AssertEmpty();
     end;
 
     local procedure Initialize()
     begin
+        LibraryVariableStorage.Clear();
         LibraryWorkflow.DeleteAllExistingWorkflows();
     end;
 
@@ -531,15 +540,10 @@ codeunit 134306 "Copy Workflow Tests"
     end;
 
     [ConfirmHandler]
-    procedure ConfirmHandlerYes(Question: Text[1024]; var Reply: Boolean)
+    procedure ConfirmHandler(Question: Text[1024]; var Reply: Boolean)
     begin
-        Reply := true;
-    end;
-
-    [ConfirmHandler]
-    procedure ConfirmHandlerNo(Question: Text[1024]; var Reply: Boolean)
-    begin
-        Reply := false;
+        Assert.ExpectedConfirm(LibraryVariableStorage.DequeueText(), Question);
+        Reply := LibraryVariableStorage.DequeueBoolean();
     end;
 }
 

--- a/src/Layers/W1/Tests/Workflow/CopyWorkflowTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Workflow/CopyWorkflowTests.Codeunit.al
@@ -350,6 +350,72 @@ codeunit 134306 "Copy Workflow Tests"
         Assert.AreEqual(0, FromWorkflow.Count, 'A new workflow was created.')
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandlerYes')]
+    [Scope('OnPrem')]
+    procedure TestResetTemplatesKeepsStepsOfWorkflowCreatedFromTemplate()
+    var
+        TemplateWorkflow: Record Workflow;
+        WorkflowFromTemplate: Record Workflow;
+        WorkflowStep: Record "Workflow Step";
+        WorkflowSetup: Codeunit "Workflow Setup";
+        WorkflowTemplatesPage: TestPage "Workflow Templates";
+        TemplateCode: Code[20];
+        WorkflowFromTemplateCode: Code[20];
+    begin
+        // [SCENARIO 640937] Resetting Microsoft templates must not remove the steps of active
+        // workflows that were created from a template and still carry the template code prefix.
+
+        // [GIVEN] A workflow template whose code starts with the Microsoft template token, with steps.
+        Initialize();
+        TemplateCode := CopyStr(WorkflowSetup.GetWorkflowTemplateToken() + 'BUG640937', 1, MaxStrLen(TemplateWorkflow.Code));
+        CreateTwoStepWorkflowWithCode(TemplateWorkflow, TemplateCode);
+        TemplateWorkflow.Validate(Template, true);
+        TemplateWorkflow.Modify(true);
+
+        // [GIVEN] An active (non-template) workflow created from that template: its code keeps the
+        // template token prefix (e.g. MS-...-01) and it has its own steps.
+        WorkflowFromTemplateCode := CopyStr(TemplateCode + '-01', 1, MaxStrLen(WorkflowFromTemplate.Code));
+        CreateTwoStepWorkflowWithCode(WorkflowFromTemplate, WorkflowFromTemplateCode);
+
+        // [WHEN] The user runs Reset Microsoft Templates and confirms.
+        WorkflowTemplatesPage.OpenView();
+        WorkflowTemplatesPage."Reset Templates".Invoke();
+
+        // [THEN] The active workflow still exists and keeps all of its steps.
+        Assert.IsTrue(WorkflowFromTemplate.Get(WorkflowFromTemplateCode), 'The workflow created from the template must not be deleted.');
+        WorkflowStep.SetRange("Workflow Code", WorkflowFromTemplateCode);
+        Assert.IsFalse(WorkflowStep.IsEmpty(), 'The steps of the workflow created from the template must not be deleted.');
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandlerNo')]
+    [Scope('OnPrem')]
+    procedure TestResetTemplatesIsSkippedWhenConfirmationDeclined()
+    var
+        TemplateWorkflow: Record Workflow;
+        WorkflowSetup: Codeunit "Workflow Setup";
+        WorkflowTemplatesPage: TestPage "Workflow Templates";
+        TemplateCode: Code[20];
+    begin
+        // [SCENARIO 640937] The Reset Microsoft Templates action asks for confirmation and does
+        // nothing when the user declines.
+
+        // [GIVEN] A Microsoft workflow template with steps.
+        Initialize();
+        TemplateCode := CopyStr(WorkflowSetup.GetWorkflowTemplateToken() + 'BUG640937', 1, MaxStrLen(TemplateWorkflow.Code));
+        CreateTwoStepWorkflowWithCode(TemplateWorkflow, TemplateCode);
+        TemplateWorkflow.Validate(Template, true);
+        TemplateWorkflow.Modify(true);
+
+        // [WHEN] The user runs Reset Microsoft Templates but declines the confirmation.
+        WorkflowTemplatesPage.OpenView();
+        WorkflowTemplatesPage."Reset Templates".Invoke();
+
+        // [THEN] Nothing is reset: the template still exists.
+        Assert.IsTrue(TemplateWorkflow.Get(TemplateCode), 'The templates must not be reset when the confirmation is declined.');
+    end;
+
     local procedure Initialize()
     begin
         LibraryWorkflow.DeleteAllExistingWorkflows();
@@ -438,6 +504,42 @@ codeunit 134306 "Copy Workflow Tests"
                     ToWorkflowRule.TestField("Field No.", FromWorkflowRule."Field No.");
                 until FromWorkflowRule.Next() = 0;
         until ToWorkflowStep.Next() = 0;
+    end;
+
+    local procedure CreateTwoStepWorkflowWithCode(var Workflow: Record Workflow; NewWorkflowCode: Code[20])
+    var
+        WorkflowEvent: Record "Workflow Event";
+        WorkflowRule: Record "Workflow Rule";
+        WorkflowResponseHandling: Codeunit "Workflow Response Handling";
+        EntryPointEventID: Integer;
+        ResponseID: Integer;
+    begin
+        Workflow.Init();
+        Workflow.Code := NewWorkflowCode;
+        Workflow.Description := CopyStr(LibraryUtility.GenerateRandomXMLText(MaxStrLen(Workflow.Description)), 1, MaxStrLen(Workflow.Description));
+        Workflow.Category := LibraryWorkflow.CreateWorkflowCategory();
+        Workflow.Template := false;
+        Workflow.Insert(true);
+
+        CreateAnyPurchaseHeaderEvent(WorkflowEvent);
+        EntryPointEventID := LibraryWorkflow.InsertEntryPointEventStep(Workflow, WorkflowEvent."Function Name");
+        ResponseID := LibraryWorkflow.InsertResponseStep(Workflow, WorkflowResponseHandling.CreateNotificationEntryCode(), EntryPointEventID);
+
+        LibraryWorkflow.InsertEventArgument(EntryPointEventID, StrSubstNo(AmountCondXmlTemplateTxt, Format(LibraryRandom.RandDec(1000, 2))));
+        LibraryWorkflow.InsertEventRule(EntryPointEventID, 0, WorkflowRule.Operator::Changed);
+        LibraryWorkflow.InsertNotificationArgument(ResponseID, UserId, 0, '');
+    end;
+
+    [ConfirmHandler]
+    procedure ConfirmHandlerYes(Question: Text[1024]; var Reply: Boolean)
+    begin
+        Reply := true;
+    end;
+
+    [ConfirmHandler]
+    procedure ConfirmHandlerNo(Question: Text[1024]; var Reply: Boolean)
+    begin
+        Reply := false;
     end;
 }
 


### PR DESCRIPTION
## What & why

Running **Reset Microsoft Templates** on the Workflow Templates page could wipe the steps out of active workflows, not just the templates. This is a Sev 1, data-loss defect (ADO Bug 640937) affecting customers with many workflows created from templates.

Root cause: `ResetWorkflowTemplates()` in codeunit 1502 "Workflow Setup" deleted the workflow *records* correctly (scoped to `Template = true`), but deleted the workflow *steps* using a separate filter that matched only on the `MS-` template code prefix. A workflow created from template `MS-XYZ` gets code `MS-XYZ-01` (`Template = false`, still `MS-` prefixed), so its steps matched that filter and were deleted, leaving the active workflow an empty shell.

The fix iterates the filtered template workflows and deletes steps/step-arguments only for each template's exact `Workflow Code`, then deletes the templates. Because `Code` is the primary key and a non-template can't reuse a template's exact code, scoping the deletion this way is provably safe. Workflows created from templates are never touched. As additional safety and clarity, the Reset action now asks for confirmation and has a clearer tooltip describing the corrected, templates-only behavior.

## Linked work

[AB#640937](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640937)

<!-- ADO Bug 640937: "Resetting Workflow Templates Removes Steps from Active Workflows". Tracked internally in Azure DevOps; no public GitHub issue. -->

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Added two regression tests in `CopyWorkflowTests.Codeunit.al`, both driving the real page action (so they also exercise the new confirmation dialog):
  - `TestResetTemplatesKeepsStepsOfWorkflowCreatedFromTemplate`: creates a template plus a workflow copied from it (`MS-...-01`), runs Reset and confirms, then asserts the copied workflow still exists and keeps all its steps. This fails on the old code and passes with the fix.
  - `TestResetTemplatesIsSkippedWhenConfirmationDeclined`: declines the confirmation and asserts nothing was reset.
- Validated the change by reading the full diff and cross-checking it against the `Library - Workflow` helper signatures, object visibility, and the surrounding AL. A container build and test run (Docker + BcContainerHelper + platform symbols) was not available in my environment, so those two boxes are intentionally left unchecked pending a local build/run of the Workflow test suite.

## Risk & compatibility

- Behavior fix that stops data loss; no schema or upgrade impact.
- Minor UX change: the Reset Microsoft Templates action now prompts for confirmation before running, and the tooltip/confirmation text are new user-facing strings (picked up by the generated translation file at build time).
- Change is limited to the `W1` base layer; there are no country-layer overrides of these objects, so no Miapp propagation is required.





