### PR TITLE
Grant inherent read on Privacy Notice tables for service-invoked capability checks

### DIFF
--- a/src/System Application/App/Privacy Notice/src/PrivacyNoticeImpl.Codeunit.al
+++ b/src/System Application/App/Privacy Notice/src/PrivacyNoticeImpl.Codeunit.al
@@ -13,7 +13,8 @@ codeunit 1565 "Privacy Notice Impl."
     InherentEntitlements = X;
     InherentPermissions = X;
     Permissions = tabledata Company = r,
-                  tabledata "Privacy Notice" = im;
+                  tabledata "Privacy Notice" = rim,
+                  tabledata "Privacy Notice Approval" = r;
 
     var
         EmptyGuid: Guid;
@@ -118,6 +119,8 @@ codeunit 1565 "Privacy Notice Impl."
         exit(CheckPrivacyNoticeApprovalState(PrivacyNoticeId, true));
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Privacy Notice", 'r')]
+    [InherentPermissions(PermissionObjectType::TableData, Database::"Privacy Notice Approval", 'r')]
     procedure CheckPrivacyNoticeApprovalState(PrivacyNoticeId: Code[50]; SkipCheckInEval: Boolean): Enum "Privacy Notice Approval State"
     var
         Company: Record Company;


### PR DESCRIPTION
## Problem

A follow-up to #9482. That PR fixed the facade **Execute** denial on the MCP capability path; this fixes the next denial one level deeper — a **tabledata Read** (`NavPermissionException 18023807`) on the **Privacy Notice** platform table.

The MCP feature gate calls `GetCopilotCapabilityStatus` during **session initialization, before the company is opened** (`McpServerInitializationMiddleware` runs `ThrowIfNotEnabledAsync` ahead of `InitializeSessionAsync` → `OpenCompanyAsync`). Role / permission-set permissions resolve against the *open* company; with no company yet, they collapse to `None`. The capability path then reads:

- `Privacy Notice` (2000000237) via `Privacy Notice Impl.CheckPrivacyNoticeApprovalState` (`PrivacyNotice.Get`), and
- `Privacy Notice Approval` (2000000238) via the `Enabled`/`Disabled` FlowFields (`CalcFormula = exist("Privacy Notice Approval" ...)`).

Both are denied for any non-SUPER user. Telemetry confirms: `Entitlements for object TableData 2000000237: Read, Insert, Modify, IndirectDelete. Role permissions: None. ... IsTenantAdmin: False` — the entitlement allows Read, but nothing supplies the grant because roles are `None`.

## Why inherent permissions (and not a permission set)

Because roles resolve to `None` in this pre-company context, a permission-set grant can't help — it's never evaluated. **Inherent permissions** are capped by license ∩ entitlement only (no role/company dependency), so the object self-grants within what the entitlement already allows.

`Privacy Notice` / `Privacy Notice Approval` are **platform tables** and can't declare table-level inherent permissions. (By contrast, `Copilot Settings` (7775) — also read on this path — already declares `InherentPermissions = rimdX` at the table level and needs no change; that's why its read already succeeds.) So the read is granted from the codeunit instead.

## Fix

On `Privacy Notice Impl.` (1565), matching the existing pattern in `User Login Time Tracker Impl.` (9013) and `Azure AD Plan Impl.` (9018):

- `[InherentPermissions(PermissionObjectType::TableData, Database::"Privacy Notice", 'r')]` and the same for `"Privacy Notice Approval"` on `CheckPrivacyNoticeApprovalState` — the self-sufficient, entitlement-capped grant, collected as the read executes in that method's scope.
- `Permissions` property: `"Privacy Notice" = im` → `rim`, and add `"Privacy Notice Approval" = r` — the indirect read the check ANDs against.

## Notes
- Work item: [AB#641612](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641612)
- Diagnosed from a production session trace (MCP Copilot Chat init, `WebServiceClient`, non-admin user).



