### PR TITLE
[Bug Fix] #641100: Export Acc. Sched. to Excel - log report usage in OnPostReport to avoid modal page in write transaction

### DIFF
--- a/src/Layers/CZ/Tests/ERM/ERMAccountScheduleII.Codeunit.al
+++ b/src/Layers/CZ/Tests/ERM/ERMAccountScheduleII.Codeunit.al
@@ -42,6 +42,7 @@
         TextValueDuplicateErr: Label 'Text value %1 should appear exactly once in Excel export, but found %2 occurrences', Comment = '%1 = Text value, %2 = Occurrence count';
         AuditLogWrittenTooEarlyErr: Label 'The audit log entry for financial report %1 must not be written before the report has finished processing.', Comment = '%1 = Financial report name';
         SheetNameTok: Label 'Sheet%1', Locked = true;
+        SheetNotListedErr: Label 'The sheet selection page must list sheet %1 of the workbook.', Comment = '%1 = Sheet number';
         IsInitialized: Boolean;
 
     [Test]
@@ -2882,6 +2883,9 @@
         LibraryERM.CreateAccScheduleName(AccScheduleName);
 
         // [GIVEN] A subscriber that opens a modal page while the report processes its data item, like the sheet selection does when updating an existing workbook with several sheets
+        // [GIVEN] The workbook contains the sheets "Sheet1" and "Sheet2"
+        LibraryVariableStorage.Enqueue(GetSheetName(1));
+        LibraryVariableStorage.Enqueue(GetSheetName(2));
         BindSubscription(ERMAccountScheduleII);
 
         // [WHEN] The financial report is exported to Excel
@@ -2890,8 +2894,9 @@
         RunExportAccSchedule(AccScheduleLine, AccScheduleName);
         UnbindSubscription(ERMAccountScheduleII);
 
-        // [THEN] The modal page was shown without a write transaction being open
+        // [THEN] The sheet selection page was shown exactly once, listing "Sheet1" and "Sheet2", without a write transaction being open
         // NameValueLookupModalPageHandler
+        LibraryVariableStorage.AssertEmpty();
 
         // [THEN] An audit log entry is created for the action
         FinancialReportAuditLog.SetRange("Report Name", AccScheduleName.Name);
@@ -3783,6 +3788,10 @@
     [ModalPageHandler]
     procedure NameValueLookupModalPageHandler(var NameValueLookup: TestPage "Name/Value Lookup")
     begin
+        Assert.IsTrue(NameValueLookup.First(), StrSubstNo(SheetNotListedErr, 1));
+        NameValueLookup.Name.AssertEquals(LibraryVariableStorage.DequeueText());
+        Assert.IsTrue(NameValueLookup.Next(), StrSubstNo(SheetNotListedErr, 2));
+        NameValueLookup.Name.AssertEquals(LibraryVariableStorage.DequeueText());
         NameValueLookup.OK().Invoke();
     end;
 
@@ -3810,8 +3819,13 @@
     begin
         TempNameValueBuffer.Init();
         TempNameValueBuffer.ID := LineNo;
-        TempNameValueBuffer.Name := CopyStr(StrSubstNo(SheetNameTok, LineNo), 1, MaxStrLen(TempNameValueBuffer.Name));
+        TempNameValueBuffer.Name := GetSheetName(LineNo);
         TempNameValueBuffer.Value := TempNameValueBuffer.Name;
         TempNameValueBuffer.Insert();
+    end;
+
+    local procedure GetSheetName(LineNo: Integer): Text[250]
+    begin
+        exit(CopyStr(StrSubstNo(SheetNameTok, LineNo), 1, 250));
     end;
 }

--- a/src/Layers/CZ/Tests/ERM/ERMAccountScheduleII.Codeunit.al
+++ b/src/Layers/CZ/Tests/ERM/ERMAccountScheduleII.Codeunit.al
@@ -2,6 +2,7 @@
 {
     Subtype = Test;
     TestPermissions = Disabled;
+    EventSubscriberInstance = Manual;
 
     trigger OnRun()
     begin
@@ -39,6 +40,8 @@
         WrongValueErr: Label 'Wrong value of the field %1 in table %2.', Comment = '%1 = Field name, %2 = Table name';
         MissingSheetDataErr: Label 'Sheet %1 is either missing or does not contain the correct data.', Comment = '%1 = Sheet number';
         TextValueDuplicateErr: Label 'Text value %1 should appear exactly once in Excel export, but found %2 occurrences', Comment = '%1 = Text value, %2 = Occurrence count';
+        AuditLogWrittenTooEarlyErr: Label 'The audit log entry for financial report %1 must not be written before the report has finished processing.', Comment = '%1 = Financial report name';
+        SheetNameTok: Label 'Sheet%1', Locked = true;
         IsInitialized: Boolean;
 
     [Test]
@@ -2862,6 +2865,41 @@
         Assert.AreEqual(1, FinancialReportAuditLog.Count(), 'Audit log entry was not created after export the financial report to PDF.');
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('NameValueLookupModalPageHandler')]
+    procedure FinRepAuditLogOnExcelDoesNotBlockModalPage()
+    var
+        AccScheduleName: Record "Acc. Schedule Name";
+        AccScheduleLine: Record "Acc. Schedule Line";
+        FinancialReportAuditLog: Record "Financial Report Audit Log";
+        ERMAccountScheduleII: Codeunit "ERM Account Schedule II";
+    begin
+        // [SCENARIO 641100] Export Acc. Sched. to Excel does not hold a write transaction open while the report processes its data item
+        Initialize();
+
+        // [GIVEN] A financial report "FR"
+        LibraryERM.CreateAccScheduleName(AccScheduleName);
+
+        // [GIVEN] A subscriber that opens a modal page while the report processes its data item, like the sheet selection does when updating an existing workbook with several sheets
+        BindSubscription(ERMAccountScheduleII);
+
+        // [WHEN] The financial report is exported to Excel
+        AccScheduleLine.SetRange("Schedule Name", AccScheduleName.Name);
+        AccScheduleLine.SetRange("Date Filter", CalcDate('<-CY>', WorkDate()), CalcDate('<CY>', WorkDate()));
+        RunExportAccSchedule(AccScheduleLine, AccScheduleName);
+        UnbindSubscription(ERMAccountScheduleII);
+
+        // [THEN] The modal page was shown without a write transaction being open
+        // NameValueLookupModalPageHandler
+
+        // [THEN] An audit log entry is created for the action
+        FinancialReportAuditLog.SetRange("Report Name", AccScheduleName.Name);
+        FinancialReportAuditLog.SetRange(User, UserId);
+        FinancialReportAuditLog.SetRange(Format, FinancialReportAuditLog.Format::Excel);
+        Assert.AreEqual(1, FinancialReportAuditLog.Count(), 'Audit log entry was not created after export the financial report to Excel.');
+    end;
+
     procedure FinancialReportWithBlockedStatus()
     var
         AccScheduleName: Record "Acc. Schedule Name";
@@ -3740,5 +3778,40 @@
     procedure RenameDefinitionConfirmHandler(Question: Text[1024]; var Reply: Boolean)
     begin
         Reply := true;
+    end;
+
+    [ModalPageHandler]
+    procedure NameValueLookupModalPageHandler(var NameValueLookup: TestPage "Name/Value Lookup")
+    begin
+        NameValueLookup.OK().Invoke();
+    end;
+
+    [EventSubscriber(ObjectType::Report, Report::"Export Acc. Sched. to Excel", 'OnIntegerOnAfterGetRecordOnAfterAccSchedLineSetFilter', '', false, false)]
+    local procedure RunModalPageOnAfterAccSchedLineSetFilter(var AccScheduleLine: Record "Acc. Schedule Line")
+    var
+        FinancialReportAuditLog: Record "Financial Report Audit Log";
+        TempNameValueBuffer: Record "Name/Value Buffer" temporary;
+        FinancialReportName: Code[10];
+    begin
+        FinancialReportName := AccScheduleLine.GetRangeMin("Schedule Name");
+
+        InsertNameValueBufferLine(TempNameValueBuffer, 1);
+        InsertNameValueBufferLine(TempNameValueBuffer, 2);
+        TempNameValueBuffer.FindFirst();
+        Page.RunModal(Page::"Name/Value Lookup", TempNameValueBuffer);
+
+        FinancialReportAuditLog.SetRange("Report Name", FinancialReportName);
+        FinancialReportAuditLog.SetRange(User, UserId);
+        FinancialReportAuditLog.SetRange(Format, FinancialReportAuditLog.Format::Excel);
+        Assert.AreEqual(0, FinancialReportAuditLog.Count(), StrSubstNo(AuditLogWrittenTooEarlyErr, FinancialReportName));
+    end;
+
+    local procedure InsertNameValueBufferLine(var TempNameValueBuffer: Record "Name/Value Buffer" temporary; LineNo: Integer)
+    begin
+        TempNameValueBuffer.Init();
+        TempNameValueBuffer.ID := LineNo;
+        TempNameValueBuffer.Name := CopyStr(StrSubstNo(SheetNameTok, LineNo), 1, MaxStrLen(TempNameValueBuffer.Name));
+        TempNameValueBuffer.Value := TempNameValueBuffer.Name;
+        TempNameValueBuffer.Insert();
     end;
 }

--- a/src/Layers/NA/BaseApp/Finance/FinancialReports/ExportAccSchedtoExcel.Report.al
+++ b/src/Layers/NA/BaseApp/Finance/FinancialReports/ExportAccSchedtoExcel.Report.al
@@ -107,13 +107,17 @@ report 29 "Export Acc. Sched. to Excel"
     trigger OnPreReport()
     var
         Company: Record Company;
-        FinancialReportAuditing: Codeunit "Financial Report Auditing";
     begin
         Company.Get(CompanyName());
         CompanyDisplayName := Company."Display Name";
         if CompanyDisplayName = '' then
             CompanyDisplayName := Company.Name;
+    end;
 
+    trigger OnPostReport()
+    var
+        FinancialReportAuditing: Codeunit "Financial Report Auditing";
+    begin
         FinancialReportAuditing.LogReportUsage(FinancialReport.Name, Enum::"Financial Report Format"::Excel, RunForExport);
     end;
 

--- a/src/Layers/NA/Tests/ERM/ERMAccountScheduleII.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM/ERMAccountScheduleII.Codeunit.al
@@ -2,6 +2,7 @@
 {
     Subtype = Test;
     TestPermissions = Disabled;
+    EventSubscriberInstance = Manual;
 
     trigger OnRun()
     begin
@@ -39,6 +40,8 @@
         WrongValueErr: Label 'Wrong value of the field %1 in table %2.', Comment = '%1 = Field name, %2 = Table name';
         MissingSheetDataErr: Label 'Sheet %1 is either missing or does not contain the correct data.', Comment = '%1 = Sheet number';
         TextValueDuplicateErr: Label 'Text value %1 should appear exactly once in Excel export, but found %2 occurrences', Comment = '%1 = Text value, %2 = Occurrence count';
+        AuditLogWrittenTooEarlyErr: Label 'The audit log entry for financial report %1 must not be written before the report has finished processing.', Comment = '%1 = Financial report name';
+        SheetNameTok: Label 'Sheet%1', Locked = true;
         IsInitialized: Boolean;
 
     [Test]
@@ -2900,6 +2903,41 @@
         Assert.AreEqual(1, FinancialReportAuditLog.Count(), 'Audit log entry was not created after export the financial report to PDF.');
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('NameValueLookupModalPageHandler')]
+    procedure FinRepAuditLogOnExcelDoesNotBlockModalPage()
+    var
+        AccScheduleName: Record "Acc. Schedule Name";
+        AccScheduleLine: Record "Acc. Schedule Line";
+        FinancialReportAuditLog: Record "Financial Report Audit Log";
+        ERMAccountScheduleII: Codeunit "ERM Account Schedule II";
+    begin
+        // [SCENARIO 641100] Export Acc. Sched. to Excel does not hold a write transaction open while the report processes its data item
+        Initialize();
+
+        // [GIVEN] A financial report "FR"
+        LibraryERM.CreateAccScheduleName(AccScheduleName);
+
+        // [GIVEN] A subscriber that opens a modal page while the report processes its data item, like the sheet selection does when updating an existing workbook with several sheets
+        BindSubscription(ERMAccountScheduleII);
+
+        // [WHEN] The financial report is exported to Excel
+        AccScheduleLine.SetRange("Schedule Name", AccScheduleName.Name);
+        AccScheduleLine.SetRange("Date Filter", CalcDate('<-CY>', WorkDate()), CalcDate('<CY>', WorkDate()));
+        RunExportAccSchedule(AccScheduleLine, AccScheduleName);
+        UnbindSubscription(ERMAccountScheduleII);
+
+        // [THEN] The modal page was shown without a write transaction being open
+        // NameValueLookupModalPageHandler
+
+        // [THEN] An audit log entry is created for the action
+        FinancialReportAuditLog.SetRange("Report Name", AccScheduleName.Name);
+        FinancialReportAuditLog.SetRange(User, UserId);
+        FinancialReportAuditLog.SetRange(Format, FinancialReportAuditLog.Format::Excel);
+        Assert.AreEqual(1, FinancialReportAuditLog.Count(), 'Audit log entry was not created after export the financial report to Excel.');
+    end;
+
     procedure FinancialReportWithBlockedStatus()
     var
         AccScheduleName: Record "Acc. Schedule Name";
@@ -3795,5 +3833,40 @@
     procedure RenameDefinitionConfirmHandler(Question: Text[1024]; var Reply: Boolean)
     begin
         Reply := true;
+    end;
+
+    [ModalPageHandler]
+    procedure NameValueLookupModalPageHandler(var NameValueLookup: TestPage "Name/Value Lookup")
+    begin
+        NameValueLookup.OK().Invoke();
+    end;
+
+    [EventSubscriber(ObjectType::Report, Report::"Export Acc. Sched. to Excel", 'OnIntegerOnAfterGetRecordOnAfterAccSchedLineSetFilter', '', false, false)]
+    local procedure RunModalPageOnAfterAccSchedLineSetFilter(var AccScheduleLine: Record "Acc. Schedule Line")
+    var
+        FinancialReportAuditLog: Record "Financial Report Audit Log";
+        TempNameValueBuffer: Record "Name/Value Buffer" temporary;
+        FinancialReportName: Code[10];
+    begin
+        FinancialReportName := AccScheduleLine.GetRangeMin("Schedule Name");
+
+        InsertNameValueBufferLine(TempNameValueBuffer, 1);
+        InsertNameValueBufferLine(TempNameValueBuffer, 2);
+        TempNameValueBuffer.FindFirst();
+        Page.RunModal(Page::"Name/Value Lookup", TempNameValueBuffer);
+
+        FinancialReportAuditLog.SetRange("Report Name", FinancialReportName);
+        FinancialReportAuditLog.SetRange(User, UserId);
+        FinancialReportAuditLog.SetRange(Format, FinancialReportAuditLog.Format::Excel);
+        Assert.AreEqual(0, FinancialReportAuditLog.Count(), StrSubstNo(AuditLogWrittenTooEarlyErr, FinancialReportName));
+    end;
+
+    local procedure InsertNameValueBufferLine(var TempNameValueBuffer: Record "Name/Value Buffer" temporary; LineNo: Integer)
+    begin
+        TempNameValueBuffer.Init();
+        TempNameValueBuffer.ID := LineNo;
+        TempNameValueBuffer.Name := CopyStr(StrSubstNo(SheetNameTok, LineNo), 1, MaxStrLen(TempNameValueBuffer.Name));
+        TempNameValueBuffer.Value := TempNameValueBuffer.Name;
+        TempNameValueBuffer.Insert();
     end;
 }

--- a/src/Layers/NA/Tests/ERM/ERMAccountScheduleII.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM/ERMAccountScheduleII.Codeunit.al
@@ -42,6 +42,7 @@
         TextValueDuplicateErr: Label 'Text value %1 should appear exactly once in Excel export, but found %2 occurrences', Comment = '%1 = Text value, %2 = Occurrence count';
         AuditLogWrittenTooEarlyErr: Label 'The audit log entry for financial report %1 must not be written before the report has finished processing.', Comment = '%1 = Financial report name';
         SheetNameTok: Label 'Sheet%1', Locked = true;
+        SheetNotListedErr: Label 'The sheet selection page must list sheet %1 of the workbook.', Comment = '%1 = Sheet number';
         IsInitialized: Boolean;
 
     [Test]
@@ -2920,6 +2921,9 @@
         LibraryERM.CreateAccScheduleName(AccScheduleName);
 
         // [GIVEN] A subscriber that opens a modal page while the report processes its data item, like the sheet selection does when updating an existing workbook with several sheets
+        // [GIVEN] The workbook contains the sheets "Sheet1" and "Sheet2"
+        LibraryVariableStorage.Enqueue(GetSheetName(1));
+        LibraryVariableStorage.Enqueue(GetSheetName(2));
         BindSubscription(ERMAccountScheduleII);
 
         // [WHEN] The financial report is exported to Excel
@@ -2928,8 +2932,9 @@
         RunExportAccSchedule(AccScheduleLine, AccScheduleName);
         UnbindSubscription(ERMAccountScheduleII);
 
-        // [THEN] The modal page was shown without a write transaction being open
+        // [THEN] The sheet selection page was shown exactly once, listing "Sheet1" and "Sheet2", without a write transaction being open
         // NameValueLookupModalPageHandler
+        LibraryVariableStorage.AssertEmpty();
 
         // [THEN] An audit log entry is created for the action
         FinancialReportAuditLog.SetRange("Report Name", AccScheduleName.Name);
@@ -3838,6 +3843,10 @@
     [ModalPageHandler]
     procedure NameValueLookupModalPageHandler(var NameValueLookup: TestPage "Name/Value Lookup")
     begin
+        Assert.IsTrue(NameValueLookup.First(), StrSubstNo(SheetNotListedErr, 1));
+        NameValueLookup.Name.AssertEquals(LibraryVariableStorage.DequeueText());
+        Assert.IsTrue(NameValueLookup.Next(), StrSubstNo(SheetNotListedErr, 2));
+        NameValueLookup.Name.AssertEquals(LibraryVariableStorage.DequeueText());
         NameValueLookup.OK().Invoke();
     end;
 
@@ -3865,8 +3874,13 @@
     begin
         TempNameValueBuffer.Init();
         TempNameValueBuffer.ID := LineNo;
-        TempNameValueBuffer.Name := CopyStr(StrSubstNo(SheetNameTok, LineNo), 1, MaxStrLen(TempNameValueBuffer.Name));
+        TempNameValueBuffer.Name := GetSheetName(LineNo);
         TempNameValueBuffer.Value := TempNameValueBuffer.Name;
         TempNameValueBuffer.Insert();
+    end;
+
+    local procedure GetSheetName(LineNo: Integer): Text[250]
+    begin
+        exit(CopyStr(StrSubstNo(SheetNameTok, LineNo), 1, 250));
     end;
 }

--- a/src/Layers/W1/BaseApp/Finance/FinancialReports/ExportAccSchedtoExcel.Report.al
+++ b/src/Layers/W1/BaseApp/Finance/FinancialReports/ExportAccSchedtoExcel.Report.al
@@ -107,13 +107,17 @@ report 29 "Export Acc. Sched. to Excel"
     trigger OnPreReport()
     var
         Company: Record Company;
-        FinancialReportAuditing: Codeunit "Financial Report Auditing";
     begin
         Company.Get(CompanyName());
         CompanyDisplayName := Company."Display Name";
         if CompanyDisplayName = '' then
             CompanyDisplayName := Company.Name;
+    end;
 
+    trigger OnPostReport()
+    var
+        FinancialReportAuditing: Codeunit "Financial Report Auditing";
+    begin
         FinancialReportAuditing.LogReportUsage(FinancialReport.Name, Enum::"Financial Report Format"::Excel, RunForExport);
     end;
 

--- a/src/Layers/W1/Tests/ERM/ERMAccountScheduleII.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMAccountScheduleII.Codeunit.al
@@ -42,6 +42,7 @@
         TextValueDuplicateErr: Label 'Text value %1 should appear exactly once in Excel export, but found %2 occurrences', Comment = '%1 = Text value, %2 = Occurrence count';
         AuditLogWrittenTooEarlyErr: Label 'The audit log entry for financial report %1 must not be written before the report has finished processing.', Comment = '%1 = Financial report name';
         SheetNameTok: Label 'Sheet%1', Locked = true;
+        SheetNotListedErr: Label 'The sheet selection page must list sheet %1 of the workbook.', Comment = '%1 = Sheet number';
         IsInitialized: Boolean;
 
     [Test]
@@ -2882,6 +2883,9 @@
         LibraryERM.CreateAccScheduleName(AccScheduleName);
 
         // [GIVEN] A subscriber that opens a modal page while the report processes its data item, like the sheet selection does when updating an existing workbook with several sheets
+        // [GIVEN] The workbook contains the sheets "Sheet1" and "Sheet2"
+        LibraryVariableStorage.Enqueue(GetSheetName(1));
+        LibraryVariableStorage.Enqueue(GetSheetName(2));
         BindSubscription(ERMAccountScheduleII);
 
         // [WHEN] The financial report is exported to Excel
@@ -2890,8 +2894,9 @@
         RunExportAccSchedule(AccScheduleLine, AccScheduleName);
         UnbindSubscription(ERMAccountScheduleII);
 
-        // [THEN] The modal page was shown without a write transaction being open
+        // [THEN] The sheet selection page was shown exactly once, listing "Sheet1" and "Sheet2", without a write transaction being open
         // NameValueLookupModalPageHandler
+        LibraryVariableStorage.AssertEmpty();
 
         // [THEN] An audit log entry is created for the action
         FinancialReportAuditLog.SetRange("Report Name", AccScheduleName.Name);
@@ -3783,6 +3788,10 @@
     [ModalPageHandler]
     procedure NameValueLookupModalPageHandler(var NameValueLookup: TestPage "Name/Value Lookup")
     begin
+        Assert.IsTrue(NameValueLookup.First(), StrSubstNo(SheetNotListedErr, 1));
+        NameValueLookup.Name.AssertEquals(LibraryVariableStorage.DequeueText());
+        Assert.IsTrue(NameValueLookup.Next(), StrSubstNo(SheetNotListedErr, 2));
+        NameValueLookup.Name.AssertEquals(LibraryVariableStorage.DequeueText());
         NameValueLookup.OK().Invoke();
     end;
 
@@ -3810,8 +3819,13 @@
     begin
         TempNameValueBuffer.Init();
         TempNameValueBuffer.ID := LineNo;
-        TempNameValueBuffer.Name := CopyStr(StrSubstNo(SheetNameTok, LineNo), 1, MaxStrLen(TempNameValueBuffer.Name));
+        TempNameValueBuffer.Name := GetSheetName(LineNo);
         TempNameValueBuffer.Value := TempNameValueBuffer.Name;
         TempNameValueBuffer.Insert();
+    end;
+
+    local procedure GetSheetName(LineNo: Integer): Text[250]
+    begin
+        exit(CopyStr(StrSubstNo(SheetNameTok, LineNo), 1, 250));
     end;
 }

--- a/src/Layers/W1/Tests/ERM/ERMAccountScheduleII.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMAccountScheduleII.Codeunit.al
@@ -2,6 +2,7 @@
 {
     Subtype = Test;
     TestPermissions = Disabled;
+    EventSubscriberInstance = Manual;
 
     trigger OnRun()
     begin
@@ -39,6 +40,8 @@
         WrongValueErr: Label 'Wrong value of the field %1 in table %2.', Comment = '%1 = Field name, %2 = Table name';
         MissingSheetDataErr: Label 'Sheet %1 is either missing or does not contain the correct data.', Comment = '%1 = Sheet number';
         TextValueDuplicateErr: Label 'Text value %1 should appear exactly once in Excel export, but found %2 occurrences', Comment = '%1 = Text value, %2 = Occurrence count';
+        AuditLogWrittenTooEarlyErr: Label 'The audit log entry for financial report %1 must not be written before the report has finished processing.', Comment = '%1 = Financial report name';
+        SheetNameTok: Label 'Sheet%1', Locked = true;
         IsInitialized: Boolean;
 
     [Test]
@@ -2862,6 +2865,41 @@
         Assert.AreEqual(1, FinancialReportAuditLog.Count(), 'Audit log entry was not created after export the financial report to PDF.');
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('NameValueLookupModalPageHandler')]
+    procedure FinRepAuditLogOnExcelDoesNotBlockModalPage()
+    var
+        AccScheduleName: Record "Acc. Schedule Name";
+        AccScheduleLine: Record "Acc. Schedule Line";
+        FinancialReportAuditLog: Record "Financial Report Audit Log";
+        ERMAccountScheduleII: Codeunit "ERM Account Schedule II";
+    begin
+        // [SCENARIO 641100] Export Acc. Sched. to Excel does not hold a write transaction open while the report processes its data item
+        Initialize();
+
+        // [GIVEN] A financial report "FR"
+        LibraryERM.CreateAccScheduleName(AccScheduleName);
+
+        // [GIVEN] A subscriber that opens a modal page while the report processes its data item, like the sheet selection does when updating an existing workbook with several sheets
+        BindSubscription(ERMAccountScheduleII);
+
+        // [WHEN] The financial report is exported to Excel
+        AccScheduleLine.SetRange("Schedule Name", AccScheduleName.Name);
+        AccScheduleLine.SetRange("Date Filter", CalcDate('<-CY>', WorkDate()), CalcDate('<CY>', WorkDate()));
+        RunExportAccSchedule(AccScheduleLine, AccScheduleName);
+        UnbindSubscription(ERMAccountScheduleII);
+
+        // [THEN] The modal page was shown without a write transaction being open
+        // NameValueLookupModalPageHandler
+
+        // [THEN] An audit log entry is created for the action
+        FinancialReportAuditLog.SetRange("Report Name", AccScheduleName.Name);
+        FinancialReportAuditLog.SetRange(User, UserId);
+        FinancialReportAuditLog.SetRange(Format, FinancialReportAuditLog.Format::Excel);
+        Assert.AreEqual(1, FinancialReportAuditLog.Count(), 'Audit log entry was not created after export the financial report to Excel.');
+    end;
+
     procedure FinancialReportWithBlockedStatus()
     var
         AccScheduleName: Record "Acc. Schedule Name";
@@ -3740,5 +3778,40 @@
     procedure RenameDefinitionConfirmHandler(Question: Text[1024]; var Reply: Boolean)
     begin
         Reply := true;
+    end;
+
+    [ModalPageHandler]
+    procedure NameValueLookupModalPageHandler(var NameValueLookup: TestPage "Name/Value Lookup")
+    begin
+        NameValueLookup.OK().Invoke();
+    end;
+
+    [EventSubscriber(ObjectType::Report, Report::"Export Acc. Sched. to Excel", 'OnIntegerOnAfterGetRecordOnAfterAccSchedLineSetFilter', '', false, false)]
+    local procedure RunModalPageOnAfterAccSchedLineSetFilter(var AccScheduleLine: Record "Acc. Schedule Line")
+    var
+        FinancialReportAuditLog: Record "Financial Report Audit Log";
+        TempNameValueBuffer: Record "Name/Value Buffer" temporary;
+        FinancialReportName: Code[10];
+    begin
+        FinancialReportName := AccScheduleLine.GetRangeMin("Schedule Name");
+
+        InsertNameValueBufferLine(TempNameValueBuffer, 1);
+        InsertNameValueBufferLine(TempNameValueBuffer, 2);
+        TempNameValueBuffer.FindFirst();
+        Page.RunModal(Page::"Name/Value Lookup", TempNameValueBuffer);
+
+        FinancialReportAuditLog.SetRange("Report Name", FinancialReportName);
+        FinancialReportAuditLog.SetRange(User, UserId);
+        FinancialReportAuditLog.SetRange(Format, FinancialReportAuditLog.Format::Excel);
+        Assert.AreEqual(0, FinancialReportAuditLog.Count(), StrSubstNo(AuditLogWrittenTooEarlyErr, FinancialReportName));
+    end;
+
+    local procedure InsertNameValueBufferLine(var TempNameValueBuffer: Record "Name/Value Buffer" temporary; LineNo: Integer)
+    begin
+        TempNameValueBuffer.Init();
+        TempNameValueBuffer.ID := LineNo;
+        TempNameValueBuffer.Name := CopyStr(StrSubstNo(SheetNameTok, LineNo), 1, MaxStrLen(TempNameValueBuffer.Name));
+        TempNameValueBuffer.Value := TempNameValueBuffer.Name;
+        TempNameValueBuffer.Insert();
     end;
 }


### PR DESCRIPTION
## What & why

`Report 29 "Export Acc. Sched. to Excel"` failed with **"Form.RunModal is not allowed in write transactions"** when a user updated an existing Excel file containing more than one worksheet.

The report is `ProcessingOnly = true` with `UseRequestPage = false`, so it has no commit boundary. `OnPreReport` called `"Financial Report Auditing".LogReportUsage(...)`, which inserts into `"Financial Report Audit Log"` and therefore opens a write transaction. That transaction was still open further down the run:

```
Integer.OnAfterGetRecord
  -> UploadClientFile
     -> "Excel Buffer".SelectSheetsName
        -> SelectSheetsNameStream
           -> PAGE.RunModal(PAGE::"Name/Value Lookup")   <-- only when the workbook has >1 sheet
```

`PAGE.RunModal` is reached only when the uploaded workbook has more than one sheet, which is exactly the reported scenario (the user added an extra sheet to a previously exported file), so the regression only surfaced for multi-sheet workbooks.

The fix moves the logging call to `OnPostReport`, so no write transaction is open while the report processes its data item. `OnPreReport` still resolves `CompanyDisplayName`, which is consumed while the sheets are written. A bare `Commit()` was deliberately **not** used — it is fragile and would commit unrelated pending work.

Introduced by PR 239876 "[BusinessCentralApps #1702] Financial Report Audit Logs". `Report 25 "Account Schedule"` also calls `LogReportUsage` from `OnPreReport`, but it is an RDLC rendering report (not `ProcessingOnly`) with no modal-page-in-transaction path — audited, not affected.

**Changed files**

- `src/Layers/W1/BaseApp/Finance/FinancialReports/ExportAccSchedtoExcel.Report.al` — moved `LogReportUsage(...)` from `OnPreReport` to a new `OnPostReport` trigger.
- `src/Layers/NA/BaseApp/Finance/FinancialReports/ExportAccSchedtoExcel.Report.al` — the NA layer holds a full copy of report 29 with the identical defect; same change applied.
- `src/Layers/W1/Tests/ERM/ERMAccountScheduleII.Codeunit.al` — added regression test `FinRepAuditLogOnExcelDoesNotBlockModalPage`, which asserts no audit log entry exists while the data item is still being processed.

## Linked work

[AB#641100](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641100) (IcM 21000001088737)




