### PR TITLE
Restoring undefined action. (Purchase Orders page can't be open in latest `main`)

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Document/EDocument.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Document/EDocument.Page.al
@@ -518,6 +518,13 @@ page 6121 "E-Document"
                 ObsoleteState = Pending;
                 ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
                 ObsoleteTag = '29.0';
+
+                trigger OnAction()
+                var
+                    EDocOrderMatch: Codeunit "E-Doc. Line Matching";
+                begin
+                    EDocOrderMatch.RunMatching(Rec);
+                end;
             }
 #endif
         }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchaseOrder.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchaseOrder.PageExt.al
@@ -77,6 +77,15 @@ pageextension 6132 "E-Doc. Purchase Order" extends "Purchase Order"
                 ObsoleteState = Pending;
                 ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
                 ObsoleteTag = '29.0';
+
+                trigger OnAction()
+                var
+                    EDocument: Record "E-Document";
+                    EDocOrderMatch: Codeunit "E-Doc. Line Matching";
+                begin
+                    EDocument.GetBySystemId(Rec."E-Document Link");
+                    EDocOrderMatch.RunMatching(EDocument);
+                end;
             }
 #endif
         }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchaseOrderList.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchaseOrderList.PageExt.al
@@ -62,6 +62,15 @@ pageextension 6137 "E-Doc. Purchase Order List" extends "Purchase Order List"
                 ObsoleteState = Pending;
                 ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
                 ObsoleteTag = '29.0';
+
+                trigger OnAction()
+                var
+                    EDocument: Record "E-Document";
+                    EDocOrderMatch: Codeunit "E-Doc. Line Matching";
+                begin
+                    EDocument.GetBySystemId(Rec."E-Document Link");
+                    EDocOrderMatch.RunMatching(EDocument);
+                end;
             }
 #endif
 

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/EDocLineMatching.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/EDocLineMatching.Codeunit.al
@@ -48,6 +48,14 @@ codeunit 6164 "E-Doc. Line Matching"
         EDocOrderLineMatching.Run();
     end;
 
+#if not CLEAN29
+    [Obsolete('Deprecated functionality', '29.0')]
+    procedure RunMatching(var EDocument: Record "E-Document"; WithCopilot: Boolean)
+    begin
+        RunMatching(EDocument);
+    end;
+
+#endif
     procedure ApplyToPurchaseOrder(var EDocument: Record "E-Document"; var TempEDocumentImportedLine: Record "E-Doc. Imported Line" temporary)
     var
         PurchaseLine: Record "Purchase Line";

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/EDocOrderLineMatching.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/EDocOrderLineMatching.Page.al
@@ -160,9 +160,9 @@ page 6167 "E-Doc. Order Line Matching"
                 end;
             }
         }
+#if not CLEAN29
         area(Prompting)
         {
-#if not CLEAN29
             action(MatchCopilot)
             {
                 Caption = 'Match with Copilot';
@@ -173,9 +173,14 @@ page 6167 "E-Doc. Order Line Matching"
                 ObsoleteState = Pending;
                 ObsoleteReason = 'The E-Document Purchase Order Matching Copilot has been deprecated. AI-assisted line matching is now handled at import time in the E-Document Purchase Draft experience by codeunit "E-Doc. AI Tool Processor".';
                 ObsoleteTag = '29.0';
+
+                trigger OnAction()
+                begin
+                    SetUserInteractions();
+                end;
             }
-#endif
         }
+#endif
         area(Navigation)
         {
             action(PurchaseOrder)


### PR DESCRIPTION
Analyzer disabled on the BCApps gate let a change that removed the body of an action to be merged. The actionref referencing an action that was not emitted was causing this failure (not emitted because of the empty onaction and no RunObject)

Follow up bugs on the respective teams (client/devtools, engineering systems for the analyzer) logged and being worked on.

Fixes [AB#645052](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645052)


