### PR TITLE
[Main] -Detail Trial Balance - Running Balance Incorrect When "Include Closing Entries" Is Disabled

### DIFF
--- a/src/Layers/BE/BaseApp/Finance/GeneralLedger/Reports/DetailTrialBalance.Report.al
+++ b/src/Layers/BE/BaseApp/Finance/GeneralLedger/Reports/DetailTrialBalance.Report.al
@@ -160,18 +160,12 @@ report 4 "Detail Trial Balance"
                         if not PrintReversedEntries and Reversed then
                             CurrReport.Skip();
 
-                        GLBalance := GLBalance + Amount;
-                        if ("Posting Date" = ClosingDate("Posting Date")) and
-                           not PrintClosingEntries
-                        then begin
-                            "Debit Amount" := 0;
-                            "Credit Amount" := 0;
-                        end;
+                        ClosingEntry := "Posting Date" = ClosingDate("Posting Date");
 
-                        if "Posting Date" = ClosingDate("Posting Date") then
-                            ClosingEntry := true
-                        else
-                            ClosingEntry := false;
+                        if ClosingEntry and not PrintClosingEntries then
+                            CurrReport.Skip();
+
+                        GLBalance := GLBalance + Amount;
 
                         NumberOfGLEntryLines += 1;
                     end;

--- a/src/Layers/BE/Tests/Report/ERMFinancialReports.Codeunit.al
+++ b/src/Layers/BE/Tests/Report/ERMFinancialReports.Codeunit.al
@@ -1635,6 +1635,63 @@ codeunit 134982 "ERM Financial Reports"
         end;
     end;
 
+    [Test]
+    [HandlerFunctions('RHDetailTrialBalance')]
+    [Scope('OnPrem')]
+    procedure DetailTrialBalanceClosingEntryExcludedFromRunningBalance()
+    var
+        AccountingPeriod: Record "Accounting Period";
+        GLAccountNo: Code[20];
+        BalGLAccountNo: Code[20];
+        FiscalYearEndDate: Date;
+        ClosingEntryDate: Date;
+        LastEntryDate: Date;
+        FirstAmount: Decimal;
+        ClosingAmount: Decimal;
+        LastAmount: Decimal;
+    begin
+        // [FEATURE] [Detail Trial Balance] [AI Test]
+        // [SCENARIO 645090] Closing entry is not added to the running balance when "Include Closing Entries Within the Period" is disabled.
+        Initialize();
+
+        // [GIVEN] A closing entry can only be posted on the ending date of a fiscal year, so anchor the scenario on the first open fiscal year.
+        AccountingPeriod.SetRange("New Fiscal Year", true);
+        AccountingPeriod.SetRange(Closed, false);
+        AccountingPeriod.FindFirst();
+        FiscalYearEndDate := CalcDate('<-1D>', AccountingPeriod."Starting Date");
+        ClosingEntryDate := ClosingDate(FiscalYearEndDate);
+        LastEntryDate := AccountingPeriod."Starting Date";
+
+        GLAccountNo := LibraryERM.CreateGLAccountNo();
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+        FirstAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+        ClosingAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+        LastAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+
+        // [GIVEN] Ordinary entry of Amount = "X" posted to G/L Account "A" on the last day of the fiscal year.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, FiscalYearEndDate, FirstAmount);
+
+        // [GIVEN] Closing entry of Amount = "C" posted to "A" on the closing date of the same fiscal year end.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, ClosingEntryDate, ClosingAmount);
+
+        // [GIVEN] Ordinary entry of Amount = "Y" posted to "A" on the first day of the new fiscal year.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, LastEntryDate, LastAmount);
+
+        // [WHEN] Save Detail Trial Balance Report for "A" with "Include Closing Entries Within the Period" = No.
+        RunDetailTrialBalanceReport(
+          GLAccountNo, false, false, false, false, CopyStr(StrSubstNo('%1..%2', FiscalYearEndDate, LastEntryDate), 1, 30));
+
+        // [THEN] The closing entry is not printed.
+        LibraryReportDataset.LoadDataSetFile();
+        LibraryReportDataset.AssertElementWithValueNotExist('EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, ClosingEntryDate));
+
+        // [THEN] Balance of the last printed entry is "X" + "Y", the excluded closing entry "C" is not accumulated.
+        LibraryReportDataset.SetRange('EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, LastEntryDate));
+        if not LibraryReportDataset.GetNextRow() then
+            Error(RowNotFoundErr, 'EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, LastEntryDate));
+        LibraryReportDataset.AssertCurrentRowValueEquals('GLBalance', FirstAmount + LastAmount);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -2526,6 +2583,28 @@ codeunit 134982 "ERM Financial Reports"
           StrSubstNo(CloseIncomeAmountMismatchErr,
             PostedGLEntry.FieldCaption("Source Currency Amount"), SourceCurrencyCode,
             -PostedGLEntry."Source Currency Amount", CloseIncomeGLEntry."Source Currency Amount"));
+    end;
+
+    local procedure CreateAndPostGenJnlLineOnPostingDate(GLAccountNo: Code[20]; BalGLAccountNo: Code[20]; PostingDate: Date; Amount: Decimal)
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+    begin
+        CreateGeneralJournalLine(GenJournalLine, GenJournalLine."Account Type"::"G/L Account", GLAccountNo, Amount);
+        GenJournalLine.Validate("Posting Date", PostingDate);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+    end;
+
+    local procedure FindGLEntryNo(GLAccountNo: Code[20]; PostingDate: Date): Integer
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        GLEntry.SetRange("G/L Account No.", GLAccountNo);
+        GLEntry.SetRange("Posting Date", PostingDate);
+        GLEntry.FindFirst();
+        exit(GLEntry."Entry No.");
     end;
 
     [ConfirmHandler]

--- a/src/Layers/CZ/Tests/Report/ERMFinancialReports.Codeunit.al
+++ b/src/Layers/CZ/Tests/Report/ERMFinancialReports.Codeunit.al
@@ -1597,6 +1597,63 @@ codeunit 134982 "ERM Financial Reports"
         end;
     end;
 
+    [Test]
+    [HandlerFunctions('RHDetailTrialBalance')]
+    [Scope('OnPrem')]
+    procedure DetailTrialBalanceClosingEntryExcludedFromRunningBalance()
+    var
+        AccountingPeriod: Record "Accounting Period";
+        GLAccountNo: Code[20];
+        BalGLAccountNo: Code[20];
+        FiscalYearEndDate: Date;
+        ClosingEntryDate: Date;
+        LastEntryDate: Date;
+        FirstAmount: Decimal;
+        ClosingAmount: Decimal;
+        LastAmount: Decimal;
+    begin
+        // [FEATURE] [Detail Trial Balance] [AI Test]
+        // [SCENARIO 645090] Closing entry is not added to the running balance when "Include Closing Entries Within the Period" is disabled.
+        Initialize();
+
+        // [GIVEN] A closing entry can only be posted on the ending date of a fiscal year, so anchor the scenario on the first open fiscal year.
+        AccountingPeriod.SetRange("New Fiscal Year", true);
+        AccountingPeriod.SetRange(Closed, false);
+        AccountingPeriod.FindFirst();
+        FiscalYearEndDate := CalcDate('<-1D>', AccountingPeriod."Starting Date");
+        ClosingEntryDate := ClosingDate(FiscalYearEndDate);
+        LastEntryDate := AccountingPeriod."Starting Date";
+
+        GLAccountNo := LibraryERM.CreateGLAccountNo();
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+        FirstAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+        ClosingAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+        LastAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+
+        // [GIVEN] Ordinary entry of Amount = "X" posted to G/L Account "A" on the last day of the fiscal year.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, FiscalYearEndDate, FirstAmount);
+
+        // [GIVEN] Closing entry of Amount = "C" posted to "A" on the closing date of the same fiscal year end.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, ClosingEntryDate, ClosingAmount);
+
+        // [GIVEN] Ordinary entry of Amount = "Y" posted to "A" on the first day of the new fiscal year.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, LastEntryDate, LastAmount);
+
+        // [WHEN] Save Detail Trial Balance Report for "A" with "Include Closing Entries Within the Period" = No.
+        RunDetailTrialBalanceReport(
+          GLAccountNo, false, false, false, false, CopyStr(StrSubstNo('%1..%2', FiscalYearEndDate, LastEntryDate), 1, 30));
+
+        // [THEN] The closing entry is not printed.
+        LibraryReportDataset.LoadDataSetFile();
+        LibraryReportDataset.AssertElementWithValueNotExist('EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, ClosingEntryDate));
+
+        // [THEN] Balance of the last printed entry is "X" + "Y", the excluded closing entry "C" is not accumulated.
+        LibraryReportDataset.SetRange('EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, LastEntryDate));
+        if not LibraryReportDataset.GetNextRow() then
+            Error(RowNotFoundErr, 'EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, LastEntryDate));
+        LibraryReportDataset.AssertCurrentRowValueEquals('GLBalance', FirstAmount + LastAmount);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -2481,6 +2538,28 @@ codeunit 134982 "ERM Financial Reports"
           StrSubstNo(CloseIncomeAmountMismatchErr,
             PostedGLEntry.FieldCaption("Source Currency Amount"), SourceCurrencyCode,
             -PostedGLEntry."Source Currency Amount", CloseIncomeGLEntry."Source Currency Amount"));
+    end;
+
+    local procedure CreateAndPostGenJnlLineOnPostingDate(GLAccountNo: Code[20]; BalGLAccountNo: Code[20]; PostingDate: Date; Amount: Decimal)
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+    begin
+        CreateGeneralJournalLine(GenJournalLine, GenJournalLine."Account Type"::"G/L Account", GLAccountNo, Amount);
+        GenJournalLine.Validate("Posting Date", PostingDate);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+    end;
+
+    local procedure FindGLEntryNo(GLAccountNo: Code[20]; PostingDate: Date): Integer
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        GLEntry.SetRange("G/L Account No.", GLAccountNo);
+        GLEntry.SetRange("Posting Date", PostingDate);
+        GLEntry.FindFirst();
+        exit(GLEntry."Entry No.");
     end;
 
     [ConfirmHandler]

--- a/src/Layers/DE/Tests/Report/ERMFinancialReports.Codeunit.al
+++ b/src/Layers/DE/Tests/Report/ERMFinancialReports.Codeunit.al
@@ -1597,6 +1597,63 @@ codeunit 134982 "ERM Financial Reports"
         end;
     end;
 
+    [Test]
+    [HandlerFunctions('RHDetailTrialBalance')]
+    [Scope('OnPrem')]
+    procedure DetailTrialBalanceClosingEntryExcludedFromRunningBalance()
+    var
+        AccountingPeriod: Record "Accounting Period";
+        GLAccountNo: Code[20];
+        BalGLAccountNo: Code[20];
+        FiscalYearEndDate: Date;
+        ClosingEntryDate: Date;
+        LastEntryDate: Date;
+        FirstAmount: Decimal;
+        ClosingAmount: Decimal;
+        LastAmount: Decimal;
+    begin
+        // [FEATURE] [Detail Trial Balance] [AI Test]
+        // [SCENARIO 645090] Closing entry is not added to the running balance when "Include Closing Entries Within the Period" is disabled.
+        Initialize();
+
+        // [GIVEN] A closing entry can only be posted on the ending date of a fiscal year, so anchor the scenario on the first open fiscal year.
+        AccountingPeriod.SetRange("New Fiscal Year", true);
+        AccountingPeriod.SetRange(Closed, false);
+        AccountingPeriod.FindFirst();
+        FiscalYearEndDate := CalcDate('<-1D>', AccountingPeriod."Starting Date");
+        ClosingEntryDate := ClosingDate(FiscalYearEndDate);
+        LastEntryDate := AccountingPeriod."Starting Date";
+
+        GLAccountNo := LibraryERM.CreateGLAccountNo();
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+        FirstAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+        ClosingAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+        LastAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+
+        // [GIVEN] Ordinary entry of Amount = "X" posted to G/L Account "A" on the last day of the fiscal year.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, FiscalYearEndDate, FirstAmount);
+
+        // [GIVEN] Closing entry of Amount = "C" posted to "A" on the closing date of the same fiscal year end.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, ClosingEntryDate, ClosingAmount);
+
+        // [GIVEN] Ordinary entry of Amount = "Y" posted to "A" on the first day of the new fiscal year.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, LastEntryDate, LastAmount);
+
+        // [WHEN] Save Detail Trial Balance Report for "A" with "Include Closing Entries Within the Period" = No.
+        RunDetailTrialBalanceReport(
+          GLAccountNo, false, false, false, false, CopyStr(StrSubstNo('%1..%2', FiscalYearEndDate, LastEntryDate), 1, 30));
+
+        // [THEN] The closing entry is not printed.
+        LibraryReportDataset.LoadDataSetFile();
+        LibraryReportDataset.AssertElementWithValueNotExist('EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, ClosingEntryDate));
+
+        // [THEN] Balance of the last printed entry is "X" + "Y", the excluded closing entry "C" is not accumulated.
+        LibraryReportDataset.SetRange('EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, LastEntryDate));
+        if not LibraryReportDataset.GetNextRow() then
+            Error(RowNotFoundErr, 'EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, LastEntryDate));
+        LibraryReportDataset.AssertCurrentRowValueEquals('GLBalance', FirstAmount + LastAmount);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -2477,6 +2534,28 @@ codeunit 134982 "ERM Financial Reports"
           StrSubstNo(CloseIncomeAmountMismatchErr,
             PostedGLEntry.FieldCaption("Source Currency Amount"), SourceCurrencyCode,
             -PostedGLEntry."Source Currency Amount", CloseIncomeGLEntry."Source Currency Amount"));
+    end;
+
+    local procedure CreateAndPostGenJnlLineOnPostingDate(GLAccountNo: Code[20]; BalGLAccountNo: Code[20]; PostingDate: Date; Amount: Decimal)
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+    begin
+        CreateGeneralJournalLine(GenJournalLine, GenJournalLine."Account Type"::"G/L Account", GLAccountNo, Amount);
+        GenJournalLine.Validate("Posting Date", PostingDate);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+    end;
+
+    local procedure FindGLEntryNo(GLAccountNo: Code[20]; PostingDate: Date): Integer
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        GLEntry.SetRange("G/L Account No.", GLAccountNo);
+        GLEntry.SetRange("Posting Date", PostingDate);
+        GLEntry.FindFirst();
+        exit(GLEntry."Entry No.");
     end;
 
     [ConfirmHandler]

--- a/src/Layers/IT/Tests/Report/ERMFinancialReports.Codeunit.al
+++ b/src/Layers/IT/Tests/Report/ERMFinancialReports.Codeunit.al
@@ -1599,6 +1599,63 @@ codeunit 134982 "ERM Financial Reports"
         end;
     end;
 
+    [Test]
+    [HandlerFunctions('RHDetailTrialBalance')]
+    [Scope('OnPrem')]
+    procedure DetailTrialBalanceClosingEntryExcludedFromRunningBalance()
+    var
+        AccountingPeriod: Record "Accounting Period";
+        GLAccountNo: Code[20];
+        BalGLAccountNo: Code[20];
+        FiscalYearEndDate: Date;
+        ClosingEntryDate: Date;
+        LastEntryDate: Date;
+        FirstAmount: Decimal;
+        ClosingAmount: Decimal;
+        LastAmount: Decimal;
+    begin
+        // [FEATURE] [Detail Trial Balance] [AI Test]
+        // [SCENARIO 645090] Closing entry is not added to the running balance when "Include Closing Entries Within the Period" is disabled.
+        Initialize();
+
+        // [GIVEN] A closing entry can only be posted on the ending date of a fiscal year, so anchor the scenario on the first open fiscal year.
+        AccountingPeriod.SetRange("New Fiscal Year", true);
+        AccountingPeriod.SetRange(Closed, false);
+        AccountingPeriod.FindFirst();
+        FiscalYearEndDate := CalcDate('<-1D>', AccountingPeriod."Starting Date");
+        ClosingEntryDate := ClosingDate(FiscalYearEndDate);
+        LastEntryDate := AccountingPeriod."Starting Date";
+
+        GLAccountNo := LibraryERM.CreateGLAccountNo();
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+        FirstAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+        ClosingAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+        LastAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+
+        // [GIVEN] Ordinary entry of Amount = "X" posted to G/L Account "A" on the last day of the fiscal year.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, FiscalYearEndDate, FirstAmount);
+
+        // [GIVEN] Closing entry of Amount = "C" posted to "A" on the closing date of the same fiscal year end.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, ClosingEntryDate, ClosingAmount);
+
+        // [GIVEN] Ordinary entry of Amount = "Y" posted to "A" on the first day of the new fiscal year.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, LastEntryDate, LastAmount);
+
+        // [WHEN] Save Detail Trial Balance Report for "A" with "Include Closing Entries Within the Period" = No.
+        RunDetailTrialBalanceReport(
+          GLAccountNo, false, false, false, false, CopyStr(StrSubstNo('%1..%2', FiscalYearEndDate, LastEntryDate), 1, 30));
+
+        // [THEN] The closing entry is not printed.
+        LibraryReportDataset.LoadDataSetFile();
+        LibraryReportDataset.AssertElementWithValueNotExist('EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, ClosingEntryDate));
+
+        // [THEN] Balance of the last printed entry is "X" + "Y", the excluded closing entry "C" is not accumulated.
+        LibraryReportDataset.SetRange('EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, LastEntryDate));
+        if not LibraryReportDataset.GetNextRow() then
+            Error(RowNotFoundErr, 'EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, LastEntryDate));
+        LibraryReportDataset.AssertCurrentRowValueEquals('GLBalance', FirstAmount + LastAmount);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -2487,6 +2544,28 @@ codeunit 134982 "ERM Financial Reports"
           StrSubstNo(CloseIncomeAmountMismatchErr,
             PostedGLEntry.FieldCaption("Source Currency Amount"), SourceCurrencyCode,
             -PostedGLEntry."Source Currency Amount", CloseIncomeGLEntry."Source Currency Amount"));
+    end;
+
+    local procedure CreateAndPostGenJnlLineOnPostingDate(GLAccountNo: Code[20]; BalGLAccountNo: Code[20]; PostingDate: Date; Amount: Decimal)
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+    begin
+        CreateGeneralJournalLine(GenJournalLine, GenJournalLine."Account Type"::"G/L Account", GLAccountNo, Amount);
+        GenJournalLine.Validate("Posting Date", PostingDate);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+    end;
+
+    local procedure FindGLEntryNo(GLAccountNo: Code[20]; PostingDate: Date): Integer
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        GLEntry.SetRange("G/L Account No.", GLAccountNo);
+        GLEntry.SetRange("Posting Date", PostingDate);
+        GLEntry.FindFirst();
+        exit(GLEntry."Entry No.");
     end;
 
     [ConfirmHandler]

--- a/src/Layers/W1/BaseApp/Finance/GeneralLedger/Reports/DetailTrialBalance.Report.al
+++ b/src/Layers/W1/BaseApp/Finance/GeneralLedger/Reports/DetailTrialBalance.Report.al
@@ -157,18 +157,12 @@ report 4 "Detail Trial Balance"
                         if not PrintReversedEntries and Reversed then
                             CurrReport.Skip();
 
-                        GLBalance := GLBalance + Amount;
-                        if ("Posting Date" = ClosingDate("Posting Date")) and
-                           not PrintClosingEntries
-                        then begin
-                            "Debit Amount" := 0;
-                            "Credit Amount" := 0;
-                        end;
+                        ClosingEntry := "Posting Date" = ClosingDate("Posting Date");
 
-                        if "Posting Date" = ClosingDate("Posting Date") then
-                            ClosingEntry := true
-                        else
-                            ClosingEntry := false;
+                        if ClosingEntry and not PrintClosingEntries then
+                            CurrReport.Skip();
+
+                        GLBalance := GLBalance + Amount;
 
                         NumberOfGLEntryLines += 1;
                     end;

--- a/src/Layers/W1/Tests/Report/ERMFinancialReports.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ERMFinancialReports.Codeunit.al
@@ -1597,6 +1597,63 @@ codeunit 134982 "ERM Financial Reports"
         end;
     end;
 
+    [Test]
+    [HandlerFunctions('RHDetailTrialBalance')]
+    [Scope('OnPrem')]
+    procedure DetailTrialBalanceClosingEntryExcludedFromRunningBalance()
+    var
+        AccountingPeriod: Record "Accounting Period";
+        GLAccountNo: Code[20];
+        BalGLAccountNo: Code[20];
+        FiscalYearEndDate: Date;
+        ClosingEntryDate: Date;
+        LastEntryDate: Date;
+        FirstAmount: Decimal;
+        ClosingAmount: Decimal;
+        LastAmount: Decimal;
+    begin
+        // [FEATURE] [Detail Trial Balance] [AI Test]
+        // [SCENARIO 645090] Closing entry is not added to the running balance when "Include Closing Entries Within the Period" is disabled.
+        Initialize();
+
+        // [GIVEN] A closing entry can only be posted on the ending date of a fiscal year, so anchor the scenario on the first open fiscal year.
+        AccountingPeriod.SetRange("New Fiscal Year", true);
+        AccountingPeriod.SetRange(Closed, false);
+        AccountingPeriod.FindFirst();
+        FiscalYearEndDate := CalcDate('<-1D>', AccountingPeriod."Starting Date");
+        ClosingEntryDate := ClosingDate(FiscalYearEndDate);
+        LastEntryDate := AccountingPeriod."Starting Date";
+
+        GLAccountNo := LibraryERM.CreateGLAccountNo();
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+        FirstAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+        ClosingAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+        LastAmount := LibraryRandom.RandDecInRange(100, 200, 2);
+
+        // [GIVEN] Ordinary entry of Amount = "X" posted to G/L Account "A" on the last day of the fiscal year.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, FiscalYearEndDate, FirstAmount);
+
+        // [GIVEN] Closing entry of Amount = "C" posted to "A" on the closing date of the same fiscal year end.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, ClosingEntryDate, ClosingAmount);
+
+        // [GIVEN] Ordinary entry of Amount = "Y" posted to "A" on the first day of the new fiscal year.
+        CreateAndPostGenJnlLineOnPostingDate(GLAccountNo, BalGLAccountNo, LastEntryDate, LastAmount);
+
+        // [WHEN] Save Detail Trial Balance Report for "A" with "Include Closing Entries Within the Period" = No.
+        RunDetailTrialBalanceReport(
+          GLAccountNo, false, false, false, false, CopyStr(StrSubstNo('%1..%2', FiscalYearEndDate, LastEntryDate), 1, 30));
+
+        // [THEN] The closing entry is not printed.
+        LibraryReportDataset.LoadDataSetFile();
+        LibraryReportDataset.AssertElementWithValueNotExist('EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, ClosingEntryDate));
+
+        // [THEN] Balance of the last printed entry is "X" + "Y", the excluded closing entry "C" is not accumulated.
+        LibraryReportDataset.SetRange('EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, LastEntryDate));
+        if not LibraryReportDataset.GetNextRow() then
+            Error(RowNotFoundErr, 'EntryNo_GLEntry', FindGLEntryNo(GLAccountNo, LastEntryDate));
+        LibraryReportDataset.AssertCurrentRowValueEquals('GLBalance', FirstAmount + LastAmount);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -2482,6 +2539,28 @@ codeunit 134982 "ERM Financial Reports"
           StrSubstNo(CloseIncomeAmountMismatchErr,
             PostedGLEntry.FieldCaption("Source Currency Amount"), SourceCurrencyCode,
             -PostedGLEntry."Source Currency Amount", CloseIncomeGLEntry."Source Currency Amount"));
+    end;
+
+    local procedure CreateAndPostGenJnlLineOnPostingDate(GLAccountNo: Code[20]; BalGLAccountNo: Code[20]; PostingDate: Date; Amount: Decimal)
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+    begin
+        CreateGeneralJournalLine(GenJournalLine, GenJournalLine."Account Type"::"G/L Account", GLAccountNo, Amount);
+        GenJournalLine.Validate("Posting Date", PostingDate);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+    end;
+
+    local procedure FindGLEntryNo(GLAccountNo: Code[20]; PostingDate: Date): Integer
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        GLEntry.SetRange("G/L Account No.", GLAccountNo);
+        GLEntry.SetRange("Posting Date", PostingDate);
+        GLEntry.FindFirst();
+        exit(GLEntry."Entry No.");
     end;
 
     [ConfirmHandler]


### PR DESCRIPTION
[Bug 645090](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/645090): [master] [ALL-E] Detail Trial Balance - Running Balance Incorrect When "Include Closing Entries" Is Disabled

[AB#645090](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645090)

**Issue**: When running the Detail Trial Balance report with "Include Closing Entries Within the Period" disabled, closing entries were excluded from the printed lines but their amounts still contributed to the "Balance" (running balance) column, causing the displayed balance to not reconcile with the entries actually shown on the report.

**Cause**: In the "G/L Entry" OnAfterGetRecord trigger in DetailTrialBalance.Report.al, GLBalance := GLBalance + Amount executed unconditionally before the closing-entry check (if ClosingEntry and not PrintClosingEntries then CurrReport.Skip(),so a skipped/hidden closing entry's amount was still accumulated into the running balance.

**Solution**: Reordered the trigger to compute ClosingEntry and perform CurrReport.Skip() before the GLBalance := GLBalance + Amount line, matching the pattern already used for the reversed-entries and corrections-only filters — so a closing entry that isn't printed no longer contributes to the balance.



