### PR TITLE
[Extensibility Request] issue 30396: expose sales document lookup

### DIFF
--- a/src/Layers/APAC/BaseApp/Sales/Document/CopySalesDocument.Report.al
+++ b/src/Layers/APAC/BaseApp/Sales/Document/CopySalesDocument.Report.al
@@ -476,7 +476,7 @@ report 292 "Copy Sales Document"
         ValidateDocNo();
     end;
 
-    protected procedure LookupSalesDoc()
+    procedure LookupSalesDoc()
     begin
         OnBeforeLookupSalesDoc(FromSalesHeader, SalesHeader, FromDocType);
 

--- a/src/Layers/APAC/BaseApp/Sales/Document/CopySalesDocument.Report.al
+++ b/src/Layers/APAC/BaseApp/Sales/Document/CopySalesDocument.Report.al
@@ -476,7 +476,7 @@ report 292 "Copy Sales Document"
         ValidateDocNo();
     end;
 
-    local procedure LookupSalesDoc()
+    protected procedure LookupSalesDoc()
     begin
         OnBeforeLookupSalesDoc(FromSalesHeader, SalesHeader, FromDocType);
 

--- a/src/Layers/W1/BaseApp/Sales/Document/CopySalesDocument.Report.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/CopySalesDocument.Report.al
@@ -398,7 +398,7 @@ report 292 "Copy Sales Document"
         ValidateDocNo();
     end;
 
-    protected procedure LookupSalesDoc()
+    procedure LookupSalesDoc()
     begin
         OnBeforeLookupSalesDoc(FromSalesHeader, SalesHeader, FromDocType);
 

--- a/src/Layers/W1/BaseApp/Sales/Document/CopySalesDocument.Report.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/CopySalesDocument.Report.al
@@ -398,7 +398,7 @@ report 292 "Copy Sales Document"
         ValidateDocNo();
     end;
 
-    local procedure LookupSalesDoc()
+    protected procedure LookupSalesDoc()
     begin
         OnBeforeLookupSalesDoc(FromSalesHeader, SalesHeader, FromDocType);
 


### PR DESCRIPTION
## Summary
Extensions with custom source document types need to reuse the standard sales document lookup instead of duplicating its filters and selection behavior. This PR exposes the existing lookup procedure to report extensions while preserving all current behavior.

Source issue repository: microsoft/AlAppExtensions; issue number: 30396

## Changes Made
- `Copy Sales Document.LookupSalesDoc` - changed the procedure from local to public in W1 and its APAC layer counterpart so report extensions can invoke the standard lookup logic.

Fixes [AB#645112](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645112)





