### PR TITLE
[SOA] Disable available-items-only search by default

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Codeunit.al
@@ -324,7 +324,7 @@ codeunit 4400 "SOA Setup"
         SOASetup."Quote Review" := false;
         SOASetup."Order Review" := false;
         SOASetup."Create Order from Quote" := true;
-        SOASetup."Search Only Available Items" := true;
+        SOASetup."Search Only Available Items" := false;
         SOASetup."Incl. Capable to Promise" := false;
         SOASetup."Send Sales Quote" := true;
     end;


### PR DESCRIPTION
## What & why

New Sales Order Agent setups currently enable `Search Only Available Items` by default. This change disables the setting by default so the agent searches all items unless an administrator explicitly enables the availability restriction.

## Linked work

Fixes [AB#642623](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/642623)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Confirmed the default initialization now assigns `false` to `Search Only Available Items`.
- Ran `git diff --check` successfully.
- No automated test was added because this is a one-line default-value change and the Sales Order Agent test app is maintained outside BCApps.

## Risk & compatibility

- Existing setup records are unchanged.
- Administrators can still enable `Search Only Available Items`.
- The behavior change applies only when default setup values are initialized.



