### PR TITLE
Fixes #8869: French sales reports must ignore comment lines when evaluating GetGoodsAndServicesText

### DIFF
--- a/src/Layers/FR/BaseApp/Sales/Document/StandardSalesDraftInvoice.Report.al
+++ b/src/Layers/FR/BaseApp/Sales/Document/StandardSalesDraftInvoice.Report.al
@@ -1288,7 +1288,7 @@ report 1303 "Standard Sales - Draft Invoice"
     begin
         SalesLine.SetRange("Document No.", Header."No.");
         SalesLine.SetRange("Document Type", Header."Document Type");
-        SalesLine.SetFilter(Type, '<> %1', SalesLine.Type::Item);
+        SalesLine.SetFilter(Type, '<>%1&<>%2', SalesLine.Type::Item, SalesLine.Type::" ");
         if not SalesLine.IsEmpty() then
             GotServices := true;
         SalesLine.SetRange(Type, SalesLine.Type::Item);

--- a/src/Layers/FR/BaseApp/Sales/History/StandardSalesCreditMemo.Report.al
+++ b/src/Layers/FR/BaseApp/Sales/History/StandardSalesCreditMemo.Report.al
@@ -1292,7 +1292,7 @@ report 1307 "Standard Sales - Credit Memo"
         GotServices: Boolean;
     begin
         SalesCrMemoLine.SetRange("Document No.", Header."No.");
-        SalesCrMemoLine.SetFilter(Type, '<> %1', SalesCrMemoLine.Type::Item);
+        SalesCrMemoLine.SetFilter(Type, '<>%1&<>%2', SalesCrMemoLine.Type::Item, SalesCrMemoLine.Type::" ");
         if not SalesCrMemoLine.IsEmpty() then
             GotServices := true;
         SalesCrMemoLine.SetRange(Type, SalesCrMemoLine.Type::Item);

--- a/src/Layers/FR/BaseApp/Sales/History/StandardSalesInvoice.Report.al
+++ b/src/Layers/FR/BaseApp/Sales/History/StandardSalesInvoice.Report.al
@@ -1614,7 +1614,7 @@ report 1306 "Standard Sales - Invoice"
         GotServices: Boolean;
     begin
         SalesInvoiceLine.SetRange("Document No.", Header."No.");
-        SalesInvoiceLine.SetFilter(Type, '<> %1', SalesInvoiceLine.Type::Item);
+        SalesInvoiceLine.SetFilter(Type, '<>%1&<>%2', SalesInvoiceLine.Type::Item, SalesInvoiceLine.Type::" ");
         if not SalesInvoiceLine.IsEmpty() then
             GotServices := true;
         SalesInvoiceLine.SetRange(Type, SalesInvoiceLine.Type::Item);


### PR DESCRIPTION
This PR fixes #8869. This issue is only related to the French localization.

**Issue**: comment lines are considered are services when the GetGoodsAndServicesText is executed when printing sales invoice and credit memos.

**Solution**: comment lines are filtered out.
