### PR TITLE
Disambiguate Production Order WIP reports

### DIFF
--- a/src/Apps/W1/PowerBIReports/App/Manufacturing/Embedded/ProductionOrderWIP.Page.al
+++ b/src/Apps/W1/PowerBIReports/App/Manufacturing/Embedded/ProductionOrderWIP.Page.al
@@ -11,8 +11,8 @@ page 37107 "Production Order WIP"
     UsageCategory = ReportsAndAnalysis;
     ApplicationArea = Manufacturing;
     PageType = UserControlHost;
-    Caption = 'Production Order WIP';
-    AboutTitle = 'About Production Order WIP';
+    Caption = 'Production Order WIP (Power BI)';
+    AboutTitle = 'About Production Order WIP (Power BI)';
     AboutText = 'View inventory valuation for selected production orders in your WIP inventory. The report also shows information about the value of consumption, capacity usage and output in WIP.';
 
     layout
@@ -52,4 +52,3 @@ page 37107 "Production Order WIP"
         ReportId := SetupHelper.OpenPowerBIEmbeddedReportPageValidation("PBI Report Setup"::"Manufacturing App");
     end;
 }
-


### PR DESCRIPTION
## What

Rename the embedded Power BI page caption from `Production Order WIP` to `Production Order WIP (Power BI)`.

## Why

Tell Me currently shows the embedded Power BI page next to the standard `Production Order - WIP` report without explaining that they are different reporting experiences. The new caption matches the existing Manufacturing Manager role center action and clearly distinguishes the Power BI report.

Fixes [AB#622074](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/622074)

## Validation

- Confirmed the standard report 5802 caption remains unchanged.
- Confirmed the embedded page and existing role center action now use the same `(Power BI)` qualifier.
- Ran `git diff --check`.

