### PR TITLE
Add buyer order reference to ZUGFeRD export

### DIFF
--- a/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
@@ -520,7 +520,7 @@ codeunit 13917 "Export ZUGFeRD Document"
         DataTypeManagement: Codeunit "Data Type Management";
         HeaderRecordRef: RecordRef;
         HeaderTradeAgreementElement, SellerTradePartyElement, BuyerTradePartyElement, SpecifiedTaxRegistrationElement, IDElement : XmlElement;
-        SellerOrderReferencedDocumentElement: XmlElement;
+        SellerOrderReferencedDocumentElement, BuyerOrderReferencedDocumentElement: XmlElement;
         PostalTradeAddressElement, ContactElement : XmlElement;
         SellerIDAttr, BuyerIDAttr : XmlAttribute;
         CustomerNo: Code[20];
@@ -536,6 +536,7 @@ codeunit 13917 "Export ZUGFeRD Document"
         CustomerEmail: Text[250];
         PhoneNumber: Text[30];
         OrderNo: Code[20];
+        ExternalDocumentNo: Code[35];
         SellerStreetName: Text;
         SellerAdditionalStreetName: Text;
         SellerCityName: Text;
@@ -566,6 +567,7 @@ codeunit 13917 "Export ZUGFeRD Document"
                     CustomerEmail := ReportSelections.GetEmailAddressExt("Report Selection Usage"::"S.Invoice".AsInteger(), RecordVariant, CustomerNo, TempBodyReportSelections);
                     PhoneNumber := SalesInvoiceHeader."Sell-to Phone No.";
                     OrderNo := SalesInvoiceHeader."Order No.";
+                    ExternalDocumentNo := SalesInvoiceHeader."External Document No.";
                     RespCentrCode := SalesInvoiceHeader."Responsibility Center";
                     GetSellerContactInfo(SalesInvoiceHeader, SellerContactName, SellerPhoneNumber, SellerEmailAddress);
                 end;
@@ -586,6 +588,7 @@ codeunit 13917 "Export ZUGFeRD Document"
                     CustomerEmail := ReportSelections.GetEmailAddressExt("Report Selection Usage"::"S.Cr.Memo".AsInteger(), RecordVariant, CustomerNo, TempBodyReportSelections);
                     PhoneNumber := SalesCrMemoHeader."Sell-to Phone No.";
                     OrderNo := SalesCrMemoHeader."Return Order No.";
+                    ExternalDocumentNo := SalesCrMemoHeader."External Document No.";
                     RespCentrCode := SalesCrMemoHeader."Responsibility Center";
                     GetSellerContactInfo(SalesCrMemoHeader, SellerContactName, SellerPhoneNumber, SellerEmailAddress);
                 end;
@@ -675,6 +678,12 @@ codeunit 13917 "Export ZUGFeRD Document"
             SellerOrderReferencedDocumentElement := XmlElement.Create('SellerOrderReferencedDocument', XmlNamespaceRAM);
             SellerOrderReferencedDocumentElement.Add(XmlElement.Create('IssuerAssignedID', XmlNamespaceRAM, OrderNo));
             HeaderTradeAgreementElement.Add(SellerOrderReferencedDocumentElement);
+        end;
+
+        if ExternalDocumentNo <> '' then begin
+            BuyerOrderReferencedDocumentElement := XmlElement.Create('BuyerOrderReferencedDocument', XmlNamespaceRAM);
+            BuyerOrderReferencedDocumentElement.Add(XmlElement.Create('IssuerAssignedID', XmlNamespaceRAM, ExternalDocumentNo));
+            HeaderTradeAgreementElement.Add(BuyerOrderReferencedDocumentElement);
         end;
 
         OnAfterInsertApplicableHeaderTradeAgreement(HeaderTradeAgreementElement, HeaderRecordRef);

--- a/src/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
@@ -177,6 +177,31 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
     end;
 
     [Test]
+    procedure ExportPostedSalesInvoiceInZUGFeRDFormatVerifyBuyerOrderReference();
+    var
+        SalesHeader: Record "Sales Header";
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        ExternalDocumentNo: Code[35];
+    begin
+        // [SCENARIO 644035] Export posted sales invoice creates electronic document in ZUGFeRD format with buyer order reference
+        Initialize();
+
+        // [GIVEN] Create and post sales invoice with external document no.
+        CreateSalesHeader(SalesHeader, "Sales Document Type"::Invoice, CreateCustomerWithoutRoutingNo());
+        ExternalDocumentNo := LibraryRandom.RandText(MaxStrLen(ExternalDocumentNo));
+        SalesHeader.Validate("External Document No.", ExternalDocumentNo);
+        CreateSalesLine(SalesHeader, Enum::"Sales Line Type"::Item, false);
+        SalesInvoiceHeader.Get(LibrarySales.PostSalesDocument(SalesHeader, true, true));
+
+        // [WHEN] Export ZUGFeRD Electronic Document.
+        ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
+
+        // [THEN] ZUGFeRD Electronic Document is created with buyer order reference from external document no.
+        VerifyBuyerOrderReference(ExternalDocumentNo, TempXMLBuffer, '/rsm:CrossIndustryInvoice');
+    end;
+
+    [Test]
     procedure ExportPostedSalesInvoiceInZUGFeRDFormatMandateBuyerReferenceAsYourReference();
     var
         SalesHeader: Record "Sales Header";
@@ -2327,6 +2352,14 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
     begin
         Path := DocumentTok + '/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerOrderReferencedDocument/ram:IssuerAssignedID';
         Assert.AreEqual(OrderNo, GetNodeByPathWithError(TempXMLBuffer, Path), StrSubstNo(IncorrectValueErr, Path));
+    end;
+
+    local procedure VerifyBuyerOrderReference(ExternalDocumentNo: Code[35]; var TempXMLBuffer: Record "XML Buffer" temporary; DocumentTok: Text);
+    var
+        Path: Text;
+    begin
+        Path := DocumentTok + '/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID';
+        Assert.AreEqual(ExternalDocumentNo, GetNodeByPathWithError(TempXMLBuffer, Path), StrSubstNo(IncorrectValueErr, Path));
     end;
 
     local procedure VerifySellerData(var TempXMLBuffer: Record "XML Buffer" temporary; DocumentTok: Text);

--- a/src/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
@@ -189,7 +189,7 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
 
         // [GIVEN] Create and post sales invoice with external document no.
         CreateSalesHeader(SalesHeader, "Sales Document Type"::Invoice, CreateCustomerWithoutRoutingNo());
-        ExternalDocumentNo := LibraryRandom.RandText(MaxStrLen(ExternalDocumentNo));
+        ExternalDocumentNo := CopyStr(LibraryRandom.RandText(MaxStrLen(ExternalDocumentNo)), 1, MaxStrLen(ExternalDocumentNo));
         SalesHeader.Validate("External Document No.", ExternalDocumentNo);
         CreateSalesLine(SalesHeader, Enum::"Sales Line Type"::Item, false);
         SalesInvoiceHeader.Get(LibrarySales.PostSalesDocument(SalesHeader, true, true));


### PR DESCRIPTION
## Why

ZUGFeRD exports the seller order reference but omits the buyer order reference used to associate an invoice with the customer's purchase order. The external document number should be emitted as `BuyerOrderReferencedDocument`, consistent with the other German e-document formats.

## Summary

- **Added** the external document number as `BuyerOrderReferencedDocument/IssuerAssignedID` for ZUGFeRD sales invoices and credit memos.
- **Added** regression coverage for posted sales invoice export.

[AB#644035](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644035)





