### PR TITLE
[Master]-Act Consumption Qty field in Component of a Firm Planned Order has amounts that point to a Released Production Order that has the same Document No if the component is the same

### DIFF
--- a/src/Layers/IT/BaseApp/Manufacturing/Document/ProdOrderCompLineList.Page.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/Document/ProdOrderCompLineList.Page.al
@@ -5,6 +5,7 @@
 namespace Microsoft.Manufacturing.Document;
 
 using Microsoft.Finance.Dimension;
+using Microsoft.Inventory.Ledger;
 
 page 5407 "Prod. Order Comp. Line List"
 {
@@ -143,10 +144,28 @@ page 5407 "Prod. Order Comp. Line List"
                     AutoFormatType = 0;
                     ApplicationArea = Manufacturing;
                 }
-                field("Act. Consumption (Qty)"; Rec."Act. Consumption (Qty)")
+                field("Act. Consumption (Qty)"; ActConsumptionQtyValue)
                 {
                     ApplicationArea = Manufacturing;
+                    AutoFormatType = 0;
                     Caption = 'Consumed Quantity (Base)';
+                    ToolTip = 'Specifies the quantity of the component that has been posted as consumed by the production order.';
+                    DecimalPlaces = 0 : 5;
+
+                    trigger OnDrillDown()
+                    var
+                        ItemLedgerEntry: Record "Item Ledger Entry";
+                    begin
+                        if not (Rec.Status in [Rec.Status::Released, Rec.Status::Finished]) then
+                            exit;
+                        ItemLedgerEntry.SetCurrentKey("Order Type", "Order No.", "Order Line No.", "Entry Type", "Prod. Order Comp. Line No.");
+                        ItemLedgerEntry.SetRange("Order Type", ItemLedgerEntry."Order Type"::Production);
+                        ItemLedgerEntry.SetRange("Order No.", Rec."Prod. Order No.");
+                        ItemLedgerEntry.SetRange("Order Line No.", Rec."Prod. Order Line No.");
+                        ItemLedgerEntry.SetRange("Entry Type", ItemLedgerEntry."Entry Type"::Consumption);
+                        ItemLedgerEntry.SetRange("Prod. Order Comp. Line No.", Rec."Line No.");
+                        Page.Run(0, ItemLedgerEntry);
+                    end;
                 }
 #if not CLEAN28
                 field("Qty. on Transfer Order (Base)"; Rec."Qty. on Transfer Order (Base)")
@@ -258,6 +277,11 @@ page 5407 "Prod. Order Comp. Line List"
     trigger OnAfterGetRecord()
     begin
         Rec.ShowShortcutDimCode(ShortcutDimCode);
+        if Rec.Status in [Rec.Status::Released, Rec.Status::Finished] then begin
+            Rec.CalcFields("Act. Consumption (Qty)");
+            ActConsumptionQtyValue := Rec."Act. Consumption (Qty)";
+        end else
+            ActConsumptionQtyValue := 0;
     end;
 
     trigger OnNewRecord(BelowxRec: Boolean)
@@ -267,5 +291,6 @@ page 5407 "Prod. Order Comp. Line List"
 
     protected var
         ShortcutDimCode: array[8] of Code[20];
+        ActConsumptionQtyValue: Decimal;
 }
 

--- a/src/Layers/IT/BaseApp/Manufacturing/Document/ProdOrderComponents.Page.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/Document/ProdOrderComponents.Page.al
@@ -14,6 +14,7 @@ using Microsoft.Manufacturing.Reports;
 using Microsoft.Warehouse.Activity;
 using Microsoft.Warehouse.Structure;
 
+
 page 99000818 "Prod. Order Components"
 {
     AutoSplitKey = true;
@@ -177,10 +178,30 @@ page 99000818 "Prod. Order Components"
                 {
                     ApplicationArea = Manufacturing;
                 }
-                field("Act. Consumption (Qty)"; Rec."Act. Consumption (Qty)")
+                field("Act. Consumption (Qty)"; ActConsumptionQtyValue)
                 {
                     ApplicationArea = Manufacturing;
+                    AutoFormatType = 0;
                     Caption = 'Consumed Quantity (Base)';
+                    ToolTip = 'Specifies the quantity of the component that has been posted as consumed by the production order.';
+                    DecimalPlaces = 0 : 5;
+                    Editable = false;
+                    BlankZero = true;
+
+                    trigger OnDrillDown()
+                    var
+                        ItemLedgerEntry: Record "Item Ledger Entry";
+                    begin
+                        if not (Rec.Status in [Rec.Status::Released, Rec.Status::Finished]) then
+                            exit;
+                        ItemLedgerEntry.SetCurrentKey("Order Type", "Order No.", "Order Line No.", "Entry Type", "Prod. Order Comp. Line No.");
+                        ItemLedgerEntry.SetRange("Order Type", ItemLedgerEntry."Order Type"::Production);
+                        ItemLedgerEntry.SetRange("Order No.", Rec."Prod. Order No.");
+                        ItemLedgerEntry.SetRange("Order Line No.", Rec."Prod. Order Line No.");
+                        ItemLedgerEntry.SetRange("Entry Type", ItemLedgerEntry."Entry Type"::Consumption);
+                        ItemLedgerEntry.SetRange("Prod. Order Comp. Line No.", Rec."Line No.");
+                        Page.Run(0, ItemLedgerEntry);
+                    end;
                 }
 #if not CLEAN28
                 field("Qty. on Transfer Order (Base)"; Rec."Qty. on Transfer Order (Base)")
@@ -713,6 +734,11 @@ page 99000818 "Prod. Order Components"
         Rec.ShowShortcutDimCode(ShortcutDimCode);
         if Rec."Variant Code" = '' then
             VariantCodeMandatory := Item.IsVariantMandatory(true, Rec."Item No.");
+        if Rec.Status in [Rec.Status::Released, Rec.Status::Finished] then begin
+            Rec.CalcFields("Act. Consumption (Qty)");
+            ActConsumptionQtyValue := Rec."Act. Consumption (Qty)";
+        end else
+            ActConsumptionQtyValue := 0;
     end;
 
     trigger OnDeleteRecord(): Boolean
@@ -733,6 +759,7 @@ page 99000818 "Prod. Order Components"
     var
         ProdOrderAvailabilityMgt: Codeunit "Prod. Order Availability Mgt.";
         VariantCodeMandatory: Boolean;
+        ActConsumptionQtyValue: Decimal;
 #pragma warning disable AA0074
 #pragma warning disable AA0470
         Text000: Label 'You cannot reserve components with status %1.';

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/ProdOrderCompLineList.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/ProdOrderCompLineList.Page.al
@@ -5,6 +5,7 @@
 namespace Microsoft.Manufacturing.Document;
 
 using Microsoft.Finance.Dimension;
+using Microsoft.Inventory.Ledger;
 
 page 5407 "Prod. Order Comp. Line List"
 {
@@ -138,10 +139,28 @@ page 5407 "Prod. Order Comp. Line List"
                     AutoFormatType = 0;
                     ApplicationArea = Manufacturing;
                 }
-                field("Act. Consumption (Qty)"; Rec."Act. Consumption (Qty)")
+                field("Act. Consumption (Qty)"; ActConsumptionQtyValue)
                 {
                     ApplicationArea = Manufacturing;
+                    AutoFormatType = 0;
                     Caption = 'Consumed Quantity (Base)';
+                    ToolTip = 'Specifies the quantity of the component that has been posted as consumed by the production order.';
+                    DecimalPlaces = 0 : 5;
+
+                    trigger OnDrillDown()
+                    var
+                        ItemLedgerEntry: Record "Item Ledger Entry";
+                    begin
+                        if not (Rec.Status in [Rec.Status::Released, Rec.Status::Finished]) then
+                            exit;
+                        ItemLedgerEntry.SetCurrentKey("Order Type", "Order No.", "Order Line No.", "Entry Type", "Prod. Order Comp. Line No.");
+                        ItemLedgerEntry.SetRange("Order Type", ItemLedgerEntry."Order Type"::Production);
+                        ItemLedgerEntry.SetRange("Order No.", Rec."Prod. Order No.");
+                        ItemLedgerEntry.SetRange("Order Line No.", Rec."Prod. Order Line No.");
+                        ItemLedgerEntry.SetRange("Entry Type", ItemLedgerEntry."Entry Type"::Consumption);
+                        ItemLedgerEntry.SetRange("Prod. Order Comp. Line No.", Rec."Line No.");
+                        Page.Run(0, ItemLedgerEntry);
+                    end;
                 }
                 field("Due Date"; Rec."Due Date")
                 {
@@ -231,6 +250,11 @@ page 5407 "Prod. Order Comp. Line List"
     trigger OnAfterGetRecord()
     begin
         Rec.ShowShortcutDimCode(ShortcutDimCode);
+        if Rec.Status in [Rec.Status::Released, Rec.Status::Finished] then begin
+            Rec.CalcFields("Act. Consumption (Qty)");
+            ActConsumptionQtyValue := Rec."Act. Consumption (Qty)";
+        end else
+            ActConsumptionQtyValue := 0;
     end;
 
     trigger OnNewRecord(BelowxRec: Boolean)
@@ -240,5 +264,6 @@ page 5407 "Prod. Order Comp. Line List"
 
     protected var
         ShortcutDimCode: array[8] of Code[20];
+        ActConsumptionQtyValue: Decimal;
 }
 

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/ProdOrderComponents.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/ProdOrderComponents.Page.al
@@ -14,6 +14,7 @@ using Microsoft.Manufacturing.Reports;
 using Microsoft.Warehouse.Activity;
 using Microsoft.Warehouse.Structure;
 
+
 page 99000818 "Prod. Order Components"
 {
     AutoSplitKey = true;
@@ -177,10 +178,30 @@ page 99000818 "Prod. Order Components"
                 {
                     ApplicationArea = Manufacturing;
                 }
-                field("Act. Consumption (Qty)"; Rec."Act. Consumption (Qty)")
+                field("Act. Consumption (Qty)"; ActConsumptionQtyValue)
                 {
                     ApplicationArea = Manufacturing;
+                    AutoFormatType = 0;
                     Caption = 'Consumed Quantity (Base)';
+                    ToolTip = 'Specifies the quantity of the component that has been posted as consumed by the production order.';
+                    DecimalPlaces = 0 : 5;
+                    Editable = false;
+                    BlankZero = true;
+
+                    trigger OnDrillDown()
+                    var
+                        ItemLedgerEntry: Record "Item Ledger Entry";
+                    begin
+                        if not (Rec.Status in [Rec.Status::Released, Rec.Status::Finished]) then
+                            exit;
+                        ItemLedgerEntry.SetCurrentKey("Order Type", "Order No.", "Order Line No.", "Entry Type", "Prod. Order Comp. Line No.");
+                        ItemLedgerEntry.SetRange("Order Type", ItemLedgerEntry."Order Type"::Production);
+                        ItemLedgerEntry.SetRange("Order No.", Rec."Prod. Order No.");
+                        ItemLedgerEntry.SetRange("Order Line No.", Rec."Prod. Order Line No.");
+                        ItemLedgerEntry.SetRange("Entry Type", ItemLedgerEntry."Entry Type"::Consumption);
+                        ItemLedgerEntry.SetRange("Prod. Order Comp. Line No.", Rec."Line No.");
+                        Page.Run(0, ItemLedgerEntry);
+                    end;
                 }
                 field("Shortcut Dimension 1 Code"; Rec."Shortcut Dimension 1 Code")
                 {
@@ -687,6 +708,11 @@ page 99000818 "Prod. Order Components"
         Rec.ShowShortcutDimCode(ShortcutDimCode);
         if Rec."Variant Code" = '' then
             VariantCodeMandatory := Item.IsVariantMandatory(true, Rec."Item No.");
+        if Rec.Status in [Rec.Status::Released, Rec.Status::Finished] then begin
+            Rec.CalcFields("Act. Consumption (Qty)");
+            ActConsumptionQtyValue := Rec."Act. Consumption (Qty)";
+        end else
+            ActConsumptionQtyValue := 0;
     end;
 
     trigger OnDeleteRecord(): Boolean
@@ -707,6 +733,7 @@ page 99000818 "Prod. Order Components"
     var
         ProdOrderAvailabilityMgt: Codeunit "Prod. Order Availability Mgt.";
         VariantCodeMandatory: Boolean;
+        ActConsumptionQtyValue: Decimal;
 #pragma warning disable AA0074
 #pragma warning disable AA0470
         Text000: Label 'You cannot reserve components with status %1.';

--- a/src/Layers/W1/Tests/SCM/SCMAvailabilitybyEvent.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMAvailabilitybyEvent.Codeunit.al
@@ -32,6 +32,7 @@ codeunit 137009 "SCM Availability by Event"
         LibraryNotificationMgt: Codeunit "Library - Notification Mgt.";
         Initialized: Boolean;
         WrongReservedQtyErr: Label 'Wrong reserved quantity in Item Availability by Event';
+        ProdOrderComponentNotFoundErr: Label 'Mocked Prod. Order Component not found on "Prod. Order Components" page.';
 
     local procedure Initialize()
     begin
@@ -652,6 +653,26 @@ codeunit 137009 "SCM Availability by Event"
           'Asserting that the ultimo Suggested Projected Inventory match');
     end;
 
+    [Test]
+    procedure ActConsumptionQtyHiddenOnFirmPlannedProdOrderComponentsPage()
+    var
+        ProdOrderComponent: Record "Prod. Order Component";
+        ProdOrderComponents: TestPage "Prod. Order Components";
+        MockedQty: Decimal;
+    begin
+        // [SCENARIO 636784] "Act. Consumption (Qty)" on "Prod. Order Components" page is 0 when the component belongs to a Firm Planned production order.
+        Initialize();
+
+        // [GIVEN] A Firm Planned Prod. Order Component with a matching Consumption Item Ledger Entry.
+        MockedQty := LibraryRandom.RandDecInRange(10, 100, 2);
+        MockProdOrderComponentWithStatus(ProdOrderComponent, ProdOrderComponent.Status::"Firm Planned");
+        MockConsumptionItemLedgerEntry(ProdOrderComponent, MockedQty);
+
+        // [WHEN] Open the "Prod. Order Components" page for the component.
+        // [THEN] The "Act. Consumption (Qty)" control shows 0 (value is hidden for Firm Planned status).
+        OpenProdOrderComponentsAndAssertActConsQty(ProdOrderComponent, ProdOrderComponents, 0);
+    end;
+
     local procedure NoSeriesSetup()
     var
         PurchPayablesSetup: Record "Purchases & Payables Setup";
@@ -726,6 +747,51 @@ codeunit 137009 "SCM Availability by Event"
         ProdOrderComponent."Remaining Quantity" := Qty;
         ProdOrderComponent."Remaining Qty. (Base)" := Qty;
         ProdOrderComponent.Insert();
+    end;
+
+    local procedure MockProdOrderComponentWithStatus(var ProdOrderComponent: Record "Prod. Order Component"; NewStatus: Enum "Production Order Status")
+    var
+        Item: Record Item;
+    begin
+        LibraryInventory.CreateItem(Item);
+
+        ProdOrderComponent.Init();
+        ProdOrderComponent.Status := NewStatus;
+        ProdOrderComponent."Prod. Order No." :=
+            CopyStr(LibraryUtility.GenerateRandomCode(ProdOrderComponent.FieldNo("Prod. Order No."), Database::"Prod. Order Component"), 1, MaxStrLen(ProdOrderComponent."Prod. Order No."));
+        ProdOrderComponent."Prod. Order Line No." := 10000;
+        ProdOrderComponent."Line No." := 10000;
+        ProdOrderComponent."Item No." := Item."No.";
+        ProdOrderComponent."Due Date" := WorkDate();
+        ProdOrderComponent.Insert();
+    end;
+
+    local procedure MockConsumptionItemLedgerEntry(ProdOrderComponent: Record "Prod. Order Component"; ConsumedQty: Decimal)
+    var
+        ItemLedgerEntry: Record "Item Ledger Entry";
+    begin
+        ItemLedgerEntry.Init();
+        ItemLedgerEntry."Entry No." := LibraryUtility.GetNewRecNo(ItemLedgerEntry, ItemLedgerEntry.FieldNo("Entry No."));
+        ItemLedgerEntry."Entry Type" := ItemLedgerEntry."Entry Type"::Consumption;
+        ItemLedgerEntry."Order Type" := ItemLedgerEntry."Order Type"::Production;
+        ItemLedgerEntry."Order No." := ProdOrderComponent."Prod. Order No.";
+        ItemLedgerEntry."Order Line No." := ProdOrderComponent."Prod. Order Line No.";
+        ItemLedgerEntry."Prod. Order Comp. Line No." := ProdOrderComponent."Line No.";
+        ItemLedgerEntry."Item No." := ProdOrderComponent."Item No.";
+        ItemLedgerEntry."Posting Date" := WorkDate();
+
+        ItemLedgerEntry.Quantity := -ConsumedQty;
+        ItemLedgerEntry.Insert();
+    end;
+
+    local procedure OpenProdOrderComponentsAndAssertActConsQty(ProdOrderComponent: Record "Prod. Order Component"; var ProdOrderComponents: TestPage "Prod. Order Components"; ExpectedShownQty: Decimal)
+    begin
+        ProdOrderComponents.OpenView();
+        ProdOrderComponents.Filter.SetFilter(Status, Format(ProdOrderComponent.Status));
+        ProdOrderComponents.Filter.SetFilter("Prod. Order No.", ProdOrderComponent."Prod. Order No.");
+        Assert.IsTrue(ProdOrderComponents.First(), ProdOrderComponentNotFoundErr);
+        ProdOrderComponents."Act. Consumption (Qty)".AssertEquals(ExpectedShownQty);
+        ProdOrderComponents.Close();
     end;
 
     local procedure GetRequisitionWkshBatch(): Code[10]


### PR DESCRIPTION
[AB#643947](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643947)

Recreated as a single, clean commit containing only the author's changes (Copilot build/test/CI commits from the previous branch have been dropped).

Supersedes #9630.


