### PR TITLE
[Main] [all-e]CompAuxNum and CompAuxLib columns should be informed for Payment Discount lines in the French Audit File.Initial Commit

### DIFF
--- a/src/Apps/FR/FECAuditFile/app/src/ExportEngine/GenerateFileFEC.Codeunit.al
+++ b/src/Apps/FR/FECAuditFile/app/src/ExportEngine/GenerateFileFEC.Codeunit.al
@@ -9,6 +9,7 @@ using Microsoft.Bank.Ledger;
 using Microsoft.Finance.GeneralLedger.Account;
 using Microsoft.Finance.GeneralLedger.Journal;
 using Microsoft.Finance.GeneralLedger.Ledger;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.AuditCodes;
 using Microsoft.Purchases.Payables;
 using Microsoft.Purchases.Vendor;
@@ -44,6 +45,8 @@ codeunit 10826 "Generate File FEC"
         SourceCodesDescription: Dictionary of [Code[10], Text[100]];
         PayablesAccounts: Dictionary of [Code[20], Code[20]];
         ReceivablesAccounts: Dictionary of [Code[20], Code[20]];
+        PmtDiscountAccounts: Dictionary of [Code[20], Boolean];
+        PmtDiscountAccountsInitialized: Boolean;
         BankAccounts: Dictionary of [Code[20], Text[100]];
         BankAccPostingGroups: Dictionary of [Code[20], Code[20]];
         ProgressDialog: Dialog;
@@ -233,6 +236,9 @@ codeunit 10826 "Generate File FEC"
                     end;
 
             end;
+        if (PartyNo = '') and IsPaymentDiscountAccount(GLEntry."G/L Account No.") then
+            GetPartyForPaymentDiscount(GLEntry, PartyNo, PartyName);
+
         AllowMultiplePosting(PartyNo, PartyName, GLEntry, Customer);
 
         FindGLRegister(GLRegister, GLEntry."Entry No.");
@@ -669,6 +675,78 @@ codeunit 10826 "Generate File FEC"
         if CustomerPostingGroup.Get(CustomerPostingGroupCode) then begin
             ReceivablesAccounts.Add(CustomerPostingGroup.Code, CustomerPostingGroup."Receivables Account");
             ReceivablesAcc := CustomerPostingGroup."Receivables Account";
+        end;
+    end;
+
+    local procedure IsPaymentDiscountAccount(GLAccountNo: Code[20]): Boolean
+    var
+        GeneralPostingSetup: Record "General Posting Setup";
+        CustomerPostingGroup: Record "Customer Posting Group";
+        VendorPostingGroup: Record "Vendor Posting Group";
+    begin
+        if GLAccountNo = '' then
+            exit(false);
+
+        if not PmtDiscountAccountsInitialized then begin
+            GeneralPostingSetup.SetLoadFields(
+                "Sales Pmt. Disc. Debit Acc.", "Sales Pmt. Disc. Credit Acc.",
+                "Purch. Pmt. Disc. Debit Acc.", "Purch. Pmt. Disc. Credit Acc.");
+            if GeneralPostingSetup.FindSet() then
+                repeat
+                    AddPmtDiscountAccount(GeneralPostingSetup."Sales Pmt. Disc. Debit Acc.");
+                    AddPmtDiscountAccount(GeneralPostingSetup."Sales Pmt. Disc. Credit Acc.");
+                    AddPmtDiscountAccount(GeneralPostingSetup."Purch. Pmt. Disc. Debit Acc.");
+                    AddPmtDiscountAccount(GeneralPostingSetup."Purch. Pmt. Disc. Credit Acc.");
+                until GeneralPostingSetup.Next() = 0;
+
+            CustomerPostingGroup.SetLoadFields("Payment Disc. Debit Acc.", "Payment Disc. Credit Acc.");
+            if CustomerPostingGroup.FindSet() then
+                repeat
+                    AddPmtDiscountAccount(CustomerPostingGroup."Payment Disc. Debit Acc.");
+                    AddPmtDiscountAccount(CustomerPostingGroup."Payment Disc. Credit Acc.");
+                until CustomerPostingGroup.Next() = 0;
+
+            VendorPostingGroup.SetLoadFields("Payment Disc. Debit Acc.", "Payment Disc. Credit Acc.");
+            if VendorPostingGroup.FindSet() then
+                repeat
+                    AddPmtDiscountAccount(VendorPostingGroup."Payment Disc. Debit Acc.");
+                    AddPmtDiscountAccount(VendorPostingGroup."Payment Disc. Credit Acc.");
+                until VendorPostingGroup.Next() = 0;
+
+            PmtDiscountAccountsInitialized := true;
+        end;
+
+        exit(PmtDiscountAccounts.ContainsKey(GLAccountNo));
+    end;
+
+    local procedure AddPmtDiscountAccount(GLAccountNo: Code[20])
+    begin
+        if (GLAccountNo <> '') and (not PmtDiscountAccounts.ContainsKey(GLAccountNo)) then
+            PmtDiscountAccounts.Add(GLAccountNo, true);
+    end;
+
+    local procedure GetPartyForPaymentDiscount(GLEntry: Record "G/L Entry"; var PartyNo: Code[20]; var PartyName: Text[100])
+    var
+        Customer: Record Customer;
+        Vendor: Record Vendor;
+    begin
+        case GLEntry."Source Type" of
+            GLEntry."Source Type"::Customer:
+                begin
+                    Customer.SetLoadFields(Name);
+                    if Customer.Get(GLEntry."Source No.") then begin
+                        PartyNo := Customer."No.";
+                        PartyName := Customer.Name;
+                    end;
+                end;
+            GLEntry."Source Type"::Vendor:
+                begin
+                    Vendor.SetLoadFields(Name);
+                    if Vendor.Get(GLEntry."Source No.") then begin
+                        PartyNo := Vendor."No.";
+                        PartyName := Vendor.Name;
+                    end;
+                end;
         end;
     end;
 

--- a/src/Apps/FR/FECAuditFile/app/src/ExportEngine/GenerateFileFEC.Codeunit.al
+++ b/src/Apps/FR/FECAuditFile/app/src/ExportEngine/GenerateFileFEC.Codeunit.al
@@ -679,44 +679,49 @@ codeunit 10826 "Generate File FEC"
     end;
 
     local procedure IsPaymentDiscountAccount(GLAccountNo: Code[20]): Boolean
+    begin
+        if GLAccountNo = '' then
+            exit(false);
+
+        InitPmtDiscountAccountList();
+        exit(PmtDiscountAccounts.ContainsKey(GLAccountNo));
+    end;
+
+    local procedure InitPmtDiscountAccountList()
     var
         GeneralPostingSetup: Record "General Posting Setup";
         CustomerPostingGroup: Record "Customer Posting Group";
         VendorPostingGroup: Record "Vendor Posting Group";
     begin
-        if GLAccountNo = '' then
-            exit(false);
+        if PmtDiscountAccountsInitialized then
+            exit;
 
-        if not PmtDiscountAccountsInitialized then begin
-            GeneralPostingSetup.SetLoadFields(
-                "Sales Pmt. Disc. Debit Acc.", "Sales Pmt. Disc. Credit Acc.",
-                "Purch. Pmt. Disc. Debit Acc.", "Purch. Pmt. Disc. Credit Acc.");
-            if GeneralPostingSetup.FindSet() then
-                repeat
-                    AddPmtDiscountAccount(GeneralPostingSetup."Sales Pmt. Disc. Debit Acc.");
-                    AddPmtDiscountAccount(GeneralPostingSetup."Sales Pmt. Disc. Credit Acc.");
-                    AddPmtDiscountAccount(GeneralPostingSetup."Purch. Pmt. Disc. Debit Acc.");
-                    AddPmtDiscountAccount(GeneralPostingSetup."Purch. Pmt. Disc. Credit Acc.");
-                until GeneralPostingSetup.Next() = 0;
+        GeneralPostingSetup.SetLoadFields(
+            "Sales Pmt. Disc. Debit Acc.", "Sales Pmt. Disc. Credit Acc.",
+            "Purch. Pmt. Disc. Debit Acc.", "Purch. Pmt. Disc. Credit Acc.");
+        if GeneralPostingSetup.FindSet() then
+            repeat
+                AddPmtDiscountAccount(GeneralPostingSetup."Sales Pmt. Disc. Debit Acc.");
+                AddPmtDiscountAccount(GeneralPostingSetup."Sales Pmt. Disc. Credit Acc.");
+                AddPmtDiscountAccount(GeneralPostingSetup."Purch. Pmt. Disc. Debit Acc.");
+                AddPmtDiscountAccount(GeneralPostingSetup."Purch. Pmt. Disc. Credit Acc.");
+            until GeneralPostingSetup.Next() = 0;
 
-            CustomerPostingGroup.SetLoadFields("Payment Disc. Debit Acc.", "Payment Disc. Credit Acc.");
-            if CustomerPostingGroup.FindSet() then
-                repeat
-                    AddPmtDiscountAccount(CustomerPostingGroup."Payment Disc. Debit Acc.");
-                    AddPmtDiscountAccount(CustomerPostingGroup."Payment Disc. Credit Acc.");
-                until CustomerPostingGroup.Next() = 0;
+        CustomerPostingGroup.SetLoadFields("Payment Disc. Debit Acc.", "Payment Disc. Credit Acc.");
+        if CustomerPostingGroup.FindSet() then
+            repeat
+                AddPmtDiscountAccount(CustomerPostingGroup."Payment Disc. Debit Acc.");
+                AddPmtDiscountAccount(CustomerPostingGroup."Payment Disc. Credit Acc.");
+            until CustomerPostingGroup.Next() = 0;
 
-            VendorPostingGroup.SetLoadFields("Payment Disc. Debit Acc.", "Payment Disc. Credit Acc.");
-            if VendorPostingGroup.FindSet() then
-                repeat
-                    AddPmtDiscountAccount(VendorPostingGroup."Payment Disc. Debit Acc.");
-                    AddPmtDiscountAccount(VendorPostingGroup."Payment Disc. Credit Acc.");
-                until VendorPostingGroup.Next() = 0;
+        VendorPostingGroup.SetLoadFields("Payment Disc. Debit Acc.", "Payment Disc. Credit Acc.");
+        if VendorPostingGroup.FindSet() then
+            repeat
+                AddPmtDiscountAccount(VendorPostingGroup."Payment Disc. Debit Acc.");
+                AddPmtDiscountAccount(VendorPostingGroup."Payment Disc. Credit Acc.");
+            until VendorPostingGroup.Next() = 0;
 
-            PmtDiscountAccountsInitialized := true;
-        end;
-
-        exit(PmtDiscountAccounts.ContainsKey(GLAccountNo));
+        PmtDiscountAccountsInitialized := true;
     end;
 
     local procedure AddPmtDiscountAccount(GLAccountNo: Code[20])

--- a/src/Apps/FR/FECAuditFile/app/src/ExportEngine/GenerateFileFEC.Codeunit.al
+++ b/src/Apps/FR/FECAuditFile/app/src/ExportEngine/GenerateFileFEC.Codeunit.al
@@ -758,10 +758,10 @@ codeunit 10826 "Generate File FEC"
         // posting setup, so an account that is a payment discount account for one setup cannot flag an
         // unrelated line that happens to post to the same account under a different setup.
         PostingGroupScope := PostingGroupScopeKey(GLEntry."Source Type", PostingGroupCode);
-        GenPostingSetupScope := GenPostingSetupScopeKey(GLEntry."Gen. Bus. Posting Group", GLEntry."Gen. Prod. Posting Group");
+        GenPostingSetupScope := GenPostingSetupScopeKey(GLEntry."Source Type", GLEntry."Gen. Bus. Posting Group", GLEntry."Gen. Prod. Posting Group");
 
         CachePostingGroupPmtDiscountAccounts(GLEntry."Source Type", PostingGroupCode, PostingGroupScope);
-        CacheGenPostingSetupPmtDiscountAccounts(GLEntry."Gen. Bus. Posting Group", GLEntry."Gen. Prod. Posting Group", GenPostingSetupScope);
+        CacheGenPostingSetupPmtDiscountAccounts(GLEntry."Source Type", GLEntry."Gen. Bus. Posting Group", GLEntry."Gen. Prod. Posting Group", GenPostingSetupScope);
 
         exit(
             IsScopedPmtDiscountAccount(PostingGroupScope, GLEntry."G/L Account No.") or
@@ -797,7 +797,7 @@ codeunit 10826 "Generate File FEC"
         end;
     end;
 
-    local procedure CacheGenPostingSetupPmtDiscountAccounts(GenBusPostingGroup: Code[20]; GenProdPostingGroup: Code[20]; ScopeKey: Text)
+    local procedure CacheGenPostingSetupPmtDiscountAccounts(SourceType: Enum "Gen. Journal Source Type"; GenBusPostingGroup: Code[20]; GenProdPostingGroup: Code[20]; ScopeKey: Text)
     var
         GeneralPostingSetup: Record "General Posting Setup";
     begin
@@ -808,11 +808,20 @@ codeunit 10826 "Generate File FEC"
         GeneralPostingSetup.SetLoadFields(
             "Sales Pmt. Disc. Debit Acc.", "Sales Pmt. Disc. Credit Acc.",
             "Purch. Pmt. Disc. Debit Acc.", "Purch. Pmt. Disc. Credit Acc.");
-        if GeneralPostingSetup.Get(GenBusPostingGroup, GenProdPostingGroup) then begin
-            AddPmtDiscountAccount(ScopeKey, GeneralPostingSetup."Sales Pmt. Disc. Debit Acc.");
-            AddPmtDiscountAccount(ScopeKey, GeneralPostingSetup."Sales Pmt. Disc. Credit Acc.");
-            AddPmtDiscountAccount(ScopeKey, GeneralPostingSetup."Purch. Pmt. Disc. Debit Acc.");
-            AddPmtDiscountAccount(ScopeKey, GeneralPostingSetup."Purch. Pmt. Disc. Credit Acc.");
+        if not GeneralPostingSetup.Get(GenBusPostingGroup, GenProdPostingGroup) then
+            exit;
+
+        case SourceType of
+            SourceType::Customer:
+                begin
+                    AddPmtDiscountAccount(ScopeKey, GeneralPostingSetup."Sales Pmt. Disc. Debit Acc.");
+                    AddPmtDiscountAccount(ScopeKey, GeneralPostingSetup."Sales Pmt. Disc. Credit Acc.");
+                end;
+            SourceType::Vendor:
+                begin
+                    AddPmtDiscountAccount(ScopeKey, GeneralPostingSetup."Purch. Pmt. Disc. Debit Acc.");
+                    AddPmtDiscountAccount(ScopeKey, GeneralPostingSetup."Purch. Pmt. Disc. Credit Acc.");
+                end;
         end;
     end;
 
@@ -837,9 +846,9 @@ codeunit 10826 "Generate File FEC"
         exit('PG|' + Format(SourceType.AsInteger()) + '|' + PostingGroupCode);
     end;
 
-    local procedure GenPostingSetupScopeKey(GenBusPostingGroup: Code[20]; GenProdPostingGroup: Code[20]): Text
+    local procedure GenPostingSetupScopeKey(SourceType: Enum "Gen. Journal Source Type"; GenBusPostingGroup: Code[20]; GenProdPostingGroup: Code[20]): Text
     begin
-        exit('GPS|' + GenBusPostingGroup + '|' + GenProdPostingGroup);
+        exit('GPS|' + Format(SourceType.AsInteger()) + '|' + GenBusPostingGroup + '|' + GenProdPostingGroup);
     end;
 
     local procedure ResetTransactionData()

--- a/src/Apps/FR/FECAuditFile/app/src/ExportEngine/GenerateFileFEC.Codeunit.al
+++ b/src/Apps/FR/FECAuditFile/app/src/ExportEngine/GenerateFileFEC.Codeunit.al
@@ -45,10 +45,12 @@ codeunit 10826 "Generate File FEC"
         SourceCodesDescription: Dictionary of [Code[10], Text[100]];
         PayablesAccounts: Dictionary of [Code[20], Code[20]];
         ReceivablesAccounts: Dictionary of [Code[20], Code[20]];
-        PmtDiscountAccounts: Dictionary of [Code[20], Boolean];
-        ProcessedCustPostingGroups: Dictionary of [Code[20], Boolean];
-        ProcessedVendPostingGroups: Dictionary of [Code[20], Boolean];
-        ProcessedGenPostingSetups: Dictionary of [Text, Boolean];
+        PmtDiscountAccounts: Dictionary of [Text, Boolean];
+        ProcessedPmtDiscountScopes: Dictionary of [Text, Boolean];
+        CachedCustomerNames: Dictionary of [Code[20], Text[100]];
+        CachedCustomerPostingGroups: Dictionary of [Code[20], Code[20]];
+        CachedVendorNames: Dictionary of [Code[20], Text[100]];
+        CachedVendorPostingGroups: Dictionary of [Code[20], Code[20]];
         BankAccounts: Dictionary of [Code[20], Text[100]];
         BankAccPostingGroups: Dictionary of [Code[20], Code[20]];
         ProgressDialog: Dialog;
@@ -683,98 +685,161 @@ codeunit 10826 "Generate File FEC"
 
     local procedure SetPartyForPaymentDiscount(GLEntry: Record "G/L Entry"; var PartyNo: Code[20]; var PartyName: Text[100])
     var
-        Customer: Record Customer;
-        Vendor: Record Vendor;
+        PartyNameValue: Text[100];
+        PartyPostingGroupCode: Code[20];
     begin
         case GLEntry."Source Type" of
             GLEntry."Source Type"::Customer:
-                begin
-                    Customer.SetLoadFields(Name, "Customer Posting Group");
-                    if Customer.Get(GLEntry."Source No.") then
-                        if IsPaymentDiscountAccount(GLEntry, Customer."Customer Posting Group") then begin
-                            PartyNo := Customer."No.";
-                            PartyName := Customer.Name;
-                        end;
-                end;
+                if GetCustomerInfo(GLEntry."Source No.", PartyNameValue, PartyPostingGroupCode) then
+                    if IsPaymentDiscountAccount(GLEntry, PartyPostingGroupCode) then begin
+                        PartyNo := GLEntry."Source No.";
+                        PartyName := PartyNameValue;
+                    end;
             GLEntry."Source Type"::Vendor:
-                begin
-                    Vendor.SetLoadFields(Name, "Vendor Posting Group");
-                    if Vendor.Get(GLEntry."Source No.") then
-                        if IsPaymentDiscountAccount(GLEntry, Vendor."Vendor Posting Group") then begin
-                            PartyNo := Vendor."No.";
-                            PartyName := Vendor.Name;
-                        end;
-                end;
+                if GetVendorInfo(GLEntry."Source No.", PartyNameValue, PartyPostingGroupCode) then
+                    if IsPaymentDiscountAccount(GLEntry, PartyPostingGroupCode) then begin
+                        PartyNo := GLEntry."Source No.";
+                        PartyName := PartyNameValue;
+                    end;
         end;
     end;
 
+    local procedure GetCustomerInfo(CustomerNo: Code[20]; var CustomerName: Text[100]; var CustomerPostingGroupCode: Code[20]): Boolean
+    var
+        Customer: Record Customer;
+    begin
+        if CachedCustomerNames.ContainsKey(CustomerNo) then begin
+            CustomerName := CachedCustomerNames.Get(CustomerNo);
+            CustomerPostingGroupCode := CachedCustomerPostingGroups.Get(CustomerNo);
+            exit(true);
+        end;
+
+        Customer.SetLoadFields(Name, "Customer Posting Group");
+        if not Customer.Get(CustomerNo) then
+            exit(false);
+
+        CustomerName := Customer.Name;
+        CustomerPostingGroupCode := Customer."Customer Posting Group";
+        CachedCustomerNames.Add(CustomerNo, CustomerName);
+        CachedCustomerPostingGroups.Add(CustomerNo, CustomerPostingGroupCode);
+        exit(true);
+    end;
+
+    local procedure GetVendorInfo(VendorNo: Code[20]; var VendorName: Text[100]; var VendorPostingGroupCode: Code[20]): Boolean
+    var
+        Vendor: Record Vendor;
+    begin
+        if CachedVendorNames.ContainsKey(VendorNo) then begin
+            VendorName := CachedVendorNames.Get(VendorNo);
+            VendorPostingGroupCode := CachedVendorPostingGroups.Get(VendorNo);
+            exit(true);
+        end;
+
+        Vendor.SetLoadFields(Name, "Vendor Posting Group");
+        if not Vendor.Get(VendorNo) then
+            exit(false);
+
+        VendorName := Vendor.Name;
+        VendorPostingGroupCode := Vendor."Vendor Posting Group";
+        CachedVendorNames.Add(VendorNo, VendorName);
+        CachedVendorPostingGroups.Add(VendorNo, VendorPostingGroupCode);
+        exit(true);
+    end;
+
     local procedure IsPaymentDiscountAccount(GLEntry: Record "G/L Entry"; PostingGroupCode: Code[20]): Boolean
+    var
+        PostingGroupScope: Text;
+        GenPostingSetupScope: Text;
     begin
         if GLEntry."G/L Account No." = '' then
             exit(false);
 
-        CachePostingGroupPmtDiscountAccounts(GLEntry."Source Type", PostingGroupCode);
-        CacheGenPostingSetupPmtDiscountAccounts(GLEntry."Gen. Bus. Posting Group", GLEntry."Gen. Prod. Posting Group");
+        // The cached result is scoped to the current source type/posting group and to the current general
+        // posting setup, so an account that is a payment discount account for one setup cannot flag an
+        // unrelated line that happens to post to the same account under a different setup.
+        PostingGroupScope := PostingGroupScopeKey(GLEntry."Source Type", PostingGroupCode);
+        GenPostingSetupScope := GenPostingSetupScopeKey(GLEntry."Gen. Bus. Posting Group", GLEntry."Gen. Prod. Posting Group");
 
-        exit(PmtDiscountAccounts.ContainsKey(GLEntry."G/L Account No."));
+        CachePostingGroupPmtDiscountAccounts(GLEntry."Source Type", PostingGroupCode, PostingGroupScope);
+        CacheGenPostingSetupPmtDiscountAccounts(GLEntry."Gen. Bus. Posting Group", GLEntry."Gen. Prod. Posting Group", GenPostingSetupScope);
+
+        exit(
+            IsScopedPmtDiscountAccount(PostingGroupScope, GLEntry."G/L Account No.") or
+            IsScopedPmtDiscountAccount(GenPostingSetupScope, GLEntry."G/L Account No."));
     end;
 
-    local procedure CachePostingGroupPmtDiscountAccounts(SourceType: Enum "Gen. Journal Source Type"; PostingGroupCode: Code[20])
+    local procedure CachePostingGroupPmtDiscountAccounts(SourceType: Enum "Gen. Journal Source Type"; PostingGroupCode: Code[20]; ScopeKey: Text)
     var
         CustomerPostingGroup: Record "Customer Posting Group";
         VendorPostingGroup: Record "Vendor Posting Group";
     begin
+        if ProcessedPmtDiscountScopes.ContainsKey(ScopeKey) then
+            exit;
+        ProcessedPmtDiscountScopes.Add(ScopeKey, true);
+
         case SourceType of
             SourceType::Customer:
                 begin
-                    if ProcessedCustPostingGroups.ContainsKey(PostingGroupCode) then
-                        exit;
-                    ProcessedCustPostingGroups.Add(PostingGroupCode, true);
                     CustomerPostingGroup.SetLoadFields("Payment Disc. Debit Acc.", "Payment Disc. Credit Acc.");
                     if CustomerPostingGroup.Get(PostingGroupCode) then begin
-                        AddPmtDiscountAccount(CustomerPostingGroup."Payment Disc. Debit Acc.");
-                        AddPmtDiscountAccount(CustomerPostingGroup."Payment Disc. Credit Acc.");
+                        AddPmtDiscountAccount(ScopeKey, CustomerPostingGroup."Payment Disc. Debit Acc.");
+                        AddPmtDiscountAccount(ScopeKey, CustomerPostingGroup."Payment Disc. Credit Acc.");
                     end;
                 end;
             SourceType::Vendor:
                 begin
-                    if ProcessedVendPostingGroups.ContainsKey(PostingGroupCode) then
-                        exit;
-                    ProcessedVendPostingGroups.Add(PostingGroupCode, true);
                     VendorPostingGroup.SetLoadFields("Payment Disc. Debit Acc.", "Payment Disc. Credit Acc.");
                     if VendorPostingGroup.Get(PostingGroupCode) then begin
-                        AddPmtDiscountAccount(VendorPostingGroup."Payment Disc. Debit Acc.");
-                        AddPmtDiscountAccount(VendorPostingGroup."Payment Disc. Credit Acc.");
+                        AddPmtDiscountAccount(ScopeKey, VendorPostingGroup."Payment Disc. Debit Acc.");
+                        AddPmtDiscountAccount(ScopeKey, VendorPostingGroup."Payment Disc. Credit Acc.");
                     end;
                 end;
         end;
     end;
 
-    local procedure CacheGenPostingSetupPmtDiscountAccounts(GenBusPostingGroup: Code[20]; GenProdPostingGroup: Code[20])
+    local procedure CacheGenPostingSetupPmtDiscountAccounts(GenBusPostingGroup: Code[20]; GenProdPostingGroup: Code[20]; ScopeKey: Text)
     var
         GeneralPostingSetup: Record "General Posting Setup";
-        SetupKey: Text;
     begin
-        SetupKey := GenBusPostingGroup + '|' + GenProdPostingGroup;
-        if ProcessedGenPostingSetups.ContainsKey(SetupKey) then
+        if ProcessedPmtDiscountScopes.ContainsKey(ScopeKey) then
             exit;
-        ProcessedGenPostingSetups.Add(SetupKey, true);
+        ProcessedPmtDiscountScopes.Add(ScopeKey, true);
 
         GeneralPostingSetup.SetLoadFields(
             "Sales Pmt. Disc. Debit Acc.", "Sales Pmt. Disc. Credit Acc.",
             "Purch. Pmt. Disc. Debit Acc.", "Purch. Pmt. Disc. Credit Acc.");
         if GeneralPostingSetup.Get(GenBusPostingGroup, GenProdPostingGroup) then begin
-            AddPmtDiscountAccount(GeneralPostingSetup."Sales Pmt. Disc. Debit Acc.");
-            AddPmtDiscountAccount(GeneralPostingSetup."Sales Pmt. Disc. Credit Acc.");
-            AddPmtDiscountAccount(GeneralPostingSetup."Purch. Pmt. Disc. Debit Acc.");
-            AddPmtDiscountAccount(GeneralPostingSetup."Purch. Pmt. Disc. Credit Acc.");
+            AddPmtDiscountAccount(ScopeKey, GeneralPostingSetup."Sales Pmt. Disc. Debit Acc.");
+            AddPmtDiscountAccount(ScopeKey, GeneralPostingSetup."Sales Pmt. Disc. Credit Acc.");
+            AddPmtDiscountAccount(ScopeKey, GeneralPostingSetup."Purch. Pmt. Disc. Debit Acc.");
+            AddPmtDiscountAccount(ScopeKey, GeneralPostingSetup."Purch. Pmt. Disc. Credit Acc.");
         end;
     end;
 
-    local procedure AddPmtDiscountAccount(GLAccountNo: Code[20])
+    local procedure AddPmtDiscountAccount(ScopeKey: Text; GLAccountNo: Code[20])
+    var
+        ScopedAccountKey: Text;
     begin
-        if (GLAccountNo <> '') and (not PmtDiscountAccounts.ContainsKey(GLAccountNo)) then
-            PmtDiscountAccounts.Add(GLAccountNo, true);
+        if GLAccountNo = '' then
+            exit;
+        ScopedAccountKey := ScopeKey + '|' + GLAccountNo;
+        if not PmtDiscountAccounts.ContainsKey(ScopedAccountKey) then
+            PmtDiscountAccounts.Add(ScopedAccountKey, true);
+    end;
+
+    local procedure IsScopedPmtDiscountAccount(ScopeKey: Text; GLAccountNo: Code[20]): Boolean
+    begin
+        exit(PmtDiscountAccounts.ContainsKey(ScopeKey + '|' + GLAccountNo));
+    end;
+
+    local procedure PostingGroupScopeKey(SourceType: Enum "Gen. Journal Source Type"; PostingGroupCode: Code[20]): Text
+    begin
+        exit('PG|' + Format(SourceType.AsInteger()) + '|' + PostingGroupCode);
+    end;
+
+    local procedure GenPostingSetupScopeKey(GenBusPostingGroup: Code[20]; GenProdPostingGroup: Code[20]): Text
+    begin
+        exit('GPS|' + GenBusPostingGroup + '|' + GenProdPostingGroup);
     end;
 
     local procedure ResetTransactionData()

--- a/src/Apps/FR/FECAuditFile/app/src/ExportEngine/GenerateFileFEC.Codeunit.al
+++ b/src/Apps/FR/FECAuditFile/app/src/ExportEngine/GenerateFileFEC.Codeunit.al
@@ -46,7 +46,9 @@ codeunit 10826 "Generate File FEC"
         PayablesAccounts: Dictionary of [Code[20], Code[20]];
         ReceivablesAccounts: Dictionary of [Code[20], Code[20]];
         PmtDiscountAccounts: Dictionary of [Code[20], Boolean];
-        PmtDiscountAccountsInitialized: Boolean;
+        ProcessedCustPostingGroups: Dictionary of [Code[20], Boolean];
+        ProcessedVendPostingGroups: Dictionary of [Code[20], Boolean];
+        ProcessedGenPostingSetups: Dictionary of [Text, Boolean];
         BankAccounts: Dictionary of [Code[20], Text[100]];
         BankAccPostingGroups: Dictionary of [Code[20], Code[20]];
         ProgressDialog: Dialog;
@@ -153,7 +155,8 @@ codeunit 10826 "Generate File FEC"
 
         GLEntry.SetLoadFields(
             "Transaction No.", "Source Type", "Source No.", "Source Code", "G/L Account No.", "G/L Account Name",
-            "Posting Date", "Document No.", "Document Date", Description, Amount, "Debit Amount", "Credit Amount");
+            "Posting Date", "Document No.", "Document Date", Description, Amount, "Debit Amount", "Credit Amount",
+            "Gen. Bus. Posting Group", "Gen. Prod. Posting Group");
 
         GLEntry.SetRange("Posting Date", StartingDate, EndingDate);
         GLEntry.SetFilter("G/L Account No.", GLAccount.GetFilter("No."));
@@ -236,8 +239,8 @@ codeunit 10826 "Generate File FEC"
                     end;
 
             end;
-        if (PartyNo = '') and IsPaymentDiscountAccount(GLEntry."G/L Account No.") then
-            GetPartyForPaymentDiscount(GLEntry, PartyNo, PartyName);
+        if PartyNo = '' then
+            SetPartyForPaymentDiscount(GLEntry, PartyNo, PartyName);
 
         AllowMultiplePosting(PartyNo, PartyName, GLEntry, Customer);
 
@@ -678,59 +681,7 @@ codeunit 10826 "Generate File FEC"
         end;
     end;
 
-    local procedure IsPaymentDiscountAccount(GLAccountNo: Code[20]): Boolean
-    begin
-        if GLAccountNo = '' then
-            exit(false);
-
-        InitPmtDiscountAccountList();
-        exit(PmtDiscountAccounts.ContainsKey(GLAccountNo));
-    end;
-
-    local procedure InitPmtDiscountAccountList()
-    var
-        GeneralPostingSetup: Record "General Posting Setup";
-        CustomerPostingGroup: Record "Customer Posting Group";
-        VendorPostingGroup: Record "Vendor Posting Group";
-    begin
-        if PmtDiscountAccountsInitialized then
-            exit;
-
-        GeneralPostingSetup.SetLoadFields(
-            "Sales Pmt. Disc. Debit Acc.", "Sales Pmt. Disc. Credit Acc.",
-            "Purch. Pmt. Disc. Debit Acc.", "Purch. Pmt. Disc. Credit Acc.");
-        if GeneralPostingSetup.FindSet() then
-            repeat
-                AddPmtDiscountAccount(GeneralPostingSetup."Sales Pmt. Disc. Debit Acc.");
-                AddPmtDiscountAccount(GeneralPostingSetup."Sales Pmt. Disc. Credit Acc.");
-                AddPmtDiscountAccount(GeneralPostingSetup."Purch. Pmt. Disc. Debit Acc.");
-                AddPmtDiscountAccount(GeneralPostingSetup."Purch. Pmt. Disc. Credit Acc.");
-            until GeneralPostingSetup.Next() = 0;
-
-        CustomerPostingGroup.SetLoadFields("Payment Disc. Debit Acc.", "Payment Disc. Credit Acc.");
-        if CustomerPostingGroup.FindSet() then
-            repeat
-                AddPmtDiscountAccount(CustomerPostingGroup."Payment Disc. Debit Acc.");
-                AddPmtDiscountAccount(CustomerPostingGroup."Payment Disc. Credit Acc.");
-            until CustomerPostingGroup.Next() = 0;
-
-        VendorPostingGroup.SetLoadFields("Payment Disc. Debit Acc.", "Payment Disc. Credit Acc.");
-        if VendorPostingGroup.FindSet() then
-            repeat
-                AddPmtDiscountAccount(VendorPostingGroup."Payment Disc. Debit Acc.");
-                AddPmtDiscountAccount(VendorPostingGroup."Payment Disc. Credit Acc.");
-            until VendorPostingGroup.Next() = 0;
-
-        PmtDiscountAccountsInitialized := true;
-    end;
-
-    local procedure AddPmtDiscountAccount(GLAccountNo: Code[20])
-    begin
-        if (GLAccountNo <> '') and (not PmtDiscountAccounts.ContainsKey(GLAccountNo)) then
-            PmtDiscountAccounts.Add(GLAccountNo, true);
-    end;
-
-    local procedure GetPartyForPaymentDiscount(GLEntry: Record "G/L Entry"; var PartyNo: Code[20]; var PartyName: Text[100])
+    local procedure SetPartyForPaymentDiscount(GLEntry: Record "G/L Entry"; var PartyNo: Code[20]; var PartyName: Text[100])
     var
         Customer: Record Customer;
         Vendor: Record Vendor;
@@ -738,21 +689,92 @@ codeunit 10826 "Generate File FEC"
         case GLEntry."Source Type" of
             GLEntry."Source Type"::Customer:
                 begin
-                    Customer.SetLoadFields(Name);
-                    if Customer.Get(GLEntry."Source No.") then begin
-                        PartyNo := Customer."No.";
-                        PartyName := Customer.Name;
-                    end;
+                    Customer.SetLoadFields(Name, "Customer Posting Group");
+                    if Customer.Get(GLEntry."Source No.") then
+                        if IsPaymentDiscountAccount(GLEntry, Customer."Customer Posting Group") then begin
+                            PartyNo := Customer."No.";
+                            PartyName := Customer.Name;
+                        end;
                 end;
             GLEntry."Source Type"::Vendor:
                 begin
-                    Vendor.SetLoadFields(Name);
-                    if Vendor.Get(GLEntry."Source No.") then begin
-                        PartyNo := Vendor."No.";
-                        PartyName := Vendor.Name;
+                    Vendor.SetLoadFields(Name, "Vendor Posting Group");
+                    if Vendor.Get(GLEntry."Source No.") then
+                        if IsPaymentDiscountAccount(GLEntry, Vendor."Vendor Posting Group") then begin
+                            PartyNo := Vendor."No.";
+                            PartyName := Vendor.Name;
+                        end;
+                end;
+        end;
+    end;
+
+    local procedure IsPaymentDiscountAccount(GLEntry: Record "G/L Entry"; PostingGroupCode: Code[20]): Boolean
+    begin
+        if GLEntry."G/L Account No." = '' then
+            exit(false);
+
+        CachePostingGroupPmtDiscountAccounts(GLEntry."Source Type", PostingGroupCode);
+        CacheGenPostingSetupPmtDiscountAccounts(GLEntry."Gen. Bus. Posting Group", GLEntry."Gen. Prod. Posting Group");
+
+        exit(PmtDiscountAccounts.ContainsKey(GLEntry."G/L Account No."));
+    end;
+
+    local procedure CachePostingGroupPmtDiscountAccounts(SourceType: Enum "Gen. Journal Source Type"; PostingGroupCode: Code[20])
+    var
+        CustomerPostingGroup: Record "Customer Posting Group";
+        VendorPostingGroup: Record "Vendor Posting Group";
+    begin
+        case SourceType of
+            SourceType::Customer:
+                begin
+                    if ProcessedCustPostingGroups.ContainsKey(PostingGroupCode) then
+                        exit;
+                    ProcessedCustPostingGroups.Add(PostingGroupCode, true);
+                    CustomerPostingGroup.SetLoadFields("Payment Disc. Debit Acc.", "Payment Disc. Credit Acc.");
+                    if CustomerPostingGroup.Get(PostingGroupCode) then begin
+                        AddPmtDiscountAccount(CustomerPostingGroup."Payment Disc. Debit Acc.");
+                        AddPmtDiscountAccount(CustomerPostingGroup."Payment Disc. Credit Acc.");
+                    end;
+                end;
+            SourceType::Vendor:
+                begin
+                    if ProcessedVendPostingGroups.ContainsKey(PostingGroupCode) then
+                        exit;
+                    ProcessedVendPostingGroups.Add(PostingGroupCode, true);
+                    VendorPostingGroup.SetLoadFields("Payment Disc. Debit Acc.", "Payment Disc. Credit Acc.");
+                    if VendorPostingGroup.Get(PostingGroupCode) then begin
+                        AddPmtDiscountAccount(VendorPostingGroup."Payment Disc. Debit Acc.");
+                        AddPmtDiscountAccount(VendorPostingGroup."Payment Disc. Credit Acc.");
                     end;
                 end;
         end;
+    end;
+
+    local procedure CacheGenPostingSetupPmtDiscountAccounts(GenBusPostingGroup: Code[20]; GenProdPostingGroup: Code[20])
+    var
+        GeneralPostingSetup: Record "General Posting Setup";
+        SetupKey: Text;
+    begin
+        SetupKey := GenBusPostingGroup + '|' + GenProdPostingGroup;
+        if ProcessedGenPostingSetups.ContainsKey(SetupKey) then
+            exit;
+        ProcessedGenPostingSetups.Add(SetupKey, true);
+
+        GeneralPostingSetup.SetLoadFields(
+            "Sales Pmt. Disc. Debit Acc.", "Sales Pmt. Disc. Credit Acc.",
+            "Purch. Pmt. Disc. Debit Acc.", "Purch. Pmt. Disc. Credit Acc.");
+        if GeneralPostingSetup.Get(GenBusPostingGroup, GenProdPostingGroup) then begin
+            AddPmtDiscountAccount(GeneralPostingSetup."Sales Pmt. Disc. Debit Acc.");
+            AddPmtDiscountAccount(GeneralPostingSetup."Sales Pmt. Disc. Credit Acc.");
+            AddPmtDiscountAccount(GeneralPostingSetup."Purch. Pmt. Disc. Debit Acc.");
+            AddPmtDiscountAccount(GeneralPostingSetup."Purch. Pmt. Disc. Credit Acc.");
+        end;
+    end;
+
+    local procedure AddPmtDiscountAccount(GLAccountNo: Code[20])
+    begin
+        if (GLAccountNo <> '') and (not PmtDiscountAccounts.ContainsKey(GLAccountNo)) then
+            PmtDiscountAccounts.Add(GLAccountNo, true);
     end;
 
     local procedure ResetTransactionData()

--- a/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
+++ b/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
@@ -2345,6 +2345,63 @@ codeunit 148017 "FEC Audit File Export Tests"
         VerifyExportGLEntriesReport(GLRegister, AuditFile, '', BankAccount."No.", BankAccount.Name);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandlerYes')]
+    procedure PaymentDiscountLineHasCustomerInfo()
+    var
+        Customer: Record Customer;
+        CustomerPostingGroup: Record "Customer Posting Group";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        AuditFile: Record "Audit File";
+        iStream: InStream;
+        StartingDate: Date;
+        InvoiceDocNo: Code[20];
+        PaymentDocNo: Code[20];
+        InvoiceAmount: Decimal;
+        DiscountAmount: Decimal;
+        PmtDiscAccountNo: Code[20];
+    begin
+        // [SCENARIO 639574] CompAuxNum and CompAuxLib are informed for Payment Discount lines in the French Audit File
+        Initialize();
+        StartingDate := GetStartingDate();
+
+        // [GIVEN] Customer with a payment-discount payment term whose posting group has a Payment Disc. Debit Acc.
+        CreateCustomer(Customer);
+        CustomerPostingGroup.Get(Customer."Customer Posting Group");
+        if CustomerPostingGroup."Payment Disc. Debit Acc." = '' then begin
+            CustomerPostingGroup.Validate("Payment Disc. Debit Acc.", LibraryERM.CreateGLAccountNo());
+            CustomerPostingGroup.Modify(true);
+        end;
+        PmtDiscAccountNo := CustomerPostingGroup."Payment Disc. Debit Acc.";
+
+        // [GIVEN] A posted sales invoice with a possible payment discount
+        CreateGenJournalBatch(GenJournalBatch);
+        InvoiceAmount := LibraryRandom.RandDecInRange(1000, 2000, 2);
+        InvoiceDocNo :=
+          CreateGenJournalLine(GenJournalBatch, "Gen. Journal Document Type"::Invoice, "Gen. Journal Account Type"::Customer,
+            Customer."No.", StartingDate, InvoiceAmount);
+        LibraryERM.FindCustomerLedgerEntry(CustLedgerEntry, "Gen. Journal Document Type"::Invoice, InvoiceDocNo);
+        DiscountAmount := CustLedgerEntry."Original Pmt. Disc. Possible";
+        Assert.IsTrue(DiscountAmount > 0, 'The posted invoice should have a possible payment discount.');
+
+        // [GIVEN] A payment for (invoice amount - discount) applied to the invoice within the discount date, so the discount is granted
+        PaymentDocNo :=
+          CreateGenJournalLine(GenJournalBatch, "Gen. Journal Document Type"::Payment, "Gen. Journal Account Type"::Customer,
+            Customer."No.", StartingDate, -(InvoiceAmount - DiscountAmount));
+        ApplyAndPostGenJournalLine(PaymentDocNo, "Gen. Journal Document Type"::Invoice, InvoiceDocNo);
+
+        // [WHEN] Export Audit File in FEC format
+        RunFECExport(AuditFile, '', StartingDate, StartingDate, false);
+
+        // [THEN] The Payment Discount line (posted to the posting group's Payment Disc. Debit Acc.) has
+        // [THEN] CompAuxNum = Customer No. and CompAuxLib = Customer Name
+        CreateReadStream(iStream, AuditFile);
+        Assert.IsTrue(
+          FindPaymentDiscountLineWithParty(iStream, PmtDiscAccountNo, Customer."No.", Customer.Name),
+          'The payment discount line with the customer number and name was not found in the FEC file.');
+    end;
+
     local procedure Initialize()
     begin
         LibrarySetupStorage.Restore();
@@ -2385,6 +2442,24 @@ codeunit 148017 "FEC Audit File Export Tests"
     begin
         AuditFile.CalcFields("File Content");
         AuditFile."File Content".CreateInStream(FileInStream, TextEncoding::UTF8);
+    end;
+
+    local procedure FindPaymentDiscountLineWithParty(var FileInStream: InStream; PmtDiscAccountNo: Code[20]; ExpectedPartyNo: Code[20]; ExpectedPartyName: Text): Boolean
+    var
+        LineFields: List of [Text];
+        LineToRead: Text;
+    begin
+        while not FileInStream.EOS() do begin
+            FileInStream.ReadText(LineToRead);
+            LineFields := LineToRead.Split('|');
+            if LineFields.Count() >= 8 then
+                if LineFields.Get(5) = PmtDiscAccountNo then begin // field 5 = CompteNum
+                    Assert.AreEqual(ExpectedPartyNo, LineFields.Get(7), GetErrorTextForAssertStmnt(7)); // field 7 = CompAuxNum
+                    Assert.AreEqual(ExpectedPartyName, LineFields.Get(8), GetErrorTextForAssertStmnt(8)); // field 8 = CompAuxLib
+                    exit(true);
+                end;
+        end;
+        exit(false);
     end;
 
     local procedure RunFECExport(var AuditFile: Record "Audit File"; GLAccountNoFilter: Text; StartDate: Date; EndDate: Date; IncludeOpeningBalances: Boolean)

--- a/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
+++ b/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
@@ -2547,6 +2547,73 @@ codeunit 148017 "FEC Audit File Export Tests"
         VerifyFilePartyNoAndName(iStream, '', '');
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandlerYes')]
+    procedure PurchPmtDiscAccountDoesNotQualifyForCustomerLine()
+    var
+        Customer: Record Customer;
+        GenBusinessPostingGroup: Record "Gen. Business Posting Group";
+        GenProductPostingGroup: Record "Gen. Product Posting Group";
+        GeneralPostingSetup: Record "General Posting Setup";
+        VATPostingSetup: Record "VAT Posting Setup";
+        GLAccount: Record "G/L Account";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        AuditFile: Record "Audit File";
+        VATCalculationType: Enum "Tax Calculation Type";
+        iStream: InStream;
+        StartingDate: Date;
+        IncomeAccountNo: Code[20];
+        LineToRead: Text;
+    begin
+        // [SCENARIO 639574] For a Customer entry only a Sales payment discount account qualifies; a Purchase payment
+        // [SCENARIO] discount account of the same general posting setup must not add customer info to the line.
+        Initialize();
+        StartingDate := GetStartingDate();
+
+        // [GIVEN] Dedicated posting groups and a VAT posting setup
+        LibraryERM.CreateGenBusPostingGroup(GenBusinessPostingGroup);
+        LibraryERM.CreateGenProdPostingGroup(GenProductPostingGroup);
+        LibraryERM.CreateVATPostingSetupWithAccounts(VATPostingSetup, VATCalculationType::"Normal VAT", LibraryRandom.RandIntInRange(10, 25));
+
+        // [GIVEN] An income G/L account that a customer sales line posts to
+        LibraryERM.CreateGLAccount(GLAccount);
+        GLAccount.Validate("Gen. Posting Type", GLAccount."Gen. Posting Type"::Sale);
+        GLAccount.Validate("Gen. Prod. Posting Group", GenProductPostingGroup.Code);
+        GLAccount.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
+        GLAccount.Modify(true);
+        IncomeAccountNo := GLAccount."No.";
+
+        // [GIVEN] The general posting setup uses that account as its Purch. Pmt. Disc. account (not the Sales one)
+        LibraryERM.CreateGeneralPostingSetup(GeneralPostingSetup, GenBusinessPostingGroup.Code, GenProductPostingGroup.Code);
+        GeneralPostingSetup.Validate("Sales Account", LibraryERM.CreateGLAccountNo());
+        GeneralPostingSetup.Validate("Purch. Pmt. Disc. Debit Acc.", IncomeAccountNo);
+        GeneralPostingSetup.Validate("Purch. Pmt. Disc. Credit Acc.", IncomeAccountNo);
+        GeneralPostingSetup.Modify(true);
+
+        // [GIVEN] A customer of that posting group posts a sales invoice line to the income (Purch. Pmt. Disc.) account
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Gen. Bus. Posting Group", GenBusinessPostingGroup.Code);
+        Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        Customer.Modify(true);
+
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, Customer."No.");
+        SalesHeader.Validate("Posting Date", StartingDate);
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::"G/L Account", IncomeAccountNo, 1);
+        SalesLine.Validate("Unit Price", LibraryRandom.RandDecInRange(100, 200, 2));
+        SalesLine.Modify(true);
+        LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [WHEN] Export Audit File in FEC format for the income (Purch. Pmt. Disc.) account
+        RunFECExport(AuditFile, IncomeAccountNo, StartingDate, StartingDate, false);
+
+        // [THEN] The customer sales line has blank CompAuxNum/CompAuxLib - a purchase discount account does not qualify for a customer
+        CreateReadStream(iStream, AuditFile);
+        iStream.ReadText(LineToRead); // header
+        VerifyFilePartyNoAndName(iStream, '', '');
+    end;
+
     local procedure Initialize()
     begin
         LibrarySetupStorage.Restore();

--- a/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
+++ b/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
@@ -2471,6 +2471,82 @@ codeunit 148017 "FEC Audit File Export Tests"
         VerifyFilePartyNoAndName(iStream, Vendor."No.", Vendor.Name);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandlerYes')]
+    procedure PaymentDiscountAccountIsScopedToPostingGroup()
+    var
+        Customer: Record Customer;
+        CustomerPostingGroup: Record "Customer Posting Group";
+        OtherCustomer: Record Customer;
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        GenJournalLine: Record "Gen. Journal Line";
+        AuditFile: Record "Audit File";
+        iStream: InStream;
+        StartingDate: Date;
+        InvoiceDocNo: Code[20];
+        InvoiceAmount: Decimal;
+        DiscountAmount: Decimal;
+        SharedPmtDiscAccountNo: Code[20];
+        LineToRead: Text;
+    begin
+        // [SCENARIO 639574] A G/L account that is a payment discount account for one posting group must not add
+        // [SCENARIO] customer info to an unrelated line of another posting group that posts to the same account.
+        Initialize();
+        StartingDate := GetStartingDate();
+
+        // [GIVEN] Customer "C1" of a dedicated posting group whose Payment Disc. Debit Acc. is the shared account
+        SharedPmtDiscAccountNo := LibraryERM.CreateGLAccountNo();
+        LibrarySales.CreateCustomer(Customer);
+        LibrarySales.CreateCustomerPostingGroup(CustomerPostingGroup);
+        CustomerPostingGroup.Validate("Receivables Account", LibraryERM.CreateGLAccountNo());
+        CustomerPostingGroup.Validate("Payment Disc. Debit Acc.", SharedPmtDiscAccountNo);
+        CustomerPostingGroup.Modify(true);
+        Customer.Validate("Customer Posting Group", CustomerPostingGroup.Code);
+        Customer.Modify(true);
+
+        // [GIVEN] A posted invoice and a payment with discount for "C1" -> discount line posts to the shared account
+        InvoiceAmount := LibraryRandom.RandDecInRange(1000, 2000, 2);
+        LibraryJournals.CreateGenJournalLineWithBatch(
+            GenJournalLine, "Gen. Journal Document Type"::Invoice, "Gen. Journal Account Type"::Customer, Customer."No.", InvoiceAmount);
+        GenJournalLine.Validate("Posting Date", StartingDate);
+        GenJournalLine.Validate("Pmt. Discount Date", CalcDate('<1M>', StartingDate));
+        GenJournalLine.Validate("Payment Discount %", LibraryRandom.RandIntInRange(2, 5));
+        GenJournalLine.Modify(true);
+        InvoiceDocNo := GenJournalLine."Document No.";
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        LibraryERM.FindCustomerLedgerEntry(CustLedgerEntry, "Gen. Journal Document Type"::Invoice, InvoiceDocNo);
+        DiscountAmount := CustLedgerEntry."Original Pmt. Disc. Possible";
+        Assert.IsTrue(DiscountAmount > 0, 'The posted invoice should have a possible payment discount.');
+
+        LibraryJournals.CreateGenJournalLineWithBatch(
+            GenJournalLine, "Gen. Journal Document Type"::Payment, "Gen. Journal Account Type"::Customer, Customer."No.", -(InvoiceAmount - DiscountAmount));
+        GenJournalLine.Validate("Posting Date", StartingDate);
+        GenJournalLine.Validate("Applies-to Doc. Type", "Gen. Journal Document Type"::Invoice);
+        GenJournalLine.Validate("Applies-to Doc. No.", InvoiceDocNo);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [GIVEN] Another customer "C2" of a different posting group posts an unrelated entry to the same shared account
+        LibrarySales.CreateCustomer(OtherCustomer);
+        LibraryJournals.CreateGenJournalLineWithBatch(
+            GenJournalLine, "Gen. Journal Document Type"::" ", "Gen. Journal Account Type"::Customer, OtherCustomer."No.", LibraryRandom.RandDecInRange(100, 200, 2));
+        GenJournalLine.Validate("Posting Date", StartingDate);
+        GenJournalLine.Validate("Bal. Account Type", "Gen. Journal Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", SharedPmtDiscAccountNo);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [WHEN] Export Audit File in FEC format for the shared account
+        RunFECExport(AuditFile, SharedPmtDiscAccountNo, StartingDate, StartingDate, false);
+
+        // [THEN] "C1" payment discount line carries C1 info, but the unrelated "C2" line has blank CompAuxNum/CompAuxLib
+        CreateReadStream(iStream, AuditFile);
+        iStream.ReadText(LineToRead); // header
+        VerifyFilePartyNoAndName(iStream, Customer."No.", Customer.Name);
+        VerifyFilePartyNoAndName(iStream, '', '');
+    end;
+
     local procedure Initialize()
     begin
         LibrarySetupStorage.Restore();

--- a/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
+++ b/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
@@ -2408,6 +2408,69 @@ codeunit 148017 "FEC Audit File Export Tests"
         VerifyFilePartyNoAndName(iStream, Customer."No.", Customer.Name);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandlerYes')]
+    procedure PaymentDiscountLineHasVendorInfo()
+    var
+        Vendor: Record Vendor;
+        VendorPostingGroup: Record "Vendor Posting Group";
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        GenJournalLine: Record "Gen. Journal Line";
+        AuditFile: Record "Audit File";
+        iStream: InStream;
+        StartingDate: Date;
+        InvoiceDocNo: Code[20];
+        InvoiceAmount: Decimal;
+        DiscountAmount: Decimal;
+        PmtDiscAccountNo: Code[20];
+        LineToRead: Text;
+    begin
+        // [SCENARIO 639574] CompAuxNum and CompAuxLib are informed for purchase Payment Discount lines in the French Audit File
+        Initialize();
+        StartingDate := GetStartingDate();
+
+        // [GIVEN] Vendor whose posting group has a Payment Disc. Credit Acc.
+        LibraryPurchase.CreateVendor(Vendor);
+        VendorPostingGroup.Get(Vendor."Vendor Posting Group");
+        if VendorPostingGroup."Payment Disc. Credit Acc." = '' then begin
+            VendorPostingGroup.Validate("Payment Disc. Credit Acc.", LibraryERM.CreateGLAccountNo());
+            VendorPostingGroup.Modify(true);
+        end;
+        PmtDiscAccountNo := VendorPostingGroup."Payment Disc. Credit Acc.";
+
+        // [GIVEN] A posted purchase invoice with a possible payment discount
+        InvoiceAmount := LibraryRandom.RandDecInRange(1000, 2000, 2);
+        LibraryJournals.CreateGenJournalLineWithBatch(
+            GenJournalLine, "Gen. Journal Document Type"::Invoice, "Gen. Journal Account Type"::Vendor, Vendor."No.", -InvoiceAmount);
+        GenJournalLine.Validate("Posting Date", StartingDate);
+        GenJournalLine.Validate("Pmt. Discount Date", CalcDate('<1M>', StartingDate));
+        GenJournalLine.Validate("Payment Discount %", LibraryRandom.RandIntInRange(2, 5));
+        GenJournalLine.Modify(true);
+        InvoiceDocNo := GenJournalLine."Document No.";
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        LibraryERM.FindVendorLedgerEntry(VendorLedgerEntry, "Gen. Journal Document Type"::Invoice, InvoiceDocNo);
+        DiscountAmount := VendorLedgerEntry."Original Pmt. Disc. Possible";
+        Assert.IsTrue(DiscountAmount < 0, 'The posted invoice should have a possible payment discount.');
+
+        // [GIVEN] A payment for (invoice amount - discount) applied to the invoice within the discount date, so the discount is granted
+        LibraryJournals.CreateGenJournalLineWithBatch(
+            GenJournalLine, "Gen. Journal Document Type"::Payment, "Gen. Journal Account Type"::Vendor, Vendor."No.", InvoiceAmount + DiscountAmount);
+        GenJournalLine.Validate("Posting Date", StartingDate);
+        GenJournalLine.Validate("Applies-to Doc. Type", "Gen. Journal Document Type"::Invoice);
+        GenJournalLine.Validate("Applies-to Doc. No.", InvoiceDocNo);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [WHEN] Export Audit File in FEC format for the Payment Disc. Credit Acc. only
+        RunFECExport(AuditFile, PmtDiscAccountNo, StartingDate, StartingDate, false);
+
+        // [THEN] The exported Payment Discount line has CompAuxNum = Vendor No. and CompAuxLib = Vendor Name
+        CreateReadStream(iStream, AuditFile);
+        iStream.ReadText(LineToRead); // header
+        VerifyFilePartyNoAndName(iStream, Vendor."No.", Vendor.Name);
+    end;
+
     local procedure Initialize()
     begin
         LibrarySetupStorage.Restore();

--- a/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
+++ b/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
@@ -2352,12 +2352,11 @@ codeunit 148017 "FEC Audit File Export Tests"
         Customer: Record Customer;
         CustomerPostingGroup: Record "Customer Posting Group";
         CustLedgerEntry: Record "Cust. Ledger Entry";
-        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalLine: Record "Gen. Journal Line";
         AuditFile: Record "Audit File";
         iStream: InStream;
         StartingDate: Date;
         InvoiceDocNo: Code[20];
-        PaymentDocNo: Code[20];
         InvoiceAmount: Decimal;
         DiscountAmount: Decimal;
         PmtDiscAccountNo: Code[20];
@@ -2367,8 +2366,8 @@ codeunit 148017 "FEC Audit File Export Tests"
         Initialize();
         StartingDate := GetStartingDate();
 
-        // [GIVEN] Customer with a payment-discount payment term whose posting group has a Payment Disc. Debit Acc.
-        CreateCustomer(Customer);
+        // [GIVEN] Customer whose posting group has a Payment Disc. Debit Acc.
+        LibrarySales.CreateCustomer(Customer);
         CustomerPostingGroup.Get(Customer."Customer Posting Group");
         if CustomerPostingGroup."Payment Disc. Debit Acc." = '' then begin
             CustomerPostingGroup.Validate("Payment Disc. Debit Acc.", LibraryERM.CreateGLAccountNo());
@@ -2377,20 +2376,28 @@ codeunit 148017 "FEC Audit File Export Tests"
         PmtDiscAccountNo := CustomerPostingGroup."Payment Disc. Debit Acc.";
 
         // [GIVEN] A posted sales invoice with a possible payment discount
-        CreateGenJournalBatch(GenJournalBatch);
         InvoiceAmount := LibraryRandom.RandDecInRange(1000, 2000, 2);
-        InvoiceDocNo :=
-          CreateGenJournalLine(GenJournalBatch, "Gen. Journal Document Type"::Invoice, "Gen. Journal Account Type"::Customer,
-            Customer."No.", StartingDate, InvoiceAmount);
+        LibraryJournals.CreateGenJournalLineWithBatch(
+            GenJournalLine, "Gen. Journal Document Type"::Invoice, "Gen. Journal Account Type"::Customer, Customer."No.", InvoiceAmount);
+        GenJournalLine.Validate("Posting Date", StartingDate);
+        GenJournalLine.Validate("Pmt. Discount Date", CalcDate('<1M>', StartingDate));
+        GenJournalLine.Validate("Payment Discount %", LibraryRandom.RandIntInRange(2, 5));
+        GenJournalLine.Modify(true);
+        InvoiceDocNo := GenJournalLine."Document No.";
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
         LibraryERM.FindCustomerLedgerEntry(CustLedgerEntry, "Gen. Journal Document Type"::Invoice, InvoiceDocNo);
         DiscountAmount := CustLedgerEntry."Original Pmt. Disc. Possible";
         Assert.IsTrue(DiscountAmount > 0, 'The posted invoice should have a possible payment discount.');
 
         // [GIVEN] A payment for (invoice amount - discount) applied to the invoice within the discount date, so the discount is granted
-        PaymentDocNo :=
-          CreateGenJournalLine(GenJournalBatch, "Gen. Journal Document Type"::Payment, "Gen. Journal Account Type"::Customer,
-            Customer."No.", StartingDate, -(InvoiceAmount - DiscountAmount));
-        ApplyAndPostGenJournalLine(PaymentDocNo, "Gen. Journal Document Type"::Invoice, InvoiceDocNo);
+        LibraryJournals.CreateGenJournalLineWithBatch(
+            GenJournalLine, "Gen. Journal Document Type"::Payment, "Gen. Journal Account Type"::Customer, Customer."No.", -(InvoiceAmount - DiscountAmount));
+        GenJournalLine.Validate("Posting Date", StartingDate);
+        GenJournalLine.Validate("Applies-to Doc. Type", "Gen. Journal Document Type"::Invoice);
+        GenJournalLine.Validate("Applies-to Doc. No.", InvoiceDocNo);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
 
         // [WHEN] Export Audit File in FEC format for the Payment Disc. Debit Acc. only
         RunFECExport(AuditFile, PmtDiscAccountNo, StartingDate, StartingDate, false);

--- a/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
+++ b/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
@@ -2361,6 +2361,7 @@ codeunit 148017 "FEC Audit File Export Tests"
         InvoiceAmount: Decimal;
         DiscountAmount: Decimal;
         PmtDiscAccountNo: Code[20];
+        LineToRead: Text;
     begin
         // [SCENARIO 639574] CompAuxNum and CompAuxLib are informed for Payment Discount lines in the French Audit File
         Initialize();
@@ -2391,15 +2392,13 @@ codeunit 148017 "FEC Audit File Export Tests"
             Customer."No.", StartingDate, -(InvoiceAmount - DiscountAmount));
         ApplyAndPostGenJournalLine(PaymentDocNo, "Gen. Journal Document Type"::Invoice, InvoiceDocNo);
 
-        // [WHEN] Export Audit File in FEC format
-        RunFECExport(AuditFile, '', StartingDate, StartingDate, false);
+        // [WHEN] Export Audit File in FEC format for the Payment Disc. Debit Acc. only
+        RunFECExport(AuditFile, PmtDiscAccountNo, StartingDate, StartingDate, false);
 
-        // [THEN] The Payment Discount line (posted to the posting group's Payment Disc. Debit Acc.) has
-        // [THEN] CompAuxNum = Customer No. and CompAuxLib = Customer Name
+        // [THEN] The exported Payment Discount line has CompAuxNum = Customer No. and CompAuxLib = Customer Name
         CreateReadStream(iStream, AuditFile);
-        Assert.IsTrue(
-          FindPaymentDiscountLineWithParty(iStream, PmtDiscAccountNo, Customer."No.", Customer.Name),
-          'The payment discount line with the customer number and name was not found in the FEC file.');
+        iStream.ReadText(LineToRead); // header
+        VerifyFilePartyNoAndName(iStream, Customer."No.", Customer.Name);
     end;
 
     local procedure Initialize()
@@ -2442,24 +2441,6 @@ codeunit 148017 "FEC Audit File Export Tests"
     begin
         AuditFile.CalcFields("File Content");
         AuditFile."File Content".CreateInStream(FileInStream, TextEncoding::UTF8);
-    end;
-
-    local procedure FindPaymentDiscountLineWithParty(var FileInStream: InStream; PmtDiscAccountNo: Code[20]; ExpectedPartyNo: Code[20]; ExpectedPartyName: Text): Boolean
-    var
-        LineFields: List of [Text];
-        LineToRead: Text;
-    begin
-        while not FileInStream.EOS() do begin
-            FileInStream.ReadText(LineToRead);
-            LineFields := LineToRead.Split('|');
-            if LineFields.Count() >= 8 then
-                if LineFields.Get(5) = PmtDiscAccountNo then begin // field 5 = CompteNum
-                    Assert.AreEqual(ExpectedPartyNo, LineFields.Get(7), GetErrorTextForAssertStmnt(7)); // field 7 = CompAuxNum
-                    Assert.AreEqual(ExpectedPartyName, LineFields.Get(8), GetErrorTextForAssertStmnt(8)); // field 8 = CompAuxLib
-                    exit(true);
-                end;
-        end;
-        exit(false);
     end;
 
     local procedure RunFECExport(var AuditFile: Record "Audit File"; GLAccountNoFilter: Text; StartDate: Date; EndDate: Date; IncludeOpeningBalances: Boolean)

--- a/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
+++ b/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
@@ -2586,6 +2586,7 @@ codeunit 148017 "FEC Audit File Export Tests"
         IncomeAccountNo := GLAccount."No.";
 
         // [GIVEN] The general posting setup uses that account as its Purch. Pmt. Disc. account (not the Sales one)
+        LibrarySetupStorage.Save(Database::"General Ledger Setup");
         GeneralLedgerSetup.Get();
         GeneralLedgerSetup.Validate("Adjust for Payment Disc.", true);
         GeneralLedgerSetup.Modify(true);

--- a/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
+++ b/src/Apps/FR/FECAuditFile/test/src/FECAuditFileExportTests.Codeunit.al
@@ -2555,6 +2555,7 @@ codeunit 148017 "FEC Audit File Export Tests"
         GenBusinessPostingGroup: Record "Gen. Business Posting Group";
         GenProductPostingGroup: Record "Gen. Product Posting Group";
         GeneralPostingSetup: Record "General Posting Setup";
+        GeneralLedgerSetup: Record "General Ledger Setup";
         VATPostingSetup: Record "VAT Posting Setup";
         GLAccount: Record "G/L Account";
         SalesHeader: Record "Sales Header";
@@ -2585,6 +2586,9 @@ codeunit 148017 "FEC Audit File Export Tests"
         IncomeAccountNo := GLAccount."No.";
 
         // [GIVEN] The general posting setup uses that account as its Purch. Pmt. Disc. account (not the Sales one)
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("Adjust for Payment Disc.", true);
+        GeneralLedgerSetup.Modify(true);
         LibraryERM.CreateGeneralPostingSetup(GeneralPostingSetup, GenBusinessPostingGroup.Code, GenProductPostingGroup.Code);
         GeneralPostingSetup.Validate("Sales Account", LibraryERM.CreateGLAccountNo());
         GeneralPostingSetup.Validate("Purch. Pmt. Disc. Debit Acc.", IncomeAccountNo);


### PR DESCRIPTION
[Bug 643980](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/643980): [MAster] [all-e]CompAuxNum and CompAuxLib columns should be informed for Payment Discount lines in the French Audit File.

Fixes [AB#643980](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643980)

ISSUE: CompAuxNum and CompAuxLib columns should be informed for Payment Discount lines in the French Audit File.

CAUSE: value not inserted for CompAuxNum and CompAuxLib columns.

SOLUTION: Code added for the CompAuxNum and CompAuxLib columns.













