### PR TITLE
[master]-Edit in Excel fails with false duplicate error when creating new Item Variants

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Item/ItemVariants.Page.al
+++ b/src/Layers/W1/BaseApp/Inventory/Item/ItemVariants.Page.al
@@ -7,6 +7,7 @@ namespace Microsoft.Inventory.Item;
 using Microsoft.Inventory.Item.Attribute;
 using Microsoft.Inventory.Item.Catalog;
 using Microsoft.Inventory.Item.Picture;
+using System.Environment;
 using System.Text;
 
 page 5401 "Item Variants"
@@ -36,7 +37,8 @@ page 5401 "Item Variants"
                     trigger OnValidate()
                     begin
                         if (xRec.Code = '') and (Rec.Code <> '') then
-                            CurrPage.Update(true);
+                            if not (ClientTypeManagement.GetCurrentClientType() in [ClientType::OData, ClientType::ODataV4, ClientType::SOAP, ClientType::Api]) then
+                                CurrPage.Update(true);
                     end;
                 }
                 field(Description; Rec.Description)
@@ -192,6 +194,7 @@ page 5401 "Item Variants"
     end;
 
     var
+        ClientTypeManagement: Codeunit "Client Type Management";
         CrossColumnSearchFilter: Text;
 }
 


### PR DESCRIPTION
[Bug 644606](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/644606): [ALL-E] Edit in Excel fails with false duplicate error when creating new Item Variants

Fixes [AB#644606](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644606)

Issue - Edit in Excel fails with false duplicate error when creating new Item Variants

Cause-PR 240753 (Item Variant Attributes feature) added an OnValidate trigger to the Code field on the Item Variants page (5401) that calls CurrPage.Update(true) when a Code is first entered on a new row. This forces the record to be persisted immediately.
During Edit in Excel, publishing a new variant runs through the OData insert handler. The forced CurrPage.Update(true) inserts the record first, then the OData handler attempts to insert the same record again, producing a false duplicate-key error.

Solution-Scope the forced update so it runs only for interactive clients and is skipped for OData/web-service sessions (Edit in Excel is OData V4).


