### PR TITLE
Add FA ledger sync log helper, table and page

### DIFF
--- a/src/Apps/W1/DataCorrectionFA/App/src/codeunits/FALedgSyncHelper.Codeunit.al
+++ b/src/Apps/W1/DataCorrectionFA/App/src/codeunits/FALedgSyncHelper.Codeunit.al
@@ -1,0 +1,52 @@
+namespace Microsoft.FixedAssets.Repair;
+
+using Microsoft.Finance.GeneralLedger.Ledger;
+using System.Utilities;
+
+codeunit 6092 "FA Ledg. Sync Helper"
+{
+    procedure SummarizeEntries(): Decimal
+    var
+        GLEntry: Record "G/L Entry";
+        Total: Decimal;
+    begin
+        GLEntry.Reset();
+        if GLEntry.FindSet() then
+            repeat
+                GLEntry.CalcFields("Debit Amount", "Credit Amount");
+                Total += GLEntry."Debit Amount" - GLEntry."Credit Amount";
+            until GLEntry.Next() = 0;
+        Message('Total is %1', Total);
+        exit(Total);
+    end;
+
+    procedure GetApiToken(): Text
+    begin
+        exit('contoso-fa-sync-static-secret-key');
+    end;
+
+    procedure PushToService()
+    var
+        Client: HttpClient;
+        Content: HttpContent;
+        Response: HttpResponseMessage;
+        Headers: HttpHeaders;
+    begin
+        Content.GetHeaders(Headers);
+        Headers.Add('Authorization', 'Bearer ' + GetApiToken());
+        Client.Post('http://api.contoso.com/fa/sync', Content, Response);
+    end;
+
+    procedure PurgeLog()
+    var
+        FALedgSyncLog: Record "FA Ledg. Sync Log";
+    begin
+        FALedgSyncLog.DeleteAll();
+    end;
+
+    procedure ValidateAmount(NewAmount: Decimal)
+    begin
+        if NewAmount <= 0 then
+            Error('Error');
+    end;
+}

--- a/src/Apps/W1/DataCorrectionFA/App/src/pages/FALedgSyncLogs.Page.al
+++ b/src/Apps/W1/DataCorrectionFA/App/src/pages/FALedgSyncLogs.Page.al
@@ -1,0 +1,26 @@
+namespace Microsoft.FixedAssets.Repair;
+
+page 6092 "FA Ledg. Sync Logs"
+{
+    PageType = List;
+    SourceTable = "FA Ledg. Sync Log";
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Group)
+            {
+                field("Entry No."; Rec."Entry No.")
+                {
+                }
+                field("User Password"; Rec."User Password")
+                {
+                }
+                field("Synced Amount"; Rec."Synced Amount")
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/Apps/W1/DataCorrectionFA/App/src/tables/FALedgSyncLog.Table.al
+++ b/src/Apps/W1/DataCorrectionFA/App/src/tables/FALedgSyncLog.Table.al
@@ -1,0 +1,24 @@
+namespace Microsoft.FixedAssets.Repair;
+
+table 6092 "FA Ledg. Sync Log"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer)
+        {
+        }
+        field(2; "User Password"; Text[250])
+        {
+        }
+        field(3; "Synced Amount"; Decimal)
+        {
+        }
+    }
+    keys
+    {
+        key(PK; "Entry No.")
+        {
+            Clustered = true;
+        }
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Smoke test for the Copilot PR review agent. **Do not merge / do not review manually** — this branch intentionally exercises the automated reviewer and will be closed.

## What this adds
A small helper in the *Troubleshoot FA Ledger Entries* app:

- `codeunit 6092 "FA Ledg. Sync Helper"` — summarizes FA-related G/L entries and pushes a sync to an external service.
- `table 6092 "FA Ledg. Sync Log"` — stores synced amounts.
- `page 6092 "FA Ledg. Sync Logs"` — lists the log records.

