### PR TITLE
Fix AA0217 in BCPT Setup Card test and build System App Modules under strict ruleset

### DIFF
--- a/build/projects/System Application Modules/.AL-Go/PreCompileApp.ps1
+++ b/build/projects/System Application Modules/.AL-Go/PreCompileApp.ps1
@@ -13,6 +13,13 @@ if($appType -eq 'app')
         # iterate through all projects in the workspace file
         foreach ($project in $workspace.folders) {
             $appFolder = $project.path
+            # The execute-permissions check applies to the System Application and Business Foundation
+            # modules. Apps under src/Tools (test framework, performance toolkit, etc.) are dev and
+            # test tooling and are exempt.
+            if ($appFolder -match '[\\/]src[\\/]Tools[\\/]') {
+                Write-Host "Skipping execute permissions verification for Tools app folder: $appFolder"
+                continue
+            }
             Write-Host "Verifying execute permissions for app folder: $appFolder"
             . $scriptPath -AppFolder $appFolder
         }

--- a/build/projects/System Application Modules/.AL-Go/PreCompileApp.ps1
+++ b/build/projects/System Application Modules/.AL-Go/PreCompileApp.ps1
@@ -13,13 +13,6 @@ if($appType -eq 'app')
         # iterate through all projects in the workspace file
         foreach ($project in $workspace.folders) {
             $appFolder = $project.path
-            # The execute-permissions check applies to the System Application and Business Foundation
-            # modules. Apps under src/Tools (test framework, performance toolkit, etc.) are dev and
-            # test tooling and are exempt.
-            if ($appFolder -match '[\\/]src[\\/]Tools[\\/]') {
-                Write-Host "Skipping execute permissions verification for Tools app folder: $appFolder"
-                continue
-            }
             Write-Host "Verifying execute permissions for app folder: $appFolder"
             . $scriptPath -AppFolder $appFolder
         }

--- a/build/projects/System Application Modules/.AL-Go/settings.json
+++ b/build/projects/System Application Modules/.AL-Go/settings.json
@@ -5,11 +5,7 @@
     "../../../src/System Application/App/*",
     "../../../src/System Application/App",
     "../../../src/Business Foundation/App/*",
-    "../../../src/Business Foundation/App",
-    "../../../src/Tools/Performance Toolkit/App",
-    "../../../src/Tools/AI Test Toolkit",
-    "../../../src/Tools/Test Framework/Test Libraries/*",
-    "../../../src/Tools/Test Framework/*"
+    "../../../src/Business Foundation/App"
   ],
   "testFolders": [
     "../../../src/System Application/Test/*",
@@ -22,7 +18,11 @@
     "../../../src/Business Foundation/Test Library/*",
     "../../../src/Business Foundation/Test",
     "../../../src/Business Foundation/Test Library",
-    "../../../src/Tools/Performance Toolkit/Test"
+    "../../../src/Tools/Performance Toolkit/App",
+    "../../../src/Tools/Performance Toolkit/Test",
+    "../../../src/Tools/AI Test Toolkit",
+    "../../../src/Tools/Test Framework/Test Libraries/*",
+    "../../../src/Tools/Test Framework/*"
   ],
   "doNotPublishApps": true,
   "rulesetFile": "../../../src/rulesets/internal.module.ruleset.json",

--- a/build/projects/System Application Modules/.AL-Go/settings.json
+++ b/build/projects/System Application Modules/.AL-Go/settings.json
@@ -3,13 +3,26 @@
   "projectName": "System Application Modules",
   "appFolders": [
     "../../../src/System Application/App/*",
-    "../../../src/Business Foundation/App/*"
+    "../../../src/System Application/App",
+    "../../../src/Business Foundation/App/*",
+    "../../../src/Business Foundation/App",
+    "../../../src/Tools/Performance Toolkit/App",
+    "../../../src/Tools/AI Test Toolkit",
+    "../../../src/Tools/Test Framework/Test Libraries/*",
+    "../../../src/Tools/Test Framework/*"
   ],
   "testFolders": [
     "../../../src/System Application/Test/*",
     "../../../src/System Application/Test Library/*",
+    "../../../src/System Application/Test",
+    "../../../src/System Application/Test Library",
+    "../../../src/System Application/Partner Test",
+    "../../../src/System Application/Partner Test/AI",
     "../../../src/Business Foundation/Test/*",
-    "../../../src/Business Foundation/Test Library/*"
+    "../../../src/Business Foundation/Test Library/*",
+    "../../../src/Business Foundation/Test",
+    "../../../src/Business Foundation/Test Library",
+    "../../../src/Tools/Performance Toolkit/Test"
   ],
   "doNotPublishApps": true,
   "rulesetFile": "../../../src/rulesets/internal.module.ruleset.json",

--- a/src/Tools/Performance Toolkit/Test/src/BCPTSetupCardTest.Codeunit.al
+++ b/src/Tools/Performance Toolkit/Test/src/BCPTSetupCardTest.Codeunit.al
@@ -131,6 +131,7 @@ codeunit 144741 "BCPT Setup Card Test"
         BCPTSetupCard: TestPage "BCPT Setup Card";
         ActualNoOfIterations: Integer;
         UnexpectedNoOfSqlStmtsLbl: Label 'Unexpected value in %1. Expected %2, Actual %3', Locked = true;
+        OrValueLbl: Label '%1 or %2', Locked = true;
     begin
         Initialize();
 
@@ -152,7 +153,7 @@ codeunit 144741 "BCPT Setup Card Test"
         // counts 2 extra SQL statements from system tables. Therefore the total is either ActualNoOfIterations or ActualNoOfIterations + 2.
         Assert.IsTrue(
             BCPTSetupCard.BCPTLines.NoOfSQLStmts.AsInteger() in [ActualNoOfIterations, ActualNoOfIterations + 2],
-            StrSubstNo(UnexpectedNoOfSqlStmtsLbl, BCPTLogEntry.FieldCaption("No. of SQL Statements"), StrSubstNo('%1 or %2', ActualNoOfIterations, ActualNoOfIterations + 2), BCPTSetupCard.BCPTLines.NoOfSQLStmts.AsInteger()));
+            StrSubstNo(UnexpectedNoOfSqlStmtsLbl, BCPTLogEntry.FieldCaption("No. of SQL Statements"), StrSubstNo(OrValueLbl, ActualNoOfIterations, ActualNoOfIterations + 2), BCPTSetupCard.BCPTLines.NoOfSQLStmts.AsInteger()));
         BCPTSetupCard.BCPTLines.AvgSQLStmts.AssertEquals(1);
         BCPTSetupCard.Close();
     end;


### PR DESCRIPTION
## What & why

The internal NAV `BuildAppModulesClean` validation broke (Bug 643259) with `error AA0217: Use a text constant or label for format string in StrSubstNo` in `BCPTSetupCardTest.Codeunit.al`. The offending line used a nested `StrSubstNo('%1 or %2', ...)` with a literal format string.

This passed on public BCApps CI but failed internally because of a coverage gap: the only public job that compiles under the strict `internal.module.ruleset.json` (where AA0217 is an error) is `System Application Modules (Clean)`, and that job does not build the Performance Toolkit from source. The Performance Toolkit is only built publicly under `Apps W1`, which uses `base.ruleset.json` where AA0217 is downgraded to a warning. So the strict ruleset and the offending file never met in public CI, while the internal build compiles every module under the strict ruleset in one pass.

This PR does two things:

- **Fixes the AA0217 error** by moving the inline `'%1 or %2'` literal into a `Locked` label (`OrValueLbl`) and referencing it. Behavior is unchanged.
- **Closes the coverage gap** so this class of break is caught in public CI. The `System Application Modules` AL-Go project now also compiles the monolithic System Application / Business Foundation apps and the Tools apps (Performance Toolkit + tests, AI Test Toolkit, Test Framework libraries, Test Runner) under the strict ruleset, matching what internal `BuildAppModulesClean` builds. This adds the 16 apps the internal build compiles that the public strict job was missing.

## Linked work

[AB#643259](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643259)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Root-caused the failure from the internal `buildappmodulesclean` log: `BCPTSetupCardTest.Codeunit.al(155,103): error AA0217`. Confirmed the culprit is the nested `StrSubstNo('%1 or %2', ...)` literal, introduced by commit a08aabe1 (PR #8823).
- Verified via the public `System Application Modules (Clean)` job log (run 29968954797) that it compiles 258 modules and never compiles the Performance Toolkit source (0 AA0217 / BCPTSetupCardTest occurrences), vs 274 in the internal build.
- Change is test-code only (a Locked label swap) plus a build-configuration change; no product behavior change, so no new tests are warranted. The settings change itself is what exercises the fixed test app under the strict ruleset.

## Risk & compatibility

- The settings change intentionally puts `Tools/Performance Toolkit/Test` (and the other listed apps) under the strict `internal.module.ruleset.json` in public CI for the first time. If any of these apps carry other latent strict-ruleset violations, this job will now surface them. The known AA0217 offender is fixed in the same PR.
- No product, upgrade, permission, or telemetry impact. Change is scoped to a single AL-Go project settings file plus one test codeunit.


