### PR TITLE
[Extensibility Request] issue 30381: expose page sender to filter subscribers

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Availability/ItemAvailabilitybyBOMLevel.Page.al
+++ b/src/Layers/W1/BaseApp/Inventory/Availability/ItemAvailabilitybyBOMLevel.Page.al
@@ -635,7 +635,7 @@ page 5871 "Item Availability by BOM Level"
     begin
     end;
 
-    [IntegrationEvent(false, false)]
+    [IntegrationEvent(true, false)]
     local procedure OnRefreshPageOnAfterSetItemFilters(var Item: Record Item)
     begin
     end;


### PR DESCRIPTION
## Summary
Extensions need access to page 5871 so they can transfer custom page filters to the item record used by availability calculations. This change includes the page sender in the existing event, enabling subscribers to access those filters without replacing standard behavior.

Source issue repository: microsoft/AlAppExtensions; issue number: 30381

## Changes Made
- `OnRefreshPageOnAfterSetItemFilters` - enabled sender access so subscribers can read page-extension filters before availability calculations.

Fixes [AB#644804](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644804)



