### PR TITLE
[Master]-For an Item of 'Type' Service or Non-Inventory we allow you to increase the Quantity of the Corrective Credit Memo which then if posted updates the Purchase Order with a negative Received and Invoiced values

### DIFF
--- a/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -602,6 +602,8 @@ table 39 "Purchase Line"
                     end;
                 end;
 
+                CheckCorrectiveCreditMemoQtyIncrease(xRec);
+
                 if (Type = Type::"Charge (Item)") and (CurrFieldNo <> 0) then begin
                     if (Quantity = 0) and ("Qty. to Assign" <> 0) then
                         FieldError("Qty. to Assign", StrSubstNo(Text011, FieldCaption(Quantity), Quantity));
@@ -4320,6 +4322,7 @@ table 39 "Purchase Line"
 #pragma warning restore AA0470
         Text029: Label 'must be positive.';
         Text030: Label 'must be negative.';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 #pragma warning disable AA0470
         Text032: Label '%1 must not be greater than the sum of %2 and %3.';
 #pragma warning restore AA0470
@@ -10952,6 +10955,18 @@ table 39 "Purchase Line"
     begin
     end;
 
+    local procedure CheckCorrectiveCreditMemoQtyIncrease(xPurchaseLine: Record "Purchase Line")
+    begin
+        if not ("Copied From Posted Doc." and IsCreditDocType()) then
+            exit;
+
+        if not IsNonInventoriableItem() then
+            exit;
+
+        if Abs("Quantity (Base)") > Abs(xPurchaseLine."Quantity (Base)") then
+            FieldError(Quantity, StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, xPurchaseLine.Quantity));
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitDefaultDimensionSources(var PurchaseLine: Record "Purchase Line"; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; FieldNo: Integer)
     begin
@@ -12327,6 +12342,7 @@ table 39 "Purchase Line"
     local procedure OnAfterIsCreditDocType(PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
     end;
+
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterIsInvoiceDocType(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)

--- a/src/Layers/APAC/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
@@ -71,6 +71,7 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         AlreadyCancelledErr: Label 'You cannot cancel this posted purchase invoice because it has already been canceled.';
         CorrCorrectiveDocErr: Label 'You cannot correct this posted purchase invoice because it represents a correction of a credit memo.';
         CancelCorrectiveDocErr: Label 'You cannot cancel this posted purchase invoice because it represents a correction of a credit memo.';
+        CancelledQtyExceedsOrderErr: Label 'The credit memo quantity to reverse exceeds the received or invoiced quantity on purchase order %1 line %2. A corrective credit memo cannot reverse more than was originally received and invoiced.', Comment = '%1 = Purchase order no. %2 = Purchase order line no.';
         VendorIsBlockedCorrectErr: Label 'You cannot correct this posted purchase invoice because vendor %1 is blocked.', Comment = '%1 = Customer name';
         VendorIsBlockedCancelErr: Label 'You cannot cancel this posted purchase invoice because vendor %1 is blocked.', Comment = '%1 = Customer name';
         ItemIsBlockedCorrectErr: Label 'You cannot correct this posted purchase invoice because item %1 %2 is blocked.', Comment = '%1 = Item No. %2 = Item Description';
@@ -860,6 +861,8 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         if IsHandled then
             exit;
 
+        CheckCancelledQuantityWithinOrderLine(PurchaseLine, CancelledQuantity, CancelledQtyBase);
+
         PurchaseLine."Quantity Invoiced" -= CancelledQuantity;
         PurchaseLine."Qty. Invoiced (Base)" -= CancelledQtyBase;
         PurchaseLine."Quantity Received" -= CancelledQuantity;
@@ -1118,6 +1121,16 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         IncomingDocumentAttachment.SetRange("Incoming Document Entry No.", IncomingDocument."Entry No.");
         IncomingDocumentAttachment.ModifyAll("Document No.", '');
         IncomingDocumentAttachment.ModifyAll("Posting Date", 0D);
+    end;
+
+    local procedure CheckCancelledQuantityWithinOrderLine(PurchaseLine: Record "Purchase Line"; CancelledQuantity: Decimal; CancelledQtyBase: Decimal)
+    begin
+        if (Abs(CancelledQuantity) > Abs(PurchaseLine."Quantity Invoiced")) or
+           (Abs(CancelledQtyBase) > Abs(PurchaseLine."Qty. Invoiced (Base)")) or
+           (Abs(CancelledQuantity) > Abs(PurchaseLine."Quantity Received")) or
+           (Abs(CancelledQtyBase) > Abs(PurchaseLine."Qty. Received (Base)"))
+        then
+            Error(CancelledQtyExceedsOrderErr, PurchaseLine."Document No.", PurchaseLine."Line No.");
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/APAC/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
@@ -44,6 +44,8 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         CreateCopyDocument(Rec, PurchaseHeader, PurchaseHeader."Document Type"::"Credit Memo", false);
         PurchaseHeader."Vendor Cr. Memo No." := PurchaseHeader."No.";
 
+        CheckPurchaseOrderLinesCanAbsorbCancellation(Rec."No.");
+
         SuppressCommit := not NoSeries.IsNoSeriesInDateOrder(PurchaseHeader."Posting No. Series");
 
         OnAfterCreateCorrectivePurchCrMemo(Rec, PurchaseHeader, CancellingOnly, SuppressCommit);
@@ -861,8 +863,6 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         if IsHandled then
             exit;
 
-        CheckCancelledQuantityWithinOrderLine(PurchaseLine, CancelledQuantity, CancelledQtyBase);
-
         PurchaseLine."Quantity Invoiced" -= CancelledQuantity;
         PurchaseLine."Qty. Invoiced (Base)" -= CancelledQtyBase;
         PurchaseLine."Quantity Received" -= CancelledQuantity;
@@ -1121,6 +1121,22 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         IncomingDocumentAttachment.SetRange("Incoming Document Entry No.", IncomingDocument."Entry No.");
         IncomingDocumentAttachment.ModifyAll("Document No.", '');
         IncomingDocumentAttachment.ModifyAll("Posting Date", 0D);
+    end;
+
+    local procedure CheckPurchaseOrderLinesCanAbsorbCancellation(PurchInvHeaderNo: Code[20])
+    var
+        PurchaseLine: Record "Purchase Line";
+        PurchInvLine: Record "Purch. Inv. Line";
+    begin
+        PurchaseLine.SetLoadFields("Quantity Invoiced", "Qty. Invoiced (Base)", "Quantity Received", "Qty. Received (Base)");
+        PurchInvLine.SetLoadFields("Order No.", "Order Line No.", Quantity, "Quantity (Base)");
+        PurchInvLine.SetRange("Document No.", PurchInvHeaderNo);
+        PurchInvLine.SetRange("Prepayment Line", false);
+        if PurchInvLine.FindSet() then
+            repeat
+                if PurchaseLine.Get(PurchaseLine."Document Type"::Order, PurchInvLine."Order No.", PurchInvLine."Order Line No.") then
+                    CheckCancelledQuantityWithinOrderLine(PurchaseLine, PurchInvLine.Quantity, PurchInvLine."Quantity (Base)");
+            until PurchInvLine.Next() = 0;
     end;
 
     local procedure CheckCancelledQuantityWithinOrderLine(PurchaseLine: Record "Purchase Line"; CancelledQuantity: Decimal; CancelledQtyBase: Decimal)

--- a/src/Layers/AU/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
+++ b/src/Layers/AU/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
@@ -32,6 +32,7 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         CorrectPostedInvoiceFromSingleOrderQst: Label 'The invoice was posted from an order. The invoice will be cancelled, and the order will open so that you can make the correction.\ \Do you want to continue?';
         CorrectPostedInvoiceFromDeletedOrderQst: Label 'The invoice was posted from an order. The order has been deleted, and the invoice will be cancelled. You can create a new invoice or order by using the Copy Document action.\ \Do you want to continue?';
         CorrectPostedInvoiceFromMultipleOrderQst: Label 'The invoice was posted from multiple orders. It will now be cancelled, and you can make a correction manually in the original orders.\ \Do you want to continue?';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 
     [Test]
     [HandlerFunctions('ConfirmHandler')]
@@ -1745,6 +1746,87 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         LibraryVariableStorage.AssertEmpty();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForServiceItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] Increasing the quantity of a corrective credit memo line for a Service item is blocked.
+        VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Item.Type::Service);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForNonInventoryItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] Increasing the quantity of a corrective credit memo line for a Non-Inventory item is blocked.
+        VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Item.Type::"Non-Inventory");
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyDecreaseAllowedForServiceItem()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] A partial reversal (decreasing the quantity) on a corrective credit memo line is still allowed.
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for a Service item
+        OriginalQty := LibraryRandom.RandIntInRange(2, 10);
+        CreateAndPostPurchaseInvForNewItemAndVendor(Item, Item.Type::Service, Vendor, LibraryRandom.RandDecInRange(10, 100, 2), OriginalQty, PurchInvHeader);
+
+        // [GIVEN] A corrective credit memo created from the posted invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+
+        // [WHEN] Decreasing the quantity of the credit memo line below the copied quantity
+        PurchaseLine.Validate(Quantity, PurchaseLine.Quantity - 1);
+
+        // [THEN] The decrease is accepted
+        PurchaseLine.TestField(Quantity, OriginalQty - 1);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ManualCreditMemoQtyIncreaseAllowed()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] A manually created credit memo (not copied from a posted invoice) is not affected by the corrective quantity check.
+        Initialize();
+
+        // [GIVEN] A manually created purchase credit memo with an item line
+        OriginalQty := LibraryRandom.RandIntInRange(2, 10);
+        CreateItemWithCost(Item, Item.Type::Service, LibraryRandom.RandDecInRange(10, 100, 2));
+        LibrarySmallBusiness.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::"Credit Memo", Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", OriginalQty);
+
+        // [WHEN] Increasing the quantity of the line
+        PurchaseLine.Validate(Quantity, PurchaseLine.Quantity + 1);
+
+        // [THEN] The increase is accepted
+        PurchaseLine.TestField(Quantity, OriginalQty + 1);
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
@@ -1932,6 +2014,41 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         CreateItemWithCost(Item, Type, UnitCost);
         LibrarySmallBusiness.CreateVendor(Vendor);
         BuyItem(Vendor, Item, Qty, PurchInvHeader);
+    end;
+
+    local procedure VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Type: Enum "Item Type")
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OriginalQty: Decimal;
+    begin
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for an item with quantity 1
+        CreateAndPostPurchaseInvForNewItemAndVendor(Item, Type, Vendor, LibraryRandom.RandDecInRange(10, 100, 2), 1, PurchInvHeader);
+
+        // [GIVEN] A corrective credit memo created from the posted invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+        OriginalQty := PurchaseLine.Quantity;
+
+        // [WHEN] Increasing the quantity of the credit memo line beyond the copied quantity
+        asserterror PurchaseLine.Validate(Quantity, OriginalQty + 1);
+
+        // [THEN] A blocking error is raised
+        Assert.ExpectedError(StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, OriginalQty));
+    end;
+
+    local procedure GetCorrectiveCreditMemoItemLine(var PurchaseLine: Record "Purchase Line"; CreditMemoNo: Code[20])
+    begin
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::"Credit Memo");
+        PurchaseLine.SetRange("Document No.", CreditMemoNo);
+        PurchaseLine.SetFilter(Type, '<>%1', PurchaseLine.Type::" ");
+        PurchaseLine.FindLast();
     end;
 
     local procedure CreateAndPostPurchaseInvForNewItemVariantAndVendor(var ItemVariant: Record "Item Variant"; var Vendor: Record Vendor; UnitCost: Decimal; Qty: Decimal; var PurchInvHeader: Record "Purch. Inv. Header")

--- a/src/Layers/AU/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
+++ b/src/Layers/AU/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
@@ -1827,6 +1827,64 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         PurchaseLine.TestField(Quantity, OriginalQty + 1);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForOrderBasedServiceItem()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OrderQty: Decimal;
+        PartialQty: Decimal;
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo] [Purchase Order]
+        // [SCENARIO 645182] A corrective credit memo created from an order-based invoice cannot be increased, so the purchase order Received/Invoiced quantities cannot be driven negative.
+        Initialize();
+
+        // [GIVEN] A purchase order for a Service item, partially received and invoiced
+        PartialQty := LibraryRandom.RandIntInRange(2, 5);
+        OrderQty := PartialQty + LibraryRandom.RandIntInRange(1, 5);
+        CreateItemWithCost(Item, Item.Type::Service, LibraryRandom.RandDecInRange(10, 100, 2));
+        LibrarySmallBusiness.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderOrder, PurchaseHeaderOrder."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", OrderQty);
+        PurchaseLineOrder.Validate("Qty. to Receive", PartialQty);
+        PurchaseLineOrder.Validate("Qty. to Invoice", PartialQty);
+        PurchaseLineOrder.Modify(true);
+        PurchInvHeader.Get(LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, true));
+
+        // [GIVEN] The order line shows the partially received and invoiced quantity
+        PurchaseLineOrder.Find();
+        PurchaseLineOrder.TestField("Quantity Received", PartialQty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", PartialQty);
+
+        // [GIVEN] A corrective credit memo created from the posted order-based invoice
+        LibraryVariableStorage.Enqueue(true); // Confirm to create the corrective credit memo from the order-based invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+        OriginalQty := PurchaseLine.Quantity;
+
+        // [WHEN] Increasing the quantity of the credit memo line beyond the copied quantity
+        asserterror PurchaseLine.Validate(Quantity, OriginalQty + 1);
+
+        // [THEN] A blocking error is raised before the credit memo can be posted
+        Assert.ExpectedError(StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, OriginalQty));
+
+        // [THEN] The purchase order line quantities are unchanged and cannot go negative
+        PurchaseLineOrder.Find();
+        PurchaseLineOrder.TestField("Quantity Received", PartialQty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", PartialQty);
+
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";

--- a/src/Layers/BE/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/BE/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -594,6 +594,8 @@ table 39 "Purchase Line"
                     end;
                 end;
 
+                CheckCorrectiveCreditMemoQtyIncrease(xRec);
+
                 if (Type = Type::"Charge (Item)") and (CurrFieldNo <> 0) then begin
                     if (Quantity = 0) and ("Qty. to Assign" <> 0) then
                         FieldError("Qty. to Assign", StrSubstNo(Text011, FieldCaption(Quantity), Quantity));
@@ -4239,6 +4241,7 @@ table 39 "Purchase Line"
 #pragma warning restore AA0470
         Text029: Label 'must be positive.';
         Text030: Label 'must be negative.';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 #pragma warning disable AA0470
         Text032: Label '%1 must not be greater than the sum of %2 and %3.';
 #pragma warning restore AA0470
@@ -10382,6 +10385,18 @@ table 39 "Purchase Line"
         exit("Matched Inv./Cr. Memo Lines" > 0);
     end;
 
+    local procedure CheckCorrectiveCreditMemoQtyIncrease(xPurchaseLine: Record "Purchase Line")
+    begin
+        if not ("Copied From Posted Doc." and IsCreditDocType()) then
+            exit;
+
+        if not IsNonInventoriableItem() then
+            exit;
+
+        if Abs("Quantity (Base)") > Abs(xPurchaseLine."Quantity (Base)") then
+            FieldError(Quantity, StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, xPurchaseLine.Quantity));
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitDefaultDimensionSources(var PurchaseLine: Record "Purchase Line"; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; FieldNo: Integer)
     begin
@@ -11757,6 +11772,7 @@ table 39 "Purchase Line"
     local procedure OnAfterIsCreditDocType(PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
     end;
+
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterIsInvoiceDocType(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)

--- a/src/Layers/CH/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/CH/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -598,6 +598,8 @@ table 39 "Purchase Line"
                     end;
                 end;
 
+                CheckCorrectiveCreditMemoQtyIncrease(xRec);
+
                 if (Type = Type::"Charge (Item)") and (CurrFieldNo <> 0) then begin
                     if (Quantity = 0) and ("Qty. to Assign" <> 0) then
                         FieldError("Qty. to Assign", StrSubstNo(Text011, FieldCaption(Quantity), Quantity));
@@ -4238,6 +4240,7 @@ table 39 "Purchase Line"
 #pragma warning restore AA0470
         Text029: Label 'must be positive.';
         Text030: Label 'must be negative.';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 #pragma warning disable AA0470
         Text032: Label '%1 must not be greater than the sum of %2 and %3.';
 #pragma warning restore AA0470
@@ -10275,6 +10278,18 @@ table 39 "Purchase Line"
         exit("Matched Inv./Cr. Memo Lines" > 0);
     end;
 
+    local procedure CheckCorrectiveCreditMemoQtyIncrease(xPurchaseLine: Record "Purchase Line")
+    begin
+        if not ("Copied From Posted Doc." and IsCreditDocType()) then
+            exit;
+
+        if not IsNonInventoriableItem() then
+            exit;
+
+        if Abs("Quantity (Base)") > Abs(xPurchaseLine."Quantity (Base)") then
+            FieldError(Quantity, StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, xPurchaseLine.Quantity));
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitDefaultDimensionSources(var PurchaseLine: Record "Purchase Line"; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; FieldNo: Integer)
     begin
@@ -11650,6 +11665,7 @@ table 39 "Purchase Line"
     local procedure OnAfterIsCreditDocType(PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
     end;
+
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterIsInvoiceDocType(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)

--- a/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -594,6 +594,8 @@ table 39 "Purchase Line"
                     end;
                 end;
 
+                CheckCorrectiveCreditMemoQtyIncrease(xRec);
+
                 if (Type = Type::"Charge (Item)") and (CurrFieldNo <> 0) then begin
                     if (Quantity = 0) and ("Qty. to Assign" <> 0) then
                         FieldError("Qty. to Assign", StrSubstNo(Text011, FieldCaption(Quantity), Quantity));
@@ -4236,6 +4238,7 @@ table 39 "Purchase Line"
 #pragma warning restore AA0470
         Text029: Label 'must be positive.';
         Text030: Label 'must be negative.';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 #pragma warning disable AA0470
         Text032: Label '%1 must not be greater than the sum of %2 and %3.';
 #pragma warning restore AA0470
@@ -10274,6 +10277,18 @@ table 39 "Purchase Line"
         exit("Matched Inv./Cr. Memo Lines" > 0);
     end;
 
+    local procedure CheckCorrectiveCreditMemoQtyIncrease(xPurchaseLine: Record "Purchase Line")
+    begin
+        if not ("Copied From Posted Doc." and IsCreditDocType()) then
+            exit;
+
+        if not IsNonInventoriableItem() then
+            exit;
+
+        if Abs("Quantity (Base)") > Abs(xPurchaseLine."Quantity (Base)") then
+            FieldError(Quantity, StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, xPurchaseLine.Quantity));
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitDefaultDimensionSources(var PurchaseLine: Record "Purchase Line"; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; FieldNo: Integer)
     begin
@@ -11649,6 +11664,7 @@ table 39 "Purchase Line"
     local procedure OnAfterIsCreditDocType(PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
     end;
+
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterIsInvoiceDocType(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)

--- a/src/Layers/ES/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/ES/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -594,6 +594,8 @@ table 39 "Purchase Line"
                     end;
                 end;
 
+                CheckCorrectiveCreditMemoQtyIncrease(xRec);
+
                 if (Type = Type::"Charge (Item)") and (CurrFieldNo <> 0) then begin
                     if (Quantity = 0) and ("Qty. to Assign" <> 0) then
                         FieldError("Qty. to Assign", StrSubstNo(Text011, FieldCaption(Quantity), Quantity));
@@ -4242,6 +4244,7 @@ table 39 "Purchase Line"
 #pragma warning restore AA0470
         Text029: Label 'must be positive.';
         Text030: Label 'must be negative.';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 #pragma warning disable AA0470
         Text032: Label '%1 must not be greater than the sum of %2 and %3.';
 #pragma warning restore AA0470
@@ -10298,6 +10301,18 @@ table 39 "Purchase Line"
         exit("Matched Inv./Cr. Memo Lines" > 0);
     end;
 
+    local procedure CheckCorrectiveCreditMemoQtyIncrease(xPurchaseLine: Record "Purchase Line")
+    begin
+        if not ("Copied From Posted Doc." and IsCreditDocType()) then
+            exit;
+
+        if not IsNonInventoriableItem() then
+            exit;
+
+        if Abs("Quantity (Base)") > Abs(xPurchaseLine."Quantity (Base)") then
+            FieldError(Quantity, StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, xPurchaseLine.Quantity));
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitDefaultDimensionSources(var PurchaseLine: Record "Purchase Line"; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; FieldNo: Integer)
     begin
@@ -11673,6 +11688,7 @@ table 39 "Purchase Line"
     local procedure OnAfterIsCreditDocType(PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
     end;
+
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterIsInvoiceDocType(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)

--- a/src/Layers/ES/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
@@ -69,6 +69,7 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         AlreadyCancelledErr: Label 'You cannot cancel this posted purchase invoice because it has already been canceled.';
         CorrCorrectiveDocErr: Label 'You cannot correct this posted purchase invoice because it represents a correction of a credit memo.';
         CancelCorrectiveDocErr: Label 'You cannot cancel this posted purchase invoice because it represents a correction of a credit memo.';
+        CancelledQtyExceedsOrderErr: Label 'The credit memo quantity to reverse exceeds the received or invoiced quantity on purchase order %1 line %2. A corrective credit memo cannot reverse more than was originally received and invoiced.', Comment = '%1 = Purchase order no. %2 = Purchase order line no.';
         VendorIsBlockedCorrectErr: Label 'You cannot correct this posted purchase invoice because vendor %1 is blocked.', Comment = '%1 = Customer name';
         VendorIsBlockedCancelErr: Label 'You cannot cancel this posted purchase invoice because vendor %1 is blocked.', Comment = '%1 = Customer name';
         ItemIsBlockedCorrectErr: Label 'You cannot correct this posted purchase invoice because item %1 %2 is blocked.', Comment = '%1 = Item No. %2 = Item Description';
@@ -859,6 +860,8 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         if IsHandled then
             exit;
 
+        CheckCancelledQuantityWithinOrderLine(PurchaseLine, CancelledQuantity, CancelledQtyBase);
+
         PurchaseLine."Quantity Invoiced" -= CancelledQuantity;
         PurchaseLine."Qty. Invoiced (Base)" -= CancelledQtyBase;
         PurchaseLine."Quantity Received" -= CancelledQuantity;
@@ -1095,6 +1098,16 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         IncomingDocumentAttachment.SetRange("Incoming Document Entry No.", IncomingDocument."Entry No.");
         IncomingDocumentAttachment.ModifyAll("Document No.", '');
         IncomingDocumentAttachment.ModifyAll("Posting Date", 0D);
+    end;
+
+    local procedure CheckCancelledQuantityWithinOrderLine(PurchaseLine: Record "Purchase Line"; CancelledQuantity: Decimal; CancelledQtyBase: Decimal)
+    begin
+        if (Abs(CancelledQuantity) > Abs(PurchaseLine."Quantity Invoiced")) or
+           (Abs(CancelledQtyBase) > Abs(PurchaseLine."Qty. Invoiced (Base)")) or
+           (Abs(CancelledQuantity) > Abs(PurchaseLine."Quantity Received")) or
+           (Abs(CancelledQtyBase) > Abs(PurchaseLine."Qty. Received (Base)"))
+        then
+            Error(CancelledQtyExceedsOrderErr, PurchaseLine."Document No.", PurchaseLine."Line No.");
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/ES/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
@@ -44,6 +44,8 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         CreateCopyDocument(Rec, PurchaseHeader, PurchaseHeader."Document Type"::"Credit Memo", false);
         PurchaseHeader."Vendor Cr. Memo No." := PurchaseHeader."No.";
 
+        CheckPurchaseOrderLinesCanAbsorbCancellation(Rec."No.");
+
         SuppressCommit := not NoSeries.IsNoSeriesInDateOrder(PurchaseHeader."Posting No. Series");
 
         OnAfterCreateCorrectivePurchCrMemo(Rec, PurchaseHeader, CancellingOnly, SuppressCommit);
@@ -860,8 +862,6 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         if IsHandled then
             exit;
 
-        CheckCancelledQuantityWithinOrderLine(PurchaseLine, CancelledQuantity, CancelledQtyBase);
-
         PurchaseLine."Quantity Invoiced" -= CancelledQuantity;
         PurchaseLine."Qty. Invoiced (Base)" -= CancelledQtyBase;
         PurchaseLine."Quantity Received" -= CancelledQuantity;
@@ -1098,6 +1098,22 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         IncomingDocumentAttachment.SetRange("Incoming Document Entry No.", IncomingDocument."Entry No.");
         IncomingDocumentAttachment.ModifyAll("Document No.", '');
         IncomingDocumentAttachment.ModifyAll("Posting Date", 0D);
+    end;
+
+    local procedure CheckPurchaseOrderLinesCanAbsorbCancellation(PurchInvHeaderNo: Code[20])
+    var
+        PurchaseLine: Record "Purchase Line";
+        PurchInvLine: Record "Purch. Inv. Line";
+    begin
+        PurchaseLine.SetLoadFields("Quantity Invoiced", "Qty. Invoiced (Base)", "Quantity Received", "Qty. Received (Base)");
+        PurchInvLine.SetLoadFields("Order No.", "Order Line No.", Quantity, "Quantity (Base)");
+        PurchInvLine.SetRange("Document No.", PurchInvHeaderNo);
+        PurchInvLine.SetRange("Prepayment Line", false);
+        if PurchInvLine.FindSet() then
+            repeat
+                if PurchaseLine.Get(PurchaseLine."Document Type"::Order, PurchInvLine."Order No.", PurchInvLine."Order Line No.") then
+                    CheckCancelledQuantityWithinOrderLine(PurchaseLine, PurchInvLine.Quantity, PurchInvLine."Quantity (Base)");
+            until PurchInvLine.Next() = 0;
     end;
 
     local procedure CheckCancelledQuantityWithinOrderLine(PurchaseLine: Record "Purchase Line"; CancelledQuantity: Decimal; CancelledQtyBase: Decimal)

--- a/src/Layers/ES/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
+++ b/src/Layers/ES/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
@@ -31,6 +31,7 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         CorrectPostedInvoiceFromSingleOrderQst: Label 'The invoice was posted from an order. The invoice will be cancelled, and the order will open so that you can make the correction.\ \Do you want to continue?';
         CorrectPostedInvoiceFromDeletedOrderQst: Label 'The invoice was posted from an order. The order has been deleted, and the invoice will be cancelled. You can create a new invoice or order by using the Copy Document action.\ \Do you want to continue?';
         CorrectPostedInvoiceFromMultipleOrderQst: Label 'The invoice was posted from multiple orders. It will now be cancelled, and you can make a correction manually in the original orders.\ \Do you want to continue?';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 
     [Test]
     [HandlerFunctions('ConfirmHandler')]
@@ -1688,6 +1689,87 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         LibraryVariableStorage.AssertEmpty();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForServiceItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] Increasing the quantity of a corrective credit memo line for a Service item is blocked.
+        VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Item.Type::Service);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForNonInventoryItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] Increasing the quantity of a corrective credit memo line for a Non-Inventory item is blocked.
+        VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Item.Type::"Non-Inventory");
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyDecreaseAllowedForServiceItem()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] A partial reversal (decreasing the quantity) on a corrective credit memo line is still allowed.
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for a Service item
+        OriginalQty := LibraryRandom.RandIntInRange(2, 10);
+        CreateAndPostPurchaseInvForNewItemAndVendor(Item, Item.Type::Service, Vendor, LibraryRandom.RandDecInRange(10, 100, 2), OriginalQty, PurchInvHeader);
+
+        // [GIVEN] A corrective credit memo created from the posted invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+
+        // [WHEN] Decreasing the quantity of the credit memo line below the copied quantity
+        PurchaseLine.Validate(Quantity, PurchaseLine.Quantity - 1);
+
+        // [THEN] The decrease is accepted
+        PurchaseLine.TestField(Quantity, OriginalQty - 1);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ManualCreditMemoQtyIncreaseAllowed()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] A manually created credit memo (not copied from a posted invoice) is not affected by the corrective quantity check.
+        Initialize();
+
+        // [GIVEN] A manually created purchase credit memo with an item line
+        OriginalQty := LibraryRandom.RandIntInRange(2, 10);
+        CreateItemWithCost(Item, Item.Type::Service, LibraryRandom.RandDecInRange(10, 100, 2));
+        LibrarySmallBusiness.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::"Credit Memo", Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", OriginalQty);
+
+        // [WHEN] Increasing the quantity of the line
+        PurchaseLine.Validate(Quantity, PurchaseLine.Quantity + 1);
+
+        // [THEN] The increase is accepted
+        PurchaseLine.TestField(Quantity, OriginalQty + 1);
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
@@ -1872,6 +1954,41 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         CreateItemWithCost(Item, Type, UnitCost);
         LibrarySmallBusiness.CreateVendor(Vendor);
         BuyItem(Vendor, Item, Qty, PurchInvHeader);
+    end;
+
+    local procedure VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Type: Enum "Item Type")
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OriginalQty: Decimal;
+    begin
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for an item with quantity 1
+        CreateAndPostPurchaseInvForNewItemAndVendor(Item, Type, Vendor, LibraryRandom.RandDecInRange(10, 100, 2), 1, PurchInvHeader);
+
+        // [GIVEN] A corrective credit memo created from the posted invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+        OriginalQty := PurchaseLine.Quantity;
+
+        // [WHEN] Increasing the quantity of the credit memo line beyond the copied quantity
+        asserterror PurchaseLine.Validate(Quantity, OriginalQty + 1);
+
+        // [THEN] A blocking error is raised
+        Assert.ExpectedError(StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, OriginalQty));
+    end;
+
+    local procedure GetCorrectiveCreditMemoItemLine(var PurchaseLine: Record "Purchase Line"; CreditMemoNo: Code[20])
+    begin
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::"Credit Memo");
+        PurchaseLine.SetRange("Document No.", CreditMemoNo);
+        PurchaseLine.SetFilter(Type, '<>%1', PurchaseLine.Type::" ");
+        PurchaseLine.FindLast();
     end;
 
     local procedure CreateAndPostPurchaseInvForNewItemVariantAndVendor(var ItemVariant: Record "Item Variant"; var Vendor: Record Vendor; UnitCost: Decimal; Qty: Decimal; var PurchInvHeader: Record "Purch. Inv. Header")

--- a/src/Layers/ES/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
+++ b/src/Layers/ES/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
@@ -1770,6 +1770,64 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         PurchaseLine.TestField(Quantity, OriginalQty + 1);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForOrderBasedServiceItem()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OrderQty: Decimal;
+        PartialQty: Decimal;
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo] [Purchase Order]
+        // [SCENARIO 645182] A corrective credit memo created from an order-based invoice cannot be increased, so the purchase order Received/Invoiced quantities cannot be driven negative.
+        Initialize();
+
+        // [GIVEN] A purchase order for a Service item, partially received and invoiced
+        PartialQty := LibraryRandom.RandIntInRange(2, 5);
+        OrderQty := PartialQty + LibraryRandom.RandIntInRange(1, 5);
+        CreateItemWithCost(Item, Item.Type::Service, LibraryRandom.RandDecInRange(10, 100, 2));
+        LibrarySmallBusiness.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderOrder, PurchaseHeaderOrder."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", OrderQty);
+        PurchaseLineOrder.Validate("Qty. to Receive", PartialQty);
+        PurchaseLineOrder.Validate("Qty. to Invoice", PartialQty);
+        PurchaseLineOrder.Modify(true);
+        PurchInvHeader.Get(LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, true));
+
+        // [GIVEN] The order line shows the partially received and invoiced quantity
+        PurchaseLineOrder.Find();
+        PurchaseLineOrder.TestField("Quantity Received", PartialQty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", PartialQty);
+
+        // [GIVEN] A corrective credit memo created from the posted order-based invoice
+        LibraryVariableStorage.Enqueue(true); // Confirm to create the corrective credit memo from the order-based invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+        OriginalQty := PurchaseLine.Quantity;
+
+        // [WHEN] Increasing the quantity of the credit memo line beyond the copied quantity
+        asserterror PurchaseLine.Validate(Quantity, OriginalQty + 1);
+
+        // [THEN] A blocking error is raised before the credit memo can be posted
+        Assert.ExpectedError(StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, OriginalQty));
+
+        // [THEN] The purchase order line quantities are unchanged and cannot go negative
+        PurchaseLineOrder.Find();
+        PurchaseLineOrder.TestField("Quantity Received", PartialQty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", PartialQty);
+
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";

--- a/src/Layers/FI/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/FI/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -595,6 +595,8 @@ table 39 "Purchase Line"
                     end;
                 end;
 
+                CheckCorrectiveCreditMemoQtyIncrease(xRec);
+
                 if (Type = Type::"Charge (Item)") and (CurrFieldNo <> 0) then begin
                     if (Quantity = 0) and ("Qty. to Assign" <> 0) then
                         FieldError("Qty. to Assign", StrSubstNo(Text011, FieldCaption(Quantity), Quantity));
@@ -4229,6 +4231,7 @@ table 39 "Purchase Line"
 #pragma warning restore AA0470
         Text029: Label 'must be positive.';
         Text030: Label 'must be negative.';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 #pragma warning disable AA0470
         Text032: Label '%1 must not be greater than the sum of %2 and %3.';
 #pragma warning restore AA0470
@@ -10267,6 +10270,18 @@ table 39 "Purchase Line"
         exit("Matched Inv./Cr. Memo Lines" > 0);
     end;
 
+    local procedure CheckCorrectiveCreditMemoQtyIncrease(xPurchaseLine: Record "Purchase Line")
+    begin
+        if not ("Copied From Posted Doc." and IsCreditDocType()) then
+            exit;
+
+        if not IsNonInventoriableItem() then
+            exit;
+
+        if Abs("Quantity (Base)") > Abs(xPurchaseLine."Quantity (Base)") then
+            FieldError(Quantity, StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, xPurchaseLine.Quantity));
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitDefaultDimensionSources(var PurchaseLine: Record "Purchase Line"; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; FieldNo: Integer)
     begin
@@ -11642,6 +11657,7 @@ table 39 "Purchase Line"
     local procedure OnAfterIsCreditDocType(PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
     end;
+
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterIsInvoiceDocType(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)

--- a/src/Layers/GB/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/GB/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -597,6 +597,8 @@ table 39 "Purchase Line"
                     end;
                 end;
 
+                CheckCorrectiveCreditMemoQtyIncrease(xRec);
+
                 if (Type = Type::"Charge (Item)") and (CurrFieldNo <> 0) then begin
                     if (Quantity = 0) and ("Qty. to Assign" <> 0) then
                         FieldError("Qty. to Assign", StrSubstNo(Text011, FieldCaption(Quantity), Quantity));
@@ -4256,6 +4258,7 @@ table 39 "Purchase Line"
 #pragma warning restore AA0470
         Text029: Label 'must be positive.';
         Text030: Label 'must be negative.';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 #pragma warning disable AA0470
         Text032: Label '%1 must not be greater than the sum of %2 and %3.';
 #pragma warning restore AA0470
@@ -10318,6 +10321,18 @@ table 39 "Purchase Line"
         exit("Matched Inv./Cr. Memo Lines" > 0);
     end;
 
+    local procedure CheckCorrectiveCreditMemoQtyIncrease(xPurchaseLine: Record "Purchase Line")
+    begin
+        if not ("Copied From Posted Doc." and IsCreditDocType()) then
+            exit;
+
+        if not IsNonInventoriableItem() then
+            exit;
+
+        if Abs("Quantity (Base)") > Abs(xPurchaseLine."Quantity (Base)") then
+            FieldError(Quantity, StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, xPurchaseLine.Quantity));
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitDefaultDimensionSources(var PurchaseLine: Record "Purchase Line"; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; FieldNo: Integer)
     begin
@@ -11693,6 +11708,7 @@ table 39 "Purchase Line"
     local procedure OnAfterIsCreditDocType(PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
     end;
+
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterIsInvoiceDocType(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)

--- a/src/Layers/IT/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -612,6 +612,8 @@ table 39 "Purchase Line"
                     end;
                 end;
 
+                CheckCorrectiveCreditMemoQtyIncrease(xRec);
+
                 if (Type = Type::"Charge (Item)") and (CurrFieldNo <> 0) then begin
                     if (Quantity = 0) and ("Qty. to Assign" <> 0) then
                         FieldError("Qty. to Assign", StrSubstNo(Text011, FieldCaption(Quantity), Quantity));
@@ -4485,6 +4487,7 @@ table 39 "Purchase Line"
 #pragma warning restore AA0470
         Text029: Label 'must be positive.';
         Text030: Label 'must be negative.';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 #pragma warning disable AA0470
         Text032: Label '%1 must not be greater than the sum of %2 and %3.';
 #pragma warning restore AA0470
@@ -10553,6 +10556,18 @@ table 39 "Purchase Line"
         exit("Matched Inv./Cr. Memo Lines" > 0);
     end;
 
+    local procedure CheckCorrectiveCreditMemoQtyIncrease(xPurchaseLine: Record "Purchase Line")
+    begin
+        if not ("Copied From Posted Doc." and IsCreditDocType()) then
+            exit;
+
+        if not IsNonInventoriableItem() then
+            exit;
+
+        if Abs("Quantity (Base)") > Abs(xPurchaseLine."Quantity (Base)") then
+            FieldError(Quantity, StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, xPurchaseLine.Quantity));
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitDefaultDimensionSources(var PurchaseLine: Record "Purchase Line"; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; FieldNo: Integer)
     begin
@@ -11923,6 +11938,7 @@ table 39 "Purchase Line"
     local procedure OnAfterIsCreditDocType(PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
     end;
+
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterIsInvoiceDocType(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)

--- a/src/Layers/IT/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
@@ -75,6 +75,7 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         AlreadyCancelledErr: Label 'You cannot cancel this posted purchase invoice because it has already been canceled.';
         CorrCorrectiveDocErr: Label 'You cannot correct this posted purchase invoice because it represents a correction of a credit memo.';
         CancelCorrectiveDocErr: Label 'You cannot cancel this posted purchase invoice because it represents a correction of a credit memo.';
+        CancelledQtyExceedsOrderErr: Label 'The credit memo quantity to reverse exceeds the received or invoiced quantity on purchase order %1 line %2. A corrective credit memo cannot reverse more than was originally received and invoiced.', Comment = '%1 = Purchase order no. %2 = Purchase order line no.';
         VendorIsBlockedCorrectErr: Label 'You cannot correct this posted purchase invoice because vendor %1 is blocked.', Comment = '%1 = Customer name';
         VendorIsBlockedCancelErr: Label 'You cannot cancel this posted purchase invoice because vendor %1 is blocked.', Comment = '%1 = Customer name';
         ItemIsBlockedCorrectErr: Label 'You cannot correct this posted purchase invoice because item %1 %2 is blocked.', Comment = '%1 = Item No. %2 = Item Description';
@@ -863,6 +864,8 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         if IsHandled then
             exit;
 
+        CheckCancelledQuantityWithinOrderLine(PurchaseLine, CancelledQuantity, CancelledQtyBase);
+
         PurchaseLine."Quantity Invoiced" -= CancelledQuantity;
         PurchaseLine."Qty. Invoiced (Base)" -= CancelledQtyBase;
         PurchaseLine."Quantity Received" -= CancelledQuantity;
@@ -1122,6 +1125,16 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         IncomingDocumentAttachment.SetRange("Incoming Document Entry No.", IncomingDocument."Entry No.");
         IncomingDocumentAttachment.ModifyAll("Document No.", '');
         IncomingDocumentAttachment.ModifyAll("Posting Date", 0D);
+    end;
+
+    local procedure CheckCancelledQuantityWithinOrderLine(PurchaseLine: Record "Purchase Line"; CancelledQuantity: Decimal; CancelledQtyBase: Decimal)
+    begin
+        if (Abs(CancelledQuantity) > Abs(PurchaseLine."Quantity Invoiced")) or
+           (Abs(CancelledQtyBase) > Abs(PurchaseLine."Qty. Invoiced (Base)")) or
+           (Abs(CancelledQuantity) > Abs(PurchaseLine."Quantity Received")) or
+           (Abs(CancelledQtyBase) > Abs(PurchaseLine."Qty. Received (Base)"))
+        then
+            Error(CancelledQtyExceedsOrderErr, PurchaseLine."Document No.", PurchaseLine."Line No.");
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/IT/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
@@ -43,6 +43,8 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         OnRunOnBeforeCreateCopyDocument(Rec);
         CreateCopyDocument(Rec, PurchaseHeader, PurchaseHeader."Document Type"::"Credit Memo", false);
 
+        CheckPurchaseOrderLinesCanAbsorbCancellation(Rec."No.");
+
         SuppressCommit := not NoSeries.IsNoSeriesInDateOrder(PurchaseHeader."Posting No. Series");
 
         OnBeforeUpdateCheckTotal(Rec, PurchaseHeader, CancellingOnly, SuppressCommit);
@@ -864,8 +866,6 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         if IsHandled then
             exit;
 
-        CheckCancelledQuantityWithinOrderLine(PurchaseLine, CancelledQuantity, CancelledQtyBase);
-
         PurchaseLine."Quantity Invoiced" -= CancelledQuantity;
         PurchaseLine."Qty. Invoiced (Base)" -= CancelledQtyBase;
         PurchaseLine."Quantity Received" -= CancelledQuantity;
@@ -1125,6 +1125,22 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         IncomingDocumentAttachment.SetRange("Incoming Document Entry No.", IncomingDocument."Entry No.");
         IncomingDocumentAttachment.ModifyAll("Document No.", '');
         IncomingDocumentAttachment.ModifyAll("Posting Date", 0D);
+    end;
+
+    local procedure CheckPurchaseOrderLinesCanAbsorbCancellation(PurchInvHeaderNo: Code[20])
+    var
+        PurchaseLine: Record "Purchase Line";
+        PurchInvLine: Record "Purch. Inv. Line";
+    begin
+        PurchaseLine.SetLoadFields("Quantity Invoiced", "Qty. Invoiced (Base)", "Quantity Received", "Qty. Received (Base)");
+        PurchInvLine.SetLoadFields("Order No.", "Order Line No.", Quantity, "Quantity (Base)");
+        PurchInvLine.SetRange("Document No.", PurchInvHeaderNo);
+        PurchInvLine.SetRange("Prepayment Line", false);
+        if PurchInvLine.FindSet() then
+            repeat
+                if PurchaseLine.Get(PurchaseLine."Document Type"::Order, PurchInvLine."Order No.", PurchInvLine."Order Line No.") then
+                    CheckCancelledQuantityWithinOrderLine(PurchaseLine, PurchInvLine.Quantity, PurchInvLine."Quantity (Base)");
+            until PurchInvLine.Next() = 0;
     end;
 
     local procedure CheckCancelledQuantityWithinOrderLine(PurchaseLine: Record "Purchase Line"; CancelledQuantity: Decimal; CancelledQtyBase: Decimal)

--- a/src/Layers/IT/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
@@ -31,6 +31,7 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         CorrectPostedInvoiceFromSingleOrderQst: Label 'The invoice was posted from an order. The invoice will be cancelled, and the order will open so that you can make the correction.\ \Do you want to continue?';
         CorrectPostedInvoiceFromDeletedOrderQst: Label 'The invoice was posted from an order. The order has been deleted, and the invoice will be cancelled. You can create a new invoice or order by using the Copy Document action.\ \Do you want to continue?';
         CorrectPostedInvoiceFromMultipleOrderQst: Label 'The invoice was posted from multiple orders. It will now be cancelled, and you can make a correction manually in the original orders.\ \Do you want to continue?';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 
     [Test]
     [HandlerFunctions('ConfirmHandler')]
@@ -1686,6 +1687,87 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         LibraryVariableStorage.AssertEmpty();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForServiceItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] Increasing the quantity of a corrective credit memo line for a Service item is blocked.
+        VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Item.Type::Service);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForNonInventoryItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] Increasing the quantity of a corrective credit memo line for a Non-Inventory item is blocked.
+        VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Item.Type::"Non-Inventory");
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyDecreaseAllowedForServiceItem()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] A partial reversal (decreasing the quantity) on a corrective credit memo line is still allowed.
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for a Service item
+        OriginalQty := LibraryRandom.RandIntInRange(2, 10);
+        CreateAndPostPurchaseInvForNewItemAndVendor(Item, Item.Type::Service, Vendor, LibraryRandom.RandDecInRange(10, 100, 2), OriginalQty, PurchInvHeader);
+
+        // [GIVEN] A corrective credit memo created from the posted invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+
+        // [WHEN] Decreasing the quantity of the credit memo line below the copied quantity
+        PurchaseLine.Validate(Quantity, PurchaseLine.Quantity - 1);
+
+        // [THEN] The decrease is accepted
+        PurchaseLine.TestField(Quantity, OriginalQty - 1);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ManualCreditMemoQtyIncreaseAllowed()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] A manually created credit memo (not copied from a posted invoice) is not affected by the corrective quantity check.
+        Initialize();
+
+        // [GIVEN] A manually created purchase credit memo with an item line
+        OriginalQty := LibraryRandom.RandIntInRange(2, 10);
+        CreateItemWithCost(Item, Item.Type::Service, LibraryRandom.RandDecInRange(10, 100, 2));
+        LibrarySmallBusiness.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::"Credit Memo", Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", OriginalQty);
+
+        // [WHEN] Increasing the quantity of the line
+        PurchaseLine.Validate(Quantity, PurchaseLine.Quantity + 1);
+
+        // [THEN] The increase is accepted
+        PurchaseLine.TestField(Quantity, OriginalQty + 1);
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
@@ -1870,6 +1952,41 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         CreateItemWithCost(Item, Type, UnitCost);
         CreateVendor(Vendor);
         BuyItem(Vendor, Item, Qty, PurchInvHeader);
+    end;
+
+    local procedure VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Type: Enum "Item Type")
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OriginalQty: Decimal;
+    begin
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for an item with quantity 1
+        CreateAndPostPurchaseInvForNewItemAndVendor(Item, Type, Vendor, LibraryRandom.RandDecInRange(10, 100, 2), 1, PurchInvHeader);
+
+        // [GIVEN] A corrective credit memo created from the posted invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+        OriginalQty := PurchaseLine.Quantity;
+
+        // [WHEN] Increasing the quantity of the credit memo line beyond the copied quantity
+        asserterror PurchaseLine.Validate(Quantity, OriginalQty + 1);
+
+        // [THEN] A blocking error is raised
+        Assert.ExpectedError(StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, OriginalQty));
+    end;
+
+    local procedure GetCorrectiveCreditMemoItemLine(var PurchaseLine: Record "Purchase Line"; CreditMemoNo: Code[20])
+    begin
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::"Credit Memo");
+        PurchaseLine.SetRange("Document No.", CreditMemoNo);
+        PurchaseLine.SetFilter(Type, '<>%1', PurchaseLine.Type::" ");
+        PurchaseLine.FindLast();
     end;
 
     local procedure CreateAndPostPurchaseInvForNewItemVariantAndVendor(var ItemVariant: Record "Item Variant"; var Vendor: Record Vendor; UnitCost: Decimal; Qty: Decimal; var PurchInvHeader: Record "Purch. Inv. Header")

--- a/src/Layers/IT/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
@@ -1768,6 +1768,64 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         PurchaseLine.TestField(Quantity, OriginalQty + 1);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForOrderBasedServiceItem()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OrderQty: Decimal;
+        PartialQty: Decimal;
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo] [Purchase Order]
+        // [SCENARIO 645182] A corrective credit memo created from an order-based invoice cannot be increased, so the purchase order Received/Invoiced quantities cannot be driven negative.
+        Initialize();
+
+        // [GIVEN] A purchase order for a Service item, partially received and invoiced
+        PartialQty := LibraryRandom.RandIntInRange(2, 5);
+        OrderQty := PartialQty + LibraryRandom.RandIntInRange(1, 5);
+        CreateItemWithCost(Item, Item.Type::Service, LibraryRandom.RandDecInRange(10, 100, 2));
+        LibrarySmallBusiness.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderOrder, PurchaseHeaderOrder."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", OrderQty);
+        PurchaseLineOrder.Validate("Qty. to Receive", PartialQty);
+        PurchaseLineOrder.Validate("Qty. to Invoice", PartialQty);
+        PurchaseLineOrder.Modify(true);
+        PurchInvHeader.Get(LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, true));
+
+        // [GIVEN] The order line shows the partially received and invoiced quantity
+        PurchaseLineOrder.Find();
+        PurchaseLineOrder.TestField("Quantity Received", PartialQty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", PartialQty);
+
+        // [GIVEN] A corrective credit memo created from the posted order-based invoice
+        LibraryVariableStorage.Enqueue(true); // Confirm to create the corrective credit memo from the order-based invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+        OriginalQty := PurchaseLine.Quantity;
+
+        // [WHEN] Increasing the quantity of the credit memo line beyond the copied quantity
+        asserterror PurchaseLine.Validate(Quantity, OriginalQty + 1);
+
+        // [THEN] A blocking error is raised before the credit memo can be posted
+        Assert.ExpectedError(StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, OriginalQty));
+
+        // [THEN] The purchase order line quantities are unchanged and cannot go negative
+        PurchaseLineOrder.Find();
+        PurchaseLineOrder.TestField("Quantity Received", PartialQty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", PartialQty);
+
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";

--- a/src/Layers/NA/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NA/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -637,6 +637,8 @@ table 39 "Purchase Line"
                     end;
                 end;
 
+                CheckCorrectiveCreditMemoQtyIncrease(xRec);
+
                 if (Type = Type::"Charge (Item)") and (CurrFieldNo <> 0) then begin
                     if (Quantity = 0) and ("Qty. to Assign" <> 0) then
                         FieldError("Qty. to Assign", StrSubstNo(Text011, FieldCaption(Quantity), Quantity));
@@ -4371,6 +4373,7 @@ table 39 "Purchase Line"
 #pragma warning restore AA0470
         Text029: Label 'must be positive.';
         Text030: Label 'must be negative.';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 #pragma warning disable AA0470
         Text032: Label '%1 must not be greater than the sum of %2 and %3.';
 #pragma warning restore AA0470
@@ -10610,6 +10613,18 @@ table 39 "Purchase Line"
         exit("Matched Inv./Cr. Memo Lines" > 0);
     end;
 
+    local procedure CheckCorrectiveCreditMemoQtyIncrease(xPurchaseLine: Record "Purchase Line")
+    begin
+        if not ("Copied From Posted Doc." and IsCreditDocType()) then
+            exit;
+
+        if not IsNonInventoriableItem() then
+            exit;
+
+        if Abs("Quantity (Base)") > Abs(xPurchaseLine."Quantity (Base)") then
+            FieldError(Quantity, StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, xPurchaseLine.Quantity));
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitDefaultDimensionSources(var PurchaseLine: Record "Purchase Line"; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; FieldNo: Integer)
     begin
@@ -11995,6 +12010,7 @@ table 39 "Purchase Line"
     local procedure OnAfterIsCreditDocType(PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
     end;
+
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterIsInvoiceDocType(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)

--- a/src/Layers/NA/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
@@ -31,6 +31,7 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         CorrectPostedInvoiceFromSingleOrderQst: Label 'The invoice was posted from an order. The invoice will be cancelled, and the order will open so that you can make the correction.\ \Do you want to continue?';
         CorrectPostedInvoiceFromDeletedOrderQst: Label 'The invoice was posted from an order. The order has been deleted, and the invoice will be cancelled. You can create a new invoice or order by using the Copy Document action.\ \Do you want to continue?';
         CorrectPostedInvoiceFromMultipleOrderQst: Label 'The invoice was posted from multiple orders. It will now be cancelled, and you can make a correction manually in the original orders.\ \Do you want to continue?';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 
     [Test]
     [HandlerFunctions('ConfirmHandler')]
@@ -1687,6 +1688,87 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         LibraryVariableStorage.AssertEmpty();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForServiceItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] Increasing the quantity of a corrective credit memo line for a Service item is blocked.
+        VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Item.Type::Service);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForNonInventoryItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] Increasing the quantity of a corrective credit memo line for a Non-Inventory item is blocked.
+        VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Item.Type::"Non-Inventory");
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyDecreaseAllowedForServiceItem()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] A partial reversal (decreasing the quantity) on a corrective credit memo line is still allowed.
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for a Service item
+        OriginalQty := LibraryRandom.RandIntInRange(2, 10);
+        CreateAndPostPurchaseInvForNewItemAndVendor(Item, Item.Type::Service, Vendor, LibraryRandom.RandDecInRange(10, 100, 2), OriginalQty, PurchInvHeader);
+
+        // [GIVEN] A corrective credit memo created from the posted invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+
+        // [WHEN] Decreasing the quantity of the credit memo line below the copied quantity
+        PurchaseLine.Validate(Quantity, PurchaseLine.Quantity - 1);
+
+        // [THEN] The decrease is accepted
+        PurchaseLine.TestField(Quantity, OriginalQty - 1);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ManualCreditMemoQtyIncreaseAllowed()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] A manually created credit memo (not copied from a posted invoice) is not affected by the corrective quantity check.
+        Initialize();
+
+        // [GIVEN] A manually created purchase credit memo with an item line
+        OriginalQty := LibraryRandom.RandIntInRange(2, 10);
+        CreateItemWithCost(Item, Item.Type::Service, LibraryRandom.RandDecInRange(10, 100, 2));
+        LibrarySmallBusiness.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::"Credit Memo", Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", OriginalQty);
+
+        // [WHEN] Increasing the quantity of the line
+        PurchaseLine.Validate(Quantity, PurchaseLine.Quantity + 1);
+
+        // [THEN] The increase is accepted
+        PurchaseLine.TestField(Quantity, OriginalQty + 1);
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
@@ -1871,6 +1953,41 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         CreateItemWithCost(Item, Type, UnitCost);
         LibrarySmallBusiness.CreateVendor(Vendor);
         BuyItem(Vendor, Item, Qty, PurchInvHeader);
+    end;
+
+    local procedure VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Type: Enum "Item Type")
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OriginalQty: Decimal;
+    begin
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for an item with quantity 1
+        CreateAndPostPurchaseInvForNewItemAndVendor(Item, Type, Vendor, LibraryRandom.RandDecInRange(10, 100, 2), 1, PurchInvHeader);
+
+        // [GIVEN] A corrective credit memo created from the posted invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+        OriginalQty := PurchaseLine.Quantity;
+
+        // [WHEN] Increasing the quantity of the credit memo line beyond the copied quantity
+        asserterror PurchaseLine.Validate(Quantity, OriginalQty + 1);
+
+        // [THEN] A blocking error is raised
+        Assert.ExpectedError(StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, OriginalQty));
+    end;
+
+    local procedure GetCorrectiveCreditMemoItemLine(var PurchaseLine: Record "Purchase Line"; CreditMemoNo: Code[20])
+    begin
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::"Credit Memo");
+        PurchaseLine.SetRange("Document No.", CreditMemoNo);
+        PurchaseLine.SetFilter(Type, '<>%1', PurchaseLine.Type::" ");
+        PurchaseLine.FindLast();
     end;
 
     local procedure CreateAndPostPurchaseInvForNewItemVariantAndVendor(var ItemVariant: Record "Item Variant"; var Vendor: Record Vendor; UnitCost: Decimal; Qty: Decimal; var PurchInvHeader: Record "Purch. Inv. Header")

--- a/src/Layers/NA/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
@@ -1769,6 +1769,64 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         PurchaseLine.TestField(Quantity, OriginalQty + 1);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForOrderBasedServiceItem()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OrderQty: Decimal;
+        PartialQty: Decimal;
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo] [Purchase Order]
+        // [SCENARIO 645182] A corrective credit memo created from an order-based invoice cannot be increased, so the purchase order Received/Invoiced quantities cannot be driven negative.
+        Initialize();
+
+        // [GIVEN] A purchase order for a Service item, partially received and invoiced
+        PartialQty := LibraryRandom.RandIntInRange(2, 5);
+        OrderQty := PartialQty + LibraryRandom.RandIntInRange(1, 5);
+        CreateItemWithCost(Item, Item.Type::Service, LibraryRandom.RandDecInRange(10, 100, 2));
+        LibrarySmallBusiness.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderOrder, PurchaseHeaderOrder."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", OrderQty);
+        PurchaseLineOrder.Validate("Qty. to Receive", PartialQty);
+        PurchaseLineOrder.Validate("Qty. to Invoice", PartialQty);
+        PurchaseLineOrder.Modify(true);
+        PurchInvHeader.Get(LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, true));
+
+        // [GIVEN] The order line shows the partially received and invoiced quantity
+        PurchaseLineOrder.Find();
+        PurchaseLineOrder.TestField("Quantity Received", PartialQty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", PartialQty);
+
+        // [GIVEN] A corrective credit memo created from the posted order-based invoice
+        LibraryVariableStorage.Enqueue(true); // Confirm to create the corrective credit memo from the order-based invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+        OriginalQty := PurchaseLine.Quantity;
+
+        // [WHEN] Increasing the quantity of the credit memo line beyond the copied quantity
+        asserterror PurchaseLine.Validate(Quantity, OriginalQty + 1);
+
+        // [THEN] A blocking error is raised before the credit memo can be posted
+        Assert.ExpectedError(StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, OriginalQty));
+
+        // [THEN] The purchase order line quantities are unchanged and cannot go negative
+        PurchaseLineOrder.Find();
+        PurchaseLineOrder.TestField("Quantity Received", PartialQty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", PartialQty);
+
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";

--- a/src/Layers/NL/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NL/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -594,6 +594,8 @@ table 39 "Purchase Line"
                     end;
                 end;
 
+                CheckCorrectiveCreditMemoQtyIncrease(xRec);
+
                 if (Type = Type::"Charge (Item)") and (CurrFieldNo <> 0) then begin
                     if (Quantity = 0) and ("Qty. to Assign" <> 0) then
                         FieldError("Qty. to Assign", StrSubstNo(Text011, FieldCaption(Quantity), Quantity));
@@ -4223,6 +4225,7 @@ table 39 "Purchase Line"
 #pragma warning restore AA0470
         Text029: Label 'must be positive.';
         Text030: Label 'must be negative.';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 #pragma warning disable AA0470
         Text032: Label '%1 must not be greater than the sum of %2 and %3.';
 #pragma warning restore AA0470
@@ -10261,6 +10264,18 @@ table 39 "Purchase Line"
         exit("Matched Inv./Cr. Memo Lines" > 0);
     end;
 
+    local procedure CheckCorrectiveCreditMemoQtyIncrease(xPurchaseLine: Record "Purchase Line")
+    begin
+        if not ("Copied From Posted Doc." and IsCreditDocType()) then
+            exit;
+
+        if not IsNonInventoriableItem() then
+            exit;
+
+        if Abs("Quantity (Base)") > Abs(xPurchaseLine."Quantity (Base)") then
+            FieldError(Quantity, StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, xPurchaseLine.Quantity));
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitDefaultDimensionSources(var PurchaseLine: Record "Purchase Line"; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; FieldNo: Integer)
     begin
@@ -11636,6 +11651,7 @@ table 39 "Purchase Line"
     local procedure OnAfterIsCreditDocType(PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
     end;
+
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterIsInvoiceDocType(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)

--- a/src/Layers/NO/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NO/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -595,6 +595,8 @@ table 39 "Purchase Line"
                     end;
                 end;
 
+                CheckCorrectiveCreditMemoQtyIncrease(xRec);
+
                 if (Type = Type::"Charge (Item)") and (CurrFieldNo <> 0) then begin
                     if (Quantity = 0) and ("Qty. to Assign" <> 0) then
                         FieldError("Qty. to Assign", StrSubstNo(Text011, FieldCaption(Quantity), Quantity));
@@ -4242,6 +4244,7 @@ table 39 "Purchase Line"
 #pragma warning restore AA0470
         Text029: Label 'must be positive.';
         Text030: Label 'must be negative.';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 #pragma warning disable AA0470
         Text032: Label '%1 must not be greater than the sum of %2 and %3.';
 #pragma warning restore AA0470
@@ -10288,6 +10291,18 @@ table 39 "Purchase Line"
         exit("Matched Inv./Cr. Memo Lines" > 0);
     end;
 
+    local procedure CheckCorrectiveCreditMemoQtyIncrease(xPurchaseLine: Record "Purchase Line")
+    begin
+        if not ("Copied From Posted Doc." and IsCreditDocType()) then
+            exit;
+
+        if not IsNonInventoriableItem() then
+            exit;
+
+        if Abs("Quantity (Base)") > Abs(xPurchaseLine."Quantity (Base)") then
+            FieldError(Quantity, StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, xPurchaseLine.Quantity));
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitDefaultDimensionSources(var PurchaseLine: Record "Purchase Line"; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; FieldNo: Integer)
     begin
@@ -11663,6 +11678,7 @@ table 39 "Purchase Line"
     local procedure OnAfterIsCreditDocType(PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
     end;
+
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterIsInvoiceDocType(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)

--- a/src/Layers/NO/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
+++ b/src/Layers/NO/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
@@ -31,6 +31,7 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         CorrectPostedInvoiceFromSingleOrderQst: Label 'The invoice was posted from an order. The invoice will be cancelled, and the order will open so that you can make the correction.\ \Do you want to continue?';
         CorrectPostedInvoiceFromDeletedOrderQst: Label 'The invoice was posted from an order. The order has been deleted, and the invoice will be cancelled. You can create a new invoice or order by using the Copy Document action.\ \Do you want to continue?';
         CorrectPostedInvoiceFromMultipleOrderQst: Label 'The invoice was posted from multiple orders. It will now be cancelled, and you can make a correction manually in the original orders.\ \Do you want to continue?';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 
     [Test]
     [HandlerFunctions('ConfirmHandler')]
@@ -1688,6 +1689,87 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         LibraryVariableStorage.AssertEmpty();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForServiceItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] Increasing the quantity of a corrective credit memo line for a Service item is blocked.
+        VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Item.Type::Service);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForNonInventoryItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] Increasing the quantity of a corrective credit memo line for a Non-Inventory item is blocked.
+        VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Item.Type::"Non-Inventory");
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyDecreaseAllowedForServiceItem()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] A partial reversal (decreasing the quantity) on a corrective credit memo line is still allowed.
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for a Service item
+        OriginalQty := LibraryRandom.RandIntInRange(2, 10);
+        CreateAndPostPurchaseInvForNewItemAndVendor(Item, Item.Type::Service, Vendor, LibraryRandom.RandDecInRange(10, 100, 2), OriginalQty, PurchInvHeader);
+
+        // [GIVEN] A corrective credit memo created from the posted invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+
+        // [WHEN] Decreasing the quantity of the credit memo line below the copied quantity
+        PurchaseLine.Validate(Quantity, PurchaseLine.Quantity - 1);
+
+        // [THEN] The decrease is accepted
+        PurchaseLine.TestField(Quantity, OriginalQty - 1);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ManualCreditMemoQtyIncreaseAllowed()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] A manually created credit memo (not copied from a posted invoice) is not affected by the corrective quantity check.
+        Initialize();
+
+        // [GIVEN] A manually created purchase credit memo with an item line
+        OriginalQty := LibraryRandom.RandIntInRange(2, 10);
+        CreateItemWithCost(Item, Item.Type::Service, LibraryRandom.RandDecInRange(10, 100, 2));
+        LibrarySmallBusiness.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::"Credit Memo", Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", OriginalQty);
+
+        // [WHEN] Increasing the quantity of the line
+        PurchaseLine.Validate(Quantity, PurchaseLine.Quantity + 1);
+
+        // [THEN] The increase is accepted
+        PurchaseLine.TestField(Quantity, OriginalQty + 1);
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
@@ -1872,6 +1954,41 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         CreateItemWithCost(Item, Type, UnitCost);
         LibrarySmallBusiness.CreateVendor(Vendor);
         BuyItem(Vendor, Item, Qty, PurchInvHeader);
+    end;
+
+    local procedure VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Type: Enum "Item Type")
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OriginalQty: Decimal;
+    begin
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for an item with quantity 1
+        CreateAndPostPurchaseInvForNewItemAndVendor(Item, Type, Vendor, LibraryRandom.RandDecInRange(10, 100, 2), 1, PurchInvHeader);
+
+        // [GIVEN] A corrective credit memo created from the posted invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+        OriginalQty := PurchaseLine.Quantity;
+
+        // [WHEN] Increasing the quantity of the credit memo line beyond the copied quantity
+        asserterror PurchaseLine.Validate(Quantity, OriginalQty + 1);
+
+        // [THEN] A blocking error is raised
+        Assert.ExpectedError(StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, OriginalQty));
+    end;
+
+    local procedure GetCorrectiveCreditMemoItemLine(var PurchaseLine: Record "Purchase Line"; CreditMemoNo: Code[20])
+    begin
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::"Credit Memo");
+        PurchaseLine.SetRange("Document No.", CreditMemoNo);
+        PurchaseLine.SetFilter(Type, '<>%1', PurchaseLine.Type::" ");
+        PurchaseLine.FindLast();
     end;
 
     local procedure CreateAndPostPurchaseInvForNewItemVariantAndVendor(var ItemVariant: Record "Item Variant"; var Vendor: Record Vendor; UnitCost: Decimal; Qty: Decimal; var PurchInvHeader: Record "Purch. Inv. Header")

--- a/src/Layers/NO/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
+++ b/src/Layers/NO/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
@@ -1770,6 +1770,64 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         PurchaseLine.TestField(Quantity, OriginalQty + 1);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForOrderBasedServiceItem()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OrderQty: Decimal;
+        PartialQty: Decimal;
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo] [Purchase Order]
+        // [SCENARIO 645182] A corrective credit memo created from an order-based invoice cannot be increased, so the purchase order Received/Invoiced quantities cannot be driven negative.
+        Initialize();
+
+        // [GIVEN] A purchase order for a Service item, partially received and invoiced
+        PartialQty := LibraryRandom.RandIntInRange(2, 5);
+        OrderQty := PartialQty + LibraryRandom.RandIntInRange(1, 5);
+        CreateItemWithCost(Item, Item.Type::Service, LibraryRandom.RandDecInRange(10, 100, 2));
+        LibrarySmallBusiness.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderOrder, PurchaseHeaderOrder."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", OrderQty);
+        PurchaseLineOrder.Validate("Qty. to Receive", PartialQty);
+        PurchaseLineOrder.Validate("Qty. to Invoice", PartialQty);
+        PurchaseLineOrder.Modify(true);
+        PurchInvHeader.Get(LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, true));
+
+        // [GIVEN] The order line shows the partially received and invoiced quantity
+        PurchaseLineOrder.Find();
+        PurchaseLineOrder.TestField("Quantity Received", PartialQty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", PartialQty);
+
+        // [GIVEN] A corrective credit memo created from the posted order-based invoice
+        LibraryVariableStorage.Enqueue(true); // Confirm to create the corrective credit memo from the order-based invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+        OriginalQty := PurchaseLine.Quantity;
+
+        // [WHEN] Increasing the quantity of the credit memo line beyond the copied quantity
+        asserterror PurchaseLine.Validate(Quantity, OriginalQty + 1);
+
+        // [THEN] A blocking error is raised before the credit memo can be posted
+        Assert.ExpectedError(StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, OriginalQty));
+
+        // [THEN] The purchase order line quantities are unchanged and cannot go negative
+        PurchaseLineOrder.Find();
+        PurchaseLineOrder.TestField("Quantity Received", PartialQty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", PartialQty);
+
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";

--- a/src/Layers/NZ/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
+++ b/src/Layers/NZ/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
@@ -31,6 +31,7 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         CorrectPostedInvoiceFromSingleOrderQst: Label 'The invoice was posted from an order. The invoice will be cancelled, and the order will open so that you can make the correction.\ \Do you want to continue?';
         CorrectPostedInvoiceFromDeletedOrderQst: Label 'The invoice was posted from an order. The order has been deleted, and the invoice will be cancelled. You can create a new invoice or order by using the Copy Document action.\ \Do you want to continue?';
         CorrectPostedInvoiceFromMultipleOrderQst: Label 'The invoice was posted from multiple orders. It will now be cancelled, and you can make a correction manually in the original orders.\ \Do you want to continue?';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 
     [Test]
     [HandlerFunctions('ConfirmHandler')]
@@ -1686,6 +1687,87 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         LibraryVariableStorage.AssertEmpty();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForServiceItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] Increasing the quantity of a corrective credit memo line for a Service item is blocked.
+        VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Item.Type::Service);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForNonInventoryItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] Increasing the quantity of a corrective credit memo line for a Non-Inventory item is blocked.
+        VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Item.Type::"Non-Inventory");
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyDecreaseAllowedForServiceItem()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] A partial reversal (decreasing the quantity) on a corrective credit memo line is still allowed.
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for a Service item
+        OriginalQty := LibraryRandom.RandIntInRange(2, 10);
+        CreateAndPostPurchaseInvForNewItemAndVendor(Item, Item.Type::Service, Vendor, LibraryRandom.RandDecInRange(10, 100, 2), OriginalQty, PurchInvHeader);
+
+        // [GIVEN] A corrective credit memo created from the posted invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+
+        // [WHEN] Decreasing the quantity of the credit memo line below the copied quantity
+        PurchaseLine.Validate(Quantity, PurchaseLine.Quantity - 1);
+
+        // [THEN] The decrease is accepted
+        PurchaseLine.TestField(Quantity, OriginalQty - 1);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ManualCreditMemoQtyIncreaseAllowed()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] A manually created credit memo (not copied from a posted invoice) is not affected by the corrective quantity check.
+        Initialize();
+
+        // [GIVEN] A manually created purchase credit memo with an item line
+        OriginalQty := LibraryRandom.RandIntInRange(2, 10);
+        CreateItemWithCost(Item, Item.Type::Service, LibraryRandom.RandDecInRange(10, 100, 2));
+        LibrarySmallBusiness.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::"Credit Memo", Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", OriginalQty);
+
+        // [WHEN] Increasing the quantity of the line
+        PurchaseLine.Validate(Quantity, PurchaseLine.Quantity + 1);
+
+        // [THEN] The increase is accepted
+        PurchaseLine.TestField(Quantity, OriginalQty + 1);
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
@@ -1870,6 +1952,41 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         CreateItemWithCost(Item, Type, UnitCost);
         LibrarySmallBusiness.CreateVendor(Vendor);
         BuyItem(Vendor, Item, Qty, PurchInvHeader);
+    end;
+
+    local procedure VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Type: Enum "Item Type")
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OriginalQty: Decimal;
+    begin
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for an item with quantity 1
+        CreateAndPostPurchaseInvForNewItemAndVendor(Item, Type, Vendor, LibraryRandom.RandDecInRange(10, 100, 2), 1, PurchInvHeader);
+
+        // [GIVEN] A corrective credit memo created from the posted invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+        OriginalQty := PurchaseLine.Quantity;
+
+        // [WHEN] Increasing the quantity of the credit memo line beyond the copied quantity
+        asserterror PurchaseLine.Validate(Quantity, OriginalQty + 1);
+
+        // [THEN] A blocking error is raised
+        Assert.ExpectedError(StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, OriginalQty));
+    end;
+
+    local procedure GetCorrectiveCreditMemoItemLine(var PurchaseLine: Record "Purchase Line"; CreditMemoNo: Code[20])
+    begin
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::"Credit Memo");
+        PurchaseLine.SetRange("Document No.", CreditMemoNo);
+        PurchaseLine.SetFilter(Type, '<>%1', PurchaseLine.Type::" ");
+        PurchaseLine.FindLast();
     end;
 
     local procedure CreateAndPostPurchaseInvForNewItemVariantAndVendor(var ItemVariant: Record "Item Variant"; var Vendor: Record Vendor; UnitCost: Decimal; Qty: Decimal; var PurchInvHeader: Record "Purch. Inv. Header")

--- a/src/Layers/NZ/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
+++ b/src/Layers/NZ/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
@@ -1768,6 +1768,64 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         PurchaseLine.TestField(Quantity, OriginalQty + 1);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForOrderBasedServiceItem()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OrderQty: Decimal;
+        PartialQty: Decimal;
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo] [Purchase Order]
+        // [SCENARIO 645182] A corrective credit memo created from an order-based invoice cannot be increased, so the purchase order Received/Invoiced quantities cannot be driven negative.
+        Initialize();
+
+        // [GIVEN] A purchase order for a Service item, partially received and invoiced
+        PartialQty := LibraryRandom.RandIntInRange(2, 5);
+        OrderQty := PartialQty + LibraryRandom.RandIntInRange(1, 5);
+        CreateItemWithCost(Item, Item.Type::Service, LibraryRandom.RandDecInRange(10, 100, 2));
+        LibrarySmallBusiness.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderOrder, PurchaseHeaderOrder."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", OrderQty);
+        PurchaseLineOrder.Validate("Qty. to Receive", PartialQty);
+        PurchaseLineOrder.Validate("Qty. to Invoice", PartialQty);
+        PurchaseLineOrder.Modify(true);
+        PurchInvHeader.Get(LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, true));
+
+        // [GIVEN] The order line shows the partially received and invoiced quantity
+        PurchaseLineOrder.Find();
+        PurchaseLineOrder.TestField("Quantity Received", PartialQty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", PartialQty);
+
+        // [GIVEN] A corrective credit memo created from the posted order-based invoice
+        LibraryVariableStorage.Enqueue(true); // Confirm to create the corrective credit memo from the order-based invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+        OriginalQty := PurchaseLine.Quantity;
+
+        // [WHEN] Increasing the quantity of the credit memo line beyond the copied quantity
+        asserterror PurchaseLine.Validate(Quantity, OriginalQty + 1);
+
+        // [THEN] A blocking error is raised before the credit memo can be posted
+        Assert.ExpectedError(StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, OriginalQty));
+
+        // [THEN] The purchase order line quantities are unchanged and cannot go negative
+        PurchaseLineOrder.Find();
+        PurchaseLineOrder.TestField("Quantity Received", PartialQty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", PartialQty);
+
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -599,6 +599,8 @@ table 39 "Purchase Line"
                     end;
                 end;
 
+                CheckCorrectiveCreditMemoQtyIncrease(xRec);
+
                 if (Type = Type::"Charge (Item)") and (CurrFieldNo <> 0) then begin
                     if (Quantity = 0) and ("Qty. to Assign" <> 0) then
                         FieldError("Qty. to Assign", StrSubstNo(Text011, FieldCaption(Quantity), Quantity));
@@ -4410,6 +4412,7 @@ table 39 "Purchase Line"
 #pragma warning restore AA0470
         Text029: Label 'must be positive.';
         Text030: Label 'must be negative.';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 #pragma warning disable AA0470
         Text032: Label '%1 must not be greater than the sum of %2 and %3.';
 #pragma warning restore AA0470
@@ -10511,6 +10514,18 @@ table 39 "Purchase Line"
         exit("Matched Inv./Cr. Memo Lines" > 0);
     end;
 
+    local procedure CheckCorrectiveCreditMemoQtyIncrease(xPurchaseLine: Record "Purchase Line")
+    begin
+        if not ("Copied From Posted Doc." and IsCreditDocType()) then
+            exit;
+
+        if not IsNonInventoriableItem() then
+            exit;
+
+        if Abs("Quantity (Base)") > Abs(xPurchaseLine."Quantity (Base)") then
+            FieldError(Quantity, StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, xPurchaseLine.Quantity));
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitDefaultDimensionSources(var PurchaseLine: Record "Purchase Line"; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; FieldNo: Integer)
     begin
@@ -11886,6 +11901,7 @@ table 39 "Purchase Line"
     local procedure OnAfterIsCreditDocType(PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
     end;
+
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterIsInvoiceDocType(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)

--- a/src/Layers/SE/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/SE/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -595,6 +595,8 @@ table 39 "Purchase Line"
                     end;
                 end;
 
+                CheckCorrectiveCreditMemoQtyIncrease(xRec);
+
                 if (Type = Type::"Charge (Item)") and (CurrFieldNo <> 0) then begin
                     if (Quantity = 0) and ("Qty. to Assign" <> 0) then
                         FieldError("Qty. to Assign", StrSubstNo(Text011, FieldCaption(Quantity), Quantity));
@@ -4229,6 +4231,7 @@ table 39 "Purchase Line"
 #pragma warning restore AA0470
         Text029: Label 'must be positive.';
         Text030: Label 'must be negative.';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 #pragma warning disable AA0470
         Text032: Label '%1 must not be greater than the sum of %2 and %3.';
 #pragma warning restore AA0470
@@ -10267,6 +10270,18 @@ table 39 "Purchase Line"
         exit("Matched Inv./Cr. Memo Lines" > 0);
     end;
 
+    local procedure CheckCorrectiveCreditMemoQtyIncrease(xPurchaseLine: Record "Purchase Line")
+    begin
+        if not ("Copied From Posted Doc." and IsCreditDocType()) then
+            exit;
+
+        if not IsNonInventoriableItem() then
+            exit;
+
+        if Abs("Quantity (Base)") > Abs(xPurchaseLine."Quantity (Base)") then
+            FieldError(Quantity, StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, xPurchaseLine.Quantity));
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitDefaultDimensionSources(var PurchaseLine: Record "Purchase Line"; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; FieldNo: Integer)
     begin
@@ -11642,6 +11657,7 @@ table 39 "Purchase Line"
     local procedure OnAfterIsCreditDocType(PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
     end;
+
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterIsInvoiceDocType(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)

--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -594,6 +594,8 @@ table 39 "Purchase Line"
                     end;
                 end;
 
+                CheckCorrectiveCreditMemoQtyIncrease(xRec);
+
                 if (Type = Type::"Charge (Item)") and (CurrFieldNo <> 0) then begin
                     if (Quantity = 0) and ("Qty. to Assign" <> 0) then
                         FieldError("Qty. to Assign", StrSubstNo(Text011, FieldCaption(Quantity), Quantity));
@@ -4218,6 +4220,7 @@ table 39 "Purchase Line"
 #pragma warning restore AA0470
         Text029: Label 'must be positive.';
         Text030: Label 'must be negative.';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 #pragma warning disable AA0470
         Text032: Label '%1 must not be greater than the sum of %2 and %3.';
 #pragma warning restore AA0470
@@ -10256,6 +10259,18 @@ table 39 "Purchase Line"
         exit("Matched Inv./Cr. Memo Lines" > 0);
     end;
 
+    local procedure CheckCorrectiveCreditMemoQtyIncrease(xPurchaseLine: Record "Purchase Line")
+    begin
+        if not ("Copied From Posted Doc." and IsCreditDocType()) then
+            exit;
+
+        if not IsNonInventoriableItem() then
+            exit;
+
+        if Abs("Quantity (Base)") > Abs(xPurchaseLine."Quantity (Base)") then
+            FieldError(Quantity, StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, xPurchaseLine.Quantity));
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitDefaultDimensionSources(var PurchaseLine: Record "Purchase Line"; var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; FieldNo: Integer)
     begin
@@ -11631,6 +11646,7 @@ table 39 "Purchase Line"
     local procedure OnAfterIsCreditDocType(PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
     end;
+
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterIsInvoiceDocType(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)

--- a/src/Layers/W1/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
@@ -71,6 +71,7 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         AlreadyCancelledErr: Label 'You cannot cancel this posted purchase invoice because it has already been canceled.';
         CorrCorrectiveDocErr: Label 'You cannot correct this posted purchase invoice because it represents a correction of a credit memo.';
         CancelCorrectiveDocErr: Label 'You cannot cancel this posted purchase invoice because it represents a correction of a credit memo.';
+        CancelledQtyExceedsOrderErr: Label 'The credit memo quantity to reverse exceeds the received or invoiced quantity on purchase order %1 line %2. A corrective credit memo cannot reverse more than was originally received and invoiced.', Comment = '%1 = Purchase order no. %2 = Purchase order line no.';
         VendorIsBlockedCorrectErr: Label 'You cannot correct this posted purchase invoice because vendor %1 is blocked.', Comment = '%1 = Customer name';
         VendorIsBlockedCancelErr: Label 'You cannot cancel this posted purchase invoice because vendor %1 is blocked.', Comment = '%1 = Customer name';
         ItemIsBlockedCorrectErr: Label 'You cannot correct this posted purchase invoice because item %1 %2 is blocked.', Comment = '%1 = Item No. %2 = Item Description';
@@ -859,6 +860,8 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         if IsHandled then
             exit;
 
+        CheckCancelledQuantityWithinOrderLine(PurchaseLine, CancelledQuantity, CancelledQtyBase);
+
         PurchaseLine."Quantity Invoiced" -= CancelledQuantity;
         PurchaseLine."Qty. Invoiced (Base)" -= CancelledQtyBase;
         PurchaseLine."Quantity Received" -= CancelledQuantity;
@@ -1095,6 +1098,16 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         IncomingDocumentAttachment.SetRange("Incoming Document Entry No.", IncomingDocument."Entry No.");
         IncomingDocumentAttachment.ModifyAll("Document No.", '');
         IncomingDocumentAttachment.ModifyAll("Posting Date", 0D);
+    end;
+
+    local procedure CheckCancelledQuantityWithinOrderLine(PurchaseLine: Record "Purchase Line"; CancelledQuantity: Decimal; CancelledQtyBase: Decimal)
+    begin
+        if (Abs(CancelledQuantity) > Abs(PurchaseLine."Quantity Invoiced")) or
+           (Abs(CancelledQtyBase) > Abs(PurchaseLine."Qty. Invoiced (Base)")) or
+           (Abs(CancelledQuantity) > Abs(PurchaseLine."Quantity Received")) or
+           (Abs(CancelledQtyBase) > Abs(PurchaseLine."Qty. Received (Base)"))
+        then
+            Error(CancelledQtyExceedsOrderErr, PurchaseLine."Document No.", PurchaseLine."Line No.");
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/W1/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
@@ -44,6 +44,8 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         CreateCopyDocument(Rec, PurchaseHeader, PurchaseHeader."Document Type"::"Credit Memo", false);
         PurchaseHeader."Vendor Cr. Memo No." := PurchaseHeader."No.";
 
+        CheckPurchaseOrderLinesCanAbsorbCancellation(Rec."No.");
+
         SuppressCommit := not NoSeries.IsNoSeriesInDateOrder(PurchaseHeader."Posting No. Series");
 
         OnAfterCreateCorrectivePurchCrMemo(Rec, PurchaseHeader, CancellingOnly, SuppressCommit);
@@ -860,8 +862,6 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         if IsHandled then
             exit;
 
-        CheckCancelledQuantityWithinOrderLine(PurchaseLine, CancelledQuantity, CancelledQtyBase);
-
         PurchaseLine."Quantity Invoiced" -= CancelledQuantity;
         PurchaseLine."Qty. Invoiced (Base)" -= CancelledQtyBase;
         PurchaseLine."Quantity Received" -= CancelledQuantity;
@@ -1098,6 +1098,20 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         IncomingDocumentAttachment.SetRange("Incoming Document Entry No.", IncomingDocument."Entry No.");
         IncomingDocumentAttachment.ModifyAll("Document No.", '');
         IncomingDocumentAttachment.ModifyAll("Posting Date", 0D);
+    end;
+
+    local procedure CheckPurchaseOrderLinesCanAbsorbCancellation(PurchInvHeaderNo: Code[20])
+    var
+        PurchaseLine: Record "Purchase Line";
+        PurchInvLine: Record "Purch. Inv. Line";
+    begin
+        PurchInvLine.SetRange("Document No.", PurchInvHeaderNo);
+        PurchInvLine.SetRange("Prepayment Line", false);
+        if PurchInvLine.FindSet() then
+            repeat
+                if PurchaseLine.Get(PurchaseLine."Document Type"::Order, PurchInvLine."Order No.", PurchInvLine."Order Line No.") then
+                    CheckCancelledQuantityWithinOrderLine(PurchaseLine, PurchInvLine.Quantity, PurchInvLine."Quantity (Base)");
+            until PurchInvLine.Next() = 0;
     end;
 
     local procedure CheckCancelledQuantityWithinOrderLine(PurchaseLine: Record "Purchase Line"; CancelledQuantity: Decimal; CancelledQtyBase: Decimal)

--- a/src/Layers/W1/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/History/CorrectPostedPurchInvoice.Codeunit.al
@@ -1105,6 +1105,8 @@ codeunit 1313 "Correct Posted Purch. Invoice"
         PurchaseLine: Record "Purchase Line";
         PurchInvLine: Record "Purch. Inv. Line";
     begin
+        PurchaseLine.SetLoadFields("Quantity Invoiced", "Qty. Invoiced (Base)", "Quantity Received", "Qty. Received (Base)");
+        PurchInvLine.SetLoadFields("Order No.", "Order Line No.", Quantity, "Quantity (Base)");
         PurchInvLine.SetRange("Document No.", PurchInvHeaderNo);
         PurchInvLine.SetRange("Prepayment Line", false);
         if PurchInvLine.FindSet() then

--- a/src/Layers/W1/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
@@ -31,6 +31,7 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         CorrectPostedInvoiceFromSingleOrderQst: Label 'The invoice was posted from an order. The invoice will be cancelled, and the order will open so that you can make the correction.\ \Do you want to continue?';
         CorrectPostedInvoiceFromDeletedOrderQst: Label 'The invoice was posted from an order. The order has been deleted, and the invoice will be cancelled. You can create a new invoice or order by using the Copy Document action.\ \Do you want to continue?';
         CorrectPostedInvoiceFromMultipleOrderQst: Label 'The invoice was posted from multiple orders. It will now be cancelled, and you can make a correction manually in the original orders.\ \Do you want to continue?';
+        CorrectiveCreditMemoQtyIncreaseErr: Label 'must not be greater than %1 because a corrective credit memo can only reverse the original posted invoice, not add quantity.', Comment = '%1 - the quantity copied from the posted purchase invoice';
 
     [Test]
     [HandlerFunctions('ConfirmHandler')]
@@ -1686,6 +1687,87 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         LibraryVariableStorage.AssertEmpty();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForServiceItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] Increasing the quantity of a corrective credit memo line for a Service item is blocked.
+        VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Item.Type::Service);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForNonInventoryItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] Increasing the quantity of a corrective credit memo line for a Non-Inventory item is blocked.
+        VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Item.Type::"Non-Inventory");
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyDecreaseAllowedForServiceItem()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] A partial reversal (decreasing the quantity) on a corrective credit memo line is still allowed.
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for a Service item
+        OriginalQty := LibraryRandom.RandIntInRange(2, 10);
+        CreateAndPostPurchaseInvForNewItemAndVendor(Item, Item.Type::Service, Vendor, LibraryRandom.RandDecInRange(10, 100, 2), OriginalQty, PurchInvHeader);
+
+        // [GIVEN] A corrective credit memo created from the posted invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+
+        // [WHEN] Decreasing the quantity of the credit memo line below the copied quantity
+        PurchaseLine.Validate(Quantity, PurchaseLine.Quantity - 1);
+
+        // [THEN] The decrease is accepted
+        PurchaseLine.TestField(Quantity, OriginalQty - 1);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ManualCreditMemoQtyIncreaseAllowed()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo]
+        // [SCENARIO 636861] A manually created credit memo (not copied from a posted invoice) is not affected by the corrective quantity check.
+        Initialize();
+
+        // [GIVEN] A manually created purchase credit memo with an item line
+        OriginalQty := LibraryRandom.RandIntInRange(2, 10);
+        CreateItemWithCost(Item, Item.Type::Service, LibraryRandom.RandDecInRange(10, 100, 2));
+        LibrarySmallBusiness.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::"Credit Memo", Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", OriginalQty);
+
+        // [WHEN] Increasing the quantity of the line
+        PurchaseLine.Validate(Quantity, PurchaseLine.Quantity + 1);
+
+        // [THEN] The increase is accepted
+        PurchaseLine.TestField(Quantity, OriginalQty + 1);
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
@@ -1870,6 +1952,41 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         CreateItemWithCost(Item, Type, UnitCost);
         LibrarySmallBusiness.CreateVendor(Vendor);
         BuyItem(Vendor, Item, Qty, PurchInvHeader);
+    end;
+
+    local procedure VerifyCorrectiveCreditMemoQtyIncreaseIsBlocked(Type: Enum "Item Type")
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OriginalQty: Decimal;
+    begin
+        Initialize();
+
+        // [GIVEN] A posted purchase invoice for an item with quantity 1
+        CreateAndPostPurchaseInvForNewItemAndVendor(Item, Type, Vendor, LibraryRandom.RandDecInRange(10, 100, 2), 1, PurchInvHeader);
+
+        // [GIVEN] A corrective credit memo created from the posted invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+        OriginalQty := PurchaseLine.Quantity;
+
+        // [WHEN] Increasing the quantity of the credit memo line beyond the copied quantity
+        asserterror PurchaseLine.Validate(Quantity, OriginalQty + 1);
+
+        // [THEN] A blocking error is raised
+        Assert.ExpectedError(StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, OriginalQty));
+    end;
+
+    local procedure GetCorrectiveCreditMemoItemLine(var PurchaseLine: Record "Purchase Line"; CreditMemoNo: Code[20])
+    begin
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::"Credit Memo");
+        PurchaseLine.SetRange("Document No.", CreditMemoNo);
+        PurchaseLine.SetFilter(Type, '<>%1', PurchaseLine.Type::" ");
+        PurchaseLine.FindLast();
     end;
 
     local procedure CreateAndPostPurchaseInvForNewItemVariantAndVendor(var ItemVariant: Record "Item Variant"; var Vendor: Record Vendor; UnitCost: Decimal; Qty: Decimal; var PurchInvHeader: Record "Purch. Inv. Header")

--- a/src/Layers/W1/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/O365CorrectPurchaseInvoice.Codeunit.al
@@ -1768,6 +1768,64 @@ codeunit 138025 "O365 Correct Purchase Invoice"
         PurchaseLine.TestField(Quantity, OriginalQty + 1);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    [Scope('OnPrem')]
+    procedure CorrectiveCreditMemoQtyIncreaseBlockedForOrderBasedServiceItem()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseHeaderCorrection: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        CorrectPostedPurchInvoice: Codeunit "Correct Posted Purch. Invoice";
+        OrderQty: Decimal;
+        PartialQty: Decimal;
+        OriginalQty: Decimal;
+    begin
+        // [FEATURE] [Corrective Credit Memo] [Purchase Order]
+        // [SCENARIO 645182] A corrective credit memo created from an order-based invoice cannot be increased, so the purchase order Received/Invoiced quantities cannot be driven negative.
+        Initialize();
+
+        // [GIVEN] A purchase order for a Service item, partially received and invoiced
+        PartialQty := LibraryRandom.RandIntInRange(2, 5);
+        OrderQty := PartialQty + LibraryRandom.RandIntInRange(1, 5);
+        CreateItemWithCost(Item, Item.Type::Service, LibraryRandom.RandDecInRange(10, 100, 2));
+        LibrarySmallBusiness.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderOrder, PurchaseHeaderOrder."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", OrderQty);
+        PurchaseLineOrder.Validate("Qty. to Receive", PartialQty);
+        PurchaseLineOrder.Validate("Qty. to Invoice", PartialQty);
+        PurchaseLineOrder.Modify(true);
+        PurchInvHeader.Get(LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, true));
+
+        // [GIVEN] The order line shows the partially received and invoiced quantity
+        PurchaseLineOrder.Find();
+        PurchaseLineOrder.TestField("Quantity Received", PartialQty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", PartialQty);
+
+        // [GIVEN] A corrective credit memo created from the posted order-based invoice
+        LibraryVariableStorage.Enqueue(true); // Confirm to create the corrective credit memo from the order-based invoice
+        CorrectPostedPurchInvoice.CreateCreditMemoCopyDocument(PurchInvHeader, PurchaseHeaderCorrection);
+        GetCorrectiveCreditMemoItemLine(PurchaseLine, PurchaseHeaderCorrection."No.");
+        OriginalQty := PurchaseLine.Quantity;
+
+        // [WHEN] Increasing the quantity of the credit memo line beyond the copied quantity
+        asserterror PurchaseLine.Validate(Quantity, OriginalQty + 1);
+
+        // [THEN] A blocking error is raised before the credit memo can be posted
+        Assert.ExpectedError(StrSubstNo(CorrectiveCreditMemoQtyIncreaseErr, OriginalQty));
+
+        // [THEN] The purchase order line quantities are unchanged and cannot go negative
+        PurchaseLineOrder.Find();
+        PurchaseLineOrder.TestField("Quantity Received", PartialQty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", PartialQty);
+
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";


### PR DESCRIPTION
[AB#645182](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645182)





