### PR TITLE
Enable TranslationsWithNamespaces in app.json

### DIFF
--- a/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/app.json
+++ b/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/app.json
@@ -20,7 +20,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "internalsVisibleTo": [
     {

--- a/src/Apps/APAC/EDocumentFormats/PINT A-NZ/test/app.json
+++ b/src/Apps/APAC/EDocumentFormats/PINT A-NZ/test/app.json
@@ -52,7 +52,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/AT/ContosoCoffeeDemoDatasetAT/app/app.json
+++ b/src/Apps/AT/ContosoCoffeeDemoDatasetAT/app/app.json
@@ -32,5 +32,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/AT/EDocument_AT/demo data/app.json
+++ b/src/Apps/AT/EDocument_AT/demo data/app.json
@@ -40,7 +40,8 @@
     "screenshots": [],
     "platform": "29.0.0.0",
     "features": [
-        "TranslationFile"
+        "TranslationFile",
+        "TranslationsWithNamespaces"
     ],
     "idRanges": [
         {

--- a/src/Apps/AT/ExpenseAgent_AT/app/app.json
+++ b/src/Apps/AT/ExpenseAgent_AT/app/app.json
@@ -29,7 +29,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/AT/ExpenseAgent_AT/demo data/app.json
+++ b/src/Apps/AT/ExpenseAgent_AT/demo data/app.json
@@ -53,6 +53,7 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/AT/IntrastatAT/app/app.json
+++ b/src/Apps/AT/IntrastatAT/app/app.json
@@ -37,5 +37,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/AU/ContosoCoffeeDemoDatasetAU/app/app.json
+++ b/src/Apps/AU/ContosoCoffeeDemoDatasetAU/app/app.json
@@ -32,5 +32,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/AU/EDocument_AU/demo data/app.json
+++ b/src/Apps/AU/EDocument_AU/demo data/app.json
@@ -40,7 +40,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/AU/ExpenseAgent_AU/app/app.json
+++ b/src/Apps/AU/ExpenseAgent_AU/app/app.json
@@ -29,7 +29,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/AU/ExpenseAgent_AU/demo data/app.json
+++ b/src/Apps/AU/ExpenseAgent_AU/demo data/app.json
@@ -53,6 +53,7 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/BE/ContosoCoffeeDemoDatasetBE/app/app.json
+++ b/src/Apps/BE/ContosoCoffeeDemoDatasetBE/app/app.json
@@ -32,5 +32,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/BE/EDocument_BE/demo data/app.json
+++ b/src/Apps/BE/EDocument_BE/demo data/app.json
@@ -53,6 +53,7 @@
     "application": "30.0.0.0",
     "target": "OnPrem",
     "features": [
-        "TranslationFile"
+        "TranslationFile",
+        "TranslationsWithNamespaces"
     ]
 }

--- a/src/Apps/BE/IntrastatBE/app/app.json
+++ b/src/Apps/BE/IntrastatBE/app/app.json
@@ -33,5 +33,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/BE/PeppolBE/App/app.json
+++ b/src/Apps/BE/PeppolBE/App/app.json
@@ -31,7 +31,8 @@
   "application": "30.0.0.0",
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/BE/ShopifyBE/App/app.json
+++ b/src/Apps/BE/ShopifyBE/App/app.json
@@ -37,6 +37,7 @@
   "target": "OnPrem",
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/BE/ShopifyBE/Test/app.json
+++ b/src/Apps/BE/ShopifyBE/Test/app.json
@@ -65,6 +65,7 @@
   },
   "application": "30.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/CA/ContosoCoffeeDemoDatasetCA/app/app.json
+++ b/src/Apps/CA/ContosoCoffeeDemoDatasetCA/app/app.json
@@ -36,5 +36,8 @@
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
   },
-  "target": "OnPrem"
+  "target": "OnPrem",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CA/EDocument_CA/demo data/app.json
+++ b/src/Apps/CA/EDocument_CA/demo data/app.json
@@ -40,7 +40,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/CA/ExpenseAgent_CA/app/app.json
+++ b/src/Apps/CA/ExpenseAgent_CA/app/app.json
@@ -29,7 +29,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/CA/ExpenseAgent_CA/demo data/app.json
+++ b/src/Apps/CA/ExpenseAgent_CA/demo data/app.json
@@ -53,6 +53,7 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/CH/ContosoCoffeeDemoDatasetCH/app/app.json
+++ b/src/Apps/CH/ContosoCoffeeDemoDatasetCH/app/app.json
@@ -36,5 +36,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CH/EDocument_CH/demo data/app.json
+++ b/src/Apps/CH/EDocument_CH/demo data/app.json
@@ -40,7 +40,8 @@
     "screenshots": [],
     "platform": "29.0.0.0",
     "features": [
-        "TranslationFile"
+        "TranslationFile",
+        "TranslationsWithNamespaces"
     ],
     "idRanges": [
         {

--- a/src/Apps/CH/SwissQRBill/app/app.json
+++ b/src/Apps/CH/SwissQRBill/app/app.json
@@ -33,5 +33,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CZ/AdvancePaymentsLocalization/app/app.json
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/app/app.json
@@ -46,5 +46,8 @@
       "publisher": "Microsoft"
     }
   ],
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CZ/AdvancePaymentsLocalization/demo data/app.json
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/demo data/app.json
@@ -39,5 +39,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CZ/AdvancedLocalizationPack/app/app.json
+++ b/src/Apps/CZ/AdvancedLocalizationPack/app/app.json
@@ -27,5 +27,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CZ/BankingDocumentsLocalization/app/app.json
+++ b/src/Apps/CZ/BankingDocumentsLocalization/app/app.json
@@ -27,5 +27,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CZ/BankingDocumentsLocalization/demo data/app.json
+++ b/src/Apps/CZ/BankingDocumentsLocalization/demo data/app.json
@@ -39,5 +39,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CZ/CashDeskLocalization/app/app.json
+++ b/src/Apps/CZ/CashDeskLocalization/app/app.json
@@ -27,5 +27,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CZ/CashDeskLocalization/demo data/app.json
+++ b/src/Apps/CZ/CashDeskLocalization/demo data/app.json
@@ -39,5 +39,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CZ/CompensationLocalization/app/app.json
+++ b/src/Apps/CZ/CompensationLocalization/app/app.json
@@ -27,5 +27,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CZ/CompensationLocalization/demo data/app.json
+++ b/src/Apps/CZ/CompensationLocalization/demo data/app.json
@@ -39,5 +39,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CZ/ContosoCoffeeDemoDatasetCZ/app/app.json
+++ b/src/Apps/CZ/ContosoCoffeeDemoDatasetCZ/app/app.json
@@ -35,5 +35,8 @@
   },
   "resourceFolders": [
     ".resources"
+  ],
+  "features": [
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/CZ/CoreLocalizationPack/app/app.json
+++ b/src/Apps/CZ/CoreLocalizationPack/app/app.json
@@ -34,5 +34,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CZ/EDocument_CZ/demo data/app.json
+++ b/src/Apps/CZ/EDocument_CZ/demo data/app.json
@@ -40,7 +40,8 @@
     "screenshots": [],
     "platform": "29.0.0.0",
     "features": [
-        "TranslationFile"
+        "TranslationFile",
+        "TranslationsWithNamespaces"
     ],
     "idRanges": [
         {

--- a/src/Apps/CZ/FixedAssetLocalization/app/app.json
+++ b/src/Apps/CZ/FixedAssetLocalization/app/app.json
@@ -27,5 +27,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CZ/FixedAssetLocalization/demo data/app.json
+++ b/src/Apps/CZ/FixedAssetLocalization/demo data/app.json
@@ -39,5 +39,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CZ/IntrastatCZ/app/app.json
+++ b/src/Apps/CZ/IntrastatCZ/app/app.json
@@ -39,5 +39,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/CZ/IntrastatCZ/demo data/app.json
+++ b/src/Apps/CZ/IntrastatCZ/demo data/app.json
@@ -54,5 +54,8 @@
     ".resources"
   ],
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/DE/ContosoCoffeeDemoDatasetDE/app/app.json
+++ b/src/Apps/DE/ContosoCoffeeDemoDatasetDE/app/app.json
@@ -20,7 +20,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "screenshots": [],
   "platform": "29.0.0.0",

--- a/src/Apps/DE/EDocumentDE/app/app.json
+++ b/src/Apps/DE/EDocumentDE/app/app.json
@@ -51,6 +51,7 @@
   "application": "30.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/DE/EDocumentDE/demo data/app.json
+++ b/src/Apps/DE/EDocumentDE/demo data/app.json
@@ -40,7 +40,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {
@@ -56,6 +57,7 @@
   "application": "30.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/DE/EDocumentDE/test/app.json
+++ b/src/Apps/DE/EDocumentDE/test/app.json
@@ -72,7 +72,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceFolders": [
     ".resources"

--- a/src/Apps/DE/Elster/app/app.json
+++ b/src/Apps/DE/Elster/app/app.json
@@ -20,5 +20,8 @@
   },
   "platform": "29.0.0.0",
   "target": "OnPrem",
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/DE/ExpenseAgent_DE/app/app.json
+++ b/src/Apps/DE/ExpenseAgent_DE/app/app.json
@@ -29,7 +29,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/DE/ExpenseAgent_DE/demo data/app.json
+++ b/src/Apps/DE/ExpenseAgent_DE/demo data/app.json
@@ -53,6 +53,7 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/DE/IntrastatDE/app/app.json
+++ b/src/Apps/DE/IntrastatDE/app/app.json
@@ -33,5 +33,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/DE/PEPPOLDE/app/app.json
+++ b/src/Apps/DE/PEPPOLDE/app/app.json
@@ -37,7 +37,8 @@
   "application": "30.0.0.0",
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/DK/C52012DataMigration/app/app.json
+++ b/src/Apps/DK/C52012DataMigration/app/app.json
@@ -27,5 +27,8 @@
       "name": "C5 2012 Data Migration Tests",
       "publisher": "Microsoft"
     }
+  ],
+  "features": [
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/DK/ContosoCoffeeDemoDatasetDK/app/app.json
+++ b/src/Apps/DK/ContosoCoffeeDemoDatasetDK/app/app.json
@@ -32,5 +32,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/DK/DKCore/app/app.json
+++ b/src/Apps/DK/DKCore/app/app.json
@@ -25,5 +25,8 @@
       "from": 13600,
       "to": 13699
     }
+  ],
+  "features": [
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/DK/EDocumentFormatOIOUBL/app/app.json
+++ b/src/Apps/DK/EDocumentFormatOIOUBL/app/app.json
@@ -45,5 +45,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "OnPrem"
+  "target": "OnPrem",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/DK/EDocumentFormatOIOUBL/test/app.json
+++ b/src/Apps/DK/EDocumentFormatOIOUBL/test/app.json
@@ -52,7 +52,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/DK/EDocument_DK/demo data/app.json
+++ b/src/Apps/DK/EDocument_DK/demo data/app.json
@@ -40,7 +40,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/DK/ElectronicVATDeclarationDK/app/app.json
+++ b/src/Apps/DK/ElectronicVATDeclarationDK/app/app.json
@@ -41,5 +41,8 @@
       "publisher": "Microsoft"
     }
   ],
-  "target": "OnPrem"
+  "target": "OnPrem",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/DK/EnforcedDigitalVouchersDK/app/app.json
+++ b/src/Apps/DK/EnforcedDigitalVouchersDK/app/app.json
@@ -22,7 +22,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/DK/ExpenseAgent_DK/app/app.json
+++ b/src/Apps/DK/ExpenseAgent_DK/app/app.json
@@ -29,7 +29,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/DK/ExpenseAgent_DK/demo data/app.json
+++ b/src/Apps/DK/ExpenseAgent_DK/demo data/app.json
@@ -53,6 +53,7 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/DK/FIK/app/app.json
+++ b/src/Apps/DK/FIK/app/app.json
@@ -20,5 +20,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/DK/ImportDKPayroll/app/app.json
+++ b/src/Apps/DK/ImportDKPayroll/app/app.json
@@ -20,5 +20,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/DK/NemhandelNotification/app/app.json
+++ b/src/Apps/DK/NemhandelNotification/app/app.json
@@ -41,5 +41,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/DK/OIOUBL/app/app.json
+++ b/src/Apps/DK/OIOUBL/app/app.json
@@ -27,5 +27,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/DK/SAFTModificationDK/app/app.json
+++ b/src/Apps/DK/SAFTModificationDK/app/app.json
@@ -50,5 +50,8 @@
       "publisher": "Microsoft"
     }
   ],
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/DK/VATReportsDK/app/app.json
+++ b/src/Apps/DK/VATReportsDK/app/app.json
@@ -20,5 +20,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/ES/ContosoCoffeeDemoDatasetES/app/app.json
+++ b/src/Apps/ES/ContosoCoffeeDemoDatasetES/app/app.json
@@ -32,5 +32,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/ES/EDocumentES/demo data/app.json
+++ b/src/Apps/ES/EDocumentES/demo data/app.json
@@ -40,7 +40,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {
@@ -56,6 +57,7 @@
   "application": "30.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/ES/EDocumentFormats/DocumentRegistration/app/app.json
+++ b/src/Apps/ES/EDocumentFormats/DocumentRegistration/app/app.json
@@ -27,7 +27,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "screenshots": [],
   "platform": "29.0.0.0",

--- a/src/Apps/ES/EDocumentFormats/DocumentRegistration/test/app.json
+++ b/src/Apps/ES/EDocumentFormats/DocumentRegistration/test/app.json
@@ -50,7 +50,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "screenshots": [],
   "platform": "29.0.0.0",

--- a/src/Apps/ES/EDocumentFormats/FacturaE/app/app.json
+++ b/src/Apps/ES/EDocumentFormats/FacturaE/app/app.json
@@ -20,7 +20,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "screenshots": [],
   "platform": "29.0.0.0",

--- a/src/Apps/ES/EDocumentFormats/FacturaE/test/app.json
+++ b/src/Apps/ES/EDocumentFormats/FacturaE/test/app.json
@@ -52,7 +52,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/ES/EDocument_ES/demo data/app.json
+++ b/src/Apps/ES/EDocument_ES/demo data/app.json
@@ -40,7 +40,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {
@@ -56,6 +57,7 @@
   "application": "30.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/ES/ExpenseAgent_ES/app/app.json
+++ b/src/Apps/ES/ExpenseAgent_ES/app/app.json
@@ -29,7 +29,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/ES/ExpenseAgent_ES/demo data/app.json
+++ b/src/Apps/ES/ExpenseAgent_ES/demo data/app.json
@@ -53,6 +53,7 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/ES/IntrastatES/app/app.json
+++ b/src/Apps/ES/IntrastatES/app/app.json
@@ -33,5 +33,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/FI/ContosoCoffeeDemoDatasetFI/app/app.json
+++ b/src/Apps/FI/ContosoCoffeeDemoDatasetFI/app/app.json
@@ -32,5 +32,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/FI/EDocument_FI/demo data/app.json
+++ b/src/Apps/FI/EDocument_FI/demo data/app.json
@@ -40,7 +40,8 @@
     "screenshots": [],
     "platform": "29.0.0.0",
     "features": [
-        "TranslationFile"
+        "TranslationFile",
+        "TranslationsWithNamespaces"
     ],
     "idRanges": [
         {

--- a/src/Apps/FI/IntrastatFI/app/app.json
+++ b/src/Apps/FI/IntrastatFI/app/app.json
@@ -33,5 +33,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/FR/ContosoCoffeeDemoDatasetFR/app/app.json
+++ b/src/Apps/FR/ContosoCoffeeDemoDatasetFR/app/app.json
@@ -32,5 +32,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/FR/EDocument_FR/EReportingFR/app/app.json
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/app/app.json
@@ -48,6 +48,7 @@
   ],
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/FR/EDocument_FR/EReportingFR/test/app.json
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/test/app.json
@@ -46,7 +46,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceFolders": [
     ".resources"

--- a/src/Apps/FR/EDocument_FR/demo data/app.json
+++ b/src/Apps/FR/EDocument_FR/demo data/app.json
@@ -40,7 +40,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {
@@ -56,6 +57,7 @@
   "application": "30.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/FR/ExpenseAgent_FR/app/app.json
+++ b/src/Apps/FR/ExpenseAgent_FR/app/app.json
@@ -29,7 +29,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/FR/ExpenseAgent_FR/demo data/app.json
+++ b/src/Apps/FR/ExpenseAgent_FR/demo data/app.json
@@ -53,6 +53,7 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/FR/FAReportsFR/app/app.json
+++ b/src/Apps/FR/FAReportsFR/app/app.json
@@ -28,7 +28,8 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "target": "Cloud"
 }

--- a/src/Apps/FR/FAReportsFR/test/app.json
+++ b/src/Apps/FR/FAReportsFR/test/app.json
@@ -59,7 +59,8 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "target": "OnPrem"
 }

--- a/src/Apps/FR/FECAuditFile/app/app.json
+++ b/src/Apps/FR/FECAuditFile/app/app.json
@@ -33,5 +33,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/FR/IntrastatFR/app/app.json
+++ b/src/Apps/FR/IntrastatFR/app/app.json
@@ -33,5 +33,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/FR/PaymentManagementFR/app/app.json
+++ b/src/Apps/FR/PaymentManagementFR/app/app.json
@@ -36,6 +36,7 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/FR/PaymentManagementFR/test/app.json
+++ b/src/Apps/FR/PaymentManagementFR/test/app.json
@@ -48,6 +48,7 @@
   "target": "OnPrem",
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/FR/ServiceDeclarationFR/app/app.json
+++ b/src/Apps/FR/ServiceDeclarationFR/app/app.json
@@ -33,5 +33,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/GB/ContosoCoffeeDemoDatasetGB/app/app.json
+++ b/src/Apps/GB/ContosoCoffeeDemoDatasetGB/app/app.json
@@ -34,6 +34,7 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/GB/EDocument_GB/demo data/app.json
+++ b/src/Apps/GB/EDocument_GB/demo data/app.json
@@ -40,7 +40,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/GB/ExpenseAgent_GB/app/app.json
+++ b/src/Apps/GB/ExpenseAgent_GB/app/app.json
@@ -29,7 +29,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/GB/ExpenseAgent_GB/demo data/app.json
+++ b/src/Apps/GB/ExpenseAgent_GB/demo data/app.json
@@ -53,6 +53,7 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/GB/GovTalk/app/app.json
+++ b/src/Apps/GB/GovTalk/app/app.json
@@ -35,6 +35,7 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/GB/GovTalk/demo data/app.json
+++ b/src/Apps/GB/GovTalk/demo data/app.json
@@ -42,6 +42,7 @@
   "target": "OnPrem",
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/GB/GovTalk/test/app.json
+++ b/src/Apps/GB/GovTalk/test/app.json
@@ -58,6 +58,7 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/GB/IdealPostcodes/app/app.json
+++ b/src/Apps/GB/IdealPostcodes/app/app.json
@@ -31,7 +31,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "screenshots": [],
   "platform": "29.0.0.0",

--- a/src/Apps/GB/IdealPostcodes/test/app.json
+++ b/src/Apps/GB/IdealPostcodes/test/app.json
@@ -32,7 +32,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "screenshots": [],
   "platform": "29.0.0.0",

--- a/src/Apps/GB/PostingDateCheckOnPosting/app/app.json
+++ b/src/Apps/GB/PostingDateCheckOnPosting/app/app.json
@@ -30,6 +30,7 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/GB/PostingDateCheckOnPosting/test/app.json
+++ b/src/Apps/GB/PostingDateCheckOnPosting/test/app.json
@@ -55,6 +55,7 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/GB/ReportsGB/app/app.json
+++ b/src/Apps/GB/ReportsGB/app/app.json
@@ -37,6 +37,7 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/GB/ReportsGB/test/app.json
+++ b/src/Apps/GB/ReportsGB/test/app.json
@@ -60,6 +60,7 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/GB/ReverseChargeVAT/app/app.json
+++ b/src/Apps/GB/ReverseChargeVAT/app/app.json
@@ -31,6 +31,7 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/GB/ReverseChargeVAT/test/app.json
+++ b/src/Apps/GB/ReverseChargeVAT/test/app.json
@@ -54,6 +54,7 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/GB/UKMakingTaxDigital/app/app.json
+++ b/src/Apps/GB/UKMakingTaxDigital/app/app.json
@@ -27,5 +27,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/GB/VATReporting/app/app.json
+++ b/src/Apps/GB/VATReporting/app/app.json
@@ -31,6 +31,7 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/GB/VATReporting/test/app.json
+++ b/src/Apps/GB/VATReporting/test/app.json
@@ -54,6 +54,7 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/IN/ContosoCoffeeDemoDatasetIN/app/app.json
+++ b/src/Apps/IN/ContosoCoffeeDemoDatasetIN/app/app.json
@@ -80,5 +80,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/IN/INChargeGroup/app/ChargeGroupBase/app.json
+++ b/src/Apps/IN/INChargeGroup/app/ChargeGroupBase/app.json
@@ -35,7 +35,8 @@
   ],
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2139720",
   "resourceExposurePolicy": {

--- a/src/Apps/IN/INChargeGroup/app/app.json
+++ b/src/Apps/IN/INChargeGroup/app/app.json
@@ -38,5 +38,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/IN/INDataMigration/app.json
+++ b/src/Apps/IN/INDataMigration/app.json
@@ -57,5 +57,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "target": "OnPrem"
+  "target": "OnPrem",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/IN/INFADepreciation/app/app.json
+++ b/src/Apps/IN/INFADepreciation/app/app.json
@@ -11,7 +11,8 @@
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [],

--- a/src/Apps/IN/INGST/app/GSTBase/app.json
+++ b/src/Apps/IN/INGST/app/GSTBase/app.json
@@ -35,7 +35,8 @@
   ],
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2139720",
   "resourceExposurePolicy": {

--- a/src/Apps/IN/INGST/app/GSTDistribution/app.json
+++ b/src/Apps/IN/INGST/app/GSTDistribution/app.json
@@ -6,7 +6,8 @@
   "brief": "Contains features for GST distribution for services.",
   "description": "GST Distribution enables you to distribute GST receivables to locations.",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=724013",

--- a/src/Apps/IN/INGST/app/GSTPayments/app.json
+++ b/src/Apps/IN/INGST/app/GSTPayments/app.json
@@ -7,7 +7,8 @@
   "description": "GST on payments allows GST calculation on bank payments, bank receipts, bank charges, and cash payments and receipts. ",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=724013",

--- a/src/Apps/IN/INGST/app/GSTPurchase/app.json
+++ b/src/Apps/IN/INGST/app/GSTPurchase/app.json
@@ -7,7 +7,8 @@
   "description": "GST Purchase lets you calculate GST on purchase transactions such as purchase orders, invoices, purchase returns, credit memos, and journals.",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=724013",

--- a/src/Apps/IN/INGST/app/GSTReconcilation/app.json
+++ b/src/Apps/IN/INGST/app/GSTReconcilation/app.json
@@ -6,7 +6,8 @@
   "brief": "Contains features for reconciling Goods and Services Tax.",
   "description": "GST Reconciliation provides features for reconciling GST on purchase invoices with vendor invoices.",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=724013",

--- a/src/Apps/IN/INGST/app/GSTReturnSettlement/app.json
+++ b/src/Apps/IN/INGST/app/GSTReturnSettlement/app.json
@@ -6,7 +6,8 @@
   "brief": "Returns and settlement for GST payables and receivables.",
   "description": "GST Return and Settlement lets you settle GST payables with GST receiveables, and pay differential amounts to tax authorities.",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=724013",

--- a/src/Apps/IN/INGST/app/GSTSales/app.json
+++ b/src/Apps/IN/INGST/app/GSTSales/app.json
@@ -7,7 +7,8 @@
   "description": "GST Sales lets you calculate GST on sales transactions such as sales orders, invoices, sales returns, credit memos, and journals.",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=724013",

--- a/src/Apps/IN/INGST/app/GSTService/app.json
+++ b/src/Apps/IN/INGST/app/GSTService/app.json
@@ -6,7 +6,8 @@
   "brief": "GST on Service lets you calculate GST on service transactions such as Service Quote, Service Contract, Service Order, Service Invoice and Service Credit Memo.",
   "description": "GST on services contains feature for calculating GST when creating transactions related to service.",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=724013",

--- a/src/Apps/IN/INGST/app/GSTServiceTransfer/app.json
+++ b/src/Apps/IN/INGST/app/GSTServiceTransfer/app.json
@@ -7,7 +7,8 @@
   "description": "GST Service Transfer allows you to calculate GST when you transfer service from one location to another.",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=724013",

--- a/src/Apps/IN/INGST/app/GSTStockTransfer/app.json
+++ b/src/Apps/IN/INGST/app/GSTStockTransfer/app.json
@@ -7,7 +7,8 @@
   "description": "GST Stock Transfer contains features for calculating GST when you transfer stock.",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=724013",

--- a/src/Apps/IN/INGST/app/GSTSubcontracting/app.json
+++ b/src/Apps/IN/INGST/app/GSTSubcontracting/app.json
@@ -7,7 +7,8 @@
   "description": "GST Subcontracting Features",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=724013",

--- a/src/Apps/IN/INGST/app/app.json
+++ b/src/Apps/IN/INGST/app/app.json
@@ -12,7 +12,8 @@
   "logo": "ExtensionLogo.png",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "dependencies": [
     {

--- a/src/Apps/IN/INGST/test/GSTPurchase/app.json
+++ b/src/Apps/IN/INGST/test/GSTPurchase/app.json
@@ -6,7 +6,8 @@
   "brief": "Contains GST On Purchase Automated Tests",
   "description": "Contains GST On Purchase Automated Tests",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=724013",

--- a/src/Apps/IN/INGST/test/GSTSales/app.json
+++ b/src/Apps/IN/INGST/test/GSTSales/app.json
@@ -6,7 +6,8 @@
   "brief": "Contains GST Sales Automated Tests",
   "description": "Contains GST Sales Automated Tests",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=724013",

--- a/src/Apps/IN/INGateEntry/app/app.json
+++ b/src/Apps/IN/INGateEntry/app/app.json
@@ -38,5 +38,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/IN/INReports/app/app.json
+++ b/src/Apps/IN/INReports/app/app.json
@@ -10,7 +10,8 @@
   "help": "https://go.microsoft.com/fwlink/?linkid=2139720",
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INReports/test/app.json
+++ b/src/Apps/IN/INReports/test/app.json
@@ -10,7 +10,8 @@
   "help": "https://go.microsoft.com/fwlink/?linkid=2139720",
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INTCS/app/TCSBase/app.json
+++ b/src/Apps/IN/INTCS/app/TCSBase/app.json
@@ -11,7 +11,8 @@
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INTCS/app/TCSOnReceipt/app.json
+++ b/src/Apps/IN/INTCS/app/TCSOnReceipt/app.json
@@ -12,7 +12,8 @@
   "logo": "ExtensionLogo.png",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "dependencies": [
     {

--- a/src/Apps/IN/INTCS/app/TCSOnSales/app.json
+++ b/src/Apps/IN/INTCS/app/TCSOnSales/app.json
@@ -12,7 +12,8 @@
   "logo": "ExtensionLogo.png",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "dependencies": [
     {

--- a/src/Apps/IN/INTCS/app/app.json
+++ b/src/Apps/IN/INTCS/app/app.json
@@ -11,7 +11,8 @@
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INTCS/test/TCSBase/app.json
+++ b/src/Apps/IN/INTCS/test/TCSBase/app.json
@@ -10,7 +10,8 @@
   "help": "https://go.microsoft.com/fwlink/?linkid=2139281",
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INTCS/test/TCSOnReceipt/app.json
+++ b/src/Apps/IN/INTCS/test/TCSOnReceipt/app.json
@@ -10,7 +10,8 @@
   "help": "https://go.microsoft.com/fwlink/?linkid=2139281",
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "screenshots": [],

--- a/src/Apps/IN/INTCS/test/TCSOnSales/app.json
+++ b/src/Apps/IN/INTCS/test/TCSOnSales/app.json
@@ -10,7 +10,8 @@
   "help": "https://go.microsoft.com/fwlink/?linkid=2139281",
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INTCS/test/TCSReturnAndSettlement/app.json
+++ b/src/Apps/IN/INTCS/test/TCSReturnAndSettlement/app.json
@@ -10,7 +10,8 @@
   "help": "https://go.microsoft.com/fwlink/?linkid=2139281",
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INTCS/test/app.json
+++ b/src/Apps/IN/INTCS/test/app.json
@@ -10,7 +10,8 @@
   "help": "https://go.microsoft.com/fwlink/?linkid=2139281",
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INTDS/app/TDSBase/app.json
+++ b/src/Apps/IN/INTDS/app/TDSBase/app.json
@@ -11,7 +11,8 @@
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INTDS/app/TDSForCustomer/app.json
+++ b/src/Apps/IN/INTDS/app/TDSForCustomer/app.json
@@ -11,7 +11,8 @@
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INTDS/app/TDSOnPayments/app.json
+++ b/src/Apps/IN/INTDS/app/TDSOnPayments/app.json
@@ -14,7 +14,8 @@
   "platform": "29.0.0.0",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "dependencies": [
     {

--- a/src/Apps/IN/INTDS/app/TDSOnPurchase/app.json
+++ b/src/Apps/IN/INTDS/app/TDSOnPurchase/app.json
@@ -12,7 +12,8 @@
   "logo": "ExtensionLogo.png",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "application": "30.0.0.0",
   "platform": "29.0.0.0",

--- a/src/Apps/IN/INTDS/app/app.json
+++ b/src/Apps/IN/INTDS/app/app.json
@@ -11,7 +11,8 @@
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INTDS/test/TDSBase/app.json
+++ b/src/Apps/IN/INTDS/test/TDSBase/app.json
@@ -10,7 +10,8 @@
   "help": "https://go.microsoft.com/fwlink/?linkid=2139181",
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INTDS/test/TDSOnCustomer/app.json
+++ b/src/Apps/IN/INTDS/test/TDSOnCustomer/app.json
@@ -10,7 +10,8 @@
   "help": "https://go.microsoft.com/fwlink/?linkid=2139280",
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INTDS/test/TDSOnPurchase/app.json
+++ b/src/Apps/IN/INTDS/test/TDSOnPurchase/app.json
@@ -10,7 +10,8 @@
   "help": "https://go.microsoft.com/fwlink/?linkid=2139181",
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INTDS/test/TDSReturnAndSettlement/app.json
+++ b/src/Apps/IN/INTDS/test/TDSReturnAndSettlement/app.json
@@ -10,7 +10,8 @@
   "help": "https://go.microsoft.com/fwlink/?linkid=2139181",
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "platform": "29.0.0.0",

--- a/src/Apps/IN/INTDS/test/app.json
+++ b/src/Apps/IN/INTDS/test/app.json
@@ -10,7 +10,8 @@
   "help": "https://go.microsoft.com/fwlink/?linkid=2139181",
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INTaxBase/app/app.json
+++ b/src/Apps/IN/INTaxBase/app/app.json
@@ -6,7 +6,8 @@
   "brief": "Common Tax Setups",
   "description": "Tax base contains common setups for GST, TDS and TCS.",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=724013",

--- a/src/Apps/IN/INTaxBase/test/app.json
+++ b/src/Apps/IN/INTaxBase/test/app.json
@@ -10,7 +10,8 @@
   "help": "https://go.microsoft.com/fwlink/?linkid=2139281",
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png",
   "dependencies": [

--- a/src/Apps/IN/INVoucherInterface/app/app.json
+++ b/src/Apps/IN/INVoucherInterface/app/app.json
@@ -6,7 +6,8 @@
   "brief": "Contains functionality of Voucher Interface",
   "description": "Voucher Interface provides features that cover business scenarios in India. Voucher Interface is a standard solution for companies that record cash, bank, and journal transactions.",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=724013",

--- a/src/Apps/IN/QRGeneration/app/app.json
+++ b/src/Apps/IN/QRGeneration/app/app.json
@@ -12,7 +12,8 @@
   "logo": "ExtensionLogo.png",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "dependencies": [],
   "screenshots": [],

--- a/src/Apps/IS/ContosoCoffeeDemoDatasetIS/app/app.json
+++ b/src/Apps/IS/ContosoCoffeeDemoDatasetIS/app/app.json
@@ -32,5 +32,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/IS/ISCore/app/app.json
+++ b/src/Apps/IS/ISCore/app/app.json
@@ -26,5 +26,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/IT/ContosoCoffeeDemoDatasetIT/app/app.json
+++ b/src/Apps/IT/ContosoCoffeeDemoDatasetIT/app/app.json
@@ -36,5 +36,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/IT/EDocumentIT/demo data/app.json
+++ b/src/Apps/IT/EDocumentIT/demo data/app.json
@@ -40,7 +40,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/IT/IntrastatIT/app/app.json
+++ b/src/Apps/IT/IntrastatIT/app/app.json
@@ -40,5 +40,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/IT/ServiceDeclarationIT/app/app.json
+++ b/src/Apps/IT/ServiceDeclarationIT/app/app.json
@@ -40,5 +40,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/IT/SubcontractingMigrationIT/App/app.json
+++ b/src/Apps/IT/SubcontractingMigrationIT/App/app.json
@@ -38,7 +38,8 @@
   "target": "Cloud",
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/IT/SubcontractingMigrationIT/Test/app.json
+++ b/src/Apps/IT/SubcontractingMigrationIT/Test/app.json
@@ -37,7 +37,8 @@
   "target": "Cloud",
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/MX/ContosoCoffeeDemoDatasetMX/app/app.json
+++ b/src/Apps/MX/ContosoCoffeeDemoDatasetMX/app/app.json
@@ -36,5 +36,8 @@
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
   },
-  "target": "OnPrem"
+  "target": "OnPrem",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/NA/Ceridian/app/app.json
+++ b/src/Apps/NA/Ceridian/app/app.json
@@ -20,5 +20,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/NA/EnvestnetYodleeBankFeeds/app/app.json
+++ b/src/Apps/NA/EnvestnetYodleeBankFeeds/app/app.json
@@ -27,5 +27,8 @@
       "publisher": "Microsoft"
     }
   ],
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/NA/ExtendedBankDepositNA/app/app.json
+++ b/src/Apps/NA/ExtendedBankDepositNA/app/app.json
@@ -38,6 +38,7 @@
     "application":  "30.0.0.0",
     "features":  [
                      "TranslationFile",
-                     "GenerateCaptions"
+                     "GenerateCaptions",
+                     "TranslationsWithNamespaces"
                  ]
 }

--- a/src/Apps/NA/MX_DIOT/app/app.json
+++ b/src/Apps/NA/MX_DIOT/app/app.json
@@ -29,5 +29,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/NA/PEPPOLNA/app/app.json
+++ b/src/Apps/NA/PEPPOLNA/app/app.json
@@ -30,6 +30,7 @@
   ],
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/NL/ContosoCoffeeDemoDatasetNL/app/app.json
+++ b/src/Apps/NL/ContosoCoffeeDemoDatasetNL/app/app.json
@@ -32,5 +32,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/NL/EDocument_NL/demo data/app.json
+++ b/src/Apps/NL/EDocument_NL/demo data/app.json
@@ -53,6 +53,7 @@
   "application": "30.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/NL/NLDigitalTaxDeclaration/app/app.json
+++ b/src/Apps/NL/NLDigitalTaxDeclaration/app/app.json
@@ -20,5 +20,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/NO/ContosoCoffeeDemoDatasetNO/app/app.json
+++ b/src/Apps/NO/ContosoCoffeeDemoDatasetNO/app/app.json
@@ -33,5 +33,8 @@
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
   },
-  "target": "OnPrem"
+  "target": "OnPrem",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/NO/EDocument_NO/demo data/app.json
+++ b/src/Apps/NO/EDocument_NO/demo data/app.json
@@ -53,6 +53,7 @@
     "application": "30.0.0.0",
     "target": "OnPrem",
     "features": [
-        "TranslationFile"
+        "TranslationFile",
+        "TranslationsWithNamespaces"
     ]
 }

--- a/src/Apps/NO/ElectronicVATSubmission/app/app.json
+++ b/src/Apps/NO/ElectronicVATSubmission/app/app.json
@@ -32,5 +32,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/NO/ImportNOPayroll/app/app.json
+++ b/src/Apps/NO/ImportNOPayroll/app/app.json
@@ -20,5 +20,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/NO/NorwegianSAFT/app/app.json
+++ b/src/Apps/NO/NorwegianSAFT/app/app.json
@@ -20,5 +20,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/NO/PEPPOLNO/app/app.json
+++ b/src/Apps/NO/PEPPOLNO/app/app.json
@@ -31,7 +31,8 @@
   "application": "30.0.0.0",
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/NZ/ContosoCoffeeDemoDatasetNZ/app/app.json
+++ b/src/Apps/NZ/ContosoCoffeeDemoDatasetNZ/app/app.json
@@ -32,5 +32,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/NZ/EDocument_NZ/demo data/app.json
+++ b/src/Apps/NZ/EDocument_NZ/demo data/app.json
@@ -40,7 +40,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/NZ/ExpenseAgent_NZ/app/app.json
+++ b/src/Apps/NZ/ExpenseAgent_NZ/app/app.json
@@ -29,7 +29,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/NZ/ExpenseAgent_NZ/demo data/app.json
+++ b/src/Apps/NZ/ExpenseAgent_NZ/demo data/app.json
@@ -53,6 +53,7 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/RU/CDTracking/app/app.json
+++ b/src/Apps/RU/CDTracking/app/app.json
@@ -20,5 +20,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "target": "OnPrem",
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/SE/ContosoCoffeeDemoDatasetSE/app/app.json
+++ b/src/Apps/SE/ContosoCoffeeDemoDatasetSE/app/app.json
@@ -36,5 +36,8 @@
     "allowDebugging": true,
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
-  }
+  },
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/SE/EDocument_SE/demo data/app.json
+++ b/src/Apps/SE/EDocument_SE/demo data/app.json
@@ -53,6 +53,7 @@
     "application": "30.0.0.0",
     "target": "OnPrem",
     "features": [
-        "TranslationFile"
+        "TranslationFile",
+        "TranslationsWithNamespaces"
     ]
 }

--- a/src/Apps/SE/PeppolSE/App/app.json
+++ b/src/Apps/SE/PeppolSE/App/app.json
@@ -37,7 +37,8 @@
   "application": "30.0.0.0",
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/SE/SECore/app/app.json
+++ b/src/Apps/SE/SECore/app/app.json
@@ -30,5 +30,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "target": "OnPrem"
+  "target": "OnPrem",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/SE/SIE/app/app.json
+++ b/src/Apps/SE/SIE/app/app.json
@@ -37,5 +37,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/US/ContosoCoffeeDemoDatasetUS/app/app.json
+++ b/src/Apps/US/ContosoCoffeeDemoDatasetUS/app/app.json
@@ -36,5 +36,8 @@
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
   },
-  "target": "OnPrem"
+  "target": "OnPrem",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/US/EDocument_US/demo data/app.json
+++ b/src/Apps/US/EDocument_US/demo data/app.json
@@ -40,7 +40,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/US/ExpenseAgent_US/app/app.json
+++ b/src/Apps/US/ExpenseAgent_US/app/app.json
@@ -29,7 +29,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/US/ExpenseAgent_US/demo data/app.json
+++ b/src/Apps/US/ExpenseAgent_US/demo data/app.json
@@ -53,6 +53,7 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/US/HybridGP_US/app/app.json
+++ b/src/Apps/US/HybridGP_US/app/app.json
@@ -40,6 +40,7 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/US/HybridGP_US/test/app.json
+++ b/src/Apps/US/HybridGP_US/test/app.json
@@ -53,6 +53,7 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/US/HybridSL_US/app/app.json
+++ b/src/Apps/US/HybridSL_US/app/app.json
@@ -46,6 +46,7 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/US/HybridSL_US/test/app.json
+++ b/src/Apps/US/HybridSL_US/test/app.json
@@ -54,6 +54,7 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/US/IRS1096/app/app.json
+++ b/src/Apps/US/IRS1096/app/app.json
@@ -26,5 +26,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/US/IRSForms/app/app.json
+++ b/src/Apps/US/IRSForms/app/app.json
@@ -29,7 +29,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/US/IRSForms/test library/app.json
+++ b/src/Apps/US/IRSForms/test library/app.json
@@ -26,7 +26,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "screenshots": [],
   "platform": "29.0.0.0",

--- a/src/Apps/US/IRSForms/test/app.json
+++ b/src/Apps/US/IRSForms/test/app.json
@@ -45,7 +45,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/W1/AIDevelopmentToolkit/app/app.json
+++ b/src/Apps/W1/AIDevelopmentToolkit/app/app.json
@@ -46,6 +46,7 @@
     "GenerateCaptions",
     "TranslationFile",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/AIDevelopmentToolkitDesign/app/app.json
+++ b/src/Apps/W1/AIDevelopmentToolkitDesign/app/app.json
@@ -40,6 +40,7 @@
     "GenerateCaptions",
     "TranslationFile",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/AIDevelopmentToolkitEvaluation/app/app.json
+++ b/src/Apps/W1/AIDevelopmentToolkitEvaluation/app/app.json
@@ -76,6 +76,7 @@
     "GenerateCaptions",
     "TranslationFile",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/AMCBanking365Fundamentals/app/app.json
+++ b/src/Apps/W1/AMCBanking365Fundamentals/app/app.json
@@ -33,6 +33,7 @@
   "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "contextSensitiveHelpUrl": "https://amcbanking.com/kb/",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/APIReportsFinance/App/app.json
+++ b/src/Apps/W1/APIReportsFinance/App/app.json
@@ -22,6 +22,7 @@
   ],
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/APIV1/app/app.json
+++ b/src/Apps/W1/APIV1/app/app.json
@@ -34,5 +34,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/APIV2/app/app.json
+++ b/src/Apps/W1/APIV2/app/app.json
@@ -38,5 +38,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/AgentDesignExperience/app/app.json
+++ b/src/Apps/W1/AgentDesignExperience/app/app.json
@@ -52,6 +52,7 @@
     "GenerateCaptions",
     "TranslationFile",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/AgentDesignExperience/test/app.json
+++ b/src/Apps/W1/AgentDesignExperience/test/app.json
@@ -42,7 +42,8 @@
     "GenerateCaptions",
     "TranslationFile",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ],
   "target": "OnPrem",
   "resourceFolders": [

--- a/src/Apps/W1/AgentSamples/app/app.json
+++ b/src/Apps/W1/AgentSamples/app/app.json
@@ -46,7 +46,8 @@
     "GenerateCaptions",
     "TranslationFile",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ],
   "resourceFolders": [
     ".resources"

--- a/src/Apps/W1/AgentSamples/test/app.json
+++ b/src/Apps/W1/AgentSamples/test/app.json
@@ -33,7 +33,8 @@
     "GenerateCaptions",
     "TranslationFile",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/W1/AuditFileExport/app/app.json
+++ b/src/Apps/W1/AuditFileExport/app/app.json
@@ -28,6 +28,7 @@
   },
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/AuditFileExport/test/app.json
+++ b/src/Apps/W1/AuditFileExport/test/app.json
@@ -46,6 +46,7 @@
   },
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/AutomaticAccountCodes/app/app.json
+++ b/src/Apps/W1/AutomaticAccountCodes/app/app.json
@@ -25,5 +25,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/BankAccRecWithAI/app/app.json
+++ b/src/Apps/W1/BankAccRecWithAI/app/app.json
@@ -39,6 +39,7 @@
   "application": "30.0.0.0",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/BankAccRecWithAI/test/app.json
+++ b/src/Apps/W1/BankAccRecWithAI/test/app.json
@@ -58,6 +58,7 @@
   "application": "30.0.0.0",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/BankDeposits/app/app.json
+++ b/src/Apps/W1/BankDeposits/app/app.json
@@ -36,6 +36,7 @@
   "application": "30.0.0.0",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/BasicExperience/app/app.json
+++ b/src/Apps/W1/BasicExperience/app/app.json
@@ -31,7 +31,8 @@
     "en-AU"
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "application": "30.0.0.0"
 }

--- a/src/Apps/W1/BasicExperience/test/app.json
+++ b/src/Apps/W1/BasicExperience/test/app.json
@@ -46,6 +46,7 @@
     "en-AU"
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/ClientAddIns/app/app.json
+++ b/src/Apps/W1/ClientAddIns/app/app.json
@@ -28,6 +28,7 @@
   "application": "30.0.0.0",
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/CompanyHub/app/app.json
+++ b/src/Apps/W1/CompanyHub/app/app.json
@@ -26,5 +26,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/ConnectivityApps/app/app.json
+++ b/src/Apps/W1/ConnectivityApps/app/app.json
@@ -31,5 +31,8 @@
     "includeSourceInSymbolFile": true
   },
   "target": "OnPrem",
-  "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2204236"
+  "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2204236",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/app.json
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/app.json
@@ -43,7 +43,8 @@
   },
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceFolders": [
     ".resources"

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/app.json
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/app.json
@@ -39,7 +39,8 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://learn.microsoft.com/en-us/dynamics365/business-central/contoso-coffee/contoso-coffee-intro"
 }

--- a/src/Apps/W1/CreateProductInformationWithCopilot/app/app.json
+++ b/src/Apps/W1/CreateProductInformationWithCopilot/app/app.json
@@ -36,6 +36,7 @@
   ],
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/CrossEnvironmentIntercompany/app/app.json
+++ b/src/Apps/W1/CrossEnvironmentIntercompany/app/app.json
@@ -21,6 +21,7 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/DataArchive/App/app.json
+++ b/src/Apps/W1/DataArchive/App/app.json
@@ -27,6 +27,7 @@
   },
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2206251",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/DataArchive/Test/app.json
+++ b/src/Apps/W1/DataArchive/Test/app.json
@@ -41,6 +41,7 @@
   },
   "application": "30.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/DataCorrectionFA/App/app.json
+++ b/src/Apps/W1/DataCorrectionFA/App/app.json
@@ -28,6 +28,7 @@
   },
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/DataSearch/App/app.json
+++ b/src/Apps/W1/DataSearch/App/app.json
@@ -29,7 +29,8 @@
   ],
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/W1/DataSearch/Test/app.json
+++ b/src/Apps/W1/DataSearch/Test/app.json
@@ -42,7 +42,8 @@
   ],
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": false,

--- a/src/Apps/W1/DynamicsGPHistoricalData/app/app.json
+++ b/src/Apps/W1/DynamicsGPHistoricalData/app/app.json
@@ -28,6 +28,7 @@
   },
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/DynamicsGPHistorySmartLists/app/app.json
+++ b/src/Apps/W1/DynamicsGPHistorySmartLists/app/app.json
@@ -33,5 +33,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/EDocument/App/app.json
+++ b/src/Apps/W1/EDocument/App/app.json
@@ -113,6 +113,7 @@
     ".resources"
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/EDocument/Demo Data/app.json
+++ b/src/Apps/W1/EDocument/Demo Data/app.json
@@ -149,6 +149,7 @@
   "application": "30.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/EDocument/Test/app.json
+++ b/src/Apps/W1/EDocument/Test/app.json
@@ -98,6 +98,7 @@
     ".resources"
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/EDocumentConnectors/Avalara/App/app.json
+++ b/src/Apps/W1/EDocumentConnectors/Avalara/App/app.json
@@ -49,6 +49,7 @@
   "application": "30.0.0.0",
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/EDocumentConnectors/Avalara/Test/app.json
+++ b/src/Apps/W1/EDocumentConnectors/Avalara/Test/app.json
@@ -75,7 +75,8 @@
   "application": "30.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceFolders": [
     ".resources"

--- a/src/Apps/W1/EDocumentConnectors/B2Brouter/app/app.json
+++ b/src/Apps/W1/EDocumentConnectors/B2Brouter/app/app.json
@@ -43,6 +43,7 @@
   "target": "Cloud",
   "features": [
     "TranslationFile",
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/EDocumentConnectors/B2Brouter/test/app.json
+++ b/src/Apps/W1/EDocumentConnectors/B2Brouter/test/app.json
@@ -59,7 +59,8 @@
     },
     "features": [
         "NoImplicitWith",
-        "TranslationFile"
+        "TranslationFile",
+        "TranslationsWithNamespaces"
     ],
     "target": "OnPrem",
     "resourceFolders": [

--- a/src/Apps/W1/EDocumentConnectors/Continia/App/app.json
+++ b/src/Apps/W1/EDocumentConnectors/Continia/App/app.json
@@ -41,7 +41,8 @@
   "application": "30.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "logo": "ExtensionLogo.png"
 }

--- a/src/Apps/W1/EDocumentConnectors/Continia/Test/app.json
+++ b/src/Apps/W1/EDocumentConnectors/Continia/Test/app.json
@@ -68,6 +68,7 @@
   "target": "OnPrem",
   "logo": "ExtensionLogo.png",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/EDocumentConnectors/ForNAV/App/app.json
+++ b/src/Apps/W1/EDocumentConnectors/ForNAV/App/app.json
@@ -44,6 +44,7 @@
   "preprocessorSymbols": [],
   "features": [
     "TranslationFile",
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/EDocumentConnectors/ForNAV/Test/app.json
+++ b/src/Apps/W1/EDocumentConnectors/ForNAV/Test/app.json
@@ -72,6 +72,7 @@
   },
   "features": [
     "TranslationFile",
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/EDocumentConnectors/Logiq/app/app.json
+++ b/src/Apps/W1/EDocumentConnectors/Logiq/app/app.json
@@ -41,7 +41,8 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "target": "Cloud"
 }

--- a/src/Apps/W1/EDocumentConnectors/Logiq/test/app.json
+++ b/src/Apps/W1/EDocumentConnectors/Logiq/test/app.json
@@ -70,7 +70,8 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "target": "OnPrem",
   "resourceFolders": [

--- a/src/Apps/W1/EDocumentConnectors/Microsoft365/app/app.json
+++ b/src/Apps/W1/EDocumentConnectors/Microsoft365/app/app.json
@@ -42,6 +42,7 @@
   "application": "30.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/EDocumentConnectors/Microsoft365/test/app.json
+++ b/src/Apps/W1/EDocumentConnectors/Microsoft365/test/app.json
@@ -47,6 +47,7 @@
   "application": "30.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/EDocumentConnectors/Pagero/app/app.json
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/app/app.json
@@ -42,6 +42,7 @@
   "application": "30.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/EDocumentConnectors/Pagero/test/app.json
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/test/app.json
@@ -71,7 +71,8 @@
   "application": "30.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceFolders": [
     ".resources"

--- a/src/Apps/W1/EDocumentConnectors/SignUp/app/app.json
+++ b/src/Apps/W1/EDocumentConnectors/SignUp/app/app.json
@@ -42,6 +42,7 @@
     "application": "30.0.0.0",
     "target": "OnPrem",
     "features": [
-        "TranslationFile"
+        "TranslationFile",
+        "TranslationsWithNamespaces"
     ]
 }

--- a/src/Apps/W1/EDocumentConnectors/SignUp/test/app.json
+++ b/src/Apps/W1/EDocumentConnectors/SignUp/test/app.json
@@ -94,7 +94,8 @@
         "includeSourceInSymbolFile": true
     },
     "features": [
-        "TranslationFile"
+        "TranslationFile",
+        "TranslationsWithNamespaces"
     ],
     "target": "OnPrem",
     "resourceFolders": [

--- a/src/Apps/W1/ESGStatisticalAccountsDemoTool/app/app.json
+++ b/src/Apps/W1/ESGStatisticalAccountsDemoTool/app/app.json
@@ -40,7 +40,8 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://learn.microsoft.com/en-us/dynamics365/business-central/contoso-coffee/contoso-coffee-intro",
   "target": "Cloud"

--- a/src/Apps/W1/EU3PartyTradePurchase/app/app.json
+++ b/src/Apps/W1/EU3PartyTradePurchase/app/app.json
@@ -32,5 +32,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/Email - Current User Connector/app/app.json
+++ b/src/Apps/W1/Email - Current User Connector/app/app.json
@@ -51,6 +51,7 @@
   },
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/Email - Microsoft 365 Connector/app/app.json
+++ b/src/Apps/W1/Email - Microsoft 365 Connector/app/app.json
@@ -51,6 +51,7 @@
   },
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/Email - Outlook REST API/app/app.json
+++ b/src/Apps/W1/Email - Outlook REST API/app/app.json
@@ -42,6 +42,7 @@
   },
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/Email - SMTP API/app/app.json
+++ b/src/Apps/W1/Email - SMTP API/app/app.json
@@ -49,5 +49,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2134520"
+  "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2134520",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/Email - SMTP Connector/app/app.json
+++ b/src/Apps/W1/Email - SMTP Connector/app/app.json
@@ -52,5 +52,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2134520"
+  "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2134520",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/EmailLogging/app/app.json
+++ b/src/Apps/W1/EmailLogging/app/app.json
@@ -33,5 +33,8 @@
     "includeSourceInSymbolFile": true
   },
   "target": "OnPrem",
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/EnforcedDigitalVouchers/app/app.json
+++ b/src/Apps/W1/EnforcedDigitalVouchers/app/app.json
@@ -39,7 +39,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/W1/EnforcedDigitalVouchers/test library/app.json
+++ b/src/Apps/W1/EnforcedDigitalVouchers/test library/app.json
@@ -35,6 +35,7 @@
   "application": "30.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/EnforcedDigitalVouchers/test/app.json
+++ b/src/Apps/W1/EnforcedDigitalVouchers/test/app.json
@@ -74,6 +74,7 @@
   },
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/ErrorMessagesWithRecommendations/App/app.json
+++ b/src/Apps/W1/ErrorMessagesWithRecommendations/App/app.json
@@ -30,6 +30,7 @@
   "features": [
     "NoImplicitWith",
     "GenerateCaptions",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/ErrorMessagesWithRecommendations/Test/app.json
+++ b/src/Apps/W1/ErrorMessagesWithRecommendations/Test/app.json
@@ -54,6 +54,7 @@
   "features": [
     "NoImplicitWith",
     "GenerateCaptions",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/EssentialBusinessHeadlines/App/app.json
+++ b/src/Apps/W1/EssentialBusinessHeadlines/App/app.json
@@ -28,6 +28,7 @@
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=870429",
   "application": "30.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/EssentialBusinessHeadlines/Test/app.json
+++ b/src/Apps/W1/EssentialBusinessHeadlines/Test/app.json
@@ -45,6 +45,7 @@
   },
   "application": "30.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/ExcelReports/App/app.json
+++ b/src/Apps/W1/ExcelReports/App/app.json
@@ -35,6 +35,7 @@
   ],
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/ExcelReports/Test/app.json
+++ b/src/Apps/W1/ExcelReports/Test/app.json
@@ -51,6 +51,7 @@
   },
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/ExciseTaxes/app/app.json
+++ b/src/Apps/W1/ExciseTaxes/app/app.json
@@ -29,7 +29,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/W1/ExciseTaxes/test/app.json
+++ b/src/Apps/W1/ExciseTaxes/test/app.json
@@ -59,7 +59,8 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "target": "OnPrem"
 }

--- a/src/Apps/W1/ExpenseAgent/app/app.json
+++ b/src/Apps/W1/ExpenseAgent/app/app.json
@@ -143,7 +143,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/W1/ExpenseAgent/demo data/app.json
+++ b/src/Apps/W1/ExpenseAgent/demo data/app.json
@@ -93,6 +93,7 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/ExpenseAgent/test/app.json
+++ b/src/Apps/W1/ExpenseAgent/test/app.json
@@ -50,7 +50,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/W1/ExpenseWithholdingTax/app/app.json
+++ b/src/Apps/W1/ExpenseWithholdingTax/app/app.json
@@ -35,7 +35,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/W1/External File Storage - Azure Blob Service Connector/App/app.json
+++ b/src/Apps/W1/External File Storage - Azure Blob Service Connector/App/app.json
@@ -38,6 +38,7 @@
   ],
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/External File Storage - Azure Blob Service Connector/Test/app.json
+++ b/src/Apps/W1/External File Storage - Azure Blob Service Connector/Test/app.json
@@ -53,6 +53,7 @@
   },
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2134520",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/External File Storage - Azure File Service Connector/App/app.json
+++ b/src/Apps/W1/External File Storage - Azure File Service Connector/App/app.json
@@ -38,6 +38,7 @@
   ],
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/External File Storage - Azure File Service Connector/Test/app.json
+++ b/src/Apps/W1/External File Storage - Azure File Service Connector/Test/app.json
@@ -53,6 +53,7 @@
   },
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2134520",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/External File Storage - SFTP Connector/App/app.json
+++ b/src/Apps/W1/External File Storage - SFTP Connector/App/app.json
@@ -38,6 +38,7 @@
   ],
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/External File Storage - SFTP Connector/Test/app.json
+++ b/src/Apps/W1/External File Storage - SFTP Connector/Test/app.json
@@ -52,6 +52,7 @@
   },
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2134520",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/External File Storage - SharePoint Connector/App/app.json
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/App/app.json
@@ -38,6 +38,7 @@
   ],
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/External File Storage - SharePoint Connector/Test/app.json
+++ b/src/Apps/W1/External File Storage - SharePoint Connector/Test/app.json
@@ -53,6 +53,7 @@
   },
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2134520",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/External Storage - Document Attachments/Test/app.json
+++ b/src/Apps/W1/External Storage - Document Attachments/Test/app.json
@@ -51,7 +51,8 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2134520",
   "target": "Cloud"

--- a/src/Apps/W1/External Storage - Document Attachments/app/app.json
+++ b/src/Apps/W1/External Storage - Document Attachments/app/app.json
@@ -33,7 +33,8 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2134520",
   "target": "Cloud"

--- a/src/Apps/W1/ExternalEvents/app/app.json
+++ b/src/Apps/W1/ExternalEvents/app/app.json
@@ -28,7 +28,8 @@
   },
   "application": "30.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 
 }

--- a/src/Apps/W1/ExternalEvents/test/app.json
+++ b/src/Apps/W1/ExternalEvents/test/app.json
@@ -59,6 +59,7 @@
   },
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/FieldServiceIntegration/app/app.json
+++ b/src/Apps/W1/FieldServiceIntegration/app/app.json
@@ -36,6 +36,7 @@
   "application": "30.0.0.0",
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/FieldServiceIntegration/test library/app.json
+++ b/src/Apps/W1/FieldServiceIntegration/test library/app.json
@@ -36,6 +36,7 @@
   ],
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/FieldServiceIntegration/test/app.json
+++ b/src/Apps/W1/FieldServiceIntegration/test/app.json
@@ -66,6 +66,7 @@
   ],
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/HybridAPI/app/app.json
+++ b/src/Apps/W1/HybridAPI/app/app.json
@@ -33,5 +33,8 @@
     "includeSourceInSymbolFile": true
   },
   "target": "Cloud",
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/HybridBC/app/app.json
+++ b/src/Apps/W1/HybridBC/app/app.json
@@ -33,5 +33,8 @@
     "includeSourceInSymbolFile": true
   },
   "target": "Cloud",
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/HybridBC14/app/app.json
+++ b/src/Apps/W1/HybridBC14/app/app.json
@@ -48,6 +48,7 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/HybridBC14/test/app.json
+++ b/src/Apps/W1/HybridBC14/test/app.json
@@ -75,6 +75,7 @@
   "application": "30.0.0.0",
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/HybridBC14HistoricalData/app/app.json
+++ b/src/Apps/W1/HybridBC14HistoricalData/app/app.json
@@ -29,6 +29,7 @@
   "target": "Cloud",
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/HybridBCLast/app/app.json
+++ b/src/Apps/W1/HybridBCLast/app/app.json
@@ -40,5 +40,8 @@
     "includeSourceInSymbolFile": true
   },
   "target": "Cloud",
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/HybridBaseDeployment/app/app.json
+++ b/src/Apps/W1/HybridBaseDeployment/app/app.json
@@ -63,5 +63,8 @@
       "name": "BC14 Reimplementation Tool Tests",
       "publisher": "Microsoft"
     }
+  ],
+  "features": [
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/HybridGP/app/app.json
+++ b/src/Apps/W1/HybridGP/app/app.json
@@ -52,5 +52,8 @@
     "includeSourceInSymbolFile": true
   },
   "target": "Cloud",
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/HybridSL/app/app.json
+++ b/src/Apps/W1/HybridSL/app/app.json
@@ -54,6 +54,7 @@
   "target": "Cloud",
   "features": [
     "TranslationFile",
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-JsonExchange/app.json
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-JsonExchange/app.json
@@ -60,7 +60,8 @@
   ],
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2139719",
   "resourceExposurePolicy": {

--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-PostingHandler/app.json
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-PostingHandler/app.json
@@ -53,7 +53,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2139719",
   "resourceExposurePolicy": {

--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-ScriptHandler/app.json
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-ScriptHandler/app.json
@@ -40,7 +40,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2139719",
   "resourceExposurePolicy": {

--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-UseCaseBuilder/app.json
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-UseCaseBuilder/app.json
@@ -52,7 +52,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2139719",
   "resourceExposurePolicy": {

--- a/src/Apps/W1/INTaxEngine/app/app.json
+++ b/src/Apps/W1/INTaxEngine/app/app.json
@@ -37,5 +37,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/INTaxEngine/test/TaxEngine-JsonExchange/app.json
+++ b/src/Apps/W1/INTaxEngine/test/TaxEngine-JsonExchange/app.json
@@ -34,7 +34,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2139719",
   "resourceExposurePolicy": {

--- a/src/Apps/W1/INTaxEngine/test/TaxEngine-PostingHandler/app.json
+++ b/src/Apps/W1/INTaxEngine/test/TaxEngine-PostingHandler/app.json
@@ -46,7 +46,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2139719",
   "resourceExposurePolicy": {

--- a/src/Apps/W1/INTaxEngine/test/TaxEngine-ScriptHandler/app.json
+++ b/src/Apps/W1/INTaxEngine/test/TaxEngine-ScriptHandler/app.json
@@ -46,7 +46,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2139719",
   "resourceExposurePolicy": {

--- a/src/Apps/W1/INTaxEngine/test/TaxEngine-UseCaseBuilder/app.json
+++ b/src/Apps/W1/INTaxEngine/test/TaxEngine-UseCaseBuilder/app.json
@@ -46,7 +46,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2139719",
   "resourceExposurePolicy": {

--- a/src/Apps/W1/ImageAnalysis/app/app.json
+++ b/src/Apps/W1/ImageAnalysis/app/app.json
@@ -26,5 +26,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/Intrastat/app/app.json
+++ b/src/Apps/W1/Intrastat/app/app.json
@@ -28,6 +28,7 @@
   "application": "30.0.0.0",
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/Intrastat/demo data/app.json
+++ b/src/Apps/W1/Intrastat/demo data/app.json
@@ -39,5 +39,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/LatePaymentPredictor/app/app.json
+++ b/src/Apps/W1/LatePaymentPredictor/app/app.json
@@ -29,5 +29,8 @@
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/LibraryNoTransactions/app/app.json
+++ b/src/Apps/W1/LibraryNoTransactions/app/app.json
@@ -26,6 +26,7 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/MSWalletPayments/app/app.json
+++ b/src/Apps/W1/MSWalletPayments/app/app.json
@@ -28,6 +28,7 @@
   },
   "application": "30.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/Manufacturing/app/app.json
+++ b/src/Apps/W1/Manufacturing/app/app.json
@@ -29,6 +29,7 @@
   },
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/MasterDataManagement/app/app.json
+++ b/src/Apps/W1/MasterDataManagement/app/app.json
@@ -36,6 +36,7 @@
   "application": "30.0.0.0",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/MasterDataManagement/test library/app.json
+++ b/src/Apps/W1/MasterDataManagement/test library/app.json
@@ -27,5 +27,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/MicrosoftUniversalPrint/app/app.json
+++ b/src/Apps/W1/MicrosoftUniversalPrint/app/app.json
@@ -29,6 +29,7 @@
   "features": [
     "TranslationFile",
     "GenerateCaptions",
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/OnPrem Permissions/app/app.json
+++ b/src/Apps/W1/OnPrem Permissions/app/app.json
@@ -20,5 +20,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/OnboardingSignals/app/app.json
+++ b/src/Apps/W1/OnboardingSignals/app/app.json
@@ -35,7 +35,8 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "target": "Cloud"
 }

--- a/src/Apps/W1/OnboardingSignals/test/app.json
+++ b/src/Apps/W1/OnboardingSignals/test/app.json
@@ -47,6 +47,7 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/PEPPOL/App/app.json
+++ b/src/Apps/W1/PEPPOL/App/app.json
@@ -23,7 +23,8 @@
   "application": "30.0.0.0",
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/W1/PEPPOL/Test/app.json
+++ b/src/Apps/W1/PEPPOL/Test/app.json
@@ -67,7 +67,8 @@
   "application": "30.0.0.0",
   "features": [
     "TranslationFile",
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/W1/PayPalPaymentsStandard/app/app.json
+++ b/src/Apps/W1/PayPalPaymentsStandard/app/app.json
@@ -26,5 +26,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/PayablesAgent/app/app.json
+++ b/src/Apps/W1/PayablesAgent/app/app.json
@@ -44,7 +44,8 @@
     ],
     "features": [
         "TranslationFile",
-        "NoImplicitWith"
+        "NoImplicitWith",
+        "TranslationsWithNamespaces"
     ],
     "resourceFolders": [
         ".resources"

--- a/src/Apps/W1/PaymentPractices/App/app.json
+++ b/src/Apps/W1/PaymentPractices/App/app.json
@@ -28,7 +28,8 @@
   "application": "30.0.0.0",
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "internalsVisibleTo": [
     {

--- a/src/Apps/W1/PaymentPractices/Test Library/app.json
+++ b/src/Apps/W1/PaymentPractices/Test Library/app.json
@@ -41,6 +41,7 @@
   "application": "30.0.0.0",
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/PaymentPractices/Test/app.json
+++ b/src/Apps/W1/PaymentPractices/Test/app.json
@@ -59,6 +59,7 @@
   "application": "30.0.0.0",
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/PlanConfiguration/app/app.json
+++ b/src/Apps/W1/PlanConfiguration/app/app.json
@@ -38,5 +38,8 @@
     "allowDownloadingSource": false,
     "includeSourceInSymbolFile": false
   },
-  "target": "OnPrem"
+  "target": "OnPrem",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/PowerBIReports/App/app.json
+++ b/src/Apps/W1/PowerBIReports/App/app.json
@@ -35,7 +35,8 @@
   ],
   "features": [
     "TranslationFile",
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ],
   "resourceFolders": [".resources"]
 }

--- a/src/Apps/W1/PowerBIReports/Test Library/app.json
+++ b/src/Apps/W1/PowerBIReports/Test Library/app.json
@@ -47,6 +47,7 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/PowerBIReports/Test/app.json
+++ b/src/Apps/W1/PowerBIReports/Test/app.json
@@ -65,6 +65,7 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/QBMigration/app/app.json
+++ b/src/Apps/W1/QBMigration/app/app.json
@@ -33,5 +33,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/Quality Management/Demo Data/app.json
+++ b/src/Apps/W1/Quality Management/Demo Data/app.json
@@ -40,7 +40,8 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://learn.microsoft.com/en-us/dynamics365/business-central/contoso-coffee/contoso-coffee-intro",
   "target": "Cloud"

--- a/src/Apps/W1/Quality Management/Test Library/app.json
+++ b/src/Apps/W1/Quality Management/Test Library/app.json
@@ -55,6 +55,7 @@
   ],
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/Quality Management/app/app.json
+++ b/src/Apps/W1/Quality Management/app/app.json
@@ -32,7 +32,8 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "internalsVisibleTo": [
     {

--- a/src/Apps/W1/Quality Management/test/app.json
+++ b/src/Apps/W1/Quality Management/test/app.json
@@ -57,7 +57,8 @@
   ],
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "platform": "29.0.0.0",
   "application": "30.0.0.0",

--- a/src/Apps/W1/QuickbooksPayrollFileImport/app/app.json
+++ b/src/Apps/W1/QuickbooksPayrollFileImport/app/app.json
@@ -26,5 +26,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/RecommendedApps/app/app.json
+++ b/src/Apps/W1/RecommendedApps/app/app.json
@@ -31,5 +31,8 @@
     "includeSourceInSymbolFile": true
   },
   "target": "OnPrem",
-  "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2173058"
+  "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2173058",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/ReviewGLEntries/app/app.json
+++ b/src/Apps/W1/ReviewGLEntries/app/app.json
@@ -22,7 +22,8 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/W1/ReviewGLEntries/test/app.json
+++ b/src/Apps/W1/ReviewGLEntries/test/app.json
@@ -40,6 +40,7 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/SAF-T/app/app.json
+++ b/src/Apps/W1/SAF-T/app/app.json
@@ -40,5 +40,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/SalesAndInventoryForecast/app/app.json
+++ b/src/Apps/W1/SalesAndInventoryForecast/app/app.json
@@ -26,5 +26,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/SalesLinesSuggestions/app/app.json
+++ b/src/Apps/W1/SalesLinesSuggestions/app/app.json
@@ -29,7 +29,8 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "internalsVisibleTo": [
     {

--- a/src/Apps/W1/SalesLinesSuggestions/test/app.json
+++ b/src/Apps/W1/SalesLinesSuggestions/test/app.json
@@ -68,7 +68,8 @@
   "target": "OnPrem",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "resourceFolders": [
     ".resources"

--- a/src/Apps/W1/SalesOrderAgent/app/app.json
+++ b/src/Apps/W1/SalesOrderAgent/app/app.json
@@ -51,7 +51,8 @@
   "propagateDependencies": true,
   "features": [
     "TranslationFile",
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ],
   "resourceFolders": [
     ".resources"

--- a/src/Apps/W1/SendToEmailPrinter/App/app.json
+++ b/src/Apps/W1/SendToEmailPrinter/App/app.json
@@ -33,6 +33,7 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/ServiceDeclaration/app/app.json
+++ b/src/Apps/W1/ServiceDeclaration/app/app.json
@@ -30,5 +30,8 @@
     "includeSourceInSymbolFile": true
   },
   "application": "30.0.0.0",
-  "target": "Cloud"
+  "target": "Cloud",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Apps/W1/ServiceManagement/app/app.json
+++ b/src/Apps/W1/ServiceManagement/app/app.json
@@ -29,6 +29,7 @@
   },
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/Shopify/App/app.json
+++ b/src/Apps/W1/Shopify/App/app.json
@@ -36,7 +36,8 @@
   "target": "OnPrem",
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceFolders": [
     ".resources"

--- a/src/Apps/W1/Shopify/Test/app.json
+++ b/src/Apps/W1/Shopify/Test/app.json
@@ -100,6 +100,7 @@
     ".resources"
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/SimplifiedBankStatementImport/App/app.json
+++ b/src/Apps/W1/SimplifiedBankStatementImport/App/app.json
@@ -26,6 +26,7 @@
   },
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/SimplifiedBankStatementImport/Test/app.json
+++ b/src/Apps/W1/SimplifiedBankStatementImport/Test/app.json
@@ -46,6 +46,7 @@
   },
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/SmartList/app/app.json
+++ b/src/Apps/W1/SmartList/app/app.json
@@ -21,7 +21,8 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/W1/StatisticalAccounts/app/app.json
+++ b/src/Apps/W1/StatisticalAccounts/app/app.json
@@ -22,7 +22,8 @@
   ],
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": false,

--- a/src/Apps/W1/StatisticalAccounts/test/app.json
+++ b/src/Apps/W1/StatisticalAccounts/test/app.json
@@ -44,7 +44,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Apps/W1/Subcontracting/App/app.json
+++ b/src/Apps/W1/Subcontracting/App/app.json
@@ -23,7 +23,8 @@
   ],
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/W1/Subcontracting/Test/app.json
+++ b/src/Apps/W1/Subcontracting/Test/app.json
@@ -46,7 +46,8 @@
   ],
   "features": [
     "TranslationFile",
-    "ExcludeGeneratedTranslations"
+    "ExcludeGeneratedTranslations",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/W1/Subscription Billing/App/app.json
+++ b/src/Apps/W1/Subscription Billing/App/app.json
@@ -47,7 +47,8 @@
   },
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceFolders": [".resources"]
 }

--- a/src/Apps/W1/Subscription Billing/Demo Data/app.json
+++ b/src/Apps/W1/Subscription Billing/Demo Data/app.json
@@ -41,7 +41,8 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceFolders": [
     ".resources"

--- a/src/Apps/W1/Subscription Billing/Test/app.json
+++ b/src/Apps/W1/Subscription Billing/Test/app.json
@@ -82,7 +82,8 @@
   ],
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Apps/W1/Sustainability/app/app.json
+++ b/src/Apps/W1/Sustainability/app/app.json
@@ -42,7 +42,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceFolders": [
     ".resources"

--- a/src/Apps/W1/Sustainability/test/app.json
+++ b/src/Apps/W1/Sustainability/test/app.json
@@ -65,7 +65,8 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "target": "OnPrem"
 }

--- a/src/Apps/W1/SustainabilityContosoCoffeeDemoDataset/app/app.json
+++ b/src/Apps/W1/SustainabilityContosoCoffeeDemoDataset/app/app.json
@@ -56,7 +56,8 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "contextSensitiveHelpUrl": "https://learn.microsoft.com/en-us/dynamics365/business-central/contoso-coffee/contoso-coffee-intro",
   "target": "Cloud"

--- a/src/Apps/W1/SustainabilityCopilotSuggestion/app/app.json
+++ b/src/Apps/W1/SustainabilityCopilotSuggestion/app/app.json
@@ -51,6 +51,7 @@
   ],
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/SustainabilityCopilotSuggestion/test/app.json
+++ b/src/Apps/W1/SustainabilityCopilotSuggestion/test/app.json
@@ -76,6 +76,7 @@
   "application": "30.0.0.0",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/SyncBase/app/app.json
+++ b/src/Apps/W1/SyncBase/app/app.json
@@ -28,6 +28,7 @@
   "application": "30.0.0.0",
   "target": "Cloud",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/TransactionStorage/App/app.json
+++ b/src/Apps/W1/TransactionStorage/App/app.json
@@ -21,7 +21,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": false,

--- a/src/Apps/W1/UKSendRemittanceAdvice/App/app.json
+++ b/src/Apps/W1/UKSendRemittanceAdvice/App/app.json
@@ -28,6 +28,7 @@
   },
   "application": "30.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/UKSendRemittanceAdvice/Test/app.json
+++ b/src/Apps/W1/UKSendRemittanceAdvice/Test/app.json
@@ -51,6 +51,7 @@
   },
   "application": "30.0.0.0",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/VATGroupManagement/app/app.json
+++ b/src/Apps/W1/VATGroupManagement/app/app.json
@@ -33,6 +33,7 @@
   },
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Apps/W1/WithholdingTax/Test/app.json
+++ b/src/Apps/W1/WithholdingTax/Test/app.json
@@ -47,7 +47,8 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "target": "OnPrem"
 }

--- a/src/Apps/W1/WithholdingTax/app/app.json
+++ b/src/Apps/W1/WithholdingTax/app/app.json
@@ -22,7 +22,8 @@
     }
   ],
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Business Foundation/App/AuditCodes/app.json
+++ b/src/Business Foundation/App/AuditCodes/app.json
@@ -25,7 +25,8 @@
     "TranslationFile",
     "GenerateCaptions",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Business Foundation/App/NoSeries/app.json
+++ b/src/Business Foundation/App/NoSeries/app.json
@@ -42,7 +42,8 @@
     "TranslationFile",
     "GenerateCaptions",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Business Foundation/App/NoSeriesCopilot/app.json
+++ b/src/Business Foundation/App/NoSeriesCopilot/app.json
@@ -44,7 +44,8 @@
     "TranslationFile",
     "GenerateCaptions",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Business Foundation/App/app.json
+++ b/src/Business Foundation/App/app.json
@@ -42,7 +42,8 @@
     "TranslationFile",
     "GenerateCaptions",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Business Foundation/Test Library/NoSeries/app.json
+++ b/src/Business Foundation/Test Library/NoSeries/app.json
@@ -38,7 +38,8 @@
     "TranslationFile",
     "GenerateCaptions",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Business Foundation/Test Library/NoSeriesCopilot/app.json
+++ b/src/Business Foundation/Test Library/NoSeriesCopilot/app.json
@@ -36,7 +36,8 @@
     "TranslationFile",
     "GenerateCaptions",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Business Foundation/Test Library/app.json
+++ b/src/Business Foundation/Test Library/app.json
@@ -38,7 +38,8 @@
     "TranslationFile",
     "GenerateCaptions",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Business Foundation/Test/NoSeries/app.json
+++ b/src/Business Foundation/Test/NoSeries/app.json
@@ -72,7 +72,8 @@
     "NoImplicitWith",
     "NoPromotedActionProperties",
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Business Foundation/Test/NoSeriesCopilot/app.json
+++ b/src/Business Foundation/Test/NoSeriesCopilot/app.json
@@ -80,7 +80,8 @@
     "NoImplicitWith",
     "NoPromotedActionProperties",
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Business Foundation/Test/app.json
+++ b/src/Business Foundation/Test/app.json
@@ -88,7 +88,8 @@
     "NoImplicitWith",
     "NoPromotedActionProperties",
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Layers/CZ/DemoTool/app.json
+++ b/src/Layers/CZ/DemoTool/app.json
@@ -61,5 +61,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Layers/IN/DemoTool/app.json
+++ b/src/Layers/IN/DemoTool/app.json
@@ -61,5 +61,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Layers/SE/DemoTool/app.json
+++ b/src/Layers/SE/DemoTool/app.json
@@ -19,5 +19,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Layers/W1/Application/app.json
+++ b/src/Layers/W1/Application/app.json
@@ -49,6 +49,7 @@
     "GenerateCaptions",
     "TranslationFile",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/Foundation/Comments/app.json
+++ b/src/Layers/W1/BaseApp/Modules/Foundation/Comments/app.json
@@ -20,6 +20,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/Foundation/UserTask/app.json
+++ b/src/Layers/W1/BaseApp/Modules/Foundation/UserTask/app.json
@@ -20,6 +20,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/ApplicationArea/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/ApplicationArea/app.json
@@ -41,6 +41,7 @@
                  ],
     "target":  "OnPrem",
     "features":  [
-                     "NoImplicitWith"
+                     "NoImplicitWith",
+                     "TranslationsWithNamespaces"
                  ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/AzureADAuthentication/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/AzureADAuthentication/app.json
@@ -45,6 +45,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/DatabaseInformation/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/DatabaseInformation/app.json
@@ -27,6 +27,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/DateAndTime/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/DateAndTime/app.json
@@ -20,6 +20,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/DesignerDiagnostics/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/DesignerDiagnostics/app.json
@@ -27,6 +27,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/DevTools/CodeCoverage/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/DevTools/CodeCoverage/app.json
@@ -27,6 +27,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/Device/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/Device/app.json
@@ -20,6 +20,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/DotNetAliases/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/DotNetAliases/app.json
@@ -24,6 +24,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/DotNetWrappers/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/DotNetWrappers/app.json
@@ -31,6 +31,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/Email/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/Email/app.json
@@ -43,6 +43,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/ErrorMessage/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/ErrorMessage/app.json
@@ -49,6 +49,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/EventRecorder/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/EventRecorder/app.json
@@ -33,6 +33,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/ExceptionHandling/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/ExceptionHandling/app.json
@@ -27,6 +27,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/ExtensionManagement/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/ExtensionManagement/app.json
@@ -27,6 +27,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/FileOperations/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/FileOperations/app.json
@@ -45,6 +45,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/ForwardLinks/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/ForwardLinks/app.json
@@ -20,6 +20,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/JobQueue/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/JobQueue/app.json
@@ -71,6 +71,7 @@
                  ],
     "target":  "OnPrem",
     "features":  [
-                     "NoImplicitWith"
+                     "NoImplicitWith",
+                     "TranslationsWithNamespaces"
                  ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/Logging/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/Logging/app.json
@@ -39,6 +39,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/Media/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/Media/app.json
@@ -33,6 +33,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/MemoryStorage/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/MemoryStorage/app.json
@@ -20,6 +20,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/Notifications/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/Notifications/app.json
@@ -41,6 +41,7 @@
                ],
   "target":  "OnPrem",
   "features":  [
-                   "NoImplicitWith"
+                   "NoImplicitWith",
+                   "TranslationsWithNamespaces"
                ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/ObjectSelection/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/ObjectSelection/app.json
@@ -20,6 +20,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/OnboardingSignal/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/OnboardingSignal/app.json
@@ -27,6 +27,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/PageDesigner/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/PageDesigner/app.json
@@ -33,6 +33,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/PageInspection/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/PageInspection/app.json
@@ -33,6 +33,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/PermissionSets/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/PermissionSets/app.json
@@ -53,6 +53,7 @@
                  ],
     "target":  "OnPrem",
     "features":  [
-                     "NoImplicitWith"
+                     "NoImplicitWith",
+                     "TranslationsWithNamespaces"
                  ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/PowerAutomate/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/PowerAutomate/app.json
@@ -39,6 +39,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/PowerBI/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/PowerBI/app.json
@@ -75,6 +75,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/PrinterManagement/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/PrinterManagement/app.json
@@ -27,6 +27,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/Profile/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/Profile/app.json
@@ -59,6 +59,7 @@
                  ],
     "target":  "OnPrem",
     "features":  [
-                     "NoImplicitWith"
+                     "NoImplicitWith",
+                     "TranslationsWithNamespaces"
                  ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/RecordConversion/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/RecordConversion/app.json
@@ -20,6 +20,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/RecordLookup/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/RecordLookup/app.json
@@ -20,6 +20,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/RequestPage/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/RequestPage/app.json
@@ -35,6 +35,7 @@
                  ],
     "target":  "OnPrem",
     "features":  [
-                     "NoImplicitWith"
+                     "NoImplicitWith",
+                     "TranslationsWithNamespaces"
                  ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/Translation/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/Translation/app.json
@@ -27,6 +27,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/User/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/User/app.json
@@ -39,6 +39,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/WebRequest/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/WebRequest/app.json
@@ -39,6 +39,7 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/BaseApp/Modules/System/Xml/app.json
+++ b/src/Layers/W1/BaseApp/Modules/System/Xml/app.json
@@ -41,6 +41,7 @@
                  ],
     "target":  "OnPrem",
     "features":  [
-                     "NoImplicitWith"
+                     "NoImplicitWith",
+                     "TranslationsWithNamespaces"
                  ]
 }

--- a/src/Layers/W1/BaseApp/app.json
+++ b/src/Layers/W1/BaseApp/app.json
@@ -311,7 +311,8 @@
   ],
   "target": "OnPrem",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Layers/W1/DemoTool/app.json
+++ b/src/Layers/W1/DemoTool/app.json
@@ -12,5 +12,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Layers/W1/Tests/ApplicationTestLibrary/app.json
+++ b/src/Layers/W1/Tests/ApplicationTestLibrary/app.json
@@ -38,5 +38,8 @@
     "includeSourceInSymbolFile": true
   },
   "propagateDependencies": true,
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Layers/W1/Tests/BCPT-SampleTests/app.json
+++ b/src/Layers/W1/Tests/BCPT-SampleTests/app.json
@@ -42,6 +42,7 @@
   "target": "Cloud",
   "features": [
     "GenerateCaptions",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/Layers/W1/Tests/ERM/app.json
+++ b/src/Layers/W1/Tests/ERM/app.json
@@ -49,5 +49,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Layers/W1/Tests/Misc/app.json
+++ b/src/Layers/W1/Tests/Misc/app.json
@@ -49,5 +49,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Layers/W1/Tests/Rapid Start/app.json
+++ b/src/Layers/W1/Tests/Rapid Start/app.json
@@ -31,5 +31,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Layers/W1/Tests/TestLibraries/app.json
+++ b/src/Layers/W1/Tests/TestLibraries/app.json
@@ -32,5 +32,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/Layers/W1/Tests/Upgrade/app.json
+++ b/src/Layers/W1/Tests/Upgrade/app.json
@@ -29,5 +29,8 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "30.0.0.0"
+  "application": "30.0.0.0",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/System Application/App/Agent/app.json
+++ b/src/System Application/App/Agent/app.json
@@ -110,6 +110,7 @@
   "propagateDependencies": true,
   "features": [
     "TranslationFile",
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/System Application/App/Azure Blob Services API/app.json
+++ b/src/System Application/App/Azure Blob Services API/app.json
@@ -50,7 +50,9 @@
     }
   ],
   "screenshots": [],
-  "features": [],
+  "features": [
+    "TranslationsWithNamespaces"
+  ],
   "platform": "29.0.0.0",
   "idRanges": [
     {

--- a/src/System Application/App/Azure File Services API/app.json
+++ b/src/System Application/App/Azure File Services API/app.json
@@ -62,7 +62,8 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ],
   "target": "OnPrem"
 }

--- a/src/System Application/App/Azure Storage Services Authorization/app.json
+++ b/src/System Application/App/Azure Storage Services Authorization/app.json
@@ -31,7 +31,9 @@
     }
   ],
   "screenshots": [],
-  "features": [],
+  "features": [
+    "TranslationsWithNamespaces"
+  ],
   "platform": "29.0.0.0",
   "idRanges": [
     {

--- a/src/System Application/App/Data Archive/app.json
+++ b/src/System Application/App/Data Archive/app.json
@@ -22,5 +22,8 @@
     }
   ],
   "target": "OnPrem",
-  "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2173136"
+  "contextSensitiveHelpUrl": "https://go.microsoft.com/fwlink/?linkid=2173136",
+  "features": [
+    "TranslationsWithNamespaces"
+  ]
 }

--- a/src/System Application/App/Microsoft User Feedback/app.json
+++ b/src/System Application/App/Microsoft User Feedback/app.json
@@ -14,7 +14,8 @@
   "screenshots": [],
   "platform": "29.0.0.0",
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ],
   "target": "OnPrem",
   "idRanges": [

--- a/src/System Application/App/Rest Client/app.json
+++ b/src/System Application/App/Rest Client/app.json
@@ -45,6 +45,7 @@
   },
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/System Application/App/SharePoint Authorization/app.json
+++ b/src/System Application/App/SharePoint Authorization/app.json
@@ -19,7 +19,9 @@
     }
   ],
   "screenshots": [],
-  "features": [],
+  "features": [
+    "TranslationsWithNamespaces"
+  ],
   "platform": "29.0.0.0",
   "idRanges": [
     {

--- a/src/System Application/App/SharePoint/app.json
+++ b/src/System Application/App/SharePoint/app.json
@@ -55,7 +55,9 @@
     }
   ],
   "screenshots": [],
-  "features": [],
+  "features": [
+    "TranslationsWithNamespaces"
+  ],
   "platform": "29.0.0.0",
   "idRanges": [
     {

--- a/src/System Application/App/app.json
+++ b/src/System Application/App/app.json
@@ -39,7 +39,8 @@
   ],
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/System Application/Partner Test/app.json
+++ b/src/System Application/Partner Test/app.json
@@ -53,7 +53,8 @@
   "platform": "29.0.0.0",
   "features": [
     "GenerateCaptions",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/System Application/Test Library/SharePoint/app.json
+++ b/src/System Application/Test Library/SharePoint/app.json
@@ -49,7 +49,9 @@
     }
   ],
   "screenshots": [],
-  "features": [],
+  "features": [
+    "TranslationsWithNamespaces"
+  ],
   "platform": "29.0.0.0",
   "idRanges": [
     {

--- a/src/System Application/Test Library/app.json
+++ b/src/System Application/Test Library/app.json
@@ -28,7 +28,8 @@
   "screenshots": [],
   "features": [
     "GenerateCaptions",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/System Application/Test/Agent/app.json
+++ b/src/System Application/Test/Agent/app.json
@@ -57,7 +57,8 @@
   ],
   "features": [
     "NoImplicitWith",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "target": "OnPrem",
   "contextSensitiveHelpUrl": "https://learn.microsoft.com/dynamics365/business-central/"

--- a/src/System Application/Test/Azure Blob Services API/app.json
+++ b/src/System Application/Test/Azure Blob Services API/app.json
@@ -37,7 +37,9 @@
     }
   ],
   "screenshots": [],
-  "features": [],
+  "features": [
+    "TranslationsWithNamespaces"
+  ],
   "platform": "29.0.0.0",
   "idRanges": [
     {

--- a/src/System Application/Test/Azure Storage Services Authorization/app.json
+++ b/src/System Application/Test/Azure Storage Services Authorization/app.json
@@ -31,7 +31,9 @@
     }
   ],
   "screenshots": [],
-  "features": [],
+  "features": [
+    "TranslationsWithNamespaces"
+  ],
   "platform": "29.0.0.0",
   "idRanges": [
     {

--- a/src/System Application/Test/Date and Time/app.json
+++ b/src/System Application/Test/Date and Time/app.json
@@ -44,6 +44,7 @@
     "includeSourceInSymbolFile": false
   },
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/System Application/Test/Rest Client/app.json
+++ b/src/System Application/Test/Rest Client/app.json
@@ -54,6 +54,7 @@
     "includeSourceInSymbolFile": true
   },
   "features": [
-    "NoImplicitWith"
+    "NoImplicitWith",
+    "TranslationsWithNamespaces"
   ]
 }

--- a/src/System Application/Test/SharePoint Authorization/app.json
+++ b/src/System Application/Test/SharePoint Authorization/app.json
@@ -43,7 +43,9 @@
     }
   ],
   "screenshots": [],
-  "features": [],
+  "features": [
+    "TranslationsWithNamespaces"
+  ],
   "platform": "29.0.0.0",
   "idRanges": [
     {

--- a/src/System Application/Test/SharePoint/app.json
+++ b/src/System Application/Test/SharePoint/app.json
@@ -67,7 +67,9 @@
     }
   ],
   "screenshots": [],
-  "features": [],
+  "features": [
+    "TranslationsWithNamespaces"
+  ],
   "platform": "29.0.0.0",
   "idRanges": [
     {

--- a/src/System Application/Test/app.json
+++ b/src/System Application/Test/app.json
@@ -53,7 +53,8 @@
   "platform": "29.0.0.0",
   "features": [
     "GenerateCaptions",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Tools/AI Test Toolkit/app.json
+++ b/src/Tools/AI Test Toolkit/app.json
@@ -45,7 +45,8 @@
     "TranslationFile",
     "GenerateCaptions",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Tools/Performance Toolkit/App/app.json
+++ b/src/Tools/Performance Toolkit/App/app.json
@@ -46,7 +46,8 @@
   ],
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Tools/Performance Toolkit/Test/app.json
+++ b/src/Tools/Performance Toolkit/Test/app.json
@@ -35,7 +35,8 @@
   "platform": "29.0.0.0",
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Tools/Red Team Scan/app.json
+++ b/src/Tools/Red Team Scan/app.json
@@ -16,7 +16,8 @@
   "platform": "29.0.0.0",
   "target": "OnPrem",
   "features": [
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "idRanges": [
     {

--- a/src/Tools/Test Framework/Test Libraries/Any/app.json
+++ b/src/Tools/Test Framework/Test Libraries/Any/app.json
@@ -22,7 +22,8 @@
   ],
   "features": [
     "GenerateCaptions",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Tools/Test Framework/Test Libraries/Assert/app.json
+++ b/src/Tools/Test Framework/Test Libraries/Assert/app.json
@@ -22,7 +22,8 @@
   ],
   "features": [
     "GenerateCaptions",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Tools/Test Framework/Test Libraries/LibraryAgent/app.json
+++ b/src/Tools/Test Framework/Test Libraries/LibraryAgent/app.json
@@ -44,7 +44,8 @@
     "GenerateCaptions",
     "TranslationFile",
     "NoImplicitWith",
-    "NoPromotedActionProperties"
+    "NoPromotedActionProperties",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Tools/Test Framework/Test Libraries/Permissions Mock/app.json
+++ b/src/Tools/Test Framework/Test Libraries/Permissions Mock/app.json
@@ -22,7 +22,8 @@
   ],
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Tools/Test Framework/Test Libraries/Variable Storage/app.json
+++ b/src/Tools/Test Framework/Test Libraries/Variable Storage/app.json
@@ -29,7 +29,8 @@
   ],
   "features": [
     "GenerateCaptions",
-    "TranslationFile"
+    "TranslationFile",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Tools/Test Framework/Test Runner/app.json
+++ b/src/Tools/Test Framework/Test Runner/app.json
@@ -22,7 +22,8 @@
   ],
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "resourceExposurePolicy": {
     "allowDebugging": true,

--- a/src/Tools/Test Framework/Test Stability Tools/Prevent Metadata Updates/app.json
+++ b/src/Tools/Test Framework/Test Stability Tools/Prevent Metadata Updates/app.json
@@ -22,7 +22,8 @@
   ],
   "features": [
     "TranslationFile",
-    "GenerateCaptions"
+    "GenerateCaptions",
+    "TranslationsWithNamespaces"
   ],
   "target": "OnPrem"
 }


### PR DESCRIPTION
Adds the TranslationsWithNamespaces feature to every app that can use it, so translation IDs become namespace-qualified.

Excluded: Dynamics SL Historical Data. The feature requires runtime 18.0 or greater and that app pins runtime 14.0, so enabling it fails the build with AL0666.

Four app.json files carry a duplicate "features" key, where only the last occurrence takes effect. Every occurrence is updated so the result is correct regardless of which one the compiler honours:
  src/Apps/DE/EDocumentDE/demo data/app.json
  src/Apps/ES/EDocumentES/demo data/app.json
  src/Apps/ES/EDocument_ES/demo data/app.json
  src/Apps/FR/EDocument_FR/demo data/app.json

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->





