### PR TITLE
[Shopify] Fix Price List header defaults in dated discount test helper

### DIFF
--- a/src/Apps/W1/Shopify/Test/Products/ShpfyProductInitTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Products/ShpfyProductInitTest.Codeunit.al
@@ -281,6 +281,9 @@ codeunit 139603 "Shpfy Product Init Test"
         PriceListLine: Record "Price List Line";
     begin
         LibraryPriceCalculation.CreatePriceHeader(PriceListHeader, PriceListHeader."Price Type"::Sale, PriceListHeader."Source Type"::"All Customers", '');
+        // Allow each line to carry its own date range; otherwise the line dates must match the (empty) header dates.
+        PriceListHeader.Validate("Allow Updating Defaults", true);
+        PriceListHeader.Modify(true);
 
         // Discount that applies up to and including the boundary date.
         PriceListLine.Init();


### PR DESCRIPTION
## What & why

Follow-up to #9709 ([AB#642673](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642673)). That PR fixed the test-isolation duplicate-key error so `UnitTestCalcPriceUsesCurrentWorkDate` (codeunit 139605) could be re-enabled. With the test now running end-to-end in NAV, it surfaced a second, latent bug in the `CreateDatedAllCustDiscPriceList` helper (codeunit 139603):

```
Ending Date must be equal to ''  in Price List Line: Price List Code=GU00000034, Line No.=0. Current value is '01/01/27'.
  Price List Line(Table 7001).TestHeadersValue line 25
  Price List Line(Table 7001).Ending Date - OnValidate(Trigger) line 2
  Shpfy Product Init Test(CodeUnit 139603).CreateDatedAllCustDiscPriceList line 15
```

`LibraryPriceCalculation.CreatePriceHeader` leaves `"Allow Updating Defaults" = false`. With that off, `Price List Line`.`TestHeadersValue` forces every line's `Starting Date` / `Ending Date` to equal the header's (empty) dates. The helper deliberately creates **two** "All Customers" discount lines with **different** date ranges (50% up to the boundary date, 20% from the day after), which a single header can only express when it allows per-line defaults.

## Fix

Set `"Allow Updating Defaults" := true` on the header right after creation — while it is still in `Draft` status, and turning the flag on has no side effects (the field's guard only fires when turning it off with existing lines). Each line then keeps its own date range; activation propagates status only and does not reset the line dates.

## Linked work

Fixes [AB#642673](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642673)

## How I validated this

- Root-caused against `PriceListLine.Table.al` `TestHeadersValue` (dates are only skipped when `Allow Updating Defaults` is true) and `PriceListHeader.Table.al` (the flag's `OnValidate` only checks lines when turning it **off**).
- Changed file compiles clean (AL language server reports 0 errors for the Shopify Test project).
- A live local test run is currently blocked only by an unrelated local build-environment gap (the `MockAzureKeyVaultSecretProvider` DotNet assembly probing path in an untouched file); CI has these test assemblies, so the re-enabled test exercises this path there.

## Follow-up

The test remains disabled NAV-side in `App/DisabledTests/ShpfyProductPriceCalcTest.DisabledTest.json`. Once this is uptaken, that entry should be removed to re-enable it (the NAV re-enable PR was failing on the error fixed here).



