### PR TITLE
[releases/28.x] [Shopify] Make codeunit 30272 "Shpfy Update Price Source" public

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyUpdatePriceSource.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyUpdatePriceSource.Codeunit.al
@@ -10,7 +10,7 @@ using Microsoft.Sales.Customer;
 
 codeunit 30272 "Shpfy Update Price Source"
 {
-    Access = Internal;
+    Access = Public;
     EventSubscriberInstance = Manual;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Price Source - Customer", 'OnBeforeGetId', '', true, false)]


### PR DESCRIPTION
## Summary
Backport of bug #638340 to releases/28.x.

Fixes [AB#643242](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643242)

Original PR: #8587

