### PR TITLE
[Extensibility Request] issue 30384: expose planning suggestions variable

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Availability/ItemAvailabilitybyEvent.Page.al
+++ b/src/Layers/W1/BaseApp/Inventory/Availability/ItemAvailabilitybyEvent.Page.al
@@ -478,12 +478,12 @@ page 5530 "Item Availability by Event"
         EnableShowDocumentAction: Boolean;
 
     protected var
-        IncludePlanningSuggestions: Boolean;
         TempInvtPageData: Record "Inventory Page Data" temporary;
         ItemNo: Code[20];
         LocationFilter: Text;
         VariantFilter: Text;
         PeriodType: Option Day,Week,Month,Quarter,Year;
+        IncludePlanningSuggestions: Boolean;
 
     protected procedure InitAndCalculatePeriodEntries()
     begin

--- a/src/Layers/W1/BaseApp/Inventory/Availability/ItemAvailabilitybyEvent.Page.al
+++ b/src/Layers/W1/BaseApp/Inventory/Availability/ItemAvailabilitybyEvent.Page.al
@@ -473,12 +473,12 @@ page 5530 "Item Availability by Event"
         ForecastName: Code[10];
         LastUpdateTime: DateTime;
         SelectedDate: Date;
-        IncludePlanningSuggestions: Boolean;
         IncludeBlanketOrders: Boolean;
         Emphasize: Boolean;
         EnableShowDocumentAction: Boolean;
 
     protected var
+        IncludePlanningSuggestions: Boolean;
         TempInvtPageData: Record "Inventory Page Data" temporary;
         ItemNo: Code[20];
         LocationFilter: Text;


### PR DESCRIPTION
## Summary
Page extensions need access to the setting that controls whether planning suggestions are included on the Item Availability by Event page. This change exposes the existing variable through the page's protected scope without changing its behavior.

Source issue repository: microsoft/AlAppExtensions; issue number: 30384

## Changes Made
- `Page 5530 "Item Availability by Event"` - moved `IncludePlanningSuggestions` to the protected variable section so page extensions can access it.

Fixes [AB#644568](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644568)



