### PR TITLE
[releases/28.x] [Shopify] Fix duplicate object id in code coverage merge

### DIFF
--- a/src/Apps/W1/Shopify/Test/Transactions/ShpfyTransactionsTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Transactions/ShpfyTransactionsTest.Codeunit.al
@@ -10,7 +10,7 @@ using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Integration.Shopify;
 using System.TestLibraries.Utilities;
 
-codeunit 139554 "Shpfy Transactions Test"
+codeunit 139575 "Shpfy Transactions Test"
 {
     Subtype = Test;
     TestType = Uncategorized;


### PR DESCRIPTION
## Summary

Fixes the autodetected build break tracked by Bug 644543 (`RunALTestBusinessFoundationModules_Group1` gate task failing on `releases/28.x`).

## Root cause

`Shpfy Transactions Test` was backported to `releases/28.x` as **codeunit 139554**. The code-coverage merger (`CCMerger`) flattens all W1 sources — BCApps *and* the NAV-native tree — into a single object namespace keyed by `country:id:type`. The NAV-native `Library - Intrastat` codeunit is also **139554**, so the merge failed with:

```
Duplicated object id in file: '...\Shopify\Test\Transactions\ShpfyTransactionsTest.Codeunit.al'
with app\apps\w1\intrastat\test\src\libraryintrastat.codeunit.al
System.ArgumentException: An item with the same key has already been added.
```

## Fix

Renumber the test codeunit **139554 → 139575**. Verified empirically:

- 139575 is unused repo-wide across BCApps `releases/28.x`.
- NAV-native Intrastat on 28.x only occupies **139550** and **139554** in the 139xxx space.
- The failing merge itself proves every other Shopify Test id merges cleanly, so a free slot is safe.

Fixes [AB#644543](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644543)



