### PR TITLE
[Subcontracting] Bug 642535: Add mixed receive-only warehouse receipt test

### DIFF
--- a/src/Apps/W1/Subcontracting/Test/Libraries/SubcWarehouseLibrary.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Libraries/SubcWarehouseLibrary.Codeunit.al
@@ -416,6 +416,22 @@ codeunit 149908 "Subc. Warehouse Library"
     end;
 
     /// <summary>
+    /// Creates a bin-mandatory location that requires warehouse receipts but not warehouse put-aways.
+    /// </summary>
+    /// <param name="Location">The location record which will be created and updated</param>
+    /// <param name="ReceiveBin">The receipt bin record which will be created and assigned to the location</param>
+    internal procedure CreateLocationWithRequireReceiveOnlyAndBinMandatory(var Location: Record Location; var ReceiveBin: Record Bin)
+    begin
+        LibraryWarehouse.CreateLocationWMS(Location, true, false, false, true, false);
+        Location.Validate("Require Receive", true);
+        Location.Validate("Require Put-away", false);
+        LibraryWarehouse.CreateBin(ReceiveBin, Location.Code, 'RECEIVE', '', '');
+        Location.Validate("Receipt Bin Code", ReceiveBin.Code);
+        Location.Modify(true);
+        LibraryInventory.UpdateInventoryPostingSetup(Location);
+    end;
+
+    /// <summary>
     /// Creates a location with bin mandatory enabled only.
     /// </summary>
     /// <param name="Location">The location record which will be created and updated</param>

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWhseCombinedScenarios.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWhseCombinedScenarios.Codeunit.al
@@ -233,6 +233,131 @@ codeunit 149906 "Subc. Whse Combined Scenarios"
     end;
 
     [Test]
+    procedure MixedOperationsAtBinMandatoryReceiveOnlyLocation()
+    var
+        Item: Record Item;
+        ItemLedgerEntry: Record "Item Ledger Entry";
+        Location: Record Location;
+        MachineCenter: array[2] of Record "Machine Center";
+        PostedWhseReceiptHeader: Record "Posted Whse. Receipt Header";
+        PostedWhseReceiptLine: Record "Posted Whse. Receipt Line";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        ReceiveBin: Record Bin;
+        Vendor: Record Vendor;
+        WarehouseActivityLine: Record "Warehouse Activity Line";
+        WarehouseEmployee: Record "Warehouse Employee";
+        WarehouseEntry: Record "Warehouse Entry";
+        WarehouseReceiptHeader: Record "Warehouse Receipt Header";
+        WarehouseReceiptLine: Record "Warehouse Receipt Line";
+        WorkCenter: array[2] of Record "Work Center";
+        ItemTrackingErrorText: Text;
+        Quantity: Decimal;
+        ItemTrackingOpened: Boolean;
+    begin
+        // [SCENARIO 642535] Post mixed subcontracting operations at a bin-mandatory receive-only location
+        Initialize();
+        Quantity := LibraryRandom.RandIntInRange(10, 20);
+
+        // [GIVEN] A production item with last and not-last subcontracting operations for the same vendor
+        SubcWarehouseLibrary.CreateAndCalculateNeededWorkAndMachineCenterSameVendor(WorkCenter, MachineCenter, true);
+        SubcWarehouseLibrary.CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        SubcWarehouseLibrary.UpdateProdBomAndRoutingWithRoutingLinkForBothOperations(Item, WorkCenter);
+
+        // [GIVEN] A bin-mandatory location that requires receipt but not put-away
+        SubcWarehouseLibrary.CreateLocationWithRequireReceiveOnlyAndBinMandatory(Location, ReceiveBin);
+        LibraryWarehouse.CreateWarehouseEmployee(WarehouseEmployee, Location.Code, false);
+
+        // [GIVEN] The subcontractor uses the receive-only location
+        Vendor.Get(WorkCenter[1]."Subcontractor No.");
+        Vendor."Subc. Location Code" := Location.Code;
+        Vendor."Location Code" := Location.Code;
+        Vendor.Modify();
+
+        // [GIVEN] One released production order and one purchase order containing both operation lines
+        SubcWarehouseLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released,
+            ProductionOrder."Source Type"::Item, Item."No.", Quantity, Location.Code);
+        SubcWarehouseLibrary.UpdateSubMgmtSetupWithReqWkshTemplate();
+        SubcWarehouseLibrary.CreateSubcontractingOrdersViaWorksheet(ProductionOrder."No.", PurchaseHeader);
+        LibraryPurchase.ReleasePurchaseDocument(PurchaseHeader);
+
+        // [GIVEN] One warehouse receipt containing both operation lines
+        SubcWarehouseLibrary.CreateWarehouseReceiptUsingGetSourceDocuments(WarehouseReceiptHeader, Location.Code);
+        SetBinCodeOnWarehouseReceiptLines(WarehouseReceiptHeader, ReceiveBin.Code);
+        WarehouseReceiptLine.SetRange("No.", WarehouseReceiptHeader."No.");
+        WarehouseReceiptLine.SetRange("Source No.", PurchaseHeader."No.");
+        Assert.RecordCount(WarehouseReceiptLine, 2);
+
+        // [GIVEN] The not-last operation has no operational bin or inventory quantity
+        WarehouseReceiptLine.SetRange("Subc. Purchase Line Type", "Subc. Purchase Line Type"::NotLastOperation);
+        WarehouseReceiptLine.FindFirst();
+        Assert.AreEqual('', WarehouseReceiptLine."Bin Code", 'Not-last operation should not use a bin');
+        Assert.AreEqual(0, WarehouseReceiptLine."Qty. (Base)", 'Not-last operation should have zero base quantity');
+
+        // [THEN] Item tracking remains blocked for the not-last operation
+        ItemTrackingOpened := TryOpenItemTrackingLines(WarehouseReceiptHeader, WarehouseReceiptLine);
+        ItemTrackingErrorText := GetLastErrorText();
+        Assert.IsFalse(ItemTrackingOpened, 'Item tracking should be blocked for the not-last operation');
+        Assert.AreEqual(
+            'Item tracking lines can only be viewed for subcontracting purchase lines which are linked to a routing line which is the last operation.',
+            ItemTrackingErrorText, 'Unexpected item tracking error');
+
+        // [GIVEN] The last operation uses the receipt bin and carries the inventory quantity
+        WarehouseReceiptLine.SetRange("Subc. Purchase Line Type", "Subc. Purchase Line Type"::LastOperation);
+        WarehouseReceiptLine.FindFirst();
+        Assert.AreEqual(ReceiveBin.Code, WarehouseReceiptLine."Bin Code", 'Last operation should use the receipt bin');
+        Assert.AreEqual(Quantity, WarehouseReceiptLine."Qty. (Base)", 'Last operation should have the production quantity');
+
+        // [WHEN] The mixed warehouse receipt is posted
+        SubcWarehouseLibrary.PostWarehouseReceipt(WarehouseReceiptHeader, PostedWhseReceiptHeader);
+
+        // [THEN] Both lines are included in the posted warehouse receipt
+        PostedWhseReceiptLine.SetRange("No.", PostedWhseReceiptHeader."No.");
+        PostedWhseReceiptLine.SetRange("Item No.", Item."No.");
+        Assert.RecordCount(PostedWhseReceiptLine, 2);
+
+        // [THEN] Only the last operation creates one output item ledger entry
+        ItemLedgerEntry.SetRange("Item No.", Item."No.");
+        ItemLedgerEntry.SetRange("Location Code", Location.Code);
+        ItemLedgerEntry.SetRange("Entry Type", ItemLedgerEntry."Entry Type"::Output);
+        ItemLedgerEntry.SetRange("Order No.", ProductionOrder."No.");
+        Assert.RecordCount(ItemLedgerEntry, 1);
+        ItemLedgerEntry.CalcSums(Quantity);
+        Assert.AreEqual(Quantity, ItemLedgerEntry.Quantity, 'Only the last operation should post output inventory');
+
+        // [THEN] Both subcontracting operations create their capacity entries
+        SubcWarehouseLibrary.VerifyCapacityLedgerEntry(WorkCenter[1]."No.", Quantity);
+        SubcWarehouseLibrary.VerifyCapacityLedgerEntry(WorkCenter[2]."No.", Quantity);
+
+        // [THEN] Only one warehouse entry is created directly in the receipt bin
+        WarehouseEntry.SetRange("Item No.", Item."No.");
+        WarehouseEntry.SetRange("Location Code", Location.Code);
+        WarehouseEntry.SetRange("Bin Code", ReceiveBin.Code);
+        Assert.RecordCount(WarehouseEntry, 1);
+        WarehouseEntry.FindFirst();
+        Assert.AreEqual(Quantity, WarehouseEntry.Quantity, 'The last operation should create one warehouse entry');
+        SubcWarehouseLibrary.VerifyBinContents(Location.Code, ReceiveBin.Code, Item."No.", Quantity);
+
+        // [THEN] No warehouse put-away is created
+        WarehouseActivityLine.SetRange("Activity Type", WarehouseActivityLine."Activity Type"::"Put-away");
+        WarehouseActivityLine.SetRange("Location Code", Location.Code);
+        WarehouseActivityLine.SetRange("Item No.", Item."No.");
+        Assert.RecordIsEmpty(WarehouseActivityLine);
+    end;
+
+    [TryFunction]
+    local procedure TryOpenItemTrackingLines(WarehouseReceiptHeader: Record "Warehouse Receipt Header"; WarehouseReceiptLine: Record "Warehouse Receipt Line")
+    var
+        WarehouseReceiptPage: TestPage "Warehouse Receipt";
+    begin
+        WarehouseReceiptPage.OpenEdit();
+        WarehouseReceiptPage.GoToRecord(WarehouseReceiptHeader);
+        WarehouseReceiptPage.WhseReceiptLines.GoToRecord(WarehouseReceiptLine);
+        WarehouseReceiptPage.WhseReceiptLines.ItemTrackingLines.Invoke();
+    end;
+
+    [Test]
     procedure ProdOrderWithMultipleOperationsDifferentVendors()
     var
         PutAwayBin: Record Bin;

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWhseCombinedScenarios.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWhseCombinedScenarios.Codeunit.al
@@ -238,52 +238,22 @@ codeunit 149906 "Subc. Whse Combined Scenarios"
         Item: Record Item;
         ItemLedgerEntry: Record "Item Ledger Entry";
         Location: Record Location;
-        MachineCenter: array[2] of Record "Machine Center";
         PostedWhseReceiptHeader: Record "Posted Whse. Receipt Header";
         PostedWhseReceiptLine: Record "Posted Whse. Receipt Line";
         ProductionOrder: Record "Production Order";
         PurchaseHeader: Record "Purchase Header";
         ReceiveBin: Record Bin;
-        Vendor: Record Vendor;
         WarehouseActivityLine: Record "Warehouse Activity Line";
-        WarehouseEmployee: Record "Warehouse Employee";
         WarehouseEntry: Record "Warehouse Entry";
         WarehouseReceiptHeader: Record "Warehouse Receipt Header";
         WarehouseReceiptLine: Record "Warehouse Receipt Line";
         WorkCenter: array[2] of Record "Work Center";
-        WarehouseReceiptPage: TestPage "Warehouse Receipt";
         Quantity: Decimal;
     begin
         // [SCENARIO 642535] Post mixed subcontracting operations at a bin-mandatory receive-only location
-        Initialize();
-        Quantity := LibraryRandom.RandIntInRange(10, 20);
-
-        // [GIVEN] A production item with last and not-last subcontracting operations for the same vendor
-        SubcWarehouseLibrary.CreateAndCalculateNeededWorkAndMachineCenterSameVendor(WorkCenter, MachineCenter, true);
-        SubcWarehouseLibrary.CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
-        SubcWarehouseLibrary.UpdateProdBomAndRoutingWithRoutingLinkForBothOperations(Item, WorkCenter);
-
-        // [GIVEN] A bin-mandatory location that requires receipt but not put-away
-        SubcWarehouseLibrary.CreateLocationWithRequireReceiveOnlyAndBinMandatory(Location, ReceiveBin);
-        LibraryWarehouse.CreateWarehouseEmployee(WarehouseEmployee, Location.Code, false);
-
-        // [GIVEN] The subcontractor uses the receive-only location
-        Vendor.Get(WorkCenter[1]."Subcontractor No.");
-        Vendor."Subc. Location Code" := Location.Code;
-        Vendor."Location Code" := Location.Code;
-        Vendor.Modify();
-
-        // [GIVEN] One released production order and one purchase order containing both operation lines
-        SubcWarehouseLibrary.CreateAndRefreshProductionOrder(
-            ProductionOrder, "Production Order Status"::Released,
-            ProductionOrder."Source Type"::Item, Item."No.", Quantity, Location.Code);
-        SubcWarehouseLibrary.UpdateSubMgmtSetupWithReqWkshTemplate();
-        SubcWarehouseLibrary.CreateSubcontractingOrdersViaWorksheet(ProductionOrder."No.", PurchaseHeader);
-        LibraryPurchase.ReleasePurchaseDocument(PurchaseHeader);
-
-        // [GIVEN] One warehouse receipt containing both operation lines
-        SubcWarehouseLibrary.CreateWarehouseReceiptUsingGetSourceDocuments(WarehouseReceiptHeader, Location.Code);
-        SetBinCodeOnWarehouseReceiptLines(WarehouseReceiptHeader, ReceiveBin.Code);
+        // [GIVEN] One warehouse receipt containing last and not-last operations at a bin-mandatory receive-only location
+        CreateMixedOperationsWarehouseReceiptAtBinMandatoryReceiveOnlyLocation(
+            Item, Location, ProductionOrder, PurchaseHeader, ReceiveBin, WarehouseReceiptHeader, WorkCenter, Quantity);
         WarehouseReceiptLine.SetRange("No.", WarehouseReceiptHeader."No.");
         WarehouseReceiptLine.SetRange("Source No.", PurchaseHeader."No.");
         Assert.RecordCount(WarehouseReceiptLine, 2);
@@ -293,14 +263,6 @@ codeunit 149906 "Subc. Whse Combined Scenarios"
         WarehouseReceiptLine.FindFirst();
         Assert.AreEqual('', WarehouseReceiptLine."Bin Code", 'Not-last operation should not use a bin');
         Assert.AreEqual(0, WarehouseReceiptLine."Qty. (Base)", 'Not-last operation should have zero base quantity');
-
-        // [THEN] Item tracking remains blocked for the not-last operation
-        WarehouseReceiptPage.OpenEdit();
-        WarehouseReceiptPage.GoToRecord(WarehouseReceiptHeader);
-        WarehouseReceiptPage.WhseReceiptLines.GoToRecord(WarehouseReceiptLine);
-        asserterror WarehouseReceiptPage.WhseReceiptLines.ItemTrackingLines.Invoke();
-        Assert.ExpectedError(
-            'Item tracking lines can only be viewed for subcontracting purchase lines which are linked to a routing line which is the last operation.');
 
         // [GIVEN] The last operation uses the receipt bin and carries the inventory quantity
         WarehouseReceiptLine.SetRange("Subc. Purchase Line Type", "Subc. Purchase Line Type"::LastOperation);
@@ -343,6 +305,40 @@ codeunit 149906 "Subc. Whse Combined Scenarios"
         WarehouseActivityLine.SetRange("Location Code", Location.Code);
         WarehouseActivityLine.SetRange("Item No.", Item."No.");
         Assert.RecordIsEmpty(WarehouseActivityLine);
+    end;
+
+    [Test]
+    procedure ItemTrackingBlockedForNotLastOperationAtBinMandatoryReceiveOnlyLocation()
+    var
+        Item: Record Item;
+        Location: Record Location;
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        ReceiveBin: Record Bin;
+        WarehouseReceiptHeader: Record "Warehouse Receipt Header";
+        WarehouseReceiptLine: Record "Warehouse Receipt Line";
+        WorkCenter: array[2] of Record "Work Center";
+        WarehouseReceiptPage: TestPage "Warehouse Receipt";
+        Quantity: Decimal;
+    begin
+        // [SCENARIO 642535] Item tracking is blocked for a not-last operation at a bin-mandatory receive-only location
+        // [GIVEN] One warehouse receipt containing last and not-last operations at a bin-mandatory receive-only location
+        CreateMixedOperationsWarehouseReceiptAtBinMandatoryReceiveOnlyLocation(
+            Item, Location, ProductionOrder, PurchaseHeader, ReceiveBin, WarehouseReceiptHeader, WorkCenter, Quantity);
+        WarehouseReceiptLine.SetRange("No.", WarehouseReceiptHeader."No.");
+        WarehouseReceiptLine.SetRange("Source No.", PurchaseHeader."No.");
+        WarehouseReceiptLine.SetRange("Subc. Purchase Line Type", "Subc. Purchase Line Type"::NotLastOperation);
+        WarehouseReceiptLine.FindFirst();
+
+        // [WHEN] Item tracking is opened for the not-last operation
+        WarehouseReceiptPage.OpenEdit();
+        WarehouseReceiptPage.GoToRecord(WarehouseReceiptHeader);
+        WarehouseReceiptPage.WhseReceiptLines.GoToRecord(WarehouseReceiptLine);
+        asserterror WarehouseReceiptPage.WhseReceiptLines.ItemTrackingLines.Invoke();
+
+        // [THEN] Item tracking remains blocked
+        Assert.ExpectedError(
+            'Item tracking lines can only be viewed for subcontracting purchase lines which are linked to a routing line which is the last operation.');
     end;
 
     [Test]
@@ -643,6 +639,38 @@ codeunit 149906 "Subc. Whse Combined Scenarios"
         WarehouseEntry.SetRange("Item No.", ItemNo);
         WarehouseEntry.SetRange("Location Code", LocationCode);
         Assert.RecordIsNotEmpty(WarehouseEntry);
+    end;
+
+    local procedure CreateMixedOperationsWarehouseReceiptAtBinMandatoryReceiveOnlyLocation(var Item: Record Item; var Location: Record Location; var ProductionOrder: Record "Production Order"; var PurchaseHeader: Record "Purchase Header"; var ReceiveBin: Record Bin; var WarehouseReceiptHeader: Record "Warehouse Receipt Header"; var WorkCenter: array[2] of Record "Work Center"; var Quantity: Decimal)
+    var
+        MachineCenter: array[2] of Record "Machine Center";
+        Vendor: Record Vendor;
+        WarehouseEmployee: Record "Warehouse Employee";
+    begin
+        Initialize();
+        Quantity := LibraryRandom.RandIntInRange(10, 20);
+
+        SubcWarehouseLibrary.CreateAndCalculateNeededWorkAndMachineCenterSameVendor(WorkCenter, MachineCenter, true);
+        SubcWarehouseLibrary.CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        SubcWarehouseLibrary.UpdateProdBomAndRoutingWithRoutingLinkForBothOperations(Item, WorkCenter);
+
+        SubcWarehouseLibrary.CreateLocationWithRequireReceiveOnlyAndBinMandatory(Location, ReceiveBin);
+        LibraryWarehouse.CreateWarehouseEmployee(WarehouseEmployee, Location.Code, false);
+
+        Vendor.Get(WorkCenter[1]."Subcontractor No.");
+        Vendor."Subc. Location Code" := Location.Code;
+        Vendor."Location Code" := Location.Code;
+        Vendor.Modify();
+
+        SubcWarehouseLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released,
+            ProductionOrder."Source Type"::Item, Item."No.", Quantity, Location.Code);
+        SubcWarehouseLibrary.UpdateSubMgmtSetupWithReqWkshTemplate();
+        SubcWarehouseLibrary.CreateSubcontractingOrdersViaWorksheet(ProductionOrder."No.", PurchaseHeader);
+        LibraryPurchase.ReleasePurchaseDocument(PurchaseHeader);
+
+        SubcWarehouseLibrary.CreateWarehouseReceiptUsingGetSourceDocuments(WarehouseReceiptHeader, Location.Code);
+        SetBinCodeOnWarehouseReceiptLines(WarehouseReceiptHeader, ReceiveBin.Code);
     end;
 
     local procedure VerifyLedgerEntriesForMultiVendorScenario(ItemNo: Code[20]; Quantity: Decimal; LocationCode: Code[10])

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWhseCombinedScenarios.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWhseCombinedScenarios.Codeunit.al
@@ -251,9 +251,8 @@ codeunit 149906 "Subc. Whse Combined Scenarios"
         WarehouseReceiptHeader: Record "Warehouse Receipt Header";
         WarehouseReceiptLine: Record "Warehouse Receipt Line";
         WorkCenter: array[2] of Record "Work Center";
-        ItemTrackingErrorText: Text;
+        WarehouseReceiptPage: TestPage "Warehouse Receipt";
         Quantity: Decimal;
-        ItemTrackingOpened: Boolean;
     begin
         // [SCENARIO 642535] Post mixed subcontracting operations at a bin-mandatory receive-only location
         Initialize();
@@ -296,12 +295,12 @@ codeunit 149906 "Subc. Whse Combined Scenarios"
         Assert.AreEqual(0, WarehouseReceiptLine."Qty. (Base)", 'Not-last operation should have zero base quantity');
 
         // [THEN] Item tracking remains blocked for the not-last operation
-        ItemTrackingOpened := TryOpenItemTrackingLines(WarehouseReceiptHeader, WarehouseReceiptLine);
-        ItemTrackingErrorText := GetLastErrorText();
-        Assert.IsFalse(ItemTrackingOpened, 'Item tracking should be blocked for the not-last operation');
-        Assert.AreEqual(
-            'Item tracking lines can only be viewed for subcontracting purchase lines which are linked to a routing line which is the last operation.',
-            ItemTrackingErrorText, 'Unexpected item tracking error');
+        WarehouseReceiptPage.OpenEdit();
+        WarehouseReceiptPage.GoToRecord(WarehouseReceiptHeader);
+        WarehouseReceiptPage.WhseReceiptLines.GoToRecord(WarehouseReceiptLine);
+        asserterror WarehouseReceiptPage.WhseReceiptLines.ItemTrackingLines.Invoke();
+        Assert.ExpectedError(
+            'Item tracking lines can only be viewed for subcontracting purchase lines which are linked to a routing line which is the last operation.');
 
         // [GIVEN] The last operation uses the receipt bin and carries the inventory quantity
         WarehouseReceiptLine.SetRange("Subc. Purchase Line Type", "Subc. Purchase Line Type"::LastOperation);
@@ -344,17 +343,6 @@ codeunit 149906 "Subc. Whse Combined Scenarios"
         WarehouseActivityLine.SetRange("Location Code", Location.Code);
         WarehouseActivityLine.SetRange("Item No.", Item."No.");
         Assert.RecordIsEmpty(WarehouseActivityLine);
-    end;
-
-    [TryFunction]
-    local procedure TryOpenItemTrackingLines(WarehouseReceiptHeader: Record "Warehouse Receipt Header"; WarehouseReceiptLine: Record "Warehouse Receipt Line")
-    var
-        WarehouseReceiptPage: TestPage "Warehouse Receipt";
-    begin
-        WarehouseReceiptPage.OpenEdit();
-        WarehouseReceiptPage.GoToRecord(WarehouseReceiptHeader);
-        WarehouseReceiptPage.WhseReceiptLines.GoToRecord(WarehouseReceiptLine);
-        WarehouseReceiptPage.WhseReceiptLines.ItemTrackingLines.Invoke();
     end;
 
     [Test]


### PR DESCRIPTION
## Summary
- Add regression coverage for a mixed last/not-last subcontracting warehouse receipt at a bin-mandatory receive-only location.
- Verify receipt-bin handling, item/capacity/warehouse entries, no put-away, and blocked item tracking for the not-last line.

## Root Cause
The automated suite covered receive-only lines separately and mixed lines only at receipt-plus-put-away locations, leaving this combined configuration untested.

## Fix
Add a receive-only bin-mandatory location helper and the `MixedOperationsAtBinMandatoryReceiveOnlyLocation` integration test.

## Test
Added `MixedOperationsAtBinMandatoryReceiveOnlyLocation` in codeunit 149906 (`[SCENARIO 642535]`).

Fixes [AB#642535](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642535)

🤖 Generated with GitHub Copilot




