### PR TITLE
Known senders table should only be inserted to when the task is coming from an email

### DIFF
--- a/src/Apps/W1/PayablesAgent/app/Integration/PAKnownSender.Table.al
+++ b/src/Apps/W1/PayablesAgent/app/Integration/PAKnownSender.Table.al
@@ -64,6 +64,8 @@ table 3308 "PA Known Sender"
         Setup: Record "Payables Agent Setup";
         SenderEmail: Text[250];
     begin
+        if EDocument."Outlook Mail Message Id" = '' then
+            exit;
         SenderEmail := CopyStr(EDocument."Source Details", 1, MaxStrLen(SenderEmail));
         if SenderEmail = '' then
             exit;


### PR DESCRIPTION
The table was getting populated when creating tasks by manually uploading a PDF. This functionality is scoped to tasks received by email.

I used the same approach to "distinguish the source" as in GetAgentTaskMessagePageId.

Tests for this app live in a separate repo.

Fixes [AB#646072](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646072)



