### PR TITLE
Bug 641388: Fix WIP transfer remainder over-creation when open line quantity is reduced

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
@@ -571,6 +571,7 @@ report 99001501 "Subc. Create Transf. Order"
         TransferLineToCheck.SetRange("Subc. Operation No.", PurchaseLine."Operation No.");
         TransferLineToCheck.SetRange("Derived From Line No.", 0);
         TransferLineToCheck.SetRange("Transfer WIP Item", true);
+        TransferLineToCheck.SetRange("Subc. Return Order", false);
         TransferLineToCheck.CalcSums(Quantity);
         if TransferLineToCheck.Quantity = 0 then
             exit(0);

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
@@ -552,14 +552,17 @@ report 99001501 "Subc. Create Transf. Order"
             exit(false);
 
         PostedWIPQtyBase := GetWIPQtyBase(PurchaseLine, TransferToLocationCode);
-        OpenWIPLineQtyBase := GetOpenWIPTransferLineQtyBase(PurchaseLine);
+        OpenWIPLineQtyBase := GetOpenWIPTransferLineQtyBase(PurchaseLine, ProdOrderLine);
 
         exit((PostedWIPQtyBase + OpenWIPLineQtyBase) < ExpectedQtyBase);
     end;
 
-    local procedure GetOpenWIPTransferLineQtyBase(PurchaseLine: Record "Purchase Line"): Decimal
+    local procedure GetOpenWIPTransferLineQtyBase(PurchaseLine: Record "Purchase Line"; ProdOrderLine: Record "Prod. Order Line"): Decimal
     var
         TransferLineToCheck: Record "Transfer Line";
+        Item: Record Item;
+        UOMManagement: Codeunit "Unit of Measure Management";
+        QtyPerUom: Decimal;
     begin
         TransferLineToCheck.SetCurrentKey("Subc. Prod. Order No.", "Subc. Prod. Order Line No.", "Subc. Routing Reference No.", "Subc. Routing No.", "Subc. Operation No.");
         TransferLineToCheck.SetRange("Subc. Purch. Order No.", PurchaseLine."Document No.");
@@ -568,8 +571,20 @@ report 99001501 "Subc. Create Transf. Order"
         TransferLineToCheck.SetRange("Subc. Operation No.", PurchaseLine."Operation No.");
         TransferLineToCheck.SetRange("Derived From Line No.", 0);
         TransferLineToCheck.SetRange("Transfer WIP Item", true);
-        TransferLineToCheck.CalcSums("Quantity (Base)");
-        exit(TransferLineToCheck."Quantity (Base)");
+        TransferLineToCheck.CalcSums(Quantity);
+        if TransferLineToCheck.Quantity = 0 then
+            exit(0);
+
+        // "Quantity (Base)" cannot be used here: "Qty. per Unit of Measure" is forced to 0
+        // for WIP transfer lines (see "Subc. Transfer Line".OnValidate("Transfer WIP Item")),
+        // which makes "Quantity (Base)" always evaluate to 0 for these lines. Convert the
+        // open (unposted) Quantity to the item's base UOM ourselves, using the same
+        // Purchase Line unit of measure that was used to convert it in the first place
+        // (see InsertWIPTransferLine / CalcPurchLineQtyBase).
+        Item.SetLoadFields("Base Unit of Measure");
+        Item.Get(ProdOrderLine."Item No.");
+        QtyPerUom := UOMManagement.GetQtyPerUnitOfMeasure(Item, PurchaseLine."Unit of Measure Code");
+        exit(UOMManagement.CalcBaseQty(TransferLineToCheck.Quantity, QtyPerUom));
     end;
 
     local procedure CalcPurchLineQtyBase(PurchaseLine: Record "Purchase Line"; ProdOrderLine: Record "Prod. Order Line"): Decimal

--- a/src/DisabledTests/Subcontracting_Test/Subcontracting_Test.DisabledTest.json
+++ b/src/DisabledTests/Subcontracting_Test/Subcontracting_Test.DisabledTest.json
@@ -16,11 +16,5 @@
     "codeunitId": 139989,
     "codeunitName": "Subc. Subcontracting Test",
     "method": "CancelInvoiceWithSubcontractingItemChargeIsBlocked"
-  },
-  {
-    "bug": "641388",
-    "codeunitId": 149911,
-    "codeunitName": "Subc. WIP Trans. Create Test",
-    "method": "WIPTransferRemainderCreatedWhenOpenLineQuantityReduced"
   }
 ]


### PR DESCRIPTION
## Summary
- Bug 641388: the regression test `WIPTransferRemainderCreatedWhenOpenLineQuantityReduced` (added by the bug 639382 fix) started failing once CI actually ran it, and was temporarily disabled to unblock the pipeline.
- Root cause: `GetOpenWIPTransferLineQtyBase` in `Subc. Create Transf. Order` summed `"Quantity (Base)"` on open (unposted) WIP transfer lines. But `"Qty. per Unit of Measure"` is force-set to `0` for WIP transfer lines (see `Subc. Transfer Line`.`OnValidate("Transfer WIP Item")`), which makes `"Quantity (Base)"` always evaluate to `0` for these lines regardless of the actual quantity. So after reducing an open WIP transfer line's quantity and re-running **Create Transfer Order to Subcontractor**, the existing (reduced) quantity was never counted as "already covered", and the report inserted a brand-new line for the full amount again instead of only the remainder.
- Fix: compute the open quantity from `Quantity` (which is correctly maintained) instead of the always-zero `"Quantity (Base)"`, and convert it to the item's base UOM ourselves using the same Purchase Line unit-of-measure factor used elsewhere in the report (`CalcPurchLineQtyBase` / `InsertWIPTransferLine`).
- Re-enabled the test by removing its entry from `src/DisabledTests/Subcontracting_Test/Subcontracting_Test.DisabledTest.json`.

## Test
Re-enabled and validated \WIPTransferRemainderCreatedWhenOpenLineQuantityReduced\ ([SCENARIO 639382], codeunit 149911). Also ran the full `Subc. WIP Trans. Create Test` (149911) suite (19 tests) — all pass, no regressions.

- Baseline (before fix): test FAILS — `Assert.AreEqual failed. Expected:<6> (Decimal). Actual:<8> (Decimal). Re-running Create Transfer Order must create the remaining WIP quantity after the open line was reduced.`
- After fix: test PASSES, and the full 19-test suite for codeunit 149911 passes.

Fixes [AB#641388](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641388)

🤖 Generated with GitHub Copilot




