### PR TITLE
Fix language resolution for culture-neutral AI test datasets

### DIFF
--- a/src/Tools/AI Test Toolkit/src/Languages/AITTestSuiteLanguage.Codeunit.al
+++ b/src/Tools/AI Test Toolkit/src/Languages/AITTestSuiteLanguage.Codeunit.al
@@ -124,8 +124,13 @@ codeunit 149046 "AIT Test Suite Language"
             else
                 exit(InputDatasetCode);
 
-        if not GetLanguageDatasetCode(TestInputGroup."Group Name", LanguageID, LanguageDatasetCode) then
+        if not GetLanguageDatasetCode(TestInputGroup."Group Name", LanguageID, LanguageDatasetCode) then begin
+            TestInputGroup.CalcFields("No. of Languages");
+            if TestInputGroup."No. of Languages" = 0 then
+                exit(InputDatasetCode);
+
             Error(LanguageVersionNotFoundErr, InputDatasetCode, GetLanguageDisplayName(LanguageID));
+        end;
 
         exit(LanguageDatasetCode);
     end;


### PR DESCRIPTION
Return the original dataset when a requested language variant is missing and the group has no localized versions. Localized dataset families still fail when the requested language is absent.

Fixes [AB#644244](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644244)




