### PR TITLE
[Shopify] Fix test isolation in Shpfy Product Price Calc. Test (AB#642673)

### DIFF
--- a/src/Apps/W1/Shopify/Test/Products/ShpfyProductPriceCalcTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Products/ShpfyProductPriceCalcTest.Codeunit.al
@@ -175,7 +175,7 @@ codeunit 139605 "Shpfy Product Price Calc. Test"
 
         // [INIT] Initialization startup data.
         LibraryPriceCalculation.EnableExtendedPriceCalculation();
-        LibraryPriceCalculation.AddSetup(PriceCalculationSetup, "Price Calculation Method"::"Lowest Price", "Price Type"::Sale, "Price Asset Type"::Item, "Price Calculation Handler"::"Business Central (Version 16.0)", true);
+        LibraryPriceCalculation.FindOrAddSetup(PriceCalculationSetup, "Price Calculation Method"::"Lowest Price", "Price Type"::Sale, "Price Asset Type"::Item, "Price Calculation Handler"::"Business Central (Version 16.0)", true);
         Shop := InitializeTest.CreateShop();
         Shop."Allow Line Disc." := true;
         Shop.Modify();


### PR DESCRIPTION
## What & why

`UnitTestCalcPriceUsesCurrentWorkDate` (codeunit 139605 "Shpfy Product Price Calc. Test") was disabled during the BCApps uptake because it failed deterministically across all country buckets with:

> The record in table Price Calculation Setup already exists. Identification fields and values: Code='[1-1-10]-7002'

The test called `LibraryPriceCalculation.AddSetup`, which does a plain `Insert` and throws on a duplicate key. A sibling test in the same codeunit (`UnitTestCalcPriceTestNewPricing`) inserts the same `Price Calculation Setup` row, and `CreateShop()` commits it — so when the second test ran it collided on the already-committed key.

This swaps `AddSetup` -> `FindOrAddSetup` (idempotent find-or-insert), matching the fix already applied to `UnitTestCalcPriceTestNewPricing` for [AB#642193](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642193).

## Linked work

Fixes [AB#642673](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642673)

## How I validated this

- `al_getdiagnostics` (AL language server) reports **0 errors** for the Shopify test project and the changed file.
- The change is identical in form to the already-merged `FindOrAddSetup` call in `UnitTestCalcPriceTestNewPricing`, which passes CI.

## Follow-up

The test is currently disabled NAV-side in `App/DisabledTests/ShpfyProductPriceCalcTest.DisabledTest.json` (added via NAV PR 250996). Once this change is taken up, that entry must be removed to re-enable the test.


