### PR TITLE
[Subscription Billing] Page 8002 "Extend Contract" — move key variables to protected var and add setters for PageExtension automation

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/ExtendContract.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/ExtendContract.Page.al
@@ -302,6 +302,10 @@ page 8002 "Extend Contract"
         ValidateSubscriptionEntryNo();
 
         CountTotalServiceCommitmentPackage();
+
+        if VariantCodeParam <> '' then
+            VariantCode := VariantCodeParam;
+
         CurrPage.Update();
     end;
 
@@ -607,6 +611,10 @@ page 8002 "Extend Contract"
         ExtendCustomerContract := ExtendCustomerContractParam;
         UsageDataSupplierNo := UsageDataSupplierNoParam;
         SubscriptionEntryNo := SubscriptionEntryNoParam;
+        ExtendVendorContract := ExtendVendorContractParam;
+        VendorContractNo := VendorContractNoParam;
+        ItemNo := ItemNoParam;
+        QuantityDecimal := QuantityParam;
     end;
 
     local procedure FillTempServiceCommitmentPackage()
@@ -667,6 +675,19 @@ page 8002 "Extend Contract"
         SubscriptionEntryNoParam := NewSubscriptionEntryNo;
     end;
 
+    procedure SetVendorContractParameters(NewExtendVendorContract: Boolean; NewVendorContractNo: Code[20])
+    begin
+        ExtendVendorContractParam := NewExtendVendorContract;
+        VendorContractNoParam := NewVendorContractNo;
+    end;
+
+    procedure SetItemParameters(NewItemNo: Code[20]; NewVariantCode: Code[10]; NewQuantity: Decimal)
+    begin
+        ItemNoParam := NewItemNo;
+        VariantCodeParam := NewVariantCode;
+        QuantityParam := NewQuantity;
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnBeforeExtendContract()
     begin
@@ -691,11 +712,6 @@ page 8002 "Extend Contract"
         ContractItemMgt: Codeunit "Sub. Contracts Item Management";
         ExtendContractMgt: Codeunit "Extend Sub. Contract Mgt.";
         ImportAndProcessUsageData: Codeunit "Import And Process Usage Data";
-        CustomerContractNo: Code[20];
-        VendorContractNo: Code[20];
-        UnitPrice: Decimal;
-        UnitCostLCY: Decimal;
-        ProvisionStartDate: Date;
         ProvisionStartDateEmptyErr: Label 'Provision Start Date cannot be empty.';
         NoOfSelectedPackagesLbl: Label '%1 of %2', Comment = '%1 = No. of selected service commitment packages, %2 = Total service commitment packages';
         SelectedServiceCommitmentPackages: Integer;
@@ -705,9 +721,13 @@ page 8002 "Extend Contract"
         CustomerContractNoParam: Code[20];
         ProvisionStartDateParam: Date;
         ExtendCustomerContractParam: Boolean;
+        ExtendVendorContractParam: Boolean;
+        VendorContractNoParam: Code[20];
+        ItemNoParam: Code[20];
+        VariantCodeParam: Code[10];
+        QuantityParam: Decimal;
         UsageDataSupplierNo: Code[20];
         UsageDataSupplierNoParam: Code[20];
-        SubscriptionDescription: Text[100];
         SubscriptionEntryNo: Integer;
         SubscriptionEntryNoParam: Integer;
         SupplierReferenceEntryNo: Integer;
@@ -716,7 +736,6 @@ page 8002 "Extend Contract"
         ItemMissingServCommPackageTxt: Label 'No Subscription Package is available for this item.';
         AssignServCommPackageToItemTxt: Label 'In order to extend the contract properly, please make sure that at least one package is assigned.';
         ItemNoEmptyErr: Label 'Item No. must be specified.';
-        ItemDescription: Text[100];
 
     protected var
         ItemNo: Code[20];
@@ -725,4 +744,11 @@ page 8002 "Extend Contract"
         ExtendCustomerContract: Boolean;
         ExtendVendorContract: Boolean;
         SellToCustomerNo: Code[20];
+        CustomerContractNo: Code[20];
+        VendorContractNo: Code[20];
+        SubscriptionDescription: Text[100];
+        ItemDescription: Text[100];
+        UnitPrice: Decimal;
+        UnitCostLCY: Decimal;
+        ProvisionStartDate: Date;
 }


### PR DESCRIPTION
## What & why

Page 8002 "Extend Contract" only exposed a limited set of variables in its `protected var` section, leaving several variables that partner extensions need to read or write in the global (unprotected) `var` block. This blocked automation scenarios on top of the standard "Extend Contract" flow without cloning the entire page.

This change moves seven variables (`CustomerContractNo`, `VendorContractNo`, `SubscriptionDescription`, `ItemDescription`, `UnitPrice`, `UnitCostLCY`, `ProvisionStartDate`) to `protected var`, and adds two new setter procedures (`SetVendorContractParameters()`, `SetItemParameters()`) following the existing `SetUsageBasedParameters()` pattern, so that a PageExtension can supply these values *before* `OnOpenPage` runs its validation chain, ensuring dependent fields (item description, unit price/cost, subscription packages) are populated correctly instead of appearing empty.

## Linked work

Fixes #8856

Fixes [AB#646374](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646374)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app locally with no new analyzer warnings.

**What I tested and the outcome**
- Compiled the "Subscription Billing" app locally (AL: Package) against a BC 29 Early Access Preview sandbox (29.0.52714.0); build succeeded ("Success: The package is created"). The only compiler warnings (AL0920, in RecentItemPrice/CalculationBaseByPerc/PriceByPercent codeunits) are pre-existing in main and unrelated to this change.
- Given the small, additive scope of this change (visibility change + two new setters following an existing, already-used pattern), I did not further test this in a Business Central instance.

## Risk & compatibility

None expected. All changes are additive:
- Moving variables from `var` to `protected var` does not change any existing behavior for the base app or existing callers. It only widens accessibility for PageExtensions.
- The two new setter procedures are new public entry points; no existing procedure signature is modified.
- The one behavioral addition (re-applying `VariantCodeParam` at the end of `OnOpenPage`) is guarded by `if VariantCodeParam <> ''`, so existing manual-entry behavior (no parameters supplied) is unchanged.



