### PR TITLE
[Master] - Bug 645038 Withholding Tax entries from a previous posting preview appear on unrelated documents (e.g. expense report)

### DIFF
--- a/src/Apps/W1/WithholdingTax/app/src/Purchase/Transaction/WthldgTaxPreviewHandler.Codeunit.al
+++ b/src/Apps/W1/WithholdingTax/app/src/Purchase/Transaction/WthldgTaxPreviewHandler.Codeunit.al
@@ -4,10 +4,8 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.WithholdingTax;
 
-using Microsoft.Finance.GeneralLedger.Posting;
 using Microsoft.Finance.GeneralLedger.Preview;
 using Microsoft.Foundation.Navigate;
-using Microsoft.Purchases.Posting;
 
 codeunit 6792 "Wthldg Tax Preview Handler"
 {
@@ -75,26 +73,12 @@ codeunit 6792 "Wthldg Tax Preview Handler"
         end;
     end;
 
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Purch.-Post", 'OnBeforePostPurchaseDoc', '', false, false)]
-    local procedure OnBeforePostPurchaseDoc()
-    begin
-        TempWithholdingTaxEntry.Reset();
-        if not TempWithholdingTaxEntry.IsEmpty() then
-            TempWithholdingTaxEntry.DeleteAll();
-    end;
-
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Gen. Jnl.-Post", OnBeforeCode, '', false, false)]
-    local procedure OnBeforeGenJnlDoc()
-    begin
-        TempWithholdingTaxEntry.Reset();
-        if not TempWithholdingTaxEntry.IsEmpty() then
-            TempWithholdingTaxEntry.DeleteAll();
-    end;
-
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Gen. Jnl.-Post Preview", 'OnAfterBindSubscription', '', false, false)]
     local procedure OnAfterBindSubscription()
     begin
         PreviewPosting := true;
+        TempWithholdingTaxEntry.Reset();
+        TempWithholdingTaxEntry.DeleteAll();
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Gen. Jnl.-Post Preview", 'OnAfterUnBindSubscription', '', false, false)]


### PR DESCRIPTION
**Workitem Bug 645038**: [master] Withholding Tax entries from a previous posting preview appear on unrelated documents (e.g. expense report)

Fixes [AB#645038](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645038)

**Issue**: After running a posting preview (Preview Posting) on a document, previewing a different, unrelated document — for example an expense report — showed Withholding Tax entries that belonged to the earlier preview.

**Cause**: The temporary Withholding Tax entries were only cleared from subscribers tied to actual posting (Purch.-Post.OnBeforePostPurchaseDoc and Gen. Jnl.-Post.OnBeforeCode). Those events don't fire when you merely preview a different document, so stale temp WHT entries from the previous preview leaked into the next preview.

**Solution**: In codeunit 6792 "Wthldg Tax Preview Handler", removed the OnBeforePostPurchaseDoc and OnBeforeGenJnlDoc subscribers and instead clear the temporary WHT entries at the start of every preview in Gen. Jnl.-Post Preview.OnAfterBindSubscription (TempWithholdingTaxEntry.Reset() + DeleteAll()), so each preview starts with a clean buffer. Also removed the now-unused using statements (Microsoft.Finance.GeneralLedger.Posting, Microsoft.Purchases.Posting).




