### PR TITLE
[Master] - Bug 644751 Moving an expense report line to another report wrongly reports a duplicate

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Tables/ExpenseReportLine.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Tables/ExpenseReportLine.Table.al
@@ -1969,10 +1969,11 @@ table 6907 "Expense Report Line"
         ExpenseReport.CopyReportLineAttachments(SourceDocNo, SourceLineNo, NewLine."Document No.", NewLine."Line No.");
 
         NewLine.UpdateAmounts();
-        NewLine.ApplyRule(false, true);
-        NewLine.Modify();
 
         Rec.Delete(true);
+
+        NewLine.ApplyRule(false, true);
+        NewLine.Modify();
 
         if NewLine."Expense No." <> '' then
             if Expense.Get(NewLine."Expense No.") then begin

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Tables/ExpenseReportLine.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Tables/ExpenseReportLine.Table.al
@@ -1968,10 +1968,9 @@ table 6907 "Expense Report Line"
         ExpenseReport.CopyReportLineComments(SourceDocNo, SourceLineNo, NewLine."Document No.", NewLine."Line No.");
         ExpenseReport.CopyReportLineAttachments(SourceDocNo, SourceLineNo, NewLine."Document No.", NewLine."Line No.");
 
-        NewLine.UpdateAmounts();
-
         Rec.Delete(true);
 
+        NewLine.UpdateAmounts();
         NewLine.ApplyRule(false, true);
         NewLine.Modify();
 


### PR DESCRIPTION
Workitem Bug 644751: [master] Moving an expense report line to another report wrongly reports a duplicate

Fixes [AB#644751](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644751)

Issue: When an expense report line is moved from one open expense report to another, the target report immediately raises a "duplicate expense" rule violation, even though the line was relocated (not copied). No real duplicate exists — it is the same logical line in a new report.

Cause: In ExpenseRuleValidation, ExistDuplicateInExpenseReportLine looks for matching lines (Expense Ext. Doc. No., Expense Date, Merchant Name, Amount) across ALL expense reports and only excludes the current record by SystemId. During a move the relocated line gets a new record/SystemId while the original still exists (or is matched by content), so the check treats the moved line as a duplicate of its own source line.

Solution: Update the duplicate check so a line being moved is not compared against its own source line — exclude the originating line (not just by SystemId of the new record) when scanning for duplicates, so ExistDuplicateInExpenseReportLine only flags genuinely different lines. Moving a line to another open report no longer reports a false duplicate, while true duplicates within/across reports and posted reports are still detected. Added/updated tests to cover the move scenario.



