### PR TITLE
Fix retention cleanup for bin mandatory locations

### DIFF
--- a/src/Layers/W1/BaseApp/BaseApplicationLogsDelete.Codeunit.al
+++ b/src/Layers/W1/BaseApp/BaseApplicationLogsDelete.Codeunit.al
@@ -8,6 +8,7 @@ using Microsoft.EServices.EDocument;
 using Microsoft.Finance.FinancialReports;
 using Microsoft.Integration.Dataverse;
 using Microsoft.Integration.SyncEngine;
+using Microsoft.Inventory.Location;
 using Microsoft.Projects.Project.Archive;
 using Microsoft.Purchases.Archive;
 using Microsoft.Sales.Archive;
@@ -37,6 +38,7 @@ codeunit 3995 "Base Application Logs Delete"
                 tabledata "Integration Synch. Job" = rd,
                 tabledata "Integration Synch. Job Errors" = rd,
                 tabledata "Job Queue Log Entry" = rd,
+                tabledata Location = r,
                 tabledata "Posted Invt. Pick Header" = rd,
                 tabledata "Posted Invt. Put-away Header" = rd,
                 tabledata "Posted Whse. Receipt Header" = rd,
@@ -88,6 +90,8 @@ codeunit 3995 "Base Application Logs Delete"
         then
             exit;
 
+        ExcludeBinMandatoryLocationRecords(RecRef);
+
         // if no filters have been set, something is wrong.
         if (RecRef.GetFilters() = '') or (not RecRef.MarkedOnly()) then
             RetentionPolicyLog.LogError(LogCategory(), StrSubstNo(NoFiltersErr, RecRef.Number, RecRef.Name));
@@ -97,6 +101,46 @@ codeunit 3995 "Base Application Logs Delete"
 
         // set handled
         Handled := true;
+    end;
+
+    local procedure ExcludeBinMandatoryLocationRecords(var RecRef: RecordRef)
+    var
+        Location: Record Location;
+        PostedInvtPickHeader: Record "Posted Invt. Pick Header";
+        PostedInvtPutawayHeader: Record "Posted Invt. Put-away Header";
+        LocationCodeFieldRef: FieldRef;
+        RecordId: RecordId;
+        RecordsToExclude: List of [RecordId];
+        LocationCode: Code[10];
+    begin
+        case RecRef.Number of
+            Database::"Posted Invt. Pick Header":
+                LocationCodeFieldRef := RecRef.Field(PostedInvtPickHeader.FieldNo("Location Code"));
+            Database::"Posted Invt. Put-away Header":
+                LocationCodeFieldRef := RecRef.Field(PostedInvtPutawayHeader.FieldNo("Location Code"));
+            else
+                exit;
+        end;
+
+        if not RecRef.MarkedOnly() then begin
+            if RecRef.FindSet() then
+                repeat
+                    RecRef.Mark(true);
+                until RecRef.Next() = 0;
+            RecRef.MarkedOnly(true);
+        end;
+
+        if RecRef.FindSet() then
+            repeat
+                LocationCode := LocationCodeFieldRef.Value;
+                if Location.Get(LocationCode) and Location."Bin Mandatory" then
+                    RecordsToExclude.Add(RecRef.RecordId);
+            until RecRef.Next() = 0;
+
+        foreach RecordId in RecordsToExclude do begin
+            RecRef.Get(RecordId);
+            RecRef.Mark(false);
+        end;
     end;
 
     local procedure LogCategory(): Enum "Retention Policy Log Category"

--- a/src/Layers/W1/Tests/SCM/SCMWarehouseIV.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMWarehouseIV.Codeunit.al
@@ -1599,6 +1599,74 @@ codeunit 137407 "SCM Warehouse IV"
 
     [Test]
     [Scope('OnPrem')]
+    procedure RetentionPolicySkipsPostedInvtPutAwayForBinMandatoryLocation()
+    var
+        BinMandatoryLocation: Record Location;
+        NonBinMandatoryLocation: Record Location;
+        BinMandatoryPostedInvtPutAwayHeader: Record "Posted Invt. Put-away Header";
+        NonBinMandatoryPostedInvtPutAwayHeader: Record "Posted Invt. Put-away Header";
+        RetentionPolicySetup: Record "Retention Policy Setup";
+        ApplyRetentionPolicy: Codeunit "Apply Retention Policy";
+    begin
+        // [FEATURE] [Inventory Put-Away] [Retention Policy] [Bin Mandatory]
+        // [SCENARIO 592028] Retention policy skips posted inventory put-aways for bin mandatory locations.
+        Initialize();
+
+        // [GIVEN] Expired posted inventory put-aways for locations with and without mandatory bins.
+        LibraryWarehouse.CreateLocationWMS(BinMandatoryLocation, true, true, false, false, false);
+        LibraryWarehouse.CreateLocationWMS(NonBinMandatoryLocation, false, true, false, false, false);
+        MockExpiredPostedInvtPutAway(BinMandatoryPostedInvtPutAwayHeader, BinMandatoryLocation.Code);
+        MockExpiredPostedInvtPutAway(NonBinMandatoryPostedInvtPutAwayHeader, NonBinMandatoryLocation.Code);
+        EnableRetentionPolicy(RetentionPolicySetup, Database::"Posted Invt. Put-away Header");
+
+        // [WHEN] Apply the posted inventory put-away retention policy.
+        ApplyRetentionPolicy.ApplyRetentionPolicy(RetentionPolicySetup, false);
+
+        // [THEN] The bin mandatory record remains and the other expired record is deleted.
+        Assert.IsTrue(
+            BinMandatoryPostedInvtPutAwayHeader.Get(BinMandatoryPostedInvtPutAwayHeader."No."),
+            'Posted inventory put-away for a bin mandatory location must not be deleted.');
+        Assert.IsFalse(
+            NonBinMandatoryPostedInvtPutAwayHeader.Get(NonBinMandatoryPostedInvtPutAwayHeader."No."),
+            'Expired posted inventory put-away for a non-bin mandatory location must be deleted.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure RetentionPolicySkipsPostedInvtPickForBinMandatoryLocation()
+    var
+        BinMandatoryLocation: Record Location;
+        NonBinMandatoryLocation: Record Location;
+        BinMandatoryPostedInvtPickHeader: Record "Posted Invt. Pick Header";
+        NonBinMandatoryPostedInvtPickHeader: Record "Posted Invt. Pick Header";
+        RetentionPolicySetup: Record "Retention Policy Setup";
+        ApplyRetentionPolicy: Codeunit "Apply Retention Policy";
+    begin
+        // [FEATURE] [Inventory Pick] [Retention Policy] [Bin Mandatory]
+        // [SCENARIO 592028] Retention policy skips posted inventory picks for bin mandatory locations.
+        Initialize();
+
+        // [GIVEN] Expired posted inventory picks for locations with and without mandatory bins.
+        LibraryWarehouse.CreateLocationWMS(BinMandatoryLocation, true, false, true, false, false);
+        LibraryWarehouse.CreateLocationWMS(NonBinMandatoryLocation, false, false, true, false, false);
+        MockExpiredPostedInvtPick(BinMandatoryPostedInvtPickHeader, BinMandatoryLocation.Code);
+        MockExpiredPostedInvtPick(NonBinMandatoryPostedInvtPickHeader, NonBinMandatoryLocation.Code);
+        EnableRetentionPolicy(RetentionPolicySetup, Database::"Posted Invt. Pick Header");
+
+        // [WHEN] Apply the posted inventory pick retention policy.
+        ApplyRetentionPolicy.ApplyRetentionPolicy(RetentionPolicySetup, false);
+
+        // [THEN] The bin mandatory record remains and the other expired record is deleted.
+        Assert.IsTrue(
+            BinMandatoryPostedInvtPickHeader.Get(BinMandatoryPostedInvtPickHeader."No."),
+            'Posted inventory pick for a bin mandatory location must not be deleted.');
+        Assert.IsFalse(
+            NonBinMandatoryPostedInvtPickHeader.Get(NonBinMandatoryPostedInvtPickHeader."No."),
+            'Expired posted inventory pick for a non-bin mandatory location must be deleted.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure OnCreatingStockkeepingUnitValidatePhysInvtCountingPeriodCode()
     var
         Location: Record Location;
@@ -4258,6 +4326,7 @@ codeunit 137407 "SCM Warehouse IV"
         WarehouseSetup.Modify();
         LibrarySetupStorage.Save(DATABASE::"Service Mgt. Setup");
         LibrarySetupStorage.Save(DATABASE::"Sales & Receivables Setup");
+        LibrarySetupStorage.Save(DATABASE::"Retention Policy Setup");
         NoSeriesSetup();
         isInitialized := true;
         Commit();
@@ -4918,6 +4987,27 @@ codeunit 137407 "SCM Warehouse IV"
         PostedInvtPickHeader."No." := LibraryUtility.GenerateRandomCode(PostedInvtPickHeader.FieldNo("No."), DATABASE::"Posted Invt. Pick Header");
         PostedInvtPickHeader."Location Code" := LocationCode;
         PostedInvtPickHeader.Insert();
+    end;
+
+    local procedure MockExpiredPostedInvtPutAway(var PostedInvtPutAwayHeader: Record "Posted Invt. Put-away Header"; LocationCode: Code[10])
+    begin
+        MockPostedInvtPutAway(PostedInvtPutAwayHeader, LocationCode);
+        PostedInvtPutAwayHeader."Registering Date" := CalcDate('<-2Y>', Today());
+        PostedInvtPutAwayHeader.Modify();
+    end;
+
+    local procedure MockExpiredPostedInvtPick(var PostedInvtPickHeader: Record "Posted Invt. Pick Header"; LocationCode: Code[10])
+    begin
+        MockPostedInvtPick(PostedInvtPickHeader, LocationCode);
+        PostedInvtPickHeader."Registering Date" := CalcDate('<-2Y>', Today());
+        PostedInvtPickHeader.Modify();
+    end;
+
+    local procedure EnableRetentionPolicy(var RetentionPolicySetup: Record "Retention Policy Setup"; TableId: Integer)
+    begin
+        RetentionPolicySetup.Get(TableId);
+        RetentionPolicySetup.Validate(Enabled, true);
+        RetentionPolicySetup.Modify(true);
     end;
 
     local procedure NoSeriesSetup()
@@ -5878,4 +5968,3 @@ codeunit 137407 "SCM Warehouse IV"
         SalesOrderStatistics.OK().Invoke();
     end;
 }
-


### PR DESCRIPTION
## Summary

- prevent retention policy runs from failing on posted inventory documents from bin-mandatory locations
- preserve the existing manual deletion restriction for those documents
- cover both posted inventory picks and put-aways with regression tests

## Root cause

The default retention policies pass expired records as a filtered set, while subset policies pass a marked set. Both paths eventually invoke the table delete triggers, which reject bin-mandatory locations and abort the entire cleanup batch.

The BaseApp retention deletion handler now normalizes the two candidate-set forms into marks and excludes records belonging to bin-mandatory locations before deleting the remaining expired records.

## Validation

- added end-to-end retention policy tests for tables 7340 and 7342
- verified the modified BaseApp codeunit compiles without errors
- full local BaseApp compilation remains blocked by three pre-existing missing `Permissions Overview` symbol errors outside this change

Fixes [AB#592028](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/592028)


