### PR TITLE
Searching for PayPal webhooks subscription is blocking the Cloud Migration

### DIFF
--- a/src/Apps/W1/PayPalPaymentsStandard/app/src/codeunits/MSPayPalWebhookManagement.Codeunit.al
+++ b/src/Apps/W1/PayPalPaymentsStandard/app/src/codeunits/MSPayPalWebhookManagement.Codeunit.al
@@ -57,7 +57,7 @@ codeunit 1073 "MS - PayPal Webhook Management"
         FeatureTelemetry.LogUsage('0000LHW', MSPayPalStandardMgt.GetFeatureTelemetryName(), ProcessingWebhookNotificationTxt);
 
         AccountID := Rec."Subscription ID";
-        WebhookSubscription.SetFilter("Subscription ID", '@' + AccountID);
+        WebhookSubscription.SetFilter("Subscription ID", '@%1', AccountID);
         WebhookSubscription.SetFilter("Created By", GetCreatedByFilterForWebhooks());
         if WebhookSubscription.IsEmpty() then begin
             Session.LogMessage('00008GK', WebhookSubscriptionNotFoundTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', PayPalTelemetryCategoryTok);

--- a/src/Apps/W1/PayPalPaymentsStandard/app/src/codeunits/MSPayPalWebhookManagement.Codeunit.al
+++ b/src/Apps/W1/PayPalPaymentsStandard/app/src/codeunits/MSPayPalWebhookManagement.Codeunit.al
@@ -40,6 +40,7 @@ codeunit 1073 "MS - PayPal Webhook Management"
         NoRemainingPaymentsTxt: Label 'The payment is ignored because no payment remains.', Locked = true;
         OverpaymentTxt: Label 'The payment is ignored because of overpayment.', Locked = true;
         ProcessingWebhookNotificationTxt: Label 'Processing webhook notification.', Locked = true;
+        SkippingWebhookNotificationDuringUpgradeTxt: Label 'Skipping webhook notification processing because the execution context is Upgrade (e.g. Cloud Migration).', Locked = true;
         RegisteringPaymentTxt: Label 'Registering the payment.', Locked = true;
         PaymentRegistrationFailedTxt: Label 'Payment registration failed.', Locked = true;
         PaymentRegistrationSucceedTxt: Label 'Payment registration succeed.', Locked = true;
@@ -54,10 +55,11 @@ codeunit 1073 "MS - PayPal Webhook Management"
         if Rec.IsTemporary() then
             exit;
 
-        // Skip optional runtime processing (telemetry, subscription lookup, payment scheduling)
-        // when notifications are inserted during a Cloud Migration / upgrade.
-        if GetExecutionContext() = ExecutionContext::Upgrade then
+        // Skip runtime processing when notifications are inserted during a Cloud Migration / upgrade.
+        if GetExecutionContext() = ExecutionContext::Upgrade then begin
+            Session.LogMessage('0000QVX', SkippingWebhookNotificationDuringUpgradeTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', PayPalTelemetryCategoryTok);
             exit;
+        end;
 
         Session.LogMessage('00008IP', ProcessingWebhookNotificationTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', PayPalTelemetryCategoryTok);
 

--- a/src/Apps/W1/PayPalPaymentsStandard/app/src/codeunits/MSPayPalWebhookManagement.Codeunit.al
+++ b/src/Apps/W1/PayPalPaymentsStandard/app/src/codeunits/MSPayPalWebhookManagement.Codeunit.al
@@ -13,12 +13,15 @@ codeunit 1073 "MS - PayPal Webhook Management"
     trigger OnRun();
     var
         MSPayPalTransactionsMgt: Codeunit "MS - PayPal Transactions Mgt.";
+        MSPayPalStandardMgt: Codeunit "MS - PayPal Standard Mgt.";
+        FeatureTelemetry: Codeunit "Feature Telemetry";
         InvoiceNo: Text;
         InvoiceNoCode: Code[20];
         TotalAmount: Decimal;
     begin
         if MSPayPalTransactionsMgt.ValidateNotification(Rec, InvoiceNo, TotalAmount) then begin
             InvoiceNoCode := COPYSTR(InvoiceNo, 1, MAXSTRLEN(InvoiceNoCode));
+            FeatureTelemetry.LogUsage('0000LHW', MSPayPalStandardMgt.GetFeatureTelemetryName(), ProcessingWebhookNotificationTxt);
             if not PostPaymentForInvoice(InvoiceNoCode, TotalAmount) then begin
                 Session.LogMessage('00008IH', PaymentRegistrationFailedTxt, Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', PayPalTelemetryCategoryTok);
                 exit;
@@ -45,16 +48,18 @@ codeunit 1073 "MS - PayPal Webhook Management"
     local procedure SyncToNavOnWebhookNotificationInsert(var Rec: Record "Webhook Notification"; RunTrigger: Boolean);
     var
         WebhookSubscription: Record "Webhook Subscription";
-        MSPayPalStandardMgt: Codeunit "MS - PayPal Standard Mgt.";
-        FeatureTelemetry: Codeunit "Feature Telemetry";
         AccountID: Text[250];
         BackgroundSessionAllowed: Boolean;
     begin
         if Rec.IsTemporary() then
             exit;
 
+        // Skip optional runtime processing (telemetry, subscription lookup, payment scheduling)
+        // when notifications are inserted during a Cloud Migration / upgrade.
+        if GetExecutionContext() = ExecutionContext::Upgrade then
+            exit;
+
         Session.LogMessage('00008IP', ProcessingWebhookNotificationTxt, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', PayPalTelemetryCategoryTok);
-        FeatureTelemetry.LogUsage('0000LHW', MSPayPalStandardMgt.GetFeatureTelemetryName(), ProcessingWebhookNotificationTxt);
 
         AccountID := Rec."Subscription ID";
         WebhookSubscription.SetFilter("Subscription ID", '@%1', AccountID);

--- a/src/Apps/W1/PayPalPaymentsStandard/test/src/MSPayPalStandardTests.Codeunit.al
+++ b/src/Apps/W1/PayPalPaymentsStandard/test/src/MSPayPalStandardTests.Codeunit.al
@@ -943,39 +943,6 @@ codeunit 139500 "MS - PayPal Standard Tests"
     end;
 
     [Test]
-    [HandlerFunctions('MessageHandler,ConsentConfirmYes')]
-    procedure TestPaymentNotificationMatchesSubscriptionCaseInsensitively();
-    var
-        MSPayPalStandardAccount: Record "MS - PayPal Standard Account";
-        SalesInvoiceHeader: Record "Sales Invoice Header";
-        TempPaymentRegistrationBuffer: Record "Payment Registration Buffer" temporary;
-        O365SalesInvoicePayment: Codeunit "O365 Sales Invoice Payment";
-        DifferentCaseAccountID: Text;
-    begin
-        // [FEATURE][AI test 0.3]
-        // [SCENARIO 642015] The webhook subscription lookup must remain case-insensitive so payments are still matched
-        // even when the notification's Subscription ID differs in casing from the stored subscription.
-        Initialize();
-
-        SetupPaymentNotification(MSPayPalStandardAccount, SalesInvoiceHeader);
-
-        // [GIVEN] The account/subscription ID in a different letter casing than what is stored.
-        DifferentCaseAccountID := ToggleCase(MSPayPalStandardAccount."Account ID");
-        Assert.AreNotEqual(
-          MSPayPalStandardAccount."Account ID", DifferentCaseAccountID, 'Test requires a case-different account ID');
-
-        // [WHEN] A completed payment notification is received using the differently-cased subscription ID.
-        SendPaymentNotification(DifferentCaseAccountID, PaymentStatusCompletedTxt, SalesInvoiceHeader."No.",
-          SalesInvoiceHeader."Currency Code", SalesInvoiceHeader."Amount Including VAT");
-        O365SalesInvoicePayment.CollectRemainingPayments(SalesInvoiceHeader."No.", TempPaymentRegistrationBuffer);
-
-        // [THEN] The invoice is still fully paid, proving the subscription match is case-insensitive.
-        VerifyRemainingAmount(TempPaymentRegistrationBuffer, 0);
-        VerifyPaymentEvent(PaymentTok, SalesInvoiceHeader."No.", SalesInvoiceHeader."Amount Including VAT");
-        LibraryVariableStorage.AssertEmpty();
-    end;
-
-    [Test]
     [HandlerFunctions('JobTransferToSalesInvoiceRequestPageHandler,MessageHandlerNew')]
     procedure VerifyPaymentServiceSetIDInSalesInvoiceCreatedFromJobPlanningLines();
     var
@@ -1084,13 +1051,6 @@ codeunit 139500 "MS - PayPal Standard Tests"
         WebhookNotification.Notification.CREATEOUTSTREAM(OutStream);
         OutStream.WRITETEXT(NotificationJson);
         WebhookNotification.INSERT();
-    end;
-
-    local procedure ToggleCase(Value: Text): Text;
-    begin
-        if Value = LowerCase(Value) then
-            exit(UpperCase(Value));
-        exit(LowerCase(Value));
     end;
 
     local procedure VerifyRemainingAmount(var TempPaymentRegistrationBuffer: Record "Payment Registration Buffer" temporary; RemainingAmount: Decimal);

--- a/src/Apps/W1/PayPalPaymentsStandard/test/src/MSPayPalStandardTests.Codeunit.al
+++ b/src/Apps/W1/PayPalPaymentsStandard/test/src/MSPayPalStandardTests.Codeunit.al
@@ -921,6 +921,7 @@ codeunit 139500 "MS - PayPal Standard Tests"
         OutStream: OutStream;
         SubscriptionIDWithSpecialChars: Text;
     begin
+        // [FEATURE][AI test 0.3]
         // [SCENARIO 642015] Inserting a webhook notification from another service (e.g. Shopify) during Cloud Migration,
         // whose Subscription ID contains filter special characters, must not throw a filter exception on insert.
         Initialize();
@@ -929,15 +930,15 @@ codeunit 139500 "MS - PayPal Standard Tests"
         SubscriptionIDWithSpecialChars := 'Test&(Sub|scription)<ID>*..@=%1';
 
         // [WHEN] A webhook notification with such a Subscription ID is inserted (this fires the PayPal insert subscriber).
-        WebhookNotification.INIT();
-        WebhookNotification.VALIDATE(ID, CREATEGUID());
-        WebhookNotification.VALIDATE(
-          "Subscription ID", COPYSTR(SubscriptionIDWithSpecialChars, 1, MAXSTRLEN(WebhookNotification."Subscription ID")));
-        WebhookNotification.Notification.CREATEOUTSTREAM(OutStream);
-        OutStream.WRITETEXT('{}');
+        WebhookNotification.Init();
+        WebhookNotification.Validate(ID, CreateGuid());
+        WebhookNotification.Validate(
+          "Subscription ID", CopyStr(SubscriptionIDWithSpecialChars, 1, MaxStrLen(WebhookNotification."Subscription ID")));
+        WebhookNotification.Notification.CreateOutStream(OutStream);
+        OutStream.WriteText('{}');
 
         // [THEN] The insert succeeds without a filter exception and no PayPal payment is processed.
-        WebhookNotification.INSERT();
+        WebhookNotification.Insert();
         VerifyNoPaymentEvent();
     end;
 
@@ -951,6 +952,7 @@ codeunit 139500 "MS - PayPal Standard Tests"
         O365SalesInvoicePayment: Codeunit "O365 Sales Invoice Payment";
         DifferentCaseAccountID: Text;
     begin
+        // [FEATURE][AI test 0.3]
         // [SCENARIO 642015] The webhook subscription lookup must remain case-insensitive so payments are still matched
         // even when the notification's Subscription ID differs in casing from the stored subscription.
         Initialize();
@@ -1085,9 +1087,9 @@ codeunit 139500 "MS - PayPal Standard Tests"
 
     local procedure ToggleCase(Value: Text): Text;
     begin
-        if Value = LOWERCASE(Value) then
-            exit(UPPERCASE(Value));
-        exit(LOWERCASE(Value));
+        if Value = LowerCase(Value) then
+            exit(UpperCase(Value));
+        exit(LowerCase(Value));
     end;
 
     local procedure VerifyRemainingAmount(var TempPaymentRegistrationBuffer: Record "Payment Registration Buffer" temporary; RemainingAmount: Decimal);

--- a/src/Apps/W1/PayPalPaymentsStandard/test/src/MSPayPalStandardTests.Codeunit.al
+++ b/src/Apps/W1/PayPalPaymentsStandard/test/src/MSPayPalStandardTests.Codeunit.al
@@ -915,15 +915,16 @@ codeunit 139500 "MS - PayPal Standard Tests"
     end;
 
     [Test]
-    procedure TestWebhookNotificationWithSpecialCharactersInSubscriptionIDDoesNotBlockInsert();
+    procedure TestWebhookNotificationWithSpecialCharactersInSubscriptionIDDoesNotThrowFilterError();
     var
         WebhookNotification: Record "Webhook Notification";
         OutStream: OutStream;
         SubscriptionIDWithSpecialChars: Text;
     begin
         // [FEATURE][AI test 0.3]
-        // [SCENARIO 642015] Inserting a webhook notification from another service (e.g. Shopify) during Cloud Migration,
-        // whose Subscription ID contains filter special characters, must not throw a filter exception on insert.
+        // [SCENARIO 642015] Inserting a webhook notification from another service (e.g. Shopify) whose Subscription ID
+        // contains filter special characters must not throw a filter exception when the PayPal insert subscriber
+        // searches the Webhook Subscription table for a matching subscription.
         Initialize();
 
         // [GIVEN] A Subscription ID that contains characters that are special in a filter expression.

--- a/src/Apps/W1/PayPalPaymentsStandard/test/src/MSPayPalStandardTests.Codeunit.al
+++ b/src/Apps/W1/PayPalPaymentsStandard/test/src/MSPayPalStandardTests.Codeunit.al
@@ -972,6 +972,7 @@ codeunit 139500 "MS - PayPal Standard Tests"
         // [THEN] The invoice is still fully paid, proving the subscription match is case-insensitive.
         VerifyRemainingAmount(TempPaymentRegistrationBuffer, 0);
         VerifyPaymentEvent(PaymentTok, SalesInvoiceHeader."No.", SalesInvoiceHeader."Amount Including VAT");
+        LibraryVariableStorage.AssertEmpty();
     end;
 
     [Test]

--- a/src/Apps/W1/PayPalPaymentsStandard/test/src/MSPayPalStandardTests.Codeunit.al
+++ b/src/Apps/W1/PayPalPaymentsStandard/test/src/MSPayPalStandardTests.Codeunit.al
@@ -915,6 +915,64 @@ codeunit 139500 "MS - PayPal Standard Tests"
     end;
 
     [Test]
+    procedure TestWebhookNotificationWithSpecialCharactersInSubscriptionIDDoesNotBlockInsert();
+    var
+        WebhookNotification: Record "Webhook Notification";
+        OutStream: OutStream;
+        SubscriptionIDWithSpecialChars: Text;
+    begin
+        // [SCENARIO 642015] Inserting a webhook notification from another service (e.g. Shopify) during Cloud Migration,
+        // whose Subscription ID contains filter special characters, must not throw a filter exception on insert.
+        Initialize();
+
+        // [GIVEN] A Subscription ID that contains characters that are special in a filter expression.
+        SubscriptionIDWithSpecialChars := 'Test&(Sub|scription)<ID>*..@=%1';
+
+        // [WHEN] A webhook notification with such a Subscription ID is inserted (this fires the PayPal insert subscriber).
+        WebhookNotification.INIT();
+        WebhookNotification.VALIDATE(ID, CREATEGUID());
+        WebhookNotification.VALIDATE(
+          "Subscription ID", COPYSTR(SubscriptionIDWithSpecialChars, 1, MAXSTRLEN(WebhookNotification."Subscription ID")));
+        WebhookNotification.Notification.CREATEOUTSTREAM(OutStream);
+        OutStream.WRITETEXT('{}');
+
+        // [THEN] The insert succeeds without a filter exception and no PayPal payment is processed.
+        WebhookNotification.INSERT();
+        VerifyNoPaymentEvent();
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,ConsentConfirmYes')]
+    procedure TestPaymentNotificationMatchesSubscriptionCaseInsensitively();
+    var
+        MSPayPalStandardAccount: Record "MS - PayPal Standard Account";
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        TempPaymentRegistrationBuffer: Record "Payment Registration Buffer" temporary;
+        O365SalesInvoicePayment: Codeunit "O365 Sales Invoice Payment";
+        DifferentCaseAccountID: Text;
+    begin
+        // [SCENARIO 642015] The webhook subscription lookup must remain case-insensitive so payments are still matched
+        // even when the notification's Subscription ID differs in casing from the stored subscription.
+        Initialize();
+
+        SetupPaymentNotification(MSPayPalStandardAccount, SalesInvoiceHeader);
+
+        // [GIVEN] The account/subscription ID in a different letter casing than what is stored.
+        DifferentCaseAccountID := ToggleCase(MSPayPalStandardAccount."Account ID");
+        Assert.AreNotEqual(
+          MSPayPalStandardAccount."Account ID", DifferentCaseAccountID, 'Test requires a case-different account ID');
+
+        // [WHEN] A completed payment notification is received using the differently-cased subscription ID.
+        SendPaymentNotification(DifferentCaseAccountID, PaymentStatusCompletedTxt, SalesInvoiceHeader."No.",
+          SalesInvoiceHeader."Currency Code", SalesInvoiceHeader."Amount Including VAT");
+        O365SalesInvoicePayment.CollectRemainingPayments(SalesInvoiceHeader."No.", TempPaymentRegistrationBuffer);
+
+        // [THEN] The invoice is still fully paid, proving the subscription match is case-insensitive.
+        VerifyRemainingAmount(TempPaymentRegistrationBuffer, 0);
+        VerifyPaymentEvent(PaymentTok, SalesInvoiceHeader."No.", SalesInvoiceHeader."Amount Including VAT");
+    end;
+
+    [Test]
     [HandlerFunctions('JobTransferToSalesInvoiceRequestPageHandler,MessageHandlerNew')]
     procedure VerifyPaymentServiceSetIDInSalesInvoiceCreatedFromJobPlanningLines();
     var
@@ -1023,6 +1081,13 @@ codeunit 139500 "MS - PayPal Standard Tests"
         WebhookNotification.Notification.CREATEOUTSTREAM(OutStream);
         OutStream.WRITETEXT(NotificationJson);
         WebhookNotification.INSERT();
+    end;
+
+    local procedure ToggleCase(Value: Text): Text;
+    begin
+        if Value = LOWERCASE(Value) then
+            exit(UPPERCASE(Value));
+        exit(LOWERCASE(Value));
     end;
 
     local procedure VerifyRemainingAmount(var TempPaymentRegistrationBuffer: Record "Payment Registration Buffer" temporary; RemainingAmount: Decimal);


### PR DESCRIPTION
Using placeholders in SetFilter makes it more robust with regards to special characters.
The webhook subscription search stays case-insensitive, which is crucial. 

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#642015](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642015)

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

Low - the webhook subscription search stays case-insensitive, which is crucial. Using placeholders in SetFilter makes it more robust with regards to special characters.

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->








