### PR TITLE
[Subscription Billing] Rename progress tracker

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Base/Codeunits/SubBillingProgressTracker.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Base/Codeunits/SubBillingProgressTracker.Codeunit.al
@@ -6,7 +6,7 @@ namespace Microsoft.SubscriptionBilling;
 /// All dialog interaction is guarded by GuiAllowed, so callers are safe to use it from background
 /// Job Queue sessions without additional guards.
 /// </summary>
-codeunit 8035 "Progress Tracker"
+codeunit 8035 "Sub. Billing Progress Tracker"
 {
     var
         Window: Dialog;

--- a/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/BillingProposal.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/BillingProposal.Codeunit.al
@@ -12,7 +12,7 @@ codeunit 8062 "Billing Proposal"
     var
         SalesHeaderGlobal: Record "Sales Header";
         PurchaseHeaderGlobal: Record "Purchase Header";
-        ProgressTracker: Codeunit "Progress Tracker";
+        ProgressTracker: Codeunit "Sub. Billing Progress Tracker";
         LastContractNo: Code[20];
         LastPartnerNo: Code[20];
         CreatingProposalLbl: Label 'Creating billing proposal...';

--- a/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/CreateBillingDocuments.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/CreateBillingDocuments.Codeunit.al
@@ -1483,7 +1483,7 @@ codeunit 8060 "Create Billing Documents"
         TranslationHelper: Codeunit "Translation Helper";
         DocumentChangeManagement: Codeunit "Document Change Management";
         Language: Codeunit Language;
-        ProgressTracker: Codeunit "Progress Tracker";
+        ProgressTracker: Codeunit "Sub. Billing Progress Tracker";
         BillingLineNoByTempEntryNo: Dictionary of [Integer, Integer];
         DocumentDate: Date;
         PostingDate: Date;

--- a/src/Apps/W1/Subscription Billing/App/Usage Based Billing/Codeunits/GenericConnectorProcessing.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Usage Based Billing/Codeunits/GenericConnectorProcessing.Codeunit.al
@@ -8,7 +8,7 @@ codeunit 8033 "Generic Connector Processing" implements "Usage Data Processing"
     var
         ImportAndProcessUsageData: Codeunit "Import And Process Usage Data";
         CreateUsageDataBilling: Codeunit "Create Usage Data Billing";
-        ProgressTracker: Codeunit "Progress Tracker";
+        ProgressTracker: Codeunit "Sub. Billing Progress Tracker";
         ProcessImportedLinesLbl: Label 'Processing imported usage data lines...';
         CreateBillingDataLbl: Label 'Creating usage data billing...';
         ImportEntryDetailLbl: Label 'Import Entry No. %1', Comment = '%1 = Usage Data Import Entry No.';

--- a/src/Apps/W1/Subscription Billing/App/Usage Based Billing/Codeunits/ProcessUsageDataBilling.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Usage Based Billing/Codeunits/ProcessUsageDataBilling.Codeunit.al
@@ -11,7 +11,7 @@ codeunit 8026 "Process Usage Data Billing"
         UsageDataSupplier: Record "Usage Data Supplier";
         DateTimeManagement: Codeunit "Date Time Management";
         ContractItemMgt: Codeunit "Sub. Contracts Item Management";
-        ProgressTracker: Codeunit "Progress Tracker";
+        ProgressTracker: Codeunit "Sub. Billing Progress Tracker";
         ProcessBillingLbl: Label 'Processing usage based billing...';
         ImportEntryDetailLbl: Label 'Import Entry No. %1', Comment = '%1 = Usage Data Import Entry No.';
         DoesNotExistErr: Label 'No data found for processing step %1.', Comment = '%1=Name of the processing step';


### PR DESCRIPTION
## Why

The generic `Progress Tracker` object name can conflict with objects outside Subscription Billing because namespaces cannot yet be used consistently across all scenarios.

## Summary

- **Renamed** codeunit 8035 to `Sub. Billing Progress Tracker` to make its ownership explicit.
- **Updated** all Subscription Billing references and aligned the source filename with the new object name.

Fixes
[AB#644836](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644836)
