### PR TITLE
[Extensibility Request] issue 30361: add OnAutoArchiveJobOnCaseElse event to Job Archive Management

### DIFF
--- a/src/Layers/W1/BaseApp/Projects/Project/Archive/JobArchiveManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Projects/Project/Archive/JobArchiveManagement.Codeunit.al
@@ -47,6 +47,8 @@ codeunit 5139 "Job Archive Management"
                 StoreJob(Job, false);
             JobSetup."Archive Jobs"::Question:
                 ArchiveJob(Job);
+            else
+                OnAutoArchiveJobOnCaseElse(Job, JobSetup);
         end;
     end;
 
@@ -538,6 +540,11 @@ codeunit 5139 "Job Archive Management"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeDeleteJobTasks(var JobTask: Record "Job Task"; var JobTaskDimension: Record "Job Task Dimension"; var JobPlanningLine: Record "Job Planning Line"; var JobArchive: Record "Job Archive"; Job: Record Job)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAutoArchiveJobOnCaseElse(var Job: Record Job; JobsSetup: Record "Jobs Setup")
     begin
     end;
 }


### PR DESCRIPTION
## Summary

The reporter needs an extension point in `Job Archive Management.AutoArchiveJob` so that archive behaviors beyond the standard `Always` and `Question` options can be handled by extensions. Today the `case` on `Jobs Setup."Archive Jobs"` silently does nothing for any other value, leaving no way to plug in custom archive handling. This PR adds an integration event in the `else` branch of that case so subscribers can react when neither standard option applies.

Source issue repository: microsoft/ALAppExtensions; issue number: 30361

## Changes Made
- `OnAutoArchiveJobOnCaseElse` - new integration event in codeunit "Job Archive Management" raised in the `else` branch of the `Archive Jobs` case in `AutoArchiveJob`, passing the `Job` and `Jobs Setup` records so extensions can handle additional archive modes.

Fixes [AB#644126](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644126)

