### PR TITLE
[Extensibility Request] issue 30377: add OnBeforePrintOnlyIfSalesCheck event in Item Sales Statistics report

### DIFF
--- a/src/Layers/NA/BaseApp/Local/Inventory/Reports/ItemSalesStatistics.Report.al
+++ b/src/Layers/NA/BaseApp/Local/Inventory/Reports/ItemSalesStatistics.Report.al
@@ -322,6 +322,8 @@ report 10135 "Item Sales Statistics"
             }
 
             trigger OnAfterGetRecord()
+            var
+                SkipRecord: Boolean;
             begin
                 NoShow := false;
                 if BreakdownByVariant then begin
@@ -333,7 +335,9 @@ report 10135 "Item Sales Statistics"
 
                 SetRange("Variant Filter");
                 CalcFields("Sales (Qty.)", "Sales (LCY)", "COGS (LCY)");
-                if ("Sales (Qty.)" = 0) and PrintOnlyIfSales then
+                SkipRecord := ("Sales (Qty.)" = 0) and PrintOnlyIfSales;
+                OnAfterGetRecordItemOnBeforePrintOnlyIfSalesCheck(Item, PrintOnlyIfSales, SkipRecord);
+                if SkipRecord then
                     CurrReport.Skip();
                 Profit := "Sales (LCY)" - "COGS (LCY)";
                 if "Sales (LCY)" <> 0 then
@@ -487,6 +491,11 @@ report 10135 "Item Sales Statistics"
     begin
         ItemVariant.SetRange("Item No.", Item."No.");
         exit(ItemVariant.FindFirst())
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterGetRecordItemOnBeforePrintOnlyIfSalesCheck(var Item: Record Item; PrintOnlyIfSales: Boolean; var SkipRecord: Boolean)
+    begin
     end;
 }
 


### PR DESCRIPTION
## Summary

The report `10135 "Item Sales Statistics"` calculates `Sales (Qty.)` via `CalcFields` and, in the same trigger, decides whether to `CurrReport.Skip()` the record based on the private `PrintOnlyIfSales` flag before any extension code runs. Extensions that compute alternate-UOM sales figures cannot influence this skip decision because `PrintOnlyIfSales` has no accessible getter and the skip happens before the table's `OnAfterGetRecord` trigger fires. This PR exposes the already-computed skip decision through a new integration event so subscribers can override whether an item is skipped, in either direction.

Source issue repository: microsoft/AlAppExtensions; issue number: 30377

## Changes Made
- `Report 10135 "Item Sales Statistics"` - In the `Item` data item `OnAfterGetRecord` trigger, the inline `PrintOnlyIfSales` skip check was factored into a local `SkipRecord` boolean and a new integration event `OnAfterGetRecordItemOnBeforePrintOnlyIfSalesCheck(var Item; PrintOnlyIfSales; var SkipRecord)` is raised after `CalcFields` and before `CurrReport.Skip()`, letting subscribers override the skip decision. Added the matching event publisher. Behavior is unchanged when no subscriber is present.

Fixes [AB#644155](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644155)


