### PR TITLE
Fix Payment Management FR data update paths and per-company feature status

### DIFF
--- a/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/FeaturePaymentMgtFR.Codeunit.al
+++ b/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/FeaturePaymentMgtFR.Codeunit.al
@@ -5,17 +5,13 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Bank.Payment;
 
-using Microsoft.Bank.BankAccount;
 using Microsoft.Foundation.Navigate;
-using Microsoft.Purchases.Vendor;
-using Microsoft.Sales.Customer;
 using System.Environment.Configuration;
 using System.Upgrade;
 
 codeunit 10831 "Feature - PaymentMgt FR" implements "Feature Data Update"
 {
     Access = Internal;
-    Permissions = TableData "Feature Data Update Status" = rm;
     InherentEntitlements = X;
     InherentPermissions = X;
     ObsoleteReason = 'Feature Payment Management will be enabled by default in version 31.0.';
@@ -27,13 +23,11 @@ codeunit 10831 "Feature - PaymentMgt FR" implements "Feature Data Update"
         DescriptionTxt: Label 'Existing records in FR BaseApp fields will be copied to Payment App fields';
 
     procedure IsDataUpdateRequired(): Boolean;
+    var
+        PaymentDataMigrationFR: Codeunit "Payment Data Migration FR";
     begin
-        CountRecords();
-        if TempDocumentEntry.IsEmpty() then begin
-            SetUpgradeTag(false);
-            exit(false);
-        end;
-        exit(true);
+        PaymentDataMigrationFR.CountRecordsToMigrate(TempDocumentEntry);
+        exit(not TempDocumentEntry.IsEmpty());
     end;
 
     procedure ReviewData();
@@ -47,14 +41,10 @@ codeunit 10831 "Feature - PaymentMgt FR" implements "Feature Data Update"
     end;
 
     procedure AfterUpdate(FeatureDataUpdateStatus: Record "Feature Data Update Status")
-    var
-        UpdateFeatureDataUpdateStatus: Record "Feature Data Update Status";
     begin
-        UpdateFeatureDataUpdateStatus.SetRange("Feature Key", FeatureDataUpdateStatus."Feature Key");
-        UpdateFeatureDataUpdateStatus.SetFilter("Company Name", '<>%1', FeatureDataUpdateStatus."Company Name");
-        UpdateFeatureDataUpdateStatus.ModifyAll("Feature Status", FeatureDataUpdateStatus."Feature Status");
-
-        SetUpgradeTag(true);
+        // The data update runs per company, and the framework has already set the status of the company that
+        // was updated. The status of the other companies must stay Pending until their own data is migrated.
+        SetUpgradeTags();
     end;
 
     procedure UpdateData(FeatureDataUpdateStatus: Record "Feature Data Update Status");
@@ -75,227 +65,29 @@ codeunit 10831 "Feature - PaymentMgt FR" implements "Feature Data Update"
         TaskDescription := DescriptionTxt;
     end;
 
-    local procedure CountRecords()
-    var
-        BankAccount: Record "Bank Account";
-        VendorBankAccount: Record "Vendor Bank Account";
-        CustomerBankAccount: Record "Customer Bank Account";
-    begin
-        TempDocumentEntry.Reset();
-        TempDocumentEntry.DeleteAll();
-
-        InsertDocumentEntry(Database::"Bank Account", BankAccount.TableCaption, BankAccount.Count());
-        InsertDocumentEntry(Database::"Vendor Bank Account", VendorBankAccount.TableCaption, VendorBankAccount.Count());
-        InsertDocumentEntry(Database::"Customer Bank Account", CustomerBankAccount.TableCaption, CustomerBankAccount.Count());
-    end;
-
-    local procedure InsertDocumentEntry(TableID: Integer; TableName: Text; RecordCount: Integer)
-    begin
-        if RecordCount = 0 then
-            exit;
-
-        TempDocumentEntry.Init();
-        TempDocumentEntry."Entry No." += 1;
-        TempDocumentEntry."Table ID" := TableID;
-        TempDocumentEntry."Table Name" := CopyStr(TableName, 1, MaxStrLen(TempDocumentEntry."Table Name"));
-        TempDocumentEntry."No. of Records" := RecordCount;
-        TempDocumentEntry.Insert();
-    end;
-
-    local procedure UpgradeBankAccountBuffer()
-    var
-        BankAccountBufferFR: Record "Bank Account Buffer FR";
-        BankAccountBuffer: Record "Bank Account Buffer";
-    begin
-        if BankAccountBuffer.FindSet() then
-            repeat
-                BankAccountBufferFR.TransferFields(BankAccountBuffer);
-                BankAccountBufferFR.Insert();
-            until BankAccountBuffer.Next() = 0;
-    end;
-
-    local procedure UpgradePaymentClass()
-    var
-        PaymentClassFR: Record "Payment Class FR";
-        PaymentClass: Record "Payment Class";
-    begin
-        if PaymentClass.FindSet() then
-            repeat
-                PaymentClassFR.TransferFields(PaymentClass);
-                PaymentClassFR.Insert();
-            until PaymentClass.Next() = 0;
-    end;
-
-    local procedure UpgradePaymentHeader()
-    var
-        PaymentHeaderFR: Record "Payment Header FR";
-        PaymentHeader: Record "Payment Header";
-    begin
-        if PaymentHeader.FindSet() then
-            repeat
-                PaymentHeaderFR.TransferFields(PaymentHeader);
-                PaymentHeaderFR.Insert();
-            until PaymentHeader.Next() = 0;
-    end;
-
-    local procedure UpgradePaymentLine()
-    var
-        PaymentLineFR: Record "Payment Line FR";
-        PaymentLine: Record "Payment Line";
-    begin
-        if PaymentLine.FindSet() then
-            repeat
-                PaymentLineFR.TransferFields(PaymentLine);
-                PaymentLineFR.Insert();
-            until PaymentLine.Next() = 0;
-    end;
-
-    local procedure UpgradePaymentHeaderArchive()
-    var
-        PaymentHeaderArchiveFR: Record "Payment Header Archive FR";
-        PaymentHeaderArchive: Record "Payment Header Archive";
-    begin
-        if PaymentHeaderArchive.FindSet() then
-            repeat
-                PaymentHeaderArchiveFR.TransferFields(PaymentHeaderArchive);
-                PaymentHeaderArchiveFR.Insert();
-            until PaymentHeaderArchive.Next() = 0;
-    end;
-
-    local procedure UpgradePaymentLineArchive()
-    var
-        PaymentLineArchiveFR: Record "Payment Line Archive FR";
-        PaymentLineArchive: Record "Payment Line Archive";
-    begin
-        if PaymentLineArchive.FindSet() then
-            repeat
-                PaymentLineArchiveFR.TransferFields(PaymentLineArchive);
-                PaymentLineArchiveFR.Insert();
-            until PaymentLineArchive.Next() = 0;
-    end;
-
-    local procedure UpgradePaymentPostBuffer()
-    var
-        PaymentPostBufferFR: Record "Payment Post. Buffer FR";
-        PaymentPostBuffer: Record "Payment Post. Buffer";
-    begin
-        if PaymentPostBuffer.FindSet() then
-            repeat
-                PaymentPostBufferFR.TransferFields(PaymentPostBuffer);
-                PaymentPostBufferFR.Insert();
-            until PaymentPostBuffer.Next() = 0;
-    end;
-
-    local procedure UpgradePaymentStatus()
-    var
-        PaymentStatusFR: Record "Payment Status FR";
-        PaymentStatus: Record "Payment Status";
-    begin
-        if PaymentStatus.FindSet() then
-            repeat
-                PaymentStatusFR.TransferFields(PaymentStatus);
-                PaymentStatusFR.Insert();
-            until PaymentStatus.Next() = 0;
-    end;
-
-    local procedure UpgradePaymentStep()
-    var
-        PaymentStepFR: Record "Payment Step FR";
-        PaymentStep: Record "Payment Step";
-    begin
-        if PaymentStep.FindSet() then
-            repeat
-                PaymentStepFR.TransferFields(PaymentStep);
-                PaymentStepFR.Insert();
-            until PaymentStep.Next() = 0;
-    end;
-
-    local procedure UpgradePaymentStepLedger()
-    var
-        PaymentStepLedgerFR: Record "Payment Step Ledger FR";
-        PaymentStepLedger: Record "Payment Step Ledger";
-    begin
-        if PaymentStepLedger.FindSet() then
-            repeat
-                PaymentStepLedgerFR.TransferFields(PaymentStepLedger);
-                PaymentStepLedgerFR.Insert();
-            until PaymentStepLedger.Next() = 0;
-    end;
-
-    local procedure UpgradePaymentAddress()
-    var
-        PaymentAddressFR: Record "Payment Address FR";
-        PaymentAddress: Record "Payment Address";
-    begin
-        if PaymentAddress.FindSet() then
-            repeat
-                PaymentAddressFR.TransferFields(PaymentAddress);
-                PaymentAddressFR.Insert();
-            until PaymentAddress.Next() = 0;
-    end;
-
     local procedure UpgradePayment()
     var
-        BankAccount: Record "Bank Account";
-        VendorBankAccount: Record "Vendor Bank Account";
-        CustomerBankAccount: Record "Customer Bank Account";
+        PaymentDataMigrationFR: Codeunit "Payment Data Migration FR";
     begin
-        UpgradeBankAccountBuffer();
-        UpgradePaymentClass();
-        UpgradePaymentHeader();
-        UpgradePaymentHeaderArchive();
-        UpgradePaymentLine();
-        UpgradePaymentLineArchive();
-        UpgradePaymentPostBuffer();
-        UpgradePaymentStatus();
-        UpgradePaymentStep();
-        UpgradePaymentStepLedger();
-        UpgradePaymentAddress();
-
-        if BankAccount.FindSet() then
-            repeat
-#pragma warning disable AL0432
-                BankAccount."Agency Code FR" := BankAccount."Agency Code";
-                BankAccount."RIB Key FR" := BankAccount."RIB Key";
-                BankAccount."RIB Checked FR" := BankAccount."RIB Checked";
-#pragma warning restore AL0432
-                BankAccount.Modify();
-            until BankAccount.Next() = 0;
-
-        if VendorBankAccount.FindSet() then
-            repeat
-#pragma warning disable AL0432
-                VendorBankAccount."Agency Code FR" := VendorBankAccount."Agency Code";
-                VendorBankAccount."RIB Key FR" := VendorBankAccount."RIB Key";
-                VendorBankAccount."RIB Checked FR" := VendorBankAccount."RIB Checked";
-#pragma warning restore AL0432
-                VendorBankAccount.Modify();
-            until VendorBankAccount.Next() = 0;
-
-        if CustomerBankAccount.FindSet() then
-            repeat
-#pragma warning disable AL0432
-                CustomerBankAccount."Agency Code FR" := CustomerBankAccount."Agency Code";
-                CustomerBankAccount."RIB Key FR" := CustomerBankAccount."RIB Key";
-                CustomerBankAccount."RIB Checked FR" := CustomerBankAccount."RIB Checked";
-#pragma warning restore AL0432
-                CustomerBankAccount.Modify();
-            until CustomerBankAccount.Next() = 0;
+        // The same migration is run by the forced upgrade to version 31 in codeunit
+        // "Upgrade Payment Management FR", so that both scenarios migrate the same data.
+        PaymentDataMigrationFR.MigratePaymentData();
+        PaymentDataMigrationFR.RemapPaymentStepObjectIDs();
     end;
 
-    local procedure SetUpgradeTag(DataUpgradeExecuted: Boolean)
+    local procedure SetUpgradeTags()
     var
         UpgradeTag: Codeunit "Upgrade Tag";
         UpgTagPayment: Codeunit "Upg. Tag Payment Management FR";
     begin
-        // Set the upgrade tag to indicate that the data update is executed/skipped and the feature is enabled.
-        // This is needed when the feature is enabled by default in a future version, to skip the data upgrade.
-        if UpgradeTag.HasUpgradeTag(UpgTagPayment.GetPaymentUpgradeTag()) then
-            exit;
+        // Set the upgrade tags of this company to indicate that the data update is executed and the feature
+        // is enabled. This is needed when the feature is enabled by default in a future version, to skip the
+        // data upgrade. The tags are per company, so the other companies still run their own data upgrade.
+        if not UpgradeTag.HasUpgradeTag(UpgTagPayment.GetPaymentUpgradeTag()) then
+            UpgradeTag.SetUpgradeTag(UpgTagPayment.GetPaymentUpgradeTag());
 
-        UpgradeTag.SetUpgradeTag(UpgTagPayment.GetPaymentUpgradeTag());
-        if not DataUpgradeExecuted then
-            UpgradeTag.SetSkippedUpgrade(UpgTagPayment.GetPaymentUpgradeTag(), true);
+        if not UpgradeTag.HasUpgradeTag(UpgTagPayment.GetPaymentStepObjectIDsUpgradeTag()) then
+            UpgradeTag.SetUpgradeTag(UpgTagPayment.GetPaymentStepObjectIDsUpgradeTag());
     end;
 }
 #endif

--- a/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/PaymentDataMigrationFR.Codeunit.al
+++ b/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/PaymentDataMigrationFR.Codeunit.al
@@ -1,0 +1,266 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Bank.Payment;
+
+using Microsoft.Bank.BankAccount;
+using Microsoft.Foundation.Navigate;
+using Microsoft.Purchases.Vendor;
+using Microsoft.Sales.Customer;
+using System.Reflection;
+
+/// <summary>
+/// Copies the French payment data from the base application into the Payment Management FR app.
+/// This is the single implementation shared by the data update that is started from Feature Management
+/// (codeunit "Feature - PaymentMgt FR") and by the forced upgrade to version 31 (codeunit
+/// "Upgrade Payment Management FR"), so that both scenarios migrate exactly the same data.
+/// The legacy base application objects are referenced by ID because they are obsolete and are removed
+/// in version 31.
+/// </summary>
+codeunit 10844 "Payment Data Migration FR"
+{
+    Access = Internal;
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    /// <summary>
+    /// Copies all French payment data of the current company from the base application tables and fields
+    /// into the tables and fields of the Payment Management FR app.
+    /// </summary>
+    internal procedure MigratePaymentData()
+    var
+        LegacyTableIds: List of [Integer];
+        AppTableIds: List of [Integer];
+        TableIndex: Integer;
+    begin
+        GetTableMapping(LegacyTableIds, AppTableIds);
+        for TableIndex := 1 to LegacyTableIds.Count() do
+            TransferRecords(LegacyTableIds.Get(TableIndex), AppTableIds.Get(TableIndex));
+
+        TransferBankAccountFields(Database::"Bank Account");
+        TransferBankAccountFields(Database::"Customer Bank Account");
+        TransferBankAccountFields(Database::"Vendor Bank Account");
+    end;
+
+    /// <summary>
+    /// Points the payment steps at the report and XMLport objects of the Payment Management FR app.
+    /// The migrated payment steps still refer to the object IDs of the base application objects, which
+    /// were re-created in the app under new IDs. Object IDs that are not mapped, and the value 0, are
+    /// left untouched. The mapping is idempotent, so the remapping can safely be repeated.
+    /// </summary>
+    internal procedure RemapPaymentStepObjectIDs()
+    var
+        PaymentStepFR: Record "Payment Step FR";
+        ReportMap: Dictionary of [Integer, Integer];
+        XmlPortMap: Dictionary of [Integer, Integer];
+        LegacyReportNo: Integer;
+        LegacyExportNo: Integer;
+    begin
+        BuildPaymentStepObjectIDMaps(ReportMap, XmlPortMap);
+
+        if PaymentStepFR.FindSet(true) then
+            repeat
+                LegacyReportNo := PaymentStepFR."Report No.";
+                LegacyExportNo := PaymentStepFR."Export No.";
+
+                case PaymentStepFR."Action Type" of
+                    PaymentStepFR."Action Type"::Report:
+                        if ReportMap.ContainsKey(LegacyReportNo) then
+                            PaymentStepFR."Report No." := ReportMap.Get(LegacyReportNo);
+                    PaymentStepFR."Action Type"::File:
+                        case PaymentStepFR."Export Type" of
+                            PaymentStepFR."Export Type"::Report:
+                                if ReportMap.ContainsKey(LegacyExportNo) then
+                                    PaymentStepFR."Export No." := ReportMap.Get(LegacyExportNo);
+                            PaymentStepFR."Export Type"::XMLport:
+                                if XmlPortMap.ContainsKey(LegacyExportNo) then
+                                    PaymentStepFR."Export No." := XmlPortMap.Get(LegacyExportNo);
+                        end;
+                end;
+
+                OnAfterRemapPaymentStepObjectIDs(PaymentStepFR, LegacyReportNo, LegacyExportNo);
+
+                PaymentStepFR.Modify();
+            until PaymentStepFR.Next() = 0;
+    end;
+
+    /// <summary>
+    /// Counts the records that the data update will migrate, so that they can be reviewed before the
+    /// update is started. The counted tables are the tables that <see cref="MigratePaymentData"/> migrates.
+    /// </summary>
+    /// <param name="TempDocumentEntry">The buffer that receives one entry per non-empty table.</param>
+    internal procedure CountRecordsToMigrate(var TempDocumentEntry: Record "Document Entry" temporary)
+    var
+        LegacyTableIds: List of [Integer];
+        AppTableIds: List of [Integer];
+        LegacyTableId: Integer;
+    begin
+        TempDocumentEntry.Reset();
+        TempDocumentEntry.DeleteAll();
+
+        GetTableMapping(LegacyTableIds, AppTableIds);
+        foreach LegacyTableId in LegacyTableIds do
+            InsertDocumentEntry(TempDocumentEntry, LegacyTableId);
+
+        InsertDocumentEntry(TempDocumentEntry, Database::"Bank Account");
+        InsertDocumentEntry(TempDocumentEntry, Database::"Customer Bank Account");
+        InsertDocumentEntry(TempDocumentEntry, Database::"Vendor Bank Account");
+    end;
+
+    local procedure GetTableMapping(var LegacyTableIds: List of [Integer]; var AppTableIds: List of [Integer])
+    begin
+        AddTableMapping(LegacyTableIds, AppTableIds, 10869, Database::"Bank Account Buffer FR"); // 10869 - "Bank Account Buffer"
+        AddTableMapping(LegacyTableIds, AppTableIds, 10860, Database::"Payment Class FR"); // 10860 - "Payment Class"
+        AddTableMapping(LegacyTableIds, AppTableIds, 10865, Database::"Payment Header FR"); // 10865 - "Payment Header"
+        AddTableMapping(LegacyTableIds, AppTableIds, 10867, Database::"Payment Header Archive FR"); // 10867 - "Payment Header Archive"
+        AddTableMapping(LegacyTableIds, AppTableIds, 10866, Database::"Payment Line FR"); // 10866 - "Payment Line"
+        AddTableMapping(LegacyTableIds, AppTableIds, 10868, Database::"Payment Line Archive FR"); // 10868 - "Payment Line Archive"
+        AddTableMapping(LegacyTableIds, AppTableIds, 10864, Database::"Payment Post. Buffer FR"); // 10864 - "Payment Post. Buffer"
+        AddTableMapping(LegacyTableIds, AppTableIds, 10861, Database::"Payment Status FR"); // 10861 - "Payment Status"
+        AddTableMapping(LegacyTableIds, AppTableIds, 10862, Database::"Payment Step FR"); // 10862 - "Payment Step"
+        AddTableMapping(LegacyTableIds, AppTableIds, 10863, Database::"Payment Step Ledger FR"); // 10863 - "Payment Step Ledger"
+        AddTableMapping(LegacyTableIds, AppTableIds, 10870, Database::"Payment Address FR"); // 10870 - "Payment Address"
+    end;
+
+    local procedure AddTableMapping(var LegacyTableIds: List of [Integer]; var AppTableIds: List of [Integer]; LegacyTableId: Integer; AppTableId: Integer)
+    begin
+        LegacyTableIds.Add(LegacyTableId);
+        AppTableIds.Add(AppTableId);
+    end;
+
+    local procedure InsertDocumentEntry(var TempDocumentEntry: Record "Document Entry" temporary; TableId: Integer)
+    var
+        RecRef: RecordRef;
+        RecordCount: Integer;
+        TableName: Text;
+    begin
+        RecRef.Open(TableId, false);
+        RecordCount := RecRef.Count();
+        TableName := RecRef.Caption();
+        RecRef.Close();
+
+        if RecordCount = 0 then
+            exit;
+
+        TempDocumentEntry.Init();
+        TempDocumentEntry."Entry No." := TempDocumentEntry.Count() + 1;
+        TempDocumentEntry."Table ID" := TableId;
+        TempDocumentEntry."Table Name" := CopyStr(TableName, 1, MaxStrLen(TempDocumentEntry."Table Name"));
+        TempDocumentEntry."No. of Records" := RecordCount;
+        TempDocumentEntry.Insert();
+    end;
+
+    local procedure TransferRecords(SourceTableId: Integer; TargetTableId: Integer)
+    var
+        SourceField: Record Field;
+        SourceRecRef: RecordRef;
+        TargetRecRef: RecordRef;
+        ExistingRecRef: RecordRef;
+        SourceFieldRef: FieldRef;
+        TargetFieldRef: FieldRef;
+    begin
+        SourceRecRef.Open(SourceTableId, false);
+        TargetRecRef.Open(TargetTableId, false);
+        ExistingRecRef.Open(TargetTableId, false);
+
+        SourceField.SetRange(TableNo, SourceTableId);
+        SourceField.SetRange(Class, SourceField.Class::Normal);
+        SourceField.SetRange(Enabled, true);
+
+        if SourceRecRef.FindSet() then
+            repeat
+                TargetRecRef.Init();
+                if SourceField.FindSet() then
+                    repeat
+                        // The app tables do not necessarily have every field of the base application table.
+                        if TargetRecRef.FieldExist(SourceField."No.") then begin
+                            SourceFieldRef := SourceRecRef.Field(SourceField."No.");
+                            TargetFieldRef := TargetRecRef.Field(SourceField."No.");
+                            TargetFieldRef.Value := SourceFieldRef.Value;
+                        end;
+                    until SourceField.Next() = 0;
+
+                // Records that were already migrated, for example by a previous run that failed halfway, are kept.
+                if not TargetRecordExists(TargetRecRef, ExistingRecRef) then
+                    TargetRecRef.Insert();
+            until SourceRecRef.Next() = 0;
+
+        SourceRecRef.Close();
+        TargetRecRef.Close();
+        ExistingRecRef.Close();
+    end;
+
+    local procedure TargetRecordExists(var TargetRecRef: RecordRef; var ExistingRecRef: RecordRef): Boolean
+    var
+        PrimaryKeyRef: KeyRef;
+        PrimaryKeyFieldRef: FieldRef;
+        ExistingFieldRef: FieldRef;
+        FieldIndex: Integer;
+    begin
+        ExistingRecRef.Reset();
+        PrimaryKeyRef := TargetRecRef.KeyIndex(1);
+        for FieldIndex := 1 to PrimaryKeyRef.FieldCount() do begin
+            PrimaryKeyFieldRef := PrimaryKeyRef.FieldIndex(FieldIndex);
+            ExistingFieldRef := ExistingRecRef.Field(PrimaryKeyFieldRef.Number());
+            ExistingFieldRef.SetRange(PrimaryKeyFieldRef.Value());
+        end;
+        exit(not ExistingRecRef.IsEmpty());
+    end;
+
+    local procedure TransferBankAccountFields(TableId: Integer)
+    var
+        RecRef: RecordRef;
+    begin
+        // The bank account tables carry the French fields both in the base application ("Agency Code" 10851,
+        // "RIB Key" 10852 and "RIB Checked" 10853) and in the table extensions of this app ("Agency Code FR"
+        // 10805, "RIB Key FR" 10806 and "RIB Checked FR" 10807). The field numbers are the same on
+        // "Bank Account", "Customer Bank Account" and "Vendor Bank Account".
+        RecRef.Open(TableId, false);
+        if RecRef.FindSet(true) then
+            repeat
+                CopyFieldValue(RecRef, 10851, 10805);
+                CopyFieldValue(RecRef, 10852, 10806);
+                CopyFieldValue(RecRef, 10853, 10807);
+                RecRef.Modify(false);
+            until RecRef.Next() = 0;
+        RecRef.Close();
+    end;
+
+    local procedure CopyFieldValue(var RecRef: RecordRef; SourceFieldNo: Integer; TargetFieldNo: Integer)
+    var
+        SourceFieldRef: FieldRef;
+        TargetFieldRef: FieldRef;
+    begin
+        SourceFieldRef := RecRef.Field(SourceFieldNo);
+        TargetFieldRef := RecRef.Field(TargetFieldNo);
+        TargetFieldRef.Value := SourceFieldRef.Value;
+    end;
+
+    local procedure BuildPaymentStepObjectIDMaps(var ReportMap: Dictionary of [Integer, Integer]; var XmlPortMap: Dictionary of [Integer, Integer])
+    begin
+        ReportMap.Set(10843, 10846); // Recapitulation Form
+        ReportMap.Set(10860, 10845); // Payment List
+        ReportMap.Set(10862, 10850); // Suggest Vendor Payments FR
+        ReportMap.Set(10864, 10849); // Suggest Customer Payments
+        ReportMap.Set(10865, 10834); // Bill
+        ReportMap.Set(10866, 10836); // Draft
+        ReportMap.Set(10867, 10847); // Remittance
+        ReportMap.Set(10868, 10837); // Draft notice
+        ReportMap.Set(10869, 10838); // Draft recapitulation
+        ReportMap.Set(10870, 10852); // Withdraw notice
+        ReportMap.Set(10871, 10853); // Withdraw recapitulation
+        ReportMap.Set(10872, 10839); // Duplicate parameter
+        ReportMap.Set(10873, 10831); // Archive Payment Slips
+        ReportMap.Set(10880, 10840); // ETEBAC Files
+        ReportMap.Set(10881, 10851); // Withdraw
+        ReportMap.Set(10883, 10848); // SEPA ISO20022
+
+        XmlPortMap.Set(10863, 10831); // Import/Export Parameters
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterRemapPaymentStepObjectIDs(var PaymentStepFR: Record "Payment Step FR"; LegacyReportNo: Integer; LegacyExportNo: Integer)
+    begin
+    end;
+}

--- a/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/PaymentDataMigrationFR.Codeunit.al
+++ b/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/PaymentDataMigrationFR.Codeunit.al
@@ -204,9 +204,9 @@ codeunit 10844 "Payment Data Migration FR"
 
     local procedure TargetRecordExists(var TargetRecRef: RecordRef; var ExistingRecRef: RecordRef): Boolean
     var
-        PrimaryKeyRef: KeyRef;
         PrimaryKeyFieldRef: FieldRef;
         ExistingFieldRef: FieldRef;
+        PrimaryKeyRef: KeyRef;
         FieldIndex: Integer;
     begin
         ExistingRecRef.Reset();

--- a/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/PaymentDataMigrationFR.Codeunit.al
+++ b/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/PaymentDataMigrationFR.Codeunit.al
@@ -153,33 +153,28 @@ codeunit 10844 "Payment Data Migration FR"
 
     local procedure TransferRecords(SourceTableId: Integer; TargetTableId: Integer)
     var
-        SourceField: Record Field;
         SourceRecRef: RecordRef;
         TargetRecRef: RecordRef;
         ExistingRecRef: RecordRef;
         SourceFieldRef: FieldRef;
         TargetFieldRef: FieldRef;
+        TransferableFieldNos: List of [Integer];
+        FieldNo: Integer;
     begin
         SourceRecRef.Open(SourceTableId, false);
         TargetRecRef.Open(TargetTableId, false);
         ExistingRecRef.Open(TargetTableId, false);
 
-        SourceField.SetRange(TableNo, SourceTableId);
-        SourceField.SetRange(Class, SourceField.Class::Normal);
-        SourceField.SetRange(Enabled, true);
+        GetTransferableFieldNos(SourceTableId, TargetRecRef, TransferableFieldNos);
 
         if SourceRecRef.FindSet() then
             repeat
                 TargetRecRef.Init();
-                if SourceField.FindSet() then
-                    repeat
-                        // The app tables do not necessarily have every field of the base application table.
-                        if TargetRecRef.FieldExist(SourceField."No.") then begin
-                            SourceFieldRef := SourceRecRef.Field(SourceField."No.");
-                            TargetFieldRef := TargetRecRef.Field(SourceField."No.");
-                            TargetFieldRef.Value := SourceFieldRef.Value;
-                        end;
-                    until SourceField.Next() = 0;
+                foreach FieldNo in TransferableFieldNos do begin
+                    SourceFieldRef := SourceRecRef.Field(FieldNo);
+                    TargetFieldRef := TargetRecRef.Field(FieldNo);
+                    TargetFieldRef.Value := SourceFieldRef.Value;
+                end;
 
                 // Records that were already migrated, for example by a previous run that failed halfway, are kept.
                 if not TargetRecordExists(TargetRecRef, ExistingRecRef) then
@@ -189,6 +184,22 @@ codeunit 10844 "Payment Data Migration FR"
         SourceRecRef.Close();
         TargetRecRef.Close();
         ExistingRecRef.Close();
+    end;
+
+    local procedure GetTransferableFieldNos(SourceTableId: Integer; var TargetRecRef: RecordRef; var TransferableFieldNos: List of [Integer])
+    var
+        SourceField: Record Field;
+    begin
+        SourceField.SetRange(TableNo, SourceTableId);
+        SourceField.SetRange(Class, SourceField.Class::Normal);
+        SourceField.SetRange(Enabled, true);
+
+        if SourceField.FindSet() then
+            repeat
+                // The app tables do not necessarily have every field of the base application table.
+                if TargetRecRef.FieldExist(SourceField."No.") then
+                    TransferableFieldNos.Add(SourceField."No.");
+            until SourceField.Next() = 0;
     end;
 
     local procedure TargetRecordExists(var TargetRecRef: RecordRef; var ExistingRecRef: RecordRef): Boolean

--- a/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/UpgTagPaymentManagementFR.Codeunit.al
+++ b/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/UpgTagPaymentManagementFR.Codeunit.al
@@ -14,10 +14,16 @@ codeunit 10841 "Upg. Tag Payment Management FR"
     local procedure RegisterPerCompanyTags(var PerCompanyUpgradeTags: List of [Code[250]])
     begin
         PerCompanyUpgradeTags.Add(GetPaymentUpgradeTag());
+        PerCompanyUpgradeTags.Add(GetPaymentStepObjectIDsUpgradeTag());
     end;
 
     internal procedure GetPaymentUpgradeTag(): Code[250]
     begin
         exit('MS-581204-PaymentManagementUpgradeTag-20250918');
+    end;
+
+    internal procedure GetPaymentStepObjectIDsUpgradeTag(): Code[250]
+    begin
+        exit('MS-645208-PaymentStepObjectIDsUpgradeTag-20260805');
     end;
 }

--- a/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/UpgradePaymentManagementFR.Codeunit.al
+++ b/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/UpgradePaymentManagementFR.Codeunit.al
@@ -22,9 +22,10 @@ codeunit 10840 "Upgrade Payment Management FR"
         CurrentModuleInfo: ModuleInfo;
     begin
         NavApp.GetCurrentModuleInfo(CurrentModuleInfo);
-        if CurrentModuleInfo.AppVersion().Major() >= 31 then
-            UpgradePayment();
+        if CurrentModuleInfo.AppVersion().Major() < 31 then
+            exit;
 
+        UpgradePayment();
         UpgradePaymentStepObjectIDs();
     end;
 

--- a/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/UpgradePaymentManagementFR.Codeunit.al
+++ b/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/UpgradePaymentManagementFR.Codeunit.al
@@ -1,20 +1,17 @@
-#if CLEAN28
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Bank.Payment;
 
-using Microsoft.Bank.BankAccount;
-using Microsoft.Purchases.Vendor;
-using Microsoft.Sales.Customer;
-using System.Reflection;
 using System.Upgrade;
 
 codeunit 10840 "Upgrade Payment Management FR"
 {
     Access = Internal;
     Subtype = Upgrade;
+    InherentEntitlements = X;
+    InherentPermissions = X;
 
     var
         UpgradeTag: Codeunit "Upgrade Tag";
@@ -25,157 +22,37 @@ codeunit 10840 "Upgrade Payment Management FR"
         CurrentModuleInfo: ModuleInfo;
     begin
         NavApp.GetCurrentModuleInfo(CurrentModuleInfo);
-        if CurrentModuleInfo.AppVersion().Major() < 31 then
-            exit;
+        if CurrentModuleInfo.AppVersion().Major() >= 31 then
+            UpgradePayment();
 
-        UpgradePayment();
+        UpgradePaymentStepObjectIDs();
     end;
 
     local procedure UpgradePayment()
+    var
+        PaymentDataMigrationFR: Codeunit "Payment Data Migration FR";
     begin
         if UpgradeTag.HasUpgradeTag(UpgTagPayment.GetPaymentUpgradeTag()) then
             exit;
 
-        TransferFields(Database::"Bank Account", 10805, 10851); //  10805 - the existing field "Agency Code", 10851 - the new field "Agency Code FR"; 
-        TransferFields(Database::"Bank Account", 10806, 10852); // 10806 - the existing field "RIB Key", 10852 - the new field "RIB Key FR"; 
-        TransferFields(Database::"Bank Account", 10807, 10853); // 10807 - the existing field "RIB Checked", 10853 - the new field "RIB Checked FR",; 
-        TransferFields(Database::"Customer Bank Account", 10805, 10851); // 10805 - the existing field "Agency Code", 10851 - the new field "Agency Code FR",; 
-        TransferFields(Database::"Customer Bank Account", 10806, 10852); //, 10806 - the existing field "RIB Key", 10852 - the new field "RIB Key FR"; 
-        TransferFields(Database::"Customer Bank Account", 10807, 10853); // 10807 - the existing field "RIB Checked", 10853 - the new field "RIB Checked FR";
-        TransferFields(Database::"Vendor Bank Account", 10805, 10851); // 10805 - the existing field "Agency Code", 10851 - the new field "Agency Code FR"; 
-        TransferFields(Database::"Vendor Bank Account", 10806, 10852); // 10806 - the existing field "RIB Key", 10852 - the new field "RIB Key FR"; 
-        TransferFields(Database::"Vendor Bank Account", 10807, 10853); // 10807 - the existing field "RIB Checked", 10853 - the new field "RIB Checked FR";
-        TransferRecords(Database::"Bank Account Buffer", Database::"Bank Account Buffer FR");
-        TransferRecords(Database::"Payment Class", Database::"Payment Class FR");
-        TransferRecords(Database::"Payment Header", Database::"Payment Header FR");
-        TransferRecords(Database::"Payment Header Archive", Database::"Payment Header Archive FR");
-        TransferRecords(Database::"Payment Line", Database::"Payment Line FR");
-        TransferRecords(Database::"Payment Line Archive", Database::"Payment Line Archive FR");
-        TransferRecords(Database::"Payment Post. Buffer", Database::"Payment Post. Buffer FR");
-        TransferRecords(Database::"Payment Status", Database::"Payment Status FR");
-        TransferRecords(Database::"Payment Step", Database::"Payment Step FR");
-        TransferRecords(Database::"Payment Step Ledger", Database::"Payment Step Ledger FR");
-        TransferRecords(Database::"Payment Address", Database::"Payment Address FR");
-
-        RemapPaymentStepObjectIDs();
+        PaymentDataMigrationFR.MigratePaymentData();
 
         UpgradeTag.SetUpgradeTag(UpgTagPayment.GetPaymentUpgradeTag());
     end;
 
-    local procedure RemapPaymentStepObjectIDs()
+    local procedure UpgradePaymentStepObjectIDs()
     var
-        PaymentStepFR: Record "Payment Step FR";
-        ReportMap: Dictionary of [Integer, Integer];
-        XmlPortMap: Dictionary of [Integer, Integer];
-        LegacyReportNo: Integer;
-        LegacyExportNo: Integer;
+        PaymentDataMigrationFR: Codeunit "Payment Data Migration FR";
     begin
-        BuildPaymentStepObjectIDMaps(ReportMap, XmlPortMap);
-
-        if PaymentStepFR.FindSet(true) then
-            repeat
-                LegacyReportNo := PaymentStepFR."Report No.";
-                LegacyExportNo := PaymentStepFR."Export No.";
-
-                case PaymentStepFR."Action Type" of
-                    PaymentStepFR."Action Type"::Report:
-                        if ReportMap.ContainsKey(LegacyReportNo) then
-                            PaymentStepFR."Report No." := ReportMap.Get(LegacyReportNo);
-                    PaymentStepFR."Action Type"::File:
-                        case PaymentStepFR."Export Type" of
-                            PaymentStepFR."Export Type"::Report:
-                                if ReportMap.ContainsKey(LegacyExportNo) then
-                                    PaymentStepFR."Export No." := ReportMap.Get(LegacyExportNo);
-                            PaymentStepFR."Export Type"::XMLport:
-                                if XmlPortMap.ContainsKey(LegacyExportNo) then
-                                    PaymentStepFR."Export No." := XmlPortMap.Get(LegacyExportNo);
-                        end;
-                end;
-
-                OnAfterRemapPaymentStepObjectIDs(PaymentStepFR, LegacyReportNo, LegacyExportNo);
-
-                PaymentStepFR.Modify();
-            until PaymentStepFR.Next() = 0;
-    end;
-
-    local procedure BuildPaymentStepObjectIDMaps(var ReportMap: Dictionary of [Integer, Integer]; var XmlPortMap: Dictionary of [Integer, Integer])
-    begin
-        ReportMap.Set(10843, 10846); // Recapitulation Form
-        ReportMap.Set(10860, 10845); // Payment List
-        ReportMap.Set(10862, 10850); // Suggest Vendor Payments FR
-        ReportMap.Set(10864, 10849); // Suggest Customer Payments
-        ReportMap.Set(10865, 10834); // Bill
-        ReportMap.Set(10866, 10836); // Draft
-        ReportMap.Set(10867, 10847); // Remittance
-        ReportMap.Set(10868, 10837); // Draft notice
-        ReportMap.Set(10869, 10838); // Draft recapitulation
-        ReportMap.Set(10870, 10852); // Withdraw notice
-        ReportMap.Set(10871, 10853); // Withdraw recapitulation
-        ReportMap.Set(10872, 10839); // Duplicate parameter
-        ReportMap.Set(10873, 10831); // Archive Payment Slips
-        ReportMap.Set(10880, 10840); // ETEBAC Files
-        ReportMap.Set(10881, 10851); // Withdraw
-        ReportMap.Set(10883, 10848); // SEPA ISO20022
-
-        XmlPortMap.Set(10863, 10831); // Import/Export Parameters
-    end;
-
-    [IntegrationEvent(false, false)]
-    local procedure OnAfterRemapPaymentStepObjectIDs(var PaymentStepFR: Record "Payment Step FR"; LegacyReportNo: Integer; LegacyExportNo: Integer)
-    begin
-    end;
-
-    procedure TransferRecords(SourceTableId: Integer; TargetTableId: Integer)
-    var
-        SourceField: Record Field;
-        SourceRecRef: RecordRef;
-        TargetRecRef: RecordRef;
-        TargetFieldRef: FieldRef;
-        SourceFieldRef: FieldRef;
-        SourceFieldRefNo: Integer;
-    begin
-        SourceRecRef.Open(SourceTableId, false);
-        TargetRecRef.Open(TargetTableId, false);
-
-        if SourceRecRef.IsEmpty() then
+        // The remapping has its own upgrade tag on purpose. Companies that migrated the payment data from
+        // Feature Management before the remapping was introduced already have the upgrade tag of the data
+        // migration, so their payment steps would otherwise keep pointing at the base application objects.
+        // The remapping is idempotent, so it does not matter whether the data was migrated just now or earlier.
+        if UpgradeTag.HasUpgradeTag(UpgTagPayment.GetPaymentStepObjectIDsUpgradeTag()) then
             exit;
 
-        SourceRecRef.FindSet();
+        PaymentDataMigrationFR.RemapPaymentStepObjectIDs();
 
-        repeat
-            Clear(SourceField);
-            SourceField.SetRange(TableNo, SourceTableId);
-            SourceField.SetRange(Class, SourceField.Class::Normal);
-            SourceField.SetRange(Enabled, true);
-            if SourceField.Findset() then
-                repeat
-                    SourceFieldRefNo := SourceField."No.";
-                    SourceFieldRef := SourceRecRef.Field(SourceFieldRefNo);
-                    TargetFieldRef := TargetRecRef.Field(SourceFieldRefNo);
-                    TargetFieldRef.VALUE := SourceFieldRef.VALUE;
-                until SourceField.Next() = 0;
-            TargetRecRef.Insert();
-        until SourceRecRef.Next() = 0;
-        SourceRecRef.Close();
-        TargetRecRef.Close();
-    end;
-
-    procedure TransferFields(TableId: Integer; SourceFieldNo: Integer; TargetFieldNo: Integer)
-    var
-        RecRef: RecordRef;
-        TargetFieldRef: FieldRef;
-        SourceFieldRef: FieldRef;
-    begin
-        RecRef.Open(TableId, false);
-        SourceFieldRef := RecRef.Field(SourceFieldNo);
-        SourceFieldRef.SetFilter('<>%1', '');
-
-        if RecRef.FindSet() then
-            repeat
-                TargetFieldRef := RecRef.Field(TargetFieldNo);
-                TargetFieldRef.VALUE := SourceFieldRef.VALUE;
-                RecRef.Modify(false);
-            until RecRef.Next() = 0;
+        UpgradeTag.SetUpgradeTag(UpgTagPayment.GetPaymentStepObjectIDsUpgradeTag());
     end;
 }
-#endif

--- a/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/UpgradePaymentManagementFR.Codeunit.al
+++ b/src/Apps/FR/PaymentManagementFR/app/src/Codeunits/UpgradePaymentManagementFR.Codeunit.al
@@ -22,10 +22,9 @@ codeunit 10840 "Upgrade Payment Management FR"
         CurrentModuleInfo: ModuleInfo;
     begin
         NavApp.GetCurrentModuleInfo(CurrentModuleInfo);
-        if CurrentModuleInfo.AppVersion().Major() < 31 then
-            exit;
+        if CurrentModuleInfo.AppVersion().Major() >= 31 then
+            UpgradePayment();
 
-        UpgradePayment();
         UpgradePaymentStepObjectIDs();
     end;
 
@@ -50,6 +49,12 @@ codeunit 10840 "Upgrade Payment Management FR"
         // migration, so their payment steps would otherwise keep pointing at the base application objects.
         // The remapping is idempotent, so it does not matter whether the data was migrated just now or earlier.
         if UpgradeTag.HasUpgradeTag(UpgTagPayment.GetPaymentStepObjectIDsUpgradeTag()) then
+            exit;
+
+        // Only a company whose payment data was migrated can have payment steps that point at the base
+        // application objects. Marking the remapping as done for a company that has not migrated yet would
+        // skip the remapping of the data that the upgrade to version 31 migrates later.
+        if not UpgradeTag.HasUpgradeTag(UpgTagPayment.GetPaymentUpgradeTag()) then
             exit;
 
         PaymentDataMigrationFR.RemapPaymentStepObjectIDs();

--- a/src/Apps/GB/GovTalk/app/src/Codeunits/FeatureGovTalk.Codeunit.al
+++ b/src/Apps/GB/GovTalk/app/src/Codeunits/FeatureGovTalk.Codeunit.al
@@ -13,7 +13,6 @@ using System.Upgrade;
 codeunit 10526 "Feature - GovTalk" implements "Feature Data Update"
 {
     Access = Internal;
-    Permissions = TableData "Feature Data Update Status" = rm;
     InherentEntitlements = X;
     InherentPermissions = X;
     ObsoleteReason = 'Feature GovTalk will be enabled by default in version 30.0.';
@@ -45,13 +44,9 @@ codeunit 10526 "Feature - GovTalk" implements "Feature Data Update"
     end;
 
     procedure AfterUpdate(FeatureDataUpdateStatus: Record "Feature Data Update Status")
-    var
-        UpdateFeatureDataUpdateStatus: Record "Feature Data Update Status";
     begin
-        UpdateFeatureDataUpdateStatus.SetRange("Feature Key", FeatureDataUpdateStatus."Feature Key");
-        UpdateFeatureDataUpdateStatus.SetFilter("Company Name", '<>%1', FeatureDataUpdateStatus."Company Name");
-        UpdateFeatureDataUpdateStatus.ModifyAll("Feature Status", FeatureDataUpdateStatus."Feature Status");
-
+        // The data update runs per company, and the framework has already set the status of the company that
+        // was updated. The status of the other companies must stay Pending until their own data is migrated.
         SetUpgradeTag(true);
     end;
 

--- a/src/Apps/GB/ReportsGB/app/src/Codeunits/FeatureReportsGB.Codeunit.al
+++ b/src/Apps/GB/ReportsGB/app/src/Codeunits/FeatureReportsGB.Codeunit.al
@@ -10,7 +10,6 @@ using System.Upgrade;
 codeunit 10580 "Feature - Reports GB" implements "Feature Data Update"
 {
     Access = Internal;
-    Permissions = TableData "Feature Data Update Status" = rm;
     InherentEntitlements = X;
     InherentPermissions = X;
     ObsoleteReason = 'Feature Reports GB will be enabled by default in version 30.0.';
@@ -50,13 +49,9 @@ codeunit 10580 "Feature - Reports GB" implements "Feature Data Update"
     end;
 
     procedure AfterUpdate(FeatureDataUpdateStatus: Record "Feature Data Update Status")
-    var
-        UpdateFeatureDataUpdateStatus: Record "Feature Data Update Status";
     begin
-        UpdateFeatureDataUpdateStatus.SetRange("Feature Key", FeatureDataUpdateStatus."Feature Key");
-        UpdateFeatureDataUpdateStatus.SetFilter("Company Name", '<>%1', FeatureDataUpdateStatus."Company Name");
-        UpdateFeatureDataUpdateStatus.ModifyAll("Feature Status", FeatureDataUpdateStatus."Feature Status");
-
+        // The data update runs per company, and the framework has already set the status of the company that
+        // was updated. The status of the other companies must stay Pending until their own data is migrated.
         SetUpgradeTag(true);
     end;
 

--- a/src/Apps/GB/ReverseChargeVAT/app/src/Codeunits/FeatureReverseChargeVAT.Codeunit.al
+++ b/src/Apps/GB/ReverseChargeVAT/app/src/Codeunits/FeatureReverseChargeVAT.Codeunit.al
@@ -21,7 +21,6 @@ codeunit 10553 "Feature - Reverse Charge VAT" implements "Feature Data Update"
     Access = Internal;
     InherentEntitlements = X;
     InherentPermissions = X;
-    Permissions = tabledata "Feature Data Update Status" = rm;
     ObsoleteReason = 'Feature Reverse Charge VAT will be enabled by default in version 30.0.';
     ObsoleteState = Pending;
     ObsoleteTag = '27.0';
@@ -51,13 +50,9 @@ codeunit 10553 "Feature - Reverse Charge VAT" implements "Feature Data Update"
     end;
 
     procedure AfterUpdate(FeatureDataUpdateStatus: Record "Feature Data Update Status")
-    var
-        UpdateFeatureDataUpdateStatus: Record "Feature Data Update Status";
     begin
-        UpdateFeatureDataUpdateStatus.SetRange("Feature Key", FeatureDataUpdateStatus."Feature Key");
-        UpdateFeatureDataUpdateStatus.SetFilter("Company Name", '<>%1', FeatureDataUpdateStatus."Company Name");
-        UpdateFeatureDataUpdateStatus.ModifyAll("Feature Status", FeatureDataUpdateStatus."Feature Status");
-
+        // The data update runs per company, and the framework has already set the status of the company that
+        // was updated. The status of the other companies must stay Pending until their own data is migrated.
         SetUpgradeTag(true);
     end;
 


### PR DESCRIPTION
Fixes [AB#645208](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/645208)

## Why

The migration of the French payment data existed twice: codeunit 10840 `Upgrade Payment Management FR` (`#if CLEAN28`, the forced upgrade to version 31) and codeunit 10831 `Feature - PaymentMgt FR` (the data update started from Feature Management). The two implementations had drifted, and the payment step object ID remapping added in #9140 only landed in the first one. Because the Feature Management path sets the migration upgrade tag, the version 31 upgrade then skips its own migration, so customers who enabled the feature early never got their object IDs remapped at all.

The second problem is multi-company. `AfterUpdate` copied the feature status of the updated company to every other company in the environment, so companies whose data was never migrated were reported as Complete. The app took over data that was still in the base application tables, and the data update was no longer offered in those companies, which blocks the customer. The same copy-paste pattern exists in the GB apps and is corrected here as well.

## Summary

- **Added** codeunit 10844 `Payment Data Migration FR` -- the single implementation of the data migration, the payment step object ID remapping, the record counting and the `OnAfterRemapPaymentStepObjectIDs` event; codeunits 10840 and 10831 delegate to it, so the Feature Management data update now remaps the object IDs too.
- **Added** a separate upgrade tag for the remapping so companies that migrated from Feature Management before the remapping existed are repaired; codeunit 10840 is no longer restricted to `CLEAN28`, so the repair also reaches versions 28 to 30, while the migration itself still only runs from version 31.
- **Removed** the cross-company `ModifyAll` from `AfterUpdate` in `Feature - PaymentMgt FR`, `Feature - GovTalk`, `Feature - Reports GB` and `Feature - Reverse Charge VAT`, together with the permission on `Feature Data Update Status` that is no longer needed.
- **Fixed** the direction of the bank account field transfer -- the upgrade copied the app fields (10805-10807) into the base application fields (10851-10853) instead of the other way around, so the RIB data was not migrated on version 31.
- **Fixed** `IsDataUpdateRequired` to count all migrated tables instead of only the bank account tables, and to stop writing upgrade tags; a company without bank accounts marked the data upgrade as skipped, which made the forced upgrade skip its payment data.
- **Updated** the migration to reference the obsolete base application tables and fields by ID, to skip base application fields that the app tables do not have, to close the RecordRefs on all paths, and to keep records that a previous, partially failed run had already migrated.





