### PR TITLE
Use random password in CDS connection setup tests

### DIFF
--- a/src/Layers/W1/Tests/CRM integration/CDSConnectionSetupTest.Codeunit.al
+++ b/src/Layers/W1/Tests/CRM integration/CDSConnectionSetupTest.Codeunit.al
@@ -621,6 +621,7 @@ codeunit 139196 "CDS Connection Setup Test"
     procedure ServerAddressRequiredToEnableO365()
     var
         CDSConnectionSetup: Record "CDS Connection Setup";
+        Any: Codeunit "Any";
         DummyPassword: Text;
     begin
         // [FEATURE] [UT]
@@ -629,7 +630,7 @@ codeunit 139196 "CDS Connection Setup Test"
         CDSConnectionSetup.DeleteAll();
         CDSConnectionSetup.Init();
         CDSConnectionSetup."User Name" := 'tester@domain.net';
-        DummyPassword := 'T3sting!';
+        DummyPassword := Any.AlphanumericText(20);
         CDSConnectionSetup.SetPassword(DummyPassword);
         CDSConnectionSetup."Authentication Type" := CDSConnectionSetup."Authentication Type"::Office365;
         CDSConnectionSetup.Insert();
@@ -644,6 +645,7 @@ codeunit 139196 "CDS Connection Setup Test"
     procedure ServerAddressRequiredToEnable()
     var
         CDSConnectionSetup: Record "CDS Connection Setup";
+        Any: Codeunit "Any";
         DummyPassword: Text;
     begin
         // [FEATURE] [UT]
@@ -652,7 +654,7 @@ codeunit 139196 "CDS Connection Setup Test"
         CDSConnectionSetup.DeleteAll();
         CDSConnectionSetup.Init();
         CDSConnectionSetup."User Name" := 'tester@domain.net';
-        DummyPassword := 'T3sting!';
+        DummyPassword := Any.AlphanumericText(20);
         CDSConnectionSetup.SetPassword(DummyPassword);
         CDSConnectionSetup."Authentication Type" := CDSConnectionSetup."Authentication Type"::AD;
         CDSConnectionSetup.Insert();
@@ -1033,6 +1035,7 @@ codeunit 139196 "CDS Connection Setup Test"
     procedure ActionTestConnectionWhenIntegrationDisabled()
     var
         CDSConnectionSetup: Record "CDS Connection Setup";
+        Any: Codeunit "Any";
         CDSConnectionSetupPage: TestPage "CDS Connection Setup";
         DummyPassword: Text;
     begin
@@ -1042,7 +1045,7 @@ codeunit 139196 "CDS Connection Setup Test"
         // [GIVEN] Disabled CDS Connection
         InitializeSetup(false);
         CDSConnectionSetup.Get();
-        DummyPassword := 'test';
+        DummyPassword := Any.AlphanumericText(20);
         CDSConnectionSetup.SetPassword(DummyPassword);
         CDSConnectionSetup.Modify();
         // [GIVEN] Open CDS Connection Setup page
@@ -1373,12 +1376,13 @@ codeunit 139196 "CDS Connection Setup Test"
     local procedure InitializeSetup(HostName: Text; IsEnabled: Boolean)
     var
         CDSConnectionSetup: Record "CDS Connection Setup";
+        Any: Codeunit "Any";
         DummyPassword: Text;
     begin
         CDSConnectionSetup.DeleteAll();
         CDSConnectionSetup.Init();
         CDSConnectionSetup."Server Address" := CopyStr(HostName, 1, MaxStrLen(CDSConnectionSetup."Server Address"));
-        DummyPassword := 'T3sting!';
+        DummyPassword := Any.AlphanumericText(20);
         if IsEnabled then
             CDSConnectionSetup.SetPassword(DummyPassword);
         CDSConnectionSetup."Is Enabled" := IsEnabled;

--- a/src/Layers/W1/Tests/CRM integration/app.json
+++ b/src/Layers/W1/Tests/CRM integration/app.json
@@ -22,6 +22,12 @@
       "publisher": "Microsoft",
       "name": "Library Variable Storage",
       "version": "29.0.0.0"
+    },
+    {
+      "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
+      "publisher": "Microsoft",
+      "name": "Any",
+      "version": "29.0.0.0"
     }
   ],
   "target": "OnPrem",


### PR DESCRIPTION
Replace hardcoded password literals in CDSConnectionSetupTest with random passwords generated via the Any test library (Any.AlphanumericText).

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#642694](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642694)

## How I validated this

- [ x ] I read the full diff and it contains only changes I intended.
- [ x ] I built the affected app(s) locally with no new analyzer warnings.
- [ x ] I ran the change in Business Central and confirmed it behaves as expected.
- [ x ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->





