### PR TITLE
Expose AppService location and EUDB membership on Environment Information for internal consumption

### DIFF
--- a/src/System Application/App/Environment Information/src/EnvironmentInformation.Codeunit.al
+++ b/src/System Application/App/Environment Information/src/EnvironmentInformation.Codeunit.al
@@ -156,6 +156,24 @@ codeunit 457 "Environment Information"
     end;
 
     /// <summary>
+    /// Gets the physical location of the application service the environment is hosted on (for example, "Canada Central").
+    /// </summary>
+    /// <returns>The application service location if available; otherwise, an empty string.</returns>
+    procedure GetApplicationServiceLocation(): Text
+    begin
+        exit(EnvironmentInformationImpl.GetApplicationServiceLocation());
+    end;
+
+    /// <summary>
+    /// Checks whether the Azure geography of the application service the environment is hosted on is within the Microsoft EU Data Boundary (EUDB).
+    /// </summary>
+    /// <returns>True if the environment is hosted within the EU Data Boundary, false otherwise.</returns>
+    procedure IsApplicationServiceInEUDB(): Boolean
+    begin
+        exit(EnvironmentInformationImpl.IsApplicationServiceInEUDB());
+    end;
+
+    /// <summary>
     /// Gets the value of the specified environment setting. This is only callable from Microsoft published apps.
     /// </summary>
     /// <param name="SettingName">The name of the setting.</param>

--- a/src/System Application/App/Environment Information/src/EnvironmentInformation.Codeunit.al
+++ b/src/System Application/App/Environment Information/src/EnvironmentInformation.Codeunit.al
@@ -156,21 +156,27 @@ codeunit 457 "Environment Information"
     end;
 
     /// <summary>
-    /// Gets the physical location of the application service the environment is hosted on (for example, "Canada Central").
+    /// Gets the physical location of the application service the environment is hosted on (for example, "Canada Central"). This is only callable from Microsoft published apps.
     /// </summary>
-    /// <returns>The application service location if available; otherwise, an empty string.</returns>
+    /// <returns>The application service location when running on SaaS infrastructure and the information is available; otherwise, an empty string.</returns>
     procedure GetApplicationServiceLocation(): Text
+    var
+        CallerModuleInfo: ModuleInfo;
     begin
-        exit(EnvironmentInformationImpl.GetApplicationServiceLocation());
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        exit(EnvironmentInformationImpl.GetApplicationServiceLocation(CallerModuleInfo));
     end;
 
     /// <summary>
-    /// Checks whether the Azure geography of the application service the environment is hosted on is within the Microsoft EU Data Boundary (EUDB).
+    /// Checks whether the Azure geography of the application service the environment is hosted on is within the Microsoft EU Data Boundary (EUDB). This is only callable from Microsoft published apps.
     /// </summary>
-    /// <returns>True if the environment is hosted within the EU Data Boundary, false otherwise.</returns>
+    /// <returns>True when the environment is hosted within the EU Data Boundary. False means either that the environment is outside the EU Data Boundary or that the information is unavailable, including when not running on SaaS infrastructure.</returns>
     procedure IsApplicationServiceInEUDB(): Boolean
+    var
+        CallerModuleInfo: ModuleInfo;
     begin
-        exit(EnvironmentInformationImpl.IsApplicationServiceInEUDB());
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        exit(EnvironmentInformationImpl.IsApplicationServiceInEUDB(CallerModuleInfo));
     end;
 
     /// <summary>

--- a/src/System Application/App/Environment Information/src/EnvironmentInformationImpl.Codeunit.al
+++ b/src/System Application/App/Environment Information/src/EnvironmentInformationImpl.Codeunit.al
@@ -177,6 +177,16 @@ codeunit 3702 "Environment Information Impl."
         exit(NavTenantSettingsHelper.GetLinkedPowerPlatformEnvironmentId());
     end;
 
+    procedure GetApplicationServiceLocation(): Text
+    begin
+        exit(NavTenantSettingsHelper.GetAppServiceLocation());
+    end;
+
+    procedure IsApplicationServiceInEUDB(): Boolean
+    begin
+        exit(NavTenantSettingsHelper.GetAppServiceInEUDB());
+    end;
+
     procedure GetEnvironmentSetting(SettingName: Text; ModuleInfo: ModuleInfo): Text
     begin
         if ModuleInfo.Publisher <> 'Microsoft' then

--- a/src/System Application/App/Environment Information/src/EnvironmentInformationImpl.Codeunit.al
+++ b/src/System Application/App/Environment Information/src/EnvironmentInformationImpl.Codeunit.al
@@ -27,6 +27,7 @@ codeunit 3702 "Environment Information Impl."
         IsSandboxInitialized: Boolean;
         DefaultSandboxEnvironmentNameTxt: Label 'Sandbox', Locked = true;
         DefaultProductionEnvironmentNameTxt: Label 'Production', Locked = true;
+        MicrosoftPublisherOnlyErr: Label 'This procedure is only available for Microsoft published apps.';
 
     procedure IsProduction(): Boolean
     begin
@@ -177,13 +178,23 @@ codeunit 3702 "Environment Information Impl."
         exit(NavTenantSettingsHelper.GetLinkedPowerPlatformEnvironmentId());
     end;
 
-    procedure GetApplicationServiceLocation(): Text
+    procedure GetApplicationServiceLocation(CallerModuleInfo: ModuleInfo): Text
     begin
+        EnsureMicrosoftPublisher(CallerModuleInfo);
+
+        if not IsSaaSInfrastructure() then
+            exit('');
+
         exit(NavTenantSettingsHelper.GetAppServiceLocation());
     end;
 
-    procedure IsApplicationServiceInEUDB(): Boolean
+    procedure IsApplicationServiceInEUDB(CallerModuleInfo: ModuleInfo): Boolean
     begin
+        EnsureMicrosoftPublisher(CallerModuleInfo);
+
+        if not IsSaaSInfrastructure() then
+            exit(false);
+
         exit(NavTenantSettingsHelper.GetAppServiceInEUDB());
     end;
 
@@ -192,6 +203,12 @@ codeunit 3702 "Environment Information Impl."
         if ModuleInfo.Publisher <> 'Microsoft' then
             exit('');
         exit(NavTenantSettingsHelper.GetEnvironmentApplicationSetting(SettingName));
+    end;
+
+    local procedure EnsureMicrosoftPublisher(CallerModuleInfo: ModuleInfo)
+    begin
+        if CallerModuleInfo.Publisher <> 'Microsoft' then
+            Error(MicrosoftPublisherOnlyErr);
     end;
 
     [InternalEvent(false)]

--- a/src/System Application/Partner Test/Environment Information/src/EnvironmentInfoTestPartner.Codeunit.al
+++ b/src/System Application/Partner Test/Environment Information/src/EnvironmentInfoTestPartner.Codeunit.al
@@ -35,12 +35,11 @@ codeunit 139023 "Environment Info Test Partner"
     procedure IsApplicationServiceInEUDBRequiresMicrosoftPublisher()
     var
         EnvironmentInformation: Codeunit "Environment Information";
-        IsInEUDB: Boolean;
     begin
         // [SCENARIO] A partner app cannot read application service EUDB membership.
 
         // [WHEN] A partner-published app requests EUDB membership
-        asserterror IsInEUDB := EnvironmentInformation.IsApplicationServiceInEUDB();
+        asserterror EnvironmentInformation.IsApplicationServiceInEUDB();
 
         // [THEN] Access is denied
         Assert.ExpectedError(MicrosoftPublisherOnlyErr);

--- a/src/System Application/Partner Test/Environment Information/src/EnvironmentInformationTestPartner.Codeunit.al
+++ b/src/System Application/Partner Test/Environment Information/src/EnvironmentInformationTestPartner.Codeunit.al
@@ -1,0 +1,48 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Partner.Test.Environment;
+
+using System.Environment;
+using System.TestLibraries.Utilities;
+
+codeunit 139023 "Environment Info Test Partner"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Library Assert";
+        MicrosoftPublisherOnlyErr: Label 'This procedure is only available for Microsoft published apps.';
+
+    [Test]
+    procedure GetApplicationServiceLocationRequiresMicrosoftPublisher()
+    var
+        EnvironmentInformation: Codeunit "Environment Information";
+        ApplicationServiceLocation: Text;
+    begin
+        // [SCENARIO] A partner app cannot read the application service location.
+
+        // [WHEN] A partner-published app requests the application service location
+        asserterror ApplicationServiceLocation := EnvironmentInformation.GetApplicationServiceLocation();
+
+        // [THEN] Access is denied
+        Assert.ExpectedError(MicrosoftPublisherOnlyErr);
+    end;
+
+    [Test]
+    procedure IsApplicationServiceInEUDBRequiresMicrosoftPublisher()
+    var
+        EnvironmentInformation: Codeunit "Environment Information";
+        IsInEUDB: Boolean;
+    begin
+        // [SCENARIO] A partner app cannot read application service EUDB membership.
+
+        // [WHEN] A partner-published app requests EUDB membership
+        asserterror IsInEUDB := EnvironmentInformation.IsApplicationServiceInEUDB();
+
+        // [THEN] Access is denied
+        Assert.ExpectedError(MicrosoftPublisherOnlyErr);
+    end;
+}

--- a/src/System Application/Test/Environment Information/src/EnvironmentInformationTest.Codeunit.al
+++ b/src/System Application/Test/Environment Information/src/EnvironmentInformationTest.Codeunit.al
@@ -87,6 +87,34 @@ codeunit 135091 "Environment Information Test"
 
     [Test]
     [Scope('OnPrem')]
+    procedure TestApplicationServiceLocationIsEmptyOutsideSaaSInfrastructure()
+    begin
+        // [SCENARIO] Application service location is unavailable outside SaaS infrastructure.
+
+        // [GIVEN] SaaS testability is disabled
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(false);
+
+        // [WHEN] The application service location is requested
+        // [THEN] An empty location is returned
+        Assert.AreEqual('', EnvironmentInformation.GetApplicationServiceLocation(), 'Application service location should be empty outside SaaS infrastructure.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TestApplicationServiceEUDBIsFalseOutsideSaaSInfrastructure()
+    begin
+        // [SCENARIO] EUDB membership is unavailable outside SaaS infrastructure.
+
+        // [GIVEN] SaaS testability is disabled
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(false);
+
+        // [WHEN] EUDB membership is requested
+        // [THEN] False is returned
+        Assert.IsFalse(EnvironmentInformation.IsApplicationServiceInEUDB(), 'Application service EUDB membership should be false outside SaaS infrastructure.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure TestIsEarlyPreviewVersionIsSet()
     begin
         // [SCENARIO] Set the testability to true. IsEarlyPreview returns correct value.


### PR DESCRIPTION
## Summary
- Exposes App Service location and EU Data Boundary membership through `Environment Information`.
- Restricts both procedures to Microsoft-published callers.
- Returns an empty location and `false` EUDB status outside SaaS infrastructure.

`IsApplicationServiceInEUDB()` returns `false` both when outside EUDB and when the information is unavailable.

Related work item: [AB#643989](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643989)



