### PR TITLE
Enable manual task creation for Sales Order Agent

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOACreateTaskImpl.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOACreateTaskImpl.Codeunit.al
@@ -25,6 +25,15 @@ codeunit 4415 "SOA Create Task Impl"
         GlobalAgentUserSecurityID := NewAgentUserSecurityID;
     end;
 
+    internal procedure OpenCreateTaskPage(AgentUserSecurityID: Guid)
+    var
+        SOACreateTask: Page "SOA Create Task";
+    begin
+        SOACreateTask.SetAgentUserSecurityID(AgentUserSecurityID);
+        SOACreateTask.LookupMode(true);
+        SOACreateTask.RunModal();
+    end;
+
     internal procedure GetCurrentUserSalespersonCode(): Code[20]
     var
         UserSetup: Record "User Setup";

--- a/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOAMetadataProvider.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOAMetadataProvider.Codeunit.al
@@ -11,7 +11,7 @@ using System.AI;
 using System.Reflection;
 using System.Security.AccessControl;
 
-codeunit 4401 "SOA Metadata Provider" implements IAgentMetadata, IAgentFactory
+codeunit 4401 "SOA Metadata Provider" implements IAgentMetadata, IAgentFactory, IAgentManualTaskCreation
 {
     Access = Internal;
     InherentEntitlements = X;
@@ -74,7 +74,23 @@ codeunit 4401 "SOA Metadata Provider" implements IAgentMetadata, IAgentFactory
         SOASetupCU.GetDefaultAccessControls(TempAccessControlBuffer);
     end;
 
+    procedure IsManualAgentTaskCreationEnabled(AgentUserId: Guid; ManualTaskType: Enum "Manual Agent Task Creation Type"): Boolean
+    begin
+        exit(ManualTaskType = ManualTaskType::Default);
+    end;
+
+    procedure IsMultipleFileUploadAllowed(AgentUserId: Guid): Boolean
+    begin
+        exit(false);
+    end;
+
+    procedure CreateManualAgentTask(AgentUserId: Guid; Files: List of [FileUpload])
+    begin
+        SOACreateTaskImpl.OpenCreateTaskPage(AgentUserId);
+    end;
+
     var
         SOAAnnotation: Codeunit "SOA Annotation";
+        SOACreateTaskImpl: Codeunit "SOA Create Task Impl";
         SOASetupCU: Codeunit "SOA Setup";
 }

--- a/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOAMetadataProvider.EnumExt.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOAMetadataProvider.EnumExt.al
@@ -13,6 +13,6 @@ enumextension 4400 "SOA Metadata Provider" extends "Agent Metadata Provider"
     value(4400; "SO Agent")
     {
         Caption = 'Sales Order Agent';
-        Implementation = IAgentFactory = "SOA Metadata Provider", IAgentMetadata = "SOA Metadata Provider", IAgentTaskExecution = "SOA Agent Task Execution";
+        Implementation = IAgentFactory = "SOA Metadata Provider", IAgentMetadata = "SOA Metadata Provider", IAgentTaskExecution = "SOA Agent Task Execution", IAgentManualTaskCreation = "SOA Metadata Provider";
     }
 }

--- a/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Page.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Page.al
@@ -122,7 +122,7 @@ page 4400 "SOA Setup"
 
                         trigger OnDrillDown()
                         var
-                            SOACreateTask: Page "SOA Create Task";
+                            SOACreateTaskImpl: Codeunit "SOA Create Task Impl";
                         begin
                             CurrPage.AgentSetupPart.Page.GetAgentSetupBuffer(TempAgentSetupBuffer);
                             if (TempAgentSetupBuffer.State <> TempAgentSetupBuffer.State::Enabled) and (Rec."Email Monitoring" or (Rec."Email Address" <> '')) then begin
@@ -148,9 +148,7 @@ page 4400 "SOA Setup"
 
                             Commit();
 
-                            SOACreateTask.SetAgentUserSecurityID(Rec."User Security ID");
-                            SOACreateTask.LookupMode(true);
-                            SOACreateTask.RunModal();
+                            SOACreateTaskImpl.OpenCreateTaskPage(Rec."User Security ID");
                             CurrPage.Update(false);
                         end;
                     }


### PR DESCRIPTION
## Summary

- Enable default manual task creation for the Sales Order Agent.
- Open the existing SOA Create Task page from the Agent Tasks pane's New action.
- Reuse the same task-page launch helper from the SOA setup page.
- Keep manual task creation from uploaded files disabled.

## Validation

- Built the Sales Order Agent app successfully.

Fixes [AB#642289](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642289)


