### PR TITLE
Exclude spend request G/L link from replication

### DIFF
--- a/src/Layers/W1/BaseApp/Finance/SpendRequest/SpendRequestToGLLink.Table.al
+++ b/src/Layers/W1/BaseApp/Finance/SpendRequest/SpendRequestToGLLink.Table.al
@@ -10,6 +10,7 @@ using Microsoft.Finance.GeneralLedger.Ledger;
 table 6845 "Spend Request To G/L Link"
 {
     Caption = 'Spend Request To G/L Link';
+    ReplicateData = false;
     DataClassification = CustomerContent;
     LookupPageId = "Spend Request To G/L Link";
     DrillDownPageId = "Spend Request To G/L Link";


### PR DESCRIPTION
## What & why

The internal cloud migration guard reported the new `Spend Request To G/L Link` table as an unreviewed table for cloud migration. The table was introduced by [PR #8959](https://github.com/microsoft/BCApps/pull/8959). The parent Spend Request tables already opt out of replication, so this link table should do the same instead of being migrated without its parent records.

This adds `ReplicateData = false` to table 6845 to keep the Spend Request feature's replication behavior consistent and resolve the guard failure.

## Linked work

[AB#644864](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644864)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

- Confirmed PR #8959 introduced three Spend Request tables, and the two parent tables already set `ReplicateData = false`.
- Confirmed this change only adds the same property to table 6845 `Spend Request To G/L Link`.
- No tests added because this is a table metadata/property correction for an internal cloud migration guard.

## Risk & compatibility

Low risk. This aligns the link table with the existing Spend Request tables that are already excluded from data replication.

