### PR TITLE
Show a message when an e-document file cannot be viewed or no data could be extracted

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/EDocImport.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocImport.Codeunit.al
@@ -329,8 +329,10 @@ codeunit 6140 "E-Doc. Import"
         EDocumentDataStorage: Record "E-Doc. Data Storage";
         IStructuredFormatReader: Interface IStructuredFormatReader;
     begin
+        if (EDocument."Structured Data Entry No." = 0) or (not EDocumentDataStorage.Get(EDocument."Structured Data Entry No.")) then
+            Error(NoExtractedDataErr);
+
         IStructuredFormatReader := EDocument."Read into Draft Impl.";
-        EDocumentDataStorage.Get(EDocument."Structured Data Entry No.");
         IStructuredFormatReader.View(EDocument, EDocumentDataStorage.GetTempBlob());
     end;
 
@@ -914,6 +916,7 @@ codeunit 6140 "E-Doc. Import"
         DocTypeIsNotSupportedErr: Label 'Document type %1 is not supported.', Comment = '%1 - Document Type';
         FailedToFindVendorErr: Label 'No vendor is set for Edocument';
         CannotProcessEDocumentMsg: Label 'Cannot process E-Document %1 with Purchase Order %2 before Purchase Order has been matched and posted for E-Document %3.', Comment = '%1 - E-Document entry no, %2 - Purchase Order number, %3 - EDocument entry no.';
+        NoExtractedDataErr: Label 'There is no extracted data to display for this e-document. Please check if it is a valid invoice or could not be read.';
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterProcessIncomingEDocument(EDocument: Record "E-Document"; EDocImportParameters: Record "E-Doc. Import Parameters"; StartState: Enum "Import E-Doc. Proc. Status"; DesiredEndState: Enum "Import E-Doc. Proc. Status")


### PR DESCRIPTION
## What & why

When a Payables Agent e-document came from a file that is not a valid invoice, or a corrupt PDF, clicking View PDF or View extracted data threw a runtime error. This adds small guards so both actions show a clear message when there is nothing to display or the file cannot be read.

## Linked work

Fixes [AB#638785](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638785)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Corrupt PDF: View PDF now shows "the file cannot be displayed" message instead of the client render error.
- Valid non-invoice PDF: View extracted data shows a clear "no extracted data" message, and View PDF still opens the file.
- Normal invoice: both views work as before.

## Risk & compatibility

Low. Only adds guards and user messages on two view actions. No schema, data, or permission impact.



