### PR TITLE
[E-Document Formats] Fix defects in V2 draft migration for XRechnung, PINT A-NZ and Factura-E

### DIFF
--- a/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/EDocumentPINTANZHandler.Codeunit.al
+++ b/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/EDocumentPINTANZHandler.Codeunit.al
@@ -132,6 +132,7 @@ codeunit 28008 "E-Document PINT A-NZ Handler" implements IStructuredFormatReader
         EDocument."Document Type" := EDocument."Document Type"::"Purchase Credit Memo";
         EDocumentXMLHelper.SetStringValueInField(PINTANZXml, XmlNamespaces, '/cn:CreditNote/cbc:ID', MaxStrLen(EDocumentPurchaseHeader."Sales Invoice No."), EDocumentPurchaseHeader."Sales Invoice No.");
         EDocumentXMLHelper.SetStringValueInField(PINTANZXml, XmlNamespaces, '/cn:CreditNote/cac:OrderReference/cbc:ID', MaxStrLen(EDocumentPurchaseHeader."Purchase Order No."), EDocumentPurchaseHeader."Purchase Order No.");
+        EDocumentXMLHelper.SetStringValueInField(PINTANZXml, XmlNamespaces, '/cn:CreditNote/cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID', MaxStrLen(EDocumentPurchaseHeader."Applies-to Ext. Invoice No."), EDocumentPurchaseHeader."Applies-to Ext. Invoice No.");
         EDocumentXMLHelper.SetDateValueInField(PINTANZXml, XmlNamespaces, '/cn:CreditNote/cbc:IssueDate', EDocumentPurchaseHeader."Document Date");
         EDocumentXMLHelper.SetDateValueInField(PINTANZXml, XmlNamespaces, '/cn:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate', EDocumentPurchaseHeader."Due Date");
         EDocumentXMLHelper.SetCurrencyValueInField(PINTANZXml, XmlNamespaces, '/cn:CreditNote/cbc:DocumentCurrencyCode', MaxStrLen(EDocumentPurchaseHeader."Currency Code"), EDocumentPurchaseHeader."Currency Code");

--- a/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/PINTANZImport.Codeunit.al
+++ b/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/PINTANZImport.Codeunit.al
@@ -99,7 +99,7 @@ codeunit 28007 "PINT A-NZ Import"
         VendorNo := EDocumentImportHelper.FindVendorByNameAndAddress(VendorName, VendorAddress);
     end;
 
-    local procedure GetVendorRelatedData(var TempXMLBuffer: Record "XML Buffer" temporary; RootPath: Text; var ABN: Code[11]; var GLN: Code[13]; var VATRegistrationNo: Text[20]; VendorParticipantId: Text; VendorName: Text; VendorAddress: Text)
+    local procedure GetVendorRelatedData(var TempXMLBuffer: Record "XML Buffer" temporary; RootPath: Text; var ABN: Code[11]; var GLN: Code[13]; var VATRegistrationNo: Text[20]; var VendorParticipantId: Text; var VendorName: Text; var VendorAddress: Text)
     var
         ABNSchemeIdTok: Label '0151', Locked = true;
         GLNSchemeIdTok: Label '0088', Locked = true;

--- a/src/Apps/DE/EDocumentDE/app/src/XRechnung/EDocumentXRechnungHandler.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/XRechnung/EDocumentXRechnungHandler.Codeunit.al
@@ -23,6 +23,7 @@ codeunit 11039 "E-Document XRechnung Handler" implements IStructuredFormatReader
         SchemeIDGLNTok: Label '0088', Locked = true;
         InvoiceLineTok: Label 'cac:InvoiceLine', Locked = true;
         CreditNoteLineTok: Label 'cac:CreditNoteLine', Locked = true;
+        UnsupportedXmlRootElementErr: Label 'Unsupported XML root element: %1.', Comment = '%1 = local name of the XML root element';
 
     /// <summary>
     /// Reads an XRechnung format XML document and converts it into a draft purchase document.
@@ -47,6 +48,7 @@ codeunit 11039 "E-Document XRechnung Handler" implements IStructuredFormatReader
         StartEventNameTok: Label 'E-document XRechnung import started. Parsing basic information.', Locked = true;
     begin
         FeatureTelemetry.LogUsage('0000EXH', FeatureNameTok, StartEventNameTok);
+        ResetDraft(EDocument);
         EDocumentPurchaseHeader.InsertForEDocument(EDocument);
 
         XmlDocument.ReadFrom(TempBlob.CreateInStream(TextEncoding::UTF8), XRechnungXml);
@@ -59,14 +61,20 @@ codeunit 11039 "E-Document XRechnung Handler" implements IStructuredFormatReader
         case UpperCase(XmlElement.LocalName()) of
             'INVOICE':
                 begin
+                    if XmlElement.NamespaceUri() <> DefaultInvoiceTok then
+                        Error(UnsupportedXmlRootElementErr, XmlElement.LocalName());
                     PopulateEDocumentForInvoice(XRechnungXml, XmlNamespaces, EDocumentPurchaseHeader, EDocument);
                     ProcessDraft := Enum::"E-Doc. Process Draft"::"Purchase Invoice";
                 end;
             'CREDITNOTE':
                 begin
+                    if XmlElement.NamespaceUri() <> DefaultCreditNoteTok then
+                        Error(UnsupportedXmlRootElementErr, XmlElement.LocalName());
                     PopulateEDocumentForCreditNote(XRechnungXml, XmlNamespaces, EDocumentPurchaseHeader, EDocument);
                     ProcessDraft := Enum::"E-Doc. Process Draft"::"Purchase Credit Memo";
                 end;
+            else
+                Error(UnsupportedXmlRootElementErr, XmlElement.LocalName());
         end;
 
         EDocumentPurchaseHeader.Modify(false);
@@ -336,8 +344,11 @@ codeunit 11039 "E-Document XRechnung Handler" implements IStructuredFormatReader
     procedure ResetDraft(EDocument: Record "E-Document")
     var
         EDocPurchaseHeader: Record "E-Document Purchase Header";
+        EDocPurchaseLine: Record "E-Document Purchase Line";
     begin
-        EDocPurchaseHeader.GetFromEDocument(EDocument);
-        EDocPurchaseHeader.Delete(true);
+        EDocPurchaseHeader.SetRange("E-Document Entry No.", EDocument."Entry No");
+        EDocPurchaseHeader.DeleteAll();
+        EDocPurchaseLine.SetRange("E-Document Entry No.", EDocument."Entry No");
+        EDocPurchaseLine.DeleteAll();
     end;
 }

--- a/src/Apps/DE/EDocumentDE/test/src/XRechnungStructuredTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/XRechnungStructuredTests.Codeunit.al
@@ -2,6 +2,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
+using Microsoft.eServices.EDocument.Processing.Interfaces;
+
 codeunit 148500 "XRechnung Structured Tests"
 {
     Subtype = Test;
@@ -19,6 +21,7 @@ codeunit 148500 "XRechnung Structured Tests"
         IsInitialized: Boolean;
         EDocumentStatusNotUpdatedErr: Label 'The status of the EDocument was not updated to the expected status after the step was executed.';
         TestFileTok: Label 'xrechnung/xrechnung-invoice-0.xml', Locked = true;
+        UnsupportedXmlRootElementErr: Label 'Unsupported XML root element: %1.', Comment = '%1 = local name of the XML root element';
         MockCurrencyCode: Code[10];
         MockDate: Date;
 
@@ -170,6 +173,79 @@ codeunit 148500 "XRechnung Structured Tests"
         XRechnungStructuredValidations.SetMockCurrencyCode(MockCurrencyCode);
         XRechnungStructuredValidations.SetMockDate(MockDate);
         XRechnungStructuredValidations.AssertPurchaseDocument(Vendor."No.", PurchaseHeader, Item);
+    end;
+
+    [Test]
+    procedure TestXRechnungUnsupportedRootElement_IsRejected()
+    var
+        EDocument: Record "E-Document";
+        TempBlob: Codeunit "Temp Blob";
+        StructuredFormatReader: Interface IStructuredFormatReader;
+        XmlOutStream: OutStream;
+    begin
+        // [FEATURE] [E-Document] [XRechnung] [Import]
+        // [SCENARIO] An unsupported XRechnung document type is rejected instead of creating an empty draft
+        Initialize(Enum::"Service Integration"::"No Integration");
+        LibraryEDoc.CreateInboundEDocument(EDocument, EDocumentService);
+        TempBlob.CreateOutStream(XmlOutStream, TextEncoding::UTF8);
+        XmlOutStream.WriteText('<Reminder xmlns="urn:oasis:names:specification:ubl:schema:xsd:Reminder-2" />');
+        StructuredFormatReader := Enum::"E-Doc. Read into Draft"::XRechnung;
+
+        asserterror StructuredFormatReader.ReadIntoDraft(EDocument, TempBlob);
+
+        Assert.ExpectedError(StrSubstNo(UnsupportedXmlRootElementErr, 'Reminder'));
+        Assert.ExpectedErrorCode('Dialog');
+    end;
+
+    [Test]
+    procedure TestXRechnungUnexpectedRootNamespace_IsRejected()
+    var
+        EDocument: Record "E-Document";
+        TempBlob: Codeunit "Temp Blob";
+        StructuredFormatReader: Interface IStructuredFormatReader;
+        XmlOutStream: OutStream;
+    begin
+        // [FEATURE] [E-Document] [XRechnung] [Import]
+        // [SCENARIO] An Invoice from an unsupported namespace is rejected instead of creating an empty draft
+        Initialize(Enum::"Service Integration"::"No Integration");
+        LibraryEDoc.CreateInboundEDocument(EDocument, EDocumentService);
+        TempBlob.CreateOutStream(XmlOutStream, TextEncoding::UTF8);
+        XmlOutStream.WriteText('<Invoice xmlns="urn:unsupported:invoice" />');
+        StructuredFormatReader := Enum::"E-Doc. Read into Draft"::XRechnung;
+
+        asserterror StructuredFormatReader.ReadIntoDraft(EDocument, TempBlob);
+
+        Assert.ExpectedError(StrSubstNo(UnsupportedXmlRootElementErr, 'Invoice'));
+        Assert.ExpectedErrorCode('Dialog');
+    end;
+
+    [Test]
+    procedure TestXRechnungInvoice_ReadIntoDraftTwice_DoesNotDuplicateLines()
+    var
+        EDocument: Record "E-Document";
+        EDocumentPurchaseLine: Record "E-Document Purchase Line";
+        LineCountAfterFirstRead: Integer;
+    begin
+        // [FEATURE] [E-Document] [XRechnung] [Import]
+        // [SCENARIO] Re-running Read into Draft resets the previous draft instead of appending duplicate lines
+
+        // [GIVEN] A valid XRechnung XML invoice document is read into a draft
+        Initialize(Enum::"Service Integration"::"No Integration");
+        SetupXRechnungEDocumentService();
+        CreateInboundEDocumentFromXML(EDocument, TestFileTok);
+        ProcessEDocumentToStep(EDocument, "Import E-Document Steps"::"Read into Draft");
+
+        EDocumentPurchaseLine.SetRange("E-Document Entry No.", EDocument."Entry No");
+        LineCountAfterFirstRead := EDocumentPurchaseLine.Count();
+        Assert.IsTrue(LineCountAfterFirstRead > 0, 'The first read into draft should create purchase lines.');
+
+        // [WHEN] The document is read into a draft a second time
+        EDocument.Get(EDocument."Entry No");
+        ProcessEDocumentToStep(EDocument, "Import E-Document Steps"::"Read into Draft");
+
+        // [THEN] The draft contains the same number of lines
+        EDocumentPurchaseLine.SetRange("E-Document Entry No.", EDocument."Entry No");
+        Assert.AreEqual(LineCountAfterFirstRead, EDocumentPurchaseLine.Count(), 'Re-reading the draft should not duplicate purchase lines.');
     end;
 
     [PageHandler]

--- a/src/Apps/DE/EDocumentDE/test/src/XRechnungStructuredTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/XRechnungStructuredTests.Codeunit.al
@@ -2,8 +2,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
-using Microsoft.eServices.EDocument.Processing.Interfaces;
-
 codeunit 148500 "XRechnung Structured Tests"
 {
     Subtype = Test;

--- a/src/Apps/ES/EDocumentFormats/FacturaE/app/src/Core/EDocumentFacturaEHandler.Codeunit.al
+++ b/src/Apps/ES/EDocumentFormats/FacturaE/app/src/Core/EDocumentFacturaEHandler.Codeunit.al
@@ -113,7 +113,7 @@ codeunit 10766 "E-Document Factura-E Handler" implements IStructuredFormatReader
         EDocumentXMLHelper.SetNumberValueInField(FacturaEXML, XmlNamespaces, '/namespace:Facturae/Invoices/Invoice/InvoiceTotals/InvoiceTotal', EDocumentPurchaseHeader.Total);
         EDocumentXMLHelper.SetNumberValueInField(FacturaEXML, XmlNamespaces, '/namespace:Facturae/Invoices/Invoice/InvoiceTotals/TotalOutstandingAmount', EDocumentPurchaseHeader."Amount Due");
         EDocumentXMLHelper.SetDateValueInField(FacturaEXML, XmlNamespaces, '/namespace:Facturae/Invoices/Invoice/InvoiceHeader/InvoiceDocumentReference/ReferencedDocumentDate', EDocumentPurchaseHeader."Due Date");
-        EDocumentXMLHelper.SetStringValueInField(FacturaEXML, XmlNamespaces, '/namespace:Facturae/Invoices/Invoice/InvoiceHeader/Corrective/InvoiceNumber', MaxStrLen(EDocumentPurchaseHeader."Purchase Order No."), EDocumentPurchaseHeader."Purchase Order No.");
+        EDocumentXMLHelper.SetStringValueInField(FacturaEXML, XmlNamespaces, '/namespace:Facturae/Invoices/Invoice/InvoiceHeader/Corrective/InvoiceNumber', MaxStrLen(EDocumentPurchaseHeader."Applies-to Ext. Invoice No."), EDocumentPurchaseHeader."Applies-to Ext. Invoice No.");
 
         if VendorNo <> '' then
             EDocumentPurchaseHeader."[BC] Vendor No." := VendorNo;


### PR DESCRIPTION
Fixes [AB#644279](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644279)

## Summary

Verification of the local e-document formats migrated to the **V2 (draft) import pipeline** found several defects where the migrated formats deviate from the DK OIOUBL reference implementation. This PR fixes the high-confidence functional defects.

Related migrations: #9426 (PINT A-NZ, Factura-E), #9682 (OIOUBL), #9690 (XRechnung).

## Fixes

### XRechnung (DE) — `EDocumentXRechnungHandler.Codeunit.al`

| Defect | Impact |
|---|---|
| `ResetDraft` was never called from `ReadIntoDraft` | Re-running *Read into Draft* appended a second set of purchase lines, because `GetNextLineNo` keeps incrementing. `ResetDraft` was dead code. |
| `ResetDraft` used `GetFromEDocument` + `Delete(true)` | Errors when no draft header exists yet. Now deletes the header/line ranges, matching `EDocumentOIOUBLHandler`. |
| Root element `case` had no `else` and did not validate the root namespace | Unsupported documents (e.g. CII `CrossIndustryInvoice`) silently produced an empty draft and returned an uninitialised `"E-Doc. Process Draft"`. Now rejected with an error, matching OIOUBL. |

### PINT A-NZ (APAC)

| Defect | Impact |
|---|---|
| `GetVendorRelatedData` declared `VendorParticipantId` / `VendorName` / `VendorAddress` **by value** (`PINTANZImport.Codeunit.al`) | The participant-id and name+address vendor-matching fallbacks in `TryMatchVendor` always received empty strings — dead fallback logic. |
| Credit notes did not map `cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID` | `"Applies-to Ext. Invoice No."` stayed empty, so `EDocCreatePurchCrMemo` could not apply the credit memo to the original invoice. Core PEPPOL and OIOUBL both map this. |

### Factura-E (ES)

| Defect | Impact |
|---|---|
| `InvoiceHeader/Corrective/InvoiceNumber` mapped to `"Purchase Order No."` | Finish draft treats that field as a vendor order number. Rectificative invoices were never applied to the original invoice. Now mapped to `"Applies-to Ext. Invoice No."`. |

## Tests

Added three regression tests to `XRechnungStructuredTests.Codeunit.al`, mirroring the existing OIOUBL suite:

- `TestXRechnungUnsupportedRootElement_IsRejected`
- `TestXRechnungUnexpectedRootNamespace_IsRejected`
- `TestXRechnungInvoice_ReadIntoDraftTwice_DoesNotDuplicateLines`

## Not included (tracked separately)

The following gaps were also identified during verification and are being filed as work items rather than fixed here, since they need schema review and new test fixtures:

- Tax/VAT totals read from derived arithmetic instead of `cac:TaxTotal/cbc:TaxAmount` (OIOUBL, PINT A-NZ)
- Document- and line-level allowances/charges not mapped (all four formats)
- Embedded attachments (`cac:AdditionalDocumentReference`) not imported (OIOUBL, PINT A-NZ, Factura-E, XRechnung)
- Factura-E: invoice-level `GeneralDiscounts` / line `DiscountsAndRebates` not mapped; multi-invoice batches merge all lines into one draft
- XRechnung: CII (UN/CEFACT) syntax not supported; test suite sets up the service with `"E-Document Format"::Mock` rather than the real format

---

## Reviewer note: Factura-E mapping deliberately diverges from V1

The V1 importer maps `Corrective/InvoiceNumber` to a **different** field than this PR does:

| Path | `Corrective/InvoiceNumber` target |
|---|---|
| V1 (`FacturaEImport.Codeunit.al:217-218`) | `"Applies-to Doc. No."` |
| V2 before this PR (`EDocumentFacturaEHandler.Codeunit.al:116`) | `"Purchase Order No."` |
| **V2 after this PR** | **`"Applies-to Ext. Invoice No."`** |

`EDocCreatePurchCrMemo.Codeunit.al:62-73` treats the two draft fields differently:

- `"Applies-to Doc. No."` is used **verbatim** as a BC posted-invoice number.
- `"Applies-to Ext. Invoice No."` is **resolved** by looking up `Purch. Inv. Header."Vendor Invoice No."` for the vendor, and only then sets `"Applies-to Doc. No."`.

On an inbound credit memo, `Corrective/InvoiceNumber` is the original invoice number *as issued by the vendor*, not a BC document number. Therefore the resolving field is the correct target, and this matches every other V2 reader:

- core PEPPOL — `EDocumentPEPPOLHandler.Codeunit.al:151-152`
- DK OIOUBL — `EDocumentOIOUBLHandler.Codeunit.al:144`

V1's direct write to `"Applies-to Doc. No."` only applies correctly when the vendor's numbering happens to equal BC's posted invoice number; otherwise it fails to apply or mis-applies to an unrelated document. This PR intentionally does **not** preserve that V1 behavior. Please confirm this is acceptable.


