### PR TITLE
[PA][Pioneer]: Numeric line fields mis-extracted (discount, quantity, unit of measure)

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Helpers/EDocumentJsonHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Helpers/EDocumentJsonHelper.Codeunit.al
@@ -76,13 +76,13 @@ codeunit 6121 "EDocument Json Helper"
         if TryAssignToDate(JsonValue, Field) then;
     end;
 
-    internal procedure SetNumberValueInField(FieldName: Text; var FieldsJsonObject: JsonObject; var DecimalValue: Decimal)
+    internal procedure SetNumberValueInField(FieldName: Text; var FieldsJsonObject: JsonObject; var DecimalValue: Decimal): Boolean
     var
         JsonValue: JsonValue;
     begin
         if not TryGetJsonFieldValue(FieldName, FieldsJsonObject, 'value_number', JsonValue) then
-            exit;
-        if TryAssignToDecimal(JsonValue, DecimalValue) then;
+            exit(false);
+        exit(TryAssignToDecimal(JsonValue, DecimalValue));
     end;
 
     internal procedure SetCurrencyValueInField(FieldName: Text; var FieldsJsonObject: JsonObject; var Amount: Decimal; var CurrencyCode: Code[10])

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocMLLMSchemaHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocMLLMSchemaHelper.Codeunit.al
@@ -162,13 +162,19 @@ codeunit 6232 "E-Doc. MLLM Schema Helper"
                     GetDecimal(NestedObj, 'value', TempLine.Quantity);
                     GetString(NestedObj, 'unit_code', MaxStrLen(TempLine."Unit of Measure"), TempLine."Unit of Measure");
                 end;
-                if TempLine.Quantity <= 0 then
-                    TempLine.Quantity := 1;
 
                 if GetNestedObject(LineObj, 'price', NestedObj) then
                     GetDecimal(NestedObj, 'price_amount', TempLine."Unit Price");
 
                 GetDecimal(LineObj, 'line_extension_amount', TempLine."Sub Total");
+
+                if TempLine.Quantity < 0 then
+                    TempLine.Quantity := 0;
+                if TempLine.Quantity = 0 then
+                    if (TempLine."Unit Price" <> 0) and (TempLine."Sub Total" <> 0) then
+                        TempLine.Quantity := Round(TempLine."Sub Total" / TempLine."Unit Price", 0.00001)
+                    else
+                        TempLine.Quantity := 1;
 
                 if GetNestedObject(LineObj, 'allowance_charge', NestedObj) then begin
                     if GetNestedObject(NestedObj, 'amount', NestedObj2) then

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocMLLMSchemaHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocMLLMSchemaHelper.Codeunit.al
@@ -137,6 +137,7 @@ codeunit 6232 "E-Doc. MLLM Schema Helper"
         LineNumber: Integer;
         DiscountPct: Decimal;
         RoundingPrecision: Decimal;
+        QuantityProvided: Boolean;
     begin
         TempLine.DeleteAll();
 
@@ -158,8 +159,9 @@ codeunit 6232 "E-Doc. MLLM Schema Helper"
                         GetDecimal(NestedObj2, 'percent', TempLine."VAT Rate");
                 end;
 
+                QuantityProvided := false;
                 if GetNestedObject(LineObj, 'invoiced_quantity', NestedObj) then begin
-                    GetDecimal(NestedObj, 'value', TempLine.Quantity);
+                    QuantityProvided := GetDecimal(NestedObj, 'value', TempLine.Quantity);
                     GetString(NestedObj, 'unit_code', MaxStrLen(TempLine."Unit of Measure"), TempLine."Unit of Measure");
                 end;
 
@@ -168,13 +170,11 @@ codeunit 6232 "E-Doc. MLLM Schema Helper"
 
                 GetDecimal(LineObj, 'line_extension_amount', TempLine."Sub Total");
 
-                if TempLine.Quantity < 0 then
-                    TempLine.Quantity := 0;
-                if TempLine.Quantity = 0 then
-                    if (TempLine."Unit Price" <> 0) and (TempLine."Sub Total" <> 0) then
-                        TempLine.Quantity := Round(TempLine."Sub Total" / TempLine."Unit Price", 0.00001)
-                    else
-                        TempLine.Quantity := 1;
+                if not QuantityProvided then
+                    TempLine.Quantity := 1
+                else
+                    if TempLine.Quantity < 0 then
+                        TempLine.Quantity := 0;
 
                 if GetNestedObject(LineObj, 'allowance_charge', NestedObj) then begin
                     if GetNestedObject(NestedObj, 'amount', NestedObj2) then
@@ -224,20 +224,22 @@ codeunit 6232 "E-Doc. MLLM Schema Helper"
             FieldValue := DateValue;
     end;
 
-    local procedure GetDecimal(JsonObj: JsonObject; PropertyName: Text; var FieldValue: Decimal)
+    local procedure GetDecimal(JsonObj: JsonObject; PropertyName: Text; var FieldValue: Decimal): Boolean
     var
         JsonToken: JsonToken;
         DecimalValue: Decimal;
         DecimalParseFailedLbl: Label 'Could not parse decimal value returned by the model for property %1.', Comment = '%1 = JSON property name';
     begin
         if not JsonObj.Get(PropertyName, JsonToken) then
-            exit;
+            exit(false);
         if JsonToken.AsValue().IsNull() then
-            exit;
-        if Evaluate(DecimalValue, JsonToken.AsValue().AsText(), 9) then
-            FieldValue := DecimalValue
-        else
-            Session.LogMessage('0000UAR', StrSubstNo(DecimalParseFailedLbl, PropertyName), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', 'E-Document');
+            exit(false);
+        if Evaluate(DecimalValue, JsonToken.AsValue().AsText(), 9) then begin
+            FieldValue := DecimalValue;
+            exit(true);
+        end;
+        Session.LogMessage('0000UAR', StrSubstNo(DecimalParseFailedLbl, PropertyName), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', 'E-Document');
+        exit(false);
     end;
 
     local procedure GetNestedObject(JsonObj: JsonObject; PropertyName: Text; var NestedObj: JsonObject): Boolean

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentADIHandler.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentADIHandler.Codeunit.al
@@ -172,19 +172,29 @@ codeunit 6174 "E-Document ADI Handler" implements IStructureReceivedEDocument, I
     end;
 
     local procedure PopulateEDocumentPurchaseLine(FieldsJsonObject: JsonObject; var TempEDocPurchaseLine: Record "E-Document Purchase Line" temporary)
+    var
+        DerivedDiscount: Decimal;
     begin
         EDocumentJsonHelper.SetCurrencyValueInField('amount', FieldsJsonObject, TempEDocPurchaseLine."Sub Total", TempEDocPurchaseLine."Currency Code");
         EDocumentJsonHelper.SetStringValueInField('description', MaxStrLen(TempEDocPurchaseLine.Description), FieldsJsonObject, TempEDocPurchaseLine.Description);
         EDocumentJsonHelper.SetCurrencyValueInField('unitPrice', FieldsJsonObject, TempEDocPurchaseLine."Unit Price", TempEDocPurchaseLine."Currency Code");
         EDocumentJsonHelper.SetNumberValueInField('quantity', FieldsJsonObject, TempEDocPurchaseLine.Quantity);
-        if TempEDocPurchaseLine.Quantity <= 0 then
-            TempEDocPurchaseLine.Quantity := 1;
+        if TempEDocPurchaseLine.Quantity < 0 then
+            TempEDocPurchaseLine.Quantity := 0;
+        if TempEDocPurchaseLine.Quantity = 0 then
+            if (TempEDocPurchaseLine."Unit Price" <> 0) and (TempEDocPurchaseLine."Sub Total" <> 0) then
+                TempEDocPurchaseLine.Quantity := Round(TempEDocPurchaseLine."Sub Total" / TempEDocPurchaseLine."Unit Price", 0.00001)
+            else
+                TempEDocPurchaseLine.Quantity := 1;
         EDocumentJsonHelper.SetStringValueInField('productCode', MaxStrLen(TempEDocPurchaseLine."Product Code"), FieldsJsonObject, TempEDocPurchaseLine."Product Code");
         EDocumentJsonHelper.SetStringValueInField('unit', MaxStrLen(TempEDocPurchaseLine."Unit of Measure"), FieldsJsonObject, TempEDocPurchaseLine."Unit of Measure");
         EDocumentJsonHelper.SetDateValueInField('date', FieldsJsonObject, TempEDocPurchaseLine.Date);
         ResolveVATRateFromADI(FieldsJsonObject, TempEDocPurchaseLine);
-        if TempEDocPurchaseLine."Unit Price" <> 0 then
-            TempEDocPurchaseLine."Total Discount" := (TempEDocPurchaseLine."Unit Price" * TempEDocPurchaseLine.Quantity) - TempEDocPurchaseLine."Sub Total";
+        if (TempEDocPurchaseLine."Unit Price" <> 0) and (TempEDocPurchaseLine.Quantity <> 0) then begin
+            DerivedDiscount := (TempEDocPurchaseLine."Unit Price" * TempEDocPurchaseLine.Quantity) - TempEDocPurchaseLine."Sub Total";
+            if DerivedDiscount > 0 then
+                TempEDocPurchaseLine."Total Discount" := DerivedDiscount;
+        end;
     end;
 
     local procedure ResolveVATRateFromADI(FieldsJsonObject: JsonObject; var TempEDocPurchaseLine: Record "E-Document Purchase Line" temporary)

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentADIHandler.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentADIHandler.Codeunit.al
@@ -174,18 +174,17 @@ codeunit 6174 "E-Document ADI Handler" implements IStructureReceivedEDocument, I
     local procedure PopulateEDocumentPurchaseLine(FieldsJsonObject: JsonObject; var TempEDocPurchaseLine: Record "E-Document Purchase Line" temporary)
     var
         DerivedDiscount: Decimal;
+        QuantityProvided: Boolean;
     begin
         EDocumentJsonHelper.SetCurrencyValueInField('amount', FieldsJsonObject, TempEDocPurchaseLine."Sub Total", TempEDocPurchaseLine."Currency Code");
         EDocumentJsonHelper.SetStringValueInField('description', MaxStrLen(TempEDocPurchaseLine.Description), FieldsJsonObject, TempEDocPurchaseLine.Description);
         EDocumentJsonHelper.SetCurrencyValueInField('unitPrice', FieldsJsonObject, TempEDocPurchaseLine."Unit Price", TempEDocPurchaseLine."Currency Code");
-        EDocumentJsonHelper.SetNumberValueInField('quantity', FieldsJsonObject, TempEDocPurchaseLine.Quantity);
-        if TempEDocPurchaseLine.Quantity < 0 then
-            TempEDocPurchaseLine.Quantity := 0;
-        if TempEDocPurchaseLine.Quantity = 0 then
-            if (TempEDocPurchaseLine."Unit Price" <> 0) and (TempEDocPurchaseLine."Sub Total" <> 0) then
-                TempEDocPurchaseLine.Quantity := Round(TempEDocPurchaseLine."Sub Total" / TempEDocPurchaseLine."Unit Price", 0.00001)
-            else
-                TempEDocPurchaseLine.Quantity := 1;
+        QuantityProvided := EDocumentJsonHelper.SetNumberValueInField('quantity', FieldsJsonObject, TempEDocPurchaseLine.Quantity);
+        if not QuantityProvided then
+            TempEDocPurchaseLine.Quantity := 1
+        else
+            if TempEDocPurchaseLine.Quantity < 0 then
+                TempEDocPurchaseLine.Quantity := 0;
         EDocumentJsonHelper.SetStringValueInField('productCode', MaxStrLen(TempEDocPurchaseLine."Product Code"), FieldsJsonObject, TempEDocPurchaseLine."Product Code");
         EDocumentJsonHelper.SetStringValueInField('unit', MaxStrLen(TempEDocPurchaseLine."Unit of Measure"), FieldsJsonObject, TempEDocPurchaseLine."Unit of Measure");
         EDocumentJsonHelper.SetDateValueInField('date', FieldsJsonObject, TempEDocPurchaseLine.Date);

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocMLLMTests.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocMLLMTests.Codeunit.al
@@ -169,7 +169,7 @@ codeunit 135647 "EDoc MLLM Tests"
         ItemObj: JsonObject;
         QuantityObj: JsonObject;
     begin
-        // [SCENARIO] Line with quantity 0 defaults to 1
+        // [SCENARIO] Line with an explicit quantity of 0 keeps 0
         LibraryLowerPermission.SetOutsideO365Scope();
 
         ItemObj.Add('name', 'Zero Qty Item');
@@ -182,8 +182,31 @@ codeunit 135647 "EDoc MLLM Tests"
         EDocMLLMSchemaHelper.MapLinesFromJson(LinesArray, 1, TempLine, '');
 
         TempLine.FindFirst();
-        Assert.AreEqual(1, TempLine.Quantity, 'Zero quantity should default to 1');
+        Assert.AreEqual(0, TempLine.Quantity, 'Explicit zero quantity should be kept as 0');
         Assert.AreEqual('Zero Qty Item', TempLine.Description, 'Description');
+    end;
+
+    [Test]
+    procedure MapLines_MissingQuantity()
+    var
+        TempLine: Record "E-Document Purchase Line" temporary;
+        EDocMLLMSchemaHelper: Codeunit "E-Doc. MLLM Schema Helper";
+        LinesArray: JsonArray;
+        LineObj: JsonObject;
+        ItemObj: JsonObject;
+    begin
+        // [SCENARIO] Line without a quantity in the JSON defaults to 1
+        LibraryLowerPermission.SetOutsideO365Scope();
+
+        ItemObj.Add('name', 'No Qty Item');
+        LineObj.Add('item', ItemObj);
+        LinesArray.Add(LineObj);
+
+        EDocMLLMSchemaHelper.MapLinesFromJson(LinesArray, 1, TempLine, '');
+
+        TempLine.FindFirst();
+        Assert.AreEqual(1, TempLine.Quantity, 'Missing quantity should default to 1');
+        Assert.AreEqual('No Qty Item', TempLine.Description, 'Description');
     end;
 
     [Test]


### PR DESCRIPTION
## What & why

When a scanned invoice line has no quantity or a zero line total, the importer used to force the quantity to 1 and invent a discount from the price. That created phantom lines and wrong discounts. Now we keep a genuine zero quantity, only derive quantity from total over price when it makes sense, and never fabricate a discount. Unresolved units like HUR now carry through to the BC unit of measure field instead of showing blank.

## Linked work

Fixes [AB#642334](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642334)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Imported the Spanish invoice in CRONUS ES. The zero hour lines now show quantity 0 instead of 1, and the Docencia line shows 50 as on the document.
- Confirmed no discount is invented when the line total already matches price times quantity.

## Risk & compatibility

The unresolved unit fallback puts the raw code like HUR straight into the BC unit of measure field in View Extracted Data Page. 






