### PR TITLE
[28.x] Fix VariantCode lost during Contract Price Update proposal

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Base/Codeunits/SubContractsItemManagement.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Base/Codeunits/SubContractsItemManagement.Codeunit.al
@@ -159,12 +159,7 @@ codeunit 8055 "Sub. Contracts Item Management"
 
     internal procedure CreateTempSalesLine(var TempSalesLine: Record "Sales Line" temporary; var TempSalesHeader: Record "Sales Header" temporary; ServiceObject: Record "Subscription Header"; OrderDate: Date)
     begin
-        CreateTempSalesLine(TempSalesLine, TempSalesHeader, ServiceObject.Type, ServiceObject."Source No.", ServiceObject.Quantity, OrderDate);
-    end;
-
-    local procedure CreateTempSalesLine(var TempSalesLine: Record "Sales Line" temporary; var TempSalesHeader: Record "Sales Header" temporary; ServiceObjectType: enum "Service Object Type"; SourceNo: Code[20]; Quantity: Decimal; OrderDate: Date)
-    begin
-        CreateTempSalesLine(TempSalesLine, TempSalesHeader, ServiceObjectType, SourceNo, Quantity, OrderDate, '');
+        CreateTempSalesLine(TempSalesLine, TempSalesHeader, ServiceObject.Type, ServiceObject."Source No.", ServiceObject.Quantity, OrderDate, ServiceObject."Variant Code");
     end;
 
     internal procedure CreateTempSalesLine(var TempSalesLine: Record "Sales Line" temporary; var TempSalesHeader: Record "Sales Header" temporary; ServiceObjectType: enum "Service Object Type"; SourceNo: Code[20]; Quantity: Decimal; OrderDate: Date; VariantCode: Code[10])
@@ -228,12 +223,7 @@ codeunit 8055 "Sub. Contracts Item Management"
 
     internal procedure CreateTempPurchaseLine(var TempPurchaseLine: Record "Purchase Line" temporary; var TempPurchaseHeader: Record "Purchase Header" temporary; ServiceObject: Record "Subscription Header"; OrderDate: Date)
     begin
-        CreateTempPurchaseLine(TempPurchaseLine, TempPurchaseHeader, ServiceObject.Type, ServiceObject."Source No.", ServiceObject.Quantity, OrderDate);
-    end;
-
-    local procedure CreateTempPurchaseLine(var TempPurchaseLine: Record "Purchase Line" temporary; var TempPurchaseHeader: Record "Purchase Header" temporary; ServiceObjectType: enum "Service Object Type"; SourceNo: Code[20]; Quantity: Decimal; OrderDate: Date)
-    begin
-        CreateTempPurchaseLine(TempPurchaseLine, TempPurchaseHeader, ServiceObjectType, SourceNo, Quantity, OrderDate, '');
+        CreateTempPurchaseLine(TempPurchaseLine, TempPurchaseHeader, ServiceObject.Type, ServiceObject."Source No.", ServiceObject.Quantity, OrderDate, ServiceObject."Variant Code");
     end;
 
     internal procedure CreateTempPurchaseLine(var TempPurchaseLine: Record "Purchase Line" temporary; var TempPurchaseHeader: Record "Purchase Header" temporary; ServiceObjectType: enum "Service Object Type"; SourceNo: Code[20]; Quantity: Decimal; OrderDate: Date; VariantCode: Code[10])
@@ -254,6 +244,7 @@ codeunit 8055 "Sub. Contracts Item Management"
         TempPurchaseLine."No." := SourceNo;
         TempPurchaseLine.Quantity := Quantity;
         TempPurchaseLine."Currency Code" := TempPurchaseHeader."Currency Code";
+        TempPurchaseLine."Variant Code" := VariantCode;
         if OrderDate <> 0D then
             TempPurchaseLine."Expected Receipt Date" := OrderDate;
     end;

--- a/src/Apps/W1/Subscription Billing/App/Base/Codeunits/SubContractsItemManagement.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Base/Codeunits/SubContractsItemManagement.Codeunit.al
@@ -138,7 +138,7 @@ codeunit 8055 "Sub. Contracts Item Management"
         if (SellToCustomerNo = '') or (ItemNo = '') then
             exit;
         CreateTempSalesHeader(TempSalesHeader, TempSalesHeader."Document Type"::Order, SellToCustomerNo, SellToCustomerNo, 0D, CurrencyCode);
-        CreateTempSalesLine(TempSalesLine, TempSalesHeader, "Service Object Type"::Item, ItemNo, Quantity, 0D);
+        CreateTempSalesLine(TempSalesLine, TempSalesHeader, "Service Object Type"::Item, ItemNo, Quantity, 0D, '');
         UnitPrice := CalculateUnitPrice(TempSalesHeader, TempSalesLine);
     end;
 


### PR DESCRIPTION
Cherry-pick of #9850 into releases/28.x

## Why

When using the **Recent Item Prices** method in Subscription Contract Price Update, the system proposes the base item price instead of the variant-specific price. The `VariantCode` from the Subscription Header is never passed to the temporary Sales/Purchase Line used for price calculation.

## Summary

- **Fixed** `CreateTempSalesLine` ServiceObject overload to pass `ServiceObject."Variant Code"` to the full overload
- **Fixed** `CreateTempPurchaseLine` ServiceObject overload — same fix
- **Removed** dead-code 6-param local overloads that hardcoded empty VariantCode
- **Added** missing `TempPurchaseLine."Variant Code" := VariantCode` assignment

[AB#644749](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644749)





