### PR TITLE
Fix #9256: set dev container memory limit from AL-Go settings

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -12,6 +12,7 @@
   "country": "base",
   "useProjectDependencies": true,
   "repoVersion": "29.0",
+  "memoryLimit": "16G",
   "numberOfTenantsForTesting": 3,
   "workspaceCompilation": {
     "enabled": true,

--- a/build/scripts/DevEnv/NewDevEnv.psm1
+++ b/build/scripts/DevEnv/NewDevEnv.psm1
@@ -61,9 +61,14 @@ function Create-BCContainer {
         # Get artifactUrl from branch
         $artifactUrl = Get-CurrentBCArtifactUrl
 
+        $memoryLimit = Get-ConfigValue -Key "memoryLimit" -ConfigType AL-Go
+        if (-not $memoryLimit) {
+            $memoryLimit = "16G"
+        }
+
         # Create a new container with a single tenant
         $bcContainerHelperConfig.sandboxContainersAreMultitenantByDefault = $false
-        New-BcContainer -artifactUrl $artifactUrl -accept_eula -accept_insiderEula -containerName $ContainerName -auth $Authentication -Credential $Credential -includeAL -additionalParameters @("--volume ""$($baseFolder):c:\sources""")
+        New-BcContainer -artifactUrl $artifactUrl -accept_eula -accept_insiderEula -containerName $ContainerName -auth $Authentication -Credential $Credential -includeAL -memoryLimit $memoryLimit -additionalParameters @("--volume ""$($baseFolder):c:\sources""")
 
         # Move all installed apps to the dev scope
         # By default, the container is created with the global scope. We need to move all installed apps to the dev scope.


### PR DESCRIPTION
## What & why

`NewDevEnv` created the local dev container with BcContainerHelper's default 8Gb memory limit. That is too little to publish the Base Application via the dev endpoint: the server tier runs out of memory (`System.OutOfMemoryException`), the publish hangs and eventually times out, and the container's Business Central service becomes unresponsive. This is the failure reported in #9256.

CI already runs its containers at 16Gb (via the AL-Go `NewBcContainer.ps1` override and the per-project `Test Apps` settings), so only the local dev path was affected.

This change makes the memory limit an explicit, readable repo setting so local dev matches CI:
- Adds a top-level `"memoryLimit": "16G"` to `.github/AL-Go-Settings.json`.
- `Create-BCContainer` now reads it with `Get-ConfigValue -Key "memoryLimit" -ConfigType AL-Go` (falling back to `16G`) and passes it to `New-BcContainer`.

## Linked work

Fixes #9256

[AB#643353](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643353)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Reproduced #9256 on the default container: built the BaseApp from `src/Layers/W1/BaseApp` and published System App + Business Foundation + Base App via the dev endpoint. System App and Business Foundation published fine, but the Base App publish drove the server tier past the 8Gb container limit (`docker inspect .HostConfig.Memory = 8589934592`), logged repeated `System.OutOfMemoryException (0x8007000E)` in the container event log, and the publish hung with BC unresponsive.
- Verified the fix: recreated the container via the real `Create-BCContainer` code path. It read the new setting and created the container with a 16Gb limit (`docker inspect .HostConfig.Memory = 17179869184`). Re-publishing the same apps completed successfully, with the Base App installed and synced and no OutOfMemoryException.
- No automated tests added: this only changes local dev container provisioning (a settings value plus how the DevEnv script reads it); it has no product behavior or test coverage of its own.

## Risk & compatibility

Low risk, local-dev only. It does not change any app code or CI behavior (CI already used 16Gb). The per-project `Test Apps */.AL-Go/settings.json` still set `memoryLimit: 16G`; those are now redundant with the global default but were left untouched to keep the change minimal.
