### PR TITLE
Fix stale PR cleanup for empty repositories and forks

### DIFF
--- a/.github/actions/CleanUpStalePRChecks/action.ps1
+++ b/.github/actions/CleanUpStalePRChecks/action.ps1
@@ -21,7 +21,7 @@ if ($WhatIf) {
 Write-Host "Fetching open pull requests..."
 
 # Get all open pull requests with mergeable state
-$prs = gh pr list --state open --json number,title,url,mergeable --limit 1000 | ConvertFrom-Json
+$prs = @(gh pr list --state open --json number,title,url,mergeable --limit 1000 | ConvertFrom-Json)
 
 Write-Host "Found $($prs.Count) open pull requests"
 

--- a/.github/workflows/CleanUpStalePRChecks.yaml
+++ b/.github/workflows/CleanUpStalePRChecks.yaml
@@ -17,6 +17,7 @@ defaults:
 
 jobs:
   CleanUpStatusChecks:
+    if: github.repository_owner == 'microsoft'
     runs-on: ubuntu-latest
     name: Clean Up Stale PR Status Checks
     steps:


### PR DESCRIPTION
## What & why

The stale PR cleanup action fails under strict mode when `gh pr list` returns no open pull requests because the deserialized result is `$null` and has no `Count` property. Normalize the result to an array so zero, one, and multiple PRs are handled consistently.

The scheduled cleanup job is also limited to Microsoft-owned repositories, preventing copied workflows from consuming runners or modifying pull requests in forks.

## Linked work

Fixes #9867

[AB#645222](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645222)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required - be specific: scenarios, commands, screenshots for UI changes)*

- Parsed zero, one, and two PR JSON results under PowerShell strict mode and confirmed the normalized arrays report counts of 0, 1, and 2.
- Parsed the updated PowerShell action successfully and checked the workflow changes for whitespace errors.
- No automated tests were added because this is a focused GitHub Actions and PowerShell edge-case fix.

## Risk & compatibility

Low risk. The owner condition intentionally skips this scheduled maintenance job in non-Microsoft repositories, while manual action behavior remains unchanged.
