### PR TITLE
Show address lines 1-3 in address lookup display text

### DIFF
--- a/src/Apps/GB/IdealPostcodes/app/src/IPCAddressLookup.Page.al
+++ b/src/Apps/GB/IdealPostcodes/app/src/IPCAddressLookup.Page.al
@@ -20,16 +20,6 @@ page 9402 "IPC Address Lookup"
                     ApplicationArea = All;
                     ToolTip = 'Specifies address information';
                 }
-                field(City; Rec.City)
-                {
-                    ApplicationArea = All;
-                    ToolTip = 'Specifies city or town';
-                }
-                field("Post Code"; Rec."Post Code")
-                {
-                    ApplicationArea = All;
-                    ToolTip = 'Specifies post code';
-                }
             }
         }
     }

--- a/src/Apps/GB/IdealPostcodes/app/src/IPCAddressLookup.Page.al
+++ b/src/Apps/GB/IdealPostcodes/app/src/IPCAddressLookup.Page.al
@@ -20,11 +20,6 @@ page 9402 "IPC Address Lookup"
                     ApplicationArea = All;
                     ToolTip = 'Specifies address information';
                 }
-                field(Address; Rec.Address)
-                {
-                    ApplicationArea = All;
-                    ToolTip = 'Specifies street address';
-                }
                 field(City; Rec.City)
                 {
                     ApplicationArea = All;

--- a/src/Apps/GB/IdealPostcodes/app/src/IPCAddressLookup.Page.al
+++ b/src/Apps/GB/IdealPostcodes/app/src/IPCAddressLookup.Page.al
@@ -20,6 +20,24 @@ page 9402 "IPC Address Lookup"
                     ApplicationArea = All;
                     ToolTip = 'Specifies address information';
                 }
+                field(Address; Rec.Address)
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies street address';
+                    Visible = false;
+                }
+                field(City; Rec.City)
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies city or town';
+                    Visible = false;
+                }
+                field("Post Code"; Rec."Post Code")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies post code';
+                    Visible = false;
+                }
             }
         }
     }

--- a/src/Apps/GB/IdealPostcodes/app/src/IPCManagement.Codeunit.al
+++ b/src/Apps/GB/IdealPostcodes/app/src/IPCManagement.Codeunit.al
@@ -163,6 +163,7 @@ codeunit 9400 "IPC Management"
     local procedure AddAddressToBuffer(AddressJson: JsonObject; var TempIPCAddressLookup: Record "IPC Address Lookup" temporary; EntryNo: Integer; RemoveOrganisationName: Boolean)
     var
         Line1, Line2, Line3 : Text;
+        DisplayText: Text;
     begin
         Line1 := GetJsonValue(AddressJson, 'line_1');
         Line2 := GetJsonValue(AddressJson, 'line_2');
@@ -188,12 +189,13 @@ codeunit 9400 "IPC Management"
         TempIPCAddressLookup.County := CopyStr(GetJsonValue(AddressJson, 'county'), 1, MaxStrLen(TempIPCAddressLookup.County));
         TempIPCAddressLookup."Country/Region Code" := CopyStr(GetJsonValue(AddressJson, 'country_iso_2'), 1, MaxStrLen(TempIPCAddressLookup."Country/Region Code"));
 
-        // Create display text
-        TempIPCAddressLookup."Display Text" := TempIPCAddressLookup.Address;
-        if TempIPCAddressLookup.City <> '' then
-            TempIPCAddressLookup."Display Text" += ', ' + TempIPCAddressLookup.City;
-        if TempIPCAddressLookup."Post Code" <> '' then
-            TempIPCAddressLookup."Display Text" += ' ' + TempIPCAddressLookup."Post Code";
+        // Create display text from address lines 1-3
+        DisplayText := Line1;
+        if Line2 <> '' then
+            DisplayText += ', ' + Line2;
+        if Line3 <> '' then
+            DisplayText += ', ' + Line3;
+        TempIPCAddressLookup."Display Text" := CopyStr(DisplayText, 1, MaxStrLen(TempIPCAddressLookup."Display Text"));
 
         TempIPCAddressLookup.Insert();
     end;

--- a/src/Apps/GB/IdealPostcodes/test/src/TestIdealPostcodesPages.Codeunit.al
+++ b/src/Apps/GB/IdealPostcodes/test/src/TestIdealPostcodesPages.Codeunit.al
@@ -1945,7 +1945,7 @@ codeunit 148121 "Test IdealPostcodes Pages"
     [Scope('OnPrem')]
     procedure PostcodeSearchScenarioModalPageHandler(var IPCAddressLookup: TestPage "IPC Address Lookup")
     begin
-        IPCAddressLookup."Post Code".Value('TESTPOSTCODE');
+        IPCAddressLookup.GoToKey(2);
         IPCAddressLookup.OK().Invoke();
     end;
 


### PR DESCRIPTION
## Summary
- Build the Select Address modal's Display Text from address lines 1-3 (line_1/line_2/line_3) instead of address, city, and post code.
- Drop the Address, City, and Post Code columns from the modal so only Display Text is shown.
- Update the modal page test handler to select the target row by key instead of the removed Post Code column.

## Work item
Fixes [AB#645105](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645105)

## Test plan
- [ ] Compile via BCApps CI (AL-Go) against current symbols.
- [ ] Run `Test IdealPostcodes Pages` codeunit (148121), including `PostcodeSearchScenarioModalPageHandler`-dependent tests.
- [ ] Manually verify the Select Address modal in a sandbox shows a single concatenated Display Text column.


