### PR TITLE
[E-Document][Pagero] Add missing connector tests and fix receive path

### DIFF
--- a/src/Apps/W1/EDocumentConnectors/Pagero/app/PageroConnection.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/app/PageroConnection.Codeunit.al
@@ -65,7 +65,7 @@ codeunit 6361 "Pagero Connection"
         exit(true);
     end;
 
-    procedure GetReceivedDocuments(HttpRequest: HttpRequestMessage; HttpResponse: HttpResponseMessage; Retry: Boolean): Boolean
+    procedure GetReceivedDocuments(var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage; Retry: Boolean): Boolean
     var
         Parameters: Dictionary of [Text, Text];
         InputTxt: Text;
@@ -82,7 +82,7 @@ codeunit 6361 "Pagero Connection"
             exit(true);
     end;
 
-    procedure HandleGetTargetDocumentRequest(DocumentId: Text; HttpRequest: HttpRequestMessage; HttpResponse: HttpResponseMessage; Retry: Boolean): Boolean
+    procedure HandleGetTargetDocumentRequest(DocumentId: Text; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage; Retry: Boolean): Boolean
     begin
         if not PageroAPIRequests.GetTargetDocumentRequest(DocumentId, HttpRequest, HttpResponse) then
             if Retry then

--- a/src/Apps/W1/EDocumentConnectors/Pagero/app/PageroProcessing.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/app/PageroProcessing.Codeunit.al
@@ -19,7 +19,7 @@ codeunit 6369 "Pagero Processing"
                     tabledata "E-Document Service" = rm,
                     tabledata "E-Document Service Status" = rm;
 
-    procedure SendEDocument(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; var TempBlob: Codeunit "Temp Blob"; HttpRequest: HttpRequestMessage; HttpResponse: HttpResponseMessage)
+    procedure SendEDocument(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; var TempBlob: Codeunit "Temp Blob"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage)
     var
         EDocumentServiceStatus: Record "E-Document Service Status";
         FeatureTelemetry: Codeunit "Feature Telemetry";
@@ -39,7 +39,7 @@ codeunit 6369 "Pagero Processing"
         FeatureTelemetry.LogUptake('0000MSC', ExternalServiceTok, Enum::"Feature Uptake Status"::Used);
     end;
 
-    procedure GetDocumentResponse(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; HttpRequest: HttpRequestMessage; HttpResponse: HttpResponseMessage): Boolean
+    procedure GetDocumentResponse(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage): Boolean
     begin
         if not CheckIfDocumentStatusSuccessful(EDocument, EDocumentService, HttpRequest, HttpResponse) then
             exit(false);
@@ -50,7 +50,7 @@ codeunit 6369 "Pagero Processing"
         exit(true);
     end;
 
-    procedure CancelEDocument(EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; HttpRequest: HttpRequestMessage; HttpResponse: HttpResponseMessage; var Status: Enum "E-Document Service Status"): Boolean
+    procedure CancelEDocument(EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage; var Status: Enum "E-Document Service Status"): Boolean
     var
         EDocumentServiceStatus: Record "E-Document Service Status";
     begin
@@ -68,7 +68,7 @@ codeunit 6369 "Pagero Processing"
         exit(false);
     end;
 
-    procedure RestartEDocument(EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; HttpRequest: HttpRequestMessage; HttpResponse: HttpResponseMessage): Boolean
+    procedure RestartEDocument(EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage): Boolean
     begin
         if (EDocumentService."Service Integration V2" <> EDocumentService."Service Integration V2"::Pagero) then
             exit;
@@ -77,7 +77,7 @@ codeunit 6369 "Pagero Processing"
             exit(true);
     end;
 
-    procedure GetDocumentApproval(EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; HttpRequestMessage: HttpRequestMessage; HttpResponseMessage: HttpResponseMessage; var Status: Enum "E-Document Service Status"): Boolean
+    procedure GetDocumentApproval(EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; var HttpRequestMessage: HttpRequestMessage; var HttpResponseMessage: HttpResponseMessage; var Status: Enum "E-Document Service Status"): Boolean
     var
         EDocumentServiceStatus: Record "E-Document Service Status";
         PageroAPIRequests: Codeunit "Pagero API Requests";
@@ -192,6 +192,8 @@ codeunit 6369 "Pagero Processing"
 
         EDocument."Document Id" := CopyStr(DocumentId, 1, MaxStrLen(EDocument."Document Id"));
         EDocument."File Id" := CopyStr(FileId, 1, MaxStrLen(EDocument."File Id"));
+        // The framework rereads the E-Document after the interface call, so the values have to be persisted here.
+        EDocument.Modify();
         ReceiveContext.Http().SetHttpRequestMessage(HttpRequest);
         ReceiveContext.Http().SetHttpResponseMessage(HttpResponse);
     end;
@@ -320,7 +322,7 @@ codeunit 6369 "Pagero Processing"
         exit(GetNumberOfReceivedDocuments(ResponseTxt));
     end;
 
-    local procedure SendEDocument(EDocument: Record "E-Document"; TempBlob: Codeunit "Temp Blob"; HttpRequest: HttpRequestMessage; HttpResponse: HttpResponseMessage);
+    local procedure SendEDocument(EDocument: Record "E-Document"; TempBlob: Codeunit "Temp Blob"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage);
     var
         HttpContentResponse: HttpContent;
     begin

--- a/src/Apps/W1/EDocumentConnectors/Pagero/test/.resources/applicationresponse200.json
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/test/.resources/applicationresponse200.json
@@ -1,0 +1,23 @@
+{
+    "items": [
+        {
+            "createTime": "2024-04-09T08:28:42.747Z",
+            "documentInfo": {
+                "direction": "Received",
+                "documentIdentifier": "{{DOCUMENTNO}}",
+                "documentSubType": "{{SUBTYPE}}",
+                "documentType": "ApplicationResponse"
+            },
+            "fileId": "1234567890",
+            "id": "7d3f1c92-1b6a-4f0e-9c53-1f5a2d6b8e41",
+            "isFetched": false,
+            "sendMode": "Test"
+        }
+    ],
+    "meta": {
+        "count": 1,
+        "limit": 10,
+        "offset": 0,
+        "total": 1
+    }
+}

--- a/src/Apps/W1/EDocumentConnectors/Pagero/test/.resources/documentsreceived200.json
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/test/.resources/documentsreceived200.json
@@ -1,0 +1,38 @@
+{
+    "items": [
+        {
+            "attachments": [],
+            "createTime": "2024-04-08T08:28:42.747Z",
+            "distribution": "Electronic",
+            "documentInfo": {
+                "amounts": {
+                    "currency": "XYZ",
+                    "netAmount": "649.40",
+                    "totalAmount": "779.28",
+                    "vatAmount": "129.88"
+                },
+                "direction": "Received",
+                "documentIdentifier": "10000",
+                "documentSubType": "Debit",
+                "documentType": "Invoice",
+                "issueDate": "2024-04-08"
+            },
+            "documentReferences": [],
+            "eventDetails": [],
+            "fileId": "9876543210",
+            "id": "2c1a2b30-0f4d-4b0e-91a1-8f37b53de0aa",
+            "isFetched": false,
+            "isSelfBilled": false,
+            "sendMode": "Test",
+            "validationErrors": {
+                "noOfErrors": 0
+            }
+        }
+    ],
+    "meta": {
+        "count": 1,
+        "limit": 10,
+        "offset": 0,
+        "total": 1
+    }
+}

--- a/src/Apps/W1/EDocumentConnectors/Pagero/test/.resources/filepartserror.json
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/test/.resources/filepartserror.json
@@ -1,0 +1,18 @@
+{
+    "items": [
+        {
+            "id": "5555555555",
+            "fileId": "1234567890",
+            "status": "Error",
+            "error": {
+                "description": [
+                    "The document could not be processed by the receiver."
+                ]
+            }
+        }
+    ],
+    "meta": {
+        "offset": 0,
+        "total": 1
+    }
+}

--- a/src/Apps/W1/EDocumentConnectors/Pagero/test/.resources/filepartsprocessing.json
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/test/.resources/filepartsprocessing.json
@@ -1,0 +1,13 @@
+{
+    "items": [
+        {
+            "id": "5555555555",
+            "fileId": "1234567890",
+            "status": "Processing"
+        }
+    ],
+    "meta": {
+        "offset": 0,
+        "total": 1
+    }
+}

--- a/src/Apps/W1/EDocumentConnectors/Pagero/test/.resources/targetdocument.xml
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/test/.resources/targetdocument.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Invoice
+	xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+	xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+	xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+	xmlns:ccts="urn:oasis:names:specification:ubl:schema:xsd:CoreComponentParameters-2"
+	xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDatatypes-2"
+	xmlns:stat="urn:oasis:names:specification:ubl:schema:xsd:DocumentStatusCode-1.0"
+	xmlns:udt="urn:un:unece:uncefact:data:draft:UnqualifiedDataTypesSchemaModule:2"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+	<cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+	<cbc:ID>10000</cbc:ID>
+	<cbc:IssueDate>2024-04-08</cbc:IssueDate>
+	<cbc:DueDate>2024-05-08</cbc:DueDate>
+	<cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+	<cbc:DocumentCurrencyCode>XYZ</cbc:DocumentCurrencyCode>
+	<cbc:BuyerReference>4ft4</cbc:BuyerReference>
+	<cac:ContractDocumentReference>
+		<cbc:ID>10000</cbc:ID>
+	</cac:ContractDocumentReference>
+	<cac:AccountingSupplierParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="9932">GB777777771</cbc:EndpointID>
+			<cac:PartyName>
+				<cbc:Name>CRONUS UK Ltd.</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>7122 South Ashford Street</cbc:StreetName>
+				<cbc:AdditionalStreetName>Westminster</cbc:AdditionalStreetName>
+				<cbc:CityName>London</cbc:CityName>
+				<cbc:PostalZone>W2 8HG</cbc:PostalZone>
+				<cac:AddressLine>
+					<cbc:Line>Westminster</cbc:Line>
+				</cac:AddressLine>
+				<cac:Country>
+					<cbc:IdentificationCode>GB</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>GB777777771</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>CRONUS UK Ltd.</cbc:RegistrationName>
+				<cbc:CompanyID>GB777777771</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>Jim Olive</cbc:Name>
+				<cbc:ElectronicMail>JO@contoso.com</cbc:ElectronicMail>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingSupplierParty>
+	<cac:AccountingCustomerParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="9932">GB777777771</cbc:EndpointID>
+			<cac:PartyName>
+				<cbc:Name>Adatum Corporation</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Station Road, 21</cbc:StreetName>
+				<cbc:CityName>Cambridge</cbc:CityName>
+				<cbc:PostalZone>CB1 2FB</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>GB</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>GB777777771</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>Adatum Corporation</cbc:RegistrationName>
+				<cbc:CompanyID>GB777777771</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>Robert Townes</cbc:Name>
+				<cbc:ElectronicMail>robert.townes@contoso.com</cbc:ElectronicMail>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingCustomerParty>
+	<cac:Delivery>
+		<cbc:ActualDeliveryDate>2024-04-08</cbc:ActualDeliveryDate>
+		<cac:DeliveryLocation>
+			<cac:Address>
+				<cbc:StreetName>Station Road, 21</cbc:StreetName>
+				<cbc:CityName>Cambridge</cbc:CityName>
+				<cbc:PostalZone>CB1 2FB</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>GB</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:Address>
+		</cac:DeliveryLocation>
+	</cac:Delivery>
+	<cac:PaymentMeans>
+		<cbc:PaymentMeansCode>31</cbc:PaymentMeansCode>
+		<cac:PayeeFinancialAccount>
+			<cbc:ID>GB12CPBK08929965044991</cbc:ID>
+			<cac:FinancialInstitutionBranch>
+				<cbc:ID>BG99999</cbc:ID>
+			</cac:FinancialInstitutionBranch>
+		</cac:PayeeFinancialAccount>
+	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>1 Month/2% 8 days</cbc:Note>
+	</cac:PaymentTerms>
+	<cac:TaxTotal>
+		<cbc:TaxAmount currencyID="XYZ">129.88</cbc:TaxAmount>
+		<cac:TaxSubtotal>
+			<cbc:TaxableAmount currencyID="XYZ">649.4</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="XYZ">129.88</cbc:TaxAmount>
+			<cac:TaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>20</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:TaxCategory>
+		</cac:TaxSubtotal>
+	</cac:TaxTotal>
+	<cac:LegalMonetaryTotal>
+		<cbc:LineExtensionAmount currencyID="XYZ">649.4</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="XYZ">649.4</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="XYZ">779.28</cbc:TaxInclusiveAmount>
+		<cbc:AllowanceTotalAmount currencyID="XYZ">0</cbc:AllowanceTotalAmount>
+		<cbc:PrepaidAmount currencyID="XYZ">0.00</cbc:PrepaidAmount>
+		<cbc:PayableRoundingAmount currencyID="XYZ">0</cbc:PayableRoundingAmount>
+		<cbc:PayableAmount currencyID="XYZ">779.28</cbc:PayableAmount>
+	</cac:LegalMonetaryTotal>
+	<cac:InvoiceLine>
+		<cbc:ID>10000</cbc:ID>
+		<cbc:Note>Item</cbc:Note>
+		<cbc:InvoicedQuantity unitCode="PCS">1</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="XYZ">649.4</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Name>ATHENS Desk</cbc:Name>
+			<cac:SellersItemIdentification>
+				<cbc:ID>1000</cbc:ID>
+			</cac:SellersItemIdentification>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>20</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="XYZ">649.40</cbc:PriceAmount>
+			<cbc:BaseQuantity unitCode="PCS">1</cbc:BaseQuantity>
+		</cac:Price>
+	</cac:InvoiceLine>
+</Invoice>

--- a/src/Apps/W1/EDocumentConnectors/Pagero/test/src/IntegrationTests.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/test/src/IntegrationTests.Codeunit.al
@@ -8,12 +8,22 @@ using Microsoft.eServices.EDocument;
 using Microsoft.eServices.EDocument.Integration;
 using Microsoft.eServices.EDocument.Service;
 using Microsoft.EServices.EDocumentConnector;
+using Microsoft.Finance.Currency;
+using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
+using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 using Microsoft.Sales.Customer;
 using System.Security.Authentication;
 using System.Threading;
 
+/// <summary>
+/// Integration tests for the Pagero E-Document Connector. The tests cover the outbound document
+/// lifecycle (send, get response with Processing/Error/Processed filepart transitions, restart after
+/// a sending error, cancellation, and approval/rejection through application responses), the inbound
+/// document flow (receive document list, download target document and create a purchase invoice)
+/// and the connection setup card.
+/// </summary>
 codeunit 148192 "Integration Tests"
 {
     TestHttpRequestPolicy = AllowOutboundFromHandler;
@@ -22,36 +32,32 @@ codeunit 148192 "Integration Tests"
     Permissions = tabledata "E-Doc. Ext. Connection Setup" = rimd,
                     tabledata "E-Document" = r;
 
+    #region Outbound tests
 
-
-    /// <summary>
-    /// Test needs MockService running to work. 
-    /// </summary>
     [Test]
     [HandlerFunctions('HTTPSubmitHandler')]
     internal procedure SubmitDocument()
     var
         EDocument: Record "E-Document";
-        JobQueueEntry: Record "Job Queue Entry";
         EDocumentPage: TestPage "E-Document";
         EDocLogList: List of [Enum "E-Document Service Status"];
     begin
-        // Steps:
-        // Pending response -> Sent 
+        // [SCENARIO] Document is submitted to Pagero and the filepart is processed on the first get response.
+        // Pending response -> Sent
         Initialize();
 
-        // [Given] Team member 
+        // [GIVEN] Team member
         LibraryPermission.SetTeamMember();
 
-        // [When] Posting invoice and EDocument is created
+        // [WHEN] Posting invoice and EDocument is created
         LibraryEDocument.PostInvoice(Customer);
         EDocument.FindLast();
         LibraryEDocument.RunEDocumentJobQueue(EDocument);
 
-        // [When] EDocument is fetched after running Avalara SubmitDocument 
+        // [WHEN] EDocument is fetched after running Pagero SubmitDocument
         EDocument.FindLast();
 
-        // [Then] Document Id has been correctly set on E-Document, parsed from Integration response.
+        // [THEN] File Id has been correctly set on E-Document, parsed from Integration response.
         Assert.AreEqual(MockFileId(), EDocument."File Id", 'Pagero integration failed to set File Id on E-Document');
         Assert.AreEqual(Enum::"E-Document Status"::"In Progress", EDocument.Status, 'E-Document should be set to in progress');
 
@@ -75,13 +81,12 @@ codeunit 148192 "Integration Tests"
         EDocumentPage.Close();
 
         // [WHEN] Executing Get Response succesfully
-        JobQueueEntry.FindJobQueueEntry(JobQueueEntry."Object Type to Run"::Codeunit, Codeunit::"E-Document Get Response");
-        LibraryJobQueue.RunJobQueueDispatcher(JobQueueEntry);
+        RunGetResponseJob();
 
-        // [When] EDocument is fetched after running Avalara GetResponse 
+        // [WHEN] EDocument is fetched after running Pagero GetResponse
         EDocument.FindLast();
 
-        // [Then] E-Document is considered processed
+        // [THEN] E-Document is considered processed
         Assert.AreEqual(Enum::"E-Document Status"::Processed, EDocument.Status, 'E-Document should be set to processed');
         Assert.AreEqual(MockDocumentId(), EDocument."Document Id", 'Pagero integration failed to set Document Id on E-Document');
 
@@ -106,6 +111,389 @@ codeunit 148192 "Integration Tests"
         EDocumentPage.Close();
     end;
 
+    [Test]
+    [HandlerFunctions('HTTPSubmitHandler')]
+    internal procedure SubmitDocumentPendingSent()
+    var
+        EDocument: Record "E-Document";
+        EDocLogList: List of [Enum "E-Document Service Status"];
+    begin
+        // [SCENARIO] The filepart is still being processed by Pagero on the first get response, and processed on the second.
+        // Pending response -> Pending response -> Sent
+        Initialize();
+
+        // [GIVEN] Team member posts an invoice that is submitted to Pagero
+        LibraryPermission.SetTeamMember();
+        LibraryEDocument.PostInvoice(Customer);
+        EDocument.FindLast();
+        LibraryEDocument.RunEDocumentJobQueue(EDocument);
+        EDocument.FindLast();
+
+        // [THEN] E-Document is pending response as Pagero is async
+        Assert.AreEqual(Enum::"E-Document Status"::"In Progress", EDocument.Status, 'E-Document should be set to in progress');
+        VerifyOutboundFactboxValuesForSingleService(EDocument, Enum::"E-Document Service Status"::"Pending Response", 2);
+
+        // [WHEN] Pagero reports that the filepart is still being processed
+        SetFilepartStatus(FilepartStatus::Processing);
+        RunGetResponseJob();
+        EDocument.FindLast();
+
+        // [THEN] E-Document is still pending response and the filepart id is stored
+        Assert.AreEqual(Enum::"E-Document Status"::"In Progress", EDocument.Status, 'E-Document should still be in progress');
+        Assert.AreEqual(MockFilepartId(), EDocument."Filepart Id", 'Pagero integration failed to set Filepart Id on E-Document');
+        VerifyOutboundFactboxValuesForSingleService(EDocument, Enum::"E-Document Service Status"::"Pending Response", 3);
+
+        Clear(EDocLogList);
+        EDocLogList.Add(Enum::"E-Document Service Status"::"Exported");
+        EDocLogList.Add(Enum::"E-Document Service Status"::"Pending Response");
+        EDocLogList.Add(Enum::"E-Document Service Status"::"Pending Response");
+        LibraryEDocument.AssertEDocumentLogs(EDocument, EDocumentService, EDocLogList);
+
+        // [WHEN] Pagero has processed the filepart
+        SetFilepartStatus(FilepartStatus::Processed);
+        RunGetResponseJob();
+        EDocument.FindLast();
+
+        // [THEN] E-Document is considered processed
+        Assert.AreEqual(Enum::"E-Document Status"::Processed, EDocument.Status, 'E-Document should be set to processed');
+        Assert.AreEqual(MockDocumentId(), EDocument."Document Id", 'Pagero integration failed to set Document Id on E-Document');
+        VerifyOutboundFactboxValuesForSingleService(EDocument, Enum::"E-Document Service Status"::Sent, 4);
+    end;
+
+    [Test]
+    [HandlerFunctions('ServiceDownHandler')]
+    internal procedure SubmitDocumentPageroServiceDown()
+    var
+        EDocument: Record "E-Document";
+        EDocumentPage: TestPage "E-Document";
+        EDocLogList: List of [Enum "E-Document Service Status"];
+    begin
+        // [SCENARIO] Pagero returns an internal server error when the document is submitted.
+        Initialize();
+
+        // [GIVEN] Team member posts an invoice
+        LibraryPermission.SetTeamMember();
+        LibraryEDocument.PostInvoice(Customer);
+        EDocument.FindLast();
+        LibraryEDocument.RunEDocumentJobQueue(EDocument);
+        EDocument.FindLast();
+
+        // [THEN] E-Document is in error state and no file id was assigned
+        Assert.AreEqual(Enum::"E-Document Status"::Error, EDocument.Status, 'E-Document should be set to error state when service is down.');
+        Assert.AreEqual('', EDocument."File Id", 'File Id on E-Document should not be set.');
+
+        // [THEN] E-Document page shows the error
+        EDocumentPage.OpenView();
+        EDocumentPage.GoToRecord(EDocument);
+        Assert.AreEqual(Format(EDocument.Status::Error), EDocumentPage."Electronic Document Status".Value(), IncorrectValueErr);
+        Assert.AreEqual(Format(EDocument.Direction::Outgoing), EDocumentPage.Direction.Value(), IncorrectValueErr);
+
+        // [THEN] E-Document Service Status has correct error status
+        VerifyOutboundFactboxValuesForSingleService(EDocument, Enum::"E-Document Service Status"::"Sending Error", 2);
+
+        Clear(EDocLogList);
+        EDocLogList.Add(Enum::"E-Document Service Status"::"Exported");
+        EDocLogList.Add(Enum::"E-Document Service Status"::"Sending Error");
+        LibraryEDocument.AssertEDocumentLogs(EDocument, EDocumentService, EDocLogList);
+
+        // [THEN] E-Document Errors and Warnings contains the response code returned by Pagero
+        EDocumentPage.ErrorMessagesPart.First();
+        Assert.AreEqual('Error', EDocumentPage.ErrorMessagesPart."Message Type".Value(), IncorrectValueErr);
+        Assert.IsTrue(
+            EDocumentPage.ErrorMessagesPart.Description.Value().Contains('500'),
+            'The error message should contain the http status code returned by Pagero.');
+        EDocumentPage.Close();
+    end;
+
+    [Test]
+    [HandlerFunctions('HTTPSubmitHandler,EDocServicesPageHandler')]
+    internal procedure SubmitDocumentErrorRestart()
+    var
+        EDocument: Record "E-Document";
+        EDocumentPage: TestPage "E-Document";
+        EDocLogList: List of [Enum "E-Document Service Status"];
+    begin
+        // [SCENARIO] Pagero reports an error on the filepart, and the user restarts the document from the E-Document page.
+        // Pending response -> Sending error -> Pending response -> Sent
+        Initialize();
+
+        // [GIVEN] Team member posts an invoice that is submitted to Pagero
+        LibraryPermission.SetTeamMember();
+        LibraryEDocument.PostInvoice(Customer);
+        EDocument.FindLast();
+        LibraryEDocument.RunEDocumentJobQueue(EDocument);
+
+        // [WHEN] Pagero reports an error for the filepart
+        SetFilepartStatus(FilepartStatus::Error);
+        RunGetResponseJob();
+        EDocument.FindLast();
+
+        // [THEN] E-Document is in error state and the filepart id from the response is stored
+        Assert.AreEqual(Enum::"E-Document Status"::Error, EDocument.Status, 'E-Document should be set to error');
+        Assert.AreEqual(MockFilepartId(), EDocument."Filepart Id", 'Pagero integration failed to set Filepart Id on E-Document');
+        VerifyOutboundFactboxValuesForSingleService(EDocument, Enum::"E-Document Service Status"::"Sending Error", 3);
+
+        Clear(EDocLogList);
+        EDocLogList.Add(Enum::"E-Document Service Status"::"Exported");
+        EDocLogList.Add(Enum::"E-Document Service Status"::"Pending Response");
+        EDocLogList.Add(Enum::"E-Document Service Status"::"Sending Error");
+        LibraryEDocument.AssertEDocumentLogs(EDocument, EDocumentService, EDocLogList);
+
+        // [THEN] The error description returned by Pagero is shown to the user
+        EDocumentPage.OpenView();
+        EDocumentPage.GoToRecord(EDocument);
+        EDocumentPage.ErrorMessagesPart.First();
+        Assert.AreEqual('Error', EDocumentPage.ErrorMessagesPart."Message Type".Value(), IncorrectValueErr);
+        EDocumentPage.Close();
+
+        // [WHEN] User sends the document again, which restarts the filepart in Pagero
+        SetFilepartStatus(FilepartStatus::Processed);
+        EDocumentPage.OpenView();
+        EDocumentPage.GoToRecord(EDocument);
+        EDocumentPage.Send_Promoted.Invoke();
+        // Service is selected by EDocServicesPageHandler
+        EDocumentPage.Close();
+        EDocument.FindLast();
+
+        // [THEN] E-Document is pending response again
+        Assert.AreEqual(Enum::"E-Document Status"::"In Progress", EDocument.Status, 'E-Document should be set to in progress');
+        VerifyOutboundFactboxValuesForSingleService(EDocument, Enum::"E-Document Service Status"::"Pending Response", 4);
+
+        // [WHEN] Pagero has processed the restarted filepart
+        RunGetResponseJob();
+        EDocument.FindLast();
+
+        // [THEN] E-Document is considered processed
+        Assert.AreEqual(Enum::"E-Document Status"::Processed, EDocument.Status, 'E-Document should be set to processed');
+        VerifyOutboundFactboxValuesForSingleService(EDocument, Enum::"E-Document Service Status"::Sent, 5);
+
+        Clear(EDocLogList);
+        EDocLogList.Add(Enum::"E-Document Service Status"::"Exported");
+        EDocLogList.Add(Enum::"E-Document Service Status"::"Pending Response");
+        EDocLogList.Add(Enum::"E-Document Service Status"::"Sending Error");
+        EDocLogList.Add(Enum::"E-Document Service Status"::"Pending Response");
+        EDocLogList.Add(Enum::"E-Document Service Status"::Sent);
+        LibraryEDocument.AssertEDocumentLogs(EDocument, EDocumentService, EDocLogList);
+    end;
+
+    [Test]
+    [HandlerFunctions('HTTPSubmitHandler,EDocServicesPageHandler')]
+    internal procedure GetApprovalDocumentAccepted()
+    var
+        EDocument: Record "E-Document";
+        EDocumentPage: TestPage "E-Document";
+    begin
+        // [SCENARIO] The receiver accepted the sent document, so Pagero returns an application response with 'RecipientAccept'.
+        Initialize();
+        SendDocumentAndGetResponse(EDocument);
+
+        // [GIVEN] Pagero has a received application response accepting the document
+        SetApplicationResponseSubType(RecipientAcceptTok);
+
+        // [WHEN] User invokes Get Approval on the E-Document page
+        EDocumentPage.OpenView();
+        EDocumentPage.GoToRecord(EDocument);
+        EDocumentPage.GetApproval.Invoke();
+        // Service is selected by EDocServicesPageHandler
+        EDocumentPage.Close();
+
+        // [THEN] E-Document Service Status is Approved
+        VerifyServiceStatus(EDocument, Enum::"E-Document Service Status"::Approved);
+    end;
+
+    [Test]
+    [HandlerFunctions('HTTPSubmitHandler,EDocServicesPageHandler')]
+    internal procedure GetApprovalDocumentRejected()
+    var
+        EDocument: Record "E-Document";
+        EDocumentPage: TestPage "E-Document";
+    begin
+        // [SCENARIO] The receiver rejected the sent document, so Pagero returns an application response with 'RecipientReject'.
+        Initialize();
+        SendDocumentAndGetResponse(EDocument);
+
+        // [GIVEN] Pagero has a received application response rejecting the document
+        SetApplicationResponseSubType(RecipientRejectTok);
+
+        // [WHEN] User invokes Get Approval on the E-Document page
+        EDocumentPage.OpenView();
+        EDocumentPage.GoToRecord(EDocument);
+        EDocumentPage.GetApproval.Invoke();
+        // Service is selected by EDocServicesPageHandler
+        EDocumentPage.Close();
+
+        // [THEN] E-Document Service Status is Rejected
+        VerifyServiceStatus(EDocument, Enum::"E-Document Service Status"::Rejected);
+    end;
+
+    [Test]
+    [HandlerFunctions('HTTPSubmitHandler,EDocServicesPageHandler')]
+    internal procedure GetApprovalNotAllowedBeforeDocumentIsSent()
+    var
+        EDocument: Record "E-Document";
+        EDocumentPage: TestPage "E-Document";
+    begin
+        // [SCENARIO] Approval can only be requested when the document has been sent.
+        Initialize();
+
+        // [GIVEN] A document that is pending response
+        LibraryPermission.SetTeamMember();
+        LibraryEDocument.PostInvoice(Customer);
+        EDocument.FindLast();
+        LibraryEDocument.RunEDocumentJobQueue(EDocument);
+        EDocument.FindLast();
+        VerifyServiceStatus(EDocument, Enum::"E-Document Service Status"::"Pending Response");
+
+        // [WHEN] User invokes Get Approval on the E-Document page
+        EDocumentPage.OpenView();
+        EDocumentPage.GoToRecord(EDocument);
+        EDocumentPage.GetApproval.Invoke();
+        // Service is selected by EDocServicesPageHandler
+        EDocumentPage.Close();
+
+        // [THEN] A warning is shown to the user
+        EDocumentPage.OpenView();
+        EDocumentPage.GoToRecord(EDocument);
+        EDocumentPage.ErrorMessagesPart.First();
+        Assert.AreEqual('Warning', EDocumentPage.ErrorMessagesPart."Message Type".Value(), IncorrectValueErr);
+        EDocumentPage.Close();
+
+        // [THEN] The status is unchanged
+        VerifyServiceStatus(EDocument, Enum::"E-Document Service Status"::"Pending Response");
+    end;
+
+    [Test]
+    [HandlerFunctions('HTTPSubmitHandler,EDocServicesPageHandler')]
+    internal procedure CancelDocumentAfterSendingError()
+    var
+        EDocument: Record "E-Document";
+        EDocumentPage: TestPage "E-Document";
+    begin
+        // [SCENARIO] A document in sending error can be canceled in Pagero.
+        Initialize();
+
+        // [GIVEN] A document that failed with a sending error
+        LibraryPermission.SetTeamMember();
+        LibraryEDocument.PostInvoice(Customer);
+        EDocument.FindLast();
+        LibraryEDocument.RunEDocumentJobQueue(EDocument);
+        SetFilepartStatus(FilepartStatus::Error);
+        RunGetResponseJob();
+        EDocument.FindLast();
+        VerifyServiceStatus(EDocument, Enum::"E-Document Service Status"::"Sending Error");
+
+        // [WHEN] User invokes Cancel on the E-Document page
+        EDocumentPage.OpenView();
+        EDocumentPage.GoToRecord(EDocument);
+        EDocumentPage.Cancel.Invoke();
+        // Service is selected by EDocServicesPageHandler
+        EDocumentPage.Close();
+
+        // [THEN] E-Document Service Status is Canceled
+        VerifyServiceStatus(EDocument, Enum::"E-Document Service Status"::Canceled);
+    end;
+
+    [Test]
+    [HandlerFunctions('HTTPSubmitHandler,EDocServicesPageHandler')]
+    internal procedure CancelNotAllowedWhilePendingResponse()
+    var
+        EDocument: Record "E-Document";
+        EDocumentPage: TestPage "E-Document";
+    begin
+        // [SCENARIO] Cancellation is only allowed from 'Sending Error' or 'Cancel Error'.
+        Initialize();
+
+        // [GIVEN] A document that is pending response
+        LibraryPermission.SetTeamMember();
+        LibraryEDocument.PostInvoice(Customer);
+        EDocument.FindLast();
+        LibraryEDocument.RunEDocumentJobQueue(EDocument);
+        EDocument.FindLast();
+        VerifyServiceStatus(EDocument, Enum::"E-Document Service Status"::"Pending Response");
+
+        // [WHEN] User invokes Cancel on the E-Document page
+        EDocumentPage.OpenView();
+        EDocumentPage.GoToRecord(EDocument);
+        EDocumentPage.Cancel.Invoke();
+        // Service is selected by EDocServicesPageHandler
+        EDocumentPage.Close();
+
+        // [THEN] A warning is shown to the user
+        EDocumentPage.OpenView();
+        EDocumentPage.GoToRecord(EDocument);
+        EDocumentPage.ErrorMessagesPart.First();
+        Assert.AreEqual('Warning', EDocumentPage.ErrorMessagesPart."Message Type".Value(), IncorrectValueErr);
+        EDocumentPage.Close();
+
+        // [THEN] The status is unchanged
+        VerifyServiceStatus(EDocument, Enum::"E-Document Service Status"::"Pending Response");
+    end;
+
+    #endregion
+
+    #region Inbound tests
+
+    [Test]
+    [HandlerFunctions('HTTPSubmitHandler')]
+    internal procedure ReceiveDocumentCreatesPurchaseInvoice()
+    var
+        Currency: Record Currency;
+        EDocument: Record "E-Document";
+        PurchaseHeader: Record "Purchase Header";
+        EDocServicePage: TestPage "E-Document Service";
+        PreviousWorkDate: Date;
+    begin
+        // [SCENARIO] The import job downloads the documents that Pagero received on behalf of the company
+        // and creates a purchase invoice for the sending vendor.
+        Initialize();
+
+        // [GIVEN] Work date and exchange rate matching the received document
+        PreviousWorkDate := WorkDate();
+        WorkDate(DMY2Date(8, 4, 2024));
+        if not Currency.Get(MockCurrencyCode()) then begin
+            Currency.Init();
+            Currency.Validate(Code, MockCurrencyCode());
+            Currency.Insert(true);
+        end;
+        LibraryERM.CreateExchangeRate(MockCurrencyCode(), WorkDate(), 1, 1);
+        EnsureCountryISOCode();
+
+        // [GIVEN] Service is configured to look up items by item reference
+        EDocServicePage.OpenView();
+        EDocServicePage.GoToRecord(EDocumentService);
+        EDocServicePage."Resolve Unit Of Measure".SetValue(false);
+        EDocServicePage."Lookup Item Reference".SetValue(true);
+        EDocServicePage."Lookup Item GTIN".SetValue(false);
+        EDocServicePage."Lookup Account Mapping".SetValue(false);
+        EDocServicePage."Validate Line Discount".SetValue(false);
+        EDocServicePage.Close();
+
+        // [WHEN] The recurrent import job runs
+        if EDocument.FindLast() then
+            EDocument.SetFilter("Entry No", '>%1', EDocument."Entry No");
+        LibraryEDocument.RunImportJob();
+
+        // [THEN] An incoming E-Document with a purchase invoice for the vendor is created
+#pragma warning disable AA0210
+        EDocument.SetRange("Document Type", EDocument."Document Type"::"Purchase Invoice");
+        EDocument.SetRange("Bill-to/Pay-to No.", Vendor."No.");
+#pragma warning restore AA0210
+        EDocument.FindLast();
+
+        Assert.AreEqual(Format(EDocument.Direction::Incoming), Format(EDocument.Direction), IncorrectValueErr);
+        PurchaseHeader.Get(EDocument."Document Record ID");
+        Assert.AreEqual(Vendor."No.", PurchaseHeader."Buy-from Vendor No.", 'Wrong Vendor');
+
+        // [THEN] The identifiers returned by Pagero are persisted on the E-Document
+        Assert.AreEqual(MockReceivedDocumentId(), EDocument."Document Id", 'Pagero integration failed to set Document Id on the received E-Document');
+        Assert.AreEqual(MockReceivedFileId(), EDocument."File Id", 'Pagero integration failed to set File Id on the received E-Document');
+
+        WorkDate(PreviousWorkDate);
+    end;
+
+    #endregion
+
+    #region Setup tests
 
     [Test]
     [HandlerFunctions('ConfirmQst')]
@@ -131,39 +519,123 @@ codeunit 148192 "Integration Tests"
         Assert.AreEqual(ValueBefore, EDocExtConnectionSetup."Authentication URL", 'Reset Setup did not restore the Authentication URL');
     end;
 
+    #endregion
+
+    #region Handlers
+
     [ConfirmHandler]
     procedure ConfirmQst(Question: Text[1024]; var Reply: Boolean)
     begin
         Reply := true; // Automatically confirm all questions in tests
     end;
 
+    [ModalPageHandler]
+    internal procedure EDocServicesPageHandler(var EDocServicesPage: TestPage "E-Document Services")
+    begin
+        EDocServicesPage.Filter.SetFilter(Code, EDocumentService.Code);
+        EDocServicesPage.OK().Invoke();
+    end;
+
     [HttpClientHandler]
     internal procedure HTTPSubmitHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
-    var
-        ResponseJson: Text;
     begin
-        case Request.Path of
-            'https://api.pageroonline.com/file/v1/files':
-                begin
-                    ResponseJson := NavApp.GetResourceAsText('files200.json', TextEncoding::UTF8);
-                    Response.Content.WriteFrom(ResponseJson);
-                    Response.HttpStatusCode := 200;
-                end;
-            'https://api.pageroonline.com/file/v1/files/' + MockFileId() + '/fileparts':
-                begin
-                    ResponseJson := NavApp.GetResourceAsText('fileparts200.json', TextEncoding::UTF8);
-                    Response.Content.WriteFrom(ResponseJson);
-                    Response.HttpStatusCode := 200;
-                end;
-            'https://api.pageroonline.com/document/v1/documents':
-                begin
-                    ResponseJson := NavApp.GetResourceAsText('documents200.json', TextEncoding::UTF8);
-                    Response.Content.WriteFrom(ResponseJson);
-                    Response.HttpStatusCode := 200;
-                end;
+        Response.HttpStatusCode := 200;
+        case true of
+            Request.Path = FileApiUrlTok:
+                RespondWithResource(Response, FilesResourceTok);
+            Request.Path = FileApiUrlTok + '/' + MockFileId() + '/fileparts':
+                RespondWithFileparts(Response);
+            Request.Path = FilepartsApiUrlTok + '/' + MockFilepartId() + '/action':
+                Response.Content.WriteFrom(EmptyJsonTok);
+            Request.Path = DocumentApiUrlTok + '/fetch':
+                Response.Content.WriteFrom(EmptyJsonTok);
+            Request.Path.EndsWith(TargetDocumentPathTok):
+                RespondWithResource(Response, TargetDocumentResourceTok);
+            Request.Path = DocumentApiUrlTok:
+                RespondWithDocuments(Request, Response);
             else
                 Response.HttpStatusCode := 500;
         end;
+    end;
+
+    [HttpClientHandler]
+    internal procedure ServiceDownHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        Response.HttpStatusCode := 500;
+        Response.Content.WriteFrom(EmptyJsonTok);
+    end;
+
+    local procedure RespondWithFileparts(var Response: TestHttpResponseMessage)
+    begin
+        case FilepartStatus of
+            FilepartStatus::Processing:
+                RespondWithResource(Response, FilepartsProcessingResourceTok);
+            FilepartStatus::Error:
+                RespondWithResource(Response, FilepartsErrorResourceTok);
+            else
+                RespondWithResource(Response, FilepartsResourceTok);
+        end;
+    end;
+
+    local procedure RespondWithDocuments(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage)
+    var
+        QueryParameters: Dictionary of [Text, Text];
+        ResponseJson: Text;
+    begin
+        QueryParameters := Request.QueryParameters;
+        case true of
+            QueryParameters.ContainsKey(FileIdParameterTok):
+                RespondWithResource(Response, DocumentsResourceTok);
+            QueryParameters.ContainsKey(ReferenceDocumentParameterTok):
+                begin
+                    // The identifier on the application response has to match the document approval was requested for.
+                    ResponseJson := NavApp.GetResourceAsText(ApplicationResponseResourceTok, TextEncoding::UTF8);
+                    ResponseJson := ResponseJson.Replace(DocumentNoPlaceholderTok, QueryParameters.Get(ReferenceDocumentParameterTok));
+                    ResponseJson := ResponseJson.Replace(SubTypePlaceholderTok, ApplicationResponseSubType);
+                    Response.Content.WriteFrom(ResponseJson);
+                end;
+            else
+                RespondWithResource(Response, DocumentsReceivedResourceTok);
+        end;
+    end;
+
+    local procedure RespondWithResource(var Response: TestHttpResponseMessage; ResourceName: Text)
+    begin
+        Response.Content.WriteFrom(NavApp.GetResourceAsText(ResourceName, TextEncoding::UTF8));
+    end;
+
+    #endregion
+
+    #region Helpers
+
+    local procedure SendDocumentAndGetResponse(var EDocument: Record "E-Document")
+    begin
+        LibraryPermission.SetTeamMember();
+        LibraryEDocument.PostInvoice(Customer);
+        EDocument.FindLast();
+        LibraryEDocument.RunEDocumentJobQueue(EDocument);
+
+        RunGetResponseJob();
+        EDocument.FindLast();
+
+        Assert.AreEqual(Enum::"E-Document Status"::Processed, EDocument.Status, 'E-Document should be set to processed');
+        VerifyServiceStatus(EDocument, Enum::"E-Document Service Status"::Sent);
+    end;
+
+    local procedure RunGetResponseJob()
+    var
+        JobQueueEntry: Record "Job Queue Entry";
+    begin
+        JobQueueEntry.FindJobQueueEntry(JobQueueEntry."Object Type to Run"::Codeunit, Codeunit::"E-Document Get Response");
+        LibraryJobQueue.RunJobQueueDispatcher(JobQueueEntry);
+    end;
+
+    local procedure VerifyServiceStatus(EDocument: Record "E-Document"; Status: Enum "E-Document Service Status")
+    var
+        EDocumentServiceStatus: Record "E-Document Service Status";
+    begin
+        EDocumentServiceStatus.Get(EDocument."Entry No", EDocumentService.Code);
+        Assert.AreEqual(Format(Status), Format(EDocumentServiceStatus.Status), 'Wrong E-Document Service Status');
     end;
 
     local procedure VerifyOutboundFactboxValuesForSingleService(EDocument: Record "E-Document"; Status: Enum "E-Document Service Status"; Logs: Integer);
@@ -184,6 +656,28 @@ codeunit 148192 "Integration Tests"
         Assert.AreEqual(Format(Logs), Factbox.Log.Value(), IncorrectValueErr);
     end;
 
+    local procedure SetFilepartStatus(NewFilepartStatus: Option Processed,Processing,Error)
+    begin
+        FilepartStatus := NewFilepartStatus;
+    end;
+
+    local procedure SetApplicationResponseSubType(NewApplicationResponseSubType: Text)
+    begin
+        ApplicationResponseSubType := NewApplicationResponseSubType;
+    end;
+
+    local procedure EnsureCountryISOCode()
+    var
+        CountryRegion: Record "Country/Region";
+    begin
+        if CountryRegion.Get(Vendor."Country/Region Code") then
+            if CountryRegion."ISO Code" = '' then begin
+                CountryRegion."ISO Code" := 'GB';
+                CountryRegion."ISO Numeric Code" := '826';
+                CountryRegion.Modify();
+            end;
+    end;
+
     local procedure Initialize()
     var
         ConnectionSetup: Record "E-Doc. Ext. Connection Setup";
@@ -193,6 +687,15 @@ codeunit 148192 "Integration Tests"
         KeyGuid: Guid;
     begin
         LibraryPermission.SetOutsideO365Scope();
+        // Restore the work date in case a previous test failed before restoring it
+        if OriginalWorkDate = 0D then
+            OriginalWorkDate := WorkDate()
+        else
+            WorkDate(OriginalWorkDate);
+
+        SetFilepartStatus(FilepartStatus::Processed);
+        SetApplicationResponseSubType(RecipientAcceptTok);
+
         // Clean up token between runs
         if ConnectionSetup.Get() then
             ConnectionSetup.DeleteAll();
@@ -214,6 +717,11 @@ codeunit 148192 "Integration Tests"
         OAuth2Setup."Access Token Due DateTime" := CurrentDateTime() + 600 * 1000;
         OAuth2Setup.Modify();
 
+        // Detect rollback from a previous failed test and force re-initialization
+        if IsInitialized then
+            if not Customer.Get(Customer."No.") then
+                IsInitialized := false;
+
         if IsInitialized then
             exit;
 
@@ -232,6 +740,8 @@ codeunit 148192 "Integration Tests"
 
         CompanyInformation.Get();
         CompanyInformation."VAT Registration No." := 'GB777777771';
+        if CompanyInformation.Name = '' then
+            CompanyInformation.Name := 'Test Company';
         CompanyInformation.Modify();
 
         IsInitialized := true;
@@ -242,21 +752,64 @@ codeunit 148192 "Integration Tests"
         exit('1234567890');
     end;
 
+    local procedure MockFilepartId(): Text
+    begin
+        exit('5555555555');
+    end;
+
     local procedure MockDocumentId(): Text
     begin
         exit('01f00578-8650-17dc-8631-390b96a662c9');
     end;
 
+    local procedure MockReceivedDocumentId(): Text
+    begin
+        exit('2c1a2b30-0f4d-4b0e-91a1-8f37b53de0aa');
+    end;
+
+    local procedure MockReceivedFileId(): Text
+    begin
+        exit('9876543210');
+    end;
+
+    local procedure MockCurrencyCode(): Code[10]
+    begin
+        exit('XYZ');
+    end;
+
+    #endregion
+
     var
         Customer: Record Customer;
         Vendor: Record Vendor;
         EDocumentService: Record "E-Document Service";
-        LibraryEDocument: Codeunit "Library - E-Document";
-        LibraryPermission: Codeunit "Library - Lower Permissions";
-        LibraryJobQueue: Codeunit "Library - Job Queue";
-        //LibraryERM: Codeunit "Library - ERM";
         Assert: Codeunit Assert;
+        LibraryEDocument: Codeunit "Library - E-Document";
+        LibraryERM: Codeunit "Library - ERM";
+        LibraryJobQueue: Codeunit "Library - Job Queue";
+        LibraryPermission: Codeunit "Library - Lower Permissions";
         IsInitialized: Boolean;
+        OriginalWorkDate: Date;
+        FilepartStatus: Option Processed,Processing,Error;
+        ApplicationResponseSubType: Text;
         IncorrectValueErr: Label 'Wrong value';
-
+        RecipientAcceptTok: Label 'RecipientAccept', Locked = true;
+        RecipientRejectTok: Label 'RecipientReject', Locked = true;
+        FileApiUrlTok: Label 'https://api.pageroonline.com/file/v1/files', Locked = true;
+        FilepartsApiUrlTok: Label 'https://api.pageroonline.com/file/v1/fileparts', Locked = true;
+        DocumentApiUrlTok: Label 'https://api.pageroonline.com/document/v1/documents', Locked = true;
+        TargetDocumentPathTok: Label '/targetdocument', Locked = true;
+        FileIdParameterTok: Label 'fileId', Locked = true;
+        ReferenceDocumentParameterTok: Label 'referenceDocumentIdentifier', Locked = true;
+        FilesResourceTok: Label 'files200.json', Locked = true;
+        FilepartsResourceTok: Label 'fileparts200.json', Locked = true;
+        FilepartsProcessingResourceTok: Label 'filepartsprocessing.json', Locked = true;
+        FilepartsErrorResourceTok: Label 'filepartserror.json', Locked = true;
+        DocumentsResourceTok: Label 'documents200.json', Locked = true;
+        DocumentsReceivedResourceTok: Label 'documentsreceived200.json', Locked = true;
+        ApplicationResponseResourceTok: Label 'applicationresponse200.json', Locked = true;
+        TargetDocumentResourceTok: Label 'targetdocument.xml', Locked = true;
+        DocumentNoPlaceholderTok: Label '{{DOCUMENTNO}}', Locked = true;
+        SubTypePlaceholderTok: Label '{{SUBTYPE}}', Locked = true;
+        EmptyJsonTok: Label '{}', Locked = true;
 }

--- a/src/Apps/W1/EDocumentConnectors/Pagero/test/src/IntegrationTests.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/test/src/IntegrationTests.Codeunit.al
@@ -28,7 +28,7 @@ codeunit 148192 "Integration Tests"
 {
     TestHttpRequestPolicy = AllowOutboundFromHandler;
     Subtype = Test;
-    TestType = Uncategorized;
+    TestType = IntegrationTest;
     Permissions = tabledata "E-Doc. Ext. Connection Setup" = rimd,
                     tabledata "E-Document" = r;
 


### PR DESCRIPTION
Fixes [AB#559122](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/559122)

### Summary

The Pagero E-Document connector only had two tests (`SubmitDocument` and `ResetSetupRecord`). This PR adds E2E coverage for the outbound and inbound flows, modelled on the existing Avalara and Continia connector tests.

Writing the inbound E2E test exposed three defects in the connector, which are fixed here.

### Connector fixes

HTTP message parameters were passed **without `var`**. Since `HttpClient.Send` *reassigns* the response object, the new reference never propagated back to the caller:

* `Pagero Connection.GetReceivedDocuments` and `HandleGetTargetDocumentRequest` — the caller always got an empty response, so **receiving and downloading documents did not work**.
* `Pagero Processing.SendEDocument` / `GetDocumentResponse` / `CancelEDocument` / `RestartEDocument` / `GetDocumentApproval` — functionally fine, but the integration logs were stored empty.
* `Pagero Processing.DownloadDocument` never called `Modify()`, so `Document Id` and `File Id` were lost when the framework rereads the E-Document after the interface call.

### Tests

Added to the existing codeunit 148192 — every remaining id in Pagero's declared range `148191-148199` is already used by the other E-Document connector test apps.

| Test | Covers |
| --- | --- |
| `SubmitDocumentPendingSent` | filepart `Processing` → `Processed`, Filepart Id stored |
| `SubmitDocumentPageroServiceDown` | HTTP 500 → Sending Error + error message |
| `SubmitDocumentErrorRestart` | filepart `Error` → user resend → Restart action → Sent |
| `GetApprovalDocumentAccepted` / `GetApprovalDocumentRejected` | `RecipientAccept` / `RecipientReject` application responses |
| `GetApprovalNotAllowedBeforeDocumentIsSent` | warning logged, status unchanged |
| `CancelDocumentAfterSendingError` | Cancel action → Canceled |
| `CancelNotAllowedWhilePendingResponse` | warning logged, status unchanged |
| `ReceiveDocumentCreatesPurchaseInvoice` | inbound E2E: document list → target document → purchase invoice, ids persisted |

Five mock resources were added. The HTTP handler routes on request path **and query parameters**, since three different Pagero calls share the `/document/v1/documents` path, and it substitutes the real document no. into the application-response payload so the connector's identifier check passes.

### Validation

Both projects compile with the CI ruleset (`src/rulesets/base.ruleset.json`) plus CodeCop, UICop and PerTenantExtensionCop with zero errors and zero warnings.

### Evidence: the new tests really run in CI

Verified against **Pull Request Build [30255400286](https://github.com/microsoft/BCApps/actions/runs/30255400286)** (head `ee1ec3d99`, conclusion `success`).

The test app is built and published as `Microsoft_E-Document Connector - Pagero Tests_29.0.2147483647.77969.app`, listed in *Test apps to dispatch (79)*, and dispatched:

```
Dispatching 'E-Document Connector - Pagero Tests' (extensionId e1d97edc-c239-46b4-8d84-6368bdf67c8d) on tenant 'tenant3'
```

Extract from the `TestResults.xml` artifact of the *Build Unit Tests (UncategorizedTests)* job:

```xml
<testsuite name="148192 Integration Tests" tests="11" failures="0" errors="0" skipped="0" time="19.862">
```

| Test function | Time (s) | Result |
| --- | --- | --- |
| `SubmitDocument` | 8.156 | Pass |
| `SubmitDocumentPendingSent` | 0.767 | Pass |
| `SubmitDocumentPageroServiceDown` | 0.944 | Pass |
| `SubmitDocumentErrorRestart` | 1.547 | Pass |
| `GetApprovalDocumentAccepted` | 1.210 | Pass |
| `GetApprovalDocumentRejected` | 1.414 | Pass |
| `GetApprovalNotAllowedBeforeDocumentIsSent` | 1.804 | Pass |
| `CancelDocumentAfterSendingError` | 1.293 | Pass |
| `CancelNotAllowedWhilePendingResponse` | 1.970 | Pass |
| `ReceiveDocumentCreatesPurchaseInvoice` | 0.637 | Pass |
| `ResetSetupRecord` | 0.120 | Pass |

All 9 new tests execute and pass — they are not silently skipped.

### Evidence: the missing `Modify()` was a real defect, not a workaround

The framework runs the receiver interface against a **copy** of the record, inside a separate error-trapping codeunit:

```al
// EDocument/App/src/Integration/Receive/DownloadDocument.Codeunit.al
procedure SetParameters(var EDocument: Record "E-Document"; ...)
begin
    this.GlobalEDocument.Copy(EDocument);   // <- copy
...
trigger OnRun()
begin
    IDocumentReceiver.DownloadDocument(this.GlobalEDocument, ...);
end;
```

So any field a connector assigns in `DownloadDocument` is discarded unless it is explicitly persisted. Auditing every connector confirms `Modify()` is the established convention, and Pagero was the **only** one missing it:

| Connector | Fields assigned in download path | `Modify()` | Location |
| --- | --- | --- | --- |
| Avalara | `Avalara Document Id` | Yes | `Processing.Codeunit.al:312` |
| B2Brouter | `B2Brouter File Id` | Yes | `B2BrouterApiManagement.Codeunit.al:243` |
| Continia | `Continia Document Id` | Yes | `ContiniaEDocumentProcessing.Codeunit.al:222` |
| ForNAV | `ForNAV Edoc. ID`, `Document Sending Profile` | Yes | `ForNAVProcessing.Codeunit.al:222` |
| Microsoft 365 (Drive) | `Drive Item Id`, `Source Details` | Yes | `DriveProcessing.Codeunit.al:227` |
| Microsoft 365 (Outlook) | `Outlook Mail Message Id`, … | Yes | `OutlookProcessing.Codeunit.al:388` |
| SignUp | `SignUp Document Id` | Yes | `SignUpProcessing.Codeunit.al:196` |
| Logiq | none — writes only to `ReceiveContext` | n/a | — |
| **Pagero (before this PR)** | `Document Id`, `File Id` | **No** | — |
| **Pagero (after this PR)** | `Document Id`, `File Id` | Yes | `PageroProcessing.Codeunit.al:196` |

ForNAV is the closest structural match — same `HandleGetTargetDocumentRequest` → `FetchDocument` → assign → `Modify()` shape. Pagero had identical code minus the `Modify()`.

`ReceiveDocumentCreatesPurchaseInvoice` asserts both identifiers, so this regression is now covered:

```al
Assert.AreEqual(MockReceivedDocumentId(), EDocument."Document Id", ...);
Assert.AreEqual(MockReceivedFileId(), EDocument."File Id", ...);
```

### Known issue deliberately left out of scope

`Pagero Processing.DownloadDocument` ignores the boolean result of `HandleGetTargetDocumentRequest` and falls through to `FetchEDocument` even when the download produced no content. This is **pre-existing** (identical at the merge base) and the same pattern exists in ForNAV (`ForNAVProcessing.Codeunit.al:208-212`), so it is a framework-wide concern rather than something introduced here. Fixing it changes inbound production behaviour and deserves its own PR and test.


