### PR TITLE
[BC-IN] TDS Amount Not Calculated on Initial TDS Section Selection in Bank Payment Voucher

### DIFF
--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/FAGLGeneral.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/FAGLGeneral.PageExt.al
@@ -172,7 +172,13 @@ pageextension 18251 "FA GL General" extends "Fixed Asset G/L Journal"
     local procedure CallTaxEngine()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTBankPaymentVoucherExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTBankPaymentVoucherExt.PageExt.al
@@ -184,7 +184,13 @@ pageextension 18243 "GST Bank Payment Voucher Ext" extends "Bank Payment Voucher
     local procedure CallTaxEngine()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTBankReceiptVoucherExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTBankReceiptVoucherExt.PageExt.al
@@ -197,7 +197,13 @@ pageextension 18244 "GST Bank Receipt Voucher Ext" extends "Bank Receipt Voucher
     local procedure CallTaxEngine()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTCashPaymentVoucherExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTCashPaymentVoucherExt.PageExt.al
@@ -115,7 +115,13 @@ pageextension 18245 "GST Cash Payment Voucher Ext" extends "Cash Payment Voucher
     local procedure CallTaxEngine()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTCashReceiptJournalExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTCashReceiptJournalExt.PageExt.al
@@ -113,7 +113,13 @@ pageextension 18256 "GST Cash Receipt Journal Ext" extends "Cash Receipt Journal
     local procedure CallTaxEngine()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTCashReceiptVoucherExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTCashReceiptVoucherExt.PageExt.al
@@ -121,7 +121,13 @@ pageextension 18252 "GST Cash Receipt Voucher Ext" extends "Cash Receipt Voucher
     local procedure CallTaxEngine()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTGeneralJournalExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTGeneralJournalExt.PageExt.al
@@ -304,7 +304,13 @@ pageextension 18246 "GST General Journal Ext" extends "General Journal"
     local procedure CallTaxEngine()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTPaymentJournalExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTPaymentJournalExt.PageExt.al
@@ -188,7 +188,13 @@ pageextension 18250 "GST Payment Journal Ext" extends "Payment Journal"
     local procedure CallTaxEngine()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTPurchaseJournalExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTPurchaseJournalExt.PageExt.al
@@ -226,7 +226,13 @@ pageextension 18248 "GST Purchase Journal Ext" extends "Purchase Journal"
     local procedure CallTaxEngine()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTSalesJournalExt.PageExt.al
+++ b/src/Apps/IN/INGST/app/GSTPayments/src/PageExtension/GSTSalesJournalExt.PageExt.al
@@ -132,7 +132,13 @@ pageextension 18249 "GST Sales Journal Ext" extends "Sales Journal"
     local procedure CallTaxEngine()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSBase/src/pageextension/GeneralJournalTCS.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSBase/src/pageextension/GeneralJournalTCS.PageExt.al
@@ -61,7 +61,13 @@ pageextension 18809 "General Journal TCS" extends "General Journal"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/BankPaymentVoucher.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/BankPaymentVoucher.PageExt.al
@@ -113,7 +113,13 @@ pageextension 18900 "Bank Payment Voucher" extends "Bank Payment Voucher"
     procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/BankReceiptVoucher.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/BankReceiptVoucher.PageExt.al
@@ -126,7 +126,13 @@ pageextension 18901 "Bank Receipt Voucher" extends "Bank Receipt Voucher"
     procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/CashPaymentVoucher.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/CashPaymentVoucher.PageExt.al
@@ -114,7 +114,13 @@ pageextension 18902 "Cash Payment Voucher" extends "Cash Payment Voucher"
     procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/CashReceiptJournalExt.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/CashReceiptJournalExt.PageExt.al
@@ -137,7 +137,13 @@ pageextension 18904 "Cash Receipt Journal Ext" extends "Cash Receipt Journal"
     procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/CashReceiptVoucher.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/CashReceiptVoucher.PageExt.al
@@ -126,7 +126,13 @@ pageextension 18903 "Cash Receipt Voucher" extends "Cash Receipt Voucher"
     procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/PaymentJournalTCS.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSOnReceipt/src/pageextension/PaymentJournalTCS.PageExt.al
@@ -115,7 +115,13 @@ pageextension 18905 "Payment Journal TCS" extends "Payment Journal"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTCS/app/TCSOnSales/src/pageextension/SalesJournal.PageExt.al
+++ b/src/Apps/IN/INTCS/app/TCSOnSales/src/pageextension/SalesJournal.PageExt.al
@@ -57,7 +57,13 @@ pageextension 18840 "Sales Journal" extends "Sales Journal"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSForCustomer/src/pageextension/CashReceiptJournalTDS.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSForCustomer/src/pageextension/CashReceiptJournalTDS.PageExt.al
@@ -44,7 +44,13 @@ pageextension 18667 "Cash Receipt Journal TDS" extends "Cash Receipt Journal"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/BankReceiptVoucher.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/BankReceiptVoucher.PageExt.al
@@ -72,7 +72,13 @@ pageextension 18767 "Bank Receipt Voucher" extends "Bank Receipt Voucher"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/CashReceiptVoucher.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/CashReceiptVoucher.PageExt.al
@@ -72,7 +72,13 @@ pageextension 18769 "Cash Receipt Voucher" extends "Cash Receipt Voucher"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/GeneralJournalExt.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/GeneralJournalExt.PageExt.al
@@ -151,7 +151,13 @@ pageextension 18766 "General Journal Ext" extends "General Journal"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/JournalVoucher.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/JournalVoucher.PageExt.al
@@ -151,7 +151,13 @@ pageextension 18770 "Journal Voucher" extends "Journal Voucher"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/PurchaseJournalTDS.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSOnPayments/src/pageextension/PurchaseJournalTDS.PageExt.al
@@ -124,7 +124,13 @@ pageextension 18768 "Purchase Journal TDS" extends "Purchase Journal"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSReturnAndSettlement/src/pageextension/BankPaymentVoucher.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSReturnAndSettlement/src/pageextension/BankPaymentVoucher.PageExt.al
@@ -88,7 +88,13 @@ pageextension 18747 "Bank Payment Voucher" extends "Bank Payment Voucher"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSReturnAndSettlement/src/pageextension/CashPaymentVoucher.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSReturnAndSettlement/src/pageextension/CashPaymentVoucher.PageExt.al
@@ -88,7 +88,13 @@ pageextension 18748 "Cash Payment Voucher" extends "Cash Payment Voucher"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTDS/app/TDSReturnAndSettlement/src/pageextension/PaymentJnl.PageExt.al
+++ b/src/Apps/IN/INTDS/app/TDSReturnAndSettlement/src/pageextension/PaymentJnl.PageExt.al
@@ -117,7 +117,13 @@ pageextension 18746 "Payment Jnl" extends "Payment Journal"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTaxBase/app/src/codeunit/CalculateTax.Codeunit.al
+++ b/src/Apps/IN/INTaxBase/app/src/codeunit/CalculateTax.Codeunit.al
@@ -37,6 +37,7 @@ codeunit 18543 "Calculate Tax"
 
     procedure RunOnBeforeUpdateTaxAmountOnGenJnlLine(var GenJournalLine: Record "Gen. Journal Line"; var xGenJournalLine: Record "Gen. Journal Line"; var IsHandled: Boolean)
     begin
+        IsHandled := false;
         OnBeforeUpdateTaxAmountOnGenJnlLine(GenJournalLine, xGenJournalLine, IsHandled);
     end;
 

--- a/src/Apps/IN/INTaxBase/app/src/codeunit/CalculateTax.Codeunit.al
+++ b/src/Apps/IN/INTaxBase/app/src/codeunit/CalculateTax.Codeunit.al
@@ -35,6 +35,11 @@ codeunit 18543 "Calculate Tax"
         OnAfterValidateGenJnlLineFields(GenJournalLine);
     end;
 
+    procedure RunOnBeforeUpdateTaxAmountOnGenJnlLine(var GenJournalLine: Record "Gen. Journal Line"; var xGenJournalLine: Record "Gen. Journal Line"; var IsHandled: Boolean)
+    begin
+        OnBeforeUpdateTaxAmountOnGenJnlLine(GenJournalLine, xGenJournalLine, IsHandled);
+    end;
+
     procedure CallTaxEngineOnSalesLine(
         var SalesLine: Record "Sales Line";
         var xSalesLine: Record "Sales Line")
@@ -262,6 +267,11 @@ codeunit 18543 "Calculate Tax"
 
     [IntegrationEvent(false, false)]
     procedure OnBeforeCallTaxEngineForGenJnlLine(var GenJournalLine: Record "Gen. Journal Line"; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeUpdateTaxAmountOnGenJnlLine(var GenJournalLine: Record "Gen. Journal Line"; var xGenJournalLine: Record "Gen. Journal Line"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Apps/IN/INTaxBase/app/src/pageextension/CashReceiptJournal.PageExt.al
+++ b/src/Apps/IN/INTaxBase/app/src/pageextension/CashReceiptJournal.PageExt.al
@@ -87,7 +87,13 @@ pageextension 18575 "Cash Receipt Journal" extends "Cash Receipt Journal"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTaxBase/app/src/pageextension/GeneralJournal.PageExt.al
+++ b/src/Apps/IN/INTaxBase/app/src/pageextension/GeneralJournal.PageExt.al
@@ -87,7 +87,13 @@ pageextension 18545 "General Journal" extends "General Journal"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTaxBase/app/src/pageextension/PaymentJournal.PageExt.al
+++ b/src/Apps/IN/INTaxBase/app/src/pageextension/PaymentJournal.PageExt.al
@@ -87,7 +87,13 @@ pageextension 18549 "Payment Journal" extends "Payment Journal"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }

--- a/src/Apps/IN/INTaxBase/app/src/pageextension/PurchaseJournal.PageExt.al
+++ b/src/Apps/IN/INTaxBase/app/src/pageextension/PurchaseJournal.PageExt.al
@@ -84,7 +84,13 @@ pageextension 18551 "Purchase Journal" extends "Purchase Journal"
     local procedure UpdateTaxAmount()
     var
         CalculateTax: Codeunit "Calculate Tax";
+        IsHandled: Boolean;
     begin
+        CalculateTax.RunOnBeforeUpdateTaxAmountOnGenJnlLine(Rec, xRec, IsHandled);
+        if IsHandled then
+            exit;
+
+        CurrPage.SaveRecord();
         CalculateTax.CallTaxEngineOnGenJnlLine(Rec, xRec);
     end;
 }


### PR DESCRIPTION
[Bug 645153](https://dev.azure.com/dynamicssmb2/Dynamics%20SMB/_workitems/edit/645153): Incident 21000001325417 : [BC-IN] [Standard] Online: [IN Localization] TDS Amount Not Calculated on Initial TDS Section Selection in Bank Payment Voucher - 2607260030000337

[AB#645153](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645153)

**Issue:**
TDS/GST/TCS did not calculate on first entry of the tax fields (e.g. TDS Section Code) on journal/voucher pages. Tax showed only after re-editing the line (base amount visible, tax = 0).

**Cause:**
Commit #8935 removed `CurrPage.SaveRecord()` from `UpdateTaxAmount()`/`CallTaxEngine()`, so the tax engine ran on an unsaved line and produced no tax on the first pass.

**Solution:**
Restored `CurrPage.SaveRecord()` in all 31 India journal/voucher page extensions and added a single integration event `OnBeforeUpdateTaxAmountOnGenJnlLine` on codeunit `Calculate Tax`. A subscriber (e.g. customer PTE) can set `IsHandled` to take over the save + tax calculation and suppress redundant approval-workflow lookups on high-workflow environments, without forcing that on everyone.



