### PR TITLE
Fix AppSource disclaimer flow for Microsoft publishers

### DIFF
--- a/src/System Application/App/AppSource Gallery/src/AppSourceProductDetails.Page.al
+++ b/src/System Application/App/AppSource Gallery/src/AppSourceProductDetails.Page.al
@@ -178,7 +178,8 @@ page 2516 "AppSource Product Details"
 
                 trigger OnAction()
                 var
-                    ExtensionManagement: Codeunit "Extension Management";
+                    ExtensionInstallationPage: Page "Extension Installation";
+                    TempExtensionInstallationRecord: Record "Extension Installation";
                     PublisherType: Text;
                 begin
                     if PlansAreVisible then
@@ -186,10 +187,12 @@ page 2516 "AppSource Product Details"
                             exit;
 
                     PublisherType := AppSourceJsonUtilities.GetStringValue(ProductObject, 'publisherType');
-                    if PublisherType = '' then
-                        ExtensionManagement.InstallMarketplaceExtension(AppID)
-                    else
-                        ExtensionManagement.InstallMarketplaceExtensionWithPublisher(AppID, PublisherType);
+                    TempExtensionInstallationRecord.SetRange(ID, AppID);
+                    TempExtensionInstallationRecord.ID := AppID;
+                    TempExtensionInstallationRecord.ResponseUrl := '';
+                    TempExtensionInstallationRecord.PublisherType := PublisherType;
+                    ExtensionInstallationPage.SetRecord(TempExtensionInstallationRecord);
+                    ExtensionInstallationPage.RunModal();
                 end;
             }
 

--- a/src/System Application/App/AppSource Gallery/src/AppSourceProductDetails.Page.al
+++ b/src/System Application/App/AppSource Gallery/src/AppSourceProductDetails.Page.al
@@ -179,12 +179,14 @@ page 2516 "AppSource Product Details"
                 trigger OnAction()
                 var
                     ExtensionManagement: Codeunit "Extension Management";
+                    PublisherType: Text;
                 begin
                     if PlansAreVisible then
                         if not Confirm(PurchaseLicensesElsewhereLbl) then
                             exit;
 
-                    ExtensionManagement.InstallMarketplaceExtension(AppID);
+                    PublisherType := AppSourceJsonUtilities.GetStringValue(ProductObject, 'publisherType');
+                    ExtensionManagement.InstallMarketplaceExtensionWithPublisher(AppID, PublisherType);
                 end;
             }
 

--- a/src/System Application/App/AppSource Gallery/src/AppSourceProductDetails.Page.al
+++ b/src/System Application/App/AppSource Gallery/src/AppSourceProductDetails.Page.al
@@ -186,7 +186,10 @@ page 2516 "AppSource Product Details"
                             exit;
 
                     PublisherType := AppSourceJsonUtilities.GetStringValue(ProductObject, 'publisherType');
-                    ExtensionManagement.InstallMarketplaceExtensionWithPublisher(AppID, PublisherType);
+                    if PublisherType = '' then
+                        ExtensionManagement.InstallMarketplaceExtension(AppID)
+                    else
+                        ExtensionManagement.InstallMarketplaceExtensionWithPublisher(AppID, PublisherType);
                 end;
             }
 

--- a/src/System Application/App/AppSource Gallery/src/AppSourceProductDetails.Page.al
+++ b/src/System Application/App/AppSource Gallery/src/AppSourceProductDetails.Page.al
@@ -178,7 +178,7 @@ page 2516 "AppSource Product Details"
 
                 trigger OnAction()
                 var
-                    ExtensionInstallationPage: Page "Extension Installation";
+                    ExtensionManagement: Codeunit "Extension Management";
                     PublisherType: Text;
                 begin
                     if PlansAreVisible then
@@ -186,11 +186,10 @@ page 2516 "AppSource Product Details"
                             exit;
 
                     PublisherType := AppSourceJsonUtilities.GetStringValue(ProductObject, 'publisherType');
-                    ExtensionInstallationPage.SetAppID(AppID);
-                    ExtensionInstallationPage.SetPreviewKey('');
-                    ExtensionInstallationPage.SetPublisherType(PublisherType);
-                    ExtensionInstallationPage.SetResponseUrl('');
-                    ExtensionInstallationPage.RunModal();
+                    if PublisherType = '' then
+                        ExtensionManagement.InstallMarketplaceExtension(AppID)
+                    else
+                        ExtensionManagement.InstallMarketplaceExtensionWithPublisher(AppID, PublisherType);
                 end;
             }
 

--- a/src/System Application/App/AppSource Gallery/src/AppSourceProductDetails.Page.al
+++ b/src/System Application/App/AppSource Gallery/src/AppSourceProductDetails.Page.al
@@ -179,7 +179,6 @@ page 2516 "AppSource Product Details"
                 trigger OnAction()
                 var
                     ExtensionInstallationPage: Page "Extension Installation";
-                    TempExtensionInstallationRecord: Record "Extension Installation";
                     PublisherType: Text;
                 begin
                     if PlansAreVisible then
@@ -187,11 +186,10 @@ page 2516 "AppSource Product Details"
                             exit;
 
                     PublisherType := AppSourceJsonUtilities.GetStringValue(ProductObject, 'publisherType');
-                    TempExtensionInstallationRecord.SetRange(ID, AppID);
-                    TempExtensionInstallationRecord.ID := AppID;
-                    TempExtensionInstallationRecord.ResponseUrl := '';
-                    TempExtensionInstallationRecord.PublisherType := PublisherType;
-                    ExtensionInstallationPage.SetRecord(TempExtensionInstallationRecord);
+                    ExtensionInstallationPage.SetAppID(AppID);
+                    ExtensionInstallationPage.SetPreviewKey('');
+                    ExtensionInstallationPage.SetPublisherType(PublisherType);
+                    ExtensionInstallationPage.SetResponseUrl('');
                     ExtensionInstallationPage.RunModal();
                 end;
             }

--- a/src/System Application/App/Extension Management/app.json
+++ b/src/System Application/App/Extension Management/app.json
@@ -80,11 +80,6 @@
   ],
   "internalsVisibleTo": [
     {
-      "id": "79952567-63d7-4586-8b47-ba13a11a8a18",
-      "name": "AppSource Product Gallery",
-      "publisher": "Microsoft"
-    },
-    {
       "id": "6d7c736f-bfe8-4e01-9449-07295be9c6e4",
       "name": "Extension Management Test Library",
       "publisher": "Microsoft"

--- a/src/System Application/App/Extension Management/app.json
+++ b/src/System Application/App/Extension Management/app.json
@@ -80,6 +80,11 @@
   ],
   "internalsVisibleTo": [
     {
+      "id": "79952567-63d7-4586-8b47-ba13a11a8a18",
+      "name": "AppSource Product Gallery",
+      "publisher": "Microsoft"
+    },
+    {
       "id": "6d7c736f-bfe8-4e01-9449-07295be9c6e4",
       "name": "Extension Management Test Library",
       "publisher": "Microsoft"

--- a/src/System Application/App/Extension Management/src/ExtensionInstallation.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionInstallation.Page.al
@@ -25,12 +25,10 @@ page 2503 "Extension Installation"
 
     trigger OnOpenPage()
     var
-        ExtensionInstallationImpl: Codeunit "Extension Installation Impl";
         ExtensionMarketplace: Codeunit "Extension Marketplace";
         MarketplaceExtnDeployment: Page "Marketplace Extn Deployment";
     begin
         GetDetailsFromFilters();
-        ExtensionInstallationImpl.CheckPermissions();
 
         MarketplaceExtnDeployment.SetAppID(Rec.ID);
         MarketplaceExtnDeployment.SetPreviewKey(Rec.PreviewKey);
@@ -38,44 +36,14 @@ page 2503 "Extension Installation"
         MarketplaceExtnDeployment.RunModal();
         if MarketplaceExtnDeployment.GetInstalledSelected() then
             if not IsNullGuid(Rec.ID) then begin
-                if not TryInstallMarketplaceExtension(
+                ExtensionMarketplace.InstallMarketplaceExtension(
                     Rec.ID,
                     Rec.ResponseUrl,
                     MarketplaceExtnDeployment.GetLanguageId(),
-                    Rec.PreviewKey)
-                then
-                    ExtensionMarketplace.HandleInstallFailureWithRefreshSession(Rec.ID);
+                    Rec.PreviewKey);
                 MarketplaceExtnDeployment.Close();
             end;
         CurrPage.Close();
-    end;
-
-    internal procedure SetAppID(AppID: Guid)
-    begin
-        Rec.ID := AppID;
-    end;
-
-    internal procedure SetPreviewKey(PreviewKey: Text[2048])
-    begin
-        Rec.PreviewKey := PreviewKey;
-    end;
-
-    internal procedure SetPublisherType(PublisherType: Text)
-    begin
-        Rec.PublisherType := CopyStr(PublisherType, 1, MaxStrLen(Rec.PublisherType));
-    end;
-
-    internal procedure SetResponseUrl(ResponseUrl: Text)
-    begin
-        Rec.ResponseUrl := CopyStr(ResponseUrl, 1, MaxStrLen(Rec.ResponseUrl));
-    end;
-
-    [TryFunction]
-    local procedure TryInstallMarketplaceExtension(AppId: Guid; ResponseUrl: Text; LanguageId: Integer; PreviewKey: Text)
-    var
-        ExtensionMarketplace: Codeunit "Extension Marketplace";
-    begin
-        ExtensionMarketplace.InstallMarketplaceExtension(AppId, ResponseUrl, LanguageId, PreviewKey);
     end;
 
     local procedure GetDetailsFromFilters()

--- a/src/System Application/App/Extension Management/src/ExtensionInstallation.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionInstallation.Page.al
@@ -5,8 +5,6 @@
 
 namespace System.Apps;
 
-using System;
-
 /// <summary>
 /// Installs the selected extension.
 /// </summary>
@@ -55,11 +53,11 @@ page 2503 "Extension Installation"
 
     procedure SetPublisherType(PublisherType: Text)
     begin
-        Rec.PublisherType := PublisherType;
+        Rec.PublisherType := CopyStr(PublisherType, 1, MaxStrLen(Rec.PublisherType));
     end;
 
     procedure SetResponseUrl(ResponseUrl: Text)
     begin
-        Rec.ResponseUrl := ResponseUrl;
+        Rec.ResponseUrl := CopyStr(ResponseUrl, 1, MaxStrLen(Rec.ResponseUrl));
     end;
 }

--- a/src/System Application/App/Extension Management/src/ExtensionInstallation.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionInstallation.Page.al
@@ -28,57 +28,38 @@ page 2503 "Extension Installation"
         ExtensionMarketplace: Codeunit "Extension Marketplace";
         MarketplaceExtnDeployment: Page "Marketplace Extn Deployment";
     begin
-        GetDetailsFromFilters();
-
         MarketplaceExtnDeployment.SetAppID(Rec.ID);
         MarketplaceExtnDeployment.SetPreviewKey(Rec.PreviewKey);
         MarketplaceExtnDeployment.SetPublisherType(Rec.PublisherType);
         MarketplaceExtnDeployment.RunModal();
         if MarketplaceExtnDeployment.GetInstalledSelected() then
             if not IsNullGuid(Rec.ID) then begin
-                ExtensionMarketplace.InstallMarketplaceExtension(
+                ExtensionMarketplace.InstallAppsourceExtensionWithRefreshSession(
                     Rec.ID,
                     Rec.ResponseUrl,
-                    MarketplaceExtnDeployment.GetLanguageId(),
-                    Rec.PreviewKey);
+                    Rec.PublisherType);
                 MarketplaceExtnDeployment.Close();
             end;
         CurrPage.Close();
     end;
 
-    local procedure GetDetailsFromFilters()
-    var
-        RecordRef: RecordRef;
-        i: Integer;
+    procedure SetAppID(AppID: Guid)
     begin
-        RecordRef.GetTable(Rec);
-        for i := 1 to RecordRef.FieldCount() do
-            ParseFilter(RecordRef.FieldIndex(i));
-        RecordRef.SetTable(Rec);
+        Rec.ID := AppID;
     end;
 
-    local procedure ParseFilter(FieldRef: FieldRef)
-    var
-        FilterPrefixDotNet_Regex: DotNet Regex;
-        SingleQuoteDotNet_Regex: DotNet Regex;
-        EscapedEqualityDotNet_Regex: DotNet Regex;
-        "Filter": Text;
+    procedure SetPreviewKey(PreviewKey: Text[2048])
     begin
-        Filter := FieldRef.GetFilter();
-        if (Filter = '') then
-            exit;
+        Rec.PreviewKey := PreviewKey;
+    end;
 
-        FilterPrefixDotNet_Regex := FilterPrefixDotNet_Regex.Regex('^@\*([^\\]+)\*$');
-        SingleQuoteDotNet_Regex := SingleQuoteDotNet_Regex.Regex('^''([^\\]+)''$');
-        EscapedEqualityDotNet_Regex := EscapedEqualityDotNet_Regex.Regex('~');
+    procedure SetPublisherType(PublisherType: Text)
+    begin
+        Rec.PublisherType := PublisherType;
+    end;
 
-        Filter := FilterPrefixDotNet_Regex.Replace(Filter, '$1');
-        Filter := SingleQuoteDotNet_Regex.Replace(Filter, '$1');
-        Filter := EscapedEqualityDotNet_Regex.Replace(Filter, '=');
-
-        if Filter <> '' then
-            FieldRef.Value(Filter);
+    procedure SetResponseUrl(ResponseUrl: Text)
+    begin
+        Rec.ResponseUrl := ResponseUrl;
     end;
 }
-
-

--- a/src/System Application/App/Extension Management/src/ExtensionInstallation.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionInstallation.Page.al
@@ -50,22 +50,22 @@ page 2503 "Extension Installation"
         CurrPage.Close();
     end;
 
-    procedure SetAppID(AppID: Guid)
+    internal procedure SetAppID(AppID: Guid)
     begin
         Rec.ID := AppID;
     end;
 
-    procedure SetPreviewKey(PreviewKey: Text[2048])
+    internal procedure SetPreviewKey(PreviewKey: Text[2048])
     begin
         Rec.PreviewKey := PreviewKey;
     end;
 
-    procedure SetPublisherType(PublisherType: Text)
+    internal procedure SetPublisherType(PublisherType: Text)
     begin
         Rec.PublisherType := CopyStr(PublisherType, 1, MaxStrLen(Rec.PublisherType));
     end;
 
-    procedure SetResponseUrl(ResponseUrl: Text)
+    internal procedure SetResponseUrl(ResponseUrl: Text)
     begin
         Rec.ResponseUrl := CopyStr(ResponseUrl, 1, MaxStrLen(Rec.ResponseUrl));
     end;

--- a/src/System Application/App/Extension Management/src/ExtensionInstallation.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionInstallation.Page.al
@@ -5,6 +5,8 @@
 
 namespace System.Apps;
 
+using System;
+
 /// <summary>
 /// Installs the selected extension.
 /// </summary>
@@ -23,19 +25,26 @@ page 2503 "Extension Installation"
 
     trigger OnOpenPage()
     var
+        ExtensionInstallationImpl: Codeunit "Extension Installation Impl";
         ExtensionMarketplace: Codeunit "Extension Marketplace";
         MarketplaceExtnDeployment: Page "Marketplace Extn Deployment";
     begin
+        GetDetailsFromFilters();
+        ExtensionInstallationImpl.CheckPermissions();
+
         MarketplaceExtnDeployment.SetAppID(Rec.ID);
         MarketplaceExtnDeployment.SetPreviewKey(Rec.PreviewKey);
         MarketplaceExtnDeployment.SetPublisherType(Rec.PublisherType);
         MarketplaceExtnDeployment.RunModal();
         if MarketplaceExtnDeployment.GetInstalledSelected() then
             if not IsNullGuid(Rec.ID) then begin
-                ExtensionMarketplace.InstallAppsourceExtensionWithRefreshSession(
+                if not TryInstallMarketplaceExtension(
                     Rec.ID,
                     Rec.ResponseUrl,
-                    Rec.PublisherType);
+                    MarketplaceExtnDeployment.GetLanguageId(),
+                    Rec.PreviewKey)
+                then
+                    ExtensionMarketplace.HandleInstallFailureWithRefreshSession(Rec.ID);
                 MarketplaceExtnDeployment.Close();
             end;
         CurrPage.Close();
@@ -59,5 +68,47 @@ page 2503 "Extension Installation"
     procedure SetResponseUrl(ResponseUrl: Text)
     begin
         Rec.ResponseUrl := CopyStr(ResponseUrl, 1, MaxStrLen(Rec.ResponseUrl));
+    end;
+
+    [TryFunction]
+    local procedure TryInstallMarketplaceExtension(AppId: Guid; ResponseUrl: Text; LanguageId: Integer; PreviewKey: Text)
+    var
+        ExtensionMarketplace: Codeunit "Extension Marketplace";
+    begin
+        ExtensionMarketplace.InstallMarketplaceExtension(AppId, ResponseUrl, LanguageId, PreviewKey);
+    end;
+
+    local procedure GetDetailsFromFilters()
+    var
+        RecordRef: RecordRef;
+        i: Integer;
+    begin
+        RecordRef.GetTable(Rec);
+        for i := 1 to RecordRef.FieldCount() do
+            ParseFilter(RecordRef.FieldIndex(i));
+        RecordRef.SetTable(Rec);
+    end;
+
+    local procedure ParseFilter(FieldRef: FieldRef)
+    var
+        FilterPrefixDotNet_Regex: DotNet Regex;
+        SingleQuoteDotNet_Regex: DotNet Regex;
+        EscapedEqualityDotNet_Regex: DotNet Regex;
+        "Filter": Text;
+    begin
+        Filter := FieldRef.GetFilter();
+        if Filter = '' then
+            exit;
+
+        FilterPrefixDotNet_Regex := FilterPrefixDotNet_Regex.Regex('^@\*([^\\]+)\*$');
+        SingleQuoteDotNet_Regex := SingleQuoteDotNet_Regex.Regex('^''([^\\]+)''$');
+        EscapedEqualityDotNet_Regex := EscapedEqualityDotNet_Regex.Regex('~');
+
+        Filter := FilterPrefixDotNet_Regex.Replace(Filter, '$1');
+        Filter := SingleQuoteDotNet_Regex.Replace(Filter, '$1');
+        Filter := EscapedEqualityDotNet_Regex.Replace(Filter, '=');
+
+        if Filter <> '' then
+            FieldRef.Value(Filter);
     end;
 }

--- a/src/System Application/App/Extension Management/src/ExtensionInstallation.Page.al
+++ b/src/System Application/App/Extension Management/src/ExtensionInstallation.Page.al
@@ -32,6 +32,7 @@ page 2503 "Extension Installation"
 
         MarketplaceExtnDeployment.SetAppID(Rec.ID);
         MarketplaceExtnDeployment.SetPreviewKey(Rec.PreviewKey);
+        MarketplaceExtnDeployment.SetPublisherType(Rec.PublisherType);
         MarketplaceExtnDeployment.RunModal();
         if MarketplaceExtnDeployment.GetInstalledSelected() then
             if not IsNullGuid(Rec.ID) then begin

--- a/src/System Application/App/Extension Management/src/ExtensionInstallation.Table.al
+++ b/src/System Application/App/Extension Management/src/ExtensionInstallation.Table.al
@@ -7,10 +7,6 @@ namespace System.Apps;
 /// <summary>
 /// The table containing information about an extension install.
 /// </summary>
-/// <remarks>
-/// The casing of the fields is expected to match the casing in the URL filter used when calling the installation page 2503:
-/// 'ID' IS '[AppID]' AND 'PreviewKey' IS '[PreviewKey]'
-/// </remarks>
 table 2503 "Extension Installation"
 {
     Access = Internal;

--- a/src/System Application/App/Extension Management/src/ExtensionInstallation.Table.al
+++ b/src/System Application/App/Extension Management/src/ExtensionInstallation.Table.al
@@ -40,5 +40,12 @@ table 2503 "Extension Installation"
         {
             Caption = 'Response URL';
         }
+        /// <summary>
+        /// The publisher type of the extension (e.g., 'Microsoft' or 'ThirdParty').
+        /// </summary>
+        field(4; PublisherType; Text[200])
+        {
+            Caption = 'Publisher Type';
+        }
     }
 }

--- a/src/System Application/App/Extension Management/src/ExtensionInstallation.Table.al
+++ b/src/System Application/App/Extension Management/src/ExtensionInstallation.Table.al
@@ -46,6 +46,7 @@ table 2503 "Extension Installation"
         field(4; PublisherType; Text[200])
         {
             Caption = 'Publisher Type';
+            DataClassification = SystemMetadata;
         }
     }
 }

--- a/src/System Application/App/Extension Management/src/ExtensionInstallation.Table.al
+++ b/src/System Application/App/Extension Management/src/ExtensionInstallation.Table.al
@@ -7,6 +7,10 @@ namespace System.Apps;
 /// <summary>
 /// The table containing information about an extension install.
 /// </summary>
+/// <remarks>
+/// The casing of the fields is expected to match the casing in the URL filter used when calling the installation page 2503:
+/// 'ID' IS '[AppID]' AND 'PreviewKey' IS '[PreviewKey]'
+/// </remarks>
 table 2503 "Extension Installation"
 {
     Access = Internal;

--- a/src/System Application/App/Extension Management/src/ExtensionManagement.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionManagement.Codeunit.al
@@ -254,16 +254,6 @@ codeunit 2504 "Extension Management"
     end;
 
     /// <summary>
-    /// Installs a marketplace extension with publisher type information.
-    /// </summary>
-    /// <param name="AppId">The App Id of the extension to install.</param>
-    /// <param name="PublisherType">The publisher type of the extension (e.g., 'Microsoft' or 'ThirdParty').</param>
-    internal procedure InstallMarketplaceExtensionWithPublisher(AppId: Guid; PublisherType: Text)
-    begin
-        ExtensionMarketplace.InstallAppsourceExtensionWithRefreshSession(AppId, '', PublisherType);
-    end;
-
-    /// <summary>
     /// Returns the Name of the app given the App Id.
     /// </summary>
     /// <param name="AppId">The unique identifier of the app.</param>

--- a/src/System Application/App/Extension Management/src/ExtensionManagement.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionManagement.Codeunit.al
@@ -254,6 +254,16 @@ codeunit 2504 "Extension Management"
     end;
 
     /// <summary>
+    /// Installs a marketplace extension with publisher type information.
+    /// </summary>
+    /// <param name="AppId">The App Id of the extension to install.</param>
+    /// <param name="PublisherType">The publisher type of the extension (e.g., 'Microsoft' or 'ThirdParty').</param>
+    procedure InstallMarketplaceExtensionWithPublisher(AppId: Guid; PublisherType: Text)
+    begin
+        ExtensionMarketplace.InstallAppsourceExtensionWithRefreshSession(AppId, '', PublisherType);
+    end;
+
+    /// <summary>
     /// Returns the Name of the app given the App Id.
     /// </summary>
     /// <param name="AppId">The unique identifier of the app.</param>

--- a/src/System Application/App/Extension Management/src/ExtensionManagement.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionManagement.Codeunit.al
@@ -250,7 +250,17 @@ codeunit 2504 "Extension Management"
     /// <param name="AppId">The ID of the extension package.</param>
     procedure InstallMarketplaceExtension(AppId: Guid)
     begin
-        ExtensionMarketplace.InstallAppsourceExtensionWithRefreshSession(AppId, '');
+        ExtensionMarketplace.InstallAppsourceExtensionWithRefreshSession(AppId, '', '');
+    end;
+
+    /// <summary>
+    /// Installs a marketplace extension with publisher type information.
+    /// </summary>
+    /// <param name="AppId">The App Id of the extension to install.</param>
+    /// <param name="PublisherType">The publisher type of the extension (e.g., 'Microsoft' or 'ThirdParty').</param>
+    internal procedure InstallMarketplaceExtensionWithPublisher(AppId: Guid; PublisherType: Text)
+    begin
+        ExtensionMarketplace.InstallAppsourceExtensionWithRefreshSession(AppId, '', PublisherType);
     end;
 
     /// <summary>

--- a/src/System Application/App/Extension Management/src/ExtensionManagement.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionManagement.Codeunit.al
@@ -258,7 +258,7 @@ codeunit 2504 "Extension Management"
     /// </summary>
     /// <param name="AppId">The App Id of the extension to install.</param>
     /// <param name="PublisherType">The publisher type of the extension (e.g., 'Microsoft' or 'ThirdParty').</param>
-    internal procedure InstallMarketplaceExtensionWithPublisher(AppId: Guid; PublisherType: Text)
+    procedure InstallMarketplaceExtensionWithPublisher(AppId: Guid; PublisherType: Text)
     begin
         ExtensionMarketplace.InstallAppsourceExtensionWithRefreshSession(AppId, '', PublisherType);
     end;
@@ -294,4 +294,3 @@ codeunit 2504 "Extension Management"
         ExtensionOperationImpl.GetDeploymentDetailedStatusMessageAsStream(OperationId, OutStream);
     end;
 }
-

--- a/src/System Application/App/Extension Management/src/ExtensionManagement.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionManagement.Codeunit.al
@@ -258,7 +258,7 @@ codeunit 2504 "Extension Management"
     /// </summary>
     /// <param name="AppId">The App Id of the extension to install.</param>
     /// <param name="PublisherType">The publisher type of the extension (e.g., 'Microsoft' or 'ThirdParty').</param>
-    procedure InstallMarketplaceExtensionWithPublisher(AppId: Guid; PublisherType: Text)
+    internal procedure InstallMarketplaceExtensionWithPublisher(AppId: Guid; PublisherType: Text)
     begin
         ExtensionMarketplace.InstallAppsourceExtensionWithRefreshSession(AppId, '', PublisherType);
     end;

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
@@ -226,7 +226,6 @@ codeunit 2501 "Extension Marketplace"
     [TryFunction]
     procedure InstallAppsourceExtension(MarketplaceApplicationId: Text; TelemetryURL: Text; PublisherType: Text);
     var
-        TempExtensionInstallationRecord: Record "Extension Installation";
         ExtensionInstallationPage: Page "Extension Installation";
         AppId: Guid;
     begin
@@ -236,11 +235,10 @@ codeunit 2501 "Extension Marketplace"
             Error(ExtensionNotFoundErr);
         end;
 
-        TempExtensionInstallationRecord.SetRange(ID, AppId);
-        TempExtensionInstallationRecord.ID := AppId;
-        TempExtensionInstallationRecord.ResponseUrl := CopyStr(TelemetryURL, 1, MaxStrLen(TempExtensionInstallationRecord.ResponseUrl));
-        TempExtensionInstallationRecord.PublisherType := CopyStr(PublisherType, 1, MaxStrLen(TempExtensionInstallationRecord.PublisherType));
-        ExtensionInstallationPage.SetRecord(TempExtensionInstallationRecord);
+        ExtensionInstallationPage.SetAppID(AppId);
+        ExtensionInstallationPage.SetPreviewKey('');
+        ExtensionInstallationPage.SetResponseUrl(TelemetryURL);
+        ExtensionInstallationPage.SetPublisherType(PublisherType);
         ExtensionInstallationPage.RunModal();
     end;
 
@@ -254,7 +252,6 @@ codeunit 2501 "Extension Marketplace"
     [TryFunction]
     procedure InstallAppsourceExtension(AppId: Guid; TelemetryURL: Text; PublisherType: Text)
     var
-        TempExtensionInstallationRecord: Record "Extension Installation";
         ExtensionInstallationPage: Page "Extension Installation";
     begin
         if IsNullGuid(AppId) then begin
@@ -262,11 +259,10 @@ codeunit 2501 "Extension Marketplace"
             Error(ExtensionNotFoundErr);
         end;
 
-        TempExtensionInstallationRecord.SetRange(ID, AppId);
-        TempExtensionInstallationRecord.ID := AppId;
-        TempExtensionInstallationRecord.ResponseUrl := CopyStr(TelemetryURL, 1, MaxStrLen(TempExtensionInstallationRecord.ResponseUrl));
-        TempExtensionInstallationRecord.PublisherType := CopyStr(PublisherType, 1, MaxStrLen(TempExtensionInstallationRecord.PublisherType));
-        ExtensionInstallationPage.SetRecord(TempExtensionInstallationRecord);
+        ExtensionInstallationPage.SetAppID(AppId);
+        ExtensionInstallationPage.SetPreviewKey('');
+        ExtensionInstallationPage.SetResponseUrl(TelemetryURL);
+        ExtensionInstallationPage.SetPublisherType(PublisherType);
         ExtensionInstallationPage.RunModal();
     end;
 

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
@@ -244,6 +244,12 @@ codeunit 2501 "Extension Marketplace"
     end;
 
     [TryFunction]
+    procedure InstallAppsourceExtension(AppId: Guid; TelemetryURL: Text)
+    begin
+        InstallAppsourceExtension(AppId, TelemetryURL, '');
+    end;
+
+    [TryFunction]
     procedure InstallAppsourceExtension(AppId: Guid; TelemetryURL: Text; PublisherType: Text)
     var
         TempExtensionInstallationRecord: Record "Extension Installation";
@@ -301,6 +307,11 @@ codeunit 2501 "Extension Marketplace"
                 ExtensionPendingSetup.SetRange("User Id", UserSecurityId());
                 ExtensionPendingSetup.DeleteAll();
             end;
+    end;
+
+    procedure InstallAppsourceExtensionWithRefreshSession(AppId: Guid; TelemetryURL: Text);
+    begin
+        InstallAppsourceExtensionWithRefreshSession(AppId, TelemetryURL, '');
     end;
 
     [TryFunction]

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
@@ -217,7 +217,7 @@ codeunit 2501 "Extension Marketplace"
     end;
 
     [TryFunction]
-    procedure InstallAppsourceExtension(MarketplaceApplicationId: Text; TelemetryURL: Text);
+    procedure InstallAppsourceExtension(MarketplaceApplicationId: Text; TelemetryURL: Text; PublisherType: Text);
     var
         TempExtensionInstallationRecord: Record "Extension Installation";
         ExtensionInstallationPage: Page "Extension Installation";
@@ -232,12 +232,13 @@ codeunit 2501 "Extension Marketplace"
         TempExtensionInstallationRecord.SetRange(ID, AppId);
         TempExtensionInstallationRecord.ID := AppId;
         TempExtensionInstallationRecord.ResponseUrl := CopyStr(TelemetryURL, 1, MaxStrLen(TempExtensionInstallationRecord.ResponseUrl));
+        TempExtensionInstallationRecord.PublisherType := CopyStr(PublisherType, 1, MaxStrLen(TempExtensionInstallationRecord.PublisherType));
         ExtensionInstallationPage.SetRecord(TempExtensionInstallationRecord);
         ExtensionInstallationPage.RunModal();
     end;
 
     [TryFunction]
-    procedure InstallAppsourceExtension(AppId: Guid; TelemetryURL: Text)
+    procedure InstallAppsourceExtension(AppId: Guid; TelemetryURL: Text; PublisherType: Text)
     var
         TempExtensionInstallationRecord: Record "Extension Installation";
         ExtensionInstallationPage: Page "Extension Installation";
@@ -250,6 +251,7 @@ codeunit 2501 "Extension Marketplace"
         TempExtensionInstallationRecord.SetRange(ID, AppId);
         TempExtensionInstallationRecord.ID := AppId;
         TempExtensionInstallationRecord.ResponseUrl := CopyStr(TelemetryURL, 1, MaxStrLen(TempExtensionInstallationRecord.ResponseUrl));
+        TempExtensionInstallationRecord.PublisherType := CopyStr(PublisherType, 1, MaxStrLen(TempExtensionInstallationRecord.PublisherType));
         ExtensionInstallationPage.SetRecord(TempExtensionInstallationRecord);
         ExtensionInstallationPage.RunModal();
     end;
@@ -276,7 +278,7 @@ codeunit 2501 "Extension Marketplace"
         end;
     end;
 
-    procedure InstallAppsourceExtensionWithRefreshSession(AppId: Guid; TelemetryURL: Text);
+    procedure InstallAppsourceExtensionWithRefreshSession(AppId: Guid; TelemetryURL: Text; PublisherType: Text);
     var
         ExtensionPendingSetup: Record "Extension Pending Setup";
         ExtensionInstallationImpl: Codeunit "Extension Installation Impl";
@@ -284,7 +286,7 @@ codeunit 2501 "Extension Marketplace"
     begin
         ExtensionInstallationImpl.CheckPermissions();
 
-        if not InstallAppsourceExtension(AppId, TelemetryURL) then // successful installation returns false
+        if not InstallAppsourceExtension(AppId, TelemetryURL, PublisherType) then // successful installation returns false
             if ExtensionInstallationImpl.IsInstalledByAppId(AppId) then begin
                 SaveExtensionPendingSetup(AppId);
                 MySessionSettings.Init();

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
@@ -219,7 +219,7 @@ codeunit 2501 "Extension Marketplace"
     [TryFunction]
     procedure InstallAppsourceExtension(MarketplaceApplicationId: Text; TelemetryURL: Text);
     begin
-        InstallAppsourceExtension(MarketplaceApplicationId, TelemetryURL, '');
+        exit(InstallAppsourceExtension(MarketplaceApplicationId, TelemetryURL, ''));
     end;
 
     [TryFunction]
@@ -246,7 +246,7 @@ codeunit 2501 "Extension Marketplace"
     [TryFunction]
     procedure InstallAppsourceExtension(AppId: Guid; TelemetryURL: Text)
     begin
-        InstallAppsourceExtension(AppId, TelemetryURL, '');
+        exit(InstallAppsourceExtension(AppId, TelemetryURL, ''));
     end;
 
     [TryFunction]

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
@@ -268,43 +268,25 @@ codeunit 2501 "Extension Marketplace"
 
     procedure InstallAppsourceExtensionWithRefreshSession(MarketplaceApplicationID: Text; TelemetryURL: Text);
     var
-        ExtensionPendingSetup: Record "Extension Pending Setup";
         ExtensionInstallationImpl: Codeunit "Extension Installation Impl";
-        MySessionSettings: SessionSettings;
         AppId: Guid;
     begin
         ExtensionInstallationImpl.CheckPermissions();
 
         if not InstallAppsourceExtension(MarketplaceApplicationID, TelemetryURL) then begin // successful installation returns false
             AppId := MapMarketplaceIdToAppId(MarketplaceApplicationID);
-            if ExtensionInstallationImpl.IsInstalledByAppId(AppId) then begin
-                SaveExtensionPendingSetup(AppId);
-                MySessionSettings.Init();
-                MySessionSettings.RequestSessionUpdate(false);
-            end else begin
-                ExtensionPendingSetup.SetRange("User Id", UserSecurityId());
-                ExtensionPendingSetup.DeleteAll();
-            end;
+            HandleInstallFailureWithRefreshSession(AppId);
         end;
     end;
 
     procedure InstallAppsourceExtensionWithRefreshSession(AppId: Guid; TelemetryURL: Text; PublisherType: Text);
     var
-        ExtensionPendingSetup: Record "Extension Pending Setup";
         ExtensionInstallationImpl: Codeunit "Extension Installation Impl";
-        MySessionSettings: SessionSettings;
     begin
         ExtensionInstallationImpl.CheckPermissions();
 
         if not InstallAppsourceExtension(AppId, TelemetryURL, PublisherType) then // successful installation returns false
-            if ExtensionInstallationImpl.IsInstalledByAppId(AppId) then begin
-                SaveExtensionPendingSetup(AppId);
-                MySessionSettings.Init();
-                MySessionSettings.RequestSessionUpdate(false);
-            end else begin
-                ExtensionPendingSetup.SetRange("User Id", UserSecurityId());
-                ExtensionPendingSetup.DeleteAll();
-            end;
+            HandleInstallFailureWithRefreshSession(AppId);
     end;
 
     procedure InstallAppsourceExtensionWithRefreshSession(AppId: Guid; TelemetryURL: Text);
@@ -456,6 +438,22 @@ codeunit 2501 "Extension Marketplace"
         GuidedExperience: Codeunit "Guided Experience";
     begin
         exit(GuidedExperience.SetupForExtensionExists(AppId));
+    end;
+
+    internal procedure HandleInstallFailureWithRefreshSession(AppId: Guid)
+    var
+        ExtensionPendingSetup: Record "Extension Pending Setup";
+        ExtensionInstallationImpl: Codeunit "Extension Installation Impl";
+        MySessionSettings: SessionSettings;
+    begin
+        if ExtensionInstallationImpl.IsInstalledByAppId(AppId) then begin
+            SaveExtensionPendingSetup(AppId);
+            MySessionSettings.Init();
+            MySessionSettings.RequestSessionUpdate(false);
+        end else begin
+            ExtensionPendingSetup.SetRange("User Id", UserSecurityId());
+            ExtensionPendingSetup.DeleteAll();
+        end;
     end;
 
     local procedure IsFirstPartyExtension(PublishedApplication: Record "Published Application"): Boolean

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
@@ -219,14 +219,29 @@ codeunit 2501 "Extension Marketplace"
     [TryFunction]
     procedure InstallAppsourceExtension(MarketplaceApplicationId: Text; TelemetryURL: Text);
     begin
-        if not InstallAppsourceExtension(MarketplaceApplicationId, TelemetryURL, '') then
-            Error(GetLastErrorText());
+        InstallAppsourceExtensionPage(MarketplaceApplicationId, TelemetryURL, '');
     end;
 
     [TryFunction]
     procedure InstallAppsourceExtension(MarketplaceApplicationId: Text; TelemetryURL: Text; PublisherType: Text);
+    begin
+        InstallAppsourceExtensionPage(MarketplaceApplicationId, TelemetryURL, PublisherType);
+    end;
+
+    [TryFunction]
+    procedure InstallAppsourceExtension(AppId: Guid; TelemetryURL: Text)
+    begin
+        InstallAppsourceExtensionPage(AppId, TelemetryURL, '');
+    end;
+
+    [TryFunction]
+    procedure InstallAppsourceExtension(AppId: Guid; TelemetryURL: Text; PublisherType: Text)
+    begin
+        InstallAppsourceExtensionPage(AppId, TelemetryURL, PublisherType);
+    end;
+
+    local procedure InstallAppsourceExtensionPage(MarketplaceApplicationId: Text; TelemetryURL: Text; PublisherType: Text)
     var
-        ExtensionInstallationPage: Page "Extension Installation";
         AppId: Guid;
     begin
         AppId := MapMarketplaceIdToAppId(MarketplaceApplicationId);
@@ -235,23 +250,12 @@ codeunit 2501 "Extension Marketplace"
             Error(ExtensionNotFoundErr);
         end;
 
-        ExtensionInstallationPage.SetAppID(AppId);
-        ExtensionInstallationPage.SetPreviewKey('');
-        ExtensionInstallationPage.SetResponseUrl(TelemetryURL);
-        ExtensionInstallationPage.SetPublisherType(PublisherType);
-        ExtensionInstallationPage.RunModal();
+        InstallAppsourceExtensionPage(AppId, TelemetryURL, PublisherType);
     end;
 
-    [TryFunction]
-    procedure InstallAppsourceExtension(AppId: Guid; TelemetryURL: Text)
-    begin
-        if not InstallAppsourceExtension(AppId, TelemetryURL, '') then
-            Error(GetLastErrorText());
-    end;
-
-    [TryFunction]
-    procedure InstallAppsourceExtension(AppId: Guid; TelemetryURL: Text; PublisherType: Text)
+    local procedure InstallAppsourceExtensionPage(AppId: Guid; TelemetryURL: Text; PublisherType: Text)
     var
+        TempExtensionInstallationRecord: Record "Extension Installation";
         ExtensionInstallationPage: Page "Extension Installation";
     begin
         if IsNullGuid(AppId) then begin
@@ -259,10 +263,11 @@ codeunit 2501 "Extension Marketplace"
             Error(ExtensionNotFoundErr);
         end;
 
-        ExtensionInstallationPage.SetAppID(AppId);
-        ExtensionInstallationPage.SetPreviewKey('');
-        ExtensionInstallationPage.SetResponseUrl(TelemetryURL);
-        ExtensionInstallationPage.SetPublisherType(PublisherType);
+        TempExtensionInstallationRecord.SetRange(ID, AppId);
+        TempExtensionInstallationRecord.ID := AppId;
+        TempExtensionInstallationRecord.ResponseUrl := CopyStr(TelemetryURL, 1, MaxStrLen(TempExtensionInstallationRecord.ResponseUrl));
+        TempExtensionInstallationRecord.PublisherType := CopyStr(PublisherType, 1, MaxStrLen(TempExtensionInstallationRecord.PublisherType));
+        ExtensionInstallationPage.SetRecord(TempExtensionInstallationRecord);
         ExtensionInstallationPage.RunModal();
     end;
 
@@ -440,7 +445,7 @@ codeunit 2501 "Extension Marketplace"
         exit(GuidedExperience.SetupForExtensionExists(AppId));
     end;
 
-    internal procedure HandleInstallFailureWithRefreshSession(AppId: Guid)
+    local procedure HandleInstallFailureWithRefreshSession(AppId: Guid)
     var
         ExtensionPendingSetup: Record "Extension Pending Setup";
         ExtensionInstallationImpl: Codeunit "Extension Installation Impl";

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
@@ -217,6 +217,12 @@ codeunit 2501 "Extension Marketplace"
     end;
 
     [TryFunction]
+    procedure InstallAppsourceExtension(MarketplaceApplicationId: Text; TelemetryURL: Text);
+    begin
+        InstallAppsourceExtension(MarketplaceApplicationId, TelemetryURL, '');
+    end;
+
+    [TryFunction]
     procedure InstallAppsourceExtension(MarketplaceApplicationId: Text; TelemetryURL: Text; PublisherType: Text);
     var
         TempExtensionInstallationRecord: Record "Extension Installation";

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
@@ -219,7 +219,8 @@ codeunit 2501 "Extension Marketplace"
     [TryFunction]
     procedure InstallAppsourceExtension(MarketplaceApplicationId: Text; TelemetryURL: Text);
     begin
-        exit(InstallAppsourceExtension(MarketplaceApplicationId, TelemetryURL, ''));
+        if not InstallAppsourceExtension(MarketplaceApplicationId, TelemetryURL, '') then
+            Error(GetLastErrorText());
     end;
 
     [TryFunction]
@@ -246,7 +247,8 @@ codeunit 2501 "Extension Marketplace"
     [TryFunction]
     procedure InstallAppsourceExtension(AppId: Guid; TelemetryURL: Text)
     begin
-        exit(InstallAppsourceExtension(AppId, TelemetryURL, ''));
+        if not InstallAppsourceExtension(AppId, TelemetryURL, '') then
+            Error(GetLastErrorText());
     end;
 
     [TryFunction]

--- a/src/System Application/App/Extension Management/src/MarketplaceExtnDeployment.Page.al
+++ b/src/System Application/App/Extension Management/src/MarketplaceExtnDeployment.Page.al
@@ -254,11 +254,7 @@ page 2510 "Marketplace Extn Deployment"
         LanguageName := LanguageManagement.GetWindowsLanguageName(LanguageID);
         Clear(InstallSelected);
         IsThirdPartyInstall := true;
-        // For Microsoft-published apps, skip the disclaimer and go straight to installation
-        if IsThirdPartyInstall then
-            Step := Step::Disclaimer
-        else
-            Step := Step::Installation;
+        Step := Step::Disclaimer;
     end;
 
     trigger OnOpenPage()

--- a/src/System Application/App/Extension Management/src/MarketplaceExtnDeployment.Page.al
+++ b/src/System Application/App/Extension Management/src/MarketplaceExtnDeployment.Page.al
@@ -239,7 +239,7 @@ page 2510 "Marketplace Extn Deployment"
     internal procedure SetPublisherType(NewPublisherType: Text)
     begin
         PublisherType := NewPublisherType;
-        IsThirdPartyInstall := LowerCase(PublisherType) <> MicrosoftPublisherTypeLbl;
+        IsThirdPartyInstall := LowerCase(PublisherType) <> MicrosoftPublisherTypeTok;
         if IsThirdPartyInstall then
             Step := Step::Disclaimer
         else
@@ -284,5 +284,5 @@ page 2510 "Marketplace Extn Deployment"
         LearnMoreComplianceURLLbl: Label 'https://go.microsoft.com/fwlink/?linkid=2342556', Locked = true;
         LearnMoreInstallingLbl: Label 'Learn more about installing/uninstalling apps';
         InstallAppsURLLbl: Label 'https://go.microsoft.com/fwlink/?linkid=2260926', Locked = true;
-        MicrosoftPublisherTypeLbl: Label 'microsoft', Locked = true;
+        MicrosoftPublisherTypeTok: Label 'microsoft', Locked = true;
 }

--- a/src/System Application/App/Extension Management/src/MarketplaceExtnDeployment.Page.al
+++ b/src/System Application/App/Extension Management/src/MarketplaceExtnDeployment.Page.al
@@ -168,8 +168,8 @@ page 2510 "Marketplace Extn Deployment"
                 Caption = 'Back';
                 ToolTip = 'Go back to the previous step.';
                 InFooterBar = true;
-                Enabled = (Step <> Step::Disclaimer) or not IsThirdPartyPublisher();
-                Visible = (Step <> Step::Disclaimer) or not IsThirdPartyPublisher();
+                Enabled = (Step = Step::Installation) and IsThirdPartyPublisher();
+                Visible = (Step = Step::Installation) and IsThirdPartyPublisher();
 
                 trigger OnAction()
                 begin
@@ -243,9 +243,7 @@ page 2510 "Marketplace Extn Deployment"
 
     local procedure IsThirdPartyPublisher(): Boolean
     begin
-        // If PublisherType is empty or "Microsoft", return false (not third-party)
-        // Otherwise, return true (third-party)
-        exit((PublisherType <> '') and (PublisherType <> 'Microsoft'));
+        exit(LowerCase(PublisherType) <> 'microsoft');
     end;
 
     trigger OnInit()

--- a/src/System Application/App/Extension Management/src/MarketplaceExtnDeployment.Page.al
+++ b/src/System Application/App/Extension Management/src/MarketplaceExtnDeployment.Page.al
@@ -24,7 +24,7 @@ page 2510 "Marketplace Extn Deployment"
         {
             group(DisclaimerStep)
             {
-                Visible = Step = Step::Disclaimer;
+                Visible = (Step = Step::Disclaimer) and IsThirdPartyPublisher();
                 ShowCaption = false;
 
                 group(DisclaimerHeader)
@@ -168,8 +168,8 @@ page 2510 "Marketplace Extn Deployment"
                 Caption = 'Back';
                 ToolTip = 'Go back to the previous step.';
                 InFooterBar = true;
-                Enabled = Step <> Step::Disclaimer;
-                Visible = Step <> Step::Disclaimer;
+                Enabled = (Step <> Step::Disclaimer) or not IsThirdPartyPublisher();
+                Visible = (Step <> Step::Disclaimer) or not IsThirdPartyPublisher();
 
                 trigger OnAction()
                 begin
@@ -186,7 +186,7 @@ page 2510 "Marketplace Extn Deployment"
                 Caption = 'Continue';
                 ToolTip = 'Continue to the next step.';
                 InFooterBar = true;
-                Visible = Step = Step::Disclaimer;
+                Visible = (Step = Step::Disclaimer) and IsThirdPartyPublisher();
 
                 trigger OnAction()
                 begin
@@ -236,6 +236,18 @@ page 2510 "Marketplace Extn Deployment"
             InstallPreview := true;
     end;
 
+    internal procedure SetPublisherType(NewPublisherType: Text)
+    begin
+        PublisherType := NewPublisherType;
+    end;
+
+    local procedure IsThirdPartyPublisher(): Boolean
+    begin
+        // If PublisherType is empty or "Microsoft", return false (not third-party)
+        // Otherwise, return true (third-party)
+        exit((PublisherType <> '') and (PublisherType <> 'Microsoft'));
+    end;
+
     trigger OnInit()
     var
         LanguageManagement: Codeunit Language;
@@ -243,7 +255,11 @@ page 2510 "Marketplace Extn Deployment"
         LanguageID := GlobalLanguage();
         LanguageName := LanguageManagement.GetWindowsLanguageName(LanguageID);
         Clear(InstallSelected);
-        Step := Step::Disclaimer;
+        // For Microsoft-published apps, skip the disclaimer and go straight to installation
+        if IsThirdPartyPublisher() then
+            Step := Step::Disclaimer
+        else
+            Step := Step::Installation;
     end;
 
     trigger OnOpenPage()
@@ -259,6 +275,7 @@ page 2510 "Marketplace Extn Deployment"
         InstallSelected: Boolean;
         InstallPreview: Boolean;
         AppID: Guid;
+        PublisherType: Text;
         Step: Option Disclaimer,Installation;
         ActiveUsersLbl: Label 'Note: There might be other users working in the system.';
         WarningLbl: Label 'Installing extensions during business hours will disrupt other users.';

--- a/src/System Application/App/Extension Management/src/MarketplaceExtnDeployment.Page.al
+++ b/src/System Application/App/Extension Management/src/MarketplaceExtnDeployment.Page.al
@@ -24,7 +24,7 @@ page 2510 "Marketplace Extn Deployment"
         {
             group(DisclaimerStep)
             {
-                Visible = (Step = Step::Disclaimer) and IsThirdPartyPublisher();
+                Visible = (Step = Step::Disclaimer) and IsThirdPartyInstall;
                 ShowCaption = false;
 
                 group(DisclaimerHeader)
@@ -168,8 +168,8 @@ page 2510 "Marketplace Extn Deployment"
                 Caption = 'Back';
                 ToolTip = 'Go back to the previous step.';
                 InFooterBar = true;
-                Enabled = (Step = Step::Installation) and IsThirdPartyPublisher();
-                Visible = (Step = Step::Installation) and IsThirdPartyPublisher();
+                Enabled = (Step = Step::Installation) and IsThirdPartyInstall;
+                Visible = (Step = Step::Installation) and IsThirdPartyInstall;
 
                 trigger OnAction()
                 begin
@@ -186,7 +186,7 @@ page 2510 "Marketplace Extn Deployment"
                 Caption = 'Continue';
                 ToolTip = 'Continue to the next step.';
                 InFooterBar = true;
-                Visible = (Step = Step::Disclaimer) and IsThirdPartyPublisher();
+                Visible = (Step = Step::Disclaimer) and IsThirdPartyInstall;
 
                 trigger OnAction()
                 begin
@@ -239,11 +239,11 @@ page 2510 "Marketplace Extn Deployment"
     internal procedure SetPublisherType(NewPublisherType: Text)
     begin
         PublisherType := NewPublisherType;
-    end;
-
-    local procedure IsThirdPartyPublisher(): Boolean
-    begin
-        exit(LowerCase(PublisherType) <> MicrosoftPublisherTypeLbl);
+        IsThirdPartyInstall := LowerCase(PublisherType) <> MicrosoftPublisherTypeLbl;
+        if IsThirdPartyInstall then
+            Step := Step::Disclaimer
+        else
+            Step := Step::Installation;
     end;
 
     trigger OnInit()
@@ -253,8 +253,9 @@ page 2510 "Marketplace Extn Deployment"
         LanguageID := GlobalLanguage();
         LanguageName := LanguageManagement.GetWindowsLanguageName(LanguageID);
         Clear(InstallSelected);
+        IsThirdPartyInstall := true;
         // For Microsoft-published apps, skip the disclaimer and go straight to installation
-        if IsThirdPartyPublisher() then
+        if IsThirdPartyInstall then
             Step := Step::Disclaimer
         else
             Step := Step::Installation;
@@ -272,6 +273,7 @@ page 2510 "Marketplace Extn Deployment"
         LanguageID: Integer;
         InstallSelected: Boolean;
         InstallPreview: Boolean;
+        IsThirdPartyInstall: Boolean;
         AppID: Guid;
         PublisherType: Text;
         Step: Option Disclaimer,Installation;

--- a/src/System Application/App/Extension Management/src/MarketplaceExtnDeployment.Page.al
+++ b/src/System Application/App/Extension Management/src/MarketplaceExtnDeployment.Page.al
@@ -243,7 +243,7 @@ page 2510 "Marketplace Extn Deployment"
 
     local procedure IsThirdPartyPublisher(): Boolean
     begin
-        exit(LowerCase(PublisherType) <> 'microsoft');
+        exit(LowerCase(PublisherType) <> MicrosoftPublisherTypeLbl);
     end;
 
     trigger OnInit()
@@ -286,4 +286,5 @@ page 2510 "Marketplace Extn Deployment"
         LearnMoreComplianceURLLbl: Label 'https://go.microsoft.com/fwlink/?linkid=2342556', Locked = true;
         LearnMoreInstallingLbl: Label 'Learn more about installing/uninstalling apps';
         InstallAppsURLLbl: Label 'https://go.microsoft.com/fwlink/?linkid=2260926', Locked = true;
+        MicrosoftPublisherTypeLbl: Label 'microsoft', Locked = true;
 }


### PR DESCRIPTION
## Why
Installing Microsoft-published AppSource apps was showing the third-party publisher disclaimer. This created misleading UX for first-party apps.

## What changed
- Propagated `publisherType` from AppSource product data through the install flow into deployment UI state.
- Updated disclaimer logic to skip the third-party warning only when publisher is explicitly Microsoft.
- Kept safe default behavior: unknown/empty publisher still follows third-party disclaimer flow.
- Addressed review reliability issues:
  - Restored the 2-parameter `InstallAppsourceExtension(...)` overload for compatibility.
  - Fixed Back-button visibility/enabled behavior when disclaimer step is absent.
  - Added explicit `DataClassification = SystemMetadata` for the new `PublisherType` table field.
  - Replaced hardcoded "microsoft" string check with a shared constant label.

## Result
Microsoft-published apps no longer show the third-party disclaimer, while third-party/unknown publishers still do.

Fixes [AB#642452](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642452)















