### PR TITLE
[28.x] - Changing the contact of a Customer Subscription Contract doesn't update the email of the contract.

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Customer Contracts/Tables/CustomerSubscriptionContract.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Customer Contracts/Tables/CustomerSubscriptionContract.Table.al
@@ -1382,6 +1382,9 @@ table 8052 "Customer Subscription Contract"
             else
                 "Sell-to Contact" := Cont.Name;
 
+        "Sell-to Phone No." := Cont."Phone No.";
+        "Sell-to E-Mail" := Cont."E-Mail";
+
         if ("Sell-to Customer No." = "Bill-to Customer No.") or
            ("Bill-to Customer No." = '')
         then

--- a/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractsTest.Codeunit.al
@@ -1,5 +1,6 @@
 namespace Microsoft.SubscriptionBilling;
 
+using Microsoft.CRM.Contact;
 using Microsoft.Finance.Currency;
 using Microsoft.Finance.GeneralLedger.Account;
 using Microsoft.Foundation.Attachment;
@@ -26,6 +27,7 @@ codeunit 148155 "Contracts Test"
         CorrectPostedSalesInvoice: Codeunit "Correct Posted Sales Invoice";
         LibraryERM: Codeunit "Library - ERM";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
+        LibraryMarketing: Codeunit "Library - Marketing";
         LibraryRandom: Codeunit "Library - Random";
         LibrarySales: Codeunit "Library - Sales";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
@@ -36,6 +38,11 @@ codeunit 148155 "Contracts Test"
         CustShipToCodeErr: Label 'Ship-to Code should be the same as Sell-to Customer';
         CalcBaseAmountErr: Label 'Calculation Base Amount should be %1', Comment = '%1=Calculation Base Amount', Locked = true;
         SubscLineDescErr: Label 'Subscription Line Description should be %1', Comment = '%1=Subscription Line Description', Locked = true;
+        ContractEmailInitFromContactErr: Label 'Contract email should be initialized from Contact A.', Locked = true;
+        ContractEmailUpdatedToContactErr: Label 'Contract email should be updated to the newly selected Contact B email.', Locked = true;
+        ContractEmailNotPreviousContactErr: Label 'Contract email should not remain the previous Contact A email.', Locked = true;
+        ContractEmailTableValidationErr: Label 'Contract email should be updated through table validation logic.', Locked = true;
+        ContractEmailBlankOverrideErr: Label 'Contract email should be overridden to the blank email of the selected contact.', Locked = true;
 
     #region Tests
 
@@ -2149,6 +2156,91 @@ codeunit 148155 "Contracts Test"
         Assert.AreNotEqual(CustomerContract."Sell-to Address", CustomerContract."Ship-to Address", 'Ship-to Address should not be changed when Ship-to Code is set.');
     end;
 
+    [Test]
+    procedure ChangingSellToContactUpdatesContractEmail()
+    var
+        Customer: Record Customer;
+        ContactA: Record Contact;
+        ContactB: Record Contact;
+        CustomerContract: Record "Customer Subscription Contract";
+    begin
+        // [SCENARIO 642745] Changing the Sell-to Contact No. updates the Customer Subscription Contract email to the selected contact's email
+        Initialize();
+
+        // [GIVEN] A customer with two person contacts that have different email addresses
+        CreateCustomerWithTwoPersonContacts(Customer, ContactA, ContactB);
+
+        // [GIVEN] A customer subscription contract using Contact A
+        ContractTestLibrary.CreateCustomerContract(CustomerContract, Customer."No.");
+        CustomerContract.SetHideValidationDialog(true);
+        CustomerContract.Validate("Sell-to Contact No.", ContactA."No.");
+        CustomerContract.Modify(true);
+        Assert.AreEqual(ContactA."E-Mail", CustomerContract."Sell-to E-Mail", ContractEmailInitFromContactErr);
+
+        // [WHEN] Changing the Sell-to Contact No. to Contact B
+        CustomerContract.Validate("Sell-to Contact No.", ContactB."No.");
+        CustomerContract.Modify(true);
+
+        // [THEN] The contract email is updated to Contact B's email
+        Assert.AreEqual(ContactB."E-Mail", CustomerContract."Sell-to E-Mail", ContractEmailUpdatedToContactErr);
+        Assert.AreNotEqual(ContactA."E-Mail", CustomerContract."Sell-to E-Mail", ContractEmailNotPreviousContactErr);
+    end;
+
+    [Test]
+    procedure ChangingSellToContactUpdatesEmailViaTableValidate()
+    var
+        Customer: Record Customer;
+        ContactA: Record Contact;
+        ContactB: Record Contact;
+        CustomerContract: Record "Customer Subscription Contract";
+    begin
+        // [SCENARIO 642745] The email refresh happens in table validation logic, not only in the page UI
+        Initialize();
+
+        // [GIVEN] A customer with two person contacts with different emails and a contract using Contact A
+        CreateCustomerWithTwoPersonContacts(Customer, ContactA, ContactB);
+        ContractTestLibrary.CreateCustomerContract(CustomerContract, Customer."No.");
+        CustomerContract.SetHideValidationDialog(true);
+        CustomerContract.Validate("Sell-to Contact No.", ContactA."No.");
+        CustomerContract.Modify(true);
+
+        // [WHEN] Contact No. is changed through table Validate (simulating API/background/AL code)
+        CustomerContract.Validate("Sell-to Contact No.", ContactB."No.");
+
+        // [THEN] The email is updated without any page/UI involvement
+        Assert.AreEqual(ContactB."E-Mail", CustomerContract."Sell-to E-Mail", ContractEmailTableValidationErr);
+    end;
+
+    [Test]
+    procedure ChangingSellToContactToContactWithBlankEmailClearsContractEmail()
+    var
+        Customer: Record Customer;
+        ContactA: Record Contact;
+        ContactB: Record Contact;
+        CustomerContract: Record "Customer Subscription Contract";
+    begin
+        // [SCENARIO 642745] Changing to a contact with a blank email overrides the contract email (strict override)
+        Initialize();
+
+        // [GIVEN] A customer with Contact A (with email) and Contact B (blank email)
+        CreateCustomerWithTwoPersonContacts(Customer, ContactA, ContactB);
+        ContactB.Validate("E-Mail", '');
+        ContactB.Modify(false);
+
+        // [GIVEN] A contract using Contact A
+        ContractTestLibrary.CreateCustomerContract(CustomerContract, Customer."No.");
+        CustomerContract.SetHideValidationDialog(true);
+        CustomerContract.Validate("Sell-to Contact No.", ContactA."No.");
+        CustomerContract.Modify(true);
+        Assert.AreEqual(ContactA."E-Mail", CustomerContract."Sell-to E-Mail", ContractEmailInitFromContactErr);
+
+        // [WHEN] Changing the Sell-to Contact No. to Contact B (blank email)
+        CustomerContract.Validate("Sell-to Contact No.", ContactB."No.");
+
+        // [THEN] The contract email is overridden to blank, matching the selected contact
+        Assert.AreEqual('', CustomerContract."Sell-to E-Mail", ContractEmailBlankOverrideErr);
+    end;
+
     #endregion Tests
 
     #region Procedures
@@ -2568,6 +2660,24 @@ codeunit 148155 "Contracts Test"
                 if IsContractLineInvoiced then // Double check that contract line is invoiced
                     SourceServiceCommitment.TestField("Next Billing Date", CalcDate('<+1D>', SourceServiceCommitment."Subscription Line End Date"));
             until SourceServiceCommitment.Next() = 0;
+    end;
+
+    local procedure CreateCustomerWithTwoPersonContacts(var Customer: Record Customer; var PersonContactA: Record Contact; var PersonContactB: Record Contact)
+    var
+        CompanyContact: Record Contact;
+    begin
+        // Create a company contact that is related to the customer, then two person contacts belonging to that company
+        LibraryMarketing.CreateContactWithCustomer(CompanyContact, Customer);
+
+        LibraryMarketing.CreatePersonContact(PersonContactA);
+        PersonContactA.Validate("Company No.", CompanyContact."No.");
+        PersonContactA.Validate("E-Mail", 'contactA@example.com');
+        PersonContactA.Modify(false);
+
+        LibraryMarketing.CreatePersonContact(PersonContactB);
+        PersonContactB.Validate("Company No.", CompanyContact."No.");
+        PersonContactB.Validate("E-Mail", 'contactB@example.com');
+        PersonContactB.Modify(false);
     end;
 
     #endregion Procedures


### PR DESCRIPTION
[Bug 642745](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/642745): [All-e] Changing the contact of a Customer Subscription Contract doesn't update the email of the contract.

[AB#642745](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642745)

**Issue**: When a Customer Subscription Contract's "Sell-to Contact No." is changed to a different contact, the contract's email ("Sell-to E-Mail") is not refreshed. It keeps the previous/customer email, so subscription communication can be sent to the wrong contact.

**Cause**: In the UpdateSellToCust procedure in CustomerSubscriptionContract.Table.al (invoked from the "Sell-to Contact No." OnValidate trigger), the resolved Contact record's details were never copied to the contract — the email/phone lines present in the standard BaseApp Sales Header pattern were omitted. The email was only ever populated from the Customer during "Sell-to Customer No." validation (CopySellToCustomerAddressFieldsFromCustomer), never from the selected contact.

**Solution**: Added "Sell-to Phone No." := Cont."Phone No."; and "Sell-to E-Mail" := Cont."E-Mail"; in UpdateSellToCust after the contact is resolved, mirroring the standard Sales Header behavior. Now any Validate("Sell-to Contact No.", ...) — from UI, AL, API, or background — overrides the contract email with the selected contact's email (strict override, including blank), while preserving existing validations and the OnAfterUpdateSellToCust event.

