### PR TITLE
[Extensibility Request] issue 30392: make Archive Jobs extensible

### DIFF
--- a/src/Layers/W1/BaseApp/Projects/Project/Setup/JobArchiveOption.Enum.al
+++ b/src/Layers/W1/BaseApp/Projects/Project/Setup/JobArchiveOption.Enum.al
@@ -1,0 +1,15 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Projects.Project.Setup;
+
+enum 1005 "Job Archive Option"
+{
+    Extensible = true;
+    AssignmentCompatibility = true;
+
+    value(0; Never) { Caption = 'Never'; }
+    value(1; Question) { Caption = 'Question'; }
+    value(2; Always) { Caption = 'Always'; }
+}

--- a/src/Layers/W1/BaseApp/Projects/Project/Setup/JobsSetup.Table.al
+++ b/src/Layers/W1/BaseApp/Projects/Project/Setup/JobsSetup.Table.al
@@ -90,12 +90,10 @@ table 315 "Jobs Setup"
             ToolTip = 'Specifies the code for the number series that will be used to assign numbers to project WIP documents. To see the number series that have been set up in the No. Series table, click the drop-down arrow in the field.';
             TableRelation = "No. Series";
         }
-        field(50; "Archive Jobs"; Option)
+        field(50; "Archive Jobs"; Enum "Job Archive Option")
         {
             Caption = 'Archive Projects';
             ToolTip = 'Specifies if you want to automatically archive projects when: deleted, status changed, when project or project task quote sent to customer or related sales invoice posted.';
-            OptionCaption = 'Never,Question,Always';
-            OptionMembers = Never,Question,Always;
             DataClassification = CustomerContent;
         }
         field(1001; "Automatic Update Job Item Cost"; Boolean)
@@ -193,4 +191,3 @@ table 315 "Jobs Setup"
     var
         RecordHasBeenRead: Boolean;
 }
-


### PR DESCRIPTION
## Summary
The issue author needs the Archive Projects setting to support additional choices beyond the built-in Never, Question, and Always values. This PR replaces the option field with an extensible, assignment-compatible enum while preserving the existing value ordinals and behavior.

Source issue repository: microsoft/AlAppExtensions; issue number: 30392

## Changes Made
- `Jobs Setup.Archive Jobs` / `Job Archive Option` - replaced the fixed option with an extensible enum in W1 while retaining the existing choices and assignment compatibility.


Fixes [AB#644931](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644931)




