### PR TITLE
Declare TempCustomMigrationTableBuffer as temporary

### DIFF
--- a/src/Apps/W1/HybridBaseDeployment/app/src/CustomMigration/TableMappings/AddCustomMigrationMapping.Page.al
+++ b/src/Apps/W1/HybridBaseDeployment/app/src/CustomMigration/TableMappings/AddCustomMigrationMapping.Page.al
@@ -183,7 +183,7 @@ page 40016 "Add Custom Migration Mapping"
     trigger OnQueryClosePage(CloseAction: Action): Boolean
     var
         HybridCompany: Record "Hybrid Company";
-        TempCustomMigrationTableBuffer: Record "Custom Migration Table Buffer";
+        TempCustomMigrationTableBuffer: Record "Custom Migration Table Buffer" temporary;
         NewCompanyName: Text[30];
         NewSourceTableName: Text[128];
         NewDestinationTableName: Text[128];


### PR DESCRIPTION
## Summary
Declares `TempCustomMigrationTableBuffer` as `temporary` in `AddCustomMigrationMapping.Page.al`.

## Why
This keeps `main` in sync with the NAV 28.x backport of the BC14 cloud migration fixes (PR #9200). On NAV 28.x, the build ruleset (`app.ruleset.json`, `generalAction: Error`) promotes `AA0237` — *"The name of non temporary variables must not be prefixed with Temp"* — to a build-breaking error, whereas the BCApps build treats it as a warning. Adding the keyword there was required to build; this PR applies the same change on `main` so the two branches don't diverge.

## Risk
None. The backing table `Custom Migration Table Buffer` (40035) is already `TableType = Temporary`, so the `temporary` keyword is runtime-redundant and behavior-preserving.
