### PR TITLE
Image Analyzer: use Computer Vision v3.2 instead of retiring v1.0

### DIFF
--- a/src/Apps/W1/ImageAnalysis/app/src/codeunits/ImageAnalyzerExtMgt.Codeunit.al
+++ b/src/Apps/W1/ImageAnalysis/app/src/codeunits/ImageAnalyzerExtMgt.Codeunit.al
@@ -98,7 +98,10 @@ codeunit 2027 "Image Analyzer Ext. Mgt."
         if not ImageAnalysisSetup."Image-Based Attribute Recognition Enabled" then
             exit;
 
-        ImageAnalysisManagement.Initialize();
+        // Computer Vision v1.0 Analyze API retires 2026-09-13. Use the shipped v3.2 provider instead of the
+        // default v1.0. This app only reads image Tags, and v3.2 keeps the same OAuth2 auth and tags[] response
+        // shape, so there is no functional change. See ItemFromPicture.Codeunit.al which already uses v3.2.
+        ImageAnalysisManagement.Initialize(Enum::"Image Analysis Provider"::"v3.2");
         ImageAnalysisManagement.SetMedia(MediaId);
 
         case AnalysisType of


### PR DESCRIPTION
## What & why

Azure Computer Vision **v1.0 Analyze** API is retired on **2026-09-13**. The Image Analyzer app calls `ImageAnalysisManagement.Initialize()`, which defaults to the v1.0 provider, so after retirement image analysis in this app would start failing.

This switches the app to the already-shipped **v3.2** provider. The app only reads image **Tags**, and v3.2 keeps the same OAuth2 authentication and the same `tags[]` response shape, so there is no functional change. This mirrors `ItemFromPicture.Codeunit.al`, which already uses v3.2.

Minimal stopgap to remove the v1.0 retirement exposure; a move to Computer Vision v4.0 can follow on normal cadence.

## Linked work

Work item: **[AB#644272](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644272)**

<!-- TODO (author): also add an approved GitHub issue and fill 'Fixes #<n>' before requesting review -->

Fixes [AB#644272](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644272)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- One-line provider switch reusing the shipped `Enum::"Image Analysis Provider"::"v3.2"` and the existing `Image Analysis Wrapper V3.2` codeunit; no new objects or dependencies.
- No new tests: existing `ItemAttrPopulateTest` feeds a mock `tags[]` JSON directly and bypasses the HTTP wrapper, so it is provider-agnostic and still valid. `v3.2 + OAuth2` is already exercised in production by the `ItemFromPicture` consumer.
- TODO (author): local build (no new analyzer warnings) and an end-to-end run in a container before marking ready.

## Risk & compatibility

- Low risk, no functional change: Tags-only usage, unchanged auth (OAuth2) and response shape (`tags[]`).
- v3.2 retires 2028-09-25, so this removes the near-term 2026-09-13 exposure.
- Backport: should be backported to the supported released versions that still call v1.0 before 2026-09-13.





