### PR TITLE
[Extensibility Request] issue 30380: add OnSplitPostedWhseReceiptLineOnNotFindWhseItemEntryRelation event

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Tracking/ItemTrackingManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/ItemTrackingManagement.Codeunit.al
@@ -3710,7 +3710,7 @@ codeunit 6500 "Item Tracking Management"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnSplitPostedWhseReceiptLineOnNotFindWhseItemEntryRelation(PostedWhseRcptLine: Record "Posted Whse. Receipt Line"; var TempPostedWhseRcptLine: Record "Posted Whse. Receipt Line" temporary; var IsHandled: Boolean)
+    local procedure OnSplitPostedWhseReceiptLineOnNotFindWhseItemEntryRelation(PostedWhseReceiptLine: Record "Posted Whse. Receipt Line"; var TempPostedWhseReceiptLine: Record "Posted Whse. Receipt Line" temporary; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Inventory/Tracking/ItemTrackingManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/ItemTrackingManagement.Codeunit.al
@@ -1098,8 +1098,12 @@ codeunit 6500 "Item Tracking Management"
                 TempPostedWhseRcptLine.Modify();
             until WhseItemEntryRelation.Next() = 0
         else begin
-            TempPostedWhseRcptLine := PostedWhseRcptLine;
-            TempPostedWhseRcptLine.Insert();
+            IsHandled := false;
+            OnSplitPostedWhseReceiptLineOnNotFindWhseItemEntryRelation(PostedWhseRcptLine, TempPostedWhseRcptLine, IsHandled);
+            if not IsHandled then begin
+                TempPostedWhseRcptLine := PostedWhseRcptLine;
+                TempPostedWhseRcptLine.Insert();
+            end;
         end;
 
         OnAfterSplitPostedWhseReceiptLine(PostedWhseRcptLine, TempPostedWhseRcptLine);
@@ -3702,6 +3706,11 @@ codeunit 6500 "Item Tracking Management"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeSplitPostedWhseReceiptLine(PostedWhseRcptLine: Record "Posted Whse. Receipt Line"; var TempPostedWhseRcptLine: Record "Posted Whse. Receipt Line" temporary; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnSplitPostedWhseReceiptLineOnNotFindWhseItemEntryRelation(PostedWhseRcptLine: Record "Posted Whse. Receipt Line"; var TempPostedWhseRcptLine: Record "Posted Whse. Receipt Line" temporary; var IsHandled: Boolean)
     begin
     end;
 


### PR DESCRIPTION
## Summary
The reporter needs an additional integration event in codeunit 6500 `Item Tracking Management` so extensions can perform custom splitting of a posted warehouse receipt line when no `Whse. Item Entry Relation` records are found for that line. Without it, the base logic always inserts the single `PostedWhseRcptLine` and there is no extension point to override that behavior. This PR adds an `IsHandled`-guarded event in the `else` branch of `SplitPostedWhseRcptLine`, mirroring the pattern already used elsewhere in the codeunit.

Source issue repository: microsoft/ALAppExtensions; issue number: 30380

## Changes Made
- `SplitPostedWhseRcptLine` - added a new integration event `OnSplitPostedWhseReceiptLineOnNotFindWhseItemEntryRelation` in the `else` branch (when `WhseItemEntryRelation.FindSet()` finds no records), using the standard `IsHandled` pattern so subscribers can override the default insert of `PostedWhseRcptLine` into `TempPostedWhseRcptLine`. `IsHandled` is initialized to `false` before the call.
- `OnSplitPostedWhseReceiptLineOnNotFindWhseItemEntryRelation` - added the new `[IntegrationEvent(false, false)]` publisher next to the related event publishers.

Fixes [AB#644119](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644119)



