### PR TITLE
[Extensibility Request] issue 30352: add SkipNewExpirationDateCheck to OnCheckExpirationDateOnAfterCalcSumLot

### DIFF
--- a/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -4230,6 +4230,7 @@ codeunit 22 "Item Jnl.-Post Line"
         SumOfEntries: Decimal;
         SumLot: Decimal;
         IsHandled: Boolean;
+        SkipNewExpirationDateCheck: Boolean;
     begin
         IsHandled := false;
         OnBeforeCheckExpirationDate(
@@ -4310,8 +4311,9 @@ codeunit 22 "Item Jnl.-Post Line"
                         SumLot := SignFactor * ItemTrackingMgt.SumNewLotOnTrackingSpec(TempTrackingSpecification)
                     else
                         SumLot := SignFactor * TempTrackingSpecification."Quantity (Base)";
-                    OnCheckExpirationDateOnAfterCalcSumLot(SumLot, SignFactor, TempTrackingSpecification);
-                    if (SumOfEntries > 0) and
+                    SkipNewExpirationDateCheck := false;
+                    OnCheckExpirationDateOnAfterCalcSumLot(SumLot, SignFactor, TempTrackingSpecification, SkipNewExpirationDateCheck);
+                    if (not SkipNewExpirationDateCheck) and (SumOfEntries > 0) and
                        ((SumOfEntries <> SumLot) or (TempTrackingSpecification."New Lot No." <> TempTrackingSpecification."Lot No.")
                        or (TempTrackingSpecification."New Package No." <> TempTrackingSpecification."Package No."))
                     then
@@ -8200,7 +8202,7 @@ codeunit 22 "Item Jnl.-Post Line"
 #endif
 
     [IntegrationEvent(false, false)]
-    local procedure OnCheckExpirationDateOnAfterCalcSumLot(var SumLot: Decimal; SignFactor: Integer; var TempTrackingSpecification: Record "Tracking Specification" temporary)
+    local procedure OnCheckExpirationDateOnAfterCalcSumLot(var SumLot: Decimal; SignFactor: Integer; var TempTrackingSpecification: Record "Tracking Specification" temporary; var SkipNewExpirationDateCheck: Boolean)
     begin
     end;
 

--- a/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -4202,6 +4202,7 @@ codeunit 22 "Item Jnl.-Post Line"
         SumOfEntries: Decimal;
         SumLot: Decimal;
         IsHandled: Boolean;
+        SkipNewExpirationDateCheck: Boolean;
     begin
         IsHandled := false;
         OnBeforeCheckExpirationDate(
@@ -4282,8 +4283,9 @@ codeunit 22 "Item Jnl.-Post Line"
                         SumLot := SignFactor * ItemTrackingMgt.SumNewLotOnTrackingSpec(TempTrackingSpecification)
                     else
                         SumLot := SignFactor * TempTrackingSpecification."Quantity (Base)";
-                    OnCheckExpirationDateOnAfterCalcSumLot(SumLot, SignFactor, TempTrackingSpecification);
-                    if (SumOfEntries > 0) and
+                    SkipNewExpirationDateCheck := false;
+                    OnCheckExpirationDateOnAfterCalcSumLot(SumLot, SignFactor, TempTrackingSpecification, SkipNewExpirationDateCheck);
+                    if (not SkipNewExpirationDateCheck) and (SumOfEntries > 0) and
                        ((SumOfEntries <> SumLot) or (TempTrackingSpecification."New Lot No." <> TempTrackingSpecification."Lot No.")
                        or (TempTrackingSpecification."New Package No." <> TempTrackingSpecification."Package No."))
                     then
@@ -8171,7 +8173,7 @@ codeunit 22 "Item Jnl.-Post Line"
 #endif
 
     [IntegrationEvent(false, false)]
-    local procedure OnCheckExpirationDateOnAfterCalcSumLot(var SumLot: Decimal; SignFactor: Integer; var TempTrackingSpecification: Record "Tracking Specification" temporary)
+    local procedure OnCheckExpirationDateOnAfterCalcSumLot(var SumLot: Decimal; SignFactor: Integer; var TempTrackingSpecification: Record "Tracking Specification" temporary; var SkipNewExpirationDateCheck: Boolean)
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -4211,6 +4211,7 @@ codeunit 22 "Item Jnl.-Post Line"
         SumOfEntries: Decimal;
         SumLot: Decimal;
         IsHandled: Boolean;
+        SkipNewExpirationDateCheck: Boolean;
     begin
         IsHandled := false;
         OnBeforeCheckExpirationDate(
@@ -4291,8 +4292,9 @@ codeunit 22 "Item Jnl.-Post Line"
                         SumLot := SignFactor * ItemTrackingMgt.SumNewLotOnTrackingSpec(TempTrackingSpecification)
                     else
                         SumLot := SignFactor * TempTrackingSpecification."Quantity (Base)";
-                    OnCheckExpirationDateOnAfterCalcSumLot(SumLot, SignFactor, TempTrackingSpecification);
-                    if (SumOfEntries > 0) and
+                    SkipNewExpirationDateCheck := false;
+                    OnCheckExpirationDateOnAfterCalcSumLot(SumLot, SignFactor, TempTrackingSpecification, SkipNewExpirationDateCheck);
+                    if (not SkipNewExpirationDateCheck) and (SumOfEntries > 0) and
                        ((SumOfEntries <> SumLot) or (TempTrackingSpecification."New Lot No." <> TempTrackingSpecification."Lot No.")
                        or (TempTrackingSpecification."New Package No." <> TempTrackingSpecification."Package No."))
                     then
@@ -8181,7 +8183,7 @@ codeunit 22 "Item Jnl.-Post Line"
 #endif
 
     [IntegrationEvent(false, false)]
-    local procedure OnCheckExpirationDateOnAfterCalcSumLot(var SumLot: Decimal; SignFactor: Integer; var TempTrackingSpecification: Record "Tracking Specification" temporary)
+    local procedure OnCheckExpirationDateOnAfterCalcSumLot(var SumLot: Decimal; SignFactor: Integer; var TempTrackingSpecification: Record "Tracking Specification" temporary; var SkipNewExpirationDateCheck: Boolean)
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -4229,6 +4229,7 @@ codeunit 22 "Item Jnl.-Post Line"
         SumOfEntries: Decimal;
         SumLot: Decimal;
         IsHandled: Boolean;
+        SkipNewExpirationDateCheck: Boolean;
     begin
         IsHandled := false;
         OnBeforeCheckExpirationDate(
@@ -4309,8 +4310,9 @@ codeunit 22 "Item Jnl.-Post Line"
                         SumLot := SignFactor * ItemTrackingMgt.SumNewLotOnTrackingSpec(TempTrackingSpecification)
                     else
                         SumLot := SignFactor * TempTrackingSpecification."Quantity (Base)";
-                    OnCheckExpirationDateOnAfterCalcSumLot(SumLot, SignFactor, TempTrackingSpecification);
-                    if (SumOfEntries > 0) and
+                    SkipNewExpirationDateCheck := false;
+                    OnCheckExpirationDateOnAfterCalcSumLot(SumLot, SignFactor, TempTrackingSpecification, SkipNewExpirationDateCheck);
+                    if (not SkipNewExpirationDateCheck) and (SumOfEntries > 0) and
                        ((SumOfEntries <> SumLot) or (TempTrackingSpecification."New Lot No." <> TempTrackingSpecification."Lot No.")
                        or (TempTrackingSpecification."New Package No." <> TempTrackingSpecification."Package No."))
                     then
@@ -8198,7 +8200,7 @@ codeunit 22 "Item Jnl.-Post Line"
 #endif
 
     [IntegrationEvent(false, false)]
-    local procedure OnCheckExpirationDateOnAfterCalcSumLot(var SumLot: Decimal; SignFactor: Integer; var TempTrackingSpecification: Record "Tracking Specification" temporary)
+    local procedure OnCheckExpirationDateOnAfterCalcSumLot(var SumLot: Decimal; SignFactor: Integer; var TempTrackingSpecification: Record "Tracking Specification" temporary; var SkipNewExpirationDateCheck: Boolean)
     begin
     end;
 

--- a/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -4241,6 +4241,7 @@ codeunit 22 "Item Jnl.-Post Line"
         SumOfEntries: Decimal;
         SumLot: Decimal;
         IsHandled: Boolean;
+        SkipNewExpirationDateCheck: Boolean;
     begin
         IsHandled := false;
         OnBeforeCheckExpirationDate(
@@ -4321,8 +4322,9 @@ codeunit 22 "Item Jnl.-Post Line"
                         SumLot := SignFactor * ItemTrackingMgt.SumNewLotOnTrackingSpec(TempTrackingSpecification)
                     else
                         SumLot := SignFactor * TempTrackingSpecification."Quantity (Base)";
-                    OnCheckExpirationDateOnAfterCalcSumLot(SumLot, SignFactor, TempTrackingSpecification);
-                    if (SumOfEntries > 0) and
+                    SkipNewExpirationDateCheck := false;
+                    OnCheckExpirationDateOnAfterCalcSumLot(SumLot, SignFactor, TempTrackingSpecification, SkipNewExpirationDateCheck);
+                    if (not SkipNewExpirationDateCheck) and (SumOfEntries > 0) and
                        ((SumOfEntries <> SumLot) or (TempTrackingSpecification."New Lot No." <> TempTrackingSpecification."Lot No.")
                        or (TempTrackingSpecification."New Package No." <> TempTrackingSpecification."Package No."))
                     then
@@ -8516,7 +8518,7 @@ codeunit 22 "Item Jnl.-Post Line"
 #endif
 
     [IntegrationEvent(false, false)]
-    local procedure OnCheckExpirationDateOnAfterCalcSumLot(var SumLot: Decimal; SignFactor: Integer; var TempTrackingSpecification: Record "Tracking Specification" temporary)
+    local procedure OnCheckExpirationDateOnAfterCalcSumLot(var SumLot: Decimal; SignFactor: Integer; var TempTrackingSpecification: Record "Tracking Specification" temporary; var SkipNewExpirationDateCheck: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -4198,6 +4198,7 @@ codeunit 22 "Item Jnl.-Post Line"
         SumOfEntries: Decimal;
         SumLot: Decimal;
         IsHandled: Boolean;
+        SkipNewExpirationDateCheck: Boolean;
     begin
         IsHandled := false;
         OnBeforeCheckExpirationDate(
@@ -4278,8 +4279,9 @@ codeunit 22 "Item Jnl.-Post Line"
                         SumLot := SignFactor * ItemTrackingMgt.SumNewLotOnTrackingSpec(TempTrackingSpecification)
                     else
                         SumLot := SignFactor * TempTrackingSpecification."Quantity (Base)";
-                    OnCheckExpirationDateOnAfterCalcSumLot(SumLot, SignFactor, TempTrackingSpecification);
-                    if (SumOfEntries > 0) and
+                    SkipNewExpirationDateCheck := false;
+                    OnCheckExpirationDateOnAfterCalcSumLot(SumLot, SignFactor, TempTrackingSpecification, SkipNewExpirationDateCheck);
+                    if (not SkipNewExpirationDateCheck) and (SumOfEntries > 0) and
                        ((SumOfEntries <> SumLot) or (TempTrackingSpecification."New Lot No." <> TempTrackingSpecification."Lot No.")
                        or (TempTrackingSpecification."New Package No." <> TempTrackingSpecification."Package No."))
                     then
@@ -8167,7 +8169,7 @@ codeunit 22 "Item Jnl.-Post Line"
 #endif
 
     [IntegrationEvent(false, false)]
-    local procedure OnCheckExpirationDateOnAfterCalcSumLot(var SumLot: Decimal; SignFactor: Integer; var TempTrackingSpecification: Record "Tracking Specification" temporary)
+    local procedure OnCheckExpirationDateOnAfterCalcSumLot(var SumLot: Decimal; SignFactor: Integer; var TempTrackingSpecification: Record "Tracking Specification" temporary; var SkipNewExpirationDateCheck: Boolean)
     begin
     end;
 


### PR DESCRIPTION
## Summary
The reporter needs a way to bypass the mandatory `New Expiration Date` validation performed during item journal posting in codeunit 22 "Item Jnl.-Post Line". The existing `OnBeforeCheckExpirationDate` (IsHandled) event would force them to replicate the whole procedure and skip several downstream events, risking conflicts with other extensions. This PR extends the existing `OnCheckExpirationDateOnAfterCalcSumLot` integration event with a new `var SkipNewExpirationDateCheck: Boolean` parameter so a subscriber can skip only that single `TestField` check without affecting any other logic.

Source issue repository: microsoft/ALAppExtensions; issue number: 30352

## Changes Made
- `OnCheckExpirationDateOnAfterCalcSumLot` - appended a new `var SkipNewExpirationDateCheck: Boolean` parameter to the integration event; `CheckExpirationDate` now initializes it to `false`, passes it to the event, and only performs `TempTrackingSpecification.TestField("New Expiration Date", ...)` when the subscriber has not set it to `true`. Adding a parameter to an existing integration event is non-breaking for current subscribers. The same change was mirrored across the W1 base layer and its country-layer counterparts (ES, APAC, CH, RU, IT).

Fixes [AB#642607](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642607)



