### PR TITLE
[E-Document][Pagero] Disable VAT reporting date so integration tests pass on CZ

### DIFF
--- a/src/Apps/W1/EDocument/Test/src/LibraryEDocument.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/LibraryEDocument.Codeunit.al
@@ -30,8 +30,14 @@ codeunit 139629 "Library - E-Document"
 
     procedure SetupStandardVAT()
     begin
-        if (VATPostingSetup."VAT Bus. Posting Group" = '') and (VATPostingSetup."VAT Prod. Posting Group" = '') then
-            LibraryERM.CreateVATPostingSetupWithAccounts(VATPostingSetup, Enum::"Tax Calculation Type"::"Normal VAT", 1);
+        // The cached setup is lost when a failing test rolls back the transaction, so recreate it
+        // whenever the record no longer exists. Otherwise callers validate posting groups that are gone.
+        if (VATPostingSetup."VAT Bus. Posting Group" <> '') or (VATPostingSetup."VAT Prod. Posting Group" <> '') then
+            if VATPostingSetup.Get(VATPostingSetup."VAT Bus. Posting Group", VATPostingSetup."VAT Prod. Posting Group") then
+                exit;
+
+        Clear(VATPostingSetup);
+        LibraryERM.CreateVATPostingSetupWithAccounts(VATPostingSetup, Enum::"Tax Calculation Type"::"Normal VAT", 1);
     end;
 
 #if not CLEAN26

--- a/src/Apps/W1/EDocumentConnectors/Pagero/test/src/IntegrationTests.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/test/src/IntegrationTests.Codeunit.al
@@ -9,6 +9,7 @@ using Microsoft.eServices.EDocument.Integration;
 using Microsoft.eServices.EDocument.Service;
 using Microsoft.EServices.EDocumentConnector;
 using Microsoft.Finance.Currency;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
 using Microsoft.Purchases.Document;
@@ -682,6 +683,7 @@ codeunit 148192 "Integration Tests"
     var
         ConnectionSetup: Record "E-Doc. Ext. Connection Setup";
         CompanyInformation: Record "Company Information";
+        GeneralLedgerSetup: Record "General Ledger Setup";
         OAuth2Setup: Record "OAuth 2.0 Setup";
         PageroAuth: Codeunit "Pagero Auth.";
         KeyGuid: Guid;
@@ -692,6 +694,12 @@ codeunit 148192 "Integration Tests"
             OriginalWorkDate := WorkDate()
         else
             WorkDate(OriginalWorkDate);
+
+        // Disable the VAT reporting date to avoid country specific VAT date checks during posting,
+        // such as the CZ 'VAT Period does not exist for date' error raised for the current work date.
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup."VAT Reporting Date Usage" := GeneralLedgerSetup."VAT Reporting Date Usage"::Disabled;
+        GeneralLedgerSetup.Modify();
 
         SetFilepartStatus(FilepartStatus::Processed);
         SetApplicationResponseSubType(RecipientAcceptTok);


### PR DESCRIPTION
Fixes [AB#644596](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/644596)

### Problem

NAV master gate job **3610101** (BCApps update PR 251616) failed the task `RunALIntegrationTests_CZ_Extensions` twice with 10 failures in codeunit 148192 `Integration Tests` (E-Document Connector - Pagero Tests).

#9738 changed that codeunit from `TestType = Uncategorized` to `TestType = IntegrationTest`. The CZ task runs with `Arguments @{ CountryCode = 'CZ'; TestType = 'IntegrationTest' }`, so the codeunit started running on the CZ localized build for the first time. It passes on W1, so the PR build was green.

**First failure — CZ VAT period check**

```
Failure - Test method: SubmitDocument
   Error: VAT Period does not exist for date 07/29/26.
   VAT Date Handler CZL(CodeUnit 11742).VATPeriodCZLCheck line 11
   VAT Date Handler CZL(CodeUnit 11742).CheckVATDateCZL line 10
   Sales Posting Handler CZL(CodeUnit 31038).CheckVatDateOnAfterCheckSalesDoc line 4
   ...
   Integration Tests(CodeUnit 148192).SubmitDocument line 14
```

`CheckVATDateCZL(var SalesHeader)` only skips the VAT period check when the VAT reporting date is disabled:

```al
if not VATReportingDateMgt.IsVATDateEnabled() then begin
    SalesHeader.TestField("VAT Reporting Date", SalesHeader."Posting Date");
    exit;
end;
```

Every other connector test that posts documents already disables it — Avalara, Continia, ForNAV, Logiq — as do the E-Document core tests, one of which spells out why:

```al
// Disable VAT Reporting Date to avoid country-specific VAT Period checks during posting (e.g. CZ)
```

Pagero's `Initialize` did not.

**Cascade — the other 9 failures**

```
Error: The field VAT Bus. Posting Group of table Customer contains a value (GU00000000)
       that cannot be found in the related table (VAT Business Posting Group).
   Library - E-Document(CodeUnit 139629).SetupStandardSalesScenario line 27
   Integration Tests(CodeUnit 148192).Initialize line 48
```

The first failure rolls back the codeunit transaction, so the VAT posting setup is gone. `Initialize` detects the rollback and re-initializes, but `Library - E-Document.SetupStandardVAT` only created the setup when its **cached** posting group codes were blank — and they were still populated from the rolled back run. So every subsequent test validated a customer against posting groups that no longer existed.

### Fix

1. `Pagero/test/src/IntegrationTests.Codeunit.al` — disable `"VAT Reporting Date Usage"` in `Initialize`, matching the other connectors.
2. `LibraryEDocument.Codeunit.al` — `SetupStandardVAT` now recreates the VAT posting setup when the cached record no longer exists, so a single failure no longer cascades into every following test in any E-Document test codeunit.

### Notes

Test-only change; no production AL is touched. The W1 behaviour is unchanged — `"VAT Reporting Date Usage"` is already `Disabled` by default on W1, so this is a no-op there and only affects localized runs.

[AB#644596](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644596)


