### PR TITLE
Bug 638205: [Subcontracting]  Enable test codeunitId 137500 - "SCM Legacy Subcontracting"

### DIFF
--- a/src/Layers/IT/Tests/Local/SCMLegacySubcontracting.Codeunit.al
+++ b/src/Layers/IT/Tests/Local/SCMLegacySubcontracting.Codeunit.al
@@ -327,7 +327,7 @@ codeunit 137500 "SCM Legacy Subcontracting"
     procedure CheckCanDisableRaisesErrorWhenAppNotInstalled()
     var
         LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
-        ITMigrationAppNotInstalledErr: Label 'The app "IT Subcontracting Migration" must be installed before you can disable Legacy Subcontracting. Please install the app first and then use the dedicated action "Disable Legacy Subcontracting" to disable Legacy Subcontracting and migrate to the new subcontracting app.';
+        ITMigrationAppNotInstalledErr: Label 'To help you migrate safely, disabling Legacy Subcontracting and moving to the Subcontracting app is currently limited to sandbox environments. Test the migration in a sandbox copy of this environment first to validate the transition. Production environments will be enabled in a future release.';
     begin
         // [SCENARIO] CheckCanDisableLegacySubcontracting raises error when new subcontracting app is not installed
         Initialize();
@@ -502,7 +502,7 @@ codeunit 137500 "SCM Legacy Subcontracting"
         LocationTo: Record Location;
         LocationInTransit: Record Location;
         LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
-        OpenSubcontractingTransfersExistErr: Label 'There are still open transfer orders with WIP Items. All subcontracting transfer orders must be completed before disabling Legacy Subcontracting.';
+        OpenSubcontractingTransfersExistErr: Label 'To help you migrate safely, disabling Legacy Subcontracting and moving to the Subcontracting app is currently limited to sandbox environments. Test the migration in a sandbox copy of this environment first to validate the transition. Production environments will be enabled in a future release.';
     begin
         // [SCENARIO] CheckCanDisableLegacySubcontracting raises error when open WIP transfer orders exist
         Initialize();
@@ -539,7 +539,7 @@ codeunit 137500 "SCM Legacy Subcontracting"
         Item: Record Item;
         TransferLine: Record "Transfer Line";
         LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
-        OpenWIPPurchaseOrdersExistErr: Label 'There are still open subcontracting purchase orders. All subcontracting purchase orders must be completed before disabling Legacy Subcontracting.';
+        OpenWIPPurchaseOrdersExistErr: Label 'To help you migrate safely, disabling Legacy Subcontracting and moving to the Subcontracting app is currently limited to sandbox environments. Test the migration in a sandbox copy of this environment first to validate the transition. Production environments will be enabled in a future release.';
     begin
         // [SCENARIO] CheckCanDisableLegacySubcontracting raises error when open WIP purchase orders exist
         Initialize();
@@ -568,14 +568,15 @@ codeunit 137500 "SCM Legacy Subcontracting"
 
     [Test]
     [Scope('OnPrem')]
-    procedure PreCheckDisableSucceedsWhenITMigrationAppInstalled()
+    procedure PreCheckDisableFailsWhenITMigrationAppInstalled()
     var
         TransferLine: Record "Transfer Line";
         PurchaseLine: Record "Purchase Line";
         LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
         SCMLegacySubcontracting: Codeunit "SCM Legacy Subcontracting";
+        ExpectedError: Label 'To help you migrate safely, disabling Legacy Subcontracting and moving to the Subcontracting app is currently limited to sandbox environments. Test the migration in a sandbox copy of this environment first to validate the transition. Production environments will be enabled in a future release.';
     begin
-        // [SCENARIO] CheckCanDisableLegacySubcontracting succeeds when no open data exists and IT Migration app is installed
+        // [SCENARIO] CheckCanDisableLegacySubcontracting fails even when no open data exists and IT Migration app is installed
         Initialize();
 
         // [GIVEN] ManufacturingSetup."Legacy Subcontracting" = true
@@ -594,9 +595,10 @@ codeunit 137500 "SCM Legacy Subcontracting"
         BindSubscription(SCMLegacySubcontracting);
 
         // [WHEN] Call CheckCanDisableLegacySubcontracting
-        LegacySubcFeatureHandler.CheckCanDisableLegacySubcontracting();
+        asserterror LegacySubcFeatureHandler.CheckCanDisableLegacySubcontracting();
 
-        // [THEN] No error is raised - the call completed successfully
+        // [THEN] Error: disabling is limited to sandbox environments
+        Assert.ExpectedError(ExpectedError);
         UnbindSubscription(SCMLegacySubcontracting);
     end;
 


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->
As part of enabling the tests, the tests need to be fixed and this PR does it.
## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#638205](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638205)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->




