### PR TITLE
[Test] table 12116 "Withholding Tax": add positive (standard field bl…

### DIFF
--- a/src/Layers/IT/Tests/Local/ITCU2015UnitTest.Codeunit.al
+++ b/src/Layers/IT/Tests/Local/ITCU2015UnitTest.Codeunit.al
@@ -1399,6 +1399,29 @@ codeunit 144021 "IT - CU 2015 Unit Test"
         // Verification is done inside ErrorPageHandler
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure ModifyingStandardFieldOnReportedWithholdingTaxIsBlocked()
+    var
+        WithholdingTax: Record "Withholding Tax";
+    begin
+        // [FEATURE] [Withholding Tax]
+        // [SCENARIO] Modifying a standard field on a reported withholding tax entry is blocked
+        Initialize();
+
+        // [GIVEN] A reported withholding tax entry
+        WithholdingTax.Get(CreateWithholdingTaxWithAU001006WithEmptyNonTaxable(CreateVendor(), "Withholding Tax Reason"::A, 0, WorkDate(), WorkDate()));
+        WithholdingTax.Reported := true;
+        WithholdingTax.Modify(false);
+
+        // [WHEN] A standard field is modified and the record is saved
+        WithholdingTax."External Document No." := 'MODIFIED';
+        asserterror WithholdingTax.Modify(true);
+
+        // [THEN] The modification is blocked with the standard error
+        Assert.ExpectedError('Paid and/or certified withholding taxes cannot be modified.');
+    end;
+
     local procedure Initialize()
     var
         WithholdingTax: Record "Withholding Tax";


### PR DESCRIPTION
## What & why
**Follow Up PR**
Adds tests for the Withholding Tax `OnModify` guard (table 12116). The guard keeps reported/paid entries immutable for standard fields but allows edits to extension fields these tests lock that behaviors in so it can't regress.

## Linked work

[AB#640860](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640860)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- `ModifyingStandardFieldOnReportedWithholdingTaxIsBlocked` reported entry, change a standard field, expect the "cannot be modified" error. Passes.
- `ModifyingOnlyExtensionFieldOnReportedWithholdingTaxIsAllowed` reported entry, change only an extension field (id ≥ 50000, added via a small test table extension), the edit goes through. Passes.
- Test-only change, still need to run the IT test suite in a container locally before merge.

## Risk & compatibility

Tests only, no product code touched. Adds one test table extension (field 144300) scoped to the IT test app.



