### PR TITLE
[main] bug 644111 - Reorder "Open Balance Sheet" action in Accountant CZ Role Center CZL page

### DIFF
--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/Pages/AccountantCZRoleCenterCZL.Page.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/Pages/AccountantCZRoleCenterCZL.Page.al
@@ -1060,15 +1060,6 @@ page 31210 "Accountant CZ Role Center CZL"
                     Ellipsis = true;
                     ToolTip = 'Run batch to close income statement.';
                 }
-                action("Open Balance Sheet")
-                {
-                    ApplicationArea = Basic, Suite;
-                    Caption = 'Open Balance Sheet';
-                    Image = CreateYear;
-                    RunObject = report "Open Balance Sheet CZL";
-                    Ellipsis = true;
-                    ToolTip = 'Run batch to open balance sheet.';
-                }
                 action("Close Balance Sheet")
                 {
                     ApplicationArea = Basic, Suite;
@@ -1077,6 +1068,15 @@ page 31210 "Accountant CZ Role Center CZL"
                     RunObject = report "Close Balance Sheet CZL";
                     Ellipsis = true;
                     ToolTip = 'Run batch to close balance sheet.';
+                }
+                action("Open Balance Sheet")
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Open Balance Sheet';
+                    Image = CreateYear;
+                    RunObject = report "Open Balance Sheet CZL";
+                    Ellipsis = true;
+                    ToolTip = 'Run batch to open balance sheet.';
                 }
                 action("Run Consolidation")
                 {


### PR DESCRIPTION
## What & why

Reorders the "Open Balance Sheet" action in the Accountant CZ Role Center CZL page so it appears after the "Close Balance Sheet" action instead of before it.

The year-end closing workflow follows a specific sequence: close the income statement, close the balance sheet, and then open the new balance sheet. The previous ordering placed "Open Balance Sheet" before "Close Balance Sheet", which did not reflect this natural workflow and could confuse users.

## Linked work

Fixes [AB#644111](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644111)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

## What I tested and the outcome

Opened the Accountant CZ Role Center and verified the Year-End menu now lists actions in the correct order: Close Income Statement → Close Balance Sheet → Open Balance Sheet.
No tests added — this is a UI reorder-only change with no functional logic affected.

## Risk & compatibility

None. This is a purely cosmetic reordering of actions in the Role Center page. No data, permissions, telemetry, or business logic is affected.









