### PR TITLE
New Allowed Table Session Event for Retention Policies

### DIFF
--- a/src/Layers/W1/BaseApp/OtherCapabilities/RetentionPolicy/RetenPolInstallBaseApp.Codeunit.al
+++ b/src/Layers/W1/BaseApp/OtherCapabilities/RetentionPolicy/RetenPolInstallBaseApp.Codeunit.al
@@ -54,6 +54,7 @@ codeunit 3999 "Reten. Pol. Install - BaseApp"
             RetenPolAllowedTables.AddAllowedTable(Database::"Report Inbox");
             RetenPolAllowedTables.AddAllowedTable(Database::"Error Message");
             RetenPolAllowedTables.AddAllowedTable(Database::"Error Message Register");
+            RetenPolAllowedTables.AddAllowedTable(Database::"Session Event");
             if IsInitialSetup then
                 UpgradeTag.SetUpgradeTag(GetRetenPolBaseAppTablesUpgradeTag());
         end;


### PR DESCRIPTION
Issue Description
On the SQL side, this change was already implemented previously, but the BaseApp retention policy install codeunit does not yet include Session Event in its allowed table list.

To keep the AL side aligned with the existing SQL-side behavior, extend the retention policy initialization so that Session Event is added as an allowed table alongside the current system tables.

Expected Result
Retention policy installation in BaseApp adds Session Event to the allowed tables, matching the behavior already established on the SQL side.

Acceptance Criteria

Session Event is added to the BaseApp retention policy allowed tables.
The change follows the same intent as the existing SQL-side implementation.
Existing allowed tables remain unchanged.
Retention policy setup still completes successfully.

Related to #9681 
Fixes #9681 