### PR TITLE
[main] bug 642743 - Change behavior of OnValidate trigger of "EU 3-Party Intermed. Role CZL" field

### DIFF
--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/TableExtensions/PurchaseHeaderCZL.TableExt.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/TableExtensions/PurchaseHeaderCZL.TableExt.al
@@ -303,8 +303,7 @@ tableextension 11705 "Purchase Header CZL" extends "Purchase Header"
 
             trigger OnValidate()
             begin
-                if "EU 3-Party Intermed. Role CZL" then
-                    "EU 3 Party Trade" := true;
+                "EU 3 Party Trade" := "EU 3-Party Intermed. Role CZL";
             end;
         }
 #if not CLEANSCHEMA27

--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/TableExtensions/SalesHeaderCZL.TableExt.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/TableExtensions/SalesHeaderCZL.TableExt.al
@@ -284,8 +284,7 @@ tableextension 11703 "Sales Header CZL" extends "Sales Header"
 
             trigger OnValidate()
             begin
-                if "EU 3-Party Intermed. Role CZL" then
-                    "EU 3-Party Trade" := true;
+                "EU 3-Party Trade" := "EU 3-Party Intermed. Role CZL";
             end;
         }
         field(31112; "Original Doc. VAT Date CZL"; Date)


### PR DESCRIPTION
## Issue description

When the "EU 3-Party - Intermediary" field is activated in the Sales/Purchase Document header, the system correctly automatically activates the "EU 3-Party Trade" field as well. However, when the "EU 3-Party - Intermediary" field in the document header is deactivated, the system does not deactivate the "EU 3-Party Trade" field, which remains activated. This is a bug.

## Steps to reproduce the issue:

- Create a Sales Invoice for a customer from the EU (in demo data K01000003)

- In the document header, set the "EU 3-Party - Intermediary" field = True. The system automatically sets the "EU 3-Party Trade" field = True upon validation.
- Now set the "EU 3-Party - Intermediary" field = False. The system does not update the "EU 3-Party Trade" field upon validation, which remains = True. This is a bug. Correctly, the system should update this field to = False as well.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#642743](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642743)




