### PR TITLE
[Extensibility Request] issue 30359: add Direction parameter to OnBeforeScheduleRoutingLine

### DIFF
--- a/src/Layers/W1/BaseApp/Manufacturing/Routing/CalculateRoutingLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Routing/CalculateRoutingLine.Codeunit.al
@@ -1364,7 +1364,7 @@ codeunit 99000774 "Calculate Routing Line"
         CalcExpectedCost(ProdOrderRoutingLine, TotalQtyPerOperation, TotalCapacityPerOperation);
 
         IsHandled := false;
-        OnBeforeScheduleRoutingLine(ProdOrderRoutingLine, CalcStartEndDate, IsHandled);
+        OnBeforeScheduleRoutingLine(ProdOrderRoutingLine, CalcStartEndDate, IsHandled, Direction);
         if not IsHandled then
             if ProdOrderRoutingLine."Schedule Manually" then
                 CalculateRoutingLineFixed()
@@ -2345,7 +2345,7 @@ codeunit 99000774 "Calculate Routing Line"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeScheduleRoutingLine(var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var CalcStartEndDate: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeScheduleRoutingLine(var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var CalcStartEndDate: Boolean; var IsHandled: Boolean; var Direction: Option Forward,Backward)
     begin
     end;
 


### PR DESCRIPTION
## Summary
The reporter wants to influence the starting- and ending-datetime calculation in production order routing. To do that, subscribers need access to the scheduling `Direction` so they can adjust it before the routing line is scheduled. This PR exposes `Direction` as a `var` parameter on the existing publisher event so extensions can modify routing behaviour without breaking the base logic.

Source issue repository: microsoft/ALAppExtensions; issue number: 30359

## Changes Made
- `OnBeforeScheduleRoutingLine` (codeunit 99000774 "Calculate Routing Line") - appended `var Direction: Option Forward,Backward` to the publisher signature and passed the in-scope `Direction` from `CalculateRoutingLine` when raising the event, allowing subscribers to read and change the scheduling direction before the line is scheduled.

Fixes [AB#642790](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642790)

