### PR TITLE
[Main]-The Reservation Entry does not exist error when creating a Purchase Order from a Sales Order

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Tracking/ItemTrackingManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/ItemTrackingManagement.Codeunit.al
@@ -577,14 +577,6 @@ codeunit 6500 "Item Tracking Management"
         CopyItemTracking(FromRowID, ToRowID, SwapSign, false);
     end;
 
-    procedure CopyItemTracking(FromRowID: Text[250]; ToRowID: Text[250]; SwapSign: Boolean; SkipReservation: Boolean; NewReservationStatus: Enum "Reservation Status")
-    var
-        ReservEntry: Record "Reservation Entry";
-    begin
-        ReservEntry.SetPointer(FromRowID);
-        ReservEntry.SetPointerFilter();
-        CopyItemTracking3(ReservEntry, ToRowID, SwapSign, SkipReservation, NewReservationStatus);
-    end;
 
     procedure CopyItemTracking(FromRowID: Text[250]; ToRowID: Text[250]; SwapSign: Boolean; SkipReservation: Boolean)
     var
@@ -592,15 +584,15 @@ codeunit 6500 "Item Tracking Management"
     begin
         ReservEntry.SetPointer(FromRowID);
         ReservEntry.SetPointerFilter();
-        CopyItemTracking3(ReservEntry, ToRowID, SwapSign, SkipReservation, ReservEntry."Reservation Status"::Prospect);
+        CopyItemTracking3(ReservEntry, ToRowID, SwapSign, SkipReservation);
     end;
 
     procedure CopyItemTracking(var ReservEntry: Record "Reservation Entry"; ToRowID: Text[250]; SwapSign: Boolean)
     begin
-        CopyItemTracking3(ReservEntry, ToRowID, SwapSign, false, ReservEntry."Reservation Status"::Prospect);
+        CopyItemTracking3(ReservEntry, ToRowID, SwapSign, false);
     end;
 
-    local procedure CopyItemTracking3(var ReservEntry: Record "Reservation Entry"; ToRowID: Text[250]; SwapSign: Boolean; SkipReservation: Boolean; NewReservationStatus: Enum "Reservation Status")
+    local procedure CopyItemTracking3(var ReservEntry: Record "Reservation Entry"; ToRowID: Text[250]; SwapSign: Boolean; SkipReservation: Boolean)
     var
         ReservEntry1: Record "Reservation Entry";
         TempReservEntry: Record "Reservation Entry" temporary;
@@ -618,7 +610,7 @@ codeunit 6500 "Item Tracking Management"
             repeat
                 if ReservEntry.TrackingExists() then begin
                     TempReservEntry := ReservEntry;
-                    TempReservEntry."Reservation Status" := NewReservationStatus;
+                    TempReservEntry."Reservation Status" := TempReservEntry."Reservation Status"::Prospect;
                     TempReservEntry.SetPointer(ToRowID);
                     if SwapSign then begin
                         TempReservEntry."Quantity (Base)" := -TempReservEntry."Quantity (Base)";
@@ -1809,7 +1801,7 @@ codeunit 6500 "Item Tracking Management"
                     Message(Text006);
                     exit;
                 end;
-            CopyItemTracking3(FromReservEntry, ToRowID, SignFactor1 <> SignFactor2, false, FromReservEntry."Reservation Status"::Prospect);
+            CopyItemTracking3(FromReservEntry, ToRowID, SignFactor1 <> SignFactor2, false);
 
             // Copy to inbound part of transfer.
             if IsReservedFromTransferShipment(FromReservEntry) then begin

--- a/src/Layers/W1/BaseApp/Sales/Document/SalesLinePlanning.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/SalesLinePlanning.Codeunit.al
@@ -64,13 +64,11 @@ codeunit 99000850 "Sales Line-Planning"
     local procedure OnInsertDemandLinesOnCopyItemTracking(var RequisitionLine: Record "Requisition Line"; UnplannedDemand: Record "Unplanned Demand")
     var
         SalesLine: Record "Sales Line";
-        ReservationEntry: Record "Reservation Entry";
         ItemTrackingManagement: Codeunit "Item Tracking Management";
     begin
         if UnplannedDemand."Demand Type" = UnplannedDemand."Demand Type"::Sales then begin
             SalesLine.Get(UnplannedDemand."Demand SubType", UnplannedDemand."Demand Order No.", UnplannedDemand."Demand Line No.");
-            // Use new overload to set Reservation status instead of default Prospect to match Calculate Plan behavior
-            ItemTrackingManagement.CopyItemTracking(SalesLine.RowID1(), RequisitionLine.RowID1(), true, false, ReservationEntry."Reservation Status"::Reservation);
+            ItemTrackingManagement.CopyItemTracking(SalesLine.RowID1(), RequisitionLine.RowID1(), true);
         end;
     end;
 

--- a/src/Layers/W1/Tests/SCM/SCMOrderPlanningIII.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMOrderPlanningIII.Codeunit.al
@@ -52,8 +52,6 @@ codeunit 137088 "SCM Order Planning - III"
         NotAllItemsWerePlannedMsg: Label 'Not all items were planned. A total of %1 items were not planned.', Comment = '%1 = Number of items not planned';
         PlanningParametersTakenFromItemCardTxt: Label 'Item %3 at Location %4 was planned using the planning parameters from the Item Card, because no stockkeeping unit exists and %1 is set to %2.', Comment = '%1: Field Caption, %2: Missing SKU Policy, %3: Item No., %4: Location Code';
         SKUNotPlannedTxt: Label 'Item %1 at Location %2 was not planned, because no stockkeeping unit exists and %3 is set to %4.', Comment = '%1: Item No., %2: Location Code, %3: Field Caption, %4: Missing SKU Policy';
-        SerialNoErr: Label 'Serial No. %1 must exist in reservation entries';
-        ReservationEntryCountErr: Label 'Expected reservation entries with serial tracking on purchase line are %1';
         MinTotalQuantityMismatchErr: Label 'Expected total quantity >= %1, but got %2', Comment = '%1 = minimum expected quantity, %2 = actual summed quantity';
 
     [Test]
@@ -3779,59 +3777,6 @@ codeunit 137088 "SCM Order Planning - III"
         Assert.AreEqual(200, ReqLine.Quantity, RequisitionLineQuantityMismatchErr);
     end;
 
-    [Test]
-    [HandlerFunctions('MakeSupplyOrdersPageHandler,MessageHandler')]
-    [Scope('OnPrem')]
-    procedure SalesOrderPlanMakePurchOrderWithSerialTracking()
-    var
-        Item: Record Item;
-        PurchaseHeader: Record "Purchase Header";
-        PurchaseLine: Record "Purchase Line";
-        RequisitionLine: Record "Requisition Line";
-        ReservationEntry: Record "Reservation Entry";
-        SalesHeader: Record "Sales Header";
-        SalesLine: Record "Sales Line";
-        TempSalesReceivablesSetup: Record "Sales & Receivables Setup" temporary;
-        LibraryItemTracking: Codeunit "Library - Item Tracking";
-        i: Integer;
-        Quantity: Integer;
-        SerialNo: array[3] of Code[50];
-    begin
-        // [SCENARIO 618883] Creating Purchase Order from Sales Order via Order Planning preserves serial number item tracking
-        Initialize();
-        SalesHeader.DeleteAll();
-        SalesLine.DeleteAll();
-        UpdateSalesReceivablesSetup(TempSalesReceivablesSetup);
-
-        // [GIVEN] Serial-tracked item "I" and assign "Vendor No." ,"Reordering Policy" as "Order" and "Order Tracking Policy" as "Tracking Only"
-        LibraryItemTracking.CreateSerialItem(Item);
-        Item.Validate("Vendor No.", LibraryPurchase.CreateVendorNo());
-        Item.Validate("Reordering Policy", Item."Reordering Policy"::Order);
-        Item.Validate("Order Tracking Policy", Item."Order Tracking Policy"::"Tracking Only");
-        Item.Modify(true);
-
-        // [GIVEN] Create Sales Order "SO" for item "I" with quantity  and assign serial numbers
-        Quantity := ArrayLen(SerialNo);
-        CreateSalesOrder(SalesHeader, Item."No.", LocationBlue.Code, Quantity, Quantity);
-        FindSalesLine(SalesLine, SalesHeader, Item."No.");
-        for i := 1 to Quantity do begin
-            SerialNo[i] := LibraryUtility.GenerateGUID();
-            LibraryItemTracking.CreateSalesOrderItemTracking(ReservationEntry, SalesLine, SerialNo[i], '', LibraryRandom.RandIntInRange(1, 1));
-        end;
-
-        // [WHEN] Calculate Order Plan for "SO" and Make Supply Orders to create Purchase Order "PO"
-        LibraryPlanning.CalculateOrderPlanSales(RequisitionLine);
-        FindRequisitionLine(RequisitionLine, SalesHeader."No.", Item."No.", LocationBlue.Code);
-        MakeSupplyOrdersActiveOrder(SalesHeader."No.");
-
-        // [THEN] Purchase line for "PO" has reservation entries with serial numbers from "SO"
-        FindPurchaseDocumentByItemNo(PurchaseHeader, PurchaseLine, Item."No.");
-        VerifyPurchLineSerialTracking(PurchaseLine, SerialNo, Quantity);
-
-        // Tear Down
-        RestoreSalesReceivableSetup(TempSalesReceivablesSetup);
-    end;
-
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -4746,24 +4691,6 @@ codeunit 137088 "SCM Order Planning - III"
         Assert.IsTrue(
           RequisitionLine.Quantity >= MinExpectedQuantity,
                     StrSubstNo(MinTotalQuantityMismatchErr, MinExpectedQuantity, RequisitionLine.Quantity));
-    end;
-
-    local procedure VerifyPurchLineSerialTracking(PurchaseLine: Record "Purchase Line"; SerialNo: array[3] of Code[50]; Quantity: Integer)
-    var
-        ReservationEntry: Record "Reservation Entry";
-        i: Integer;
-    begin
-        ReservationEntry.SetRange("Source Type", Database::"Purchase Line");
-        ReservationEntry.SetRange("Source Subtype", PurchaseLine."Document Type".AsInteger());
-        ReservationEntry.SetRange("Source ID", PurchaseLine."Document No.");
-        ReservationEntry.SetRange("Source Ref. No.", PurchaseLine."Line No.");
-        ReservationEntry.SetFilter("Serial No.", '<>%1', '');
-        ReservationEntry.Setrange("Reservation Status", ReservationEntry."Reservation Status"::Reservation);
-        Assert.AreEqual(Quantity, ReservationEntry.Count(), StrSubstNo(ReservationEntryCountErr, Quantity));
-        for i := 1 to Quantity do begin
-            ReservationEntry.SetRange("Serial No.", SerialNo[i]);
-            Assert.IsTrue(ReservationEntry.FindFirst(), StrSubstNo(SerialNoErr, SerialNo[i]));
-        end;
     end;
 
     [ModalPageHandler]


### PR DESCRIPTION
Workitem [Bug 643358](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/643358): [ALL-E] "The Reservation Entry does not exist. Identification fields and values: Entry No.='9' Positive='No'" error when creating a Purchase Order from a Sales Order.

Fixes [AB#643358](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643358)


