### PR TITLE
Backport #9430: [28.x] E-Document ADI import crashes with untrappable JSON error when ADI response lacks outputs.1 structure

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Helpers/EDocumentJsonHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Helpers/EDocumentJsonHelper.Codeunit.al
@@ -8,13 +8,20 @@ codeunit 6121 "EDocument Json Helper"
 {
     Access = Internal;
 
+    var
+        MalformedAdiResponseTxt: label 'ADI response is missing the expected ''%1'' property; returning an empty object.', Locked = true;
+        TelemetryCategoryTxt: label 'E-Document Matching Assistance', Locked = true;
+
     internal procedure GetHeaderFields(SourceJsonObject: JsonObject): JsonObject
     var
         JsonToken: JsonToken;
-        ContentObject: JsonObject;
+        ContentObject, EmptyObject : JsonObject;
     begin
         ContentObject := GetInnerObject(SourceJsonObject);
-        ContentObject.Get('fields', JsonToken);
+        if not ContentObject.Get('fields', JsonToken) then begin
+            Session.LogMessage('0000UK1', StrSubstNo(MalformedAdiResponseTxt, 'fields'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
+            exit(EmptyObject);
+        end;
         exit(JsonToken.AsObject());
     end;
 
@@ -31,13 +38,22 @@ codeunit 6121 "EDocument Json Helper"
     internal procedure GetInnerObject(SourceJsonObject: JsonObject): JsonObject
     var
         JsonToken: JsonToken;
-        OutputsObject, InnerObject : JsonObject;
+        OutputsObject, InnerObject, EmptyObject : JsonObject;
     begin
-        SourceJsonObject.Get('outputs', JsonToken);
+        if not SourceJsonObject.Get('outputs', JsonToken) then begin
+            Session.LogMessage('0000UK2', StrSubstNo(MalformedAdiResponseTxt, 'outputs'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
+            exit(EmptyObject);
+        end;
         OutputsObject := JsonToken.AsObject();
-        OutputsObject.Get('1', JsonToken);
+        if not OutputsObject.Get('1', JsonToken) then begin
+            Session.LogMessage('0000UK3', StrSubstNo(MalformedAdiResponseTxt, '1'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
+            exit(EmptyObject);
+        end;
         InnerObject := JsonToken.AsObject();
-        InnerObject.Get('result', JsonToken);
+        if not InnerObject.Get('result', JsonToken) then begin
+            Session.LogMessage('0000UK4', StrSubstNo(MalformedAdiResponseTxt, 'result'), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', TelemetryCategoryTxt);
+            exit(EmptyObject);
+        end;
         exit(JsonToken.AsObject());
     end;
 


### PR DESCRIPTION
Backport of #9430 for [AB#644118](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644118)


