### PR TITLE
Fixed Filtering the Sales Order List using the 'Delayed' view the list shows sales orders that are out of scope

### DIFF
--- a/src/Layers/NA/BaseApp/Sales/Document/SalesOrderList.Page.al
+++ b/src/Layers/NA/BaseApp/Sales/Document/SalesOrderList.Page.al
@@ -1192,7 +1192,7 @@ page 9305 "Sales Order List"
         view(Delayed)
         {
             Caption = 'Delayed';
-            Filters = where("Document Type" = const(Order), Status = const(Released), "Completely Shipped" = const(false), "Late Order Shipping" = const(true));
+            Filters = where("Document Type" = const(Order), Status = const(Released), "Completely Shipped" = const(false), "Date Filter" = filter(<= '%workdate'), "Late Order Shipping" = const(true));
         }
         view(Released)
         {

--- a/src/Layers/NO/BaseApp/Sales/Document/SalesOrderList.Page.al
+++ b/src/Layers/NO/BaseApp/Sales/Document/SalesOrderList.Page.al
@@ -1179,7 +1179,7 @@ page 9305 "Sales Order List"
         view(Delayed)
         {
             Caption = 'Delayed';
-            Filters = where("Document Type" = const(Order), Status = const(Released), "Completely Shipped" = const(false), "Late Order Shipping" = const(true));
+            Filters = where("Document Type" = const(Order), Status = const(Released), "Completely Shipped" = const(false), "Date Filter" = filter(<= '%workdate'), "Late Order Shipping" = const(true));
         }
         view(Released)
         {

--- a/src/Layers/RU/BaseApp/Sales/Document/SalesOrderList.Page.al
+++ b/src/Layers/RU/BaseApp/Sales/Document/SalesOrderList.Page.al
@@ -1127,7 +1127,7 @@ page 9305 "Sales Order List"
         view(Delayed)
         {
             Caption = 'Delayed';
-            Filters = where("Document Type" = const(Order), Status = const(Released), "Completely Shipped" = const(false), "Late Order Shipping" = const(true));
+            Filters = where("Document Type" = const(Order), Status = const(Released), "Completely Shipped" = const(false), "Date Filter" = filter(<= '%workdate'), "Late Order Shipping" = const(true));
         }
         view(Released)
         {

--- a/src/Layers/W1/BaseApp/Sales/Document/SalesOrderList.Page.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/SalesOrderList.Page.al
@@ -1163,7 +1163,7 @@ page 9305 "Sales Order List"
         view(Delayed)
         {
             Caption = 'Delayed';
-            Filters = where("Document Type" = const(Order), Status = const(Released), "Completely Shipped" = const(false), "Late Order Shipping" = const(true));
+            Filters = where("Document Type" = const(Order), Status = const(Released), "Completely Shipped" = const(false), "Date Filter" = filter(<= '%workdate'), "Late Order Shipping" = const(true));
         }
         view(Released)
         {


### PR DESCRIPTION
Fixes [AB#642628](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642628)

Needs a backport to 28.x



