### PR TITLE
Fix missing table permissions on Stale Check action in Check Management Subscriber

### DIFF
--- a/src/Apps/IN/INVoucherInterface/app/src/codeunit/CheckManagementSubscriber.Codeunit.al
+++ b/src/Apps/IN/INVoucherInterface/app/src/codeunit/CheckManagementSubscriber.Codeunit.al
@@ -22,6 +22,11 @@ using Microsoft.Sales.Receivables;
 
 codeunit 18970 "Check Management Subscriber"
 {
+    Permissions = tabledata "Bank Account Ledger Entry" = rm,
+                  tabledata "Check Ledger Entry" = rm,
+                  tabledata "Cust. Ledger Entry" = rm,
+                  tabledata "Vendor Ledger Entry" = rm;
+
     var
         GenJnlPostLine: Codeunit "Gen. Jnl.-Post Line";
         CannotVoidNonBalanceTransErr: Label 'You cannot Financially Void checks posted in a non-balancing transaction.';


### PR DESCRIPTION
[Bug 643293](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/643293): Incident 51000001112282 : [BC-IN][Standard] Online: [India Localization] Stale Cheque action fails with "TableData 271 Bank Account Ledger Entry: Modify" permission error - 2607140040000858

[AB#643293](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643293)

**Issue:** Stale Check action failed with license error: *"...does not grant permissions on TableData 271 Bank Account Ledger Entry: Modify."*

**Cause:** Codeunit 18970 `Check Management Subscriber` modifies ledger tables directly but had no Permissions property.

**Solution:** Added Permissions property granting `rm` on `Bank Account Ledger Entry`, `Check Ledger Entry`, `Cust. Ledger Entry`, and `Vendor Ledger Entry`.

