### PR TITLE
Extract invoice date into Invoice Date field and recover due date fro…

### DIFF
--- a/src/Apps/W1/EDocument/App/.resources/Prompts/EDocMLLMExtraction-SystemPrompt.md
+++ b/src/Apps/W1/EDocument/App/.resources/Prompts/EDocMLLMExtraction-SystemPrompt.md
@@ -6,6 +6,7 @@ EXTRACTION RULES:
 3. Dates: YYYY-MM-DD format
 4. Extract ALL invoice lines with sequential IDs starting from "1"
 5. Quantity: use "1" only if no quantity column exists on the document
+6. Due date: put the payment due date in "due_date" wherever it appears on the document
 
 CUSTOMER vs VENDOR IDENTIFICATION:
 The JSON structure includes pre-filled accounting_customer_party data. This is OUR company — the buyer receiving the invoice. Use this to distinguish between customer and vendor on the document:

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocMLLMSchemaHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocMLLMSchemaHelper.Codeunit.al
@@ -70,6 +70,7 @@ codeunit 6232 "E-Doc. MLLM Schema Helper"
     begin
         GetString(HeaderObj, 'id', MaxStrLen(TempHeader."Sales Invoice No."), TempHeader."Sales Invoice No.");
         GetDate(HeaderObj, 'issue_date', TempHeader."Document Date");
+        GetDate(HeaderObj, 'issue_date', TempHeader."Invoice Date");
         GetDate(HeaderObj, 'due_date', TempHeader."Due Date");
 
         GetString(HeaderObj, 'document_currency_code', MaxStrLen(TempHeader."Currency Code"), CurrencyText);

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentADIHandler.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentADIHandler.Codeunit.al
@@ -145,6 +145,7 @@ codeunit 6174 "E-Document ADI Handler" implements IStructureReceivedEDocument, I
         EDocumentJsonHelper.SetStringValueInField('invoiceId', MaxStrLen(TempEDocPurchaseHeader."Sales Invoice No."), FieldsJsonObject, TempEDocPurchaseHeader."Sales Invoice No.");
         EDocumentJsonHelper.SetDateValueInField('dueDate', FieldsJsonObject, TempEDocPurchaseHeader."Due Date");
         EDocumentJsonHelper.SetDateValueInField('invoiceDate', FieldsJsonObject, TempEDocPurchaseHeader."Document Date");
+        EDocumentJsonHelper.SetDateValueInField('invoiceDate', FieldsJsonObject, TempEDocPurchaseHeader."Invoice Date");
         EDocumentJsonHelper.SetStringValueInField('vendorName', MaxStrLen(TempEDocPurchaseHeader."Vendor Company Name"), FieldsJsonObject, TempEDocPurchaseHeader."Vendor Company Name");
         EDocumentJsonHelper.SetStringValueInField('vendorAddress', MaxStrLen(TempEDocPurchaseHeader."Vendor Address"), FieldsJsonObject, TempEDocPurchaseHeader."Vendor Address");
         EDocumentJsonHelper.SetStringValueInField('vendorAddressRecipient', MaxStrLen(TempEDocPurchaseHeader."Vendor Address Recipient"), FieldsJsonObject, TempEDocPurchaseHeader."Vendor Address Recipient");


### PR DESCRIPTION
## What & why

Invoice Date on the purchase draft came through blank because the extractors only wrote the invoice's date into Document Date, never into the Invoice Date field. This maps the extracted date into Invoice Date too, in both the ADI and the MLLM readers, so it is no longer empty.

Also recovers the Due Date on credit memos and some invoices where it sits under PaymentMeans instead of at the top level. The MLLM reader now falls back to payment_means.payment_due_date when the top level due date is missing, matching what the PEPPOL handler already does, and the field was added to the UBL schema so the model has a slot for it.

## Linked work

Fixes [AB#642335](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642335)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior or explained below why none are needed.

**What I tested and the outcome**

- Tested on a real invoice through and confirmed Invoice Date shows in the extracted data.

## Risk & compatibility

Low. It only fills a field that used to be blank and adds a due date fallback. Document Date mapping is untouched so nothing downstream at finalisation changes. The extra schema key is additive. No permissions, upgrade or telemetry impact.




