### PR TITLE
Fix MS Doc for parameter TagCompanyName of method SetSkippedUpgrade(...)

### DIFF
--- a/src/System Application/App/Upgrade Tags/src/UpgradeTag.Codeunit.al
+++ b/src/System Application/App/Upgrade Tags/src/UpgradeTag.Codeunit.al
@@ -85,7 +85,7 @@ codeunit 9999 "Upgrade Tag"
     /// Sets the upgrade tag to skipped.
     /// </summary>
     /// <param name="ExistingTag">Tag code to set the Skipped Upgrade field</param>
-    /// <param name="TagCompanyName">Name of the company to check existance of tag</param>
+    /// <param name="TagCompanyName">Name of the company</param>
     /// <param name="SkipUpgrade">Sets the Skipped Upgrade field</param>
     procedure SetSkippedUpgrade(ExistingTag: Code[250]; TagCompanyName: Code[30]; SkipUpgrade: Boolean)
     begin


### PR DESCRIPTION
## What & why
description of param fixed only.

Fixes #9870

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
      --> not needed as MS Doc change only (no code change)
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.
       --> not needed as MS Doc change only (no code change)

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

--> not needed as MS Doc change only (no code change)

## Risk & compatibility

none