### PR TITLE
[Master]-Customer Ledger Bill Entries display default Customer Posting Group instead of Alternative Customer Posting Group set on Sales Documents in the Spanish version.

### DIFF
--- a/src/Layers/ES/BaseApp/Local/Finance/ReceivablesPayables/InvoiceSplitPayment.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Local/Finance/ReceivablesPayables/InvoiceSplitPayment.Codeunit.al
@@ -124,6 +124,7 @@ codeunit 7000005 "Invoice-Split Payment"
             GenJnlLine."Reason Code" := SalesHeader."Reason Code";
             GenJnlLine."External Document No." := GenJnlLineExtDocNo;
             GenJnlLine.Validate("Currency Code", SalesHeader."Currency Code");
+            GenJnlLine."Posting Group" := SalesHeader."Customer Posting Group";
             GenJnlLine.Amount := -TotalAmount;
             GenJnlLine."Amount (LCY)" := -TotalAmountLCY;
             GenJnlLine."System-Created Entry" := true;
@@ -194,6 +195,7 @@ codeunit 7000005 "Invoice-Split Payment"
         GenJnlLine."Reason Code" := SalesHeader."Reason Code";
         GenJnlLine."External Document No." := GenJnlLineExtDocNo;
         GenJnlLine.Validate("Currency Code", SalesHeader."Currency Code");
+        GenJnlLine."Posting Group" := SalesHeader."Customer Posting Group";
         GenJnlLine."System-Created Entry" := true;
         GenJnlLine."On Hold" := SalesHeader."On Hold";
         GenJnlLine."Source Code" := SourceCode;

--- a/src/Layers/ES/Tests/Local/CarteraPosting.Codeunit.al
+++ b/src/Layers/ES/Tests/Local/CarteraPosting.Codeunit.al
@@ -1597,6 +1597,76 @@ codeunit 147305 "Cartera Posting"
             StrSubstNo(FieldErr, GLEntry.FieldCaption("Credit Amount"), GLEntry.TableCaption()));
     end;
 
+    [Test]
+    procedure BillCustLedgEntryUsesAlternativePostingGroupFromSalesInvoice()
+    var
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        Customer: Record Customer;
+        CustomerPostingGroup2: Record "Customer Posting Group";
+        SalesHeader: Record "Sales Header";
+        SalesInvoiceNo: Code[20];
+    begin
+        // [SCENARIO 644753] Bill Customer Ledger Entries use the alternative Customer Posting Group set on the Sales Document
+        // instead of the customer's default Customer Posting Group when creating bills.
+        Initialize();
+
+        // [GIVEN] Enable "Allow Multiple Posting Groups" in Sales & Receivables Setup.
+        SetSalesAllowMultiplePostingGroups(true);
+
+        // [GIVEN] Create a customer with a bill-creating (Cartera) payment method and "Allow Multiple Posting Groups" enabled.
+        CreateCustomerWithAllowMultiplePostingGroups(Customer, true);
+
+        // [GIVEN] Create an alternative Customer Posting Group linked to the customer's default posting group.
+        LibrarySales.CreateCustomerPostingGroup(CustomerPostingGroup2);
+        LibrarySales.CreateAltCustomerPostingGroup(Customer."Customer Posting Group", CustomerPostingGroup2.Code);
+
+        // [GIVEN] Create a sales invoice and set the alternative Customer Posting Group on the Sales Document.
+        CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, Customer."No.");
+        SalesHeader.Validate("Customer Posting Group", CustomerPostingGroup2.Code);
+        SalesHeader.Modify(true);
+
+        // [WHEN] Post the sales invoice (splitting it into bills).
+        SalesInvoiceNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] The created Bill Customer Ledger Entry uses the alternative Customer Posting Group from the Sales Document.
+        LibraryERM.FindCustomerLedgerEntry(CustLedgerEntry, CustLedgerEntry."Document Type"::Bill, SalesInvoiceNo);
+        Assert.AreEqual(
+            CustomerPostingGroup2.Code,
+            CustLedgerEntry."Customer Posting Group",
+            StrSubstNo(
+                FieldErr, CustLedgerEntry.FieldCaption("Customer Posting Group"), CustLedgerEntry.TableCaption()));
+    end;
+
+    [Test]
+    procedure BillCustLedgEntryKeepsDefaultPostingGroupWhenNoAlternativeUsed()
+    var
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        Customer: Record Customer;
+        SalesHeader: Record "Sales Header";
+        SalesInvoiceNo: Code[20];
+    begin
+        // [SCENARIO 644753] When no alternative Customer Posting Group is used on the Sales Document, the Bill
+        // Customer Ledger Entry keeps the customer's default Customer Posting Group (previous behavior is not affected).
+        Initialize();
+
+        // [GIVEN] A customer with a bill-creating (Cartera) payment method and its default Customer Posting Group.
+        LibraryCarteraReceivables.CreateCarteraCustomer(Customer, '');
+
+        // [GIVEN] A sales invoice created without changing the Customer Posting Group.
+        LibraryCarteraReceivables.CreateSalesInvoice(SalesHeader, Customer."No.");
+
+        // [WHEN] Post the sales invoice (splitting it into a bill).
+        SalesInvoiceNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] The Bill Customer Ledger Entry uses the customer's default Customer Posting Group.
+        LibraryERM.FindCustomerLedgerEntry(CustLedgerEntry, CustLedgerEntry."Document Type"::Bill, SalesInvoiceNo);
+        Assert.AreEqual(
+            Customer."Customer Posting Group",
+            CustLedgerEntry."Customer Posting Group",
+            StrSubstNo(
+                FieldErr, CustLedgerEntry.FieldCaption("Customer Posting Group"), CustLedgerEntry.TableCaption()));
+    end;
+
     local procedure Initialize()
     begin
         LibraryVariableStorage.Clear();
@@ -3600,6 +3670,15 @@ codeunit 147305 "Cartera Posting"
 
         LibraryERM.SetAppliestoIdCustomer(CustLedgerEntry2);
         LibraryERM.PostCustLedgerApplication(CustLedgerEntry);
+    end;
+
+    local procedure CreateCustomerWithAllowMultiplePostingGroups(var Customer: Record Customer; AllowMultiplePostingGroups: Boolean)
+    begin
+        CreateCustomer(Customer);
+        if not AllowMultiplePostingGroups then
+            exit;
+        Customer.Validate("Allow Multiple Posting Groups", AllowMultiplePostingGroups);
+        Customer.Modify(true);
     end;
 
     [ModalPageHandler]


### PR DESCRIPTION
Fixes [AB#644753](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644753)

WorkItem [Bug 644753](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/644753): [master]-[ALL-E]-Customer Ledger Bill Entries display default Customer Posting Group instead of Alternative Customer Posting Group set on Sales Documents in the Spanish version.


**ISSUE**:- Customer Ledger Bill Entries display default Customer Posting Group instead of Alternative Customer Posting Group set on Sales Documents in the Spanish version.

**CAUSE**:- InvoiceSplitPayment.SplitSalesInv creates the Bill and Close Invoice Gen. Journal Line records without setting the Posting Group field. As a result, when the lines are posted through GenJnlPostLine.PostCust, the empty posting group defaults to the customer's current Customer Posting Group instead of using the posting group from the original invoice, which can result in incorrect customer ledger postings.

**SOLUTION** :- The invoice split posting logic was updated to explicitly set the journal line posting group from the sales document’s Customer Posting Group in all relevant bill-creation paths.


