### PR TITLE
Stabilize partial sales shipment undo test

### DIFF
--- a/src/Layers/W1/Tests/SCM/SCMWarehouseShippingIII.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMWarehouseShippingIII.Codeunit.al
@@ -118,9 +118,9 @@
     begin
         // Test PostiveAdjmt Quantity on Whse Entry after undo Sales Shipment Line with Partial Qty when Items are created with Lot and Serial specific.
         Initialize();
-        Quantity := 100;
+        Quantity := 10;
         CreateItemWithRepSysAssembly(AssemblyItem);
-        ItemTrackingWithSerialSpecific(AssemblyItem, Quantity, Quantity / LibraryRandom.RandInt(3),
+        ItemTrackingWithSerialSpecific(AssemblyItem, Quantity, Quantity / 2,
           ItemTrackingMode::AssignLotNo);
     end;
 


### PR DESCRIPTION
## Problem
`UndoSalesShipmentLinePartialWithAsmItemLotAndItemtrackingSerial` uses 100 serial-tracked units and a random shipment divisor. This adds unnecessary warehouse activity and can make the supposed partial shipment a full shipment.

## Fix
Reduce the quantity to 10 and deterministically ship half. This keeps multiple serial numbers, guarantees a partial shipment, and removes accidental stress and randomness.

This ports the stabilization for [ADO 640085](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/640085) to BCApps main. Release ports are NAV PRs 251310 and 251313.

## Validation
- `git diff --check` passed.
- No editor diagnostics in the changed AL file.
- Full local compilation remains blocked by unavailable matching reference dependencies.

## Risk
Low. Only test data is changed; product code is unaffected.


Fixes [AB#640085](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640085)


