### PR TITLE
Suppress zero-value rows in Trial Balance by Period

### DIFF
--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalbyPeriodExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalbyPeriodExcel.Report.al
@@ -91,6 +91,12 @@ report 4408 "EXR Trial Bal by Period Excel"
                         Caption = 'Period Length';
                         ToolTip = 'Specifies the period for which data is shown in the report. For example, enter "1M" for one month, "30D" for thirty days, "3Q" for three quarters, or "5Y" for five years.';
                     }
+                    field(ShowLinesWithZeroValuesField; ShowLinesWithZeroValues)
+                    {
+                        ApplicationArea = Basic, Suite;
+                        Caption = 'Show Lines with Zero Values';
+                        ToolTip = 'Specifies whether to include lines where all calculated amounts are zero.';
+                    }
                     // Used to set the date filter on the report header across multiple languages
                     field(RequestDateFilter; DateFilter)
                     {
@@ -162,6 +168,7 @@ report 4408 "EXR Trial Bal by Period Excel"
     var
         ExcelReportsTelemetry: Codeunit "Excel Reports Telemetry";
         DateFilter: Text;
+        ShowLinesWithZeroValues: Boolean;
 
     protected var
         CompanyInformation: Record "Company Information";
@@ -231,7 +238,7 @@ report 4408 "EXR Trial Bal by Period Excel"
         EXRTrialBalanceBuffer."Balance (Debit)" := LocalGLAccountBalance."Debit Amount";
         EXRTrialBalanceBuffer."Balance (Credit)" := LocalGLAccountBalance."Credit Amount";
         EXRTrialBalanceBuffer.CheckAllZero();
-        if not EXRTrialBalanceBuffer."All Zero" then
+        if ShowLinesWithZeroValues or not EXRTrialBalanceBuffer."All Zero" then
             EXRTrialBalanceBuffer.Insert(true);
     end;
 }

--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalbyPeriodExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalbyPeriodExcel.Report.al
@@ -95,6 +95,7 @@ report 4408 "EXR Trial Bal by Period Excel"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Show Lines with Zero Values';
+                        InitValue = true;
                         ToolTip = 'Specifies whether to include lines where all calculated amounts are zero.';
                     }
                     // Used to set the date filter on the report header across multiple languages

--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalbyPeriodExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalbyPeriodExcel.Report.al
@@ -91,12 +91,11 @@ report 4408 "EXR Trial Bal by Period Excel"
                         Caption = 'Period Length';
                         ToolTip = 'Specifies the period for which data is shown in the report. For example, enter "1M" for one month, "30D" for thirty days, "3Q" for three quarters, or "5Y" for five years.';
                     }
-                    field(ShowLinesWithZeroValuesField; ShowLinesWithZeroValues)
+                    field(HideLinesWithZeroValuesField; HideLinesWithZeroValues)
                     {
                         ApplicationArea = Basic, Suite;
-                        Caption = 'Show Lines with Zero Values';
-                        InitValue = true;
-                        ToolTip = 'Specifies whether to include lines where all calculated amounts are zero.';
+                        Caption = 'Hide Lines with Zero Values';
+                        ToolTip = 'Specifies whether to exclude lines where all calculated amounts are zero.';
                     }
                     // Used to set the date filter on the report header across multiple languages
                     field(RequestDateFilter; DateFilter)
@@ -169,7 +168,7 @@ report 4408 "EXR Trial Bal by Period Excel"
     var
         ExcelReportsTelemetry: Codeunit "Excel Reports Telemetry";
         DateFilter: Text;
-        ShowLinesWithZeroValues: Boolean;
+        HideLinesWithZeroValues: Boolean;
 
     protected var
         CompanyInformation: Record "Company Information";
@@ -239,7 +238,7 @@ report 4408 "EXR Trial Bal by Period Excel"
         EXRTrialBalanceBuffer."Balance (Debit)" := LocalGLAccountBalance."Debit Amount";
         EXRTrialBalanceBuffer."Balance (Credit)" := LocalGLAccountBalance."Credit Amount";
         EXRTrialBalanceBuffer.CheckAllZero();
-        if ShowLinesWithZeroValues or not EXRTrialBalanceBuffer."All Zero" then
+        if not HideLinesWithZeroValues or not EXRTrialBalanceBuffer."All Zero" then
             EXRTrialBalanceBuffer.Insert(true);
     end;
 }

--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalbyPeriodExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRTrialBalbyPeriodExcel.Report.al
@@ -230,6 +230,8 @@ report 4408 "EXR Trial Bal by Period Excel"
         EXRTrialBalanceBuffer.Balance := LocalGLAccount."Balance at Date";
         EXRTrialBalanceBuffer."Balance (Debit)" := LocalGLAccountBalance."Debit Amount";
         EXRTrialBalanceBuffer."Balance (Credit)" := LocalGLAccountBalance."Credit Amount";
-        EXRTrialBalanceBuffer.Insert(true);
+        EXRTrialBalanceBuffer.CheckAllZero();
+        if not EXRTrialBalanceBuffer."All Zero" then
+            EXRTrialBalanceBuffer.Insert(true);
     end;
 }

--- a/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
@@ -236,6 +236,45 @@ codeunit 139544 "Trial Balance Excel Reports"
     end;
 
     [Test]
+    [HandlerFunctions('EXRTrialBalanceByPeriodExcelHandler')]
+    procedure TrialBalanceByPeriodDoesntExportZeroValueDimensionCombinations()
+    var
+        GLAccount: Record "G/L Account";
+        Dimension1: Record Dimension;
+        Dimension2: Record Dimension;
+        DimensionValue1: Record "Dimension Value";
+        DimensionValue2: Record "Dimension Value";
+        Variant: Variant;
+        RequestPageXml: Text;
+    begin
+        // [SCENARIO] Trial Balance by Period only exports dimension combinations with values.
+        Initialize();
+        CreateGLAccount(GLAccount);
+        LibraryERM.CreateDimension(Dimension1);
+        LibraryERM.CreateDimensionValue(DimensionValue1, Dimension1.Code);
+        DimensionValue1."Global Dimension No." := 1;
+        DimensionValue1.Modify();
+        LibraryERM.CreateDimensionValue(DimensionValue1, Dimension1.Code);
+        DimensionValue1."Global Dimension No." := 1;
+        DimensionValue1.Modify();
+        LibraryERM.CreateDimension(Dimension2);
+        LibraryERM.CreateDimensionValue(DimensionValue2, Dimension2.Code);
+        DimensionValue2."Global Dimension No." := 2;
+        DimensionValue2.Modify();
+        LibraryERM.CreateDimensionValue(DimensionValue2, Dimension2.Code);
+        DimensionValue2."Global Dimension No." := 2;
+        DimensionValue2.Modify();
+        CreateGLEntryWithAmount(GLAccount."No.", DimensionValue1.Code, DimensionValue2.Code, '', WorkDate(), 100);
+        Commit();
+
+        RequestPageXml := Report.RunRequestPage(Report::"EXR Trial Bal by Period Excel", RequestPageXml);
+        LibraryReportDataset.RunReportAndLoad(Report::"EXR Trial Bal by Period Excel", Variant, RequestPageXml);
+
+        LibraryReportDataset.SetXmlNodeList('DataItem[@name="EXRTrialBalanceBuffer"]');
+        Assert.AreEqual(4, LibraryReportDataset.RowCount(), 'Only dimension combinations with values should be exported');
+    end;
+
+    [Test]
     [HandlerFunctions('EXRTrialBalanceBudgetExcelHandler')]
     procedure TrialBalanceBudgetExportsOnlyTheUsedDimensionValues()
     var
@@ -932,6 +971,13 @@ codeunit 139544 "Trial Balance Excel Reports"
     begin
         EXRTrialBalanceExcel.GLAccounts.SetFilter("Date Filter", Format(DMY2Date(1, 1, Date2DMY(WorkDate(), 3))) + '..' + Format(DMY2Date(31, 12, Date2DMY(WorkDate(), 3))));
         EXRTrialBalanceExcel.OK().Invoke();
+    end;
+
+    [RequestPageHandler]
+    procedure EXRTrialBalanceByPeriodExcelHandler(var EXRTrialBalanceByPeriodExcel: TestRequestPage "EXR Trial Bal by Period Excel")
+    begin
+        EXRTrialBalanceByPeriodExcel.TrialBalanceByPeriod.SetFilter("Date Filter", Format(WorkDate()));
+        EXRTrialBalanceByPeriodExcel.OK().Invoke();
     end;
 
     [RequestPageHandler]

--- a/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
@@ -251,7 +251,7 @@ codeunit 139544 "Trial Balance Excel Reports"
         LibraryReportDataset.RunReportAndLoad(Report::"EXR Trial Bal by Period Excel", Variant, RequestPageXml);
 
         LibraryReportDataset.SetXmlNodeList('DataItem[@name="EXRTrialBalanceBuffer"]');
-        Assert.AreEqual(4, LibraryReportDataset.RowCount(), 'Only dimension combinations with values should be exported');
+        Assert.AreEqual(8, LibraryReportDataset.RowCount(), 'Only dimension combinations with values should be exported');
     end;
 
     [Test]
@@ -270,7 +270,7 @@ codeunit 139544 "Trial Balance Excel Reports"
         LibraryReportDataset.RunReportAndLoad(Report::"EXR Trial Bal by Period Excel", Variant, RequestPageXml);
 
         LibraryReportDataset.SetXmlNodeList('DataItem[@name="EXRTrialBalanceBuffer"]');
-        Assert.AreEqual(9, LibraryReportDataset.RowCount(), 'All dimension combinations should be exported');
+        Assert.AreEqual(18, LibraryReportDataset.RowCount(), 'All dimension combinations should be exported');
     end;
 
     [Test]

--- a/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
@@ -236,7 +236,7 @@ codeunit 139544 "Trial Balance Excel Reports"
     end;
 
     [Test]
-    [HandlerFunctions('EXRTrialBalanceByPeriodExcelHandler')]
+    [HandlerFunctions('EXRTrialBalanceByPeriodHideZeroValuesHandler')]
     procedure TrialBalanceByPeriodDoesntExportZeroValueDimensionCombinations()
     var
         Variant: Variant;
@@ -255,7 +255,7 @@ codeunit 139544 "Trial Balance Excel Reports"
     end;
 
     [Test]
-    [HandlerFunctions('EXRTrialBalanceByPeriodShowZeroValuesHandler')]
+    [HandlerFunctions('EXRTrialBalanceByPeriodIncludeZeroValuesHandler')]
     procedure TrialBalanceByPeriodExportsZeroValueDimensionCombinationsWhenRequested()
     var
         Variant: Variant;
@@ -999,18 +999,18 @@ codeunit 139544 "Trial Balance Excel Reports"
     end;
 
     [RequestPageHandler]
-    procedure EXRTrialBalanceByPeriodExcelHandler(var EXRTrialBalanceByPeriodExcel: TestRequestPage "EXR Trial Bal by Period Excel")
+    procedure EXRTrialBalanceByPeriodHideZeroValuesHandler(var EXRTrialBalanceByPeriodExcel: TestRequestPage "EXR Trial Bal by Period Excel")
     begin
         EXRTrialBalanceByPeriodExcel.TrialBalanceByPeriod.SetFilter("Date Filter", Format(WorkDate()));
-        EXRTrialBalanceByPeriodExcel.ShowLinesWithZeroValuesField.SetValue(false);
+        EXRTrialBalanceByPeriodExcel.HideLinesWithZeroValuesField.SetValue(true);
         EXRTrialBalanceByPeriodExcel.OK().Invoke();
     end;
 
     [RequestPageHandler]
-    procedure EXRTrialBalanceByPeriodShowZeroValuesHandler(var EXRTrialBalanceByPeriodExcel: TestRequestPage "EXR Trial Bal by Period Excel")
+    procedure EXRTrialBalanceByPeriodIncludeZeroValuesHandler(var EXRTrialBalanceByPeriodExcel: TestRequestPage "EXR Trial Bal by Period Excel")
     begin
         EXRTrialBalanceByPeriodExcel.TrialBalanceByPeriod.SetFilter("Date Filter", Format(WorkDate()));
-        EXRTrialBalanceByPeriodExcel.ShowLinesWithZeroValuesField.SetValue(true);
+        EXRTrialBalanceByPeriodExcel.HideLinesWithZeroValuesField.SetValue(false);
         EXRTrialBalanceByPeriodExcel.OK().Invoke();
     end;
 

--- a/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
@@ -239,32 +239,12 @@ codeunit 139544 "Trial Balance Excel Reports"
     [HandlerFunctions('EXRTrialBalanceByPeriodExcelHandler')]
     procedure TrialBalanceByPeriodDoesntExportZeroValueDimensionCombinations()
     var
-        GLAccount: Record "G/L Account";
-        Dimension1: Record Dimension;
-        Dimension2: Record Dimension;
-        DimensionValue1: Record "Dimension Value";
-        DimensionValue2: Record "Dimension Value";
         Variant: Variant;
         RequestPageXml: Text;
     begin
         // [SCENARIO] Trial Balance by Period only exports dimension combinations with values.
         Initialize();
-        CreateGLAccount(GLAccount);
-        LibraryERM.CreateDimension(Dimension1);
-        LibraryERM.CreateDimensionValue(DimensionValue1, Dimension1.Code);
-        DimensionValue1."Global Dimension No." := 1;
-        DimensionValue1.Modify();
-        LibraryERM.CreateDimensionValue(DimensionValue1, Dimension1.Code);
-        DimensionValue1."Global Dimension No." := 1;
-        DimensionValue1.Modify();
-        LibraryERM.CreateDimension(Dimension2);
-        LibraryERM.CreateDimensionValue(DimensionValue2, Dimension2.Code);
-        DimensionValue2."Global Dimension No." := 2;
-        DimensionValue2.Modify();
-        LibraryERM.CreateDimensionValue(DimensionValue2, Dimension2.Code);
-        DimensionValue2."Global Dimension No." := 2;
-        DimensionValue2.Modify();
-        CreateGLEntryWithAmount(GLAccount."No.", DimensionValue1.Code, DimensionValue2.Code, '', WorkDate(), 100);
+        CreateTrialBalanceByPeriodDataWithUnusedDimensions();
         Commit();
 
         RequestPageXml := Report.RunRequestPage(Report::"EXR Trial Bal by Period Excel", RequestPageXml);
@@ -272,6 +252,25 @@ codeunit 139544 "Trial Balance Excel Reports"
 
         LibraryReportDataset.SetXmlNodeList('DataItem[@name="EXRTrialBalanceBuffer"]');
         Assert.AreEqual(4, LibraryReportDataset.RowCount(), 'Only dimension combinations with values should be exported');
+    end;
+
+    [Test]
+    [HandlerFunctions('EXRTrialBalanceByPeriodShowZeroValuesHandler')]
+    procedure TrialBalanceByPeriodExportsZeroValueDimensionCombinationsWhenRequested()
+    var
+        Variant: Variant;
+        RequestPageXml: Text;
+    begin
+        // [SCENARIO] Trial Balance by Period exports zero-value dimension combinations when requested.
+        Initialize();
+        CreateTrialBalanceByPeriodDataWithUnusedDimensions();
+        Commit();
+
+        RequestPageXml := Report.RunRequestPage(Report::"EXR Trial Bal by Period Excel", RequestPageXml);
+        LibraryReportDataset.RunReportAndLoad(Report::"EXR Trial Bal by Period Excel", Variant, RequestPageXml);
+
+        LibraryReportDataset.SetXmlNodeList('DataItem[@name="EXRTrialBalanceBuffer"]');
+        Assert.AreEqual(9, LibraryReportDataset.RowCount(), 'All dimension combinations should be exported');
     end;
 
     [Test]
@@ -935,6 +934,32 @@ codeunit 139544 "Trial Balance Excel Reports"
         DimensionValue.Modify();
     end;
 
+    local procedure CreateTrialBalanceByPeriodDataWithUnusedDimensions()
+    var
+        GLAccount: Record "G/L Account";
+        Dimension1: Record Dimension;
+        Dimension2: Record Dimension;
+        DimensionValue1: Record "Dimension Value";
+        DimensionValue2: Record "Dimension Value";
+    begin
+        CreateGLAccount(GLAccount);
+        LibraryERM.CreateDimension(Dimension1);
+        LibraryERM.CreateDimensionValue(DimensionValue1, Dimension1.Code);
+        DimensionValue1."Global Dimension No." := 1;
+        DimensionValue1.Modify();
+        LibraryERM.CreateDimensionValue(DimensionValue1, Dimension1.Code);
+        DimensionValue1."Global Dimension No." := 1;
+        DimensionValue1.Modify();
+        LibraryERM.CreateDimension(Dimension2);
+        LibraryERM.CreateDimensionValue(DimensionValue2, Dimension2.Code);
+        DimensionValue2."Global Dimension No." := 2;
+        DimensionValue2.Modify();
+        LibraryERM.CreateDimensionValue(DimensionValue2, Dimension2.Code);
+        DimensionValue2."Global Dimension No." := 2;
+        DimensionValue2.Modify();
+        CreateGLEntryWithAmount(GLAccount."No.", DimensionValue1.Code, DimensionValue2.Code, '', WorkDate(), 100);
+    end;
+
     local procedure CreateGLEntry(GLAccountNo: Code[20]; DimensionValue2Code: Code[20])
     begin
         CreateGLEntryWithAmount(GLAccountNo, '', DimensionValue2Code, '', WorkDate(), 1337);
@@ -977,6 +1002,15 @@ codeunit 139544 "Trial Balance Excel Reports"
     procedure EXRTrialBalanceByPeriodExcelHandler(var EXRTrialBalanceByPeriodExcel: TestRequestPage "EXR Trial Bal by Period Excel")
     begin
         EXRTrialBalanceByPeriodExcel.TrialBalanceByPeriod.SetFilter("Date Filter", Format(WorkDate()));
+        EXRTrialBalanceByPeriodExcel.ShowLinesWithZeroValuesField.SetValue(false);
+        EXRTrialBalanceByPeriodExcel.OK().Invoke();
+    end;
+
+    [RequestPageHandler]
+    procedure EXRTrialBalanceByPeriodShowZeroValuesHandler(var EXRTrialBalanceByPeriodExcel: TestRequestPage "EXR Trial Bal by Period Excel")
+    begin
+        EXRTrialBalanceByPeriodExcel.TrialBalanceByPeriod.SetFilter("Date Filter", Format(WorkDate()));
+        EXRTrialBalanceByPeriodExcel.ShowLinesWithZeroValuesField.SetValue(true);
         EXRTrialBalanceByPeriodExcel.OK().Invoke();
     end;
 


### PR DESCRIPTION
## Why

The Trial Balance by Period Excel report emits every combination of the two global dimensions, including combinations where all calculated amounts are zero. This can produce tens of thousands of irrelevant rows and substantially increase workbook size.

Users may still need the complete set of dimension combinations in some reporting scenarios, so the report should support that behavior explicitly without making it the default.

## Summary

- **Added** a Show Lines with Zero Values request-page option, disabled by default.
- **Fixed** zero-value dimension combinations being inserted unless users explicitly request them.
- **Added** regression coverage for both suppressed and included zero-value lines.

Fixes 
[AB#644914](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644914)









