### PR TITLE
[28.x] [Quality Management] UI actions to restore default shipped source configurations

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/QltyAutoConfigure.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/QltyAutoConfigure.Codeunit.al
@@ -272,6 +272,142 @@ codeunit 20402 "Qlty. Auto Configure"
         CreateDefaultItemLedgerEntryOpenToInspectConfiguration();
     end;
 
+    /// <summary>
+    /// Deletes only the source configurations that are shipped as defaults with Quality Management.
+    /// Any user-added source configurations are preserved.
+    /// </summary>
+    internal procedure DeleteShippedDefaultSourceConfigurations()
+    var
+        QltyInspectSourceConfig: Record "Qlty. Inspect. Source Config.";
+        ShippedCodes: List of [Code[20]];
+        ShippedCode: Code[20];
+    begin
+        GetShippedDefaultSourceConfigurationCodes(ShippedCodes);
+        foreach ShippedCode in ShippedCodes do
+            if QltyInspectSourceConfig.Get(ShippedCode) then
+                QltyInspectSourceConfig.Delete(true);
+    end;
+
+    /// <summary>
+    /// Deletes every source configuration, including user-added ones.
+    /// </summary>
+    internal procedure DeleteAllSourceConfigurations()
+    var
+        QltyInspectSourceConfig: Record "Qlty. Inspect. Source Config.";
+    begin
+        QltyInspectSourceConfig.DeleteAll(true);
+    end;
+
+    /// <summary>
+    /// Indicates whether the specified code corresponds to a source configuration shipped as a default with Quality Management.
+    /// </summary>
+    /// <param name="Code">The code to check.</param>
+    /// <returns>True if the code matches a shipped default source configuration; otherwise false.</returns>
+    internal procedure IsShippedDefaultSourceConfiguration(Code: Code[20]): Boolean
+    var
+        ShippedCodes: List of [Code[20]];
+    begin
+        GetShippedDefaultSourceConfigurationCodes(ShippedCodes);
+        exit(ShippedCodes.Contains(Code));
+    end;
+
+    /// <summary>
+    /// Deletes and recreates a single shipped default source configuration, discarding any customizations made to it.
+    /// Does nothing if the specified code does not correspond to a shipped default configuration.
+    /// </summary>
+    /// <param name="Code">The code of the shipped default source configuration to reset.</param>
+    internal procedure ResetShippedDefaultSourceConfiguration(Code: Code[20])
+    var
+        QltyInspectSourceConfig: Record "Qlty. Inspect. Source Config.";
+    begin
+        if not IsShippedDefaultSourceConfiguration(Code) then
+            exit;
+
+        if QltyInspectSourceConfig.Get(Code) then
+            QltyInspectSourceConfig.Delete(true);
+
+        RecreateShippedDefaultSourceConfiguration(Code);
+    end;
+
+    local procedure RecreateShippedDefaultSourceConfiguration(Code: Code[20])
+    begin
+        case Code of
+            CopyStr(TrackingSpecToInspectTok, 1, 20):
+                CreateDefaultTrackingSpecificationToInspectConfiguration();
+            CopyStr(WarehouseEntryToInspectTok, 1, 20):
+                CreateDefaultWarehouseEntryToInspectConfiguration();
+            CopyStr(WarehouseJournalToInspectTok, 1, 20):
+                CreateDefaultWarehouseJournalLineToInspectConfiguration();
+            CopyStr(SalesLineToTrackingTok, 1, 20):
+                CreateDefaultTrackingSpecificationToSalesConfiguration();
+            CopyStr(WhseReceiptToPurchLineTok, 1, 20):
+                CreateDefaultWarehouseReceiptLineToPurchConfiguration();
+            CopyStr(ProdLineToTrackingTok, 1, 20):
+                CreateDefaultTrackingSpecificationToProdConfiguration();
+            CopyStr(PurchLineToTrackingTok, 1, 20):
+                CreateDefaultTrackingSpecificationToPurchaseConfiguration();
+            CopyStr(WhseReceiptToSalesLineTok, 1, 20):
+                CreateDefaultWarehouseReceiptLineToSalesConfiguration();
+            CopyStr(WhseJournalToPurchLineTok, 1, 20):
+                CreateDefaultWarehouseJournalLineToPurchConfiguration();
+            CopyStr(WhseJournalToSalesLineTok, 1, 20):
+                CreateDefaultWarehouseJournalLineToSalesConfiguration();
+            CopyStr(PurchLineToInspectTok, 1, 20):
+                CreateDefaultPurchaseLineToInspectConfiguration();
+            CopyStr(SalesLineToInspectTok, 1, 20):
+                CreateDefaultSalesLineToInspectConfiguration();
+            CopyStr(SalesReturnLineToInspectTok, 1, 20):
+                CreateDefaultSalesReturnLineToInspectConfiguration();
+            CopyStr(ProdJnlToInspectTok, 1, 20):
+                CreateDefaultItemProdJournalToInspectConfiguration();
+            CopyStr(LedgerToInspectTok, 1, 20):
+                CreateDefaultItemLedgerOutputToInspectConfiguration();
+            CopyStr(RtngToItemJnlTok, 1, 20):
+                CreateDefaultProdOrderRoutingLineToItemJournalLineConfiguration();
+            CopyStr(ProdLineToJnlTok, 1, 20):
+                CreateDefaultProdOrderLineToItemJournalLineConfiguration();
+            CopyStr(ProdLineToRoutingTok, 1, 20):
+                CreateDefaultProdOrderLineToProdOrderRoutingConfiguration();
+            CopyStr(InTransLineToInspectTok, 1, 20):
+                CreateDefaultTransferLineReceiptToInspectConfiguration();
+            CopyStr(ProdLineToLedgerTok, 1, 20):
+                CreateDefaultProdOrderLineToItemLedgerConfiguration();
+            CopyStr(ProdRoutingToInspectTok, 1, 20):
+                CreateDefaultProdOrderRoutingLineToInspectConfiguration();
+            CopyStr(AssemblyOutputToInspectTok, 1, 20):
+                CreateDefaultAssemblyOutputToInspectConfiguration();
+            CopyStr(OpenLedgerToInspectTok, 1, 20):
+                CreateDefaultItemLedgerEntryOpenToInspectConfiguration();
+        end;
+    end;
+
+    local procedure GetShippedDefaultSourceConfigurationCodes(var ShippedCodes: List of [Code[20]])
+    begin
+        ShippedCodes.Add(CopyStr(TrackingSpecToInspectTok, 1, 20));
+        ShippedCodes.Add(CopyStr(WarehouseEntryToInspectTok, 1, 20));
+        ShippedCodes.Add(CopyStr(WarehouseJournalToInspectTok, 1, 20));
+        ShippedCodes.Add(CopyStr(SalesLineToTrackingTok, 1, 20));
+        ShippedCodes.Add(CopyStr(WhseReceiptToPurchLineTok, 1, 20));
+        ShippedCodes.Add(CopyStr(ProdLineToTrackingTok, 1, 20));
+        ShippedCodes.Add(CopyStr(PurchLineToTrackingTok, 1, 20));
+        ShippedCodes.Add(CopyStr(WhseReceiptToSalesLineTok, 1, 20));
+        ShippedCodes.Add(CopyStr(WhseJournalToPurchLineTok, 1, 20));
+        ShippedCodes.Add(CopyStr(WhseJournalToSalesLineTok, 1, 20));
+        ShippedCodes.Add(CopyStr(PurchLineToInspectTok, 1, 20));
+        ShippedCodes.Add(CopyStr(SalesLineToInspectTok, 1, 20));
+        ShippedCodes.Add(CopyStr(SalesReturnLineToInspectTok, 1, 20));
+        ShippedCodes.Add(CopyStr(ProdJnlToInspectTok, 1, 20));
+        ShippedCodes.Add(CopyStr(LedgerToInspectTok, 1, 20));
+        ShippedCodes.Add(CopyStr(RtngToItemJnlTok, 1, 20));
+        ShippedCodes.Add(CopyStr(ProdLineToJnlTok, 1, 20));
+        ShippedCodes.Add(CopyStr(ProdLineToRoutingTok, 1, 20));
+        ShippedCodes.Add(CopyStr(InTransLineToInspectTok, 1, 20));
+        ShippedCodes.Add(CopyStr(ProdLineToLedgerTok, 1, 20));
+        ShippedCodes.Add(CopyStr(ProdRoutingToInspectTok, 1, 20));
+        ShippedCodes.Add(CopyStr(AssemblyOutputToInspectTok, 1, 20));
+        ShippedCodes.Add(CopyStr(OpenLedgerToInspectTok, 1, 20));
+    end;
+
     local procedure CreateDefaultTrackingSpecificationToInspectConfiguration()
     var
         QltyInspectSourceConfig: Record "Qlty. Inspect. Source Config.";

--- a/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyInsSourceConfigList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyInsSourceConfigList.Page.al
@@ -198,7 +198,7 @@ page 20412 "Qlty. Ins. Source Config. List"
         RecreateMissingDefaultConfigurationsCompletedMsg: Label 'The missing default source configurations have been recreated.';
         ResetOnlyDefaultConfigurationsQst: Label 'This will delete and recreate the default source configurations shipped with Quality Management, discarding any customizations you have made to them. Custom source configurations that you have added will be preserved. This action cannot be undone. Do you want to continue?';
         ResetOnlyDefaultConfigurationsCompletedMsg: Label 'The default source configurations have been reset.';
-        ResetAllConfigurationsQst: Label 'This will delete every source configuration, including custom ones that you have added, and then recreate the defaults shipped with Quality Management. This action cannot be undone. This action cannot be undone. Do you want to continue?';
+        ResetAllConfigurationsQst: Label 'This will delete every source configuration, including custom ones that you have added, and then recreate the defaults shipped with Quality Management. This action cannot be undone. Do you want to continue?';
         ResetAllConfigurationsCompletedMsg: Label 'All source configurations have been reset to defaults.';
 
     trigger OnInit()

--- a/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyInsSourceConfigList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyInsSourceConfigList.Page.al
@@ -175,7 +175,6 @@ page 20412 "Qlty. Ins. Source Config. List"
 
                 group(Category_Category4)
                 {
-                    Caption = 'Restore defaults';
                     ShowAs = SplitButton;
 
                     actionref(RecreateMissingDefaultConfigurations_Promoted; RecreateMissingDefaultConfigurations)

--- a/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyInsSourceConfigList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyInsSourceConfigList.Page.al
@@ -20,7 +20,7 @@ page 20412 "Qlty. Ins. Source Config. List"
     UsageCategory = None;
     ApplicationArea = QualityManagement;
     AboutTitle = 'Populating data from tables in Business Central';
-    AboutText = 'This page defines how data is automatically populated into quality inspections from other tables, including how records are linked between source and target tables. It is read-only in most scenarios and intended for advanced configuration.';
+    AboutText = 'This page defines how data is automatically populated into quality inspections from other tables, including how records are linked between source and target tables. These configurations should not be changed under normal circumstances and should only be modified as part of advanced configuration by users who understand the impact of their changes.';
 
     layout
     {

--- a/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyInsSourceConfigList.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyInsSourceConfigList.Page.al
@@ -5,6 +5,7 @@
 namespace Microsoft.QualityManagement.Configuration.SourceConfiguration;
 
 using Microsoft.QualityManagement.Configuration;
+using System.Utilities;
 
 /// <summary>
 /// This page is intended to help with advanced configuration scenarios. If you are exploring the system we recommend that you do not make alterations on this page unless instructed by a qualified support representative or technician. 
@@ -86,8 +87,119 @@ page 20412 "Qlty. Ins. Source Config. List"
         }
     }
 
+    actions
+    {
+        area(Processing)
+        {
+            group(RestoreDefaults)
+            {
+                Caption = 'Restore defaults';
+                Image = Restore;
+                ToolTip = 'Restore the default source configurations shipped with Quality Management.';
+
+                action(RecreateMissingDefaultConfigurations)
+                {
+                    AccessByPermission = tabledata "Qlty. Inspect. Source Config." = I;
+                    ApplicationArea = QualityManagement;
+                    Caption = 'Recreate missing default configurations';
+                    ToolTip = 'Recreates any missing default source configurations shipped with Quality Management. Existing default configurations remain unchanged, even if they were customized.';
+                    Image = ApplyTemplate;
+
+                    trigger OnAction()
+                    var
+                        QltyAutoConfigure: Codeunit "Qlty. Auto Configure";
+                        ConfirmManagement: Codeunit "Confirm Management";
+                    begin
+                        if not ConfirmManagement.GetResponseOrDefault(RecreateMissingDefaultConfigurationsQst, false) then
+                            exit;
+
+                        QltyAutoConfigure.EnsureAtLeastOneSourceConfigurationExist(true);
+
+                        CurrPage.Update(false);
+                        Message(RecreateMissingDefaultConfigurationsCompletedMsg);
+                    end;
+                }
+                action(ResetOnlyDefaultConfigurations)
+                {
+                    AccessByPermission = tabledata "Qlty. Inspect. Source Config." = I;
+                    ApplicationArea = QualityManagement;
+                    Caption = 'Reset only default configurations';
+                    ToolTip = 'Deletes and recreates the default source configurations shipped with Quality Management, discarding any customizations made to them. Custom source configurations that you have added are preserved.';
+                    Image = RefreshText;
+
+                    trigger OnAction()
+                    var
+                        QltyAutoConfigure: Codeunit "Qlty. Auto Configure";
+                        ConfirmManagement: Codeunit "Confirm Management";
+                    begin
+                        if not ConfirmManagement.GetResponseOrDefault(ResetOnlyDefaultConfigurationsQst, false) then
+                            exit;
+
+                        QltyAutoConfigure.DeleteShippedDefaultSourceConfigurations();
+                        QltyAutoConfigure.EnsureAtLeastOneSourceConfigurationExist(true);
+
+                        CurrPage.Update(false);
+                        Message(ResetOnlyDefaultConfigurationsCompletedMsg);
+                    end;
+                }
+                action(ResetAllConfigurations)
+                {
+                    AccessByPermission = tabledata "Qlty. Inspect. Source Config." = I;
+                    ApplicationArea = QualityManagement;
+                    Caption = 'Reset all configurations';
+                    ToolTip = 'Deletes every source configuration, including custom ones that you have added, and then recreates the defaults shipped with Quality Management.';
+                    Image = CheckDuplicates;
+
+                    trigger OnAction()
+                    var
+                        QltyAutoConfigure: Codeunit "Qlty. Auto Configure";
+                        ConfirmManagement: Codeunit "Confirm Management";
+                    begin
+                        if not ConfirmManagement.GetResponseOrDefault(ResetAllConfigurationsQst, false) then
+                            exit;
+
+                        QltyAutoConfigure.DeleteAllSourceConfigurations();
+                        QltyAutoConfigure.EnsureAtLeastOneSourceConfigurationExist(true);
+
+                        CurrPage.Update(false);
+                        Message(ResetAllConfigurationsCompletedMsg);
+                    end;
+                }
+            }
+        }
+        area(Promoted)
+        {
+            group(Category_Process)
+            {
+                Caption = 'Process';
+
+                group(Category_Category4)
+                {
+                    Caption = 'Restore defaults';
+                    ShowAs = SplitButton;
+
+                    actionref(RecreateMissingDefaultConfigurations_Promoted; RecreateMissingDefaultConfigurations)
+                    {
+                    }
+                    actionref(ResetOnlyDefaultConfigurations_Promoted; ResetOnlyDefaultConfigurations)
+                    {
+                    }
+                    actionref(ResetAllConfigurations_Promoted; ResetAllConfigurations)
+                    {
+                    }
+                }
+            }
+        }
+    }
+
     var
         RowStyleText: Text;
+        RecreateMissingDefaultConfigurationsQst: Label 'This will recreate any missing default source configurations shipped with Quality Management. Existing configurations, including customizations, will not be changed. This action cannot be undone. Do you want to continue?';
+        RecreateMissingDefaultConfigurationsCompletedMsg: Label 'The missing default source configurations have been recreated.';
+        ResetOnlyDefaultConfigurationsQst: Label 'This will delete and recreate the default source configurations shipped with Quality Management, discarding any customizations you have made to them. Custom source configurations that you have added will be preserved. This action cannot be undone. Do you want to continue?';
+        ResetOnlyDefaultConfigurationsCompletedMsg: Label 'The default source configurations have been reset.';
+        ResetAllConfigurationsQst: Label 'This will delete every source configuration, including custom ones that you have added, and then recreate the defaults shipped with Quality Management. This action cannot be undone. This action cannot be undone. Do you want to continue?';
+        ResetAllConfigurationsCompletedMsg: Label 'All source configurations have been reset to defaults.';
 
     trigger OnInit()
     var

--- a/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyInspectSourceConfig.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyInspectSourceConfig.Page.al
@@ -4,6 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.QualityManagement.Configuration.SourceConfiguration;
 
+using Microsoft.QualityManagement.Configuration;
+using System.Utilities;
+
 /// <summary>
 /// Use this page to configure what will automatically populate from other tables into your quality inspections. This is also used to tell Business Central how to find one record from another, by setting which field in the ''From'' table connects to which field in the ''To'' table.
 /// </summary>
@@ -14,7 +17,6 @@ page 20410 "Qlty. Inspect. Source Config."
     PageType = ListPlus;
     SourceTable = "Qlty. Inspect. Source Config.";
     RefreshOnActivate = true;
-    Editable = false;
     UsageCategory = None;
     ApplicationArea = QualityManagement;
     AboutTitle = 'Populating data from tables in Business Central';
@@ -131,10 +133,49 @@ page 20410 "Qlty. Inspect. Source Config."
         }
     }
 
+    actions
+    {
+        area(Processing)
+        {
+            action(ResetDefaultConfiguration)
+            {
+                AccessByPermission = tabledata "Qlty. Inspect. Source Config." = I;
+                ApplicationArea = QualityManagement;
+                Caption = 'Reset default configuration';
+                ToolTip = 'Resets this default source configuration shipped with Quality Management, discarding any customizations made to it.';
+                Image = RefreshText;
+                Visible = IsShippedDefault;
+
+                trigger OnAction()
+                var
+                    QltyAutoConfigure: Codeunit "Qlty. Auto Configure";
+                    ConfirmManagement: Codeunit "Confirm Management";
+                begin
+                    if not ConfirmManagement.GetResponseOrDefault(StrSubstNo(ResetDefaultConfigurationQst, Rec.Code), false) then
+                        exit;
+
+                    QltyAutoConfigure.ResetShippedDefaultSourceConfiguration(Rec.Code);
+
+                    CurrPage.Update(false);
+                    Message(StrSubstNo(ResetDefaultConfigurationCompletedMsg, Rec.Code));
+                end;
+            }
+        }
+        area(Promoted)
+        {
+            actionref(ResetDefaultConfiguration_Promoted; ResetDefaultConfiguration)
+            {
+            }
+        }
+    }
+
     var
         ShowToTable: Boolean;
+        IsShippedDefault: Boolean;
         BlankLineText: Text;
         DataCaptionExprLbl: Label '%1 - %2 - %3', Locked = true, Comment = '%1=the code for this configuration, %2=The table to connect from, %3=the Table to connect to.';
+        ResetDefaultConfigurationQst: Label 'This will reset the default source configuration %1, discarding any customizations you have made to it. This action cannot be undone. Do you want to continue?', Comment = '%1=the code of the source configuration to reset';
+        ResetDefaultConfigurationCompletedMsg: Label 'The default source configuration %1 has been reset.', Comment = '%1=the code of the source configuration that was reset';
 
     trigger OnOpenPage()
     begin
@@ -147,8 +188,11 @@ page 20410 "Qlty. Inspect. Source Config."
     end;
 
     local procedure UpdateControls()
+    var
+        QltyAutoConfigure: Codeunit "Qlty. Auto Configure";
     begin
         ShowToTable := Rec."To Type" <> Rec."To Type"::Inspection;
+        IsShippedDefault := QltyAutoConfigure.IsShippedDefaultSourceConfiguration(Rec.Code);
     end;
 
     local procedure GetDataCaptionExpression(): Text

--- a/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyInspectSourceConfig.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/SourceConfiguration/QltyInspectSourceConfig.Page.al
@@ -20,7 +20,7 @@ page 20410 "Qlty. Inspect. Source Config."
     UsageCategory = None;
     ApplicationArea = QualityManagement;
     AboutTitle = 'Populating data from tables in Business Central';
-    AboutText = 'This page defines how data is automatically populated into quality inspections from other tables, including how records are linked between source and target tables. It is read-only in most scenarios and intended for advanced configuration.';
+    AboutText = 'This page defines how data is automatically populated into quality inspections from other tables, including how records are linked between source and target tables. These configurations should not be changed under normal circumstances and should only be modified as part of advanced configuration by users who understand the impact of their changes.';
 
     layout
     {

--- a/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Setup/QltyManagementSetup.Page.al
@@ -254,7 +254,7 @@ page 20400 "Qlty. Management Setup"
                 {
                     ApplicationArea = QualityManagement;
                     Caption = 'Source Configurations';
-                    ToolTip = 'View the quality inspection source configurations. This page defines how data is automatically populated into quality inspections from other tables, including how records are linked between source and target tables. It is read-only in most scenarios and intended for advanced configuration.';
+                    ToolTip = 'View the quality inspection source configurations. This page defines how data is automatically populated into quality inspections from other tables, including how records are linked between source and target tables.';
                     Image = Relationship;
                     RunObject = Page "Qlty. Ins. Source Config. List";
                     RunPageMode = View;

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
@@ -82,6 +82,8 @@ codeunit 139965 "Qlty. Tests - More Tests"
         OrderTypeProductionConditionFilterTok: Label 'WHERE(Order Type=FILTER(Production))', Locked = true;
         EntryTypeOutputConditionFilterTok: Label 'WHERE(Entry Type=FILTER(Output))', Locked = true;
         PassFailQuantityInvalidErr: Label 'The %1 and %2 cannot exceed the %3. The %3 is currently exceeded by %4.', Comment = '%1=the passed quantity caption, %2=the failed quantity caption, %3=the source quantity caption, %4=the quantity exceeded';
+        ShippedDefaultCodeTok: Label 'TRACKINGSPEC', Locked = true;
+        ModifiedDescriptionTok: Label 'MODIFIED DEFAULT DESCRIPTION', Locked = true;
 
     [Test]
     procedure TestTable_ValidateExpressionFormula()
@@ -2404,6 +2406,168 @@ codeunit 139965 "Qlty. Tests - More Tests"
         LibraryAssert.AreEqual(ExpressionFormula2Tok, QltyInspectionTemplateLine."Expression Formula", 'Expression Formula should be updated when the test code is changed.');
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler,MessageHandler')]
+    procedure QltyInsSourceConfigList_RecreateMissingDefaults()
+    var
+        QltyInspectSourceConfig: Record "Qlty. Inspect. Source Config.";
+        QltyInsSourceConfigList: TestPage "Qlty. Ins. Source Config. List";
+        CustomCode: Code[20];
+    begin
+        // [SCENARIO] Invoking the Recreate missing default configurations action restores deleted shipped defaults only when the user confirms, and preserves custom configurations.
+        Initialize();
+
+        // [GIVEN] All shipped default source configurations exist
+        QltyInspectionUtility.EnsureAtLeastOneSourceConfigurationExist(true);
+
+        // [WHEN] A shipped default source configuration is deleted
+        LibraryAssert.IsTrue(QltyInspectSourceConfig.Get(ShippedDefaultCodeTok), 'Shipped default should exist before deletion.');
+        QltyInspectSourceConfig.Delete(true);
+
+        // [THEN] The previously deleted shipped default is deleted
+        LibraryAssert.IsFalse(QltyInspectSourceConfig.Get(ShippedDefaultCodeTok), 'Shipped default should be deleted after the action.');
+
+        // [GIVEN] A custom source configuration is created
+        CustomCode := CreateCustomSourceConfiguration();
+
+        // [GIVEN] The list page is opened
+        QltyInsSourceConfigList.OpenView();
+
+        // [WHEN] Recreate missing default configurations action is invoked and the user confirms (ConfirmHandler)
+        QltyInsSourceConfigList.RecreateMissingDefaultConfigurations.Invoke();
+        QltyInsSourceConfigList.Close();
+
+        // [THEN] The previously deleted shipped default is recreated
+        LibraryAssert.IsTrue(QltyInspectSourceConfig.Get(ShippedDefaultCodeTok), 'Shipped default should be recreated after the action.');
+
+        // [THEN] The custom source configuration is preserved
+        LibraryAssert.IsTrue(QltyInspectSourceConfig.Get(CustomCode), 'Custom source configuration should be preserved.');
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler,MessageHandler')]
+    procedure QltyInsSourceConfigList_ResetOnlyDefaults()
+    var
+        QltyInspectSourceConfig: Record "Qlty. Inspect. Source Config.";
+        QltyInsSourceConfigList: TestPage "Qlty. Ins. Source Config. List";
+        OriginalDescription: Text[100];
+        ModifiedDescription: Text[100];
+        CustomCode: Code[20];
+    begin
+        // [SCENARIO] Invoking the Reset only default configurations action restores shipped defaults only when the user confirms, and preserves custom configurations.
+        Initialize();
+
+        // [GIVEN] All shipped default source configurations exist
+        QltyInspectionUtility.EnsureAtLeastOneSourceConfigurationExist(true);
+
+        // [GIVEN] The description of a shipped default source configuration is modified
+        QltyInspectSourceConfig.Get(ShippedDefaultCodeTok);
+        OriginalDescription := QltyInspectSourceConfig.Description;
+        ModifiedDescription := CopyStr(ModifiedDescriptionTok, 1, MaxStrLen(QltyInspectSourceConfig.Description));
+        QltyInspectSourceConfig.Description := ModifiedDescription;
+        QltyInspectSourceConfig.Modify();
+
+        // [GIVEN] A custom source configuration is created
+        CustomCode := CreateCustomSourceConfiguration();
+
+        // [GIVEN] The list page is opened
+        QltyInsSourceConfigList.OpenView();
+
+        // [WHEN] Reset only default configurations action is invoked and the user confirms (ConfirmHandler)
+        QltyInsSourceConfigList.ResetOnlyDefaultConfigurations.Invoke();
+        QltyInsSourceConfigList.Close();
+
+        // [THEN] The shipped default's description is reset to its original value
+        QltyInspectSourceConfig.Get(ShippedDefaultCodeTok);
+        LibraryAssert.AreEqual(OriginalDescription, QltyInspectSourceConfig.Description, 'Shipped default description should be reset.');
+
+        // [THEN] The custom source configuration is preserved
+        LibraryAssert.IsTrue(QltyInspectSourceConfig.Get(CustomCode), 'Custom source configuration should be preserved.');
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler,MessageHandler')]
+    procedure QltyInsSourceConfigList_ResetAllConfigurations()
+    var
+        QltyInspectSourceConfig: Record "Qlty. Inspect. Source Config.";
+        QltyInsSourceConfigList: TestPage "Qlty. Ins. Source Config. List";
+        CustomCode: Code[20];
+    begin
+        // [SCENARIO] Invoking the Reset all configurations action deletes every source configuration only when the user confirms, and then recreates shipped defaults.
+        Initialize();
+
+        // [GIVEN] All shipped default source configurations exist
+        QltyInspectionUtility.EnsureAtLeastOneSourceConfigurationExist(true);
+
+        // [GIVEN] A custom source configuration is created
+        CustomCode := CreateCustomSourceConfiguration();
+        LibraryAssert.IsTrue(QltyInspectSourceConfig.Get(CustomCode), 'Custom source configuration should exist before the action is invoked.');
+
+        // [GIVEN] The list page is opened
+        QltyInsSourceConfigList.OpenView();
+
+
+        // [WHEN] Reset all configurations action is invoked and the user confirms (ConfirmHandler)
+        QltyInsSourceConfigList.ResetAllConfigurations.Invoke();
+        QltyInsSourceConfigList.Close();
+
+        // [THEN] The custom source configuration is deleted
+        LibraryAssert.IsFalse(QltyInspectSourceConfig.Get(CustomCode), 'Custom source configuration should be deleted.');
+
+        // [THEN] The shipped default source configurations are recreated
+        LibraryAssert.IsTrue(QltyInspectSourceConfig.Get(ShippedDefaultCodeTok), 'Shipped default should exist after reset all.');
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler,MessageHandler')]
+    procedure QltyInspectSourceConfig_ResetDefaultConfiguration()
+    var
+        QltyInspectSourceConfig: Record "Qlty. Inspect. Source Config.";
+        QltyInspectSourceConfigCard: TestPage "Qlty. Inspect. Source Config.";
+        OriginalDescription: Text[100];
+        ModifiedDescription: Text[100];
+    begin
+        // [SCENARIO] Invoking the Reset default configuration action on the card page resets the shipped default only when the user confirms.
+        Initialize();
+
+        // [GIVEN] All shipped default source configurations exist
+        QltyInspectionUtility.EnsureAtLeastOneSourceConfigurationExist(true);
+
+        // [GIVEN] The description of a shipped default source configuration is modified
+        QltyInspectSourceConfig.Get(ShippedDefaultCodeTok);
+        OriginalDescription := QltyInspectSourceConfig.Description;
+        ModifiedDescription := CopyStr(ModifiedDescriptionTok, 1, MaxStrLen(QltyInspectSourceConfig.Description));
+        QltyInspectSourceConfig.Description := ModifiedDescription;
+        QltyInspectSourceConfig.Modify();
+
+        // [GIVEN] The card page is opened on the shipped default configuration
+        QltyInspectSourceConfigCard.OpenView();
+        QltyInspectSourceConfigCard.GoToRecord(QltyInspectSourceConfig);
+
+
+        // [WHEN] Reset default configuration action is invoked and the user confirms (ConfirmHandler)
+        QltyInspectSourceConfigCard.ResetDefaultConfiguration.Invoke();
+        QltyInspectSourceConfigCard.Close();
+
+        // [THEN] The shipped default's description is reset to its original value
+        QltyInspectSourceConfig.Get(ShippedDefaultCodeTok);
+        LibraryAssert.AreEqual(OriginalDescription, QltyInspectSourceConfig.Description, 'Shipped default description should be reset.');
+    end;
+
+    local procedure CreateCustomSourceConfiguration() CustomCode: Code[20]
+    var
+        QltyInspectSourceConfig: Record "Qlty. Inspect. Source Config.";
+        RandomText: Text;
+    begin
+        QltyInspectionUtility.GenerateRandomCharacters(17, RandomText);
+        CustomCode := CopyStr('CUS' + RandomText, 1, MaxStrLen(QltyInspectSourceConfig.Code));
+        QltyInspectSourceConfig.Init();
+        QltyInspectSourceConfig.Code := CustomCode;
+        QltyInspectSourceConfig.Description := CopyStr('Custom Test Configuration', 1, MaxStrLen(QltyInspectSourceConfig.Description));
+        QltyInspectSourceConfig.Validate("To Type", QltyInspectSourceConfig."To Type"::Inspection);
+        QltyInspectSourceConfig.Insert(true);
+    end;
+
     local procedure Initialize()
     begin
         if IsInitialized then
@@ -2481,6 +2645,12 @@ codeunit 139965 "Qlty. Tests - More Tests"
     procedure ConfirmHandler(Question: Text; var Reply: Boolean)
     begin
         Reply := true;
+    end;
+
+    [ConfirmHandler]
+    procedure ConfirmHandlerFalse(Question: Text; var Reply: Boolean)
+    begin
+        Reply := false;
     end;
 
     [MessageHandler]

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMoreTests.Codeunit.al
@@ -2647,12 +2647,6 @@ codeunit 139965 "Qlty. Tests - More Tests"
         Reply := true;
     end;
 
-    [ConfirmHandler]
-    procedure ConfirmHandlerFalse(Question: Text; var Reply: Boolean)
-    begin
-        Reply := false;
-    end;
-
     [MessageHandler]
     procedure MessageHandler(MessageText: Text)
     begin


### PR DESCRIPTION
## What & why

Adds options to unstuck environment from incomplete or damaged source configurations:

1. Make card page editable
2. Action in the card page '**Reset default configuration**': Resets this default source configuration shipped with Quality Management, discarding any customizations made to it.
3. Actions in the list page:
- '**Recreate missing default configurations**': Recreates any missing default source configurations shipped with Quality Management. Existing default configurations remain unchanged, even if they were customized.
- '**Reset only default configurations**': Deletes and recreates the default source configurations shipped with Quality Management, discarding any customizations made to them. Custom source configurations that have been added are preserved.
- '**Reset all configurations**': Deletes every source configuration, including custom ones that have been added, and then recreates the defaults shipped with Quality Management.

## Linked work

Fixes [AB#643386](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643386)


