### PR TITLE
Miapp: derive base branch from origin/HEAD instead of $env:RepoBranchName

### DIFF
--- a/build/scripts/Miapp/MicroApp.psm1
+++ b/build/scripts/Miapp/MicroApp.psm1
@@ -123,8 +123,8 @@ function Invoke-Miapp
 
     try {
 
-    if(-not (Initialize-MiappRepoBranchName)) {
-        Throw "Cannot determine base branch. Set `$env:RepoBranchName to the base branch name (for example 'main')."
+    if(-not (Get-MiappBaseBranch)) {
+        Throw "Cannot determine the base branch from 'origin/HEAD'. Ensure the repository has an 'origin' remote with a resolvable default branch (for example: git remote set-head origin --auto)."
     }
 
     $params = @{
@@ -200,11 +200,11 @@ function Assert-RepositoryIsNotBehindTheRemote {
         Throw "Your branch is behind, pull before continuing."
     }
 
-    if(Test-PendingChangeFromBranch "origin/$env:RepoBranchName") {
-        Throw "Your branch is behind origin/$($env:RepoBranchName), merge or rebase before continuing."
+    if(Test-PendingChangeFromBranch "origin/$(Get-MiappBaseBranch)") {
+        Throw "Your branch is behind origin/$(Get-MiappBaseBranch), merge or rebase before continuing."
     }
 
-    if(-not (Test-GitBranchHasAtLeastOneCommit "origin/$env:RepoBranchName")) {
+    if(-not (Test-GitBranchHasAtLeastOneCommit "origin/$(Get-MiappBaseBranch)")) {
         Throw "You need to commit at least once before continuing."
     }
 }

--- a/build/scripts/Miapp/MicroAppGitHelper.psm1
+++ b/build/scripts/Miapp/MicroAppGitHelper.psm1
@@ -434,28 +434,44 @@ function Get-GitCurrentBranch {
     git rev-parse --abbrev-ref HEAD
 }
 
-function Initialize-MiappRepoBranchName {
+$script:MiappBaseBranch = $null
+
+function Get-MiappBaseBranch {
+    <#
+    .SYNOPSIS
+    Returns the base branch Miapp integrates from, derived from the repository
+    Miapp operates on - not from any environment variable.
+
+    .DESCRIPTION
+    The base branch is resolved from 'origin/HEAD' of the current repository so
+    that Miapp always targets that repository's own default branch, even when it
+    runs inside a submodule whose default branch differs from the outer repo.
+    Deriving it from the repository (rather than an ambient variable such as
+    $env:RepoBranchName) avoids constructing a non-existent ref like
+    'origin/master' when the outer repo and the submodule use different default
+    branch names. The resolved value is cached for the lifetime of the module.
+    #>
     [CmdletBinding()]
     [OutputType([string])]
     param()
 
-    if ($env:RepoBranchName) {
-        return $env:RepoBranchName
+    if ($script:MiappBaseBranch) {
+        return $script:MiappBaseBranch
     }
 
     [string] $originHeadRef = (git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>$null)
     if ($originHeadRef -imatch '^origin/(.+)$') {
-        $env:RepoBranchName = $Matches[1]
+        $script:MiappBaseBranch = $Matches[1]
     }
 
-    if (-not $env:RepoBranchName) {
+    if (-not $script:MiappBaseBranch) {
         [string] $originHeadBranch = (git remote show origin 2>$null | Select-String 'HEAD branch:' | Select-Object -First 1)
         if ($originHeadBranch -imatch 'HEAD branch:\s*(.+)$') {
-            $env:RepoBranchName = $Matches[1].Trim()
+            $script:MiappBaseBranch = $Matches[1].Trim()
         }
     }
 
-    $env:RepoBranchName
+    $script:MiappBaseBranch
 }
 
 function Get-GitLastCommitSHA1 {
@@ -517,9 +533,9 @@ function GetGitCommittedFiles {
     [OutputType([string[]])]
     param()
 
-    # Returns files committed locally since origin/RepoBranchName
-    if (-not (Initialize-MiappRepoBranchName)) { return }
-    git diff --name-only "origin/$env:RepoBranchName...HEAD" | ? { $_ }
+    # Returns files committed locally since the base branch (origin/HEAD)
+    if (-not (Get-MiappBaseBranch)) { return }
+    git diff --name-only "origin/$(Get-MiappBaseBranch)...HEAD" | ? { $_ }
 }
 
 
@@ -724,7 +740,7 @@ Export-ModuleMember Get-GitCanonicalPath
 Export-ModuleMember Get-GitChangedFiles
 Export-ModuleMember Get-GitCurrentBranch
 Export-ModuleMember Get-GitCurrentRemoteBranch
-Export-ModuleMember Initialize-MiappRepoBranchName
+Export-ModuleMember Get-MiappBaseBranch
 Export-ModuleMember Get-GitFileStatus
 Export-ModuleMember Get-GitLastCommitSHA1
 Export-ModuleMember Get-GitMergeToolConfig

--- a/build/scripts/Miapp/MicroAppIntegrate.psm1
+++ b/build/scripts/Miapp/MicroAppIntegrate.psm1
@@ -120,7 +120,7 @@ function Invoke-IntegrateFile {
         [string] $File,
 
         [ValidateNotNullOrEmpty()]
-        [char] $Status = (Get-GitFileStatus $File "origin/$env:RepoBranchName"),
+        [char] $Status = (Get-GitFileStatus $File "origin/$(Get-MiappBaseBranch)"),
 
         [ValidateNotNull()]
         [HashTable] $Params = @{}
@@ -133,8 +133,8 @@ function Invoke-IntegrateFile {
     [string] $fileName = Get-IntegrationFileName $File
     [string] $branchPath = Get-IntegrationBranchName $File
 
-    if(($Status -ne $GitFileStatus.Deleted) -and -not (Test-GitFileDifferentFromRemote $File "origin/$env:RepoBranchName")) {
-        Write-Verbose "Skipping $File`nThe file status is '$Status' but there is no difference from the version on origin/$($env:RepoBranchName)"
+    if(($Status -ne $GitFileStatus.Deleted) -and -not (Test-GitFileDifferentFromRemote $File "origin/$(Get-MiappBaseBranch)")) {
+        Write-Verbose "Skipping $File`nThe file status is '$Status' but there is no difference from the version on origin/$(Get-MiappBaseBranch)"
         return
     }
 
@@ -154,7 +154,7 @@ function IntegrateBranchedObjects {
         [string] $File,
 
         [ValidateNotNullOrEmpty()]
-        [char] $Status = (Get-GitFileStatus $File "origin/$env:RepoBranchName"),
+        [char] $Status = (Get-GitFileStatus $File "origin/$(Get-MiappBaseBranch)"),
 
         [ValidateNotNullOrEmpty()]
         [string] $BranchPath = (Get-IntegrationBranchName $File),
@@ -331,7 +331,7 @@ function ExcludeOrStageFile {
 
     $file = Resolve-GitPath -Relative -RemoteStyle $DestFile
 
-    if ((Test-Path $DestFile) -and -not (Test-GitFileDifferentFromRemote $file "origin/$env:RepoBranchName")) {
+    if ((Test-Path $DestFile) -and -not (Test-GitFileDifferentFromRemote $file "origin/$(Get-MiappBaseBranch)")) {
         Write-Host "$file does not differ from remote version, adding to ignore list"
         AddFileToExclusionList (Get-GitCanonicalPath $file -Absolute)
     } else {
@@ -520,12 +520,12 @@ function Get-BaseFile {
         [string] $File,
 
         [Parameter()]
-        [char] $Status = (Get-GitFileStatus $File "origin/$env:RepoBranchName")
+        [char] $Status = (Get-GitFileStatus $File "origin/$(Get-MiappBaseBranch)")
     )
 
     if($Status -eq $GitFileStatus.Deleted) { return }
 
-    [string] $baseFile = Get-GitRemoteFile $File "origin/$env:RepoBranchName" $Status
+    [string] $baseFile = Get-GitRemoteFile $File "origin/$(Get-MiappBaseBranch)" $Status
 
     if($baseFile) {
         Write-Verbose "Remote base file found for $File"

--- a/build/scripts/Miapp/MicroSnapApp.psm1
+++ b/build/scripts/Miapp/MicroSnapApp.psm1
@@ -16,7 +16,7 @@ function Invoke-MiSnapApp
     )
     begin {
         if(-not $Files) {
-            # Default: validate all files committed since origin/RepoBranchName
+            # Default: validate all files committed since the base branch (origin/HEAD)
             $Files = Get-MiappCommittedFiles
         }
     }
@@ -45,19 +45,19 @@ function Invoke-MiSnapApp
 
 <#
 .SYNOPSIS
-Returns files committed locally since origin/RepoBranchName, relative to the repo root.
+Returns files committed locally since the base branch (origin/HEAD), relative to the repo root.
 #>
 function Get-MiappCommittedFiles {
     [CmdletBinding()]
     [OutputType([string[]])]
     param()
 
-    if (-not (Initialize-MiappRepoBranchName)) {
-        Write-Host -ForegroundColor Yellow "RepoBranchName is not set and could not be inferred from origin/HEAD. Cannot determine committed files."
+    if (-not (Get-MiappBaseBranch)) {
+        Write-Host -ForegroundColor Yellow "Could not determine the base branch from origin/HEAD. Cannot determine committed files."
         return
     }
 
-    git diff --name-only "origin/$env:RepoBranchName...HEAD" | ? { $_ }
+    git diff --name-only "origin/$(Get-MiappBaseBranch)...HEAD" | ? { $_ }
 }
 
 function GetBranchedObjectFileNames {

--- a/build/scripts/Miapp/README.md
+++ b/build/scripts/Miapp/README.md
@@ -266,8 +266,10 @@ $MiappConfig = @{
 
 ### Environment Variables
 
-- `$env:RepoBranchName` - Base branch name used for comparisons (defaults to `origin/HEAD`, typically `main`, when not set)
 - `$env:MIAPP_DIR` - Directory for miapp temporary files (default: $env:USERPROFILE)
+
+> The base branch used for comparisons is derived automatically from the
+> repository's own `origin/HEAD` (typically `main` for BCApps).
 
 ### Output
 


### PR DESCRIPTION
## Summary

`Miapp` (the MicroApp Integrate tooling under `build/scripts/Miapp/`) derived its base branch from `$env:RepoBranchName`. When Miapp runs inside a repository whose default branch differs from an outer/consuming repository, that ambient variable points at the wrong branch. In practice, a monorepo that vendors BCApps as a submodule sets `RepoBranchName=master` for its own repo, but BCApps' default branch is `main`. Miapp then constructed refs like `origin/master`, which do not exist in BCApps, and failed:

```
fatal: ambiguous argument 'HEAD..origin/master': unknown revision or path not in the working tree.
```

## Change

- Replace `Initialize-MiappRepoBranchName` (env-based) with **`Get-MiappBaseBranch`**, which resolves the base branch from the repository's own **`origin/HEAD`** via `git symbolic-ref --short refs/remotes/origin/HEAD`, with `git remote show origin` as a fallback. The result is cached in a module-scoped variable.
- No environment variable is read or written, so Miapp always targets the default branch of the repository it operates on.
- Update all `origin/$env:RepoBranchName` usages across `MicroApp.psm1`, `MicroAppGitHelper.psm1`, `MicroAppIntegrate.psm1`, and `MicroSnapApp.psm1`, plus the README.

## Testing

- All modules parse cleanly.
- `Get-MiappBaseBranch` returns `main` in BCApps even when `$env:RepoBranchName=master`.
- The two previously failing commands (`git log HEAD..origin/<base>` and `git log origin/<base>..HEAD`) now resolve `origin/main` and exit 0.


[AB#643986](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643986)

