### PR TITLE
fix: avoid webhook workflow to crash when processing user does not have required read permission on notifiable table

### DIFF
--- a/src/Layers/W1/BaseApp/System/API/Webhooks/APIWebhookNotificationSend.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/API/Webhooks/APIWebhookNotificationSend.Codeunit.al
@@ -1,7 +1,15 @@
 namespace Microsoft.API.Webhooks;
 
+using Microsoft.Bank.Ledger;
+using Microsoft.CostAccounting.Budget;
+using Microsoft.Finance.GeneralLedger.Budget;
+using Microsoft.Finance.GeneralLedger.Ledger;
 using Microsoft.Integration.Dataverse;
 using Microsoft.Integration.Graph;
+using Microsoft.Inventory.Analysis;
+using Microsoft.Inventory.Ledger;
+using Microsoft.Purchases.Payables;
+using Microsoft.Sales.Receivables;
 using Microsoft.Utilities;
 using System;
 using System.Environment;
@@ -21,7 +29,18 @@ codeunit 6154 "API Webhook Notification Send"
 
     Permissions = TableData "API Webhook Subscription" = rimd,
                   TableData "API Webhook Notification" = rimd,
-                  TableData "API Webhook Notification Aggr" = rimd;
+                  TableData "API Webhook Notification Aggr" = rimd,
+                  TableData "G/L Entry" = r,
+                  TableData "Item Ledger Entry" = r,
+                  TableData "Cust. Ledger Entry" = r,
+                  TableData "Detailed Cust. Ledg. Entry" = r,
+                  TableData "Vendor Ledger Entry" = r,
+                  TableData "Detailed Vendor Ledg. Entry" = r,
+                  TableData "G/L Register" = r,
+                  TableData "Item Budget Entry" = r,
+                  TableData "Cost Budget Entry" = r,
+                  TableData "G/L Budget Entry" = r,
+                  TableData "Bank Account Ledger Entry" = r;
 
     trigger OnRun()
     var
@@ -194,6 +213,7 @@ codeunit 6154 "API Webhook Notification Send"
         PostFailedTxt: Label 'Notification POST failed. Notification URL: %1. Response code %2.', Locked = true;
         PostCorrelationGuidTxt: Label 'Correlation GUID for notification POST created: %1', Locked = true;
         SameNotificationUrlDifferentTypeErr: Label 'Same notification URL cannot have multiple subscrition types.', Locked = true;
+        UserDoesNotHaveReadPermissionOnSubscribedTableMsg: Label 'User does not have read permission on subscribed table.', Locked = true;
 
     local procedure Initialize()
     begin
@@ -672,6 +692,7 @@ codeunit 6154 "API Webhook Notification Send"
 
     local procedure IsNullUpdate(var APIWebhookNotification: Record "API Webhook Notification"): Boolean
     var
+        [SecurityFiltering(SecurityFilter::Ignored)]
         RecordRef: RecordRef;
         ModifiedAt: DateTime;
         TableId: Integer;
@@ -687,6 +708,14 @@ codeunit 6154 "API Webhook Notification Send"
             exit(false);
 
         RecordRef.Open(TableId);
+
+        // ensure processing user has enough permission to check if notifiable record still exists
+        // this is to prevent crash during payload generation due to missing read access
+        if not RecordRef.ReadPermission then begin
+            Session.LogMessage('0000EW6', UserDoesNotHaveReadPermissionOnSubscribedTableMsg, Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', APIWebhookCategoryLbl, 'TableNumber', Format(TableId, 0, 9));
+            exit(false);
+        end;
+
         if not RecordRef.GetBySystemId(APIWebhookNotification."Entity ID") then begin
             // record has already been deleted
             Session.LogMessage('0000EW4', StrSubstNo(MissingEntityForNotificationTxt, GetSystemIdBySubscriptionId(APIWebhookNotification."Subscription ID"),
@@ -1939,4 +1968,3 @@ codeunit 6154 "API Webhook Notification Send"
     begin
     end;
 }
-


### PR DESCRIPTION
## What & why

when user does not have direct read access against notifiable table, emit event `0000EW6` with warning level and related table in attached metadata.

in such situation, assume there are no change to send against third party platform.

add delegated read access on financial tables which end user used to be denied access for confidential purpose.

## Linked work

Fixes #8549, AB#102318

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

- No tests added because change are tied to ACL only

## Risk & compatibility

### Security

Delegate permission have been added to the codeunit to avoid issue when webhook system is used with Entry* tables

* G/L Entry (read)
* Item Ledger Entry (read)
* Cust. Ledger Entry (read)
* Detailed Cust. Ledg. Entry (read)
* Vendor Ledger Entry (read)
* Detailed Vendor Ledg. Entry (read)
* G/L Register (read)
* Item Budget Entry (read)
* Cost Budget Entry (read)
* G/L Budget Entry (read)
* Bank Account Ledger Entry (read)

Also, Security Filter have been ignored in `IsNullUpdate` when the function is attempting to determine if the record still exists in the system.

### Telemetry

New Telemetry Event has been introduced to track cases when triggering user do not have enough permission to execute webhook job (missing read access against the notified table).

**General dimensions**

| Dimension    | Description or value |
| -------------- | ---------------------- |
| message       | **User does not have read permission on subscribed table.**
| severityLevel | **2**
| user_Id          | The user telemetry ID for the user. From the user card, you can use user_Id to identify the user who triggered this telemetry event. Learn more in [Assign a telemetry ID to users](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/administration/telemetry-enable-application-insights#assign-a-telemetry-id-to-users). |

**Custom dimensions**

| Dimension | Description or value |
| --------- | ------ |
| eventId | **AL0000EW6** |
| alCategory | **AL API Webhook** |
| alTableNumber | Specifies the ID of the table that includes the changed field. |

