### PR TITLE
Deduct already-reversed prepayment GST on AU sales prepayment credit memos

### DIFF
--- a/src/Layers/APAC/BaseApp/Sales/Posting/SalesPost.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Sales/Posting/SalesPost.Codeunit.al
@@ -7771,8 +7771,8 @@ codeunit 80 "Sales-Post"
         if SalesLine.Type <> SalesLine.Type::" " then
             if SalesLine."Prepayment Line" then begin
                 TempPrepmtVATAmtBuf.Get(0, '', SalesLine."Line No.");
-                TempPrepmtVATAmtBuf.Amount := SalesLine."Amount Including VAT" - SalesLine.Amount;
-                TempPrepmtVATAmtBuf."VAT Base Amount" := SalesLine."VAT Base Amount";
+                TempPrepmtVATAmtBuf.Amount := -SalesLine."Amount Including VAT" + SalesLine.Amount;
+                TempPrepmtVATAmtBuf."VAT Base Amount" := -SalesLine."VAT Base Amount";
                 TempPrepmtVATAmtBuf.Modify();
             end else
                 if not SalesLine."System-Created Entry" then
@@ -7786,6 +7786,44 @@ codeunit 80 "Sales-Post"
                               TempPrepmtVATAmtBuf."Prepmt Amt to Deduct" + SalesLine."Prepmt Amt to Deduct";
                             TempPrepmtVATAmtBuf.Modify();
                         end;
+    end;
+
+    local procedure DividePrepmtVATDeducted(var SalesLine: Record "Sales Line")
+    var
+        PrepmtVATReminder: Decimal;
+        PrepmtVATBaseReminder: Decimal;
+        Ratio: Decimal;
+    begin
+        if TempPrepmtVATAmtBuf.FindSet() then
+            repeat
+                TempPrepmtLineNoBuf.SetRange("New Line Number", TempPrepmtVATAmtBuf."Line No.");
+                if TempPrepmtLineNoBuf.FindSet() then
+                    repeat
+                        SalesLine.Get(SalesLine."Document Type", SalesLine."Document No.", TempPrepmtLineNoBuf."Old Line Number");
+                        Ratio := SalesLine."Prepmt Amt to Deduct" / TempPrepmtVATAmtBuf."Prepmt Amt to Deduct";
+                        DistributeAmount(
+                          TempPrepmtVATAmtBuf.Amount, Ratio,
+                          SalesLine."Prepmt. VAT Amount Deducted", PrepmtVATReminder);
+                        DistributeAmount(
+                          TempPrepmtVATAmtBuf."VAT Base Amount", Ratio,
+                          SalesLine."Prepmt. VAT Base Deducted", PrepmtVATBaseReminder);
+                        SalesLine.Modify();
+                    until TempPrepmtLineNoBuf.Next() = 0;
+            until TempPrepmtVATAmtBuf.Next() = 0;
+        TempPrepmtVATAmtBuf.DeleteAll();
+        TempPrepmtLineNoBuf.Reset();
+        TempPrepmtLineNoBuf.DeleteAll();
+    end;
+
+    local procedure DistributeAmount(AmountToDistibute: Decimal; Ratio: Decimal; var Amount: Decimal; var Reminder: Decimal)
+    var
+        DistibutedAmount: Decimal;
+        DistibutedAmountRnded: Decimal;
+    begin
+        DistibutedAmount := Reminder + AmountToDistibute * Ratio;
+        DistibutedAmountRnded := Round(DistibutedAmount, Currency."Amount Rounding Precision");
+        Reminder := DistibutedAmount - DistibutedAmountRnded;
+        Amount := Amount + DistibutedAmountRnded;
     end;
 
     local procedure UpdateTaxForPostedDoc(var SalesHeader: Record "Sales Header")
@@ -8608,6 +8646,7 @@ codeunit 80 "Sales-Post"
         OnBeforePostUpdateOrderLine(SalesHeader, TempSalesLineGlobal, SuppressCommit, SalesSetup);
 
         ResetTempLines(TempSalesLine);
+        DividePrepmtVATDeducted(TempSalesLine);
         TempSalesLine.SetRange("Prepayment Line", false);
         TempSalesLine.SetFilter(Quantity, '<>0');
         OnPostUpdateOrderLineOnAfterSetFilters(TempSalesLine);

--- a/src/Layers/APAC/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1172,6 +1172,7 @@ codeunit 442 "Sales-Post Prepayments"
         PrepmtAmtToInvTotal := SalesLine."Prepmt. Line Amount" - SalesLine."Prepmt. Amt. Inv.";
         if SalesLine.FindSet() then
             repeat
+                DeductedVATBaseAmount := 0;
                 PrepmtAmt := PrepmtAmount(SalesLine, DocumentType);
                 if PrepmtAmt <> 0 then begin
                     if IsFullGST(SalesLine) then
@@ -2001,6 +2002,8 @@ codeunit 442 "Sales-Post Prepayments"
                     SalesLine."Prepmt Amt to Deduct" := 0;
                     SalesLine."Prepmt VAT Diff. to Deduct" := 0;
                     SalesLine."Prepayment VAT Difference" := 0;
+                    SalesLine."Prepmt. VAT Amount Deducted" := 0;
+                    SalesLine."Prepmt. VAT Base Deducted" := 0;
                     OnUpdateSalesDocumentOnBeforeModifyCreditMemoSalesLine(SalesLine);
                     SalesLine.Modify();
                 until SalesLine.Next() = 0;

--- a/src/Layers/APAC/Tests/Local/ERMGSTOnPrepaymentsII.Codeunit.al
+++ b/src/Layers/APAC/Tests/Local/ERMGSTOnPrepaymentsII.Codeunit.al
@@ -1025,17 +1025,22 @@ codeunit 141027 "ERM GST On Prepayments II"
     [Scope('OnPrem')]
     procedure GSTOnSalesPrepmtCrMemoAfterPartialFinalInvoice()
     var
+        CustLedgerEntry: Record "Cust. Ledger Entry";
         GeneralLedgerSetup: Record "General Ledger Setup";
         SalesCrMemoHeader: Record "Sales Cr.Memo Header";
         SalesHeader: Record "Sales Header";
         SalesInvoiceHeader: Record "Sales Invoice Header";
         SalesLine: Record "Sales Line";
         DocumentNo: Code[20];
+        PrepmtInvoiceNo2: Code[20];
         DeductedVATAmount: Decimal;
         DeductedVATBase: Decimal;
+        Deducted2VATAmount: Decimal;
+        Deducted2VATBase: Decimal;
         PrepmtInvVATAmount: Decimal;
+        PrepmtInv2VATAmount: Decimal;
     begin
-        // [SCENARIO 8896] GST on a Sales Prepayment Credit Memo posted after a partial final Invoice excludes the prepayment GST that the partial Invoice already deducted.
+        // [SCENARIO 8896] GST on a Sales Prepayment Credit Memo posted after a partial final Invoice excludes the prepayment GST that the partial Invoice already deducted, and the posted entries of a later re-invoice cycle are correct.
 
         // [GIVEN] Full GST On Prepayment. Create Sales Order, post Sales Prepayment Invoice and make payment for the same.
         Initialize();
@@ -1069,6 +1074,44 @@ codeunit 141027 "ERM GST On Prepayments II"
         Assert.AreNearlyEqual(
           PrepmtInvVATAmount - DeductedVATAmount, SalesCrMemoHeader."Amount Including VAT" - SalesCrMemoHeader.Amount,
           LibraryERM.GetAmountRoundingPrecision(), AmountMustMatchMsg);
+
+        // [THEN] The deducted GST fields start a clean cycle after the Credit Memo.
+        SalesLine.Get(SalesLine."Document Type", SalesLine."Document No.", SalesLine."Line No.");
+        SalesLine.TestField("Prepmt. VAT Amount Deducted", 0);
+        SalesLine.TestField("Prepmt. VAT Base Deducted", 0);
+
+        // [GIVEN] Re-invoice the prepayment.
+        LibrarySales.ReopenSalesDocument(SalesHeader);
+        PrepmtInvoiceNo2 := NoSeriesBatch.GetNextNo(SalesHeader."Posting No. Series");
+        LibrarySales.PostSalesPrepaymentInvoice(SalesHeader);
+        SalesInvoiceHeader.Get(PrepmtInvoiceNo2);
+        SalesInvoiceHeader.CalcFields(Amount, "Amount Including VAT");
+        PrepmtInv2VATAmount := SalesInvoiceHeader."Amount Including VAT" - SalesInvoiceHeader.Amount;
+        SalesHeader.Get(SalesHeader."Document Type", SalesHeader."No.");
+
+        // [WHEN] Post the remaining final Invoice.
+        DocumentNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);  // Post as Ship and Invoice.
+
+        // [THEN] The final Invoice reverses exactly the GST charged by the re-invoiced prepayment.
+        GetPrepmtDeductedVATOnSalesInvoice(DocumentNo, Deducted2VATAmount, Deducted2VATBase);
+        Assert.AreNearlyEqual(
+          PrepmtInv2VATAmount, Deducted2VATAmount, LibraryERM.GetAmountRoundingPrecision(), AmountMustMatchMsg);
+
+        // [THEN] The Customer Ledger Entry of the final Invoice matches the posted document amount.
+        SalesInvoiceHeader.Get(DocumentNo);
+        SalesInvoiceHeader.CalcFields("Amount Including VAT");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Invoice);
+        CustLedgerEntry.SetRange("Document No.", DocumentNo);
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry.CalcFields(Amount);
+        Assert.AreNearlyEqual(
+          SalesInvoiceHeader."Amount Including VAT", CustLedgerEntry.Amount,
+          LibraryERM.GetAmountRoundingPrecision(), AmountMustMatchMsg);
+
+        // [THEN] The G/L and GST Sales Entries of the final Invoice carry the remaining amounts.
+        VerifyGLAndGSTSalesEntry(
+          SalesLine."No.", DocumentNo, SalesLine."Amount Including VAT" / 2,
+          -(SalesLine.Amount / 2) * SalesLine."VAT %" / 100, -SalesLine.Amount / 2);
 
         // Tear Down.
         UpdateLocalFunctionalitiesOnGeneralLedgerSetup(

--- a/src/Layers/APAC/Tests/Local/ERMGSTOnPrepaymentsII.Codeunit.al
+++ b/src/Layers/APAC/Tests/Local/ERMGSTOnPrepaymentsII.Codeunit.al
@@ -1023,6 +1023,60 @@ codeunit 141027 "ERM GST On Prepayments II"
 
     [Test]
     [Scope('OnPrem')]
+    procedure GSTOnSalesPrepmtCrMemoAfterPartialFinalInvoice()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        SalesCrMemoHeader: Record "Sales Cr.Memo Header";
+        SalesHeader: Record "Sales Header";
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        SalesLine: Record "Sales Line";
+        DocumentNo: Code[20];
+        DeductedVATAmount: Decimal;
+        DeductedVATBase: Decimal;
+        PrepmtInvVATAmount: Decimal;
+    begin
+        // [SCENARIO 8896] GST on a Sales Prepayment Credit Memo posted after a partial final Invoice excludes the prepayment GST that the partial Invoice already deducted.
+
+        // [GIVEN] Full GST On Prepayment. Create Sales Order, post Sales Prepayment Invoice and make payment for the same.
+        Initialize();
+        GeneralLedgerSetup.Get();
+        UpdateLocalFunctionalitiesOnGeneralLedgerSetup(true, true, true);  // TRUE for Enable GST, GST Reports, Full GST On Prepayment.
+        CreateSalesOrderAndUpdateGeneralPostingSetup(SalesLine, '', LibraryRandom.RandDec(10, 2), false);  // Taking blank value for Currency Code, random value for Prepayment Pct., FALSE for Prices Including VAT.
+        PostPaymentForSalesPrepaymentInvoice(SalesHeader, SalesLine);
+        FindPrepaymentSalesInvoiceHeader(SalesInvoiceHeader, SalesHeader."Sell-to Customer No.");
+        SalesInvoiceHeader.CalcFields(Amount);
+        PrepmtInvVATAmount := SalesInvoiceHeader."Amount Including VAT" - SalesInvoiceHeader.Amount;
+
+        // [GIVEN] Post a partial final Invoice, deducting part of the prepayment and its GST.
+        UpdateQuantityToInvoiceOnSalesLine(SalesLine);
+        DocumentNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);  // Post as Ship and Invoice.
+        GetPrepmtDeductedVATOnSalesInvoice(DocumentNo, DeductedVATAmount, DeductedVATBase);
+
+        // [THEN] The Sales Order line stores the prepayment GST deducted by the partial Invoice.
+        SalesLine.Get(SalesLine."Document Type", SalesLine."Document No.", SalesLine."Line No.");
+        Assert.AreNearlyEqual(
+          DeductedVATAmount, SalesLine."Prepmt. VAT Amount Deducted", LibraryERM.GetAmountRoundingPrecision(), AmountMustMatchMsg);
+        Assert.AreNearlyEqual(
+          DeductedVATBase, SalesLine."Prepmt. VAT Base Deducted", LibraryERM.GetAmountRoundingPrecision(), AmountMustMatchMsg);
+
+        // [WHEN] Post the Sales Prepayment Credit Memo.
+        LibrarySales.PostSalesPrepaymentCrMemo(SalesHeader);
+
+        // [THEN] The Credit Memo GST equals the prepaid GST minus the GST already deducted by the partial Invoice.
+        SalesHeader.Get(SalesHeader."Document Type", SalesHeader."No.");
+        SalesCrMemoHeader.Get(SalesHeader."Last Prepmt. Cr. Memo No.");
+        SalesCrMemoHeader.CalcFields(Amount, "Amount Including VAT");
+        Assert.AreNearlyEqual(
+          PrepmtInvVATAmount - DeductedVATAmount, SalesCrMemoHeader."Amount Including VAT" - SalesCrMemoHeader.Amount,
+          LibraryERM.GetAmountRoundingPrecision(), AmountMustMatchMsg);
+
+        // Tear Down.
+        UpdateLocalFunctionalitiesOnGeneralLedgerSetup(
+          GeneralLedgerSetup."Enable GST (Australia)", GeneralLedgerSetup."GST Report", GeneralLedgerSetup."Full GST on Prepayment");
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure GLEntryAfterPostPartialPurchInvAndPrepaymentInv()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
@@ -1507,6 +1561,21 @@ codeunit 141027 "ERM GST On Prepayments II"
         SalesInvoiceHeader.SetRange("Sell-to Customer No.", SellToCustomerNo);
         SalesInvoiceHeader.FindFirst();
         SalesInvoiceHeader.CalcFields("Amount Including VAT");
+    end;
+
+    local procedure GetPrepmtDeductedVATOnSalesInvoice(DocumentNo: Code[20]; var DeductedVATAmount: Decimal; var DeductedVATBase: Decimal)
+    var
+        SalesInvoiceLine: Record "Sales Invoice Line";
+    begin
+        DeductedVATAmount := 0;
+        DeductedVATBase := 0;
+        SalesInvoiceLine.SetRange("Document No.", DocumentNo);
+        SalesInvoiceLine.SetRange("Prepayment Line", true);
+        SalesInvoiceLine.FindSet();
+        repeat
+            DeductedVATAmount += SalesInvoiceLine.Amount - SalesInvoiceLine."Amount Including VAT";  // Deduction lines are negative, so this yields the reversed GST as a positive amount.
+            DeductedVATBase -= SalesInvoiceLine."VAT Base Amount";
+        until SalesInvoiceLine.Next() = 0;
     end;
 
     local procedure GetPayableAccount(No: Code[20]): Code[20]


### PR DESCRIPTION
#### What and why

AU only: a sales prepayment credit memo posted after a partial final invoice reverses the full prepayment GST instead of only the part that has not been deducted yet, so the customer ledger entry and the G/L entries carry too much GST when the order is re-invoiced.

The APAC layer already has a mechanism for exactly this: during final invoice posting, `SavePrepmtVATDeducted` collects the GST reversed by the prepayment deduction lines into a buffer, and the credit memo read sites subtract Sales Line fields 28006 `Prepmt. VAT Amount Deducted` and 28007 `Prepmt. VAT Base Deducted` from the prepaid GST (`SalesPostPrepayments` 1200-1201 and 1250-1251, gated by Full GST on Prepayment plus the credit memo document type). On the purchase side the mechanism is complete: `Purch.-Post` drains its buffer onto the purchase lines through `DividePrepmtVATDeducted` and `DistributeAmount` (7488-7545, called at 8428). On the sales side only the first half exists: the buffer is filled (`SalesPost` 7769, called 1156) and nothing ever drains it, so both fields stay at zero for the life of every document and the subtraction never subtracts anything.

This PR completes the sales side by porting `DividePrepmtVATDeducted` and `DistributeAmount` from `Purch.-Post` and calling the former from `PostUpdateOrderLine`, mirroring the purchase call site. Three deliberate deviations from a verbatim port, each needed for the port to be correct:

1. **Sign normalisation in `SavePrepmtVATDeducted`.** The prepayment deduction lines are built with Quantity = -1 on both sides, so their amounts are negative. The purchase saver negates them into positive values (`PurchPost` 7493-7494); the sales saver did not. Both credit memo read sites subtract the fields, so the stored values must be positive. The sales saver now negates exactly like the purchase one. This edit is inert for existing behaviour: the two buffer fields it feeds had no reader on the sales side until this PR.
2. **Per-line reset of `DeductedVATBaseAmount` in `UpdateVATOnLines`.** The variable is procedure-scoped, assigned only on the Full GST credit memo path, and consumed on every Full GST line. While field 28007 was always zero this was harmless; with the field populated, one line's deducted base would leak into the next line in the same run. Reset to zero at the top of each iteration.
3. **Clean cycle on consumption.** The credit memo branch of `UpdateSalesDocument` already rebases `Prepmt. Amt. Incl. VAT` and `Prepayment Amount` and clears the other per-cycle prepayment fields (2000-2004). Both deducted fields are cleared there too, so a prepayment that is re-invoiced after a credit memo starts a clean deduction cycle instead of subtracting the previous cycle's deduction again. The purchase side does not do this and keeps document-lifetime accumulators; aligning purchase the same way may be worth a follow-up, but changing purchase behaviour is out of scope here.

One more small deviation: the ported procedure resets the line number buffer before deleting it. The purchase original deletes that buffer while the filter from the last loop iteration is still active, which only clears the last group.

Out of scope: the fix proposed in the issue description (extending `RestorePrepmtAmounts` with `Prepmt. VAT Base Amt.`) is not part of this change. That procedure saves and restores a field that `UpdateVATOnLines` deliberately rewrites per posting, and under Full GST the rewrite keeps the field unchanged from the second prepayment onward, so an unconditional restore would double it. The root cause analysis is on the issue.

#### Linked work

Fixes #8896

Area label: the issue carries **Finance**. I do not have label permissions, so a maintainer would need to set it.

#### How I validated

- [x] Traced the full mechanism on both sides: buffer fill (`SalesPost` 1156/7769 vs `PurchPost` 1210/7488), drain (`PurchPost` 7510/8428, sales previously absent), read sites (`SalesPostPrepayments` 1200/1250, `PurchasePostPrepayments` 866/916), and the temp-to-database flush (`ModifyTempLine`, wholesale `TransferFields`, so the drained values persist).
- [x] Verified the global `Currency` used by `DistributeAmount` is initialised before `PostUpdateOrderLine` runs (`GetCurrency` at 346, `FinalizePosting` at 372), matching the purchase flow.
- [x] Confirmed fields 28006/28007 have no other reader or writer anywhere in the repository, so behaviour changes only on the Full GST prepayment credit memo path.
- [x] Added a regression test (`GSTOnSalesPrepmtCrMemoAfterPartialFinalInvoice` in `ERM GST On Prepayments II`): prepayment invoice, paid, partial final invoice, then prepayment credit memo under Full GST on Prepayment. It asserts the deducted GST amount and base on the order line against the posted deduction lines, and that the credit memo GST equals the prepaid GST minus the deducted GST. The existing suite cannot catch this defect: every current Full GST credit memo test posts the credit memo before any final invoice, so the fields are still zero at the read sites either way.
- [ ] Full test suite run is pending the workflow approval on this PR; I could not execute the AU suite locally.

#### Risk & compatibility

- Behaviour radius: posting results change only for APAC builds with Full GST on Prepayment enabled for the line's VAT posting setup, on a sales prepayment credit memo posted after a final invoice. Both read sites are gated by `IsFullGST` plus the credit memo document type, and nothing else reads these fields.
- Data radius: order lines that deduct a prepayment now carry values in fields 28006/28007 (previously always zero). The fields are `Editable = false` and appear on no page, report, or API in the repository.
- The existing Full GST tests that post two prepayment invoices or a prepayment credit memo without a prior final invoice are unaffected: on those paths the fields are zero at the read sites, which is exactly today's behaviour.


