### PR TITLE
[SOA] Skip Item Selector for exact items without variants

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOAItemSearch.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOAItemSearch.Codeunit.al
@@ -335,13 +335,13 @@ codeunit 4591 "SOA Item Search"
     var
         Item: Record Item;
         ItemVariant: Record "Item Variant";
+        ItemSystemId: Guid;
     begin
         if (SearchType <> 'item_get') or (CandidateCount <> 1) then
             exit(true);
 
         Item.SetLoadFields("No.");
-        Item.SetFilter(SystemId, ItemFilter);
-        if not Item.FindFirst() then
+        if (not Evaluate(ItemSystemId, ItemFilter)) or (not Item.GetBySystemId(ItemSystemId)) then
             exit(true);
 
         ItemVariant.SetRange("Item No.", Item."No.");

--- a/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOAItemSearch.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOAItemSearch.Codeunit.al
@@ -253,23 +253,26 @@ codeunit 4591 "SOA Item Search"
                 CountBeforeAvailabilityCheck := ItemFilter.Split('|').Count();
                 ApplyAvailabilityFilter := CheckAvailability and (SOASetup."Search Only Available Items" and not SOASetup."Incl. Capable to Promise");
 
-                // Run item selection for all candidate payloads so variant resolution is consistent.
-                if CandidateArray.Count() > 0 then begin
-                    SearchQuery := BuildSearchQueryText(SearchKeyWordsTrimmed);
-                    if SelectBestItem(ItemFilter, SearchQuery, GetTaskMessageContent(TaskMessageReader), CandidateArray, SelectedMatchingItemFilter, SelectedAlternativeItemFilter, SelectedMatchingItemVariants, SelectedAlternativeItemVariants, RejectedItemCount, RejectedVariantCount) then begin
-                        TelemetryCustomDimension.Add('ItemSelectorEmptySelection', Format((SelectedMatchingItemFilter = '') and (SelectedAlternativeItemFilter = '')));
-                        TelemetryCustomDimension.Add('ItemSelectorRejectedItemCount', Format(RejectedItemCount));
-                        TelemetryCustomDimension.Add('ItemSelectorRejectedVariantCount', Format(RejectedVariantCount));
-                        ItemSelectorUsed := true;
-                        TelemetryCustomDimension.Add('ItemSelectorUsed', 'true');
-                        TelemetryCustomDimension.Add('ItemSelectorMatchingCount', Format(CountFilterItems(SelectedMatchingItemFilter)));
-                        TelemetryCustomDimension.Add('ItemSelectorAlternativeCount', Format(CountFilterItems(SelectedAlternativeItemFilter)));
-                        TelemetryCustomDimension.Add('ItemSelectorNoMatchCount', Format(CountBeforeAvailabilityCheck - CountFilterItems(SelectedMatchingItemFilter) - CountFilterItems(SelectedAlternativeItemFilter)));
+                if CandidateArray.Count() > 0 then
+                    if ShouldUseItemSelector(SearchType, ItemFilter, CandidateArray.Count()) then begin
+                        SearchQuery := BuildSearchQueryText(SearchKeyWordsTrimmed);
+                        if SelectBestItem(ItemFilter, SearchQuery, GetTaskMessageContent(TaskMessageReader), CandidateArray, SelectedMatchingItemFilter, SelectedAlternativeItemFilter, SelectedMatchingItemVariants, SelectedAlternativeItemVariants, RejectedItemCount, RejectedVariantCount) then begin
+                            TelemetryCustomDimension.Add('ItemSelectorEmptySelection', Format((SelectedMatchingItemFilter = '') and (SelectedAlternativeItemFilter = '')));
+                            TelemetryCustomDimension.Add('ItemSelectorRejectedItemCount', Format(RejectedItemCount));
+                            TelemetryCustomDimension.Add('ItemSelectorRejectedVariantCount', Format(RejectedVariantCount));
+                            ItemSelectorUsed := true;
+                            TelemetryCustomDimension.Add('ItemSelectorUsed', 'true');
+                            TelemetryCustomDimension.Add('ItemSelectorMatchingCount', Format(CountFilterItems(SelectedMatchingItemFilter)));
+                            TelemetryCustomDimension.Add('ItemSelectorAlternativeCount', Format(CountFilterItems(SelectedAlternativeItemFilter)));
+                            TelemetryCustomDimension.Add('ItemSelectorNoMatchCount', Format(CountBeforeAvailabilityCheck - CountFilterItems(SelectedMatchingItemFilter) - CountFilterItems(SelectedAlternativeItemFilter)));
+                        end else begin
+                            ItemSelectorUsed := false;
+                            TelemetryCustomDimension.Add('ItemSelectorUsed', 'false');
+                        end;
                     end else begin
                         ItemSelectorUsed := false;
                         TelemetryCustomDimension.Add('ItemSelectorUsed', 'false');
                     end;
-                end;
 
                 // When selector returns both sets, prefer available matching items.
                 // If none are available, retry availability filtering for alternatives.
@@ -319,6 +322,23 @@ codeunit 4591 "SOA Item Search"
 
         IsHandled := true;
         OnAfterFindRecordItem(ItemFilter, Which, CrossColumnSearchFilter, Found, RequiredQuantity, InUOMCode);
+    end;
+
+    local procedure ShouldUseItemSelector(SearchType: Text; ItemFilter: Text; CandidateCount: Integer): Boolean
+    var
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+    begin
+        if (SearchType <> 'item_get') or (CandidateCount <> 1) then
+            exit(true);
+
+        Item.SetLoadFields("No.");
+        Item.SetFilter(SystemId, ItemFilter);
+        if not Item.FindFirst() then
+            exit(true);
+
+        ItemVariant.SetRange("Item No.", Item."No.");
+        exit(not ItemVariant.IsEmpty());
     end;
 
     local procedure GetTaskMessageContent(TaskMessageReader: Codeunit "SOA Task Message Reader"): Text

--- a/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOAItemSearch.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOAItemSearch.Codeunit.al
@@ -272,6 +272,13 @@ codeunit 4591 "SOA Item Search"
                     end else begin
                         ItemSelectorUsed := false;
                         TelemetryCustomDimension.Add('ItemSelectorUsed', 'false');
+                        TelemetryCustomDimension.Add('ItemSelectorEmptySelection', Format(false));
+                        TelemetryCustomDimension.Add('ItemSelectorRejectedItemCount', Format(0));
+                        TelemetryCustomDimension.Add('ItemSelectorRejectedVariantCount', Format(0));
+                        TelemetryCustomDimension.Add('ItemSelectorMatchingCount', Format(1));
+                        TelemetryCustomDimension.Add('ItemSelectorAlternativeCount', Format(0));
+                        TelemetryCustomDimension.Add('ItemSelectorNoMatchCount', Format(0));
+                        TelemetryCustomDimension.Add('ItemSelectorSkipReason', 'ExactItemWithoutVariants');
                     end;
 
                 // When selector returns both sets, prefer available matching items.


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

This PR avoids calling Item Selector when item search returns a single deterministic exact match and that item has no variants.

An exact item match with Item Variant records still requires Item Selector because variant intent may need to be resolved from the customer message or attachments. Standard and broader search results also continue to use Item Selector, even when they contain only one candidate, because a single search result does not guarantee an exact match.

The updated behavior:

- Skips Item Selector only when `SearchType` is `item_get`, exactly one candidate is present, and the item has no Item Variant records.
- Continues using Item Selector for exact items that have variants.
- Continues using Item Selector for standard and broader search results.
- Falls back to Item Selector if the exact item cannot be resolved while evaluating the optimization.
- Records `ItemSelectorUsed = false` when the selector is intentionally skipped.
- Leaves availability filtering and existing item-level behavior unchanged.

Deterministic resolution of an explicitly supplied Variant Code is not included in this change. It can be considered separately after measuring selector latency and token usage.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#622414](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/622414)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

- Focused AL diagnostics for `SOAItemSearch.Codeunit.al`: **No errors found**.
- Full multi-project AL build with CodeCop enabled: **Passed with no errors or warnings**.

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

Risk level: **Low**.

- The optimization applies only to a single exact item-number match without variants.
- Exact items with variants retain the existing Item Selector flow.
- Standard and broader search behavior is unchanged.
- Customers without variants avoid an unnecessary AOAI call, reducing latency and token usage.
- No schema, setup, permission, or data migration changes are required.


