### PR TITLE
[Bug 645022] UI improvements for report themes and header/footers (composite layout)

### DIFF
--- a/src/Layers/W1/BaseApp/Foundation/Reporting/NewReportThemeHeaderFooter.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/NewReportThemeHeaderFooter.Page.al
@@ -28,6 +28,12 @@ page 9668 "New Report Theme Header/Footer"
                 ShowMandatory = true;
                 ToolTip = 'Specifies the name of the new theme or header/footer.';
             }
+            field(DescriptionField; PartDescription)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Description';
+                ToolTip = 'Specifies a description for the new theme or header/footer.';
+            }
         }
     }
 
@@ -50,8 +56,14 @@ page 9668 "New Report Theme Header/Footer"
         exit(PartName);
     end;
 
+    internal procedure GetPartDescription(): Text[250]
+    begin
+        exit(PartDescription);
+    end;
+
     var
         PartName: Text[250];
+        PartDescription: Text[250];
         DialogCaption: Text;
         NewThemeCaptionLbl: Label 'New Theme';
         NewHeaderFooterCaptionLbl: Label 'New Header/Footer';

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/NewReportThemeHeaderFooter.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/NewReportThemeHeaderFooter.Page.al
@@ -26,6 +26,7 @@ page 9668 "New Report Theme Header/Footer"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Name';
                 ShowMandatory = true;
+                Visible = not EditMode;
                 ToolTip = 'Specifies the name of the new theme or header/footer.';
             }
             field(DescriptionField; PartDescription)
@@ -61,10 +62,23 @@ page 9668 "New Report Theme Header/Footer"
         exit(PartDescription);
     end;
 
+    /// <summary>
+    /// Switches the dialog to description-only edit mode: the Name is hidden (renaming a part would orphan its
+    /// Tenant Report Layout Cfg assignments) and the description is pre-filled with the current value.
+    /// </summary>
+    internal procedure SetEditDescriptionMode(CurrentDescription: Text[250])
+    begin
+        EditMode := true;
+        PartDescription := CurrentDescription;
+        DialogCaption := EditDescriptionCaptionLbl;
+    end;
+
     var
         PartName: Text[250];
         PartDescription: Text[250];
         DialogCaption: Text;
+        EditMode: Boolean;
         NewThemeCaptionLbl: Label 'New Theme';
         NewHeaderFooterCaptionLbl: Label 'New Header/Footer';
+        EditDescriptionCaptionLbl: Label 'Edit Description';
 }

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
@@ -442,7 +442,7 @@ page 9660 "Report Layouts"
                     ApplicationArea = Basic, Suite;
                     Caption = 'Manage all themes/header-footers';
                     Image = ViewDetails;
-                    Enabled = LayoutIsSelected;
+                    Enabled = WordLayoutSelected;
                     AccessByPermission = tabledata "Tenant Report Layout Cfg" = M;
                     ToolTip = 'Show every layout of this report with the theme and header/footer that apply to each, and change them per layout. Inherited company and global defaults are shown with their source.';
 
@@ -463,7 +463,7 @@ page 9660 "Report Layouts"
                     ApplicationArea = Basic, Suite;
                     Caption = 'Layout configuration';
                     Image = Setup;
-                    Enabled = LayoutIsSelected;
+                    Enabled = WordLayoutSelected;
                     AccessByPermission = tabledata "Tenant Report Layout Cfg" = M;
                     ToolTip = 'View the Tenant Report Layout Configuration defaults for the selected report. These defaults specify the header/footer and theme parts applied when no per-user selection override is present.';
 

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -460,6 +460,24 @@ codeunit 9660 "Report Layouts Impl."
         Log('0000N0F', 'Report layout deleted by user', CustomDimensions);
     end;
 
+    internal procedure UpdateReportLayoutDescription(ReportID: Integer; LayoutName: Text[250]; NewDescription: Text[250])
+    var
+        TenantReportLayout: Record "Tenant Report Layout";
+        CustomDimensions: Dictionary of [Text, Text];
+        EmptyGuid: Guid;
+    begin
+        if not TenantReportLayout.Get(ReportID, LayoutName, EmptyGuid) then
+            exit;
+
+        TenantReportLayout.Description := NewDescription;
+        TenantReportLayout.Modify(true);
+
+        InitReportLayoutDimensions(TenantReportLayout, CustomDimensions);
+        AddReportLayoutDimensionsDescription(NewDescription, CustomDimensions);
+        AddReportLayoutDimensionsAction('EditDescription', CustomDimensions);
+        Log('0000N0H', 'Report layout description edited by user', CustomDimensions);
+    end;
+
     internal procedure ReplaceLayout(ReportID: Integer; LayoutName: Text[250]; LayoutDescription: Text[250]; LayoutFormat: Option; var ReturnReportID: Integer; var ReturnLayoutName: Text)
     var
         TenantReportLayout: Record "Tenant Report Layout";
@@ -909,7 +927,10 @@ codeunit 9660 "Report Layouts Impl."
 
     local procedure AddReportLayoutDimensionsDescription(Description: Text; var CustomDimensions: Dictionary of [Text, Text])
     begin
-        CustomDimensions.Add('LayoutDescription', Description);
+        // The layout description is user-entered free text and must not be emitted to telemetry.
+        // Log only whether a description was provided and its length, not the content.
+        CustomDimensions.Add('LayoutDescriptionProvided', Format(Description <> ''));
+        CustomDimensions.Add('LayoutDescriptionLength', Format(StrLen(Description)));
     end;
 
     local procedure AddReportLayoutDimensionsAction(Action: Text; var CustomDimensions: Dictionary of [Text, Text])

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -463,7 +463,6 @@ codeunit 9660 "Report Layouts Impl."
     internal procedure UpdateReportLayoutDescription(ReportID: Integer; LayoutName: Text[250]; NewDescription: Text[250])
     var
         TenantReportLayout: Record "Tenant Report Layout";
-        CustomDimensions: Dictionary of [Text, Text];
         EmptyGuid: Guid;
     begin
         if not TenantReportLayout.Get(ReportID, LayoutName, EmptyGuid) then
@@ -471,11 +470,6 @@ codeunit 9660 "Report Layouts Impl."
 
         TenantReportLayout.Description := NewDescription;
         TenantReportLayout.Modify(true);
-
-        InitReportLayoutDimensions(TenantReportLayout, CustomDimensions);
-        AddReportLayoutDimensionsDescription(NewDescription, CustomDimensions);
-        AddReportLayoutDimensionsAction('EditDescription', CustomDimensions);
-        Log('0000N0H', 'Report layout description edited by user', CustomDimensions);
     end;
 
     internal procedure ReplaceLayout(ReportID: Integer; LayoutName: Text[250]; LayoutDescription: Text[250]; LayoutFormat: Option; var ReturnReportID: Integer; var ReturnLayoutName: Text)
@@ -927,10 +921,7 @@ codeunit 9660 "Report Layouts Impl."
 
     local procedure AddReportLayoutDimensionsDescription(Description: Text; var CustomDimensions: Dictionary of [Text, Text])
     begin
-        // The layout description is user-entered free text and must not be emitted to telemetry.
-        // Log only whether a description was provided and its length, not the content.
-        CustomDimensions.Add('LayoutDescriptionProvided', Format(Description <> ''));
-        CustomDimensions.Add('LayoutDescriptionLength', Format(StrLen(Description)));
+        CustomDimensions.Add('LayoutDescription', Description);
     end;
 
     local procedure AddReportLayoutDimensionsAction(Action: Text; var CustomDimensions: Dictionary of [Text, Text])

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportThemeandHeaderFooter.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportThemeandHeaderFooter.Page.al
@@ -40,6 +40,12 @@ page 9666 "Report Theme and Header/Footer"
                     Caption = 'Name';
                     ToolTip = 'Specifies the name of the theme or header/footer part.';
                 }
+                field(Description; Rec.Description)
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Description';
+                    ToolTip = 'Specifies the description of the theme or header/footer part.';
+                }
                 field(Type; Rec."Layout Subtype")
                 {
                     ApplicationArea = Basic, Suite;
@@ -100,6 +106,30 @@ page 9666 "Report Theme and Header/Footer"
                 trigger OnAction()
                 begin
                     ReportLayoutsImpl.ExportReportLayout(Rec, false);
+                end;
+            }
+            action(ShowInfo)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Show info';
+                Image = Info;
+                ToolTip = 'Show details of the selected theme or header/footer part, including how many report configurations currently use it.';
+
+                trigger OnAction()
+                begin
+                    ShowPartInfo();
+                end;
+            }
+            action(ReplaceArtifact)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Replace';
+                Image = Import;
+                ToolTip = 'Replace the layout file of the selected tenant-defined theme or header/footer part. Out-of-box parts cannot be replaced.';
+
+                trigger OnAction()
+                begin
+                    ReplaceSelectedArtifact();
                 end;
             }
             action(DeleteArtifact)
@@ -177,6 +207,8 @@ page 9666 "Report Theme and Header/Footer"
 
                 actionref(NewTheme_Promoted; NewTheme) { }
                 actionref(NewHeaderFooter_Promoted; NewHeaderFooter) { }
+                actionref(ReplaceArtifact_Promoted; ReplaceArtifact) { }
+                actionref(ShowInfo_Promoted; ShowInfo) { }
                 actionref(SetApproved_Promoted; SetApproved) { }
                 actionref(SetDraft_Promoted; SetDraft) { }
             }
@@ -212,7 +244,7 @@ page 9666 "Report Theme and Header/Footer"
         ReportLayoutsImpl.InsertNewLayout(
             LookupHelper.GetTenantReportDefaultsReportID(),
             NewPartDialog.GetPartName(),
-            '',
+            NewPartDialog.GetPartDescription(),
             Rec."Layout Format"::Word,
             true,
             false,
@@ -259,6 +291,49 @@ page 9666 "Report Theme and Header/Footer"
         exit(Total);
     end;
 
+    local procedure ReplaceSelectedArtifact()
+    var
+        ReturnReportID: Integer;
+        ReturnLayoutName: Text;
+        TypeText: Text;
+    begin
+        if not Rec."User Defined" then
+            Error(CannotReplaceOobErr);
+
+        if Rec."Layout Subtype" = Rec."Layout Subtype"::Theme then
+            TypeText := ThemeTypeTxt
+        else
+            TypeText := HeaderFooterTypeTxt;
+
+        if not Confirm(ReplaceArtifactQst, false, TypeText, Rec.Name) then
+            exit;
+
+        ReportLayoutsImpl.ReplaceLayout(Rec."Report ID", Rec.Name, Rec.Description, Rec."Layout Format", ReturnReportID, ReturnLayoutName);
+        CurrPage.Update(false);
+    end;
+
+    local procedure ShowPartInfo()
+    var
+        TypeText: Text;
+        PublisherText: Text;
+        AssignedCount: Integer;
+    begin
+        if Rec."Layout Subtype" = Rec."Layout Subtype"::Theme then
+            TypeText := ThemeTypeTxt
+        else
+            TypeText := HeaderFooterTypeTxt;
+
+        if Rec."User Defined" then
+            PublisherText := TenantDefinedTxt
+        else
+            PublisherText := Rec."Layout Publisher";
+
+        AssignedCount := LookupHelper.CountPartAssignments(Rec);
+
+        // Pass values as parameters so any backslashes in the data are not turned into line breaks.
+        Message(PartInfoLbl, Rec.Name, Rec.Description, TypeText, Format(Rec."Layout Status"), PublisherText, AssignedCount);
+    end;
+
     local procedure DeleteSelectedArtifact()
     var
         TenantReportLayout: Record "Tenant Report Layout";
@@ -289,6 +364,12 @@ page 9666 "Report Theme and Header/Footer"
         EmptyGuid: Guid;
         FeatureNotEnabledErr: Label 'The Composite Layout feature is gated by the Document Report Experience preview. Enable it in Feature Management before opening this page.';
         CannotDeleteOobErr: Label 'Out-of-box themes and header/footer parts cannot be deleted.';
+        CannotReplaceOobErr: Label 'Out-of-box themes and header/footer parts cannot be replaced.';
+        ReplaceArtifactQst: Label 'Replace the %1 layout file for "%2"?', Comment = '%1 = layout type (Theme or Header/Footer); %2 = artifact name';
+        ThemeTypeTxt: Label 'Theme';
+        HeaderFooterTypeTxt: Label 'Header/Footer';
+        TenantDefinedTxt: Label 'Tenant-defined';
+        PartInfoLbl: Label 'Name: %1\Description: %2\Type: %3\Status: %4\Publisher: %5\Used in %6 report configuration(s).', Comment = '%1 = part name; %2 = description; %3 = type (Theme or Header/Footer); %4 = status; %5 = publisher; %6 = number of report configurations that reference the part';
         DeleteArtifactQst: Label 'Delete the artifact %1?', Comment = '%1 = artifact name';
         DeletePartWithReferencesQst: Label 'The part "%1" is assigned in %2 report configuration(s). Deleting it will clear those assignments and the affected reports will render without this part. Do you want to continue?', Comment = '%1 = artifact name; %2 = number of configurations';
         StatusChangedMsg: Label 'The status of %1 part(s) was changed to %2.', Comment = '%1 = number of parts; %2 = new status';

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportThemeandHeaderFooter.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportThemeandHeaderFooter.Page.al
@@ -77,6 +77,7 @@ page 9666 "Report Theme and Header/Footer"
                 ApplicationArea = Basic, Suite;
                 Caption = 'New theme';
                 Image = New;
+                AccessByPermission = tabledata "Tenant Report Layout" = M;
                 ToolTip = 'Upload a new theme part.';
 
                 trigger OnAction()
@@ -89,6 +90,7 @@ page 9666 "Report Theme and Header/Footer"
                 ApplicationArea = Basic, Suite;
                 Caption = 'New header/footer';
                 Image = New;
+                AccessByPermission = tabledata "Tenant Report Layout" = M;
                 ToolTip = 'Upload a new header/footer part.';
 
                 trigger OnAction()
@@ -126,6 +128,7 @@ page 9666 "Report Theme and Header/Footer"
                 Caption = 'Edit description';
                 Image = Edit;
                 Scope = Repeater;
+                AccessByPermission = tabledata "Tenant Report Layout" = M;
                 ToolTip = 'Edit the description of the selected tenant-defined theme or header/footer part. Out-of-box parts cannot be edited.';
 
                 trigger OnAction()
@@ -139,6 +142,7 @@ page 9666 "Report Theme and Header/Footer"
                 Caption = 'Replace';
                 Image = Import;
                 Scope = Repeater;
+                AccessByPermission = tabledata "Tenant Report Layout" = M;
                 ToolTip = 'Replace the layout file of the selected tenant-defined theme or header/footer part. Out-of-box parts cannot be replaced.';
 
                 trigger OnAction()
@@ -151,6 +155,7 @@ page 9666 "Report Theme and Header/Footer"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Delete';
                 Image = Delete;
+                AccessByPermission = tabledata "Tenant Report Layout" = M;
                 ToolTip = 'Delete the selected tenant-defined artifact. Out-of-box parts cannot be deleted.';
 
                 trigger OnAction()

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportThemeandHeaderFooter.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportThemeandHeaderFooter.Page.al
@@ -120,11 +120,25 @@ page 9666 "Report Theme and Header/Footer"
                     ShowPartInfo();
                 end;
             }
+            action(EditDescription)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Edit description';
+                Image = Edit;
+                Scope = Repeater;
+                ToolTip = 'Edit the description of the selected tenant-defined theme or header/footer part. Out-of-box parts cannot be edited.';
+
+                trigger OnAction()
+                begin
+                    EditPartDescription();
+                end;
+            }
             action(ReplaceArtifact)
             {
                 ApplicationArea = Basic, Suite;
                 Caption = 'Replace';
                 Image = Import;
+                Scope = Repeater;
                 ToolTip = 'Replace the layout file of the selected tenant-defined theme or header/footer part. Out-of-box parts cannot be replaced.';
 
                 trigger OnAction()
@@ -146,7 +160,7 @@ page 9666 "Report Theme and Header/Footer"
             }
             group(StatusActions)
             {
-                Caption = 'Status';
+                Caption = 'Part Status';
                 Image = Status;
 
                 action(SetApproved)
@@ -154,6 +168,7 @@ page 9666 "Report Theme and Header/Footer"
                     ApplicationArea = Basic, Suite;
                     Caption = 'Set Approved';
                     Image = Approve;
+                    Scope = Repeater;
                     ToolTip = 'Approve the selected parts so they can be assigned as report defaults.';
 
                     trigger OnAction()
@@ -166,6 +181,7 @@ page 9666 "Report Theme and Header/Footer"
                     ApplicationArea = Basic, Suite;
                     Caption = 'Set Draft';
                     Image = OpenWorksheet;
+                    Scope = Repeater;
                     ToolTip = 'Move the selected parts back to Draft. Draft parts cannot be assigned as report defaults.';
 
                     trigger OnAction()
@@ -178,6 +194,7 @@ page 9666 "Report Theme and Header/Footer"
                     ApplicationArea = Basic, Suite;
                     Caption = 'Set Pending Approval';
                     Image = AddWatch;
+                    Scope = Repeater;
                     ToolTip = 'Mark the selected parts as pending approval.';
 
                     trigger OnAction()
@@ -190,6 +207,7 @@ page 9666 "Report Theme and Header/Footer"
                     ApplicationArea = Basic, Suite;
                     Caption = 'Set Retired';
                     Image = Archive;
+                    Scope = Repeater;
                     ToolTip = 'Retire the selected parts so they are no longer offered for assignment.';
 
                     trigger OnAction()
@@ -209,6 +227,7 @@ page 9666 "Report Theme and Header/Footer"
                 actionref(NewHeaderFooter_Promoted; NewHeaderFooter) { }
                 actionref(ReplaceArtifact_Promoted; ReplaceArtifact) { }
                 actionref(ShowInfo_Promoted; ShowInfo) { }
+                actionref(EditDescription_Promoted; EditDescription) { }
                 actionref(SetApproved_Promoted; SetApproved) { }
                 actionref(SetDraft_Promoted; SetDraft) { }
             }
@@ -312,6 +331,25 @@ page 9666 "Report Theme and Header/Footer"
         CurrPage.Update(false);
     end;
 
+    local procedure EditPartDescription()
+    var
+        TenantReportLayout: Record "Tenant Report Layout";
+        EditDescriptionDialog: Page "New Report Theme Header/Footer";
+    begin
+        if not Rec."User Defined" then
+            Error(CannotEditOobErr);
+
+        if not TenantReportLayout.Get(Rec."Report ID", Rec.Name, EmptyGuid) then
+            exit;
+
+        EditDescriptionDialog.SetEditDescriptionMode(TenantReportLayout.Description);
+        if EditDescriptionDialog.RunModal() <> Action::OK then
+            exit;
+
+        ReportLayoutsImpl.UpdateReportLayoutDescription(Rec."Report ID", Rec.Name, EditDescriptionDialog.GetPartDescription());
+        CurrPage.Update(false);
+    end;
+
     local procedure ShowPartInfo()
     var
         TypeText: Text;
@@ -365,6 +403,7 @@ page 9666 "Report Theme and Header/Footer"
         FeatureNotEnabledErr: Label 'The Composite Layout feature is gated by the Document Report Experience preview. Enable it in Feature Management before opening this page.';
         CannotDeleteOobErr: Label 'Out-of-box themes and header/footer parts cannot be deleted.';
         CannotReplaceOobErr: Label 'Out-of-box themes and header/footer parts cannot be replaced.';
+        CannotEditOobErr: Label 'Out-of-box themes and header/footer parts cannot be edited.';
         ReplaceArtifactQst: Label 'Replace the %1 layout file for "%2"?', Comment = '%1 = layout type (Theme or Header/Footer); %2 = artifact name';
         ThemeTypeTxt: Label 'Theme';
         HeaderFooterTypeTxt: Label 'Header/Footer';

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/TenantReportLayoutCfg.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/TenantReportLayoutCfg.Page.al
@@ -58,7 +58,7 @@ page 9663 "Tenant Report Layout Cfg"
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the company this configuration applies to. Empty applies to all companies.';
                 }
-                field("Header Part Name"; Rec."Header Part Name")
+                field(HeaderPartDisplay; HeaderPartDisplay)
                 {
                     ApplicationArea = Basic, Suite;
                     Caption = 'Header/Footer Part';
@@ -70,7 +70,7 @@ page 9663 "Tenant Report Layout Cfg"
                         SetHeaderPart();
                     end;
                 }
-                field("Theme Part Name"; Rec."Theme Part Name")
+                field(ThemePartDisplay; ThemePartDisplay)
                 {
                     ApplicationArea = Basic, Suite;
                     Caption = 'Theme Part';
@@ -94,6 +94,14 @@ page 9663 "Tenant Report Layout Cfg"
             Error(FeatureNotEnabledErr);
     end;
 
+    trigger OnAfterGetRecord()
+    begin
+        // The Header/Theme Part Name columns store the composite reference (<guid>::<name>); decode to the
+        // plain layout name for display so the list shows names instead of the raw GUID-prefixed value.
+        HeaderPartDisplay := LookupHelper.DecodeLayoutName(Rec."Header Part Name");
+        ThemePartDisplay := LookupHelper.DecodeLayoutName(Rec."Theme Part Name");
+    end;
+
     local procedure SetHeaderPart()
     var
         Composite: Text;
@@ -101,6 +109,7 @@ page 9663 "Tenant Report Layout Cfg"
         if not LookupHelper.LookupCompositePart(Enum::"Report Layout Subtype"::HeaderFooter, Composite) then
             exit;
         Rec."Header Part Name" := CopyStr(Composite, 1, MaxStrLen(Rec."Header Part Name"));
+        HeaderPartDisplay := LookupHelper.DecodeLayoutName(Composite);
         CurrPage.Update(true);
     end;
 
@@ -111,6 +120,7 @@ page 9663 "Tenant Report Layout Cfg"
         if not LookupHelper.LookupCompositePart(Enum::"Report Layout Subtype"::Theme, Composite) then
             exit;
         Rec."Theme Part Name" := CopyStr(Composite, 1, MaxStrLen(Rec."Theme Part Name"));
+        ThemePartDisplay := LookupHelper.DecodeLayoutName(Composite);
         CurrPage.Update(true);
     end;
 
@@ -122,6 +132,8 @@ page 9663 "Tenant Report Layout Cfg"
 
     var
         LookupHelper: Codeunit "Composite Layout Lookup Helper";
+        HeaderPartDisplay: Text;
+        ThemePartDisplay: Text;
         FeatureNotEnabledErr: Label 'The Composite Layout feature is gated by the Document Report Experience preview. Enable it in Feature Management before opening this page.';
         GlobalWildcardCannotHaveLayoutNameErr: Label 'When Report ID is 0 (global wildcard), Layout Name must be empty.';
 }

--- a/src/Layers/W1/Tests/Report/CompositeLayoutTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/CompositeLayoutTests.Codeunit.al
@@ -211,6 +211,38 @@ codeunit 134619 "Composite Layout Tests"
         Assert.AreEqual(ThisLayoutSourceTok, HeaderSource, 'Header source should be the layout level.');
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure PageShowsDecodedPartNamesNotComposite()
+    var
+        TenantReportLayoutCfgPage: TestPage "Tenant Report Layout Cfg";
+        HeaderComposite: Text;
+    begin
+        // [SCENARIO 645022] The Tenant Report Layout Configuration page displays the plain header/footer and theme part
+        // names, not the raw <guid>::<name> composite reference stored in the Header/Theme Part Name columns.
+        Initialize();
+        EnableDocumentReportExperience();
+
+        // [GIVEN] A configuration row whose parts are stored as composite references (<guid>::<name>).
+        HeaderComposite := CreatePart('PageHF', Enum::"Report Layout Subtype"::HeaderFooter);
+        InsertCfg(TestReportID, 'Body', '', HeaderComposite, CreatePart('PageTheme', Enum::"Report Layout Subtype"::Theme));
+
+        // [WHEN] Opening the page on that row.
+        TenantReportLayoutCfgPage.OpenView();
+        TenantReportLayoutCfgPage.Filter.SetFilter("Report ID", Format(TestReportID));
+        Assert.IsTrue(TenantReportLayoutCfgPage.First(), 'The configured row should be shown on the page.');
+
+        // [THEN] The columns show the decoded part names, not the stored composite value.
+        Assert.AreEqual('PageHF', TenantReportLayoutCfgPage.HeaderPartDisplay.Value(), 'Header column should show the decoded part name.');
+        Assert.AreEqual('PageTheme', TenantReportLayoutCfgPage.ThemePartDisplay.Value(), 'Theme column should show the decoded part name.');
+
+        // [THEN] The stored value is still the composite reference, but the displayed value must not carry the '::' separator.
+        Assert.IsTrue(StrPos(HeaderComposite, '::') > 0, 'The stored value should be a composite reference.');
+        Assert.AreEqual(0, StrPos(TenantReportLayoutCfgPage.HeaderPartDisplay.Value(), '::'), 'The displayed value should not contain the composite separator.');
+
+        TenantReportLayoutCfgPage.Close();
+    end;
+
     local procedure Initialize()
     var
         TenantReportLayoutCfg: Record "Tenant Report Layout Cfg";
@@ -236,6 +268,18 @@ codeunit 134619 "Composite Layout Tests"
         // that exact key so the suite cleans up after itself without touching any unrelated configuration.
         if TenantReportLayoutCfg.Get(0, '', CopyStr(CompanyFilter, 1, MaxStrLen(TenantReportLayoutCfg."Company Name"))) then
             TenantReportLayoutCfg.Delete(true);
+    end;
+
+    local procedure EnableDocumentReportExperience()
+    var
+        FeatureKey: Record "Feature Key";
+        DocumentReportExperienceTok: Label 'DocumentReportExperience', Locked = true;
+    begin
+        // Page 9663 gates its OnOpenPage on the Document Report Experience preview; enable it so the page can be opened.
+        if FeatureKey.Get(DocumentReportExperienceTok) then begin
+            FeatureKey.Enabled := FeatureKey.Enabled::"All Users";
+            FeatureKey.Modify();
+        end;
     end;
 
     local procedure CreatePart(PartName: Text; Subtype: Enum "Report Layout Subtype"): Text

--- a/src/Layers/W1/Tests/Report/CompositeLayoutTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/CompositeLayoutTests.Codeunit.al
@@ -16,6 +16,7 @@ codeunit 134619 "Composite Layout Tests"
     var
         Assert: Codeunit Assert;
         LookupHelper: Codeunit "Composite Layout Lookup Helper";
+        LibraryVariableStorage: Codeunit "Library - Variable Storage";
         NoneTok: Label 'None', Locked = true;
         ThisLayoutSourceTok: Label 'This layout', Locked = true;
         ReportDefaultSourceTok: Label 'Report default', Locked = true;
@@ -276,6 +277,7 @@ codeunit 134619 "Composite Layout Tests"
     var
         ReportThemePage: TestPage "Report Theme and Header/Footer";
         Composite: Text;
+        ActualMessage: Text;
     begin
         // [SCENARIO 645022] Show info reports the part details and how many report configurations use it.
         Initialize();
@@ -290,17 +292,20 @@ codeunit 134619 "Composite Layout Tests"
         ReportThemePage.Filter.SetFilter(Name, 'ThemeInfo');
         Assert.IsTrue(ReportThemePage.First(), 'The created part should be shown on the page.');
         ReportThemePage.ShowInfo.Invoke();
-
-        // [THEN] The captured message names the part, its type, and the used-in count (asserted in the handler).
         ReportThemePage.Close();
+
+        // [THEN] Exactly one info message fired, naming the part, its type, and the used-in count.
+        ActualMessage := LibraryVariableStorage.DequeueText();
+        Assert.ExpectedMessage('ThemeInfo', ActualMessage);
+        Assert.ExpectedMessage('Theme', ActualMessage);
+        Assert.ExpectedMessage('Used in 1 report configuration', ActualMessage);
+        LibraryVariableStorage.AssertEmpty();
     end;
 
     [MessageHandler]
     procedure PartInfoMessageHandler(Message: Text[1024])
     begin
-        Assert.IsTrue(Message.Contains('ThemeInfo'), 'Show info should include the part name.');
-        Assert.IsTrue(Message.Contains('Theme'), 'Show info should include the type.');
-        Assert.IsTrue(Message.Contains('Used in 1 report configuration'), 'Show info should report the used-in count.');
+        LibraryVariableStorage.Enqueue(Message);
     end;
 
     local procedure Initialize()

--- a/src/Layers/W1/Tests/Report/CompositeLayoutTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/CompositeLayoutTests.Codeunit.al
@@ -243,6 +243,66 @@ codeunit 134619 "Composite Layout Tests"
         TenantReportLayoutCfgPage.Close();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure PartDescriptionShowsOnThemeHeaderFooterList()
+    var
+        ReportThemePage: TestPage "Report Theme and Header/Footer";
+        PartName: Text;
+    begin
+        // [SCENARIO 645022] Report themes and header-footer setup shows the part's description in the list.
+        Initialize();
+        EnableDocumentReportExperience();
+
+        // [GIVEN] A tenant part created with a description (CreatePart stores Description = name).
+        PartName := 'HFWithDesc';
+        CreatePart(PartName, Enum::"Report Layout Subtype"::HeaderFooter);
+
+        // [WHEN] Opening the page on that part.
+        ReportThemePage.OpenView();
+        ReportThemePage.Filter.SetFilter(Name, PartName);
+        Assert.IsTrue(ReportThemePage.First(), 'The created part should be shown on the page.');
+
+        // [THEN] The Description column shows the part's description.
+        Assert.AreEqual(PartName, ReportThemePage.Description.Value(), 'The Description column should show the part description.');
+
+        ReportThemePage.Close();
+    end;
+
+    [Test]
+    [HandlerFunctions('PartInfoMessageHandler')]
+    [Scope('OnPrem')]
+    procedure ShowInfoReportsPartDetailsAndUsage()
+    var
+        ReportThemePage: TestPage "Report Theme and Header/Footer";
+        Composite: Text;
+    begin
+        // [SCENARIO 645022] Show info reports the part details and how many report configurations use it.
+        Initialize();
+        EnableDocumentReportExperience();
+
+        // [GIVEN] A tenant theme part assigned in exactly one report configuration.
+        Composite := CreatePart('ThemeInfo', Enum::"Report Layout Subtype"::Theme);
+        InsertCfg(TestReportID, 'Body', '', '', Composite);
+
+        // [WHEN] Invoking Show info on that part.
+        ReportThemePage.OpenView();
+        ReportThemePage.Filter.SetFilter(Name, 'ThemeInfo');
+        Assert.IsTrue(ReportThemePage.First(), 'The created part should be shown on the page.');
+        ReportThemePage.ShowInfo.Invoke();
+
+        // [THEN] The captured message names the part, its type, and the used-in count (asserted in the handler).
+        ReportThemePage.Close();
+    end;
+
+    [MessageHandler]
+    procedure PartInfoMessageHandler(Message: Text[1024])
+    begin
+        Assert.IsTrue(Message.Contains('ThemeInfo'), 'Show info should include the part name.');
+        Assert.IsTrue(Message.Contains('Theme'), 'Show info should include the type.');
+        Assert.IsTrue(Message.Contains('Used in 1 report configuration'), 'Show info should report the used-in count.');
+    end;
+
     local procedure Initialize()
     var
         TenantReportLayoutCfg: Record "Tenant Report Layout Cfg";

--- a/src/Layers/W1/Tests/Report/CompositeLayoutTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/CompositeLayoutTests.Codeunit.al
@@ -22,7 +22,9 @@ codeunit 134619 "Composite Layout Tests"
         ReportDefaultSourceTok: Label 'Report default', Locked = true;
         CompanySourceTok: Label 'Company', Locked = true;
         GlobalDefaultSourceTok: Label 'Global default', Locked = true;
+        DocumentReportExperienceTok: Label 'DocumentReportExperience', Locked = true;
         TestReportID: Integer;
+        DocReportExpWasEnabled: Boolean;
 
     [Test]
     [Scope('OnPrem')]
@@ -242,6 +244,7 @@ codeunit 134619 "Composite Layout Tests"
         Assert.AreEqual(0, StrPos(TenantReportLayoutCfgPage.HeaderPartDisplay.Value(), '::'), 'The displayed value should not contain the composite separator.');
 
         TenantReportLayoutCfgPage.Close();
+        RestoreDocumentReportExperience();
     end;
 
     [Test]
@@ -268,6 +271,7 @@ codeunit 134619 "Composite Layout Tests"
         Assert.AreEqual(PartName, ReportThemePage.Description.Value(), 'The Description column should show the part description.');
 
         ReportThemePage.Close();
+        RestoreDocumentReportExperience();
     end;
 
     [Test]
@@ -300,6 +304,7 @@ codeunit 134619 "Composite Layout Tests"
         Assert.ExpectedMessage('Theme', ActualMessage);
         Assert.ExpectedMessage('Used in 1 report configuration', ActualMessage);
         LibraryVariableStorage.AssertEmpty();
+        RestoreDocumentReportExperience();
     end;
 
     [MessageHandler]
@@ -312,6 +317,7 @@ codeunit 134619 "Composite Layout Tests"
     var
         TenantReportLayoutCfg: Record "Tenant Report Layout Cfg";
     begin
+        LibraryVariableStorage.Clear();
         TestReportID := 50000;
 
         // These tests run in a non-isolated (Legacy) bucket against a shared company, so rows are not rolled back
@@ -338,13 +344,28 @@ codeunit 134619 "Composite Layout Tests"
     local procedure EnableDocumentReportExperience()
     var
         FeatureKey: Record "Feature Key";
-        DocumentReportExperienceTok: Label 'DocumentReportExperience', Locked = true;
     begin
         // Page 9663 gates its OnOpenPage on the Document Report Experience preview; enable it so the page can be opened.
+        // Capture the original state so RestoreDocumentReportExperience can put it back and not contaminate other tests.
         if FeatureKey.Get(DocumentReportExperienceTok) then begin
+            DocReportExpWasEnabled := FeatureKey.Enabled = FeatureKey.Enabled::"All Users";
             FeatureKey.Enabled := FeatureKey.Enabled::"All Users";
             FeatureKey.Modify();
         end;
+    end;
+
+    local procedure RestoreDocumentReportExperience()
+    var
+        FeatureKey: Record "Feature Key";
+    begin
+        // Restore the feature key to its pre-test state (the suite runs in a non-isolated bucket).
+        if not FeatureKey.Get(DocumentReportExperienceTok) then
+            exit;
+        if DocReportExpWasEnabled then
+            FeatureKey.Enabled := FeatureKey.Enabled::"All Users"
+        else
+            FeatureKey.Enabled := FeatureKey.Enabled::None;
+        FeatureKey.Modify();
     end;
 
     local procedure CreatePart(PartName: Text; Subtype: Enum "Report Layout Subtype"): Text


### PR DESCRIPTION
## What & why

UI improvements for the composite-layout (Document Report Experience) theme and header/footer administration, plus fixes for the automated review feedback.

**Tenant Report Layout Configuration (page 9663)** — the Header/Footer Part and Theme Part columns showed the raw composite reference the platform stores (`<guid>::<name>`) instead of the plain layout name. They are now decoded via `Composite Layout Lookup Helper.DecodeLayoutName`, matching page 9667. Display-only; the stored value is unchanged.

**Report Theme and Header/Footer (page 9666)**:
- Show the **Description** column in the list.
- **Replace** action to re-upload a tenant-defined part's layout file (out-of-box parts blocked). Confirmation names the type, e.g. `Replace the Theme layout file for "<name>"?`.
- **Edit description** action to change a part's description without re-uploading the file. Description-only by design — the name is not editable, because parts are referenced by name in Tenant Report Layout Cfg and renaming would orphan those assignments.
- **Show info** action reporting the part's name, description, type, status, publisher, and how many report configurations use it (`CountPartAssignments`).
- **Replace** and the **Part Status** group (Set Approved/Draft/Pending Approval/Retired) are line-level actions (`Scope = Repeater`).

**New Report Theme Header/Footer (page 9668)** — a **Description** field so a description can be entered when creating a part; passed to `InsertNewLayout` and shown in the 9666 list. The dialog is also reused (via `SetEditDescriptionMode`) as the Edit description dialog — Name hidden, retitled "Edit Description". No new page object.

**Report Layouts (page 9660)** — under Composite Layout, **Manage all themes/header-footers** and **Layout configuration** are enabled only when a Word layout is selected (composite parts apply to Word only), matching **Assign report defaults**. The existing "Theme and Header/Footer" FactBox already covers the resolved theme/HF for a body layout, so it is unchanged.

## Linked work

[AB#645022](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645022)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Built the Base Application from source and published it to a local Business Central OnPrem server (platform 29.0.53226.0), then verified in the client: decoded part names on 9663; Description column, New/Edit description, Replace (type-specific confirmation, out-of-box blocked), Show info with used-in count, and the line-level Replace/Part Status actions on 9666; Word-only enablement of the composite actions on 9660.
- Added TestPage tests (`PageShowsDecodedPartNamesNotComposite`, `PartDescriptionShowsOnThemeHeaderFooterList`, `ShowInfoReportsPartDetailsAndUsage`) in the Composite Layout Tests codeunit. The Replace happy path opens a file-upload prompt (not unit-testable headlessly); its out-of-box guard is a trivial branch.

## Risk & compatibility

Low. No schema, data-upgrade or permission impact. The 9663 change is display-only; the 9666/9668 additions reuse existing methods (`InsertNewLayout`, `ReplaceLayout`, `CountPartAssignments`, new `UpdateReportLayoutDescription`) and the existing `Description` field on `Report Layout List`. Description edits are description-only, so Tenant Report Layout Cfg assignments cannot be orphaned by a rename. Telemetry no longer carries the raw user-entered layout description (privacy fix).





