### PR TITLE
[Extensibility Request] issue 30358: add OnBeforeOnPreReport event to Redraw Receivable Bills report

### DIFF
--- a/src/Layers/ES/BaseApp/Local/Sales/Receivables/RedrawReceivableBills.Report.al
+++ b/src/Layers/ES/BaseApp/Local/Sales/Receivables/RedrawReceivableBills.Report.al
@@ -505,12 +505,18 @@ report 7000096 "Redraw Receivable Bills"
     }
 
     trigger OnPreReport()
+    var
+        IsHandled: Boolean;
     begin
-        if NewDueDate = 0D then
-            Error(Text1100000);
+        IsHandled := false;
+        OnBeforeOnPreReport(PostingDate, NewDueDate, NewPmtMethod, IncludeDiscCollExpenses, IncludeRejExpenses, IncludeFinanceCharges, TemplName, BatchName, IsHandled);
+        if not IsHandled then begin
+            if NewDueDate = 0D then
+                Error(Text1100000);
 
-        if not GenJnlBatch.Get(TemplName, BatchName) then
-            Error(Text1100001);
+            if not GenJnlBatch.Get(TemplName, BatchName) then
+                Error(Text1100001);
+        end;
     end;
 
     var
@@ -833,6 +839,11 @@ report 7000096 "Redraw Receivable Bills"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeOnOpenRequestPagePage(var PostingDate: Date; var NewDueDate: Date; var NewPmtMethod: Code[10]; var IncludeDiscCollExpenses: Boolean; var IncludeRejExpenses: Boolean; var IncludeFinanceCharges: Boolean; var TemplName: Code[10]; var BatchName: Code[10])
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeOnPreReport(var PostingDate: Date; var NewDueDate: Date; var NewPmtMethod: Code[10]; var IncludeDiscCollExpenses: Boolean; var IncludeRejExpenses: Boolean; var IncludeFinanceCharges: Boolean; var TemplName: Code[10]; var BatchName: Code[10]; var IsHandled: Boolean)
     begin
     end;
 }


### PR DESCRIPTION
## Summary
The report author needs to automate the Redraw Receivable Bills report (7000096) so it can run in a job queue or from a button without showing the request page or any GUI. Today the `OnPreReport` trigger validates `NewDueDate` and the journal batch before any extension can set the request page variables, which blocks fully automated runs. This PR adds an integration event at the very start of `OnPreReport` so extensions can assign the request page variables and optionally bypass those validations.

Source issue repository: microsoft/AlAppExtensions; issue number: 30358

## Changes Made
- `Report 7000096 "Redraw Receivable Bills" - OnPreReport` - Raised a new `OnBeforeOnPreReport` integration event at the beginning of the trigger, guarded by an `IsHandled` flag (initialized to `false`) so subscribers can populate the request page variables and skip the `NewDueDate` and journal batch validations for automated processing.
- `OnBeforeOnPreReport` - Added the new `[IntegrationEvent(false, false)]` publisher exposing the request page variables and `IsHandled` by reference.

Fixes [AB#618758](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/618758)



