### PR TITLE
Rename email review option 'Only untrusted senders' to 'Manage per sender'

### DIFF
--- a/src/Apps/W1/PayablesAgent/app/Setup/PAEmailReviewPolicy.Enum.al
+++ b/src/Apps/W1/PayablesAgent/app/Setup/PAEmailReviewPolicy.Enum.al
@@ -16,7 +16,7 @@ enum 3305 "PA Email Review Policy"
     }
     value(1; OnlyIfUntrusted)
     {
-        Caption = 'Only untrusted senders (recommended)';
+        Caption = 'Manage per sender (recommended)';
     }
     value(2; Never)
     {


### PR DESCRIPTION
Renames the Payables Agent `Email Review Policy` enum option `OnlyIfUntrusted` caption from **'Only untrusted senders (recommended)'** to **'Manage per sender (recommended)'**.

Fixes [AB#625413](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625413)



