### PR TITLE
[Subcontracting] Bug 641607: Fix misleading error message when disabling Legacy Subcontracting with open WIP purchase orders

### DIFF
--- a/src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al
@@ -25,7 +25,7 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
         SubcontractingAppIdTok: Label '1f32a50d-0057-4b95-b5df-cc04d7e89470', Locked = true;
         SubcontractingAppInstalledErr: Label 'Cannot activate legacy subcontracting while the Subcontracting app is installed. Use the Subcontracting app features instead.';
         OpenSubcontractingTransfersExistErr: Label 'There are still open transfer orders with WIP Items. All subcontracting transfer orders must be completed before disabling Legacy Subcontracting.';
-        OpenWIPPurchaseOrdersExistErr: Label 'There are still open purchase orders with WIP Items. All subcontracting purchase orders must be completed before disabling Legacy Subcontracting.';
+        OpenWIPPurchaseOrdersExistErr: Label 'There are still open purchase orders with WIP Items. All purchase orders with WIP Items must be completed before disabling Legacy Subcontracting.';
         MigrationNotAllowedInProductionErr: Label 'To help you migrate safely, disabling Legacy Subcontracting and moving to the Subcontracting app is currently limited to sandbox environments. Test the migration in a sandbox copy of this environment first to validate the transition. Production environments will be enabled in a future release.';
         InstallSubcontractingAppQst: Label 'The Subcontracting app is required to disable Legacy Subcontracting. Do you want to install it now?';
         InstallITMigrationAppQst: Label 'The IT Subcontracting Migration app is needed to migrate your data. Do you want to install it now?';

--- a/src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al
@@ -25,7 +25,7 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
         SubcontractingAppIdTok: Label '1f32a50d-0057-4b95-b5df-cc04d7e89470', Locked = true;
         SubcontractingAppInstalledErr: Label 'Cannot activate legacy subcontracting while the Subcontracting app is installed. Use the Subcontracting app features instead.';
         OpenSubcontractingTransfersExistErr: Label 'There are still open transfer orders with WIP Items. All subcontracting transfer orders must be completed before disabling Legacy Subcontracting.';
-        OpenWIPPurchaseOrdersExistErr: Label 'There are still open subcontracting purchase orders. All subcontracting purchase orders must be completed before disabling Legacy Subcontracting.';
+        OpenWIPPurchaseOrdersExistErr: Label 'There are still open purchase orders with WIP Items. All subcontracting purchase orders must be completed before disabling Legacy Subcontracting.';
         MigrationNotAllowedInProductionErr: Label 'To help you migrate safely, disabling Legacy Subcontracting and moving to the Subcontracting app is currently limited to sandbox environments. Test the migration in a sandbox copy of this environment first to validate the transition. Production environments will be enabled in a future release.';
         InstallSubcontractingAppQst: Label 'The Subcontracting app is required to disable Legacy Subcontracting. Do you want to install it now?';
         InstallITMigrationAppQst: Label 'The IT Subcontracting Migration app is needed to migrate your data. Do you want to install it now?';

--- a/src/Layers/IT/Tests/Local/SCMLegacySubcontracting.Codeunit.al
+++ b/src/Layers/IT/Tests/Local/SCMLegacySubcontracting.Codeunit.al
@@ -578,9 +578,9 @@ codeunit 137500 "SCM Legacy Subcontracting"
         TransferLine: Record "Transfer Line";
         LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
         EnvironmentInfoTestLibrary: Codeunit "Environment Info Test Library";
-        OpenWIPPurchaseOrdersExistErr: Label 'There are still open purchase orders with WIP Items. All subcontracting purchase orders must be completed before disabling Legacy Subcontracting.';
+        OpenWIPPurchaseOrdersExistErr: Label 'There are still open purchase orders with WIP Items. All purchase orders with WIP Items must be completed before disabling Legacy Subcontracting.';
     begin
-        // [SCENARIO 641607] CheckCanDisableLegacySubcontracting error wording for open purchase orders matches the "WIP Item" filter condition instead of implying all subcontracting purchase orders
+        // [SCENARIO 641607] CheckCanDisableLegacySubcontracting error wording consistently refers to purchase orders with WIP Items in both sentences, instead of implying all subcontracting purchase orders
         Initialize();
 
         // [GIVEN] The environment is testable as a sandbox so the migration pre-checks (beyond the production gate) are reached
@@ -604,8 +604,8 @@ codeunit 137500 "SCM Legacy Subcontracting"
         // [WHEN] Call CheckCanDisableLegacySubcontracting
         asserterror LegacySubcFeatureHandler.CheckCanDisableLegacySubcontracting();
 
-        // [THEN] The error wording refers to purchase orders "with WIP Items", matching the actual filter condition, not "all subcontracting purchase orders"
-        Assert.ExpectedError(OpenWIPPurchaseOrdersExistErr);
+        // [THEN] The full error message consistently refers to purchase orders "with WIP Items" in both sentences, not "all subcontracting purchase orders"
+        Assert.AreEqual(OpenWIPPurchaseOrdersExistErr, GetLastErrorText(), 'Error message wording must consistently describe purchase orders with WIP Items in both sentences.');
 
         EnvironmentInfoTestLibrary.SetTestabilitySandbox(false);
     end;

--- a/src/Layers/IT/Tests/Local/SCMLegacySubcontracting.Codeunit.al
+++ b/src/Layers/IT/Tests/Local/SCMLegacySubcontracting.Codeunit.al
@@ -17,6 +17,7 @@ using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 using System.Environment.Configuration;
+using System.TestLibraries.Environment;
 
 codeunit 137500 "SCM Legacy Subcontracting"
 {
@@ -568,6 +569,49 @@ codeunit 137500 "SCM Legacy Subcontracting"
 
     [Test]
     [Scope('OnPrem')]
+    procedure PreCheckDisableErrorWordingMatchesWIPItemFilterForPurchaseOrders()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        Vendor: Record Vendor;
+        Item: Record Item;
+        TransferLine: Record "Transfer Line";
+        LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
+        EnvironmentInfoTestLibrary: Codeunit "Environment Info Test Library";
+        OpenWIPPurchaseOrdersExistErr: Label 'There are still open purchase orders with WIP Items. All subcontracting purchase orders must be completed before disabling Legacy Subcontracting.';
+    begin
+        // [SCENARIO 641607] CheckCanDisableLegacySubcontracting error wording for open purchase orders matches the "WIP Item" filter condition instead of implying all subcontracting purchase orders
+        Initialize();
+
+        // [GIVEN] The environment is testable as a sandbox so the migration pre-checks (beyond the production gate) are reached
+        EnvironmentInfoTestLibrary.SetTestabilitySandbox(true);
+
+        // [GIVEN] ManufacturingSetup."Legacy Subcontracting" = true
+        SetLegacySubcontracting(true);
+
+        // [GIVEN] No open WIP transfers (to pass the first check)
+        TransferLine.SetRange("WIP Item", true);
+        TransferLine.DeleteAll();
+
+        // [GIVEN] An open purchase order line with "WIP Item" = true exists
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryInventory.CreateItem(Item);
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", 1);
+        PurchaseLine."WIP Item" := true;
+        PurchaseLine.Modify();
+
+        // [WHEN] Call CheckCanDisableLegacySubcontracting
+        asserterror LegacySubcFeatureHandler.CheckCanDisableLegacySubcontracting();
+
+        // [THEN] The error wording refers to purchase orders "with WIP Items", matching the actual filter condition, not "all subcontracting purchase orders"
+        Assert.ExpectedError(OpenWIPPurchaseOrdersExistErr);
+
+        EnvironmentInfoTestLibrary.SetTestabilitySandbox(false);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure PreCheckDisableFailsWhenITMigrationAppInstalled()
     var
         TransferLine: Record "Transfer Line";
@@ -603,9 +647,15 @@ codeunit 137500 "SCM Legacy Subcontracting"
     end;
 
     local procedure Initialize()
+    var
+        EnvironmentInfoTestLibrary: Codeunit "Environment Info Test Library";
     begin
         LibraryTestInitialize.OnTestInitialize(Codeunit::"SCM Legacy Subcontracting");
         LibraryApplicationArea.EnablePremiumSetup();
+
+        // Ensure every test starts from a known, non-sandbox testability state, regardless of
+        // whether a previous test left the SingleInstance sandbox flag set (e.g. on assertion failure).
+        EnvironmentInfoTestLibrary.SetTestabilitySandbox(false);
 
         if Initialized then
             exit;


### PR DESCRIPTION
## Summary
- Bug: [Subcontracting] Misleading error message when disabling Legacy Subcontracting - says "all subcontracting purchase orders" but only checks WIP items ([AB#641607](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641607))
- Root cause: OpenWIPPurchaseOrdersExistErr in LegacySubcFeatureHandler.Codeunit.al (codeunit 99008501) said "There are still open subcontracting purchase orders. All subcontracting purchase orders must be completed...", implying every open subcontracting purchase order blocks disabling Legacy Subcontracting. The actual check, OpenWIPPurchaseLinesExist(), only looks at purchase order lines with **"WIP Item" = true**, so the wording didn't match the real filter condition. The sibling transfer-order label (OpenSubcontractingTransfersExistErr) already used the correct wording ("...transfer orders **with WIP Items**...").
- Fix: Reworded OpenWIPPurchaseOrdersExistErr to "There are still open purchase orders **with WIP Items**. All subcontracting purchase orders must be completed before disabling Legacy Subcontracting.", matching the actual filter condition and the sibling label's phrasing. No logic/filter changes.

## Test
Added `PreCheckDisableErrorWordingMatchesWIPItemFilterForPurchaseOrders` ([SCENARIO 641607]) to `SCMLegacySubcontracting.Codeunit.al`. It uses `Environment Info Test Library` to mock the environment as a sandbox so `CheckCanDisableLegacySubcontracting()` reaches the WIP-purchase-order check (bypassing the production-environment gate), creates an open purchase order line with "WIP Item" = true, and asserts the corrected error wording.

Also hardened the shared `Initialize()` to always reset the testability sandbox flag at the start of every test, so a test-order dependency / leaked global state can't mask failures in the other tests in this codeunit.

Note: This change lives in the IT-country layer (`src/Layers/IT/...`), which is merged into a country-specific view at CI build time; this workspace checkout does not contain a locally-buildable AL project (app.json/launch.json) for that merged view, so compile/publish/test could not be executed locally through the sanctioned ^Gl-mcp-action.sh tooling (3 candidate project paths were attempted and all failed due to missing project files, not code errors). The change was validated by: exact-mirroring the already-correct sibling label's wording/pattern, manual AL syntax/convention review, and an independent review pass. Recommend CI validates compile/test for this PR.

Fixes [AB#641607](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641607)

🤖 Generated with GitHub Copilot



