### PR TITLE
Add App Finance CODEOWNERS entries for owned apps

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -70,6 +70,7 @@
 /src/Apps/W1/ServiceDeclaration @microsoft/d365-bc-finance-1
 /src/Apps/W1/ServiceManagement @microsoft/d365-bc-finance-1
 /src/Apps/W1/StatisticalAccounts @microsoft/d365-bc-finance-1
+/src/Apps/W1/Subscription\ Billing @microsoft/d365-bc-finance-1
 /src/Apps/W1/Sustainability @microsoft/d365-bc-finance-1
 /src/Apps/W1/SustainabilityCopilotSuggestion @microsoft/d365-bc-finance-1
 /src/Apps/W1/VATGroupManagement @microsoft/d365-bc-finance-1

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,6 +20,60 @@
 
 # App Finance
 /src/Apps/W1/PowerBIReports @microsoft/d365-bc-finance-1
+/src/Apps/APAC/EDocumentFormats @microsoft/d365-bc-finance-1
+/src/Apps/CH/SwissQRBill @microsoft/d365-bc-finance-1
+/src/Apps/CZ/FixedAssetLocalization @microsoft/d365-bc-finance-1
+/src/Apps/DE/EDocumentDE @microsoft/d365-bc-finance-1
+/src/Apps/DE/Elster @microsoft/d365-bc-finance-1
+/src/Apps/DK/ElectronicVATDeclarationDK @microsoft/d365-bc-finance-1
+/src/Apps/DK/EnforcedDigitalVouchersDK @microsoft/d365-bc-finance-1
+/src/Apps/DK/FIK @microsoft/d365-bc-finance-1
+/src/Apps/DK/NemhandelNotification @microsoft/d365-bc-finance-1
+/src/Apps/DK/SAFTModificationDK @microsoft/d365-bc-finance-1
+/src/Apps/DK/VATReportsDK @microsoft/d365-bc-finance-1
+/src/Apps/ES/EDocumentFormats @microsoft/d365-bc-finance-1
+/src/Apps/FR/FAReportsFR @microsoft/d365-bc-finance-1
+/src/Apps/FR/FECAuditFile @microsoft/d365-bc-finance-1
+/src/Apps/FR/PaymentManagementFR @microsoft/d365-bc-finance-1
+/src/Apps/FR/ServiceDeclarationFR @microsoft/d365-bc-finance-1
+/src/Apps/GB/GovTalk @microsoft/d365-bc-finance-1
+/src/Apps/GB/IdealPostcodes @microsoft/d365-bc-finance-1
+/src/Apps/GB/PostingDateCheckOnPosting @microsoft/d365-bc-finance-1
+/src/Apps/GB/ReportsGB @microsoft/d365-bc-finance-1
+/src/Apps/GB/ReverseChargeVAT @microsoft/d365-bc-finance-1
+/src/Apps/GB/UKMakingTaxDigital @microsoft/d365-bc-finance-1
+/src/Apps/GB/UKPostcodeGetAddressIO @microsoft/d365-bc-finance-1
+/src/Apps/GB/VATReporting @microsoft/d365-bc-finance-1
+/src/Apps/NA/Ceridian @microsoft/d365-bc-finance-1
+/src/Apps/NA/EnvestnetYodleeBankFeeds @microsoft/d365-bc-finance-1
+/src/Apps/NA/ExtendedBankDepositNA @microsoft/d365-bc-finance-1
+/src/Apps/NA/MX_DIOT @microsoft/d365-bc-finance-1
+/src/Apps/NA/Onprem\ Permissions\ NA @microsoft/d365-bc-finance-1
+/src/Apps/NL/NLDigitalTaxDeclaration @microsoft/d365-bc-finance-1
+/src/Apps/NO/ElectronicVATSubmission @microsoft/d365-bc-finance-1
+/src/Apps/NO/NorwegianSAFT @microsoft/d365-bc-finance-1
+/src/Apps/SE/SIE @microsoft/d365-bc-finance-1
+/src/Apps/US/IRS1096 @microsoft/d365-bc-finance-1
+/src/Apps/US/IRSForms @microsoft/d365-bc-finance-1
+/src/Apps/W1/AMCBanking365Fundamentals @microsoft/d365-bc-finance-1
+/src/Apps/W1/AuditFileExport @microsoft/d365-bc-finance-1
+/src/Apps/W1/BankAccRecWithAI @microsoft/d365-bc-finance-1
+/src/Apps/W1/BankDeposits @microsoft/d365-bc-finance-1
+/src/Apps/W1/CompanyHub @microsoft/d365-bc-finance-1
+/src/Apps/W1/CrossEnvironmentIntercompany @microsoft/d365-bc-finance-1
+/src/Apps/W1/EnforcedDigitalVouchers @microsoft/d365-bc-finance-1
+/src/Apps/W1/ExciseTaxes @microsoft/d365-bc-finance-1
+/src/Apps/W1/MasterDataManagement @microsoft/d365-bc-finance-1
+/src/Apps/W1/PayPalPaymentsStandard @microsoft/d365-bc-finance-1
+/src/Apps/W1/ReviewGLEntries @microsoft/d365-bc-finance-1
+/src/Apps/W1/SAF-T @microsoft/d365-bc-finance-1
+/src/Apps/W1/ServiceDeclaration @microsoft/d365-bc-finance-1
+/src/Apps/W1/ServiceManagement @microsoft/d365-bc-finance-1
+/src/Apps/W1/StatisticalAccounts @microsoft/d365-bc-finance-1
+/src/Apps/W1/Sustainability @microsoft/d365-bc-finance-1
+/src/Apps/W1/SustainabilityCopilotSuggestion @microsoft/d365-bc-finance-1
+/src/Apps/W1/VATGroupManagement @microsoft/d365-bc-finance-1
+/src/Apps/W1/WithholdingTax @microsoft/d365-bc-finance-1
 
 # App Security
 dotnet.al @microsoft/d365-bc-app-security


### PR DESCRIPTION
## What

Adds CODEOWNERS entries assigning App Finance-owned apps under `/src/Apps` to `@microsoft/d365-bc-finance-1`, so the team is automatically requested for review on PRs touching those apps.

## How the list was derived

- Pulled the commit-author history (last 3 years) for every app folder under `App/Apps/<country>/<app>` in the NAV repo (`releases/28.x`).
- Filtered out infrastructure/vendor aliases (`v-*`, GitHub Copilot, and cross-cutting engineers) to surface the apps contributed to solely by the App Finance team.
- Reviewed the remaining apps with the team and confirmed ownership app-by-app.
- Verified all resulting paths exist in `src/Apps`.

## Notes

- Keeps the existing `/src/Apps/W1/PowerBIReports` entry.
- `CODEOWNERS` is owned by `@microsoft/d365-bc-engineering-systems`, whose approval is required to merge.

Fixes [AB#644167](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644167)


