### PR TITLE
[main] bug 644148 - Use VAT base amount (after discounts) for reverse charge limit check

### DIFF
--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/SalesPostingHandlerCZL.Codeunit.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/SalesPostingHandlerCZL.Codeunit.al
@@ -269,7 +269,10 @@ codeunit 31038 "Sales Posting Handler CZL"
                                 Temp1InventoryBuffer.Insert();
                             end;
 
-                            LineAmount := SalesLine."Unit Price" * QtyToInvoice;
+                            if SalesLine.Quantity <> 0 then
+                                LineAmount := SalesLine.Amount * QtyToInvoice / SalesLine.Quantity
+                            else
+                                LineAmount := 0;
                             if SalesHeader."Currency Code" <> '' then
                                 LineAmount :=
                                   CurrencyExchangeRate.ExchangeAmtFCYToLCY(

--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/SalesPostingHandlerCZL.Codeunit.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/SalesPostingHandlerCZL.Codeunit.al
@@ -248,6 +248,7 @@ codeunit 31038 "Sales Posting Handler CZL"
                                     SalesLine.TestField("Unit of Measure Code", TariffNumber."VAT Stat. UoM Code CZL");
 
                         if (TariffNumber."Statement Code CZL" <> '') and SalesHeader.Invoice then begin
+                            GetCurrency(SalesHeader."Currency Code");
                             TariffNumber.TestField("Statement Limit Code CZL");
                             CommodityCZL.Get(TariffNumber."Statement Limit Code CZL");
                         end else
@@ -270,7 +271,7 @@ codeunit 31038 "Sales Posting Handler CZL"
                             end;
 
                             if SalesLine.Quantity <> 0 then
-                                LineAmount := SalesLine.Amount * QtyToInvoice / SalesLine.Quantity
+                                LineAmount := Round(SalesLine.Amount * QtyToInvoice / SalesLine.Quantity, Currency."Amount Rounding Precision")
                             else
                                 LineAmount := 0;
                             if SalesHeader."Currency Code" <> '' then

--- a/src/Apps/CZ/CoreLocalizationPack/test/Src/ReverseChargeCZL.Codeunit.al
+++ b/src/Apps/CZ/CoreLocalizationPack/test/Src/ReverseChargeCZL.Codeunit.al
@@ -23,6 +23,7 @@ codeunit 148057 "Reverse Charge CZL"
         LibraryRandom: Codeunit "Library - Random";
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryPatterns: Codeunit "Library - Patterns";
+        LibraryTaxCZL: Codeunit "Library - Tax CZL";
         Assert: Codeunit Assert;
         SalesDocumentType: Enum "Sales Document Type";
         SalesLineType: Enum "Sales Line Type";
@@ -253,12 +254,11 @@ codeunit 148057 "Reverse Charge CZL"
 
     local procedure CreateTariffNo(var TariffNumber: Record "Tariff Number"; CommodityCode: Code[10]; UoMCode: Code[10])
     begin
-        TariffNumber.Init();
-        TariffNumber."No." := CopyStr(LibraryRandom.RandText(3), 1, MaxStrLen(CommodityCode));
+        LibraryTaxCZL.CreateTariffNumber(TariffNumber);
         TariffNumber."Statement Code CZL" := CommodityCode;
         TariffNumber."Statement Limit Code CZL" := CommodityCode;
         TariffNumber."VAT Stat. UoM Code CZL" := UoMCode;
         TariffNumber."Allow Empty UoM Code CZL" := false;
-        TariffNumber.Insert();
+        TariffNumber.Modify();
     end;
 }

--- a/src/Apps/CZ/CoreLocalizationPack/test/Src/ReverseChargeCZL.Codeunit.al
+++ b/src/Apps/CZ/CoreLocalizationPack/test/Src/ReverseChargeCZL.Codeunit.al
@@ -118,11 +118,11 @@ codeunit 148057 "Reverse Charge CZL"
     end;
 
     [Test]
-    procedure PostSalesWithCommodityAboveLimit()
+    procedure PostSalesWithCommodityUnderLimit()
     var
         TariffNumber: Record "Tariff Number";
     begin
-        // [SCENARIO] Post Sales Invoice with Commodity above limit
+        // [SCENARIO] Post Sales Invoice with Commodity under limit
         Initialize();
 
         // [GIVEN] New Customer has been created

--- a/src/Apps/CZ/CoreLocalizationPack/test/Src/ReverseChargeCZL.Codeunit.al
+++ b/src/Apps/CZ/CoreLocalizationPack/test/Src/ReverseChargeCZL.Codeunit.al
@@ -15,15 +15,14 @@ codeunit 148057 "Reverse Charge CZL"
         Item: Record Item;
         CommodityCZL: Record "Commodity CZL";
         CommoditySetupCZL: Record "Commodity Setup CZL";
+        GeneralPostingSetup: Record "General Posting Setup";
         VATPostingSetup: Record "VAT Posting Setup";
-        UnitofMeasure: Record "Unit of Measure";
-        TariffNumber: Record "Tariff Number";
         SalesLine: Record "Sales Line";
-        ItemUnitofMeasure: Record "Item Unit of Measure";
         LibraryERM: Codeunit "Library - ERM";
         LibrarySales: Codeunit "Library - Sales";
         LibraryRandom: Codeunit "Library - Random";
         LibraryInventory: Codeunit "Library - Inventory";
+        LibraryPatterns: Codeunit "Library - Patterns";
         Assert: Codeunit Assert;
         SalesDocumentType: Enum "Sales Document Type";
         SalesLineType: Enum "Sales Line Type";
@@ -34,6 +33,10 @@ codeunit 148057 "Reverse Charge CZL"
 
     local procedure Initialize();
     var
+        InventoryPostingGroup: Record "Inventory Posting Group";
+        InventoryPostingSetup: Record "Inventory Posting Setup";
+        Location: Record Location;
+        SalesReceivablesSetup: Record "Sales & Receivables Setup";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
     begin
         LibraryTestInitialize.OnTestInitialize(Codeunit::"Reverse Charge CZL");
@@ -41,6 +44,10 @@ codeunit 148057 "Reverse Charge CZL"
         if isInitialized then
             exit;
         LibraryTestInitialize.OnBeforeTestSuiteInitialize(Codeunit::"Reverse Charge CZL");
+
+        SalesReceivablesSetup.Get();
+        SalesReceivablesSetup.Validate("Invoice Rounding", false);
+        SalesReceivablesSetup.Modify();
 
         CommodityCZL.Init();
         CommodityCZL.Code := CopyStr(LibraryRandom.RandText(2), 1, MaxStrLen(CommodityCZL.Code));
@@ -52,18 +59,20 @@ codeunit 148057 "Reverse Charge CZL"
         CommoditySetupCZL."Commodity Limit Amount LCY" := 100000;
         CommoditySetupCZL.Insert();
 
-        LibraryERM.CreateVATPostingSetupWithAccounts(VatPostingSetup, TaxCalculationType::"Normal VAT", 21);
+        LibrarySales.SetPostedNoSeriesInSetup();
+        LibraryPatterns.SETNoSeries();
+
+        LibraryERM.CreateGeneralPostingSetupInvt(GeneralPostingSetup);
+        GeneralPostingSetup.Validate("Sales Line Disc. Account", LibraryERM.CreateGLAccountNo());
+        GeneralPostingSetup.Modify();
+
+        LibraryERM.CreateVATPostingSetupWithAccounts(VATPostingSetup, TaxCalculationType::"Normal VAT", 21);
         VATPostingSetup."Reverse Charge Check CZL" := ReverseChargeCheckCZL::"Limit Check";
         VATPostingSetup.Modify();
 
-        LibraryInventory.CreateUnitOfMeasureCode(UnitofMeasure);
-        TariffNumber.Init();
-        TariffNumber."No." := CopyStr(LibraryRandom.RandText(3), 1, MaxStrLen(CommodityCZL.Code));
-        TariffNumber."Statement Code CZL" := CommodityCZL.Code;
-        TariffNumber."Statement Limit Code CZL" := CommodityCZL.Code;
-        TariffNumber."VAT Stat. UoM Code CZL" := UnitofMeasure.Code;
-        TariffNumber."Allow Empty UoM Code CZL" := false;
-        TariffNumber.Insert();
+        LibraryInventory.CreateInventoryPostingGroup(InventoryPostingGroup);
+        LibraryInventory.CreateInventoryPostingSetup(InventoryPostingSetup, '', InventoryPostingGroup.Code);
+        LibraryInventory.UpdateInventoryPostingSetup(Location, InventoryPostingGroup.Code);
 
         isInitialized := true;
         Commit();
@@ -72,6 +81,8 @@ codeunit 148057 "Reverse Charge CZL"
 
     [Test]
     procedure ValidateSalesLineWithTariffNo()
+    var
+        TariffNumber: Record "Tariff Number";
     begin
         // [SCENARIO] Validate Item with Tariff No. in Sales Line
         Initialize();
@@ -83,14 +94,19 @@ codeunit 148057 "Reverse Charge CZL"
 
         // [GIVEN] New Item has been created
         LibraryInventory.CreateItem(Item);
+
+        // [GIVEN] New Tariff Number has been created
+        CreateTariffNo(TariffNumber, CommodityCZL.Code, Item."Base Unit of Measure");
+
+        // [GIVEN] Item has been updated with Tariff No. and VAT Prod. Posting Group
         Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
         Item.Validate("Tariff No.", TariffNumber."No.");
         Item.Modify();
-        LibraryInventory.CreateItemUnitOfMeasure(ItemUnitofMeasure, Item."No.", UnitofMeasure.Code, 1);
 
         // [GIVEN] New Sales Invoice has been created
         LibrarySales.CreateSalesHeader(SalesHeader, SalesDocumentType::Invoice, Customer."No.");
         SalesHeader.Validate("Posting Date", WorkDate());
+        SalesHeader.Modify();
 
         // [WHEN] Create Sales Line with Item No. with filled Tariff No. value
         LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLineType::Item, Item."No.", 1000);
@@ -102,6 +118,8 @@ codeunit 148057 "Reverse Charge CZL"
 
     [Test]
     procedure PostSalesWithCommodityAboveLimit()
+    var
+        TariffNumber: Record "Tariff Number";
     begin
         // [SCENARIO] Post Sales Invoice with Commodity above limit
         Initialize();
@@ -113,14 +131,19 @@ codeunit 148057 "Reverse Charge CZL"
 
         // [GIVEN] New Item has been created
         LibraryInventory.CreateItem(Item);
+
+        // [GIVEN] New Tariff Number has been created
+        CreateTariffNo(TariffNumber, CommodityCZL.Code, Item."Base Unit of Measure");
+
+        // [GIVEN] Item has been updated with Tariff No. and VAT Prod. Posting Group
         Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
         Item.Validate("Tariff No.", TariffNumber."No.");
         Item.Modify();
-        LibraryInventory.CreateItemUnitOfMeasure(ItemUnitofMeasure, Item."No.", UnitofMeasure.Code, 1);
 
         // [GIVEN] New Sales Invoice has been created
         LibrarySales.CreateSalesHeader(SalesHeader, SalesDocumentType::Invoice, Customer."No.");
         SalesHeader.Validate("Posting Date", WorkDate());
+        SalesHeader.Modify();
 
         // [GIVEN] Sales Line with Item No. with Unit Price bas been created
         LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLineType::Item, Item."No.", 1000);
@@ -138,6 +161,7 @@ codeunit 148057 "Reverse Charge CZL"
     [Test]
     procedure PostSalesWithCommodityAboveLimitBeforeDiscountBelowAfter()
     var
+        TariffNumber: Record "Tariff Number";
         SalesInvHeader: Record "Sales Invoice Header";
         PostedDocNo: Code[20];
     begin
@@ -147,19 +171,26 @@ codeunit 148057 "Reverse Charge CZL"
 
         // [GIVEN] New Customer has been created
         LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Gen. Bus. Posting Group", GeneralPostingSetup."Gen. Bus. Posting Group");
         Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
         Customer.Modify();
 
         // [GIVEN] New Item has been created
         LibraryInventory.CreateItem(Item);
+
+        // [GIVEN] New Tariff Number has been created
+        CreateTariffNo(TariffNumber, CommodityCZL.Code, Item."Base Unit of Measure");
+
+        // [GIVEN] Item has been updated with Tariff No. and VAT Prod. Posting Group
+        Item.Validate("Gen. Prod. Posting Group", GeneralPostingSetup."Gen. Prod. Posting Group");
         Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
         Item.Validate("Tariff No.", TariffNumber."No.");
         Item.Modify();
-        LibraryInventory.CreateItemUnitOfMeasure(ItemUnitofMeasure, Item."No.", UnitofMeasure.Code, 1);
 
         // [GIVEN] New Sales Invoice has been created
         LibrarySales.CreateSalesHeader(SalesHeader, SalesDocumentType::Invoice, Customer."No.");
         SalesHeader.Validate("Posting Date", WorkDate());
+        SalesHeader.Modify();
 
         // [GIVEN] Sales Line: Unit Price 200 * Qty 1000 = 200,000 (above limit 100,000)
         // Line Discount 60% => Amount after discount = 80,000 (below limit 100,000)
@@ -177,6 +208,8 @@ codeunit 148057 "Reverse Charge CZL"
 
     [Test]
     procedure PostSalesWithCommodityAboveLimitAfterDiscount()
+    var
+        TariffNumber: Record "Tariff Number";
     begin
         // [SCENARIO] Post Sales Invoice where amount after discount still exceeds limit.
         // Normal VAT should not be allowed - error expected.
@@ -189,14 +222,19 @@ codeunit 148057 "Reverse Charge CZL"
 
         // [GIVEN] New Item has been created
         LibraryInventory.CreateItem(Item);
+
+        // [GIVEN] New Tariff Number has been created
+        CreateTariffNo(TariffNumber, CommodityCZL.Code, Item."Base Unit of Measure");
+
+        // [GIVEN] Item has been updated with Tariff No. and VAT Prod. Posting Group
         Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
         Item.Validate("Tariff No.", TariffNumber."No.");
         Item.Modify();
-        LibraryInventory.CreateItemUnitOfMeasure(ItemUnitofMeasure, Item."No.", UnitofMeasure.Code, 1);
 
         // [GIVEN] New Sales Invoice has been created
         LibrarySales.CreateSalesHeader(SalesHeader, SalesDocumentType::Invoice, Customer."No.");
         SalesHeader.Validate("Posting Date", WorkDate());
+        SalesHeader.Modify();
 
         // [GIVEN] Sales Line: Unit Price 200 * Qty 1000 = 200,000 (above limit 100,000)
         // Line Discount 20% => Amount after discount = 160,000 (still above limit 100,000)
@@ -211,5 +249,16 @@ codeunit 148057 "Reverse Charge CZL"
         // [THEN] Error VAT Posting Setup Post Mismatch will occur (amount after discount still exceeds limit)
         Assert.ExpectedError(StrSubstNo(VATPostingSetupPostMismatchErr, CommoditySetupCZL."Commodity Code", CommoditySetupCZL."Commodity Limit Amount LCY",
                              SalesLine."VAT Calculation Type"::"Normal VAT", Item."No."));
+    end;
+
+    local procedure CreateTariffNo(var TariffNumber: Record "Tariff Number"; CommodityCode: Code[10]; UoMCode: Code[10])
+    begin
+        TariffNumber.Init();
+        TariffNumber."No." := CopyStr(LibraryRandom.RandText(3), 1, MaxStrLen(CommodityCode));
+        TariffNumber."Statement Code CZL" := CommodityCode;
+        TariffNumber."Statement Limit Code CZL" := CommodityCode;
+        TariffNumber."VAT Stat. UoM Code CZL" := UoMCode;
+        TariffNumber."Allow Empty UoM Code CZL" := false;
+        TariffNumber.Insert();
     end;
 }

--- a/src/Apps/CZ/CoreLocalizationPack/test/Src/ReverseChargeCZL.Codeunit.al
+++ b/src/Apps/CZ/CoreLocalizationPack/test/Src/ReverseChargeCZL.Codeunit.al
@@ -101,9 +101,9 @@ codeunit 148057 "Reverse Charge CZL"
     end;
 
     [Test]
-    procedure PostSalesWithCommodityUnderLimit()
+    procedure PostSalesWithCommodityAboveLimit()
     begin
-        // [SCENARIO] Post Sales Invoice with Commodity under limit
+        // [SCENARIO] Post Sales Invoice with Commodity above limit
         Initialize();
 
         // [GIVEN] New Customer has been created
@@ -131,6 +131,84 @@ codeunit 148057 "Reverse Charge CZL"
         asserterror LibrarySales.PostSalesDocument(SalesHeader, false, false);
 
         // [THEN] Error VAT Posting Setup Post Mismatch will occurs
+        Assert.ExpectedError(StrSubstNo(VATPostingSetupPostMismatchErr, CommoditySetupCZL."Commodity Code", CommoditySetupCZL."Commodity Limit Amount LCY",
+                             SalesLine."VAT Calculation Type"::"Normal VAT", Item."No."));
+    end;
+
+    [Test]
+    procedure PostSalesWithCommodityAboveLimitBeforeDiscountBelowAfter()
+    var
+        SalesInvHeader: Record "Sales Invoice Header";
+        PostedDocNo: Code[20];
+    begin
+        // [SCENARIO] Post Sales Invoice where amount before discount exceeds limit but amount after discount is below limit.
+        // The limit check must use the amount after discount (VAT base), so posting with Normal VAT should succeed.
+        Initialize();
+
+        // [GIVEN] New Customer has been created
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        Customer.Modify();
+
+        // [GIVEN] New Item has been created
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
+        Item.Validate("Tariff No.", TariffNumber."No.");
+        Item.Modify();
+        LibraryInventory.CreateItemUnitOfMeasure(ItemUnitofMeasure, Item."No.", UnitofMeasure.Code, 1);
+
+        // [GIVEN] New Sales Invoice has been created
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesDocumentType::Invoice, Customer."No.");
+        SalesHeader.Validate("Posting Date", WorkDate());
+
+        // [GIVEN] Sales Line: Unit Price 200 * Qty 1000 = 200,000 (above limit 100,000)
+        // Line Discount 60% => Amount after discount = 80,000 (below limit 100,000)
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLineType::Item, Item."No.", 1000);
+        SalesLine.Validate("Unit Price", 200);
+        SalesLine.Validate("Line Discount %", 60);
+        SalesLine.Modify(true);
+
+        // [WHEN] Post Sales Invoice
+        PostedDocNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] Sales Invoice is posted successfully (amount after discount is below limit, Normal VAT is correct)
+        SalesInvHeader.Get(PostedDocNo);
+    end;
+
+    [Test]
+    procedure PostSalesWithCommodityAboveLimitAfterDiscount()
+    begin
+        // [SCENARIO] Post Sales Invoice where amount after discount still exceeds limit.
+        // Normal VAT should not be allowed - error expected.
+        Initialize();
+
+        // [GIVEN] New Customer has been created
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        Customer.Modify();
+
+        // [GIVEN] New Item has been created
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
+        Item.Validate("Tariff No.", TariffNumber."No.");
+        Item.Modify();
+        LibraryInventory.CreateItemUnitOfMeasure(ItemUnitofMeasure, Item."No.", UnitofMeasure.Code, 1);
+
+        // [GIVEN] New Sales Invoice has been created
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesDocumentType::Invoice, Customer."No.");
+        SalesHeader.Validate("Posting Date", WorkDate());
+
+        // [GIVEN] Sales Line: Unit Price 200 * Qty 1000 = 200,000 (above limit 100,000)
+        // Line Discount 20% => Amount after discount = 160,000 (still above limit 100,000)
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLineType::Item, Item."No.", 1000);
+        SalesLine.Validate("Unit Price", 200);
+        SalesLine.Validate("Line Discount %", 20);
+        SalesLine.Modify(true);
+
+        // [WHEN] Post Sales Invoice
+        asserterror LibrarySales.PostSalesDocument(SalesHeader, false, false);
+
+        // [THEN] Error VAT Posting Setup Post Mismatch will occur (amount after discount still exceeds limit)
         Assert.ExpectedError(StrSubstNo(VATPostingSetupPostMismatchErr, CommoditySetupCZL."Commodity Code", CommoditySetupCZL."Commodity Limit Amount LCY",
                              SalesLine."VAT Calculation Type"::"Normal VAT", Item."No."));
     end;


### PR DESCRIPTION
## What & why

The commodity limit check for Reverse Charge VAT in `CheckTariffNo` (codeunit 31038 "Sales Posting Handler CZL") was evaluating the invoice amount against the commodity threshold using `Unit Price × Quantity` — the gross amount before any discounts.

Per the Czech GFR regulation, the decisive amount should be the total VAT base stated on the tax document, i.e. the amount **after** line discounts and invoice discounts. This change fixes the calculation to use `SalesLine.Amount` (prorated for partial invoicing) instead of the gross unit price amount.

## Linked work

Fixes [AB#644148](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644148)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Posted a sales invoice where `Unit Price × Qty` exceeded the commodity limit but the amount after a 60% line discount fell below it — invoice posted successfully with Normal VAT (previously would have errored).
- Posted a sales invoice where the amount after a 20% line discount still exceeded the commodity limit — error correctly raised, Normal VAT blocked.
- New test procedures added to `ReverseChargeCZL.Codeunit.al` (codeunit 148057):
  - `PostSalesWithCommodityAboveLimitBeforeDiscountBelowAfter` — positive scenario, passes.
  - `PostSalesWithCommodityAboveLimitAfterDiscount` — negative scenario, passes.
- Existing test `PostSalesWithCommodityUnderLimit` still passes (no regression).

## Risk & compatibility

The limit evaluation logic changes for all sales invoices that have line or invoice discounts and use a commodity subject to Reverse Charge limit check. Customers whose invoices previously passed the limit check only due to gross amount being below the threshold are unaffected. Customers who relied on the gross amount to trigger Reverse Charge (i.e. gross > limit but net < limit) will now correctly use Normal VAT — this is a **behavioral change** aligned with the regulation.

No data migration or upgrade codeunit needed. No feature flag required.










