### PR TITLE
Let the agent see and set vendor posting groups and CIF or NIF

### DIFF
--- a/src/Apps/W1/PayablesAgent/app/PermissionSets/PayablesAgRun.Permissionset.al
+++ b/src/Apps/W1/PayablesAgent/app/PermissionSets/PayablesAgRun.Permissionset.al
@@ -9,6 +9,7 @@ namespace Microsoft.Agent.PayablesAgent;
 using Microsoft.eServices.EDocument;
 using Microsoft.Finance.Deferral;
 using Microsoft.Finance.Dimension;
+using Microsoft.Finance.VAT.Registration;
 using Microsoft.Foundation.Attachment;
 using Microsoft.Integration.Entity;
 using System.Agents;
@@ -42,6 +43,8 @@ permissionset 3303 "Payables Ag. - Run"
         tabledata "Deferral Line" = IMD,
         tabledata "Dimension Set Entry" = im,
         tabledata "Dimension Set Tree Node" = im,
+    // Missing permissions for vendor creation
+    tabledata "VAT Registration Log" = i, // Validating VAT Registration No. on the vendor card writes an audit entry to the VAT Registration Log
     // Change Log
     tabledata "Change Log Entry" = i, // Needed when the customer has Change Log or Monitor Sensitive Fields enabled for tables the agent writes to (e.g. User Environment Login on login)
     // Other

--- a/src/Apps/W1/PayablesAgent/app/PermissionSets/PayablesAgRun.Permissionset.al
+++ b/src/Apps/W1/PayablesAgent/app/PermissionSets/PayablesAgRun.Permissionset.al
@@ -43,8 +43,8 @@ permissionset 3303 "Payables Ag. - Run"
         tabledata "Deferral Line" = IMD,
         tabledata "Dimension Set Entry" = im,
         tabledata "Dimension Set Tree Node" = im,
-    // Missing permissions for vendor creation
-    tabledata "VAT Registration Log" = i, // Validating VAT Registration No. on the vendor card writes an audit entry to the VAT Registration Log
+        // Missing permissions for vendor creation
+        tabledata "VAT Registration Log" = i, // Validating VAT Registration No. on the vendor card writes an audit entry to the VAT Registration Log
     // Change Log
     tabledata "Change Log Entry" = i, // Needed when the customer has Change Log or Monitor Sensitive Fields enabled for tables the agent writes to (e.g. User Environment Login on login)
     // Other

--- a/src/Apps/W1/PayablesAgent/app/Profile/PageCustomizations/PAVendorCard.PageCust.al
+++ b/src/Apps/W1/PayablesAgent/app/Profile/PageCustomizations/PAVendorCard.PageCust.al
@@ -19,7 +19,7 @@ pagecustomization "PA Vendor Card" customizes "Vendor Card"
     {
         modify(Invoicing)
         {
-            Visible = false; // VAT information is to difficult to validate currently.
+            Visible = true;
         }
         modify(VendorStatisticsFactBox)
         {


### PR DESCRIPTION
## What & why

The payables agent could not see or set the vendor posting groups or the CIF or NIF when it created a new vendor, so vendor creation stalled and the agent kept asking the user where the fields were. The reason is that the invoicing tab on the vendor card was hidden in the agent profile, which also hide the VAT registration number.

This makes the invoicing tab visible again so the agent can fill the posting groups and the tax id. It also grants the agent the right to write the VAT registration log entry that is created when the number is validated, because without it saving the number failed with a permission error.

Fixes [AB#642338](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642338)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] No tests added because this is a profile visibility and permission change that was verified in product.

**What I tested and the outcome**

- Published the Payables Agent to a local BC server and reran the reported case.
- The agent created vendor V00070, set the CIF or NIF and the posting groups, and the vendor completed with no permission error. Before the fix the same run stopped saying it could not find or update those fields.

## Risk & compatibility

Low. The agent now sees the full invoicing tab, including the VAT related fields that were hidden before, and it has one extra indirect insert permission on the VAT registration log.






