### PR TITLE
[Payables Agent] Write transaction in Payable Agent code triggered by Confirm dialog

### DIFF
--- a/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Codeunit.al
+++ b/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Codeunit.al
@@ -201,19 +201,26 @@ codeunit 3307 "Payables Agent Setup"
     procedure GetAgent(var Agent: Record Agent): Boolean
     var
         PayablesAgentSetup: Record "Payables Agent Setup";
+        SetupChanged: Boolean;
     begin
         PayablesAgentSetup.GetSetup();
         // We attempt to find the agent by the security id stored in the setup record.
         if Agent.Get(PayablesAgentSetup."User Security Id") then
             exit(true);
         // If the agent could not be found, and there was a user security id configured, we need to clear it, since it is not valid anymore.
-        if not IsNullGuid(PayablesAgentSetup."User Security Id") then
+        if not IsNullGuid(PayablesAgentSetup."User Security Id") then begin
             Clear(PayablesAgentSetup."User Security Id");
+            SetupChanged := true;
+        end;
         // If the agent could not be found from the configured security id, we attempt to find it by the user name.
         Agent.SetRange("User Name", AgentUserName());
-        if Agent.FindFirst() then
+        if Agent.FindFirst() then begin
             PayablesAgentSetup."User Security Id" := Agent."User Security ID";
-        PayablesAgentSetup.Modify();
+            SetupChanged := true;
+        end;
+        // Only persist when the setup record actually changed.
+        if SetupChanged then
+            PayablesAgentSetup.Modify();
         exit(not IsNullGuid(Agent."User Security ID"));
     end;
 


### PR DESCRIPTION
## What & why

GetAgent unconditionally called PayablesAgentSetup.Modify(), opening a write transaction even when nothing changed. When invoked from agent action visibility checks (ShowCanCreateAgent) around a Confirm dialog, this left an open write transaction that blocked subsequent Page.RunModal calls. Now only persist when the setup record actually changed.

Fixes [AB#641849](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641849)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.




