### PR TITLE
Use ReadCommitted isolation for CalcFields in Job Queue Entry GetXmlContent

### DIFF
--- a/src/Layers/W1/BaseApp/Modules/System/JobQueue/JobQueueEntry.Table.al
+++ b/src/Layers/W1/BaseApp/Modules/System/JobQueue/JobQueueEntry.Table.al
@@ -1209,6 +1209,7 @@ table 472 "Job Queue Entry"
     var
         InStr: InStream;
     begin
+        ReadIsolation(IsolationLevel::ReadCommitted);
         CalcFields(XML);
         if XML.HasValue() then begin
             XML.CreateInStream(InStr, TEXTENCODING::UTF8);


### PR DESCRIPTION
## What & why

`Job Queue Entry.GetXmlContent()` calls `CalcFields(XML)` to read the report request page parameters BLOB. Without an explicit read isolation level, the FlowField calculation inherits whatever isolation the surrounding transaction is using, which can take locks on the job queue entry record (or block on locks held elsewhere) just to read parameter XML.

This adds `ReadIsolation(IsolationLevel::ReadCommitted);` immediately before the `CalcFields(XML)` call so the BLOB is fetched with an explicit, non-blocking read isolation level.

## Linked work

[AB#644633](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644633)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

No tests added: this is a one-line read isolation hint on an existing `CalcFields` call and does not change the returned value or any observable behavior of `GetXmlContent()`. Existing coverage of report parameter get/set paths (`GetReportParameters`, `RunReportRequestPage`) still applies.

## Risk & compatibility

Low. `ReadIsolation` only affects how the FlowField is read; the procedure's signature, return value, and `OnAfterGetXmlContent` event are unchanged. `ReadCommitted` is the same effective isolation as the default for reads, so no behavior change is expected, only removal of implicit isolation escalation when the caller is inside an updating transaction.

