### PR TITLE
[releases/26.5] Trigger SyncMirroredRepository on push instead of schedule

### DIFF
--- a/.azuredevops/SyncMirroredRepository.yml
+++ b/.azuredevops/SyncMirroredRepository.yml
@@ -1,10 +1,8 @@
 name: 1.0.$(Year:yy)$(DayOfYear).$(Rev:r) # This is the build number
 
 pr: none
-trigger: none
-schedules:
-- cron: '0 8 * * *'
-  displayName: Daily Sync
+trigger:
+  batch: true
   branches:
     include:
     - main


### PR DESCRIPTION
This pull request backports #7983 to releases/26.5

Fixes [AB#633614](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633614)

