### PR TITLE
[MAIN]-Bug 644801-IRS Reporting Period - Copy Setup process will copy the 1099 Adjustments as part of the process of copying from one IRS Reporting Period to a new Period setup.

### DIFF
--- a/src/Apps/US/IRSForms/app/src/Setup/IRSReportingPeriod.Codeunit.al
+++ b/src/Apps/US/IRSForms/app/src/Setup/IRSReportingPeriod.Codeunit.al
@@ -229,6 +229,7 @@ codeunit 10042 "IRS Reporting Period"
             repeat
                 NewIRS1099VendorFormBoxAdj := IRS1099VendorFormBoxAdj;
                 NewIRS1099VendorFormBoxAdj."Period No." := ToPeriodNo;
+                NewIRS1099VendorFormBoxAdj.Amount := 0;
                 NewIRS1099VendorFormBoxAdj.Insert();
             until IRS1099VendorFormBoxAdj.Next() = 0;
             UpdateSummaryMessage(SetupCompletedMessage, SomethingHasBeenCopied, IRS1099VendorFormBoxAdj.TableCaption, IRS1099VendorFormBoxAdj.Count(), SummaryMessageCreated);

--- a/src/Apps/US/IRSForms/test library/src/LibraryIRSReportingPeriod.Codeunit.al
+++ b/src/Apps/US/IRSForms/test library/src/LibraryIRSReportingPeriod.Codeunit.al
@@ -65,4 +65,14 @@ codeunit 148000 "Library IRS Reporting Period"
             exit(CalcDate('<1Y>', GLEntry."Posting Date"));
         exit(WorkDate());
     end;
+
+    /// <summary>
+    /// Copies IRS reporting period setup from one period to another.
+    /// </summary>
+    procedure CopyPeriodSetup(FromPeriodNo: Code[20]; ToPeriodNo: Code[20])
+    var
+        IRSReportingPeriod: Codeunit "IRS Reporting Period";
+    begin
+        IRSReportingPeriod.CopyReportingPeriodSetup(FromPeriodNo, ToPeriodNo);
+    end;
 }

--- a/src/Apps/US/IRSForms/test/src/IRSReportingPeriodTests.Codeunit.al
+++ b/src/Apps/US/IRSForms/test/src/IRSReportingPeriodTests.Codeunit.al
@@ -13,8 +13,12 @@ codeunit 148016 "IRS Reporting Period Tests"
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryUtility: Codeunit "Library - Utility";
         Assert: Codeunit Assert;
+        LibraryIRSReportingPeriod: Codeunit "Library IRS Reporting Period";
+        LibraryIRS1099FormBox: Codeunit "Library IRS 1099 Form Box";
+        LibraryRandom: Codeunit "Library - Random";
         IsInitialized: Boolean;
         StartingEndingDateOverlapErr: Label 'The starting date and ending date overlap with an existing reporting period.';
+        AmountShouldBeResetErr: Label 'Amount should be reset to 0';
 
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
@@ -190,6 +194,54 @@ codeunit 148016 "IRS Reporting Period Tests"
         Assert.RecordIsNotEmpty(IRS1099Form);
     end;
 
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    [HandlerFunctions('CopySetupMessageHandler')]
+    procedure VendorFormBoxAdjustmentAmountIsResetWhenCopyingSetup()
+    var
+        IRS1099VendorFormBoxAdj: Record "IRS 1099 Vendor Form Box Adj.";
+        FromPeriodNo: Code[20];
+        ToPeriodNo: Code[20];
+        FormNo: Code[20];
+        FormBoxNo: Code[20];
+        VendorNo: Code[20];
+        Amount: Decimal;
+        FromStartDate: Date;
+        FromEndDate: Date;
+        ToStartDate: Date;
+        ToEndDate: Date;
+    begin
+        // [SCENARIO 623874] When copying reporting period setup with vendor form box adjustments, the Amount field is reset to 0 in the target period
+        Initialize();
+
+        // [GIVEN] Reporting period for current year with vendor form box adjustment "V" for form "MISC" box "01" with Amount = 1000
+        FromStartDate := CalcDate('<-CY>', WorkDate());
+        FromEndDate := CalcDate('<CY>', WorkDate());
+        FromPeriodNo := LibraryIRSReportingPeriod.CreateReportingPeriod(FromStartDate, FromEndDate);
+        FormNo := LibraryIRS1099FormBox.CreateSingleFormInReportingPeriod(FromStartDate, FromEndDate);
+        FormBoxNo := LibraryIRS1099FormBox.CreateSingleFormBoxInReportingPeriod(FromStartDate, FromEndDate, FormNo);
+        VendorNo := LibraryIRS1099FormBox.CreateVendorNoWithFormBox(FromStartDate, FromEndDate, FormNo, FormBoxNo);
+        Amount := LibraryRandom.RandDec(1000, 2);
+        LibraryIRS1099FormBox.AddAdjustmentAmountForVendor(FromStartDate, FromEndDate, VendorNo, FormNo, FormBoxNo, Amount);
+
+        // [GIVEN] Reporting period for next year exists
+        ToStartDate := CalcDate('<1Y>', FromStartDate);
+        ToEndDate := CalcDate('<1Y>', FromEndDate);
+        ToPeriodNo := LibraryIRSReportingPeriod.CreateReportingPeriod(ToStartDate, ToEndDate);
+
+        // [WHEN] Copy setup from current year to next year
+        LibraryIRSReportingPeriod.CopyPeriodSetup(FromPeriodNo, ToPeriodNo);
+
+        // [THEN] Vendor form box adjustment is copied to next year with Amount = 0
+        IRS1099VendorFormBoxAdj.SetRange("Period No.", ToPeriodNo);
+        IRS1099VendorFormBoxAdj.SetRange("Vendor No.", VendorNo);
+        IRS1099VendorFormBoxAdj.SetRange("Form No.", FormNo);
+        IRS1099VendorFormBoxAdj.SetRange("Form Box No.", FormBoxNo);
+        Assert.RecordIsNotEmpty(IRS1099VendorFormBoxAdj);
+        IRS1099VendorFormBoxAdj.FindFirst();
+        Assert.AreEqual(0, IRS1099VendorFormBoxAdj.Amount, AmountShouldBeResetErr);
+    end;
+
     trigger OnRun()
     begin
         // [FEATURE] [1099]
@@ -204,6 +256,12 @@ codeunit 148016 "IRS Reporting Period Tests"
 
         IsInitialized := true;
         LibraryTestInitialize.OnAfterTestSuiteInitialize(Codeunit::"IRS Reporting Period Tests");
+    end;
+
+    [MessageHandler]
+    procedure CopySetupMessageHandler(Message: Text[1024])
+    begin
+        // Handle the setup copied message
     end;
 
 }


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why
**Issue**: Copy Setup was incorrectly carrying 1099 adjustment amounts from source period to target period.

**Cause**: The copy logic duplicated the full adjustment record, including the Amount field, instead of resetting it for the new period.
<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work
[AB#644801](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644801)
<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#644801](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644801)
**Solution**: Update copy logic to explicitly set Amount = 0 before insert in target period, and add an automated test to validate this behavior during setup copy.
## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->












