### PR TITLE
[Subcontracting] Bug 638816: Preserve Transfer WIP Item flag when toggling off Direct Transfer without a transit route

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferLineExt.Codeunit.al
@@ -154,5 +154,6 @@ codeunit 99001544 "Subc. Transfer Line Ext."
         TransferLine."Subc. Work Center No." := TempTransferLine."Subc. Work Center No.";
         TransferLine."Subc. Operation No." := TempTransferLine."Subc. Operation No.";
         TransferLine."Subc. Return Order" := TempTransferLine."Subc. Return Order";
+        TransferLine."Transfer WIP Item" := TempTransferLine."Transfer WIP Item";
     end;
 }

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -1699,6 +1699,77 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
             'WIP Transfer Line must retain Transfer WIP Item = true after toggling off Direct Transfer.');
     end;
 
+    [Test]
+    [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
+    procedure TogglingOffDirectTransferWithoutTransitRouteOnWIPTransferOrder()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        TransferHeader: Record "Transfer Header";
+        TransferLine: Record "Transfer Line";
+        WorkCenter: array[2] of Record "Work Center";
+        PurchaseHeaderPage: TestPage "Purchase Order";
+    begin
+        // [SCENARIO 638816] Toggling off Direct Transfer on a Subcontracting Transfer Order with a
+        // WIP item line must not throw "No items are currently in transit" even when NO transfer route
+        // exists (In-Transit Code stays empty), matching the reproduction reported after the first fix.
+
+        // [GIVEN] Complete setup with subcontracting WIP item
+        Initialize();
+
+        SubcWarehouseLibrary.CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter, true);
+        SubcWarehouseLibrary.CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        SetTransferWIPItemOnRoutingLine(Item."Routing No.", WorkCenter[2]."No.", true);
+
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+
+        // [GIVEN] Create and refresh released production order at manufacturing components location
+        LibraryManufacturing.CreateProductionOrder(
+            ProductionOrder, "Production Order Status"::Released,
+            ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+        SetProdOrderLocationToCompSetupLocationAndRefresh(ProductionOrder);
+
+        // [GIVEN] NO transfer route exists -> Transfer Header created with Direct Transfer = true
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+        PurchaseHeaderPage.OpenView();
+        PurchaseHeaderPage.GoToRecord(PurchaseHeader);
+        PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [GIVEN] WIP Transfer Line exists with Direct Transfer = true on the header
+        TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+#pragma warning disable AA0210
+        TransferLine.SetRange("Transfer WIP Item", true);
+#pragma warning restore AA0210
+        TransferLine.SetRange("Subc. Return Order", false);
+        TransferLine.FindFirst();
+
+        TransferHeader.Get(TransferLine."Document No.");
+        Assert.IsTrue(TransferHeader."Direct Transfer",
+            'Transfer Header must initially have Direct Transfer = true when no transit route exists.');
+
+        // [WHEN] Toggle off Direct Transfer on the Transfer Header while In-Transit Code is empty
+        // (no transit route was created, so no In-Transit Code can be inherited)
+        TransferHeader.Validate("Direct Transfer", false);
+        TransferHeader.Modify(true);
+
+        // [THEN] No "No items are currently in transit" error is thrown and Direct Transfer is now false
+        TransferHeader.Get(TransferLine."Document No.");
+        Assert.IsFalse(TransferHeader."Direct Transfer",
+            'Direct Transfer must be toggled off successfully without error even without a transit route.');
+
+        // [THEN] WIP Transfer Line still exists and retains Transfer WIP Item = true
+        TransferLine.FindFirst();
+        Assert.IsTrue(TransferLine."Transfer WIP Item",
+            'WIP Transfer Line must retain Transfer WIP Item = true after toggling off Direct Transfer.');
+    end;
+
     [PageHandler]
     procedure HandleTransferOrder(var TransfOrderPage: TestPage "Transfer Order")
     begin


### PR DESCRIPTION
## Summary
Follow-up to #8755 (Bug 638816). After the first fix merged, the PM reproduced the same `No items are currently in transit` error in a **different scenario**: toggling off **Direct Transfer** on a Subcontracting Transfer Order with a WIP item line when **no transfer route exists** (In-Transit Code stays empty).

## Root cause
When Direct Transfer is toggled off, base `TransferHeader.UpdateTransLines` re-validates the line's `Item No.`. Base `Item No.` OnValidate calls `Init()`, which resets the custom field `Transfer WIP Item` (99001560) to `false`. The Subc subscriber `CopySubFieldsFromTempTransferLineToTransferLine` restored **every** `Subc.*` field **except** `Transfer WIP Item`. So at the later `OnUpdateTransLinesOnAfterUpdateFromDirectTransfer` event, the guard added in #8755 (`if not TransferLine."Transfer WIP Item"`) saw `false` and did **not** skip the redundant `Validate("Transfer WIP Item", true)`. That cascaded: WIP OnValidate → `Validate(Quantity)` → `UpdateWithWarehouseShipReceive` → `Validate("Qty. to Receive")` → `Error` (Qty in Transit = 0 with empty In-Transit Code).

The prior fix's guard was correct but ineffective because the flag was already reset upstream. With a transfer route present (existing tests) the cascade didn't error, which is why the gap wasn't caught the first time.

## Fix
Restore `Transfer WIP Item` alongside the other Subc fields in `CopySubFieldsFromTempTransferLineToTransferLine` (one line, consistent with the 9 sibling assignments). The prior guard now correctly skips the redundant re-validation in **all** toggle scenarios (route or no route).

## Test
Added `TogglingOffDirectTransferWithoutTransitRouteOnWIPTransferOrder` (codeunit 149911) — [SCENARIO 638816] — which creates **no** transfer route and toggles Direct Transfer off. It fails with the error before the fix and passes after. Existing toggle tests (`NoErrorWhenTogglingOffDirectTransferOnWIPTransferOrder`, `ToggleOffDirectTransferOnWIPTransferOrderDoesNotError`, `WIPTransferLineDescriptionNotClearedWhenDirectTransferEnabled`) remain green.

> Note: one pre-existing failure in codeunit 149911 (`WIPTransferRemainderCreatedWhenOpenLineQuantityReduced`, SCENARIO 639382) is unrelated — it fails identically on `main` without this change.

Fixes [AB#638816](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638816)

🤖 Generated with GitHub Copilot

