### PR TITLE
Grant indirect read on Privacy Notice tables in Privacy Notice Impl.

### DIFF
--- a/src/System Application/App/Privacy Notice/src/PrivacyNoticeImpl.Codeunit.al
+++ b/src/System Application/App/Privacy Notice/src/PrivacyNoticeImpl.Codeunit.al
@@ -13,7 +13,8 @@ codeunit 1565 "Privacy Notice Impl."
     InherentEntitlements = X;
     InherentPermissions = X;
     Permissions = tabledata Company = r,
-                  tabledata "Privacy Notice" = im;
+                  tabledata "Privacy Notice" = rim,
+                  tabledata "Privacy Notice Approval" = r;
 
     var
         EmptyGuid: Guid;


### PR DESCRIPTION
## Summary

Least-privilege companion to the platform change **microsoft.ghe.com/bic/BC-Platform!45667**, which adds `InherentPermissions = rX` (indirect read) to the `Privacy Notice` (2000000237) and `Privacy Notice Approval` (2000000238) system tables.

`Privacy Notice Impl.CheckPrivacyNoticeApprovalState` reads `Privacy Notice` and — via the `Enabled`/`Disabled` FlowFields — `Privacy Notice Approval`. In service / Copilot / MCP sessions the capability check runs **before a company is opened**, so role permissions resolve to `None` and the read is denied (`NavPermissionException 18023807`) for any non-SUPER user, even though the entitlement allows Read.

## Change

Add indirect read to the codeunit's `Permissions` property so the platform's inherent `rX` can be **promoted** to the direct read that `Get()`/`CalcFields` require:

```al
Permissions = tabledata Company = r,
              tabledata "Privacy Notice" = rim,        // was: im
              tabledata "Privacy Notice Approval" = r; // new
```

This is the classic `Permissions` property (indirect grants), not the `[InherentPermissions]` attribute — the attribute can't reference platform tables (AL0720).

## Why this split (least privilege)

The alternative was direct inherent read (`RX`) on the platform tables alone — a single-repo fix, but it grants **direct** read to everyone. We chose indirect (`rX`) on the platform side so only objects that explicitly declare indirect read (like this one) can read the tables, keeping least privilege. The cost is this paired change.

## Dependency

Requires the platform PR to ship first (or together) — indirect read here is a no-op without the platform tables' `InherentPermissions = rX`.

## Validation

Reproduced on a local `PlatformCore` NST with a non-SUPER user (`D365 BASIC`) hitting the Copilot capability path (`18023807` on 2000000237). With the platform `rX` change + this indirect-read change published, the capability check succeeds.

Work item: [AB#644260](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644260)



