### PR TITLE
[Extensibility Request] issue 30383: add purchase line transfer event

### DIFF
--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchAvailabilityMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchAvailabilityMgt.Codeunit.al
@@ -288,6 +288,7 @@ codeunit 99000973 "Purch. Availability Mgt."
     var
         PurchHeader: Record "Purchase Header";
         RecRef: RecordRef;
+        IsHandled: Boolean;
     begin
         PurchHeader.Get(SourceSubtype, SourceID);
         RecRef.GetTable(PurchHeader);
@@ -310,9 +311,18 @@ codeunit 99000973 "Purch. Availability Mgt."
                     InventoryPageData."Gross Requirement" := InventoryEventBuffer."Remaining Quantity (Base)";
                     InventoryPageData."Reserved Requirement" := InventoryEventBuffer."Reserved Quantity (Base)";
                 end;
-            else
-                Error(UnsupportedEntitySourceErr, SourceType, SourceSubtype);
+            else begin
+                IsHandled := false;
+                OnTransferPurchaseLineOnBeforeUnsupportedSourceError(InventoryPageData, InventoryEventBuffer, IsHandled, SourceType, SourceSubtype, SourceID, PurchHeader);
+                if not IsHandled then
+                    Error(UnsupportedEntitySourceErr, SourceType, SourceSubtype);
+            end;
         end;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnTransferPurchaseLineOnBeforeUnsupportedSourceError(var InventoryPageData: Record "Inventory Page Data"; InventoryEventBuffer: Record "Inventory Event Buffer"; var IsHandled: Boolean; SourceType: Integer; SourceSubtype: Integer; SourceID: Code[20]; PurchaseHeader: Record "Purchase Header")
+    begin
     end;
 
     // Page "Item Availability Line List"


### PR DESCRIPTION
## Summary
Extensions need to handle additional purchase document types, such as Blanket Orders, while transferring purchase availability data without duplicating standard header setup or encountering the unsupported-source error. This PR publishes an IsHandled event immediately before that error so subscribers can populate Inventory Page Data for custom document types while preserving existing standard behavior.

Source issue repository: microsoft/AlAppExtensions; issue number: 30383

## Changes Made
- `Purch. Availability Mgt.TransferPurchaseLine` - added an IsHandled integration event before the unsupported-source error so extensions can handle additional purchase document types.

Fixes [AB#644932](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644932)





