### PR TITLE
Obsolete MLLM Payables Agent rollout scaffold

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/FileFormat/EDocPDFFileFormat.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/FileFormat/EDocPDFFileFormat.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.EServices.EDocument.Format;
 
 using Microsoft.eServices.EDocument.Processing.Import;
 using Microsoft.eServices.EDocument.Processing.Interfaces;
-using System.Config;
 using System.Utilities;
 
 codeunit 6191 "E-Doc. PDF File Format" implements IEDocFileFormat
@@ -22,12 +21,9 @@ codeunit 6191 "E-Doc. PDF File Format" implements IEDocFileFormat
 
     procedure PreferredStructureDataImplementation(): Enum "Structure Received E-Doc."
     var
-        FeatureConfiguration: Codeunit "Feature Configuration";
         Result: Enum "Structure Received E-Doc.";
-        IsExperiment: Boolean;
     begin
-        IsExperiment := FeatureConfiguration.GetConfiguration(MLLMExperimentTok) = 'mllm';
-        Result := IsExperiment ? "Structure Received E-Doc."::MLLM : "Structure Received E-Doc."::ADI;
+        Result := "Structure Received E-Doc."::MLLM;
 #if not CLEAN29
 #pragma warning disable AL0432
         OnAfterSetIStructureReceivedEDocumentForPdf(Result);
@@ -52,7 +48,4 @@ codeunit 6191 "E-Doc. PDF File Format" implements IEDocFileFormat
     begin
         exit('pdf');
     end;
-
-    var
-        MLLMExperimentTok: Label 'EDocMLLMExtraction', Locked = true;
 }

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/FileFormat/EDocPDFFileFormat.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/FileFormat/EDocPDFFileFormat.Codeunit.al
@@ -28,7 +28,11 @@ codeunit 6191 "E-Doc. PDF File Format" implements IEDocFileFormat
     begin
         IsExperiment := FeatureConfiguration.GetConfiguration(MLLMExperimentTok) = 'mllm';
         Result := IsExperiment ? "Structure Received E-Doc."::MLLM : "Structure Received E-Doc."::ADI;
+#if not CLEAN29
+#pragma warning disable AL0432
         OnAfterSetIStructureReceivedEDocumentForPdf(Result);
+#pragma warning restore AL0432
+#endif
         exit(Result);
     end;
 
@@ -36,10 +40,13 @@ codeunit 6191 "E-Doc. PDF File Format" implements IEDocFileFormat
     /// Allows subscribers to override which structure data implementation is used for PDF processing.
     /// This is specifically used by the Payables Agent to force MLLM processing on, regardless of the experiment setting.
     /// </summary>
+#if not CLEAN29
     [IntegrationEvent(false, false)]
+    [Obsolete('The MLLM Payables Agent feature is fully rolled out; the override event used to roll it out is no longer needed.', '29.0')]
     local procedure OnAfterSetIStructureReceivedEDocumentForPdf(var Result: Enum "Structure Received E-Doc.")
     begin
     end;
+#endif
 
     procedure FileExtension(): Text
     begin

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocMLLMTests.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocMLLMTests.Codeunit.al
@@ -8,7 +8,6 @@ using Microsoft.eServices.EDocument.Format;
 using Microsoft.eServices.EDocument.Processing.Import;
 using Microsoft.eServices.EDocument.Processing.Import.Purchase;
 using Microsoft.Finance.GeneralLedger.Setup;
-using System.TestLibraries.Config;
 
 codeunit 135647 "EDoc MLLM Tests"
 {
@@ -203,66 +202,47 @@ codeunit 135647 "EDoc MLLM Tests"
     end;
 
     [Test]
-    procedure PreferredImpl_ControlAllocation_ReturnsADI()
+    procedure PreferredImpl_ReturnsMLLM()
     var
         EDocPDFFileFormat: Codeunit "E-Doc. PDF File Format";
-        FeatureConfigTestLib: Codeunit "Feature Config Test Lib.";
     begin
-        // [SCENARIO] With control allocation, PreferredStructureDataImplementation returns ADI
+        // [SCENARIO] PDF documents use MLLM as the preferred structure data implementation
         LibraryLowerPermission.SetOutsideO365Scope();
-
-        FeatureConfigTestLib.UseControlAllocation();
-
-        Assert.AreEqual(
-            "Structure Received E-Doc."::ADI,
-            EDocPDFFileFormat.PreferredStructureDataImplementation(),
-            'Control allocation should return ADI');
-    end;
-
-    [Test]
-    procedure PreferredImpl_TreatmentAllocation_ReturnsMLLM()
-    // var
-    //     EDocPDFFileFormat: Codeunit "E-Doc. PDF File Format";
-    //     FeatureConfigTestLib: Codeunit "Feature Config Test Lib.";
-    begin
-        // Bug #624677: ECS must be enabled for this test to pass. See wiki for ECS configuration.
-        // [SCENARIO] With treatment allocation, PreferredStructureDataImplementation returns MLLM
-        // LibraryLowerPermission.SetOutsideO365Scope();
-
-        // FeatureConfigTestLib.UseTreatmentAllocation();
-
-        // Assert.AreEqual(
-        //     "Structure Received E-Doc."::MLLM,
-        //     EDocPDFFileFormat.PreferredStructureDataImplementation(),
-        //     'Treatment allocation should return MLLM');
-    end;
-
-    [Test]
-    procedure PreferredImpl_EventOverride_TakesPrecedence()
-    var
-        EDocPDFFileFormat: Codeunit "E-Doc. PDF File Format";
-        FeatureConfigTestLib: Codeunit "Feature Config Test Lib.";
-        EDocMLLMTests: Codeunit "EDoc MLLM Tests";
-    begin
-        // [SCENARIO] An event subscriber can override the result regardless of experiment allocation
-        LibraryLowerPermission.SetOutsideO365Scope();
-
-        FeatureConfigTestLib.UseControlAllocation(); // Would normally return ADI
-        BindSubscription(EDocMLLMTests);
 
         Assert.AreEqual(
             "Structure Received E-Doc."::MLLM,
             EDocPDFFileFormat.PreferredStructureDataImplementation(),
-            'Event override should take precedence over experiment allocation');
+            'PDF processing should return MLLM');
+    end;
+
+#if not CLEAN29
+    [Test]
+    procedure PreferredImpl_EventOverride_TakesPrecedence()
+    var
+        EDocPDFFileFormat: Codeunit "E-Doc. PDF File Format";
+        EDocMLLMTests: Codeunit "EDoc MLLM Tests";
+    begin
+        // [SCENARIO] An event subscriber can override the default preferred implementation
+        LibraryLowerPermission.SetOutsideO365Scope();
+
+        BindSubscription(EDocMLLMTests);
+
+        Assert.AreEqual(
+            "Structure Received E-Doc."::ADI,
+            EDocPDFFileFormat.PreferredStructureDataImplementation(),
+            'Event override should take precedence over the default');
 
         UnbindSubscription(EDocMLLMTests);
     end;
 
+#pragma warning disable AL0432
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"E-Doc. PDF File Format", OnAfterSetIStructureReceivedEDocumentForPdf, '', false, false)]
-    local procedure OverrideToMLLM(var Result: Enum "Structure Received E-Doc.")
+    local procedure OverrideToADI(var Result: Enum "Structure Received E-Doc.")
     begin
-        Result := "Structure Received E-Doc."::MLLM;
+        Result := "Structure Received E-Doc."::ADI;
     end;
+#pragma warning restore AL0432
+#endif
 
     local procedure EnsureGLSetup()
     var

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocumentStructuredTests.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocumentStructuredTests.Codeunit.al
@@ -15,7 +15,6 @@ using Microsoft.Foundation.Attachment;
 using Microsoft.Purchases.Vendor;
 using Microsoft.Sales.Customer;
 using System.IO;
-using System.TestLibraries.Config;
 using System.TestLibraries.Utilities;
 
 codeunit 139891 "E-Document Structured Tests"
@@ -447,61 +446,20 @@ codeunit 139891 "E-Document Structured Tests"
     end;
     #endregion
 
-    #region Experiment Configuration
+    #region Preferred Structure Implementation
     [Test]
-    procedure TestExperiment_ControlAllocation_PreferredImplIsADI()
+    procedure TestPdfPreferredImplIsMLLM()
     var
         EDocPDFFileFormat: Codeunit "E-Doc. PDF File Format";
-        FeatureConfigTestLib: Codeunit "Feature Config Test Lib.";
     begin
-        // [SCENARIO] With control allocation, the PDF file format returns ADI as the preferred implementation
+        // [SCENARIO] The PDF file format returns MLLM as the preferred structure data implementation
         LibraryLowerPermission.SetOutsideO365Scope();
 
-        FeatureConfigTestLib.UseControlAllocation();
-
         Assert.AreEqual(
-            "Structure Received E-Doc."::ADI,
+            "Structure Received E-Doc."::MLLM,
             EDocPDFFileFormat.PreferredStructureDataImplementation(),
-            'Control allocation should prefer ADI for PDF processing');
+            'PDF processing should prefer MLLM');
     end;
-
-    // Todo: Reenable once #624677 is fixed
-    // [Test]
-    // procedure TestExperiment_TreatmentAllocation_PreferredImplIsMLLM()
-    // var
-    //     EDocPDFFileFormat: Codeunit "E-Doc. PDF File Format";
-    //     FeatureConfigTestLib: Codeunit "Feature Config Test Lib.";
-    // begin
-    //     // [SCENARIO] With treatment allocation, the PDF file format returns MLLM as the preferred implementation
-    //     LibraryLowerPermission.SetOutsideO365Scope();
-
-    //     FeatureConfigTestLib.UseTreatmentAllocation();
-
-    //     Assert.AreEqual(
-    //         "Structure Received E-Doc."::MLLM,
-    //         EDocPDFFileFormat.PreferredStructureDataImplementation(),
-    //         'Treatment allocation should prefer MLLM for PDF processing');
-    // end;
-
-    // Todo: Reenable once #624677 is fixed
-    // [Test]
-    // procedure TestExperiment_TreatmentAllocation_MLLMProcessesValidDocument()
-    // var
-    //     EDocument: Record "E-Document";
-    //     FeatureConfigTestLib: Codeunit "Feature Config Test Lib.";
-    // begin
-    //     // [SCENARIO] With treatment allocation active, MLLM is used to process a valid UBL invoice E2E
-    //     Initialize(Enum::"Service Integration"::"Mock");
-    //     SetupMLLMEDocumentService();
-
-    //     FeatureConfigTestLib.UseTreatmentAllocation();
-
-    //     CreateInboundEDocumentFromJSON(EDocument, 'mllm/mllm-invoice-valid-0.json');
-    //     if ProcessEDocumentToStep(EDocument, "Import E-Document Steps"::"Read into Draft") then
-    //         StructuredValidations.AssertFullMLLMDocumentExtracted(EDocument."Entry No")
-    //     else
-    //         Assert.Fail(EDocumentStatusNotUpdatedErr);
-    // end;
     #endregion
 
     #region Fallback

--- a/src/Apps/W1/PayablesAgent/app/Integration/PAEvents.Codeunit.al
+++ b/src/Apps/W1/PayablesAgent/app/Integration/PAEvents.Codeunit.al
@@ -5,7 +5,9 @@
 namespace Microsoft.Agent.PayablesAgent;
 
 using Microsoft.eServices.EDocument;
+#if not CLEAN29
 using Microsoft.eServices.EDocument.Format;
+#endif
 using Microsoft.eServices.EDocument.Processing.Import;
 using Microsoft.eServices.EDocument.Processing.Import.Purchase;
 using Microsoft.EServices.EDocumentConnector.Microsoft365;

--- a/src/Apps/W1/PayablesAgent/app/Integration/PAEvents.Codeunit.al
+++ b/src/Apps/W1/PayablesAgent/app/Integration/PAEvents.Codeunit.al
@@ -18,6 +18,8 @@ codeunit 3316 "PA Events"
     InherentEntitlements = X;
     InherentPermissions = X;
 
+#if not CLEAN29
+#pragma warning disable AL0432
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"E-Doc. PDF File Format", OnAfterSetIStructureReceivedEDocumentForPdf, '', false, false)]
     local procedure UseMLLMWhenEnabledInSetup(var Result: Enum "Structure Received E-Doc.")
     var
@@ -27,6 +29,8 @@ codeunit 3316 "PA Events"
         if PayablesAgentSetup."Use MLLM Processing" then
             Result := "Structure Received E-Doc."::MLLM;
     end;
+#pragma warning restore AL0432
+#endif
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"E-Doc. Import", OnAfterProcessIncomingEDocument, '', false, false)]
     local procedure TrackFinalizedEDocuments(EDocument: Record "E-Document")

--- a/src/Apps/W1/PayablesAgent/app/Setup/PAMLLMSetup.Page.al
+++ b/src/Apps/W1/PayablesAgent/app/Setup/PAMLLMSetup.Page.al
@@ -1,13 +1,17 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 
-#pragma warning disable AS0007
+#pragma warning disable AS0007, AL0432
 namespace Microsoft.Agent.PayablesAgent;
 
 page 3311 "PA MLLM Setup"
 {
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The MLLM Payables Agent feature is fully rolled out; the setup page used to roll it out is no longer needed.';
+    ObsoleteTag = '29.0';
     PageType = Card;
     Extensible = false;
     ApplicationArea = All;
@@ -38,3 +42,4 @@ page 3311 "PA MLLM Setup"
         Rec.GetSetup();
     end;
 }
+#endif

--- a/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Table.al
+++ b/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Table.al
@@ -68,11 +68,23 @@ table 3303 "Payables Agent Setup"
         {
             DataClassification = SystemMetadata;
         }
+#if not CLEANSCHEMA29
+#pragma warning disable AS0072
         field(11; "Use MLLM Processing"; Boolean)
         {
             Caption = 'Use MLLM Processing';
             DataClassification = SystemMetadata;
+            ObsoleteReason = 'The MLLM Payables Agent feature is fully rolled out; the toggle used to roll it out is no longer needed.';
+#if not CLEAN29
+            ObsoleteState = Pending;
+            ObsoleteTag = '29.0';
+#else
+            ObsoleteState = Removed;
+            ObsoleteTag = '32.0';
+#endif
         }
+#pragma warning restore AS0072
+#endif
         field(12; "Email Review Policy"; Enum "PA Email Review Policy")
         {
             Caption = 'Email review';

--- a/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Table.al
+++ b/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Table.al
@@ -68,7 +68,7 @@ table 3303 "Payables Agent Setup"
         {
             DataClassification = SystemMetadata;
         }
-#if not CLEANSCHEMA29
+#if not CLEANSCHEMA32
 #pragma warning disable AS0072
         field(11; "Use MLLM Processing"; Boolean)
         {


### PR DESCRIPTION
## Summary

The MLLM Payables Agent feature (and MLLM PDF extraction) is fully rolled out. This removes / obsoletes the rollout scaffold so MLLM is the permanent behavior.

## Changes

**Obsoleted the Payables Agent MLLM toggle scaffold** (standard BC obsoletion, Pending, tag 29.0, guarded by CLEAN29 / CLEANSCHEMA29): the `Use MLLM Processing` field (11) on `Payables Agent Setup`, the `PA MLLM Setup` page (3311), the `UseMLLMWhenEnabledInSetup` subscriber in `PA Events`, and the `OnAfterSetIStructureReceivedEDocumentForPdf` integration event + call site on `E-Doc. PDF File Format`.

**Removed the MLLM rollout experiment gate:** `PreferredStructureDataImplementation` no longer consults the `EDocMLLMExtraction` `Feature Configuration` experiment (its `System.Config` using / label are gone) and now returns `MLLM` directly.

**Tests:** experiment-based ADI/MLLM tests are replaced with tests asserting MLLM is the preferred PDF structure implementation; the event-override test is retained (guarded by CLEAN29) while the override event is still pending.

## Notes

- The consuming test in the Microsoft-internal NAV repo (PayablesAgentUtilities) and the submodule pointer bump will follow in a separate NAV PR.

Co-authored with GitHub Copilot.
[AB#642735](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642735)





