### PR TITLE
Indent the case block under the IsHandled guard

### DIFF
--- a/src/Layers/APAC/BaseApp/Bank/Check/CheckManagement.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Bank/Check/CheckManagement.Codeunit.al
@@ -286,151 +286,151 @@ codeunit 367 CheckManagement
         IsHandled := false;
         OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
         if not IsHandled then
-        case CheckLedgEntry."Bal. Account Type" of
-            CheckLedgEntry."Bal. Account Type"::"G/L Account":
-                FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
-            CheckLedgEntry."Bal. Account Type"::Customer:
-                begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
-                        if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
-                            GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
-                    CustLedgEntry.SetCurrentKey("Transaction No.");
-                    CustLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    CustLedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    CustLedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    if CustLedgEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostCust(GenJnlLine2, CustLedgEntry, BalanceAmountLCY);
-                            CustLedgEntry.CalcFields("Original Amount");
-                            SetGenJnlLine(
-                              GenJnlLine2, -CustLedgEntry."Original Amount", CustLedgEntry."Currency Code", CheckLedgEntry."Document No.",
-                              CustLedgEntry."Global Dimension 1 Code", CustLedgEntry."Global Dimension 2 Code", CustLedgEntry."Dimension Set ID");
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until CustLedgEntry.Next() = 0;
-                end;
-            CheckLedgEntry."Bal. Account Type"::Vendor:
-                begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
-                            GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
-                    VendorLedgEntry.SetCurrentKey("Transaction No.");
-                    VendorLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    VendorLedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    VendorLedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    OnFinancialVoidCheckOnAfterVendorLedgEntrySetFilters(VendorLedgEntry, BankAccLedgEntry2);
-                    if VendorLedgEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostVend(GenJnlLine2, VendorLedgEntry, BalanceAmountLCY);
-                            VendorLedgEntry.CalcFields("Original Amount");
-                            GenJnlLine2.Validate("Currency Code", VendorLedgEntry."Currency Code");
-                            if ConfirmFinancialVoid.GetVoidType() = 0 then begin
-                                GenJnlLine2.Validate(Amount, -VendorLedgEntry."Original Amount");
-                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)" + WHTAmount;
-                            end else begin
-                                GenJnlLine2.Validate(Amount, -VendorLedgEntry."Original Amount" + WHTAmount);
+            case CheckLedgEntry."Bal. Account Type" of
+                CheckLedgEntry."Bal. Account Type"::"G/L Account":
+                    FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
+                CheckLedgEntry."Bal. Account Type"::Customer:
+                    begin
+                        if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
+                            if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                                GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
+                        CustLedgEntry.SetCurrentKey("Transaction No.");
+                        CustLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        CustLedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        CustLedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        if CustLedgEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostCust(GenJnlLine2, CustLedgEntry, BalanceAmountLCY);
+                                CustLedgEntry.CalcFields("Original Amount");
+                                SetGenJnlLine(
+                                  GenJnlLine2, -CustLedgEntry."Original Amount", CustLedgEntry."Currency Code", CheckLedgEntry."Document No.",
+                                  CustLedgEntry."Global Dimension 1 Code", CustLedgEntry."Global Dimension 2 Code", CustLedgEntry."Dimension Set ID");
                                 BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            end;
-                            GenJnlLine2."Interest Amount" := 0;
-                            GenJnlLine2."Interest Amount (LCY)" := 0;
-                            MakeAppliesID(GenJnlLine2."Applies-to ID", CheckLedgEntry."Document No.");
-                            GenJnlLine2."Shortcut Dimension 1 Code" := VendorLedgEntry."Global Dimension 1 Code";
-                            GenJnlLine2."Shortcut Dimension 2 Code" := VendorLedgEntry."Global Dimension 2 Code";
-                            GenJnlLine2."Dimension Set ID" := VendorLedgEntry."Dimension Set ID";
-                            GenJnlLine2."Source Currency Code" := VendorLedgEntry."Currency Code";
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            if GenJnlLine2."Posting Group" <> VendorLedgEntry."Vendor Posting Group" then
-                                GenJnlLine2."Posting Group" := VendorLedgEntry."Vendor Posting Group";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until VendorLedgEntry.Next() = 0;
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until CustLedgEntry.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::Vendor:
+                    begin
+                        if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                            if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                                GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
+                        VendorLedgEntry.SetCurrentKey("Transaction No.");
+                        VendorLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        VendorLedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        VendorLedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        OnFinancialVoidCheckOnAfterVendorLedgEntrySetFilters(VendorLedgEntry, BankAccLedgEntry2);
+                        if VendorLedgEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostVend(GenJnlLine2, VendorLedgEntry, BalanceAmountLCY);
+                                VendorLedgEntry.CalcFields("Original Amount");
+                                GenJnlLine2.Validate("Currency Code", VendorLedgEntry."Currency Code");
+                                if ConfirmFinancialVoid.GetVoidType() = 0 then begin
+                                    GenJnlLine2.Validate(Amount, -VendorLedgEntry."Original Amount");
+                                    BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)" + WHTAmount;
+                                end else begin
+                                    GenJnlLine2.Validate(Amount, -VendorLedgEntry."Original Amount" + WHTAmount);
+                                    BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                end;
+                                GenJnlLine2."Interest Amount" := 0;
+                                GenJnlLine2."Interest Amount (LCY)" := 0;
+                                MakeAppliesID(GenJnlLine2."Applies-to ID", CheckLedgEntry."Document No.");
+                                GenJnlLine2."Shortcut Dimension 1 Code" := VendorLedgEntry."Global Dimension 1 Code";
+                                GenJnlLine2."Shortcut Dimension 2 Code" := VendorLedgEntry."Global Dimension 2 Code";
+                                GenJnlLine2."Dimension Set ID" := VendorLedgEntry."Dimension Set ID";
+                                GenJnlLine2."Source Currency Code" := VendorLedgEntry."Currency Code";
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                if GenJnlLine2."Posting Group" <> VendorLedgEntry."Vendor Posting Group" then
+                                    GenJnlLine2."Posting Group" := VendorLedgEntry."Vendor Posting Group";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until VendorLedgEntry.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::"Bank Account":
+                    begin
+                        BankAccLedgEntry3.SetCurrentKey("Transaction No.");
+                        BankAccLedgEntry3.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        BankAccLedgEntry3.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        BankAccLedgEntry3.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        BankAccLedgEntry3.SetFilter("Entry No.", '<>%1', BankAccLedgEntry2."Entry No.");
+                        if BankAccLedgEntry3.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostBankAccount(GenJnlLine2, BankAccLedgEntry3);
+                                GenJnlLine2.Validate(Amount, -BankAccLedgEntry3.Amount);
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                GenJnlLine2."Shortcut Dimension 1 Code" := BankAccLedgEntry3."Global Dimension 1 Code";
+                                GenJnlLine2."Shortcut Dimension 2 Code" := BankAccLedgEntry3."Global Dimension 2 Code";
+                                GenJnlLine2."Dimension Set ID" := BankAccLedgEntry3."Dimension Set ID";
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until BankAccLedgEntry3.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::"Fixed Asset":
+                    begin
+                        FALedgEntry.SetCurrentKey("Transaction No.");
+                        FALedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        FALedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        FALedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        if FALedgEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostFixedAsset(GenJnlLine2, FALedgEntry);
+                                GenJnlLine2.Validate(Amount, -FALedgEntry.Amount);
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                GenJnlLine2."Shortcut Dimension 1 Code" := FALedgEntry."Global Dimension 1 Code";
+                                GenJnlLine2."Shortcut Dimension 2 Code" := FALedgEntry."Global Dimension 2 Code";
+                                GenJnlLine2."Dimension Set ID" := FALedgEntry."Dimension Set ID";
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until FALedgEntry.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::Employee:
+                    begin
+                        if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                            if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                                GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
+                        EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
+                        EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        EmployeeLedgerEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        EmployeeLedgerEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        if EmployeeLedgerEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostEmp(GenJnlLine2, EmployeeLedgerEntry);
+                                EmployeeLedgerEntry.CalcFields("Original Amount");
+                                SetGenJnlLine(
+                                  GenJnlLine2, -EmployeeLedgerEntry."Original Amount", EmployeeLedgerEntry."Currency Code", CheckLedgEntry."Document No.",
+                                  EmployeeLedgerEntry."Global Dimension 1 Code", EmployeeLedgerEntry."Global Dimension 2 Code", EmployeeLedgerEntry."Dimension Set ID");
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until EmployeeLedgerEntry.Next() = 0;
+                    end;
+                else begin
+                    GenJnlLine2."Bal. Account Type" := CheckLedgEntry."Bal. Account Type";
+                    GenJnlLine2.Validate("Bal. Account No.", CheckLedgEntry."Bal. Account No.");
+                    GenJnlLine2."Shortcut Dimension 1 Code" := '';
+                    GenJnlLine2."Shortcut Dimension 2 Code" := '';
+                    GenJnlLine2."Dimension Set ID" := 0;
+                    GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                    GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                    OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                    GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                    OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
                 end;
-            CheckLedgEntry."Bal. Account Type"::"Bank Account":
-                begin
-                    BankAccLedgEntry3.SetCurrentKey("Transaction No.");
-                    BankAccLedgEntry3.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    BankAccLedgEntry3.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    BankAccLedgEntry3.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    BankAccLedgEntry3.SetFilter("Entry No.", '<>%1', BankAccLedgEntry2."Entry No.");
-                    if BankAccLedgEntry3.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostBankAccount(GenJnlLine2, BankAccLedgEntry3);
-                            GenJnlLine2.Validate(Amount, -BankAccLedgEntry3.Amount);
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            GenJnlLine2."Shortcut Dimension 1 Code" := BankAccLedgEntry3."Global Dimension 1 Code";
-                            GenJnlLine2."Shortcut Dimension 2 Code" := BankAccLedgEntry3."Global Dimension 2 Code";
-                            GenJnlLine2."Dimension Set ID" := BankAccLedgEntry3."Dimension Set ID";
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until BankAccLedgEntry3.Next() = 0;
-                end;
-            CheckLedgEntry."Bal. Account Type"::"Fixed Asset":
-                begin
-                    FALedgEntry.SetCurrentKey("Transaction No.");
-                    FALedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    FALedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    FALedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    if FALedgEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostFixedAsset(GenJnlLine2, FALedgEntry);
-                            GenJnlLine2.Validate(Amount, -FALedgEntry.Amount);
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            GenJnlLine2."Shortcut Dimension 1 Code" := FALedgEntry."Global Dimension 1 Code";
-                            GenJnlLine2."Shortcut Dimension 2 Code" := FALedgEntry."Global Dimension 2 Code";
-                            GenJnlLine2."Dimension Set ID" := FALedgEntry."Dimension Set ID";
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until FALedgEntry.Next() = 0;
-                end;
-            CheckLedgEntry."Bal. Account Type"::Employee:
-                begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
-                            GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
-                    EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
-                    EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    EmployeeLedgerEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    EmployeeLedgerEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    if EmployeeLedgerEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostEmp(GenJnlLine2, EmployeeLedgerEntry);
-                            EmployeeLedgerEntry.CalcFields("Original Amount");
-                            SetGenJnlLine(
-                              GenJnlLine2, -EmployeeLedgerEntry."Original Amount", EmployeeLedgerEntry."Currency Code", CheckLedgEntry."Document No.",
-                              EmployeeLedgerEntry."Global Dimension 1 Code", EmployeeLedgerEntry."Global Dimension 2 Code", EmployeeLedgerEntry."Dimension Set ID");
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until EmployeeLedgerEntry.Next() = 0;
-                end;
-            else begin
-                GenJnlLine2."Bal. Account Type" := CheckLedgEntry."Bal. Account Type";
-                GenJnlLine2.Validate("Bal. Account No.", CheckLedgEntry."Bal. Account No.");
-                GenJnlLine2."Shortcut Dimension 1 Code" := '';
-                GenJnlLine2."Shortcut Dimension 2 Code" := '';
-                GenJnlLine2."Dimension Set ID" := 0;
-                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
             end;
-        end;
 
         if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
             BankAccLedgEntry2.Open := false;

--- a/src/Layers/NA/BaseApp/Bank/Check/CheckManagement.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Bank/Check/CheckManagement.Codeunit.al
@@ -262,152 +262,152 @@ codeunit 367 CheckManagement
         IsHandled := false;
         OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
         if not IsHandled then
-        case CheckLedgEntry."Bal. Account Type" of
-            CheckLedgEntry."Bal. Account Type"::"G/L Account":
-                FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
-            CheckLedgEntry."Bal. Account Type"::Customer:
-                begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
-                        if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
-                            GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
-                    CustLedgEntry.SetCurrentKey(CustLedgEntry."Transaction No.");
-                    CustLedgEntry.SetRange(CustLedgEntry."Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    CustLedgEntry.SetRange(CustLedgEntry."Document No.", BankAccLedgEntry2."Document No.");
-                    CustLedgEntry.SetRange(CustLedgEntry."Posting Date", BankAccLedgEntry2."Posting Date");
-                    if CustLedgEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostCust(GenJnlLine2, CustLedgEntry, BalanceAmountLCY);
-                            CustLedgEntry.CalcFields(CustLedgEntry."Original Amount");
-                            SetGenJnlLine(
-                              GenJnlLine2, -CustLedgEntry."Original Amount", CustLedgEntry."Currency Code", CheckLedgEntry."Document No.",
-                              CustLedgEntry."Global Dimension 1 Code", CustLedgEntry."Global Dimension 2 Code", CustLedgEntry."Dimension Set ID");
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            if ConfirmFinancialVoid.GetVoidType() <> 0 then begin
+            case CheckLedgEntry."Bal. Account Type" of
+                CheckLedgEntry."Bal. Account Type"::"G/L Account":
+                    FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
+                CheckLedgEntry."Bal. Account Type"::Customer:
+                    begin
+                        if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
+                            if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
                                 GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
-                                CustLedgEntry."Applies-to ID" := CheckLedgEntry."Document No.";
-                                CustLedgEntry."Amount to Apply" := CheckLedgEntry.Amount;
-                                CustLedgEntry.Modify();
-                            end;
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until CustLedgEntry.Next() = 0;
-                end;
-            CheckLedgEntry."Bal. Account Type"::Vendor:
-                begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
-                            GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
-                    VendorLedgEntry.SetCurrentKey(VendorLedgEntry."Transaction No.");
-                    VendorLedgEntry.SetRange(VendorLedgEntry."Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    VendorLedgEntry.SetRange(VendorLedgEntry."Document No.", BankAccLedgEntry2."Document No.");
-                    VendorLedgEntry.SetRange(VendorLedgEntry."Posting Date", BankAccLedgEntry2."Posting Date");
-                    OnFinancialVoidCheckOnAfterVendorLedgEntrySetFilters(VendorLedgEntry, BankAccLedgEntry2);
-                    if VendorLedgEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostVend(GenJnlLine2, VendorLedgEntry, BalanceAmountLCY);
-                            VendorLedgEntry.CalcFields(VendorLedgEntry."Original Amount");
-                            SetGenJnlLine(
-                              GenJnlLine2, -VendorLedgEntry."Original Amount", VendorLedgEntry."Currency Code", CheckLedgEntry."Document No.",
-                              VendorLedgEntry."Global Dimension 1 Code", VendorLedgEntry."Global Dimension 2 Code", VendorLedgEntry."Dimension Set ID");
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            if ConfirmFinancialVoid.GetVoidType() <> 0 then begin
+                        CustLedgEntry.SetCurrentKey(CustLedgEntry."Transaction No.");
+                        CustLedgEntry.SetRange(CustLedgEntry."Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        CustLedgEntry.SetRange(CustLedgEntry."Document No.", BankAccLedgEntry2."Document No.");
+                        CustLedgEntry.SetRange(CustLedgEntry."Posting Date", BankAccLedgEntry2."Posting Date");
+                        if CustLedgEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostCust(GenJnlLine2, CustLedgEntry, BalanceAmountLCY);
+                                CustLedgEntry.CalcFields(CustLedgEntry."Original Amount");
+                                SetGenJnlLine(
+                                  GenJnlLine2, -CustLedgEntry."Original Amount", CustLedgEntry."Currency Code", CheckLedgEntry."Document No.",
+                                  CustLedgEntry."Global Dimension 1 Code", CustLedgEntry."Global Dimension 2 Code", CustLedgEntry."Dimension Set ID");
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                if ConfirmFinancialVoid.GetVoidType() <> 0 then begin
+                                    GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
+                                    CustLedgEntry."Applies-to ID" := CheckLedgEntry."Document No.";
+                                    CustLedgEntry."Amount to Apply" := CheckLedgEntry.Amount;
+                                    CustLedgEntry.Modify();
+                                end;
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until CustLedgEntry.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::Vendor:
+                    begin
+                        if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                            if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
                                 GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
-                                VendorLedgEntry."Applies-to ID" := CheckLedgEntry."Document No.";
-                                VendorLedgEntry."Amount to Apply" := CheckLedgEntry.Amount;
-                                VendorLedgEntry.Modify();
-                            end;
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            if GenJnlLine2."Posting Group" <> VendorLedgEntry."Vendor Posting Group" then
-                                GenJnlLine2."Posting Group" := VendorLedgEntry."Vendor Posting Group";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until VendorLedgEntry.Next() = 0;
+                        VendorLedgEntry.SetCurrentKey(VendorLedgEntry."Transaction No.");
+                        VendorLedgEntry.SetRange(VendorLedgEntry."Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        VendorLedgEntry.SetRange(VendorLedgEntry."Document No.", BankAccLedgEntry2."Document No.");
+                        VendorLedgEntry.SetRange(VendorLedgEntry."Posting Date", BankAccLedgEntry2."Posting Date");
+                        OnFinancialVoidCheckOnAfterVendorLedgEntrySetFilters(VendorLedgEntry, BankAccLedgEntry2);
+                        if VendorLedgEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostVend(GenJnlLine2, VendorLedgEntry, BalanceAmountLCY);
+                                VendorLedgEntry.CalcFields(VendorLedgEntry."Original Amount");
+                                SetGenJnlLine(
+                                  GenJnlLine2, -VendorLedgEntry."Original Amount", VendorLedgEntry."Currency Code", CheckLedgEntry."Document No.",
+                                  VendorLedgEntry."Global Dimension 1 Code", VendorLedgEntry."Global Dimension 2 Code", VendorLedgEntry."Dimension Set ID");
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                if ConfirmFinancialVoid.GetVoidType() <> 0 then begin
+                                    GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
+                                    VendorLedgEntry."Applies-to ID" := CheckLedgEntry."Document No.";
+                                    VendorLedgEntry."Amount to Apply" := CheckLedgEntry.Amount;
+                                    VendorLedgEntry.Modify();
+                                end;
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                if GenJnlLine2."Posting Group" <> VendorLedgEntry."Vendor Posting Group" then
+                                    GenJnlLine2."Posting Group" := VendorLedgEntry."Vendor Posting Group";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until VendorLedgEntry.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::"Bank Account":
+                    begin
+                        BankAccLedgEntry3.SetCurrentKey(BankAccLedgEntry3."Transaction No.");
+                        BankAccLedgEntry3.SetRange(BankAccLedgEntry3."Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        BankAccLedgEntry3.SetRange(BankAccLedgEntry3."Document No.", BankAccLedgEntry2."Document No.");
+                        BankAccLedgEntry3.SetRange(BankAccLedgEntry3."Posting Date", BankAccLedgEntry2."Posting Date");
+                        BankAccLedgEntry3.SetFilter(BankAccLedgEntry3."Entry No.", '<>%1', BankAccLedgEntry2."Entry No.");
+                        if BankAccLedgEntry3.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostBankAccount(GenJnlLine2, BankAccLedgEntry3);
+                                GenJnlLine2.Validate(Amount, -BankAccLedgEntry3.Amount);
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                GenJnlLine2."Shortcut Dimension 1 Code" := BankAccLedgEntry3."Global Dimension 1 Code";
+                                GenJnlLine2."Shortcut Dimension 2 Code" := BankAccLedgEntry3."Global Dimension 2 Code";
+                                GenJnlLine2."Dimension Set ID" := BankAccLedgEntry3."Dimension Set ID";
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until BankAccLedgEntry3.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::"Fixed Asset":
+                    begin
+                        FALedgEntry.SetCurrentKey(FALedgEntry."Transaction No.");
+                        FALedgEntry.SetRange(FALedgEntry."Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        FALedgEntry.SetRange(FALedgEntry."Document No.", BankAccLedgEntry2."Document No.");
+                        FALedgEntry.SetRange(FALedgEntry."Posting Date", BankAccLedgEntry2."Posting Date");
+                        if FALedgEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostFixedAsset(GenJnlLine2, FALedgEntry);
+                                GenJnlLine2.Validate(Amount, -FALedgEntry.Amount);
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                GenJnlLine2."Shortcut Dimension 1 Code" := FALedgEntry."Global Dimension 1 Code";
+                                GenJnlLine2."Shortcut Dimension 2 Code" := FALedgEntry."Global Dimension 2 Code";
+                                GenJnlLine2."Dimension Set ID" := FALedgEntry."Dimension Set ID";
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until FALedgEntry.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::Employee:
+                    begin
+                        if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                            if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                                GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
+                        EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
+                        EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        EmployeeLedgerEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        EmployeeLedgerEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        if EmployeeLedgerEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostEmp(GenJnlLine2, EmployeeLedgerEntry);
+                                EmployeeLedgerEntry.CalcFields(EmployeeLedgerEntry."Original Amount");
+                                SetGenJnlLine(
+                                  GenJnlLine2, -EmployeeLedgerEntry."Original Amount", EmployeeLedgerEntry."Currency Code", CheckLedgEntry."Document No.",
+                                  EmployeeLedgerEntry."Global Dimension 1 Code", EmployeeLedgerEntry."Global Dimension 2 Code", EmployeeLedgerEntry."Dimension Set ID");
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until EmployeeLedgerEntry.Next() = 0;
+                    end;
+                else begin
+                    GenJnlLine2."Bal. Account Type" := CheckLedgEntry."Bal. Account Type";
+                    GenJnlLine2.Validate("Bal. Account No.", CheckLedgEntry."Bal. Account No.");
+                    GenJnlLine2."Shortcut Dimension 1 Code" := '';
+                    GenJnlLine2."Shortcut Dimension 2 Code" := '';
+                    GenJnlLine2."Dimension Set ID" := 0;
+                    GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                    GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                    OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                    GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                    OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
                 end;
-            CheckLedgEntry."Bal. Account Type"::"Bank Account":
-                begin
-                    BankAccLedgEntry3.SetCurrentKey(BankAccLedgEntry3."Transaction No.");
-                    BankAccLedgEntry3.SetRange(BankAccLedgEntry3."Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    BankAccLedgEntry3.SetRange(BankAccLedgEntry3."Document No.", BankAccLedgEntry2."Document No.");
-                    BankAccLedgEntry3.SetRange(BankAccLedgEntry3."Posting Date", BankAccLedgEntry2."Posting Date");
-                    BankAccLedgEntry3.SetFilter(BankAccLedgEntry3."Entry No.", '<>%1', BankAccLedgEntry2."Entry No.");
-                    if BankAccLedgEntry3.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostBankAccount(GenJnlLine2, BankAccLedgEntry3);
-                            GenJnlLine2.Validate(Amount, -BankAccLedgEntry3.Amount);
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            GenJnlLine2."Shortcut Dimension 1 Code" := BankAccLedgEntry3."Global Dimension 1 Code";
-                            GenJnlLine2."Shortcut Dimension 2 Code" := BankAccLedgEntry3."Global Dimension 2 Code";
-                            GenJnlLine2."Dimension Set ID" := BankAccLedgEntry3."Dimension Set ID";
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until BankAccLedgEntry3.Next() = 0;
-                end;
-            CheckLedgEntry."Bal. Account Type"::"Fixed Asset":
-                begin
-                    FALedgEntry.SetCurrentKey(FALedgEntry."Transaction No.");
-                    FALedgEntry.SetRange(FALedgEntry."Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    FALedgEntry.SetRange(FALedgEntry."Document No.", BankAccLedgEntry2."Document No.");
-                    FALedgEntry.SetRange(FALedgEntry."Posting Date", BankAccLedgEntry2."Posting Date");
-                    if FALedgEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostFixedAsset(GenJnlLine2, FALedgEntry);
-                            GenJnlLine2.Validate(Amount, -FALedgEntry.Amount);
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            GenJnlLine2."Shortcut Dimension 1 Code" := FALedgEntry."Global Dimension 1 Code";
-                            GenJnlLine2."Shortcut Dimension 2 Code" := FALedgEntry."Global Dimension 2 Code";
-                            GenJnlLine2."Dimension Set ID" := FALedgEntry."Dimension Set ID";
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until FALedgEntry.Next() = 0;
-                end;
-            CheckLedgEntry."Bal. Account Type"::Employee:
-                begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
-                            GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
-                    EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
-                    EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    EmployeeLedgerEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    EmployeeLedgerEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    if EmployeeLedgerEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostEmp(GenJnlLine2, EmployeeLedgerEntry);
-                            EmployeeLedgerEntry.CalcFields(EmployeeLedgerEntry."Original Amount");
-                            SetGenJnlLine(
-                              GenJnlLine2, -EmployeeLedgerEntry."Original Amount", EmployeeLedgerEntry."Currency Code", CheckLedgEntry."Document No.",
-                              EmployeeLedgerEntry."Global Dimension 1 Code", EmployeeLedgerEntry."Global Dimension 2 Code", EmployeeLedgerEntry."Dimension Set ID");
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until EmployeeLedgerEntry.Next() = 0;
-                end;
-            else begin
-                GenJnlLine2."Bal. Account Type" := CheckLedgEntry."Bal. Account Type";
-                GenJnlLine2.Validate("Bal. Account No.", CheckLedgEntry."Bal. Account No.");
-                GenJnlLine2."Shortcut Dimension 1 Code" := '';
-                GenJnlLine2."Shortcut Dimension 2 Code" := '';
-                GenJnlLine2."Dimension Set ID" := 0;
-                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
             end;
-        end;
 
         if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
             BankAccLedgEntry2.Open := false;

--- a/src/Layers/RU/BaseApp/Bank/Check/CheckManagement.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Bank/Check/CheckManagement.Codeunit.al
@@ -268,154 +268,154 @@ codeunit 367 CheckManagement
         IsHandled := false;
         OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
         if not IsHandled then
-        case CheckLedgEntry."Bal. Account Type" of
-            CheckLedgEntry."Bal. Account Type"::"G/L Account":
-                FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
-            CheckLedgEntry."Bal. Account Type"::Customer:
-                begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
-                        if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
-                            GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
-                    CustLedgEntry.SetCurrentKey("Transaction No.");
-                    CustLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    CustLedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    CustLedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    if CustLedgEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostCust(GenJnlLine2, CustLedgEntry, BalanceAmountLCY);
-                            GenJnlLine2."Agreement No." := CustLedgEntry."Agreement No.";
-                            CustLedgEntry.CalcFields("Original Amount");
-                            SetGenJnlLine(
-                              GenJnlLine2, -CustLedgEntry."Original Amount", CustLedgEntry."Currency Code", CheckLedgEntry."Document No.",
-                              CustLedgEntry."Global Dimension 1 Code", CustLedgEntry."Global Dimension 2 Code", CustLedgEntry."Dimension Set ID");
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            GenJnlLine2.Prepayment := CustLedgEntry.Prepayment;
-                            if GLSetup."Void Payment as Correction" then
-                                GenJnlLine2.Validate(Correction, true);
-                            GenJnlLine2."Agreement No." := CustLedgEntry."Agreement No.";
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until CustLedgEntry.Next() = 0;
+            case CheckLedgEntry."Bal. Account Type" of
+                CheckLedgEntry."Bal. Account Type"::"G/L Account":
+                    FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
+                CheckLedgEntry."Bal. Account Type"::Customer:
+                    begin
+                        if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
+                            if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                                GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
+                        CustLedgEntry.SetCurrentKey("Transaction No.");
+                        CustLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        CustLedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        CustLedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        if CustLedgEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostCust(GenJnlLine2, CustLedgEntry, BalanceAmountLCY);
+                                GenJnlLine2."Agreement No." := CustLedgEntry."Agreement No.";
+                                CustLedgEntry.CalcFields("Original Amount");
+                                SetGenJnlLine(
+                                  GenJnlLine2, -CustLedgEntry."Original Amount", CustLedgEntry."Currency Code", CheckLedgEntry."Document No.",
+                                  CustLedgEntry."Global Dimension 1 Code", CustLedgEntry."Global Dimension 2 Code", CustLedgEntry."Dimension Set ID");
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                GenJnlLine2.Prepayment := CustLedgEntry.Prepayment;
+                                if GLSetup."Void Payment as Correction" then
+                                    GenJnlLine2.Validate(Correction, true);
+                                GenJnlLine2."Agreement No." := CustLedgEntry."Agreement No.";
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until CustLedgEntry.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::Vendor:
+                    begin
+                        if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                            if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                                GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
+                        VendorLedgEntry.SetCurrentKey("Transaction No.");
+                        VendorLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        VendorLedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        VendorLedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        OnFinancialVoidCheckOnAfterVendorLedgEntrySetFilters(VendorLedgEntry, BankAccLedgEntry2);
+                        if VendorLedgEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostVend(GenJnlLine2, VendorLedgEntry, BalanceAmountLCY);
+                                GenJnlLine2."Agreement No." := VendorLedgEntry."Agreement No.";
+                                VendorLedgEntry.CalcFields("Original Amount");
+                                SetGenJnlLine(
+                                  GenJnlLine2, -VendorLedgEntry."Original Amount", VendorLedgEntry."Currency Code", CheckLedgEntry."Document No.",
+                                  VendorLedgEntry."Global Dimension 1 Code", VendorLedgEntry."Global Dimension 2 Code", VendorLedgEntry."Dimension Set ID");
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                GenJnlLine2.Prepayment := VendorLedgEntry.Prepayment;
+                                if GLSetup."Void Payment as Correction" then
+                                    GenJnlLine2.Validate(Correction, true);
+                                GenJnlLine2."Agreement No." := VendorLedgEntry."Agreement No.";
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                if GenJnlLine2."Posting Group" <> VendorLedgEntry."Vendor Posting Group" then
+                                    GenJnlLine2."Posting Group" := VendorLedgEntry."Vendor Posting Group";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until VendorLedgEntry.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::"Bank Account":
+                    begin
+                        BankAccLedgEntry3.SetCurrentKey("Transaction No.");
+                        BankAccLedgEntry3.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        BankAccLedgEntry3.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        BankAccLedgEntry3.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        BankAccLedgEntry3.SetFilter("Entry No.", '<>%1', BankAccLedgEntry2."Entry No.");
+                        if BankAccLedgEntry3.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostBankAccount(GenJnlLine2, BankAccLedgEntry3);
+                                GenJnlLine2.Validate(Amount, -BankAccLedgEntry3.Amount);
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                if GLSetup."Void Payment as Correction" then
+                                    GenJnlLine2.Validate(Correction, true);
+                                GenJnlLine2."Shortcut Dimension 1 Code" := BankAccLedgEntry3."Global Dimension 1 Code";
+                                GenJnlLine2."Shortcut Dimension 2 Code" := BankAccLedgEntry3."Global Dimension 2 Code";
+                                GenJnlLine2."Dimension Set ID" := BankAccLedgEntry3."Dimension Set ID";
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until BankAccLedgEntry3.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::"Fixed Asset":
+                    begin
+                        FALedgEntry.SetCurrentKey("Transaction No.");
+                        FALedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        FALedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        FALedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        if FALedgEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostFixedAsset(GenJnlLine2, FALedgEntry);
+                                GenJnlLine2.Validate(Amount, -FALedgEntry.Amount);
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                if GLSetup."Void Payment as Correction" then
+                                    GenJnlLine2.Validate(Correction, true);
+                                GenJnlLine2."Shortcut Dimension 1 Code" := FALedgEntry."Global Dimension 1 Code";
+                                GenJnlLine2."Shortcut Dimension 2 Code" := FALedgEntry."Global Dimension 2 Code";
+                                GenJnlLine2."Dimension Set ID" := FALedgEntry."Dimension Set ID";
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until FALedgEntry.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::Employee:
+                    begin
+                        if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                            if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                                GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
+                        EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
+                        EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        EmployeeLedgerEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        EmployeeLedgerEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        if EmployeeLedgerEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostEmp(GenJnlLine2, EmployeeLedgerEntry);
+                                EmployeeLedgerEntry.CalcFields("Original Amount");
+                                SetGenJnlLine(
+                                  GenJnlLine2, -EmployeeLedgerEntry."Original Amount", EmployeeLedgerEntry."Currency Code", CheckLedgEntry."Document No.",
+                                  EmployeeLedgerEntry."Global Dimension 1 Code", EmployeeLedgerEntry."Global Dimension 2 Code", EmployeeLedgerEntry."Dimension Set ID");
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until EmployeeLedgerEntry.Next() = 0;
+                    end;
+                else begin
+                    GenJnlLine2."Bal. Account Type" := CheckLedgEntry."Bal. Account Type";
+                    GenJnlLine2.Validate("Bal. Account No.", CheckLedgEntry."Bal. Account No.");
+                    GenJnlLine2."Shortcut Dimension 1 Code" := '';
+                    GenJnlLine2."Shortcut Dimension 2 Code" := '';
+                    GenJnlLine2."Dimension Set ID" := 0;
+                    GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                    GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                    OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                    GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                    OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
                 end;
-            CheckLedgEntry."Bal. Account Type"::Vendor:
-                begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
-                            GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
-                    VendorLedgEntry.SetCurrentKey("Transaction No.");
-                    VendorLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    VendorLedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    VendorLedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    OnFinancialVoidCheckOnAfterVendorLedgEntrySetFilters(VendorLedgEntry, BankAccLedgEntry2);
-                    if VendorLedgEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostVend(GenJnlLine2, VendorLedgEntry, BalanceAmountLCY);
-                            GenJnlLine2."Agreement No." := VendorLedgEntry."Agreement No.";
-                            VendorLedgEntry.CalcFields("Original Amount");
-                            SetGenJnlLine(
-                              GenJnlLine2, -VendorLedgEntry."Original Amount", VendorLedgEntry."Currency Code", CheckLedgEntry."Document No.",
-                              VendorLedgEntry."Global Dimension 1 Code", VendorLedgEntry."Global Dimension 2 Code", VendorLedgEntry."Dimension Set ID");
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            GenJnlLine2.Prepayment := VendorLedgEntry.Prepayment;
-                            if GLSetup."Void Payment as Correction" then
-                                GenJnlLine2.Validate(Correction, true);
-                            GenJnlLine2."Agreement No." := VendorLedgEntry."Agreement No.";
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            if GenJnlLine2."Posting Group" <> VendorLedgEntry."Vendor Posting Group" then
-                                GenJnlLine2."Posting Group" := VendorLedgEntry."Vendor Posting Group";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until VendorLedgEntry.Next() = 0;
-                end;
-            CheckLedgEntry."Bal. Account Type"::"Bank Account":
-                begin
-                    BankAccLedgEntry3.SetCurrentKey("Transaction No.");
-                    BankAccLedgEntry3.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    BankAccLedgEntry3.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    BankAccLedgEntry3.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    BankAccLedgEntry3.SetFilter("Entry No.", '<>%1', BankAccLedgEntry2."Entry No.");
-                    if BankAccLedgEntry3.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostBankAccount(GenJnlLine2, BankAccLedgEntry3);
-                            GenJnlLine2.Validate(Amount, -BankAccLedgEntry3.Amount);
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            if GLSetup."Void Payment as Correction" then
-                                GenJnlLine2.Validate(Correction, true);
-                            GenJnlLine2."Shortcut Dimension 1 Code" := BankAccLedgEntry3."Global Dimension 1 Code";
-                            GenJnlLine2."Shortcut Dimension 2 Code" := BankAccLedgEntry3."Global Dimension 2 Code";
-                            GenJnlLine2."Dimension Set ID" := BankAccLedgEntry3."Dimension Set ID";
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until BankAccLedgEntry3.Next() = 0;
-                end;
-            CheckLedgEntry."Bal. Account Type"::"Fixed Asset":
-                begin
-                    FALedgEntry.SetCurrentKey("Transaction No.");
-                    FALedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    FALedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    FALedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    if FALedgEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostFixedAsset(GenJnlLine2, FALedgEntry);
-                            GenJnlLine2.Validate(Amount, -FALedgEntry.Amount);
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            if GLSetup."Void Payment as Correction" then
-                                GenJnlLine2.Validate(Correction, true);
-                            GenJnlLine2."Shortcut Dimension 1 Code" := FALedgEntry."Global Dimension 1 Code";
-                            GenJnlLine2."Shortcut Dimension 2 Code" := FALedgEntry."Global Dimension 2 Code";
-                            GenJnlLine2."Dimension Set ID" := FALedgEntry."Dimension Set ID";
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until FALedgEntry.Next() = 0;
-                end;
-            CheckLedgEntry."Bal. Account Type"::Employee:
-                begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
-                            GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
-                    EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
-                    EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    EmployeeLedgerEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    EmployeeLedgerEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    if EmployeeLedgerEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostEmp(GenJnlLine2, EmployeeLedgerEntry);
-                            EmployeeLedgerEntry.CalcFields("Original Amount");
-                            SetGenJnlLine(
-                              GenJnlLine2, -EmployeeLedgerEntry."Original Amount", EmployeeLedgerEntry."Currency Code", CheckLedgEntry."Document No.",
-                              EmployeeLedgerEntry."Global Dimension 1 Code", EmployeeLedgerEntry."Global Dimension 2 Code", EmployeeLedgerEntry."Dimension Set ID");
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until EmployeeLedgerEntry.Next() = 0;
-                end;
-            else begin
-                GenJnlLine2."Bal. Account Type" := CheckLedgEntry."Bal. Account Type";
-                GenJnlLine2.Validate("Bal. Account No.", CheckLedgEntry."Bal. Account No.");
-                GenJnlLine2."Shortcut Dimension 1 Code" := '';
-                GenJnlLine2."Shortcut Dimension 2 Code" := '';
-                GenJnlLine2."Dimension Set ID" := 0;
-                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
             end;
-        end;
 
         if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
             BankAccLedgEntry2.Open := false;

--- a/src/Layers/W1/BaseApp/Bank/Check/CheckManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Bank/Check/CheckManagement.Codeunit.al
@@ -255,140 +255,140 @@ codeunit 367 CheckManagement
         IsHandled := false;
         OnFinancialVoidCheckOnBeforeCheckBalAccountType(GenJnlLine2, CheckLedgEntry, BankAccLedgEntry3, BalanceAmountLCY, IsHandled);
         if not IsHandled then
-        case CheckLedgEntry."Bal. Account Type" of
-            CheckLedgEntry."Bal. Account Type"::"G/L Account":
-                FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
-            CheckLedgEntry."Bal. Account Type"::Customer:
-                begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
-                        if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
-                            GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
-                    CustLedgEntry.SetCurrentKey("Transaction No.");
-                    CustLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    CustLedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    CustLedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    if CustLedgEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostCust(GenJnlLine2, CustLedgEntry, BalanceAmountLCY);
-                            CustLedgEntry.CalcFields("Original Amount");
-                            SetGenJnlLine(
-                              GenJnlLine2, -CustLedgEntry."Original Amount", CustLedgEntry."Currency Code", CheckLedgEntry."Document No.",
-                              CustLedgEntry."Global Dimension 1 Code", CustLedgEntry."Global Dimension 2 Code", CustLedgEntry."Dimension Set ID");
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until CustLedgEntry.Next() = 0;
+            case CheckLedgEntry."Bal. Account Type" of
+                CheckLedgEntry."Bal. Account Type"::"G/L Account":
+                    FinancialVoidPostGLAccount(GenJnlLine2, BankAccLedgEntry2, CheckLedgEntry, BalanceAmountLCY);
+                CheckLedgEntry."Bal. Account Type"::Customer:
+                    begin
+                        if ConfirmFinancialVoid.GetVoidType() = 0 then   // Unapply entry
+                            if UnApplyCustInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                                GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
+                        CustLedgEntry.SetCurrentKey("Transaction No.");
+                        CustLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        CustLedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        CustLedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        if CustLedgEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostCust(GenJnlLine2, CustLedgEntry, BalanceAmountLCY);
+                                CustLedgEntry.CalcFields("Original Amount");
+                                SetGenJnlLine(
+                                  GenJnlLine2, -CustLedgEntry."Original Amount", CustLedgEntry."Currency Code", CheckLedgEntry."Document No.",
+                                  CustLedgEntry."Global Dimension 1 Code", CustLedgEntry."Global Dimension 2 Code", CustLedgEntry."Dimension Set ID");
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until CustLedgEntry.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::Vendor:
+                    begin
+                        if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                            if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                                GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
+                        VendorLedgEntry.SetCurrentKey("Transaction No.");
+                        VendorLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        VendorLedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        VendorLedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        OnFinancialVoidCheckOnAfterVendorLedgEntrySetFilters(VendorLedgEntry, BankAccLedgEntry2);
+                        if VendorLedgEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostVend(GenJnlLine2, VendorLedgEntry, BalanceAmountLCY);
+                                VendorLedgEntry.CalcFields("Original Amount");
+                                SetGenJnlLine(
+                                  GenJnlLine2, -VendorLedgEntry."Original Amount", VendorLedgEntry."Currency Code", CheckLedgEntry."Document No.",
+                                  VendorLedgEntry."Global Dimension 1 Code", VendorLedgEntry."Global Dimension 2 Code", VendorLedgEntry."Dimension Set ID");
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                if GenJnlLine2."Posting Group" <> VendorLedgEntry."Vendor Posting Group" then
+                                    GenJnlLine2."Posting Group" := VendorLedgEntry."Vendor Posting Group";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until VendorLedgEntry.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::"Bank Account":
+                    begin
+                        BankAccLedgEntry3.SetCurrentKey("Transaction No.");
+                        BankAccLedgEntry3.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        BankAccLedgEntry3.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        BankAccLedgEntry3.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        BankAccLedgEntry3.SetFilter("Entry No.", '<>%1', BankAccLedgEntry2."Entry No.");
+                        if BankAccLedgEntry3.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostBankAccount(GenJnlLine2, BankAccLedgEntry3);
+                                GenJnlLine2.Validate(Amount, -BankAccLedgEntry3.Amount);
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                GenJnlLine2."Shortcut Dimension 1 Code" := BankAccLedgEntry3."Global Dimension 1 Code";
+                                GenJnlLine2."Shortcut Dimension 2 Code" := BankAccLedgEntry3."Global Dimension 2 Code";
+                                GenJnlLine2."Dimension Set ID" := BankAccLedgEntry3."Dimension Set ID";
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until BankAccLedgEntry3.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::"Fixed Asset":
+                    begin
+                        FALedgEntry.SetCurrentKey("Transaction No.");
+                        FALedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        FALedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        FALedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        if FALedgEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostFixedAsset(GenJnlLine2, FALedgEntry);
+                                GenJnlLine2.Validate(Amount, -FALedgEntry.Amount);
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                GenJnlLine2."Shortcut Dimension 1 Code" := FALedgEntry."Global Dimension 1 Code";
+                                GenJnlLine2."Shortcut Dimension 2 Code" := FALedgEntry."Global Dimension 2 Code";
+                                GenJnlLine2."Dimension Set ID" := FALedgEntry."Dimension Set ID";
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until FALedgEntry.Next() = 0;
+                    end;
+                CheckLedgEntry."Bal. Account Type"::Employee:
+                    begin
+                        if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
+                            if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
+                                GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
+                        EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
+                        EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
+                        EmployeeLedgerEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
+                        EmployeeLedgerEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
+                        if EmployeeLedgerEntry.FindSet() then
+                            repeat
+                                OnFinancialVoidCheckOnBeforePostEmp(GenJnlLine2, EmployeeLedgerEntry);
+                                EmployeeLedgerEntry.CalcFields("Original Amount");
+                                SetGenJnlLine(
+                                  GenJnlLine2, -EmployeeLedgerEntry."Original Amount", EmployeeLedgerEntry."Currency Code", CheckLedgEntry."Document No.",
+                                  EmployeeLedgerEntry."Global Dimension 1 Code", EmployeeLedgerEntry."Global Dimension 2 Code", EmployeeLedgerEntry."Dimension Set ID");
+                                BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
+                                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                                GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
+                            until EmployeeLedgerEntry.Next() = 0;
+                    end;
+                else begin
+                    GenJnlLine2."Bal. Account Type" := CheckLedgEntry."Bal. Account Type";
+                    GenJnlLine2.Validate("Bal. Account No.", CheckLedgEntry."Bal. Account No.");
+                    GenJnlLine2."Shortcut Dimension 1 Code" := '';
+                    GenJnlLine2."Shortcut Dimension 2 Code" := '';
+                    GenJnlLine2."Dimension Set ID" := 0;
+                    GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
+                    GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
+                    OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
+                    GenJnlPostLine.RunWithCheck(GenJnlLine2);
+                    OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
                 end;
-            CheckLedgEntry."Bal. Account Type"::Vendor:
-                begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyVendInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
-                            GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
-                    VendorLedgEntry.SetCurrentKey("Transaction No.");
-                    VendorLedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    VendorLedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    VendorLedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    OnFinancialVoidCheckOnAfterVendorLedgEntrySetFilters(VendorLedgEntry, BankAccLedgEntry2);
-                    if VendorLedgEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostVend(GenJnlLine2, VendorLedgEntry, BalanceAmountLCY);
-                            VendorLedgEntry.CalcFields("Original Amount");
-                            SetGenJnlLine(
-                              GenJnlLine2, -VendorLedgEntry."Original Amount", VendorLedgEntry."Currency Code", CheckLedgEntry."Document No.",
-                              VendorLedgEntry."Global Dimension 1 Code", VendorLedgEntry."Global Dimension 2 Code", VendorLedgEntry."Dimension Set ID");
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            if GenJnlLine2."Posting Group" <> VendorLedgEntry."Vendor Posting Group" then
-                                GenJnlLine2."Posting Group" := VendorLedgEntry."Vendor Posting Group";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until VendorLedgEntry.Next() = 0;
-                end;
-            CheckLedgEntry."Bal. Account Type"::"Bank Account":
-                begin
-                    BankAccLedgEntry3.SetCurrentKey("Transaction No.");
-                    BankAccLedgEntry3.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    BankAccLedgEntry3.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    BankAccLedgEntry3.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    BankAccLedgEntry3.SetFilter("Entry No.", '<>%1', BankAccLedgEntry2."Entry No.");
-                    if BankAccLedgEntry3.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostBankAccount(GenJnlLine2, BankAccLedgEntry3);
-                            GenJnlLine2.Validate(Amount, -BankAccLedgEntry3.Amount);
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            GenJnlLine2."Shortcut Dimension 1 Code" := BankAccLedgEntry3."Global Dimension 1 Code";
-                            GenJnlLine2."Shortcut Dimension 2 Code" := BankAccLedgEntry3."Global Dimension 2 Code";
-                            GenJnlLine2."Dimension Set ID" := BankAccLedgEntry3."Dimension Set ID";
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until BankAccLedgEntry3.Next() = 0;
-                end;
-            CheckLedgEntry."Bal. Account Type"::"Fixed Asset":
-                begin
-                    FALedgEntry.SetCurrentKey("Transaction No.");
-                    FALedgEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    FALedgEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    FALedgEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    if FALedgEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostFixedAsset(GenJnlLine2, FALedgEntry);
-                            GenJnlLine2.Validate(Amount, -FALedgEntry.Amount);
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            GenJnlLine2."Shortcut Dimension 1 Code" := FALedgEntry."Global Dimension 1 Code";
-                            GenJnlLine2."Shortcut Dimension 2 Code" := FALedgEntry."Global Dimension 2 Code";
-                            GenJnlLine2."Dimension Set ID" := FALedgEntry."Dimension Set ID";
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until FALedgEntry.Next() = 0;
-                end;
-            CheckLedgEntry."Bal. Account Type"::Employee:
-                begin
-                    if ConfirmFinancialVoid.GetVoidType() = 0 then // Unapply entry
-                        if UnApplyEmpInvoices(CheckLedgEntry, ConfirmFinancialVoid.GetVoidDate()) then
-                            GenJnlLine2."Applies-to ID" := CheckLedgEntry."Document No.";
-                    EmployeeLedgerEntry.SetCurrentKey("Transaction No.");
-                    EmployeeLedgerEntry.SetRange("Transaction No.", BankAccLedgEntry2."Transaction No.");
-                    EmployeeLedgerEntry.SetRange("Document No.", BankAccLedgEntry2."Document No.");
-                    EmployeeLedgerEntry.SetRange("Posting Date", BankAccLedgEntry2."Posting Date");
-                    if EmployeeLedgerEntry.FindSet() then
-                        repeat
-                            OnFinancialVoidCheckOnBeforePostEmp(GenJnlLine2, EmployeeLedgerEntry);
-                            EmployeeLedgerEntry.CalcFields("Original Amount");
-                            SetGenJnlLine(
-                              GenJnlLine2, -EmployeeLedgerEntry."Original Amount", EmployeeLedgerEntry."Currency Code", CheckLedgEntry."Document No.",
-                              EmployeeLedgerEntry."Global Dimension 1 Code", EmployeeLedgerEntry."Global Dimension 2 Code", EmployeeLedgerEntry."Dimension Set ID");
-                            BalanceAmountLCY := BalanceAmountLCY + GenJnlLine2."Amount (LCY)";
-                            OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                            GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                            GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                            GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                            OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
-                        until EmployeeLedgerEntry.Next() = 0;
-                end;
-            else begin
-                GenJnlLine2."Bal. Account Type" := CheckLedgEntry."Bal. Account Type";
-                GenJnlLine2.Validate("Bal. Account No.", CheckLedgEntry."Bal. Account No.");
-                GenJnlLine2."Shortcut Dimension 1 Code" := '';
-                GenJnlLine2."Shortcut Dimension 2 Code" := '';
-                GenJnlLine2."Dimension Set ID" := 0;
-                GenJnlLine2."Journal Template Name" := BankAccLedgEntry2."Journal Templ. Name";
-                GenJnlLine2."Journal Batch Name" := BankAccLedgEntry2."Journal Batch Name";
-                OnFinancialVoidCheckOnBeforePostBalAccLine(GenJnlLine2, CheckLedgEntry);
-                GenJnlPostLine.RunWithCheck(GenJnlLine2);
-                OnFinancialVoidCheckOnAfterPostBalAccLine(GenJnlLine2, CheckLedgEntry, GenJnlPostLine);
             end;
-        end;
 
         if ConfirmFinancialVoid.GetVoidDate() = CheckLedgEntry."Check Date" then begin
             BankAccLedgEntry2.Open := false;


### PR DESCRIPTION
## What & why

Small formatting follow up to #9421. In FinancialVoidCheck the case block runs under `if not IsHandled then` but was left at the same indentation as the guard. This indents the whole case block one level so it reads correctly. Pure whitespace, no behavior change.

## Linked work

[AB#640242](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640242)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] The change is whitespace only, git diff --ignore-all-space is empty.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.

**What I tested and the outcome**

- Confirmed the diff is pure reindentation of the case block in all four layers (APAC, NA, RU, W1). No logic touched.

## Risk & compatibility

None. Reindentation only, no code changes.


