### PR TITLE
Improve error messages when there are no quantities to reverse in shipped/received lines in Sales/Purchase/Transfer

### DIFF
--- a/src/Layers/IN/Tests/SCM/SCMTransfers.Codeunit.al
+++ b/src/Layers/IN/Tests/SCM/SCMTransfers.Codeunit.al
@@ -39,6 +39,7 @@
         IncorrectSNUndoneErr: Label 'The Serial No. of the item on the transfer shipment line that was undone was different from the SN on the corresponding transfer line.';
         ItemIsNotOnInventoryErr: Label 'Item %1 is not in inventory.', Locked = true;
         LocationCodeSameErr: Label 'Location Code must be same.';
+        NoLinesToReverseErr: Label 'No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.';
         NoOfLinesMustBeEqualErr: Label 'No. of Line Must Be Equal.';
         RoundingBalanceErr: Label 'This will cause the quantity and base quantity fields to be out of balance.';
         RoundingErr: Label 'is of lower precision than expected';
@@ -196,6 +197,32 @@
 
         // [THEN] The order can be fully shipped and received with no error
         ShipAndReceiveTransOrderFully(TransferHeader, false);
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandlerYes')]
+    [Scope('OnPrem')]
+    procedure UndoAlreadyUndoneTransferShipmentError()
+    var
+        TransferHeader: Record "Transfer Header";
+        QtyToShip: Integer;
+    begin
+        // [FEATURE] [Transfer] [Order] [Undo Shipment]
+        // [SCENARIO] Undoing an already-fully-reversed Transfer Shipment Line raises NoLinesToReverseErr.
+        Initialize();
+        QtyToShip := LibraryRandom.RandInt(10) + 1;
+
+        // [GIVEN] A shipped Transfer Order with one line
+        CreateAndShipTransferOrder(TransferHeader, QtyToShip, false, false);
+
+        // [GIVEN] The posted Transfer Shipment Line has been undone
+        LibraryInventory.UndoTransferShipments(TransferHeader."No.");
+
+        // [WHEN] Undo Transfer Shipment is invoked again on the same order (no non-correction lines remain)
+        asserterror LibraryInventory.UndoTransferShipments(TransferHeader."No.");
+
+        // [THEN] The error indicates that there are no lines with a quantity available for reversal
+        Assert.ExpectedError(NoLinesToReverseErr);
     end;
 
     [Test]

--- a/src/Layers/RU/BaseApp/Sales/History/UndoSalesShipmentLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Sales/History/UndoSalesShipmentLine.Codeunit.al
@@ -89,7 +89,7 @@ codeunit 5815 "Undo Sales Shipment Line"
         Text059: Label '%1 %2 %3', Comment = '%1 = SalesShipmentLine."Document No.". %2 = SalesShipmentLine.FIELDCAPTION("Line No."). %3 = SalesShipmentLine."Line No.". This is used in a progress window.';
 #pragma warning restore AA0074
         AlreadyReversedErr: Label 'This shipment has already been reversed.';
-        NoLinesToReverseErr: Label 'There are no lines with quantity to reverse.';
+        NoLinesToReverseErr: Label 'No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.';
         InvoiceCancelledQst: Label 'The quantity to undo might differ from the original shipment because the invoice was cancelled. Do you want to proceed with the undo?';
 
     /// <summary>
@@ -128,6 +128,7 @@ codeunit 5815 "Undo Sales Shipment Line"
         OnCodeOnAfterSalesShptLineSetFilters(SalesShipmentLine, UndoSalesShptLineParams."Hide Dialog");
         if SalesShipmentLine.IsEmpty() then
             Error(NoLinesToReverseErr);
+
         SalesShipmentLine.FindFirst();
         repeat
             if not UndoSalesShptLineParams."Hide Dialog" then

--- a/src/Layers/RU/Tests/Job/JobConsumptionPurchase.Codeunit.al
+++ b/src/Layers/RU/Tests/Job/JobConsumptionPurchase.Codeunit.al
@@ -2729,7 +2729,7 @@ codeunit 136302 "Job Consumption Purchase"
         asserterror UndoPurchRcptLine(PurchaseReceiptNo, PurchaseReceiptLineNo);
 
         // [THEN] Error message informs user that there is nothing to Undo
-        Assert.ExpectedError('There is no lines with quantity to process.');
+        Assert.ExpectedError('No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.');
     end;
 
     [Test]

--- a/src/Layers/W1/BaseApp/Inventory/Transfer/UndoTransferShipment.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Transfer/UndoTransferShipment.Codeunit.al
@@ -64,6 +64,7 @@ codeunit 9030 "Undo Transfer Shipment"
         AlreadyReceivedErr: Label 'This shipment has already been received. Undo Shipment can only be applied to posted, but not received Transfer Lines.';
         NoDerivedTransOrderLineNoErr: Label 'The Transfer Shipment Line is missing a value in the field Derived Trans. Order Line No. This is automatically populated when posting new Transfer Shipments';
         NoTransOrderLineNoErr: Label 'The Transfer Shipment Line is missing a value in the field Trans. Order Line No. This is automatically populated when posting new Transfer Shipments';
+        NoLinesToReverseErr: Label 'No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.';
 
     procedure SetHideDialog(NewHideDialog: Boolean)
     begin
@@ -86,9 +87,9 @@ codeunit 9030 "Undo Transfer Shipment"
         TransShptLine.SetFilter(Quantity, '<>0');
         TransShptLine.SetRange("Correction Line", false);
         OnCodeOnAfterTransShptLineSetFilters(TransShptLine);
-
         if TransShptLine.IsEmpty() then
-            Error(AlreadyReversedErr);
+            Error(NoLinesToReverseErr);
+
         TransShptLine.FindSet();
         repeat
             if not HideDialog then

--- a/src/Layers/W1/BaseApp/Purchases/History/UndoPurchaseReceiptLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/History/UndoPurchaseReceiptLine.Codeunit.al
@@ -69,7 +69,7 @@ codeunit 5813 "Undo Purchase Receipt Line"
         Text003: Label 'Checking lines...';
         Text004: Label 'This receipt has already been invoiced. Undo Receipt can be applied only to posted, but not invoiced receipts.';
 #pragma warning restore AA0074
-        NoLinesForCorrectionErr: Label 'There is no lines with quantity to process.';
+        NoLinesToReverseErr: Label 'No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.';
         AlreadyReversedErr: Label 'This receipt has already been reversed.';
 
     procedure SetHideDialog(NewHideDialog: Boolean)
@@ -172,7 +172,7 @@ codeunit 5813 "Undo Purchase Receipt Line"
         PurchRcptLine.SetRange(Correction, false);
         OnCheckPurchRcptLinesAfterPurchRcptLineSetFilters(PurchRcptLine);
         if PurchRcptLine.IsEmpty() then
-            Error(NoLinesForCorrectionErr);
+            Error(NoLinesToReverseErr);
 
         PurchRcptLine.FindFirst();
         repeat

--- a/src/Layers/W1/BaseApp/Purchases/History/UndoReturnShipmentLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/History/UndoReturnShipmentLine.Codeunit.al
@@ -66,6 +66,7 @@ codeunit 5814 "Undo Return Shipment Line"
         Text004: Label 'This shipment has already been invoiced. Undo Return Shipment can be applied only to posted, but not invoiced shipments.';
 #pragma warning restore AA0074
         AlreadyReversedErr: Label 'This return shipment has already been reversed.';
+        NoLinesToReverseErr: Label 'No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.';
 
     procedure SetHideDialog(NewHideDialog: Boolean)
     begin
@@ -82,11 +83,13 @@ codeunit 5814 "Undo Return Shipment Line"
         PostedWhseShptLineFound: Boolean;
     begin
         OnBeforeCode(ReturnShptLine, UndoPostingMgt);
+
         Clear(ItemJnlPostLine);
         ReturnShptLine.SetFilter(Quantity, '<>0');
         ReturnShptLine.SetRange(Correction, false);
         if ReturnShptLine.IsEmpty() then
-            Error(AlreadyReversedErr);
+            Error(NoLinesToReverseErr);
+
         ReturnShptLine.FindFirst();
         repeat
             if not HideDialog then

--- a/src/Layers/W1/BaseApp/Sales/History/UndoReturnReceiptLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/History/UndoReturnReceiptLine.Codeunit.al
@@ -70,6 +70,7 @@ codeunit 5816 "Undo Return Receipt Line"
         Text004: Label 'This receipt has already been invoiced. Undo Return Receipt can be applied only to posted, but not invoiced receipts.';
 #pragma warning restore AA0074
         AlreadyReversedErr: Label 'This return receipt has already been reversed.';
+        NoLinesToReverseErr: Label 'No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.';
 
     /// <summary>
     /// Sets whether the confirmation dialog should be hidden when undoing return receipt lines.
@@ -97,7 +98,7 @@ codeunit 5816 "Undo Return Receipt Line"
             ReturnRcptLine.SetRange(Correction, false);
             ReturnRcptLine.SetFilter(Quantity, '<>0');
             if ReturnRcptLine.IsEmpty() then
-                Error(AlreadyReversedErr);
+                Error(NoLinesToReverseErr);
 
             ReturnRcptLine.FindFirst();
             repeat

--- a/src/Layers/W1/BaseApp/Sales/History/UndoSalesShipmentLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/History/UndoSalesShipmentLine.Codeunit.al
@@ -89,7 +89,7 @@ codeunit 5815 "Undo Sales Shipment Line"
         Text059: Label '%1 %2 %3', Comment = '%1 = SalesShipmentLine."Document No.". %2 = SalesShipmentLine.FIELDCAPTION("Line No."). %3 = SalesShipmentLine."Line No.". This is used in a progress window.';
 #pragma warning restore AA0074
         AlreadyReversedErr: Label 'This shipment has already been reversed.';
-        NoLinesToReverseErr: Label 'There are no lines with quantity to reverse.';
+        NoLinesToReverseErr: Label 'No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.';
         InvoiceCancelledQst: Label 'The quantity to undo might differ from the original shipment because the invoice was cancelled. Do you want to proceed with the undo?';
 
     /// <summary>
@@ -128,6 +128,7 @@ codeunit 5815 "Undo Sales Shipment Line"
         OnCodeOnAfterSalesShptLineSetFilters(SalesShipmentLine, UndoSalesShptLineParams."Hide Dialog");
         if SalesShipmentLine.IsEmpty() then
             Error(NoLinesToReverseErr);
+
         SalesShipmentLine.FindFirst();
         repeat
             if not UndoSalesShptLineParams."Hide Dialog" then

--- a/src/Layers/W1/Tests/Job/JobConsumptionPurchase.Codeunit.al
+++ b/src/Layers/W1/Tests/Job/JobConsumptionPurchase.Codeunit.al
@@ -2756,7 +2756,7 @@ codeunit 136302 "Job Consumption Purchase"
         asserterror UndoPurchRcptLine(PurchaseReceiptNo, PurchaseReceiptLineNo);
 
         // [THEN] Error message informs user that there is nothing to Undo
-        Assert.ExpectedError('There is no lines with quantity to process.');
+        Assert.ExpectedError('No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.');
     end;
 
     [Test]

--- a/src/Layers/W1/Tests/SCM/SCMInventoryCostingIII.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMInventoryCostingIII.Codeunit.al
@@ -33,7 +33,7 @@ codeunit 137288 "SCM Inventory Costing III"
         UndoShipmentInvoicedErr: Label 'This shipment has already been invoiced. Undo %1 can be applied only to posted, but not invoiced shipments.';
         UndoShipmentMessage: Label 'Do you really want to undo the selected Shipment lines?';
         ShipmentAlreadyReversedErr: Label 'There are no lines with quantity to reverse.';
-        ReturnShipmentAlreadyReversedErr: Label 'This return shipment has already been reversed.';
+        ReturnShipmentNoLinesToReverseErr: Label 'No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.';
 
     [Test]
     [HandlerFunctions('ItemTrackingLinesPageHandler,EnterQuantityToCreatePageHandler,ConfirmHandler,PostedItemTrackingLinesHandler')]
@@ -407,7 +407,7 @@ codeunit 137288 "SCM Inventory Costing III"
         asserterror UndoReturnShipment(PurchaseLine);
 
         // Verify: Verify error after undo Invoiced Return Shipment.
-        Assert.ExpectedError(ReturnShipmentAlreadyReversedErr);
+        Assert.ExpectedError(ReturnShipmentNoLinesToReverseErr);
     end;
 
     [Test]

--- a/src/Layers/W1/Tests/SCM/SCMInventoryCostingIII.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMInventoryCostingIII.Codeunit.al
@@ -32,7 +32,7 @@ codeunit 137288 "SCM Inventory Costing III"
         UndoReturnReceiptMessage: Label 'Do you really want to undo the selected Return Receipt lines?';
         UndoShipmentInvoicedErr: Label 'This shipment has already been invoiced. Undo %1 can be applied only to posted, but not invoiced shipments.';
         UndoShipmentMessage: Label 'Do you really want to undo the selected Shipment lines?';
-        ShipmentAlreadyReversedErr: Label 'There are no lines with quantity to reverse.';
+        ShipmentNoLinesToReverseErr: Label 'No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.';
         ReturnShipmentNoLinesToReverseErr: Label 'No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.';
 
     [Test]
@@ -820,7 +820,7 @@ codeunit 137288 "SCM Inventory Costing III"
         asserterror UndoSalesShipment(SalesLine);
 
         // Verify: Verify error after undo Invoiced Sales Shipment.
-        Assert.ExpectedError(ShipmentAlreadyReversedErr);
+        Assert.ExpectedError(ShipmentNoLinesToReverseErr);
     end;
 
     [Test]

--- a/src/Layers/W1/Tests/SCM/SCMRevaluation.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMRevaluation.Codeunit.al
@@ -26,7 +26,7 @@ codeunit 137010 "SCM Revaluation"
         ErrorCostMustBeEqual: Label 'Cost must be Equal';
         ErrorGeneratedMustBeSame: Label 'Error Generated Must Be Same';
         UndoReceiptErrorMessage: Label 'You cannot undo line %1, because a revaluation has already been posted.';
-        ReturnReceiptAlreadyReversedErr: Label 'This return receipt has already been reversed.';
+        ReturnReceiptNoLinesToReverseErr: Label 'No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.';
         DimensionValueErr: Label 'Dimension value should be match';
 
     [Test]
@@ -803,7 +803,7 @@ codeunit 137010 "SCM Revaluation"
         ReturnReceiptLine.FindFirst();
         asserterror UndoSalesReturnReceipt(SalesReturnOrderNo, ItemNo);
         Assert.AreEqual(
-          ReturnReceiptAlreadyReversedErr, GetLastErrorText,
+          ReturnReceiptNoLinesToReverseErr, GetLastErrorText,
           ErrorGeneratedMustBeSame);
     end;
 
@@ -819,7 +819,7 @@ codeunit 137010 "SCM Revaluation"
             WorkDate(), ItemJournalLine."Document No.", true, "Inventory Value Calc. Per"::Item,
             true, false, false, "Inventory Value Calc. Base"::" ", false); // ByLocation = true
         Commit();
-        
+
         CalculateInventoryValue.UseRequestPage(false);
         CalculateInventoryValue.SetItemJnlLine(ItemJournalLine);
         Item.SetRange("No.", Item."No.");

--- a/src/Layers/W1/Tests/SCM/SCMTransfers.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMTransfers.Codeunit.al
@@ -39,6 +39,7 @@
         IncorrectSNUndoneErr: Label 'The Serial No. of the item on the transfer shipment line that was undone was different from the SN on the corresponding transfer line.';
         ItemIsNotOnInventoryErr: Label 'Item %1 is not in inventory.', Locked = true;
         LocationCodeSameErr: Label 'Location Code must be same.';
+        NoLinesToReverseErr: Label 'No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.';
         NoOfLinesMustBeEqualErr: Label 'No. of Line Must Be Equal.';
         RoundingBalanceErr: Label 'This will cause the quantity and base quantity fields to be out of balance.';
         RoundingErr: Label 'is of lower precision than expected';
@@ -196,6 +197,32 @@
 
         // [THEN] The order can be fully shipped and received with no error
         ShipAndReceiveTransOrderFully(TransferHeader, false);
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandlerYes')]
+    [Scope('OnPrem')]
+    procedure UndoAlreadyUndoneTransferShipmentError()
+    var
+        TransferHeader: Record "Transfer Header";
+        QtyToShip: Integer;
+    begin
+        // [FEATURE] [Transfer] [Order] [Undo Shipment]
+        // [SCENARIO] Undoing an already-fully-reversed Transfer Shipment Line raises NoLinesToReverseErr.
+        Initialize();
+        QtyToShip := LibraryRandom.RandInt(10) + 1;
+
+        // [GIVEN] A shipped Transfer Order with one line
+        CreateAndShipTransferOrder(TransferHeader, QtyToShip, false, false);
+
+        // [GIVEN] The posted Transfer Shipment Line has been undone
+        LibraryInventory.UndoTransferShipments(TransferHeader."No.");
+
+        // [WHEN] Undo Transfer Shipment is invoked again on the same order (no non-correction lines remain)
+        asserterror LibraryInventory.UndoTransferShipments(TransferHeader."No.");
+
+        // [THEN] The error indicates that there are no lines with a quantity available for reversal
+        Assert.ExpectedError(NoLinesToReverseErr);
     end;
 
     [Test]


### PR DESCRIPTION
## What & why

**Problem**
When a user selects only a comment/blank line (Type = " ") on a Posted Return Shipment and triggers Undo Return Shipment, Business Central raises:

This return shipment has already been reversed.

The shipment has not been reversed - the message is misleading and, as reported, throws AI agents off course.


**Cause**
In Code(), the codeunit narrows the selection with SetFilter(Quantity, '<>0') and SetRange(Correction, false). Comment/blank lines have Quantity = 0, so the filter empties the set and the code falls into the "already reversed" branch — a message that is only accurate for the per-line Correction = true check further down.


**Fix**
1. Clear-up situation when error message is misleading
Split the two situations into two distinct errors:
    1. Empty set after filtering → new action-oriented message. 
    2. Line already reversed (per-line check) → keep the existing AlreadyReversedErr (accurate for that path).

Message wording is action-oriented so both users and AI agents get a clear next step.

2. Sync-up error message across Undo scenarios

## Linked work

Fixes [AB#644161](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644161)




