### PR TITLE
[BC14] Harden upgrade start: run synchronously when TaskScheduler is unavailable (Bug 642739)

### DIFF
--- a/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14MigrationOrchestrator.codeunit.al
+++ b/src/Apps/W1/HybridBC14/app/src/Orchestration/BC14MigrationOrchestrator.codeunit.al
@@ -42,8 +42,8 @@ codeunit 46862 "BC14 Migration Orchestrator"
         OneStepUpgradeFailedLbl: Label 'One Step Upgrade scheduling failed in webhook: %1. The user can start the upgrade manually.', Locked = true, Comment = '%1 = Error text';
         InvokeUpgradeInProcessLbl: Label 'InvokeCompanyUpgrade: running upgrade in-process for company %1 (session creation suppressed by subscriber).', Locked = true, Comment = '%1 = Company Name';
         InvokeUpgradeScheduledTaskLbl: Label 'InvokeCompanyUpgrade: scheduled background task for company %1 with delay %2.', Locked = true, Comment = '%1 = Company Name, %2 = Delay duration';
-        InvokeUpgradeStartSessionLbl: Label 'InvokeCompanyUpgrade: TaskScheduler unavailable; falling back to Session.StartSession for company %1.', Locked = true, Comment = '%1 = Company Name';
-        InvokeUpgradeStartSessionFallbackMsg: Label 'The background task scheduler is busy. The upgrade will start in a separate session and may take a moment to begin.';
+        InvokeUpgradeStartSessionLbl: Label 'InvokeCompanyUpgrade: TaskScheduler unavailable; running the upgrade synchronously in the current session for company %1.', Locked = true, Comment = '%1 = Company Name';
+        InvokeUpgradeStartSessionFallbackMsg: Label 'The background task scheduler is busy. The upgrade is running in the current session and may take a few minutes to complete.';
 
     #region Orchestrator
 
@@ -156,7 +156,6 @@ codeunit 46862 "BC14 Migration Orchestrator"
     internal procedure InvokeCompanyUpgrade(var HybridReplicationSummary: Record "Hybrid Replication Summary"; CompanyName: Text[50]; DelayUpgrade: Duration)
     var
         BC14StatusMgr: Codeunit "BC14 Migration Status Mgr.";
-        SessionID: Integer;
         RunSynchronously: Boolean;
     begin
         if DelayUpgrade = 0 then
@@ -179,9 +178,15 @@ codeunit 46862 "BC14 Migration Orchestrator"
             TaskScheduler.CreateTask(
                 Codeunit::"BC14 Company Upgrade Task", Codeunit::"BC14 Migration Failure Handler", true, CompanyName, CurrentDateTime() + DelayUpgrade, HybridReplicationSummary.RecordId, GetDefaultJobTimeout());
         end else begin
+            // TaskScheduler is unavailable. Session.StartSession has no failure codeunit, so if the
+            // spawned session crashed the company would be left stuck in Started with no running
+            // task/session and nothing to recover it (Bug 642739). Run the upgrade synchronously in
+            // the current session instead — the same hardening the Historical dispatch fallback
+            // already uses — so any failure surfaces to the caller and the "BC14 Company Upgrade
+            // Task" marks the company Failed rather than orphaning it in Started.
             Session.LogMessage('0000TXC', StrSubstNo(InvokeUpgradeStartSessionLbl, CompanyName), Verbosity::Warning, DataClassification::OrganizationIdentifiableInformation, TelemetryScope::ExtensionPublisher, 'Category', BC14Telemetry.GetCategory());
             BC14StatusMgr.UpdateCompanyMessage(CopyStr(CompanyName, 1, 30), InvokeUpgradeStartSessionFallbackMsg);
-            Session.StartSession(SessionID, Codeunit::"BC14 Company Upgrade Task", CompanyName, HybridReplicationSummary, GetDefaultJobTimeout());
+            Codeunit.Run(Codeunit::"BC14 Company Upgrade Task", HybridReplicationSummary);
         end;
     end;
 


### PR DESCRIPTION
## What & why

During BC14 cloud migration a company could get stuck in **Upgrade Status = Started** with no running task/session and no way to recover short of a manual database edit (Bug 642739).

Root cause is the fallback path in `BC14 Migration Orchestrator.InvokeCompanyUpgrade`. When `TaskScheduler.CanCreateTask()` is `false`, the company is already marked Started (that transition happens inside `BC14 Company Upgrade Task.OnRun`, so a company only reaches Started once the task/session is actually running). The fallback then started the work with `Session.StartSession`, which — unlike `TaskScheduler.CreateTask` — has **no failure codeunit**. If that spawned session crashed, nothing ran `BC14 Migration Failure Handler`, so the company was orphaned in Started forever. This is the only start path that reaches Started without a failure handler behind it; the two `CreateTask` paths and the Historical dispatch fallback are already covered.

**Fix:** run the upgrade **synchronously** via `Codeunit.Run` in that fallback — the exact hardening the Historical dispatch fallback in `BC14 Migration Runner` already applies for the same reason. Any failure now surfaces to the caller and `BC14 Company Upgrade Task` marks the company **Failed**, so it can be resumed with **Continue migration** instead of being stuck. Also removed the now-unused `SessionID` local and corrected the telemetry/user-facing messages (the fallback no longer starts a separate session).

Net change: one file, ~3 lines of logic (plus a comment).

## Linked work

[AB#642739](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642739)

<!-- Internal BC14 reimplementation preview work item tracked in ADO; there is no public GitHub issue. -->

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior.

**What I tested and the outcome**

- The fallback now reuses the same `Codeunit.Run(Codeunit::"BC14 Company Upgrade Task", HybridReplicationSummary)` call that the existing synchronous branch (`RunSynchronously`) already uses and that the migration-flow tests exercise, so its success/failure behavior is already covered. I deliberately did **not** add a bespoke test that forces `TaskScheduler.CanCreateTask() = false`, since that platform condition can't be simulated reliably without adding a test-only seam — which would be more machinery than the fix itself.
- **Not built/run locally:** this is the first-party v29 app (runtime 18) and my local toolchain only has the AL 18 compiler with no v29 symbols, so I could not compile it here. Relying on CI to compile and run the suite — opened as draft for that reason.

## Risk & compatibility

- **No new fields, codeunits, pages, or telemetry ids.** Behavioral change confined to one already-degraded branch (`TaskScheduler` unavailable).
- In that branch the upgrade now runs **in the caller's session** instead of a spawned one, so it can block the caller until the company finishes — but this only happens when the task scheduler is unavailable (a rare degraded state), the existing `RunSynchronously` branch already runs in-process, and a surfaced error is strictly better than a silent stuck-in-Started company.


