### PR TITLE
Guard SignUpConnectionSetup.Insert() in InitConnectionSetup

### DIFF
--- a/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpAuthentication.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpAuthentication.Codeunit.al
@@ -59,7 +59,8 @@ codeunit 6442 "SignUp Authentication"
         this.SignUpConnectionSetup."Service URL" := this.GetServiceApi();
         this.StorageSet(this.SignUpConnectionSetup."Marketplace Tenant", this.GetMarketplaceTenant());
         this.StorageSet(this.SignUpConnectionSetup."Client Tenant", this.GetClientTenant());
-        if this.SignUpConnectionSetup.Insert() then;
+        if not this.SignUpConnectionSetup.Insert() then
+            this.SignUpConnectionSetup.Modify();
     end;
 
     /// <summary>

--- a/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpAuthentication.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpAuthentication.Codeunit.al
@@ -59,7 +59,7 @@ codeunit 6442 "SignUp Authentication"
         this.SignUpConnectionSetup."Service URL" := this.GetServiceApi();
         this.StorageSet(this.SignUpConnectionSetup."Marketplace Tenant", this.GetMarketplaceTenant());
         this.StorageSet(this.SignUpConnectionSetup."Client Tenant", this.GetClientTenant());
-        this.SignUpConnectionSetup.Insert();
+        if this.SignUpConnectionSetup.Insert() then;
     end;
 
     /// <summary>


### PR DESCRIPTION
## Summary

Guards the `SignUpConnectionSetup.Insert()` call in `InitConnectionSetup`: if the insert fails (the record already exists), it falls back to `Modify()` instead of raising an error.

```al
- this.SignUpConnectionSetup.Insert();
+ if not this.SignUpConnectionSetup.Insert() then
+     this.SignUpConnectionSetup.Modify();
```

[AB#622605](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622605)

