### PR TITLE
Change RU download handler to be manual

### DIFF
--- a/src/Layers/RU/Tests/Local/ERMActItemsReceiptM7.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMActItemsReceiptM7.Codeunit.al
@@ -148,8 +148,8 @@ codeunit 144708 "ERM Act Items Receipt M-7"
         ActItemsReceiptM7.UseRequestPage(false);
         ActItemsReceiptM7.Run();
 
-        exit(InvtDocumentHeader."No.");
         UnbindSubscription(RUReportDownloadHandler);
+        exit(InvtDocumentHeader."No.");
     end;
 
     local procedure PrintM7ItemReceipt(LineQty: Integer) DocumentNo: Code[20]

--- a/src/Layers/RU/Tests/Local/ERMActItemsReceiptM7.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMActItemsReceiptM7.Codeunit.al
@@ -15,8 +15,6 @@ codeunit 144708 "ERM Act Items Receipt M-7"
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         isInitialized: Boolean;
         ValueNotExistErr: Label 'Value %1 does not exist on worksheet %2';
 
@@ -102,10 +100,6 @@ codeunit 144708 "ERM Act Items Receipt M-7"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         if isInitialized then
             exit;
 
@@ -117,8 +111,10 @@ codeunit 144708 "ERM Act Items Receipt M-7"
 
     local procedure PrintM7PurchOrder(var PurchaseHeader: Record "Purchase Header"; LineQty: Integer)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         ActItemsReceiptM7: Report "Act Items Receipt M-7";
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         CreatePurchDocument(PurchaseHeader, LineQty);
@@ -130,13 +126,16 @@ codeunit 144708 "ERM Act Items Receipt M-7"
         ActItemsReceiptM7.SetFileNameSilent(LibraryReportValidation.GetFileName());
         ActItemsReceiptM7.UseRequestPage(false);
         ActItemsReceiptM7.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintM7ItemDocumentReceipt(LineQty: Integer): Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         InvtDocumentHeader: Record "Invt. Document Header";
         ActItemsReceiptM7: Report "Act Items Receipt M-7";
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         CreateItemDocumentReceipt(InvtDocumentHeader, LineQty);
@@ -150,13 +149,16 @@ codeunit 144708 "ERM Act Items Receipt M-7"
         ActItemsReceiptM7.Run();
 
         exit(InvtDocumentHeader."No.");
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintM7ItemReceipt(LineQty: Integer) DocumentNo: Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         ItemReceiptHeader: Record "Invt. Receipt Header";
         ActItemsReceiptM7: Report "Act Items Receipt M-7";
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         DocumentNo := CreateAndPostItemDocument(LineQty);
@@ -168,6 +170,7 @@ codeunit 144708 "ERM Act Items Receipt M-7"
         ActItemsReceiptM7.SetFileNameSilent(LibraryReportValidation.GetFileName());
         ActItemsReceiptM7.UseRequestPage(false);
         ActItemsReceiptM7.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CreatePurchDocument(var PurchaseHeader: Record "Purchase Header"; LineQty: Integer)

--- a/src/Layers/RU/Tests/Local/ERMActItemsReceiptM7.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMActItemsReceiptM7.Codeunit.al
@@ -15,6 +15,8 @@ codeunit 144708 "ERM Act Items Receipt M-7"
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         isInitialized: Boolean;
         ValueNotExistErr: Label 'Value %1 does not exist on worksheet %2';
 
@@ -100,6 +102,10 @@ codeunit 144708 "ERM Act Items Receipt M-7"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         if isInitialized then
             exit;
 

--- a/src/Layers/RU/Tests/Local/ERMAdvanceStatement.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMAdvanceStatement.Codeunit.al
@@ -12,8 +12,6 @@ codeunit 144707 "ERM Advance Statement"
     var
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryPurchase: Codeunit "Library - Purchase";
@@ -167,10 +165,6 @@ codeunit 144707 "ERM Advance Statement"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         LibrarySetupStorage.Restore();
         if IsInitialized then
             exit;
@@ -240,27 +234,33 @@ codeunit 144707 "ERM Advance Statement"
 
     local procedure RunAdvanceStatementReport(var PurchaseHeader: Record "Purchase Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         AdvanceStatement: Report "Advance Statement";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         PurchaseHeader.SetRecFilter();
         AdvanceStatement.SetTableView(PurchaseHeader);
         AdvanceStatement.SetFileNameSilent(LibraryReportValidation.GetFileName());
         AdvanceStatement.UseRequestPage(false);
         AdvanceStatement.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunPostedAdvanceStatementReport(DocumentNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PurchInvHeader: Record "Purch. Inv. Header";
         PostedAdvanceStatement: Report "Posted Advance Statement";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         PurchInvHeader.SetRange("No.", DocumentNo);
         PostedAdvanceStatement.SetTableView(PurchInvHeader);
         PostedAdvanceStatement.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PostedAdvanceStatement.UseRequestPage(false);
         PostedAdvanceStatement.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure UpdateOKPOCodeInCompanyInfo(NewOKPOCode: Code[10])

--- a/src/Layers/RU/Tests/Local/ERMAdvanceStatement.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMAdvanceStatement.Codeunit.al
@@ -12,6 +12,8 @@ codeunit 144707 "ERM Advance Statement"
     var
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryPurchase: Codeunit "Library - Purchase";
@@ -165,6 +167,10 @@ codeunit 144707 "ERM Advance Statement"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         LibrarySetupStorage.Restore();
         if IsInitialized then
             exit;

--- a/src/Layers/RU/Tests/Local/ERMBillofLadingReport.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMBillofLadingReport.Codeunit.al
@@ -147,11 +147,14 @@ codeunit 144722 "ERM Bill of Lading Report"
     local procedure RunReport(var SalesHeader: Record "Sales Header"; FileName: Text)
     var
         BillOfLading: Report "Bill of Lading";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
     begin
+        BindSubscription(RUReportDownloadHandler);
         BillOfLading.SetTestMode(true);
         BillOfLading.SetFileNameSilent(FileName);
         BillOfLading.SetTableView(SalesHeader);
         BillOfLading.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     [RequestPageHandler]

--- a/src/Layers/RU/Tests/Local/ERMCalculateVATperLines.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMCalculateVATperLines.Codeunit.al
@@ -14,6 +14,8 @@ codeunit 144512 "ERM Calculate VAT per Lines"
         Assert: Codeunit Assert;
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         IsInitialized: Boolean;
         IncorrectFieldValueErr: Label 'Field %1 has incorrect value';
@@ -82,6 +84,10 @@ codeunit 144512 "ERM Calculate VAT per Lines"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         if IsInitialized then
             exit;
 

--- a/src/Layers/RU/Tests/Local/ERMCalculateVATperLines.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMCalculateVATperLines.Codeunit.al
@@ -14,8 +14,6 @@ codeunit 144512 "ERM Calculate VAT per Lines"
         Assert: Codeunit Assert;
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         IsInitialized: Boolean;
         IncorrectFieldValueErr: Label 'Field %1 has incorrect value';
@@ -84,10 +82,6 @@ codeunit 144512 "ERM Calculate VAT per Lines"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         if IsInitialized then
             exit;
 
@@ -290,9 +284,11 @@ codeunit 144512 "ERM Calculate VAT per Lines"
 
     local procedure FacturaInvoiceExcelExport(SalesHeader: Record "Sales Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         OrderFacturaInvoice: Report "Order Factura-Invoice (A)";
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(SalesHeader."No.");
         FileName := LibraryReportValidation.GetFileName();
         SalesHeader.SetRange("Document Type", SalesHeader."Document Type");
@@ -302,14 +298,17 @@ codeunit 144512 "ERM Calculate VAT per Lines"
         OrderFacturaInvoice.SetFileNameSilent(FileName);
         OrderFacturaInvoice.UseRequestPage(false);
         OrderFacturaInvoice.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PostedFacturaInvoiceExcelExport(DocumentNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesInvHeader: Record "Sales Invoice Header";
         PostedFacturaInvoice: Report "Posted Factura-Invoice (A)";
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(DocumentNo);
         FileName := LibraryReportValidation.GetFileName();
         SalesInvHeader.SetRange("No.", DocumentNo);
@@ -318,20 +317,24 @@ codeunit 144512 "ERM Calculate VAT per Lines"
         PostedFacturaInvoice.SetFileNameSilent(FileName);
         PostedFacturaInvoice.UseRequestPage(false);
         PostedFacturaInvoice.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyFacturaTotals(CurrencyCode: Code[10])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         VATAmount: Decimal;
         TotalInclVAT: Decimal;
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         VATAmount := LibraryVariableStorage.DequeueDecimal();
         TotalInclVAT := LibraryVariableStorage.DequeueDecimal();
         CalcCurrencyVATAmount(VATAmount, TotalInclVAT, CurrencyCode);
         FileName := LibraryReportValidation.GetFileName();
         LibraryRUReports.VerifyFactura_VATAmount(FileName, Format(VATAmount), 7);
         LibraryRUReports.VerifyFactura_AmountInclVAT(FileName, Format(TotalInclVAT), 7);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure SalesDocCalcVATPerLineFactura(CurrencyCode: Code[10])

--- a/src/Layers/RU/Tests/Local/ERMCashOrders.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMCashOrders.Codeunit.al
@@ -15,8 +15,6 @@ codeunit 144723 "ERM Cash Orders"
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryERM: Codeunit "Library - ERM";
         DecimalFormatTok: Label '<Sign><Integer><Decimals,3>', Locked = true;
         StdTextTok: Label 'Amount %1, including VAT %2', Locked = true;
@@ -490,11 +488,13 @@ codeunit 144723 "ERM Cash Orders"
     [Scope('OnPrem')]
     procedure CashReportCO4PageNumberingTwoBanks()
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         GenJournalLine: Record "Gen. Journal Line";
         BankAccountNo: array[2] of Code[20];
         PageNumber: array[2] of Integer;
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         // [FEATURE] [Report]
         // [SCENARIO 377267] Page numbering in "Cash Report CO - 4" must consider "Last Cash Report Page No." of a certain Cash Account
         Initialize();
@@ -523,6 +523,7 @@ codeunit 144723 "ERM Cash Orders"
         Clear(LibraryReportValidation);
         LibraryReportValidation.SetFullFileName(FileName);
         VerifyPageNumbers(BankAccountNo[1], PageNumber[1] + 1);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     [Test]
@@ -772,10 +773,6 @@ codeunit 144723 "ERM Cash Orders"
 
     local procedure Initialize()
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         Clear(LibraryReportValidation);
         LibraryVariableStorage.Clear();
         LibrarySetupStorage.Restore();
@@ -1060,49 +1057,61 @@ codeunit 144723 "ERM Cash Orders"
 
     local procedure RunCashOutgoingOrderReport(var GenJournalLine: Record "Gen. Journal Line")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         CashOutgoingOrder: Report "Cash Outgoing Order";
         FileManagement: Codeunit "File Management";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFullFileName(FileManagement.ServerTempFileName('xlsx'));
         CashOutgoingOrder.SetFileNameSilent(LibraryReportValidation.GetFileName());
         CashOutgoingOrder.SetTableView(GenJournalLine);
         CashOutgoingOrder.UseRequestPage(false);
         CashOutgoingOrder.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunCashIngoingOrderReport(var GenJournalLine: Record "Gen. Journal Line")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         CashIngoingOrder: Report "Cash Ingoing Order";
         FileManagement: Codeunit "File Management";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFullFileName(FileManagement.ServerTempFileName('xlsx'));
         CashIngoingOrder.SetFileNameSilent(LibraryReportValidation.GetFileName());
         CashIngoingOrder.SetTableView(GenJournalLine);
         CashIngoingOrder.UseRequestPage(false);
         CashIngoingOrder.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunCashReportCO4(BankAccountNo: Code[20]; CashReportType: Option; PrintTitleSheet: Boolean; PrintLastSheet: Boolean; ReportDate: Date)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         CashReportCO4: Report "Cash Report CO-4";
         FileManagement: Codeunit "File Management";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFullFileName(FileManagement.ServerTempFileName('xlsx'));
         CashReportCO4.InitializeRequest(BankAccountNo, ReportDate, PrintTitleSheet, PrintLastSheet, CashReportType);
         CashReportCO4.SetFileNameSilent(LibraryReportValidation.GetFileName());
         CashReportCO4.UseRequestPage(false);
         CashReportCO4.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunCashReportCO4WithRequestPage(BankAccountNo: Code[20]; CashReportType: Option; PrintTitleSheet: Boolean; PrintLastSheet: Boolean; ReportDate: Date)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         CashReportCO4: Report "Cash Report CO-4";
         FileManagement: Codeunit "File Management";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFullFileName(FileManagement.ServerTempFileName('xlsx'));
         CashReportCO4.InitializeRequest(BankAccountNo, ReportDate, PrintTitleSheet, PrintLastSheet, CashReportType);
         CashReportCO4.SetFileNameSilent(LibraryReportValidation.GetFileName());
         CashReportCO4.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure SetAccountantNameInCompanyInformation(NewAccountantName: Text[50])

--- a/src/Layers/RU/Tests/Local/ERMCashOrders.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMCashOrders.Codeunit.al
@@ -15,6 +15,8 @@ codeunit 144723 "ERM Cash Orders"
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryERM: Codeunit "Library - ERM";
         DecimalFormatTok: Label '<Sign><Integer><Decimals,3>', Locked = true;
         StdTextTok: Label 'Amount %1, including VAT %2', Locked = true;
@@ -770,6 +772,10 @@ codeunit 144723 "ERM Cash Orders"
 
     local procedure Initialize()
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         Clear(LibraryReportValidation);
         LibraryVariableStorage.Clear();
         LibrarySetupStorage.Restore();

--- a/src/Layers/RU/Tests/Local/ERMCorrFacturaTest.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMCorrFacturaTest.Codeunit.al
@@ -17,8 +17,6 @@ codeunit 144718 "ERM Corr. Factura Test"
         LibraryUtility: Codeunit "Library - Utility";
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryRandom: Codeunit "Library - Random";
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
@@ -178,11 +176,13 @@ codeunit 144718 "ERM Corr. Factura Test"
     [Scope('OnPrem')]
     procedure PrintPostedFacturaCrMemoFacturaInvoice()
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesHeader: Record "Sales Header";
         SalesCrMemoLine: Record "Sales Cr.Memo Line";
         DocumentNo: Code[20];
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         // [FEATURE] [Factura-Invoice] [Credit Memo]
         // [SCENARIO 201525] Verify REP 12484 "Posted Cr. M. Factura-Invoice" base values
         Initialize();
@@ -217,16 +217,19 @@ codeunit 144718 "ERM Corr. Factura Test"
         // [THEN] Column "9" = -1000 (Amount Including VAT)
         LibraryRUReports.VerifyFactura_AmountInclVAT(
           LibraryReportValidation.GetFileName(), FormatAmount(-SalesCrMemoLine."Amount Including VAT"), 0);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     [Test]
     [Scope('OnPrem')]
     procedure PrintPostedPrepmtFacturaCrMemoFacturaInvoice()
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesCrMemoLine: Record "Sales Cr.Memo Line";
         DocumentNo: Code[20];
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         // [FEATURE] [Factura-Invoice] [Credit Memo] [Prepayment]
         // [SCENARIO 201525] Verify REP 12484 "Posted Cr. M. Factura-Invoice" base values in case of prepayment
         Initialize();
@@ -259,16 +262,13 @@ codeunit 144718 "ERM Corr. Factura Test"
         // [THEN] Column "9" = -1000 (Amount Including VAT)
         // LibraryRUReports.VerifyFactura_AmountInclVAT(
         // LibraryReportValidation.GetFileName(),FormatAmount(-SalesCrMemoLine."Amount Including VAT"),0);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         LibraryVariableStorage.Clear();
         Clear(LibraryVariableStorage);
         LibraryERMCountryData.UpdatePrepaymentAccounts();
@@ -286,53 +286,65 @@ codeunit 144718 "ERM Corr. Factura Test"
 
     local procedure RunCorrFacturaReport(var CorrSalesHeader: Record "Sales Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesCorrFacturaInvoice: Report "Sales Corr. Factura-Invoice";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         CorrSalesHeader.SetRecFilter();
         SalesCorrFacturaInvoice.SetFileNameSilent(LibraryReportValidation.GetFileName());
         SalesCorrFacturaInvoice.SetTableView(CorrSalesHeader);
         SalesCorrFacturaInvoice.UseRequestPage(false);
         SalesCorrFacturaInvoice.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunPostedCorrInvoiceReport(InvNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesInvoiceHeader: Record "Sales Invoice Header";
         PstdSalesCorrFactInv: Report "Pstd. Sales Corr. Fact. Inv.";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         SalesInvoiceHeader.SetRange("No.", InvNo);
         PstdSalesCorrFactInv.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PstdSalesCorrFactInv.SetTableView(SalesInvoiceHeader);
         PstdSalesCorrFactInv.UseRequestPage(false);
         PstdSalesCorrFactInv.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunPostedCorrCrMemoReport(InvNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesCrMemoHeader: Record "Sales Cr.Memo Header";
         PstdSalesCorrCrMFact: Report "Pstd. Sales Corr. Cr. M. Fact.";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         SalesCrMemoHeader.SetRange("No.", InvNo);
         PstdSalesCorrCrMFact.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PstdSalesCorrCrMFact.SetTableView(SalesCrMemoHeader);
         PstdSalesCorrCrMFact.UseRequestPage(false);
         PstdSalesCorrCrMFact.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunPostedCrMemoFacturaInvoice(InvNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesCrMemoHeader: Record "Sales Cr.Memo Header";
         PostedCrMFacturaInvoice: Report "Posted Cr. M. Factura-Invoice";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         SalesCrMemoHeader.SetRange("No.", InvNo);
         PostedCrMFacturaInvoice.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PostedCrMFacturaInvoice.SetTableView(SalesCrMemoHeader);
         PostedCrMFacturaInvoice.UseRequestPage(false);
         PostedCrMFacturaInvoice.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CreatePostSalesDoc(var SalesHeader: Record "Sales Header"; DocType: Enum "Sales Document Type"): Code[20]
@@ -554,9 +566,11 @@ codeunit 144718 "ERM Corr. Factura Test"
 
     local procedure VerifyCorrFacturaReport(CorrDocNo: Code[20]; DocNo: Code[20]; CorrDocDate: Date; DocDate: Date; QtyBefore: Decimal; QtyAfter: Decimal; UoMCode: Code[10]; UoMOKEICode: Code[3])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         LocMgt: Codeunit "Localisation Management";
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         FileName := LibraryReportValidation.GetFileName();
         LibraryRUReports.VerifyCorrFactura_CorrDocNo(FileName, CorrDocNo);
         LibraryRUReports.VerifyCorrFactura_DocNo(FileName, DocNo);
@@ -566,39 +580,48 @@ codeunit 144718 "ERM Corr. Factura Test"
         LibraryRUReports.VerifyCorrFactura_Qty(FileName, Format(QtyAfter), 1);
         LibraryRUReports.VerifyCorrFactura_UOMCode(FileName, UoMOKEICode, 1);
         LibraryRUReports.VerifyCorrFactura_UOMName(FileName, UoMCode, 1);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyCorrFacturaReportCurrency(CurrencyCode: Code[10])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         CurrencyDescription: Text[30];
         CurrencyDigitalCode: Code[3];
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         GetCurrencyInfo(CurrencyCode, CurrencyDescription, CurrencyDigitalCode);
         FileName := LibraryReportValidation.GetFileName();
         LibraryRUReports.VerifyCorrFactura_CurrencyName(FileName, CurrencyDescription);
         LibraryRUReports.VerifyCorrFactura_CurrencyCode(FileName, CurrencyDigitalCode);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyCorrFacturaReportDash(CheckingLine: Integer)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         Offset: Integer;
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         Offset := CheckingLine - 22;
         FileName := LibraryReportValidation.GetFileName();
         LibraryRUReports.VerifyCorrFactura_Amount(FileName, '-', Offset);
         LibraryRUReports.VerifyCorrFactura_VATAmount(FileName, '-', Offset);
         LibraryRUReports.VerifyCorrFactura_AmountInclVAT(FileName, '-', Offset);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyCorrFacturaReportHeader(CustomerNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         CompanyInformation: Record "Company Information";
         Customer: Record Customer;
         LocalReportMgt: Codeunit "Local Report Management";
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         FileName := LibraryReportValidation.GetFileName();
         LibraryRUReports.VerifyCorrFactura_CompanyName(FileName, LocalReportMgt.GetCompanyName());
         LibraryRUReports.VerifyCorrFactura_CompanyAddress(FileName, LocalReportMgt.GetLegalAddress());
@@ -613,13 +636,16 @@ codeunit 144718 "ERM Corr. Factura Test"
           LibraryReportValidation.GetFileName(), LibraryRUReports.GetCustomerFullAddress(Customer."No."));
         LibraryRUReports.VerifyCorrFactura_BuyerINN(
           LibraryReportValidation.GetFileName(), Customer."VAT Registration No." + ' / ' + Customer."KPP Code");
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyCorrFacturaReportLine(ItemNo: Code[20]; Price: Decimal; Amount: Decimal; VATPct: Decimal; VATAmount: Decimal; AmountInclVAT: Decimal)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         Item: Record Item;
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         Item.Get(ItemNo);
         FileName := LibraryReportValidation.GetFileName();
         LibraryRUReports.VerifyCorrFactura_LineNo(FileName, '1', 0);
@@ -630,6 +656,7 @@ codeunit 144718 "ERM Corr. Factura Test"
         LibraryRUReports.VerifyCorrFactura_VATPct(FileName, Format(VATPct), 0);
         LibraryRUReports.VerifyCorrFactura_VATAmount(FileName, FormatAmount(VATAmount), 0);
         LibraryRUReports.VerifyCorrFactura_AmountInclVAT(FileName, FormatAmount(AmountInclVAT), 0);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     [ConfirmHandler]

--- a/src/Layers/RU/Tests/Local/ERMCorrFacturaTest.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMCorrFacturaTest.Codeunit.al
@@ -17,6 +17,8 @@ codeunit 144718 "ERM Corr. Factura Test"
         LibraryUtility: Codeunit "Library - Utility";
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryRandom: Codeunit "Library - Random";
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
@@ -263,6 +265,10 @@ codeunit 144718 "ERM Corr. Factura Test"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         LibraryVariableStorage.Clear();
         Clear(LibraryVariableStorage);
         LibraryERMCountryData.UpdatePrepaymentAccounts();

--- a/src/Layers/RU/Tests/Local/ERMFA1Report.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFA1Report.Codeunit.al
@@ -16,8 +16,6 @@ codeunit 144711 "ERM FA-1 Report"
         LibraryRandom: Codeunit "Library - Random";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         isInitialized: Boolean;
         ZeroMonthsTxt: Label '0 months';
@@ -453,10 +451,6 @@ codeunit 144711 "ERM FA-1 Report"
 
     local procedure Initialize()
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         Clear(LibraryReportValidation);
 
         if isInitialized then
@@ -757,50 +751,62 @@ codeunit 144711 "ERM FA-1 Report"
 
     local procedure RunFAReleaseActReport(FADocHeader: Record "FA Document Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         FAReleaseActRep: Report "FA Release Act FA-1";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(FADocHeader."No.");
         FADocHeader.SetRecFilter();
         FAReleaseActRep.SetFileNameSilent(LibraryReportValidation.GetFileName());
         FAReleaseActRep.SetTableView(FADocHeader);
         FAReleaseActRep.UseRequestPage(false);
         FAReleaseActRep.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunPostedFAReleaseActReport(PostedFADocHeader: Record "Posted FA Doc. Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PostedFAReleaseActRep: Report "FA Posted Release Act FA-1";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(PostedFADocHeader."No.");
         PostedFADocHeader.SetRecFilter();
         PostedFAReleaseActRep.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PostedFAReleaseActRep.SetTableView(PostedFADocHeader);
         PostedFAReleaseActRep.UseRequestPage(false);
         PostedFAReleaseActRep.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunSalesReleaseActReport(SalesHeader: Record "Sales Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesFAReleaseRep: Report "Sales FA Release FA-1";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(SalesHeader."No.");
         SalesHeader.SetRecFilter();
         SalesFAReleaseRep.SetFileNameSilent(LibraryReportValidation.GetFileName());
         SalesFAReleaseRep.SetTableView(SalesHeader);
         SalesFAReleaseRep.UseRequestPage(false);
         SalesFAReleaseRep.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunPostedSalesReleaseActReport(SalesInvHeader: Record "Sales Invoice Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PostedSalesFAReleaseRep: Report "Posted Sales FA Release FA-1";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(SalesInvHeader."No.");
         SalesInvHeader.SetRecFilter();
         PostedSalesFAReleaseRep.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PostedSalesFAReleaseRep.SetTableView(SalesInvHeader);
         PostedSalesFAReleaseRep.UseRequestPage(false);
         PostedSalesFAReleaseRep.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyFA1ReportValues(FixedAsset: Record "Fixed Asset"; ReasonDocNo: Code[20]; ReasonDocDate: Date; DocNo: Code[20]; DocDate: Date; FADocDate: Date)

--- a/src/Layers/RU/Tests/Local/ERMFA1Report.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFA1Report.Codeunit.al
@@ -16,6 +16,8 @@ codeunit 144711 "ERM FA-1 Report"
         LibraryRandom: Codeunit "Library - Random";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         isInitialized: Boolean;
         ZeroMonthsTxt: Label '0 months';
@@ -451,6 +453,10 @@ codeunit 144711 "ERM FA-1 Report"
 
     local procedure Initialize()
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         Clear(LibraryReportValidation);
 
         if isInitialized then

--- a/src/Layers/RU/Tests/Local/ERMFA3ReportTest.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFA3ReportTest.Codeunit.al
@@ -10,8 +10,6 @@ codeunit 144715 "ERM FA-3 Report Test"
         LibraryRandom: Codeunit "Library - Random";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         isInitialized: Boolean;
 
@@ -49,10 +47,6 @@ codeunit 144715 "ERM FA-3 Report Test"
 
     local procedure Initialize()
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         Clear(LibraryReportValidation);
 
         if isInitialized then
@@ -160,26 +154,32 @@ codeunit 144715 "ERM FA-3 Report Test"
 
     local procedure RunFAMovementReport(FADocHeader: Record "FA Document Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         FAMovementRep: Report "FA Movement FA-3";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(FADocHeader."No.");
         FADocHeader.SetRecFilter();
         FAMovementRep.SetFileNameSilent(LibraryReportValidation.GetFileName());
         FAMovementRep.SetTableView(FADocHeader);
         FAMovementRep.UseRequestPage(false);
         FAMovementRep.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunPostedFAMovementReport(PostedFADocHeader: Record "Posted FA Doc. Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PostedFAMovementRep: Report "FA Posted Movement FA-3";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(PostedFADocHeader."No.");
         PostedFADocHeader.SetRecFilter();
         PostedFAMovementRep.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PostedFAMovementRep.SetTableView(PostedFADocHeader);
         PostedFAMovementRep.UseRequestPage(false);
         PostedFAMovementRep.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RemoveMandatorySignSetup()

--- a/src/Layers/RU/Tests/Local/ERMFA3ReportTest.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFA3ReportTest.Codeunit.al
@@ -10,6 +10,8 @@ codeunit 144715 "ERM FA-3 Report Test"
         LibraryRandom: Codeunit "Library - Random";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         isInitialized: Boolean;
 
@@ -47,6 +49,10 @@ codeunit 144715 "ERM FA-3 Report Test"
 
     local procedure Initialize()
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         Clear(LibraryReportValidation);
 
         if isInitialized then

--- a/src/Layers/RU/Tests/Local/ERMFA4ReportTest.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFA4ReportTest.Codeunit.al
@@ -12,6 +12,8 @@ codeunit 144717 "ERM FA-4 Report Test"
         LibraryRandom: Codeunit "Library - Random";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         StdRepMgt: Codeunit "Local Report Management";
         isInitialized: Boolean;
@@ -93,6 +95,10 @@ codeunit 144717 "ERM FA-4 Report Test"
 
     local procedure Initialize()
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         Clear(LibraryReportValidation);
 
         if isInitialized then

--- a/src/Layers/RU/Tests/Local/ERMFA4ReportTest.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFA4ReportTest.Codeunit.al
@@ -12,8 +12,6 @@ codeunit 144717 "ERM FA-4 Report Test"
         LibraryRandom: Codeunit "Library - Random";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         StdRepMgt: Codeunit "Local Report Management";
         isInitialized: Boolean;
@@ -95,10 +93,6 @@ codeunit 144717 "ERM FA-4 Report Test"
 
     local procedure Initialize()
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         Clear(LibraryReportValidation);
 
         if isInitialized then
@@ -296,50 +290,62 @@ codeunit 144717 "ERM FA-4 Report Test"
 
     local procedure RunFAWriteOffFA4(FADocHeader: Record "FA Document Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         FAWriteoffActFA4: Report "FA Write-off Act FA-4";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(FADocHeader."No.");
         FADocHeader.SetRecFilter();
         FAWriteoffActFA4.SetFileNameSilent(LibraryReportValidation.GetFileName());
         FAWriteoffActFA4.SetTableView(FADocHeader);
         FAWriteoffActFA4.UseRequestPage(false);
         FAWriteoffActFA4.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunPostedFAWriteOffFA4(PostedFADocHeader: Record "Posted FA Doc. Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PostedFAWriteoffActFA4: Report "FA Posted Writeoff Act FA-4";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(PostedFADocHeader."No.");
         PostedFADocHeader.SetRecFilter();
         PostedFAWriteoffActFA4.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PostedFAWriteoffActFA4.SetTableView(PostedFADocHeader);
         PostedFAWriteoffActFA4.UseRequestPage(false);
         PostedFAWriteoffActFA4.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunFAWriteOffFA4a(FADocHeader: Record "FA Document Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         FAWriteoffActFA4a: Report "FA Writeoff Act FA-4a";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(FADocHeader."No.");
         FADocHeader.SetRecFilter();
         FAWriteoffActFA4a.SetFileNameSilent(LibraryReportValidation.GetFileName());
         FAWriteoffActFA4a.SetTableView(FADocHeader);
         FAWriteoffActFA4a.UseRequestPage(false);
         FAWriteoffActFA4a.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunPostedFAWriteOffFA4a(PostedFADocHeader: Record "Posted FA Doc. Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PostedFAWriteoffActFA4a: Report "Posted FA Writeoff Act FA-4a";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(PostedFADocHeader."No.");
         PostedFADocHeader.SetRecFilter();
         PostedFAWriteoffActFA4a.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PostedFAWriteoffActFA4a.SetTableView(PostedFADocHeader);
         PostedFAWriteoffActFA4a.UseRequestPage(false);
         PostedFAWriteoffActFA4a.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RemoveMandatorySignSetup()

--- a/src/Layers/RU/Tests/Local/ERMFAInventoryTest.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFAInventoryTest.Codeunit.al
@@ -12,6 +12,8 @@ codeunit 144716 "ERM FA Inventory Test"
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         ValueNotExistErr: Label 'Value %1 does not exist on worksheet %2';
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
 
@@ -87,6 +89,10 @@ codeunit 144716 "ERM FA Inventory Test"
 
     local procedure Initialize()
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         LibraryVariableStorage.Clear();
     end;
 

--- a/src/Layers/RU/Tests/Local/ERMFAInventoryTest.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFAInventoryTest.Codeunit.al
@@ -12,8 +12,6 @@ codeunit 144716 "ERM FA Inventory Test"
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         ValueNotExistErr: Label 'Value %1 does not exist on worksheet %2';
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
 
@@ -89,10 +87,6 @@ codeunit 144716 "ERM FA Inventory Test"
 
     local procedure Initialize()
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         LibraryVariableStorage.Clear();
     end;
 
@@ -220,9 +214,11 @@ codeunit 144716 "ERM FA Inventory Test"
 
     local procedure RunFAINV1Report(FAJournalBatch: Record "FA Journal Batch"; EmployeeNo: Code[20]; FALocationCode: Code[10])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         FAJournalLine: Record "FA Journal Line";
         FAPhysInventoryINV1: Report "FA Phys. Inventory INV-1";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         FilterFAJnlLine(FAJournalLine, FAJournalBatch);
         FAJournalLine.SetRange("Employee No.", EmployeeNo);
@@ -234,13 +230,16 @@ codeunit 144716 "ERM FA Inventory Test"
         FAPhysInventoryINV1.UseRequestPage(true);
         Commit();
         FAPhysInventoryINV1.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunFAINV1aReport(FAJournalBatch: Record "FA Journal Batch")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         FAJournalLine: Record "FA Journal Line";
         FAPhysInventoryINV1a: Report "FA Phys. Inventory INV-1a";
     begin
+        BindSubscription(RUReportDownloadHandler);
         ClearPrintingData(FAJournalBatch);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         FilterFAJnlLine(FAJournalLine, FAJournalBatch);
@@ -249,6 +248,7 @@ codeunit 144716 "ERM FA Inventory Test"
         FAPhysInventoryINV1a.SetTableView(FAJournalLine);
         FAPhysInventoryINV1a.UseRequestPage(false);
         FAPhysInventoryINV1a.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyINV1FirstPageValues(EmployeeNo: Code[20]; FALocationCode: Code[10]; InventoryDocNo: Code[20]; InventoryDate: Date; DocumentNo: Code[20]; DocumentDate: Date; StartingDate: Date; EndingDate: Date)

--- a/src/Layers/RU/Tests/Local/ERMFAReportsTest.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFAReportsTest.Codeunit.al
@@ -317,10 +317,7 @@ codeunit 144714 "ERM FA Reports Test"
 
     local procedure Initialize()
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
+        EnsureHandlerBound();
         LibraryVariableStorage.Clear();
 
         if isInitialized then
@@ -328,6 +325,16 @@ codeunit 144714 "ERM FA Reports Test"
 
         Commit();
         isInitialized := true;
+    end;
+
+    local procedure EnsureHandlerBound()
+    begin
+        // Bind the RU report download handler before any report is exported. Called from the report
+        // print helpers (not only Initialize) because several FA report tests do not call Initialize.
+        if RUReportHandlerBound then
+            exit;
+        BindSubscription(RUReportDownloadHandler);
+        RUReportHandlerBound := true;
     end;
 
     local procedure FAMovement()
@@ -446,6 +453,7 @@ codeunit 144714 "ERM FA Reports Test"
         FADocHeader: Record "FA Document Header";
         FA2Report: Report "FA Movement FA-2";
     begin
+        EnsureHandlerBound();
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         FADocHeader.SetRange("No.", FADocNo);
@@ -460,6 +468,7 @@ codeunit 144714 "ERM FA Reports Test"
         PostedFADocHeader: Record "Posted FA Doc. Header";
         PostedFA2Report: Report "FA Posted Movement FA-2";
     begin
+        EnsureHandlerBound();
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         PostedFADocHeader.SetRange("No.", PostedFADocNo);
@@ -483,6 +492,7 @@ codeunit 144714 "ERM FA Reports Test"
         PurchHeader: Record "Purchase Header";
         FA14Report: Report "Purch. FA Receipt FA-14";
     begin
+        EnsureHandlerBound();
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         PurchHeader.SetRange("No.", DocumentNo);
@@ -499,6 +509,7 @@ codeunit 144714 "ERM FA Reports Test"
         PurchInvHeader: Record "Purch. Inv. Header";
         FA14Report: Report "Posted Purch. FA Receipt FA-14";
     begin
+        EnsureHandlerBound();
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         PurchInvHeader.SetRange("No.", DocumentNo);
@@ -597,6 +608,7 @@ codeunit 144714 "ERM FA Reports Test"
         FixedAsset: Record "Fixed Asset";
         FAInvCardFA6: Report "FA Inventory Card FA-6";
     begin
+        EnsureHandlerBound();
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         FixedAsset.SetRange("No.", FANo);
@@ -672,6 +684,7 @@ codeunit 144714 "ERM FA Reports Test"
         FADocumentHeader: Record "FA Document Header";
         FAMovementFA15: Report "FA Movement FA-15";
     begin
+        EnsureHandlerBound();
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         FADocumentHeader.SetRange("No.", DocumentNo);
@@ -686,6 +699,7 @@ codeunit 144714 "ERM FA Reports Test"
         PostedFADocHeader: Record "Posted FA Doc. Header";
         PostedFAMovementFA15: Report "Posted FA Movement FA-15";
     begin
+        EnsureHandlerBound();
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         PostedFADocHeader.SetRange("No.", DocumentNo);

--- a/src/Layers/RU/Tests/Local/ERMFAReportsTest.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFAReportsTest.Codeunit.al
@@ -13,8 +13,6 @@ codeunit 144714 "ERM FA Reports Test"
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
@@ -317,7 +315,6 @@ codeunit 144714 "ERM FA Reports Test"
 
     local procedure Initialize()
     begin
-        EnsureHandlerBound();
         LibraryVariableStorage.Clear();
 
         if isInitialized then
@@ -325,16 +322,6 @@ codeunit 144714 "ERM FA Reports Test"
 
         Commit();
         isInitialized := true;
-    end;
-
-    local procedure EnsureHandlerBound()
-    begin
-        // Bind the RU report download handler before any report is exported. Called from the report
-        // print helpers (not only Initialize) because several FA report tests do not call Initialize.
-        if RUReportHandlerBound then
-            exit;
-        BindSubscription(RUReportDownloadHandler);
-        RUReportHandlerBound := true;
     end;
 
     local procedure FAMovement()
@@ -450,10 +437,11 @@ codeunit 144714 "ERM FA Reports Test"
 
     local procedure PrintFAMovement(FADocNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         FADocHeader: Record "FA Document Header";
         FA2Report: Report "FA Movement FA-2";
     begin
-        EnsureHandlerBound();
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         FADocHeader.SetRange("No.", FADocNo);
@@ -461,14 +449,16 @@ codeunit 144714 "ERM FA Reports Test"
         FA2Report.SetFileNameSilent(LibraryReportValidation.GetFileName());
         FA2Report.UseRequestPage(false);
         FA2Report.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintPostedFAMovement(PostedFADocNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PostedFADocHeader: Record "Posted FA Doc. Header";
         PostedFA2Report: Report "FA Posted Movement FA-2";
     begin
-        EnsureHandlerBound();
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         PostedFADocHeader.SetRange("No.", PostedFADocNo);
@@ -476,6 +466,7 @@ codeunit 144714 "ERM FA Reports Test"
         PostedFA2Report.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PostedFA2Report.UseRequestPage(false);
         PostedFA2Report.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyFA2ReportValues(DocNo: Code[20]; PostingDate: Date; Qty: Decimal; Amount: Decimal; BookValue: Decimal)
@@ -489,10 +480,11 @@ codeunit 144714 "ERM FA Reports Test"
 
     local procedure PrintFA14Receipt(DocumentNo: Code[20]; NoOfLines: Integer; Amounts: array[20] of Decimal)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PurchHeader: Record "Purchase Header";
         FA14Report: Report "Purch. FA Receipt FA-14";
     begin
-        EnsureHandlerBound();
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         PurchHeader.SetRange("No.", DocumentNo);
@@ -502,14 +494,16 @@ codeunit 144714 "ERM FA Reports Test"
         FA14Report.Run();
 
         VerifyFA14ReportLineAmounts(NoOfLines, Amounts);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintPostedFA14Receipt(DocumentNo: Code[20]; NoOfLines: Integer; Amounts: array[20] of Decimal)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PurchInvHeader: Record "Purch. Inv. Header";
         FA14Report: Report "Posted Purch. FA Receipt FA-14";
     begin
-        EnsureHandlerBound();
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         PurchInvHeader.SetRange("No.", DocumentNo);
@@ -519,6 +513,7 @@ codeunit 144714 "ERM FA Reports Test"
         FA14Report.Run();
 
         VerifyFA14ReportLineAmounts(NoOfLines, Amounts);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyFA14ReportLineAmounts(NoOfLines: Integer; Amounts: array[20] of Decimal)
@@ -605,10 +600,11 @@ codeunit 144714 "ERM FA Reports Test"
 
     local procedure PrintF6FAInvCard(FANo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         FixedAsset: Record "Fixed Asset";
         FAInvCardFA6: Report "FA Inventory Card FA-6";
     begin
-        EnsureHandlerBound();
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         FixedAsset.SetRange("No.", FANo);
@@ -617,6 +613,7 @@ codeunit 144714 "ERM FA Reports Test"
         FAInvCardFA6.SetFileNameSilent(LibraryReportValidation.GetFileName());
         FAInvCardFA6.UseRequestPage(false);
         FAInvCardFA6.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure FormatAmount(Amount: Decimal): Text
@@ -681,10 +678,11 @@ codeunit 144714 "ERM FA Reports Test"
 
     local procedure PrintFA15(DocumentNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         FADocumentHeader: Record "FA Document Header";
         FAMovementFA15: Report "FA Movement FA-15";
     begin
-        EnsureHandlerBound();
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         FADocumentHeader.SetRange("No.", DocumentNo);
@@ -692,14 +690,16 @@ codeunit 144714 "ERM FA Reports Test"
         FAMovementFA15.SetFileNameSilent(LibraryReportValidation.GetFileName());
         FAMovementFA15.UseRequestPage(false);
         FAMovementFA15.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintPostedFA15(DocumentNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PostedFADocHeader: Record "Posted FA Doc. Header";
         PostedFAMovementFA15: Report "Posted FA Movement FA-15";
     begin
-        EnsureHandlerBound();
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         PostedFADocHeader.SetRange("No.", DocumentNo);
@@ -707,6 +707,7 @@ codeunit 144714 "ERM FA Reports Test"
         PostedFAMovementFA15.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PostedFAMovementFA15.UseRequestPage(false);
         PostedFAMovementFA15.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyFA15ReportValues(DocumentNo: Code[20]; BookValue: Decimal; Amount: Decimal)

--- a/src/Layers/RU/Tests/Local/ERMFAReportsTest.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFAReportsTest.Codeunit.al
@@ -13,6 +13,8 @@ codeunit 144714 "ERM FA Reports Test"
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
@@ -315,6 +317,10 @@ codeunit 144714 "ERM FA Reports Test"
 
     local procedure Initialize()
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         LibraryVariableStorage.Clear();
 
         if isInitialized then

--- a/src/Layers/RU/Tests/Local/ERMFacturaInvoiceGovReg451.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFacturaInvoiceGovReg451.Codeunit.al
@@ -12,6 +12,8 @@ codeunit 144514 "ERM FacturaInvoiceGovReg451"
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryResource: Codeunit "Library - Resource";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryERM: Codeunit "Library - ERM";
         LibraryRUReports: Codeunit "Library RU Reports";
         Assert: Codeunit Assert;
@@ -104,6 +106,10 @@ codeunit 144514 "ERM FacturaInvoiceGovReg451"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         Clear(LibraryReportValidation);
 
         if IsInitialized then

--- a/src/Layers/RU/Tests/Local/ERMFacturaInvoiceGovReg451.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFacturaInvoiceGovReg451.Codeunit.al
@@ -12,8 +12,6 @@ codeunit 144514 "ERM FacturaInvoiceGovReg451"
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryResource: Codeunit "Library - Resource";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryERM: Codeunit "Library - ERM";
         LibraryRUReports: Codeunit "Library RU Reports";
         Assert: Codeunit Assert;
@@ -106,10 +104,6 @@ codeunit 144514 "ERM FacturaInvoiceGovReg451"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         Clear(LibraryReportValidation);
 
         if IsInitialized then
@@ -177,8 +171,10 @@ codeunit 144514 "ERM FacturaInvoiceGovReg451"
 
     local procedure VerifyPrepFacturaLineValues(DocNo: Text)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         FileName := LibraryReportValidation.GetFileName();
         LibraryRUReports.VerifyFactura_DocNo(FileName, DocNo);
         LibraryRUReports.VerifyFactura_Unit(FileName, DashTxt, 0);
@@ -189,6 +185,7 @@ codeunit 144514 "ERM FacturaInvoiceGovReg451"
         LibraryRUReports.VerifyFactura_CountryCode(FileName, DashTxt, 0);
         LibraryRUReports.VerifyFactura_CountryName(FileName, DashTxt, 0);
         LibraryRUReports.VerifyFactura_GTD(FileName, DashTxt, 0);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyAddressNotDash(ShipToAddress1: Text[50]; ShipToAddress2: Text[50])
@@ -217,10 +214,12 @@ codeunit 144514 "ERM FacturaInvoiceGovReg451"
 
     local procedure FacturaInvoiceExcelExport(DocumentNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesHeader: Record "Sales Header";
         OrderFacturaInvoice: Report "Order Factura-Invoice (A)";
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(DocumentNo);
         FileName := LibraryReportValidation.GetFileName();
         SalesHeader.SetRange("No.", DocumentNo);
@@ -229,14 +228,17 @@ codeunit 144514 "ERM FacturaInvoiceGovReg451"
         OrderFacturaInvoice.SetFileNameSilent(FileName);
         OrderFacturaInvoice.UseRequestPage(false);
         OrderFacturaInvoice.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PostedFacturaInvoiceExcelExport(DocumentNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesInvHeader: Record "Sales Invoice Header";
         PostedFacturaInvoice: Report "Posted Factura-Invoice (A)";
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(DocumentNo);
         FileName := LibraryReportValidation.GetFileName();
         SalesInvHeader.SetRange("No.", DocumentNo);
@@ -244,6 +246,7 @@ codeunit 144514 "ERM FacturaInvoiceGovReg451"
         PostedFacturaInvoice.SetFileNameSilent(FileName);
         PostedFacturaInvoice.UseRequestPage(false);
         PostedFacturaInvoice.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure ResourceGLMixedOrderFacturaDashPrint(SalesLine1Type: Enum "Sales Line Type"; ResourceFANo: Code[20])

--- a/src/Layers/RU/Tests/Local/ERMFacturaInvoiceSubUnit.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFacturaInvoiceSubUnit.Codeunit.al
@@ -16,8 +16,6 @@ codeunit 144513 "ERM FacturaInvoiceSubUnit"
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         Assert: Codeunit Assert;
         IsInitialized: Boolean;
@@ -164,10 +162,6 @@ codeunit 144513 "ERM FacturaInvoiceSubUnit"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         Clear(LibraryReportValidation);
 
         if IsInitialized then
@@ -245,8 +239,10 @@ codeunit 144513 "ERM FacturaInvoiceSubUnit"
 
     local procedure FacturaInvoiceExcelExport(SalesHeader: Record "Sales Header"; IsProforma: Boolean) FileName: Text
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         OrderFacturaInvoice: Report "Order Factura-Invoice (A)";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(SalesHeader."No.");
         FileName := LibraryReportValidation.GetFileName();
         Commit();
@@ -256,13 +252,16 @@ codeunit 144513 "ERM FacturaInvoiceSubUnit"
         OrderFacturaInvoice.SetFileNameSilent(FileName);
         OrderFacturaInvoice.UseRequestPage(false);
         OrderFacturaInvoice.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PostedFacturaInvoiceExcelExport(DocumentNo: Code[20]) FileName: Text
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesInvHeader: Record "Sales Invoice Header";
         PostedFacturaInvoice: Report "Posted Factura-Invoice (A)";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(DocumentNo);
         FileName := LibraryReportValidation.GetFileName();
         Commit();
@@ -271,6 +270,7 @@ codeunit 144513 "ERM FacturaInvoiceSubUnit"
         PostedFacturaInvoice.SetFileNameSilent(FileName);
         PostedFacturaInvoice.UseRequestPage(false);
         PostedFacturaInvoice.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CreateCustomerAndInvoice(var SalesHeader: Record "Sales Header"; var Customer: Record Customer; var ShipToAddress: Record "Ship-to Address")
@@ -332,15 +332,18 @@ codeunit 144513 "ERM FacturaInvoiceSubUnit"
 
     local procedure VerifyAddressKPPCode(Customer: Record Customer; ShipToAddress: Record "Ship-to Address"; ShipToKPPCode: Code[10])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         LocalReportMgt: Codeunit "Local Report Management";
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         FileName := LibraryReportValidation.GetFileName();
         LibraryRUReports.VerifyFactura_ConsigneeAndAddress(
               FileName,
               LocalReportMgt.GetShipToAddrName(Customer."No.", ShipToAddress.Code, ShipToAddress.Name, ShipToAddress."Name 2") + '  ' +
               LocalReportMgt.GetFullAddr(ShipToAddress."Post Code", ShipToAddress.City, ShipToAddress.Address, ShipToAddress."Address 2", '', ShipToAddress.County));
         LibraryRUReports.VerifyFactura_BuyerINN(FileName, Customer."VAT Registration No." + ' / ' + ShipToKPPCode);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyVATLedgerKPPCode(VATLedgerCode: Code[20]; KPPCode: Code[20])
@@ -397,10 +400,12 @@ codeunit 144513 "ERM FacturaInvoiceSubUnit"
 
     local procedure VerifyFacturaReportHeader(CustomerNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         CompanyInformation: Record "Company Information";
         LocalReportMgt: Codeunit "Local Report Management";
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         FileName := LibraryReportValidation.GetFileName();
         LibraryRUReports.VerifyFactura_SellerName(FileName, LocalReportMgt.GetCompanyName());
         LibraryRUReports.VerifyFactura_SellerAddress(FileName, LocalReportMgt.GetLegalAddress());
@@ -409,5 +414,6 @@ codeunit 144513 "ERM FacturaInvoiceSubUnit"
           FileName, CompanyInformation."VAT Registration No." + ' / ' + CompanyInformation."KPP Code");
         LibraryRUReports.VerifyFactura_BuyerName(FileName, LocalReportMgt.GetCustName(CustomerNo));
         LibraryRUReports.VerifyFactura_BuyerAddress(FileName, LibraryRUReports.GetCustomerFullAddress(CustomerNo));
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 }

--- a/src/Layers/RU/Tests/Local/ERMFacturaInvoiceSubUnit.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMFacturaInvoiceSubUnit.Codeunit.al
@@ -16,6 +16,8 @@ codeunit 144513 "ERM FacturaInvoiceSubUnit"
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         Assert: Codeunit Assert;
         IsInitialized: Boolean;
@@ -162,6 +164,10 @@ codeunit 144513 "ERM FacturaInvoiceSubUnit"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         Clear(LibraryReportValidation);
 
         if IsInitialized then

--- a/src/Layers/RU/Tests/Local/ERMGLReports.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMGLReports.Codeunit.al
@@ -17,6 +17,8 @@ codeunit 144101 "ERM G/L Reports"
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryFixedAsset: Codeunit "Library - Fixed Asset";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryJournals: Codeunit "Library - Journals";
         LibraryUtility: Codeunit "Library - Utility";
         IsInitialized: Boolean;
@@ -839,6 +841,10 @@ codeunit 144101 "ERM G/L Reports"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         Clear(LibraryReportValidation);
 
         if IsInitialized then

--- a/src/Layers/RU/Tests/Local/ERMGLReports.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMGLReports.Codeunit.al
@@ -17,8 +17,6 @@ codeunit 144101 "ERM G/L Reports"
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryFixedAsset: Codeunit "Library - Fixed Asset";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryJournals: Codeunit "Library - Journals";
         LibraryUtility: Codeunit "Library - Utility";
         IsInitialized: Boolean;
@@ -841,10 +839,6 @@ codeunit 144101 "ERM G/L Reports"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         Clear(LibraryReportValidation);
 
         if IsInitialized then
@@ -1228,9 +1222,11 @@ codeunit 144101 "ERM G/L Reports"
 
     local procedure RunCustomerAccountingCard(CustomerNo: Code[20]; GLAccountNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         Customer: Record Customer;
         CustomerAccountingCard: Report "Customer Accounting Card";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         LibraryVariableStorage.Enqueue(LibraryReportValidation.GetFileName());
         Commit();
@@ -1242,13 +1238,16 @@ codeunit 144101 "ERM G/L Reports"
         CustomerAccountingCard.SetTableView(Customer);
         CustomerAccountingCard.UseRequestPage(true);
         CustomerAccountingCard.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunCustomerGLTurnover(GLAccountNo: Code[20]; ReportDate: Date; SkipZeroLines: Boolean)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         Customer: Record Customer;
         CustomerGLTurnover: Report "Customer G/L Turnover";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryVariableStorage.Enqueue(SkipZeroLines);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         LibraryVariableStorage.Enqueue(LibraryReportValidation.GetFileName());
@@ -1259,6 +1258,7 @@ codeunit 144101 "ERM G/L Reports"
         CustomerGLTurnover.SetTableView(Customer);
         CustomerGLTurnover.UseRequestPage(true);
         CustomerGLTurnover.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunGLAccountCardReport(var GLAccount: Record "G/L Account")
@@ -1273,8 +1273,10 @@ codeunit 144101 "ERM G/L Reports"
 
     local procedure RunVendorGLTurnover(GLAccountNo: Code[20]; ReportDate: Date)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         Vendor: Record Vendor;
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         LibraryVariableStorage.Enqueue(LibraryReportValidation.GetFileName());
         Commit();
@@ -1282,6 +1284,7 @@ codeunit 144101 "ERM G/L Reports"
         Vendor.SetRange("Date Filter", ReportDate);
         Vendor.SetRange("G/L Account Filter", GLAccountNo);
         REPORT.RunModal(REPORT::"Vendor G/L Turnover", true, false, Vendor);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunFATurnover(FANoFilter: Text; DepreciationBookCode: Code[10])
@@ -1469,12 +1472,16 @@ codeunit 144101 "ERM G/L Reports"
     [RequestPageHandler]
     [Scope('OnPrem')]
     procedure FATurnoverHandler(var FATurnover: TestRequestPage "FA Turnover")
+    var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
     begin
+        BindSubscription(RUReportDownloadHandler);
         FATurnover."Starting Date".SetValue(WorkDate());
         FATurnover."Ending Date".SetValue(WorkDate());
         FATurnover."Depreciation Book Code".SetValue(LibraryVariableStorage.DequeueText());
         FATurnover."Skip zero lines".SetValue(true);
         FATurnover.SaveAsExcel(LibraryReportValidation.GetFileName());
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     [RequestPageHandler]

--- a/src/Layers/RU/Tests/Local/ERMINV17Report.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMINV17Report.Codeunit.al
@@ -12,6 +12,8 @@ codeunit 144704 "ERM INV-17 Report"
         LibraryERM: Codeunit "Library - ERM";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LocMgt: Codeunit "Localisation Management";
         isInitialized: Boolean;
 
@@ -76,6 +78,10 @@ codeunit 144704 "ERM INV-17 Report"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         Clear(LibraryReportValidation);
 
         if isInitialized then

--- a/src/Layers/RU/Tests/Local/ERMINV17Report.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMINV17Report.Codeunit.al
@@ -12,8 +12,6 @@ codeunit 144704 "ERM INV-17 Report"
         LibraryERM: Codeunit "Library - ERM";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LocMgt: Codeunit "Localisation Management";
         isInitialized: Boolean;
 
@@ -78,10 +76,6 @@ codeunit 144704 "ERM INV-17 Report"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         Clear(LibraryReportValidation);
 
         if isInitialized then
@@ -440,26 +434,32 @@ codeunit 144704 "ERM INV-17 Report"
 
     local procedure RunINV17Report(InvtActHeader: Record "Invent. Act Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         InvActRep: Report "Invent. Act INV-17";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(InvtActHeader."No.");
         InvtActHeader.SetRecFilter();
         InvActRep.SetFileNameSilent(LibraryReportValidation.GetFileName());
         InvActRep.SetTableView(InvtActHeader);
         InvActRep.UseRequestPage(false);
         InvActRep.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunINV17SupplementReport(InvtActHeader: Record "Invent. Act Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SupplementInvActRep: Report "Supplement to INV-17";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(InvtActHeader."No.");
         InvtActHeader.SetRecFilter();
         SupplementInvActRep.SetFileNameSilent(LibraryReportValidation.GetFileName());
         SupplementInvActRep.SetTableView(InvtActHeader);
         SupplementInvActRep.UseRequestPage(false);
         SupplementInvActRep.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyReportHeader(ReasonDocNo: Code[20]; ReasonDocDate: Date; DocNo: Code[20]; DocDate: Date; InvDate: Date)

--- a/src/Layers/RU/Tests/Local/ERMINV18Report.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMINV18Report.Codeunit.al
@@ -11,8 +11,6 @@ codeunit 144710 "ERM INV-18 Report"
         LibraryRandom: Codeunit "Library - Random";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         AmountType: Option " ",QtyPlus,AmountPlus,QtyMinus,AmountMinus;
         isInitialized: Boolean;
 
@@ -34,10 +32,6 @@ codeunit 144710 "ERM INV-18 Report"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         Clear(LibraryReportValidation);
 
         if isInitialized then
@@ -109,15 +103,18 @@ codeunit 144710 "ERM INV-18 Report"
 
     local procedure RunINV18Report()
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         FAJournalLine: Record "FA Journal Line";
         INV18Rep: Report "FA Comparative Sheet INV-18";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         FilterFAJournalLineWithEmptyBatch(FAJournalLine);
         INV18Rep.SetFileNameSilent(LibraryReportValidation.GetFileName());
         INV18Rep.SetTableView(FAJournalLine);
         INV18Rep.UseRequestPage(false);
         INV18Rep.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure FilterFAJournalLineWithEmptyBatch(var FAJournalLine: Record "FA Journal Line")

--- a/src/Layers/RU/Tests/Local/ERMINV18Report.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMINV18Report.Codeunit.al
@@ -11,6 +11,8 @@ codeunit 144710 "ERM INV-18 Report"
         LibraryRandom: Codeunit "Library - Random";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         AmountType: Option " ",QtyPlus,AmountPlus,QtyMinus,AmountMinus;
         isInitialized: Boolean;
 
@@ -32,6 +34,10 @@ codeunit 144710 "ERM INV-18 Report"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         Clear(LibraryReportValidation);
 
         if isInitialized then

--- a/src/Layers/RU/Tests/Local/ERMItemAndPhysInventory.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMItemAndPhysInventory.Codeunit.al
@@ -13,6 +13,8 @@ codeunit 144709 "ERM Item And Phys. Inventory"
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         isInitialized: Boolean;
         ValueNotExistErr: Label 'Value %1 does not exist on worksheet %2';
         ValueNotExistInColErr: Label 'Value %1 does not exist in column %2', Comment = '%1:Function GetItemJnlLineNewAmount, %2:ColumnID in Excel Buffer';
@@ -232,6 +234,10 @@ codeunit 144709 "ERM Item And Phys. Inventory"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         if isInitialized then
             exit;
 

--- a/src/Layers/RU/Tests/Local/ERMItemAndPhysInventory.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMItemAndPhysInventory.Codeunit.al
@@ -13,8 +13,6 @@ codeunit 144709 "ERM Item And Phys. Inventory"
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         isInitialized: Boolean;
         ValueNotExistErr: Label 'Value %1 does not exist on worksheet %2';
         ValueNotExistInColErr: Label 'Value %1 does not exist in column %2', Comment = '%1:Function GetItemJnlLineNewAmount, %2:ColumnID in Excel Buffer';
@@ -234,10 +232,6 @@ codeunit 144709 "ERM Item And Phys. Inventory"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         if isInitialized then
             exit;
 
@@ -249,9 +243,11 @@ codeunit 144709 "ERM Item And Phys. Inventory"
 
     local procedure PrintM17ItemCard(ItemNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         Item: Record Item;
         ItemCardM17: Report "Item Card M-17";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         Item.SetRange("No.", ItemNo);
@@ -259,6 +255,7 @@ codeunit 144709 "ERM Item And Phys. Inventory"
         ItemCardM17.SetFileNameSilent(LibraryReportValidation.GetFileName());
         ItemCardM17.UseRequestPage(false);
         ItemCardM17.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintINV3PhysInvForm(var ItemJnlLine: Record "Item Journal Line"; Sign: Integer)
@@ -272,8 +269,10 @@ codeunit 144709 "ERM Item And Phys. Inventory"
 
     local procedure PrintINV3PhysInvFormForExistingJournal(var ItemJnlLine: Record "Item Journal Line")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PhysInventoryFormINV3: Report "Phys. Inventory Form INV-3";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         ItemJnlLine.SetRange("Journal Template Name", ItemJnlLine."Journal Template Name");
         ItemJnlLine.SetRange("Journal Batch Name", ItemJnlLine."Journal Batch Name");
@@ -281,12 +280,15 @@ codeunit 144709 "ERM Item And Phys. Inventory"
         PhysInventoryFormINV3.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PhysInventoryFormINV3.UseRequestPage(false);
         PhysInventoryFormINV3.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintINV19PhysInvForm(var ItemJnlLine: Record "Item Journal Line"; Sign: Integer)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PhysInvFormINV19: Report "Phys. Inventory Form INV-19";
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         InitPhysInvJournal(ItemJnlLine, Sign);
@@ -298,6 +300,7 @@ codeunit 144709 "ERM Item And Phys. Inventory"
         PhysInvFormINV19.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PhysInvFormINV19.UseRequestPage(false);
         PhysInvFormINV19.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure InitPhysInvJournal(var ItemJnlLine: Record "Item Journal Line"; Sign: Integer)

--- a/src/Layers/RU/Tests/Local/ERMLetterofAttorneyM2A.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMLetterofAttorneyM2A.Codeunit.al
@@ -13,6 +13,8 @@ codeunit 144713 "ERM Letter of Attorney M-2A"
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryRandom: Codeunit "Library - Random";
         Assert: Codeunit Assert;
         NoSeriesChangedErr: Label 'No Series changed after running report with preview.';
@@ -92,6 +94,10 @@ codeunit 144713 "ERM Letter of Attorney M-2A"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         if isInitialized then
             exit;
 

--- a/src/Layers/RU/Tests/Local/ERMLetterofAttorneyM2A.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMLetterofAttorneyM2A.Codeunit.al
@@ -13,8 +13,6 @@ codeunit 144713 "ERM Letter of Attorney M-2A"
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryRandom: Codeunit "Library - Random";
         Assert: Codeunit Assert;
         NoSeriesChangedErr: Label 'No Series changed after running report with preview.';
@@ -94,10 +92,6 @@ codeunit 144713 "ERM Letter of Attorney M-2A"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         if isInitialized then
             exit;
 
@@ -120,10 +114,12 @@ codeunit 144713 "ERM Letter of Attorney M-2A"
 
     local procedure CreateLetterOfAttorneyAndPrint(Preview: Boolean)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         LetterOfAttorneyHeader: Record "Letter of Attorney Header";
         Employee: Record Employee;
         LetterOfAttorneyM2A: Report "Letter of Attorney M-2A";
     begin
+        BindSubscription(RUReportDownloadHandler);
         CreateAttHeader(LetterOfAttorneyHeader);
 
         Employee.Get(LetterOfAttorneyHeader."Employee No.");
@@ -133,6 +129,7 @@ codeunit 144713 "ERM Letter of Attorney M-2A"
         LetterOfAttorneyM2A.SetTableView(LetterOfAttorneyHeader);
         LetterOfAttorneyM2A.UseRequestPage(false);
         LetterOfAttorneyM2A.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CreateAttHeader(var LetterOfAttorneyHeader: Record "Letter of Attorney Header")

--- a/src/Layers/RU/Tests/Local/ERMPurchaseReceiptM4.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMPurchaseReceiptM4.Codeunit.al
@@ -279,8 +279,8 @@ codeunit 144703 "ERM Purchase Receipt M-4"
         PurchaseReceiptM4.UseRequestPage(false);
         PurchaseReceiptM4.Run();
 
-        exit(PurchaseHeader."No.");
         UnbindSubscription(RUReportDownloadHandler);
+        exit(PurchaseHeader."No.");
     end;
 
     local procedure PrintM4PostedPurchaseInvoice(var LineQty: Integer) DocumentNo: Code[20]

--- a/src/Layers/RU/Tests/Local/ERMPurchaseReceiptM4.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMPurchaseReceiptM4.Codeunit.al
@@ -14,6 +14,8 @@ codeunit 144703 "ERM Purchase Receipt M-4"
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryRandom: Codeunit "Library - Random";
         LibraryInventory: Codeunit "Library - Inventory";
@@ -240,6 +242,10 @@ codeunit 144703 "ERM Purchase Receipt M-4"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         if isInitialized then
             exit;
 

--- a/src/Layers/RU/Tests/Local/ERMPurchaseReceiptM4.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMPurchaseReceiptM4.Codeunit.al
@@ -14,8 +14,6 @@ codeunit 144703 "ERM Purchase Receipt M-4"
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryRandom: Codeunit "Library - Random";
         LibraryInventory: Codeunit "Library - Inventory";
@@ -137,11 +135,13 @@ codeunit 144703 "ERM Purchase Receipt M-4"
     [Scope('OnPrem')]
     procedure PrintM4PurchaseOrderWith20CharsItemNo()
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
         PurchaseReceiptM4: Report "Purchase Receipt M-4";
         GLAccountNo: Code[20];
     begin
+        BindSubscription(RUReportDownloadHandler);
         // [SCENARIO 203310] M-4 Report for Purchase Order can be printed if line has "No." of 20 chars
         Initialize();
 
@@ -164,12 +164,14 @@ codeunit 144703 "ERM Purchase Receipt M-4"
 
         // [THEN] M-4 Report is printed and contains "PO"'s "No."
         LibraryReportValidation.VerifyCellValue(5, 7, PurchaseHeader."No.");
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     [Test]
     [Scope('OnPrem')]
     procedure PrintM4PostedPurchaseOrderWith20CharsItemNo()
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PurchaseHeader: Record "Purchase Header";
         PurchInvHeader: Record "Purch. Inv. Header";
         PurchaseLine: Record "Purchase Line";
@@ -177,6 +179,7 @@ codeunit 144703 "ERM Purchase Receipt M-4"
         DocumentNo: Code[20];
         GLAccountNo: Code[20];
     begin
+        BindSubscription(RUReportDownloadHandler);
         // [SCENARIO 203310] M-4 Report for Posted Purchase Order can be printed if line has "No." of 20 chars
         Initialize();
 
@@ -202,18 +205,21 @@ codeunit 144703 "ERM Purchase Receipt M-4"
 
         // [THEN] M-4 Report is printed and contains "No." of posted Purchase Receipt
         LibraryReportValidation.VerifyCellValue(5, 7, DocumentNo);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     [Test]
     [Scope('OnPrem')]
     procedure PrintM4PurchaseInvoiceWith32PurchaseLines()
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
         ItemNo: Code[20];
         Index: Integer;
         PurchaseReceiptM4: Report "Purchase Receipt M-4";
     begin
+        BindSubscription(RUReportDownloadHandler);
         // [SCENARIO 360186] M-4 report lost a line on print form
         Initialize();
 
@@ -236,16 +242,13 @@ codeunit 144703 "ERM Purchase Receipt M-4"
         // [THEN] Line with quantity = 30 should exists on the report
         LibraryReportValidation.VerifyCellValue(
             LibraryReportValidation.FindRowNoFromColumnNoAndValue(6, '30'), 1, ItemNo);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         if isInitialized then
             exit;
 
@@ -257,9 +260,11 @@ codeunit 144703 "ERM Purchase Receipt M-4"
 
     local procedure PrintM4PurchaseOrder(var LineQty: Integer): Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PurchaseHeader: Record "Purchase Header";
         PurchaseReceiptM4: Report "Purchase Receipt M-4";
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         LineQty := LibraryRandom.RandIntInRange(2, 5);
@@ -275,14 +280,17 @@ codeunit 144703 "ERM Purchase Receipt M-4"
         PurchaseReceiptM4.Run();
 
         exit(PurchaseHeader."No.");
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintM4PostedPurchaseInvoice(var LineQty: Integer) DocumentNo: Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PurchaseHeader: Record "Purchase Header";
         PurchInvHeader: Record "Purch. Inv. Header";
         PostedPurchaseReceiptM4: Report "Posted Purchase Receipt M-4";
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         LineQty := LibraryRandom.RandIntInRange(2, 5);
@@ -295,6 +303,7 @@ codeunit 144703 "ERM Purchase Receipt M-4"
         PostedPurchaseReceiptM4.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PostedPurchaseReceiptM4.UseRequestPage(false);
         PostedPurchaseReceiptM4.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure GetVendorFromPurchOrder(var Vendor: Record Vendor; DocumentNo: Code[20])

--- a/src/Layers/RU/Tests/Local/ERMPurchaseVATLedgerExport.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMPurchaseVATLedgerExport.Codeunit.al
@@ -15,8 +15,6 @@ codeunit 147141 "ERM Purchase VAT Ledger Export"
         LibrarySales: Codeunit "Library - Sales";
         LibraryJournals: Codeunit "Library - Journals";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryRUReports: Codeunit "Library RU Reports";
         Assert: Codeunit Assert;
@@ -648,10 +646,6 @@ codeunit 147141 "ERM Purchase VAT Ledger Export"
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         LibrarySetupStorage.Restore();
         if IsInitialized then
             exit;
@@ -814,9 +808,11 @@ codeunit 147141 "ERM Purchase VAT Ledger Export"
 
     local procedure RunVATLedgerExportReportOnDate(VendorNo: Code[20]; StartDate: Date; EndDate: Date; AddSheet: Boolean; UseExternalDocNo: Boolean)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         VATLedgerCode: Code[20];
         FileName: Text[1024];
     begin
+        BindSubscription(RUReportDownloadHandler);
         VATLedgerCode :=
           LibraryPurchase.CreatePurchaseVATLedger(StartDate, EndDate, VendorNo, UseExternalDocNo, true);
         if AddSheet then
@@ -826,6 +822,7 @@ codeunit 147141 "ERM Purchase VAT Ledger Export"
         FileName := LibraryReportValidation.GetFileName();
 
         LibraryPurchase.ExportPurchaseVATLedger(VATLedgerCode, AddSheet, FileName);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CreateAndPostPurchInvoice(var VendorNo: Code[20]; CurrencyCode: Code[10]; VATRate: Decimal; AddSheet: Boolean) DocumentNo: Code[20]

--- a/src/Layers/RU/Tests/Local/ERMPurchaseVATLedgerExport.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMPurchaseVATLedgerExport.Codeunit.al
@@ -15,6 +15,8 @@ codeunit 147141 "ERM Purchase VAT Ledger Export"
         LibrarySales: Codeunit "Library - Sales";
         LibraryJournals: Codeunit "Library - Journals";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryRUReports: Codeunit "Library RU Reports";
         Assert: Codeunit Assert;
@@ -646,6 +648,10 @@ codeunit 147141 "ERM Purchase VAT Ledger Export"
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         LibrarySetupStorage.Restore();
         if IsInitialized then
             exit;

--- a/src/Layers/RU/Tests/Local/ERMRUBase.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMRUBase.Codeunit.al
@@ -20,6 +20,8 @@ codeunit 144001 "ERM RU - Base"
         LibrarySales: Codeunit "Library - Sales";
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryRandom: Codeunit "Library - Random";
         LibraryUtility: Codeunit "Library - Utility";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
@@ -1416,6 +1418,10 @@ codeunit 144001 "ERM RU - Base"
     var
         DummySalesHeader: Record "Sales Header";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         LibrarySetupStorage.Restore();
 
         if IsInitialized then

--- a/src/Layers/RU/Tests/Local/ERMRUBase.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMRUBase.Codeunit.al
@@ -20,8 +20,6 @@ codeunit 144001 "ERM RU - Base"
         LibrarySales: Codeunit "Library - Sales";
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryRandom: Codeunit "Library - Random";
         LibraryUtility: Codeunit "Library - Utility";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
@@ -1418,7 +1416,6 @@ codeunit 144001 "ERM RU - Base"
     var
         DummySalesHeader: Record "Sales Header";
     begin
-        EnsureHandlerBound();
         LibrarySetupStorage.Restore();
 
         if IsInitialized then
@@ -1470,24 +1467,16 @@ codeunit 144001 "ERM RU - Base"
 
     local procedure ExecuteBankPaymentOrderReport(GenJournalLine: Record "Gen. Journal Line")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         BankPaymentOrder: Report "Bank Payment Order";
     begin
-        EnsureHandlerBound();
+        BindSubscription(RUReportDownloadHandler);
         Commit();
         GenJournalLine.SetRecFilter();
         BankPaymentOrder.SetTableView(GenJournalLine);
         BankPaymentOrder.SetFileNameSilent(LibraryReportValidation.GetFileName());
         BankPaymentOrder.RunModal();
-    end;
-
-    local procedure EnsureHandlerBound()
-    begin
-        // Bind the RU report download handler before any report is exported. Called from the report
-        // run helpers (not only Initialize) because some report tests do not call Initialize.
-        if RUReportHandlerBound then
-            exit;
-        BindSubscription(RUReportDownloadHandler);
-        RUReportHandlerBound := true;
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CreateStandardText(): Text[250]

--- a/src/Layers/RU/Tests/Local/ERMRUBase.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMRUBase.Codeunit.al
@@ -1418,10 +1418,7 @@ codeunit 144001 "ERM RU - Base"
     var
         DummySalesHeader: Record "Sales Header";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
+        EnsureHandlerBound();
         LibrarySetupStorage.Restore();
 
         if IsInitialized then
@@ -1475,11 +1472,22 @@ codeunit 144001 "ERM RU - Base"
     var
         BankPaymentOrder: Report "Bank Payment Order";
     begin
+        EnsureHandlerBound();
         Commit();
         GenJournalLine.SetRecFilter();
         BankPaymentOrder.SetTableView(GenJournalLine);
         BankPaymentOrder.SetFileNameSilent(LibraryReportValidation.GetFileName());
         BankPaymentOrder.RunModal();
+    end;
+
+    local procedure EnsureHandlerBound()
+    begin
+        // Bind the RU report download handler before any report is exported. Called from the report
+        // run helpers (not only Initialize) because some report tests do not call Initialize.
+        if RUReportHandlerBound then
+            exit;
+        BindSubscription(RUReportDownloadHandler);
+        RUReportHandlerBound := true;
     end;
 
     local procedure CreateStandardText(): Text[250]

--- a/src/Layers/RU/Tests/Local/ERMRUVoidCheck.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMRUVoidCheck.Codeunit.al
@@ -20,6 +20,8 @@ codeunit 144015 "ERM RU Void Check"
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryJournals: Codeunit "Library - Journals";
         Assert: Codeunit Assert;
         isInitialized: Boolean;
@@ -508,6 +510,10 @@ codeunit 144015 "ERM RU Void Check"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         LibrarySetupStorage.Restore();
         if isInitialized then
             exit;

--- a/src/Layers/RU/Tests/Local/ERMRUVoidCheck.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMRUVoidCheck.Codeunit.al
@@ -20,8 +20,6 @@ codeunit 144015 "ERM RU Void Check"
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryJournals: Codeunit "Library - Journals";
         Assert: Codeunit Assert;
         isInitialized: Boolean;
@@ -510,10 +508,6 @@ codeunit 144015 "ERM RU Void Check"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         LibrarySetupStorage.Restore();
         if isInitialized then
             exit;
@@ -869,24 +863,30 @@ codeunit 144015 "ERM RU Void Check"
 
     local procedure PrintCashOutgoingOrder(GenJournalLine: Record "Gen. Journal Line")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         CashOutgoingOrder: Report "Cash Outgoing Order";
     begin
+        BindSubscription(RUReportDownloadHandler);
         CashOutgoingOrder.SetFileNameSilent(LibraryReportValidation.GetFileName());
         GenJournalLine.SetRecFilter();
         CashOutgoingOrder.SetTableView(GenJournalLine);
         CashOutgoingOrder.UseRequestPage(false);
         CashOutgoingOrder.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintCashIngoingOrder(GenJournalLine: Record "Gen. Journal Line")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         CashIngoingOrder: Report "Cash Ingoing Order";
     begin
+        BindSubscription(RUReportDownloadHandler);
         CashIngoingOrder.SetFileNameSilent(LibraryReportValidation.GetFileName());
         GenJournalLine.SetRecFilter();
         CashIngoingOrder.SetTableView(GenJournalLine);
         CashIngoingOrder.UseRequestPage(false);
         CashIngoingOrder.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyVendorLedgerEntries(VendorNo: Code[20]; DocumentType: Enum "Gen. Journal Document Type"; ExpectedCount: Integer; IsOpen: Boolean)

--- a/src/Layers/RU/Tests/Local/ERMReconciliationReport.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMReconciliationReport.Codeunit.al
@@ -17,6 +17,8 @@
         LibraryUtility: Codeunit "Library - Utility";
         LibraryJournals: Codeunit "Library - Journals";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         Assert: Codeunit Assert;
@@ -629,6 +631,10 @@
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         LibraryVariableStorage.Clear();
         LibrarySetupStorage.Restore();
         if IsInitialized then

--- a/src/Layers/RU/Tests/Local/ERMReconciliationReport.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMReconciliationReport.Codeunit.al
@@ -17,8 +17,6 @@
         LibraryUtility: Codeunit "Library - Utility";
         LibraryJournals: Codeunit "Library - Journals";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         Assert: Codeunit Assert;
@@ -631,10 +629,6 @@
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         LibraryVariableStorage.Clear();
         LibrarySetupStorage.Restore();
         if IsInitialized then
@@ -779,9 +773,11 @@
 
     local procedure PrintVendorReconciliationRequestPage(VendorNo: Code[20]; ReportDate: Date; UseRequestPage: Boolean)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         Vendor: Record Vendor;
         VendorReconciliationAct: Report "Vendor - Reconciliation Act";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         VendorReconciliationAct.InitializeRequest(ReportDate, ReportDate, LibraryReportValidation.GetFileName(), true);
         Vendor.SetRange("No.", VendorNo);
@@ -789,6 +785,7 @@
         VendorReconciliationAct.SetTableView(Vendor);
         Commit();
         VendorReconciliationAct.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintCustomerReconciliation(CustomerNo1: Code[20]; CustomerNo2: Code[20]; ReportDate: Date)
@@ -798,9 +795,11 @@
 
     local procedure PrintCustomerReconciliationRequestPage(CustomerNo1: Code[20]; CustomerNo2: Code[20]; ReportDate: Date; UseRequestPage: Boolean)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         Customer: Record Customer;
         CustomerReconciliationAct: Report "Customer - Reconciliation Act";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         Clear(CustomerReconciliationAct);
         CustomerReconciliationAct.InitializeRequest(ReportDate, ReportDate, LibraryReportValidation.GetFileName(), true);
@@ -812,13 +811,16 @@
         CustomerReconciliationAct.SetTableView(Customer);
         Commit();
         CustomerReconciliationAct.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintCustomerReconciliationWithCurrency(CustomerNo: Code[20]; ReportDate: Date; CurrencyCode: Code[10])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         Customer: Record Customer;
         CustomerReconciliationAct: Report "Customer - Reconciliation Act";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryVariableStorage.Enqueue(CurrencyCode);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         Clear(CustomerReconciliationAct);
@@ -828,6 +830,7 @@
         CustomerReconciliationAct.SetTableView(Customer);
         Commit();
         CustomerReconciliationAct.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintReconciliation(IsVendorReconciliation: Boolean; VendorNo: Code[20]; CustomerNo: Code[20]; ReportDate: Date)

--- a/src/Layers/RU/Tests/Local/ERMSalesShipmentM15.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMSalesShipmentM15.Codeunit.al
@@ -12,6 +12,8 @@ codeunit 144706 "ERM Sales Shipment M-15"
         LibrarySales: Codeunit "Library - Sales";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryRandom: Codeunit "Library - Random";
         isInitialized: Boolean;
@@ -174,6 +176,10 @@ codeunit 144706 "ERM Sales Shipment M-15"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         if isInitialized then
             exit;
 

--- a/src/Layers/RU/Tests/Local/ERMSalesShipmentM15.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMSalesShipmentM15.Codeunit.al
@@ -12,8 +12,6 @@ codeunit 144706 "ERM Sales Shipment M-15"
         LibrarySales: Codeunit "Library - Sales";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryRandom: Codeunit "Library - Random";
         isInitialized: Boolean;
@@ -176,10 +174,6 @@ codeunit 144706 "ERM Sales Shipment M-15"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         if isInitialized then
             exit;
 
@@ -236,8 +230,10 @@ codeunit 144706 "ERM Sales Shipment M-15"
 
     local procedure PrintM15SalesOrder(var SalesHeader: Record "Sales Header"; var LineQty: Integer; Preview: Boolean)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesShipmentM15: Report "Sales Shipment M-15";
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         LineQty := LibraryRandom.RandIntInRange(2, 5);
@@ -252,14 +248,17 @@ codeunit 144706 "ERM Sales Shipment M-15"
         SalesShipmentM15.UseRequestPage(false);
         SalesShipmentM15.Run();
         SalesHeader.Find(); // re-read record as there is an assignments inside report
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintM15SalesShipment(var LineQty: Integer) DocumentNo: Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesHeader: Record "Sales Header";
         SalesInvoiceHeader: Record "Sales Invoice Header";
         PostedSalesShipmentM15: Report "Posted Sales Shipment M-15";
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         LineQty := LibraryRandom.RandIntInRange(2, 5);
@@ -273,6 +272,7 @@ codeunit 144706 "ERM Sales Shipment M-15"
         PostedSalesShipmentM15.SetFileNameSilent(LibraryReportValidation.GetFileName());
         PostedSalesShipmentM15.UseRequestPage(false);
         PostedSalesShipmentM15.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure GetSalesOrderIntWrittenAmount(var SalesHeader: Record "Sales Header"): Text

--- a/src/Layers/RU/Tests/Local/ERMSalesVATLedgerExport.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMSalesVATLedgerExport.Codeunit.al
@@ -17,6 +17,8 @@ codeunit 147140 "ERM Sales VAT Ledger Export"
         LibraryPurchase: Codeunit "Library - Purchase";
         LibrarySales: Codeunit "Library - Sales";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryRUReports: Codeunit "Library RU Reports";
         VATLedgerMgt: Codeunit "VAT Ledger Management";
@@ -560,6 +562,10 @@ codeunit 147140 "ERM Sales VAT Ledger Export"
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         SalesReceivablesSetup: Record "Sales & Receivables Setup";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         LibrarySetupStorage.Restore();
         if IsInitialized then
             exit;

--- a/src/Layers/RU/Tests/Local/ERMSalesVATLedgerExport.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMSalesVATLedgerExport.Codeunit.al
@@ -17,8 +17,6 @@ codeunit 147140 "ERM Sales VAT Ledger Export"
         LibraryPurchase: Codeunit "Library - Purchase";
         LibrarySales: Codeunit "Library - Sales";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryRUReports: Codeunit "Library RU Reports";
         VATLedgerMgt: Codeunit "VAT Ledger Management";
@@ -562,10 +560,6 @@ codeunit 147140 "ERM Sales VAT Ledger Export"
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         SalesReceivablesSetup: Record "Sales & Receivables Setup";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         LibrarySetupStorage.Restore();
         if IsInitialized then
             exit;
@@ -626,8 +620,10 @@ codeunit 147140 "ERM Sales VAT Ledger Export"
 
     local procedure RunVATLedgerExportReport(CustomerNo: Code[20]; AddSheet: Boolean) VATLedgerCode: Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         FileName: Text[1024];
     begin
+        BindSubscription(RUReportDownloadHandler);
         VATLedgerCode :=
           LibrarySales.CreateSalesVATLedger(LibraryRandom.RandDate(-2), LibraryRandom.RandDateFromInRange(WorkDate(), 5, 10), CustomerNo);
         if AddSheet then
@@ -637,6 +633,7 @@ codeunit 147140 "ERM Sales VAT Ledger Export"
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         FileName := LibraryReportValidation.GetFileName();
         LibrarySales.ExportSalesVATLedger(VATLedgerCode, AddSheet, FileName);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CreateAndPostSalesInvoice(var SalesHeader: Record "Sales Header"; CurrencyCode: Code[10]; VATRate: Decimal; AddSheet: Boolean): Code[20]

--- a/src/Layers/RU/Tests/Local/ERMShipmentRequestM11.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMShipmentRequestM11.Codeunit.al
@@ -281,8 +281,8 @@ codeunit 144705 "ERM Shipment Request M-11"
         ShipmentRequestM11.UseRequestPage(false);
         ShipmentRequestM11.Run();
 
-        exit(TransferHeader."No.");
         UnbindSubscription(RUReportDownloadHandler);
+        exit(TransferHeader."No.");
     end;
 
     local procedure PrintM11TransferShipment(LineQty: Integer): Code[20]
@@ -311,8 +311,8 @@ codeunit 144705 "ERM Shipment Request M-11"
         ShipmentRequestM11.UseRequestPage(false);
         ShipmentRequestM11.Run();
 
-        exit(TransferShipmentHeader."No.");
         UnbindSubscription(RUReportDownloadHandler);
+        exit(TransferShipmentHeader."No.");
     end;
 
     local procedure PrintM11TransferReceipt(LineQty: Integer): Code[20]
@@ -341,8 +341,8 @@ codeunit 144705 "ERM Shipment Request M-11"
         ShipmentRequestM11.UseRequestPage(false);
         ShipmentRequestM11.Run();
 
-        exit(TransferReceiptHeader."No.");
         UnbindSubscription(RUReportDownloadHandler);
+        exit(TransferReceiptHeader."No.");
     end;
 
     local procedure PrintM11ItemReclassJnl(LineQty: Integer): Code[20]

--- a/src/Layers/RU/Tests/Local/ERMShipmentRequestM11.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMShipmentRequestM11.Codeunit.al
@@ -13,8 +13,6 @@ codeunit 144705 "ERM Shipment Request M-11"
         LibraryUtility: Codeunit "Library - Utility";
         LibraryDimension: Codeunit "Library - Dimension";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryRandom: Codeunit "Library - Random";
         isInitialized: Boolean;
@@ -249,10 +247,6 @@ codeunit 144705 "ERM Shipment Request M-11"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         if isInitialized then
             exit;
 
@@ -264,12 +258,14 @@ codeunit 144705 "ERM Shipment Request M-11"
 
     local procedure PrintM11TransferOrder(LineQty: Integer): Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         TransferHeader: Record "Transfer Header";
         ShipmentRequestM11: Report "Shipment Request M-11";
         ItemNo: array[5] of Code[20];
         Qty: array[5] of Decimal;
         i: Integer;
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         for i := 1 to LineQty do begin
@@ -286,10 +282,12 @@ codeunit 144705 "ERM Shipment Request M-11"
         ShipmentRequestM11.Run();
 
         exit(TransferHeader."No.");
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintM11TransferShipment(LineQty: Integer): Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         TransferHeader: Record "Transfer Header";
         TransferShipmentHeader: Record "Transfer Shipment Header";
         ShipmentRequestM11: Report "Shipment Request M-11";
@@ -297,6 +295,7 @@ codeunit 144705 "ERM Shipment Request M-11"
         ItemNo: array[5] of Code[20];
         Qty: array[5] of Decimal;
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         FromLocationCode := InitItemInventory(ItemNo, Qty, LineQty);
@@ -313,10 +312,12 @@ codeunit 144705 "ERM Shipment Request M-11"
         ShipmentRequestM11.Run();
 
         exit(TransferShipmentHeader."No.");
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintM11TransferReceipt(LineQty: Integer): Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         TransferHeader: Record "Transfer Header";
         TransferReceiptHeader: Record "Transfer Receipt Header";
         ShipmentRequestM11: Report "Shipment Request M-11";
@@ -324,6 +325,7 @@ codeunit 144705 "ERM Shipment Request M-11"
         ItemNo: array[5] of Code[20];
         Qty: array[5] of Decimal;
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         FromLocationCode := InitItemInventory(ItemNo, Qty, LineQty);
@@ -340,6 +342,7 @@ codeunit 144705 "ERM Shipment Request M-11"
         ShipmentRequestM11.Run();
 
         exit(TransferReceiptHeader."No.");
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintM11ItemReclassJnl(LineQty: Integer): Code[20]
@@ -351,11 +354,13 @@ codeunit 144705 "ERM Shipment Request M-11"
 
     local procedure PrintM11ItemReclassJnlItemNo(LineQty: Integer; ItemNo: Array[22] of Code[20]) DocumentNo: Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         ItemJnlLine: Record "Item Journal Line";
         ShipmentRequestM11: Report "Shipment Request M-11";
         Qty: array[22] of Decimal;
         i: Integer;
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         DocumentNo := LibraryUtility.GenerateGUID();
@@ -373,6 +378,7 @@ codeunit 144705 "ERM Shipment Request M-11"
         ShipmentRequestM11.SetTableView(ItemJnlLine);
         ShipmentRequestM11.UseRequestPage(false);
         ShipmentRequestM11.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CreateTransferOrder(var TransferHeader: Record "Transfer Header"; FromLocationCode: Code[10]; ItemNo: array[3] of Code[20]; Quantity: array[3] of Decimal; LineQty: Integer)

--- a/src/Layers/RU/Tests/Local/ERMShipmentRequestM11.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMShipmentRequestM11.Codeunit.al
@@ -13,6 +13,8 @@ codeunit 144705 "ERM Shipment Request M-11"
         LibraryUtility: Codeunit "Library - Utility";
         LibraryDimension: Codeunit "Library - Dimension";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryRandom: Codeunit "Library - Random";
         isInitialized: Boolean;
@@ -247,6 +249,10 @@ codeunit 144705 "ERM Shipment Request M-11"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         if isInitialized then
             exit;
 

--- a/src/Layers/RU/Tests/Local/ERMStatisticFormFNS1.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMStatisticFormFNS1.Codeunit.al
@@ -13,6 +13,8 @@ codeunit 147150 "ERM Statistic Form FNS-1"
         TempItemJournalBuffer: Record "Item Journal Buffer" temporary;
         StatisticFormFNS1: Report "Statistic Form FNS-1";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryHumanResource: Codeunit "Library - Human Resource";
@@ -44,6 +46,10 @@ codeunit 147150 "ERM Statistic Form FNS-1"
     var
         HumanResourcesSetup: Record "Human Resources Setup";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         if IsInitialized then
             exit;
 

--- a/src/Layers/RU/Tests/Local/ERMStatisticFormFNS1.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMStatisticFormFNS1.Codeunit.al
@@ -13,8 +13,6 @@ codeunit 147150 "ERM Statistic Form FNS-1"
         TempItemJournalBuffer: Record "Item Journal Buffer" temporary;
         StatisticFormFNS1: Report "Statistic Form FNS-1";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryHumanResource: Codeunit "Library - Human Resource";
@@ -46,10 +44,6 @@ codeunit 147150 "ERM Statistic Form FNS-1"
     var
         HumanResourcesSetup: Record "Human Resources Setup";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         if IsInitialized then
             exit;
 
@@ -82,8 +76,10 @@ codeunit 147150 "ERM Statistic Form FNS-1"
 
     local procedure RunStatisticReport()
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         ResponsibleEmployee: Record Employee;
     begin
+        BindSubscription(RUReportDownloadHandler);
         StatisticFormFNS1.UseRequestPage(true);
         ResponsibleEmployee.Get(ResponsibleEmployeeNo);
         StatisticFormFNS1.SetSilentResponsibleEmployee(ResponsibleEmployee);
@@ -92,6 +88,7 @@ codeunit 147150 "ERM Statistic Form FNS-1"
         StatisticFormFNS1.SetSilentEmployeeStatisticalBuffer(TempItemJournalBuffer);
         Commit();
         StatisticFormFNS1.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CreateEmployeeStatisticalBuffer(StatisticalLines: Integer)

--- a/src/Layers/RU/Tests/Local/ERMTORG29Report.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMTORG29Report.Codeunit.al
@@ -11,6 +11,8 @@ codeunit 144712 "ERM TORG-29 Report"
         LibraryUtility: Codeunit "Library - Utility";
         LibraryPriceCalculation: Codeunit "Library - Price Calculation";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         TORG29Helper: Codeunit "TORG-29 Helper";
         isInitialized: Boolean;
         ReceiptsDetailing: Option Document,Item,Operation;
@@ -232,6 +234,10 @@ codeunit 144712 "ERM TORG-29 Report"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         Clear(LibraryReportValidation);
         Clear(TORG29Helper);
         LibraryPriceCalculation.DisableExtendedPriceCalculation();

--- a/src/Layers/RU/Tests/Local/ERMTORG29Report.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMTORG29Report.Codeunit.al
@@ -11,8 +11,6 @@ codeunit 144712 "ERM TORG-29 Report"
         LibraryUtility: Codeunit "Library - Utility";
         LibraryPriceCalculation: Codeunit "Library - Price Calculation";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         TORG29Helper: Codeunit "TORG-29 Helper";
         isInitialized: Boolean;
         ReceiptsDetailing: Option Document,Item,Operation;
@@ -234,10 +232,6 @@ codeunit 144712 "ERM TORG-29 Report"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         Clear(LibraryReportValidation);
         Clear(TORG29Helper);
         LibraryPriceCalculation.DisableExtendedPriceCalculation();
@@ -365,9 +359,11 @@ codeunit 144712 "ERM TORG-29 Report"
 
     local procedure RunTORG29Report(LocationCode: Code[10]; PostingDate: Date)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         TORG29Rep: Report "Item Report TORG-29";
         SalesType: Option "Customer Price Group","All Customers",Campaign;
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         TORG29Rep.SetFileNameSilent(LibraryReportValidation.GetFileName());
         TORG29Rep.InitializeRequest(
@@ -375,6 +371,7 @@ codeunit 144712 "ERM TORG-29 Report"
           AmountType::Cost, SalesType::"All Customers", '', true, true);
         TORG29Rep.UseRequestPage(false);
         TORG29Rep.RunModal();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure GetLastValueEntryDate(): Date

--- a/src/Layers/RU/Tests/Local/ERMTaxRegisterReport.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMTaxRegisterReport.Codeunit.al
@@ -11,8 +11,6 @@ codeunit 144721 "ERM Tax Register Report"
         LibraryRandom: Codeunit "Library - Random";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         StdRepMgt: Codeunit "Local Report Management";
         Assert: Codeunit Assert;
         isInitialized: Boolean;
@@ -39,10 +37,6 @@ codeunit 144721 "ERM Tax Register Report"
 
     local procedure Initialize()
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         Clear(LibraryReportValidation);
 
         if isInitialized then
@@ -113,8 +107,10 @@ codeunit 144721 "ERM Tax Register Report"
 
     local procedure RunTaxRegisterReport(var TaxRegister: Record "Tax Register")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         TaxRegisterRep: Report "Tax Register";
     begin
+        BindSubscription(RUReportDownloadHandler);
         TaxRegister.SetRecFilter();
         TaxRegister.SetFilter(
           "Date Filter", '%1..%2', CalcDate('<-CM>', WorkDate()), CalcDate('<CM>', WorkDate()));
@@ -125,6 +121,7 @@ codeunit 144721 "ERM Tax Register Report"
         TaxRegisterRep.SetTableView(TaxRegister);
         TaxRegisterRep.UseRequestPage(false);
         TaxRegisterRep.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyReportValues(var TaxRegister: Record "Tax Register"; TaxRegisterEntry: Record "Tax Register Item Entry")

--- a/src/Layers/RU/Tests/Local/ERMTaxRegisterReport.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMTaxRegisterReport.Codeunit.al
@@ -11,6 +11,8 @@ codeunit 144721 "ERM Tax Register Report"
         LibraryRandom: Codeunit "Library - Random";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         StdRepMgt: Codeunit "Local Report Management";
         Assert: Codeunit Assert;
         isInitialized: Boolean;
@@ -37,6 +39,10 @@ codeunit 144721 "ERM Tax Register Report"
 
     local procedure Initialize()
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         Clear(LibraryReportValidation);
 
         if isInitialized then

--- a/src/Layers/RU/Tests/Local/ERMTorg12Report.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMTorg12Report.Codeunit.al
@@ -14,6 +14,8 @@ codeunit 144702 "ERM Torg-12 Report"
         LibrarySales: Codeunit "Library - Sales";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryRandom: Codeunit "Library - Random";
         LibraryInventory: Codeunit "Library - Inventory";
@@ -213,6 +215,10 @@ codeunit 144702 "ERM Torg-12 Report"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         if isInitialized then
             exit;
 

--- a/src/Layers/RU/Tests/Local/ERMTorg12Report.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMTorg12Report.Codeunit.al
@@ -14,8 +14,6 @@ codeunit 144702 "ERM Torg-12 Report"
         LibrarySales: Codeunit "Library - Sales";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryRandom: Codeunit "Library - Random";
         LibraryInventory: Codeunit "Library - Inventory";
@@ -215,10 +213,6 @@ codeunit 144702 "ERM Torg-12 Report"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         if isInitialized then
             exit;
 
@@ -233,9 +227,11 @@ codeunit 144702 "ERM Torg-12 Report"
 
     local procedure PrintTorg12ToExcel(SalesHeader: Record "Sales Header"; Preview: Boolean)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesHeaderWithFilters: Record "Sales Header";
         OrderItemShipmentTORG12: Report "Order Item Shipment TORG-12";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         OrderItemShipmentTORG12.InitializeRequest(LibraryReportValidation.GetFileName(), Preview);
@@ -245,6 +241,7 @@ codeunit 144702 "ERM Torg-12 Report"
         SalesHeaderWithFilters.SetRange("No.", SalesHeader."No.");
         OrderItemShipmentTORG12.SetTableView(SalesHeaderWithFilters);
         OrderItemShipmentTORG12.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure GetShipmentLinesAmount(DocumentNo: Code[20]) TotalAmount: Decimal
@@ -298,10 +295,12 @@ codeunit 144702 "ERM Torg-12 Report"
 
     local procedure CreateSalesShipmentAndPrintTorg12Report(QuantityOfLines: Integer; QtyToShip: Decimal) DocumentNo: Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesHeader: Record "Sales Header";
         SalesShipmentHeader: Record "Sales Shipment Header";
         PostedShipShipmentTORG12: Report "Posted Ship. Shipment TORG-12";
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         LibraryRUReports.CreateSalesOrder(SalesHeader, SalesHeader."Document Type"::Order, QuantityOfLines);
@@ -317,14 +316,17 @@ codeunit 144702 "ERM Torg-12 Report"
         PostedShipShipmentTORG12.SetTableView(SalesShipmentHeader);
         PostedShipShipmentTORG12.UseRequestPage(false);
         PostedShipShipmentTORG12.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CreateSalesInvoiceAndPrintTorg12Report(QuantityOfLines: Integer; QtyToShip: Decimal) DocumentNo: Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesHeader: Record "Sales Header";
         SalesInvoiceHeader: Record "Sales Invoice Header";
         PostedInvShipmentTORG12: Report "Posted Inv. Shipment TORG-12";
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         LibraryRUReports.CreateSalesOrder(SalesHeader, SalesHeader."Document Type"::Order, QuantityOfLines);
@@ -340,14 +342,17 @@ codeunit 144702 "ERM Torg-12 Report"
         PostedInvShipmentTORG12.SetTableView(SalesInvoiceHeader);
         PostedInvShipmentTORG12.UseRequestPage(false);
         PostedInvShipmentTORG12.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CreateSalesCrMemoAndPrintTorg12Report(QuantityOfLines: Integer; QtyToShip: Decimal) DocumentNo: Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesHeader: Record "Sales Header";
         SalesCrMemoHeader: Record "Sales Cr.Memo Header";
         PostedCrMShipmentTORG12: Report "Posted Cr. M. Shipment TORG-12";
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         LibraryRUReports.CreateSalesOrder(SalesHeader, SalesHeader."Document Type"::"Credit Memo", QuantityOfLines);
@@ -363,6 +368,7 @@ codeunit 144702 "ERM Torg-12 Report"
         PostedCrMShipmentTORG12.SetTableView(SalesCrMemoHeader);
         PostedCrMShipmentTORG12.UseRequestPage(false);
         PostedCrMShipmentTORG12.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CreateSalesOrderWithSignature(var SalesHeader: Record "Sales Header"; var ReleasedByEmployeeName: Text[100]; var AccountantEmployeeName: Text[100]; var PassedByEmployeeName: Text[100])

--- a/src/Layers/RU/Tests/Local/ERMVATAgent.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMVATAgent.Codeunit.al
@@ -22,6 +22,8 @@ codeunit 144009 "ERM VAT Agent"
         LibrarySales: Codeunit "Library - Sales";
         LibraryJournals: Codeunit "Library - Journals";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryRandom: Codeunit "Library - Random";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRUReports: Codeunit "Library RU Reports";
@@ -574,6 +576,10 @@ codeunit 144009 "ERM VAT Agent"
         SalesSetup: Record "Sales & Receivables Setup";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         if IsInitialized then
             exit;
 

--- a/src/Layers/RU/Tests/Local/ERMVATAgent.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMVATAgent.Codeunit.al
@@ -22,8 +22,6 @@ codeunit 144009 "ERM VAT Agent"
         LibrarySales: Codeunit "Library - Sales";
         LibraryJournals: Codeunit "Library - Journals";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryRandom: Codeunit "Library - Random";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryRUReports: Codeunit "Library RU Reports";
@@ -148,6 +146,7 @@ codeunit 144009 "ERM VAT Agent"
     [Scope('OnPrem')]
     procedure PrintFacturaInvoiceForVATAgentWithPrepayment()
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         GenJournalLine: Record "Gen. Journal Line";
         PurchInvLine: Record "Purch. Inv. Line";
         LocalReportMgt: Codeunit "Local Report Management";
@@ -157,6 +156,7 @@ codeunit 144009 "ERM VAT Agent"
         InvAmount: Decimal;
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         // [FEATURE] [Prepayment]
         // [SCENARIO 377108] Print Posted Purchase Factura-Invoice report for VAT Agent of Non-resident type with Prepayment
         Initialize();
@@ -199,6 +199,7 @@ codeunit 144009 "ERM VAT Agent"
         // [THEN] Amount including VAT is printed '59,00'
         LibraryRUReports.VerifyFactura_AmountInclVAT(
           FileName, LocalReportMgt.FormatReportValue(PurchInvLine."Amount Including VAT (LCY)", 2), 0);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     [Test]
@@ -576,10 +577,6 @@ codeunit 144009 "ERM VAT Agent"
         SalesSetup: Record "Sales & Receivables Setup";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         if IsInitialized then
             exit;
 
@@ -1064,10 +1061,12 @@ codeunit 144009 "ERM VAT Agent"
 
     local procedure RunPstdPurchFacturaInvoiceReport(var PurchInvLine: Record "Purch. Inv. Line"; VendorNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PurchInvHeader: Record "Purch. Inv. Header";
         PstdPurchFacturaInvoice: Report "Pstd. Purch. Factura-Invoice";
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         PurchInvHeader.SetRange("Buy-from Vendor No.", VendorNo);
         PurchInvHeader.FindFirst();
         PurchInvHeader.SetRecFilter();
@@ -1082,6 +1081,7 @@ codeunit 144009 "ERM VAT Agent"
         PstdPurchFacturaInvoice.SetFileNameSilent(FileName);
         PstdPurchFacturaInvoice.UseRequestPage(false);
         PstdPurchFacturaInvoice.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CalcExpectedAmount(DocNo: Code[20]; BaseAmount: Decimal): Decimal

--- a/src/Layers/RU/Tests/Local/ERMVATInvoicesJnlExport.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMVATInvoicesJnlExport.Codeunit.al
@@ -14,6 +14,8 @@ codeunit 147135 "ERM VAT Invoices Jnl. Export"
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LocalReportManagement: Codeunit "Local Report Management";
         LibraryRandom: Codeunit "Library - Random";
         Assert: Codeunit Assert;
@@ -220,6 +222,10 @@ codeunit 147135 "ERM VAT Invoices Jnl. Export"
 
     local procedure Initialize()
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         if IsInitialized then
             exit;
 

--- a/src/Layers/RU/Tests/Local/ERMVATInvoicesJnlExport.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMVATInvoicesJnlExport.Codeunit.al
@@ -14,8 +14,6 @@ codeunit 147135 "ERM VAT Invoices Jnl. Export"
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryUtility: Codeunit "Library - Utility";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LocalReportManagement: Codeunit "Local Report Management";
         LibraryRandom: Codeunit "Library - Random";
         Assert: Codeunit Assert;
@@ -222,10 +220,6 @@ codeunit 147135 "ERM VAT Invoices Jnl. Export"
 
     local procedure Initialize()
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         if IsInitialized then
             exit;
 
@@ -388,14 +382,17 @@ codeunit 147135 "ERM VAT Invoices Jnl. Export"
 
     local procedure VATInvoicesJournalExport(PostingDate: Date)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         VATInvoicesJournal: Report "VAT Invoices Journal";
     begin
+        BindSubscription(RUReportDownloadHandler);
         VATInvoicesJournal.InitializeRequest(
           Date2DMY(PostingDate, 3), 1, PostingDate, CalcDate('<1M>', PostingDate), false);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
         VATInvoicesJournal.SetFileNameSilent(LibraryReportValidation.GetFileName());
         VATInvoicesJournal.UseRequestPage(false);
         VATInvoicesJournal.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure GetSalesInvHeader(InvNo: Code[20]; var SalesInvHeader: Record "Sales Invoice Header")

--- a/src/Layers/RU/Tests/Local/ERMWaybill1TReport.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMWaybill1TReport.Codeunit.al
@@ -13,8 +13,6 @@ codeunit 144701 "ERM Waybill 1-T Report"
         LibraryRandom: Codeunit "Library - Random";
         LibrarySales: Codeunit "Library - Sales";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LocMgt: Codeunit "Localisation Management";
         StdRepMgt: Codeunit "Local Report Management";
         LibraryUtility: Codeunit "Library - Utility";
@@ -94,10 +92,6 @@ codeunit 144701 "ERM Waybill 1-T Report"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         Clear(LibraryReportValidation);
 
         if isInitialized then
@@ -151,11 +145,13 @@ codeunit 144701 "ERM Waybill 1-T Report"
     [Scope('OnPrem')]
     procedure CreateSalesShipmentAndVerify1TReport(QuantityOfLines: Integer)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesHeader: Record "Sales Header";
         SalesShipmentHeader: Record "Sales Shipment Header";
         PostedShipItemWaybill1T: Report "Posted Ship. Item Waybill 1-T";
         DocumentNo: Code[20];
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         CreateReleasedSalesOrder(SalesHeader, QuantityOfLines);
@@ -172,16 +168,19 @@ codeunit 144701 "ERM Waybill 1-T Report"
 
         SalesShipmentHeader.Get(DocumentNo);
         VerifyShipmentWaybill1TReport(SalesShipmentHeader);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     [Scope('OnPrem')]
     procedure CreateSalesInvoiceAndVerify1TReport(QuantityOfLines: Integer)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         SalesHeader: Record "Sales Header";
         SalesInvoiceHeader: Record "Sales Invoice Header";
         PostedInvoiceItemWaybill1T: Report "Posted Inv. Item Waybill 1-T";
         DocumentNo: Code[20];
     begin
+        BindSubscription(RUReportDownloadHandler);
         Initialize();
 
         CreateReleasedSalesOrder(SalesHeader, QuantityOfLines);
@@ -198,6 +197,7 @@ codeunit 144701 "ERM Waybill 1-T Report"
 
         SalesInvoiceHeader.Get(DocumentNo);
         VerifyInvoiceWaybill1TReport(SalesInvoiceHeader);
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CreateSalesOrderWithSignatures(var SalesHeader: Record "Sales Header"; var ResponsibleEmployeeName: Text[100]; var AccountantEmployeeName: Text[100]; var ReleasedByEmployeeName: Text[100])
@@ -256,8 +256,10 @@ codeunit 144701 "ERM Waybill 1-T Report"
 
     local procedure PrintOrderItemWaybill1TToExcel(SalesHeader: Record "Sales Header")
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         OrderItemWaybill1T: Report "Order Item Waybill 1-T";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(LibraryUtility.GenerateGUID());
 
         SalesHeader.SetRange("No.", SalesHeader."No.");
@@ -267,6 +269,7 @@ codeunit 144701 "ERM Waybill 1-T Report"
         OrderItemWaybill1T.SetTableView(SalesHeader);
         OrderItemWaybill1T.UseRequestPage(false);
         OrderItemWaybill1T.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure VerifyWaybillHeaderValues(DocumentNo: Code[20]; PostingDate: Date; ShipToAddress: Text; BillToAddress: Text)

--- a/src/Layers/RU/Tests/Local/ERMWaybill1TReport.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/ERMWaybill1TReport.Codeunit.al
@@ -13,6 +13,8 @@ codeunit 144701 "ERM Waybill 1-T Report"
         LibraryRandom: Codeunit "Library - Random";
         LibrarySales: Codeunit "Library - Sales";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LocMgt: Codeunit "Localisation Management";
         StdRepMgt: Codeunit "Local Report Management";
         LibraryUtility: Codeunit "Library - Utility";
@@ -92,6 +94,10 @@ codeunit 144701 "ERM Waybill 1-T Report"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         Clear(LibraryReportValidation);
 
         if isInitialized then

--- a/src/Layers/RU/Tests/Local/RUReportDownloadHandler.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/RUReportDownloadHandler.Codeunit.al
@@ -1,23 +1,36 @@
 codeunit 147210 "RU Report Download Handler"
 {
-    // Test helper (non-test codeunit). RU local reports export Excel through a client-side download
-    // (codeunit "File Management".DownloadHandler). In container-based test runs that client download
-    // does not materialize the file at the server session path the report tests read from
-    // ("Library - Report Validation" reads TemporaryPath + name), so the tests fail opening the file.
-    // This static subscriber copies the server-side source file to the requested target path so the
-    // report validation can open it. A single shared, non-test handler is used (instead of per-test
-    // manual subscribers) because many RU report test codeunits rely on this behavior; a static
-    // subscriber is allowed here because this is not a test codeunit (AL0501 only applies to those).
+    // Test helper (non-test codeunit) for RU report tests. RU local reports download their Excel
+    // output client-side, which doesn't materialize the file at the server path the tests read from
+    // in container runs; this subscriber copies the source file to the target so validation can open it.
+    //
+    // Manual subscriber: each RU report test binds it (see the test codeunits' Initialize), so it stays
+    // scoped to RU tests and never interferes with shared W1 report tests. A future RU test that forgets
+    // to bind fails in the BCApps run (file never produced) instead of breaking NAV. As a safeguard the
+    // copy only runs for a target whose directory exists on the server (bug 645025).
+
+    EventSubscriberInstance = Manual;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"File Management", 'OnBeforeDownloadHandler', '', false, false)]
     local procedure CopyServerFileToTargetOnBeforeDownloadHandler(ToFileName: Text; FromFileName: Text; var IsHandled: Boolean)
     var
         FileManagement: Codeunit "File Management";
+        TargetDirectory: Text;
     begin
         if (FromFileName = '') or (ToFileName = '') then
             exit;
         if not FileManagement.ServerFileExists(FromFileName) then
             exit;
+
+        // Only redirect to a server-side copy when the target directory actually exists on the server.
+        // A bare/relative target yields an empty or non-existent directory here, so we skip and let the
+        // platform's normal download flow handle it.
+        TargetDirectory := FileManagement.GetDirectoryName(ToFileName);
+        if TargetDirectory = '' then
+            exit;
+        if not FileManagement.ServerDirectoryExists(TargetDirectory) then
+            exit;
+
         FileManagement.CopyServerFile(FromFileName, ToFileName, true);
         IsHandled := true;
     end;

--- a/src/Layers/RU/Tests/Local/SCMInventoryreports.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/SCMInventoryreports.Codeunit.al
@@ -17,8 +17,6 @@ codeunit 144102 "SCM Inventory reports"
         LibraryWarehouse: Codeunit "Library - Warehouse";
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryUtility: Codeunit "Library - Utility";
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
@@ -357,10 +355,6 @@ codeunit 144102 "SCM Inventory reports"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         LibraryVariableStorage.Clear();
 
         if IsInitialized then
@@ -593,10 +587,12 @@ codeunit 144102 "SCM Inventory reports"
 
     local procedure RunUnpostedTorg16Report(ItemDocumentNo: Code[20]; OperationType: Text; OrderNo: Text; OrderDate: Date; WriteOffSource: Text)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         InvtDocumentHeader: Record "Invt. Document Header";
         ItemWriteOffActTorg16: Report "Item Write-off act TORG-16";
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         ItemWriteOffActTorg16.InitializeRequest(
           OperationType, OrderNo, OrderDate, WriteOffSource);
         LibraryReportValidation.SetFileName(ItemDocumentNo);
@@ -606,14 +602,17 @@ codeunit 144102 "SCM Inventory reports"
         ItemWriteOffActTorg16.SetFileNameSilent(FileName);
         ItemWriteOffActTorg16.UseRequestPage(false);
         ItemWriteOffActTorg16.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunPostedTorg16Report(ItemShipmentNo: Code[20]; OperationType: Text; OrderNo: Text; OrderDate: Date; WriteOffSource: Text)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         InvtShipmentHeader: Record "Invt. Shipment Header";
         PostedItemWriteOffActTorg16: Report "Posted Item Write-off TORG-16";
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         PostedItemWriteOffActTorg16.InitializeRequest(
           OperationType, OrderNo, OrderDate, WriteOffSource);
         LibraryReportValidation.SetFileName(ItemShipmentNo);
@@ -623,14 +622,17 @@ codeunit 144102 "SCM Inventory reports"
         PostedItemWriteOffActTorg16.SetFileNameSilent(FileName);
         PostedItemWriteOffActTorg16.UseRequestPage(false);
         PostedItemWriteOffActTorg16.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunUnpostedTorg1Report(PurchaseDocNo: Code[20]; ShowActualQty: Boolean; ReportNo: Text; ReportDate: Date; ReportOperationType: Text)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         PurchaseHeader: Record "Purchase Header";
         ItemsReceiptActTORG1: Report "Items Receipt Act TORG-1";
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         ItemsReceiptActTORG1.InitializeRequest(
           ShowActualQty, ReportNo, ReportDate, ReportOperationType);
         LibraryReportValidation.SetFileName(PurchaseDocNo);
@@ -640,13 +642,16 @@ codeunit 144102 "SCM Inventory reports"
         ItemsReceiptActTORG1.SetFileNameSilent(FileName);
         ItemsReceiptActTORG1.UseRequestPage(false);
         ItemsReceiptActTORG1.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure RunReceiptDeviationsTorg2Report(DocumentNo: Code[20]; OrderNo: Text; OrderDate: Date; OperationType: Text; TableId: Integer; DocumentType: Integer)
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         ReceiptDeviationsTORG2: Report "Receipt Deviations TORG-2";
         FileName: Text;
     begin
+        BindSubscription(RUReportDownloadHandler);
         ReceiptDeviationsTORG2.InitializeRequest(OrderNo, OrderDate, OperationType);
         LibraryReportValidation.SetFileName(DocumentNo);
         FileName := LibraryReportValidation.GetFileName();
@@ -656,6 +661,7 @@ codeunit 144102 "SCM Inventory reports"
         ReceiptDeviationsTORG2.SetFileNameSilent(FileName);
         ReceiptDeviationsTORG2.UseRequestPage(false);
         ReceiptDeviationsTORG2.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure AddEmployeeSignatures(var Members: array[5, 2] of Text; ItemDocumentNo: Code[20])

--- a/src/Layers/RU/Tests/Local/SCMInventoryreports.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/SCMInventoryreports.Codeunit.al
@@ -17,6 +17,8 @@ codeunit 144102 "SCM Inventory reports"
         LibraryWarehouse: Codeunit "Library - Warehouse";
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryUtility: Codeunit "Library - Utility";
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
@@ -355,6 +357,10 @@ codeunit 144102 "SCM Inventory reports"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         LibraryVariableStorage.Clear();
 
         if IsInitialized then

--- a/src/Layers/RU/Tests/Local/SCMTorg13Test.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/SCMTorg13Test.Codeunit.al
@@ -12,8 +12,6 @@ codeunit 144720 "SCM Torg-13 Test"
     var
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryReportValidation: Codeunit "Library - Report Validation";
-        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
-        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryRandom: Codeunit "Library - Random";
         LibraryERM: Codeunit "Library - ERM";
@@ -201,10 +199,6 @@ codeunit 144720 "SCM Torg-13 Test"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
-        if not RUReportHandlerBound then begin
-            BindSubscription(RUReportDownloadHandler);
-            RUReportHandlerBound := true;
-        end;
         if isInitialized then
             exit;
 
@@ -216,9 +210,11 @@ codeunit 144720 "SCM Torg-13 Test"
 
     local procedure PrintTorg13ForReclassJnlLine(JournalNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         ReclassificationItemJournalLine: Record "Item Journal Line";
         ItemReclassTORG13: Report "Item Reclass. TORG-13";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(JournalNo);
 
         ReclassificationItemJournalLine.SetRange("No.", JournalNo);
@@ -227,27 +223,33 @@ codeunit 144720 "SCM Torg-13 Test"
         ItemReclassTORG13.SetTableView(ReclassificationItemJournalLine);
         ItemReclassTORG13.UseRequestPage(false);
         ItemReclassTORG13.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PrintTorg13ForTransferOrder(HeaderNo: Code[20])
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         TransferHeader: Record "Transfer Header";
         TransferOrderTORG13: Report "Transfer Order TORG-13";
     begin
+        BindSubscription(RUReportDownloadHandler);
         LibraryReportValidation.SetFileName(HeaderNo);
         TransferHeader.SetRange("No.", HeaderNo);
         TransferOrderTORG13.InitializeRequest(LibraryReportValidation.GetFileName());
         TransferOrderTORG13.SetTableView(TransferHeader);
         TransferOrderTORG13.UseRequestPage(false);
         TransferOrderTORG13.Run();
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PostTransferAndPrintTorg13ForTransferReceipt(HeaderNo: Code[20]): Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         TransferHeader: Record "Transfer Header";
         TransferReceiptHeader: Record "Transfer Receipt Header";
         TransferReceiptTORG13: Report "Transfer Receipt TORG-13";
     begin
+        BindSubscription(RUReportDownloadHandler);
         TransferHeader.Get(HeaderNo);
         LibraryInventory.PostTransferHeader(TransferHeader, true, true);
 
@@ -260,14 +262,17 @@ codeunit 144720 "SCM Torg-13 Test"
 
         TransferReceiptHeader.FindFirst();
         exit(TransferReceiptHeader."No.");
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure PostTransferAndPrintTorg13ForTransferShipment(HeaderNo: Code[20]): Code[20]
     var
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
         TransferHeader: Record "Transfer Header";
         TransferShipmentHeader: Record "Transfer Shipment Header";
         TransferShipmentTORG13: Report "Transfer Shipment TORG-13";
     begin
+        BindSubscription(RUReportDownloadHandler);
         TransferHeader.Get(HeaderNo);
         LibraryInventory.PostTransferHeader(TransferHeader, true, true);
 
@@ -280,6 +285,7 @@ codeunit 144720 "SCM Torg-13 Test"
 
         TransferShipmentHeader.FindFirst();
         exit(TransferShipmentHeader."No.");
+        UnbindSubscription(RUReportDownloadHandler);
     end;
 
     local procedure CreateTransferOrder(): Code[20]

--- a/src/Layers/RU/Tests/Local/SCMTorg13Test.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/SCMTorg13Test.Codeunit.al
@@ -261,8 +261,8 @@ codeunit 144720 "SCM Torg-13 Test"
         TransferReceiptTORG13.Run();
 
         TransferReceiptHeader.FindFirst();
-        exit(TransferReceiptHeader."No.");
         UnbindSubscription(RUReportDownloadHandler);
+        exit(TransferReceiptHeader."No.");
     end;
 
     local procedure PostTransferAndPrintTorg13ForTransferShipment(HeaderNo: Code[20]): Code[20]
@@ -284,8 +284,8 @@ codeunit 144720 "SCM Torg-13 Test"
         TransferShipmentTORG13.Run();
 
         TransferShipmentHeader.FindFirst();
-        exit(TransferShipmentHeader."No.");
         UnbindSubscription(RUReportDownloadHandler);
+        exit(TransferShipmentHeader."No.");
     end;
 
     local procedure CreateTransferOrder(): Code[20]

--- a/src/Layers/RU/Tests/Local/SCMTorg13Test.Codeunit.al
+++ b/src/Layers/RU/Tests/Local/SCMTorg13Test.Codeunit.al
@@ -12,6 +12,8 @@ codeunit 144720 "SCM Torg-13 Test"
     var
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryReportValidation: Codeunit "Library - Report Validation";
+        RUReportDownloadHandler: Codeunit "RU Report Download Handler";
+        RUReportHandlerBound: Boolean;
         LibraryRUReports: Codeunit "Library RU Reports";
         LibraryRandom: Codeunit "Library - Random";
         LibraryERM: Codeunit "Library - ERM";
@@ -199,6 +201,10 @@ codeunit 144720 "SCM Torg-13 Test"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
+        if not RUReportHandlerBound then begin
+            BindSubscription(RUReportDownloadHandler);
+            RUReportHandlerBound := true;
+        end;
         if isInitialized then
             exit;
 


### PR DESCRIPTION
[AB#645025](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645025)

The `CopyServerFileToTargetOnBeforeDownloadHandler` procedure was added in a previous PR to enable RU tests to run in BCApps. The reason being that the way downloads were handled assumed an on-prem like setup which worked in NAV but not in containers on BCApps. The handler does work for RU as intended, both in BCApps and NAV. The issue is that it was made too generic and accidentally triggered for some W1 tests, breaking them in NAV. 
This updates the handler to be fully manual, and manually subscribes each relevant RU test to it.

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->








