### PR TITLE
Rename TempCustomMigrationTableBuffer back to CustomMigrationTableBuffer

### DIFF
--- a/src/Apps/W1/HybridBaseDeployment/app/src/CustomMigration/TableMappings/AddCustomMigrationMapping.Page.al
+++ b/src/Apps/W1/HybridBaseDeployment/app/src/CustomMigration/TableMappings/AddCustomMigrationMapping.Page.al
@@ -183,7 +183,7 @@ page 40016 "Add Custom Migration Mapping"
     trigger OnQueryClosePage(CloseAction: Action): Boolean
     var
         HybridCompany: Record "Hybrid Company";
-        TempCustomMigrationTableBuffer: Record "Custom Migration Table Buffer";
+        CustomMigrationTableBuffer: Record "Custom Migration Table Buffer";
         NewCompanyName: Text[30];
         NewSourceTableName: Text[128];
         NewDestinationTableName: Text[128];
@@ -206,10 +206,10 @@ page 40016 "Add Custom Migration Mapping"
                 NewDestinationTableName := DestinationTableName.Replace(AllCompaniesTok, HybridCompany.Name);
                 NewCompanyName := HybridCompany.Name;
 #pragma warning restore AA0139
-                TempCustomMigrationTableBuffer.SaveMigrationTableMapping(MappingType, NewSourceTableName, NewDestinationTableName, TargetTableName, NewCompanyName, DataPerCompany, GlobalPreserveCloudData);
+                CustomMigrationTableBuffer.SaveMigrationTableMapping(MappingType, NewSourceTableName, NewDestinationTableName, TargetTableName, NewCompanyName, DataPerCompany, GlobalPreserveCloudData);
             until HybridCompany.Next() = 0;
         end else
-            TempCustomMigrationTableBuffer.SaveMigrationTableMapping(MappingType, SourceTableName, DestinationTableName, TargetTableName, CompanyName, DataPerCompany, GlobalPreserveCloudData);
+            CustomMigrationTableBuffer.SaveMigrationTableMapping(MappingType, SourceTableName, DestinationTableName, TargetTableName, CompanyName, DataPerCompany, GlobalPreserveCloudData);
 
         exit(true);
     end;


### PR DESCRIPTION
## Summary
Renames `TempCustomMigrationTableBuffer` back to `CustomMigrationTableBuffer` in `AddCustomMigrationMapping.Page.al` (declaration + both call sites).

## Why
The variable is only a handle used to call `SaveMigrationTableMapping` — its own fields are never read or written; the method persists to the `Migration Setup Table Mapping` / `Replication Table Mapping` tables. PR #9200 renamed it to `TempCustomMigrationTableBuffer`, which is misleading (it isn't used as a data buffer) and trips `AA0237` ("non temporary variables must not be prefixed with Temp") under stricter rulesets — e.g. the NAV build, where AA0237 is an error rather than a warning.

This restores the pre-#9200 name, keeping `main` consistent with the NAV 28.x backport and PR #9663.

## Risk
None — the change is naming-only and behavior-preserving.

[AB#642621](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642621)


