### PR TITLE
[Extensibility Request] issue 29078: Add OnBeforeTestTransferLine event

### DIFF
--- a/src/Layers/IT/BaseApp/Inventory/Transfer/TransferHeader.Table.al
+++ b/src/Layers/IT/BaseApp/Inventory/Transfer/TransferHeader.Table.al
@@ -1779,6 +1779,8 @@ table 5740 "Transfer Header"
     var
         DummyTrackingSpecification: Record "Tracking Specification";
     begin
+        OnBeforeTestTransferLine(TransferLine, Ship);
+
         if Ship then
             DummyTrackingSpecification.CheckItemTrackingQuantity(Database::"Transfer Line", 0, "No.", TransferLine."Line No.",
                 TransferLine."Qty. to Ship (Base)", TransferLine."Qty. to Ship (Base)", true, false)
@@ -2166,6 +2168,11 @@ table 5740 "Transfer Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnUpdateTransLinesOnAfterUpdateFromDirectTransfer(var TransferLine: Record "Transfer Line"; TempTransferLine: Record "Transfer Line")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeTestTransferLine(TransferLine: Record "Transfer Line"; Ship: Boolean)
     begin
     end;
 }

--- a/src/Layers/NA/BaseApp/Inventory/Transfer/TransferHeader.Table.al
+++ b/src/Layers/NA/BaseApp/Inventory/Transfer/TransferHeader.Table.al
@@ -1664,6 +1664,8 @@ table 5740 "Transfer Header"
     var
         DummyTrackingSpecification: Record "Tracking Specification";
     begin
+        OnBeforeTestTransferLine(TransferLine, Ship);
+
         if Ship then
             DummyTrackingSpecification.CheckItemTrackingQuantity(Database::"Transfer Line", 0, "No.", TransferLine."Line No.",
                 TransferLine."Qty. to Ship (Base)", TransferLine."Qty. to Ship (Base)", true, false)
@@ -2051,6 +2053,11 @@ table 5740 "Transfer Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnUpdateTransLinesOnAfterUpdateFromDirectTransfer(var TransferLine: Record "Transfer Line"; TempTransferLine: Record "Transfer Line")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeTestTransferLine(TransferLine: Record "Transfer Line"; Ship: Boolean)
     begin
     end;
 }

--- a/src/Layers/RU/BaseApp/Inventory/Transfer/TransferHeader.Table.al
+++ b/src/Layers/RU/BaseApp/Inventory/Transfer/TransferHeader.Table.al
@@ -1592,6 +1592,8 @@ table 5740 "Transfer Header"
     var
         DummyTrackingSpecification: Record "Tracking Specification";
     begin
+        OnBeforeTestTransferLine(TransferLine, Ship);
+
         if Ship then
             DummyTrackingSpecification.CheckItemTrackingQuantity(Database::"Transfer Line", 0, "No.", TransferLine."Line No.",
                 TransferLine."Qty. to Ship (Base)", TransferLine."Qty. to Ship (Base)", true, false)
@@ -1979,6 +1981,11 @@ table 5740 "Transfer Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnUpdateTransLinesOnAfterUpdateFromDirectTransfer(var TransferLine: Record "Transfer Line"; TempTransferLine: Record "Transfer Line")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeTestTransferLine(TransferLine: Record "Transfer Line"; Ship: Boolean)
     begin
     end;
 }

--- a/src/Layers/W1/BaseApp/Inventory/Transfer/TransferHeader.Table.al
+++ b/src/Layers/W1/BaseApp/Inventory/Transfer/TransferHeader.Table.al
@@ -1573,6 +1573,8 @@ table 5740 "Transfer Header"
     var
         DummyTrackingSpecification: Record "Tracking Specification";
     begin
+        OnBeforeTestTransferLine(TransferLine, Ship);
+
         if Ship then
             DummyTrackingSpecification.CheckItemTrackingQuantity(Database::"Transfer Line", 0, "No.", TransferLine."Line No.",
                 TransferLine."Qty. to Ship (Base)", TransferLine."Qty. to Ship (Base)", true, false)
@@ -1960,6 +1962,11 @@ table 5740 "Transfer Header"
 
     [IntegrationEvent(false, false)]
     local procedure OnUpdateTransLinesOnAfterUpdateFromDirectTransfer(var TransferLine: Record "Transfer Line"; TempTransferLine: Record "Transfer Line")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeTestTransferLine(TransferLine: Record "Transfer Line"; Ship: Boolean)
     begin
     end;
 }


### PR DESCRIPTION
## Summary
When testing transfer line item tracking quantities, `TestTransferLine` on the `Transfer Header` table has no extensibility point, so add-on developers cannot hook into or extend this check for their own scenarios. This PR adds an integration event at the start of `TestTransferLine` so subscribers can observe or extend the transfer line test logic before the standard item tracking quantity check runs.

Source issue repository: microsoft/ALAppExtensions; issue number: 29078

## Changes Made
- `TestTransferLine` (Transfer Header table) - Added a call to a new `OnBeforeTestTransferLine` integration event at the start of the procedure, named per the event naming convention for events at the beginning of a procedure. Propagated the same change to the RU, NA, and IT layer counterparts.

Fixes [AB#598042](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/598042)




