### PR TITLE
[releases/28.x] [Shopify] Skip refund credit memo while transaction is pending

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order Refunds/Codeunits/ShpfyRefundsAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/Codeunits/ShpfyRefundsAPI.Codeunit.al
@@ -12,6 +12,7 @@ codeunit 30228 "Shpfy Refunds API"
         JsonHelper: Codeunit "Shpfy Json Helper";
         RefundEnumConvertor: Codeunit "Shpfy Refund Enum Convertor";
         RefundCantCreateCreditMemoErr: Label 'This refund cannot be used to create a credit memo because it has already been considered during order import and reduced the quantity and amounts of the order. Only refunds with a non-zero refunded amount and related to real item returns can be used to create credit memos.';
+        RefundHasPendingTransactionsErr: Label 'This refund cannot be used to create a credit memo or return order yet because it has one or more pending transactions. The refunded amount is only final once the related transactions succeed. Retry after the transactions are no longer pending.';
 
     internal procedure GetRefunds(JRefunds: JsonArray)
     var
@@ -29,6 +30,26 @@ codeunit 30228 "Shpfy Refunds API"
         RefundLine.SetRange("Can Create Credit Memo", false);
         if not RefundLine.IsEmpty() then
             Error(RefundCantCreateCreditMemoErr);
+        if HasPendingRefundTransactions(RefundId) then
+            Error(RefundHasPendingTransactionsErr);
+    end;
+
+    /// <summary>
+    /// Checks whether the refund still has transactions that are pending in Shopify. While a refund
+    /// transaction is pending, Shopify reports a refunded amount of 0, so creating a credit memo at
+    /// that point would produce a balancing line that zeroes out the document.
+    /// </summary>
+    /// <param name="RefundId">The Shopify refund id.</param>
+    /// <returns>True if at least one refund transaction is still pending.</returns>
+    internal procedure HasPendingRefundTransactions(RefundId: BigInteger): Boolean
+    var
+        OrderTransaction: Record "Shpfy Order Transaction";
+    begin
+        OrderTransaction.SetCurrentKey("Refund Id", Type, Status);
+        OrderTransaction.SetRange("Refund Id", RefundId);
+        OrderTransaction.SetRange(Type, "Shpfy Transaction Type"::Refund);
+        OrderTransaction.SetRange(Status, "Shpfy Transaction Status"::Pending);
+        exit(not OrderTransaction.IsEmpty());
     end;
 
     local procedure GetRefund(RefundId: BigInteger; UpdatedAt: DateTime)

--- a/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyRetRefProcCrMemo.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyRetRefProcCrMemo.Codeunit.al
@@ -64,6 +64,7 @@ codeunit 30243 "Shpfy RetRefProc Cr.Memo" implements "Shpfy IReturnRefund Proces
     var
         RefundLine: Record "Shpfy Refund Line";
         CreateSalesDocRefund: codeunit "Shpfy Create Sales Doc. Refund";
+        RefundsAPI: Codeunit "Shpfy Refunds API";
         IDocumentSource: Interface "Shpfy IDocument Source";
         ErrorInfo: ErrorInfo;
         TextBuilder: TextBuilder;
@@ -80,6 +81,9 @@ codeunit 30243 "Shpfy RetRefProc Cr.Memo" implements "Shpfy IReturnRefund Proces
         RefundLine.SetRange("Refund Id", SourceDocumentId);
         RefundLine.SetRange("Can Create Credit Memo", false);
         if not RefundLine.IsEmpty() then
+            exit;
+
+        if (SourceDocumentType = "Shpfy Source Document Type"::Refund) and RefundsAPI.HasPendingRefundTransactions(SourceDocumentId) then
             exit;
 
         CreateSalesDocRefund.SetSource(SourceDocumentId);

--- a/src/Apps/W1/Shopify/App/src/Transactions/Tables/ShpfyOrderTransaction.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Transactions/Tables/ShpfyOrderTransaction.Table.al
@@ -292,6 +292,9 @@ table 30133 "Shpfy Order Transaction"
         key(Key5; "Shopify Order Id", Status)
         {
         }
+        key(Key6; "Refund Id", Type, Status)
+        {
+        }
     }
 
     fieldgroups

--- a/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
@@ -447,10 +447,12 @@ codeunit 139611 "Shpfy Order Refund Test"
         IReturnRefundProcess: Interface "Shpfy IReturnRefund Process";
         CanCreateDocument: Boolean;
         ErrorInfo: ErrorInfo;
+        RefundAccount: Code[20];
     begin
         // [SCENARIO] Create a Credit Memo from a Shopify Refund where only the shipment is refunded.
         Initialize();
         Shop := InitializeTest.CreateShop();
+        RefundAccount := Shop."Refund Account";
         Shop."Refund Account" := '';
         Shop.Modify(false);
 
@@ -474,6 +476,103 @@ codeunit 139611 "Shpfy Order Refund Test"
 
         // Tear down
         ResetProccesOnRefund(RefundId);
+        Shop."Refund Account" := RefundAccount;
+        Shop.Modify(false);
+    end;
+
+    [Test]
+    procedure UnitTestDoesNotCreateCrMemoFromRefundWithPendingTransaction()
+    var
+        SalesHeader: Record "Sales Header";
+        Shop: Record "Shpfy Shop";
+        OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
+        IReturnRefundProcess: Interface "Shpfy IReturnRefund Process";
+        RefundId: BigInteger;
+        OrderId, OrderLineId : BigInteger;
+        ReturnId: BigInteger;
+    begin
+        // [SCENARIO] A credit memo is not created from a refund while it still has a pending transaction (Bug 640432).
+        Initialize();
+
+        // [GIVEN] Shop configured to auto create credit memos
+        Shop := InitializeTest.CreateShop();
+
+        // [GIVEN] A processed Shopify order with a return and a refund that can create a credit memo
+        CerateProcessedShopifyOrder(OrderId, OrderLineId);
+        CreateShopifyReturn(ReturnId, OrderId);
+        RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, ReturnId, 156.38, Shop.Code);
+        OrderRefundsHelper.CreateRefundLine(RefundId, OrderLineId, "Shpfy Restock Type"::Return);
+        // [GIVEN] The refund still has a pending transaction in Shopify
+        OrderRefundsHelper.CreateRefundTransaction(OrderId, RefundId, 156.38, "Shpfy Transaction Status"::Pending);
+
+        // [WHEN] Execute IReturnRefundProcess.CreateSalesDocument(Enum::"Shpfy Source Document Type"::Refund, RefundId)
+        IReturnRefundProcess := Enum::"Shpfy ReturnRefund ProcessType"::"Auto Create Credit Memo";
+        SalesHeader := IReturnRefundProcess.CreateSalesDocument(Enum::"Shpfy Source Document Type"::Refund, RefundId);
+
+        // [THEN] No sales document is created (creation is skipped and retried on a later sync)
+        LibraryAssert.AreEqual('', SalesHeader."No.", 'No credit memo must be created while the refund has a pending transaction.');
+    end;
+
+    [Test]
+    procedure UnitTestCreatesCrMemoFromRefundWithSucceededTransaction()
+    var
+        SalesHeader: Record "Sales Header";
+        Shop: Record "Shpfy Shop";
+        OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
+        IReturnRefundProcess: Interface "Shpfy IReturnRefund Process";
+        RefundId: BigInteger;
+        OrderId, OrderLineId : BigInteger;
+        ReturnId: BigInteger;
+    begin
+        // [SCENARIO] The pending-transaction guard only blocks pending transactions; a succeeded transaction still creates the credit memo (Bug 640432).
+        Initialize();
+
+        // [GIVEN] Shop configured to auto create credit memos
+        Shop := InitializeTest.CreateShop();
+
+        // [GIVEN] A processed Shopify order with a return and a refund that can create a credit memo
+        CerateProcessedShopifyOrder(OrderId, OrderLineId);
+        CreateShopifyReturn(ReturnId, OrderId);
+        RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, ReturnId, 156.38, Shop.Code);
+        OrderRefundsHelper.CreateRefundLine(RefundId, OrderLineId, "Shpfy Restock Type"::Return);
+        // [GIVEN] The refund transaction has already succeeded
+        OrderRefundsHelper.CreateRefundTransaction(OrderId, RefundId, 156.38, "Shpfy Transaction Status"::Success);
+
+        // [WHEN] Execute IReturnRefundProcess.CreateSalesDocument(Enum::"Shpfy Source Document Type"::Refund, RefundId)
+        IReturnRefundProcess := Enum::"Shpfy ReturnRefund ProcessType"::"Auto Create Credit Memo";
+        SalesHeader := IReturnRefundProcess.CreateSalesDocument(Enum::"Shpfy Source Document Type"::Refund, RefundId);
+
+        // [THEN] A credit memo is created
+        LibraryAssert.AreEqual(Enum::"Sales Document Type"::"Credit Memo", SalesHeader."Document Type", 'A credit memo must be created when the refund transaction has succeeded.');
+        LibraryAssert.AreNotEqual('', SalesHeader."No.", 'The credit memo must have a number.');
+    end;
+
+    [Test]
+    procedure UnitTestVerifyRefundCanCreateCreditMemoErrorsWithPendingTransaction()
+    var
+        Shop: Record "Shpfy Shop";
+        OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
+        RefundsAPI: Codeunit "Shpfy Refunds API";
+        RefundId: BigInteger;
+        OrderId, OrderLineId : BigInteger;
+        ReturnId: BigInteger;
+    begin
+        // [SCENARIO] Manually verifying a refund that still has a pending transaction throws an error (Bug 640432).
+        Initialize();
+        Shop := InitializeTest.CreateShop();
+
+        // [GIVEN] A refund that can create a credit memo but still has a pending transaction
+        CerateProcessedShopifyOrder(OrderId, OrderLineId);
+        CreateShopifyReturn(ReturnId, OrderId);
+        RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, ReturnId, 156.38, Shop.Code);
+        OrderRefundsHelper.CreateRefundLine(RefundId, OrderLineId, "Shpfy Restock Type"::Return);
+        OrderRefundsHelper.CreateRefundTransaction(OrderId, RefundId, 156.38, "Shpfy Transaction Status"::Pending);
+
+        // [WHEN] Execute RefundsAPI.VerifyRefundCanCreateCreditMemo
+        asserterror RefundsAPI.VerifyRefundCanCreateCreditMemo(RefundId);
+
+        // [THEN] It throws the pending-transactions error
+        LibraryAssert.ExpectedError('This refund cannot be used to create a credit memo or return order yet because it has one or more pending transactions. The refunded amount is only final once the related transactions succeed. Retry after the transactions are no longer pending.');
     end;
 
     local procedure Initialize()

--- a/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundsHelper.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundsHelper.Codeunit.al
@@ -381,6 +381,20 @@ codeunit 139564 "Shpfy Order Refunds Helper"
         exit(RefundHeader."Refund Id");
     end;
 
+    internal procedure CreateRefundTransaction(OrderId: BigInteger; RefundId: BigInteger; Amount: Decimal; Status: Enum "Shpfy Transaction Status"): BigInteger
+    var
+        OrderTransaction: Record "Shpfy Order Transaction";
+    begin
+        OrderTransaction."Shopify Transaction Id" := Any.IntegerInRange(100000, 9999999);
+        OrderTransaction."Shopify Order Id" := OrderId;
+        OrderTransaction."Refund Id" := RefundId;
+        OrderTransaction.Type := "Shpfy Transaction Type"::Refund;
+        OrderTransaction.Status := Status;
+        OrderTransaction.Amount := Amount;
+        OrderTransaction.Insert();
+        exit(OrderTransaction."Shopify Transaction Id");
+    end;
+
     internal procedure SetDefaultSeed()
     begin
         Any.SetDefaultSeed();


### PR DESCRIPTION
## Summary
Backport of bug #640432 to releases/28.x.

Fixes [AB#643243](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643243)

Original PR: #9112

Cherry-picked #9112's merge commit. Two files needed manual conflict resolution because `releases/28.x` predates a later ""return order"" feature: kept the 28.x wording of the existing `RefundCantCreateCreditMemoErr` label and omitted the unrelated `Shop` lookup that isn't present on this branch. The fix itself (new `HasPendingRefundTransactions` helper, the two guard calls, and the `Refund Id/Type/Status` key) is applied unchanged.

## Test plan
Includes the tests added in #9112:
- `UnitTestDoesNotCreateCrMemoFromRefundWithPendingTransaction`
- `UnitTestCreatesCrMemoFromRefundWithSucceededTransaction`
- `UnitTestVerifyRefundCanCreateCreditMemoErrorsWithPendingTransaction`




