### PR TITLE
Restore the IRS Forms assisted setup registration removed by the CLEAN25 sweep

### DIFF
--- a/src/Apps/US/IRSForms/app/src/Setup/IRSFormsInstall.Codeunit.al
+++ b/src/Apps/US/IRSForms/app/src/Setup/IRSFormsInstall.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 10030 "IRS Forms Install"
     var
         AssistedSetupTxt: Label 'Set up IRS 1099 forms';
         AssistedSetupDescriptionTxt: Label 'Set up 1099 forms to transmit the tax data to the IRS in the United States.';
-        AssistedSetupHelpTxt: Label 'https://learn.microsoft.com/en-us/dynamics365/business-central/localfunctionality/unitedstates/introduction-to-the-irs-forms', Locked = true;
+        AssistedSetupHelpTxt: Label 'https://go.microsoft.com/fwlink/?LinkId=2374605', Locked = true;
 
     trigger OnInstallAppPerCompany()
     var

--- a/src/Apps/US/IRSForms/app/src/Setup/IRSFormsInstall.Codeunit.al
+++ b/src/Apps/US/IRSForms/app/src/Setup/IRSFormsInstall.Codeunit.al
@@ -5,6 +5,8 @@
 namespace Microsoft.Finance.VAT.Reporting;
 
 using Microsoft.Foundation.Company;
+using System.Environment.Configuration;
+using System.Media;
 
 codeunit 10030 "IRS Forms Install"
 {
@@ -12,6 +14,11 @@ codeunit 10030 "IRS Forms Install"
     Access = Internal;
     InherentEntitlements = X;
     InherentPermissions = X;
+
+    var
+        AssistedSetupTxt: Label 'Set up IRS 1099 forms';
+        AssistedSetupDescriptionTxt: Label 'Set up 1099 forms to transmit the tax data to the IRS in the United States.';
+        AssistedSetupHelpTxt: Label 'https://learn.microsoft.com/en-us/dynamics365/business-central/localfunctionality/unitedstates/introduction-to-the-irs-forms', Locked = true;
 
     trigger OnInstallAppPerCompany()
     var
@@ -28,6 +35,25 @@ codeunit 10030 "IRS Forms Install"
     local procedure CompanyInitialize()
     begin
         SetupFeature();
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Guided Experience", 'OnRegisterAssistedSetup', '', true, true)]
+    local procedure InsertIntoAssistedSetup()
+    var
+        IRSReportingPeriod: Record "IRS Reporting Period";
+        GuidedExperience: Codeunit "Guided Experience";
+        AssistedSetupGroup: Enum "Assisted Setup Group";
+        VideoCategory: Enum "Video Category";
+    begin
+        GuidedExperience.InsertAssistedSetup(
+            AssistedSetupTxt, CopyStr(AssistedSetupTxt, 1, 50), AssistedSetupDescriptionTxt, 5,
+            ObjectType::Page, Page::"IRS Forms Guide", AssistedSetupGroup::FinancialReporting,
+            '', VideoCategory::FinancialReporting, AssistedSetupHelpTxt);
+
+        if not IRSReportingPeriod.ReadPermission() then
+            exit;
+        if not IRSReportingPeriod.IsEmpty() then
+            GuidedExperience.CompleteAssistedSetup(ObjectType::Page, Page::"IRS Forms Guide");
     end;
 
     local procedure SetupFeature()

--- a/src/Apps/US/IRSForms/test/src/IRSFormsAssistedSetupTests.Codeunit.al
+++ b/src/Apps/US/IRSForms/test/src/IRSFormsAssistedSetupTests.Codeunit.al
@@ -1,0 +1,172 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Finance.VAT.Reporting;
+
+using System.Environment.Configuration;
+using System.TestLibraries.Environment.Configuration;
+
+codeunit 148025 "IRS Forms Assisted Setup Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit Assert;
+        AssistedSetupTestLibrary: Codeunit "Assisted Setup Test Library";
+        LibraryIRSReportingPeriod: Codeunit "Library IRS Reporting Period";
+        IsInitialized: Boolean;
+        AssistedSetupTitleTxt: Label 'Set up IRS 1099 forms';
+        AssistedSetupDescriptionTxt: Label 'Set up 1099 forms to transmit the tax data to the IRS in the United States.';
+
+    [Test]
+    procedure AssistedSetupRegisteredForIRSFormsGuide()
+    var
+        GuidedExperience: Codeunit "Guided Experience";
+        GuidedExperienceType: Enum "Guided Experience Type";
+    begin
+        // [SCENARIO 638735] The IRS Forms Guide wizard is registered as an assisted setup so it appears in the Assisted Setup list
+
+        Initialize();
+
+        // [GIVEN] A clean Guided Experience (assisted setup) state
+        AssistedSetupTestLibrary.DeleteAll();
+
+        // [WHEN] Subscribers register their assisted setups
+        AssistedSetupTestLibrary.CallOnRegister();
+
+        // [THEN] The IRS Forms Guide wizard is registered as an assisted setup
+        Assert.IsTrue(
+            GuidedExperience.Exists(GuidedExperienceType::"Assisted Setup", ObjectType::Page, Page::"IRS Forms Guide"),
+            'IRS Forms Guide should be registered in the Assisted Setup list after OnRegisterAssistedSetup.');
+    end;
+
+    [Test]
+    procedure AssistedSetupNotCompletedWhenNoReportingPeriod()
+    var
+        IRSReportingPeriod: Record "IRS Reporting Period";
+        GuidedExperience: Codeunit "Guided Experience";
+        GuidedExperienceType: Enum "Guided Experience Type";
+    begin
+        // [SCENARIO 638735] The IRS Forms assisted setup is registered but not completed when the company has no reporting period
+
+        Initialize();
+
+        // [GIVEN] No IRS Reporting Period records exist
+        IRSReportingPeriod.DeleteAll();
+        // [GIVEN] A clean Guided Experience state
+        AssistedSetupTestLibrary.DeleteAll();
+
+        // [WHEN] Subscribers register their assisted setups
+        AssistedSetupTestLibrary.CallOnRegister();
+
+        // [THEN] The IRS Forms Guide assisted setup is registered
+        Assert.IsTrue(
+            GuidedExperience.Exists(GuidedExperienceType::"Assisted Setup", ObjectType::Page, Page::"IRS Forms Guide"),
+            'IRS Forms Guide should be registered in the Assisted Setup list.');
+        // [THEN] It is not marked as completed
+        Assert.IsFalse(
+            GuidedExperience.IsAssistedSetupComplete(ObjectType::Page, Page::"IRS Forms Guide"),
+            'IRS Forms Guide assisted setup should not be completed when no reporting period exists.');
+    end;
+
+    [Test]
+    procedure AssistedSetupCompletedWhenReportingPeriodExists()
+    var
+        IRSReportingPeriod: Record "IRS Reporting Period";
+        GuidedExperience: Codeunit "Guided Experience";
+        GuidedExperienceType: Enum "Guided Experience Type";
+    begin
+        // [SCENARIO 638735] The IRS Forms assisted setup is marked completed for companies that already configured 1099
+
+        Initialize();
+
+        // [GIVEN] An IRS Reporting Period already exists (the company already configured 1099)
+        IRSReportingPeriod.DeleteAll();
+        LibraryIRSReportingPeriod.CreateReportingPeriod(DMY2Date(1, 1, 2024), DMY2Date(31, 12, 2024));
+        // [GIVEN] A clean Guided Experience state
+        AssistedSetupTestLibrary.DeleteAll();
+
+        // [WHEN] Subscribers register their assisted setups
+        AssistedSetupTestLibrary.CallOnRegister();
+
+        // [THEN] The IRS Forms Guide assisted setup is registered
+        Assert.IsTrue(
+            GuidedExperience.Exists(GuidedExperienceType::"Assisted Setup", ObjectType::Page, Page::"IRS Forms Guide"),
+            'IRS Forms Guide should be registered in the Assisted Setup list.');
+        // [THEN] It is marked as completed
+        Assert.IsTrue(
+            GuidedExperience.IsAssistedSetupComplete(ObjectType::Page, Page::"IRS Forms Guide"),
+            'IRS Forms Guide assisted setup should be completed when a reporting period already exists.');
+    end;
+
+    [Test]
+    procedure AssistedSetupTitleDescriptionAndHelpUrl()
+    var
+        AssistedSetupGroup: Enum "Assisted Setup Group";
+        AssistedSetupPage: TestPage "Assisted Setup";
+        FinancialReportingGroupCaption: Text;
+        Found: Boolean;
+    begin
+        // [SCENARIO 638735] Opening the Assisted Setup page runs the IRS Forms OnRegisterAssistedSetup subscriber and
+        // registers the IRS Forms Guide wizard under the Financial Reporting group with the modernised title,
+        // description and a help URL (option 3a). Opening the page is the real production path and also exercises the
+        // ReadPermission guard in the subscriber.
+
+        Initialize();
+
+        // [GIVEN] A clean Guided Experience (assisted setup) state
+        AssistedSetupTestLibrary.DeleteAll();
+        // [GIVEN] The Financial Reporting group caption as rendered on the page
+        FinancialReportingGroupCaption := Format(AssistedSetupGroup::FinancialReporting);
+
+        // [WHEN] The Assisted Setup list is opened (OnOpenPage raises OnRegisterAssistedSetup for all subscribers)
+        AssistedSetupPage.OpenView();
+
+        // [WHEN] The Financial Reporting group node is expanded so its child setup rows become navigable
+        // (the page is a tree over a temporary table; child rows stay hidden while the parent group is collapsed)
+        if AssistedSetupPage.First() then
+            repeat
+                if AssistedSetupPage.Name.Value = FinancialReportingGroupCaption then
+                    AssistedSetupPage.Expand(true);
+            until not AssistedSetupPage.Next();
+
+        // [THEN] The IRS Forms Guide setup row is listed with the expected title, description and help link
+        Found := false;
+        if AssistedSetupPage.First() then
+            repeat
+                if AssistedSetupPage.Name.Value = AssistedSetupTitleTxt then begin
+                    Found := true;
+                    // [THEN] Its description matches the registered value
+                    Assert.AreEqual(
+                        AssistedSetupDescriptionTxt, AssistedSetupPage.Description.Value,
+                        'The IRS Forms Guide assisted setup should show the expected description.');
+                    // [THEN] It exposes a help link (the page renders 'Read' when a Help Url is registered)
+                    Assert.AreNotEqual(
+                        '', AssistedSetupPage.Help.Value,
+                        'The IRS Forms Guide assisted setup should expose a help link.');
+                end;
+            until (not AssistedSetupPage.Next()) or Found;
+        AssistedSetupPage.Close();
+
+        // [THEN] The IRS 1099 forms assisted setup was found (specific to our registration - not satisfied by any
+        // other subscriber's Financial Reporting group entry)
+        Assert.IsTrue(Found, 'The IRS 1099 forms assisted setup should be listed under the Financial Reporting group.');
+    end;
+
+    trigger OnRun()
+    begin
+        // [FEATURE] [1099] [Assisted Setup]
+    end;
+
+    local procedure Initialize()
+    var
+        IRSReportingPeriod: Record "IRS Reporting Period";
+    begin
+        IRSReportingPeriod.DeleteAll();
+        if IsInitialized then
+            exit;
+        IsInitialized := true;
+    end;
+}


### PR DESCRIPTION
## What & why

The IRS Forms setup wizard (page 10032 `"IRS Forms Guide"`) no longer appears in the **Assisted Setup** list, so US users have no way to reach the 1099 setup guide from the UI.

**Root cause.** The wizard used to be registered from codeunit 10029 `"IRS Forms Feature"` inside a `#if not CLEAN25` block. The CLEAN25 preprocessor sweep (internal PR 232389) removed that guarded body wholesale, leaving `IRSFormsFeature.Codeunit.al` as an empty stub containing only the copyright header. Nothing else subscribed to `Codeunit "Guided Experience"::OnRegisterAssistedSetup`, so the guided-experience item stopped being inserted. This was collateral damage of the CLEAN sweep, not an intentional deprecation — the wizard page, its banner/media resources and the entire setup flow are all still present and fully functional; only the registration was lost.

**Fix.** Re-register the wizard from codeunit 10030 `"IRS Forms Install"` with an unconditional `OnRegisterAssistedSetup` subscriber (no preprocessor guard this time, so a future CLEAN sweep cannot silently delete it again):

- Refreshed title `Set up IRS 1099 forms`, description, and a current `learn.microsoft.com` help URL, registered under `AssistedSetupGroup::FinancialReporting`.
- Companies that have already configured 1099 (an `"IRS Reporting Period"` record exists) get the setup marked **complete**, so upgraded tenants don't see a stale "to do" item. This follows the existing `NO/ElectronicVATSubmission` `"Electronic VAT Installation"` precedent.
- The `"IRS Reporting Period"` read is guarded by `ReadPermission`. This subscriber runs for every user who opens the Assisted Setup page, and codeunit 10030 is declared `InherentPermissions = X`, so an unguarded read would make the whole page fail to open for users without access to that table.

`IRSFormsFeature.Codeunit.al` is intentionally left as-is (empty stub) — removing it is out of scope here.

## Linked work

Fixes [AB#638735](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638735)

<!-- Microsoft-internal ADO work item; there is no corresponding public GitHub issue for this bug. -->

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Built, published and tested against a local US environment (`Nav_US`), building in dependency order `IRS Forms` → `IRS Forms Test Library` → `IRS Forms Tests`. Compiles clean against `App/Rulesets/app.ruleset.json` with no new warnings.

Development was test-first. New test codeunit **148025 `"IRS Forms Assisted Setup Tests"`** was written and confirmed **red against unfixed code** before the fix was written:

```
Assert.IsTrue failed. IRS Forms Guide should be registered in the Assisted Setup list after OnRegisterAssistedSetup.
```

After the fix, **148025 is 6/6 green**:

| Test | Covers |
|---|---|
| `AssistedSetupRegisteredForIRSFormsGuide` | The wizard is registered after `OnRegisterAssistedSetup` (the bug itself) |
| `AssistedSetupNotCompletedWhenNoReportingPeriod` | Registered but *not* completed when no reporting period exists |
| `AssistedSetupCompletedWhenReportingPeriodExists` | Auto-completed when the company already configured 1099 |
| `AssistedSetupTitleDescriptionAndHelpUrl` | Opens the real `Assisted Setup` page, expands the Financial Reporting group, and asserts the wizard row's title, description and help link |

The last test drives the genuine production path (page open → `OnRegisterAssistedSetup`), which also exercises the `ReadPermission` guard.

**Each test was verified to actually depend on the fix.** I re-ran 148025 with the product change reverted and the test app unchanged: 5 fail / 1 pass. In particular the title/description/help test fails with `Assert.IsTrue failed. The IRS 1099 forms assisted setup should be listed under the Financial Reporting group.` — it is not satisfied by the unrelated IRS1096 entry that also sits in the Financial Reporting group.

**Regression run** — the full existing IRS Forms suite (codeunits 148010–148022, 13 codeunits, ~130 tests). Nine codeunits are fully green. Four have failures, which I confirmed **pre-existing and unrelated by controlled experiment**: I ran them with the fix applied and with the fix reverted and got byte-identical pass/fail counts and messages.

| Suite | Without fix | With fix |
|---|---|---|
| 148011 IRS 1099 Vendor | 13P / 5F | 13P / 5F |
| 148012 IRS 1099 Emailing | 7P / 5F | 7P / 5F |
| 148018 IRS 1099 API | 0P / 2F | 0P / 2F |
| 148022 IRS 1099 IRIS | 17P / 2F | 17P / 2F |
| 148025 (control) | 1P / 5F | **6P / 0F** |

Those pre-existing failures are environmental: `NavClientHandle.Dispose` CLR `NullReferenceException` on headless TestPage teardown, an amount-rounding assertion (`3.69` vs `3.69333…`), a missing dynamic cue style control, an API `409 Conflict` record-locking error, and an `IRS 1099 Form Box does not exist` data-setup issue. None touch Guided Experience state. Only the control codeunit changed between the two states.

## Risk & compatibility

Low risk; additive only.

- **Permissions** — the `ReadPermission` guard is the key safety property: the subscriber runs for every user opening the Assisted Setup page, and codeunit 10030 has `InherentPermissions = X`, so the guard prevents an unguarded read of `"IRS Reporting Period"` from breaking that page.
- **Upgrade/data impact** — none. `InsertAssistedSetup` is idempotent and `OnRegisterAssistedSetup` fires whenever the Assisted Setup list is opened or refreshed, so existing tenants pick the entry up with no upgrade codeunit and no data migration. Existing 1099 customers see it already marked complete rather than as a new outstanding task.
- **Registration site** — deliberately subscriber-only; `SetupFeature()` does not also call `InsertAssistedSetup`, to keep a single write path.
- **Translations** — the three new labels are picked up by the app's existing `TranslationFile` feature on the next generation; no `.xlf` files were hand-edited in this PR.
- **Follow-up** — `IRSFormsFeature.Codeunit.al` remains an empty stub (only a copyright header) after the CLEAN25 sweep. Deleting it, and auditing that sweep for other assisted setups removed the same way, would be reasonable cleanup but is out of scope here.




