### PR TITLE
[Extensibility Request] issue 30362: add OnPostDocumentLinesOnBeforeInsertPostedHeaders event to Service-Post

### DIFF
--- a/src/Layers/IT/BaseApp/Service/Posting/ServicePost.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Service/Posting/ServicePost.Codeunit.al
@@ -271,6 +271,7 @@ codeunit 5980 "Service-Post"
         TempTrackingSpecification: Record "Tracking Specification" temporary;
         GenJnlPostPreview: Codeunit "Gen. Jnl.-Post Preview";
         ServiceDocumentArchiveMgmt: Codeunit "Service Document Archive Mgmt.";
+        IsHandled: Boolean;
     begin
         LockTables(ServiceLine, GLEntry);
         // update quantities upon posting options and test related fields.
@@ -281,14 +282,17 @@ codeunit 5980 "Service-Post"
             ServShipmentNo := ServDocumentsMgt.PrepareShipmentHeader();
             WhseShip := not TempWarehouseShipmentHeader.IsEmpty();
         end;
-        if Invoice then
-            if ServiceHeader."Document Type" in [ServiceHeader."Document Type"::Order, ServiceHeader."Document Type"::Invoice] then begin
-                ServInvoiceNo := ServDocumentsMgt.PrepareInvoiceHeader(Window);
-                ServDocumentsMgt.UpdateIncomingDocument(ServiceHeader."Incoming Document Entry No.", ServiceHeader."Posting Date", ServInvoiceNo);
-            end else begin
-                ServCrMemoNo := ServDocumentsMgt.PrepareCrMemoHeader(Window);
-                ServDocumentsMgt.UpdateIncomingDocument(ServiceHeader."Incoming Document Entry No.", ServiceHeader."Posting Date", ServCrMemoNo);
-            end;
+        IsHandled := false;
+        OnPostDocumentLinesOnBeforeInsertPostedHeaders(ServiceHeader, IsHandled, ServInvoiceNo, ServCrMemoNo);
+        if not IsHandled then
+            if Invoice then
+                if ServiceHeader."Document Type" in [ServiceHeader."Document Type"::Order, ServiceHeader."Document Type"::Invoice] then begin
+                    ServInvoiceNo := ServDocumentsMgt.PrepareInvoiceHeader(Window);
+                    ServDocumentsMgt.UpdateIncomingDocument(ServiceHeader."Incoming Document Entry No.", ServiceHeader."Posting Date", ServInvoiceNo);
+                end else begin
+                    ServCrMemoNo := ServDocumentsMgt.PrepareCrMemoHeader(Window);
+                    ServDocumentsMgt.UpdateIncomingDocument(ServiceHeader."Incoming Document Entry No.", ServiceHeader."Posting Date", ServCrMemoNo);
+                end;
 
         if WhseShip then begin
             WarehouseShipmentHeader.Get(TempWarehouseShipmentHeader."No.");
@@ -960,6 +964,11 @@ codeunit 5980 "Service-Post"
 
     [IntegrationEvent(false, false)]
     local procedure OnSetCommitBehavior(var IgnoreCommit: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnPostDocumentLinesOnBeforeInsertPostedHeaders(var ServiceHeader: Record "Service Header"; var IsHandled: Boolean; var ServInvoiceNo: Code[20]; var ServCrMemoNo: Code[20])
     begin
     end;
 }

--- a/src/Layers/IT/BaseApp/Service/Posting/ServicePost.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Service/Posting/ServicePost.Codeunit.al
@@ -283,7 +283,7 @@ codeunit 5980 "Service-Post"
             WhseShip := not TempWarehouseShipmentHeader.IsEmpty();
         end;
         IsHandled := false;
-        OnPostDocumentLinesOnBeforeInsertPostedHeaders(ServiceHeader, IsHandled, ServInvoiceNo, ServCrMemoNo);
+        OnPostDocumentLinesOnBeforeInsertPostedHeaders(ServiceHeader, ServDocumentsMgt, IsHandled, ServInvoiceNo, ServCrMemoNo);
         if not IsHandled then
             if Invoice then
                 if ServiceHeader."Document Type" in [ServiceHeader."Document Type"::Order, ServiceHeader."Document Type"::Invoice] then begin
@@ -968,7 +968,7 @@ codeunit 5980 "Service-Post"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnPostDocumentLinesOnBeforeInsertPostedHeaders(var ServiceHeader: Record "Service Header"; var IsHandled: Boolean; var ServInvoiceNo: Code[20]; var ServCrMemoNo: Code[20])
+    local procedure OnPostDocumentLinesOnBeforeInsertPostedHeaders(var ServiceHeader: Record "Service Header"; var ServDocumentsMgt: Codeunit "Serv-Documents Mgt."; var IsHandled: Boolean; var ServInvoiceNo: Code[20]; var ServCrMemoNo: Code[20])
     begin
     end;
 }

--- a/src/Layers/NA/BaseApp/Service/Posting/ServicePost.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Service/Posting/ServicePost.Codeunit.al
@@ -268,6 +268,7 @@ codeunit 5980 "Service-Post"
         TempTrackingSpecification: Record "Tracking Specification" temporary;
         GenJnlPostPreview: Codeunit "Gen. Jnl.-Post Preview";
         ServiceDocumentArchiveMgmt: Codeunit "Service Document Archive Mgmt.";
+        IsHandled: Boolean;
     begin
         LockTables(ServiceLine, GLEntry);
         // update quantities upon posting options and test related fields.
@@ -278,14 +279,17 @@ codeunit 5980 "Service-Post"
             ServShipmentNo := ServDocumentsMgt.PrepareShipmentHeader();
             WhseShip := not TempWarehouseShipmentHeader.IsEmpty();
         end;
-        if Invoice then
-            if ServiceHeader."Document Type" in [ServiceHeader."Document Type"::Order, ServiceHeader."Document Type"::Invoice] then begin
-                ServInvoiceNo := ServDocumentsMgt.PrepareInvoiceHeader(Window);
-                ServDocumentsMgt.UpdateIncomingDocument(ServiceHeader."Incoming Document Entry No.", ServiceHeader."Posting Date", ServInvoiceNo);
-            end else begin
-                ServCrMemoNo := ServDocumentsMgt.PrepareCrMemoHeader(Window);
-                ServDocumentsMgt.UpdateIncomingDocument(ServiceHeader."Incoming Document Entry No.", ServiceHeader."Posting Date", ServCrMemoNo);
-            end;
+        IsHandled := false;
+        OnPostDocumentLinesOnBeforeInsertPostedHeaders(ServiceHeader, IsHandled, ServInvoiceNo, ServCrMemoNo);
+        if not IsHandled then
+            if Invoice then
+                if ServiceHeader."Document Type" in [ServiceHeader."Document Type"::Order, ServiceHeader."Document Type"::Invoice] then begin
+                    ServInvoiceNo := ServDocumentsMgt.PrepareInvoiceHeader(Window);
+                    ServDocumentsMgt.UpdateIncomingDocument(ServiceHeader."Incoming Document Entry No.", ServiceHeader."Posting Date", ServInvoiceNo);
+                end else begin
+                    ServCrMemoNo := ServDocumentsMgt.PrepareCrMemoHeader(Window);
+                    ServDocumentsMgt.UpdateIncomingDocument(ServiceHeader."Incoming Document Entry No.", ServiceHeader."Posting Date", ServCrMemoNo);
+                end;
 
         if WhseShip then begin
             WarehouseShipmentHeader.Get(TempWarehouseShipmentHeader."No.");
@@ -915,6 +919,11 @@ codeunit 5980 "Service-Post"
 
     [IntegrationEvent(false, false)]
     local procedure OnSetCommitBehavior(var IgnoreCommit: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnPostDocumentLinesOnBeforeInsertPostedHeaders(var ServiceHeader: Record "Service Header"; var IsHandled: Boolean; var ServInvoiceNo: Code[20]; var ServCrMemoNo: Code[20])
     begin
     end;
 }

--- a/src/Layers/NA/BaseApp/Service/Posting/ServicePost.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Service/Posting/ServicePost.Codeunit.al
@@ -280,7 +280,7 @@ codeunit 5980 "Service-Post"
             WhseShip := not TempWarehouseShipmentHeader.IsEmpty();
         end;
         IsHandled := false;
-        OnPostDocumentLinesOnBeforeInsertPostedHeaders(ServiceHeader, IsHandled, ServInvoiceNo, ServCrMemoNo);
+        OnPostDocumentLinesOnBeforeInsertPostedHeaders(ServiceHeader, ServDocumentsMgt, IsHandled, ServInvoiceNo, ServCrMemoNo);
         if not IsHandled then
             if Invoice then
                 if ServiceHeader."Document Type" in [ServiceHeader."Document Type"::Order, ServiceHeader."Document Type"::Invoice] then begin
@@ -923,7 +923,7 @@ codeunit 5980 "Service-Post"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnPostDocumentLinesOnBeforeInsertPostedHeaders(var ServiceHeader: Record "Service Header"; var IsHandled: Boolean; var ServInvoiceNo: Code[20]; var ServCrMemoNo: Code[20])
+    local procedure OnPostDocumentLinesOnBeforeInsertPostedHeaders(var ServiceHeader: Record "Service Header"; var ServDocumentsMgt: Codeunit "Serv-Documents Mgt."; var IsHandled: Boolean; var ServInvoiceNo: Code[20]; var ServCrMemoNo: Code[20])
     begin
     end;
 }

--- a/src/Layers/W1/BaseApp/Service/Posting/ServicePost.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Service/Posting/ServicePost.Codeunit.al
@@ -268,6 +268,7 @@ codeunit 5980 "Service-Post"
         TempTrackingSpecification: Record "Tracking Specification" temporary;
         GenJnlPostPreview: Codeunit "Gen. Jnl.-Post Preview";
         ServiceDocumentArchiveMgmt: Codeunit "Service Document Archive Mgmt.";
+        IsHandled: Boolean;
     begin
         LockTables(ServiceLine, GLEntry);
         // update quantities upon posting options and test related fields.
@@ -278,14 +279,17 @@ codeunit 5980 "Service-Post"
             ServShipmentNo := ServDocumentsMgt.PrepareShipmentHeader();
             WhseShip := not TempWarehouseShipmentHeader.IsEmpty();
         end;
-        if Invoice then
-            if ServiceHeader."Document Type" in [ServiceHeader."Document Type"::Order, ServiceHeader."Document Type"::Invoice] then begin
-                ServInvoiceNo := ServDocumentsMgt.PrepareInvoiceHeader(Window);
-                ServDocumentsMgt.UpdateIncomingDocument(ServiceHeader."Incoming Document Entry No.", ServiceHeader."Posting Date", ServInvoiceNo);
-            end else begin
-                ServCrMemoNo := ServDocumentsMgt.PrepareCrMemoHeader(Window);
-                ServDocumentsMgt.UpdateIncomingDocument(ServiceHeader."Incoming Document Entry No.", ServiceHeader."Posting Date", ServCrMemoNo);
-            end;
+        IsHandled := false;
+        OnPostDocumentLinesOnBeforeInsertPostedHeaders(ServiceHeader, IsHandled, ServInvoiceNo, ServCrMemoNo);
+        if not IsHandled then
+            if Invoice then
+                if ServiceHeader."Document Type" in [ServiceHeader."Document Type"::Order, ServiceHeader."Document Type"::Invoice] then begin
+                    ServInvoiceNo := ServDocumentsMgt.PrepareInvoiceHeader(Window);
+                    ServDocumentsMgt.UpdateIncomingDocument(ServiceHeader."Incoming Document Entry No.", ServiceHeader."Posting Date", ServInvoiceNo);
+                end else begin
+                    ServCrMemoNo := ServDocumentsMgt.PrepareCrMemoHeader(Window);
+                    ServDocumentsMgt.UpdateIncomingDocument(ServiceHeader."Incoming Document Entry No.", ServiceHeader."Posting Date", ServCrMemoNo);
+                end;
 
         if WhseShip then begin
             WarehouseShipmentHeader.Get(TempWarehouseShipmentHeader."No.");
@@ -915,6 +919,11 @@ codeunit 5980 "Service-Post"
 
     [IntegrationEvent(false, false)]
     local procedure OnSetCommitBehavior(var IgnoreCommit: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnPostDocumentLinesOnBeforeInsertPostedHeaders(var ServiceHeader: Record "Service Header"; var IsHandled: Boolean; var ServInvoiceNo: Code[20]; var ServCrMemoNo: Code[20])
     begin
     end;
 }

--- a/src/Layers/W1/BaseApp/Service/Posting/ServicePost.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Service/Posting/ServicePost.Codeunit.al
@@ -280,7 +280,7 @@ codeunit 5980 "Service-Post"
             WhseShip := not TempWarehouseShipmentHeader.IsEmpty();
         end;
         IsHandled := false;
-        OnPostDocumentLinesOnBeforeInsertPostedHeaders(ServiceHeader, IsHandled, ServInvoiceNo, ServCrMemoNo);
+        OnPostDocumentLinesOnBeforeInsertPostedHeaders(ServiceHeader, ServDocumentsMgt, IsHandled, ServInvoiceNo, ServCrMemoNo);
         if not IsHandled then
             if Invoice then
                 if ServiceHeader."Document Type" in [ServiceHeader."Document Type"::Order, ServiceHeader."Document Type"::Invoice] then begin
@@ -923,7 +923,7 @@ codeunit 5980 "Service-Post"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnPostDocumentLinesOnBeforeInsertPostedHeaders(var ServiceHeader: Record "Service Header"; var IsHandled: Boolean; var ServInvoiceNo: Code[20]; var ServCrMemoNo: Code[20])
+    local procedure OnPostDocumentLinesOnBeforeInsertPostedHeaders(var ServiceHeader: Record "Service Header"; var ServDocumentsMgt: Codeunit "Serv-Documents Mgt."; var IsHandled: Boolean; var ServInvoiceNo: Code[20]; var ServCrMemoNo: Code[20])
     begin
     end;
 }


### PR DESCRIPTION
## Summary
The reporter builds solutions with custom Service document types and needs to control which posted document is created during Service posting. Codeunit 5980 `Service-Post` currently hardcodes the decision of whether a posted service invoice or credit memo header is created, so extensions cannot alter this flow the way they can in Sales-Post. This PR adds an `IsHandled` integration event immediately before that logic, bringing Service-Post extensibility in line with Sales-Post.

Source issue repository: microsoft/AlAppExtensions; issue number: 30362

## Changes Made
- `OnPostDocumentLinesOnBeforeInsertPostedHeaders` - new `IsHandled` integration event raised in `PostDocumentLines` right before the posted service invoice/credit memo header creation, letting subscribers replace the standard decision; the same change is propagated to the NA and IT layer counterparts.

Fixes [AB#643301](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643301)





