### PR TITLE
[Shopify] Add catalog filters to Sync Catalog Prices report

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Catalogs/Codeunits/ShpfySyncCatalogPrices.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Catalogs/Codeunits/ShpfySyncCatalogPrices.Codeunit.al
@@ -13,36 +13,12 @@ using Microsoft.Inventory.Item;
 codeunit 30295 "Shpfy Sync Catalog Prices"
 {
     Access = Internal;
-    TableNo = "Shpfy Shop";
-
-    trigger OnRun()
-    var
-        Catalog: Record "Shpfy Catalog";
-        CatalogIds: List of [BigInteger];
-    begin
-        SetShop(Rec);
-        Catalog.SetRange("Shop Code", Shop.Code);
-        Catalog.SetRange("Sync Prices", true);
-        if CatalogType <> CatalogType::" " then
-            Catalog.SetRange("Catalog Type", CatalogType);
-        if CompanyId <> '' then
-            Catalog.SetRange("Company SystemId", CompanyId);
-        if Catalog.FindSet() then
-            repeat
-                if not CatalogIds.Contains(Catalog.Id) then begin
-                    CatalogIds.Add(Catalog.Id);
-                    ProductPriceCalc.SetShopAndCatalog(Shop, Catalog);
-                    SyncCatalogPrices(Catalog);
-                end;
-            until Catalog.Next() = 0;
-    end;
 
     var
         Shop: Record "Shpfy Shop";
         CatalogAPI: Codeunit "Shpfy Catalog API";
         ProductPriceCalc: Codeunit "Shpfy Product Price Calc.";
-        CompanyId: Text;
-        CatalogType: Enum "Shpfy Catalog Type";
+        ProcessedCatalogIds: List of [BigInteger];
 
     internal procedure SyncCatalogPrices(var Catalog: Record "Shpfy Catalog")
     var
@@ -105,21 +81,25 @@ codeunit 30295 "Shpfy Sync Catalog Prices"
         end;
     end;
 
-    local procedure SetShop(ShopifyShop: Record "Shpfy Shop")
+    internal procedure SetShop(ShopifyShop: Record "Shpfy Shop")
     begin
         Shop := ShopifyShop;
         Shop.SetRecFilter();
         CatalogAPI.SetShop(Shop);
+        Clear(ProcessedCatalogIds);
     end;
 
-    internal procedure SetCompanyId(ShopifyCompanyId: Text)
+    internal procedure SyncCatalog(var Catalog: Record "Shpfy Catalog")
     begin
-        CompanyId := ShopifyCompanyId;
+        if ProcessedCatalogIds.Contains(Catalog.Id) then
+            exit;
+        ProcessedCatalogIds.Add(Catalog.Id);
+        ProductPriceCalc.SetShopAndCatalog(Shop, Catalog);
+        SyncCatalogPrices(Catalog);
     end;
 
     internal procedure SetCatalogType(ShopifyCatalogType: Enum "Shpfy Catalog Type")
     begin
-        CatalogType := ShopifyCatalogType;
         CatalogAPI.SetCatalogType(ShopifyCatalogType);
     end;
 }

--- a/src/Apps/W1/Shopify/App/src/Catalogs/Reports/ShpfySyncCatalogPrices.Report.al
+++ b/src/Apps/W1/Shopify/App/src/Catalogs/Reports/ShpfySyncCatalogPrices.Report.al
@@ -21,6 +21,26 @@ report 30116 "Shpfy Sync Catalog Prices"
         {
             RequestFilterFields = Code;
 
+            dataitem(Catalog; "Shpfy Catalog")
+            {
+                DataItemLink = "Shop Code" = field(Code);
+                RequestFilterFields = "Id", "Name";
+
+                trigger OnPreDataItem()
+                begin
+                    Catalog.SetRange("Sync Prices", true);
+                    if CompanyId <> '' then
+                        Catalog.SetRange("Company SystemId", CompanyId);
+                    if CatalogType <> CatalogType::" " then
+                        Catalog.SetRange("Catalog Type", CatalogType);
+                end;
+
+                trigger OnAfterGetRecord()
+                begin
+                    SyncCatalogPrices.SyncCatalog(Catalog);
+                end;
+            }
+
             trigger OnPreDataItem()
             begin
                 if not Shop.HasFilter() then
@@ -29,9 +49,8 @@ report 30116 "Shpfy Sync Catalog Prices"
 
             trigger OnAfterGetRecord()
             begin
-                SetCatalogType(CatalogType);
-                SyncCatalogPrices.SetCompanyId(CompanyId);
-                SyncCatalogPrices.Run(Shop);
+                SyncCatalogPrices.SetCatalogType(CatalogType);
+                SyncCatalogPrices.SetShop(Shop);
             end;
         }
     }

--- a/src/Apps/W1/Shopify/App/src/Catalogs/Reports/ShpfySyncCatalogPrices.Report.al
+++ b/src/Apps/W1/Shopify/App/src/Catalogs/Reports/ShpfySyncCatalogPrices.Report.al
@@ -28,6 +28,12 @@ report 30116 "Shpfy Sync Catalog Prices"
 
                 trigger OnPreDataItem()
                 begin
+                    Catalog.AddLoadFields(
+                        "Id", "Company SystemId", "Name", "Shop Code", "Sync Prices", "Catalog Type",
+                        "Customer Price Group", "Customer Discount Group", "Gen. Bus. Posting Group",
+                        "VAT Bus. Posting Group", "Tax Area Code", "Tax Liable", "VAT Country/Region Code",
+                        "Customer Posting Group", "Prices Including VAT", "Allow Line Disc.", "Customer No.",
+                        "Currency Code", SystemModifiedAt);
                     Catalog.SetRange("Sync Prices", true);
                     if CompanyId <> '' then
                         Catalog.SetRange("Company SystemId", CompanyId);


### PR DESCRIPTION
Fixes [AB#645074](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645074)

### Summary
The Shopify **Sync Catalog Prices** report (30116) runs as a nightly background Job Queue task that processes **all** catalogs with *Sync Prices* enabled in a single session. For merchants with many large B2B catalogs (ICM 21000001134460: 150+ catalogs x ~24k items) the run cannot finish within Business Central's hard **12-hour background-session limit** and is cancelled every night (`NavNCLOperationCanceledException`, error 22928073), so catalog prices never fully sync.

### Change
- Restructure report **30116** to iterate a nested `Shpfy Catalog` dataitem exposing **`Id`** and **`Name`** request filters, in addition to the existing Shop `Code` filter.
- This lets a run be scoped to a single catalog or a subset, so the work can be split across **multiple concurrent Job Queue entries**, each completing within its own 12-hour budget.
- Codeunit **30295** gains `SetShop` and `SyncCatalog` (retaining catalog de-duplication) and drops the now-unused `OnRun`/`TableNo`/`CompanyId` path. `SetCatalogType` is preserved (still forwards the catalog type to `Shpfy Catalog API` for the company-vs-market product URL, and is used by tests).

Existing company/market page actions and background-sync scheduling are unchanged.

### Filter pane
The request page now shows Shop + Catalog (Id/Name) filters.

### Validation
- `Shpfy Connector` app builds clean.
- `Shpfy Connector Test` app builds clean; catalog tests unaffected (they call `SyncCatalogPrices`/`SetCatalogType` directly).

> Note: this is the mitigation lever (make the sync fit by batching). The underlying redundant recompute/read-back of unchanged prices is tracked separately in [AB#645074](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645074).


