### PR TITLE
[MAIN]-Fix-Bug 644909 Cant modify Item Template after Item deletion

### DIFF
--- a/src/Layers/APAC/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/APAC/BaseApp/Inventory/Item/Item.Table.al
@@ -2974,6 +2974,9 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
+        if "No." = '' then
+            exit;
+
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then

--- a/src/Layers/APAC/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/APAC/BaseApp/Inventory/Item/Item.Table.al
@@ -2974,12 +2974,12 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
-        if "No." = '' then
-            exit;
-
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then
+            exit;
+
+        if "No." = '' then
             exit;
 
         WarehouseEntry.SetRange("Item No.", "No.");

--- a/src/Layers/CH/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/CH/BaseApp/Inventory/Item/Item.Table.al
@@ -3002,6 +3002,9 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
+        if "No." = '' then
+            exit;
+
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then

--- a/src/Layers/CH/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/CH/BaseApp/Inventory/Item/Item.Table.al
@@ -3002,12 +3002,12 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
-        if "No." = '' then
-            exit;
-
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then
+            exit;
+
+        if "No." = '' then
             exit;
 
         WarehouseEntry.SetRange("Item No.", "No.");

--- a/src/Layers/CZ/Tests/SCM/UTItemTable.Codeunit.al
+++ b/src/Layers/CZ/Tests/SCM/UTItemTable.Codeunit.al
@@ -14,8 +14,6 @@ codeunit 134827 "UT Item Table"
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryInventory: Codeunit "Library - Inventory";
-        ItemNotRegisteredTxt: Label 'This item is not registered. To continue, choose one of the following options:';
-        ItemNameWithFilterCharsTxt: Label '&I*t|e(m''I)t)e&m*';
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibraryWarehouse: Codeunit "Library - Warehouse";
@@ -23,6 +21,9 @@ codeunit 134827 "UT Item Table"
         isInitialized: Boolean;
         InternationalUoMEachTxt: Label 'EA', Locked = true;
         NonExistingInternationalUoMTxt: Label 'NOTEXIST', Locked = true;
+        ItemNotRegisteredTxt: Label 'This item is not registered. To continue, choose one of the following options:';
+        ItemNameWithFilterCharsTxt: Label '&I*t|e(m''I)t)e&m*';
+        ItemTrackingCodeNotUpdatedErr: Label 'Item Tracking Code must be updated on the item template.';
 
     [Test]
     [Scope('OnPrem')]
@@ -533,6 +534,82 @@ codeunit 134827 "UT Item Table"
 
         Assert.AreEqual(Item[2]."No.", Item[1].GetItemNo(RandomText1), '');
         Assert.AreEqual(Item[2]."No.", Item[1].GetItemNo(RandomText2), '');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TestNoWhseEntriesExistWithBlankItemNo()
+    var
+        Item: Record Item;
+    begin
+        // [SCENARIO 644909] TestNoWhseEntriesExist procedure should handle blank Item No. without errors
+
+        Initialize();
+
+        // [GIVEN] Item record "I" with blank No.
+        Item.Init();
+
+        // [WHEN] TestNoWhseEntriesExist is called on "I"
+        Item.TestNoWhseEntriesExist(Item.FieldCaption("Item Tracking Code"));
+
+        // [THEN] No error occurs
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TestModifyItemTemplateItemTrackingCodeAfterItemDeletion()
+    var
+        Bin: Record Bin;
+        Item: Record Item;
+        ItemJournalLine: Record "Item Journal Line";
+        ItemTempl: Record "Item Templ.";
+        ItemTrackingCode: Record "Item Tracking Code";
+        Location: Record Location;
+        LibraryCosting: Codeunit "Library - Costing";
+        LibraryFiscalYear: Codeunit "Library - Fiscal Year";
+        LibraryItemTracking: Codeunit "Library - Item Tracking";
+    begin
+        // [SCENARIO 644909] User can modify Item Template after item deletion
+        Initialize();
+
+        // [GIVEN] An item and a location with mandatory bins
+        LibraryInventory.CreateItem(Item);
+        LibraryWarehouse.CreateLocation(Location);
+        Location.Validate("Bin Mandatory", true);
+        Location.Modify(true);
+        LibraryInventory.UpdateInventoryPostingSetup(Location);
+        LibraryWarehouse.CreateBin(Bin, Location.Code, '', '', '');
+
+        // [GIVEN] Positive and negative adjustments posted for the item in the bin
+        LibraryInventory.CreateItemJournalLineInItemTemplate(
+            ItemJournalLine, Item."No.", Location.Code, Bin.Code, 1);
+        LibraryInventory.PostItemJournalLine(ItemJournalLine."Journal Template Name", ItemJournalLine."Journal Batch Name");
+        LibraryInventory.CreateItemJournalLineInItemTemplate(
+            ItemJournalLine, Item."No.", Location.Code, Bin.Code, 1);
+        ItemJournalLine.Validate("Entry Type", ItemJournalLine."Entry Type"::"Negative Adjmt.");
+        ItemJournalLine.Modify(true);
+        LibraryInventory.PostItemJournalLine(ItemJournalLine."Journal Template Name", ItemJournalLine."Journal Batch Name");
+
+        // [GIVEN] Item cost entries are adjusted, accounting periods are closed, and the item is deleted
+        LibraryCosting.AdjustCostItemEntries(Item."No.", '');
+        LibraryFiscalYear.CloseAccountingPeriod();
+        LibraryFiscalYear.CreateFiscalYear();
+        Item.Delete(true);
+
+        // [GIVEN] An item template and warehouse-tracked item tracking code
+        ItemTempl.Init();
+        ItemTempl.Validate(Code, CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(ItemTempl.Code)));
+        ItemTempl.Insert(true);
+
+        LibraryItemTracking.CreateItemTrackingCode(ItemTrackingCode, false, true);
+        ItemTrackingCode.Validate("Lot Warehouse Tracking", true);
+        ItemTrackingCode.Modify(true);
+
+        // [WHEN] Item template item tracking code is modified
+        ItemTempl.Validate("Item Tracking Code", ItemTrackingCode.Code);
+
+        // [THEN] No error occurs and value is applied
+        Assert.AreEqual(ItemTrackingCode.Code, ItemTempl."Item Tracking Code", ItemTrackingCodeNotUpdatedErr);
     end;
 
     local procedure Initialize()

--- a/src/Layers/CZ/Tests/SCM/UTItemTable.Codeunit.al
+++ b/src/Layers/CZ/Tests/SCM/UTItemTable.Codeunit.al
@@ -538,25 +538,6 @@ codeunit 134827 "UT Item Table"
 
     [Test]
     [Scope('OnPrem')]
-    procedure TestNoWhseEntriesExistWithBlankItemNo()
-    var
-        Item: Record Item;
-    begin
-        // [SCENARIO 644909] TestNoWhseEntriesExist procedure should handle blank Item No. without errors
-
-        Initialize();
-
-        // [GIVEN] Item record "I" with blank No.
-        Item.Init();
-
-        // [WHEN] TestNoWhseEntriesExist is called on "I"
-        Item.TestNoWhseEntriesExist(Item.FieldCaption("Item Tracking Code"));
-
-        // [THEN] No error occurs
-    end;
-
-    [Test]
-    [Scope('OnPrem')]
     procedure TestModifyItemTemplateItemTrackingCodeAfterItemDeletion()
     var
         Bin: Record Bin;
@@ -594,6 +575,10 @@ codeunit 134827 "UT Item Table"
         LibraryCosting.AdjustCostItemEntries(Item."No.", '');
         LibraryFiscalYear.CloseAccountingPeriod();
         LibraryFiscalYear.CreateFiscalYear();
+        Commit();
+
+        // [WHEN] Item is deleted
+        Item.Get(Item."No.");
         Item.Delete(true);
 
         // [GIVEN] An item template and warehouse-tracked item tracking code

--- a/src/Layers/ES/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/ES/BaseApp/Inventory/Item/Item.Table.al
@@ -2970,6 +2970,9 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
+        if "No." = '' then
+            exit;
+
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then

--- a/src/Layers/ES/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/ES/BaseApp/Inventory/Item/Item.Table.al
@@ -2970,12 +2970,12 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
-        if "No." = '' then
-            exit;
-
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then
+            exit;
+
+        if "No." = '' then
             exit;
 
         WarehouseEntry.SetRange("Item No.", "No.");

--- a/src/Layers/GB/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/GB/BaseApp/Inventory/Item/Item.Table.al
@@ -2976,6 +2976,9 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
+        if "No." = '' then
+            exit;
+
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then

--- a/src/Layers/GB/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/GB/BaseApp/Inventory/Item/Item.Table.al
@@ -2976,12 +2976,12 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
-        if "No." = '' then
-            exit;
-
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then
+            exit;
+
+        if "No." = '' then
             exit;
 
         WarehouseEntry.SetRange("Item No.", "No.");

--- a/src/Layers/IT/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/IT/BaseApp/Inventory/Item/Item.Table.al
@@ -2973,6 +2973,9 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
+        if "No." = '' then
+            exit;
+
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then

--- a/src/Layers/IT/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/IT/BaseApp/Inventory/Item/Item.Table.al
@@ -2973,12 +2973,12 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
-        if "No." = '' then
-            exit;
-
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then
+            exit;
+
+        if "No." = '' then
             exit;
 
         WarehouseEntry.SetRange("Item No.", "No.");

--- a/src/Layers/NA/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/NA/BaseApp/Inventory/Item/Item.Table.al
@@ -3019,6 +3019,9 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
+        if "No." = '' then
+            exit;
+
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then

--- a/src/Layers/NA/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/NA/BaseApp/Inventory/Item/Item.Table.al
@@ -3019,12 +3019,12 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
-        if "No." = '' then
-            exit;
-
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then
+            exit;
+
+        if "No." = '' then
             exit;
 
         WarehouseEntry.SetRange("Item No.", "No.");

--- a/src/Layers/RU/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/RU/BaseApp/Inventory/Item/Item.Table.al
@@ -2983,6 +2983,9 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
+        if "No." = '' then
+            exit;
+
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then

--- a/src/Layers/RU/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/RU/BaseApp/Inventory/Item/Item.Table.al
@@ -2983,12 +2983,12 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
-        if "No." = '' then
-            exit;
-
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then
+            exit;
+
+        if "No." = '' then
             exit;
 
         WarehouseEntry.SetRange("Item No.", "No.");

--- a/src/Layers/W1/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/W1/BaseApp/Inventory/Item/Item.Table.al
@@ -2962,6 +2962,9 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
+        if "No." = '' then
+            exit;
+
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then

--- a/src/Layers/W1/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/W1/BaseApp/Inventory/Item/Item.Table.al
@@ -2962,12 +2962,12 @@ table 27 Item
         WarehouseEntry: Record "Warehouse Entry";
         IsHandled: Boolean;
     begin
-        if "No." = '' then
-            exit;
-
         IsHandled := false;
         OnBeforeTestNoWhseEntriesExist(Rec, CurrentFieldName, IsHandled);
         if IsHandled then
+            exit;
+
+        if "No." = '' then
             exit;
 
         WarehouseEntry.SetRange("Item No.", "No.");

--- a/src/Layers/W1/Tests/SCM/UTItemTable.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/UTItemTable.Codeunit.al
@@ -14,8 +14,6 @@ codeunit 134827 "UT Item Table"
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryInventory: Codeunit "Library - Inventory";
-        ItemNotRegisteredTxt: Label 'This item is not registered. To continue, choose one of the following options:';
-        ItemNameWithFilterCharsTxt: Label '&I*t|e(m''I)t)e&m*';
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibraryWarehouse: Codeunit "Library - Warehouse";
@@ -23,6 +21,9 @@ codeunit 134827 "UT Item Table"
         isInitialized: Boolean;
         InternationalUoMEachTxt: Label 'EA', Locked = true;
         NonExistingInternationalUoMTxt: Label 'NOTEXIST', Locked = true;
+        ItemNotRegisteredTxt: Label 'This item is not registered. To continue, choose one of the following options:';
+        ItemNameWithFilterCharsTxt: Label '&I*t|e(m''I)t)e&m*';
+        ItemTrackingCodeNotUpdatedErr: Label 'Item Tracking Code must be updated on the item template.';
 
     [Test]
     [Scope('OnPrem')]
@@ -533,6 +534,82 @@ codeunit 134827 "UT Item Table"
 
         Assert.AreEqual(Item[2]."No.", Item[1].GetItemNo(RandomText1), '');
         Assert.AreEqual(Item[4]."No.", Item[1].GetItemNo(RandomText2), '');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TestNoWhseEntriesExistWithBlankItemNo()
+    var
+        Item: Record Item;
+    begin
+        // [SCENARIO 644909] TestNoWhseEntriesExist procedure should handle blank Item No. without errors
+
+        Initialize();
+
+        // [GIVEN] Item record "I" with blank No.
+        Item.Init();
+
+        // [WHEN] TestNoWhseEntriesExist is called on "I"
+        Item.TestNoWhseEntriesExist(Item.FieldCaption("Item Tracking Code"));
+
+        // [THEN] No error occurs
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TestModifyItemTemplateItemTrackingCodeAfterItemDeletion()
+    var
+        Bin: Record Bin;
+        Item: Record Item;
+        ItemJournalLine: Record "Item Journal Line";
+        ItemTempl: Record "Item Templ.";
+        ItemTrackingCode: Record "Item Tracking Code";
+        Location: Record Location;
+        LibraryCosting: Codeunit "Library - Costing";
+        LibraryFiscalYear: Codeunit "Library - Fiscal Year";
+        LibraryItemTracking: Codeunit "Library - Item Tracking";
+    begin
+        // [SCENARIO 644909] User can modify Item Template after item deletion
+        Initialize();
+
+        // [GIVEN] An item and a location with mandatory bins
+        LibraryInventory.CreateItem(Item);
+        LibraryWarehouse.CreateLocation(Location);
+        Location.Validate("Bin Mandatory", true);
+        Location.Modify(true);
+        LibraryInventory.UpdateInventoryPostingSetup(Location);
+        LibraryWarehouse.CreateBin(Bin, Location.Code, '', '', '');
+
+        // [GIVEN] Positive and negative adjustments posted for the item in the bin
+        LibraryInventory.CreateItemJournalLineInItemTemplate(
+            ItemJournalLine, Item."No.", Location.Code, Bin.Code, 1);
+        LibraryInventory.PostItemJournalLine(ItemJournalLine."Journal Template Name", ItemJournalLine."Journal Batch Name");
+        LibraryInventory.CreateItemJournalLineInItemTemplate(
+            ItemJournalLine, Item."No.", Location.Code, Bin.Code, 1);
+        ItemJournalLine.Validate("Entry Type", ItemJournalLine."Entry Type"::"Negative Adjmt.");
+        ItemJournalLine.Modify(true);
+        LibraryInventory.PostItemJournalLine(ItemJournalLine."Journal Template Name", ItemJournalLine."Journal Batch Name");
+
+        // [GIVEN] Item cost entries are adjusted, accounting periods are closed, and the item is deleted
+        LibraryCosting.AdjustCostItemEntries(Item."No.", '');
+        LibraryFiscalYear.CloseAccountingPeriod();
+        LibraryFiscalYear.CreateFiscalYear();
+        Item.Delete(true);
+
+        // [GIVEN] An item template and warehouse-tracked item tracking code
+        ItemTempl.Init();
+        ItemTempl.Validate(Code, CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(ItemTempl.Code)));
+        ItemTempl.Insert(true);
+
+        LibraryItemTracking.CreateItemTrackingCode(ItemTrackingCode, false, true);
+        ItemTrackingCode.Validate("Lot Warehouse Tracking", true);
+        ItemTrackingCode.Modify(true);
+
+        // [WHEN] Item template item tracking code is modified
+        ItemTempl.Validate("Item Tracking Code", ItemTrackingCode.Code);
+
+        // [THEN] No error occurs and value is applied
+        Assert.AreEqual(ItemTrackingCode.Code, ItemTempl."Item Tracking Code", ItemTrackingCodeNotUpdatedErr);
     end;
 
     local procedure Initialize()

--- a/src/Layers/W1/Tests/SCM/UTItemTable.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/UTItemTable.Codeunit.al
@@ -538,25 +538,6 @@ codeunit 134827 "UT Item Table"
 
     [Test]
     [Scope('OnPrem')]
-    procedure TestNoWhseEntriesExistWithBlankItemNo()
-    var
-        Item: Record Item;
-    begin
-        // [SCENARIO 644909] TestNoWhseEntriesExist procedure should handle blank Item No. without errors
-
-        Initialize();
-
-        // [GIVEN] Item record "I" with blank No.
-        Item.Init();
-
-        // [WHEN] TestNoWhseEntriesExist is called on "I"
-        Item.TestNoWhseEntriesExist(Item.FieldCaption("Item Tracking Code"));
-
-        // [THEN] No error occurs
-    end;
-
-    [Test]
-    [Scope('OnPrem')]
     procedure TestModifyItemTemplateItemTrackingCodeAfterItemDeletion()
     var
         Bin: Record Bin;
@@ -594,6 +575,10 @@ codeunit 134827 "UT Item Table"
         LibraryCosting.AdjustCostItemEntries(Item."No.", '');
         LibraryFiscalYear.CloseAccountingPeriod();
         LibraryFiscalYear.CreateFiscalYear();
+        Commit();
+
+        // [WHEN] Item is deleted
+        Item.Get(Item."No.");
         Item.Delete(true);
 
         // [GIVEN] An item template and warehouse-tracked item tracking code


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why
**Issue**: Modifying an Item Template after deleting an item could fail with a warehouse-entry validation error.
**Cause**: Item.TestNoWhseEntriesExist queried warehouse entries when invoked on the temporary blank-No. Item record used by Item Template validation.
<!-- A few sentences: what does this change do, and what problem does it solve? -->
Solution: Exit TestNoWhseEntriesExist immediately when Item."No." is blank, with regression automation covering the deleted-item template-update flow: Exit TestNoWhseEntriesExist immediately when Item."No." is blank, with regression automation covering the deleted-item template-update flow
## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #
[AB#644909](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644909)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->







