### PR TITLE
[Main]-Production BOM Version certification does not check Variant Mandatory on lines

### DIFF
--- a/src/Layers/CZ/Tests/SCM-Manufacturing/SCMManufacturing.Codeunit.al
+++ b/src/Layers/CZ/Tests/SCM-Manufacturing/SCMManufacturing.Codeunit.al
@@ -5076,6 +5076,74 @@ codeunit 137404 "SCM Manufacturing"
         VerifyCalendarEntryExistence("Capacity Type"::"Machine Center", MachineCenter[2]."No.", false);
     end;
 
+    [Test]
+    procedure CertifyProdBOMVersionWithMissingMandatoryVariantError()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ProductionBOMHeader: Record "Production BOM Header";
+        ProductionBOMLine: Record "Production BOM Line";
+        ProductionBOMVersion: Record "Production BOM Version";
+    begin
+        // [SCENARIO 642632] Certifying a Production BOM Version with a variant-mandatory item and blank Variant Code on a line is blocked.
+        Initialize();
+
+        // [GIVEN] Item with "Variant Mandatory if Exists" = Yes and one Item Variant.
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Variant Mandatory if Exists", Item."Variant Mandatory if Exists"::Yes);
+        Item.Modify(true);
+        LibraryInventory.CreateItemVariant(ItemVariant, Item."No.");
+
+        // [GIVEN] Production BOM Header with a Version that has a line referencing the item and blank Variant Code.
+        LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, Item."Base Unit of Measure");
+        LibraryManufacturing.CreateProductionBOMVersion(
+            ProductionBOMVersion, ProductionBOMHeader."No.", LibraryUtility.GenerateGUID(), Item."Base Unit of Measure");
+        LibraryManufacturing.CreateProductionBOMLine(
+            ProductionBOMHeader, ProductionBOMLine, ProductionBOMVersion."Version Code",
+            ProductionBOMLine.Type::Item, Item."No.", LibraryRandom.RandInt(10));
+
+        // [WHEN] Certifying the Production BOM Version.
+        asserterror ModifyProductionBOMVersionStatus(ProductionBOMVersion, ProductionBOMVersion.Status::Certified);
+
+        // [THEN] Certification is blocked because Variant Code must have a value.
+        Assert.ExpectedTestFieldError(ProductionBOMLine.FieldCaption("Variant Code"), '');
+    end;
+
+    [Test]
+    procedure CertifyProdBOMVersionWithMandatoryVariant()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ProductionBOMHeader: Record "Production BOM Header";
+        ProductionBOMLine: Record "Production BOM Line";
+        ProductionBOMVersion: Record "Production BOM Version";
+    begin
+        // [SCENARIO 642632] Certifying a Production BOM Version succeeds when the variant-mandatory item line has a Variant Code.
+        Initialize();
+
+        // [GIVEN] Item with "Variant Mandatory if Exists" = Yes and one Item Variant.
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Variant Mandatory if Exists", Item."Variant Mandatory if Exists"::Yes);
+        Item.Modify(true);
+        LibraryInventory.CreateItemVariant(ItemVariant, Item."No.");
+
+        // [GIVEN] Production BOM Header with a Version that has a line referencing the item with the Variant Code specified.
+        LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, Item."Base Unit of Measure");
+        LibraryManufacturing.CreateProductionBOMVersion(
+          ProductionBOMVersion, ProductionBOMHeader."No.", LibraryUtility.GenerateGUID(), Item."Base Unit of Measure");
+        LibraryManufacturing.CreateProductionBOMLine(
+          ProductionBOMHeader, ProductionBOMLine, ProductionBOMVersion."Version Code",
+          ProductionBOMLine.Type::Item, Item."No.", LibraryRandom.RandInt(10));
+        ProductionBOMLine.Validate("Variant Code", ItemVariant.Code);
+        ProductionBOMLine.Modify(true);
+
+        // [WHEN] Certifying the Production BOM Version.
+        ModifyProductionBOMVersionStatus(ProductionBOMVersion, ProductionBOMVersion.Status::Certified);
+
+        // [THEN] The Production BOM Version is Certified.
+        ProductionBOMVersion.TestField(Status, ProductionBOMVersion.Status::Certified);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";

--- a/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMVersion.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMVersion.Table.al
@@ -244,7 +244,7 @@ table 99000779 "Production BOM Version"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckVariantIfMandatory(var ProductionBOMVersion: Record "Production BOM Version"; var xProductionBOMVersion: Record "Production BOM Version"; var ProductionBOMLine: Record "Production BOM Line"; var IsHandled: Boolean)
+    local procedure OnBeforeCheckVariantIfMandatory(var ProductionBOMVersion: Record "Production BOM Version"; xProductionBOMVersion: Record "Production BOM Version"; var ProductionBOMLine: Record "Production BOM Line"; var IsHandled: Boolean)
     begin
     end;
 }

--- a/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMVersion.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMVersion.Table.al
@@ -73,11 +73,12 @@ table 99000779 "Production BOM Version"
 
             trigger OnValidate()
             var
-                ProdBOMHeader: Record "Production BOM Header";
                 PlanningAssignment: Record "Planning Assignment";
+                ProdBOMHeader: Record "Production BOM Header";
+                ProdBOMLineRec: Record "Production BOM Line";
                 ProdBOMCheck: Codeunit "Production BOM-Check";
-                SkipCommit: Boolean;
                 IsHandled: Boolean;
+                SkipCommit: Boolean;
             begin
                 IsHandled := false;
                 OnBeforeOnValidateStatus(Rec, xRec, IsHandled);
@@ -85,6 +86,13 @@ table 99000779 "Production BOM Version"
                     exit;
 
                 if (Status <> xRec.Status) and (Status = Status::Certified) then begin
+                    ProdBOMLineRec.SetLoadFields(Type, "No.", "Variant Code");
+                    ProdBOMLineRec.SetRange("Production BOM No.", "Production BOM No.");
+                    ProdBOMLineRec.SetRange("Version Code", "Version Code");
+                    if ProdBOMLineRec.FindSet() then
+                        repeat
+                            CheckVariantIfMandatory(ProdBOMLineRec);
+                        until ProdBOMLineRec.Next() = 0;
                     ProdBOMCheck.ProdBOMLineCheck("Production BOM No.", "Version Code");
                     TestField("Unit of Measure Code");
                     ProdBOMHeader.Get("Production BOM No.");
@@ -168,6 +176,20 @@ table 99000779 "Production BOM Version"
 #pragma warning restore AA0470
 #pragma warning restore AA0074
 
+    local procedure CheckVariantIfMandatory(var ProductionBOMLine: Record "Production BOM Line")
+    var
+        Item: Record Item;
+        IsHandled: Boolean;
+    begin
+        IsHandled := false;
+        OnBeforeCheckVariantIfMandatory(Rec, xRec, ProductionBOMLine, IsHandled);
+        if IsHandled then
+            exit;
+
+        if Item.IsVariantMandatory(ProductionBOMLine.Type = ProductionBOMLine.Type::Item, ProductionBOMLine."No.") then
+            ProductionBOMLine.TestField("Variant Code");
+    end;
+
     procedure AssistEdit(OldProdBOMVersion: Record "Production BOM Version"): Boolean
     var
         NoSeries: Codeunit "No. Series";
@@ -218,6 +240,11 @@ table 99000779 "Production BOM Version"
 
     [IntegrationEvent(true, false)]
     local procedure OnBeforeOnValidateStatus(var ProductionBOMVersion: Record "Production BOM Version"; var xProductionBOMVersion: Record "Production BOM Version"; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckVariantIfMandatory(var ProductionBOMVersion: Record "Production BOM Version"; xProductionBOMVersion: Record "Production BOM Version"; var ProductionBOMLine: Record "Production BOM Line"; var IsHandled: Boolean)
     begin
     end;
 }

--- a/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMVersion.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMVersion.Table.al
@@ -86,7 +86,7 @@ table 99000779 "Production BOM Version"
                     exit;
 
                 if (Status <> xRec.Status) and (Status = Status::Certified) then begin
-                    ProdBOMLineRec.SetLoadFields(Type, "No.", "Variant Code");
+                    ProdBOMLineRec.SetLoadFields("Production BOM No.", "Version Code", "Line No.", Type, "No.", "Variant Code");
                     ProdBOMLineRec.SetRange("Production BOM No.", "Production BOM No.");
                     ProdBOMLineRec.SetRange("Version Code", "Version Code");
                     if ProdBOMLineRec.FindSet() then

--- a/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMVersion.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMVersion.Table.al
@@ -244,7 +244,7 @@ table 99000779 "Production BOM Version"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckVariantIfMandatory(var ProductionBOMVersion: Record "Production BOM Version"; xProductionBOMVersion: Record "Production BOM Version"; var ProductionBOMLine: Record "Production BOM Line"; var IsHandled: Boolean)
+    local procedure OnBeforeCheckVariantIfMandatory(var ProductionBOMVersion: Record "Production BOM Version"; var xProductionBOMVersion: Record "Production BOM Version"; var ProductionBOMLine: Record "Production BOM Line"; var IsHandled: Boolean)
     begin
     end;
 }

--- a/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMVersion.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMVersion.Table.al
@@ -75,7 +75,6 @@ table 99000779 "Production BOM Version"
             var
                 PlanningAssignment: Record "Planning Assignment";
                 ProdBOMHeader: Record "Production BOM Header";
-                ProdBOMLineRec: Record "Production BOM Line";
                 ProdBOMCheck: Codeunit "Production BOM-Check";
                 IsHandled: Boolean;
                 SkipCommit: Boolean;
@@ -86,13 +85,7 @@ table 99000779 "Production BOM Version"
                     exit;
 
                 if (Status <> xRec.Status) and (Status = Status::Certified) then begin
-                    ProdBOMLineRec.SetLoadFields("Production BOM No.", "Version Code", "Line No.", Type, "No.", "Variant Code");
-                    ProdBOMLineRec.SetRange("Production BOM No.", "Production BOM No.");
-                    ProdBOMLineRec.SetRange("Version Code", "Version Code");
-                    if ProdBOMLineRec.FindSet() then
-                        repeat
-                            CheckVariantIfMandatory(ProdBOMLineRec);
-                        until ProdBOMLineRec.Next() = 0;
+                    CheckVariantMandatoryOnLines();
                     ProdBOMCheck.ProdBOMLineCheck("Production BOM No.", "Version Code");
                     TestField("Unit of Measure Code");
                     ProdBOMHeader.Get("Production BOM No.");
@@ -175,6 +168,19 @@ table 99000779 "Production BOM Version"
         Text001: Label 'You cannot rename the %1 when %2 is %3.';
 #pragma warning restore AA0470
 #pragma warning restore AA0074
+
+    local procedure CheckVariantMandatoryOnLines()
+    var
+        ProdBOMLineRec: Record "Production BOM Line";
+    begin
+        ProdBOMLineRec.SetLoadFields("Production BOM No.", "Version Code", "Line No.", Type, "No.", "Variant Code");
+        ProdBOMLineRec.SetRange("Production BOM No.", "Production BOM No.");
+        ProdBOMLineRec.SetRange("Version Code", "Version Code");
+        if ProdBOMLineRec.FindSet() then
+            repeat
+                CheckVariantIfMandatory(ProdBOMLineRec);
+            until ProdBOMLineRec.Next() = 0;
+    end;
 
     local procedure CheckVariantIfMandatory(var ProductionBOMLine: Record "Production BOM Line")
     var

--- a/src/Layers/W1/Tests/SCM-Manufacturing/SCMManufacturing.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/SCMManufacturing.Codeunit.al
@@ -5072,6 +5072,74 @@ codeunit 137404 "SCM Manufacturing"
         VerifyCalendarEntryExistence("Capacity Type"::"Machine Center", MachineCenter[2]."No.", false);
     end;
 
+    [Test]
+    procedure CertifyProdBOMVersionWithMissingMandatoryVariantError()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ProductionBOMHeader: Record "Production BOM Header";
+        ProductionBOMLine: Record "Production BOM Line";
+        ProductionBOMVersion: Record "Production BOM Version";
+    begin
+        // [SCENARIO 642632] Certifying a Production BOM Version with a variant-mandatory item and blank Variant Code on a line is blocked.
+        Initialize();
+
+        // [GIVEN] Item with "Variant Mandatory if Exists" = Yes and one Item Variant.
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Variant Mandatory if Exists", Item."Variant Mandatory if Exists"::Yes);
+        Item.Modify(true);
+        LibraryInventory.CreateItemVariant(ItemVariant, Item."No.");
+
+        // [GIVEN] Production BOM Header with a Version that has a line referencing the item and blank Variant Code.
+        LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, Item."Base Unit of Measure");
+        LibraryManufacturing.CreateProductionBOMVersion(
+            ProductionBOMVersion, ProductionBOMHeader."No.", LibraryUtility.GenerateGUID(), Item."Base Unit of Measure");
+        LibraryManufacturing.CreateProductionBOMLine(
+            ProductionBOMHeader, ProductionBOMLine, ProductionBOMVersion."Version Code",
+            ProductionBOMLine.Type::Item, Item."No.", LibraryRandom.RandInt(10));
+
+        // [WHEN] Certifying the Production BOM Version.
+        asserterror ModifyProductionBOMVersionStatus(ProductionBOMVersion, ProductionBOMVersion.Status::Certified);
+
+        // [THEN] Certification is blocked because Variant Code must have a value.
+        Assert.ExpectedTestFieldError(ProductionBOMLine.FieldCaption("Variant Code"), '');
+    end;
+
+    [Test]
+    procedure CertifyProdBOMVersionWithMandatoryVariant()
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        ProductionBOMHeader: Record "Production BOM Header";
+        ProductionBOMLine: Record "Production BOM Line";
+        ProductionBOMVersion: Record "Production BOM Version";
+    begin
+        // [SCENARIO 642632] Certifying a Production BOM Version succeeds when the variant-mandatory item line has a Variant Code.
+        Initialize();
+
+        // [GIVEN] Item with "Variant Mandatory if Exists" = Yes and one Item Variant.
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Variant Mandatory if Exists", Item."Variant Mandatory if Exists"::Yes);
+        Item.Modify(true);
+        LibraryInventory.CreateItemVariant(ItemVariant, Item."No.");
+
+        // [GIVEN] Production BOM Header with a Version that has a line referencing the item with the Variant Code specified.
+        LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, Item."Base Unit of Measure");
+        LibraryManufacturing.CreateProductionBOMVersion(
+          ProductionBOMVersion, ProductionBOMHeader."No.", LibraryUtility.GenerateGUID(), Item."Base Unit of Measure");
+        LibraryManufacturing.CreateProductionBOMLine(
+          ProductionBOMHeader, ProductionBOMLine, ProductionBOMVersion."Version Code",
+          ProductionBOMLine.Type::Item, Item."No.", LibraryRandom.RandInt(10));
+        ProductionBOMLine.Validate("Variant Code", ItemVariant.Code);
+        ProductionBOMLine.Modify(true);
+
+        // [WHEN] Certifying the Production BOM Version.
+        ModifyProductionBOMVersionStatus(ProductionBOMVersion, ProductionBOMVersion.Status::Certified);
+
+        // [THEN] The Production BOM Version is Certified.
+        ProductionBOMVersion.TestField(Status, ProductionBOMVersion.Status::Certified);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";


### PR DESCRIPTION
Workitem:- [Bug 642632](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/642632): [ALL-E] Production BOM Version certification does not check Variant Mandatory on lines

Fixes [AB#642632](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642632)


**ISSUE**:- Production BOM Version certification does not check Variant Mandatory on lines

**CAUSE**:- Production BOM Version certification does not check whether Variant Code is populated for items with Variant Mandatory enabled.

**SOLUTION**:- Added a validation during Production BOM Version certification to ensure that the Variant Code is specified for Production BOM lines containing items with Variant Mandatory enabled







