### PR TITLE
[main] bug 639499 - fix: Remove Status = Released condition from Send action buttons on Cash Document page

### DIFF
--- a/src/Apps/CZ/CashDeskLocalization/app/Src/Pages/CashDocumentCZP.Page.al
+++ b/src/Apps/CZ/CashDeskLocalization/app/Src/Pages/CashDocumentCZP.Page.al
@@ -540,7 +540,7 @@ page 31160 "Cash Document CZP"
                     ApplicationArea = Basic, Suite;
                     Caption = 'Release and Send';
                     Image = SendConfirmation;
-                    Enabled = (Rec."Document Type" = Rec."Document Type"::Receipt);
+                    Enabled = Rec."Document Type" = Rec."Document Type"::Receipt;
                     Ellipsis = true;
                     ToolTip = 'Release and prepare to send the document according to the customer''s sending profile, such as attachment to an email. The Send document to window opens first so you can confirm or select a sending profile.';
 
@@ -631,7 +631,7 @@ page 31160 "Cash Document CZP"
                     Caption = 'Post and Send';
                     Ellipsis = true;
                     Image = PostSendTo;
-                    Enabled = (Rec."Document Type" = Rec."Document Type"::Receipt);
+                    Enabled = Rec."Document Type" = Rec."Document Type"::Receipt;
                     ToolTip = 'Finalize and prepare to send the document according to the customer''s sending profile, such as attachment to an email. The Send document to window opens first so you can confirm or select a sending profile.';
 
                     trigger OnAction()

--- a/src/Apps/CZ/CashDeskLocalization/app/Src/Pages/CashDocumentCZP.Page.al
+++ b/src/Apps/CZ/CashDeskLocalization/app/Src/Pages/CashDocumentCZP.Page.al
@@ -540,7 +540,7 @@ page 31160 "Cash Document CZP"
                     ApplicationArea = Basic, Suite;
                     Caption = 'Release and Send';
                     Image = SendConfirmation;
-                    Enabled = (Rec."Document Type" = Rec."Document Type"::Receipt) and (Rec.Status = Rec.Status::Released);
+                    Enabled = (Rec."Document Type" = Rec."Document Type"::Receipt);
                     Ellipsis = true;
                     ToolTip = 'Release and prepare to send the document according to the customer''s sending profile, such as attachment to an email. The Send document to window opens first so you can confirm or select a sending profile.';
 
@@ -631,7 +631,7 @@ page 31160 "Cash Document CZP"
                     Caption = 'Post and Send';
                     Ellipsis = true;
                     Image = PostSendTo;
-                    Enabled = (Rec."Document Type" = Rec."Document Type"::Receipt) and (Rec.Status = Rec.Status::Released);
+                    Enabled = (Rec."Document Type" = Rec."Document Type"::Receipt);
                     ToolTip = 'Finalize and prepare to send the document according to the customer''s sending profile, such as attachment to an email. The Send document to window opens first so you can confirm or select a sending profile.';
 
                     trigger OnAction()


### PR DESCRIPTION
## What & why

Removed the `Rec.Status = Rec.Status::Released` condition from the `Enabled` property of the "Release and Send" and "Post and Send" actions on the Cash Document page. Both actions are now enabled whenever the document type is Receipt, regardless of its status.

## Linked work

Fixes [AB#639499](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639499)



