### PR TITLE
Update Email Folder tooltip to reference renamed 'Manage per sender' review option

### DIFF
--- a/src/Apps/W1/PayablesAgent/app/Integration/PAKnownSender.Table.al
+++ b/src/Apps/W1/PayablesAgent/app/Integration/PAKnownSender.Table.al
@@ -31,7 +31,7 @@ table 3308 "PA Known Sender"
         {
             DataClassification = CustomerContent;
             Caption = 'Review policy';
-            ToolTip = 'Specifies how an incoming email from this sender is handled. ''Ask'' requests human review. ''Approve'' processes without review (effective when overall email review is ''Only if untrusted''). ''Reject'' ignores the email.';
+            ToolTip = 'Specifies how an incoming email from this sender is handled. ''Ask'' requests human review. ''Approve'' processes without review (effective when overall email review is ''Manage per sender''). ''Reject'' ignores the email.';
         }
     }
     keys

--- a/src/Apps/W1/PayablesAgent/app/Integration/PAKnownSenders.Page.al
+++ b/src/Apps/W1/PayablesAgent/app/Integration/PAKnownSenders.Page.al
@@ -29,7 +29,7 @@ page 3313 "PA Known Senders"
                 field("Sender Policy"; Rec."Sender Policy")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies how an incoming email from this sender is handled. ''Ask'' requests human review. ''Approve'' processes without review (effective when overall email review is ''Only if untrusted''). ''Reject'' ignores the email.';
+                    ToolTip = 'Specifies how an incoming email from this sender is handled. ''Ask'' requests human review. ''Approve'' processes without review (effective when overall email review is ''Manage per sender''). ''Reject'' ignores the email.';
                 }
             }
         }

--- a/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Codeunit.al
+++ b/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Codeunit.al
@@ -698,7 +698,7 @@ codeunit 3307 "Payables Agent Setup"
     var
         AlwaysLbl: Label 'Always';
         NeverLbl: Label 'Never';
-        OnlyIfUntrustedLbl: Label 'Only if untrusted';
+        OnlyIfUntrustedLbl: Label 'Manage per sender';
     begin
         case Policy of
             Policy::Always:

--- a/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Page.al
+++ b/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Page.al
@@ -316,7 +316,7 @@ page 3304 "Payables Agent Setup"
                     {
                         Caption = 'Email review';
                         ShowMandatory = true;
-                        ToolTip = 'Specifies when the agent should request human review before processing an incoming email. ''Only if untrusted'' skips review for previously approved senders and any email that arrives in a configured subfolder.';
+                        ToolTip = 'Specifies when the agent should request human review before processing an incoming email. ''Manage per sender'' skips review for previously approved senders and any email that arrives in a configured subfolder.';
 
                         trigger OnValidate()
                         begin
@@ -610,6 +610,6 @@ page 3304 "Payables Agent Setup"
         ManageKnownSendersLbl: Label 'Manage known senders';
         KnownSendersHintLbl: Label 'Add your regular senders and set the review policy for each. Approve emails automatically for senders you trust.';
         FolderIgnoresListConfirmLbl: Label 'You have %1 known senders. With subfolder ''%2'' configured, the agent will process every email there without consulting the list. The list is kept and will be used again if you remove the subfolder. Continue?', Comment = '%1 = number of known senders, %2 = folder name';
-        PolicyIgnoresListConfirmLbl: Label 'You have %1 known senders. The list won''t affect processing while review is set to ''%2''. The list is kept and will be used again if you switch back to ''Only if untrusted''. Continue?', Comment = '%1 = number of known senders, %2 = review policy';
+        PolicyIgnoresListConfirmLbl: Label 'You have %1 known senders. The list won''t affect processing while review is set to ''%2''. The list is kept and will be used again if you switch back to ''Manage per sender''. Continue?', Comment = '%1 = number of known senders, %2 = review policy';
 
 }

--- a/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Page.al
+++ b/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Page.al
@@ -236,7 +236,7 @@ page 3304 "Payables Agent Setup"
                     field(MailboxFolder; TempOutlookSetup."Email Folder")
                     {
                         Caption = 'Folder';
-                        ToolTip = 'Specifies the email folder that the agent monitors. Leave blank to monitor the entire mailbox. When a folder is set and email review is ''Only if untrusted'', every email in it is treated as trusted and skips review, so the known-senders list is not consulted.';
+                        ToolTip = 'Specifies the email folder that the agent monitors. Leave blank to monitor the entire mailbox. When a folder is set and email review is ''Manage per sender'', every email in it is treated as trusted and skips review, so the known-senders list is not consulted.';
                         Editable = false;
 
                         trigger OnAssistEdit()


### PR DESCRIPTION
Follow-up to #9693: updates the remaining Payables Agent strings that still referenced the old email review option name `Only if untrusted` to the renamed `Manage per sender` — the Email Folder tooltip, the Email review field tooltip, the known-senders review-policy tooltips (page + table), the policy label used in messages, and the switch-back confirmation prompt.

Fixes [AB#644602](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644602)


