### PR TITLE
Add missing telemetry event IDs to E-Document Session.LogMessage calls

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentPEPPOLHandler.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentPEPPOLHandler.Codeunit.al
@@ -550,7 +550,7 @@ codeunit 6173 "E-Document PEPPOL Handler" implements IStructuredFormatReader, IE
         if OutboundEDocument.FindLast() then
             EDocMessageMgt.CreateMessage(OutboundEDocument, "E-Document Message Type"::"PEPPOL Order Response", "E-Document Direction"::Incoming, ResponseType, TempBlob)
         else
-            Session.LogMessage('', OrderResponseNoMatchTelemetryTxt, Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', 'E-Document');
+            Session.LogMessage('0000UWG', OrderResponseNoMatchTelemetryTxt, Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', 'E-Document');
 
         // Response stored on the outbound E-Document; inbound carrier must not continue through the import pipeline.
         EDocument.DeleteOrphanedImport();

--- a/src/Apps/W1/EDocumentConnectors/Avalara/App/src/Activation/Activation.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Avalara/App/src/Activation/Activation.Codeunit.al
@@ -162,7 +162,7 @@ codeunit 6378 Activation
     begin
         // Use Insert(true) to trigger table triggers and validation
         if not ActivationHeader.Insert(true) then begin
-            Session.LogMessage('', 'Failed to insert Activation Header', Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Avalara Activation');
+            Session.LogMessage('0000UWD', 'Failed to insert Activation Header', Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Avalara Activation');
             exit(false);
         end;
 
@@ -204,7 +204,7 @@ codeunit 6378 Activation
 
         // Use Insert(true) to trigger table triggers and validation
         if not ActivationMandate.Insert(true) then
-            Session.LogMessage('', 'Failed to insert Activation Mandate', Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Avalara Activation');
+            Session.LogMessage('0000UWE', 'Failed to insert Activation Mandate', Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Avalara Activation');
     end;
 
     local procedure GetNestedJsonText(JsonObj: JsonObject; ParentFieldName: Text; ChildFieldName: Text): Text

--- a/src/Apps/W1/EDocumentConnectors/Avalara/App/src/Connection/HttpExecutor.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Avalara/App/src/Connection/HttpExecutor.Codeunit.al
@@ -35,7 +35,7 @@ codeunit 6377 "Http Executor"
         FeatureTelemetry.LogUsage('0000NHA', this.AvalaraProcessing.GetAvalaraTok(), 'Avalara request.');
 
         if not HttpClient.Send(Request.GetRequest(), this.HttpResponseMessage) then begin
-            Session.LogMessage('', HttpSendFailedMsg, Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', this.AvalaraProcessing.GetAvalaraTok());
+            Session.LogMessage('0000UW6', HttpSendFailedMsg, Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', this.AvalaraProcessing.GetAvalaraTok());
             Error(HttpSendFailedMsg);
         end;
         HttpResponse := this.HttpResponseMessage;
@@ -61,12 +61,12 @@ codeunit 6377 "Http Executor"
         case LocalHttpResponseMessage.HttpStatusCode() of
             200:
                 begin
-                    Session.LogMessage('', HTTPSuccessMsg, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', this.AvalaraProcessing.GetAvalaraTok());
+                    Session.LogMessage('0000UW7', HTTPSuccessMsg, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', this.AvalaraProcessing.GetAvalaraTok());
                     exit;
                 end;
             201:
                 begin
-                    Session.LogMessage('', HTTPSuccessAndCreatedMsg, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', this.AvalaraProcessing.GetAvalaraTok());
+                    Session.LogMessage('0000UW8', HTTPSuccessAndCreatedMsg, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', this.AvalaraProcessing.GetAvalaraTok());
                     exit;
                 end;
             400:
@@ -85,7 +85,7 @@ codeunit 6377 "Http Executor"
         end;
 
         FriendlyErrorMsg := StrSubstNo(HttpErrorMsg, LocalHttpResponseMessage.HttpStatusCode(), FriendlyErrorMsg);
-        Session.LogMessage('', StrSubstNo(HttpErrorMsg, LocalHttpResponseMessage.HttpStatusCode(), Response), Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', this.AvalaraProcessing.GetAvalaraTok());
+        Session.LogMessage('0000UW9', StrSubstNo(HttpErrorMsg, LocalHttpResponseMessage.HttpStatusCode(), Response), Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', this.AvalaraProcessing.GetAvalaraTok());
         Error(FriendlyErrorMsg);
     end;
 

--- a/src/Apps/W1/EDocumentConnectors/Avalara/App/src/Documents/AvalaraDocumentManagement.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Avalara/App/src/Documents/AvalaraDocumentManagement.Codeunit.al
@@ -131,7 +131,7 @@ codeunit 6371 "Avalara Document Management"
     local procedure InsertDocumentBuffer(var TempDocumentBuffer: Record "Avalara Document Buffer" temporary): Boolean
     begin
         if not TempDocumentBuffer.Insert(true) then begin
-            Session.LogMessage('', 'Failed to insert Avalara Document Buffer', Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Avalara Document Parser');
+            Session.LogMessage('0000UW1', 'Failed to insert Avalara Document Buffer', Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Avalara Document Parser');
             exit(false);
         end;
 
@@ -251,7 +251,7 @@ codeunit 6371 "Avalara Document Management"
     begin
         // Validate inputs
         if DocumentID = '' then begin
-            Session.LogMessage('', 'Document ID is required for download', Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Avalara Document Management');
+            Session.LogMessage('0000UW2', 'Document ID is required for download', Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Avalara Document Management');
             exit(false);
         end;
 
@@ -260,7 +260,7 @@ codeunit 6371 "Avalara Document Management"
 
         // Try to download - if it fails (e.g., 404 not found), return false without rollback
         if not TryDownloadFromApi(DocumentID, MediaType, TempBlob) then begin
-            Session.LogMessage('', StrSubstNo(FailedToDownloadDocumentMsg, DocumentID, MediaType), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Avalara Document Management');
+            Session.LogMessage('0000UW3', StrSubstNo(FailedToDownloadDocumentMsg, DocumentID, MediaType), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Avalara Document Management');
             exit(false);
         end;
 
@@ -268,11 +268,11 @@ codeunit 6371 "Avalara Document Management"
         FileName := GetFileNameForMediaType(DocumentID, MediaType);
 
         if not AttachToEDocument(EDocument, TempBlob, FileName) then begin
-            Session.LogMessage('', StrSubstNo(FailedToAttachDocumentMsg, DocumentID), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Avalara Document Management');
+            Session.LogMessage('0000UW4', StrSubstNo(FailedToAttachDocumentMsg, DocumentID), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Avalara Document Management');
             exit(false);
         end;
 
-        Session.LogMessage('', StrSubstNo(SuccessfullyDownloadedMsg, DocumentID, MediaType), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Avalara Document Management');
+        Session.LogMessage('0000UW5', StrSubstNo(SuccessfullyDownloadedMsg, DocumentID, MediaType), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Avalara Document Management');
         exit(true);
     end;
 

--- a/src/Apps/W1/EDocumentConnectors/Avalara/App/src/Integration/Processing.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Avalara/App/src/Integration/Processing.Codeunit.al
@@ -500,7 +500,7 @@ ValueObject : JsonToken;
         ResponseMessage := RestClient.Get(RequestPath);
 
         if not ResponseMessage.GetIsSuccessStatusCode() then begin
-            Session.LogMessage('', StrSubstNo(GetFieldsFailedErr, ResponseMessage.GetHttpStatusCode(), ResponseMessage.GetReasonPhrase()), Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', AvalaraTok);
+            Session.LogMessage('0000UWF', StrSubstNo(GetFieldsFailedErr, ResponseMessage.GetHttpStatusCode(), ResponseMessage.GetReasonPhrase()), Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', AvalaraTok);
             exit;
         end;
 

--- a/src/Apps/W1/EDocumentConnectors/Avalara/App/src/Maintenance/Maintenance.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Avalara/App/src/Maintenance/Maintenance.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 6373 Maintenance
             ProcessedCount += 1;
         until EDocument.Next() = 0;
 
-        Session.LogMessage('',
+        Session.LogMessage('0000UWA',
             StrSubstNo(ProcessingCompletedMsg, ProcessedCount, SuccessCount),
             Verbosity::Normal,
             DataClassification::SystemMetadata,
@@ -86,7 +86,7 @@ codeunit 6373 Maintenance
                 SuccessCount += 1;
 
         if SuccessCount > 0 then begin
-            Session.LogMessage('',
+            Session.LogMessage('0000UWB',
                 StrSubstNo(SuccessfullyDownloadedDocumentMsg, DocumentId, EDocument."Entry No"),
                 Verbosity::Normal,
                 DataClassification::SystemMetadata,
@@ -111,7 +111,7 @@ codeunit 6373 Maintenance
 
         EDocumentErrorHelper.LogSimpleErrorMessage(EDocument, ErrorText);
 
-        Session.LogMessage('',
+        Session.LogMessage('0000UWC',
             StrSubstNo(DocumentDownloadFailedLogMsg, EDocument."Entry No", DocumentId),
             Verbosity::Warning,
             DataClassification::SystemMetadata,

--- a/src/Apps/W1/EDocumentConnectors/Avalara/App/src/Shared/AvalaraFunctions.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Avalara/App/src/Shared/AvalaraFunctions.Codeunit.al
@@ -190,7 +190,7 @@ codeunit 6800 "Avalara Functions"
             AvalaraInputField.Insert();
         end;
 
-        Session.LogMessage('', StrSubstNo(FieldsLoadedMsg, FieldsArray.Count(), MandateInput), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', AvalaraCategoryTok);
+        Session.LogMessage('0000UVW', StrSubstNo(FieldsLoadedMsg, FieldsArray.Count(), MandateInput), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', AvalaraCategoryTok);
     end;
 
     /// <summary>
@@ -210,7 +210,7 @@ codeunit 6800 "Avalara Functions"
     begin
         // Validate input
         if Mandate = '' then begin
-            Session.LogMessage('', 'Empty mandate provided to GetAvailableMediaTypesForMandate', Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', AvalaraCategoryTok);
+            Session.LogMessage('0000UVX', 'Empty mandate provided to GetAvailableMediaTypesForMandate', Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', AvalaraCategoryTok);
             exit(GetDefaultMediaTypes());
         end;
 
@@ -221,13 +221,13 @@ codeunit 6800 "Avalara Functions"
 
         // Handle API failure
         if ResponseContent = '' then begin
-            Session.LogMessage('', StrSubstNo(FailedToRetrieveMediaTypesMsg, Mandate), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', AvalaraCategoryTok);
+            Session.LogMessage('0000UVY', StrSubstNo(FailedToRetrieveMediaTypesMsg, Mandate), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', AvalaraCategoryTok);
             exit(GetDefaultMediaTypes());
         end;
 
         // Parse JSON response
         if not TryParseMediaTypesResponse(ResponseContent, ResponseJson, ValueArray) then begin
-            Session.LogMessage('', StrSubstNo(InvalidJsonResponseMsg, Mandate), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', AvalaraCategoryTok);
+            Session.LogMessage('0000UVZ', StrSubstNo(InvalidJsonResponseMsg, Mandate), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', AvalaraCategoryTok);
             exit(GetDefaultMediaTypes());
         end;
 
@@ -238,7 +238,7 @@ codeunit 6800 "Avalara Functions"
         if MediaTypeList.Count = 0 then
             exit(GetDefaultMediaTypes());
 
-        Session.LogMessage('', StrSubstNo(RetrievedMediaTypesMsg, MediaTypeList.Count, Mandate), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', AvalaraCategoryTok);
+        Session.LogMessage('0000UW0', StrSubstNo(RetrievedMediaTypesMsg, MediaTypeList.Count, Mandate), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', AvalaraCategoryTok);
 
         exit(MediaTypeList);
     end;


### PR DESCRIPTION
## Summary

21 `Session.LogMessage` call sites in the E-Document apps passed an **empty string** (`''`) as the telemetry event ID, so the traces they emit cannot be aggregated, filtered or alerted on by event ID in the standard telemetry pipeline.

Most notably, **every single `Session.LogMessage` call in the Avalara E-Document connector was untagged** (20 of 20) — that app is effectively invisible in telemetry when querying by event ID. It does set `'Category'` custom dimensions, so the messages aren't completely untraceable, but they can't be grouped or monitored the normal way.

One further call in the core E-Document app (`EDocumentPEPPOLHandler.Codeunit.al`) was also missing its tag; the rest of that app already follows the convention.

## Change

Tags were allocated by running `Expand-TelemetryTags`, which reserves IDs centrally, so there is no collision risk. They cover the contiguous range **`0000UVW`–`0000UWG`**.

| File | Tags |
|---|---|
| `Avalara/App/src/Shared/AvalaraFunctions.Codeunit.al` | `0000UVW`–`0000UW0` |
| `Avalara/App/src/Documents/AvalaraDocumentManagement.Codeunit.al` | `0000UW1`–`0000UW5` |
| `Avalara/App/src/Connection/HttpExecutor.Codeunit.al` | `0000UW6`–`0000UW9` |
| `Avalara/App/src/Maintenance/Maintenance.Codeunit.al` | `0000UWA`–`0000UWC` |
| `Avalara/App/src/Activation/Activation.Codeunit.al` | `0000UWD`, `0000UWE` |
| `Avalara/App/src/Integration/Processing.Codeunit.al` | `0000UWF` |
| `EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentPEPPOLHandler.Codeunit.al` | `0000UWG` |

[AB#644900](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644900)






