### PR TITLE
[DO NOT MERGE] Test: failOn newWarning with workspace compilation (AL-Go #2300)

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go/16948d91ca57e875e3d823536bac740c0ca1fdbd/Actions/.Modules/settings.schema.json",
+  "failOn": "newWarning",
   "type": "PTE",
   "templateUrl": "https://github.com/microsoft/AL-Go-PTE@preview",
   "bcContainerHelperVersion": "preview",

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -104,7 +104,7 @@ jobs:
           lfs: true
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/ReadSettings@4f4c47f96c9201b21882dcb090d50c2b478cd227
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Run Build Initialize hook
         if: hashFiles(format('{0}/.AL-Go/BuildInitialize.ps1', inputs.project)) != ''
-        uses: microsoft/AL-Go/Actions/RunHook@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/RunHook@4f4c47f96c9201b21882dcb090d50c2b478cd227
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Determine whether to build project
         id: DetermineBuildProject
-        uses: microsoft/AL-Go/Actions/DetermineBuildProject@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/DetermineBuildProject@4f4c47f96c9201b21882dcb090d50c2b478cd227
         with:
           shell: ${{ inputs.shell }}
           skippedProjectsJson: ${{ inputs.skippedProjectsJson }}
@@ -131,7 +131,7 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/ReadSecrets@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/ReadSecrets@4f4c47f96c9201b21882dcb090d50c2b478cd227
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -149,7 +149,7 @@ jobs:
       - name: Determine ArtifactUrl
         id: determineArtifactUrl
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@4f4c47f96c9201b21882dcb090d50c2b478cd227
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -164,7 +164,7 @@ jobs:
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@4f4c47f96c9201b21882dcb090d50c2b478cd227
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -177,14 +177,14 @@ jobs:
       - name: Download Previous Release
         id: DownloadPreviousRelease
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && env.skipUpgrade == 'False'
-        uses: microsoft/AL-Go/Actions/DownloadPreviousRelease@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/DownloadPreviousRelease@4f4c47f96c9201b21882dcb090d50c2b478cd227
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
 
       - name: Compile Apps
         id: compile
-        uses: microsoft/AL-Go/Actions/CompileApps@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/CompileApps@4f4c47f96c9201b21882dcb090d50c2b478cd227
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && fromJson(env.workspaceCompilation).enabled == true
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -211,7 +211,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "NeedsContext=$needsContextPath"
 
       - name: Build
-        uses: microsoft/AL-Go/Actions/RunPipeline@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/RunPipeline@4f4c47f96c9201b21882dcb090d50c2b478cd227
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -231,7 +231,7 @@ jobs:
       - name: Sign
         id: sign
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != '')) && (hashFiles(format('{0}/.buildartifacts/Apps/*.app',inputs.project)) != '')
-        uses: microsoft/AL-Go/Actions/Sign@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/Sign@4f4c47f96c9201b21882dcb090d50c2b478cd227
         with:
           shell: ${{ inputs.shell }}
           azureCredentialsJson: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).AZURE_CREDENTIALS }}'
@@ -239,7 +239,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@4f4c47f96c9201b21882dcb090d50c2b478cd227
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -354,7 +354,7 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: (success() || failure()) && env.doNotRunTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@4f4c47f96c9201b21882dcb090d50c2b478cd227
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -363,7 +363,7 @@ jobs:
       - name: Analyze BCPT Test Results
         id: analyzeTestResultsBCPT
         if: (success() || failure()) && env.doNotRunBcptTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@4f4c47f96c9201b21882dcb090d50c2b478cd227
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -372,7 +372,7 @@ jobs:
       - name: Analyze Page Scripting Test Results
         id: analyzeTestResultsPageScripting
         if: (success() || failure()) && env.doNotRunpageScriptingTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@4f4c47f96c9201b21882dcb090d50c2b478cd227
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -380,7 +380,7 @@ jobs:
 
       - name: Cleanup
         if: always() && steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/PipelineCleanup@16948d91ca57e875e3d823536bac740c0ca1fdbd
+        uses: microsoft/AL-Go/Actions/PipelineCleanup@4f4c47f96c9201b21882dcb090d50c2b478cd227
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}

--- a/src/Apps/NZ/ContosoCoffeeDemoDatasetNZ/app/DemoTool/Contoso Helpers/ContosoNZCounty.Codeunit.al
+++ b/src/Apps/NZ/ContosoCoffeeDemoDatasetNZ/app/DemoTool/Contoso Helpers/ContosoNZCounty.Codeunit.al
@@ -15,7 +15,10 @@ codeunit 17118 "Contoso NZ County"
         tabledata County = rim;
 
     procedure SetOverwriteData(Overwrite: Boolean)
+    var
+        UnusedValue: Integer;
     begin
+        UnusedValue := 42;
         OverwriteData := Overwrite;
     end;
 


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE - test PR.** Validates an AL-Go change and will be closed.

## Purpose
Validates microsoft/AL-Go PR #2300 (branch `aholstrup1-vigilant-spork`, SHA 4f4c47f9) which makes `failOn: newWarning` work with **workspace compilation**. Previously the new-warning check only ran in `RunPipeline`, so it had no effect when `workspaceCompilation` was enabled (compilation happens in `CompileApps`).

## What this PR does
1. Repoints AL-Go actions in `_BuildALGoProject.yaml` to the fix branch (`@4f4c47f9`).
2. Enables `"failOn": "newWarning"` at repo level.
3. Introduces one new warning (AA0206 - unused variable) in an NZ-only demo codeunit.

## Expected result
CI/CD **fails** for project **Apps NZ** with *"New warnings were introduced in this PR"* (AA0206), demonstrating the check now fires under workspace compilation.

