### PR TITLE
Fixing PA storage leak problem

### DIFF
--- a/src/Apps/W1/EDocumentConnectors/Microsoft365/app/src/OutlookProcessing.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Microsoft365/app/src/OutlookProcessing.Codeunit.al
@@ -79,8 +79,7 @@ codeunit 6385 "Outlook Processing"
         // Dedup is still bounded by the category-exclude filter set in RetrieveEmailsWithRecovery.
         if (LatestReceivedDateTime >= OutlookSetup."Last Sync At") and (OutlookSetup."Email Folder Id" = '') then begin
             OutlookSetup.Get();
-            // +10 ms so the next run's 'receivedDateTime ge' filter strictly excludes the email we just processed. See bug 637266 for the proper fix.
-            OutlookSetup."Last Sync At" := LatestReceivedDateTime + 10;
+            OutlookSetup."Last Sync At" := LatestReceivedDateTime;
             OutlookSetup.Modify();
         end;
     end;
@@ -99,9 +98,12 @@ codeunit 6385 "Outlook Processing"
         // In folder mode, dedup is enforced server-side by the category-exclude filter only.
         // Applying "Earliest Email" would drop emails moved into the folder after that floor.
         if not FolderConfigured then
-            TempFilters."Earliest Email" := OutlookSetup."Last Sync At";
+            // An extra second is added at retrieval: Graph compares (either with `ge` or `gt`) with subsecond precision, but returns receivedDateTime truncated to whole seconds. 
+            // A single refetch in the email module, even if the email is later not processed, creates a Tenant Media record for the email. The second bump avoids this.
+            TempFilters."Earliest Email" := OutlookSetup."Last Sync At" + 1000;
+
         // When the user has not configured a folder, default to Inbox so that Sent Items,
-        // Junk, and other non-Inbox folders are excluded from monitoring. 
+        // Junk, and other non-Inbox folders are excluded from monitoring.
         if FolderConfigured then
             TempFilters."Folder Id" := OutlookSetup."Email Folder Id"
         else


### PR DESCRIPTION
# Problem

Sending an email to a Payables Agent monitored inbox with an attachment would cause the TenantMedia table to grow with a record every minute, until a different email was received that didn't contain an attachment.

## Why?

Several things compounded: feature gap in the email module + using receivedAt to set the floor when retrieving emails + Graph `gt` comparing with subsecond precision while returning rounded seconds.

A call to the email module to fetch received emails already persist in database email-related records. In the case of email attachments, this inserts TenantMedia records. The behavior is always like this whether or not the inbox is a temporary record.

In order to decide from when to read emails, we persist the datetime when the last email was received. This is stored in the Database with ~30 ms precision. Graph allows for comparing with `gt` (although currently the Outlook connector (email module), only uses `ge` without possibility of changing this), and it works for comparisons with subsecond precision. However, the value returned for the datetime when the email is received is truncated to the seconds. This means that if an email arrived at 12:40:39.32 that value would be used for comparison (Graph call returns the value in some headers with this precision), but in the createdDatetime it would show 12:40:39 and such value would be stored, if you then queried emails arriving after this value (`gt`) you would still get the same email because the comparison considers subseconds and `12:40:39 < 12:40:39.32`.

# Suggested solution

Persist the right value of the last received email, but query 1 second after, this gets rid of subsecond comparison problems, with the tradeoff of possibly (unlikely) missing emails arriving within a second. The tradeoff is accepted in comparison to the other options that I further ellaborate on later.

# Why did the other fixes failed?

Previous fixes tried to store in the field a slightly larger value. The first fix was too small for SQL to correctly store it, the second one still had the Graph subsecond comparison/second return problem.

# What other alternatives were considered/tried

- Complement the email module to support `gt` rather than `ge` with an additional TempFilter: Still had the subsecond problem, inherent for how Graph returns these values.
- A "preflight" call that retrieved the emails without persisting: Needs not trivial changes to the email module that go beyond the scope of something to be hot-fixed and that require discussion with the team maintaining the email module (behavior could be triggered by passing a temp record, or via a formal contract with TempFilters or via the versioned interfaces, each with pros/cons).

# How has this been verified

Locally reproduced the problem, configuring the outlook connector with a custom token, verified the threshold works, validated Graph's subsecond behavior when querying emails.

Fixes [AB#637266](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637266)

