### PR TITLE
Bug 643397: Miapp uses a stale RepoBranchName

### DIFF
--- a/build/scripts/Miapp/MicroAppGitHelper.psm1
+++ b/build/scripts/Miapp/MicroAppGitHelper.psm1
@@ -440,7 +440,13 @@ function Initialize-MiappRepoBranchName {
     param()
 
     if ($env:RepoBranchName) {
-        return $env:RepoBranchName
+        git show-ref --verify --quiet "refs/remotes/origin/$env:RepoBranchName"
+        if ($LASTEXITCODE -eq 0) {
+            return $env:RepoBranchName
+        }
+
+        Write-Warning "RepoBranchName '$env:RepoBranchName' does not exist on origin. Falling back to origin/HEAD."
+        $env:RepoBranchName = $null
     }
 
     [string] $originHeadRef = (git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>$null)

--- a/build/scripts/Miapp/README.md
+++ b/build/scripts/Miapp/README.md
@@ -266,7 +266,7 @@ $MiappConfig = @{
 
 ### Environment Variables
 
-- `$env:RepoBranchName` - Base branch name used for comparisons (defaults to `origin/HEAD`, typically `main`, when not set)
+- `$env:RepoBranchName` - Base branch name used for comparisons. A valid explicit value is preserved. An unset value, or a stale value that does not exist on the current repository's `origin`, falls back to `origin/HEAD` (typically `main`).
 - `$env:MIAPP_DIR` - Directory for miapp temporary files (default: $env:USERPROFILE)
 
 ### Output


### PR DESCRIPTION
**ISSUE:**
Initialize NAV enlistment, cd App/BCApps, run Invoke-Miapp.
It fails with the error: Exception: fatal: HEAD does not point to a branch
Miapp fails in BCApps when `RepoBranchName` contains a stale value from another repository, such as `master` from NAV.

**CAUSE:**
Miapp trusts the environment value without checking whether the branch exists on the current repository's `origin`.

**SOLUTION:**
Preserve valid explicit base branches. When the configured branch does not exist on `origin`, show a warning and fall back to the current repository's `origin/HEAD`.

**TESTS:**
Validated valid, unset, and stale base-branch values. Verified that `Invoke-Miapp` automatically uses `main` when the inherited value is `master`.

Fixes [AB#643397](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643397)



