### PR TITLE
[main] bug 643971 - Implement checks for blocked customers and vendors in advance letters

### DIFF
--- a/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/TableExtensions/CustomerCZZ.TableExt.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/TableExtensions/CustomerCZZ.TableExt.al
@@ -16,4 +16,17 @@ tableextension 31045 "Customer CZZ" extends Customer
         SalesAdvLetterHeaderCZZ.SetFilter(Status, '%1|%2', SalesAdvLetterHeaderCZZ.Status::"To Pay", SalesAdvLetterHeaderCZZ.Status::"To Use");
         exit(SalesAdvLetterHeaderCZZ.Count());
     end;
+
+    /// <summary>
+    /// Checks if the customer is blocked for the specified advance letter and raises an error if blocked.
+    /// </summary>
+    /// <param name="Transaction">Indicates whether this is a posting transaction.</param>
+    procedure CheckBlockedCustOnAdvanceLettersCZZ(Transaction: Boolean)
+    begin
+        if "Privacy Blocked" then
+            CustPrivacyBlockedErrorMessage(Rec, Transaction);
+
+        if Blocked <> Blocked::" " then
+            CustBlockedErrorMessage(Rec, Transaction);
+    end;
 }

--- a/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/TableExtensions/VendorCZZ.TableExt.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/TableExtensions/VendorCZZ.TableExt.al
@@ -16,4 +16,18 @@ tableextension 31046 "Vendor CZZ" extends Vendor
         PurchAdvLetterHeaderCZZ.SetFilter(Status, '%1|%2', PurchAdvLetterHeaderCZZ.Status::"To Pay", PurchAdvLetterHeaderCZZ.Status::"To Use");
         exit(PurchAdvLetterHeaderCZZ.Count());
     end;
+
+
+    /// <summary>
+    /// Checks if the vendor is blocked for the specified advance letter and raises an error if blocked.
+    /// </summary>
+    /// <param name="Transaction">Indicates whether this is a posting transaction.</param>
+    procedure CheckBlockedVendOnAdvanceLettersCZZ(Transaction: Boolean)
+    begin
+        if "Privacy Blocked" then
+            VendPrivacyBlockedErrorMessage(Rec, Transaction);
+
+        if Blocked <> Blocked::" " then
+            VendBlockedErrorMessage(Rec, Transaction);
+    end;
 }

--- a/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/Tables/PurchAdvLetterHeaderCZZ.Table.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/Tables/PurchAdvLetterHeaderCZZ.Table.al
@@ -94,6 +94,7 @@ table 31008 "Purch. Adv. Letter Header CZZ"
 
                 GetVendor("Pay-to Vendor No.");
                 Vendor.TestField("Vendor Posting Group");
+                Vendor.CheckBlockedVendOnAdvanceLettersCZZ(false);
                 "Pay-to Name" := Vendor.Name;
                 "Pay-to Name 2" := Vendor."Name 2";
                 CopyPayToVendorAddressFieldsFromVendor(Vendor, false);
@@ -1621,6 +1622,8 @@ table 31008 "Purch. Adv. Letter Header CZZ"
 
     procedure CheckPurchaseAdvanceLetterPostRestrictions()
     begin
+        Vendor.Get("Pay-to Vendor No.");
+        Vendor.CheckBlockedVendOnAdvanceLettersCZZ(true);
         OnCheckPurchaseAdvanceLetterPostRestrictions();
     end;
 

--- a/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/Tables/SalesAdvLetterHeaderCZZ.Table.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/Tables/SalesAdvLetterHeaderCZZ.Table.al
@@ -98,6 +98,7 @@ table 31004 "Sales Adv. Letter Header CZZ"
 
                 GetCustomer("Bill-to Customer No.");
                 Customer.TestField("Customer Posting Group");
+                Customer.CheckBlockedCustOnAdvanceLettersCZZ(false);
 
                 SetBillToCustomerAddressFieldsFromCustomer(Customer);
 
@@ -1731,6 +1732,8 @@ table 31004 "Sales Adv. Letter Header CZZ"
 
     procedure CheckSalesAdvanceLetterPostRestrictions()
     begin
+        Customer.Get("Bill-to Customer No.");
+        Customer.CheckBlockedCustOnAdvanceLettersCZZ(true);
         OnCheckSalesAdvanceLetterPostRestrictions();
     end;
 

--- a/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/PurchaseAdvancePaymentsCZZ.Codeunit.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/PurchaseAdvancePaymentsCZZ.Codeunit.al
@@ -31,6 +31,8 @@ codeunit 148108 "Purchase Advance Payments CZZ"
         UnapplyAdvLetterQst: Label 'Unapply advance letter: %1\Continue?', Comment = '%1 = Advance Letters';
         UsageNoPossibleQst: Label 'Usage all applicated advances is not possible.\Continue?';
         PostCashDocumentQst: Label 'Do you want to post Cash Document Header %1?', Comment = '%1 = Cash Document No.';
+        BlockedVendorErr: Label 'You cannot %1 this type of document when Vendor %2 is blocked with type %3', Comment = '%1 = create/post, %2 = vendor no., %3 = blocked type';
+        PrivacyBlockedVendorErr: Label 'You cannot %1 this type of document when Vendor %2 is blocked for privacy.', Comment = '%1 = create/post, %2 = vendor no.';
 
     local procedure Initialize()
     var
@@ -2641,6 +2643,117 @@ codeunit 148108 "Purchase Advance Payments CZZ"
         Assert.AreEqual(0, VATEntry.Amount, 'The sum of VAT amount in VAT Entries must be zero.');
 
         SetPostVATDocForReverseCharge(false);
+    end;
+
+    [Test]
+    procedure CreatePurchAdvLetterWithVendorBlockedAll()
+    begin
+        CreatePurchAdvLetterWithBlockedVendorBase(Enum::"Vendor Blocked"::All, false);
+    end;
+
+    [Test]
+    procedure CreatePurchAdvLetterWithVendorBlockedPayment()
+    begin
+        CreatePurchAdvLetterWithBlockedVendorBase(Enum::"Vendor Blocked"::Payment, false);
+    end;
+
+    [Test]
+    procedure CreatePurchAdvLetterWithPrivacyBlockedVendor()
+    begin
+        CreatePurchAdvLetterWithBlockedVendorBase(Enum::"Vendor Blocked"::" ", true);
+    end;
+
+    [Test]
+    procedure PostPaymentPurchAdvLetterWithVendorBlockedAll()
+    begin
+        PostPaymentPurchAdvLetterWithBlockedVendorBase(Enum::"Vendor Blocked"::All, false);
+    end;
+
+    [Test]
+    procedure PostPaymentPurchAdvLetterWithVendorBlockedPayment()
+    begin
+        PostPaymentPurchAdvLetterWithBlockedVendorBase(Enum::"Vendor Blocked"::Payment, false);
+    end;
+
+    [Test]
+    procedure PostPaymentPurchAdvLetterWithPrivacyBlockedVendor()
+    begin
+        PostPaymentPurchAdvLetterWithBlockedVendorBase(Enum::"Vendor Blocked"::" ", true);
+    end;
+
+    local procedure CreatePurchAdvLetterWithBlockedVendorBase(VendorBlocked: Enum "Vendor Blocked"; PrivacyBlocked: Boolean)
+    var
+        PurchAdvLetterHeaderCZZ: Record "Purch. Adv. Letter Header CZZ";
+        Vendor: Record Vendor;
+    begin
+        // [SCENARIO] Creating purchase advance letter with blocked vendor must fail
+        Initialize();
+
+        // [GIVEN] Vendor has been created and blocked
+        CreateBlockedVendor(Vendor, VendorBlocked, PrivacyBlocked);
+
+        // [WHEN] Create purchase advance letter with blocked vendor
+        asserterror LibraryPurchAdvancesCZZ.CreatePurchAdvLetterHeader(PurchAdvLetterHeaderCZZ, AdvanceLetterTemplateCZZ.Code, Vendor."No.", '');
+
+        // [THEN] Error will occur
+        if PrivacyBlocked then
+            Assert.ExpectedError(StrSubstNo(PrivacyBlockedVendorErr, 'create', Vendor."No."))
+        else
+            Assert.ExpectedError(StrSubstNo(BlockedVendorErr, 'create', Vendor."No.", VendorBlocked));
+    end;
+
+    local procedure PostPaymentPurchAdvLetterWithBlockedVendorBase(VendorBlocked: Enum "Vendor Blocked"; PrivacyBlocked: Boolean)
+    var
+        PurchAdvLetterHeaderCZZ: Record "Purch. Adv. Letter Header CZZ";
+        PurchAdvLetterLineCZZ: Record "Purch. Adv. Letter Line CZZ";
+        GenJournalLine: Record "Gen. Journal Line";
+        Vendor: Record Vendor;
+    begin
+        // [SCENARIO] Posting payment for purchase advance letter with blocked vendor must fail
+        Initialize();
+
+        // [GIVEN] Purchase advance letter has been created
+        // [GIVEN] Purchase advance letter line with normal VAT has been created
+        CreatePurchAdvLetter(PurchAdvLetterHeaderCZZ, PurchAdvLetterLineCZZ);
+
+        // [GIVEN] Purchase advance letter has been released
+        ReleasePurchAdvLetter(PurchAdvLetterHeaderCZZ);
+
+        // [GIVEN] Purchase advance payment has been prepared in general journal
+        LibraryPurchAdvancesCZZ.CreatePurchAdvancePayment(
+            GenJournalLine, PurchAdvLetterHeaderCZZ."Pay-to Vendor No.", PurchAdvLetterLineCZZ."Amount Including VAT",
+            PurchAdvLetterHeaderCZZ."Currency Code", PurchAdvLetterHeaderCZZ."No.", 0, 0D);
+
+        // [GIVEN] Vendor has been blocked
+        Vendor.Get(PurchAdvLetterHeaderCZZ."Pay-to Vendor No.");
+        if PrivacyBlocked then
+            Vendor.Validate("Privacy Blocked", PrivacyBlocked)
+        else
+            Vendor.Validate(Blocked, VendorBlocked);
+        Vendor.Modify(true);
+
+        // [WHEN] Post purchase advance payment
+        asserterror PostGenJournalLine(GenJournalLine);
+
+        // [THEN] Error will occur
+        if PrivacyBlocked then
+            Assert.ExpectedError(StrSubstNo(PrivacyBlockedVendorErr, 'post', Vendor."No."))
+        else
+            Assert.ExpectedError(StrSubstNo(BlockedVendorErr, 'post', Vendor."No.", VendorBlocked));
+    end;
+
+    local procedure CreateBlockedVendor(var Vendor: Record Vendor; VendorBlocked: Enum "Vendor Blocked"; PrivacyBlocked: Boolean)
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+    begin
+        LibraryPurchAdvancesCZZ.FindVATPostingSetup(VATPostingSetup);
+        LibraryPurchAdvancesCZZ.CreateVendor(Vendor);
+        Vendor.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        if PrivacyBlocked then
+            Vendor.Validate("Privacy Blocked", PrivacyBlocked)
+        else
+            Vendor.Validate(Blocked, VendorBlocked);
+        Vendor.Modify(true);
     end;
 
     local procedure CreatePurchAdvLetterBase(var PurchAdvLetterHeaderCZZ: Record "Purch. Adv. Letter Header CZZ"; var PurchAdvLetterLineCZZ: Record "Purch. Adv. Letter Line CZZ"; VendorNo: Code[20]; CurrencyCode: Code[10]; VATPostingSetup: Record "VAT Posting Setup")

--- a/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/SalesAdvancePaymentsCZZ.Codeunit.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/SalesAdvancePaymentsCZZ.Codeunit.al
@@ -32,6 +32,8 @@ codeunit 148109 "Sales Advance Payments CZZ"
         UnapplyAdvLetterQst: Label 'Unapply advance letter: %1\Continue?', Comment = '%1 = Advance Letters';
         UsageNoPossibleQst: Label 'Usage all applicated advances is not possible.\Continue?';
         PostCashDocumentQst: Label 'Do you want to post Cash Document Header %1?', Comment = '%1 = Cash Document No.';
+        BlockedCustomerErr: Label 'You cannot %1 this type of document when Customer %2 is blocked with type %3', Comment = '%1 = create/post, %2 = customer no., %3 = blocked type';
+        PrivacyBlockedCustomerErr: Label 'You cannot %1 this type of document when Customer %2 is blocked for privacy.', Comment = '%1 = create/post, %2 = customer no.';
 
     local procedure Initialize()
     var
@@ -2771,6 +2773,129 @@ codeunit 148109 "Sales Advance Payments CZZ"
 
         // [THEN] Verify no error occur when Copy the Document from Posted Sales Invoice to Sales Return Order.
         CopyDocumentMgt.CopySalesDoc("Sales Document Type From"::"Posted Invoice", DocumentNo, SalesHeader[2]);
+    end;
+
+    [Test]
+    procedure CreateSalesAdvLetterWithCustomerBlockedAll()
+    begin
+        CreateSalesAdvLetterWithBlockedCustomerBase(Enum::"Customer Blocked"::All, false);
+    end;
+
+    [Test]
+    procedure CreateSalesAdvLetterWithCustomerBlockedShip()
+    begin
+        CreateSalesAdvLetterWithBlockedCustomerBase(Enum::"Customer Blocked"::Ship, false);
+    end;
+
+    [Test]
+    procedure CreateSalesAdvLetterWithCustomerBlockedInvoice()
+    begin
+        CreateSalesAdvLetterWithBlockedCustomerBase(Enum::"Customer Blocked"::Invoice, false);
+    end;
+
+    [Test]
+    procedure CreateSalesAdvLetterWithPrivacyBlockedCustomer()
+    begin
+        CreateSalesAdvLetterWithBlockedCustomerBase(Enum::"Customer Blocked"::" ", true);
+    end;
+
+    [Test]
+    procedure PostPaymentSalesAdvLetterWithCustomerBlockedAll()
+    begin
+        PostPaymentSalesAdvLetterWithBlockedCustomerBase(Enum::"Customer Blocked"::All, false);
+    end;
+
+    [Test]
+    procedure PostPaymentSalesAdvLetterWithCustomerBlockedShip()
+    begin
+        PostPaymentSalesAdvLetterWithBlockedCustomerBase(Enum::"Customer Blocked"::Ship, false);
+    end;
+
+    [Test]
+    procedure PostPaymentSalesAdvLetterWithCustomerBlockedInvoice()
+    begin
+        PostPaymentSalesAdvLetterWithBlockedCustomerBase(Enum::"Customer Blocked"::Invoice, false);
+    end;
+
+    [Test]
+    procedure PostPaymentSalesAdvLetterWithPrivacyBlockedCustomer()
+    begin
+        PostPaymentSalesAdvLetterWithBlockedCustomerBase(Enum::"Customer Blocked"::" ", true);
+    end;
+
+    local procedure CreateSalesAdvLetterWithBlockedCustomerBase(CustomerBlocked: Enum "Customer Blocked"; PrivacyBlocked: Boolean)
+    var
+        SalesAdvLetterHeaderCZZ: Record "Sales Adv. Letter Header CZZ";
+        Customer: Record Customer;
+    begin
+        // [SCENARIO] Creating sales advance letter with blocked customer must fail
+        Initialize();
+
+        // [GIVEN] Customer has been created and blocked
+        CreateBlockedCustomer(Customer, CustomerBlocked, PrivacyBlocked);
+
+        // [WHEN] Create sales advance letter with blocked customer
+        asserterror LibrarySalesAdvancesCZZ.CreateSalesAdvLetterHeader(SalesAdvLetterHeaderCZZ, AdvanceLetterTemplateCZZ.Code, Customer."No.", '');
+
+        // [THEN] Error will occur
+        if PrivacyBlocked then
+            Assert.ExpectedError(StrSubstNo(PrivacyBlockedCustomerErr, 'create', Customer."No."))
+        else
+            Assert.ExpectedError(StrSubstNo(BlockedCustomerErr, 'create', Customer."No.", CustomerBlocked));
+    end;
+
+    local procedure PostPaymentSalesAdvLetterWithBlockedCustomerBase(CustomerBlocked: Enum "Customer Blocked"; PrivacyBlocked: Boolean)
+    var
+        SalesAdvLetterHeaderCZZ: Record "Sales Adv. Letter Header CZZ";
+        SalesAdvLetterLineCZZ: Record "Sales Adv. Letter Line CZZ";
+        Customer: Record Customer;
+        GenJournalLine: Record "Gen. Journal Line";
+    begin
+        // [SCENARIO] Posting payment for sales advance letter with blocked customer must fail
+        Initialize();
+
+        // [GIVEN] Sales advance letter has been created
+        // [GIVEN] Sales advance letter line with normal VAT has been created
+        CreateSalesAdvLetter(SalesAdvLetterHeaderCZZ, SalesAdvLetterLineCZZ);
+
+        // [GIVEN] Sales advance letter has been released
+        LibrarySalesAdvancesCZZ.ReleaseSalesAdvLetter(SalesAdvLetterHeaderCZZ);
+
+        // [GIVEN] Sales advance payment has been prepared in general journal
+        LibrarySalesAdvancesCZZ.CreateSalesAdvancePayment(
+            GenJournalLine, SalesAdvLetterHeaderCZZ."Bill-to Customer No.", -SalesAdvLetterLineCZZ."Amount Including VAT",
+            SalesAdvLetterHeaderCZZ."Currency Code", SalesAdvLetterHeaderCZZ."No.", 0, 0D);
+
+        // [GIVEN] Customer has been blocked
+        Customer.Get(SalesAdvLetterHeaderCZZ."Bill-to Customer No.");
+        if PrivacyBlocked then
+            Customer.Validate("Privacy Blocked", PrivacyBlocked)
+        else
+            Customer.Validate(Blocked, CustomerBlocked);
+        Customer.Modify(true);
+
+        // [WHEN] Post sales advance payment
+        asserterror LibrarySalesAdvancesCZZ.PostSalesAdvancePayment(GenJournalLine);
+
+        // [THEN] Error will occur
+        if PrivacyBlocked then
+            Assert.ExpectedError(StrSubstNo(PrivacyBlockedCustomerErr, 'post', Customer."No."))
+        else
+            Assert.ExpectedError(StrSubstNo(BlockedCustomerErr, 'post', Customer."No.", CustomerBlocked));
+    end;
+
+    local procedure CreateBlockedCustomer(var Customer: Record Customer; CustomerBlocked: Enum "Customer Blocked"; PrivacyBlocked: Boolean)
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+    begin
+        LibrarySalesAdvancesCZZ.FindVATPostingSetup(VATPostingSetup);
+        LibrarySalesAdvancesCZZ.CreateCustomer(Customer);
+        Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        if PrivacyBlocked then
+            Customer.Validate("Privacy Blocked", PrivacyBlocked)
+        else
+            Customer.Validate(Blocked, CustomerBlocked);
+        Customer.Modify(true);
     end;
 
     local procedure CreateSalesAdvLetterBase(var SalesAdvLetterHeaderCZZ: Record "Sales Adv. Letter Header CZZ"; var SalesAdvLetterLineCZZ: Record "Sales Adv. Letter Line CZZ"; CustomerNo: Code[20]; CurrencyCode: Code[10]; VATPostingSetup: Record "VAT Posting Setup")


### PR DESCRIPTION
## What & why

Add blocked vendor/customer validation to advance letter headers and posting. When a vendor or customer is blocked (All, Payment for vendors; All, Ship, Invoice for customers) or privacy-blocked, the system now raises an error when:

Setting the vendor/customer on a purchase/sales advance letter header (validation).
Posting an advance letter payment (post restrictions check).
This aligns advance letter behavior with standard purchase/sales document blocking and prevents users from creating or posting advance letters for blocked parties.

## Linked work

Fixes [AB#643971](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643971)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

## What I tested and the outcome

App changes (4 files):

CustomerCZZ.TableExt.al — added CheckBlockedCustOnAdvanceLettersCZZ(Transaction) that checks Privacy Blocked and Blocked <> " ".
VendorCZZ.TableExt.al — added CheckBlockedVendOnAdvanceLettersCZZ(Transaction) with the same logic for vendors.
SalesAdvLetterHeaderCZZ.Table.al — calls the customer check on "Bill-to Customer No." validation (Transaction=false) and in CheckSalesAdvanceLetterPostRestrictions (Transaction=true).
PurchAdvLetterHeaderCZZ.Table.al — calls the vendor check on "Pay-to Vendor No." validation (Transaction=false) and in CheckPurchaseAdvanceLetterPostRestrictions (Transaction=true).
Test changes (2 files, 14 new tests):

Purchase Advance Payments (codeunit 148108) — 6 tests:

CreatePurchAdvLetterWithVendorBlockedAll — error on validation with Blocked::All
CreatePurchAdvLetterWithVendorBlockedPayment — error on validation with Blocked::Payment
CreatePurchAdvLetterWithPrivacyBlockedVendor — error on validation with Privacy Blocked
PostPaymentPurchAdvLetterWithVendorBlockedAll — error on posting with Blocked::All
PostPaymentPurchAdvLetterWithVendorBlockedPayment — error on posting with Blocked::Payment
PostPaymentPurchAdvLetterWithPrivacyBlockedVendor — error on posting with Privacy Blocked

Sales Advance Payments (codeunit 148109) — 8 tests:

CreateSalesAdvLetterWithCustomerBlockedAll — error on validation with Blocked::All
CreateSalesAdvLetterWithCustomerBlockedShip — error on validation with Blocked::Ship
CreateSalesAdvLetterWithCustomerBlockedInvoice — error on validation with Blocked::Invoice
CreateSalesAdvLetterWithPrivacyBlockedCustomer — error on validation with Privacy Blocked
PostPaymentSalesAdvLetterWithCustomerBlockedAll — error on posting with Blocked::All
PostPaymentSalesAdvLetterWithCustomerBlockedShip — error on posting with Blocked::Ship
PostPaymentSalesAdvLetterWithCustomerBlockedInvoice — error on posting with Blocked::Invoice
PostPaymentSalesAdvLetterWithPrivacyBlockedCustomer — error on posting with Privacy Blocked

All tests verify the exact error message text. Helper functions CreateBlockedVendor/CreateBlockedCustomer and shared base procedures reduce duplication.

## Risk & compatibility

This is a stricter validation — advance letters previously allowed blocked vendors/customers. Existing advance letters with blocked parties will fail on subsequent payment posting, which is the intended behavior matching standard document blocking.




